### PR TITLE
Update Claude model version in CI and make it configurable via env var

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -104,7 +104,7 @@ jobs:
           prompt = f"Generate SHORT, customer-friendly release notes for iOS app version {version}. Key changes: Features: {features[:3] if features else []}, Bugfixes: {bugfixes[:2] if bugfixes else []}, Other: {other_changes[:2] if other_changes and not features and not bugfixes else []}. Requirements: MAXIMUM 5 bullet points total, use warm friendly language, focus on user benefits, keep each point under 15 words, no technical jargon. Format as simple bullet points, no headers or markdown."
 
           # Use model from environment variable with fallback
-          model = os.getenv("CLAUDE_MODEL", "claude-sonnet-4-20250514")
+          model = os.getenv("CLAUDE_MODEL", "claude-sonnet-4-5-20250929")
 
           try:
               response = client.messages.create(
@@ -132,6 +132,7 @@ jobs:
         env:
           VERSION: ${{ steps.version.outputs.version }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          CLAUDE_MODEL: ${{ vars.CLAUDE_MODEL }}
 
       - name: Store release notes for later use
         run: |

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -39,8 +39,8 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 
-          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
-          # model: "claude-opus-4-20250514"
+          # Optional: Specify model (defaults to Claude Sonnet)
+          model: ${{ vars.CLAUDE_MODEL || 'claude-sonnet-4-5-20250929' }}
 
           # Direct prompt for automated review (no @claude mention needed)
           direct_prompt: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -40,8 +40,8 @@ jobs:
           additional_permissions: |
             actions: read
 
-          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
-          # model: "claude-opus-4-20250514"
+          # Optional: Specify model (defaults to Claude Sonnet)
+          model: ${{ vars.CLAUDE_MODEL || 'claude-sonnet-4-5-20250929' }}
 
           # Optional: Customize the trigger phrase (default: @claude)
           # trigger_phrase: "/claude"


### PR DESCRIPTION
### Update GitHub Actions workflows to default to model "claude-sonnet-4-5-20250929" and make the model configurable via repository variable CLAUDE_MODEL for CI release notes, code review, and chat actions
This change updates three GitHub Actions workflows to explicitly set the Claude model and allow overriding via the `CLAUDE_MODEL` repository variable.

- Update [auto-release.yml](https://github.com/ephemeraHQ/convos-ios/pull/157/files#diff-5a93af5afcdcd2bdc566f58652f8af7fec28b2d02acb9bec8ee97e9334362731) to export `CLAUDE_MODEL` to the Python script and change the fallback in `os.getenv` to `"claude-sonnet-4-5-20250929"`
- Add `model: ${{ vars.CLAUDE_MODEL || 'claude-sonnet-4-5-20250929' }}` to [claude-code-review.yml](https://github.com/ephemeraHQ/convos-ios/pull/157/files#diff-27456786e30ce9b1fa39c43f4e26f41177ee995f0a650d6d5aba7a826efbfe30) and adjust comments
- Add `model: ${{ vars.CLAUDE_MODEL || 'claude-sonnet-4-5-20250929' }}` to [claude.yml](https://github.com/ephemeraHQ/convos-ios/pull/157/files#diff-53fec9c265fdba82268df5cd90315b8da57cce43d8e20efbf5c0bdcd1de1342e) and update comments

#### 📍Where to Start
Start with the model selection and environment variable handling in [auto-release.yml](https://github.com/ephemeraHQ/convos-ios/pull/157/files#diff-5a93af5afcdcd2bdc566f58652f8af7fec28b2d02acb9bec8ee97e9334362731), then review the `model` inputs in [claude-code-review.yml](https://github.com/ephemeraHQ/convos-ios/pull/157/files#diff-27456786e30ce9b1fa39c43f4e26f41177ee995f0a650d6d5aba7a826efbfe30) and [claude.yml](https://github.com/ephemeraHQ/convos-ios/pull/157/files#diff-53fec9c265fdba82268df5cd90315b8da57cce43d8e20efbf5c0bdcd1de1342e).

----

_[Macroscope](https://app.macroscope.com) summarized fe7265c._