### PR TITLE
Register device at app level not inbox level

### DIFF
--- a/Convos.xcodeproj/xcshareddata/xcschemes/ConvosCore.xcscheme
+++ b/Convos.xcodeproj/xcshareddata/xcschemes/ConvosCore.xcscheme
@@ -61,4 +61,3 @@
       revealArchiveInOrganizer = "YES">
    </ArchiveAction>
 </Scheme>
-

--- a/ConvosAppClip/ConvosAppClipApp.swift
+++ b/ConvosAppClip/ConvosAppClipApp.swift
@@ -21,16 +21,18 @@ struct ConvosAppClipApp: App {
 
         Logger.info("App starting with environment: \(environment)")
 
-        let convos: ConvosClient = .client(environment: environment)
-        self.session = convos.session
-        self.conversationsViewModel = .init(session: session)
-        appDelegate.session = session
-
+        // Configure Firebase BEFORE creating ConvosClient
+        // This prevents a race condition where SessionManager tries to use AppCheck before it's configured
         if let url = ConfigManager.shared.currentEnvironment.firebaseConfigURL {
             FirebaseHelperCore.configure(with: url)
         } else {
             Logger.error("Missing Firebase plist URL for current environment")
         }
+
+        let convos: ConvosClient = .client(environment: environment)
+        self.session = convos.session
+        self.conversationsViewModel = .init(session: session)
+        appDelegate.session = session
     }
 
     var body: some Scene {

--- a/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift
+++ b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift
@@ -23,8 +23,6 @@ public protocol ConvosAPIClientProtocol: ConvosAPIBaseProtocol, AnyObject {
     func authenticate(appCheckToken: String,
                       retryCount: Int) async throws -> String
 
-    func checkAuth() async throws
-
     func uploadAttachment(
         data: Data,
         filename: String,
@@ -38,7 +36,6 @@ public protocol ConvosAPIClientProtocol: ConvosAPIBaseProtocol, AnyObject {
     ) async throws -> String
 
     // Push notifications
-    func registerDevice(deviceId: String, pushToken: String?) async throws
     func subscribeToTopics(deviceId: String, clientId: String, topics: [String]) async throws
     func unsubscribeFromTopics(clientId: String, topics: [String]) async throws
     func unregisterInstallation(clientId: String) async throws
@@ -176,7 +173,6 @@ final class ConvosAPIClient: BaseConvosAPIClient, ConvosAPIClientProtocol {
 
     private func reAuthenticate() async throws -> String {
         let firebaseAppCheckToken = try await FirebaseHelperCore.getAppCheckToken()
-
         return try await authenticate(
             appCheckToken: firebaseAppCheckToken,
             retryCount: 0
@@ -247,11 +243,6 @@ final class ConvosAPIClient: BaseConvosAPIClient, ConvosAPIClientProtocol {
         try keychainService.saveString(authResponse.token, for: .init(deviceId: deviceId))
         Logger.info("Successfully authenticated and stored JWT token")
         return authResponse.token
-    }
-
-    func checkAuth() async throws {
-        let request = try authenticatedRequest(for: "v2/auth-check")
-        let _: ConvosAPI.AuthCheckResponse = try await performRequest(request)
     }
 
     // MARK: - Private Helpers

--- a/ConvosCore/Sources/ConvosCore/API/MockAPIClient.swift
+++ b/ConvosCore/Sources/ConvosCore/API/MockAPIClient.swift
@@ -35,10 +35,6 @@ class MockAPIClient: MockBaseAPIClient, ConvosAPIClientProtocol {
         return "mock-jwt-token"
     }
 
-    func checkAuth() async throws {
-        // Mock implementation - always succeeds
-    }
-
     func uploadAttachment(
         data: Data,
         filename: String,

--- a/ConvosCore/Sources/ConvosCore/AppEnvironment.swift
+++ b/ConvosCore/Sources/ConvosCore/AppEnvironment.swift
@@ -163,7 +163,7 @@ public enum AppEnvironment {
 }
 
 public extension AppEnvironment {
-    private var isTestingEnvironment: Bool {
+    var isTestingEnvironment: Bool {
         switch self {
         case .tests:
             true

--- a/ConvosCore/Sources/ConvosCore/Messaging/MessagingService.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/MessagingService.swift
@@ -26,6 +26,7 @@ final class MessagingService: MessagingServiceProtocol {
         databaseReader: any DatabaseReader,
         environment: AppEnvironment,
         startsStreamingServices: Bool,
+        deviceRegistrationManager: (any DeviceRegistrationManagerProtocol)? = nil,
         overrideJWTToken: String? = nil
     ) -> MessagingService {
         let identityStore = environment.defaultIdentityStore
@@ -37,6 +38,7 @@ final class MessagingService: MessagingServiceProtocol {
             databaseWriter: databaseWriter,
             environment: environment,
             startsStreamingServices: startsStreamingServices,
+            deviceRegistrationManager: deviceRegistrationManager,
             overrideJWTToken: overrideJWTToken
         )
         return MessagingService(

--- a/ConvosCore/Sources/ConvosCore/Syncing/SyncingManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/SyncingManager.swift
@@ -49,12 +49,14 @@ actor SyncingManager: SyncingManagerProtocol {
 
     init(identityStore: any KeychainIdentityStoreProtocol,
          databaseWriter: any DatabaseWriter,
-         databaseReader: any DatabaseReader) {
+         databaseReader: any DatabaseReader,
+         deviceRegistrationManager: (any DeviceRegistrationManagerProtocol)? = nil) {
         self.identityStore = identityStore
         self.streamProcessor = StreamProcessor(
             identityStore: identityStore,
             databaseWriter: databaseWriter,
-            databaseReader: databaseReader
+            databaseReader: databaseReader,
+            deviceRegistrationManager: deviceRegistrationManager
         )
         self.profileWriter = MemberProfileWriter(databaseWriter: databaseWriter)
         self.joinRequestsManager = InviteJoinRequestsManager(

--- a/ConvosCore/Tests/ConvosCoreTests/InboxStateMachineTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/InboxStateMachineTests.swift
@@ -81,9 +81,9 @@ struct InboxStateMachineTests {
 
         let stateMachine = InboxStateMachine(
             clientId: clientId,
-            identityStore: await fixtures.identityStore,
+            identityStore: fixtures.identityStore,
             invitesRepository: mockInvites,
-            databaseWriter: await fixtures.databaseManager.dbWriter,
+            databaseWriter: fixtures.databaseManager.dbWriter,
             syncingManager: nil,
             savesInboxToDatabase: false, // Don't save to database
             environment: .tests
@@ -193,9 +193,9 @@ struct InboxStateMachineTests {
 
         let stateMachine = InboxStateMachine(
             clientId: wrongClientId,
-            identityStore: await fixtures.identityStore,
+            identityStore: fixtures.identityStore,
             invitesRepository: mockInvites,
-            databaseWriter: await fixtures.databaseManager.dbWriter,
+            databaseWriter: fixtures.databaseManager.dbWriter,
             syncingManager: nil,
             savesInboxToDatabase: true,
             environment: .tests
@@ -432,9 +432,9 @@ struct InboxStateMachineTests {
 
         let stateMachine = InboxStateMachine(
             clientId: clientId,
-            identityStore: await fixtures.identityStore,
+            identityStore: fixtures.identityStore,
             invitesRepository: mockInvites,
-            databaseWriter: await fixtures.databaseManager.dbWriter,
+            databaseWriter: fixtures.databaseManager.dbWriter,
             syncingManager: nil,
             savesInboxToDatabase: true,
             environment: .tests
@@ -490,7 +490,6 @@ struct InboxStateMachineTests {
 
         // Verify state progression
         let observedStates = await collector.getStates()
-        #expect(observedStates.contains("idle"))
         #expect(observedStates.contains("registering"))
         #expect(observedStates.contains("authenticatingBackend"))
         #expect(observedStates.contains("ready"))


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Register device at app level by configuring Firebase in `ConvosApp.App.init` and `ConvosAppClipApp.App.init` before creating `ConvosClient` and shifting registration from `InboxStateMachine` to `SessionManager`
Move Firebase setup to app initializers with an environment gate for tests, remove `checkAuth()` and `registerDevice` from `ConvosAPIClientProtocol`, and centralize device registration and push token observation in `SessionManager` with `DeviceRegistrationManager` while extracting authentication into `InboxStateMachine.authenticateBackend` using Firebase AppCheck.

#### 📍Where to Start
Start with Firebase initialization in `App.init` in [Convos/ConvosApp.swift](https://github.com/ephemeraHQ/convos-ios/pull/204/files#diff-de23c5a6e10cb84b89d91ed62b707b654c28566f38cc339af8b3cbbf6e003014), then review device registration flow beginning in `SessionManager` in [ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift](https://github.com/ephemeraHQ/convos-ios/pull/204/files#diff-047bb043999d66a7809a8ab86918296f5f449652df54267763f6ec8da0a71ca7) and authentication changes in `InboxStateMachine.authenticateBackend` in [ConvosCore/Sources/ConvosCore/Inboxes/InboxStateMachine.swift](https://github.com/ephemeraHQ/convos-ios/pull/204/files#diff-314f69bca557159935a2f6c3e545b7374a861df38d5bda997858ecee5fad58f1).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized fdacc03.
<!-- Macroscope's review summary ends here -->

<!-- Macroscope's pull request summary ends here -->