### PR TITLE
Delete invites when deleting convos

### DIFF
--- a/ConvosCore/Sources/ConvosCore/Inboxes/AuthorizeInboxOperation.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/AuthorizeInboxOperation.swift
@@ -74,9 +74,11 @@ final class AuthorizeInboxOperation: AuthorizeInboxOperationProtocol {
             databaseReader: databaseReader,
             databaseWriter: databaseWriter
         ) : nil
+        let invitesRepository = InvitesRepository(databaseReader: databaseReader)
         stateMachine = InboxStateMachine(
             identityStore: environment.defaultIdentityStore,
             inboxWriter: inboxWriter,
+            invitesRepository: invitesRepository,
             syncingManager: syncingManager,
             inviteJoinRequestsManager: inviteJoinRequestsManager,
             pushNotificationRegistrar: PushNotificationRegistrar(

--- a/ConvosCore/Sources/ConvosCore/Inboxes/InboxStateMachine.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/InboxStateMachine.swift
@@ -403,13 +403,14 @@ public actor InboxStateMachine {
         Logger.info("Deleting inbox '\(client.inboxId)'...")
 
         removePushNotificationObservers()
+
+        // before unregistering, delete invites from backend
+        try await deleteAllInvites(for: client, apiClient: apiClient)
         await pushNotificationRegistrar.unregisterInstallation(client: client, apiClient: apiClient)
 
         emitStateChange(.deleting)
         syncingManager?.stop()
         inviteJoinRequestsManager?.stop()
-        // before deleting, delete invites from backend
-        try await deleteAllInvites(for: client, apiClient: apiClient)
         try await inboxWriter.deleteInbox(inboxId: client.inboxId)
         if let identity = try? await identityStore.identity(for: client.inboxId) {
             let keys = identity.clientKeys

--- a/ConvosCore/Sources/ConvosCore/Storage/Repositories/InvitesRepository.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Repositories/InvitesRepository.swift
@@ -1,0 +1,23 @@
+import Combine
+import Foundation
+import GRDB
+
+protocol InvitesRepositoryProtocol {
+    func fetchInvites(for creatorInboxId: String) async throws -> [Invite]
+}
+
+class InvitesRepository: InvitesRepositoryProtocol {
+    let databaseReader: any DatabaseReader
+
+    init(databaseReader: any DatabaseReader) {
+        self.databaseReader = databaseReader
+    }
+
+    func fetchInvites(for creatorInboxId: String) async throws -> [Invite] {
+        try await databaseReader.read { db in
+            try DBInvite.filter(DBInvite.Columns.creatorInboxId)
+                .fetchAll(db)
+                .map { $0.hydrateInvite() }
+        }
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Storage/Repositories/InvitesRepository.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Repositories/InvitesRepository.swift
@@ -15,7 +15,7 @@ class InvitesRepository: InvitesRepositoryProtocol {
 
     func fetchInvites(for creatorInboxId: String) async throws -> [Invite] {
         try await databaseReader.read { db in
-            try DBInvite.filter(DBInvite.Columns.creatorInboxId)
+            try DBInvite.filter(DBInvite.Columns.creatorInboxId == creatorInboxId)
                 .fetchAll(db)
                 .map { $0.hydrateInvite() }
         }


### PR DESCRIPTION
### Delete all invites for an inbox during delete flow by invoking `InboxStateMachine.handleDelete` with a wired `InvitesRepository` in [InboxStateMachine.swift](https://github.com/ephemeraHQ/convos-ios/pull/117/files#diff-314f69bca557159935a2f6c3e545b7374a861df38d5bda997858ecee5fad58f1) and [AuthorizeInboxOperation.swift](https://github.com/ephemeraHQ/convos-ios/pull/117/files#diff-2d3ccac80e5bdf045e9dcfb27745e2ca150f112561fa312c57766afa70088ad7)
- Add `invitesRepository` dependency to `InboxStateMachine` and extend its initializer to accept it in [InboxStateMachine.swift](https://github.com/ephemeraHQ/convos-ios/pull/117/files#diff-314f69bca557159935a2f6c3e545b7374a861df38d5bda997858ecee5fad58f1).
- Implement invite deletion in `InboxStateMachine.handleDelete` by fetching invites and calling `apiClient.deleteInvite` for each via new private `deleteAllInvites` in [InboxStateMachine.swift](https://github.com/ephemeraHQ/convos-ios/pull/117/files#diff-314f69bca557159935a2f6c3e545b7374a861df38d5bda997858ecee5fad58f1).
- Wire `InvitesRepository` into `InboxStateMachine` construction from `AuthorizeInboxOperation.init` in [AuthorizeInboxOperation.swift](https://github.com/ephemeraHQ/convos-ios/pull/117/files#diff-2d3ccac80e5bdf045e9dcfb27745e2ca150f112561fa312c57766afa70088ad7).
- Introduce `InvitesRepositoryProtocol` and `InvitesRepository` to read invites from the database in [InvitesRepository.swift](https://github.com/ephemeraHQ/convos-ios/pull/117/files#diff-950618d453223f9a3a9db5e3dd870509b8061f82562f0cf02804a7007bc1be6e).

#### 📍Where to Start
Start with the delete flow in `InboxStateMachine.handleDelete` in [InboxStateMachine.swift](https://github.com/ephemeraHQ/convos-ios/pull/117/files#diff-314f69bca557159935a2f6c3e545b7374a861df38d5bda997858ecee5fad58f1), then review how `InvitesRepository` is injected from `AuthorizeInboxOperation.init` in [AuthorizeInboxOperation.swift](https://github.com/ephemeraHQ/convos-ios/pull/117/files#diff-2d3ccac80e5bdf045e9dcfb27745e2ca150f112561fa312c57766afa70088ad7) and the repository implementation in [InvitesRepository.swift](https://github.com/ephemeraHQ/convos-ios/pull/117/files#diff-950618d453223f9a3a9db5e3dd870509b8061f82562f0cf02804a7007bc1be6e).

----

_[Macroscope](https://app.macroscope.com) summarized 94ea8e6._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Deleting an inbox now removes its associated invites, preventing orphaned invites and ensuring cleaner account cleanup.
  - Errors from invite deletion are now surfaced during inbox removal, improving consistency of failure handling.

- Refactor
  - Centralized invite data access behind a repository to standardize invite management across the app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->