### PR TITLE
Always save the inbox to the database

### DIFF
--- a/Convos.xcodeproj/project.pbxproj
+++ b/Convos.xcodeproj/project.pbxproj
@@ -104,7 +104,6 @@
 /* Begin PBXFileReference section */
 		7A1C3C512DB6F75000B723C0 /* Convos.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; path = Convos.xcodeproj; sourceTree = "<group>"; };
 		7A7BB1322DB6FF8E009B8BBF /* Convos.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; path = Convos.xcodeproj; sourceTree = "<group>"; };
-		7A95EF7F2EB670930086CCB1 /* ConvosCore.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = ConvosCore.xctestplan; sourceTree = "<group>"; };
 		7AC599312E5592F900D65D07 /* KeychainIdentityStoreExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = KeychainIdentityStoreExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		7AC5993D2E5592FA00D65D07 /* KeychainIdentityStoreTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = KeychainIdentityStoreTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		7ACA8BA32DE16DE200848799 /* ConvosTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ConvosTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -174,6 +173,7 @@
 				"Conversation Creation/NewConversationView.swift",
 				"Conversation Creation/NewConversationViewModel.swift",
 				"Conversation Creation/QRScannerView.swift",
+				"Conversation Creation/QRScannerViewModel.swift",
 				"Conversation Detail/ConversationForkedInfoView.swift",
 				"Conversation Detail/ConversationInfoEditView.swift",
 				"Conversation Detail/ConversationInfoView.swift",
@@ -428,7 +428,6 @@
 		D8A2B6882DA4BA4B00EF8577 = {
 			isa = PBXGroup;
 			children = (
-				7A95EF7F2EB670930086CCB1 /* ConvosCore.xctestplan */,
 				7AD5458D2E4EA89400500ADF /* ConvosCore */,
 				D8477AD42DCBA52F00E31E54 /* .env */,
 				D8477AD52DCBA52F00E31E54 /* .env.example */,

--- a/Convos.xcodeproj/xcshareddata/xcschemes/ConvosCore.xcscheme
+++ b/Convos.xcodeproj/xcshareddata/xcschemes/ConvosCore.xcscheme
@@ -11,8 +11,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "NO"
-      shouldAutocreateTestPlan = "YES">
+      shouldUseLaunchSchemeArgsEnv = "NO">
       <EnvironmentVariables>
          <EnvironmentVariable
             key = "TEST_SERVER_ENABLED"
@@ -20,6 +19,12 @@
             isEnabled = "YES">
          </EnvironmentVariable>
       </EnvironmentVariables>
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:ConvosCore.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+      </TestPlans>
       <Testables>
          <TestableReference
             skipped = "NO"

