### PR TITLE
Bitrise Setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,11 @@ secrets: ## Generate Secrets.swift from .env
 
 .PHONY: entitlements
 entitlements: ## Generate entitlements file from .env
-	./Scripts/generate_entitlements.sh	
+	./Scripts/generate_entitlements.sh
+
+.PHONY: mock-env
+mock-env: ## Generate a mock .env file for PR builds using Scripts/generate-mock-env.sh
+	./Scripts/generate-mock-env.sh
 
 .PHONY: upload_symbols
 upload_symbols: ## Upload symbols to Sentry

--- a/Scripts/generate-mock-env.sh
+++ b/Scripts/generate-mock-env.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+
+# Exit on any error and ensure pipeline failures are caught
+set -e
+set -o pipefail
+
+# style the output
+function info {
+  echo "[$(basename "${0}")] [INFO] ${1}"
+}
+
+function die {
+  echo "[$(basename "${0}")] [ERROR] ${1}"
+  exit 1
+}
+
+# This script generates a mock .env file for PR builds
+# Usage: ./generate-mock-env.sh
+#
+# The script reads keys from .env.example and creates a .env file
+# using MOCK_ prefixed Bitrise secrets (e.g., MOCK_FIREBASE_APP_CHECK_TOKEN)
+
+info "🔑 Generating mock .env file for PR builds"
+
+# Check if .env.example file exists
+if [ ! -f ".env.example" ]; then
+  die ".env.example file not found"
+fi
+
+# Remove existing .env file if it exists
+if [ -f ".env" ]; then
+  info "Removing existing .env file"
+  rm .env
+fi
+
+# Read .env.example and generate .env with mock values
+while IFS='=' read -r key value || [[ -n "$key" ]]; do
+  # Skip comments and empty lines
+  [[ $key =~ ^#.*$ ]] && continue
+  [[ -z $key ]] && continue
+
+  # Remove any leading/trailing whitespace from key
+  key=$(echo "$key" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+
+  # Skip if key is empty after trimming
+  [[ -z $key ]] && continue
+
+  # Create the mock secret name with MOCK_ prefix
+  mock_secret="MOCK_${key}"
+
+  # Get the mock value from Bitrise environment variable
+  mock_value="${!mock_secret}"
+
+  # If the mock secret is not set, use a default mock value
+  if [ -z "$mock_value" ]; then
+    mock_value="mock_$(echo "$key" | tr '[:upper:]' '[:lower:]')"  # lowercase version of key
+    info "Using default mock value for $key: $mock_value"
+  else
+    info "Using Bitrise secret $mock_secret for $key"
+  fi
+
+  # Write to .env file
+  echo "$key=$mock_value" >> .env
+
+done < .env.example
+
+info "✅ Generated mock .env file with $(wc -l < .env) environment variables"


### PR DESCRIPTION
### Add Bitrise CI setup with mock environment generation for PR builds
Adds CI infrastructure for Bitrise by creating a mock environment file generation system for PR builds. The changes include:

- A new `mock-env` make target in [Makefile](https://github.com/ephemeraHQ/convos-ios/pull/38/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52) that executes the environment generation script
- A new shell script [Scripts/generate-mock-env.sh](https://github.com/ephemeraHQ/convos-ios/pull/38/files#diff-cb465f4583ec75fb5778ad0342500e1b3fefd68dd8edc33236459934f00ff31a) that reads environment variable keys from `.env.example`, retrieves corresponding values from Bitrise secrets with `MOCK_` prefix, and writes them to a `.env` file with fallback to default mock values

#### 📍Where to Start
Start with the `mock-env` target in [Makefile](https://github.com/ephemeraHQ/convos-ios/pull/38/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52) to understand the entry point, then review the main logic in [Scripts/generate-mock-env.sh](https://github.com/ephemeraHQ/convos-ios/pull/38/files#diff-cb465f4583ec75fb5778ad0342500e1b3fefd68dd8edc33236459934f00ff31a).

----

_[Macroscope](https://app.macroscope.com) summarized 03f1395._