### PR TITLE
Prevent new convo on join

### DIFF
--- a/Convos/Conversation Creation/NewConversationView.swift
+++ b/Convos/Conversation Creation/NewConversationView.swift
@@ -104,7 +104,7 @@ struct NewConversationView: View {
 #Preview {
     @Previewable @State var viewModel: NewConversationViewModel = .init(
         session: ConvosClient.mock().session,
-        showScannerOnAppear: false
+        showingFullScreenScanner: false
     )
     @Previewable @State var presented: Bool = true
     VStack {

--- a/Convos/Conversation Creation/NewConversationViewModel.swift
+++ b/Convos/Conversation Creation/NewConversationViewModel.swift
@@ -19,6 +19,7 @@ class NewConversationViewModel: Identifiable {
     private(set) var messagesTopBarTrailingItem: MessagesView.TopBarTrailingItem = .scan
     private(set) var shouldConfirmDeletingConversation: Bool = true
     private let startedWithFullscreenScanner: Bool
+    private let autoCreateConversation: Bool
     private(set) var showingFullScreenScanner: Bool
     var presentingJoinConversationSheet: Bool = false
     var presentingInvalidInviteSheet: Bool = false
@@ -42,12 +43,14 @@ class NewConversationViewModel: Identifiable {
 
     init(
         session: any SessionManagerProtocol,
-        showScannerOnAppear: Bool = false,
+        autoCreateConversation: Bool = false,
+        showingFullScreenScanner: Bool = false,
         delegate: NewConversationsViewModelDelegate? = nil
     ) {
         self.session = session
-        self.startedWithFullscreenScanner = showScannerOnAppear
-        self.showingFullScreenScanner = showScannerOnAppear
+        self.autoCreateConversation = autoCreateConversation
+        self.startedWithFullscreenScanner = showingFullScreenScanner
+        self.showingFullScreenScanner = showingFullScreenScanner
         self.delegate = delegate
 
         start()
@@ -97,7 +100,7 @@ class NewConversationViewModel: Identifiable {
             if showingFullScreenScanner {
                 self.conversationViewModel?.showsInfoView = false
             }
-            if !showingFullScreenScanner {
+            if autoCreateConversation {
                 try await draftConversationComposer.draftConversationWriter.createConversation()
             }
         } catch is CancellationError {

--- a/Convos/Conversations List/ConversationsViewModel.swift
+++ b/Convos/Conversations List/ConversationsViewModel.swift
@@ -98,7 +98,11 @@ final class ConversationsViewModel {
             presentingMaxNumberOfConvosReachedInfo = true
             return
         }
-        newConversationViewModel = .init(session: session, delegate: self)
+        newConversationViewModel = .init(
+            session: session,
+            autoCreateConversation: true,
+            delegate: self
+        )
     }
 
     func onJoinConvo() {
@@ -106,7 +110,11 @@ final class ConversationsViewModel {
             presentingMaxNumberOfConvosReachedInfo = true
             return
         }
-        newConversationViewModel = .init(session: session, showScannerOnAppear: true, delegate: self)
+        newConversationViewModel = .init(
+            session: session,
+            showingFullScreenScanner: true,
+            delegate: self
+        )
     }
 
     private func join(from inviteCode: String) {
@@ -119,7 +127,6 @@ final class ConversationsViewModel {
         // All validation (already joined, invalid codes, etc.) is handled by ConversationStateMachine
         newConversationViewModel = .init(
             session: session,
-            showScannerOnAppear: false,
             delegate: self,
         )
         _ = newConversationViewModel?.join(inviteUrlString: inviteCode)


### PR DESCRIPTION
### Prevent creating a new conversation during join flows by gating draft creation behind `NewConversationViewModel.autoCreateConversation` and updating `ConversationsViewModel.onJoinConvo` and `ConversationsViewModel.join(from:)` in [ConversationsViewModel.swift](https://github.com/ephemeraHQ/convos-ios/pull/112/files#diff-e9ac0abeb6f4ab9d1335cf93b09f18a543936af17c742b0f60b5f57e26c07fce)
- Add `autoCreateConversation` to `NewConversationViewModel` and update `init(session:autoCreateConversation:showingFullScreenScanner:delegate:)` to create a draft only when `autoCreateConversation` is true in [NewConversationViewModel.swift](https://github.com/ephemeraHQ/convos-ios/pull/112/files#diff-bc0af06ca6587e88461a662416743a0ef38cc55d66fc169caad65a62fb3abe47).
- Update conversations list flows to pass explicit flags: `ConversationsViewModel.onStartConvo` sets `autoCreateConversation: true`, `ConversationsViewModel.onJoinConvo` sets `showingFullScreenScanner: true`, and `ConversationsViewModel.join(from:)` relies on defaults and then calls `join(inviteUrlString:)` in [ConversationsViewModel.swift](https://github.com/ephemeraHQ/convos-ios/pull/112/files#diff-e9ac0abeb6f4ab9d1335cf93b09f18a543936af17c742b0f60b5f57e26c07fce).
- Rename the preview initializer argument to `showingFullScreenScanner` in [NewConversationView.swift](https://github.com/ephemeraHQ/convos-ios/pull/112/files#diff-98EWM95ct8tBYWroCxXYN9vCgN7NTcR6nUsvCx1mEdLZ34243f915b084f6).

#### 📍Where to Start
Start with `NewConversationViewModel.init(session:autoCreateConversation:showingFullScreenScanner:delegate:)` in [NewConversationViewModel.swift](https://github.com/ephemeraHQ/convos-ios/pull/112/files#diff-bc0af06ca6587e88461a662416743a0ef38cc55d66fc169caad65a62fb3abe47).

----

_[Macroscope](https://app.macroscope.com) summarized 0d73123._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Starting a new conversation now opens a draft automatically, reducing taps to begin chatting.
  * Joining an existing conversation reliably presents a full-screen scanner when selected for a smoother invite flow.
  * Conversation creation and joining flows are more consistent and predictable across entry points.
  * No visual changes to previews; behavior aligns with the updated flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->