--- a/Convos/Conversation Creation/JoinConversationView.swift
+++ b/Convos/Conversation Creation/JoinConversationView.swift
@@ -8,7 +8,6 @@ struct JoinConversationView: View {
     let allowsDismissal: Bool
     let onScannedCode: (String) -> Void
 
-    @State private var qrScannerCoordinator: QRScannerView.Coordinator?
     @State private var showingExplanation: Bool = false
 
     @Environment(\.dismiss) private var dismiss: DismissAction
@@ -17,7 +16,7 @@ struct JoinConversationView: View {
     var body: some View {
         NavigationStack {
             ZStack {
-                QRScannerView(viewModel: viewModel, coordinator: $qrScannerCoordinator)
+                QRScannerView(viewModel: viewModel)
                     .ignoresSafeArea()
 
                 let cutoutSize = 240.0
@@ -63,35 +62,22 @@ struct JoinConversationView: View {
                         }
                         .padding(.bottom, DesignConstants.Spacing.step3x)
 
-                        Button {
-                            withAnimation {
-                                showingExplanation.toggle()
-                            }
-                        } label: {
-                            if showingExplanation {
-                                Text("Scan a convo code to access the app")
+                        VStack(spacing: DesignConstants.Spacing.step3x) {
+                            HStack(spacing: DesignConstants.Spacing.step2x) {
+                                Image(systemName: "qrcode")
+                                    .foregroundStyle(.white)
+                                Text("Join a convo by invitation only")
                                     .font(.system(size: 16.0))
                                     .multilineTextAlignment(.center)
                                     .foregroundStyle(.white)
-                            } else {
-                                VStack(spacing: DesignConstants.Spacing.step3x) {
-                                    HStack(spacing: DesignConstants.Spacing.step2x) {
-                                        Image(systemName: "qrcode")
-                                            .foregroundStyle(.white)
-                                        Text("Join a convo by invitation only")
-                                            .font(.system(size: 16.0))
-                                            .multilineTextAlignment(.center)
-                                            .foregroundStyle(.white)
-                                    }
-                                    Text("Ask a friend to invite you to a convo, then scan its code or tap its link to enter the app.")
-                                        .font(.system(size: 16.0))
-                                        .multilineTextAlignment(.center)
-                                        .foregroundStyle(.white)
-                                        .opacity(0.6)
-                                }
-                                .padding(.horizontal, DesignConstants.Spacing.step10x)
                             }
+                            Text("Ask a friend to invite you to a convo, then scan its code or tap its link to enter the app.")
+                                .font(.system(size: 16.0))
+                                .multilineTextAlignment(.center)
+                                .foregroundStyle(.white)
+                                .opacity(0.6)
                         }
+                        .padding(.horizontal, DesignConstants.Spacing.step10x)
 
                         Spacer()
 
@@ -177,7 +163,10 @@ struct JoinConversationView: View {
             // Request access for the first time
             viewModel.requestAccess()
         case .authorized:
-            viewModel.onSetupCamera?()
+            // Already authorized (e.g., user came back from Settings)
+            // Update the view model state and trigger camera setup
+            viewModel.cameraAuthorized = true
+            viewModel.triggerCameraSetup()
         @unknown default:
             break
         }

--- a/Convos/Conversation Creation/QRScannerViewModel.swift
+++ b/Convos/Conversation Creation/QRScannerViewModel.swift
@@ -1,0 +1,81 @@
+import AVFoundation
+import SwiftUI
+
+@MainActor
+@Observable
+class QRScannerViewModel: NSObject, AVCaptureMetadataOutputObjectsDelegate {
+    var scannedCode: String?
+    var cameraAuthorized: Bool = false
+    var cameraSetupCompleted: Bool = false
+    var isScanningEnabled: Bool = true
+    var showInvalidInviteCodeFormat: Bool = false
+    var invalidInviteCode: String?
+    var presentingInvalidInviteSheet: Bool = false
+
+    // Minimum time to wait before allowing another scan (in seconds)
+    private let minimumScanInterval: TimeInterval = 3.0
+    private var lastScanTime: Date?
+
+    // callback for camera setup - set by QRScannerView
+    var setupCameraCallback: (() -> Void)?
+
+    func requestAccess() {
+        AVCaptureDevice.requestAccess(for: .video) { [weak self] granted in
+            Task { @MainActor in
+                self?.cameraAuthorized = granted
+                if granted {
+                    self?.triggerCameraSetup()
+                }
+            }
+        }
+    }
+
+    /// Triggers camera setup if the callback is available (called when camera becomes authorized)
+    func triggerCameraSetup() {
+        setupCameraCallback?()
+    }
+
+    nonisolated func metadataOutput(
+        _ output: AVCaptureMetadataOutput,
+        didOutput metadataObjects: [AVMetadataObject],
+        from connection: AVCaptureConnection
+    ) {
+        Task { @MainActor in
+            // Only process if scanning is enabled and we're not showing an error
+            guard isScanningEnabled else { return }
+
+            guard !presentingInvalidInviteSheet else { return }
+
+            // Check if enough time has passed since the last scan
+            let now = Date()
+            if let lastScan = lastScanTime {
+                let timeSinceLastScan = now.timeIntervalSince(lastScan)
+                guard timeSinceLastScan >= minimumScanInterval else { return }
+            }
+
+            lastScanTime = now
+
+            if let metadataObject = metadataObjects.first {
+                guard let readableObject = metadataObject as? AVMetadataMachineReadableCodeObject else { return }
+                guard let stringValue = readableObject.stringValue else { return }
+
+                AudioServicesPlaySystemSound(SystemSoundID(kSystemSoundID_Vibrate))
+                scannedCode = stringValue
+
+                // Disable further scanning after detecting a code
+                isScanningEnabled = false
+            }
+        }
+    }
+
+    func resetScanning() {
+        isScanningEnabled = true
+        scannedCode = nil
+        // Note: we intentionally do NOT reset lastScanTime here
+        // to maintain the minimum interval even across resets
+    }
+
+    func resetScanTimer() {
+        lastScanTime = nil
+    }
+}

--- a/ConvosCore.xctestplan
+++ b/ConvosCore.xctestplan
@@ -1,7 +1,7 @@
 {
   "configurations" : [
     {
-      "id" : "217FE7F2-A58A-4C34-9821-3CD768352D65",
+      "id" : "5712C5B8-C706-4C2F-AD6A-6E754A6C0CA2",
       "name" : "Test Scheme Action",
       "options" : {
 
@@ -9,16 +9,30 @@
     }
   ],
   "defaultOptions" : {
+    "environmentVariableEntries" : [
+      {
+        "key" : "TEST_SERVER_ENABLED",
+        "value" : "true"
+      }
+    ],
     "performanceAntipatternCheckerEnabled" : true
   },
   "testTargets" : [
     {
+      "parallelizable" : true,
+      "skippedTests" : {
+        "suites" : [
+          {
+            "name" : "InboxStateMachineTests"
+          }
+        ]
+      },
       "target" : {
-        "containerPath" : "container:",
+        "containerPath" : "container:ConvosCore",
         "identifier" : "ConvosCoreTests",
         "name" : "ConvosCoreTests"
       }
     }
   ],
-  "version" : 1
+  "version" : 2
 }

--- a/ConvosCore/Sources/ConvosCore/Inboxes/AuthorizeInboxOperation.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/AuthorizeInboxOperation.swift
@@ -47,7 +47,6 @@ final class AuthorizeInboxOperation: AuthorizeInboxOperationProtocol {
         databaseWriter: any DatabaseWriter,
         environment: AppEnvironment,
         startsStreamingServices: Bool,
-        deviceRegistrationManager: (any DeviceRegistrationManagerProtocol)? = nil,
         overrideJWTToken: String? = nil
     ) -> AuthorizeInboxOperation {
         let operation = AuthorizeInboxOperation(
@@ -57,7 +56,6 @@ final class AuthorizeInboxOperation: AuthorizeInboxOperationProtocol {
             databaseWriter: databaseWriter,
             environment: environment,
             startsStreamingServices: startsStreamingServices,
-            deviceRegistrationManager: deviceRegistrationManager,
             overrideJWTToken: overrideJWTToken
         )
         operation.authorize(inboxId: inboxId, clientId: clientId)
@@ -68,9 +66,7 @@ final class AuthorizeInboxOperation: AuthorizeInboxOperationProtocol {
         identityStore: any KeychainIdentityStoreProtocol,
         databaseReader: any DatabaseReader,
         databaseWriter: any DatabaseWriter,
-        environment: AppEnvironment,
-        deviceRegistrationManager: (any DeviceRegistrationManagerProtocol)? = nil,
-        savesInboxToDatabase: Bool = true
+        environment: AppEnvironment
     ) -> AuthorizeInboxOperation {
         // Generate clientId before creating state machine
         let clientId = ClientId.generate().value
@@ -80,9 +76,7 @@ final class AuthorizeInboxOperation: AuthorizeInboxOperationProtocol {
             databaseReader: databaseReader,
             databaseWriter: databaseWriter,
             environment: environment,
-            startsStreamingServices: true,
-            deviceRegistrationManager: deviceRegistrationManager,
-            savesInboxToDatabase: savesInboxToDatabase
+            startsStreamingServices: true
         )
         operation.register(clientId: clientId)
         return operation
@@ -95,15 +89,13 @@ final class AuthorizeInboxOperation: AuthorizeInboxOperationProtocol {
         databaseWriter: any DatabaseWriter,
         environment: AppEnvironment,
         startsStreamingServices: Bool,
-        deviceRegistrationManager: (any DeviceRegistrationManagerProtocol)? = nil,
-        savesInboxToDatabase: Bool = true,
         overrideJWTToken: String? = nil
     ) {
         let syncingManager = startsStreamingServices ? SyncingManager(
             identityStore: identityStore,
             databaseWriter: databaseWriter,
             databaseReader: databaseReader,
-            deviceRegistrationManager: deviceRegistrationManager
+            deviceRegistrationManager: DeviceRegistrationManager(environment: environment)
         ) : nil
         let invitesRepository = InvitesRepository(databaseReader: databaseReader)
         stateMachine = InboxStateMachine(
@@ -112,7 +104,6 @@ final class AuthorizeInboxOperation: AuthorizeInboxOperationProtocol {
             invitesRepository: invitesRepository,
             databaseWriter: databaseWriter,
             syncingManager: syncingManager,
-            savesInboxToDatabase: savesInboxToDatabase,
             overrideJWTToken: overrideJWTToken,
             environment: environment
         )

--- a/ConvosCore/Sources/ConvosCore/Messaging/MessagingService.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/MessagingService.swift
@@ -26,7 +26,6 @@ final class MessagingService: MessagingServiceProtocol {
         databaseReader: any DatabaseReader,
         environment: AppEnvironment,
         startsStreamingServices: Bool,
-        deviceRegistrationManager: (any DeviceRegistrationManagerProtocol)? = nil,
         overrideJWTToken: String? = nil
     ) -> MessagingService {
         let identityStore = environment.defaultIdentityStore
@@ -38,7 +37,6 @@ final class MessagingService: MessagingServiceProtocol {
             databaseWriter: databaseWriter,
             environment: environment,
             startsStreamingServices: startsStreamingServices,
-            deviceRegistrationManager: deviceRegistrationManager,
             overrideJWTToken: overrideJWTToken
         )
         return MessagingService(

--- a/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
@@ -130,8 +130,7 @@ public final class SessionManager: SessionManagerProtocol {
             databaseWriter: databaseWriter,
             databaseReader: databaseReader,
             environment: environment,
-            startsStreamingServices: true,
-            deviceRegistrationManager: deviceRegistrationManager
+            startsStreamingServices: true
         )
     }
 
@@ -292,6 +291,7 @@ public final class SessionManager: SessionManagerProtocol {
 
         // Delete all from database
         let inboxWriter = InboxWriter(dbWriter: databaseWriter)
+        Logger.info("Deleting all inboxes from database")
         try await inboxWriter.deleteAll()
 
         await UnusedInboxCache.shared

--- a/ConvosCore/Tests/ConvosCoreTests/InboxStateMachineTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/InboxStateMachineTests.swift
@@ -33,7 +33,6 @@ struct InboxStateMachineTests {
             invitesRepository: mockInvites,
             databaseWriter: fixtures.databaseManager.dbWriter,
             syncingManager: mockSync,
-            savesInboxToDatabase: true,
             overrideJWTToken: "test-jwt-token",  // Skip backend auth for tests
             environment: .tests
         )
@@ -72,8 +71,8 @@ struct InboxStateMachineTests {
         try? await fixtures.cleanup()
     }
 
-    @Test("Register without saving to database still saves to keychain")
-    func testRegisterWithoutDatabaseSave() async throws {
+    @Test("Register saves to both keychain and database")
+    func testRegisterSavesToKeychainAndDatabase() async throws {
         let fixtures = TestFixtures()
 
         let clientId = ClientId.generate().value
@@ -85,7 +84,7 @@ struct InboxStateMachineTests {
             invitesRepository: mockInvites,
             databaseWriter: fixtures.databaseManager.dbWriter,
             syncingManager: nil,
-            savesInboxToDatabase: false, // Don't save to database
+            overrideJWTToken: "test-jwt-token",
             environment: .tests
         )
 
@@ -116,11 +115,12 @@ struct InboxStateMachineTests {
         let savedIdentity = try await fixtures.identityStore.identity(for: result!.client.inboxId)
         #expect(savedIdentity.clientId == clientId)
 
-        // Verify NOT saved to database
+        // Verify saved to database
         let dbInboxes = try await fixtures.databaseManager.dbReader.read { db in
             try DBInbox.fetchAll(db)
         }
-        #expect(dbInboxes.isEmpty, "Should not save to database when savesInboxToDatabase is false")
+        #expect(dbInboxes.count == 1, "Should save to database")
+        #expect(dbInboxes.first?.clientId == clientId)
 
         // Clean up
         try? result?.client.deleteLocalDatabase()
@@ -145,7 +145,6 @@ struct InboxStateMachineTests {
             invitesRepository: mockInvites,
             databaseWriter: fixtures.databaseManager.dbWriter,
             syncingManager: mockSync,
-            savesInboxToDatabase: true,
             overrideJWTToken: "test-jwt-token",  // Skip backend auth for tests
             environment: .tests
         )
@@ -197,7 +196,6 @@ struct InboxStateMachineTests {
             invitesRepository: mockInvites,
             databaseWriter: fixtures.databaseManager.dbWriter,
             syncingManager: nil,
-            savesInboxToDatabase: true,
             environment: .tests
         )
 
@@ -246,7 +244,6 @@ struct InboxStateMachineTests {
             invitesRepository: mockInvites,
             databaseWriter: fixtures.databaseManager.dbWriter,
             syncingManager: mockSync,
-            savesInboxToDatabase: true,
             overrideJWTToken: "test-jwt-token",  // Skip backend auth for tests
             environment: .tests
         )
@@ -312,7 +309,6 @@ struct InboxStateMachineTests {
             invitesRepository: mockInvites,
             databaseWriter: fixtures.databaseManager.dbWriter,
             syncingManager: mockSync,
-            savesInboxToDatabase: true,
             overrideJWTToken: "test-jwt-token",  // Skip backend auth for tests
             environment: .tests
         )
@@ -383,7 +379,6 @@ struct InboxStateMachineTests {
             invitesRepository: mockInvites,
             databaseWriter: fixtures.databaseManager.dbWriter,
             syncingManager: mockSync,
-            savesInboxToDatabase: true,
             overrideJWTToken: "test-jwt-token",  // Skip backend auth for tests
             environment: .tests
         )
@@ -436,7 +431,6 @@ struct InboxStateMachineTests {
             invitesRepository: mockInvites,
             databaseWriter: fixtures.databaseManager.dbWriter,
             syncingManager: nil,
-            savesInboxToDatabase: true,
             environment: .tests
         )
 
@@ -518,7 +512,6 @@ struct InboxStateMachineTests {
             invitesRepository: mockInvites,
             databaseWriter: fixtures.databaseManager.dbWriter,
             syncingManager: mockSync,
-            savesInboxToDatabase: true,
             overrideJWTToken: "test-jwt-token",  // Skip backend auth for tests
             environment: .tests
         )

--- a/ConvosCore/Tests/ConvosCoreTests/InboxWriterTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/InboxWriterTests.swift
@@ -1,0 +1,144 @@
+@testable import ConvosCore
+import Foundation
+import GRDB
+import Testing
+
+/// Tests for InboxWriter
+///
+/// Tests cover:
+/// - Saving new inbox
+/// - Detecting clientId mismatch (invariant violation)
+/// - Idempotent saves with matching clientId
+@Suite("InboxWriter Tests")
+struct InboxWriterTests {
+
+    @Test("Save creates new inbox in database")
+    func testSaveNewInbox() async throws {
+        let fixtures = TestFixtures()
+        let inboxWriter = InboxWriter(dbWriter: fixtures.databaseManager.dbWriter)
+
+        let inboxId = "test-inbox-id"
+        let clientId = ClientId.generate().value
+
+        let savedInbox = try await inboxWriter.save(inboxId: inboxId, clientId: clientId)
+
+        #expect(savedInbox.inboxId == inboxId)
+        #expect(savedInbox.clientId == clientId)
+
+        // Verify it's in the database
+        let dbInbox = try await fixtures.databaseManager.dbReader.read { db in
+            try DBInbox.fetchOne(db, id: inboxId)
+        }
+
+        #expect(dbInbox != nil)
+        #expect(dbInbox?.clientId == clientId)
+
+        try? await fixtures.cleanup()
+    }
+
+    @Test("Save is idempotent when clientId matches")
+    func testSaveIdempotentWithMatchingClientId() async throws {
+        let fixtures = TestFixtures()
+        let inboxWriter = InboxWriter(dbWriter: fixtures.databaseManager.dbWriter)
+
+        let inboxId = "test-inbox-id"
+        let clientId = ClientId.generate().value
+
+        // Save once
+        let firstSave = try await inboxWriter.save(inboxId: inboxId, clientId: clientId)
+
+        // Save again with same clientId
+        let secondSave = try await inboxWriter.save(inboxId: inboxId, clientId: clientId)
+
+        #expect(firstSave.inboxId == secondSave.inboxId)
+        #expect(firstSave.clientId == secondSave.clientId)
+
+        // Verify only one record in database
+        let dbInboxes = try await fixtures.databaseManager.dbReader.read { db in
+            try DBInbox.fetchAll(db)
+        }
+
+        #expect(dbInboxes.count == 1)
+
+        try? await fixtures.cleanup()
+    }
+
+    @Test("Save throws error when clientId doesn't match (invariant violation)")
+    func testSaveThrowsOnClientIdMismatch() async throws {
+        let fixtures = TestFixtures()
+        let inboxWriter = InboxWriter(dbWriter: fixtures.databaseManager.dbWriter)
+
+        let inboxId = "test-inbox-id"
+        let originalClientId = ClientId.generate().value
+        let differentClientId = ClientId.generate().value
+
+        // Save with original clientId
+        _ = try await inboxWriter.save(inboxId: inboxId, clientId: originalClientId)
+
+        // Attempt to save with different clientId should throw
+        await #expect(throws: InboxWriterError.self) {
+            try await inboxWriter.save(inboxId: inboxId, clientId: differentClientId)
+        }
+
+        // Verify the original clientId is still in database (unchanged)
+        let dbInbox = try await fixtures.databaseManager.dbReader.read { db in
+            try DBInbox.fetchOne(db, id: inboxId)
+        }
+
+        #expect(dbInbox?.clientId == originalClientId)
+
+        try? await fixtures.cleanup()
+    }
+
+    @Test("Delete removes inbox from database")
+    func testDeleteInbox() async throws {
+        let fixtures = TestFixtures()
+        let inboxWriter = InboxWriter(dbWriter: fixtures.databaseManager.dbWriter)
+
+        let inboxId = "test-inbox-id"
+        let clientId = ClientId.generate().value
+
+        // Save inbox
+        _ = try await inboxWriter.save(inboxId: inboxId, clientId: clientId)
+
+        // Verify it exists
+        var dbInbox = try await fixtures.databaseManager.dbReader.read { db in
+            try DBInbox.fetchOne(db, id: inboxId)
+        }
+        #expect(dbInbox != nil)
+
+        // Delete it
+        try await inboxWriter.delete(inboxId: inboxId)
+
+        // Verify it's gone
+        dbInbox = try await fixtures.databaseManager.dbReader.read { db in
+            try DBInbox.fetchOne(db, id: inboxId)
+        }
+        #expect(dbInbox == nil)
+
+        try? await fixtures.cleanup()
+    }
+
+    @Test("Delete by clientId removes inbox from database")
+    func testDeleteByClientId() async throws {
+        let fixtures = TestFixtures()
+        let inboxWriter = InboxWriter(dbWriter: fixtures.databaseManager.dbWriter)
+
+        let inboxId = "test-inbox-id"
+        let clientId = ClientId.generate().value
+
+        // Save inbox
+        _ = try await inboxWriter.save(inboxId: inboxId, clientId: clientId)
+
+        // Delete by clientId
+        try await inboxWriter.delete(clientId: clientId)
+
+        // Verify it's gone
+        let dbInbox = try await fixtures.databaseManager.dbReader.read { db in
+            try DBInbox.fetchOne(db, id: inboxId)
+        }
+        #expect(dbInbox == nil)
+
+        try? await fixtures.cleanup()
+    }
+}


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Always persist inbox records during `InboxStateMachine.handleAuthorize` and `InboxStateMachine.handleRegister`, and enforce client identity consistency across `InboxWriter.save` and deletion paths
Make inbox persistence unconditional during authorization and registration, add identity consistency checks, and make deletion idempotent across multiple states. Update camera scanning flow to use callbacks in `QRScannerViewModel` and remove coordinator binding in `QRScannerView`. Require explicit test plans and skip `InboxStateMachineTests` in the shared plan with `TEST_SERVER_ENABLED=true` and version 2.

#### 📍Where to Start
Start with `InboxStateMachine` state transitions and persistence logic in [InboxStateMachine.swift](https://github.com/ephemeraHQ/convos-ios/pull/206/files#diff-314f69bca557159935a2f6c3e545b7374a861df38d5bda997858ecee5fad58f1), then review invariant enforcement in `InboxWriter.save` in [InboxWriter.swift](https://github.com/ephemeraHQ/convos-ios/pull/206/files#diff-d31351dd3519a84b88e4b68a677f5132b97fed735549a049daebf75b3fe16d57).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 459a664.
<!-- Macroscope's review summary ends here -->

<!-- Macroscope's pull request summary ends here -->