### PR TITLE
Process messages in ascending order

### DIFF
--- a/ConvosCore/Sources/ConvosCore/Syncing/SyncingManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/SyncingManager.swift
@@ -155,7 +155,10 @@ final class SyncingManager: SyncingManagerProtocol {
             )
             for conversation in conversations {
                 guard case .group = conversation else { continue }
-                let messagesSinceLastProcessed = try await conversation.messages(afterNs: lastProcessedMessageNs)
+                let messagesSinceLastProcessed = try await conversation.messages(
+                    afterNs: lastProcessedMessageNs,
+                    direction: .ascending
+                )
                 let dbConversation = try await conversationWriter.store(conversation: conversation)
                 for message in messagesSinceLastProcessed {
                     try await messageWriter.store(message: message, for: dbConversation)


### PR DESCRIPTION
### Request catch-up messages in ascending order in `SyncingManager` by calling `messages(afterNs:direction:)` with `.ascending` when fetching after `lastProcessedMessageNs`
The syncing flow that iterates conversations changes the fetch call from `messages(afterNs:)` to `messages(afterNs:direction:)` with `.ascending` for catch-up after `lastProcessedMessageNs`. Change is in [SyncingManager.swift](https://github.com/ephemeraHQ/convos-ios/pull/110/files#diff-ba2362cf646b78283a1af17654ea8d2c18f6b1cb686a78e7761e10f1b0328101).

#### 📍Where to Start
Start in the `SyncingManager` code path that iterates conversations and issues the `messages(afterNs:direction:)` request in [SyncingManager.swift](https://github.com/ephemeraHQ/convos-ios/pull/110/files#diff-ba2362cf646b78283a1af17654ea8d2c18f6b1cb686a78e7761e10f1b0328101).

----

_[Macroscope](https://app.macroscope.com) summarized 87526de._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message syncing to ensure a consistent chronological order during fetches.
  * Reduced chances of misordered messages and occasional unread-state inconsistencies for more reliable conversation updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->