### PR TITLE
Remove explode soon in group settings

### DIFF
--- a/Convos/Conversation Detail/ConversationInfoView.swift
+++ b/Convos/Conversation Detail/ConversationInfoView.swift
@@ -215,15 +215,6 @@ struct ConversationInfoView: View {
 
                 Section {
                     FeatureRowItem(
-                        imageName: "explodeIcon",
-                        symbolName: "",
-                        title: "Explode convo",
-                        subtitle: "Set a timer"
-                    ) {
-                        SoonLabel()
-                    }
-
-                    FeatureRowItem(
                         imageName: nil,
                         symbolName: "timer",
                         title: "Disappear",


### PR DESCRIPTION
### Remove the 'Explode convo' row from the Convo rules section in `Convos/Conversation Detail/ConversationInfoView.body` to reflect removal "soon" in group settings
This change removes the `FeatureRowItem` for the 'Explode convo' option from the Convo rules section in [ConversationInfoView.swift](https://github.com/ephemeraHQ/convos-ios/pull/142/files#diff-9e5f1d124e13a2cd9c91c36d90046e2e2b03fd46def10ee4e0d2e1fcb5396061). The adjacent 'Disappear' item remains unchanged.

#### 📍Where to Start
Start in the `ConversationInfoView.body` view to see the removed `FeatureRowItem` in [ConversationInfoView.swift](https://github.com/ephemeraHQ/convos-ios/pull/142/files#diff-9e5f1d124e13a2cd9c91c36d90046e2e2b03fd46def10ee4e0d2e1fcb5396061).

----

_[Macroscope](https://app.macroscope.com) summarized 391fe9b._