### PR TITLE
Fix unused inbox cache, add tests

### DIFF
--- a/ConvosCore/Sources/ConvosCore/Inboxes/ConversationStateMachine.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/ConversationStateMachine.swift
@@ -343,15 +343,6 @@ public actor ConversationStateMachine {
             conversationId: externalConversationId,
             origin: .created
         )))
-
-        // Clear unused inbox from keychain now that conversation is successfully created
-        await UnusedInboxCache.shared
-            .clearUnusedInbox(
-                with: client.inboxId,
-                databaseWriter: databaseWriter,
-                databaseReader: databaseReader,
-                environment: environment
-            )
     }
 
     private func handleValidate(inviteCode: String, previousResult: ConversationReadyResult?) async throws {
@@ -409,14 +400,6 @@ public actor ConversationStateMachine {
         if let existingConversation, existingIdentity != nil {
             Logger.info("Found existing convo by invite tag...")
             let prevInboxReady = try await inboxStateManager.waitForInboxReadyResult()
-            // Clear unused inbox since we're deleting it
-            await UnusedInboxCache.shared
-                .clearUnusedInbox(
-                    with: prevInboxReady.client.inboxId,
-                    databaseWriter: databaseWriter,
-                    databaseReader: databaseReader,
-                    environment: environment
-                )
             try await inboxStateManager.delete()
             let inboxReady = try await inboxStateManager.reauthorize(
                 inboxId: existingConversation.inboxId,
@@ -506,15 +489,6 @@ public actor ConversationStateMachine {
         _ = try await dm.prepare(text: text)
         try await dm.publish()
 
-        // Clear unused inbox from keychain now that we sent the join request
-        await UnusedInboxCache.shared
-            .clearUnusedInbox(
-                with: client.inboxId,
-                databaseWriter: databaseWriter,
-                databaseReader: databaseReader,
-                environment: environment
-            )
-
         // Clean up previous conversation, do this without matching the `conversationId`.
         // We don't need the created conversation during the 'joining' state and
         // want to make sure it is deleted even if the conversation never shows in
@@ -589,15 +563,6 @@ public actor ConversationStateMachine {
                 client: inboxReady.client,
                 apiClient: inboxReady.apiClient,
             )
-
-            // Clear unused inbox from keychain now that we sent the join request
-            await UnusedInboxCache.shared
-                .clearUnusedInbox(
-                    with: inboxReady.client.inboxId,
-                    databaseWriter: databaseWriter,
-                    databaseReader: databaseReader,
-                    environment: environment
-                )
 
             try await inboxStateManager.delete()
         }

--- a/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
@@ -293,13 +293,6 @@ public final class SessionManager: SessionManagerProtocol {
         let inboxWriter = InboxWriter(dbWriter: databaseWriter)
         Logger.info("Deleting all inboxes from database")
         try await inboxWriter.deleteAll()
-
-        await UnusedInboxCache.shared
-            .clearUnusedInbox(
-                databaseWriter: databaseWriter,
-                databaseReader: databaseReader,
-                environment: environment
-            )
     }
 
     // MARK: - Messaging Services

--- a/ConvosCore/Tests/ConvosCoreTests/UnusedInboxCacheTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/UnusedInboxCacheTests.swift
@@ -1,0 +1,450 @@
+@preconcurrency @testable import ConvosCore
+import Foundation
+import GRDB
+import Testing
+import XMTPiOS
+
+/// Comprehensive tests for UnusedInboxCache
+///
+/// Tests cover:
+/// - Pre-creating unused inboxes
+/// - Consuming unused inboxes without race conditions
+/// - Concurrent consumption attempts (race condition prevention)
+/// - Keychain fallback path
+/// - Clearing unused inboxes
+/// - Ensuring same inbox is never consumed twice
+@Suite("UnusedInboxCache Tests")
+struct UnusedInboxCacheTests {
+
+    // MARK: - Basic Functionality Tests
+
+    @Test("prepareUnusedInboxIfNeeded creates an unused inbox")
+    func testPrepareUnusedInbox() async throws {
+        let fixtures = TestFixtures()
+        let cache = UnusedInboxCache.shared
+
+        // Clear any existing unused inbox
+        await cache.clearUnusedInboxFromKeychain()
+
+        // Prepare unused inbox
+        await cache.prepareUnusedInboxIfNeeded(
+            databaseWriter: fixtures.databaseManager.dbWriter,
+            databaseReader: fixtures.databaseManager.dbReader,
+            environment: .tests
+        )
+
+        // Give it time to create
+        try await Task.sleep(for: .seconds(5))
+
+        // Verify an unused inbox was created (check keychain or service)
+        // We can't directly access private properties, but we can verify by consuming it
+        let messagingService = await cache.consumeOrCreateMessagingService(
+            databaseWriter: fixtures.databaseManager.dbWriter,
+            databaseReader: fixtures.databaseManager.dbReader,
+            environment: .tests
+        )
+
+        let result = try await messagingService.inboxStateManager.waitForInboxReadyResult()
+        #expect(result.client.inboxId.isEmpty == false)
+
+        // Clean up
+        await messagingService.stopAndDelete()
+        try? await fixtures.cleanup()
+    }
+
+    @Test("consumeOrCreateMessagingService returns a valid service")
+    func testConsumeOrCreateReturnsValidService() async throws {
+        let fixtures = TestFixtures()
+        let cache = UnusedInboxCache.shared
+
+        // Clear any existing unused inbox
+        await cache.clearUnusedInboxFromKeychain()
+
+        let messagingService = await cache.consumeOrCreateMessagingService(
+            databaseWriter: fixtures.databaseManager.dbWriter,
+            databaseReader: fixtures.databaseManager.dbReader,
+            environment: .tests
+        )
+
+        let result = try await messagingService.inboxStateManager.waitForInboxReadyResult()
+        #expect(result.client.inboxId.isEmpty == false)
+
+        // Clean up
+        await messagingService.stopAndDelete()
+        try? await fixtures.cleanup()
+    }
+
+    // MARK: - Race Condition Tests
+
+    @Test("Concurrent consumeOrCreateMessagingService calls never return the same service")
+    func testConcurrentConsumptionNoDuplicates() async throws {
+        let fixtures = TestFixtures()
+        let cache = UnusedInboxCache.shared
+
+        // Clear any existing unused inbox
+        await cache.clearUnusedInboxFromKeychain()
+
+        // Pre-create an unused inbox to increase likelihood of race
+        await cache.prepareUnusedInboxIfNeeded(
+            databaseWriter: fixtures.databaseManager.dbWriter,
+            databaseReader: fixtures.databaseManager.dbReader,
+            environment: .tests
+        )
+
+        // Give it time to create
+        try await Task.sleep(for: .seconds(5))
+
+        // Call rapidly multiple times - since cache is an actor, calls are serialized
+        // but the code still needs to handle the "already consuming" case
+        var services: [MessagingService] = []
+        for _ in 0..<5 {
+            let service = await cache.consumeOrCreateMessagingService(
+                databaseWriter: fixtures.databaseManager.dbWriter,
+                databaseReader: fixtures.databaseManager.dbReader,
+                environment: .tests
+            )
+            services.append(service)
+        }
+
+        // Wait for all services to be ready and collect their inbox IDs
+        var inboxIds: [String] = []
+        for service in services {
+            let result = try await service.inboxStateManager.waitForInboxReadyResult()
+            inboxIds.append(result.client.inboxId)
+        }
+
+        // CRITICAL: All inbox IDs must be unique - no duplicates allowed
+        let uniqueInboxIds = Set(inboxIds)
+        #expect(uniqueInboxIds.count == 5, "All 5 services must have unique inbox IDs. Got: \(uniqueInboxIds.count) unique out of 5")
+
+        if uniqueInboxIds.count != 5 {
+            Issue.record("RACE CONDITION DETECTED: Same inbox consumed multiple times!")
+            Issue.record("Inbox IDs: \(inboxIds)")
+        }
+
+        // Clean up
+        for service in services {
+            await service.stopAndDelete()
+        }
+        try? await fixtures.cleanup()
+    }
+
+    @Test("Sequential consumption always returns different services")
+    func testSequentialConsumptionDifferentServices() async throws {
+        let fixtures = TestFixtures()
+        let cache = UnusedInboxCache.shared
+
+        // Clear any existing unused inbox
+        await cache.clearUnusedInboxFromKeychain()
+
+        // Consume first service
+        let service1 = await cache.consumeOrCreateMessagingService(
+            databaseWriter: fixtures.databaseManager.dbWriter,
+            databaseReader: fixtures.databaseManager.dbReader,
+            environment: .tests
+        )
+        let result1 = try await service1.inboxStateManager.waitForInboxReadyResult()
+        let inboxId1 = result1.client.inboxId
+
+        // Consume second service
+        let service2 = await cache.consumeOrCreateMessagingService(
+            databaseWriter: fixtures.databaseManager.dbWriter,
+            databaseReader: fixtures.databaseManager.dbReader,
+            environment: .tests
+        )
+        let result2 = try await service2.inboxStateManager.waitForInboxReadyResult()
+        let inboxId2 = result2.client.inboxId
+
+        // CRITICAL: Inbox IDs must be different
+        #expect(inboxId1 != inboxId2, "Sequential consumptions must return different inboxes")
+
+        // Clean up
+        await service1.stopAndDelete()
+        await service2.stopAndDelete()
+        try? await fixtures.cleanup()
+    }
+
+    @Test("Rapid fire consumption attempts all return unique services")
+    func testRapidFireConsumptionUniqueness() async throws {
+        let fixtures = TestFixtures()
+        let cache = UnusedInboxCache.shared
+
+        // Clear any existing unused inbox
+        await cache.clearUnusedInboxFromKeychain()
+
+        // Create 10 services as fast as possible
+        var services: [MessagingService] = []
+        for _ in 0..<10 {
+            let service = await cache.consumeOrCreateMessagingService(
+                databaseWriter: fixtures.databaseManager.dbWriter,
+                databaseReader: fixtures.databaseManager.dbReader,
+                environment: .tests
+            )
+            services.append(service)
+        }
+
+        // Collect all inbox IDs
+        var inboxIds: [String] = []
+        for service in services {
+            let result = try await service.inboxStateManager.waitForInboxReadyResult()
+            inboxIds.append(result.client.inboxId)
+        }
+
+        // CRITICAL: All must be unique
+        let uniqueInboxIds = Set(inboxIds)
+        #expect(uniqueInboxIds.count == 10, "All 10 rapid-fire services must have unique inbox IDs. Got: \(uniqueInboxIds.count) unique out of 10")
+
+        if uniqueInboxIds.count != 10 {
+            Issue.record("RACE CONDITION DETECTED in rapid-fire test!")
+            Issue.record("Unique IDs: \(uniqueInboxIds.count) out of 10")
+        }
+
+        // Clean up
+        for service in services {
+            await service.stopAndDelete()
+        }
+        try? await fixtures.cleanup()
+    }
+
+    // MARK: - Atomic Cleanup Tests
+
+    @Test("Consuming clears both memory and keychain atomically")
+    func testAtomicCleanupOnConsumption() async throws {
+        let fixtures = TestFixtures()
+        let cache = UnusedInboxCache.shared
+
+        // Clear any existing unused inbox
+        await cache.clearUnusedInboxFromKeychain()
+
+        // Prepare an unused inbox (this creates both in-memory service and keychain entry)
+        await cache.prepareUnusedInboxIfNeeded(
+            databaseWriter: fixtures.databaseManager.dbWriter,
+            databaseReader: fixtures.databaseManager.dbReader,
+            environment: .tests
+        )
+
+        // Give it time to create
+        try await Task.sleep(for: .seconds(5))
+
+        // Consume the unused inbox
+        let service1 = await cache.consumeOrCreateMessagingService(
+            databaseWriter: fixtures.databaseManager.dbWriter,
+            databaseReader: fixtures.databaseManager.dbReader,
+            environment: .tests
+        )
+
+        let result1 = try await service1.inboxStateManager.waitForInboxReadyResult()
+        let consumedInboxId = result1.client.inboxId
+
+        // CRITICAL: Verify that BOTH keychain and memory are cleared atomically
+        // This prevents the dangerous scenario where one is cleared but not the other
+
+        // 1. Verify keychain is cleared immediately after consumption
+        let isStillUnused = await cache.isUnusedInbox(consumedInboxId)
+        #expect(!isStillUnused, "Consumed inbox should not be marked as unused in keychain")
+
+        // 2. Verify memory is cleared by attempting another consumption
+        // This should return a DIFFERENT inbox, not reuse the consumed one
+        let service2 = await cache.consumeOrCreateMessagingService(
+            databaseWriter: fixtures.databaseManager.dbWriter,
+            databaseReader: fixtures.databaseManager.dbReader,
+            environment: .tests
+        )
+
+        let result2 = try await service2.inboxStateManager.waitForInboxReadyResult()
+        let newInboxId = result2.client.inboxId
+
+        // 3. CRITICAL: The new inbox must be different - proves memory was cleared
+        #expect(newInboxId != consumedInboxId, "Second consumption must return a different inbox - proves atomic cleanup")
+
+        // Clean up
+        await service1.stopAndDelete()
+        await service2.stopAndDelete()
+        try? await fixtures.cleanup()
+    }
+
+    @Test("Keychain cleared even when consuming via memory")
+    func testKeychainClearedWhenConsumingFromMemory() async throws {
+        let fixtures = TestFixtures()
+        let cache = UnusedInboxCache.shared
+
+        // Clear any existing unused inbox
+        await cache.clearUnusedInboxFromKeychain()
+
+        // Prepare an unused inbox (creates both in-memory service AND keychain entry)
+        await cache.prepareUnusedInboxIfNeeded(
+            databaseWriter: fixtures.databaseManager.dbWriter,
+            databaseReader: fixtures.databaseManager.dbReader,
+            environment: .tests
+        )
+
+        // Give it time to create
+        try await Task.sleep(for: .seconds(5))
+
+        // Before consuming, the keychain should have the inbox
+        // We can't directly check keychain, but we know it exists because prepareUnusedInboxIfNeeded succeeded
+
+        // Consume - this uses the in-memory service path
+        let service = await cache.consumeOrCreateMessagingService(
+            databaseWriter: fixtures.databaseManager.dbWriter,
+            databaseReader: fixtures.databaseManager.dbReader,
+            environment: .tests
+        )
+
+        let result = try await service.inboxStateManager.waitForInboxReadyResult()
+        let consumedInboxId = result.client.inboxId
+
+        // CRITICAL: Even though we consumed via memory, keychain must also be cleared
+        let isStillInKeychain = await cache.isUnusedInbox(consumedInboxId)
+        #expect(!isStillInKeychain, "Keychain must be cleared even when consuming via memory path")
+
+        // Clean up
+        await service.stopAndDelete()
+        try? await fixtures.cleanup()
+    }
+
+    @Test("Both paths clear atomically - memory and keychain")
+    func testBothConsumptionPathsClearAtomically() async throws {
+        let fixtures = TestFixtures()
+        let cache = UnusedInboxCache.shared
+
+        // Test 1: Consume via memory path
+        await cache.clearUnusedInboxFromKeychain()
+        await cache.prepareUnusedInboxIfNeeded(
+            databaseWriter: fixtures.databaseManager.dbWriter,
+            databaseReader: fixtures.databaseManager.dbReader,
+            environment: .tests
+        )
+        try await Task.sleep(for: .seconds(5))
+
+        let service1 = await cache.consumeOrCreateMessagingService(
+            databaseWriter: fixtures.databaseManager.dbWriter,
+            databaseReader: fixtures.databaseManager.dbReader,
+            environment: .tests
+        )
+        let result1 = try await service1.inboxStateManager.waitForInboxReadyResult()
+        let inboxId1 = result1.client.inboxId
+
+        // Verify both cleared
+        let isUnused1 = await cache.isUnusedInbox(inboxId1)
+        #expect(!isUnused1, "Memory path: keychain must be cleared")
+
+        // Test 2: Consume via keychain path
+        // (In a real scenario, the memory service might not exist but keychain does)
+        await cache.clearUnusedInboxFromKeychain()
+
+        let service2 = await cache.consumeOrCreateMessagingService(
+            databaseWriter: fixtures.databaseManager.dbWriter,
+            databaseReader: fixtures.databaseManager.dbReader,
+            environment: .tests
+        )
+        let result2 = try await service2.inboxStateManager.waitForInboxReadyResult()
+        let inboxId2 = result2.client.inboxId
+
+        // Verify cleared
+        let isUnused2 = await cache.isUnusedInbox(inboxId2)
+        #expect(!isUnused2, "Keychain path: must be cleared")
+
+        // Verify different inboxes
+        #expect(inboxId1 != inboxId2, "Each consumption should return unique inbox")
+
+        // Clean up
+        await service1.stopAndDelete()
+        await service2.stopAndDelete()
+        try? await fixtures.cleanup()
+    }
+
+    // MARK: - isUnusedInbox Tests
+
+    @Test("isUnusedInbox correctly identifies unused inbox")
+    func testIsUnusedInbox() async throws {
+        let fixtures = TestFixtures()
+        let cache = UnusedInboxCache.shared
+
+        // Clear any existing unused inbox
+        await cache.clearUnusedInboxFromKeychain()
+
+        // Prepare an unused inbox
+        await cache.prepareUnusedInboxIfNeeded(
+            databaseWriter: fixtures.databaseManager.dbWriter,
+            databaseReader: fixtures.databaseManager.dbReader,
+            environment: .tests
+        )
+
+        // Give it time to create
+        try await Task.sleep(for: .seconds(5))
+
+        // Consume to get the inbox ID
+        let service = await cache.consumeOrCreateMessagingService(
+            databaseWriter: fixtures.databaseManager.dbWriter,
+            databaseReader: fixtures.databaseManager.dbReader,
+            environment: .tests
+        )
+
+        let result = try await service.inboxStateManager.waitForInboxReadyResult()
+        _ = result.client.inboxId
+
+        // Check a random ID
+        let isRandomUnused = await cache.isUnusedInbox("random-inbox-id")
+        #expect(!isRandomUnused, "Random ID should not be unused")
+
+        // Clean up
+        await service.stopAndDelete()
+        try? await fixtures.cleanup()
+    }
+
+    // MARK: - Stress Tests
+
+    @Test("Stress test: 10 rapid sequential consumptions all unique")
+    func testStressConcurrentConsumptions() async throws {
+        let fixtures = TestFixtures()
+        let cache = UnusedInboxCache.shared
+
+        // Clear any existing unused inbox
+        await cache.clearUnusedInboxFromKeychain()
+
+        // Create services rapidly in sequence (not concurrent due to Sendable restrictions)
+        // The actor isolation on UnusedInboxCache ensures thread safety
+        let serviceCount = 10
+        var services: [MessagingService] = []
+
+        for _ in 0..<serviceCount {
+            let service = await cache.consumeOrCreateMessagingService(
+                databaseWriter: fixtures.databaseManager.dbWriter,
+                databaseReader: fixtures.databaseManager.dbReader,
+                environment: .tests
+            )
+            services.append(service)
+        }
+
+        // Collect all inbox IDs
+        var inboxIds: [String] = []
+        for service in services {
+            let result = try await service.inboxStateManager.waitForInboxReadyResult()
+            inboxIds.append(result.client.inboxId)
+        }
+
+        // CRITICAL: All must be unique
+        let uniqueInboxIds = Set(inboxIds)
+        #expect(uniqueInboxIds.count == serviceCount, "All \(serviceCount) rapid sequential services must have unique inbox IDs. Got: \(uniqueInboxIds.count) unique")
+
+        if uniqueInboxIds.count != serviceCount {
+            Issue.record("RACE CONDITION DETECTED in rapid sequential test!")
+            Issue.record("Unique IDs: \(uniqueInboxIds.count) out of \(serviceCount)")
+
+            // Find duplicates
+            var counts: [String: Int] = [:]
+            for id in inboxIds {
+                counts[id, default: 0] += 1
+            }
+            let duplicates = counts.filter { $0.value > 1 }
+            Issue.record("Duplicated inbox IDs: \(duplicates)")
+        }
+
+        // Clean up
+        for service in services {
+            await service.stopAndDelete()
+        }
+        try? await fixtures.cleanup()
+    }
+}

--- a/dev/test
+++ b/dev/test
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eou pipefail
 
-echo "🧪 Running InboxStateMachine tests with local XMTP node..."
+echo "🧪 Running InboxStateMachine and UnusedInboxCache tests with local XMTP node..."
 echo ""
 
 # Check if Docker is running
@@ -50,6 +50,7 @@ if TEST_SERVER_ENABLED=true xcodebuild test \
     -scheme ConvosCore \
     -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.0' \
     -only-testing:ConvosCoreTests/InboxStateMachineTests \
+    -only-testing:ConvosCoreTests/UnusedInboxCacheTests \
     2>&1 | tee test-output.log; then
     echo ""
     echo "✅ All tests passed!"


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Remove unused inbox clearing from `ConversationStateMachine` and `SessionManager` and add atomic consumption with concurrency guard in `UnusedInboxCache` to support fixing unused inbox cache and add tests
Introduce atomic unused inbox consumption in `UnusedInboxCache` with an `isConsumingUnusedInbox` guard, immediate keychain clearing during `consumeOrCreateMessagingService`, and a `createFreshMessagingService` fallback; remove external unused inbox clearing calls from `ConversationStateMachine` and `SessionManager`; add `isUnusedInbox` and `clearUnusedInboxFromKeychain`; add tests for race-free consumption and keychain clearing; update local test script to run the new suite. See [UnusedInboxCache.swift](https://github.com/ephemeraHQ/convos-ios/pull/211/files#diff-f0fa420edcbb4b84596d955430ce62fac2027d0d82e4f34b2bc694e43bd55106) and [ConversationStateMachine.swift](https://github.com/ephemeraHQ/convos-ios/pull/211/files#diff-a1762ce564035d6cdd7e3b2d3200cfe0db6c3ec5fac03636392780086ba58344).

#### 📍Where to Start
Start with `UnusedInboxCache.consumeOrCreateMessagingService` in [UnusedInboxCache.swift](https://github.com/ephemeraHQ/convos-ios/pull/211/files#diff-f0fa420edcbb4b84596d955430ce62fac2027d0d82e4f34b2bc694e43bd55106), then review the removed `clearUnusedInbox` calls in `ConversationStateMachine` in [ConversationStateMachine.swift](https://github.com/ephemeraHQ/convos-ios/pull/211/files#diff-a1762ce564035d6cdd7e3b2d3200cfe0db6c3ec5fac03636392780086ba58344).

----
<!-- Macroscope's review summary starts here -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 629070a. 3 files reviewed, 32 issues evaluated, 31 issues filtered, 0 comments posted</summary>

### 🗂️ Filtered Issues
<details>
<summary>ConvosCore/Sources/ConvosCore/Inboxes/ConversationStateMachine.swift — 0 comments posted, 17 evaluated, 17 filtered</summary>

- [line 318](https://github.com/ephemeraHQ/convos-ios/blob/629070ac73010a625715a0c64dd71d0ff6c1f2c3/ConvosCore/Sources/ConvosCore/Inboxes/ConversationStateMachine.swift#L318): The function emits `emitStateChange(.creating)` and then performs multiple awaited operations (`waitForInboxReadyResult()`, `prepareConversation()`, `publish()`, `processConversation(...)`) that can throw. On any thrown error or task cancellation after `.creating` is emitted, there is no error-state emission or compensating action. The actor's externally visible state can remain stuck at `.creating` with a published or partially-created conversation, violating at-most-once/terminal-state guarantees and leaving the system in an inconsistent state. <b>[ Low confidence ]</b>
- [line 321](https://github.com/ephemeraHQ/convos-ios/blob/629070ac73010a625715a0c64dd71d0ff6c1f2c3/ConvosCore/Sources/ConvosCore/Inboxes/ConversationStateMachine.swift#L321): `waitForInboxReadyResult()` is awaited immediately after emitting `.creating` without any timeout, fallback, or cancellation-aware state transition. If the inbox never becomes ready (e.g., due to a hang or external failure), the actor remains in `.creating` indefinitely and no terminal state is emitted, violating the requirement that every input reaches a defined terminal state. <b>[ Low confidence ]</b>
- [line 328](https://github.com/ephemeraHQ/convos-ios/blob/629070ac73010a625715a0c64dd71d0ff6c1f2c3/ConvosCore/Sources/ConvosCore/Inboxes/ConversationStateMachine.swift#L328): The code uses `optimisticConversation.id` captured before `publish()` as the `conversationId` in `ConversationReadyResult`. If `publish()` or subsequent `processConversation(...)` normalizes or canonicalizes the conversation (e.g., server assigns a definitive ID differing from the optimistic one), returning the pre-publish `id` would violate the contract to use canonicalized values and could cause downstream mismatches or failures. <b>[ Low confidence ]</b>
- [line 331](https://github.com/ephemeraHQ/convos-ios/blob/629070ac73010a625715a0c64dd71d0ff6c1f2c3/ConvosCore/Sources/ConvosCore/Inboxes/ConversationStateMachine.swift#L331): If `publish()` succeeds but `processConversation(...)` later throws, the conversation has already been published (external side effect) but the state never transitions to a terminal outcome. If the caller retries `handleCreate()` after the failure, the current logic will `prepareConversation()` and `publish()` again, potentially creating duplicate conversations. There is no idempotency guard or compensating cleanup to prevent double-application of the creation side effect. <b>[ Low confidence ]</b>
- [line 383](https://github.com/ephemeraHQ/convos-ios/blob/629070ac73010a625715a0c64dd71d0ff6c1f2c3/ConvosCore/Sources/ConvosCore/Inboxes/ConversationStateMachine.swift#L383): Identity lookup errors are silently treated as “identity missing,” which can trigger destructive deletion of a legitimate conversation. In lines 383–387 the code uses `try? await identityStore.identity(for:)`, collapsing any thrown error into `nil`. The subsequent guard at lines 389–397 interprets `existingIdentity == nil` as “cleanup failed and identity does not exist,” and deletes the conversation via `DBConversation.deleteAll`. A transient `identityStore` failure (I/O, permission, timeout) will therefore delete valid state. This conflates operational errors with a real “identity absent” condition. The code should distinguish between “not found” vs. “error” (e.g., catch and branch on a specific not-found error, or fail fast without deleting on general errors). <b>[ Low confidence ]</b>
- [line 402](https://github.com/ephemeraHQ/convos-ios/blob/629070ac73010a625715a0c64dd71d0ff6c1f2c3/ConvosCore/Sources/ConvosCore/Inboxes/ConversationStateMachine.swift#L402): Risky ordering of inbox state transitions: deleting the current inbox before ensuring reauthorization succeeds can leave the system without an active inbox and without cleaning up prior resources on failure. At lines 402–407, the code obtains `prevInboxReady`, then calls `inboxStateManager.delete()` and only then attempts `reauthorize(inboxId:clientId:)`. If `reauthorize` throws, the function throws after having already deleted the previous inbox state, and it does not perform any rollback or cleanup of `prevInboxReady.client`/`apiClient`. This violates correct ordering and single paired cleanup guarantees, leaving the app in a degraded state. The code should reauthorize first (or stage the new state), then atomically switch, or ensure a try/finally that restores or cleans up on failure. <b>[ Low confidence ]</b>
- [line 410](https://github.com/ephemeraHQ/convos-ios/blob/629070ac73010a625715a0c64dd71d0ff6c1f2c3/ConvosCore/Sources/ConvosCore/Inboxes/ConversationStateMachine.swift#L410): Emitting the ready state before completing cleanup of the previous conversation can cause race conditions where other components act on the new ready state while the cleanup is still in progress. At lines 410–416, `emitStateChange(.ready(...))` is called before `await cleanUpPreviousConversationIfNeeded(...)`. This can lead to observers starting operations on the new conversation while previous resources (`prevInboxReady.client/apiClient`, inbox cache, etc.) are still active, risking double-use or conflicting state. To preserve invariants, either perform cleanup before advertising the ready state, or add explicit synchronization so that observers cannot observe a mixed state. <b>[ Low confidence ]</b>
- [line 412](https://github.com/ephemeraHQ/convos-ios/blob/629070ac73010a625715a0c64dd71d0ff6c1f2c3/ConvosCore/Sources/ConvosCore/Inboxes/ConversationStateMachine.swift#L412): Removal of unused-inbox cache clearing introduces a contract/regression risk: stale cache entries are no longer cleared when switching to an existing, already joined conversation. The diff shows the deletion of `UnusedInboxCache.shared.clearUnusedInbox(with: prevInboxReady.client.inboxId, ...)`. Previously, after moving to the ready state, the code cleared any cached “unused inbox” for the previous inbox id. Without this, the cache may retain outdated entries, potentially causing later misclassification or unintended deletions/revocations when the cache is consulted. This breaks contract parity for observable side effects and can lead to inconsistent behavior. If cleanup has been moved elsewhere, ensure it is invoked reliably on all success paths; otherwise, reintroduce or replace this cleanup. <b>[ Low confidence ]</b>
- [line 417](https://github.com/ephemeraHQ/convos-ios/blob/629070ac73010a625715a0c64dd71d0ff6c1f2c3/ConvosCore/Sources/ConvosCore/Inboxes/ConversationStateMachine.swift#L417): Missing cleanup of the previous inbox/resources when an existing conversation exists but has not yet joined. In the `else` branch of lines 417–440 (where `existingConversation.hasJoined == false`), the code emits `.validated(...)` and `enqueueAction(.join)` but never calls `cleanUpPreviousConversationIfNeeded(...)`. This can leave `previousResult`’s resources (or the `prevInboxReady` state) uncleaned, creating leaks or duplicate active clients until some later, non-guaranteed cleanup occurs. Ensure previous state is cleaned deterministically on this path, or defer via a visible, reliable mechanism. <b>[ Low confidence ]</b>
- [line 483](https://github.com/ephemeraHQ/convos-ios/blob/629070ac73010a625715a0c64dd71d0ff6c1f2c3/ConvosCore/Sources/ConvosCore/Inboxes/ConversationStateMachine.swift#L483): Insufficient validation of `inviterInboxId` and contradiction with the in-line comment. The comment says "Validate that the hex conversion succeeded and produced a valid inbox ID", but the code only checks `!inviterInboxId.isEmpty`. This allows malformed (non-hex or otherwise invalid) IDs to proceed to `client.newConversation(with:)`, deferring failure to a later step and potentially producing partial effects before a throw. This also creates uncertainty over the intended invariant, since the comment explicitly claims stronger validation than is implemented. <b>[ Low confidence ]</b>
- [line 492](https://github.com/ephemeraHQ/convos-ios/blob/629070ac73010a625715a0c64dd71d0ff6c1f2c3/ConvosCore/Sources/ConvosCore/Inboxes/ConversationStateMachine.swift#L492): Regression introduced by the diff: removal of clearing `UnusedInboxCache` after sending the join request. Previously, after a successful `publish`, the code cleared the unused inbox from keychain via `UnusedInboxCache.shared.clearUnusedInbox(with: client.inboxId, ...)`. Removing this side effect can leave stale entries in the cache/keychain, causing inconsistent behavior (e.g., later misclassification as unused, repeated cleanup attempts, or privacy/storage leakage). This is a contract parity issue: external state was previously updated; now it is not. <b>[ Low confidence ]</b>
- [line 504](https://github.com/ephemeraHQ/convos-ios/blob/629070ac73010a625715a0c64dd71d0ff6c1f2c3/ConvosCore/Sources/ConvosCore/Inboxes/ConversationStateMachine.swift#L504): Possible leak/race: assigning a new `streamConversationsTask` without canceling or awaiting any prior task can lead to multiple concurrent streaming tasks. If `handleJoin` can be invoked while a previous stream is active, this causes duplicate streaming, races in state emission, or leaked resources. Before reassigning `streamConversationsTask`, the existing task should be canceled and awaited, or otherwise safely torn down to ensure at-most-once behavior and proper cleanup. <b>[ Low confidence ]</b>
- [line 515](https://github.com/ephemeraHQ/convos-ios/blob/629070ac73010a625715a0c64dd71d0ff6c1f2c3/ConvosCore/Sources/ConvosCore/Inboxes/ConversationStateMachine.swift#L515): Cancellation path inside the streaming task returns without emitting any terminal state. At `guard !Task.isCancelled else { return }`, the task exits silently, leaving the state machine likely stuck in `.joining` without a defined outcome. Every input (including cancellations) should reach a visible terminal state (e.g., `.error(.cancelled)` or a specific `.cancelled` state) to preserve invariants and avoid hanging UI/flows. <b>[ Low confidence ]</b>
- [line 545](https://github.com/ephemeraHQ/convos-ios/blob/629070ac73010a625715a0c64dd71d0ff6c1f2c3/ConvosCore/Sources/ConvosCore/Inboxes/ConversationStateMachine.swift#L545): Comment and implementation contradiction about handling invites: The comment says, "For invites, we need the external conversation ID if available, capture before changing state" (lines 542–544), but the code only captures `conversationId` when `_state` is `.ready` (lines 545–547). If invites correspond to a different state case (e.g., `.invited`) that also holds a conversation ID, this implementation will not capture it before changing state, potentially skipping necessary cleanup/unsubscribe for invited conversations. Align the switch to include the invite case(s) that carry an ID, or clarify the comment to match the implemented behavior. <b>[ Low confidence ]</b>
- [line 551](https://github.com/ephemeraHQ/convos-ios/blob/629070ac73010a625715a0c64dd71d0ff6c1f2c3/ConvosCore/Sources/ConvosCore/Inboxes/ConversationStateMachine.swift#L551): Ordering of side effects can allow messages to be accepted after the `deleting` state is emitted. The function calls `emitStateChange(.deleting)` (line 551) before canceling `streamConversationsTask` (line 554) and finishing `messageStreamContinuation` (line 555). Observers of the state change may enqueue or send messages in response to `.deleting` while the stream is still open, violating the stated intention to "Cancel any ongoing tasks and stop accepting new messages" immediately. To enforce mutual exclusion and eliminate race windows, cancel the task and finish the continuation first (swap-and-clear), then emit the `deleting` state in a single critical section. <b>[ Low confidence ]</b>
- [line 551](https://github.com/ephemeraHQ/convos-ios/blob/629070ac73010a625715a0c64dd71d0ff6c1f2c3/ConvosCore/Sources/ConvosCore/Inboxes/ConversationStateMachine.swift#L551): Errors thrown inside `handleDelete()` can leave the state stuck at `deleting` without a defined terminal outcome. Specifically, after `emitStateChange(.deleting)` (line 551), the function awaits `waitForInboxReadyResult()` (line 559), `cleanUp(...)` (lines 561–565), and `inboxStateManager.delete()` (line 567). Any thrown error before reaching the final `emitStateChange(.uninitialized)` (line 570) results in no terminal state being emitted and the system remaining in a partially torn-down `deleting` state with the message stream already canceled/finished (lines 554–555). This violates the invariant that every input (including failure) must reach a defined terminal state and can cause observers to hang or remain in an inconsistent state. Use a `do/catch` with a `defer` or structured error emission to ensure a terminal state (e.g., `.error` or `.uninitialized`) is always emitted on all paths after effects are introduced. <b>[ Low confidence ]</b>
- [line 567](https://github.com/ephemeraHQ/convos-ios/blob/629070ac73010a625715a0c64dd71d0ff6c1f2c3/ConvosCore/Sources/ConvosCore/Inboxes/ConversationStateMachine.swift#L567): `inboxStateManager.delete()` (line 567) is only executed when `conversationId` is non-nil (lines 557–568). If `_state` is `.ready` with `result.conversationId == nil`, or `_state` is not `.ready`, the inbox deletion is skipped entirely but the function still emits `.uninitialized` (line 570). This can lead to the local inbox state remaining undeleted while the state machine advertises an uninitialized state, potentially leaking resources or leaving storage unsubscribed inconsistently. Unless `delete()` semantically requires a conversation ID, deletion should not be gated on `conversationId` being present; perform `inboxStateManager.delete()` regardless, while guarding only external unsubscribe/cleanup to the ID. <b>[ Low confidence ]</b>
</details>

<details>
<summary>ConvosCore/Sources/ConvosCore/Messaging/UnusedInboxCache.swift — 0 comments posted, 10 evaluated, 10 filtered</summary>

- [line 25](https://github.com/ephemeraHQ/convos-ios/blob/629070ac73010a625715a0c64dd71d0ff6c1f2c3/ConvosCore/Sources/ConvosCore/Messaging/UnusedInboxCache.swift#L25): A file-scoped mutable global `isConsumingUnusedInbox` is introduced without any synchronization. If read/written from multiple threads (typical for messaging or keychain-related flows), this can cause data races, stale reads, and non-deterministic behavior. Global mutable state should be guarded (e.g., via `actor`, serial queue, lock, or `@MainActor`) to enforce at-most-once semantics and mutual exclusion when used. <b>[ Low confidence ]</b>
- [line 99](https://github.com/ephemeraHQ/convos-ios/blob/629070ac73010a625715a0c64dd71d0ff6c1f2c3/ConvosCore/Sources/ConvosCore/Messaging/UnusedInboxCache.swift#L99): Clears cached service and keychain immediately in the pre-created unused service path, then ignores database save errors, resulting in a running `MessagingService` with no persisted record and no durable reference. In the `if let unusedService = unusedMessagingService` path, the code sets `isConsumingUnusedInbox = true`, sets `unusedMessagingService = nil`, and calls `clearUnusedInboxFromKeychain()` (lines 99–102) before awaiting readiness and attempting to save the inbox to the database (lines 105–114). If `waitForInboxReadyResult()` or the DB save fails, the catch only logs, and the method still returns `unusedService` and schedules creation of a new unused inbox. This can leave the current inbox untracked in the database and not recoverable via keychain on subsequent launches, breaking invariants around persistence and potentially causing duplication or loss of state. Safer options: defer clearing until after a successful save, or implement error handling that retries save or re-registers the inbox reference; alternatively, abort consumption on save failure. <b>[ Low confidence ]</b>
- [line 104](https://github.com/ephemeraHQ/convos-ios/blob/629070ac73010a625715a0c64dd71d0ff6c1f2c3/ConvosCore/Sources/ConvosCore/Messaging/UnusedInboxCache.swift#L104): The branch that consumes a pre-created `unusedMessagingService` swallows failures when persisting the consumed inbox to the database. In `consumeOrCreateMessagingService`, the code catches any error from `waitForInboxReadyResult()` and subsequent save, logs it, and still returns the service. This leaves the app running with a MessagingService that is considered "consumed" but not recorded in the database, potentially breaking downstream logic that expects an inbox record to exist after consumption (e.g., queries that assume the inbox has been saved). The function does not propagate the failure, retry, or establish any compensating action to ensure eventual consistency. <b>[ Out of scope ]</b>
- [line 133](https://github.com/ephemeraHQ/convos-ios/blob/629070ac73010a625715a0c64dd71d0ff6c1f2c3/ConvosCore/Sources/ConvosCore/Messaging/UnusedInboxCache.swift#L133): Clearing the unused inbox keychain entry immediately when consuming via keychain ID can orphan a valid pre-created inbox if authorization fails. In `consumeOrCreateMessagingService`, when `getUnusedInboxFromKeychain()` finds an ID, the code sets `isConsumingUnusedInbox = true` and calls `clearUnusedInboxFromKeychain()` BEFORE resolving identity and creating the `MessagingService`. If the identity lookup throws (transient keychain or store failure), the code logs the error and falls through to creating a fresh service via registration, while the original pre-created inbox ID has been discarded and there is no associated `unusedMessagingService` to clean up via `stopAndDelete`. This can lead to an external resource leak: a registered but untracked unused inbox on the server side, and also breaks the one-unused-inbox invariant until background creation re-establishes a new one. <b>[ Low confidence ]</b>
- [line 135](https://github.com/ephemeraHQ/convos-ios/blob/629070ac73010a625715a0c64dd71d0ff6c1f2c3/ConvosCore/Sources/ConvosCore/Messaging/UnusedInboxCache.swift#L135): Clears keychain entry (`clearUnusedInboxFromKeychain()`) before successfully establishing identity/authorization for an unused inbox ID path, which can permanently orphan the inbox if `identityStore.identity(for:)` fails. In the `if let unusedInboxId = getUnusedInboxFromKeychain()` path, the code immediately sets `isConsumingUnusedInbox = true` and calls `clearUnusedInboxFromKeychain()` (lines 134–136) before attempting `identityStore.identity(for:)`. If that call throws (lines 145–175), the catch just logs and falls through to creating a fresh messaging service, leaving the previously discovered unused inbox ID gone from keychain with no retry or recovery. This produces an inconsistent state: server-side inbox remains but local state has neither keychain reference nor DB record, and the app proceeds with a fresh service. To preserve invariants, either delay clearing the keychain until after successful authorization or persist a recovery token/record to enable subsequent retries. <b>[ Low confidence ]</b>
- [line 188](https://github.com/ephemeraHQ/convos-ios/blob/629070ac73010a625715a0c64dd71d0ff6c1f2c3/ConvosCore/Sources/ConvosCore/Messaging/UnusedInboxCache.swift#L188): `clearUnusedInboxFromKeychain()` swallows all errors from `keychainService.delete(UnusedInboxKeychainItem())` and only logs at debug level. Callers have no way to know the operation failed, which can lead to inconsistent state (e.g., UI or logic assuming the unused inbox was cleared while the keychain still retains it). This is a runtime behavior issue: failure paths are not surfaced or recoverable, and there is no defined terminal state for callers beyond silent failure. <b>[ Low confidence ]</b>
- [line 211](https://github.com/ephemeraHQ/convos-ios/blob/629070ac73010a625715a0c64dd71d0ff6c1f2c3/ConvosCore/Sources/ConvosCore/Messaging/UnusedInboxCache.swift#L211): The detached background `Task` operates concurrently and uses `databaseWriter` and `databaseReader` at the same time as the returned `MessagingService` may also use them. There is no visible synchronization or mutual exclusion in this method to prevent races or interleaving side effects. If `DatabaseWriter`/`DatabaseReader` or the underlying storage are not thread-safe for concurrent writes/reads in this pattern, this can cause data races, inconsistent state, or corruption. Even if they are thread-safe, concurrent creation of an "unused inbox" could interfere with ongoing authorization or service operations, violating intended sequencing. <b>[ Low confidence ]</b>
- [line 211](https://github.com/ephemeraHQ/convos-ios/blob/629070ac73010a625715a0c64dd71d0ff6c1f2c3/ConvosCore/Sources/ConvosCore/Messaging/UnusedInboxCache.swift#L211): The detached `Task` is fire-and-forget: its result and potential errors are not observed, and there is no cancellation or lifecycle binding. If `createNewUnusedInbox(...)` fails internally (e.g., due to I/O errors), those errors are silently discarded, making failures invisible and potentially leaving the system in an unexpected state for the "next time" assumption. Moreover, because the `Task` is not stored or tied to actor/service lifecycle, it may continue executing after `UnusedInboxCache` is deinitialized, using captured `databaseWriter`/`databaseReader`/`environment` references indefinitely. <b>[ Low confidence ]</b>
- [line 211](https://github.com/ephemeraHQ/convos-ios/blob/629070ac73010a625715a0c64dd71d0ff6c1f2c3/ConvosCore/Sources/ConvosCore/Messaging/UnusedInboxCache.swift#L211): Scheduling a detached background `Task` on every call to `createFreshMessagingService` can lead to duplicate and concurrent creation of unused inboxes without any coalescing or at-most-once guard. Each invocation of `createFreshMessagingService` spawns a new `Task` that calls `createNewUnusedInbox(...)`. If multiple calls occur close together, multiple inboxes may be created concurrently, violating uniqueness and potentially wasting resources or producing inconsistent cache state. There is no state flag, mutex, debounce, or idempotency guard around the creation. <b>[ Low confidence ]</b>
- [line 336](https://github.com/ephemeraHQ/convos-ios/blob/629070ac73010a625715a0c64dd71d0ff6c1f2c3/ConvosCore/Sources/ConvosCore/Messaging/UnusedInboxCache.swift#L336): `saveUnusedInboxToKeychain(_:)` swallows persistence errors and `createNewUnusedInbox` continues to register and store an in-memory `unusedMessagingService` even if the keychain write failed. This creates an inconsistent state where `unusedMessagingService` exists but the keychain lacks the corresponding `UnusedInboxKeychainItem`. Later logic that relies on the keychain (e.g., `isUnusedInbox(_:)` and fallback paths in `consumeOrCreateMessagingService`) may misclassify or miss the pre-created inbox, potentially triggering unnecessary new inbox creation or failing to recognize the cached inbox in parity checks. <b>[ Out of scope ]</b>
</details>

<details>
<summary>ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift — 0 comments posted, 5 evaluated, 4 filtered</summary>

- [line 276](https://github.com/ephemeraHQ/convos-ios/blob/629070ac73010a625715a0c64dd71d0ff6c1f2c3/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift#L276): Potentially inconsistent state due to unconditional `DeviceRegistrationManager.clearRegistrationState()` in `defer` even when database deletion fails. If `InboxWriter.deleteAll()` throws, device registration is still cleared while local inbox data remains, which may break external contract expectations (e.g., app stops receiving messages while stale local data persists). There is no compensating rollback or user-visible error handling that restores registration. <b>[ Low confidence ]</b>
- [line 278](https://github.com/ephemeraHQ/convos-ios/blob/629070ac73010a625715a0c64dd71d0ff6c1f2c3/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift#L278): Potential deadlock when calling `serviceQueue.sync(flags: .barrier)` if `deleteAllInboxes()` is invoked from work already executing on `serviceQueue`. Synchronous dispatch to the same queue (serial or concurrent with `.barrier`) can deadlock because the barrier block requires exclusive access and will not execute until the current work finishes, but the current work is waiting on the sync call to return. Without a visible guard preventing calls from `serviceQueue`, this is a reachable deadlock scenario. <b>[ Low confidence ]</b>
- [line 284](https://github.com/ephemeraHQ/convos-ios/blob/629070ac73010a625715a0c64dd71d0ff6c1f2c3/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift#L284): No timeout or cancellation handling for `withTaskGroup` that awaits `messagingService.stopAndDelete()`. If any `stopAndDelete()` never returns (e.g., awaiting a stuck network operation), `deleteAllInboxes()` can hang indefinitely, preventing `defer { DeviceRegistrationManager.clearRegistrationState() }` from running and leaving the system in a half-shutdown state. <b>[ Low confidence ]</b>
- [line 284](https://github.com/ephemeraHQ/convos-ios/blob/629070ac73010a625715a0c64dd71d0ff6c1f2c3/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift#L284): No visibility into or aggregation of failures from individual `stopAndDelete()` tasks. Using `withTaskGroup(of: Void.self)` without per-task error handling or a `withThrowingTaskGroup` means any internal failure is silently ignored by the calling context (assuming non-throwing API), and the code proceeds to `InboxWriter.deleteAll()`. This can result in a partial cleanup where services weren’t fully stopped/deleted but the database is wiped, yielding inconsistent state. <b>[ Low confidence ]</b>
</details>


</details><!-- Macroscope's review summary ends here -->
<!-- Macroscope's pull request summary ends here -->