### PR TITLE
Cached Inbox

### DIFF
--- a/Convos/App Settings/AppSettingsView.swift
+++ b/Convos/App Settings/AppSettingsView.swift
@@ -18,7 +18,7 @@ struct ConvosToolbarButton: View {
             }
             .padding(padding ? DesignConstants.Spacing.step2x : 0)
         }
-        .glassEffect(.regular.tint(.white).interactive())
+        .glassEffect(.regular.interactive(), in: .rect(cornerRadius: 12.0))
     }
 }
 
@@ -88,6 +88,8 @@ struct AppSettingsView: View {
                             HStack(alignment: .firstTextBaseline, spacing: 0.0) {
                                 Text("Secured by ")
                                 Image("xmtpIcon")
+                                    .renderingMode(.template)
+                                    .foregroundStyle(.colorTextPrimary)
                                     .padding(.trailing, 1.0)
                                 Text("XMTP")
                             }

--- a/Convos/App Settings/AppSettingsView.swift
+++ b/Convos/App Settings/AppSettingsView.swift
@@ -18,7 +18,6 @@ struct ConvosToolbarButton: View {
             }
             .padding(padding ? DesignConstants.Spacing.step2x : 0)
         }
-        .glassEffect(.regular.interactive(), in: .rect(cornerRadius: 12.0))
     }
 }
 
@@ -157,6 +156,7 @@ struct AppSettingsView: View {
 
                 ToolbarItem(placement: .principal) {
                     ConvosToolbarButton(padding: true) {}
+                        .glassEffect(.regular.tint(.colorBackgroundPrimary).interactive(), in: Capsule())
                         .disabled(true)
                 }
             }

