### PR TITLE
Start the app on the scan screen

### DIFF
--- a/Convos/App Settings/AppSettingsView.swift
+++ b/Convos/App Settings/AppSettingsView.swift
@@ -34,6 +34,15 @@ struct AppSettingsView: View {
         NavigationStack {
             List {
                 Section {
+                    Text("Thanks for being here early. Expect changes and sometimes a hiccup. \n\nAll convos are temporary for now.")
+                        .multilineTextAlignment(.leading)
+                        .lineLimit(nil)
+                } header: {
+                    Text("Early Access")
+                        .foregroundStyle(.colorTextSecondary)
+                }
+
+                Section {
                     NavigationLink {
                         EmptyView()
                     } label: {

--- a/Convos/Conversation Creation/JoinConversationView.swift
+++ b/Convos/Conversation Creation/JoinConversationView.swift
@@ -8,12 +8,14 @@ struct JoinConversationView: View {
     @State private var qrScannerCoordinator: QRScannerView.Coordinator?
     @State private var showingExplanation: Bool = false
     @State private var showingScanFailedForInviteCode: String?
+    let allowsDismissal: Bool
     let onScannedCode: (String) -> Bool
 
     @Environment(\.dismiss) private var dismiss: DismissAction
     @Environment(\.openURL) private var openURL: OpenURLAction
 
-    init(onScannedCode: @escaping (String) -> Bool) {
+    init(allowsDismissal: Bool = true, onScannedCode: @escaping (String) -> Bool) {
+        self.allowsDismissal = allowsDismissal
         self.onScannedCode = onScannedCode
     }
 
@@ -129,9 +131,11 @@ struct JoinConversationView: View {
             }
             .ignoresSafeArea()
             .toolbar {
-                ToolbarItem(placement: .topBarLeading) {
-                    Button(role: .close) {
-                        dismiss()
+                if allowsDismissal {
+                    ToolbarItem(placement: .topBarLeading) {
+                        Button(role: .close) {
+                            dismiss()
+                        }
                     }
                 }
             }

--- a/Convos/Conversation Creation/NewConversationView.swift
+++ b/Convos/Conversation Creation/NewConversationView.swift
@@ -39,7 +39,7 @@ struct NewConversationView: View {
                 @Bindable var viewModel = viewModel
                 Group {
                     if viewModel.showingFullScreenScanner {
-                        JoinConversationView { inviteCode in
+                        JoinConversationView(allowsDismissal: viewModel.allowsDismissingScanner) { inviteCode in
                             viewModel.join(inviteUrlString: inviteCode)
                         }
                     } else {

--- a/Convos/Conversation Creation/NewConversationViewModel.swift
+++ b/Convos/Conversation Creation/NewConversationViewModel.swift
@@ -19,6 +19,7 @@ class NewConversationViewModel: Identifiable {
     private(set) var messagesTopBarTrailingItem: MessagesView.TopBarTrailingItem = .scan
     private(set) var shouldConfirmDeletingConversation: Bool = true
     private let startedWithFullscreenScanner: Bool
+    let allowsDismissingScanner: Bool
     private let autoCreateConversation: Bool
     private(set) var showingFullScreenScanner: Bool
     var presentingJoinConversationSheet: Bool = false
@@ -45,12 +46,14 @@ class NewConversationViewModel: Identifiable {
         session: any SessionManagerProtocol,
         autoCreateConversation: Bool = false,
         showingFullScreenScanner: Bool = false,
+        allowsDismissingScanner: Bool = true,
         delegate: NewConversationsViewModelDelegate? = nil
     ) {
         self.session = session
         self.autoCreateConversation = autoCreateConversation
         self.startedWithFullscreenScanner = showingFullScreenScanner
         self.showingFullScreenScanner = showingFullScreenScanner
+        self.allowsDismissingScanner = allowsDismissingScanner
         self.delegate = delegate
 
         start()

--- a/Convos/Conversations List/ConversationsListEmptyCTA.swift
+++ b/Convos/Conversations List/ConversationsListEmptyCTA.swift
@@ -76,6 +76,8 @@ struct ConversationsListEmptyCTA: View {
             .padding(.vertical, DesignConstants.Spacing.step4x)
             .padding(.horizontal, DesignConstants.Spacing.step6x)
         }
+        .padding(DesignConstants.Spacing.step6x)
+        .background(.colorBackgroundPrimary)
     }
 }
 

--- a/Convos/Conversations List/ConversationsListItem.swift
+++ b/Convos/Conversations List/ConversationsListItem.swift
@@ -61,8 +61,6 @@ struct ListItemView<LeadingContent: View, SubtitleContent: View, AccessoryConten
         .padding(.horizontal, DesignConstants.Spacing.step6x)
         .padding(.vertical, DesignConstants.Spacing.step3x)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .background(.colorBackgroundPrimary)
-        .contentShape(Rectangle())
     }
 }
 
@@ -90,16 +88,6 @@ struct ConversationsListItem: View {
             },
             accessoryContent: {}
         )
-    }
-}
-
-struct ConversationsListItemButtonStyle: ButtonStyle {
-    @State private var isPressed: Bool = false
-
-    func makeBody(configuration: Configuration) -> some View {
-        configuration.label
-            .background(configuration.isPressed ? Color(.systemGray6) : Color(.clear))
-            .animation(.easeOut(duration: 0.15), value: configuration.isPressed)
     }
 }
 

--- a/Convos/Conversations List/ConversationsViewModel.swift
+++ b/Convos/Conversations List/ConversationsViewModel.swift
@@ -107,6 +107,8 @@ final class ConversationsViewModel {
         } catch {
             Logger.error("Error fetching conversations: \(error)")
             self.conversations = []
+            self.conversationsCount = 0
+            self.hasEarlyAccess = false
         }
         if !hasEarlyAccess {
             self.newConversationViewModel = .init(

--- a/Convos/Conversations List/ConversationsViewModel.swift
+++ b/Convos/Conversations List/ConversationsViewModel.swift
@@ -45,6 +45,8 @@ final class ConversationsViewModel {
             if conversationsCount > 1 {
                 hasCreatedMoreThanOneConvo = true
             }
+
+            hasEarlyAccess = conversationsCount > 0
         }
     }
 

--- a/Convos/Early Access/EarlyAccessInfoView.swift
+++ b/Convos/Early Access/EarlyAccessInfoView.swift
@@ -1,0 +1,49 @@
+import SwiftUI
+
+struct EarlyAccessInfoView: View {
+    @Environment(\.dismiss) var dismiss: DismissAction
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: DesignConstants.Spacing.step4x) {
+            Text("Real life is off the record.™")
+                .font(.caption)
+                .foregroundColor(.colorTextSecondary)
+            Text("Early Access")
+                .font(.system(.largeTitle))
+                .fontWeight(.bold)
+
+            Text("Thanks for being here early. Expect changes and sometimes a hiccup.")
+                .font(.body)
+                .foregroundStyle(.colorTextPrimary)
+
+            Text("All convos are temporary for now.")
+                .font(.body)
+                .foregroundStyle(.colorTextSecondary)
+
+            VStack(spacing: DesignConstants.Spacing.step2x) {
+                Button {
+                    dismiss()
+                } label: {
+                    Text("Got it")
+                }
+                .convosButtonStyle(.rounded(fullWidth: true))
+            }
+            .padding(.top, DesignConstants.Spacing.step4x)
+        }
+        .padding([.leading, .top, .trailing], DesignConstants.Spacing.step10x)
+    }
+}
+
+#Preview {
+    @Previewable @State var presentingEarlyAccessInfo: Bool = false
+    VStack {
+        Button {
+            presentingEarlyAccessInfo.toggle()
+        } label: {
+            Text("Toggle")
+        }
+    }
+    .selfSizingSheet(isPresented: $presentingEarlyAccessInfo) {
+        EarlyAccessInfoView()
+    }
+}

--- a/Convos/Early Access/EarlyAccessInfoView.swift
+++ b/Convos/Early Access/EarlyAccessInfoView.swift
@@ -30,7 +30,7 @@ struct EarlyAccessInfoView: View {
             }
             .padding(.top, DesignConstants.Spacing.step4x)
         }
-        .padding([.leading, .top, .trailing], DesignConstants.Spacing.step10x)
+        .padding(DesignConstants.Spacing.step10x)
     }
 }
 

--- a/Convos/Explode/ExplodeInfoView.swift
+++ b/Convos/Explode/ExplodeInfoView.swift
@@ -13,6 +13,7 @@ struct SoonLabel: View {
             )
     }
 }
+
 struct ExplodeInfoView: View {
     @Environment(\.dismiss) var dismiss: DismissAction
 


### PR DESCRIPTION
### Route first-time users without early access to a non-dismissible full-screen scanner from `ConversationsView` to start the app on the scan screen
This change updates the conversations flow to start on the scan screen for users without early access and adds early access messaging and state. It introduces a non-dismissible full-screen scanner via `NewConversationViewModel` configuration, adds an informational sheet, and adjusts list and empty states.

- Initialize `ConversationsViewModel` with session-only wiring and set `hasEarlyAccess` based on conversation count; pre-create `NewConversationViewModel` with `allowsDismissingScanner=false` when there are zero conversations in [ConversationsViewModel.swift](https://github.com/ephemeraHQ/convos-ios/pull/126/files#diff-e9ac0abeb6f4ab9d1335cf93b09f18a543936af17c742b0f60b5f57e26c07fce)
- Conditionally render the full-screen scanner or the split view in [ConversationsView.swift](https://github.com/ephemeraHQ/convos-ios/pull/126/files#diff-e334ebb478fd67135890a69270ef256dd0f442e21d1497561579d82fa86ab705); add scrollable empty state, row highlighting, swipe-to-delete, and early access/limit info sheets
- Add `allowsDismissingScanner` to `NewConversationViewModel` and pass through to `JoinConversationView` to hide the close button when required in [NewConversationViewModel.swift](https://github.com/ephemeraHQ/convos-ios/pull/126/files#diff-bc0af06ca6587e88461a662416743a0ef38cc55d66fc169caad65a62fb3abe47), [NewConversationView.swift](https://github.com/ephemeraHQ/convos-ios/pull/126/files#diff-be8eeec29bfb3f245f16cd6258d1ef28ced1aa75bad52187e34243f915b084f6), and [JoinConversationView.swift](https://github.com/ephemeraHQ/convos-ios/pull/126/files#diff-44eb95a6ab991c7ccb6ec1ab4c9c9ce95d669bc8b66eb72e4eff37ec085a0f73)
- Add an Early Access info sheet component in [EarlyAccessInfoView.swift](https://github.com/ephemeraHQ/convos-ios/pull/126/files#diff-ef46c95000313c2a3666afb322353286de052f803ccd5c51a06daa38607cac75) and an Early Access section in settings in [AppSettingsView.swift](https://github.com/ephemeraHQ/convos-ios/pull/126/files#diff-30e98d39613710cf0f912b477ed30a8638995959caa9cb2e9facdc10e1c3f8b9)
- Adjust empty CTA layout and list row styling in [ConversationsListEmptyCTA.swift](https://github.com/ephemeraHQ/convos-ios/pull/126/files#diff-218afe41a8e924ccd66c55a2d7105816e7c9dfba5594735a3801eb06a15ad8e1) and [ConversationsListItem.swift](https://github.com/ephemeraHQ/convos-ios/pull/126/files#diff-18994ce872c2892ea92063c94fad8dd4e9d635417f8fc85c6d4d9c645754f6a1)

#### 📍Where to Start
Start with the conditional routing and model bootstrapping in `ConversationsView.body` and `ConversationsViewModel.init(session:)` in [ConversationsView.swift](https://github.com/ephemeraHQ/convos-ios/pull/126/files#diff-e334ebb478fd67135890a69270ef256dd0f442e21d1497561579d82fa86ab705) and [ConversationsViewModel.swift](https://github.com/ephemeraHQ/convos-ios/pull/126/files#diff-e9ac0abeb6f4ab9d1335cf93b09f18a543936af17c742b0f60b5f57e26c07fce).

----

_[Macroscope](https://app.macroscope.com) summarized c6b8612._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Early Access info screen and one-time early-access flow in Conversations.
  * Early Access notice added to Settings.
  * Join-conversation scanner can be configured to allow or prevent dismissal.
  * Preconfigured new-conversation scanner shown when appropriate.

* **Style**
  * Conversations list: improved selected-row highlighting, rounded backgrounds, zero insets, responsive sidebar width.
  * Empty-state: scrollable layout on larger screens; compact mode tighter insets and hidden separators.
  * List item background and custom press style removed; empty CTA gains padding and primary background.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->