### PR TITLE
Bug fixes

### DIFF
--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/MessagesViewController.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/MessagesViewController.swift
@@ -571,10 +571,13 @@ extension MessagesViewController: KeyboardListenerDelegate {
     }
 
     private func calculateNewBottomInset(for info: KeyboardInfo) -> CGFloat {
-        let keyboardFrame = collectionView.window?.convert(info.frameEnd, to: view)
+        guard let keyboardFrame = collectionView.window?.convert(info.frameEnd, to: view),
+              !keyboardFrame.isEmpty else {
+            return bottomBarHeight
+        }
         let keyboardInset = (bottomBarHeight + collectionView.frame.minY +
                      collectionView.frame.size.height -
-                     (keyboardFrame?.minY ?? 0) - collectionView.safeAreaInsets.bottom)
+                     keyboardFrame.minY - collectionView.safeAreaInsets.bottom)
         let inset = max(keyboardInset, bottomBarHeight)
         Logger.info("Calculated new bottom inset: \(inset) (keyboard: \(keyboardInset), bottomBar: \(bottomBarHeight))")
         return inset

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesBottomBar.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesBottomBar.swift
@@ -18,55 +18,121 @@ struct MessagesBottomBar: View {
     let onDisplayNameEndedEditing: () -> Void
     let onProfileSettings: () -> Void
 
-    @State private var isExpanded: Bool = false
+    @State private var progress: CGFloat = 0.0
+    //    @State private var isExpanded: Bool = false
     @Namespace private var namespace: Namespace.ID
 
     var body: some View {
-        GlassEffectContainer {
-            ZStack {
-                if !isExpanded {
-                    MessagesInputView(
-                        profile: profile,
-                        profileImage: $profileImage,
-                        displayName: $displayName,
-                        emptyDisplayNamePlaceholder: emptyDisplayNamePlaceholder,
-                        messageText: $messageText,
-                        sendButtonEnabled: $sendButtonEnabled,
-                        focusState: $focusState,
-                        onProfilePhotoTap: onProfilePhotoTap,
-                        onSendMessage: onSendMessage
-                    )
-                    .clipShape(.rect(cornerRadius: 26.0))
-                    .glassEffect(.regular.interactive(), in: .rect(cornerRadius: 26.0))
-                    .glassEffectID("input", in: namespace)
-                    .glassEffectTransition(.matchedGeometry)
-                }
-
-                if isExpanded {
-                    QuickEditView(
-                        placeholderText: "\(emptyDisplayNamePlaceholder)...",
-                        text: $displayName,
-                        image: $profileImage,
-                        focusState: $focusState,
-                        focused: .displayName,
-                        onSubmit: onDisplayNameEndedEditing,
-                        onSettings: onProfileSettings
-                    )
-                    .frame(maxWidth: 320.0)
-                    .padding(DesignConstants.Spacing.step6x)
-                    .clipShape(.rect(cornerRadius: 40.0))
-                    .glassEffect(.regular.interactive(), in: .rect(cornerRadius: 40.0))
-                    .glassEffectID("profileEditor", in: namespace)
-                    .glassEffectTransition(.matchedGeometry)
-                }
-            }
+        PrimarySecondaryContainerView(
+            progress: progress,
+            primaryProperties: .init(
+                cornerRadius: (MessagesInputView.defaultHeight + (DesignConstants.Spacing.step4x)) / 2.0,
+                padding: DesignConstants.Spacing.step2x,
+                fixedSizeHorizontal: false
+            ),
+            secondaryProperties: .init(
+                cornerRadius: 40.0,
+                padding: DesignConstants.Spacing.step6x,
+                fixedSizeHorizontal: false
+            )
+        ) {
+            MessagesInputView(
+                profile: profile,
+                profileImage: $profileImage,
+                displayName: $displayName,
+                emptyDisplayNamePlaceholder: emptyDisplayNamePlaceholder,
+                messageText: $messageText,
+                sendButtonEnabled: $sendButtonEnabled,
+                focusState: $focusState,
+                onProfilePhotoTap: onProfilePhotoTap,
+                onSendMessage: onSendMessage
+            )
+        } secondaryContent: {
+            QuickEditView(
+                placeholderText: "\(emptyDisplayNamePlaceholder)...",
+                text: $displayName,
+                image: $profileImage,
+                focusState: $focusState,
+                focused: .displayName,
+                onSubmit: onDisplayNameEndedEditing,
+                onSettings: onProfileSettings
+            )
         }
+//        GlassEffectContainer {
+//            ZStack {
+//                if !isExpanded {
+//                    MessagesInputView(
+//                        profile: profile,
+//                        profileImage: $profileImage,
+//                        displayName: $displayName,
+//                        emptyDisplayNamePlaceholder: emptyDisplayNamePlaceholder,
+//                        messageText: $messageText,
+//                        sendButtonEnabled: $sendButtonEnabled,
+//                        focusState: $focusState,
+//                        onProfilePhotoTap: onProfilePhotoTap,
+//                        onSendMessage: onSendMessage
+//                    )
+//                    .clipShape(.rect(cornerRadius: 26.0))
+//                    .glassEffect(.regular.interactive(), in: .rect(cornerRadius: 26.0))
+//                    .glassEffectID("input", in: namespace)
+//                    .glassEffectTransition(.matchedGeometry)
+//                }
+//
+//                if isExpanded {
+//                    QuickEditView(
+//                        placeholderText: "\(emptyDisplayNamePlaceholder)...",
+//                        text: $displayName,
+//                        image: $profileImage,
+//                        focusState: $focusState,
+//                        focused: .displayName,
+//                        onSubmit: onDisplayNameEndedEditing,
+//                        onSettings: onProfileSettings
+//                    )
+//                    .frame(maxWidth: 320.0)
+//                    .padding(DesignConstants.Spacing.step6x)
+//                    .clipShape(.rect(cornerRadius: 40.0))
+//                    .glassEffect(.regular.interactive(), in: .rect(cornerRadius: 40.0))
+//                    .glassEffectID("profileEditor", in: namespace)
+//                    .glassEffectTransition(.matchedGeometry)
+//                }
+//            }
+//        }
         .padding(.horizontal, 10.0)
         .padding(.vertical, DesignConstants.Spacing.step2x)
         .onChange(of: viewModelFocus) { _, newValue in
-            withAnimation(.bouncy(duration: 0.4, extraBounce: 0.01)) {
-                isExpanded = newValue == .displayName ? true : false
+            withAnimation(.bouncy(duration: 0.5, extraBounce: 0.2)) {
+                progress = newValue == .displayName ? 1.0 : 0.0
             }
+//            withAnimation(.bouncy(duration: 0.4, extraBounce: 0.01)) {
+//                isExpanded = newValue == .displayName ? true : false
+//            }
         }
     }
+}
+
+#Preview {
+    @Previewable @State var profile: Profile = .mock()
+    @Previewable @State var profileName: String = ""
+    @Previewable @State var messageText: String = ""
+    @Previewable @State var sendButtonEnabled: Bool = false
+    @Previewable @State var profileImage: UIImage?
+    @Previewable @FocusState var focusState: MessagesViewInputFocus?
+    @Previewable @State var viewModelFocus: MessagesViewInputFocus?
+    MessagesBottomBar(
+        profile: profile,
+        displayName: $profileName,
+        messageText: $messageText,
+        sendButtonEnabled: $sendButtonEnabled,
+        profileImage: $profileImage,
+        focusState: $focusState,
+        viewModelFocus: viewModelFocus,
+        onProfilePhotoTap: {
+            viewModelFocus = .displayName
+        },
+        onSendMessage: {},
+        onDisplayNameEndedEditing: {
+            viewModelFocus = .message
+        },
+        onProfileSettings: {}
+    )
 }

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesInputView.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesInputView.swift
@@ -42,10 +42,10 @@ struct MessagesInputView: View {
                 .font(.system(size: 16.0))
                 .foregroundStyle(.colorTextPrimary)
                 .tint(.colorTextPrimary)
-                .frame(maxWidth: .infinity, minHeight: Self.defaultHeight, alignment: .center)
+                .frame(minHeight: Self.defaultHeight, alignment: .center)
                 .padding(.horizontal, DesignConstants.Spacing.step3x)
             }
-            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
+            .frame(maxHeight: .infinity, alignment: .center)
 
             Button {
                 onSendMessage()
@@ -61,8 +61,7 @@ struct MessagesInputView: View {
             .disabled(!sendButtonEnabled)
         }
 //        .padding(DesignConstants.Spacing.step2x)
-//        .frame(maxWidth: .infinity, alignment: .bottom)
-        .fixedSize(horizontal: false, vertical: true)
+        .frame(alignment: .bottom)
     }
 }
 

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesInputView.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesInputView.swift
@@ -60,8 +60,8 @@ struct MessagesInputView: View {
             .frame(width: sendButtonSize, height: sendButtonSize, alignment: .bottomLeading)
             .disabled(!sendButtonEnabled)
         }
