### PR TITLE
Upload PFP and env config

### DIFF
--- a/Convos.xcodeproj/project.pbxproj
+++ b/Convos.xcodeproj/project.pbxproj
@@ -574,7 +574,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.convos.tests;
+				PRODUCT_BUNDLE_IDENTIFIER = "org.convos.ios-preview.tests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_VERSION = 5.0;
@@ -591,7 +591,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.convos.tests;
+				PRODUCT_BUNDLE_IDENTIFIER = "org.convos.ios-preview.tests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_VERSION = 5.0;
@@ -616,7 +616,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				MARKETING_VERSION = 1.0.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.convos.preview.ConvosNSE;
+				PRODUCT_BUNDLE_IDENTIFIER = "org.convos.ios-preview.ConvosNSE";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -642,7 +642,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				MARKETING_VERSION = 1.0.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.convos.preview.ConvosNSE;
+				PRODUCT_BUNDLE_IDENTIFIER = "org.convos.ios-preview.ConvosNSE";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -672,7 +672,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.convos.preview;
+				PRODUCT_BUNDLE_IDENTIFIER = "org.convos.ios-preview";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
@@ -701,7 +701,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.convos.preview;
+				PRODUCT_BUNDLE_IDENTIFIER = "org.convos.ios-preview";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;

--- a/Convos/Conversation Detail/GroupEditState.swift
+++ b/Convos/Conversation Detail/GroupEditState.swift
@@ -185,20 +185,24 @@ class GroupEditState {
     }
 
     private func uploadImageAndUpdateProfile() async throws {
-        // @jarodl fix this
-//        let compressedImageData = try await prepareImageForUpload()
-//        let filename = "group-image-\(UUID().uuidString).jpg"
-//
-//        guard case .success(let uploadedImage) = imageState else {
-//            throw GroupImageError.importFailed
-//        }
+        let compressedImageData = try await prepareImageForUpload()
+        let filename = "group-image-\(UUID().uuidString).jpg"
 
-//        _ = try await messagingService.uploadImageAndExecute(
-//            data: compressedImageData,
-//            filename: filename) { uploadedURL in
-//            try await self.updateGroupImage(imageURL: uploadedURL)
-//            ImageCache.shared.setImageForConversation(uploadedImage, conversationId: self.conversation.id)
-//        }
+        guard case .success(let uploadedImage) = imageState else {
+            throw GroupImageError.importFailed
+        }
+
+        // Use the GroupMetadataWriter to handle both upload and metadata update
+        let uploadedURL = try await groupMetadataWriter.uploadAndUpdateGroupImage(
+            groupId: conversation.id,
+            imageData: compressedImageData,
+            filename: filename
+        )
+
+        Logger.info("Group image uploaded and metadata updated successfully: \(uploadedURL)")
+
+        // Cache the uploaded image for instant UI updates
+        ImageCache.shared.setImageForConversation(uploadedImage, conversationId: conversation.id)
     }
 
     @MainActor

