### PR TITLE
[Draft] Set `AppUsesNonExemptEncryption` to true for Convos (Prod)

### DIFF
--- a/Convos.xcodeproj/project.pbxproj
+++ b/Convos.xcodeproj/project.pbxproj
@@ -1589,7 +1589,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Convos/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = Convos;
-				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
+				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = YES;
 				INFOPLIST_KEY_NSCameraUsageDescription = "To join a convo, scan its QR code";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;


### PR DESCRIPTION
### TL;DR

Updated app encryption declaration in project settings to indicate the app uses non-exempt encryption.

### What changed?

Changed `INFOPLIST_KEY_ITSAppUsesNonExemptEncryption` from `NO` to `YES` in the Xcode project file. This setting informs Apple that the app uses encryption that is not exempt from export compliance documentation requirements.

### How to test?

1. Build the app and verify that the generated Info.plist contains the key `ITSAppUsesNonExemptEncryption` set to `YES`
2. Ensure the app can still be submitted to the App Store without export compliance issues

### Why make this change?

The app uses encryption technologies that are subject to export regulations. This change ensures compliance with App Store requirements for apps that use non-exempt encryption, allowing proper export compliance documentation to be provided during app submission.