### PR TITLE
Fix inbox state machine tests, fix warnings

### DIFF
--- a/Convos.xcodeproj/xcshareddata/xcschemes/ConvosCore.xcscheme
+++ b/Convos.xcodeproj/xcshareddata/xcschemes/ConvosCore.xcscheme
@@ -6,6 +6,22 @@
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES"
       buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "ConvosCore"
+               BuildableName = "ConvosCore"
+               BlueprintName = "ConvosCore"
+               ReferencedContainer = "container:ConvosCore">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
    </BuildAction>
    <TestAction
       buildConfiguration = "Debug"

--- a/ConvosCore/ConvosCore.xctestplan
+++ b/ConvosCore/ConvosCore.xctestplan
@@ -1,0 +1,31 @@
+{
+  "configurations" : [
+    {
+      "id" : "5712C5B8-C706-4C2F-AD6A-6E754A6C0CA2",
+      "name" : "Test Scheme Action",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "environmentVariableEntries" : [
+      {
+        "key" : "TEST_SERVER_ENABLED",
+        "value" : "true"
+      }
+    ],
+    "performanceAntipatternCheckerEnabled" : true
+  },
+  "testTargets" : [
+    {
+      "parallelizable" : true,
+      "target" : {
+        "containerPath" : "container:",
+        "identifier" : "ConvosCoreTests",
+        "name" : "ConvosCoreTests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/dev/test
+++ b/dev/test
@@ -40,13 +40,13 @@ fi
 # Run the tests
 echo ""
 echo "🧪 Running tests..."
-cd "$(dirname "$0")/.."
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$SCRIPT_DIR/../ConvosCore"
 
-# Use xcodebuild to run tests on iOS Simulator
+# Use xcodebuild to run tests on iOS Simulator from within the ConvosCore package directory
 # Pass environment variable using -testProductsPath approach won't work
 # We need to set it before running xcodebuild
 if TEST_SERVER_ENABLED=true xcodebuild test \
-    -project Convos.xcodeproj \
     -scheme ConvosCore \
     -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.0' \
     -only-testing:ConvosCoreTests/InboxStateMachineTests \
@@ -63,7 +63,7 @@ fi
 # Stop the XMTP node
 echo ""
 echo "🛑 Stopping Docker containers..."
-cd "$(dirname "$0")"
+cd "$SCRIPT_DIR"
 ./compose down
 
 exit $test_exit_code


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Fix ConvosCore test execution and make `KeyboardListener` delegate management thread-safe to address inbox state machine tests and warnings
Add a `ConvosCore` scheme entry for test/run/analyze, update the test plan to set `TEST_SERVER_ENABLED=true` with performance checks, and refactor `KeyboardListener` with `@MainActor`, `nonisolated` accessors, and locked delegate handling.

#### 📍Where to Start
Start with `KeyboardListener` changes in [KeyboardListener.swift](https://github.com/ephemeraHQ/convos-ios/pull/209/files#diff-15cf38182e9a67f829b3c05b908a61ae81319f3119bc255599665151fccd83b2).

----
<!-- Macroscope's review summary starts here -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 40a1010. 1 file reviewed, 3 issues evaluated, 1 issue filtered, 0 comments posted</summary>

### 🗂️ Filtered Issues
<details>
<summary>Convos/Conversation Detail/Messages/Messages View Controller/Keyboard/KeyboardListener.swift — 0 comments posted, 3 evaluated, 1 filtered</summary>

- [line 82](https://github.com/ephemeraHQ/convos-ios/blob/40a10109051b558a708a688ad5614fd438443a35/Convos/Conversation Detail/Messages/Messages View Controller/Keyboard/KeyboardListener.swift#L82): The fallback timer interval uses `info.animationDuration + 0.1` without validation. If `animationDuration` is zero, negative, NaN, or excessively large (all are reachable depending on `KeyboardInfo` parsing of `notification.userInfo`), the timer may fire immediately, never schedule correctly, or be delayed far beyond intended, causing missing or late `keyboardDidChangeFrame` delivery. Clamp to a reasonable non-negative range and handle invalid values explicitly to preserve deterministic behavior. <b>[ Low confidence ]</b>
</details>


</details><!-- Macroscope's review summary ends here -->
<!-- Macroscope's pull request summary ends here -->