### PR TITLE
Remove "Early" language for AppStore submission

### DIFF
--- a/Convos/App Settings/AppSettingsView.swift
+++ b/Convos/App Settings/AppSettingsView.swift
@@ -1,6 +1,34 @@
 import ConvosCore
 import SwiftUI
 
+struct EarlyLabel: View {
+    var body: some View {
+        Text("Early")
+            .font(.system(size: 14.0))
+            .foregroundStyle(.colorTextSecondary)
+            .padding(.vertical, DesignConstants.Spacing.stepX)
+            .padding(.horizontal, DesignConstants.Spacing.step2x)
+            .background(
+                Capsule()
+                    .fill(.colorFillMinimal)
+            )
+    }
+}
+
+struct NewLabel: View {
+    var body: some View {
+        Text("New")
+            .font(.system(size: 14.0))
+            .foregroundStyle(.colorTextSecondary)
+            .padding(.vertical, DesignConstants.Spacing.stepX)
+            .padding(.horizontal, DesignConstants.Spacing.step2x)
+            .background(
+                Capsule()
+                    .fill(.colorFillMinimal)
+            )
+    }
+}
+
 struct ConvosToolbarButton: View {
     let padding: Bool
     let action: () -> Void
@@ -16,6 +44,8 @@ struct ConvosToolbarButton: View {
                 Text("Convos")
                     .font(.system(size: 16.0, weight: .medium))
                     .foregroundStyle(.colorTextPrimary)
+
+                EarlyLabel()
             }
             .padding(padding ? DesignConstants.Spacing.step2x : 0)
         }
