### PR TITLE
Revoke installation on delete

### DIFF
--- a/ConvosCore/Sources/ConvosCore/Inboxes/InboxStateMachine.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/InboxStateMachine.swift
@@ -406,6 +406,12 @@ public actor InboxStateMachine {
         syncingManager?.stop()
         inviteJoinRequestsManager?.stop()
         try await inboxWriter.deleteInbox(inboxId: client.inboxId)
+        let identity = try await identityStore.identity(for: client.inboxId)
+        let keys = identity.clientKeys
+        try await client.revokeInstallations(
+            signingKey: keys.signingKey,
+            installationIds: [client.installationId]
+        )
         try await identityStore.delete(inboxId: client.inboxId)
         try client.deleteLocalDatabase()
         Logger.info("Successfully deleted inbox \(client.inboxId)")


### PR DESCRIPTION
### Revoke the current client installation on inbox delete by updating `InboxStateMachine.handleDelete` in [InboxStateMachine.swift](https://github.com/ephemeraHQ/convos-ios/pull/106/files#diff-314f69bca557159935a2f6c3e545b7374a861df38d5bda997858ecee5fad58f1) to call `client.revokeInstallations` with the stored signing key and current installationId before removing the identity and local database
The delete flow in `InboxStateMachine.handleDelete` retrieves the identity from the identity store using the client's `inboxId`, extracts `clientKeys`, and invokes `client.revokeInstallations` with the signing key and the current installationId prior to deleting the identity and the local database. The change is implemented in [InboxStateMachine.swift](https://github.com/ephemeraHQ/convos-ios/pull/106/files#diff-314f69bca557159935a2f6c3e545b7374a861df38d5bda997858ecee5fad58f1).

#### 📍Where to Start
Start with `InboxStateMachine.handleDelete` in [InboxStateMachine.swift](https://github.com/ephemeraHQ/convos-ios/pull/106/files#diff-314f69bca557159935a2f6c3e545b7374a861df38d5bda997858ecee5fad58f1), focusing on the newly added pre-deletion steps that fetch the identity and call `client.revokeInstallations`.

----

_[Macroscope](https://app.macroscope.com) summarized 5241a32._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Inbox deletion now attempts to revoke the associated device/session on the server before removing local data, reducing orphaned installations.
  * If no related identity is found, revocation is skipped (logged).
  * If server revocation fails, the error is logged but local cleanup continues, ensuring deletion completes locally.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->