### PR TITLE
Simplify release workflow, remove PR automation

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,20 +1,20 @@
-name: Auto Create Release PR
+name: Auto Release
 
 on:
   push:
     tags:
-      - '*.*.*' # Triggers on semantic version tags (e.g., 1.0.0, no v prefix)
+      - '*.*.**' # Triggers on semantic version tags (e.g., 1.0.0, 1.0.0-dev.123456, no v prefix)
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
-  auto-release-pr:
+  auto-release:
     runs-on: ubuntu-latest
     permissions:
       contents: write       # Read/write repository contents, tags, and releases
-      pull-requests: write  # Create pull requests
+      actions: read         # Read workflow status
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -174,80 +174,17 @@ jobs:
 
           echo "Version verified: dev branch has $current_version, tag is $tag_version"
 
-      - name: Verify rebase merge compatibility
-        run: |
-          # Check if dev has commits that main doesn't have
-          git fetch origin main
-          git fetch origin dev
-
-          # Check if dev is ahead of main
-          if [ $(git rev-list --count origin/main..origin/dev) -gt 0 ]; then
-            echo "Rebase merge is possible"
-            echo "   Dev branch has new commits to bring to main"
-          else
-            echo "No new commits to merge"
-            echo "   Dev branch is already up to date with main"
-            exit 1
-          fi
-
-      - name: Create Pull Request
-        id: create-pr
-        run: |
-          python3 -c '
-          import os
-          import subprocess
-
-          # Read release notes
-          with open("release-notes.txt", "r") as f:
-              release_notes = f.read()
-
-          # Create PR description
-          version = os.environ["VERSION"]
-          pr_body = f"# Release {version}\n\n{release_notes}\n\n---\n*Generated automatically by GitHub Actions*"
-
-          # Check if PR already exists
-          pr_check = subprocess.run(
-              ["gh", "pr", "list", "--base", "main", "--head", "dev", "--state", "open", "--json", "number"],
-              capture_output=True, text=True
-          )
-
-          if pr_check.returncode == 0 and pr_check.stdout.strip() != "[]":
-              print("PR from dev to main already exists; skipping creation.")
-              print(pr_check.stdout)
-              exit(0)
-
-          # Create PR using GitHub CLI
-          pr_result = subprocess.run([
-              "gh", "pr", "create",
-              "--title", f"Release {version}",
-              "--body", pr_body,
-              "--base", "main",
-              "--head", "dev"
-          ], capture_output=True, text=True)
-
-          if pr_result.returncode == 0:
-              print("Pull Request created successfully!")
-              print(pr_result.stdout)
-          else:
-              print("Failed to create PR:")
-              print(pr_result.stderr)
-              exit(1)
-          '
-        env:
-          VERSION: ${{ steps.version.outputs.version }}
 
       - name: Output summary
         run: |
-          echo "Auto-release PR workflow completed!"
+          echo "Auto-release workflow completed!"
           echo "Version: ${{ steps.version.outputs.version }}"
           echo "GitHub Release: Created/updated with release notes"
-          echo "Pull Request: Created from dev to main"
           echo ""
           echo "Release pipeline created:"
           echo "  - GitHub Release available for Bitrise"
           echo "  - Release notes will be used by Bitrise for App Store submission"
           echo ""
           echo "Next steps:"
-          echo "1. Review the generated PR"
-          echo "2. Use 'Rebase and merge' button (linear history)"
-          echo "3. Bitrise will build and deploy automatically"
+          echo "1. Use 'make promote-release' to fast-forward merge dev to main"
+          echo "2. Bitrise will build and deploy automatically"

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -21,7 +21,7 @@ This command handles the entire release workflow automatically.
    ```bash
    make tag-release
    ```
-   
+
    This will:
    - Ensure you're on the `dev` branch
    - Update version in Xcode project
@@ -33,12 +33,11 @@ This command handles the entire release workflow automatically.
    - Verifies version in `dev` branch matches the tag
    - Generates AI-powered release notes using Claude
    - Creates a GitHub Release with the generated notes
-   - Creates a PR from `dev` to `main`
 
-4. **Review and Deploy**:
-   - Review the auto-generated PR and release notes
-   - Merge PR to `main` using "Rebase and merge" (linear history)
-   - Bitrise automatically builds and deploys to TestFlight
+4. **Promote Release to Main**:
+   - Use `make promote-release` to fast-forward merge dev to main
+   - This ensures the tag exists on both branches
+   - Bitrise automatically builds and deploys to App Store Connect to TestFlight
 
 ## Release Notes
 
@@ -59,19 +58,18 @@ These notes are used for:
 
 1. **Tag Creation** → Triggers GitHub Actions
 2. **GitHub Release** → Created with AI-generated notes
-3. **PR Merge to `main`** → Triggers Bitrise production build
+3. **Release Promotion** → `make promote-release` fast-forwards main to dev
 4. **Bitrise Reads Release Notes** → From GitHub Release API
 5. **App Store Connect** → Deploys with release notes to TestFlight
 6. **TestFlight** → Ready for internal/external testing
 
 ## GitHub Actions Workflow
 
-The automated workflow (`auto-release-pr.yml`) triggers on semantic version tags and:
+The automated workflow (`auto-release.yml`) triggers on semantic version tags (including dev versions) and:
 
-- Triggers on semantic version tags (e.g., `1.0.1`)
+- Triggers on semantic version tags (e.g., `1.0.1`, `1.0.0-dev.123456`)
 - AI-powered release notes generation using Anthropic Claude
 - Creates GitHub Release with generated notes
-- Creates PR from `dev` to `main` for linear history
 - Verifies version consistency between dev branch and tag
 - Provides release notes to Bitrise for App Store Connect
 
@@ -119,10 +117,11 @@ This will install all required dependencies and set up the development environme
 ## Best Practices
 
 1. **Use semantic versioning** (1.0.0, 1.0.1, 1.1.0, 2.0.0)
-2. **Test on TestFlight** before creating release PR
-3. **Review AI-generated notes** for accuracy
-4. **Keep release notes user-friendly** for customer-facing content
-5. **Use descriptive commit messages** for better release notes
+2. **Test the dev build on TestFlight** triggered by `make tag-release`
+3. **Test the prod build on TestFlight** happens after `make promote-release` merges dev to main
+4. **Review AI-generated notes** for accuracy
+5. **Keep release notes user-friendly** for customer-facing content
+6. **Use descriptive commit messages** for better release notes
 
 ## Support
 

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -88,7 +88,7 @@ workflows:
     - save-spm-cache@1: {}
     meta:
       bitrise.io:
-        stack: osx-xcode-26.0.x-edge
+        stack: osx-xcode-26.0.x
     envs:
     - BITRISE_SCHEME: Convos (Dev)
       opts:
@@ -168,11 +168,10 @@ workflows:
     - save-spm-cache@1: {}
     meta:
       bitrise.io:
-        stack: osx-xcode-26.0.x-edge
+        stack: osx-xcode-26.0.x
     triggers:
       push:
       - branch: main
-      enabled: false
     envs:
     - BITRISE_SCHEME: Convos (Prod)
       opts:


### PR DESCRIPTION
- Remove PR creation from release workflow (when merging dev to main)
- Support dev version tags (*.*.**) for 1.0.0-dev and 1.0.0-dev.[short commit hash]
- Add local `make promote-release` command
- Rename auto-release-pr.yml → auto-release.yml