### PR TITLE
Add invite only text to join screen

### DIFF
--- a/Convos/Conversation Creation/JoinConversationView.swift
+++ b/Convos/Conversation Creation/JoinConversationView.swift
@@ -74,14 +74,22 @@ struct JoinConversationView: View {
                                     .multilineTextAlignment(.center)
                                     .foregroundStyle(.white)
                             } else {
-                                HStack(spacing: DesignConstants.Spacing.step2x) {
-                                    Image(systemName: "qrcode")
-                                        .foregroundStyle(.white)
-                                    Text("Join a convo")
+                                VStack(spacing: DesignConstants.Spacing.step3x) {
+                                    HStack(spacing: DesignConstants.Spacing.step2x) {
+                                        Image(systemName: "qrcode")
+                                            .foregroundStyle(.white)
+                                        Text("Join a convo by invitation only")
+                                            .font(.system(size: 16.0))
+                                            .multilineTextAlignment(.center)
+                                            .foregroundStyle(.white)
+                                    }
+                                    Text("Ask a friend to invite you to a convo, then scan its code or tap its link to enter the app.")
                                         .font(.system(size: 16.0))
                                         .multilineTextAlignment(.center)
                                         .foregroundStyle(.white)
+                                        .opacity(0.6)
                                 }
+                                .padding(.horizontal, DesignConstants.Spacing.step10x)
                             }
                         }
 


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Update JoinConversationView to display invitation-only join text on the join screen
Replace the non-explanation header in `JoinConversationView` with an invitation-only title and a brief explanatory line, and adjust layout spacing and padding in [JoinConversationView.swift](https://github.com/ephemeraHQ/convos-ios/pull/187/files#diff-44eb95a6ab991c7ccb6ec1ab4c9c9ce95d669bc8b66eb72e4eff37ec085a0f73).

#### 📍Where to Start
Start with the `View.body` layout changes in [JoinConversationView.swift](https://github.com/ephemeraHQ/convos-ios/pull/187/files#diff-44eb95a6ab991c7ccb6ec1ab4c9c9ce95d669bc8b66eb72e4eff37ec085a0f73).

----

<!-- MACROSCOPE_FOOTER_START -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized a60c63d. 1 file reviewed, 1 issue evaluated, 1 issue filtered, 0 comments posted</summary>

### 🗂️ Filtered Issues
<details>
<summary>Convos/Conversation Creation/JoinConversationView.swift — 0 comments posted, 1 evaluated, 1 filtered</summary>

- [line 156](https://github.com/ephemeraHQ/convos-ios/blob/a60c63d0551b22de85da86a4a8b266adb613ff17/Convos/Conversation Creation/JoinConversationView.swift#L156): The `onChange` handler for `viewModel.scannedCode` triggers `attemptToScanCode` every time the optional becomes non-nil, without any debouncing, gating, or one-shot consumption. If the underlying QR scanner emits the same code repeatedly (common behavior as frames are processed) or rapidly emits multiple updates, `onScannedCode` can be invoked multiple times, potentially causing duplicated navigation/actions or re-entrancy. There is no state flip (e.g., disabling scanning or clearing `scannedCode` atomically) to ensure at-most-once delivery. This violates at-most-once and atomic consumption guarantees after an external effect and can lead to double-application. <b>[ Low confidence ]</b>
</details>


</details>
<!-- MACROSCOPE_FOOTER_END -->
<!-- Macroscope's pull request summary ends here -->