### PR TITLE
Message list UI fixes

### DIFF
--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Cells/TextMessageCollectionCell.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Cells/TextMessageCollectionCell.swift
@@ -44,7 +44,8 @@ class TextMessageCollectionCell: UICollectionViewCell {
             }
             .frame(maxWidth: .infinity, alignment: .leading)
         }
-        .margins(.vertical, 0.0)
+        .margins(.top, DesignConstants.Spacing.stepX)
+        .margins(.bottom, 0.0)
     }
 
     override func preferredLayoutAttributesFitting(

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/MessagesViewController.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/MessagesViewController.swift
@@ -356,7 +356,9 @@ extension MessagesViewController {
             let bubbleType: MessagesCollectionCell.BubbleType
             if index < visibleMessages.count - 1 {
                 let nextMessage = visibleMessages[index + 1]
-                bubbleType = message.base.sender.id == nextMessage.base.sender.id ? .normal : .tailed
+                let timeDifference = nextMessage.base.date.timeIntervalSince(message.base.date)
+                let willShowTimestamp = timeDifference > 3600
+                bubbleType = message.base.sender.id == nextMessage.base.sender.id && !willShowTimestamp ? .normal : .tailed
             } else {
                 bubbleType = .tailed
             }

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/DBMessage.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/DBMessage.swift
@@ -157,6 +157,25 @@ extension DBMessage {
         )
     }
 
+    func with(status: MessageStatus) -> Self {
+        .init(
+            id: id,
+            clientMessageId: clientMessageId,
+            conversationId: conversationId,
+            senderId: senderId,
+            dateNs: dateNs,
+            date: date,
+            status: status,
+            messageType: messageType,
+            contentType: contentType,
+            text: text,
+            emoji: emoji,
+            sourceMessageId: sourceMessageId,
+            attachmentUrls: attachmentUrls,
+            update: update
+        )
+    }
+
     func with(clientMessageId: String) -> DBMessage {
         .init(
             id: id,


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->

<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->

<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->

### Adjust message list spacing and bubble tailing to refine conversation message layout in `TextMessageCollectionCell.setup`, `DefaultMessagesLayoutDelegate.interItemSpacing`, and `MessagesViewController.processUpdates`

Update inter-item spacing to 0.0 by default with `DesignConstants.Spacing.stepX` added above outgoing messages that follow incoming ones; add top margin to text message cells; set bubble tailing to `.tailed` when a timestamp will show due to a gap > 3600 seconds.

#### 📍Where to Start

Start with the spacing logic in `DefaultMessagesLayoutDelegate.interItemSpacing` in [Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Data Source/DefaultMessagesLayoutDelegate.swift](https://github.com/ephemeraHQ/convos-ios/pull/196/files#diff-968308ddba6efffc0e7a155c339a9d2e880eac39b480d96376c41ddbacb23fe5), then review bubble determination in `MessagesViewController.processUpdates` in [Convos/Conversation Detail/Messages/Messages View Controller/View Controller/MessagesViewController.swift](https://github.com/ephemeraHQ/convos-ios/pull/196/files#diff-1427b816e5e93d8bc7ea882f5eabd9671135c6f9b9ebc6b0a6f7116a2f8a37c3).

---

<!-- Macroscope's review summary starts here -->

<details>
<summary>📊 Macroscope summarized 8d238b7. 4 files reviewed, 4 issues evaluated, 4 issues filtered, 0 comments posted</summary>

### 🗂️ Filtered Issues

<details>
<summary>Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Data Source/DefaultMessagesLayoutDelegate.swift — 0 comments posted, 1 evaluated, 1 filtered</summary>

- [line 144](https://github.com/ephemeraHQ/convos-ios/blob/8d238b7f0bc58dbb4e4328ed4fd2765f9cf5541c/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Data Source/DefaultMessagesLayoutDelegate.swift#L144): `interItemSpacing(_:of:after:)` indexes into `sections` and `sections[...].cells` without bounds checks (`let item = sections[indexPath.section].cells[indexPath.item]`). If the provided `indexPath` is out of range (e.g., stale during updates, or a layout query for an index that no longer exists), this will cause a runtime crash due to out-of-bounds array access. This is inconsistent with the subsequent use of `safeCell(at:)` for the next item, which defensively guards bounds. To be robust, the method should also use a safe access for the current `indexPath` (e.g., a `safeCell(at:)` check) and return a sensible default (e.g., `nil` or `0`) when out of range. **[ Low confidence ]**

</details>

<details>
<summary>ConvosCore/Sources/ConvosCore/Storage/Writers/OutgoingMessageWriter.swift — 0 comments posted, 3 evaluated, 3 filtered</summary>

- [line 53](https://github.com/ephemeraHQ/convos-ios/blob/8d238b7f0bc58dbb4e4328ed4fd2765f9cf5541c/ConvosCore/Sources/ConvosCore/Storage/Writers/OutgoingMessageWriter.swift#L53): Using `[weak self]` in the `databaseWriter.write` closure and `guard let self else { return }` can silently skip persisting the local message if `self` is deallocated at the moment the closure executes. The method will still proceed to publish and emit `sentMessage`, leaving no corresponding local record and causing inconsistencies or auditability gaps, especially if publish succeeds. Given this is a short-lived closure invoked synchronously for a write, retaining `self` here is unlikely to cause a retain cycle and would avoid silent no-op behavior. Alternatively, explicitly handle the `self == nil` case by aborting the send before publishing. **[ Out of scope ]**
- [line 77](https://github.com/ephemeraHQ/convos-ios/blob/8d238b7f0bc58dbb4e4328ed4fd2765f9cf5541c/ConvosCore/Sources/ConvosCore/Storage/Writers/OutgoingMessageWriter.swift#L77): On the success path, the persisted `DBMessage.status` is left as `.unpublished` and never updated to a sent/published/acknowledged state after `try await sender.publish()` succeeds. This can leave the message permanently in a pending state in storage even though it was actually published, causing downstream consumers that rely on the stored status to see an inconsistent state. Consider updating the stored message status (and any other relevant fields) on success to preserve state parity. **[ Low confidence ]**
- [line 80](https://github.com/ephemeraHQ/convos-ios/blob/8d238b7f0bc58dbb4e4328ed4fd2765f9cf5541c/ConvosCore/Sources/ConvosCore/Storage/Writers/OutgoingMessageWriter.swift#L80): The `Combine` event emitted on success uses the raw input `text` (`sentMessageSubject.send(text)`) rather than any canonicalized/normalized content that may result from `sender.prepare(text:)`. If `prepare` mutates, trims, encodes, or otherwise transforms the content (or generates rich content), subscribers will receive an event that does not match the actual published payload, breaking contract parity and potentially causing UI/state mismatches. Emit the canonicalized content or include the `clientMessageId` so downstream components can look up the final persisted record. **[ Low confidence ]**

</details>

</details>

\<!-- Macroscope's review summary ends here -->

<!-- Macroscope's pull request summary ends here -->