### PR TITLE
Request notifications inline in convo view

### DIFF
--- a/Convos/Conversation Creation/QRScannerView.swift
+++ b/Convos/Conversation Creation/QRScannerView.swift
@@ -3,6 +3,7 @@ import ConvosCore
 import SwiftUI
 
 // MARK: - QR Scanner Delegate
+@MainActor
 @Observable
 class QRScannerViewModel: NSObject, AVCaptureMetadataOutputObjectsDelegate {
     var scannedCode: String?
@@ -19,13 +20,11 @@ class QRScannerViewModel: NSObject, AVCaptureMetadataOutputObjectsDelegate {
     private var lastScanTime: Date?
 
     func requestAccess() {
-        AVCaptureDevice.requestAccess(for: .video) { granted in
-            DispatchQueue.main.async {
-                self.cameraAuthorized = granted
-                if granted {
-                    // Trigger camera setup using the callback
-                    self.onSetupCamera?()
-                }
+        AVCaptureDevice.requestAccess(for: .video) { @MainActor [weak self] granted in
+            self?.cameraAuthorized = granted
+            if granted {
+                // Trigger camera setup using the callback
+                self?.onSetupCamera?()
             }
         }
     }
@@ -121,12 +120,10 @@ struct QRScannerView: UIViewRepresentable {
             self.setupCamera()
         }
 
-        checkCameraAuthorization { authorized in
-            DispatchQueue.main.async {
-                self.viewModel.cameraAuthorized = authorized
-                if authorized {
-                    self.setupCamera()
-                }
+        checkCameraAuthorization { @MainActor [weak viewModel] authorized in
+            viewModel?.cameraAuthorized = authorized
+            if authorized {
+                self.setupCamera()
             }
         }
 

--- a/Convos/Conversation Detail/Messages/Messages View Controller/Keyboard/KeyboardListener.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/Keyboard/KeyboardListener.swift
@@ -1,6 +1,7 @@
 import Foundation
 import UIKit
 
+@MainActor
 protocol KeyboardListenerDelegate: AnyObject {
     func keyboardWillShow(info: KeyboardInfo)
     func keyboardDidShow(info: KeyboardInfo)
@@ -40,7 +41,7 @@ final class KeyboardListener {
         subscribeToKeyboardNotifications()
     }
 
-    @objc
+    @objc @MainActor
     private func keyboardWillShow(_ notification: Notification) {
         guard let info = KeyboardInfo(notification) else {
             return
@@ -52,7 +53,7 @@ final class KeyboardListener {
         }
     }
 
-    @objc
+    @objc @MainActor
     private func keyboardWillChangeFrame(_ notification: Notification) {
         guard let info = KeyboardInfo(notification) else {
             return
@@ -74,7 +75,7 @@ final class KeyboardListener {
         }
     }
 
-    @objc
+    @objc @MainActor
     private func keyboardDidChangeFrame(_ notification: Notification) {
         guard let info = KeyboardInfo(notification) else {
             return
@@ -91,7 +92,7 @@ final class KeyboardListener {
         }
     }
 
-    @objc
+    @objc @MainActor
     private func keyboardDidShow(_ notification: Notification) {
         guard let info = KeyboardInfo(notification) else {
             return
@@ -103,7 +104,7 @@ final class KeyboardListener {
         }
     }
 
-    @objc
+    @objc @MainActor
     private func keyboardWillHide(_ notification: Notification) {
         guard let info = KeyboardInfo(notification) else {
             return
@@ -115,7 +116,7 @@ final class KeyboardListener {
         }
     }
 
-    @objc
+    @objc @MainActor
     private func keyboardDidHide(_ notification: Notification) {
         guard let info = KeyboardInfo(notification) else {
             return
@@ -127,6 +128,7 @@ final class KeyboardListener {
         }
     }
 
+    @MainActor
     private func handleMissingDidChangeFrame() {
         guard let info = pendingDidChangeFrameInfo else { return }
 

--- a/Convos/Conversation Detail/Messages/Messages View Controller/Reactions/MessageReactionMenuViewModel.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/Reactions/MessageReactionMenuViewModel.swift
@@ -2,6 +2,7 @@ import Combine
 import Foundation
 import SwiftUI
 
+@MainActor
 @Observable
 class MessageReactionMenuViewModel {
     enum ViewState {

--- a/ConvosCore/Sources/ConvosCore/Inboxes/ConversationStateMachine.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/ConversationStateMachine.swift
@@ -317,11 +317,6 @@ public actor ConversationStateMachine {
     private func handleCreate() async throws {
         emitStateChange(.creating)
 
-        // Request push notification permissions when user creates a conversation
-        // Device is already registered (from app launch), and will be updated
-        // automatically when APNS token arrives via the observer
-        await PushNotificationRegistrar.requestNotificationAuthorizationIfNeeded()
-
         let inboxReady = try await inboxStateManager.waitForInboxReadyResult()
         Logger.info("Inbox ready, creating conversation...")
 
@@ -492,11 +487,6 @@ public actor ConversationStateMachine {
         previousReadyResult: ConversationReadyResult?
     ) async throws {
         emitStateChange(.joining(invite: invite, placeholder: placeholder))
-
-        // Request push notification permissions when user joins a conversation
-        // Device is already registered (from app launch), and will be updated
-        // automatically when APNS token arrives via the observer
-        await PushNotificationRegistrar.requestNotificationAuthorizationIfNeeded()
 
         Logger.info("Requesting to join conversation...")
 


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Request push notifications inline in NewConversationView and gate prompting via `ConversationViewModel.shouldAskToAllowNotifications`
Add `AllowPushNotificationsView` to the New Conversation flow to present a staged inline prompt and call `ConversationViewModel.requestPushNotificationsPermission()`; track authorization via `ConversationViewModel.shouldAskToAllowNotifications` and update it with `checkNotificationPermissions()`; remove proactive authorization requests from `ConversationStateMachine` create/join paths; annotate related view models, delegates, and keyboard handlers with `@MainActor` and move main-thread dispatch to actor annotations.

#### 📍Where to Start
Start with the inline prompt wiring in `NewConversationView` and the permission state logic in `ConversationViewModel`: see [NewConversationView.swift](https://github.com/ephemeraHQ/convos-ios/pull/205/files#diff-be8eeec29bfb3f245f16cd6258d1ef28ced1aa75bad52187e34243f915b084f6) and [ConversationViewModel.swift](https://github.com/ephemeraHQ/convos-ios/pull/205/files#diff-d056b0b131534648b6d13cddafd053be956f5d23d035ad2538db85a8cc370d8d).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 40db8f8.
<!-- Macroscope's review summary ends here -->

<!-- Macroscope's pull request summary ends here -->