@@ -33,6 +63,63 @@ struct AppSettingsView: View {
     var body: some View {
         NavigationStack {
             List {
+                Section {
+                    NavigationLink {
+                        EmptyView()
+                    } label: {
+                        HStack {
+                            Text("Quickname")
+                                .foregroundStyle(.colorTextPrimary)
+
+                            Spacer()
+                            ProfileAvatarView(profile: .empty(), profileImage: nil)
+                                .frame(width: 16.0, height: 16.0)
+                            Text("Somebody")
+                                .foregroundStyle(.colorTextPrimary)
+                        }
+                    }
+                    .disabled(true)
+                } header: {
+                    HStack {
+                        Text("Names")
+                            .foregroundStyle(.colorTextSecondary)
+                        Spacer()
+                        SoonLabel()
+                    }
+                } footer: {
+                    Text("Each time you join a convo, you'll choose a name")
+                        .foregroundStyle(.colorTextSecondary)
+                }
+
+                Section {
+                    NavigationLink {
+                        EmptyView()
+                    } label: {
+                        HStack {
+                            Text("Customize new convos")
+                                .foregroundStyle(.colorTextPrimary)
+                            Spacer()
+                            SoonLabel()
+                        }
+                    }
+                    .disabled(true)
+
+                    NavigationLink {
+                        EmptyView()
+                    } label: {
+                        HStack {
+                            Text("Notifications")
+                                .foregroundStyle(.colorTextPrimary)
+                            Spacer()
+                            SoonLabel()
+                        }
+                    }
+                    .disabled(true)
+                } header: {
+                    Text("Preferences")
+                        .foregroundStyle(.colorTextSecondary)
+                }
+
                 Section {
                     Button {
                         openURL(URL(string: "https://xmtp.org")!)

--- a/Convos/App Settings/AppSettingsView.swift
+++ b/Convos/App Settings/AppSettingsView.swift
@@ -15,20 +15,6 @@ struct EarlyLabel: View {
     }
 }
 
-struct NewLabel: View {
-    var body: some View {
-        Text("New")
-            .font(.system(size: 14.0))
-            .foregroundStyle(.colorTextSecondary)
-            .padding(.vertical, DesignConstants.Spacing.stepX)
-            .padding(.horizontal, DesignConstants.Spacing.step2x)
-            .background(
-                Capsule()
-                    .fill(.colorFillMinimal)
-            )
-    }
-}
-
 struct ConvosToolbarButton: View {
     let padding: Bool
     let action: () -> Void

--- a/Convos/App Settings/AppSettingsView.swift
+++ b/Convos/App Settings/AppSettingsView.swift
@@ -1,20 +1,6 @@
 import ConvosCore
 import SwiftUI
 
-struct EarlyLabel: View {
-    var body: some View {
-        Text("Early")
-            .font(.system(size: 14.0))
-            .foregroundStyle(.colorTextSecondary)
-            .padding(.vertical, DesignConstants.Spacing.stepX)
-            .padding(.horizontal, DesignConstants.Spacing.step2x)
-            .background(
-                Capsule()
-                    .fill(.colorFillMinimal)
-            )
-    }
-}
-
 struct ConvosToolbarButton: View {
     let padding: Bool
     let action: () -> Void
@@ -30,8 +16,6 @@ struct ConvosToolbarButton: View {
                 Text("Convos")
                     .font(.system(size: 16.0, weight: .medium))
                     .foregroundStyle(.colorTextPrimary)
-
-                EarlyLabel()
             }
             .padding(padding ? DesignConstants.Spacing.step2x : 0)
         }
@@ -49,70 +33,6 @@ struct AppSettingsView: View {
     var body: some View {
         NavigationStack {
             List {
-                Section {
-                    Text("Thanks for being here early. Expect changes and sometimes a hiccup. \n\nAll convos are temporary for now.")
-                        .multilineTextAlignment(.leading)
-                        .lineLimit(nil)
-                } header: {
-                    Text("Early Access")
-                        .foregroundStyle(.colorTextSecondary)
-                }
-
-                Section {
-                    NavigationLink {
-                        EmptyView()
-                    } label: {
-                        HStack {
-                            Text("Quickname")
-                                .foregroundStyle(.colorTextPrimary)
-
-                            Spacer()
-                            ProfileAvatarView(profile: .empty(), profileImage: nil)
-                                .frame(width: 16.0, height: 16.0)
-                            Text("Somebody")
-                                .foregroundStyle(.colorTextPrimary)
-                        }
-                    }
-                    .disabled(true)
-                } header: {
-                    HStack {
-                        Text("Names")
-                            .foregroundStyle(.colorTextSecondary)
-                        Spacer()
-                        SoonLabel()
-                    }
-                } footer: {
-                    Text("Each time you join a convo, you'll choose a name")
-                        .foregroundStyle(.colorTextSecondary)
-                }
-
-                Section {
-                    NavigationLink {
-                        EmptyView()
-                    } label: {
-                        HStack {
-                            Text("Customize new convos")
-                                .foregroundStyle(.colorTextPrimary)
-                            SoonLabel()
-                        }
-                    }
-                    .disabled(true)
-
-                    NavigationLink {
-                        EmptyView()
-                    } label: {
-                        HStack {
-                            Text("Notifications")
-                                .foregroundStyle(.colorTextPrimary)
-                            SoonLabel()
-                        }
-                    }
-                    .disabled(true)
-                } header: {
-                    Text("Preferences")
-                        .foregroundStyle(.colorTextSecondary)
-                }
-
                 Section {
                     Button {
                         openURL(URL(string: "https://xmtp.org")!)

--- a/Convos/App Settings/AppSettingsView.swift
+++ b/Convos/App Settings/AppSettingsView.swift
@@ -1,20 +1,6 @@
 import ConvosCore
 import SwiftUI
 
-struct EarlyLabel: View {
-    var body: some View {
-        Text("Early")
-            .font(.system(size: 14.0))
-            .foregroundStyle(.colorTextSecondary)
-            .padding(.vertical, DesignConstants.Spacing.stepX)
-            .padding(.horizontal, DesignConstants.Spacing.step2x)
-            .background(
-                Capsule()
-                    .fill(.colorFillMinimal)
-            )
-    }
-}
-
 struct ConvosToolbarButton: View {
     let padding: Bool
     let action: () -> Void
@@ -30,8 +16,6 @@ struct ConvosToolbarButton: View {
                 Text("Convos")
                     .font(.system(size: 16.0, weight: .medium))
                     .foregroundStyle(.colorTextPrimary)
-
-                EarlyLabel()
             }
             .padding(padding ? DesignConstants.Spacing.step2x : 0)
         }

--- a/Convos/Conversation Detail/ConversationInfoView.swift
+++ b/Convos/Conversation Detail/ConversationInfoView.swift
@@ -1,13 +1,6 @@
 import ConvosCore
 import SwiftUI
 
-// Temporary placeholder - remove when features are ready
-struct SoonLabel: View {
-    var body: some View {
-        EmptyView()
-    }
-}
-
 struct FeatureRowItem<AccessoryView: View>: View {
     let imageName: String?
     let symbolName: String
@@ -177,8 +170,6 @@ struct ConversationInfoView: View {
                         .foregroundStyle(.colorTextSecondary)
                 }
 
-                // Hidden for App Store release - features not ready yet
-                /*
                 Section {
                     FeatureRowItem(
                         imageName: nil,
@@ -221,10 +212,7 @@ struct ConversationInfoView: View {
                         .font(.system(size: 14.0, weight: .semibold))
                         .foregroundStyle(.colorTextSecondary)
                 }
-                */
 
-                // Hidden for App Store release - features not ready yet
-                /*
                 Section {
                     FeatureRowItem(
                         imageName: "explodeIcon",
@@ -248,10 +236,7 @@ struct ConversationInfoView: View {
                         .font(.system(size: 14.0, weight: .semibold))
                         .foregroundStyle(.colorTextSecondary)
                 }
-                */
 
-                // Hidden for App Store release - features not ready yet
-                /*
                 Section {
                     HStack {
                         Text("Vanish")
@@ -281,7 +266,6 @@ struct ConversationInfoView: View {
                     Text("Choose who can manage the group")
                         .foregroundStyle(.colorTextSecondary)
                 }
-                */
 
                 if viewModel.canRemoveMembers {
                     Section {

--- a/Convos/Conversation Detail/ConversationInfoView.swift
+++ b/Convos/Conversation Detail/ConversationInfoView.swift
@@ -1,6 +1,13 @@
 import ConvosCore
 import SwiftUI
 
+// Temporary placeholder - remove when features are ready
+struct SoonLabel: View {
+    var body: some View {
+        EmptyView()
+    }
+}
+
 struct FeatureRowItem<AccessoryView: View>: View {
     let imageName: String?
     let symbolName: String
@@ -53,7 +60,7 @@ struct FeatureRowItem<AccessoryView: View>: View {
 
 #Preview {
     FeatureRowItem(imageName: nil, symbolName: "eyeglasses", title: "Peek-a-boo", subtitle: "Blur when people peek") {
-        SoonLabel()
+        EmptyView()
     }
     .padding(DesignConstants.Spacing.step4x)
 }
@@ -170,6 +177,8 @@ struct ConversationInfoView: View {
                         .foregroundStyle(.colorTextSecondary)
                 }
 
+                // Hidden for App Store release - features not ready yet
+                /*
                 Section {
                     FeatureRowItem(
                         imageName: nil,
@@ -178,7 +187,7 @@ struct ConversationInfoView: View {
                         subtitle: nil
                     ) {
                         SoonLabel()
-//                        Toggle("", isOn: $viewModel.notificationsEnabled)
+                        // Toggle("", isOn: $viewModel.notificationsEnabled)
                     }
 
                     FeatureRowItem(
@@ -212,7 +221,10 @@ struct ConversationInfoView: View {
                         .font(.system(size: 14.0, weight: .semibold))
                         .foregroundStyle(.colorTextSecondary)
                 }
+                */
 
+                // Hidden for App Store release - features not ready yet
+                /*
                 Section {
                     FeatureRowItem(
                         imageName: "explodeIcon",
@@ -236,7 +248,10 @@ struct ConversationInfoView: View {
                         .font(.system(size: 14.0, weight: .semibold))
                         .foregroundStyle(.colorTextSecondary)
                 }
+                */
 
+                // Hidden for App Store release - features not ready yet
+                /*
                 Section {
                     HStack {
                         Text("Vanish")
@@ -266,6 +281,7 @@ struct ConversationInfoView: View {
                     Text("Choose who can manage the group")
                         .foregroundStyle(.colorTextSecondary)
                 }
+                */
 
                 if viewModel.canRemoveMembers {
                     Section {

--- a/Convos/Conversation Detail/ConversationInfoView.swift
+++ b/Convos/Conversation Detail/ConversationInfoView.swift
@@ -53,7 +53,7 @@ struct FeatureRowItem<AccessoryView: View>: View {
 
 #Preview {
     FeatureRowItem(imageName: nil, symbolName: "eyeglasses", title: "Peek-a-boo", subtitle: "Blur when people peek") {
-        EmptyView()
+        SoonLabel()
     }
     .padding(DesignConstants.Spacing.step4x)
 }

--- a/Convos/Conversations List/ConversationsViewModel.swift
+++ b/Convos/Conversations List/ConversationsViewModel.swift
@@ -179,11 +179,10 @@ final class ConversationsViewModel {
     }
 
     private func checkShouldShowEarlyAccessInfo() {
-        // Disabled for App Store release
-        // if !hasSeenEarlyAccessInfo {
-        //     presentingEarlyAccessInfo = true
-        //     hasSeenEarlyAccessInfo = true
-        // }
+        if !hasSeenEarlyAccessInfo {
+            presentingEarlyAccessInfo = true
+            hasSeenEarlyAccessInfo = true
+        }
     }
 
     private func join(from inviteCode: String) {

--- a/Convos/Conversations List/ConversationsViewModel.swift
+++ b/Convos/Conversations List/ConversationsViewModel.swift
@@ -179,10 +179,11 @@ final class ConversationsViewModel {
     }
 
     private func checkShouldShowEarlyAccessInfo() {
-        if !hasSeenEarlyAccessInfo {
-            presentingEarlyAccessInfo = true
-            hasSeenEarlyAccessInfo = true
-        }
+        // Disabled for App Store release
+        // if !hasSeenEarlyAccessInfo {
+        //     presentingEarlyAccessInfo = true
+        //     hasSeenEarlyAccessInfo = true
+        // }
     }
 
     private func join(from inviteCode: String) {

--- a/Convos/Early Access/EarlyAccessInfoView.swift
+++ b/Convos/Early Access/EarlyAccessInfoView.swift
@@ -8,13 +8,17 @@ struct EarlyAccessInfoView: View {
             Text("Real life is off the record.™")
                 .font(.caption)
                 .foregroundColor(.colorTextSecondary)
-            Text("Welcome to Convos")
+            Text("Early Access")
                 .font(.system(.largeTitle))
                 .fontWeight(.bold)
 
-            Text("Your convos, encrypted and ephemeral.")
+            Text("Thanks for being here early.")
                 .font(.body)
                 .foregroundStyle(.colorTextPrimary)
+
+            Text("All convos are temporary for now.")
+                .font(.body)
+                .foregroundStyle(.colorTextSecondary)
 
             VStack(spacing: DesignConstants.Spacing.step2x) {
                 Button {

--- a/Convos/Early Access/EarlyAccessInfoView.swift
+++ b/Convos/Early Access/EarlyAccessInfoView.swift
@@ -8,17 +8,13 @@ struct EarlyAccessInfoView: View {
             Text("Real life is off the record.™")
                 .font(.caption)
                 .foregroundColor(.colorTextSecondary)
-            Text("Early Access")
+            Text("Welcome to Convos")
                 .font(.system(.largeTitle))
                 .fontWeight(.bold)
 
-            Text("Thanks for being here early. Expect changes and sometimes a hiccup.")
+            Text("Your convos, encrypted and ephemeral.")
                 .font(.body)
                 .foregroundStyle(.colorTextPrimary)
-
-            Text("All convos are temporary for now.")
-                .font(.body)
-                .foregroundStyle(.colorTextSecondary)
 
             VStack(spacing: DesignConstants.Spacing.step2x) {
                 Button {

--- a/Convos/Early Access/EarlyAccessInfoView.swift
+++ b/Convos/Early Access/EarlyAccessInfoView.swift
@@ -8,15 +8,16 @@ struct EarlyAccessInfoView: View {
             Text("Real life is off the record.™")
                 .font(.caption)
                 .foregroundColor(.colorTextSecondary)
-            Text("Early Access")
+
+            Text("Convos aren't forever")
                 .font(.system(.largeTitle))
                 .fontWeight(.bold)
 
-            Text("Thanks for being here early.")
+            Text("You can explode a convo as soon you're done with it.")
                 .font(.body)
                 .foregroundStyle(.colorTextPrimary)
 
-            Text("All convos are temporary for now.")
+            Text("All convos will explode 30 days after they're created.")
                 .font(.body)
                 .foregroundStyle(.colorTextSecondary)
 

--- a/Convos/Explode/ExplodeInfoView.swift
+++ b/Convos/Explode/ExplodeInfoView.swift
@@ -1,5 +1,19 @@
 import SwiftUI
 
+struct SoonLabel: View {
+    var body: some View {
+        Text("Soon")
+            .font(.system(size: 14.0))
+            .foregroundStyle(.colorTextSecondary)
+            .padding(.vertical, DesignConstants.Spacing.stepX)
+            .padding(.horizontal, DesignConstants.Spacing.step2x)
+            .background(
+                Capsule()
+                    .fill(.colorFillMinimal)
+            )
+    }
+}
+
 struct ExplodeInfoView: View {
     @Environment(\.dismiss) var dismiss: DismissAction
 

--- a/Convos/Explode/ExplodeInfoView.swift
+++ b/Convos/Explode/ExplodeInfoView.swift
@@ -1,19 +1,5 @@
 import SwiftUI
 
-struct SoonLabel: View {
-    var body: some View {
-        Text("Soon")
-            .font(.system(size: 14.0))
-            .foregroundStyle(.colorTextSecondary)
-            .padding(.vertical, DesignConstants.Spacing.stepX)
-            .padding(.horizontal, DesignConstants.Spacing.step2x)
-            .background(
-                Capsule()
-                    .fill(.colorFillMinimal)
-            )
-    }
-}
-
 struct ExplodeInfoView: View {
     @Environment(\.dismiss) var dismiss: DismissAction
 
@@ -36,16 +22,6 @@ struct ExplodeInfoView: View {
                     Text("Got it")
                 }
                 .convosButtonStyle(.rounded(fullWidth: true))
-
-                Button {
-                } label: {
-                    HStack {
-                        Text("Learn more")
-
-                        SoonLabel()
-                    }
-                }
-                .convosButtonStyle(.text)
             }
             .padding(.top, DesignConstants.Spacing.step4x)
         }

--- a/Convos/Shared Views/MaxedOutInfoView.swift
+++ b/Convos/Shared Views/MaxedOutInfoView.swift
@@ -10,7 +10,7 @@ struct MaxedOutInfoView: View {
             Text("Maxed out")
                 .font(.system(.largeTitle))
                 .fontWeight(.bold)
-            Text("This early version of the app supports up to \(maxNumberOfConvos) convos. Consider exploding some to make room for new ones.")
+            Text("The app currently supports up to \(maxNumberOfConvos) convos. Consider exploding some to make room for new ones.")
                 .font(.body)
                 .foregroundStyle(.colorTextSecondary)
 


### PR DESCRIPTION
### Remove all “Early” labels and Early Access UI from App Settings, toolbar, and info views for App Store submission
This change removes the `EarlyLabel` component and all “Early Access” UI and copy across settings and info views. It updates titles and text to reflect current behavior and adjusts layout where needed.

- Delete `EarlyLabel` and remove its usage from the toolbar button in [AppSettingsView.swift](https://github.com/ephemeraHQ/convos-ios/pull/139/files#diff-30e98d39613710cf0f912b477ed30a8638995959caa9cb2e9facdc10e1c3f8b9)
- Remove the “Early Access” section from [AppSettingsView.swift](https://github.com/ephemeraHQ/convos-ios/pull/139/files#diff-30e98d39613710cf0f912b477ed30a8638995959caa9cb2e9facdc10e1c3f8b9) and right-align `SoonLabel` in two rows with `Spacer()`
- Update `EarlyAccessInfoView` title to “Convos aren't forever” and copy to describe explodable convos and 30-day auto-explosion in [EarlyAccessInfoView.swift](https://github.com/ephemeraHQ/convos-ios/pull/139/files#diff-ef46c95000313c2a3666afb322353286de052f803ccd5c51a06daa38607cac75)
- Remove the secondary “Learn more” action from [ExplodeInfoView.swift](https://github.com/ephemeraHQ/convos-ios/pull/139/files#diff-e892d06a06226a32dd4118cb7c7dfc6232c1df2d69f444281feb8c759f4c16ca)
- Update copy in [MaxedOutInfoView.swift](https://github.com/ephemeraHQ/convos-ios/pull/139/files#diff-bf585b5f02c5a80937197e1a61a05ce1b7d6004fae9264e08420a07f9f697599) to remove early-version phrasing
- Minor comment formatting in [ConversationInfoView.swift](https://github.com/ephemeraHQ/convos-ios/pull/139/files#diff-30ae741e90f8fd3b2d28bd543f330b1bb685d691d37fd1e95edcc8bd87159a2a)

#### 📍Where to Start
Start with the removal of `EarlyLabel` and the App Settings adjustments in [AppSettingsView.swift](https://github.com/ephemeraHQ/convos-ios/pull/139/files#diff-30e98d39613710cf0f912b477ed30a8638995959caa9cb2e9facdc10e1c3f8b9).

----

_[Macroscope](https://app.macroscope.com) summarized f02e890._