### PR TITLE
Update Claude Code PR review to use API key

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -23,8 +23,9 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-      issues: read
+      issues: write
       id-token: write
+      actions: read
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -13,17 +13,17 @@ on:
 jobs:
   claude:
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body || '', '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body || '', '@claude') || contains(github.event.issue.title, '@claude')))
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '/claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '/claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body || '', '/claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body || '', '/claude') || contains(github.event.issue.title, '/claude')))
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
-      actions: read # Required for Claude to read CI results on PRs
+      actions: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
### Switch GitHub Actions Claude review workflows to authenticate with `ANTHROPIC_API_KEY` and adjust triggers and permissions in [.github/workflows/claude-code-review.yml](https://github.com/ephemeraHQ/convos-ios/pull/151/files#diff-27456786e30ce9b1fa39c43f4e26f41177ee995f0a650d6d5aba7a826efbfe30) and [.github/workflows/claude.yml](https://github.com/ephemeraHQ/convos-ios/pull/151/files#diff-53fec9c265fdba82268df5cd90315b8da57cce43d8e20efbf5c0bdcd1de1342e)
- Update `.github/workflows/claude-code-review.yml` to run only on non-fork pull requests, change permissions for `pull-requests` and `issues` to write, add `actions: read`, keep `contents: read` and `id-token: write`, and replace the `claude_code_oauth_token` input with `anthropic_api_key`.
- Update `.github/workflows/claude.yml` to trigger on the `/claude` phrase, guard event body checks with default empty strings, change permissions for `pull-requests` and `issues` to write while retaining `contents: read`, `id-token: write`, and `actions: read`, and replace the `claude_code_oauth_token` input with `anthropic_api_key`.
- Apply whitespace-only comment and blank-line adjustments in both files.

#### 📍Where to Start
Start with the workflow triggers and inputs in [.github/workflows/claude.yml](https://github.com/ephemeraHQ/convos-ios/pull/151/files#diff-53fec9c265fdba82268df5cd90315b8da57cce43d8e20efbf5c0bdcd1de1342e), then review the job condition and permissions in [.github/workflows/claude-code-review.yml](https://github.com/ephemeraHQ/convos-ios/pull/151/files#diff-27456786e30ce9b1fa39c43f4e26f41177ee995f0a650d6d5aba7a826efbfe30).

----

_[Macroscope](https://app.macroscope.com) summarized 86efa22._