### PR TITLE
Better handling of dropped notifications

### DIFF
--- a/ConvosCore/Sources/ConvosCore/Inboxes/CachedPushNotificationHandler.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/CachedPushNotificationHandler.swift
@@ -41,6 +41,9 @@ public class CachedPushNotificationHandler {
         Logger.info("Processing push notification for inbox: \(inboxId), type: \(payload.notificationType?.displayName ?? "unknown")")
         Logger.info("🔍 PARSED PAYLOAD: notificationType=\(payload.notificationType?.rawValue ?? "nil"), hasNotificationData=\(payload.notificationData != nil)")
 
+        // Store the payload for NSE to retrieve after processing
+        processedPayload = payload
+
         // Get or create messaging service for this inbox
         let messagingService = getOrCreateMessagingService(for: inboxId)
         try await messagingService.processPushNotification(payload: payload)

--- a/ConvosCore/Sources/ConvosCore/Notifications/PushNotificationPayload.swift
+++ b/ConvosCore/Sources/ConvosCore/Notifications/PushNotificationPayload.swift
@@ -18,8 +18,8 @@ public final class PushNotificationPayload {
     public let notificationData: NotificationData?
 
     // Decoded content properties (mutable for NSE processing)
-    public internal(set) var decodedTitle: String?
-    public internal(set) var decodedBody: String?
+    public var decodedTitle: String?
+    public var decodedBody: String?
 
     public init(userInfo: [AnyHashable: Any]) {
         self.inboxId = userInfo["inboxId"] as? String

--- a/NotificationService/NotificationService.swift
+++ b/NotificationService/NotificationService.swift
@@ -35,55 +35,44 @@ class NotificationService: UNNotificationServiceExtension {
         Logger.info("NSE: Extension time expiring, cleaning up XMTP resources")
         pushHandler?.cleanup()
 
-        // Only deliver notification if we successfully decoded content
-        if hasDecodedContent() {
-            Logger.info("NSE: Delivering notification with decoded content on timeout")
-            if let contentHandler = contentHandler, let bestAttemptContent = bestAttemptContent {
-                contentHandler(bestAttemptContent)
-            }
-        } else {
-            Logger.info("NSE: Suppressing notification - no decoded content available on timeout")
-            // Don't call contentHandler - this suppresses the notification
-        }
+        // With notification filtering entitlement, we can choose not to show anything on timeout
+        // by not calling contentHandler. This completely suppresses the notification.
+        Logger.info("NSE: Timeout - dropping notification by not calling contentHandler")
+        // Don't call contentHandler - notification is dropped
     }
 
     private func handlePushNotification(userInfo: [AnyHashable: Any]) async {
-        // Set initial notification content
-        updateNotificationContent(userInfo: userInfo)
+        // Don't set initial content yet - wait to see if we should drop the notification
 
         do {
             try await pushHandler?.handlePushNotification(userInfo: userInfo)
+
+            // Only set initial content if we're going to show the notification
+            updateNotificationContent(userInfo: userInfo)
         } catch {
             // Check if this is a message that should be dropped
             if let error = error as? NotificationError, error == .messageShouldBeDropped {
                 Logger.info("Notification dropped - message from self or non-text")
-                // Cleanup and return without delivering any notification
                 Logger.info("NSE: Cleaning up XMTP resources after dropping notification")
                 pushHandler?.cleanup()
+                // Don't call contentHandler - this drops the notification with filtering entitlement
                 return
             }
-            // For other errors, continue with generic notification
+            // For any other errors, also drop the notification
+            // Better to show nothing than generic/incorrect content
             Logger.error("Push notification processing error: \(error)")
+            Logger.info("NSE: Dropping notification due to processing error")
+            pushHandler?.cleanup()
+            // Don't call contentHandler - this drops the notification with filtering entitlement
+            return
         }
 
         // Check if the task was cancelled before calling contentHandler
         guard !Task.isCancelled else {
             Logger.info("NSE: Task cancelled, cleaning up XMTP resources")
             pushHandler?.cleanup()
-
-            // Try to use any partial decoded content
-            updateNotificationContentWithDecodedData(userInfo: userInfo)
-
-            // Only deliver notification if we successfully decoded content
-            if hasDecodedContent() {
-                Logger.info("NSE: Delivering notification with decoded content after cancellation")
-                if let contentHandler = contentHandler, let bestAttemptContent = bestAttemptContent {
-                    contentHandler(bestAttemptContent)
-                }
-            } else {
-                Logger.info("NSE: Suppressing notification - no decoded content available after cancellation")
-                // Don't call contentHandler - this suppresses the notification
-            }
+            Logger.info("NSE: Dropping notification - task was cancelled")
+            // Don't call contentHandler - this drops the notification with filtering entitlement
             return
         }
 
@@ -149,22 +138,5 @@ class NotificationService: UNNotificationServiceExtension {
 
             Logger.info("Applied fallback notification content")
         }
-    }
-
-    private func hasDecodedContent() -> Bool {
-        // Check if we have decoded content from the push handler
-        if let processedPayload = pushHandler?.getProcessedPayload() {
-            // For protocol messages, we need decoded content
-            if processedPayload.notificationType == .protocolMessage {
-                return processedPayload.decodedBody != nil || processedPayload.decodedTitle != nil
-            }
-            // For other known notification types (like invite join requests), no decoding is needed
-            if processedPayload.notificationType == .inviteJoinRequest {
-                return true
-            }
-            // For unknown/nil notification types, don't deliver to be safe
-            return false
-        }
-        return false
     }
 }


### PR DESCRIPTION
### Drop notifications in the Notification Service Extension on processing errors, cancellation, or timeout to better handle dropped notifications by not calling `NotificationService.contentHandler` in `NotificationService.handlePushNotification` and `NotificationService.serviceExtensionTimeWillExpire`.
- Modify `NotificationService.handlePushNotification` to stop setting initial content at start, deliver content only after successful processing, and skip calling `contentHandler` with cleanup on errors, cancellation, or when `messageShouldBeDropped` in [NotificationService.swift](https://github.com/ephemeraHQ/convos-ios/pull/77/files#diff-cd6c8fdb4518bf3bbc5ee11b88947aa53f113197875ddb7ca91ee8dd4eb0eed4); update `serviceExtensionTimeWillExpire` to always skip `contentHandler` on timeout; remove `hasDecodedContent`.
- In `CachedPushNotificationHandler.handlePushNotification`, store the parsed payload into `processedPayload` before creating/using `MessagingService` in [CachedPushNotificationHandler.swift](https://github.com/ephemeraHQ/convos-ios/pull/77/files#diff-8992fe00bd350d79bacff8f2f63387f389fd9950d45aafee2f67216d253365c1).
- Make `PushNotificationPayload.decodedTitle` and `PushNotificationPayload.decodedBody` publicly settable in [PushNotificationPayload.swift](https://github.com/ephemeraHQ/convos-ios/pull/77/files#diff-8f7a244e637a828edc036b49ca7bf8e6a79c41949cd99b987e5627e998853395).

#### 📍Where to Start
Start with `NotificationService.handlePushNotification` in [NotificationService.swift](https://github.com/ephemeraHQ/convos-ios/pull/77/files#diff-cd6c8fdb4518bf3bbc5ee11b88947aa53f113197875ddb7ca91ee8dd4eb0eed4).

----

_[Macroscope](https://app.macroscope.com) summarized b6e535b._