### PR TITLE
Fix tapping on notification not taking you to a convo

### DIFF
--- a/Convos/App Delegate/ConvosAppDelegate.swift
+++ b/Convos/App Delegate/ConvosAppDelegate.swift
@@ -88,8 +88,8 @@ extension ConvosAppDelegate: UNUserNotificationCenterDelegate {
         }
 
         // Handle regular conversation notifications (Protocol messages)
-        if let inboxId = payload.inboxId,
-           let conversationId = payload.notificationData?.protocolData?.conversationId {
+        let conversationId = response.notification.request.content.threadIdentifier
+        if let inboxId = payload.inboxId {
             Logger.info("Handling conversation notification tap for inboxId: \(inboxId), conversationId: \(conversationId)")
             DispatchQueue.main.async {
                 NotificationCenter.default.post(

--- a/ConvosCore/Sources/ConvosCore/Inboxes/MessagingService+PushNotifications.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/MessagingService+PushNotifications.swift
@@ -75,6 +75,7 @@ extension MessagingService {
             encryptedMessage: encryptedMessage,
             contentTopic: contentTopic,
             currentInboxId: currentInboxId,
+            userInfo: payload.userInfo,
             client: client
         )
     }
@@ -84,6 +85,7 @@ extension MessagingService {
         encryptedMessage: String,
         contentTopic: String,
         currentInboxId: String,
+        userInfo: [AnyHashable: Any],
         client: any XMTPClientProvider
     ) async throws -> DecodedNotificationContent? {
         // Extract conversation ID from topic path
@@ -140,7 +142,12 @@ extension MessagingService {
             notificationTitle = nil
         }
 
-        return .init(title: notificationTitle, body: notificationBody, conversationId: conversationId)
+        return .init(
+            title: notificationTitle,
+            body: notificationBody,
+            conversationId: conversationId,
+            userInfo: userInfo
+        )
     }
 
     /// Handles invite join request notifications
@@ -250,7 +257,12 @@ extension MessagingService {
 
             let conversationName = dBConversation.name ?? ""
             let title = conversationName.isEmpty ? "Untitled" : conversationName
-            return .init(title: title, body: "Someone accepted your invite", conversationId: groupId)
+            return .init(
+                title: title,
+                body: "Someone accepted your invite",
+                conversationId: groupId,
+                userInfo: payload.userInfo
+            )
         } catch {
             Logger.error("Failed to add member to group: \(error.localizedDescription)")
             throw error

--- a/ConvosCore/Sources/ConvosCore/Notifications/PushNotificationPayload.swift
+++ b/ConvosCore/Sources/ConvosCore/Notifications/PushNotificationPayload.swift
@@ -6,23 +6,26 @@ public struct DecodedNotificationContent {
     public let body: String
     public let conversationId: String?
     public let isDroppedMessage: Bool
+    public let userInfo: [AnyHashable: Any]
 
-    init(title: String?, body: String, conversationId: String?) {
+    init(title: String?, body: String, conversationId: String?, userInfo: [AnyHashable: Any]) {
         self.title = title
         self.body = body
         self.conversationId = conversationId
         self.isDroppedMessage = false
+        self.userInfo = userInfo
     }
 
-    init(isDroppedMessage: Bool) {
+    init(isDroppedMessage: Bool, userInfo: [AnyHashable: Any]) {
         self.title = nil
         self.body = ""
         self.conversationId = nil
         self.isDroppedMessage = isDroppedMessage
+        self.userInfo = userInfo
     }
 
     static var droppedMessage: DecodedNotificationContent {
-        .init(isDroppedMessage: true)
+        .init(isDroppedMessage: true, userInfo: [:])
     }
 }
 
@@ -31,12 +34,14 @@ public final class PushNotificationPayload {
     public let inboxId: String?
     public let notificationType: NotificationType?
     public let notificationData: NotificationData?
+    public let userInfo: [AnyHashable: Any]
 
     // Decoded content properties (mutable for NSE processing)
     public var decodedTitle: String?
     public var decodedBody: String?
 
     public init(userInfo: [AnyHashable: Any]) {
+        self.userInfo = userInfo
         self.inboxId = userInfo["inboxId"] as? String
         self.notificationType = NotificationType(rawValue: userInfo["notificationType"] as? String ?? "")
         self.notificationData = NotificationData(dictionary: userInfo["notificationData"] as? [String: Any])

--- a/NotificationService/NotificationService.swift
+++ b/NotificationService/NotificationService.swift
@@ -140,6 +140,7 @@ class NotificationService: UNNotificationServiceExtension {
 extension DecodedNotificationContent {
     var notificationContent: UNNotificationContent {
         let content = UNMutableNotificationContent()
+        content.userInfo = userInfo
         if let title {
             content.title = title
         }
@@ -164,6 +165,8 @@ extension PushNotificationPayload {
         if let displayBody = displayBody {
             content.body = displayBody
         }
+
+        content.userInfo = userInfo
 
         // Set thread identifier for conversation grouping
         if let conversationId = notificationData?.protocolData?.conversationId {


### PR DESCRIPTION
_Macroscope is automatically generating a summary of this pull request..._

<picture>
<source media="(prefers-color-scheme: dark)" srcset="https://prasso.ai/static/prassoai-pr-loader-small-dark-no-text.gif">
<img src="https://prasso.ai/static/prassoai-pr-loader-small-light-no-text.gif" alt="_Macroscope is automatically generating a summary of this pull request..._">
</picture>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Delivered push notifications now preserve and expose full user metadata, enabling richer notification content and behavior.
* **Bug Fixes**
  * Improved reliability when opening conversation notifications by deriving the conversation reference from the notification thread, ensuring taps work even when some IDs are missing.
  * Ensures user metadata is consistently included in notification content across all paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->