### PR TITLE
Rename turnkeyAddress with identityAddress

### DIFF
--- a/Convos/Core/API/ConvosAPIClient+Models.swift
+++ b/Convos/Core/API/ConvosAPIClient+Models.swift
@@ -36,7 +36,7 @@ enum ConvosAPI {
         let identities: [Identity]
         struct Identity: Decodable {
             let id: String
-            let turnkeyAddress: String?
+            let identityAddress: String?
             let xmtpId: String
         }
     }
@@ -58,7 +58,7 @@ enum ConvosAPI {
             let id: String
         }
         struct Identity: Encodable {
-            let turnkeyAddress: String?
+            let identityAddress: String?
             let xmtpId: String
             let xmtpInstallationId: String?
         }
@@ -147,7 +147,7 @@ enum ConvosAPI {
         }
         struct Identity: Decodable {
             let id: String
-            let turnkeyAddress: String?
+            let identityAddress: String?
             let xmtpId: String?
         }
         struct Profile: Decodable {
@@ -173,7 +173,7 @@ enum ConvosAPI {
         let description: String?
         let avatar: String?
         let xmtpId: String
-        let turnkeyAddress: String?
+        let identityAddress: String?
     }
 }
 

--- a/Convos/Core/API/MockAPIClient.swift
+++ b/Convos/Core/API/MockAPIClient.swift
@@ -59,7 +59,7 @@ class MockAPIClient: MockBaseAPIClient, ConvosAPIClientProtocol {
             identities: [
                 ConvosAPI.UserResponse.Identity(
                     id: "identity_1",
-                    turnkeyAddress: "0xMOCKADDRESS1",
+                    identityAddress: "0xMOCKADDRESS1",
                     xmtpId: "mock-xmtp-id"
                 )
             ]
@@ -77,7 +77,7 @@ class MockAPIClient: MockBaseAPIClient, ConvosAPIClientProtocol {
             ),
             identity: ConvosAPI.CreatedUserResponse.Identity(
                 id: "identity_1",
-                turnkeyAddress: requestBody.identity.turnkeyAddress,
+                identityAddress: requestBody.identity.identityAddress,
                 xmtpId: requestBody.identity.xmtpId
             ),
             profile: ConvosAPI.CreatedUserResponse.Profile(
@@ -152,7 +152,7 @@ class MockAPIClient: MockBaseAPIClient, ConvosAPIClientProtocol {
             description: "This is a mock profile.",
             avatar: nil,
             xmtpId: "mock-xmtp-id",
-            turnkeyAddress: "0xMOCKADDRESS1"
+            identityAddress: "0xMOCKADDRESS1"
         )
     }
 
@@ -165,7 +165,7 @@ class MockAPIClient: MockBaseAPIClient, ConvosAPIClientProtocol {
                 description: "This is a mock profile for \(id).",
                 avatar: nil,
                 xmtpId: "mock-xmtp-id-\(id)",
-                turnkeyAddress: "0xMOCKADDRESS\(id)"
+                identityAddress: "0xMOCKADDRESS\(id)"
             )
             result[id] = profile
         }
@@ -183,7 +183,7 @@ class MockAPIClient: MockBaseAPIClient, ConvosAPIClientProtocol {
                 description: "Profile matching query: \(query)",
                 avatar: nil,
                 xmtpId: "mock-xmtp-id-search1",
-                turnkeyAddress: "0xMOCKADDRESSSEARCH1"
+                identityAddress: "0xMOCKADDRESSSEARCH1"
             )
         ]
     }

--- a/Convos/Core/Inboxes/InboxStateMachine.swift
+++ b/Convos/Core/Inboxes/InboxStateMachine.swift
@@ -408,7 +408,7 @@ actor InboxStateMachine {
             userId: inbox.providerId,
             userType: .onDevice,
             device: .current(),
-            identity: .init(turnkeyAddress: inbox.signingKey.identity.identifier,
+            identity: .init(identityAddress: inbox.signingKey.identity.identifier,
                             xmtpId: client.inboxId,
                             xmtpInstallationId: client.installationId),
             profile: .init(

--- a/Convos/Core/Storage/Writers/InboxWriter.swift
+++ b/Convos/Core/Storage/Writers/InboxWriter.swift
@@ -33,7 +33,7 @@ final class InboxWriter: InboxWriterProtocol {
             .init(
                 id: $0.id,
                 inboxId: inboxId,
-                walletAddress: $0.turnkeyAddress
+                walletAddress: $0.identityAddress
             )
         }
         try await databaseWriter.write { db in
@@ -70,7 +70,7 @@ final class InboxWriter: InboxWriterProtocol {
             .init(
                 id: user.identity.id,
                 inboxId: inboxId,
-                walletAddress: user.identity.turnkeyAddress
+                walletAddress: user.identity.identityAddress
             )
         ]
         let member: Member = .init(inboxId: inboxId)


### PR DESCRIPTION
### Rename turnkeyAddress property to identityAddress across ConvosAPI models and related components
This change renames the `turnkeyAddress` property to `identityAddress` across multiple API model structs and their usage throughout the codebase. The affected components include:

- API model structs in [ConvosAPIClient+Models.swift](https://github.com/ephemeraHQ/convos-ios/pull/50/files#diff-6d3dde51aedf557391d801be3a39fb51c090b505c42205c3c2d33bf0f398dc6f) where `ConvosAPI.UserResponse.Identity`, `ConvosAPI.CreateUserRequest.Identity`, `ConvosAPI.CreatedUserResponse.Identity`, and `ConvosAPI.ProfileResponse` now use `identityAddress` for JSON encoding/decoding
- Mock API client implementations in [MockAPIClient.swift](https://github.com/ephemeraHQ/convos-ios/pull/50/files#diff-a040789a21e92168574b1380d693c2a57b51b8fe666577b07c6c4fae1bd220e7) updated to use the new property name in initializer calls
- User creation logic in [InboxStateMachine.swift](https://github.com/ephemeraHQ/convos-ios/pull/50/files#diff-bbbcd7be50c9e9c032adcf5b0459396101f1210d4d3965aa6e04b2456d904f4b) modified to pass `identityAddress` in API requests
- Storage operations in [InboxWriter.swift](https://github.com/ephemeraHQ/convos-ios/pull/50/files#diff-d3753a108d1561d041148c9113980c3b7364a3c83b1bdf368a5ceb84ec99a37b) updated to map from the renamed property when persisting wallet addresses

#### 📍Where to Start
Start with the API model definitions in [ConvosAPIClient+Models.swift](https://github.com/ephemeraHQ/convos-ios/pull/50/files#diff-6d3dde51aedf557391d801be3a39fb51c090b505c42205c3c2d33bf0f398dc6f) to understand the core property rename, then follow the usage through `InboxStateMachine.createUser` method in [InboxStateMachine.swift](https://github.com/ephemeraHQ/convos-ios/pull/50/files#diff-bbbcd7be50c9e9c032adcf5b0459396101f1210d4d3965aa6e04b2456d904f4b).

----

_[Macroscope](https://app.macroscope.com) summarized 16e8a1d._