### PR TITLE
Fix navigation bar in Messages VC

### DIFF
--- a/Convos/Chat List/ChatList.swift
+++ b/Convos/Chat List/ChatList.swift
@@ -109,8 +109,7 @@ struct ChatListView: View {
                 .navigationDestination(item: $selectedConversation) { conversation in
                     MessagesView(messagingService: MockMessagingService())
                         .ignoresSafeArea()
-                        .navigationTitle(conversation.otherParticipant?.username ?? "Chat")
-                        .navigationBarTitleDisplayMode(.inline)
+                        .toolbarVisibility(.hidden, for: .navigationBar)
                 }
 
                 // Dropdown menu overlay

--- a/Convos/Chat List/ChatList.swift
+++ b/Convos/Chat List/ChatList.swift
@@ -106,7 +106,7 @@ struct ChatListView: View {
                     }
                 }
                 .navigationBarHidden(true)
-                .navigationDestination(item: $selectedConversation) { conversation in
+                .navigationDestination(item: $selectedConversation) { _ in
                     MessagesView(messagingService: MockMessagingService())
                         .ignoresSafeArea()
                         .toolbarVisibility(.hidden, for: .navigationBar)

--- a/Convos/Core/Chat/Messages View Controller/View Controller/MessagesViewController.swift
+++ b/Convos/Core/Chat/Messages View Controller/View Controller/MessagesViewController.swift
@@ -133,9 +133,15 @@ final class MessagesViewController: UIViewController {
         // Set content inset to just the base navigation bar height plus safe area
         let navHeight = (traitCollection.verticalSizeClass == .compact ?
             MessagesNavigationBar.Constant.compactHeight :
-            MessagesNavigationBar.Constant.regularHeight) + view.safeAreaInsets.top
+            MessagesNavigationBar.Constant.regularHeight)
         collectionView.contentInset.top = navHeight
         collectionView.verticalScrollIndicatorInsets.top = collectionView.contentInset.top
+    }
+
+    // MARK: - Actions
+
+    @objc func onBack() {
+        navigationController?.popViewController(animated: true)
     }
 
     // MARK: - Private Setup Methods
@@ -146,6 +152,7 @@ final class MessagesViewController: UIViewController {
             UIImage(systemName: "chevron.left",
                     withConfiguration: UIImage.SymbolConfiguration(weight: .medium)),
             for: .normal)
+        navigationBar.leftButton.addTarget(self, action: #selector(onBack), for: .touchUpInside)
         navigationBar.rightButton.setImage(
             UIImage(systemName: "timer",
                     withConfiguration: UIImage.SymbolConfiguration(weight: .medium)),
@@ -498,7 +505,7 @@ extension MessagesViewController: UIScrollViewDelegate, UICollectionViewDelegate
             return
         }
 
-        if scrollView.contentOffset.y <= -scrollView.adjustedContentInset.top + scrollView.bounds.height {
+        if scrollView.contentOffset.y <= -scrollView.adjustedContentInset.top {
             loadPreviousMessages()
         }
     }


### PR DESCRIPTION
### Hide navigation bar and implement back navigation in MessagesViewController
* Updates navigation behavior in [ChatList.swift](https://github.com/ephemeraHQ/convos-ios/pull/16/files#diff-7727eec723b70804da4c8f19ebb758242edc4e564cab982260aacb06900255eb) by removing conversation parameter passing and hiding the navigation bar
* Modifies content inset calculation and scroll behavior in [MessagesViewController.swift](https://github.com/ephemeraHQ/convos-ios/pull/16/files#diff-04a8743cbb4447f5f3dfa6870daee376f91ee31bca7779366b073ba6db8def30)
* Implements back navigation functionality through the navigation bar's left button
* Updates previous message loading trigger to occur only when scrolled to the very top

#### 📍Where to Start
Start with the navigation changes in [ChatList.swift](https://github.com/ephemeraHQ/convos-ios/pull/16/files#diff-7727eec723b70804da4c8f19ebb758242edc4e564cab982260aacb06900255eb) as it contains the initial navigation setup that affects the MessagesViewController.

----

_[Macroscope](https://app.macroscope.com) summarized f8343c6._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a back button in the chat messages view for easier navigation.

- **Style**
  - Updated chat navigation to hide the navigation bar in the messages view, providing a cleaner interface.

- **Bug Fixes**
  - Improved scrolling behavior in chat by adjusting when previous messages are loaded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->