### PR TITLE
Fix marking conversations as read

### DIFF
--- a/Convos/Conversation Creation/NewConversationViewModel.swift
+++ b/Convos/Conversation Creation/NewConversationViewModel.swift
@@ -150,6 +150,19 @@ class NewConversationViewModel: Identifiable {
             return
         }
 
+        draftConversationComposer.draftConversationWriter.conversationIdPublisher
+            .receive(on: DispatchQueue.main)
+            .sink { conversationId in
+                // Notify that active conversation has changed
+                Logger.info("Active conversation changed: \(conversationId)")
+                NotificationCenter.default.post(
+                    name: .activeConversationChanged,
+                    object: nil,
+                    userInfo: ["conversationId": conversationId as Any]
+                )
+            }
+            .store(in: &cancellables)
+
         Publishers.Merge(
             draftConversationComposer.draftConversationWriter.sentMessage.map { _ in () },
             draftConversationComposer.draftConversationRepository.messagesRepository

--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -65,8 +65,6 @@ struct ConversationView: View {
                     }
             }
         }
-        .onAppear(perform: viewModel.onAppear)
-        .onDisappear(perform: viewModel.onDisappear)
         .onChange(of: viewModel.focus) {
             focusState = viewModel.focus
         }

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -237,17 +237,6 @@ class ConversationViewModel {
             .store(in: &cancellables)
     }
 
