### PR TITLE
Proper early badge

### DIFF
--- a/Convos/App Settings/AppSettingsView.swift
+++ b/Convos/App Settings/AppSettingsView.swift
@@ -1,6 +1,20 @@
 import ConvosCore
 import SwiftUI
 
+struct EarlyLabel: View {
+    var body: some View {
+        Text("Early")
+            .font(.system(size: 14.0))
+            .foregroundStyle(.colorTextSecondary)
+            .padding(.vertical, DesignConstants.Spacing.stepX)
+            .padding(.horizontal, DesignConstants.Spacing.step2x)
+            .background(
+                Capsule()
+                    .fill(.colorFillMinimal)
+            )
+    }
+}
+
 struct ConvosToolbarButton: View {
     let padding: Bool
     let action: () -> Void
@@ -9,19 +23,15 @@ struct ConvosToolbarButton: View {
         Button {
             action()
         } label: {
-            HStack(spacing: DesignConstants.Spacing.stepX) {
+            HStack(spacing: DesignConstants.Spacing.step2x) {
                 Image("convosOrangeIcon")
                     .frame(width: 24.0, height: 24.0)
-                    .padding(.trailing, DesignConstants.Spacing.stepX)
 
                 Text("Convos")
                     .font(.system(size: 16.0, weight: .medium))
                     .foregroundStyle(.colorTextPrimary)
 
-                Text("Early")
-                    .font(.system(size: 16.0))
-                    .foregroundStyle(.colorTextSecondary)
-                    .padding(.trailing, DesignConstants.Spacing.step2x)
+                EarlyLabel()
             }
             .padding(padding ? DesignConstants.Spacing.step2x : 0)
         }


### PR DESCRIPTION
### Introduce a capsule-styled 14pt `EarlyLabel` and update `ConvosToolbarButton` spacing and badge usage in [AppSettingsView.swift](https://github.com/ephemeraHQ/convos-ios/pull/132/files#diff-30e98d39613710cf0f912b477ed30a8638995959caa9cb2e9facdc10e1c3f8b9) to show the proper early badge
This change adds a reusable SwiftUI `EarlyLabel` view and applies it in the toolbar button, adjusting layout and spacing in the process.

- Add `EarlyLabel` rendering "Early" with 14pt font, secondary text color, vertical and horizontal padding, and a capsule background using minimal fill in [AppSettingsView.swift](https://github.com/ephemeraHQ/convos-ios/pull/132/files#diff-30e98d39613710cf0f912b477ed30a8638995959caa9cb2e9facdc10e1c3f8b9)
- Update `ConvosToolbarButton` label `HStack` spacing from `stepX` to `step2x`, remove trailing icon padding, and replace inline `Text("Early")` with `EarlyLabel` in [AppSettingsView.swift](https://github.com/ephemeraHQ/convos-ios/pull/132/files#diff-30e98d39613710cf0f912b477ed30a8638995959caa9cb2e9facdc10e1c3f8b9)

#### 📍Where to Start
Start with the `EarlyLabel` SwiftUI view definition in [AppSettingsView.swift](https://github.com/ephemeraHQ/convos-ios/pull/132/files#diff-30e98d39613710cf0f912b477ed30a8638995959caa9cb2e9facdc10e1c3f8b9), then review its integration within `ConvosToolbarButton`.

----

_[Macroscope](https://app.macroscope.com) summarized a2c90fb._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * The “Early” label in the toolbar now appears as a pill with a subtle background and secondary text color, improving contrast and legibility.
  * Spacing around the “Early” label has been refined for a cleaner, more balanced toolbar layout.
  * Padding is now integrated into the label for a more consistent appearance across the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->