-        .padding(DesignConstants.Spacing.step2x)
-        .frame(maxWidth: .infinity, alignment: .bottom)
+//        .padding(DesignConstants.Spacing.step2x)
+//        .frame(maxWidth: .infinity, alignment: .bottom)
         .fixedSize(horizontal: false, vertical: true)
     }
 }

--- a/Convos/ConvosApp.swift
+++ b/Convos/ConvosApp.swift
@@ -8,11 +8,13 @@ struct ConvosApp: App {
     init() {
         SDKConfiguration.configureSDKs()
 
-        // Initialize Logger with correct production flag
-        let isProduction = ConfigManager.shared.currentEnvironment == .production
-        _ = Logger.Default(isProduction: isProduction)
-
         Logger.info("🚀 App starting with environment: \(ConfigManager.shared.currentEnvironment)")
+
+        do {
+            try convos.prepare()
+        } catch {
+            Logger.error("Convos SDK failed preparing: \(error.localizedDescription)")
+        }
     }
 
     var body: some Scene {


### PR DESCRIPTION
### Fix keyboard frame handling in MessagesViewController and transition animation in MessagesBottomBar to address bugs
- Fixes keyboard frame handling in `MessagesViewController.KeyboardListenerDelegate.calculateNewBottomInset` method by safely unwrapping converted coordinates and falling back to `bottomBarHeight` when frame is unavailable
- Replaces boolean-based transition with progress-driven animation in [MessagesBottomBar.swift](https://github.com/ephemeraHQ/convos-ios/pull/55/files#diff-b66861cd8ab11a6d499676511b14e2fba66afdb7467461c01255f35000b416a2) using `PrimarySecondaryContainerView`
- Removes width constraints and padding from [MessagesInputView.swift](https://github.com/ephemeraHQ/convos-ios/pull/55/files#diff-4508fdb3045721662e5482a1b03fca193b1fb35261a02807c7ac5f8feb70ba9f) to rely on container sizing
- Adds Convos SDK preparation with error handling to [ConvosApp.swift](https://github.com/ephemeraHQ/convos-ios/pull/55/files#diff-de23c5a6e10cb84b89d91ed62b707b654c28566f38cc339af8b3cbbf6e003014) app initializer

#### 📍Where to Start
Start with the `calculateNewBottomInset` method in [MessagesViewController.swift](https://github.com/ephemeraHQ/convos-ios/pull/55/files#diff-1427b816e5e93d8bc7ea882f5eabd9671135c6f9b9ebc6b0a6f7116a2f8a37c3) to understand the keyboard frame handling fix.

----

_[Macroscope](https://app.macroscope.com) summarized 1384771._