### PR TITLE
Wait for user to request camera access

### DIFF
--- a/Convos/Conversation Creation/QRScannerView.swift
+++ b/Convos/Conversation Creation/QRScannerView.swift
@@ -54,8 +54,6 @@ struct QRScannerView: UIViewRepresentable {
             viewModel?.cameraAuthorized = authorized
             if authorized {
                 self.setupCamera(on: view, coordinator: context.coordinator)
-            } else {
-                viewModel?.requestAccess()
             }
         }
 


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Stop invoking `QRScannerView.UIViewRepresentable.makeUIView` else-branch to request camera access and wait for the user to request access in Convos Conversation Creation QR scanner
Remove the unauthorized branch in `QRScannerView.UIViewRepresentable.makeUIView` so it only sets `viewModel.cameraAuthorized` and initializes the camera when already authorized, skipping `viewModel.requestAccess()` on initial unauthorized state in [QRScannerView.swift](https://github.com/ephemeraHQ/convos-ios/pull/214/files#diff-8511bc081400a56b38b9d4bba7ef6214ff6ab85dff4c9645d9ac6ef17e774278).

#### 📍Where to Start
Start in `QRScannerView.UIViewRepresentable.makeUIView` in [QRScannerView.swift](https://github.com/ephemeraHQ/convos-ios/pull/214/files#diff-8511bc081400a56b38b9d4bba7ef6214ff6ab85dff4c9645d9ac6ef17e774278) to review the authorization check and the removed call to `viewModel.requestAccess()`.

----
<!-- Macroscope's review summary starts here -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized c3bccd3. 1 file reviewed, 3 issues evaluated, 3 issues filtered, 0 comments posted</summary>

### 🗂️ Filtered Issues
<details>
<summary>Convos/Conversation Creation/QRScannerView.swift — 0 comments posted, 3 evaluated, 3 filtered</summary>

- [line 47](https://github.com/ephemeraHQ/convos-ios/blob/c3bccd3988e8fe09be2342c04cee2cf652e60774/Convos/Conversation Creation/QRScannerView.swift#L47): Threading violation risk: `viewModel.setupCameraCallback` executes `self.setupCamera(on:coordinator:)`, which performs UI operations (e.g., adding sublayers) and AV session configuration. The closure doesn't enforce main-thread execution. If external code calls `setupCameraCallback` from a background thread, this will mutate UIKit layers off the main thread, leading to undefined behavior or crashes. Fix by ensuring the closure marshals to the main thread, e.g., `[weak self, weak view, weak coordinator] in DispatchQueue.main.async { ... }` or marking `setupCamera` with `@MainActor` and calling it accordingly. <b>[ Low confidence ]</b>
- [line 47](https://github.com/ephemeraHQ/convos-ios/blob/c3bccd3988e8fe09be2342c04cee2cf652e60774/Convos/Conversation Creation/QRScannerView.swift#L47): Retain cycle: The closure assigned to `viewModel.setupCameraCallback` captures `self` strongly via the call to `self.setupCamera(on:coordinator:)` while being stored on `viewModel`, which is itself held strongly by `self` (`QRScannerView`). This creates a reference cycle `viewModel -> setupCameraCallback (closure) -> self (QRScannerView) -> viewModel`, preventing deallocation. To fix, capture `self` weakly in the closure (e.g., `[weak self, weak view, weak coordinator]` guard let self = self ...), or refactor to avoid capturing `self` at all (e.g., call a static helper or route through the coordinator). <b>[ Low confidence ]</b>
- [line 67](https://github.com/ephemeraHQ/convos-ios/blob/c3bccd3988e8fe09be2342c04cee2cf652e60774/Convos/Conversation Creation/QRScannerView.swift#L67): First-run permission flow regression: In the camera authorization check, for `.notDetermined` the completion is invoked with `false` and there is no subsequent request for access. The accompanying diff shows removal of a `requestAccess()` call in this location. This means on first launch (no prior camera permission), the app will neither request permission nor set up the camera, leaving scanning non-functional without another code path to request access. Remedy by initiating `AVCaptureDevice.requestAccess(for: .video)` when authorization is `.notDetermined`, or delegating to a clearly invoked path that requests permission. <b>[ Low confidence ]</b>
</details>


</details><!-- Macroscope's review summary ends here -->
<!-- Macroscope's pull request summary ends here -->