### PR TITLE
Fix all project warnings

### DIFF
--- a/ConvosCore/Sources/ConvosCore/API/MockAPIClient.swift
+++ b/ConvosCore/Sources/ConvosCore/API/MockAPIClient.swift
@@ -10,7 +10,13 @@ enum MockAPIError: Error {
     case invalidURL
 }
 
-class MockBaseAPIClient: ConvosAPIBaseProtocol {
+final class MockAPIClient: ConvosAPIClientProtocol, Sendable {
+    let overrideJWTToken: String?
+
+    init(overrideJWTToken: String? = nil) {
+        self.overrideJWTToken = overrideJWTToken
+    }
+
     func request(for path: String, method: String, queryParameters: [String: String]?) throws -> URLRequest {
         guard let url = URL(string: "http://example.com") else {
             throw MockAPIError.invalidURL
@@ -20,15 +26,6 @@ class MockBaseAPIClient: ConvosAPIBaseProtocol {
 
     func registerDevice(deviceId: String, pushToken: String?) async throws {
         // Mock implementation - no-op
-    }
-}
-
-class MockAPIClient: MockBaseAPIClient, ConvosAPIClientProtocol {
-    let overrideJWTToken: String?
-
-    init(overrideJWTToken: String? = nil) {
-        self.overrideJWTToken = overrideJWTToken
-        super.init()
     }
 
     func authenticate(appCheckToken: String, retryCount: Int = 0) async throws -> String {

--- a/ConvosCore/Sources/ConvosCore/AppEnvironment.swift
+++ b/ConvosCore/Sources/ConvosCore/AppEnvironment.swift
@@ -19,7 +19,7 @@ public enum BuildEnvironment {
 /// environment-specific configuration including API URLs, database paths, XMTP endpoints,
 /// and keychain/app group settings. The environment determines build behavior, logging,
 /// and service configuration throughout the app.
-public enum AppEnvironment {
+public enum AppEnvironment: Sendable {
     case local(config: ConvosConfiguration)
     case tests
     case dev(config: ConvosConfiguration)

--- a/ConvosCore/Sources/ConvosCore/ConvosConfiguration.swift
+++ b/ConvosCore/Sources/ConvosCore/ConvosConfiguration.swift
@@ -1,14 +1,14 @@
 import Foundation
 
 /// Configuration values passed from the host app to ConvosCore
-/// 
+///
 /// This is a pure data container - all configuration values must be provided
 /// by the host application. The host app is responsible for reading these
 /// values from its configuration files (config.json, Secrets, etc.)
-/// 
+///
 /// ConvosCore does not have any hardcoded configuration values to ensure
 /// that all environments are properly configured through the host app.
-public struct ConvosConfiguration {
+public struct ConvosConfiguration: Sendable {
     public let apiBaseURL: String
     public let appGroupIdentifier: String
     public let relyingPartyIdentifier: String

--- a/ConvosCore/Sources/ConvosCore/Device/DeviceRegistrationManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Device/DeviceRegistrationManager.swift
@@ -38,7 +38,7 @@ public actor DeviceRegistrationManager: DeviceRegistrationManagerProtocol {
     // MARK: - Properties
 
     private let environment: AppEnvironment
-    private let apiClient: any ConvosAPIBaseProtocol
+    private let apiClient: any ConvosAPIClientProtocol
     private var isRegistering: Bool = false
     nonisolated(unsafe) private var pushTokenObserver: NSObjectProtocol?
 

--- a/ConvosCore/Sources/ConvosCore/Logging/Logger.swift
+++ b/ConvosCore/Sources/ConvosCore/Logging/Logger.swift
@@ -478,6 +478,7 @@ public enum Logger {
                 return header + "=== LOGS ===\nFile does not exist\n"
             }
 
+            let maxLogLines = self.maxLogLines
             // Read last maxLogLines lines by tailing from end asynchronously
             let tailed: String = await withCheckedContinuation { continuation in
                 readQueue.async {
@@ -505,7 +506,7 @@ public enum Logger {
                             let chunk = try handle.read(upToCount: readSize) ?? Data()
                             chunks.append(chunk)
                             newlineCount += countNewlines(chunk)
-                            if newlineCount >= self.maxLogLines { break }
+                            if newlineCount >= maxLogLines { break }
                             if position == 0 { break }
                         }
 
@@ -514,8 +515,8 @@ public enum Logger {
                         for c in chunks.reversed() { combined.append(c) }
 
                         // If we have more than needed, find start index of last maxLogLines
-                        if newlineCount > self.maxLogLines {
-                            var needed = self.maxLogLines
+                        if newlineCount > maxLogLines {
+                            var needed = maxLogLines
                             var idx = combined.count - 1
                             let bytes = [UInt8](combined)
                             while idx >= 0 && needed > 0 {

--- a/ConvosCore/Sources/ConvosCore/Messaging/MockMessagingService.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/MockMessagingService.swift
@@ -3,7 +3,7 @@ import Foundation
 import UIKit
 import XMTPiOS
 
-public class MockMessagingService: MessagingServiceProtocol {
+public final class MockMessagingService: MessagingServiceProtocol, @unchecked Sendable {
     public let currentUser: ConversationMember = .mock()
     public let allUsers: [ConversationMember]
     public let _conversations: [Conversation]

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/Conversation.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/Conversation.swift
@@ -3,7 +3,7 @@ import GRDB
 
 // MARK: - Conversation
 
-public struct Conversation: Codable, Hashable, Identifiable {
+public struct Conversation: Codable, Hashable, Identifiable, Sendable {
     public let id: String
     public let inboxId: String
     public let clientId: String

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/ConversationMember.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/ConversationMember.swift
@@ -2,7 +2,7 @@ import Foundation
 
 // MARK: - ConversationMember
 
-public struct ConversationMember: Codable, Hashable, Identifiable {
+public struct ConversationMember: Codable, Hashable, Identifiable, Sendable {
     public var id: String { profile.id }
     public let profile: Profile
     public let role: MemberRole

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/ConversationTypes.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/ConversationTypes.swift
@@ -3,7 +3,7 @@ import GRDB
 
 // MARK: - ConversationKind
 
-public enum ConversationKind: String, Codable, Hashable, SQLExpressible, CaseIterable {
+public enum ConversationKind: String, Codable, Hashable, SQLExpressible, CaseIterable, Sendable {
     case group, dm
 }
 
@@ -23,7 +23,7 @@ public extension Array where Element == ConversationKind {
 
 // MARK: - Consent
 
-public enum Consent: String, Codable, Hashable, SQLExpressible, CaseIterable {
+public enum Consent: String, Codable, Hashable, SQLExpressible, CaseIterable, Sendable {
     case allowed, denied, unknown
 }
 
@@ -47,7 +47,7 @@ public extension Array where Element == Consent {
 
 // MARK: - MemberRole
 
-public enum MemberRole: String, Codable, Hashable, CaseIterable {
+public enum MemberRole: String, Codable, Hashable, CaseIterable, Sendable {
     case member, admin, superAdmin = "super_admin"
 
     public var displayName: String {

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/ConversationUpdate.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/ConversationUpdate.swift
@@ -1,8 +1,8 @@
 import Foundation
 
-public struct ConversationUpdate: Hashable, Codable {
-    public struct MetadataChange: Hashable, Codable {
-        public enum Field: String, Codable {
+public struct ConversationUpdate: Hashable, Codable, Sendable {
+    public struct MetadataChange: Hashable, Codable, Sendable {
+        public enum Field: String, Codable, Sendable {
             case name = "group_name",
                  description = "description",
                  image = "group_image_url_square",

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/DBConversation.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/DBConversation.swift
@@ -3,14 +3,14 @@ import GRDB
 
 // MARK: - DBConversation
 
-public enum CommitLogForkStatus: String, Codable, Hashable {
+public enum CommitLogForkStatus: String, Codable, Hashable, Sendable {
     case forked, notForked = "not_forked", unknown
 }
 
 public struct DBConversation: Codable, FetchableRecord, PersistableRecord, Identifiable, Hashable {
     public static var databaseTableName: String = "conversation"
 
-    public struct DebugInfo: Codable, Hashable {
+    public struct DebugInfo: Codable, Hashable, Sendable {
         public let epoch: UInt64
         public let maybeForked: Bool
         public let forkDetails: String

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/DBMessage.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/DBMessage.swift
@@ -1,11 +1,11 @@
 import Foundation
 import GRDB
 
-public enum MessageStatus: String, Hashable, Codable {
+public enum MessageStatus: String, Hashable, Codable, Sendable {
     case unpublished, published, failed, unknown
 }
 
-public enum MessageSource: String, Hashable, Codable {
+public enum MessageSource: String, Hashable, Codable, Sendable {
     case incoming, outgoing
 
     public var isIncoming: Bool {

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/Invite.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/Invite.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct Invite: Codable, Hashable, Identifiable, Equatable {
+public struct Invite: Codable, Hashable, Identifiable, Equatable, Sendable {
     public var id: String {
         urlSlug
     }

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/Message.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/Message.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public protocol MessageType {
+public protocol MessageType: Sendable {
     var id: String { get }
     var conversation: Conversation { get }
     var sender: ConversationMember { get }
@@ -10,7 +10,7 @@ public protocol MessageType {
     var date: Date { get }
 }
 
-public enum AnyMessage: Hashable, Codable {
+public enum AnyMessage: Hashable, Codable, Sendable {
     case message(Message),
          reply(MessageReply)
 
@@ -24,7 +24,7 @@ public enum AnyMessage: Hashable, Codable {
     }
 }
 
-public enum MessageContent: Hashable, Codable {
+public enum MessageContent: Hashable, Codable, Sendable {
     case text(String),
          emoji(String), // all emoji, not a reaction
          attachment(URL),
@@ -50,7 +50,7 @@ public enum MessageContent: Hashable, Codable {
     }
 }
 
-public struct Message: MessageType, Hashable, Codable {
+public struct Message: MessageType, Hashable, Codable, Sendable {
     public let id: String
     public let conversation: Conversation
     public let sender: ConversationMember
@@ -62,7 +62,7 @@ public struct Message: MessageType, Hashable, Codable {
     public let reactions: [MessageReaction]
 }
 
-public struct MessageReply: MessageType, Hashable, Codable {
+public struct MessageReply: MessageType, Hashable, Codable, Sendable {
     public let id: String
     public let conversation: Conversation
     public let sender: ConversationMember
@@ -75,7 +75,7 @@ public struct MessageReply: MessageType, Hashable, Codable {
     public let reactions: [MessageReaction]
 }
 
-public struct MessageReaction: MessageType, Hashable, Codable {
+public struct MessageReaction: MessageType, Hashable, Codable, Sendable {
     public let id: String
     public let conversation: Conversation
     public let sender: ConversationMember

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/MessagePreview.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/MessagePreview.swift
@@ -2,7 +2,7 @@ import Foundation
 
 // MARK: - MessagePreview
 
-public struct MessagePreview: Codable, Equatable, Hashable {
+public struct MessagePreview: Codable, Equatable, Hashable, Sendable {
     public let text: String
     public let createdAt: Date
 }

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/Profile.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/Profile.swift
@@ -1,7 +1,7 @@
 import Foundation
 import GRDB
 
-public struct Profile: Codable, Identifiable, Hashable {
+public struct Profile: Codable, Identifiable, Hashable, Sendable {
     public var id: String { inboxId }
     public let inboxId: String
     public let name: String?


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Fix project warnings by consolidating `ConvosAPIClientProtocol` authentication and retry logic in `ConvosAPIClient.performRequest` and by adding `Sendable` and actor-safety across ConvosCore
Unify the API client by merging `ConvosAPIBaseProtocol` into `ConvosAPIClientProtocol` and implementing a single `final` `ConvosAPIClient` with 401 re-authentication that sets `X-Convos-AuthToken` using a fresh JWT. Add `Sendable` to core models and services, serialize keychain operations with a private `DispatchQueue`, and mark keyboard notification delegation as `@MainActor` with locked `NSHashTable` access. Replace detached action tasks with structured `Task` in inbox processing. Add a ConvosCore test scheme and test plan, and update the dev test script to run tests from the ConvosCore directory.

#### 📍Where to Start
Start with `ConvosAPIClient.performRequest` and `ConvosAPIClient.reAuthenticate` in [ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift](https://github.com/ephemeraHQ/convos-ios/pull/210/files#diff-d9c911c02b64ae370c51a1048b35e6e5dfc05805b43efd9be61a31fa422500b8) to review the 401 handling and token update, then trace protocol changes in `ConvosAPIClientProtocol` and usage in `DeviceRegistrationManager`.

----
<!-- Macroscope's review summary starts here -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 4b24f8c. 16 files reviewed, 26 issues evaluated, 24 issues filtered, 0 comments posted</summary>

### 🗂️ Filtered Issues
<details>
<summary>ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift — 0 comments posted, 8 evaluated, 7 filtered</summary>

- [line 63](https://github.com/ephemeraHQ/convos-ios/blob/4b24f8c38cf421b176ce1caff3d2723fd5a1e35d/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift#L63): The initializer uses `fatalError("Failed constructing API base URL")` when `URL(string: environment.apiBaseURL)` returns `nil`. If `environment.apiBaseURL` is invalid (including empty or malformed), the process will terminate at runtime during initialization. While termination in the initialization path can be acceptable for enforcing required configuration pre-effects, this still creates a deployment-invalid path where a misconfigured `AppEnvironment` string causes a hard crash. Consider making the initializer throwing (e.g., `init(...) throws`) or validating `apiBaseURL` earlier in boot, with a controlled error outcome, to avoid non-graceful termination. If termination is intended, ensure this invariant is documented and that upstream wiring guarantees a valid `apiBaseURL` before constructing `BaseConvosAPIClient`. <b>[ Code style ]</b>
- [line 258](https://github.com/ephemeraHQ/convos-ios/blob/4b24f8c38cf421b176ce1caff3d2723fd5a1e35d/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift#L258): For `200...203, 206...299` success responses, the code always attempts to decode `data` using `JSONDecoder`. If the server returns a `2xx` with an empty body (which can happen for `200` or `201` depending on API), decoding empty `Data()` will throw, even when `T` could reasonably be an empty collection or a marker type. There is a special-case for `T == EmptyResponse`, but no fallback for other valid empty payloads. This yields incorrect runtime errors for legitimately empty bodies. Consider explicitly handling empty `data` by returning an appropriate empty value when `T` conforms to `RangeReplaceableCollection` or by decoding `"[]"`/`"{}"` based on expected `T`, or by tightening contract to never send 2xx with empty body for non-`EmptyResponse`. <b>[ Out of scope ]</b>
- [line 266](https://github.com/ephemeraHQ/convos-ios/blob/4b24f8c38cf421b176ce1caff3d2723fd5a1e35d/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift#L266): Improper handling of `304 Not Modified`: returning `EmptyResponse`, an empty dict/array, or `APIError.noContent` does not preserve contract parity with cache semantics. `304` indicates the client should use its cached representation. This implementation either returns a synthetic empty value or throws, which can lead to data loss or incorrect UI/state. At minimum, the handler should consult a cache or explicitly document and consistently signal a cache-hit path. Without that, callers cannot distinguish `304` from a true `no content` on a write/DELETE and will mishandle results. <b>[ Out of scope ]</b>
- [line 271](https://github.com/ephemeraHQ/convos-ios/blob/4b24f8c38cf421b176ce1caff3d2723fd5a1e35d/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift#L271): Incorrect handling of `204`, `205`, and `304` "no content" responses: the code attempts to return an "empty" value by casting an untyped empty dictionary `[:]` or array `[]` to generic `T` (`Decodable`). This will almost always fail for realistic `T` such as `[MyModel]` or any concrete `struct`, because the literal `[]` is `[Any]` without contextual typing, and `[:]` is `[String: Any]`. As a result, even when an empty array or object would be a valid value for `T`, the code falls through to `throw APIError.noContent`. This produces incorrect runtime behavior for valid empty payloads and cannot satisfy `Decodable` types. A correct approach would construct appropriate empty JSON (`"[]"` for arrays, `"{}"` for objects) and decode it into `T`, or constrain `T` to `RangeReplaceableCollection` for empty arrays and return `T.init()`, or special-case known emptyable types. <b>[ Out of scope ]</b>
- [line 367](https://github.com/ephemeraHQ/convos-ios/blob/4b24f8c38cf421b176ce1caff3d2723fd5a1e35d/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift#L367): `uploadAttachment` derives a publicly accessible URL by stripping the query string from the presigned URL (`publicURL = "scheme://host" + path`). This assumes the presigned URL host/path correspond to a directly accessible public object URL. In S3 and many setups, the presigned URL host is not a public endpoint (e.g., `s3.amazonaws.com` with signed query) and bucket/object may default to private. As a result, the returned `publicURL` can be invalid or non-accessible, yielding an externally visible artifact that does not actually serve the uploaded content. The method thus may return a malformed or unusable URL. A safer approach is to have the backend return the canonical public URL explicitly, or construct it using known bucket/CloudFront domain configuration rather than presigned URL components. <b>[ Low confidence ]</b>
- [line 376](https://github.com/ephemeraHQ/convos-ios/blob/4b24f8c38cf421b176ce1caff3d2723fd5a1e35d/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift#L376): `uploadAttachment` accepts an `acl` parameter (default `"public-read"`) but does not use it when performing the PUT to S3. It neither passes `x-amz-acl` nor includes ACL constraints in headers. For presigned PUT URLs that require an ACL header, omitting it will cause signature validation failure (typically 403). Even if the upload succeeds, the object may default to private, making the returned URL inaccessible. This is a runtime contract mismatch: the function signature implies the ACL matters, but it is ignored. Include the ACL header (`x-amz-acl`) when required by the presign policy, or remove the parameter if ACL is managed server-side. <b>[ Low confidence ]</b>
- [line 385](https://github.com/ephemeraHQ/convos-ios/blob/4b24f8c38cf421b176ce1caff3d2723fd5a1e35d/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift#L385): `uploadAttachment` performs the S3 upload using `URLSession.shared` instead of the client’s configured `session`. This can break expected lifecycle, cancellation, timeout, or proxy settings associated with the `ConvosAPIClient`’s `URLSession`. If the caller cancels tasks or configures the client session for specific behaviors (e.g., ephemeral cache, custom delegates), the S3 upload will ignore them. Use the same `session` instance for consistency and correct cancellation semantics. <b>[ Code style ]</b>
</details>

<details>
<summary>ConvosCore/Sources/ConvosCore/API/MockAPIClient.swift — 0 comments posted, 3 evaluated, 3 filtered</summary>

- [line 14](https://github.com/ephemeraHQ/convos-ios/blob/4b24f8c38cf421b176ce1caff3d2723fd5a1e35d/ConvosCore/Sources/ConvosCore/API/MockAPIClient.swift#L14): The `overrideJWTToken` is accepted and stored (`init(overrideJWTToken:)` and `let overrideJWTToken`) but never used by any method. Specifically, `authenticate(appCheckToken:retryCount:)` always returns a hardcoded token (`"mock-jwt-token"`) and `request(for:method:queryParameters:)` does not attach an `Authorization` header or otherwise leverage the override token. This creates a contract-parity mismatch: callers that supply an override JWT (via `MockAPIClientFactory.client(environment:overrideJWTToken:)`) will not see that token applied or returned, potentially breaking logic that relies on an override. If the override is intended to bypass authentication or seed request authorization, the current implementation silently ignores that input. <b>[ Low confidence ]</b>
- [line 20](https://github.com/ephemeraHQ/convos-ios/blob/4b24f8c38cf421b176ce1caff3d2723fd5a1e35d/ConvosCore/Sources/ConvosCore/API/MockAPIClient.swift#L20): The `request(for:method:queryParameters:)` method ignores all of its inputs (`path`, `method`, and `queryParameters`) and returns a `URLRequest` for a hardcoded URL (`"http://example.com"`), with no HTTP method or query parameters set. This causes contract-parity failures: callers expecting a request targeted at a specific `path`, with a specified `method`, and encoded `queryParameters`, will instead receive a generic GET request pointing at `example.com`. If any code subsequently executes this `URLRequest`, it could perform an unintended network call to a public domain over cleartext HTTP, and it will certainly not hit the intended API path or include the intended query string. Even when used purely as a mock, this violates the expected shape of the artifact (the request) and can produce misleading behavior in tests. <b>[ Low confidence ]</b>
- [line 41](https://github.com/ephemeraHQ/convos-ios/blob/4b24f8c38cf421b176ce1caff3d2723fd5a1e35d/ConvosCore/Sources/ConvosCore/API/MockAPIClient.swift#L41): The returned URL strings in `uploadAttachment(data:filename:contentType:acl:)` and `uploadAttachmentAndExecute(data:filename:afterUpload:)` are constructed by simple string interpolation of `filename` into a URL path (e.g., `"https://mock-api.example.com/uploads/\(filename)"`) without any URL-encoding or sanitization. If `filename` contains characters that are not valid in a URL path (spaces, `#`, `?`, `%`, unicode, etc.), the resulting string will be an invalid or ambiguous URL. This violates the external artifact validity constraint: callers interpreting the returned string as a URL may fail to parse it or inadvertently change its semantics (e.g., `?` starting a query). Since this client is Sendable and used across async boundaries, malformed URLs can surface unpredictably at runtime. <b>[ Low confidence ]</b>
</details>

<details>
<summary>ConvosCore/Sources/ConvosCore/Inboxes/InboxStateMachine.swift — 0 comments posted, 3 evaluated, 2 filtered</summary>

- [line 60](https://github.com/ephemeraHQ/convos-ios/blob/4b24f8c38cf421b176ce1caff3d2723fd5a1e35d/ConvosCore/Sources/ConvosCore/Inboxes/InboxStateMachine.swift#L60): `InboxReadyResult` is marked `@unchecked Sendable` while storing existential references `client: any XMTPClientProvider` and `apiClient: any ConvosAPIClientProtocol` that are not constrained to be `Sendable`. This suppresses the compiler’s sendability checks and allows instances to cross concurrency domains with potentially non-Sendable (and non-thread-safe) underlying types (e.g., `XMTPiOS.Client`). If any caller uses `client` or `apiClient` off the intended actor/thread, this can lead to data races or undefined behavior at runtime. The comment asserts actor isolation in the state machine, but the struct is `public` and there is no language-enforced guard preventing misuse by other code paths. To avoid runtime races, either (a) require `XMTPClientProvider` and `ConvosAPIClientProtocol` to be `Sendable` (or `@unchecked Sendable`) and prove their internals are safe, (b) make the properties actor-isolated (e.g., store `isolated` references or wrap in an actor), or (c) avoid exposing a `@unchecked Sendable` container and instead pass identifiers/handles that are Sendable and retrieve the clients within the appropriate actor context. <b>[ Low confidence ]</b>
- [line 263](https://github.com/ephemeraHQ/convos-ios/blob/4b24f8c38cf421b176ce1caff3d2723fd5a1e35d/ConvosCore/Sources/ConvosCore/Inboxes/InboxStateMachine.swift#L263): Cancelling `currentTask` and immediately starting a new `Task` does not enforce at-most-once completion callbacks. The cancelled task may still run and eventually call `await self.setProcessingComplete()`, and the new task will also call `await self.setProcessingComplete()`. With actor isolation, both calls will serialize but can lead to double-application of completion logic, out-of-order state transitions, or incorrectly toggling `isProcessing`. There is no atomic swap-and-clear or guard linking the completion to the specific `action` or `Task` instance, so an older task can affect the state after a new task has started. This violates required invariants (at-most-once callback consumption, correct ordering) and risks incorrect queue progression. <b>[ Low confidence ]</b>
</details>

<details>
<summary>ConvosCore/Sources/ConvosCore/Logging/Logger.swift — 0 comments posted, 3 evaluated, 3 filtered</summary>

- [line 501](https://github.com/ephemeraHQ/convos-ios/blob/4b24f8c38cf421b176ce1caff3d2723fd5a1e35d/ConvosCore/Sources/ConvosCore/Logging/Logger.swift#L501): Potential unbounded memory usage when the log file contains fewer than `maxLogLines` newline characters (e.g., very long lines or binary content). The loop will read chunks until `position == 0`, appending all chunks into `chunks`, then concatenate into `combined`. This can load the entire file into memory, risking high memory consumption or fragmentation for large logs. Consider imposing a maximum byte limit, streaming trimming, or early abort with a clear message when size exceeds a threshold. <b>[ Low confidence ]</b>
- [line 518](https://github.com/ephemeraHQ/convos-ios/blob/4b24f8c38cf421b176ce1caff3d2723fd5a1e35d/ConvosCore/Sources/ConvosCore/Logging/Logger.swift#L518): When tailing the file to return only the last `maxLogLines` lines, the code trims the combined data only if `newlineCount > maxLogLines` (line `if newlineCount > maxLogLines { ... }`). If `newlineCount == maxLogLines`, it does not trim, returning the entire concatenated chunk(s) starting at the earlier chunk boundary. This can include extra leading content (a partial or full line preceding the last `maxLogLines` lines), violating the intended contract of returning exactly the last `maxLogLines` lines. To fix, perform the same trimming logic when `newlineCount >= maxLogLines` and compute the start offset to the byte after the Nth-from-end newline. <b>[ Already posted ]</b>
- [line 531](https://github.com/ephemeraHQ/convos-ios/blob/4b24f8c38cf421b176ce1caff3d2723fd5a1e35d/ConvosCore/Sources/ConvosCore/Logging/Logger.swift#L531): If UTF-8 decoding fails when constructing `String(data: combined, encoding: .utf8)`, the code substitutes an empty string and returns `"(Empty file)"`. This silently discards non-UTF8 log content and misrepresents the file as empty, causing data loss at a data-conversion boundary. Instead, return a clear error or use a lossy conversion (e.g., `String(decoding:combined,as:UTF8.self)` or attempt ISO-8859-1) or include a note indicating decoding failure. <b>[ Low confidence ]</b>
</details>

<details>
<summary>ConvosCore/Sources/ConvosCore/Messaging/MockMessagingService.swift — 0 comments posted, 5 evaluated, 5 filtered</summary>

- [line 6](https://github.com/ephemeraHQ/convos-ios/blob/4b24f8c38cf421b176ce1caff3d2723fd5a1e35d/ConvosCore/Sources/ConvosCore/Messaging/MockMessagingService.swift#L6): The class is marked `@unchecked Sendable` while containing unsynchronized mutable state (`unpublishedMessages`, `currentConversation`, `messages`, `messagesSubject`, `messageTimer`). Declaring `@unchecked Sendable` asserts to Swift's concurrency runtime that instances can be safely shared across concurrency domains, but this class is not an actor and has no synchronization. This creates a risk of data races and undefined behavior if the object is sent between threads/tasks, which `@unchecked Sendable` now permits. <b>[ Low confidence ]</b>
- [line 25](https://github.com/ephemeraHQ/convos-ios/blob/4b24f8c38cf421b176ce1caff3d2723fd5a1e35d/ConvosCore/Sources/ConvosCore/Messaging/MockMessagingService.swift#L25): Potential crash due to indexing into an empty array: `_conversations[0]` is used when `currentConversation` is `nil`. If `Self.randomConversations(with:)` returns an empty array, `randomElement()` returns `nil`, and `_conversations[0]` will trigger an out-of-bounds runtime fatal error. <b>[ Low confidence ]</b>
- [line 26](https://github.com/ephemeraHQ/convos-ios/blob/4b24f8c38cf421b176ce1caff3d2723fd5a1e35d/ConvosCore/Sources/ConvosCore/Messaging/MockMessagingService.swift#L26): Passing `allUsers` directly into `Self.generateRandomMessages(users:)` without verifying it is non-empty can lead to downstream runtime failures if the generator assumes at least one user (e.g., selecting a random sender). There is no guard ensuring `allUsers` contains elements. <b>[ Already posted ]</b>
- [line 78](https://github.com/ephemeraHQ/convos-ios/blob/4b24f8c38cf421b176ce1caff3d2723fd5a1e35d/ConvosCore/Sources/ConvosCore/Messaging/MockMessagingService.swift#L78): Constructed upload URLs are not URL-escaped. Using `filename` directly in `"https://example.com/uploads/\(filename)"` can produce malformed or unsafe URLs if `filename` contains spaces, reserved characters, or path traversal sequences. This can lead to failed requests or security issues when consumers use the returned string as a URL. <b>[ Low confidence ]</b>
- [line 86](https://github.com/ephemeraHQ/convos-ios/blob/4b24f8c38cf421b176ce1caff3d2723fd5a1e35d/ConvosCore/Sources/ConvosCore/Messaging/MockMessagingService.swift#L86): Same unescaped filename problem exists in `uploadImageAndExecute`: `uploadedURL` is built with `"https://example.com/uploads/\(filename)"` before invoking `afterUpload`. This can propagate malformed/unsafe URLs to the callback and return value. <b>[ Already posted ]</b>
</details>

<details>
<summary>ConvosCore/Sources/ConvosCore/Storage/Models/ConversationUpdate.swift — 0 comments posted, 4 evaluated, 4 filtered</summary>

- [line 5](https://github.com/ephemeraHQ/convos-ios/blob/4b24f8c38cf421b176ce1caff3d2723fd5a1e35d/ConvosCore/Sources/ConvosCore/Storage/Models/ConversationUpdate.swift#L5): `Field` uses `Codable` with `RawRepresentable` via `enum Field: String, Codable`. Adding the case `.unknown` without a raw value does not make decoding resilient: when decoding an unknown raw string, `Swift.Decoder` will fail to initialize `Field` and throw, rather than mapping to `.unknown`. This creates a runtime decoding failure for forward-incompatible data (e.g., server introduces a new field). To support unknown values gracefully, custom `init(from:)`/`encode(to:)` or a non-`RawRepresentable` coding approach is needed. <b>[ Already posted ]</b>
- [line 41](https://github.com/ephemeraHQ/convos-ios/blob/4b24f8c38cf421b176ce1caff3d2723fd5a1e35d/ConvosCore/Sources/ConvosCore/Storage/Models/ConversationUpdate.swift#L41): In `profile`, `.description` and `.name` paths return `creator.profile` without checking `metadataChange.newValue` for non-nil, while `summary` only emits text when `newValue` is non-nil. This mismatch can produce a non-nil `profile` for a description/name update with a nil `newValue` (e.g., clear/delete), while `summary` is empty, causing `showsInMessagesList` to be `false`. This inconsistency can lead to blank/hidden artifacts or unexpected UI states where an update has a `profile` but no visible message. <b>[ Out of scope ]</b>
- [line 41](https://github.com/ephemeraHQ/convos-ios/blob/4b24f8c38cf421b176ce1caff3d2723fd5a1e35d/ConvosCore/Sources/ConvosCore/Storage/Models/ConversationUpdate.swift#L41): `profile` and `summary` only inspect `metadataChanges.first`, silently ignoring subsequent entries. If the first change is unrelated (e.g., `.custom`) but later entries include `.name`, `.image` with a non-nil `newValue`, or `.description` with a non-nil `newValue`, the code will fail to construct the expected `profile` and `summary`. This causes silent data loss/inconsistency because multiple changes are representable (array) but only the first is considered. <b>[ Out of scope ]</b>
- [line 59](https://github.com/ephemeraHQ/convos-ios/blob/4b24f8c38cf421b176ce1caff3d2723fd5a1e35d/ConvosCore/Sources/ConvosCore/Storage/Models/ConversationUpdate.swift#L59): `showsInMessagesList` suppresses visibility whenever any `metadataChanges` entry has `Field.showsInMessagesList == false`, even if the update has a non-empty `summary` due to `addedMembers` or other visible changes. Specifically, the guard `metadataChanges.allSatisfy({ $0.field.showsInMessagesList })` will return `false` if there is a mixed update (e.g., members added plus a `.custom` metadata change), causing `showsInMessagesList` to return `false` despite `summary` being non-empty. This creates a contract mismatch where a legitimate visible update is silently hidden. <b>[ Out of scope ]</b>
</details>


</details><!-- Macroscope's review summary ends here -->
<!-- Macroscope's pull request summary ends here -->