### PR TITLE
Fix convo info showing on join error

### DIFF
--- a/Convos/Conversation Creation/NewConversationViewModel.swift
+++ b/Convos/Conversation Creation/NewConversationViewModel.swift
@@ -200,7 +200,6 @@ class NewConversationViewModel: Identifiable {
     private func handleJoinSuccess() {
         presentingJoinConversationSheet = false
         displayError = nil
-        conversationViewModel.showsInfoView = true
     }
 
     @MainActor
@@ -210,7 +209,6 @@ class NewConversationViewModel: Identifiable {
 
             if startedWithFullscreenScanner {
                 showingFullScreenScanner = true
-                conversationViewModel.showsInfoView = false
             }
 
             // Set the display error
@@ -249,6 +247,11 @@ class NewConversationViewModel: Identifiable {
             isCreatingConversation = false
             messagesTopBarTrailingItemEnabled = false
             messagesBottomBarEnabled = false
+            if startedWithFullscreenScanner {
+                conversationViewModel.showsInfoView = false
+            } else {
+                conversationViewModel.showsInfoView = true
+            }
             currentError = nil
             qrScannerViewModel.resetScanning()
 
@@ -271,6 +274,7 @@ class NewConversationViewModel: Identifiable {
         case .joining:
             // This is the waiting state - user is waiting for inviter to accept
             conversationViewModel.checkNotificationPermissions()
+            conversationViewModel.showsInfoView = true
             messagesTopBarTrailingItemEnabled = false
             messagesTopBarTrailingItem = .share
             messagesBottomBarEnabled = false
@@ -282,6 +286,7 @@ class NewConversationViewModel: Identifiable {
             Logger.info("Waiting for invite acceptance...")
 
         case .ready:
+            conversationViewModel.showsInfoView = true
             messagesTopBarTrailingItemEnabled = true
             messagesBottomBarEnabled = true
             isWaitingForInviteAcceptance = false
@@ -300,6 +305,9 @@ class NewConversationViewModel: Identifiable {
             isWaitingForInviteAcceptance = false
             isCreatingConversation = false
             currentError = error
+            if startedWithFullscreenScanner {
+                conversationViewModel.showsInfoView = false
+            }
             Logger.error("Conversation state error: \(error.localizedDescription)")
             // Handle specific error types
             handleError(error)
@@ -321,7 +329,6 @@ class NewConversationViewModel: Identifiable {
 
         if startedWithFullscreenScanner {
             showingFullScreenScanner = true
-            conversationViewModel.showsInfoView = false
         }
     }
 

--- a/ConvosCore/Sources/ConvosCore/Inboxes/InboxStateMachine.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/InboxStateMachine.swift
@@ -208,7 +208,7 @@ public actor InboxStateMachine {
         self.environment = environment
 
         // Initialize API client
-        Logger.info("Initializing API client (JWT override: \(overrideJWTToken != nil))...")
+        Logger.info("Initializing API client (JWT override: \(self.overrideJWTToken != nil))...")
         self.apiClient = ConvosAPIClientFactory.client(
             environment: environment,
             overrideJWTToken: self.overrideJWTToken


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Control `ConversationViewModel.showsInfoView` via `NewConversationViewModel.handleStateChange` to fix convo info showing on join error
Route info view visibility through state changes in `NewConversationViewModel`, removing direct toggles in `handleJoinSuccess`, `handleJoinError`, and `handleError`; adjust logging in `InboxStateMachine.init` to reflect `self.overrideJWTToken` state. See [NewConversationViewModel.swift](https://github.com/ephemeraHQ/convos-ios/pull/213/files#diff-9fe55a1ae8a316e2507a854b41b4ffb798098f2b5115fc2116749424cc4aa4bc) and [InboxStateMachine.swift](https://github.com/ephemeraHQ/convos-ios/pull/213/files#diff-314f69bca557159935a2f6c3e545b7374a861df38d5bda997858ecee5fad58f1).

#### 📍Where to Start
Start in `NewConversationViewModel.handleStateChange` in [NewConversationViewModel.swift](https://github.com/ephemeraHQ/convos-ios/pull/213/files#diff-9fe55a1ae8a316e2507a854b41b4ffb798098f2b5115fc2116749424cc4aa4bc), then review related changes in `handleJoinSuccess`, `handleJoinError`, and `handleError`. Finally, check the log adjustment in [InboxStateMachine.swift](https://github.com/ephemeraHQ/convos-ios/pull/213/files#diff-314f69bca557159935a2f6c3e545b7374a861df38d5bda997858ecee5fad58f1).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 1f23061.
<!-- Macroscope's review summary ends here -->

<!-- Macroscope's pull request summary ends here -->