### PR TITLE
Stop streaming in NSE

### DIFF
--- a/.github/workflows/swiftlint.yml
+++ b/.github/workflows/swiftlint.yml
@@ -3,9 +3,9 @@ name: SwiftLint
 on:
   workflow_dispatch: # ← optional, to run manually
   pull_request:
-    branches: ['main']
+    branches: ['main', 'dev']
   push:
-    branches: ['main']
+    branches: ['main', 'dev']
 
 jobs:
   SwiftLint:

--- a/ConvosCore/Sources/ConvosCore/Inboxes/AuthorizeInboxOperation.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/AuthorizeInboxOperation.swift
@@ -30,12 +30,14 @@ final class AuthorizeInboxOperation: AuthorizeInboxOperationProtocol {
         databaseReader: any DatabaseReader,
         databaseWriter: any DatabaseWriter,
         environment: AppEnvironment,
+        startsStreamingServices: Bool,
         registersForPushNotifications: Bool = true
     ) -> AuthorizeInboxOperation {
         let operation = AuthorizeInboxOperation(
             databaseReader: databaseReader,
             databaseWriter: databaseWriter,
             environment: environment,
+            startsStreamingServices: startsStreamingServices,
             registersForPushNotifications: registersForPushNotifications
         )
         operation.authorize(inboxId: inboxId)
@@ -52,6 +54,7 @@ final class AuthorizeInboxOperation: AuthorizeInboxOperationProtocol {
             databaseReader: databaseReader,
             databaseWriter: databaseWriter,
             environment: environment,
+            startsStreamingServices: true,
             registersForPushNotifications: registersForPushNotifications
         )
         operation.register()
@@ -62,17 +65,20 @@ final class AuthorizeInboxOperation: AuthorizeInboxOperationProtocol {
         databaseReader: any DatabaseReader,
         databaseWriter: any DatabaseWriter,
         environment: AppEnvironment,
+        startsStreamingServices: Bool,
         registersForPushNotifications: Bool
     ) {
         let inboxWriter = InboxWriter(databaseWriter: databaseWriter)
+        let syncingManager = startsStreamingServices ? SyncingManager(databaseWriter: databaseWriter) : nil
+        let inviteJoinRequestsManager = startsStreamingServices ? InviteJoinRequestsManager(
+            databaseReader: databaseReader,
+            databaseWriter: databaseWriter
+        ) : nil
         stateMachine = InboxStateMachine(
             identityStore: environment.defaultIdentityStore,
             inboxWriter: inboxWriter,
-            syncingManager: SyncingManager(databaseWriter: databaseWriter),
-            inviteJoinRequestsManager: InviteJoinRequestsManager(
-                databaseReader: databaseReader,
-                databaseWriter: databaseWriter
-            ),
+            syncingManager: syncingManager,
+            inviteJoinRequestsManager: inviteJoinRequestsManager,
             pushNotificationRegistrar: PushNotificationRegistrar(
                 environment: environment
             ),

--- a/ConvosCore/Sources/ConvosCore/Inboxes/CachedPushNotificationHandler.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/CachedPushNotificationHandler.swift
@@ -73,6 +73,7 @@ public class CachedPushNotificationHandler {
             databaseWriter: databaseWriter,
             databaseReader: databaseReader,
             environment: environment,
+            startsStreamingServices: false,
             registersForPushNotifications: false
         )
         messagingServices[inboxId] = messagingService

--- a/ConvosCore/Sources/ConvosCore/Messaging/MessagingService.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/MessagingService.swift
@@ -23,6 +23,7 @@ final class MessagingService: MessagingServiceProtocol {
         databaseWriter: any DatabaseWriter,
         databaseReader: any DatabaseReader,
         environment: AppEnvironment,
+        startsStreamingServices: Bool,
         registersForPushNotifications: Bool = true
     ) -> MessagingService {
         let authorizationOperation = AuthorizeInboxOperation.authorize(
@@ -30,6 +31,7 @@ final class MessagingService: MessagingServiceProtocol {
             databaseReader: databaseReader,
             databaseWriter: databaseWriter,
             environment: environment,
+            startsStreamingServices: startsStreamingServices,
             registersForPushNotifications: registersForPushNotifications
         )
         return .init(

--- a/ConvosCore/Sources/ConvosCore/Messaging/UnusedInboxCache.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/UnusedInboxCache.swift
@@ -106,6 +106,7 @@ actor UnusedInboxCache {
                 databaseReader: databaseReader,
                 databaseWriter: databaseWriter,
                 environment: environment,
+                startsStreamingServices: true,
                 registersForPushNotifications: true
             )
             return MessagingService(
@@ -157,6 +158,7 @@ actor UnusedInboxCache {
             databaseReader: databaseReader,
             databaseWriter: databaseWriter,
             environment: environment,
+            startsStreamingServices: true,
             registersForPushNotifications: false
         )
 

--- a/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
@@ -73,7 +73,8 @@ actor SessionManager: SessionManagerProtocol {
             for: inboxId,
             databaseWriter: databaseWriter,
             databaseReader: databaseReader,
-            environment: environment
+            environment: environment,
+            startsStreamingServices: true
         )
         messagingServices.append(messagingService)
         return messagingService

--- a/ConvosCore/Sources/ConvosCore/Syncing/SyncingManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/SyncingManager.swift
@@ -32,6 +32,7 @@ final class SyncingManager: SyncingManagerProtocol {
     }
 
     func start(with client: AnyClientProvider, apiClient: any ConvosAPIClientProtocol) {
+        // each client (currently) has one conversation
         listConversationsTask = Task { [weak self] in
             do {
                 guard let self else { return }


### PR DESCRIPTION
### Add `startsStreamingServices` control across inbox authorization and set it to false in `CachedPushNotificationHandler.getOrCreateMessagingService` to stop streaming in the Notification Service Extension
- Add a `startsStreamingServices` Boolean to `MessagingService.authorizedMessagingService` and `AuthorizeInboxOperation.authorize`, plumb it through `AuthorizeInboxOperation.init`, and construct `InboxStateMachine` with optional managers that only start when the flag is true ([AuthorizeInboxOperation.swift](https://github.com/ephemeraHQ/convos-ios/pull/87/files#diff-2d3ccac80e5bdf045e9dcfb27745e2ca150f112561fa312c57766afa70088ad7), [InboxStateMachine.swift](https://github.com/ephemeraHQ/convos-ios/pull/87/files#diff-314f69bca557159935a2f6c3e545b7374a861df38d5bda997858ecee5fad58f1), [MessagingService.swift](https://github.com/ephemeraHQ/convos-ios/pull/87/files#diff-ae5f8bf667b2cb7b826678407b9697d1fe69352397220d80aaeeb65fd1090884)).
- Set `startsStreamingServices: false` in `CachedPushNotificationHandler.getOrCreateMessagingService` so NSE-created services do not start streaming ([CachedPushNotificationHandler.swift](https://github.com/ephemeraHQ/convos-ios/pull/87/files#diff-8992fe00bd350d79bacff8f2f63387f389fd9950d45aafee2f67216d253365c1)).
- Set `startsStreamingServices: true` for registration, session start, and unused inbox flows ([UnusedInboxCache.swift](https://github.com/ephemeraHQ/convos-ios/pull/87/files#diff-f0fa420edcbb4b84596d955430ce62fac2027d0d82e4f34b2bc694e43bd55106), [SessionManager.swift](https://github.com/ephemeraHQ/convos-ios/pull/87/files#diff-047bb043999d66a7809a8ab86918296f5f449652df54267763f6ec8da0a71ca7)).

#### 📍Where to Start
Start with `AuthorizeInboxOperation.authorize` in [AuthorizeInboxOperation.swift](https://github.com/ephemeraHQ/convos-ios/pull/87/files#diff-2d3ccac80e5bdf045e9dcfb27745e2ca150f112561fa312c57766afa70088ad7), then review `AuthorizeInboxOperation.init` and the optional manager handling in [InboxStateMachine.swift](https://github.com/ephemeraHQ/convos-ios/pull/87/files#diff-314f69bca557159935a2f6c3e545b7374a861df38d5bda997858ecee5fad58f1).

----

_[Macroscope](https://app.macroscope.com) summarized cf88c93._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Streaming/background syncing now enabled only when requested during inbox authorization.
* Performance
  * Reduced startup work and lower resource use by deferring streaming services when unnecessary.
* Reliability
  * Authorization and cleanup flows handle optional background services more safely, avoiding errors when services are omitted.
* Refactor
  * State handling adapted to support optional background managers without changing user-visible behavior.
* Chores
  * CI lint workflow now also runs for the dev branch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->