--- a/Convos/Conversation Creation/NewConversationViewModel.swift
+++ b/Convos/Conversation Creation/NewConversationViewModel.swift
@@ -71,7 +71,7 @@ class NewConversationViewModel: SelectableConversationViewModelType, Identifiabl
         newConversationTask = Task { [weak self] in
             guard let self else { return }
             do {
-                let messagingService = try session.addInbox()
+                let messagingService = try await session.addInbox()
                 self.messagingService = messagingService
                 guard !Task.isCancelled else { return }
                 let draftConversationComposer = messagingService.draftConversationComposer()
@@ -123,7 +123,7 @@ class NewConversationViewModel: SelectableConversationViewModelType, Identifiabl
                 // Ensure we have a messaging service
                 if self.messagingService == nil {
                     Logger.info("No messaging service found, starting one while joining conversation...")
-                    let messagingService = try session.addInbox()
+                    let messagingService = try await session.addInbox()
                     self.messagingService = messagingService
                 }
 

--- a/Convos/Conversation Creation/NewConversationViewModel.swift
+++ b/Convos/Conversation Creation/NewConversationViewModel.swift
@@ -107,7 +107,7 @@ class NewConversationViewModel: SelectableConversationViewModelType, Identifiabl
         Task { [weak self] in
             guard let self else { return }
             guard let messagingService else { return }
-            try session.deleteInbox(for: messagingService)
+            try await session.deleteInbox(for: messagingService)
             await draftConversationComposer?.draftConversationWriter.delete()
             self.messagingService = nil
         }

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -326,16 +326,18 @@ class ConversationViewModel {
     }
 
     func leaveConvo() {
-        do {
-            try session.deleteInbox(inboxId: conversation.inboxId)
-            presentingConversationSettings = false
-            NotificationCenter.default.post(
-                name: .leftConversationNotification,
-                object: nil,
-                userInfo: ["inboxId": conversation.inboxId, "conversationId": conversation.id]
-            )
-        } catch {
-            Logger.error("Error leaving convo: \(error.localizedDescription)")
+        Task {
+            do {
+                try await session.deleteInbox(inboxId: conversation.inboxId)
+                presentingConversationSettings = false
+                NotificationCenter.default.post(
+                    name: .leftConversationNotification,
+                    object: nil,
+                    userInfo: ["inboxId": conversation.inboxId, "conversationId": conversation.id]
+                )
+            } catch {
+                Logger.error("Error leaving convo: \(error.localizedDescription)")
+            }
         }
     }
 
@@ -358,7 +360,7 @@ class ConversationViewModel {
                     groupId: conversation.id,
                     memberInboxIds: memberIdsToRemove
                 )
-                try session.deleteInbox(inboxId: conversation.inboxId)
+                try await session.deleteInbox(inboxId: conversation.inboxId)
                 presentingConversationSettings = false
             } catch {
                 Logger.error("Error exploding convo: \(error.localizedDescription)")

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Cells/InviteCell.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Cells/InviteCell.swift
@@ -22,10 +22,7 @@ struct InviteView: View {
     var body: some View {
         VStack {
             Group {
-                QRCodeView(
-                    identifier: invite.inviteUrlString,
-                    backgroundColor: .colorFillMinimal
-                )
+                QRCodeView(identifier: invite.inviteUrlString)
                 .frame(maxWidth: 220, maxHeight: 220)
                 .padding(DesignConstants.Spacing.step12x)
             }

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Cells/TypingIndicatorCollectionCell.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Cells/TypingIndicatorCollectionCell.swift
@@ -22,43 +22,12 @@ struct TypingIndicatorView: View {
                     .padding(.vertical, 8)
                     .padding(.horizontal, 12.0)
                     .font(.body)
-                TypingIndicatorDots()
+                PulsingCircleView.typingIndicator
             }
             .padding(.horizontal, 12)
             .padding(.vertical, 4)
         } avatarView: {
             Spacer()
-        }
-    }
-}
-
-struct TypingIndicatorDots: View {
-    @State private var animate: Bool = false
-
-    let dotCount: Int = 3
-    let dotSize: CGFloat = 10
-    let dotSpacing: CGFloat = 6
-    let animationDuration: Double = 0.6
-
-    var body: some View {
-        HStack(spacing: dotSpacing) {
-            ForEach(0..<dotCount, id: \.self) { index in
-                Circle()
-                    .fill(Color.gray)
-                    .frame(width: dotSize, height: dotSize)
-                    .scaleEffect(animate ? 1.0 : 0.5)
-                    .opacity(animate ? 1.0 : 0.3)
-                    .animation(
-                        Animation
-                            .easeInOut(duration: animationDuration)
-                            .repeatForever()
-                            .delay(Double(index) * animationDuration / Double(dotCount)),
-                        value: animate
-                    )
-            }
-        }
-        .onAppear {
-            animate = true
         }
     }
 }

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/MessagesViewController.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/MessagesViewController.swift
@@ -539,11 +539,9 @@ extension MessagesViewController: UIScrollViewDelegate, UICollectionViewDelegate
 
     private func updateBottomInsetForBottomBarHeight() {
         guard isViewLoaded else {
-            Logger.info("View not loading, skipping bottom inset update...")
             return
         }
 
-        Logger.info("Updated bottom bar height: \(bottomBarHeight)")
         if let lastKeyboardFrameChange {
             let newBottomInset = calculateNewBottomInset(for: lastKeyboardFrameChange)
             updateBottomInset(inset: newBottomInset, info: lastKeyboardFrameChange)
@@ -557,7 +555,6 @@ extension MessagesViewController: UIScrollViewDelegate, UICollectionViewDelegate
 
 extension MessagesViewController: KeyboardListenerDelegate {
     func keyboardWillChangeFrame(info: KeyboardInfo) {
-        Logger.info("keyboardWillChangeFrame")
         guard shouldHandleKeyboardFrameChange(info: info) else { return }
 
         self.lastKeyboardFrameChange = info
@@ -569,16 +566,13 @@ extension MessagesViewController: KeyboardListenerDelegate {
 
     private func updateBottomInset(inset: CGFloat, info: KeyboardInfo?) {
         guard collectionView.contentInset.bottom != inset else { return }
-        Logger.info("Updating bottom inset: \(inset)")
         updateCollectionViewInsets(to: inset, with: info)
     }
 
     func keyboardWillHide(info: KeyboardInfo) {
-        Logger.info("keyboardWillHide")
     }
 
     func keyboardDidChangeFrame(info: KeyboardInfo) {
-        Logger.info("keyboardDidChangeFrame")
         guard currentInterfaceActions.options.contains(.changingKeyboardFrame) else { return }
         currentInterfaceActions.options.remove(.changingKeyboardFrame)
     }
@@ -601,12 +595,10 @@ extension MessagesViewController: KeyboardListenerDelegate {
                      collectionView.frame.size.height -
                      keyboardFrame.minY - collectionView.safeAreaInsets.bottom)
         let inset = max(keyboardInset, bottomBarHeight)
-        Logger.info("Calculated new bottom inset: \(inset) (keyboard: \(keyboardInset), bottomBar: \(bottomBarHeight))")
         return inset
     }
 
     private func updateCollectionViewInsets(to topInset: CGFloat) {
-        Logger.info("updateCollectionViewInsets topInset: \(topInset)")
         let positionSnapshot = messagesLayout.getContentOffsetSnapshot(from: .top)
 
         if currentControllerActions.options.contains(.updatingCollection) {
@@ -618,7 +610,6 @@ extension MessagesViewController: KeyboardListenerDelegate {
         currentInterfaceActions.options.insert(.changingContentInsets)
         UIView.animate(withDuration: 0.2, animations: {
             self.collectionView.performBatchUpdates({
-                Logger.info("Setting new top inset: \(topInset)")
                 self.collectionView.contentInset.top = topInset
                 self.collectionView.verticalScrollIndicatorInsets.top = topInset
             }, completion: nil)
@@ -632,7 +623,6 @@ extension MessagesViewController: KeyboardListenerDelegate {
     }
 
     private func updateCollectionViewInsets(to newBottomInset: CGFloat, with info: KeyboardInfo?) {
-        Logger.info("updateCollectionViewInsets: \(newBottomInset)")
         let positionSnapshot = messagesLayout.getContentOffsetSnapshot(from: .bottom)
 
         if currentControllerActions.options.contains(.updatingCollection) {
@@ -644,7 +634,6 @@ extension MessagesViewController: KeyboardListenerDelegate {
         currentInterfaceActions.options.insert(.changingContentInsets)
         UIView.animate(withDuration: info?.animationDuration ?? 0.2, animations: {
             self.collectionView.performBatchUpdates({
-                Logger.info("Setting new bottom inset: \(newBottomInset)")
                 self.collectionView.contentInset.bottom = newBottomInset
                 self.collectionView.verticalScrollIndicatorInsets.bottom = newBottomInset
             }, completion: nil)

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/MessagesViewController.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/MessagesViewController.swift
@@ -381,6 +381,7 @@ extension MessagesViewController {
         }
 
         guard currentInterfaceActions.options.isEmpty else {
+            Logger.info("Interface actions exist, scheduling delayed update...")
             scheduleDelayedUpdate(for: conversation,
                                   with: messages,
                                   invite: invite,
@@ -539,6 +540,7 @@ extension MessagesViewController: UIScrollViewDelegate, UICollectionViewDelegate
 
     private func updateBottomInsetForBottomBarHeight() {
         guard isViewLoaded else {
+            Logger.info("View not loading, skipping bottom inset update...")
             return
         }
 

--- a/Convos/Conversation Detail/Messages/MessagesViewRepresentable.swift
+++ b/Convos/Conversation Detail/Messages/MessagesViewRepresentable.swift
@@ -10,11 +10,7 @@ struct MessagesViewRepresentable: UIViewControllerRepresentable {
     let bottomBarHeight: CGFloat
 
     func makeUIViewController(context: Context) -> MessagesViewController {
-        let messagesViewController = MessagesViewController()
-        messagesViewController.topBarHeight = topBarHeight
-        messagesViewController.bottomBarHeight = bottomBarHeight
-        messagesViewController.onTapMessage = onTapMessage
-        return messagesViewController
+        return MessagesViewController()
     }
 
     func updateUIViewController(_ messagesViewController: MessagesViewController, context: Context) {

--- a/Convos/Conversations List/ConversationsView.swift
+++ b/Convos/Conversations List/ConversationsView.swift
@@ -156,7 +156,7 @@ struct ConversationsView: View {
         }
         .fullScreenCover(item: $viewModel.newConversationViewModel) { viewModel in
             NewConversationView(viewModel: viewModel)
-                .background(.white)
+                .background(.colorBackgroundPrimary)
                 .interactiveDismissDisabled()
                 .navigationTransition(
                     .zoom(

--- a/Convos/Conversations List/ConversationsViewModel.swift
+++ b/Convos/Conversations List/ConversationsViewModel.swift
@@ -14,6 +14,7 @@ final class ConversationsViewModel: SelectableConversationViewModelType {
 
     var selectedConversation: Conversation? {
         didSet {
+            guard selectedConversation != oldValue else { return }
             Logger.debug("did set selectedConversation")
             if let selectedConversation {
                 selectedConversationViewModel = conversationViewModel(for: selectedConversation)

--- a/Convos/Conversations List/ConversationsViewModel.swift
+++ b/Convos/Conversations List/ConversationsViewModel.swift
@@ -17,7 +17,9 @@ final class ConversationsViewModel: SelectableConversationViewModelType {
             guard selectedConversation != oldValue else { return }
             Logger.debug("did set selectedConversation")
             if let selectedConversation {
-                selectedConversationViewModel = conversationViewModel(for: selectedConversation)
+                Task {
+                    selectedConversationViewModel = await conversationViewModel(for: selectedConversation)
+                }
             } else {
                 selectedConversationViewModel = nil
             }
@@ -78,28 +80,32 @@ final class ConversationsViewModel: SelectableConversationViewModelType {
     }
 
     func deleteAllInboxes() {
-        do {
-            try session.deleteAllInboxes()
-        } catch {
-            Logger.error("Error deleting all accounts: \(error)")
+        Task {
+            do {
+                try await session.deleteAllInboxes()
+            } catch {
+                Logger.error("Error deleting all accounts: \(error)")
+            }
         }
     }
 
     func leave(conversation: Conversation) {
-        do {
-            try session.deleteInbox(inboxId: conversation.inboxId)
-            NotificationCenter.default.post(
-                name: .leftConversationNotification,
-                object: nil,
-                userInfo: ["inboxId": conversation.inboxId, "conversationId": conversation.id]
-            )
-        } catch {
-            Logger.error("Error leaving convo: \(error.localizedDescription)")
+        Task {
+            do {
+                try await session.deleteInbox(inboxId: conversation.inboxId)
+                NotificationCenter.default.post(
+                    name: .leftConversationNotification,
+                    object: nil,
+                    userInfo: ["inboxId": conversation.inboxId, "conversationId": conversation.id]
+                )
+            } catch {
+                Logger.error("Error leaving convo: \(error.localizedDescription)")
+            }
         }
     }
 
-    func conversationViewModel(for conversation: Conversation) -> ConversationViewModel {
-        let messagingService = session.messagingService(for: conversation.inboxId)
+    func conversationViewModel(for conversation: Conversation) async -> ConversationViewModel {
+        let messagingService = await session.messagingService(for: conversation.inboxId)
         return .init(
             conversation: conversation,
             session: session,

--- a/Convos/Shared Views/MonogramView.swift
+++ b/Convos/Shared Views/MonogramView.swift
@@ -22,7 +22,7 @@ struct MonogramView: View {
                     .font(.system(size: fontSize, weight: .semibold, design: .rounded))
                     .minimumScaleFactor(0.01)
                     .lineLimit(1)
-                    .foregroundColor(.white)
+                    .foregroundColor(.colorTextPrimaryInverted)
                     .padding(padding)
             }
             .frame(width: side, height: side)

--- a/Convos/Shared Views/PrimarySecondaryContainerView.swift
+++ b/Convos/Shared Views/PrimarySecondaryContainerView.swift
@@ -120,7 +120,7 @@ struct PrimarySecondaryContainerView<PrimaryContent: View,
         }
         .compositingGroup()
         .clipShape(.rect(cornerRadius: cornerRadius))
-        .glassEffect(.regular.tint(.white).interactive(), in: .rect(cornerRadius: cornerRadius))
+        .glassEffect(.regular.interactive(), in: .rect(cornerRadius: cornerRadius))
         .scaleEffect(
             x: 1 + (blurProgress * 0.15),
             y: 1 - (blurProgress * 0.05)
@@ -230,7 +230,7 @@ struct PrimarySecondaryContainerView<PrimaryContent: View,
                         Image(systemName: "arrow.up")
                             .resizable()
                             .aspectRatio(contentMode: .fit)
-                            .foregroundStyle(.white)
+                            .foregroundStyle(.colorTextPrimaryInverted)
                             .padding(.horizontal, 12.0)
                     }
                     .frame(width: 40.0, height: 40.0)

--- a/Convos/Shared Views/PulsingCircleView.swift
+++ b/Convos/Shared Views/PulsingCircleView.swift
@@ -1,0 +1,237 @@
+import SwiftUI
+
+/// A reusable pulsing circle animation component that can be configured for various use cases
+public struct PulsingCircleView: View {
+    /// Configuration for the pulsing circles
+    public struct Configuration {
+        /// Number of circles to display
+        public let count: Int
+        /// Size of each circle
+        public let size: CGFloat
+        /// Color of the circles
+        public let color: Color
+        /// Spacing between circles (ignored if count is 1)
+        public let spacing: CGFloat
+        /// Duration of one complete animation cycle
+        public let animationDuration: Double
+        /// Layout axis for multiple circles
+        public let axis: Axis
+        /// Scale range for the animation
+        public let scaleRange: ClosedRange<CGFloat>
+        /// Opacity range for the animation
+        public let opacityRange: ClosedRange<Double>
+
+        public init(
+            count: Int = 1,
+            size: CGFloat = 10,
+            color: Color = .gray,
+            spacing: CGFloat = 6,
+            animationDuration: Double = 0.6,
+            axis: Axis = .horizontal,
+            scaleRange: ClosedRange<CGFloat> = 0.5...1.0,
+            opacityRange: ClosedRange<Double> = 0.3...1.0
+        ) {
+            self.count = count
+            self.size = size
+            self.color = color
+            self.spacing = spacing
+            self.animationDuration = animationDuration
+            self.axis = axis
+            self.scaleRange = scaleRange
+            self.opacityRange = opacityRange
+        }
+
+        /// Default configuration for a typing indicator
+        public static var typingIndicator: Configuration {
+            Configuration(
+                count: 3,
+                size: 10,
+                color: .gray,
+                spacing: 6,
+                animationDuration: 0.6
+            )
+        }
+
+        /// Default configuration for a single loading indicator
+        public static var loadingIndicator: Configuration {
+            Configuration(
+                count: 1,
+                size: 20,
+                color: .colorFillTertiary,
+                animationDuration: 1.0,
+                scaleRange: 0.8...1.2,
+                opacityRange: 0.5...1.0
+            )
+        }
+
+        /// Default configuration for a progress indicator
+        public static var progressIndicator: Configuration {
+            Configuration(
+                count: 5,
+                size: 8,
+                color: .colorFillTertiary,
+                spacing: 4,
+                animationDuration: 0.8,
+                axis: .horizontal
+            )
+        }
+    }
+
+    let configuration: Configuration
+    @State private var animate: Bool = false
+
+    /// Initialize with a custom configuration
+    public init(configuration: Configuration) {
+        self.configuration = configuration
+    }
+
+    /// Initialize with preset configurations
+    public init(_ preset: Configuration = .typingIndicator) {
+        self.configuration = preset
+    }
+
+    public var body: some View {
+        Group {
+            if configuration.count == 1 {
+                // Single circle
+                Circle()
+                    .fill(configuration.color)
+                    .frame(width: configuration.size, height: configuration.size)
+                    .scaleEffect(
+                        animate
+                            ? configuration.scaleRange.upperBound
+                            : configuration.scaleRange.lowerBound
+                    )
+                    .opacity(
+                        animate
+                            ? configuration.opacityRange.upperBound
+                            : configuration.opacityRange.lowerBound
+                    )
+                    .animation(
+                        Animation
+                            .easeInOut(duration: configuration.animationDuration)
+                            .repeatForever(autoreverses: true),
+                        value: animate
+                    )
+            } else {
+                // Multiple circles
+                if configuration.axis == .horizontal {
+                    HStack(spacing: configuration.spacing) {
+                        circlesContent
+                    }
+                } else {
+                    VStack(spacing: configuration.spacing) {
+                        circlesContent
+                    }
+                }
+            }
+        }
+        .onAppear {
+            animate = true
+        }
+        .onDisappear {
+            animate = false
+        }
+    }
+
+    @ViewBuilder
+    private var circlesContent: some View {
+        ForEach(0..<configuration.count, id: \.self) { index in
+            Circle()
+                .fill(configuration.color)
+                .frame(width: configuration.size, height: configuration.size)
+                .scaleEffect(
+                    animate
+                        ? configuration.scaleRange.upperBound
+                        : configuration.scaleRange.lowerBound
+                )
+                .opacity(
+                    animate
+                        ? configuration.opacityRange.upperBound
+                        : configuration.opacityRange.lowerBound
+                )
+                .animation(
+                    Animation
+                        .easeInOut(duration: configuration.animationDuration)
+                        .repeatForever()
+                        .delay(Double(index) * configuration.animationDuration / Double(configuration.count)),
+                    value: animate
+                )
+        }
+    }
+}
+
+// MARK: - Convenience Initializers
+
+public extension PulsingCircleView {
+    /// Create a typing indicator with default settings
+    static var typingIndicator: PulsingCircleView {
+        PulsingCircleView(.typingIndicator)
+    }
+
+    /// Create a loading indicator with default settings
+    static var loadingIndicator: PulsingCircleView {
+        PulsingCircleView(.loadingIndicator)
+    }
+
+    /// Create a progress indicator with default settings
+    static var progressIndicator: PulsingCircleView {
+        PulsingCircleView(.progressIndicator)
+    }
+}
+
+// MARK: - Preview
+
+#Preview("Typing Indicator") {
+    PulsingCircleView.typingIndicator
+        .padding()
+}
+
+#Preview("Loading Indicator") {
+    PulsingCircleView.loadingIndicator
+        .padding()
+}
+
+#Preview("Progress Indicator") {
+    PulsingCircleView.progressIndicator
+        .padding()
+}
+
+#Preview("Custom Vertical") {
+    PulsingCircleView(
+        configuration: .init(
+            count: 4,
+            size: 12,
+            color: .purple,
+            spacing: 8,
+            animationDuration: 1.2,
+            axis: .vertical,
+            scaleRange: 0.3...1.5,
+            opacityRange: 0.2...1.0
+        )
+    )
+    .padding()
+}
+
+#Preview("All Presets") {
+    VStack(spacing: 40) {
+        VStack {
+            Text("Typing Indicator")
+                .font(.caption)
+            PulsingCircleView.typingIndicator
+        }
+
+        VStack {
+            Text("Loading Indicator")
+                .font(.caption)
+            PulsingCircleView.loadingIndicator
+        }
+
+        VStack {
+            Text("Progress Indicator")
+                .font(.caption)
+            PulsingCircleView.progressIndicator
+        }
+    }
+    .padding()
+}

--- a/Convos/Shared Views/QRCodeView.swift
+++ b/Convos/Shared Views/QRCodeView.swift
@@ -11,15 +11,7 @@ struct QRCodeView: View {
     @Environment(\.displayScale) private var displayScale: CGFloat
     @Environment(\.colorScheme) private var colorScheme: ColorScheme
 
-    /// Initialize with automatic light/dark mode support
-    init(identifier: String) {
-        self.identifier = identifier
-        self.backgroundColor = nil
-        self.foregroundColor = nil
-    }
-
-    /// Initialize with custom colors
-    init(identifier: String, backgroundColor: Color, foregroundColor: Color) {
+    init(identifier: String, backgroundColor: Color = .colorBackgroundPrimary, foregroundColor: Color = .colorTextPrimary) {
         self.identifier = identifier
         self.backgroundColor = backgroundColor
         self.foregroundColor = foregroundColor
@@ -87,7 +79,7 @@ struct QRCodeView: View {
             ShareLink(item: identifier) {
                 Image(systemName: "square.and.arrow.up")
                     .font(.system(size: 24.0, weight: .medium))
-                    .foregroundStyle(.white)
+                    .foregroundStyle(.colorTextPrimaryInverted)
                     .frame(width: 60, height: 60)
                     .padding(DesignConstants.Spacing.step2x)
             }

--- a/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient+Models.swift
+++ b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient+Models.swift
@@ -142,6 +142,15 @@ public enum ConvosAPI {
         public let inviteLinkURL: String
     }
 
+    public struct InviteDetailsWithGroupResponse: Decodable {
+        public let id: String
+        public let name: String?
+        public let description: String?
+        public let imageUrl: String?
+        public let inviteLinkURL: String
+        public let groupId: String
+    }
+
     public struct PublicInviteDetailsResponse: Decodable {
         public let id: String
         public let name: String?

--- a/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift
+++ b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift
@@ -46,6 +46,7 @@ public protocol ConvosAPIClientProtocol: ConvosAPIBaseProtocol {
 
     func createInvite(_ requestBody: ConvosAPI.CreateInviteCode) async throws -> ConvosAPI.InviteDetailsResponse
     func inviteDetails(_ inviteCode: String) async throws -> ConvosAPI.InviteDetailsResponse
+    func inviteDetailsWithGroup(_ inviteCode: String) async throws -> ConvosAPI.InviteDetailsWithGroupResponse
     func publicInviteDetails(_ code: String) async throws -> ConvosAPI.PublicInviteDetailsResponse
     func requestToJoin(_ inviteCode: String) async throws -> ConvosAPI.RequestToJoinResponse
     func deleteRequestToJoin(_ requestId: String) async throws -> ConvosAPI.DeleteRequestToJoinResponse
@@ -284,6 +285,12 @@ final class ConvosAPIClient: BaseConvosAPIClient, ConvosAPIClientProtocol {
     func inviteDetails(_ code: String) async throws -> ConvosAPI.InviteDetailsResponse {
         let request = try authenticatedRequest(for: "v1/invites/\(code)")
         let invite: ConvosAPI.InviteDetailsResponse = try await performRequest(request)
+        return invite
+    }
+
+    func inviteDetailsWithGroup(_ code: String) async throws -> ConvosAPI.InviteDetailsWithGroupResponse {
+        let request = try authenticatedRequest(for: "v1/invites/\(code)/with-group")
+        let invite: ConvosAPI.InviteDetailsWithGroupResponse = try await performRequest(request)
         return invite
     }
 

--- a/ConvosCore/Sources/ConvosCore/API/MockAPIClient.swift
+++ b/ConvosCore/Sources/ConvosCore/API/MockAPIClient.swift
@@ -136,6 +136,17 @@ class MockAPIClient: MockBaseAPIClient, ConvosAPIClientProtocol {
             )
     }
 
+    func inviteDetailsWithGroup(_ inviteId: String) async throws -> ConvosAPI.InviteDetailsWithGroupResponse {
+        return ConvosAPI.InviteDetailsWithGroupResponse(
+            id: "invite_123",
+            name: "My Group",
+            description: nil,
+            imageUrl: nil,
+            inviteLinkURL: "http://convos.org/join/invite_123",
+            groupId: "my_group_123"
+        )
+    }
+
     func checkUsername(_ username: String) async throws -> ConvosAPI.UsernameCheckResponse {
         return ConvosAPI.UsernameCheckResponse(taken: username == "takenusername")
     }

--- a/ConvosCore/Sources/ConvosCore/Inboxes/CachedPushNotificationHandler.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/CachedPushNotificationHandler.swift
@@ -41,6 +41,9 @@ public class CachedPushNotificationHandler {
         Logger.info("Processing push notification for inbox: \(inboxId), type: \(payload.notificationType?.displayName ?? "unknown")")
         Logger.info("🔍 PARSED PAYLOAD: notificationType=\(payload.notificationType?.rawValue ?? "nil"), hasNotificationData=\(payload.notificationData != nil)")
 
+        // Store the payload for NSE to retrieve after processing
+        processedPayload = payload
+
         // Get or create messaging service for this inbox
         let messagingService = getOrCreateMessagingService(for: inboxId)
         try await messagingService.processPushNotification(payload: payload)

--- a/ConvosCore/Sources/ConvosCore/Inboxes/ConversationStateMachine.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/ConversationStateMachine.swift
@@ -76,12 +76,12 @@ public actor ConversationStateMachine {
 
     private func addStateContinuation(_ continuation: AsyncStream<State>.Continuation) {
         stateContinuations.append(continuation)
-        continuation.yield(_state)
         continuation.onTermination = { [weak self] _ in
             Task {
                 await self?.removeStateContinuation(continuation)
             }
         }
+        continuation.yield(_state)
     }
 
     private func emitStateChange(_ newState: State) {

--- a/ConvosCore/Sources/ConvosCore/Inboxes/ConversationStateMachine.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/ConversationStateMachine.swift
@@ -168,11 +168,16 @@ public actor ConversationStateMachine {
         isProcessing = true
         let action = actionQueue.removeFirst()
 
-        currentTask = Task {
-            await processAction(action)
-            isProcessing = false
-            processNextAction()
+        currentTask = Task.detached { [weak self] in
+            guard let self else { return }
+            await self.processAction(action)
+            await self.setProcessingComplete()
         }
+    }
+
+    private func setProcessingComplete() {
+        isProcessing = false
+        processNextAction()
     }
 
     private func processAction(_ action: Action) async {

--- a/ConvosCore/Sources/ConvosCore/Inboxes/InboxStateMachine.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/InboxStateMachine.swift
@@ -218,11 +218,16 @@ public actor InboxStateMachine {
         isProcessing = true
         let action = actionQueue.removeFirst()
 
-        currentTask = Task {
-            await processAction(action)
-            isProcessing = false
-            processNextAction()
+        currentTask = Task.detached { [weak self] in
+            guard let self else { return }
+            await self.processAction(action)
+            await self.setProcessingComplete()
         }
+    }
+
+    private func setProcessingComplete() {
+        isProcessing = false
+        processNextAction()
     }
 
     private func processAction(_ action: Action) async {

--- a/ConvosCore/Sources/ConvosCore/Inboxes/InboxStateMachine.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/InboxStateMachine.swift
@@ -125,12 +125,12 @@ public actor InboxStateMachine {
 
     private func addStateContinuation(_ continuation: AsyncStream<State>.Continuation) {
         stateContinuations.append(continuation)
-        continuation.yield(_state)
         continuation.onTermination = { [weak self] _ in
             Task {
                 await self?.removeStateContinuation(continuation)
             }
         }
+        continuation.yield(_state)
     }
 
     private func emitStateChange(_ newState: State) {

--- a/ConvosCore/Sources/ConvosCore/Inboxes/MockInboxesService.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/MockInboxesService.swift
@@ -9,7 +9,7 @@ public class MockInboxesService: SessionManagerProtocol {
         Just(AuthServiceState.unknown).eraseToAnyPublisher()
     }
 
-    public func addInbox() throws -> AnyMessagingService {
+    public func addInbox() async throws -> AnyMessagingService {
         MockMessagingService()
     }
 

--- a/ConvosCore/Sources/ConvosCore/Inboxes/MockInboxesService.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/MockInboxesService.swift
@@ -13,13 +13,13 @@ public class MockInboxesService: SessionManagerProtocol {
         MockMessagingService()
     }
 
-    public func deleteInbox(inboxId: String) throws {
+    public func deleteInbox(inboxId: String) async throws {
     }
 
-    public func deleteAllInboxes() throws {
+    public func deleteAllInboxes() async throws {
     }
 
-    public func deleteInbox(for messagingService: AnyMessagingService) throws {
+    public func deleteInbox(for messagingService: AnyMessagingService) async throws {
     }
 
     public func deleteAllAccounts() throws {
@@ -29,7 +29,7 @@ public class MockInboxesService: SessionManagerProtocol {
         self
     }
 
-    public func messagingService(for inboxId: String) -> AnyMessagingService {
+    public func messagingService(for inboxId: String) async -> AnyMessagingService {
         MockMessagingService()
     }
 

--- a/ConvosCore/Sources/ConvosCore/Inboxes/PushNotificationRegistrar.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/PushNotificationRegistrar.swift
@@ -13,6 +13,7 @@ protocol PushNotificationRegistrarProtocol {
 
 public final class PushNotificationRegistrar: PushNotificationRegistrarProtocol {
     private let environment: AppEnvironment
+    private let keychainService: KeychainService<LastRegisteredPushTokenKeychainItem> = .init()
 
     init(environment: AppEnvironment) {
         self.environment = environment
@@ -55,8 +56,13 @@ public final class PushNotificationRegistrar: PushNotificationRegistrarProtocol 
     func registerForNotificationsIfNeeded(client: any XMTPClientProvider, apiClient: any ConvosAPIClientProtocol) async {
         guard let token = Self.token, !token.isEmpty else { return }
 
-        let deviceId = await currentDeviceId()
         let identityId = client.inboxId
+        let lastRegisteredPushToken = lastSavedPushToken(for: identityId)
+        guard token != lastRegisteredPushToken else {
+            return
+        }
+
+        let deviceId = await currentDeviceId()
         let installationId = client.installationId
         do {
             try await apiClient.registerForNotifications(deviceId: deviceId,
@@ -64,6 +70,7 @@ public final class PushNotificationRegistrar: PushNotificationRegistrarProtocol 
                                                          identityId: identityId,
                                                          xmtpInstallationId: installationId)
             Logger.info("Registered notifications mapping for deviceId=\(deviceId), installationId=\(installationId)")
+            savePushToken(token, for: identityId)
         } catch {
             Logger.error("Failed to register notifications mapping: \(error)")
         }
@@ -72,6 +79,7 @@ public final class PushNotificationRegistrar: PushNotificationRegistrarProtocol 
     func unregisterInstallation(client: any XMTPClientProvider, apiClient: any ConvosAPIClientProtocol) async {
         do {
             try await apiClient.unregisterInstallation(xmtpInstallationId: client.installationId)
+            deleteLastUsedPushTokenFromKeychain(for: client.inboxId)
             Logger.info("Unregistered installation: \(client.installationId)")
         } catch {
             Logger.error("Failed to unregister installation: \(error)")
@@ -82,6 +90,33 @@ public final class PushNotificationRegistrar: PushNotificationRegistrarProtocol 
 
     private func currentDeviceId() async -> String {
         await MainActor.run { DeviceInfo.deviceIdentifier }
+    }
+
+    private func lastSavedPushToken(for inboxId: String) -> String? {
+        do {
+            return try keychainService.retrieveString(.init(inboxId: inboxId))
+        } catch {
+            Logger.debug("Last saved push token not found in keychain: \(error)")
+            return nil
+        }
+    }
+
+    private func savePushToken(_ token: String, for inboxId: String) {
+        do {
+            try keychainService.saveString(token, for: .init(inboxId: inboxId))
+            Logger.info("Saved push token to keychain: \(inboxId)")
+        } catch {
+            Logger.error("Failed to save push token to keychain: \(error)")
+        }
+    }
+
+    private func deleteLastUsedPushTokenFromKeychain(for inboxId: String) {
+        do {
+            try keychainService.delete(.init(inboxId: inboxId))
+            Logger.debug("Deleted last used push token from keychain")
+        } catch {
+            Logger.debug("Failed to delete last used push token from keychain: \(error)")
+        }
     }
 }
 

--- a/ConvosCore/Sources/ConvosCore/Inboxes/PushNotificationRegistrar.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/PushNotificationRegistrar.swift
@@ -69,7 +69,7 @@ public final class PushNotificationRegistrar: PushNotificationRegistrarProtocol 
                                                          pushToken: token,
                                                          identityId: identityId,
                                                          xmtpInstallationId: installationId)
-            Logger.info("Registered notifications mapping for deviceId=\(deviceId), installationId=\(installationId)")
+            Logger.info("Registered notifications mapping for deviceId=\(deviceId), inboxId=\(identityId)")
             savePushToken(token, for: identityId)
         } catch {
             Logger.error("Failed to register notifications mapping: \(error)")

--- a/ConvosCore/Sources/ConvosCore/Messaging/MessagingService.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/MessagingService.swift
@@ -4,12 +4,6 @@ import GRDB
 import XMTPiOS
 
 final class MessagingService: MessagingServiceProtocol {
-    // MARK: - Unused Inbox Management
-
-    private static let keychainService: KeychainService<UnusedInboxKeychainItem> = .init()
-    private static var isCreatingUnusedInbox: Bool = false
-    private static let unusedInboxQueue: DispatchQueue = DispatchQueue(label: "org.convos.unused-inbox-queue")
-    private static var unusedMessagingService: MessagingService?
     var identifier: String {
         guard case .ready(let result) = inboxStateManager.currentState else {
             return internalIdentifier
@@ -46,90 +40,22 @@ final class MessagingService: MessagingServiceProtocol {
         )
     }
 
-    static func registeredMessagingService(
+        static func registeredMessagingService(
         databaseWriter: any DatabaseWriter,
         databaseReader: any DatabaseReader,
         environment: AppEnvironment
-    ) -> MessagingService {
-        // Check if we have a pre-created unused messaging service
-        if let unusedService = unusedMessagingService {
-            Logger.info("Using pre-created unused messaging service")
-
-            // Clear the static reference
-            unusedMessagingService = nil
-
-            // Clear the unused inbox from keychain
-            clearUnusedInbox()
-
-            // Schedule background task to create a new unused inbox
-            scheduleUnusedInboxCreation(
-                databaseWriter: databaseWriter,
-                databaseReader: databaseReader,
-                environment: environment
-            )
-
-            // Return the pre-created service
-            return unusedService
-        }
-
-        // Check for an unused inbox ID in keychain (fallback)
-        if let unusedInboxId = getUnusedInbox() {
-            Logger.info("Using unused inbox ID from keychain: \(unusedInboxId)")
-
-            // Clear the unused inbox from keychain
-            clearUnusedInbox()
-
-            // Schedule background task to create a new unused inbox
-            scheduleUnusedInboxCreation(
-                databaseWriter: databaseWriter,
-                databaseReader: databaseReader,
-                environment: environment
-            )
-
-            // Use the existing inbox with authorize
-            let authorizationOperation = AuthorizeInboxOperation.authorize(
-                inboxId: unusedInboxId,
-                databaseReader: databaseReader,
-                databaseWriter: databaseWriter,
-                environment: environment,
-                registersForPushNotifications: true
-            )
-            return .init(
-                inboxId: unusedInboxId,
-                authorizationOperation: authorizationOperation,
-                databaseWriter: databaseWriter,
-                databaseReader: databaseReader
-            )
-        }
-
-        // No unused inbox available, create a new one
-        Logger.info("No unused inbox available, creating new one")
-        let authorizationOperation = AuthorizeInboxOperation.register(
-            databaseReader: databaseReader,
-            databaseWriter: databaseWriter,
-            environment: environment,
-            registersForPushNotifications: true
-        )
-
-        // Schedule background task to create an unused inbox for next time
-        scheduleUnusedInboxCreation(
+    ) async -> MessagingService {
+        return await UnusedInboxCache.shared.consumeOrCreateMessagingService(
             databaseWriter: databaseWriter,
             databaseReader: databaseReader,
             environment: environment
         )
-
-        return .init(
-            inboxId: nil,
-            authorizationOperation: authorizationOperation,
-            databaseWriter: databaseWriter,
-            databaseReader: databaseReader
-        )
     }
 
-    private init(inboxId: String?,
-                 authorizationOperation: AuthorizeInboxOperation,
-                 databaseWriter: any DatabaseWriter,
-                 databaseReader: any DatabaseReader) {
+    internal init(inboxId: String?,
+                  authorizationOperation: AuthorizeInboxOperation,
+                  databaseWriter: any DatabaseWriter,
+                  databaseReader: any DatabaseReader) {
         self.inboxId = inboxId
         self.internalIdentifier = inboxId ?? UUID().uuidString
         self.authorizationOperation = authorizationOperation
@@ -278,161 +204,12 @@ final class MessagingService: MessagingServiceProtocol {
         databaseReader: any DatabaseReader,
         environment: AppEnvironment
     ) {
-        // Check if we already have an unused messaging service ready
-        if unusedMessagingService != nil {
-            Logger.debug("Unused messaging service already exists, skipping creation")
-            return
-        }
-
-        // Check if we have an unused inbox ID in keychain
-        if let unusedInboxId = getUnusedInbox() {
-            Logger.info("Found unused inbox ID in keychain, authorizing it: \(unusedInboxId)")
-
-            // Create and authorize the messaging service in background
-            Task {
-                let authorizationOperation = AuthorizeInboxOperation.authorize(
-                    inboxId: unusedInboxId,
-                    databaseReader: databaseReader,
-                    databaseWriter: databaseWriter,
-                    environment: environment,
-                    registersForPushNotifications: false // Don't register for push for unused inbox
-                )
-
-                let messagingService = MessagingService(
-                    inboxId: unusedInboxId,
-                    authorizationOperation: authorizationOperation,
-                    databaseWriter: databaseWriter,
-                    databaseReader: databaseReader
-                )
-
-                do {
-                    // Wait for it to be ready
-                    _ = try await messagingService.inboxStateManager.waitForInboxReadyResult()
-
-                    // Store it as the unused messaging service
-                    unusedMessagingService = messagingService
-
-                    Logger.info("Successfully authorized unused inbox from keychain: \(unusedInboxId)")
-                } catch {
-                    Logger.error("Failed to authorize unused inbox from keychain: \(error)")
-                    // Clear the invalid inbox ID from keychain
-                    clearUnusedInbox()
-                    // Clean up the messaging service
-                    await messagingService.authorizationOperation.stopAndDelete()
-
-                    // Schedule creation of a new unused inbox
-                    scheduleUnusedInboxCreation(
-                        databaseWriter: databaseWriter,
-                        databaseReader: databaseReader,
-                        environment: environment
-                    )
-                }
-            }
-            return
-        }
-
-        // No unused inbox exists, schedule creation of a new one
-        Logger.info("No unused inbox found, scheduling creation on app startup")
-        scheduleUnusedInboxCreation(
-            databaseWriter: databaseWriter,
-            databaseReader: databaseReader,
-            environment: environment
-        )
-    }
-
-    // MARK: - Private Unused Inbox Methods
-
-    private static func getUnusedInbox() -> String? {
-        do {
-            return try keychainService.retrieveString(UnusedInboxKeychainItem())
-        } catch {
-            Logger.debug("No unused inbox found in keychain: \(error)")
-            return nil
-        }
-    }
-
-    private static func saveUnusedInbox(_ inboxId: String) {
-        do {
-            try keychainService.saveString(inboxId, for: UnusedInboxKeychainItem())
-            Logger.info("Saved unused inbox to keychain: \(inboxId)")
-        } catch {
-            Logger.error("Failed to save unused inbox to keychain: \(error)")
-        }
-    }
-
-    private static func clearUnusedInbox() {
-        do {
-            try keychainService.delete(UnusedInboxKeychainItem())
-            Logger.debug("Cleared unused inbox from keychain")
-        } catch {
-            Logger.debug("Failed to clear unused inbox from keychain: \(error)")
-        }
-    }
-
-    private static func scheduleUnusedInboxCreation(
-        databaseWriter: any DatabaseWriter,
-        databaseReader: any DatabaseReader,
-        environment: AppEnvironment
-    ) {
-        unusedInboxQueue.async {
-            guard !isCreatingUnusedInbox else {
-                Logger.debug("Already creating unused inbox, skipping")
-                return
-            }
-
-            isCreatingUnusedInbox = true
-
-            Task {
-                await createUnusedInbox(
-                    databaseWriter: databaseWriter,
-                    databaseReader: databaseReader,
-                    environment: environment
-                )
-
-                await MainActor.run {
-                    isCreatingUnusedInbox = false
-                }
-            }
-        }
-    }
-
-    private static func createUnusedInbox(
-        databaseWriter: any DatabaseWriter,
-        databaseReader: any DatabaseReader,
-        environment: AppEnvironment
-    ) async {
-        Logger.info("Creating new unused inbox in background")
-
-        let authorizationOperation = AuthorizeInboxOperation.register(
-            databaseReader: databaseReader,
-            databaseWriter: databaseWriter,
-            environment: environment,
-            registersForPushNotifications: false // Don't register for push for unused inbox
-        )
-
-        let tempMessagingService = MessagingService(
-            inboxId: nil,
-            authorizationOperation: authorizationOperation,
-            databaseWriter: databaseWriter,
-            databaseReader: databaseReader
-        )
-
-        // Wait for the inbox to be ready
-        do {
-            let result = try await tempMessagingService.inboxStateManager.waitForInboxReadyResult()
-            let inboxId = result.client.inboxId
-
-            // Save the inbox ID to keychain
-            saveUnusedInbox(inboxId)
-
-            // Store the messaging service instance
-            unusedMessagingService = tempMessagingService
-
-            Logger.info("Successfully created unused inbox: \(inboxId)")
-        } catch {
-            Logger.error("Failed to create unused inbox: \(error)")
-            // Clean up on error
-            await tempMessagingService.authorizationOperation.stopAndDelete()
+        Task {
+            await UnusedInboxCache.shared.prepareUnusedInboxIfNeeded(
+                databaseWriter: databaseWriter,
+                databaseReader: databaseReader,
+                environment: environment
+            )
         }
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Messaging/UnusedInboxCache.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/UnusedInboxCache.swift
@@ -196,6 +196,11 @@ actor UnusedInboxCache {
         databaseReader: any DatabaseReader,
         environment: AppEnvironment
     ) async {
+        guard unusedMessagingService == nil else {
+            Logger.debug("Unused messaging service exists, skipping creating new unused inbox...")
+            return
+        }
+
         guard !isCreatingUnusedInbox else {
             Logger.debug("Already creating unused inbox, skipping")
             return

--- a/ConvosCore/Sources/ConvosCore/Messaging/UnusedInboxCache.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/UnusedInboxCache.swift
@@ -1,0 +1,269 @@
+import Foundation
+import GRDB
+
+/// Manages pre-created unused inboxes for faster user onboarding
+actor UnusedInboxCache {
+    static let shared: UnusedInboxCache = .init()
+
+    // MARK: - Properties
+
+    private let keychainService: KeychainService<UnusedInboxKeychainItem>
+    private var unusedMessagingService: MessagingService?
+    private var isCreatingUnusedInbox: Bool = false
+
+    // MARK: - Initialization
+
+    private init() {
+        self.keychainService = KeychainService<UnusedInboxKeychainItem>()
+    }
+
+    // MARK: - Public Methods
+
+    /// Checks if an unused inbox is available and prepares one if needed
+    func prepareUnusedInboxIfNeeded(
+        databaseWriter: any DatabaseWriter,
+        databaseReader: any DatabaseReader,
+        environment: AppEnvironment
+    ) async {
+        // Check if we already have an unused messaging service ready
+        if unusedMessagingService != nil {
+            Logger.debug("Unused messaging service already exists")
+            return
+        }
+
+        // Check if we have an unused inbox ID in keychain
+        if let unusedInboxId = getUnusedInboxFromKeychain() {
+            Logger.info("Found unused inbox ID in keychain: \(unusedInboxId)")
+            await authorizeUnusedInbox(
+                inboxId: unusedInboxId,
+                databaseWriter: databaseWriter,
+                databaseReader: databaseReader,
+                environment: environment
+            )
+            return
+        }
+
+        // No unused inbox exists, create a new one
+        Logger.info("No unused inbox found, creating new one")
+        Task(priority: .background) {
+            await createNewUnusedInbox(
+                databaseWriter: databaseWriter,
+                databaseReader: databaseReader,
+                environment: environment
+            )
+        }
+    }
+
+    /// Consumes the unused inbox if available, or creates a new one
+    func consumeOrCreateMessagingService(
+        databaseWriter: any DatabaseWriter,
+        databaseReader: any DatabaseReader,
+        environment: AppEnvironment
+    ) async -> MessagingService {
+        // Check if we have a pre-created unused messaging service
+        if let unusedService = unusedMessagingService {
+            Logger.info("Using pre-created unused messaging service")
+
+            // Clear the reference
+            unusedMessagingService = nil
+
+            // Clear from keychain
+            clearUnusedInboxFromKeychain()
+
+            // Schedule creation of a new unused inbox for next time
+            Task(priority: .background) {
+                await createNewUnusedInbox(
+                    databaseWriter: databaseWriter,
+                    databaseReader: databaseReader,
+                    environment: environment
+                )
+            }
+
+            return unusedService
+        }
+
+        // Check for an unused inbox ID in keychain (fallback)
+        if let unusedInboxId = getUnusedInboxFromKeychain() {
+            Logger.info("Using unused inbox ID from keychain: \(unusedInboxId)")
+
+            // Clear from keychain
+            clearUnusedInboxFromKeychain()
+
+            // Schedule creation of a new unused inbox for next time
+            Task(priority: .background) {
+                await createNewUnusedInbox(
+                    databaseWriter: databaseWriter,
+                    databaseReader: databaseReader,
+                    environment: environment
+                )
+            }
+
+            // Use the existing inbox with authorize
+            let authorizationOperation = AuthorizeInboxOperation.authorize(
+                inboxId: unusedInboxId,
+                databaseReader: databaseReader,
+                databaseWriter: databaseWriter,
+                environment: environment,
+                registersForPushNotifications: true
+            )
+            return MessagingService(
+                inboxId: unusedInboxId,
+                authorizationOperation: authorizationOperation,
+                databaseWriter: databaseWriter,
+                databaseReader: databaseReader
+            )
+        }
+
+        // No unused inbox available, create a new one
+        Logger.info("No unused inbox available, creating new one")
+
+        // Schedule creation of an unused inbox for next time
+        Task(priority: .background) {
+            await createNewUnusedInbox(
+                databaseWriter: databaseWriter,
+                databaseReader: databaseReader,
+                environment: environment
+            )
+        }
+
+        // Create and return a new messaging service
+        let authorizationOperation = AuthorizeInboxOperation.register(
+            databaseReader: databaseReader,
+            databaseWriter: databaseWriter,
+            environment: environment,
+            registersForPushNotifications: true
+        )
+
+        return MessagingService(
+            inboxId: nil,
+            authorizationOperation: authorizationOperation,
+            databaseWriter: databaseWriter,
+            databaseReader: databaseReader
+        )
+    }
+
+    // MARK: - Private Methods
+
+    private func authorizeUnusedInbox(
+        inboxId: String,
+        databaseWriter: any DatabaseWriter,
+        databaseReader: any DatabaseReader,
+        environment: AppEnvironment
+    ) async {
+        let authorizationOperation = AuthorizeInboxOperation.authorize(
+            inboxId: inboxId,
+            databaseReader: databaseReader,
+            databaseWriter: databaseWriter,
+            environment: environment,
+            registersForPushNotifications: false
+        )
+
+        let messagingService = MessagingService(
+            inboxId: inboxId,
+            authorizationOperation: authorizationOperation,
+            databaseWriter: databaseWriter,
+            databaseReader: databaseReader
+        )
+
+        do {
+            // Wait for it to be ready
+            _ = try await messagingService.inboxStateManager.waitForInboxReadyResult()
+
+            // Store it as the unused messaging service
+            unusedMessagingService = messagingService
+
+            Logger.info("Successfully authorized unused inbox: \(inboxId)")
+        } catch {
+            Logger.error("Failed to authorize unused inbox: \(error)")
+            // Clear the invalid inbox ID from keychain
+            clearUnusedInboxFromKeychain()
+            // Clean up the messaging service
+            await messagingService.stopAndDelete()
+
+            // Create a new unused inbox
+            Task(priority: .background) {
+                await createNewUnusedInbox(
+                    databaseWriter: databaseWriter,
+                    databaseReader: databaseReader,
+                    environment: environment
+                )
+            }
+        }
+    }
+
+    private func createNewUnusedInbox(
+        databaseWriter: any DatabaseWriter,
+        databaseReader: any DatabaseReader,
+        environment: AppEnvironment
+    ) async {
+        guard !isCreatingUnusedInbox else {
+            Logger.debug("Already creating unused inbox, skipping")
+            return
+        }
+
+        isCreatingUnusedInbox = true
+        defer { isCreatingUnusedInbox = false }
+
+        Logger.info("Creating new unused inbox in background")
+
+        let authorizationOperation = AuthorizeInboxOperation.register(
+            databaseReader: databaseReader,
+            databaseWriter: databaseWriter,
+            environment: environment,
+            registersForPushNotifications: false
+        )
+
+        let tempMessagingService = MessagingService(
+            inboxId: nil,
+            authorizationOperation: authorizationOperation,
+            databaseWriter: databaseWriter,
+            databaseReader: databaseReader
+        )
+
+        do {
+            let result = try await tempMessagingService.inboxStateManager.waitForInboxReadyResult()
+            let inboxId = result.client.inboxId
+
+            // Save the inbox ID to keychain
+            saveUnusedInboxToKeychain(inboxId)
+
+            // Store the messaging service instance
+            unusedMessagingService = tempMessagingService
+
+            Logger.info("Successfully created unused inbox: \(inboxId)")
+        } catch {
+            Logger.error("Failed to create unused inbox: \(error)")
+            // Clean up on error
+            await tempMessagingService.stopAndDelete()
+        }
+    }
+
+    // MARK: - Keychain Helpers
+
+    private func getUnusedInboxFromKeychain() -> String? {
+        do {
+            return try keychainService.retrieveString(UnusedInboxKeychainItem())
+        } catch {
+            Logger.debug("No unused inbox found in keychain: \(error)")
+            return nil
+        }
+    }
+
+    private func saveUnusedInboxToKeychain(_ inboxId: String) {
+        do {
+            try keychainService.saveString(inboxId, for: UnusedInboxKeychainItem())
+            Logger.info("Saved unused inbox to keychain: \(inboxId)")
+        } catch {
+            Logger.error("Failed to save unused inbox to keychain: \(error)")
+        }
+    }
+
+    private func clearUnusedInboxFromKeychain() {
+        do {
+            try keychainService.delete(UnusedInboxKeychainItem())
+            Logger.debug("Cleared unused inbox from keychain")
+        } catch {
+            Logger.debug("Failed to clear unused inbox from keychain: \(error)")
+        }
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Notifications/PushNotificationPayload.swift
+++ b/ConvosCore/Sources/ConvosCore/Notifications/PushNotificationPayload.swift
@@ -18,8 +18,8 @@ public final class PushNotificationPayload {
     public let notificationData: NotificationData?
 
     // Decoded content properties (mutable for NSE processing)
-    public internal(set) var decodedTitle: String?
-    public internal(set) var decodedBody: String?
+    public var decodedTitle: String?
+    public var decodedBody: String?
 
     public init(userInfo: [AnyHashable: Any]) {
         self.inboxId = userInfo["inboxId"] as? String

--- a/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
@@ -42,6 +42,13 @@ class SessionManager: SessionManagerProtocol {
             }
             .store(in: &cancellables)
         observe()
+
+        // Schedule creation of unused inbox on app startup
+        MessagingService.createUnusedInboxIfNeeded(
+            databaseWriter: databaseWriter,
+            databaseReader: databaseReader,
+            environment: environment
+        )
     }
 
     deinit {

--- a/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
@@ -186,8 +186,8 @@ class SessionManager: SessionManagerProtocol {
 
     // MARK: Public
 
-    func addInbox() throws -> AnyMessagingService {
-        let messagingService = MessagingService.registeredMessagingService(
+    func addInbox() async throws -> AnyMessagingService {
+        let messagingService = await MessagingService.registeredMessagingService(
             databaseWriter: databaseWriter,
             databaseReader: databaseReader,
             environment: environment

--- a/ConvosCore/Sources/ConvosCore/Sessions/SessionManagerProtocol.swift
+++ b/ConvosCore/Sources/ConvosCore/Sessions/SessionManagerProtocol.swift
@@ -3,10 +3,10 @@ import Foundation
 
 public protocol SessionManagerProtocol {
     func addInbox() async throws -> AnyMessagingService
-    func deleteInbox(inboxId: String) throws
-    func deleteInbox(for messagingService: AnyMessagingService) throws
-    func deleteAllInboxes() throws
-    func messagingService(for inboxId: String) -> AnyMessagingService
+    func deleteInbox(inboxId: String) async throws
+    func deleteInbox(for messagingService: AnyMessagingService) async throws
+    func deleteAllInboxes() async throws
+    func messagingService(for inboxId: String) async -> AnyMessagingService
     func conversationsRepository(for consent: [Consent]) -> any ConversationsRepositoryProtocol
     func conversationsCountRepo(
         for consent: [Consent],

--- a/ConvosCore/Sources/ConvosCore/Sessions/SessionManagerProtocol.swift
+++ b/ConvosCore/Sources/ConvosCore/Sessions/SessionManagerProtocol.swift
@@ -2,7 +2,7 @@ import Combine
 import Foundation
 
 public protocol SessionManagerProtocol {
-    func addInbox() throws -> AnyMessagingService
+    func addInbox() async throws -> AnyMessagingService
     func deleteInbox(inboxId: String) throws
     func deleteInbox(for messagingService: AnyMessagingService) throws
     func deleteAllInboxes() throws

--- a/ConvosCore/Sources/ConvosCore/Shared/ConvosKeychainItem.swift
+++ b/ConvosCore/Sources/ConvosCore/Shared/ConvosKeychainItem.swift
@@ -14,6 +14,14 @@ struct ConvosJWTKeychainItem: KeychainItemProtocol {
     }
 }
 
+struct LastRegisteredPushTokenKeychainItem: KeychainItemProtocol {
+    let inboxId: String
+
+    var account: String {
+        return "push-token-\(inboxId)"
+    }
+}
+
 struct UnusedInboxKeychainItem: KeychainItemProtocol {
     static let account: String = "unused-inbox"
 

--- a/ConvosCore/Sources/ConvosCore/Shared/ConvosKeychainItem.swift
+++ b/ConvosCore/Sources/ConvosCore/Shared/ConvosKeychainItem.swift
@@ -13,3 +13,11 @@ struct ConvosJWTKeychainItem: KeychainItemProtocol {
         return inboxId
     }
 }
+
+struct UnusedInboxKeychainItem: KeychainItemProtocol {
+    static let account: String = "unused-inbox"
+
+    var account: String {
+        return Self.account
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Utilities/QRCodeGenerator.swift
+++ b/ConvosCore/Sources/ConvosCore/Utilities/QRCodeGenerator.swift
@@ -1,0 +1,165 @@
+import CoreImage.CIFilterBuiltins
+import CoreImage
+import Foundation
+import UIKit
+
+/// A reusable QR code generator that can be used throughout the app
+///
+/// This generator automatically caches generated QR codes based on their content and options.
+/// Different options (colors, size, etc.) for the same content will be cached separately.
+public enum QRCodeGenerator {
+    public struct Options {
+        /// The scale factor to use for rendering (defaults to main screen scale)
+        public let scale: CGFloat
+        /// The target display size in points
+        public let displaySize: CGFloat
+        /// Whether to use rounded markers
+        public let roundedMarkers: Bool
+        /// Whether to use rounded data cells
+        public let roundedData: Bool
+        /// The size of the center space (0.0 to 1.0)
+        public let centerSpaceSize: Float
+        /// Error correction level: "L", "M", "Q", "H"
+        public let correctionLevel: String
+        /// Foreground color
+        public let foregroundColor: CIColor
+        /// Background color
+        public let backgroundColor: CIColor
+
+        public init(
+            scale: CGFloat? = nil,
+            displaySize: CGFloat = 220,
+            roundedMarkers: Bool = true,
+            roundedData: Bool = false,
+            centerSpaceSize: Float = 0.3,
+            correctionLevel: String = "H",
+            foregroundColor: UIColor = .black,
+            backgroundColor: UIColor = .white
+        ) {
+            self.scale = scale ?? 3.0 // Default to 3x if not provided
+            self.displaySize = displaySize
+            self.roundedMarkers = roundedMarkers
+            self.roundedData = roundedData
+            self.centerSpaceSize = centerSpaceSize
+            self.correctionLevel = correctionLevel
+            self.foregroundColor = CIColor(color: foregroundColor)
+            self.backgroundColor = CIColor(color: backgroundColor)
+        }
+    }
+
+    /// Custom hash key for options that includes all relevant properties
+    private struct OptionsHashKey: Hashable {
+        let scale: CGFloat
+        let displaySize: CGFloat
+        let roundedMarkers: Bool
+        let roundedData: Bool
+        let centerSpaceSize: Float
+        let correctionLevel: String
+        let foregroundRed: CGFloat
+        let foregroundGreen: CGFloat
+        let foregroundBlue: CGFloat
+        let foregroundAlpha: CGFloat
+        let backgroundRed: CGFloat
+        let backgroundGreen: CGFloat
+        let backgroundBlue: CGFloat
+        let backgroundAlpha: CGFloat
+
+        init(options: Options) {
+            self.scale = options.scale
+            self.displaySize = options.displaySize
+            self.roundedMarkers = options.roundedMarkers
+            self.roundedData = options.roundedData
+            self.centerSpaceSize = options.centerSpaceSize
+            self.correctionLevel = options.correctionLevel
+            self.foregroundRed = options.foregroundColor.red
+            self.foregroundGreen = options.foregroundColor.green
+            self.foregroundBlue = options.foregroundColor.blue
+            self.foregroundAlpha = options.foregroundColor.alpha
+            self.backgroundRed = options.backgroundColor.red
+            self.backgroundGreen = options.backgroundColor.green
+            self.backgroundBlue = options.backgroundColor.blue
+            self.backgroundAlpha = options.backgroundColor.alpha
+        }
+    }
+
+    /// Creates a cache key based on the string and options
+    private static func cacheKey(for string: String, options: Options) -> String {
+        var hasher = Hasher()
+        hasher.combine(string)
+        hasher.combine(OptionsHashKey(options: options))
+        return "qr_\(hasher.finalize())"
+    }
+
+    /// Generates a QR code image from the given string
+    /// - Parameters:
+    ///   - from: The string to encode
+    ///   - options: Generation options
+    /// - Returns: The generated QR code image, or nil if generation fails
+    public static func generate(from string: String, options: Options = .init()) -> UIImage? {
+        let cacheKey = cacheKey(for: string, options: options)
+
+        // Check cache first
+        if let cachedImage = ImageCache.shared.image(for: cacheKey) {
+            return cachedImage
+        }
+
+        let context = CIContext()
+        let filter = CIFilter.roundedQRCodeGenerator()
+
+        filter.message = Data(string.utf8)
+        filter.roundedMarkers = options.roundedMarkers ? 1 : 0
+        filter.roundedData = options.roundedData
+        filter.centerSpaceSize = options.centerSpaceSize
+        filter.correctionLevel = options.correctionLevel
+        filter.color1 = options.foregroundColor
+        filter.color0 = options.backgroundColor
+
+        guard let outputImage = filter.outputImage else { return nil }
+
+        let outputExtent = outputImage.extent
+        let baseSize = max(outputExtent.width, outputExtent.height)
+
+        // Scale to match the display size * scale factor
+        let targetPixelSize = options.displaySize * options.scale
+        let scaleFactor = targetPixelSize / baseSize
+
+        let transform = CGAffineTransform(scaleX: scaleFactor, y: scaleFactor)
+        let scaledImage = outputImage.transformed(by: transform)
+
+        guard let cgImage = context.createCGImage(scaledImage, from: scaledImage.extent) else { return nil }
+        let image = UIImage(cgImage: cgImage)
+
+        // Cache the generated image
+        ImageCache.shared.cacheImage(image, for: cacheKey)
+
+        return image
+    }
+
+    /// Generates a QR code asynchronously
+    /// - Parameters:
+    ///   - from: The string to encode
+    ///   - options: Generation options
+    /// - Returns: The generated QR code image, or nil if generation fails
+    public static func generate(from string: String, options: Options = .init()) async -> UIImage? {
+        let cacheKey = cacheKey(for: string, options: options)
+
+        // Check cache first
+        if let cachedImage = ImageCache.shared.image(for: cacheKey) {
+            return cachedImage
+        }
+
+        // Generate in background
+        return await Task.detached(priority: .userInitiated) {
+            generate(from: string, options: options)
+        }.value
+    }
+
+    /// Clears a specific QR code from the cache
+    /// - Parameters:
+    ///   - string: The string content of the QR code
+    ///   - options: The options used to generate the QR code
+    public static func clearFromCache(string: String, options: Options = .init()) {
+        let cacheKey = cacheKey(for: string, options: options)
+        ImageCache.shared.removeImage(for: cacheKey)
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Utilities/QRCodeGenerator.swift
+++ b/ConvosCore/Sources/ConvosCore/Utilities/QRCodeGenerator.swift
@@ -1,5 +1,4 @@
 import CoreImage.CIFilterBuiltins
-import CoreImage
 import Foundation
 import UIKit
 
@@ -44,6 +43,26 @@ public enum QRCodeGenerator {
             self.correctionLevel = correctionLevel
             self.foregroundColor = CIColor(color: foregroundColor)
             self.backgroundColor = CIColor(color: backgroundColor)
+        }
+
+        /// Configuration for QR codes in light mode
+        public static var qrCodeLight: Options {
+            Options(
+                scale: 3.0, // Default to 3x for retina displays
+                displaySize: 220,
+                foregroundColor: .black, // Dark QR code
+                backgroundColor: .clear  // Light background
+            )
+        }
+
+        /// Configuration for QR codes in dark mode
+        public static var qrCodeDark: Options {
+            Options(
+                scale: 3.0, // Default to 3x for retina displays
+                displaySize: 220,
+                foregroundColor: .white, // Light QR code
+                backgroundColor: .clear  // Dark background
+            )
         }
     }
 
@@ -154,6 +173,32 @@ public enum QRCodeGenerator {
         }.value
     }
 
+    /// Pre-generates QR codes for both light and dark modes
+    /// - Parameters:
+    ///   - string: The string to encode
+    ///   - scale: Optional scale factor (defaults to 3.0)
+    /// - Returns: Tuple of (lightModeImage, darkModeImage)
+    public static func pregenerate(from string: String, scale: CGFloat = 3.0) async -> (light: UIImage?, dark: UIImage?) {
+        let lightOptions = Options(
+            scale: scale,
+            displaySize: 220,
+            foregroundColor: .black,
+            backgroundColor: .white
+        )
+
+        let darkOptions = Options(
+            scale: scale,
+            displaySize: 220,
+            foregroundColor: .white,
+            backgroundColor: .black
+        )
+
+        async let lightImage = generate(from: string, options: lightOptions)
+        async let darkImage = generate(from: string, options: darkOptions)
+
+        return await (lightImage, darkImage)
+    }
+
     /// Clears a specific QR code from the cache
     /// - Parameters:
     ///   - string: The string content of the QR code
@@ -161,5 +206,12 @@ public enum QRCodeGenerator {
     public static func clearFromCache(string: String, options: Options = .init()) {
         let cacheKey = cacheKey(for: string, options: options)
         ImageCache.shared.removeImage(for: cacheKey)
+    }
+
+    /// Clears QR codes for both light and dark modes from cache
+    /// - Parameter string: The string content of the QR code
+    public static func clearFromCacheAllModes(string: String) {
+        clearFromCache(string: string, options: Options.qrCodeLight)
+        clearFromCache(string: string, options: Options.qrCodeDark)
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Utilities/QRCodeGenerator.swift
+++ b/ConvosCore/Sources/ConvosCore/Utilities/QRCodeGenerator.swift
@@ -146,7 +146,7 @@ public enum QRCodeGenerator {
         let scaledImage = outputImage.transformed(by: transform)
 
         guard let cgImage = context.createCGImage(scaledImage, from: scaledImage.extent) else { return nil }
-        let image = UIImage(cgImage: cgImage)
+        let image = UIImage(cgImage: cgImage, scale: options.scale, orientation: .up)
 
         // Cache the generated image
         ImageCache.shared.cacheImage(image, for: cacheKey)

--- a/ConvosTests/SessionManagerTests.swift
+++ b/ConvosTests/SessionManagerTests.swift
@@ -34,7 +34,7 @@ struct SessionManagerTests {
         let inboxId = inbox.inboxId
         Logger.info("🔍 Found inbox with ID: \(inboxId)")
 
-        let messagingService = sessionManager.messagingService(for: inboxId)
+        let messagingService = await sessionManager.messagingService(for: inboxId)
         var inboxReadyIterator = messagingService.inboxReadyPublisher.values.makeAsyncIterator()
 
         Logger.info("🔍 Waiting for messaging service...")
@@ -80,7 +80,7 @@ struct SessionManagerTests {
         let inboxId = inbox.inboxId
         Logger.info("🔍 Found inbox with ID: \(inboxId)")
 
-        let messagingService = sessionManager.messagingService(for: inboxId)
+        let messagingService = await sessionManager.messagingService(for: inboxId)
         var inboxReadyIterator = messagingService.inboxReadyPublisher.values.makeAsyncIterator()
 
         Logger.info("🔍 Waiting for messaging service...")

--- a/NotificationService/NotificationService.swift
+++ b/NotificationService/NotificationService.swift
@@ -35,55 +35,44 @@ class NotificationService: UNNotificationServiceExtension {
         Logger.info("NSE: Extension time expiring, cleaning up XMTP resources")
         pushHandler?.cleanup()
 
-        // Only deliver notification if we successfully decoded content
-        if hasDecodedContent() {
-            Logger.info("NSE: Delivering notification with decoded content on timeout")
-            if let contentHandler = contentHandler, let bestAttemptContent = bestAttemptContent {
-                contentHandler(bestAttemptContent)
-            }
-        } else {
-            Logger.info("NSE: Suppressing notification - no decoded content available on timeout")
-            // Don't call contentHandler - this suppresses the notification
-        }
+        // With notification filtering entitlement, we can choose not to show anything on timeout
+        // by not calling contentHandler. This completely suppresses the notification.
+        Logger.info("NSE: Timeout - dropping notification by not calling contentHandler")
+        // Don't call contentHandler - notification is dropped
     }
 
     private func handlePushNotification(userInfo: [AnyHashable: Any]) async {
-        // Set initial notification content
-        updateNotificationContent(userInfo: userInfo)
+        // Don't set initial content yet - wait to see if we should drop the notification
 
         do {
             try await pushHandler?.handlePushNotification(userInfo: userInfo)
+
+            // Only set initial content if we're going to show the notification
+            updateNotificationContent(userInfo: userInfo)
         } catch {
             // Check if this is a message that should be dropped
             if let error = error as? NotificationError, error == .messageShouldBeDropped {
                 Logger.info("Notification dropped - message from self or non-text")
-                // Cleanup and return without delivering any notification
                 Logger.info("NSE: Cleaning up XMTP resources after dropping notification")
                 pushHandler?.cleanup()
+                // Don't call contentHandler - this drops the notification with filtering entitlement
                 return
             }
-            // For other errors, continue with generic notification
+            // For any other errors, also drop the notification
+            // Better to show nothing than generic/incorrect content
             Logger.error("Push notification processing error: \(error)")
+            Logger.info("NSE: Dropping notification due to processing error")
+            pushHandler?.cleanup()
+            // Don't call contentHandler - this drops the notification with filtering entitlement
+            return
         }
 
         // Check if the task was cancelled before calling contentHandler
         guard !Task.isCancelled else {
             Logger.info("NSE: Task cancelled, cleaning up XMTP resources")
             pushHandler?.cleanup()
-
-            // Try to use any partial decoded content
-            updateNotificationContentWithDecodedData(userInfo: userInfo)
-
-            // Only deliver notification if we successfully decoded content
-            if hasDecodedContent() {
-                Logger.info("NSE: Delivering notification with decoded content after cancellation")
-                if let contentHandler = contentHandler, let bestAttemptContent = bestAttemptContent {
-                    contentHandler(bestAttemptContent)
-                }
-            } else {
-                Logger.info("NSE: Suppressing notification - no decoded content available after cancellation")
-                // Don't call contentHandler - this suppresses the notification
-            }
+            Logger.info("NSE: Dropping notification - task was cancelled")
+            // Don't call contentHandler - this drops the notification with filtering entitlement
             return
         }
 
@@ -149,22 +138,5 @@ class NotificationService: UNNotificationServiceExtension {
 
             Logger.info("Applied fallback notification content")
         }
-    }
-
-    private func hasDecodedContent() -> Bool {
-        // Check if we have decoded content from the push handler
-        if let processedPayload = pushHandler?.getProcessedPayload() {
-            // For protocol messages, we need decoded content
-            if processedPayload.notificationType == .protocolMessage {
-                return processedPayload.decodedBody != nil || processedPayload.decodedTitle != nil
-            }
-            // For other known notification types (like invite join requests), no decoding is needed
-            if processedPayload.notificationType == .inviteJoinRequest {
-                return true
-            }
-            // For unknown/nil notification types, don't deliver to be safe
-            return false
-        }
-        return false
     }
 }


### PR DESCRIPTION
### Introduce cached unused inbox creation and consumption by adding `ConvosCore/Messaging/UnusedInboxCache` and making `MessagingService.registeredMessagingService` async so `SessionManager` can precreate and consume a cached inbox
- Add `UnusedInboxCache` actor to precreate and cache `MessagingService` instances and update `MessagingService.registeredMessagingService` to async, with `MessagingService.createUnusedInboxIfNeeded` for background preparation ([UnusedInboxCache.swift](https://github.com/ephemeraHQ/convos-ios/pull/76/files#diff-f0fa420edcbb4b84596d955430ce62fac2027d0d82e4f34b2bc694e43bd55106), [MessagingService.swift](https://github.com/ephemeraHQ/convos-ios/pull/76/files#diff-ae5f8bf667b2cb7b826678407b9697d1fe69352397220d80aaeeb65fd1090884)).
- Convert `SessionManager` to an actor, make key APIs async, start services once at init, observe via `Task`, and schedule unused inbox preparation ([SessionManager.swift](https://github.com/ephemeraHQ/convos-ios/pull/76/files#diff-047bb043999d66a7809a8ab86918296f5f449652df54267763f6ec8da0a71ca7), [SessionManagerProtocol.swift](https://github.com/ephemeraHQ/convos-ios/pull/76/files#diff-53c8bce662d171e3f085b6bc08d1b682ffaf15b6d364c40ce89b5f20e8a0021a)).
- Cache APNs tokens per inbox in keychain to skip redundant registrations and clear on unregister in `PushNotificationRegistrar` ([PushNotificationRegistrar.swift](https://github.com/ephemeraHQ/convos-ios/pull/76/files#diff-e569c660c5ed0ae5742f05f12a89b7da3abfe28a12ef4d12476a13035ff36b69), [ConvosKeychainItem.swift](https://github.com/ephemeraHQ/convos-ios/pull/76/files#diff-009beb71b5a9798166719a12a85ba6a7053e1186e749453a4290c6a861a8d921)).
- Suppress notifications on extension timeout, processing errors, or cancellation in `NotificationService`; only deliver on success ([NotificationService.swift](https://github.com/ephemeraHQ/convos-ios/pull/76/files#diff-cd6c8fdb4518bf3bbc5ee11b88947aa53f113197875ddb7ca91ee8dd4eb0eed4)).
- Add `QRCodeGenerator` with configurable options and caching and refactor `QRCodeView` to use semantic colors and environment-driven regeneration ([QRCodeGenerator.swift](https://github.com/ephemeraHQ/convos-ios/pull/76/files#diff-52521e4b7dbb6be24e83bc7a7568f74720140c0318b9a81e8017b7c8cf047e79), [QRCodeView.swift](https://github.com/ephemeraHQ/convos-ios/pull/76/files#diff-2cc11207364fc7ad585e16e0b98a4092fea3f2a48b9d9f49e404db3b6733bf82)).
- Update state machines to process actions via `Task.detached` and add invite group membership pre-check; relax setters on `PushNotificationPayload` ([ConversationStateMachine.swift](https://github.com/ephemeraHQ/convos-ios/pull/76/files#diff-a1762ce564035d6cdd7e3b2d3200cfe0db6c3ec5fac03636392780086ba58344), [InboxStateMachine.swift](https://github.com/ephemeraHQ/convos-ios/pull/76/files#diff-314f69bca557159935a2f6c3e545b7374a861df38d5bda997858ecee5fad58f1), [PushNotificationPayload.swift](https://github.com/ephemeraHQ/convos-ios/pull/76/files#diff-8f7a244e637a828edc036b49ca7bf8e6a79c41949cd99b987e5627e998853395)).
- Introduce `PulsingCircleView` and adopt it for typing indicator; adjust color usage and glass effects in views ([PulsingCircleView.swift](https://github.com/ephemeraHQ/convos-ios/pull/76/files#diff-e8031b5be1b85e5572c76add7f38bd33d3c2e8b657dba7c64eb4eb12d0631941), [TypingIndicatorCollectionCell.swift](https://github.com/ephemeraHQ/convos-ios/pull/76/files#diff-a5a9437a1e9f0fa17e871530cc09a560e28cd541baedcaa96f9892f99e99e980), [MonogramView.swift](https://github.com/ephemeraHQ/convos-ios/pull/76/files#diff-0fb6e7f0b8750046b63dc9f57b76994824cc2847514688e436c7d7c89dfcc20c), [PrimarySecondaryContainerView.swift](https://github.com/ephemeraHQ/convos-ios/pull/76/files#diff-5524e91fa9ed8ef0a7b7796cd4f5858c24e620a7b60e9988d40284981264fa05), [AppSettingsView.swift](https://github.com/ephemeraHQ/convos-ios/pull/76/files#diff-30e98d39613710cf0f912b477ed30a8638995959caa9cb2e9facdc10e1c3f8b9)).
- Add invite-with-group API and mocks and make inbox services and tests async-compatible ([ConvosAPIClient.swift](https://github.com/ephemeraHQ/convos-ios/pull/76/files#diff-d9c911c02b64ae370c51a1048b35e6e5dfc05805b43efd9be61a31fa422500b8), [ConvosAPIClient+Models.swift](https://github.com/ephemeraHQ/convos-ios/pull/76/files#diff-869f0fb39659b9175c5a2597ca99467c503f8bdf5805e619872b7c8e07f73ce3), [MockAPIClient.swift](https://github.com/ephemeraHQ/convos-ios/pull/76/files#diff-2bb3de5f3c601401bfc2c9de163c0c739e3fd0a28ea5a990439169c2cfe12b98), [MockInboxesService.swift](https://github.com/ephemeraHQ/convos-ios/pull/76/files#diff-caab853973a7b6084bc75165155835fe8fc0145122057b3640b64af8f42d89d5), [SessionManagerTests.swift](https://github.com/ephemeraHQ/convos-ios/pull/76/files#diff-13b53f1c51adf529e270bd7715ea6ac02ffae549cf45294ab3e304e68cbf6abf)).

#### 📍Where to Start
Start with the `consumeOrCreateMessagingService` and `prepareUnusedInboxIfNeeded` flows in [UnusedInboxCache.swift](https://github.com/ephemeraHQ/convos-ios/pull/76/files#diff-f0fa420edcbb4b84596d955430ce62fac2027d0d82e4f34b2bc694e43bd55106), then review how `MessagingService.registeredMessagingService` delegates to the cache in [MessagingService.swift](https://github.com/ephemeraHQ/convos-ios/pull/76/files#diff-ae5f8bf667b2cb7b826678407b9697d1fe69352397220d80aaeeb65fd1090884) and how `SessionManager` schedules unused inbox preparation at startup in [SessionManager.swift](https://github.com/ephemeraHQ/convos-ios/pull/76/files#diff-047bb043999d66a7809a8ab86918296f5f449652df54267763f6ec8da0a71ca7).

----

_[Macroscope](https://app.macroscope.com) summarized c1e32b9._