### PR TITLE
Add tests for ConversationStateMachine

### DIFF
--- a/ConvosCore/Sources/ConvosCore/AppEnvironment.swift
+++ b/ConvosCore/Sources/ConvosCore/AppEnvironment.swift
@@ -25,6 +25,16 @@ public enum AppEnvironment: Sendable {
     case dev(config: ConvosConfiguration)
     case production(config: ConvosConfiguration)
 
+    // Only used for testing
+    public var defaultOverrideJWTToken: String? {
+        switch self {
+        case .tests:
+            return "test-override-jwt-token"
+        default:
+            return nil
+        }
+    }
+
     public var name: String {
         switch self {
         case .local:

--- a/ConvosCore/Sources/ConvosCore/Auth/Keychain/MockKeychainService.swift
+++ b/ConvosCore/Sources/ConvosCore/Auth/Keychain/MockKeychainService.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+/// Mock keychain service for testing
+///
+/// Provides an in-memory implementation of KeychainServiceProtocol for unit tests.
+/// All data is stored in memory and cleared when the instance is deallocated.
+final class MockKeychainService: KeychainServiceProtocol, @unchecked Sendable {
+    private var storage: [String: Data] = [:]
+    private let queue: DispatchQueue = DispatchQueue(label: "com.convos.mockKeychainService", qos: .userInitiated)
+
+    func saveString(_ value: String, account: String) throws {
+        guard let data = value.data(using: .utf8) else {
+            throw KeychainError.unknown(errSecParam)
+        }
+        try saveData(data, account: account)
+    }
+
+    func saveData(_ data: Data, account: String) throws {
+        queue.sync {
+            storage[account] = data
+        }
+    }
+
+    func retrieveString(account: String) throws -> String? {
+        guard let data = try retrieveData(account: account) else {
+            return nil
+        }
+        return String(data: data, encoding: .utf8)
+    }
+
+    func retrieveData(account: String) throws -> Data? {
+        return queue.sync {
+            storage[account]
+        }
+    }
+
+    func delete(account: String) throws {
+        queue.sync {
+            _ = storage.removeValue(forKey: account)
+        }
+    }
+
+    // Test helpers
+
+    func clear() {
+        queue.sync {
+            storage.removeAll()
+        }
+    }
+
+    func contains(account: String) -> Bool {
+        return queue.sync {
+            storage[account] != nil
+        }
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/ConvosClient+App.swift
+++ b/ConvosCore/Sources/ConvosCore/ConvosClient+App.swift
@@ -6,10 +6,12 @@ extension ConvosClient {
         let databaseManager = DatabaseManager(environment: environment)
         let databaseWriter = databaseManager.dbWriter
         let databaseReader = databaseManager.dbReader
+        let identityStore = KeychainIdentityStore(accessGroup: environment.keychainAccessGroup)
         let sessionManager = SessionManager(
             databaseWriter: databaseWriter,
             databaseReader: databaseReader,
-            environment: environment
+            environment: environment,
+            identityStore: identityStore
         )
         return .init(sessionManager: sessionManager,
                      databaseManager: databaseManager,

--- a/ConvosCore/Sources/ConvosCore/ConvosClient.swift
+++ b/ConvosCore/Sources/ConvosCore/ConvosClient.swift
@@ -28,10 +28,12 @@ public final class ConvosClient {
 
     public static func testClient() -> ConvosClient {
         let databaseManager = MockDatabaseManager.shared
+        let identityStore = MockKeychainIdentityStore()
         let sessionManager = SessionManager(
             databaseWriter: databaseManager.dbWriter,
             databaseReader: databaseManager.dbReader,
-            environment: .tests
+            environment: .tests,
+            identityStore: identityStore
         )
         return .init(sessionManager: sessionManager,
                      databaseManager: databaseManager,

--- a/ConvosCore/Sources/ConvosCore/Inboxes/AuthorizeInboxOperation.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/AuthorizeInboxOperation.swift
@@ -2,17 +2,6 @@ import Combine
 import Foundation
 import GRDB
 
-extension AppEnvironment {
-    var defaultIdentityStore: any KeychainIdentityStoreProtocol {
-        switch self {
-        case .local, .dev, .production:
-            KeychainIdentityStore(accessGroup: keychainAccessGroup)
-        case .tests:
-            MockKeychainIdentityStore()
-        }
-    }
-}
-
 protocol AuthorizeInboxOperationProtocol {
     func stopAndDelete() async
     func stopAndDelete()

--- a/ConvosCore/Sources/ConvosCore/Inboxes/CachedPushNotificationHandler.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/CachedPushNotificationHandler.swift
@@ -25,23 +25,27 @@ public actor CachedPushNotificationHandler {
     ///   - databaseReader: Database reader instance
     ///   - databaseWriter: Database writer instance
     ///   - environment: App environment
+    ///   - identityStore: Identity store instance
     public static func initialize(
         databaseReader: any DatabaseReader,
         databaseWriter: any DatabaseWriter,
-        environment: AppEnvironment
+        environment: AppEnvironment,
+        identityStore: any KeychainIdentityStoreProtocol
     ) {
         _shared = CachedPushNotificationHandler(
             databaseReader: databaseReader,
             databaseWriter: databaseWriter,
-            environment: environment
+            environment: environment,
+            identityStore: identityStore
         )
     }
 
     private let databaseReader: any DatabaseReader
     private let databaseWriter: any DatabaseWriter
     private let environment: AppEnvironment
+    private let identityStore: any KeychainIdentityStoreProtocol
 
-    private var messagingServices: [String: MessagingService] = [:] // Keyed by inboxId or inboxId:jwt
+    private var messagingServices: [String: MessagingService] = [:] // Keyed by inboxId
 
     // Track last access time for cleanup (keyed by inboxId)
     private var lastAccessTime: [String: Date] = [:]
@@ -52,11 +56,13 @@ public actor CachedPushNotificationHandler {
     private init(
         databaseReader: any DatabaseReader,
         databaseWriter: any DatabaseWriter,
-        environment: AppEnvironment
+        environment: AppEnvironment,
+        identityStore: any KeychainIdentityStoreProtocol
     ) {
         self.databaseReader = databaseReader
         self.databaseWriter = databaseWriter
         self.environment = environment
+        self.identityStore = identityStore
     }
 
     /// Handles a push notification using the structured payload with timeout protection
@@ -146,6 +152,7 @@ public actor CachedPushNotificationHandler {
             databaseWriter: databaseWriter,
             databaseReader: databaseReader,
             environment: environment,
+            identityStore: identityStore,
             startsStreamingServices: false,
             overrideJWTToken: overrideJWTToken
         )

--- a/ConvosCore/Sources/ConvosCore/Inboxes/InboxStateMachine.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/InboxStateMachine.swift
@@ -204,14 +204,14 @@ public actor InboxStateMachine {
         self.invitesRepository = invitesRepository
         self.databaseWriter = databaseWriter
         self.syncingManager = syncingManager
-        self.overrideJWTToken = overrideJWTToken
+        self.overrideJWTToken = overrideJWTToken ?? environment.defaultOverrideJWTToken
         self.environment = environment
 
         // Initialize API client
         Logger.info("Initializing API client (JWT override: \(overrideJWTToken != nil))...")
         self.apiClient = ConvosAPIClientFactory.client(
             environment: environment,
-            overrideJWTToken: overrideJWTToken
+            overrideJWTToken: self.overrideJWTToken
         )
 
         // Set custom XMTP host if provided

--- a/ConvosCore/Sources/ConvosCore/Messaging/MessagingService.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/MessagingService.swift
@@ -12,23 +12,24 @@ import XMTPiOS
 /// The service handles authorization, streaming, and push notification registration.
 final class MessagingService: MessagingServiceProtocol {
     private let authorizationOperation: any AuthorizeInboxOperationProtocol
-    internal let inboxStateManager: any InboxStateManagerProtocol
+    let inboxStateManager: any InboxStateManagerProtocol
     internal let identityStore: any KeychainIdentityStoreProtocol
     internal let databaseReader: any DatabaseReader
     internal let databaseWriter: any DatabaseWriter
     private let environment: AppEnvironment
     private var cancellables: Set<AnyCancellable> = []
 
+    // swiftlint:disable:next function_parameter_count
     static func authorizedMessagingService(
         for inboxId: String,
         clientId: String,
         databaseWriter: any DatabaseWriter,
         databaseReader: any DatabaseReader,
         environment: AppEnvironment,
+        identityStore: any KeychainIdentityStoreProtocol,
         startsStreamingServices: Bool,
         overrideJWTToken: String? = nil
     ) -> MessagingService {
-        let identityStore = environment.defaultIdentityStore
         let authorizationOperation = AuthorizeInboxOperation.authorize(
             inboxId: inboxId,
             clientId: clientId,
@@ -44,18 +45,6 @@ final class MessagingService: MessagingServiceProtocol {
             databaseWriter: databaseWriter,
             databaseReader: databaseReader,
             identityStore: identityStore,
-            environment: environment
-        )
-    }
-
-    static func registeredMessagingService(
-        databaseWriter: any DatabaseWriter,
-        databaseReader: any DatabaseReader,
-        environment: AppEnvironment
-    ) async -> MessagingService {
-        return await UnusedInboxCache.shared.consumeOrCreateMessagingService(
-            databaseWriter: databaseWriter,
-            databaseReader: databaseReader,
             environment: environment
         )
     }

--- a/ConvosCore/Sources/ConvosCore/Notifications/NotificationExtensionEnvironment.swift
+++ b/ConvosCore/Sources/ConvosCore/Notifications/NotificationExtensionEnvironment.swift
@@ -36,13 +36,15 @@ public struct NotificationExtensionEnvironment {
     public static func createPushNotificationHandler() throws -> CachedPushNotificationHandler {
         let environment = try getEnvironment()
         let databaseManager = DatabaseManager(environment: environment)
+        let identityStore = KeychainIdentityStore(accessGroup: environment.keychainAccessGroup)
 
         Logger.info("Creating CachedPushNotificationHandler with environment: \(environment.name)")
 
         CachedPushNotificationHandler.initialize(
             databaseReader: databaseManager.dbReader,
             databaseWriter: databaseManager.dbWriter,
-            environment: environment
+            environment: environment,
+            identityStore: identityStore
         )
         return CachedPushNotificationHandler.shared
     }

--- a/ConvosCore/Sources/ConvosCore/Shared/ConvosKeychainItem.swift
+++ b/ConvosCore/Sources/ConvosCore/Shared/ConvosKeychainItem.swift
@@ -1,23 +1,12 @@
 import Foundation
 
-extension KeychainItemProtocol {
-    static var service: String {
-        return "org.convos.ios.KeychainItemProtocol.v2"
-    }
-}
-
-struct ConvosJWTKeychainItem: KeychainItemProtocol {
-    let deviceId: String
-
-    var account: String {
+/// Account identifiers for specific keychain items
+enum KeychainAccount {
+    /// Account for storing JWT tokens, keyed by device ID
+    static func jwt(deviceId: String) -> String {
         return deviceId
     }
-}
 
-struct UnusedInboxKeychainItem: KeychainItemProtocol {
-    static let account: String = "unused-inbox"
-
-    var account: String {
-        return Self.account
-    }
+    /// Account for storing the unused inbox ID
+    static let unusedInbox: String = "unused-inbox"
 }

--- a/ConvosCore/Sources/ConvosCore/Syncing/StreamProcessor.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/StreamProcessor.swift
@@ -247,7 +247,7 @@ actor StreamProcessor: StreamProcessorProtocol {
             )
             Logger.info("Subscribed to push topics \(context): \(conversationTopic), \(welcomeTopic)")
         } catch {
-            Logger.error("Failed subscribing to topics \(context): \(error)")
+            Logger.warning("Failed subscribing to topics \(context): \(error)")
         }
     }
 }

--- a/ConvosCore/Tests/ConvosCoreTests/TestHelpers.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/TestHelpers.swift
@@ -24,6 +24,7 @@ func waitForState(
 class TestFixtures {
     let environment: AppEnvironment
     let identityStore: MockKeychainIdentityStore
+    let keychainService: MockKeychainService
     let databaseManager: MockDatabaseManager
 
     var clientA: (any XMTPClientProvider)?
@@ -37,6 +38,7 @@ class TestFixtures {
     init() {
         self.environment = .tests
         self.identityStore = MockKeychainIdentityStore()
+        self.keychainService = MockKeychainService()
         self.databaseManager = MockDatabaseManager.makeTestDatabase()
     }
 

--- a/dev/test
+++ b/dev/test
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eou pipefail
 
-echo "🧪 Running InboxStateMachine and UnusedInboxCache tests with local XMTP node..."
+echo "🧪 Running ConvosCore integration tests with local XMTP node..."
 echo ""
 
 # Check if Docker is running
@@ -51,6 +51,7 @@ if TEST_SERVER_ENABLED=true xcodebuild test \
     -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.0' \
     -only-testing:ConvosCoreTests/InboxStateMachineTests \
     -only-testing:ConvosCoreTests/UnusedInboxCacheTests \
+    -only-testing:ConvosCoreTests/ConversationStateMachineTests \
     2>&1 | tee test-output.log; then
     echo ""
     echo "✅ All tests passed!"


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Add ConversationStateMachine tests and refactor messaging and keychain dependencies to inject `KeychainIdentityStoreProtocol` and `KeychainServiceProtocol` across `MessagingService`, `UnusedInboxCache`, and related handlers
Add a new `ConversationStateMachineTests` suite validating creation, transitions, queuing, deletion, stopping, state sequence emission, sequential creations, and join flows. Refactor messaging to require injected `KeychainIdentityStoreProtocol` and use `KeychainServiceProtocol` with account-based storage; remove `MessagingService.registeredMessagingService`. Expose `UnusedInboxCache` initialization and public methods, return `any MessagingServiceProtocol`, and clear unused inbox immediately. Require `identityStore` in cached push handler and session manager, and use `AppEnvironment.defaultOverrideJWTToken` in `InboxStateMachine` when `overrideJWTToken` is nil.

#### 📍Where to Start
Start with the test coverage in `ConversationStateMachineTests` in [ConversationStateMachineTests.swift](https://github.com/ephemeraHQ/convos-ios/pull/212/files#diff-31b68901eb4e1a8480fdbc785760b1ccd18c574f733322f63b5008dcf12c39a0), then follow dependency injection changes beginning at `MessagingService.authorizedMessagingService` in [MessagingService.swift](https://github.com/ephemeraHQ/convos-ios/pull/212/files#diff-ae5f8bf667b2cb7b826678407b9697d1fe69352397220d80aaeeb65fd1090884) and `UnusedInboxCache` in [UnusedInboxCache.swift](https://github.com/ephemeraHQ/convos-ios/pull/212/files#diff-f0fa420edcbb4b84596d955430ce62fac2027d0d82e4f34b2bc694e43bd55106).

----
<!-- Macroscope's review summary starts here -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 62e9e3c. 15 files reviewed, 60 issues evaluated, 57 issues filtered, 0 comments posted</summary>

### 🗂️ Filtered Issues
<details>
<summary>ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift — 0 comments posted, 7 evaluated, 7 filtered</summary>

- [line 58](https://github.com/ephemeraHQ/convos-ios/blob/62e9e3cc9c863b83ad1301b72d12bd0e2bcf3000/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift#L58): Switching `keychainService` from the generic `KeychainService<ConvosJWTKeychainItem>` to the existential `any KeychainServiceProtocol = KeychainService()` in `ConvosAPIClient` removes the item-specific typing that may have been used to scope the keychain service, account, or key derivation. If other parts of `ConvosAPIClient` rely on the concrete generic type for account/service selection (e.g., by defaulting to a specific `KeychainItem` configuration), data may now be stored under a different keychain namespace or not retrievable by read paths that still assume the old conventions. This is a runtime behavioral change risk: tokens/credentials could be saved to one logical location and later attempts to read may look in another, leading to failures to authenticate without a compile-time error. <b>[ Low confidence ]</b>
- [line 167](https://github.com/ephemeraHQ/convos-ios/blob/62e9e3cc9c863b83ad1301b72d12bd0e2bcf3000/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift#L167): No validation of `deviceId` before use in the request body and as part of the keychain account identifier. If `DeviceInfo.deviceIdentifier` is empty or otherwise invalid, the backend may reject the request (e.g., 400), and the keychain save could fail or create an unusable entry. This leads to a runtime failure path that could be proactively guarded with explicit validation and a clear error (e.g., `APIError.invalidDeviceId`). <b>[ Low confidence ]</b>
- [line 192](https://github.com/ephemeraHQ/convos-ios/blob/62e9e3cc9c863b83ad1301b72d12bd0e2bcf3000/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift#L192): Unsafe conversion of backoff `delay` from `Double` to `UInt64` for `Task.sleep`. The code constructs `UInt64(delay * 1_000_000_000)`. If `TimeInterval.calculateExponentialBackoff(for:)` returns a negative value, NaN, or an extremely large value (due to misconfiguration or overflow), this conversion can trap at runtime or overflow, and `Task.sleep` may misbehave. Guard the computed delay: ensure it is finite, non-negative, within a reasonable upper bound, and convert using safe clamping or explicit error handling. <b>[ Low confidence ]</b>
- [line 208](https://github.com/ephemeraHQ/convos-ios/blob/62e9e3cc9c863b83ad1301b72d12bd0e2bcf3000/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift#L208): Contract-parity risk introduced by changing the `keychainService.saveString` call to use `account: KeychainAccount.jwt(deviceId:)`. If `KeychainAccount.jwt(deviceId:)` produces a different account identifier than the previous `.init(deviceId:)` (as implied by the diff), the JWT token will be stored under a different key than prior versions. Any read path expecting the old key will fail to find the token, causing downstream authentication to break (e.g., repeated re-authentication, token-not-found errors). This is a runtime behavior change and must be coordinated with all read sites to maintain parity. <b>[ Low confidence ]</b>
- [line 230](https://github.com/ephemeraHQ/convos-ios/blob/62e9e3cc9c863b83ad1301b72d12bd0e2bcf3000/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift#L230): Empty JWT values are not validated before being set on the `X-Convos-AuthToken` header. If `overrideJWTToken` or a keychain-retrieved `keychainJWT` is an empty string (or effectively empty/whitespace), the code will still set `X-Convos-AuthToken` to an empty value. This can lead to requests being sent with a blank auth header, which may not be treated the same as an absent header by the server and can break client-side re-authentication logic that relies on the absence of the header. Guard against empty strings before setting the header and treat them as “no token.” <b>[ Low confidence ]</b>
- [line 235](https://github.com/ephemeraHQ/convos-ios/blob/62e9e3cc9c863b83ad1301b72d12bd0e2bcf3000/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift#L235): Keychain account lookup change may break token retrieval. The diff changes the keychain access from `retrieveString(.init(deviceId: deviceId))` to `retrieveString(account: KeychainAccount.jwt(deviceId: deviceId))`. If the previously stored JWT used a different account identifier than `KeychainAccount.jwt(deviceId:)`, this path will fail to retrieve existing tokens for current users, leading to unintended re-authentication loops and degraded UX. Validate that the new `KeychainAccount.jwt(deviceId:)` resolves to the same account/key as the previously stored value, or implement a migration/fallback (e.g., try both legacy and new account keys). <b>[ Low confidence ]</b>
- [line 237](https://github.com/ephemeraHQ/convos-ios/blob/62e9e3cc9c863b83ad1301b72d12bd0e2bcf3000/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift#L237): Log messages may be misleading in presence of empty JWT values. The code logs "Using override JWT token from notification payload" and "Using JWT token from keychain" even if the token value is an empty string, because there is no validation against emptiness before setting headers. This can complicate debugging and mask the real condition (no usable token). Add explicit empty-string checks and adjust logs to reflect actual token usability. <b>[ Already posted ]</b>
</details>

<details>
<summary>ConvosCore/Sources/ConvosCore/Auth/Keychain/MockKeychainService.swift — 0 comments posted, 1 evaluated, 1 filtered</summary>

- [line 28](https://github.com/ephemeraHQ/convos-ios/blob/62e9e3cc9c863b83ad1301b72d12bd0e2bcf3000/ConvosCore/Sources/ConvosCore/Auth/Keychain/MockKeychainService.swift#L28): `retrieveString(account:)` silently collapses two distinct states into `nil`: (1) no value stored for the given `account`, and (2) a value is stored but it is not valid UTF-8. This conflates absence with invalid data and loses information at the data-conversion boundary. Callers cannot distinguish between a missing entry and an encoding error, which can mask bugs (e.g., if `saveData(_:account:)` was used to store arbitrary bytes). A more robust behavior would either throw on invalid encoding or surface a distinct error/value so that absence and decode failure are not indistinguishable. <b>[ Low confidence ]</b>
</details>

<details>
<summary>ConvosCore/Sources/ConvosCore/Auth/KeychainService.swift — 0 comments posted, 5 evaluated, 3 filtered</summary>

- [line 34](https://github.com/ephemeraHQ/convos-ios/blob/62e9e3cc9c863b83ad1301b72d12bd0e2bcf3000/ConvosCore/Sources/ConvosCore/Auth/KeychainService.swift#L34): Breaking contract: the service identifier used to store/retrieve keychain items was changed from a per-item service (previously `T.service` via a generic `KeychainItemProtocol`) to a single fixed `serviceIdentifier` (`"org.convos.ios.KeychainService.v2"`). This change makes previously stored items (under the old service name(s)) unreachable by the new retrieval and delete paths, causing lookups to return `nil` and deletes to do nothing for legacy entries. Any higher-level logic expecting continuity (e.g., reading items saved by prior app versions) will fail at runtime. A migration or dual-service lookup is required to preserve contract parity. <b>[ Low confidence ]</b>
- [line 69](https://github.com/ephemeraHQ/convos-ios/blob/62e9e3cc9c863b83ad1301b72d12bd0e2bcf3000/ConvosCore/Sources/ConvosCore/Auth/KeychainService.swift#L69): In `saveData(_:account:)`, when `SecItemAdd` returns `errSecDuplicateItem`, the code attempts an update via `SecItemUpdate`. If another process or extension deletes the item between these two calls (a cross-process race), `SecItemUpdate` can return `errSecItemNotFound`. The current code throws `KeychainError.unknown(updateStatus)` and exits, leaving the item unsaved. A more robust approach is to retry `SecItemAdd` once on `errSecItemNotFound` from the update path, ensuring the save operation reaches a defined terminal state (either success or a clear failure unrelated to this race). <b>[ Low confidence ]</b>
- [line 81](https://github.com/ephemeraHQ/convos-ios/blob/62e9e3cc9c863b83ad1301b72d12bd0e2bcf3000/ConvosCore/Sources/ConvosCore/Auth/KeychainService.swift#L81): Silent data conversion failure in `retrieveString(account:)`: if `retrieveData(account:)` returns non-UTF-8 bytes (e.g., data stored via `saveData` not originating from `saveString`), the method returns `nil` without distinguishing between "item not found" and "decoding failed". This conflates error states and can lead callers to misinterpret a present-but-undecodable value as absence, losing error visibility. Consider throwing a specific error on decoding failure or returning a result that differentiates these cases. <b>[ Code style ]</b>
</details>

<details>
<summary>ConvosCore/Sources/ConvosCore/Auth/MockAuthService.swift — 0 comments posted, 5 evaluated, 4 filtered</summary>

- [line 154](https://github.com/ephemeraHQ/convos-ios/blob/62e9e3cc9c863b83ad1301b72d12bd0e2bcf3000/ConvosCore/Sources/ConvosCore/Auth/MockAuthService.swift#L154): `deleteAll()` and `deleteAccount(with:)` do not emit an auth state change. They clear keychain and in-memory user (`_currentUser = nil`) but never notify subscribers via `authStateSubject`. This leaves observers with stale state (e.g., still seeing `.authorized` or `.registered`) after destructive operations, causing inconsistent UI or business logic compared to `signOut()`, which does publish `.unauthorized`. <b>[ Low confidence ]</b>
- [line 159](https://github.com/ephemeraHQ/convos-ios/blob/62e9e3cc9c863b83ad1301b72d12bd0e2bcf3000/ConvosCore/Sources/ConvosCore/Auth/MockAuthService.swift#L159): `deleteAccount(with providerId:)` ignores its `providerId` parameter and unconditionally deletes the single static account (`mock-user`). In any multi-account context or when the provided ID doesn't correspond to the one stored, this will delete the wrong account or behave incorrectly. At a minimum, it violates the API's expectation that the provided ID is used to select what to delete. <b>[ Low confidence ]</b>
- [line 164](https://github.com/ephemeraHQ/convos-ios/blob/62e9e3cc9c863b83ad1301b72d12bd0e2bcf3000/ConvosCore/Sources/ConvosCore/Auth/MockAuthService.swift#L164): `signOut()` leaves the service in a potentially inconsistent state if keychain deletion fails. The method attempts to `delete` from keychain only when `persist` is true; if this throws, the function exits early without clearing `_currentUser` or publishing `.unauthorized`. This partial failure means the caller attempted to sign out, but the in-memory session and published state remain as if still signed in. A safer approach is to clear in-memory state and publish unauthorized regardless of keychain deletion success, possibly logging the keychain error. <b>[ Low confidence ]</b>
- [line 172](https://github.com/ephemeraHQ/convos-ios/blob/62e9e3cc9c863b83ad1301b72d12bd0e2bcf3000/ConvosCore/Sources/ConvosCore/Auth/MockAuthService.swift#L172): Unstable and non-persistent inbox mapping. The methods `save(inboxId:for:)` and `saveProviderIdMapping(providerId:for:)` are empty (no-ops), yet `inboxId(for:)` returns a freshly generated `UUID().uuidString` every time it is called. This silently breaks the expected contract of a mapping: callers cannot retrieve a consistent inbox ID for the same provider ID across calls or sessions, and there is no error indicating the lack of persistence. This will result in inconsistent behavior and prevents any correlation of inboxes to providers. <b>[ Low confidence ]</b>
</details>

<details>
<summary>ConvosCore/Sources/ConvosCore/ConvosClient+App.swift — 0 comments posted, 2 evaluated, 2 filtered</summary>

- [line 6](https://github.com/ephemeraHQ/convos-ios/blob/62e9e3cc9c863b83ad1301b72d12bd0e2bcf3000/ConvosCore/Sources/ConvosCore/ConvosClient+App.swift#L6): The factory constructs `DatabaseManager(environment:)` and immediately reads `dbWriter` and `dbReader` without any error handling or validation. If the database manager requires I/O, migrations, or file-system availability during initialization and those operations fail due to environment, permissions, or corruption, this function has no defined failure outcome and proceeds to build `SessionManager`, potentially leading to runtime crashes or undefined behavior when `SessionManager` uses `dbWriter`/`dbReader`. Add explicit error handling or validation in the factory to ensure a safe terminal state on initialization failures. <b>[ Low confidence ]</b>
- [line 9](https://github.com/ephemeraHQ/convos-ios/blob/62e9e3cc9c863b83ad1301b72d12bd0e2bcf3000/ConvosCore/Sources/ConvosCore/ConvosClient+App.swift#L9): The function constructs `KeychainIdentityStore(accessGroup: environment.keychainAccessGroup)` without validating `environment.keychainAccessGroup`. If `keychainAccessGroup` is `nil`, empty, or does not match an entitlement provisioned for the app, the keychain store could fail at initialization or on first use, causing runtime errors. This factory method has no guardrails or fallback, so invalid inputs are reachable and can lead to runtime failure. Add explicit validation (e.g., non-empty and entitlement check) and a defined failure outcome (error/log/early termination pre-effects) before creating `KeychainIdentityStore`. <b>[ Already posted ]</b>
</details>

<details>
<summary>ConvosCore/Sources/ConvosCore/ConvosClient.swift — 0 comments posted, 2 evaluated, 2 filtered</summary>

- [line 30](https://github.com/ephemeraHQ/convos-ios/blob/62e9e3cc9c863b83ad1301b72d12bd0e2bcf3000/ConvosCore/Sources/ConvosCore/ConvosClient.swift#L30): Using the singleton `MockDatabaseManager.shared` introduces shared mutable state across test runs and factory invocations. Because `testClient()` returns a `ConvosClient` bound to the same global database instance, tests that create multiple clients (serially or in parallel) can leak state into each other or observe stale data left over from previous executions. This can cause nondeterministic behavior, race conditions, and flakiness in concurrent test environments. A safer approach is to construct an isolated database manager per test (e.g., an in-memory instance) and ensure explicit teardown/reset for every call. <b>[ Out of scope ]</b>
- [line 32](https://github.com/ephemeraHQ/convos-ios/blob/62e9e3cc9c863b83ad1301b72d12bd0e2bcf3000/ConvosCore/Sources/ConvosCore/ConvosClient.swift#L32): The factory returns a `ConvosClient` backed by a real `SessionManager` (`SessionManager(...)`) instead of a mock. In test contexts, this can introduce external effects (e.g., background tasks, timers, network or filesystem I/O) depending on `SessionManager`'s behavior, leading to nondeterministic tests and resource contention. Using a concrete implementation in `testClient()` also creates asymmetric contract vs. `mock()`, which returns a fully mocked `SessionManager`. If `SessionManager` performs side effects during initialization or first use, `testClient()` can cause unintended runtime behavior in tests. Prefer a mock/fake session manager for test isolation unless those effects are explicitly required. <b>[ Out of scope ]</b>
</details>

<details>
<summary>ConvosCore/Sources/ConvosCore/Inboxes/CachedPushNotificationHandler.swift — 0 comments posted, 3 evaluated, 3 filtered</summary>

- [line 41](https://github.com/ephemeraHQ/convos-ios/blob/62e9e3cc9c863b83ad1301b72d12bd0e2bcf3000/ConvosCore/Sources/ConvosCore/Inboxes/CachedPushNotificationHandler.swift#L41): `CachedPushNotificationHandler.initialize(...)` overwrites the existing `_shared` instance without cleanup or protection against concurrent calls. Multiple invocations can leak the previous actor instance and any resources it holds (e.g., cached `MessagingService`s), and concurrent calls can race because static stored properties are not actor-isolated. Consider guarding against double-initialization, synchronizing access, or providing an idempotent initializer that either no-ops after first init or explicitly calls `cleanup()` on the old instance before replacement. <b>[ Low confidence ]</b>
- [line 109](https://github.com/ephemeraHQ/convos-ios/blob/62e9e3cc9c863b83ad1301b72d12bd0e2bcf3000/ConvosCore/Sources/ConvosCore/Inboxes/CachedPushNotificationHandler.swift#L109): On timeout or error during `handlePushNotification`, a newly created `MessagingService` may remain cached without being used, and there is no immediate cleanup on failure paths. While `cleanupStaleServices()` will eventually remove stale entries based on `lastAccessTime`, this only happens upon subsequent handler invocations and after up to `maxServiceAge` seconds. In long-lived processes, this can retain resources longer than necessary. Consider removing the created service on failure/timeouts or updating `lastAccessTime` strategy to ensure timely cleanup of never-used services. <b>[ Low confidence ]</b>
- [line 154](https://github.com/ephemeraHQ/convos-ios/blob/62e9e3cc9c863b83ad1301b72d12bd0e2bcf3000/ConvosCore/Sources/ConvosCore/Inboxes/CachedPushNotificationHandler.swift#L154): Messaging services are cached solely by `inboxId` in `messagingServices` and `getOrCreateMessagingService(for:clientId:overrideJWTToken:)` ignores `overrideJWTToken` for cache keying. If two notifications for the same `inboxId` arrive with different `overrideJWTToken` values, the existing cached `MessagingService` is reused and the new JWT is silently ignored. This can lead to processing with an incorrect/expired token or the wrong authorization context. Consider keying the cache by a composite key (e.g., `inboxId + jwtHash`) or invalidating/recreating the service when the provided `overrideJWTToken` differs from the one used to create the cached instance. <b>[ Low confidence ]</b>
</details>

<details>
<summary>ConvosCore/Sources/ConvosCore/Inboxes/InboxStateMachine.swift — 0 comments posted, 4 evaluated, 4 filtered</summary>

- [line 211](https://github.com/ephemeraHQ/convos-ios/blob/62e9e3cc9c863b83ad1301b72d12bd0e2bcf3000/ConvosCore/Sources/ConvosCore/Inboxes/InboxStateMachine.swift#L211): Misleading JWT override log: the initializer logs `Initializing API client (JWT override: \(overrideJWTToken != nil))...` using the raw `overrideJWTToken` parameter, but the actual value used is `self.overrideJWTToken = overrideJWTToken ?? environment.defaultOverrideJWTToken`. If `overrideJWTToken` is `nil` and `environment.defaultOverrideJWTToken` is non-nil, the log will incorrectly report `false` while the client is created with an override token. This causes observability/debugging errors and can mislead operators. <b>[ Already posted ]</b>
- [line 212](https://github.com/ephemeraHQ/convos-ios/blob/62e9e3cc9c863b83ad1301b72d12bd0e2bcf3000/ConvosCore/Sources/ConvosCore/Inboxes/InboxStateMachine.swift#L212): Incorrect configuration ordering: `apiClient` is initialized before setting `XMTPEnvironment.customLocalAddress`. If `ConvosAPIClientFactory.client(...)` reads `XMTPEnvironment.customLocalAddress` during initialization, it will use stale/default values and ignore the intended `environment.customLocalAddress`. The configuration should be applied before constructing components that consume it. <b>[ Low confidence ]</b>
- [line 227](https://github.com/ephemeraHQ/convos-ios/blob/62e9e3cc9c863b83ad1301b72d12bd0e2bcf3000/ConvosCore/Sources/ConvosCore/Inboxes/InboxStateMachine.swift#L227): Global `XMTPEnvironment.customLocalAddress` mutation from an `actor` without synchronization can race with other threads/tasks. Actors do not protect arbitrary global variables; setting a global var from within an actor does not provide thread-safety. If other parts of the program read or write `XMTPEnvironment.customLocalAddress` concurrently, you can observe torn or out-of-order writes, especially in multi-threaded contexts, leading to inconsistent configuration during runtime. <b>[ Low confidence ]</b>
- [line 229](https://github.com/ephemeraHQ/convos-ios/blob/62e9e3cc9c863b83ad1301b72d12bd0e2bcf3000/ConvosCore/Sources/ConvosCore/Inboxes/InboxStateMachine.swift#L229): Global environment mutation lacks reset and can leak across instances: when `environment.customLocalAddress` is `nil`, the code only logs "Using default XMTP endpoints" and does not reset `XMTPEnvironment.customLocalAddress` to a default value. If a previous initialization set a custom address, subsequent initializations with `nil` leave the global override in place, violating expected per-environment configuration. This is a persistent global state bug. <b>[ Low confidence ]</b>
</details>

<details>
<summary>ConvosCore/Sources/ConvosCore/Messaging/UnusedInboxCache.swift — 0 comments posted, 16 evaluated, 16 filtered</summary>

- [line 26](https://github.com/ephemeraHQ/convos-ios/blob/62e9e3cc9c863b83ad1301b72d12bd0e2bcf3000/ConvosCore/Sources/ConvosCore/Messaging/UnusedInboxCache.swift#L26): In `UnusedInboxCache`, the initializer now accepts `keychainService: any KeychainServiceProtocol = KeychainService()` and a required `identityStore`. If callers rely on a shared/singleton `KeychainService` instance (for coordinated access, caching, or synchronization), this default will create a new instance per actor initialization, which could lead to divergent state or configuration unless the implementation is stateless. If `KeychainService` maintains internal state (e.g., in-memory cache of last-read values, migration flags, or scoped configuration), multiple instances could cause subtle runtime issues such as inconsistent reads or duplicated writes. <b>[ Code style ]</b>
- [line 43](https://github.com/ephemeraHQ/convos-ios/blob/62e9e3cc9c863b83ad1301b72d12bd0e2bcf3000/ConvosCore/Sources/ConvosCore/Messaging/UnusedInboxCache.swift#L43): Actor reentrancy can cause duplicate authorization/creation. The method checks `unusedMessagingService == nil` and then awaits `authorizeUnusedInbox(...)` or `createNewUnusedInbox(...)`. Because actors in Swift are reentrant at suspension points, another concurrent call to `public func prepareUnusedInboxIfNeeded(...)` can enter while the first call is suspended at `await`, observe that `unusedMessagingService` is still `nil`, and proceed as well. This can lead to two concurrent preparations/creations for an unused inbox, violating at-most-once semantics and potentially creating multiple unused inboxes or authorizing twice. To fix, set and clear an in-progress flag or placeholder state before the first await (e.g., mark preparation started), or eagerly set `unusedMessagingService` to a sentinel/provisional state to prevent a second call from entering the preparation branch. <b>[ Already posted ]</b>
- [line 58](https://github.com/ephemeraHQ/convos-ios/blob/62e9e3cc9c863b83ad1301b72d12bd0e2bcf3000/ConvosCore/Sources/ConvosCore/Messaging/UnusedInboxCache.swift#L58): Stale keychain `unusedInboxId` is not invalidated on authorization failure. When `getUnusedInboxFromKeychain()` returns an ID and `authorizeUnusedInbox(...)` throws, the code immediately proceeds to `createNewUnusedInbox(...)` without clearing or updating the stored unused inbox identifier. This can cause subsequent runs to repeatedly try to authorize the same stale ID, potentially looping on failures or causing ambiguity between the newly created inbox and the stale keychain entry. Fix by explicitly removing or invalidating the unused ID from keychain in the failure path before creating a new inbox. <b>[ Low confidence ]</b>
- [line 58](https://github.com/ephemeraHQ/convos-ios/blob/62e9e3cc9c863b83ad1301b72d12bd0e2bcf3000/ConvosCore/Sources/ConvosCore/Messaging/UnusedInboxCache.swift#L58): Cancellation is not respected. If `authorizeUnusedInbox(...)` is cancelled (e.g., throws `CancellationError`), the generic `catch` will handle it as a normal error and proceed to `createNewUnusedInbox(...)`, performing effects after cancellation. This violates typical cancellation semantics and can lead to unintended side effects when the enclosing task was asked to stop. Fix by either checking `Task.isCancelled` and returning early or by catching `CancellationError` separately and returning without creating a new inbox. <b>[ Low confidence ]</b>
- [line 122](https://github.com/ephemeraHQ/convos-ios/blob/62e9e3cc9c863b83ad1301b72d12bd0e2bcf3000/ConvosCore/Sources/ConvosCore/Messaging/UnusedInboxCache.swift#L122): Prematurely clearing the cached unused inbox ID from keychain in the keychain-fallback path can cause unrecoverable loss of the pre-created inbox on transient failures. In `consumeOrCreateMessagingService`, when `getUnusedInboxFromKeychain()` returns an `inboxId`, the code immediately calls `clearUnusedInboxFromKeychain()` before verifying that `identityStore.identity(for:)` succeeds and before constructing/returning a working `MessagingService`. If `identityStore.identity(for:)` or subsequent authorization setup fails (e.g., a temporary keychain/identity store outage), the cached inbox ID is irreversibly deleted and the flow falls through to fresh creation, discarding a potentially valid pre-created inbox. This violates the optimization's intent and causes silent data loss of a recoverable cached resource. A safer approach is to delay clearing the keychain until after authorization/identity lookup succeeds, or to clear only after constructing a `MessagingService` and confirming readiness, while still preventing concurrent consumption via actor serialization. <b>[ Low confidence ]</b>
- [line 175](https://github.com/ephemeraHQ/convos-ios/blob/62e9e3cc9c863b83ad1301b72d12bd0e2bcf3000/ConvosCore/Sources/ConvosCore/Messaging/UnusedInboxCache.swift#L175): `clearUnusedInboxFromKeychain()` fully swallows errors from `keychainService.delete(account:)`, only logging at debug level and not signaling failure to callers. As a public method that implies it will clear the unused inbox state, silently failing can leave the cache uncleared while the caller continues under the assumption it succeeded, leading to inconsistent application state. <b>[ Low confidence ]</b>
- [line 201](https://github.com/ephemeraHQ/convos-ios/blob/62e9e3cc9c863b83ad1301b72d12bd0e2bcf3000/ConvosCore/Sources/ConvosCore/Messaging/UnusedInboxCache.swift#L201): The background `Task(priority: .background)` captures `databaseWriter`, `databaseReader`, and `environment` and invokes `await createNewUnusedInbox(...)` potentially after the caller has moved on or during shutdown. There is no lifetime guarantee, cancellation, or liveness check for these resources. If the supplied `DatabaseWriter`/`DatabaseReader` are short‑lived or are closed/invalidated after `createFreshMessagingService` returns, the detached task may attempt I/O on a closed or deinitialized database, causing runtime errors or inconsistent state. The code should either (a) ensure these dependencies are long‑lived and valid for the duration of the detached task, (b) create the unused inbox synchronously before returning, or (c) pass in a long‑lived resource handle/cancellation token and defensively check for shutdown before performing work. <b>[ Low confidence ]</b>
- [line 201](https://github.com/ephemeraHQ/convos-ios/blob/62e9e3cc9c863b83ad1301b72d12bd0e2bcf3000/ConvosCore/Sources/ConvosCore/Messaging/UnusedInboxCache.swift#L201): Failure in the background prefetch path is silent and unobservable. The `Task` does not provide any logging, error handling, or completion signaling if `createNewUnusedInbox(...)` fails internally (e.g., returns a failed state or early termination). This can break the invariant implied by the method’s contract (“schedule creation of an unused inbox for next time”), leaving the system without a prepared inbox and no visibility to trigger remediation. Consider adding structured error handling, logging, or a callback/signal so the actor can record failure and retry or mark the cache state accordingly. <b>[ Low confidence ]</b>
- [line 236](https://github.com/ephemeraHQ/convos-ios/blob/62e9e3cc9c863b83ad1301b72d12bd0e2bcf3000/ConvosCore/Sources/ConvosCore/Messaging/UnusedInboxCache.swift#L236): The function uses an actor-scoped `identityStore` instead of the `environment`-scoped store, creating a potential cross-environment inconsistency. Previously, `identityStore` appears to have been derived from `environment.defaultIdentityStore` (per the diff), ensuring that all operations (keychain lookup, authorization, and messaging) used the same environment context. Now, `identityStore` may belong to a different environment than the `environment` parameter passed to `AuthorizeInboxOperation.authorize` and `MessagingService`, which can lead to fetching credentials from one store while authorizing against another environment, causing subtle runtime failures or incorrect authorization. This affects calls at `identityStore.identity(for:)`, passing `identityStore` into `AuthorizeInboxOperation.authorize`, and `MessagingService` construction. <b>[ Low confidence ]</b>
- [line 238](https://github.com/ephemeraHQ/convos-ios/blob/62e9e3cc9c863b83ad1301b72d12bd0e2bcf3000/ConvosCore/Sources/ConvosCore/Messaging/UnusedInboxCache.swift#L238): Destructive keychain clearing on any identity lookup error: In the `do/catch` around `identityStore.identity(for:)`, the `catch` blindly calls `clearUnusedInboxFromKeychain()` and rethrows. If the error is transient (e.g., keychain access temporarily unavailable, permissions issue, or other recoverable failure), this code will irreversibly delete potentially valid credentials. It should distinguish between "not found/invalid" errors and transient/system errors before clearing. <b>[ Out of scope ]</b>
- [line 264](https://github.com/ephemeraHQ/convos-ios/blob/62e9e3cc9c863b83ad1301b72d12bd0e2bcf3000/ConvosCore/Sources/ConvosCore/Messaging/UnusedInboxCache.swift#L264): Potential resource leak or double-running service: On success, the code assigns `unusedMessagingService = messagingService` without stopping or tearing down any previously stored `unusedMessagingService`. If this actor is called multiple times (even serially), the existing service could continue running (streams, timers, sockets), leading to leaks and duplicate background activity. Before overwriting, the code should stop and delete the previous `unusedMessagingService` (or ensure idempotent replacement) to maintain a single paired cleanup and avoid double-application. <b>[ Out of scope ]</b>
- [line 270](https://github.com/ephemeraHQ/convos-ios/blob/62e9e3cc9c863b83ad1301b72d12bd0e2bcf3000/ConvosCore/Sources/ConvosCore/Messaging/UnusedInboxCache.swift#L270): Destructive keychain clearing on any authorization failure: In the `catch` after waiting for inbox readiness, the code calls `clearUnusedInboxFromKeychain()` for any error. Authorization failures can be due to network/server errors, timeouts, or temporary backend issues. Clearing the keychain on such errors will delete valid credentials and force re-authorization unnecessarily. Clearing should be reserved for specific error cases indicating invalid credentials or revoked inbox. <b>[ Out of scope ]</b>
- [line 304](https://github.com/ephemeraHQ/convos-ios/blob/62e9e3cc9c863b83ad1301b72d12bd0e2bcf3000/ConvosCore/Sources/ConvosCore/Messaging/UnusedInboxCache.swift#L304): The function now uses `identityStore` implicitly (likely an actor property) rather than the environment-derived `environment.defaultIdentityStore` that was previously bound locally (as shown removed in the diff). This is a contract parity change: the created `AuthorizeInboxOperation` and `MessagingService` are now initialized with a potentially different `identityStore` than the environment’s default. If the actor’s `identityStore` is configured differently, points to a different identity, or is not yet initialized to the expected store, the authorization and messaging setup can proceed against the wrong identity or data backend, causing runtime failures (e.g., authorization mismatches, creating the unused inbox under the wrong account, or reading/writing to an unexpected database). This can yield subtle inconsistencies: an inbox ID saved to keychain that does not correspond to the messaging service or database context expected by callers relying on `environment.defaultIdentityStore`. <b>[ Previously rejected ]</b>
- [line 339](https://github.com/ephemeraHQ/convos-ios/blob/62e9e3cc9c863b83ad1301b72d12bd0e2bcf3000/ConvosCore/Sources/ConvosCore/Messaging/UnusedInboxCache.swift#L339): `getUnusedInboxFromKeychain()` returns `nil` for any thrown error from `keychainService.retrieveString(account:)`, conflating "not found" with other keychain errors (e.g., access denied, corrupted item, transient OS errors). As a result, `isUnusedInbox(_:)` will return `false` in all error cases, potentially masking operational issues and producing incorrect logic when the unused inbox actually exists but retrieval failed. <b>[ Low confidence ]</b>
- [line 340](https://github.com/ephemeraHQ/convos-ios/blob/62e9e3cc9c863b83ad1301b72d12bd0e2bcf3000/ConvosCore/Sources/ConvosCore/Messaging/UnusedInboxCache.swift#L340): The switch from using `UnusedInboxKeychainItem()` to `KeychainAccount.unusedInbox` for both deletion and retrieval may break existing persisted data. If prior versions stored the unused inbox under the `UnusedInboxKeychainItem()` key, `getUnusedInboxFromKeychain()` will now return `nil` and `clearUnusedInboxFromKeychain()` will not delete the old entry, leaving stale data in the keychain and causing `isUnusedInbox(_:)` to incorrectly return `false`. This is a runtime migration issue: the new code silently stops recognizing previously stored values and fails to clean them up. <b>[ Low confidence ]</b>
- [line 349](https://github.com/ephemeraHQ/convos-ios/blob/62e9e3cc9c863b83ad1301b72d12bd0e2bcf3000/ConvosCore/Sources/ConvosCore/Messaging/UnusedInboxCache.swift#L349): In `UnusedInboxCache.saveUnusedInboxToKeychain`, the storage call changed from `try keychainService.saveString(inboxId, for: UnusedInboxKeychainItem())` to `try keychainService.saveString(inboxId, account: KeychainAccount.unusedInbox)`. This alters how the keychain entry is scoped (account/service/key derivation). Unless all corresponding read paths were also updated to use `KeychainAccount.unusedInbox` with the same `KeychainService` configuration, there is a risk of writing to one logical location and reading from another, causing runtime cache misses and duplicated or orphaned entries. Additionally, if previously the generic item type encoded a different service identifier, the new default `KeychainService()` may be using a different service, leading to silent data loss or failure to retrieve pre-existing values unless a migration is provided. <b>[ Low confidence ]</b>
</details>

<details>
<summary>ConvosCore/Sources/ConvosCore/Notifications/NotificationExtensionEnvironment.swift — 0 comments posted, 1 evaluated, 1 filtered</summary>

- [line 38](https://github.com/ephemeraHQ/convos-ios/blob/62e9e3cc9c863b83ad1301b72d12bd0e2bcf3000/ConvosCore/Sources/ConvosCore/Notifications/NotificationExtensionEnvironment.swift#L38): `NotificationExtensionEnvironment.createPushNotificationHandler()` constructs a local `DatabaseManager` and does not retain it. If `dbReader`/`dbWriter` lifetimes depend on `DatabaseManager` (common with GRDB where the manager owns the pool/queue), `DatabaseManager` may be deallocated once the function returns, leaving `CachedPushNotificationHandler` with invalid/closed database handles. This can cause runtime errors during later notification processing. Ensure the owner of the handler retains the `DatabaseManager` (or the underlying DB objects) for at least as long as the handler needs them, or pass independently owned `dbReader`/`dbWriter` that outlive the manager. <b>[ Low confidence ]</b>
</details>

<details>
<summary>ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift — 0 comments posted, 11 evaluated, 11 filtered</summary>

- [line 71](https://github.com/ephemeraHQ/convos-ios/blob/62e9e3cc9c863b83ad1301b72d12bd0e2bcf3000/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift#L71): Inconsistent identity store usage can yield mismatched state: inside the initialization task, identities are loaded via the initializer parameter `identityStore` (`identityStore.loadAll()`), while elsewhere the code consistently references the property `self.identityStore`. If `self.identityStore` is ever swapped/mutated before the task runs (or differs from the parameter due to subclassing/wrapping), `startMessagingServices(for:)` would start services based on identities from a different store than `self.identityStore`, introducing subtle state divergence and silent data loss/mismatch. To preserve invariants, use `self.identityStore` consistently inside the closure. <b>[ Low confidence ]</b>
- [line 78](https://github.com/ephemeraHQ/convos-ios/blob/62e9e3cc9c863b83ad1301b72d12bd0e2bcf3000/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift#L78): Behavioral regression and lifecycle-coupling: switching from the singleton `UnusedInboxCache.shared` to an instance property `self.unusedInboxCache` inside the background task means cache preparation now depends on the lifetime of `SessionManager`. In the new code, the `unusedInboxPrepTask` closure captures `[weak self]` and exits early if `self` is deallocated (or if the task is cancelled), thereby skipping `prepareUnusedInboxIfNeeded`. Previously, using the singleton ensured preparation could proceed independently of `SessionManager` lifetime. This can lead to the unused inbox never being prepared if `SessionManager` is torn down or not retained, violating at-most-once and startup preparation expectations. <b>[ Low confidence ]</b>
- [line 80](https://github.com/ephemeraHQ/convos-ios/blob/62e9e3cc9c863b83ad1301b72d12bd0e2bcf3000/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift#L80): Potential double-application and race condition: by replacing `UnusedInboxCache.shared` with a per-instance `unusedInboxCache`, multiple `SessionManager` instances can concurrently run `unusedInboxCache.prepareUnusedInboxIfNeeded(...)`. If the preparation operation is not strictly idempotent and synchronized in the cache implementation, this can cause concurrent work against `databaseWriter/databaseReader`, violating at-most-once effect guarantees, and potentially leading to duplicate or out-of-order updates. <b>[ Low confidence ]</b>
- [line 125](https://github.com/ephemeraHQ/convos-ios/blob/62e9e3cc9c863b83ad1301b72d12bd0e2bcf3000/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift#L125): Potential deadlock risk: calling `serviceQueue.sync { ... }` may deadlock if `startMessagingServices(for:)` is invoked while already executing on `serviceQueue` (e.g., from code dispatched onto the same serial queue). Dispatching synchronously onto the same queue causes a self-deadlock at runtime. Consider using `async` or ensuring the method is never called from `serviceQueue`, with an explicit guard, e.g., `dispatchPrecondition(condition: .notOnQueue(serviceQueue))`. <b>[ Low confidence ]</b>
- [line 126](https://github.com/ephemeraHQ/convos-ios/blob/62e9e3cc9c863b83ad1301b72d12bd0e2bcf3000/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift#L126): Duplicate service creation and silent overwrite: the loop creates a new service for each `identity` and assigns it into `messagingServices[identity.clientId]`. If `identities` contains multiple entries with the same `clientId` (or if a service already exists for that `clientId`), the new service will overwrite the previous entry without stopping or cleaning up the existing service, potentially causing leaks, double-starts, or orphaned background work. There is also a mismatch between the filter predicate (based on `inboxId`) and the map key (`clientId`), which could allow multiple `inboxId`s to map to the same `clientId`, amplifying this issue. Add explicit de-duplication by `clientId`, or check for existence and reconcile (e.g., skip, restart safely, or stop the old service before replacement). <b>[ Low confidence ]</b>
- [line 133](https://github.com/ephemeraHQ/convos-ios/blob/62e9e3cc9c863b83ad1301b72d12bd0e2bcf3000/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift#L133): The function `startMessagingService(for:clientId:)` accepts `inboxId` and `clientId` as `String` inputs and forwards them directly to `MessagingService.authorizedMessagingService(...)` without any validation (e.g., non-empty, non-whitespace, format constraints). If either string is empty or malformed, this could lead to an incorrectly initialized or failing messaging service internally with no local error handling or fallback. At minimum, guard against empty or whitespace-only values and provide a defined failure or fallback path. <b>[ Out of scope ]</b>
- [line 134](https://github.com/ephemeraHQ/convos-ios/blob/62e9e3cc9c863b83ad1301b72d12bd0e2bcf3000/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift#L134): The log statement `Logger.info("Starting messaging service for inboxId: \(inboxId) clientId: \(clientId)")` emits raw `inboxId` and `clientId`. If these identifiers are sensitive, this can leak PII or security-relevant identifiers into logs. Consider redacting or hashing identifiers, or using structured logging with appropriate privacy controls. <b>[ Out of scope ]</b>
- [line 253](https://github.com/ephemeraHQ/convos-ios/blob/62e9e3cc9c863b83ad1301b72d12bd0e2bcf3000/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift#L253): Non-atomic acquire-and-register sequence introduced by switching to `unusedInboxCache.consumeOrCreateMessagingService(...)`. Consuming or creating a service from the cache is an effect that occurs before registration. If a failure occurs after consumption (e.g., task cancellation, deadlock in `serviceQueue.sync`, or a crash when reading state), the cache entry has been consumed but the service is not registered, leaving the system in an inconsistent state (lost or leaked unused inbox). The previous call to `MessagingService.registeredMessagingService(...)` likely returned a service already registered, avoiding this window. <b>[ Low confidence ]</b>
- [line 258](https://github.com/ephemeraHQ/convos-ios/blob/62e9e3cc9c863b83ad1301b72d12bd0e2bcf3000/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift#L258): Potential deadlock when calling `serviceQueue.sync { ... }` from code that is already executing on the same `serviceQueue`. On a serial `DispatchQueue`, synchronously dispatching to itself will block forever. Since there is no visible guard ensuring `addInbox()` is never invoked while already on `serviceQueue`, the deadlock is reachable. This would hang the task and any resources consumed before the sync. <b>[ Out of scope ]</b>
- [line 259](https://github.com/ephemeraHQ/convos-ios/blob/62e9e3cc9c863b83ad1301b72d12bd0e2bcf3000/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift#L259): Missing validation of `clientId` prior to using it as a dictionary key. If `clientId` can be empty, malformed, or otherwise invalid according to downstream assumptions, the registry may end up with hard-to-address entries (e.g., empty key) and future lookups may silently fail or collide with reserved values. <b>[ Out of scope ]</b>
- [line 260](https://github.com/ephemeraHQ/convos-ios/blob/62e9e3cc9c863b83ad1301b72d12bd0e2bcf3000/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift#L260): Silent overwrite of existing service when `messagingServices[clientId] = messagingService` is executed with a `clientId` that already exists in the dictionary. This will replace the prior service without any check, logging, or error, potentially terminating or losing the previous service, violating uniqueness/mutual-exclusion invariants and causing inconsistent state. <b>[ Out of scope ]</b>
</details>

<details>
<summary>ConvosCore/Sources/ConvosCore/Syncing/StreamProcessor.swift — 0 comments posted, 3 evaluated, 3 filtered</summary>

- [line 231](https://github.com/ephemeraHQ/convos-ios/blob/62e9e3cc9c863b83ad1301b72d12bd0e2bcf3000/ConvosCore/Sources/ConvosCore/Syncing/StreamProcessor.swift#L231): No validation of derived topic strings before subscribing. `conversationId.xmtpGroupTopicFormat` and `client.installationId.xmtpWelcomeTopicFormat` are used to build topics, but the code does not verify that the resulting strings are non-empty and valid. If either `conversationId` or `installationId` is empty or malformed (not guarded elsewhere in this method), the API could receive invalid topics, leading to rejected subscription or undefined server behavior. <b>[ Low confidence ]</b>
- [line 234](https://github.com/ephemeraHQ/convos-ios/blob/62e9e3cc9c863b83ad1301b72d12bd0e2bcf3000/ConvosCore/Sources/ConvosCore/Syncing/StreamProcessor.swift#L234): Errors from `identityStore.identity(for:)` are suppressed using `try?`, and the code falls back to treating the identity as not found. This conflates real errors (e.g., transient storage/IO failure) with the identity genuinely not existing, causing the function to skip topic subscription silently even when the identity may exist. This can lead to missed push topic subscriptions and make diagnosis harder because the actual error is discarded. Prefer explicitly catching and logging the error and differentiating between 'not found' and other failures, or retrying as appropriate. <b>[ Low confidence ]</b>
- [line 246](https://github.com/ephemeraHQ/convos-ios/blob/62e9e3cc9c863b83ad1301b72d12bd0e2bcf3000/ConvosCore/Sources/ConvosCore/Syncing/StreamProcessor.swift#L246): Possible duplicate topics are sent without deduplication. If `conversationTopic` and `welcomeTopic` end up equal (due to unexpected input or formatter behavior), the array `[conversationTopic, welcomeTopic]` will contain duplicates. Some backends reject duplicates or waste resources processing them. It's safer to deduplicate topics before invoking `subscribeToTopics`. <b>[ Code style ]</b>
</details>


</details><!-- Macroscope's review summary ends here -->
<!-- Macroscope's pull request summary ends here -->