-    private func markConversationAsRead() {
-        Task { [weak self] in
-            guard let self, let localStateWriter = self.localStateWriter else { return }
-            do {
-                try await localStateWriter.setUnread(false, for: self.conversation.id)
-            } catch {
-                Logger.warning("Failed marking conversation as read: \(error.localizedDescription)")
-            }
-        }
-    }
-
     // MARK: - Public
 
     func onConversationInfoTap() {
@@ -377,14 +366,6 @@ class ConversationViewModel {
 
     func onProfileSettings() {
         presentingProfileSettings = true
-    }
-
-    func onAppear() {
-        markConversationAsRead()
-    }
-
-    func onDisappear() {
-        markConversationAsRead()
     }
 
     func remove(member: ConversationMember) {

--- a/Convos/Conversations List/ConversationsViewModel.swift
+++ b/Convos/Conversations List/ConversationsViewModel.swift
@@ -99,6 +99,7 @@ final class ConversationsViewModel {
     }
 
     func deleteAllInboxes() {
+        selectedConversation = nil
         Task {
             do {
                 try await session.deleteAllInboxes()
@@ -109,6 +110,10 @@ final class ConversationsViewModel {
     }
 
     func leave(conversation: Conversation) {
+        if selectedConversation == conversation {
+            selectedConversation = nil
+        }
+
         Task {
             do {
                 try await session.deleteInbox(inboxId: conversation.inboxId)

--- a/Convos/Conversations List/ConversationsViewModel.swift
+++ b/Convos/Conversations List/ConversationsViewModel.swift
@@ -103,6 +103,7 @@ final class ConversationsViewModel {
         Task {
             do {
                 try await session.deleteAllInboxes()
+                await MainActor.run { self.localStateWriters.removeAll() }
             } catch {
                 Logger.error("Error deleting all accounts: \(error)")
             }
@@ -117,6 +118,7 @@ final class ConversationsViewModel {
         Task {
             do {
                 try await session.deleteInbox(inboxId: conversation.inboxId)
+                _ = await MainActor.run { self.localStateWriters.removeValue(forKey: conversation.inboxId) }
             } catch {
                 Logger.error("Error leaving convo: \(error.localizedDescription)")
             }

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationWriter.swift
@@ -63,7 +63,7 @@ class ConversationWriter: ConversationWriterProtocol {
         let localState = ConversationLocalState(
             conversationId: conversation.id,
             isPinned: false,
-            isUnread: true,
+            isUnread: false,
             isUnreadUpdatedAt: Date.distantPast,
             isMuted: false
         )

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/IncomingMessageWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/IncomingMessageWriter.swift
@@ -62,24 +62,6 @@ class IncomingMessageWriter: IncomingMessageWriterProtocol {
                     Logger.error("Failed saving incoming message \(message.id): \(error)")
                 }
             }
-
-            if let localState = try ConversationLocalState
-                .filter(Column("conversationId") == conversation.id)
-                .fetchOne(db) {
-                Logger.info("Marking conversation as unread: \(conversation.id)")
-                if localState.isUnreadUpdatedAt < message.date {
-                    try localState.with(isUnread: true).save(db)
-                }
-            } else {
-                Logger.info("Creating local state for conversation: \(conversation.id)")
-                try ConversationLocalState(
-                    conversationId: conversation.id,
-                    isPinned: false,
-                    isUnread: true,
-                    isUnreadUpdatedAt: Date(),
-                    isMuted: false
-                ).save(db)
-            }
         }
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Syncing/SyncingManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/SyncingManager.swift
@@ -211,7 +211,7 @@ final class SyncingManager: SyncingManagerProtocol {
             try await messageWriter.store(message: message, for: dbConversation)
 
             // Update the last processed message timestamp
-            lastProcessedMessageAt = Date()
+            lastProcessedMessageAt = max(self.lastProcessedMessageAt ?? message.sentAt, message.sentAt)
 
             // Mark conversation as unread if it's not the active conversation and not from current user
             if conversation.id != activeConversationId && message.senderInboxId != client.inboxId {

--- a/ConvosCore/Sources/ConvosCore/Syncing/SyncingManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/SyncingManager.swift
@@ -18,7 +18,7 @@ final class SyncingManager: SyncingManagerProtocol {
     private var streamMessagesTask: Task<Void, Never>?
     private var streamConversationsTask: Task<Void, Never>?
     private var syncMemberProfilesTasks: [Task<Void, Error>] = []
-    private let consentStates: [ConsentState] = [.allowed, .unknown]
+    private let consentStates: [ConsentState] = [.allowed]
 
     // Track last sync times for member profiles per conversation
     private var lastMemberProfileSync: [String: Date] = [:]


### PR DESCRIPTION
### Fix marking conversations as read by marking the selected conversation as read in `ConversationsViewModel` and marking incoming messages as unread in `SyncingManager` only when the conversation is inactive
- Update `SyncingManager` to track the active conversation via `.activeConversationChanged` notifications and mark conversations unread only for messages not from the current user when the conversation is not active in both catch-up and live streams; see [SyncingManager.swift](https://github.com/ephemeraHQ/convos-ios/pull/108/files#diff-ba2362cf646b78283a1af17654ea8d2c18f6b1cb686a78e7761e10f1b0328101).
- Update `ConversationsViewModel` to mark the selected conversation as read and cache `ConversationLocalStateWriter` instances by `inboxId`; see [ConversationsViewModel.swift](https://github.com/ephemeraHQ/convos-ios/pull/108/files#diff-e9ac0abeb6f4ab9d1335cf93b09f18a543936af17c742b0f60b5f57e26c07fce).
- Emit `.activeConversationChanged` from `NewConversationViewModel` when the draft conversation ID changes; see [NewConversationViewModel.swift](https://github.com/ephemeraHQ/convos-ios/pull/108/files#diff-bc0af06ca6587e88461a662416743a0ef38cc55d66fc169caad65a62fb3abe47).
- Remove unread-state mutations from `IncomingMessageWriter.store`; see [IncomingMessageWriter.swift](https://github.com/ephemeraHQ/convos-ios/pull/108/files#diff-214371d5cccf7b16f4408fd58c74733a7d61314a74ebb428d08a97e20309c777).
- Initialize new `ConversationLocalState` with `isUnread = false` in `ConversationWriter._store`; see [ConversationWriter.swift](https://github.com/ephemeraHQ/convos-ios/pull/108/files#diff-113bfd0c28b1a3b561f19e4574a0937082fe5c92a262e57573eee7728940a726).
- Remove `onAppear`/`onDisappear` hooks from `ConversationView` and the `markConversationAsRead` path from `ConversationViewModel`; see [ConversationView.swift](https://github.com/ephemeraHQ/convos-ios/pull/108/files#diff-8d85226aa6385ce7a0aca11596c32eb20e3c3e89b37f51651c35fceb5e28f6bc) and [ConversationViewModel.swift](https://github.com/ephemeraHQ/convos-ios/pull/108/files#diff-d056b0b131534648b6d13cddafd053be956f5d23d035ad2538db85a8cc370d8d).

#### 📍Where to Start
Start with the unread handling in `SyncingManager.start(with:apiClient:)` and its initializer observer setup in [SyncingManager.swift](https://github.com/ephemeraHQ/convos-ios/pull/108/files#diff-ba2362cf646b78283a1af17654ea8d2c18f6b1cb686a78e7761e10f1b0328101).

----

_[Macroscope](https://app.macroscope.com) summarized 882e3d0._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Real-time unread updates during sync that respect the conversation you’re currently viewing.
- Improvements
  - Selecting a conversation immediately marks it as read.
  - New conversations start without an unread badge.
  - Incoming messages mark conversations as unread unless you’re actively viewing them or they’re from your own inbox.
- Bug Fixes
  - Reduced incorrect unread counts and badge flicker when messages arrive while a conversation is open.
  - More reliable active conversation tracking across the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->