### PR TITLE
Remove `userId` parameter from init flow and fix race condition

### DIFF
--- a/Convos/Conversation Creation/NewConversationViewModel.swift
+++ b/Convos/Conversation Creation/NewConversationViewModel.swift
@@ -82,6 +82,8 @@ class NewConversationViewModel: Identifiable {
             }
         }
         if !showScannerOnAppear {
+            // Activate the deferred identity right before creating a real conversation
+            await messagingService.activateDeferredInbox(registersForPushNotifications: true)
             try await draftConversationComposer.draftConversationWriter.createConversation()
         }
     }
@@ -125,6 +127,10 @@ class NewConversationViewModel: Identifiable {
         joinConversationTask = Task { [weak self] in
             guard let self else { return }
             do {
+                // Ensure the deferred identity is activated before contacting backend
+                if let messagingService {
+                    await messagingService.activateDeferredInbox(registersForPushNotifications: true)
+                }
                 // Request to join
                 do {
                     try await draftConversationComposer?.draftConversationWriter.requestToJoin(inviteCode: inviteCode)

--- a/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient+Models.swift
+++ b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient+Models.swift
@@ -1,11 +1,5 @@
 import Foundation
 
-extension ConvosAPI.CreateUserRequest.Profile {
-    static var empty: Self {
-        .init(name: nil, username: nil, description: nil, avatar: nil)
-    }
-}
-
 public enum ConvosAPI {
     public enum AuthenticatorTransport: String, Codable {
         case ble = "AUTHENTICATOR_TRANSPORT_BLE"
@@ -46,9 +40,9 @@ public enum ConvosAPI {
         }
     }
 
-    public struct CreateUserRequest: Encodable {
-        public let userId: String
-        public let userType: UserType
+    public struct InitRequest: Encodable {
+        // public let userId: String
+        // public let userType: UserType
         public let device: Device
         public let identity: Identity
         public let profile: Profile
@@ -70,6 +64,30 @@ public enum ConvosAPI {
         public struct Profile: Encodable {
             public let name: String?
             public let username: String?
+            public let description: String?
+            public let avatar: String?
+        }
+    }
+    
+    public struct InitResponse: Decodable {
+        // public let id: String
+        // public let userId: String
+        public let device: Device
+        public let identity: Identity
+        public let profile: Profile
+        public struct Device: Decodable {
+            public let id: String
+            public let os: String
+            public let name: String?
+        }
+        public struct Identity: Decodable {
+            public let id: String
+            public let identityAddress: String?
+            public let xmtpId: String?
+        }
+        public struct Profile: Decodable {
+            public let id: String
+            public let name: String?
             public let description: String?
             public let avatar: String?
         }
@@ -160,30 +178,6 @@ public enum ConvosAPI {
         public let inviteLinkURL: String
     }
 
-    public struct CreatedUserResponse: Decodable {
-        public let id: String
-        public let userId: String
-        public let device: Device
-        public let identity: Identity
-        public let profile: Profile
-        public struct Device: Decodable {
-            public let id: String
-            public let os: String
-            public let name: String?
-        }
-        public struct Identity: Decodable {
-            public let id: String
-            public let identityAddress: String?
-            public let xmtpId: String?
-        }
-        public struct Profile: Decodable {
-            public let id: String
-            public let name: String?
-            public let description: String?
-            public let avatar: String?
-        }
-    }
-
     public struct UsernameCheckResponse: Decodable {
         public let taken: Bool
     }
@@ -237,7 +231,13 @@ public enum ConvosAPI {
     }
 }
 
-extension ConvosAPI.CreateUserRequest.Device {
+extension ConvosAPI.InitRequest.Profile {
+    static var empty: Self {
+        .init(name: nil, username: nil, description: nil, avatar: nil)
+    }
+}
+
+extension ConvosAPI.InitRequest.Device {
     static func current() -> Self {
         return .init(
             os: DeviceInfo.osString,

--- a/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient+Models.swift
+++ b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient+Models.swift
@@ -30,27 +30,10 @@ public enum ConvosAPI {
         public let walletAddress: String
     }
 
-    public struct UserResponse: Decodable {
-        public let id: String
-        public let identities: [Identity]
-        public struct Identity: Decodable {
-            public let id: String
-            public let identityAddress: String?
-            public let xmtpId: String
-        }
-    }
-
     public struct InitRequest: Encodable {
-        // public let userId: String
-        // public let userType: UserType
         public let device: Device
         public let identity: Identity
         public let profile: Profile
-
-        public enum UserType: String, Encodable {
-            case onDevice
-            case turnkey
-        }
         public struct Device: Encodable {
             public let os: String
             public let name: String?
@@ -70,8 +53,6 @@ public enum ConvosAPI {
     }
 
     public struct InitResponse: Decodable {
-        // public let id: String
-        // public let userId: String
         public let device: Device
         public let identity: Identity
         public let profile: Profile

--- a/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient+Models.swift
+++ b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient+Models.swift
@@ -212,7 +212,7 @@ public enum ConvosAPI {
     }
 }
 
-extension ConvosAPI.InitRequest.Profile {
+public extension ConvosAPI.InitRequest.Profile {
     static var empty: Self {
         .init(name: nil, username: nil, description: nil, avatar: nil)
     }

--- a/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient+Models.swift
+++ b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient+Models.swift
@@ -68,7 +68,7 @@ public enum ConvosAPI {
             public let avatar: String?
         }
     }
-    
+
     public struct InitResponse: Decodable {
         // public let id: String
         // public let userId: String

--- a/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift
+++ b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift
@@ -192,13 +192,13 @@ final class ConvosAPIClient: BaseConvosAPIClient, ConvosAPIClientProtocol {
     // Global init state per inbox
     private static var initializedInboxes: Set<String> = []
     private static let initLock = NSLock()
-    
+
     private var hasInitializedWithBackend: Bool {
         Self.initLock.lock()
         defer { Self.initLock.unlock() }
         return Self.initializedInboxes.contains(client.inboxId)
     }
-    
+
     private func markAsInitialized() {
         Self.initLock.lock()
         defer { Self.initLock.unlock() }

--- a/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift
+++ b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift
@@ -40,8 +40,7 @@ public protocol ConvosAPIClientProtocol: ConvosAPIBaseProtocol, AnyObject {
                       installationId: String,
                       signature: String) async throws -> String
 
-    func getUser() async throws -> ConvosAPI.UserResponse
-    func createUser(_ requestBody: ConvosAPI.CreateUserRequest) async throws -> ConvosAPI.CreatedUserResponse
+    func initWithBackend(_ requestBody: ConvosAPI.InitRequest) async throws -> ConvosAPI.InitResponse
     func checkUsername(_ username: String) async throws -> ConvosAPI.UsernameCheckResponse
 
     func createInvite(_ requestBody: ConvosAPI.CreateInviteCode) async throws -> ConvosAPI.InviteDetailsResponse
@@ -73,7 +72,7 @@ public protocol ConvosAPIClientProtocol: ConvosAPIBaseProtocol, AnyObject {
     ) async throws -> String
 
     // Push notifications
-    func getDevice(userId: String, deviceId: String) async throws -> ConvosAPI.DeviceUpdateResponse
+    func getDevice(deviceId: String) async throws -> ConvosAPI.DeviceUpdateResponse
     func registerForNotifications(deviceId: String,
                                   pushToken: String,
                                   identityId: String,
@@ -248,20 +247,14 @@ final class ConvosAPIClient: BaseConvosAPIClient, ConvosAPIClientProtocol {
         return authResponse.token
     }
 
-    // MARK: - Users
+    // MARK: - Init
 
-    func getUser() async throws -> ConvosAPI.UserResponse {
-        let request = try authenticatedRequest(for: "v1/users/me")
-        let user: ConvosAPI.UserResponse = try await performRequest(request)
-        return user
-    }
-
-    func createUser(_ requestBody: ConvosAPI.CreateUserRequest) async throws -> ConvosAPI.CreatedUserResponse {
-        var request = try authenticatedRequest(for: "v1/users", method: "POST")
+    func initWithBackend(_ requestBody: ConvosAPI.InitRequest) async throws -> ConvosAPI.InitResponse {
+        var request = try authenticatedRequest(for: "v1/init", method: "POST")
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        Logger.info("Sending create user request with body: \(requestBody)")
+        Logger.info("Sending init request with body: \(requestBody)")
         request.httpBody = try JSONEncoder().encode(requestBody)
-        Logger.info("Creating user with json body: \(request.httpBody?.prettyPrintedJSONString ?? "")")
+        Logger.info("Init with json body: \(request.httpBody?.prettyPrintedJSONString ?? "")")
         return try await performRequest(request)
     }
 
@@ -515,9 +508,9 @@ final class ConvosAPIClient: BaseConvosAPIClient, ConvosAPIClientProtocol {
 
     // MARK: - Device Management
 
-    func getDevice(userId: String, deviceId: String) async throws -> ConvosAPI.DeviceUpdateResponse {
+    func getDevice(deviceId: String) async throws -> ConvosAPI.DeviceUpdateResponse {
         let request = try authenticatedRequest(
-            for: "v1/devices/\(userId)/\(deviceId)",
+            for: "v1/devices/\(deviceId)",
             method: "GET"
         )
 

--- a/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift
+++ b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift
@@ -252,9 +252,8 @@ final class ConvosAPIClient: BaseConvosAPIClient, ConvosAPIClientProtocol {
     func initWithBackend(_ requestBody: ConvosAPI.InitRequest) async throws -> ConvosAPI.InitResponse {
         var request = try authenticatedRequest(for: "v1/init", method: "POST")
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        Logger.info("Sending init request with body: \(requestBody)")
         request.httpBody = try JSONEncoder().encode(requestBody)
-        Logger.info("Init with json body: \(request.httpBody?.prettyPrintedJSONString ?? "")")
+        Logger.info("Initializing user with backend")
         return try await performRequest(request)
     }
 

--- a/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift
+++ b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift
@@ -255,7 +255,7 @@ final class ConvosAPIClient: BaseConvosAPIClient, ConvosAPIClientProtocol {
             Logger.info("No JWT token found, authenticating before init...")
             _ = try await reAuthenticate()
         }
-        
+
         var request = try authenticatedRequest(for: "v1/init", method: "POST")
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.httpBody = try JSONEncoder().encode(requestBody)
@@ -347,13 +347,13 @@ final class ConvosAPIClient: BaseConvosAPIClient, ConvosAPIClientProtocol {
         queryParameters: [String: String]? = nil
     ) throws -> URLRequest {
         var request = try request(for: path, method: method, queryParameters: queryParameters)
-        
+
         // Add JWT token if available (might be missing or expired)
         if let jwt = try? keychainService.retrieveString(.init(inboxId: client.inboxId)) {
             request.setValue(jwt, forHTTPHeaderField: "X-Convos-AuthToken")
         }
         // If no JWT, the request will get a 401 and trigger authentication in performRequest
-        
+
         return request
     }
 
@@ -536,7 +536,7 @@ final class ConvosAPIClient: BaseConvosAPIClient, ConvosAPIClientProtocol {
             Logger.info("No JWT token found, authenticating before push registration...")
             _ = try await reAuthenticate()
         }
-        
+
         var request = try authenticatedRequest(for: "v1/notifications/register", method: "POST")
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
 

--- a/ConvosCore/Sources/ConvosCore/API/MockAPIClient.swift
+++ b/ConvosCore/Sources/ConvosCore/API/MockAPIClient.swift
@@ -34,7 +34,7 @@ class MockBaseAPIClient: ConvosAPIBaseProtocol {
 }
 
 class MockAPIClient: MockBaseAPIClient, ConvosAPIClientProtocol {
-    func getDevice(userId: String, deviceId: String) async throws -> ConvosAPI.DeviceUpdateResponse {
+    func getDevice(deviceId: String) async throws -> ConvosAPI.DeviceUpdateResponse {
         return ConvosAPI.DeviceUpdateResponse(
             id: deviceId,
             pushToken: "existing-push-token",
@@ -64,34 +64,19 @@ class MockAPIClient: MockBaseAPIClient, ConvosAPIClientProtocol {
         return "mock-jwt-token"
     }
 
-    func getUser() async throws -> ConvosAPI.UserResponse {
-        return ConvosAPI.UserResponse(
-            id: "user_123",
-            identities: [
-                ConvosAPI.UserResponse.Identity(
-                    id: "identity_1",
-                    identityAddress: "0xMOCKADDRESS1",
-                    xmtpId: "mock-xmtp-id"
-                )
-            ]
-        )
-    }
-
-    func createUser(_ requestBody: ConvosAPI.CreateUserRequest) async throws -> ConvosAPI.CreatedUserResponse {
-        return ConvosAPI.CreatedUserResponse(
-            id: "created_user_123",
-            userId: requestBody.userId,
-            device: ConvosAPI.CreatedUserResponse.Device(
+    func initWithBackend(_ requestBody: ConvosAPI.InitRequest) async throws -> ConvosAPI.InitResponse {
+        return ConvosAPI.InitResponse(
+            device: ConvosAPI.InitResponse.Device(
                 id: "device_1",
                 os: requestBody.device.os,
                 name: requestBody.device.name
             ),
-            identity: ConvosAPI.CreatedUserResponse.Identity(
+            identity: ConvosAPI.InitResponse.Identity(
                 id: "identity_1",
                 identityAddress: requestBody.identity.identityAddress,
                 xmtpId: requestBody.identity.xmtpId
             ),
-            profile: ConvosAPI.CreatedUserResponse.Profile(
+            profile: ConvosAPI.InitResponse.Profile(
                 id: "profile_1",
                 name: requestBody.profile.name,
                 description: requestBody.profile.description,

--- a/ConvosCore/Sources/ConvosCore/AppEnvironment+SecureStorage.swift
+++ b/ConvosCore/Sources/ConvosCore/AppEnvironment+SecureStorage.swift
@@ -67,6 +67,23 @@ public extension AppEnvironment {
 
         return nil
     }
+
+    /// Deletes the shared environment configuration stored in Keychain for the NSE
+    static func clearSecureConfigurationForNotificationExtension() {
+        guard let bundleIdentifier = Bundle.main.bundleIdentifier,
+              let appGroupIdentifier = bundleIdentifier.asAppGroupIdentifier else {
+            return
+        }
+
+        let keychainQuery: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: "SharedAppConfiguration",
+            kSecAttrService as String: "ConvosEnvironment",
+            kSecAttrAccessGroup as String: appGroupIdentifier
+        ]
+
+        SecItemDelete(keychainQuery as CFDictionary)
+    }
 }
 
 extension String {

--- a/ConvosCore/Sources/ConvosCore/Inboxes/InboxStateMachine.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/InboxStateMachine.swift
@@ -542,11 +542,8 @@ extension InboxStateMachine {
 
         do {
             emitStateChange(.registering)
-            if (try? jwtService.retrieveString(.init(inboxId: result.client.inboxId))) == nil {
-                _ = try await initWithBackend(client: result.client, apiClient: result.apiClient)
-            } else {
-                Logger.info("JWT exists; skipping initWithBackend for inbox \(result.client.inboxId)")
-            }
+            // Rely on API client to single-flight and skip if already initialized
+            _ = try await initWithBackend(client: result.client, apiClient: result.apiClient)
             hasActivatedDeferredIdentity = true
             backendInitialized = true
 

--- a/ConvosCore/Sources/ConvosCore/Inboxes/InboxStateMachine.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/InboxStateMachine.swift
@@ -353,7 +353,7 @@ public actor InboxStateMachine {
         let apiClient = try await authorizeConvosBackend(client: client)
         emitStateChange(.registering)
         Logger.info("Creating identity in backend...")
-        _ = try await createUser(
+        _ = try await initWithBackend(
             client: client,
             apiClient: apiClient
         )
@@ -480,22 +480,20 @@ public actor InboxStateMachine {
         return apiClient
     }
 
-    // MARK: - User Creation
+    // MARK: - Init
 
-    private func createUser(
+    private func initWithBackend(
         client: any XMTPClientProvider,
         apiClient: any ConvosAPIClientProtocol
-    ) async throws -> ConvosAPI.CreatedUserResponse {
-        let requestBody: ConvosAPI.CreateUserRequest = .init(
-            userId: UUID().uuidString, // @jarod remove this
-            userType: .onDevice,
+    ) async throws -> ConvosAPI.InitResponse {
+        let requestBody: ConvosAPI.InitRequest = .init(
             device: .current(),
             identity: .init(identityAddress: nil,
                             xmtpId: client.inboxId,
                             xmtpInstallationId: client.installationId),
             profile: .empty
         )
-        return try await apiClient.createUser(requestBody)
+        return try await apiClient.initWithBackend(requestBody)
     }
 }
 

--- a/ConvosCore/Sources/ConvosCore/Inboxes/InboxStateManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/InboxStateManager.swift
@@ -94,6 +94,14 @@ public final class InboxStateManager {
         throw InboxStateError.inboxNotReady
     }
 
+    public func activateDeferredInbox(registersForPushNotifications: Bool) async {
+        await stateMachine?.activateDeferredInbox(registersForPushNotifications: registersForPushNotifications)
+    }
+
+    public func registerForPushNotifications() async {
+        await stateMachine?.registerForPushNotifications()
+    }
+
     public func observeState(_ handler: @escaping (InboxStateMachine.State) -> Void) -> StateObserverHandle {
         let observer = ClosureStateObserver(handler: handler)
         addObserver(observer)

--- a/ConvosCore/Sources/ConvosCore/Inboxes/PushNotificationRegistrar.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/PushNotificationRegistrar.swift
@@ -29,6 +29,10 @@ public final class PushNotificationRegistrar: PushNotificationRegistrarProtocol 
         UserDefaults.standard.string(forKey: tokenKey)
     }
 
+    public static func clearToken() {
+        UserDefaults.standard.removeObject(forKey: tokenKey)
+    }
+
     func registerForRemoteNotifications() async {
         await MainActor.run {
             UIApplication.shared.registerForRemoteNotifications()

--- a/ConvosCore/Sources/ConvosCore/Messaging/MessagingService.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/MessagingService.swift
@@ -24,7 +24,9 @@ final class MessagingService: MessagingServiceProtocol {
         databaseReader: any DatabaseReader,
         environment: AppEnvironment,
         startsStreamingServices: Bool,
-        registersForPushNotifications: Bool = true
+        registersForPushNotifications: Bool = true,
+        deferBackendInitialization: Bool = false,
+        persistInboxOnReady: Bool = true
     ) -> MessagingService {
         let authorizationOperation = AuthorizeInboxOperation.authorize(
             inboxId: inboxId,
@@ -32,7 +34,9 @@ final class MessagingService: MessagingServiceProtocol {
             databaseWriter: databaseWriter,
             environment: environment,
             startsStreamingServices: startsStreamingServices,
-            registersForPushNotifications: registersForPushNotifications
+            registersForPushNotifications: registersForPushNotifications,
+            deferBackendInitialization: deferBackendInitialization,
+            persistInboxOnReady: persistInboxOnReady
         )
         return .init(
             inboxId: inboxId,
@@ -78,6 +82,10 @@ final class MessagingService: MessagingServiceProtocol {
 
     func stopAndDelete() async {
         await authorizationOperation.stopAndDelete()
+    }
+
+    func activateDeferredInbox(registersForPushNotifications: Bool = true) async {
+        await authorizationOperation.activateDeferredInbox(registersForPushNotifications: registersForPushNotifications)
     }
 
     // MARK: Push Notifications

--- a/ConvosCore/Sources/ConvosCore/Messaging/MessagingServiceProtocol.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/MessagingServiceProtocol.swift
@@ -8,6 +8,7 @@ public protocol MessagingServiceProtocol: AnyObject {
     func stopAndDelete() async
 
     func registerForPushNotifications() async
+    func activateDeferredInbox(registersForPushNotifications: Bool) async
 
     func myProfileRepository() -> any MyProfileRepositoryProtocol
     func myProfileWriter() -> any MyProfileWriterProtocol

--- a/ConvosCore/Sources/ConvosCore/Messaging/MockMessagingService.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/MockMessagingService.swift
@@ -42,6 +42,10 @@ public class MockMessagingService: MessagingServiceProtocol {
         // Mock implementation - no-op
     }
 
+    public func activateDeferredInbox(registersForPushNotifications: Bool) async {
+        // Mock implementation - no-op
+    }
+
     public func myProfileWriter() -> any MyProfileWriterProtocol {
         self
     }

--- a/ConvosCore/Sources/ConvosCore/Messaging/UnusedInboxCache.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/UnusedInboxCache.swift
@@ -169,8 +169,10 @@ actor UnusedInboxCache {
             databaseReader: databaseReader,
             databaseWriter: databaseWriter,
             environment: environment,
-            startsStreamingServices: true,
-            registersForPushNotifications: false
+            startsStreamingServices: false,
+            registersForPushNotifications: false,
+            deferBackendInitialization: true,
+            persistInboxOnReady: false
         )
 
         let messagingService = MessagingService(
@@ -187,7 +189,7 @@ actor UnusedInboxCache {
             // Store it as the unused messaging service
             unusedMessagingService = messagingService
 
-            Logger.info("Successfully authorized unused inbox: \(inboxId)")
+            Logger.info("Successfully authorized unused inbox (deferred): \(inboxId)")
         } catch {
             Logger.error("Failed to authorize unused inbox: \(error)")
             // Clear the invalid inbox ID from keychain
@@ -230,7 +232,9 @@ actor UnusedInboxCache {
             databaseReader: databaseReader,
             databaseWriter: databaseWriter,
             environment: environment,
-            registersForPushNotifications: false
+            registersForPushNotifications: false,
+            deferBackendInitialization: true,
+            persistInboxOnReady: false
         )
 
         let tempMessagingService = MessagingService(

--- a/ConvosCore/Sources/ConvosCore/Messaging/UnusedInboxCache.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/UnusedInboxCache.swift
@@ -54,6 +54,17 @@ actor UnusedInboxCache {
         }
     }
 
+    /// Clears any cached unused inbox and prevents it from being used.
+    /// - Note: This also clears the "unused inbox" keychain item so the next app start won't reuse it.
+    func reset() async {
+        // Best-effort stop and drop any in-memory unused service
+        if let service = unusedMessagingService {
+            await service.stopAndDelete()
+        }
+        unusedMessagingService = nil
+        clearUnusedInboxFromKeychain()
+    }
+
     /// Consumes the unused inbox if available, or creates a new one
     func consumeOrCreateMessagingService(
         databaseWriter: any DatabaseWriter,

--- a/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
@@ -1,8 +1,8 @@
 import Combine
 import Foundation
 import GRDB
-import UserNotifications
 import Security
+import UserNotifications
 
 public extension Notification.Name {
     static let leftConversationNotification: Notification.Name = Notification.Name("LeftConversationNotification")

--- a/ConvosCore/Sources/ConvosCore/Shared/ConvosKeychainItem.swift
+++ b/ConvosCore/Sources/ConvosCore/Shared/ConvosKeychainItem.swift
@@ -29,3 +29,11 @@ struct UnusedInboxKeychainItem: KeychainItemProtocol {
         return Self.account
     }
 }
+
+struct BackendInitializedKeychainItem: KeychainItemProtocol {
+    let inboxId: String
+
+    var account: String {
+        return "backend-init-\(inboxId)"
+    }
+}


### PR DESCRIPTION
Following backend update https://github.com/ephemeraHQ/convos-backend/pull/122 - removed `userId` and `userType` from init request:

 - Renamed `CreateUserRequest` → `InitRequest`
 - Renamed `CreatedUserResponse` → `InitResponse`
 - Renamed `createUser()` → `initWithBackend()`
 - Updated `/v1/users` → `/v1/init` endpoint
 - Simplified device endpoint to remove `userId` parameter
 - Implemented lazy authentication to avoid race conditions
 - Optimized init flow to proactively authenticate when needed
 - Fixed race condition where push notification registration could happen before backend initialization by tracking init state
 - Implemented single-flight pattern to prevent multiple concurrent initialization attempts
 - Added persistent initialization tracking (more specifically across app restarts)
 - Established sequential execution: authenticate → init → push register → user actions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Single-step backend init for onboarding (device, identity, profile). Deferred backend initialization and an explicit "activate deferred inbox" flow. Ability to clear stored environment config for extensions.

* **Refactor**
  * Device lookup no longer requires a user ID. Public APIs consolidated around init semantics; mocks updated to match.

* **Bug Fixes / Reliability**
  * Improved auth handling with on-demand re-auth, retry for 401s, clearer bad-request errors. Added durable init tracking and broader cleanup on account wipe.

* **Chores**
  * Exposed push-token clear and unused-inbox reset APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->