### PR TITLE
Update claude model for release note writing

### DIFF
--- a/.github/workflows/auto-release-pr.yml
+++ b/.github/workflows/auto-release-pr.yml
@@ -105,7 +105,7 @@ jobs:
 
           try:
               response = client.messages.create(
-                  model="claude-3-5-sonnet-20241022",
+                  model="claude-sonnet-4-20250514",
                   max_tokens=200,
                   temperature=0.8,
                   messages=[{"role": "user", "content": prompt}]


### PR DESCRIPTION
### Set `.github/workflows/auto-release-pr.yml` to pass model `claude-sonnet-4-20250514` to `client.messages.create` for release note writing
Modify the auto-release PR workflow to change the model identifier used by the message creation step in [auto-release-pr.yml](https://github.com/ephemeraHQ/convos-ios/pull/94/files#diff-6467d34a77697552883d803c9eb1e68fc45a49472e99a587ca847c5d4540b4ac).

#### 📍Where to Start
Start with the step that invokes `client.messages.create` in [auto-release-pr.yml](https://github.com/ephemeraHQ/convos-ios/pull/94/files#diff-6467d34a77697552883d803c9eb1e68fc45a49472e99a587ca847c5d4540b4ac).

----

_[Macroscope](https://app.macroscope.com) summarized 7bba9e7._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release automation to improve the clarity and consistency of generated release notes.
  * Enhances future release communications with more readable, concise summaries.
  * No impact on application features, performance, or user workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->