### PR TITLE
Add user search

### DIFF
--- a/graphite-demo/frontend.jsx
+++ b/graphite-demo/frontend.jsx
@@ -1,7 +1,8 @@
 import React, { useEffect, useState } from 'react';
 
-const TaskSearch = () => {
+const TaskAndUserSearch = () => {
   const [tasks, setTasks] = useState([]);
+  const [users, setUsers] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [searchQuery, setSearchQuery] = useState('');
@@ -16,14 +17,15 @@ const TaskSearch = () => {
         return response.json();
       })
       .then(data => {
-        setTasks(data);
+        setTasks(data.tasks);
+        setUsers(data.users);
         setLoading(false);
       })
       .catch(error => {
         setError(error.message);
         setLoading(false);
       });
-  }, [searchQuery]); // Depend on searchQuery
+  }, [searchQuery]);
 
   if (loading) {
     return <div>Loading...</div>;
@@ -35,13 +37,14 @@ const TaskSearch = () => {
 
   return (
     <div>
-      <h2>Task Search</h2>
+      <h2>Search Tasks and Users</h2>
       <input
         type="text"
-        placeholder="Search tasks..."
+        placeholder="Search tasks and users..."
         value={searchQuery}
         onChange={(e) => setSearchQuery(e.target.value)}
       />
+      <h3>Tasks</h3>
       <ul>
         {tasks.map(task => (
           <li key={task.id}>
@@ -49,8 +52,16 @@ const TaskSearch = () => {
           </li>
         ))}
       </ul>
+      <h3>Users</h3>
+      <ul>
+        {users.map(user => (
+          <li key={user.id}>
+            <p>{user.name}</p>
+          </li>
+        ))}
+      </ul>
     </div>
   );
 };
 
-export default TaskSearch;
+export default TaskAndUserSearch;

--- a/graphite-demo/server.js
+++ b/graphite-demo/server.js
@@ -18,17 +18,38 @@ const tasks = [
   }
 ];
 
+// Fake data for users
+const users = [
+  {
+    id: 101,
+    name: 'Alice Smith'
+  },
+  {
+    id: 102,
+    name: 'Bob Johnson'
+  },
+  {
+    id: 103,
+    name: 'Charlie Brown'
+  }
+];
+
 app.get('/search', (req, res) => {
   // Retrieve the query parameter
   const query = req.query.query?.toLowerCase() || '';
 
   // Filter tasks based on the query
-  const filteredTasks = tasks.filter(task => task.description.toLowerCase().includes(query));
+  const filteredTasks = tasks.filter(task =>
+    task.description.toLowerCase().includes(query)
+  ).sort((a, b) => a.description.localeCompare(b.description));
 
-  // Sort the filtered tasks alphabetically by description
-  const sortedTasks = filteredTasks.sort((a, b) => a.description.localeCompare(b.description));
+  // Filter users based on the query
+  const filteredUsers = users.filter(user =>
+    user.name.toLowerCase().includes(query)
+  ).sort((a, b) => a.name.localeCompare(b.name));
 
-  res.json(sortedTasks);
+  // Return both sets of results
+  res.json({ tasks: filteredTasks, users: filteredUsers });
 });
 
 app.listen(port, () => {


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Add user search by updating `TaskAndUserSearch` React component and modifying Express `app.get('/search')` to return `{ tasks, users }` filtered and sorted
Rename the React `TaskSearch` component to `TaskAndUserSearch`, add `users` state, and update fetch handling and UI to display both tasks and users from `{ tasks, users }`. Modify Express `app.get('/search')` to filter and sort tasks by description and users by name, and return an object with both arrays.

#### 📍Where to Start
Start with the `app.get('/search')` handler in [server.js](https://github.com/ephemeraHQ/convos-ios/pull/195/files#diff-d5c3b928f53ccb3225ebe5a3d21d3f7bd256109576695e5eb29abcf0419d1865), then review the fetch and rendering changes in [frontend.jsx](https://github.com/ephemeraHQ/convos-ios/pull/195/files#diff-74684716a2390999e6c9fb601758e2d880bf89c32cfc18df6051c08f1320eff3).

----
<!-- Macroscope's review summary starts here -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized f1a680d. 2 files reviewed, 3 issues evaluated, 3 issues filtered, 0 comments posted</summary>

### 🗂️ Filtered Issues
<details>
<summary>graphite-demo/frontend.jsx — 0 comments posted, 3 evaluated, 3 filtered</summary>

- [line 10](https://github.com/ephemeraHQ/convos-ios/blob/f1a680d42cb2861f95700abedabec2a1eaf4f033/graphite-demo/frontend.jsx#L10): The effect at lines 10-28 fires every time `searchQuery` changes and issues a fetch without cancelling or tagging the request. If the user types quickly, an earlier (slower) request can resolve after a later one, letting stale results overwrite the current query’s data when the older promise resolves. That race yields incorrect UI state even though the component believes it shows the most recent search. Consider aborting previous requests or checking the captured query before applying the result. <b>[ Out of scope ]</b>
- [line 20](https://github.com/ephemeraHQ/convos-ios/blob/f1a680d42cb2861f95700abedabec2a1eaf4f033/graphite-demo/frontend.jsx#L20): `setTasks(data.tasks)` and `setUsers(data.users)` (lines 20-21) assume the `/search` response always includes `tasks` and `users`. If either field is missing or still returned in the old format (the previous code consumed the entire array), `tasks`/`users` become `undefined`, and the subsequent `.map` calls at lines 49 and 57 throw (`tasks.map is not a function`). Please guard these assignments or default them to empty arrays before rendering. <b>[ Low confidence ]</b>
- [line 24](https://github.com/ephemeraHQ/convos-ios/blob/f1a680d42cb2861f95700abedabec2a1eaf4f033/graphite-demo/frontend.jsx#L24): After a network error, `error` is set (line 25) but never cleared when a later fetch succeeds. On a subsequent successful response (lines 20-23), `loading` becomes `false` yet `error` remains truthy, so the render path at lines 34-36 keeps returning the error UI and hides valid data. Please reset `error` (e.g., to `null`) when starting a request or after a successful response. <b>[ Out of scope ]</b>
</details>


</details><!-- Macroscope's review summary ends here -->

<!-- Macroscope's pull request summary ends here -->