--- a/Convos/Convos Client/AppEnvironment.swift
+++ b/Convos/Convos Client/AppEnvironment.swift
@@ -1,12 +1,13 @@
 import Foundation
 
 enum AppEnvironment {
-    case local, tests, dev, production
+    case local, tests, dev, otrDev, production
 
     var apiBaseURL: String {
         switch self {
         case .local, .tests: "http://localhost:4000/api/"
         case .dev: "https://api.convos-dev.convos-api.xyz/api/"
+        case .otrDev: "https://api.convos-otr-dev.convos-api.xyz/api/"
         case .production: "https://api.convos-prod.convos-api.xyz/api/"
         }
     }
@@ -17,7 +18,7 @@ enum AppEnvironment {
 
     var appGroupIdentifier: String {
         switch self {
-        case .local, .tests, .dev:
+        case .local, .tests, .dev, .otrDev:
             "group.com.convos.preview"
         case .production: "group.com.convos.prod"
         }
@@ -26,6 +27,7 @@ enum AppEnvironment {
     var relyingPartyIdentifier: String {
         switch self {
         case .local, .tests, .dev: "preview.convos.org"
+        case .otrDev: "otr-preview.convos.org"
         case .production: "convos.org"
         }
     }

--- a/Convos/Convos Client/Convos API/ConvosAPIClient.swift
+++ b/Convos/Convos Client/Convos API/ConvosAPIClient.swift
@@ -367,7 +367,6 @@ final class ConvosAPIClient: BaseConvosAPIClient, ConvosAPIClientProtocol {
         var s3Request = URLRequest(url: s3URL)
         s3Request.httpMethod = "PUT"
         s3Request.setValue(contentType, forHTTPHeaderField: "Content-Type")
-        s3Request.setValue(acl, forHTTPHeaderField: "x-amz-acl")
         s3Request.httpBody = data
 
         Logger.info("Uploading to S3: \(s3URL.absoluteString)")

--- a/Convos/Convos Client/Inboxes/InboxStateMachine.swift
+++ b/Convos/Convos Client/Inboxes/InboxStateMachine.swift
@@ -6,7 +6,7 @@ private extension AppEnvironment {
     var xmtpEnv: XMTPEnvironment {
         switch self {
         case .local, .tests: return .local
-        case .dev: return .dev
+        case .dev, .otrDev: return .dev
         case .production: return .production
         }
     }

--- a/Convos/Convos Client/Messaging/MessagingService.swift
+++ b/Convos/Convos Client/Messaging/MessagingService.swift
@@ -106,6 +106,7 @@ final class MessagingService: MessagingServiceProtocol {
     func groupMetadataWriter() -> any GroupMetadataWriterProtocol {
         GroupMetadataWriter(client: clientValue.value,
                             clientPublisher: clientPublisher,
+                            inboxReadyValue: inboxReadyValue,
                             databaseWriter: databaseWriter)
     }
 
@@ -116,14 +117,16 @@ final class MessagingService: MessagingServiceProtocol {
     }
 
     func uploadImage(data: Data, filename: String) async throws -> String {
-        // @jarodl fix this
-        return ""
-//        return try await apiClient.uploadAttachment(
-//            data: data,
-//            filename: filename,
-//            contentType: "image/jpeg",
-//            acl: "public-read"
-//        )
+        guard let inboxReady = inboxReadyValue.value else {
+            throw InboxStateError.inboxNotReady
+        }
+
+        return try await inboxReady.apiClient.uploadAttachment(
+            data: data,
+            filename: filename,
+            contentType: "image/jpeg",
+            acl: "public-read"
+        )
     }
 
     func uploadImageAndExecute(
@@ -131,12 +134,14 @@ final class MessagingService: MessagingServiceProtocol {
         filename: String,
         afterUpload: @escaping (String) async throws -> Void
     ) async throws -> String {
-        // @jarodl fix this
-        return ""
-//        return try await apiClient.uploadAttachmentAndExecute(
-//            data: data,
-//            filename: filename,
-//            afterUpload: afterUpload
-//        )
+        guard let inboxReady = inboxReadyValue.value else {
+            throw InboxStateError.inboxNotReady
+        }
+
+        return try await inboxReady.apiClient.uploadAttachmentAndExecute(
+            data: data,
+            filename: filename,
+            afterUpload: afterUpload
+        )
     }
 }

--- a/Convos/Convos Client/Messaging/MockMessagingService.swift
+++ b/Convos/Convos Client/Messaging/MockMessagingService.swift
@@ -457,6 +457,10 @@ class MockGroupMetadataWriter: GroupMetadataWriterProtocol {
     func updateGroupName(groupId: String, name: String) async throws {}
     func updateGroupDescription(groupId: String, description: String) async throws {}
     func updateGroupImageUrl(groupId: String, imageUrl: String) async throws {}
+    func uploadAndUpdateGroupImage(groupId: String, imageData: Data, filename: String) async throws -> String {
+        // Return a mock URL for testing
+        return "https://example.com/uploads/\(filename)"
+    }
     func addGroupMembers(groupId: String, memberInboxIds: [String]) async throws {}
     func removeGroupMembers(groupId: String, memberInboxIds: [String]) async throws {}
     func promoteToAdmin(groupId: String, memberInboxId: String) async throws {}

--- a/Convos/Convos.entitlements
+++ b/Convos/Convos.entitlements
@@ -4,9 +4,9 @@
 <dict>
 	<key>com.apple.developer.associated-domains</key>
 	<array>
-		<string>webcredentials:preview.convos.org</string>
-		<string>applinks:preview.convos.org</string>
-		<string>applinks:*.preview.convos.org</string>
+		<string>webcredentials:otr-preview.convos.org</string>
+		<string>applinks:otr-preview.convos.org</string>
+		<string>applinks:*.otr-preview.convos.org</string>
 	</array>
 	<key>com.apple.developer.devicecheck.appattest-environment</key>
 	<string>development</string>

--- a/Convos/ConvosApp.swift
+++ b/Convos/ConvosApp.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 @main
 struct ConvosApp: App {
-    let convos: ConvosClient = .client(environment: .dev)
+    let convos: ConvosClient = .client(environment: .otrDev)
     let analyticsService: AnalyticsServiceProtocol = PosthogAnalyticsService.shared
 
     init() {


### PR DESCRIPTION
### Implement group profile picture upload functionality and configure app for otrDev environment
- Implements the `uploadImageAndUpdateProfile()` method in [GroupEditState.swift](https://github.com/ephemeraHQ/convos-ios/pull/40/files#diff-bd31e7bbac20fd53543377206d874f52c1c8b76a19b6a92252c840556758031a) to enable group profile picture uploads with image compression and metadata updates
- Adds `otrDev` environment configuration to [AppEnvironment.swift](https://github.com/ephemeraHQ/convos-ios/pull/40/files#diff-ac0ff1934af00df8123b7dcf84ed1e1788cad175cd941511b1454e748735d5ab) with new API base URL and relying party identifier
- Implements `uploadImage` and `uploadImageAndExecute` methods in [MessagingService.swift](https://github.com/ephemeraHQ/convos-ios/pull/40/files#diff-1ff87f94e86eb8d0121e1df7403c4d024e7dc954ee4bb3bb2eef6f678c4ccc21) with inbox readiness checks
- Adds `uploadAndUpdateGroupImage` method to [GroupMetadataWriter.swift](https://github.com/ephemeraHQ/convos-ios/pull/40/files#diff-5262d83b5326f0ef23117d0ad9e2acae6047b1f316bb42dba252b871cca9b819) that combines image upload and metadata update operations
- Updates bundle identifiers from `com.convos.*` to `org.convos.ios-preview.*` format in [project.pbxproj](https://github.com/ephemeraHQ/convos-ios/pull/40/files#diff-d58364582ce5ff189bf9f87c20898db7df50a681e6e9df35dca291d7b9373da7)
- Changes default app environment from `.dev` to `.otrDev` in [ConvosApp.swift](https://github.com/ephemeraHQ/convos-ios/pull/40/files#diff-de23c5a6e10cb84b89d91ed62b707b654c28566f38cc339af8b3cbbf6e003014)
- Updates associated domains from `preview.convos.org` to `otr-preview.convos.org` in [Convos.entitlements](https://github.com/ephemeraHQ/convos-ios/pull/40/files#diff-c9469000f5c59bd8c7c2be4f0a2c690c2bea807a2a47b4ff6d48d7505dbbd74e)
- Removes `x-amz-acl` header from S3 upload requests in [ConvosAPIClient.swift](https://github.com/ephemeraHQ/convos-ios/pull/40/files#diff-776693be35e1ee2e7e3420e0808b9a30619b69c4a07ac4ec9c9a880c6785b491)

#### 📍Where to Start
Start with the `uploadImageAndUpdateProfile()` method in [GroupEditState.swift](https://github.com/ephemeraHQ/convos-ios/pull/40/files#diff-bd31e7bbac20fd53543377206d874f52c1c8b76a19b6a92252c840556758031a) to understand how the group profile picture upload feature is implemented.

----

_[Macroscope](https://app.macroscope.com) summarized 4bbe87e._ (Automatic summaries will resume when PR exits draft mode or review begins).