### PR TITLE
Fix app scheme and retain the /join/ path

### DIFF
--- a/ConvosCore/Sources/ConvosCore/Extensions/URL+Extensions.swift
+++ b/ConvosCore/Sources/ConvosCore/Extensions/URL+Extensions.swift
@@ -3,19 +3,19 @@ import Foundation
 extension URL {
     public var convosInviteCode: String? {
         // Handle formats:
-        // Format 1: convos://code (host=code for direct invite codes)
-        // Format 2: https://domain.com/code (host="domain.com", pathComponents=["code"])
+        // Format 1: convos://join/invite-code (app scheme with host="join", pathComponents=["invite-code"])
+        // Format 2: https://domain.com/invite-code (universal link with pathComponents=["invite-code"])
 
         let pathComponents = pathComponents.filter { $0 != "/" }
         var inviteCode: String?
 
         if scheme?.hasPrefix("convos") == true {
-            // App scheme: convos://code or convos-dev://code
-            if let host = host, !host.isEmpty {
-                inviteCode = host
+            // App scheme: convos://join/invite-code
+            if host == "join" && pathComponents.count >= 1 {
+                inviteCode = pathComponents[0]
             }
         } else if scheme == "https" {
-            // Universal link: https://domain.com/code
+            // Universal link: https://domain.com/invite-code
             if pathComponents.count == 1 {
                 inviteCode = pathComponents[0]
             }


### PR DESCRIPTION
### Require `host == "join"` and extract invite code from the first path component in `URL.convosInviteCode` to fix app scheme and retain the /join/ path in [URL+Extensions.swift](https://github.com/ephemeraHQ/convos-ios/pull/130/files#diff-4752735f6ff2e8726a9909cf2e953b196065230764b9b571d4fe375612bc9cad)
Update the parsing logic in `URL.convosInviteCode` to only return an invite code for `convos*` URLs when the host equals `"join"` and at least one path component exists, deriving the code from the first component. The `https` universal link handling remains constrained to a single path component. See [URL+Extensions.swift](https://github.com/ephemeraHQ/convos-ios/pull/130/files#diff-4752735f6ff2e8726a9909cf2e953b196065230764b9b571d4fe375612bc9cad).

#### 📍Where to Start
Start with the `URL.convosInviteCode` computed property in [URL+Extensions.swift](https://github.com/ephemeraHQ/convos-ios/pull/130/files#diff-4752735f6ff2e8726a9909cf2e953b196065230764b9b571d4fe375612bc9cad).

----

_[Macroscope](https://app.macroscope.com) summarized a676777._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved reliability of invite link detection.
  - Correctly recognizes app links in the format: convos://join/<invite-code>.
  - Correctly recognizes universal links in the format: https://<domain>/<invite-code>.
  - Handles invalid or empty codes more gracefully, preventing failed joins.

- Chores
  - Internal link-parsing logic clarified without changing the public API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->