### PR TITLE
Embed GRDB-dynamic

### DIFF
--- a/Convos.xcodeproj/project.pbxproj
+++ b/Convos.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		D808504A2DC9534800E708B0 /* TurnkeySDK in Frameworks */ = {isa = PBXBuildFile; productRef = D80850492DC9534800E708B0 /* TurnkeySDK */; };
 		D80BAAC22DB2C36500C2FB42 /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = D80BAAC12DB2C36500C2FB42 /* Sentry */; };
 		D834386F2DB19D8C00A50F45 /* Factory in Frameworks */ = {isa = PBXBuildFile; productRef = D834386E2DB19D8C00A50F45 /* Factory */; };
+		D85B9B9F2DD26BC400831D58 /* GRDB-dynamic in Embed Frameworks */ = {isa = PBXBuildFile; productRef = D808502E2DC94EDF00E708B0 /* GRDB-dynamic */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		D8A2B6BB2DA4BBA400EF8577 /* AnchorKit in Frameworks */ = {isa = PBXBuildFile; productRef = D8A2B6BA2DA4BBA400EF8577 /* AnchorKit */; };
 		D8B5A9042DC272BD006003A4 /* XMTPiOS in Frameworks */ = {isa = PBXBuildFile; productRef = D8B5A9032DC272BD006003A4 /* XMTPiOS */; };
 /* End PBXBuildFile section */
@@ -49,6 +50,17 @@
 			dstSubfolderSpec = 10;
 			files = (
 				D80850462DC94FF300E708B0 /* GRDB-dynamic in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D85B9BA02DD26BC400831D58 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				D85B9B9F2DD26BC400831D58 /* GRDB-dynamic in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -213,6 +225,7 @@
 				D8A2B68E2DA4BA4B00EF8577 /* Frameworks */,
 				D8A2B68F2DA4BA4B00EF8577 /* Resources */,
 				D808503B2DC94F4C00E708B0 /* Embed Foundation Extensions */,
+				D85B9BA02DD26BC400831D58 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);

--- a/Convos.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Convos.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -78,8 +78,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/hmlongco/Factory",
       "state" : {
-        "revision" : "c8110886836ab4dd1136dbac0c04f0f36cd68540",
-        "version" : "2.4.5"
+        "revision" : "f1e35a1672fcb71a40ef6b7aaf1ea38a458c4485",
+        "version" : "2.4.12"
       }
     },
     {
@@ -87,8 +87,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/groue/GRDB.swift",
       "state" : {
-        "revision" : "04e73c26c4ce8218ab85aaf791942bb0b204f330",
-        "version" : "7.4.1"
+        "revision" : "a5a1be26b4513dc7ec360eb56bc08a345bac6649",
+        "version" : "7.5.0"
       }
     },
     {
@@ -114,8 +114,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/PostHog/posthog-ios.git",
       "state" : {
-        "revision" : "1b011434301250ca75098c40fecad9ba3d209307",
-        "version" : "3.24.0"
+        "revision" : "d640df892fcb3bbeadf02b9ec28eeb682df53d24",
+        "version" : "3.25.0"
       }
     },
     {
@@ -123,8 +123,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getsentry/sentry-cocoa",
       "state" : {
-        "revision" : "2c6c1b81d9f6e6178064b4e9b457abe1c118bcda",
-        "version" : "8.49.0"
+        "revision" : "6c81e671154e63464dd6749b7ba3279dd390a146",
+        "version" : "8.50.1"
       }
     },
     {
@@ -186,8 +186,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "c51907a839e63ebf0ba2076bba73dd96436bd1b9",
-        "version" : "2.81.0"
+        "revision" : "34d486b01cd891297ac615e40d5999536a1e138d",
+        "version" : "2.83.0"
       }
     },
     {
@@ -195,8 +195,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-http2.git",
       "state" : {
-        "revision" : "170f4ca06b6a9c57b811293cebcb96e81b661310",
-        "version" : "1.35.0"
+        "revision" : "4281466512f63d1bd530e33f4aa6993ee7864be0",
+        "version" : "1.36.0"
       }
     },
     {
@@ -204,8 +204,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-ssl.git",
       "state" : {
-        "revision" : "0cc3528ff48129d64ab9cab0b1cd621634edfc6b",
-        "version" : "2.29.3"
+        "revision" : "4b38f35946d00d8f6176fe58f96d83aba64b36c7",
+        "version" : "2.31.0"
       }
     },
     {


### PR DESCRIPTION
### Configure Xcode project to embed `GRDB-dynamic` framework in app bundle
* Added `GRDB-dynamic` framework to the "Embed Frameworks" build phase in [project.pbxproj](https://github.com/ephemeraHQ/convos-ios/pull/19/files#diff-d58364582ce5ff189bf9f87c20898db7df50a681e6e9df35dca291d7b9373da7)
* Updated Swift Package Manager dependency resolution in [Package.resolved](https://github.com/ephemeraHQ/convos-ios/pull/19/files#diff-5ba8a77e39b2341f31e30e2a5f83f64478805bad91b91be196ecb480b14ec4b0)

#### 📍Where to Start
Start with the framework embedding configuration in [project.pbxproj](https://github.com/ephemeraHQ/convos-ios/pull/19/files#diff-d58364582ce5ff189bf9f87c20898db7df50a681e6e9df35dca291d7b9373da7), specifically the new "Embed Frameworks" `PBXCopyFilesBuildPhase` section.

----

_[Macroscope](https://app.macroscope.com) summarized 97cdd5d._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated several third-party dependencies to their latest versions.
  - Modified project settings to embed and code-sign the GRDB-dynamic framework within the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->