### PR TITLE
Add XMTP logs to debug menu

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -137,6 +137,7 @@ custom_rules:
 
 excluded:
   - ConvosCore/.build
+  - ConvosLogging/.build
   - ConvosCore/Tests
   - ConvosTests
   - ConvosTests/Helpers

--- a/Convos.xcodeproj/project.pbxproj
+++ b/Convos.xcodeproj/project.pbxproj
@@ -276,6 +276,7 @@
 				"Utilities & Extensions/DeviceInfo.swift",
 				"Utilities & Extensions/UIViewController+Extensions.swift",
 				"Utilities & Extensions/View+SelfSizingSheet.swift",
+				Utilities/Log.swift,
 			);
 			target = 7ADC0C6D2E2977800053978A /* ConvosAppClip */;
 		};

--- a/Convos.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Convos.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "796a2ee8782ec3931977072d61d6868bd73339ac68462e638664cbc522e413e5",
+  "originHash" : "c0d2a22500c9e4d8102df408342490e39c95bbaf0a6483004ea4cc88ca98640f",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -179,6 +179,15 @@
       "state" : {
         "revision" : "8c0c0a8b49e080e54e5e328cc552821ff07cd341",
         "version" : "1.2.1"
+      }
+    },
+    {
+      "identity" : "swift-log",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-log",
+      "state" : {
+        "revision" : "ce592ae52f982c847a4efc0dd881cc9eb32d29f2",
+        "version" : "1.6.4"
       }
     },
     {

--- a/Convos.xcodeproj/xcshareddata/xcschemes/Convos (Dev).xcscheme
+++ b/Convos.xcodeproj/xcshareddata/xcschemes/Convos (Dev).xcscheme
@@ -5,7 +5,8 @@
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES"
-      buildArchitectures = "Automatic">
+      buildArchitectures = "Automatic"
+      buildConfiguration = "Dev">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"

--- a/Convos.xcodeproj/xcshareddata/xcschemes/Convos (Local).xcscheme
+++ b/Convos.xcodeproj/xcshareddata/xcschemes/Convos (Local).xcscheme
@@ -5,7 +5,8 @@
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES"
-      buildArchitectures = "Automatic">
+      buildArchitectures = "Automatic"
+      buildConfiguration = "Local">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"

--- a/Convos/App Settings/AppSettingsView.swift
+++ b/Convos/App Settings/AppSettingsView.swift
@@ -112,7 +112,7 @@ struct AppSettingsView: View {
 
                     if !ConfigManager.shared.currentEnvironment.isProduction {
                         NavigationLink {
-                            DebugExportView()
+                            DebugExportView(environment: ConfigManager.shared.currentEnvironment)
                         } label: {
                             Text("Debug")
                         }

--- a/Convos/Config/Dev.xcconfig
+++ b/Convos/Config/Dev.xcconfig
@@ -4,6 +4,15 @@
 CONFIG_FILE = config.dev.json
 DEVELOPMENT_TEAM = FY4NZR34Z3
 
+// Swift compiler flags - define DEBUG for conditional compilation (if needed for dev/testflight)
+// Note: SWIFT_ACTIVE_COMPILATION_CONDITIONS propagates to Swift Package dependencies
+// Comment out the line below if you don't want DEBUG in TestFlight builds
+SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG
+
+// Override Swift Package optimization for debugging
+// This ensures ConvosCore and other Swift Packages are not optimized
+OTHER_SWIFT_FLAGS = $(inherited) -Onone
+
 // Bundle IDs for all targets
 MAIN_BUNDLE_ID = org.convos.ios-preview
 PRODUCT_BUNDLE_IDENTIFIER = $(MAIN_BUNDLE_ID)
@@ -33,13 +42,19 @@ INFOPLIST_PREPROCESS = YES
 INFOPLIST_PREFIX_HEADER = $(SRCROOT)/Convos/Config/InfoPlistPrefix.Dev.h
 
 // Release-level build settings for App Store compliance (TestFlight)
-// These ensure builds are fully optimized
-SWIFT_OPTIMIZATION_LEVEL = -O
-SWIFT_COMPILATION_MODE = wholemodule
-ENABLE_NS_ASSERTIONS = NO
-ENABLE_TESTABILITY = NO
-COPY_PHASE_STRIP = YES
-STRIP_INSTALLED_PRODUCT = YES
-STRIP_STYLE = all
-DEAD_CODE_STRIPPING = YES
-DEBUG_INFORMATION_FORMAT = dwarf-with-dsym
+// NOTE: Optimization is disabled to allow debugging. Re-enable for actual TestFlight builds.
+// For debuggable Dev builds:
+SWIFT_OPTIMIZATION_LEVEL = -Onone
+ENABLE_TESTABILITY = YES
+DEBUG_INFORMATION_FORMAT = dwarf
+
+// For release-optimized TestFlight builds, use these instead:
+// SWIFT_OPTIMIZATION_LEVEL = -O
+// SWIFT_COMPILATION_MODE = wholemodule
+// ENABLE_NS_ASSERTIONS = NO
+// ENABLE_TESTABILITY = NO
+// COPY_PHASE_STRIP = YES
+// STRIP_INSTALLED_PRODUCT = YES
+// STRIP_STYLE = all
+// DEAD_CODE_STRIPPING = YES
+// DEBUG_INFORMATION_FORMAT = dwarf-with-dsym

--- a/Convos/Config/Local.xcconfig
+++ b/Convos/Config/Local.xcconfig
@@ -2,6 +2,15 @@
 CONFIG_FILE = config.local.json
 DEVELOPMENT_TEAM = FY4NZR34Z3
 
+// Swift compiler flags - define DEBUG for conditional compilation
+// Note: SWIFT_ACTIVE_COMPILATION_CONDITIONS propagates to Swift Package dependencies
+// This overrides Package.swift settings when building from Xcode
+SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG
+
+// Override Swift Package optimization for debugging
+// This ensures ConvosCore and other Swift Packages are not optimized
+OTHER_SWIFT_FLAGS = $(inherited) -Onone
+
 // Bundle IDs for all targets
 MAIN_BUNDLE_ID = org.convos.ios-local
 PRODUCT_BUNDLE_IDENTIFIER = $(MAIN_BUNDLE_ID)

--- a/Convos/Conversation Creation/NewConversationViewModel.swift
+++ b/Convos/Conversation Creation/NewConversationViewModel.swift
@@ -133,7 +133,7 @@ class NewConversationViewModel: Identifiable {
                 do {
                     try await conversationStateManager.createConversation()
                 } catch {
-                    Logger.error("Error auto-creating conversation: \(error.localizedDescription)")
+                    Log.error("Error auto-creating conversation: \(error.localizedDescription)")
                     guard !Task.isCancelled else { return }
                     await MainActor.run { [weak self] in
                         self?.handleCreationError(error)
@@ -144,7 +144,7 @@ class NewConversationViewModel: Identifiable {
     }
 
     deinit {
-        Logger.info("deinit")
+        Log.info("deinit")
         cancellables.removeAll()
         newConversationTask?.cancel()
         joinConversationTask?.cancel()
@@ -171,7 +171,7 @@ class NewConversationViewModel: Identifiable {
                     self?.handleJoinSuccess()
                 }
             } catch {
-                Logger.error("Error joining new conversation: \(error.localizedDescription)")
+                Log.error("Error joining new conversation: \(error.localizedDescription)")
                 guard !Task.isCancelled else { return }
                 await MainActor.run { [weak self] in
                     self?.handleJoinError(error)
@@ -181,7 +181,7 @@ class NewConversationViewModel: Identifiable {
     }
 
     func deleteConversation() {
-        Logger.info("Deleting conversation")
+        Log.info("Deleting conversation")
         newConversationTask?.cancel()
         joinConversationTask?.cancel()
         Task { [weak self] in
@@ -189,7 +189,7 @@ class NewConversationViewModel: Identifiable {
             do {
                 try await conversationStateManager.delete()
             } catch {
-                Logger.error("Failed deleting conversation: \(error.localizedDescription)")
+                Log.error("Failed deleting conversation: \(error.localizedDescription)")
             }
         }
     }
@@ -283,7 +283,7 @@ class NewConversationViewModel: Identifiable {
             conversationViewModel.untitledConversationPlaceholder = "Untitled"
             isCreatingConversation = false
             currentError = nil
-            Logger.info("Waiting for invite acceptance...")
+            Log.info("Waiting for invite acceptance...")
 
         case .ready:
             conversationViewModel.showsInfoView = true
@@ -293,7 +293,7 @@ class NewConversationViewModel: Identifiable {
             isCreatingConversation = false
             showingFullScreenScanner = false
             currentError = nil
-            Logger.info("Conversation ready!")
+            Log.info("Conversation ready!")
 
         case .deleting:
             isWaitingForInviteAcceptance = false
@@ -308,7 +308,7 @@ class NewConversationViewModel: Identifiable {
             if startedWithFullscreenScanner {
                 conversationViewModel.showsInfoView = false
             }
-            Logger.error("Conversation state error: \(error.localizedDescription)")
+            Log.error("Conversation state error: \(error.localizedDescription)")
             // Handle specific error types
             handleError(error)
         }
@@ -338,7 +338,7 @@ class NewConversationViewModel: Identifiable {
         conversationStateManager.conversationIdPublisher
             .receive(on: DispatchQueue.main)
             .sink { conversationId in
-                Logger.info("Active conversation changed: \(conversationId)")
+                Log.info("Active conversation changed: \(conversationId)")
                 NotificationCenter.default.post(
                     name: .activeConversationChanged,
                     object: nil,

--- a/Convos/Conversation Creation/QRScannerView.swift
+++ b/Convos/Conversation Creation/QRScannerView.swift
@@ -87,7 +87,7 @@ struct QRScannerView: UIViewRepresentable {
         captureSession.sessionPreset = .high
 
         guard let videoCaptureDevice = AVCaptureDevice.default(for: .video) else {
-            Logger.info("Failed to get video capture device")
+            Log.info("Failed to get video capture device")
             return
         }
 
@@ -96,14 +96,14 @@ struct QRScannerView: UIViewRepresentable {
         do {
             videoInput = try AVCaptureDeviceInput(device: videoCaptureDevice)
         } catch {
-            Logger.info("Failed to create video input: \(error)")
+            Log.info("Failed to create video input: \(error)")
             return
         }
 
         if captureSession.canAddInput(videoInput) {
             captureSession.addInput(videoInput)
         } else {
-            Logger.info("Cannot add video input")
+            Log.info("Cannot add video input")
             return
         }
 
@@ -114,7 +114,7 @@ struct QRScannerView: UIViewRepresentable {
             metadataOutput.setMetadataObjectsDelegate(viewModel, queue: DispatchQueue.main)
             metadataOutput.metadataObjectTypes = [.qr]
         } else {
-            Logger.info("Cannot add metadata output")
+            Log.info("Cannot add metadata output")
             return
         }
 

--- a/Convos/Conversation Detail/ConversationInfoView.swift
+++ b/Convos/Conversation Detail/ConversationInfoView.swift
@@ -306,7 +306,7 @@ struct ConversationInfoView: View {
                             let url = try await viewModel.exportDebugLogs()
                             exportedLogsURL = url
                         } catch {
-                            Logger.error("Failed to export logs for conversation: \(error.localizedDescription)")
+                            Log.error("Failed to export logs for conversation: \(error.localizedDescription)")
                             exportedLogsURL = nil
                         }
                     }

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -143,7 +143,7 @@ class ConversationViewModel {
             self.conversation = try conversationRepository.fetchConversation() ?? conversation
             self.profile = try myProfileRepository.fetch()
         } catch {
-            Logger.error("Error fetching messages or conversation: \(error.localizedDescription)")
+            Log.error("Error fetching messages or conversation: \(error.localizedDescription)")
             self.messages = []
         }
 
@@ -155,7 +155,7 @@ class ConversationViewModel {
 
         presentingConversationForked = conversation.isForked
 
-        Logger.info("Created for conversation: \(conversation.id)")
+        Log.info("Created for conversation: \(conversation.id)")
 
         observe()
 
@@ -187,11 +187,11 @@ class ConversationViewModel {
             self.conversation = try conversationRepository.fetchConversation() ?? conversation
             self.profile = try myProfileRepository.fetch()
         } catch {
-            Logger.error("Error fetching messages or conversation: \(error.localizedDescription)")
+            Log.error("Error fetching messages or conversation: \(error.localizedDescription)")
             self.messages = []
         }
 
-        Logger.info("🔄 created for draft conversation: \(conversation.id)")
+        Log.info("🔄 created for draft conversation: \(conversation.id)")
 
         observe()
         setupMyProfileRepository()
@@ -281,7 +281,7 @@ class ConversationViewModel {
                         for: conversation.id
                     )
                 } catch {
-                    Logger.error("Failed updating group name: \(error)")
+                    Log.error("Failed updating group name: \(error)")
                 }
             }
         }
@@ -297,7 +297,7 @@ class ConversationViewModel {
                         for: conversation
                     )
                 } catch {
-                    Logger.error("Failed updating group image: \(error)")
+                    Log.error("Failed updating group image: \(error)")
                 }
             }
         }
@@ -314,7 +314,7 @@ class ConversationViewModel {
                         for: conversation.id
                     )
                 } catch {
-                    Logger.error("Failed updating group description: \(error)")
+                    Log.error("Failed updating group description: \(error)")
                 }
             }
         }
@@ -354,7 +354,7 @@ class ConversationViewModel {
             do {
                 try await outgoingMessageWriter.send(text: prevMessageText)
             } catch {
-                Logger.error("Error sending message: \(error)")
+                Log.error("Error sending message: \(error)")
             }
         }
     }
@@ -382,7 +382,7 @@ class ConversationViewModel {
                 do {
                     try await myProfileWriter.update(displayName: trimmedDisplayName, conversationId: conversation.id)
                 } catch {
-                    Logger.error("Error updating profile display name: \(error.localizedDescription)")
+                    Log.error("Error updating profile display name: \(error.localizedDescription)")
                 }
             }
         }
@@ -396,7 +396,7 @@ class ConversationViewModel {
                 do {
                     try await myProfileWriter.update(avatar: profileImage, conversationId: conversation.id)
                 } catch {
-                    Logger.error("Error updating profile image: \(error.localizedDescription)")
+                    Log.error("Error updating profile image: \(error.localizedDescription)")
                 }
             }
         }
@@ -413,7 +413,7 @@ class ConversationViewModel {
             do {
                 try await metadataWriter.removeMembers([member.profile.inboxId], from: conversation.id)
             } catch {
-                Logger.error("Error removing member: \(error.localizedDescription)")
+                Log.error("Error removing member: \(error.localizedDescription)")
             }
         }
     }
@@ -428,7 +428,7 @@ class ConversationViewModel {
                     self.conversation.postLeftConversationNotification()
                 }
             } catch {
-                Logger.error("Error leaving convo: \(error.localizedDescription)")
+                Log.error("Error leaving convo: \(error.localizedDescription)")
             }
         }
     }
@@ -453,7 +453,7 @@ class ConversationViewModel {
                 conversation.postLeftConversationNotification()
                 presentingConversationSettings = false
             } catch {
-                Logger.error("Error exploding convo: \(error.localizedDescription)")
+                Log.error("Error exploding convo: \(error.localizedDescription)")
             }
         }
     }

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/MessagesViewController.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/MessagesViewController.swift
@@ -317,7 +317,7 @@ extension MessagesViewController {
                                 animated: Bool = true,
                                 requiresIsolatedProcess: Bool,
                                 completion: (() -> Void)? = nil) {
-        Logger.info("Processing updates with \(messages.count) messages")
+        Log.info("Processing updates with \(messages.count) messages")
         let visibleMessages = messages.filter { message in
             message.base.content.showsInMessagesList
         }
@@ -382,7 +382,7 @@ extension MessagesViewController {
         }
 
         guard currentInterfaceActions.options.isEmpty else {
-            Logger.info("Interface actions exist, scheduling delayed update...")
+            Log.info("Interface actions exist, scheduling delayed update...")
             scheduleDelayedUpdate(for: conversation,
                                   with: messages,
                                   invite: invite,
@@ -541,7 +541,7 @@ extension MessagesViewController: UIScrollViewDelegate, UICollectionViewDelegate
 
     private func updateBottomInsetForBottomBarHeight() {
         guard isViewLoaded else {
-            Logger.info("View not loading, skipping bottom inset update...")
+            Log.info("View not loading, skipping bottom inset update...")
             return
         }
 

--- a/Convos/Conversations List/ConversationsViewModel.swift
+++ b/Convos/Conversations List/ConversationsViewModel.swift
@@ -128,7 +128,7 @@ final class ConversationsViewModel {
                 hasEarlyAccess = true
             }
         } catch {
-            Logger.error("Error fetching conversations: \(error)")
+            Log.error("Error fetching conversations: \(error)")
             self.conversations = []
             self.conversationsCount = 0
         }
@@ -233,7 +233,7 @@ final class ConversationsViewModel {
                 // Clear all cached writers
                 await MainActor.run { self.localStateWriters.removeAll() }
             } catch {
-                Logger.error("Error deleting all accounts: \(error)")
+                Log.error("Error deleting all accounts: \(error)")
             }
         }
     }
@@ -255,7 +255,7 @@ final class ConversationsViewModel {
                 // Remove cached writer for deleted inbox
                 _ = await MainActor.run { self.localStateWriters.removeValue(forKey: conversation.inboxId) }
             } catch {
-                Logger.error("Error leaving convo: \(error.localizedDescription)")
+                Log.error("Error leaving convo: \(error.localizedDescription)")
             }
         }
     }
@@ -268,7 +268,7 @@ final class ConversationsViewModel {
                     guard let conversationId: String = notification.userInfo?["conversationId"] as? String else {
                         return
                     }
-                    Logger.info("Left conversation notification received for conversation: \(conversationId)")
+                    Log.info("Left conversation notification received for conversation: \(conversationId)")
                     if selectedConversation?.id == conversationId {
                         selectedConversation = nil
                     }
@@ -314,17 +314,20 @@ final class ConversationsViewModel {
         guard let userInfo = notification.userInfo,
               let inboxId = userInfo["inboxId"] as? String,
               let conversationId = userInfo["conversationId"] as? String else {
-            Logger.warning("Conversation notification tapped but missing required userInfo")
+            Log.warning("Conversation notification tapped but missing required userInfo")
             return
         }
 
-        Logger.info("Handling conversation notification tap for inboxId: \(inboxId), conversationId: \(conversationId)")
+        Log
+            .info(
+                "Handling conversation notification tap for inboxId: \(inboxId), conversationId: \(conversationId)"
+            )
 
         if let conversation = conversations.first(where: { $0.id == conversationId }) {
-            Logger.info("Found conversation, selecting it")
+            Log.info("Found conversation, selecting it")
             selectedConversation = conversation
         } else {
-            Logger.warning("Conversation \(conversationId) not found in current conversation list")
+            Log.warning("Conversation \(conversationId) not found in current conversation list")
         }
     }
 
@@ -365,7 +368,7 @@ final class ConversationsViewModel {
 
                 try await writer.setUnread(false, for: conversation.id)
             } catch {
-                Logger.warning("Failed marking conversation as read: \(error.localizedDescription)")
+                Log.warning("Failed marking conversation as read: \(error.localizedDescription)")
             }
         }
     }

--- a/Convos/ConvosApp.swift
+++ b/Convos/ConvosApp.swift
@@ -1,6 +1,7 @@
 import ConvosCore
 import SwiftUI
 import UserNotifications
+import XMTPiOS
 
 @main
 struct ConvosApp: App {
@@ -11,16 +12,15 @@ struct ConvosApp: App {
 
     init() {
         let environment = ConfigManager.shared.currentEnvironment
-        Logger.configure(environment: environment)
+        // Configure logging (automatically disabled in production)
+        ConvosLog.configure(environment: environment)
 
-        switch environment {
-        case .production:
-            Logger.Default.configureForProduction(true)
-        default:
-            Logger.Default.configureForProduction(false)
+        // only enable LibXMTP logging in non-production environments
+        if !environment.isProduction {
+            Log.info("Activating LibXMTP Log Writer...")
+            Client.activatePersistentLibXMTPLogWriter(logLevel: .debug, rotationSchedule: .hourly, maxFiles: 10)
         }
-
-        Logger.info("App starting with environment: \(environment)")
+        Log.info("App starting with environment: \(environment)")
 
         // Run migration to wipe app data (must be done synchronously before app starts)
         Self.runDataWipeMigrationSync(environment: environment)
@@ -29,12 +29,12 @@ struct ConvosApp: App {
         // This prevents a race condition where SessionManager tries to use AppCheck before it's configured
         switch environment {
         case .tests:
-            Logger.info("Running in test environment, skipping Firebase config...")
+            Log.info("Running in test environment, skipping Firebase config...")
         default:
             if let url = ConfigManager.shared.currentEnvironment.firebaseConfigURL {
                 FirebaseHelperCore.configure(with: url)
             } else {
-                Logger.error("Missing Firebase plist URL for current environment")
+                Log.error("Missing Firebase plist URL for current environment")
             }
         }
 
@@ -59,11 +59,11 @@ struct ConvosApp: App {
 
         // Check if migration has already been run
         guard !defaults.bool(forKey: migrationKey) else {
-            Logger.info("Data wipe migration already completed, skipping")
+            Log.info("Data wipe migration already completed, skipping")
             return
         }
 
-        Logger.info("Running data wipe migration...")
+        Log.info("Running data wipe migration...")
 
         // 1. Wipe documents directory
         let documentsDirectory = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first
@@ -75,11 +75,11 @@ struct ConvosApp: App {
                 )
                 for fileURL in fileURLs {
                     try FileManager.default.removeItem(at: fileURL)
-                    Logger.info("Deleted: \(fileURL.lastPathComponent)")
+                    Log.info("Deleted: \(fileURL.lastPathComponent)")
                 }
-                Logger.info("Successfully wiped documents directory")
+                Log.info("Successfully wiped documents directory")
             } catch {
-                Logger.error("Error wiping documents directory: \(error)")
+                Log.error("Error wiping documents directory: \(error)")
             }
         }
 
@@ -96,9 +96,9 @@ struct ConvosApp: App {
             if FileManager.default.fileExists(atPath: fileURL.path) {
                 do {
                     try FileManager.default.removeItem(at: fileURL)
-                    Logger.info("Deleted database file: \(fileName)")
+                    Log.info("Deleted database file: \(fileName)")
                 } catch {
-                    Logger.error("Error deleting \(fileName): \(error)")
+                    Log.error("Error deleting \(fileName): \(error)")
                 }
             }
         }
@@ -106,6 +106,6 @@ struct ConvosApp: App {
         // 3. Mark migration as completed
         defaults.set(true, forKey: migrationKey)
         defaults.synchronize()
-        Logger.info("Data wipe migration completed and marked as done")
+        Log.info("Data wipe migration completed and marked as done")
     }
 }

--- a/Convos/ConvosAppDelegate.swift
+++ b/Convos/ConvosAppDelegate.swift
@@ -19,15 +19,15 @@ class ConvosAppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCent
         let tokenParts = deviceToken.map { data in String(format: "%02.2hhx", data) }
         let token = tokenParts.joined()
 
-        Logger.info("Received device token from APNS: \(token)")
+        Log.info("Received device token from APNS")
         // Store token in shared storage
         PushNotificationRegistrar.save(token: token)
-        Logger.info("Stored device token in shared storage")
+        Log.info("Stored device token in shared storage")
     }
 
     func application(_ application: UIApplication,
                      didFailToRegisterForRemoteNotificationsWithError error: Error) {
-        Logger.error("Failed to register for remote notifications: \(error)")
+        Log.error("Failed to register for remote notifications: \(error)")
     }
 
     // MARK: - UNUserNotificationCenterDelegate
@@ -48,7 +48,7 @@ class ConvosAppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCent
 
         // Show notification banner when app is in foreground
         // NSE processes all notifications regardless of app state
-        Logger.info("App in foreground - showing notification banner")
+        Log.info("App in foreground - showing notification banner")
         return [.banner]
     }
 
@@ -56,7 +56,7 @@ class ConvosAppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCent
     func userNotificationCenter(_ center: UNUserNotificationCenter,
                                 didReceive response: UNNotificationResponse) async {
         let userInfo = response.notification.request.content.userInfo
-        Logger.debug("Notification tapped")
+        Log.debug("Notification tapped")
 
         // Check if this is an explosion notification
         if let notificationType = userInfo["notificationType"] as? String,
@@ -82,17 +82,23 @@ class ConvosAppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCent
         let conversationId = response.notification.request.content.threadIdentifier
 
         guard !conversationId.isEmpty else {
-            Logger.warning("Notification tapped but conversationId is empty")
+            Log.warning("Notification tapped but conversationId is empty")
             return
         }
 
         guard let session = session,
               let inboxId = await session.inboxId(for: conversationId) else {
-            Logger.warning("Notification tapped but could not find inboxId for conversationId: \(conversationId)")
+            Log
+                .warning(
+                    "Notification tapped but could not find inboxId for conversationId: \(conversationId)"
+                )
             return
         }
 
-        Logger.info("Handling conversation notification tap for inboxId: \(inboxId), conversationId: \(conversationId)")
+        Log
+            .info(
+                "Handling conversation notification tap for inboxId: \(inboxId), conversationId: \(conversationId)"
+            )
         DispatchQueue.main.async {
             NotificationCenter.default.post(
                 name: .conversationNotificationTapped,

--- a/Convos/Debug View/DebugExportView.swift
+++ b/Convos/Debug View/DebugExportView.swift
@@ -1,9 +1,12 @@
+import ConvosCore
 import SwiftUI
 
 struct DebugExportView: View {
+    let environment: AppEnvironment
+
     var body: some View {
         List {
-            DebugViewSection()
+            DebugViewSection(environment: environment)
         }
         .navigationTitle("Debug")
         .toolbarTitleDisplayMode(.inline)
@@ -11,5 +14,5 @@ struct DebugExportView: View {
 }
 
 #Preview {
-    NavigationStack { DebugExportView() }
+    NavigationStack { DebugExportView(environment: .tests) }
 }

--- a/Convos/DeepLinking/DeepLinkHandler.swift
+++ b/Convos/DeepLinking/DeepLinkHandler.swift
@@ -13,12 +13,12 @@ final class DeepLinkHandler {
             url.scheme == ConfigManager.shared.appUrlScheme
 
         guard isValidScheme else {
-            Logger.warning("Dismissing deep link with invalid scheme")
+            Log.warning("Dismissing deep link with invalid scheme")
             return nil
         }
 
         guard let inviteCode = url.convosInviteCode else {
-            Logger.warning("Deep link is missing invite code")
+            Log.warning("Deep link is missing invite code")
             return nil
         }
 
@@ -27,7 +27,7 @@ final class DeepLinkHandler {
 
     private static func isValidHost(_ host: String?) -> Bool {
         guard let host = host else {
-            Logger.warning("Deep link is missing host")
+            Log.warning("Deep link is missing host")
             return false
         }
 

--- a/Convos/Shared Views/AvatarView.swift
+++ b/Convos/Shared Views/AvatarView.swift
@@ -66,7 +66,7 @@ struct AvatarView: View {
             }
         } catch {
             // Keep showing monogram on error
-            Logger.error("Error loading image cacheable object: \(cacheableObject) from url: \(imageURL)")
+            Log.error("Error loading image cacheable object: \(cacheableObject) from url: \(imageURL)")
             cachedImage = nil
         }
 

--- a/Convos/Shared Views/BackspaceTextField.swift
+++ b/Convos/Shared Views/BackspaceTextField.swift
@@ -53,11 +53,11 @@ struct BackspaceTextField: UIViewRepresentable {
         }
 
         func textFieldDidBeginEditing(_ textField: UITextField) {
-            Logger.info("Started editing textfield")
+            Log.info("Started editing textfield")
         }
 
         func textFieldDidEndEditing(_ textField: UITextField) {
-            Logger.info("Ended editing textfield")
+            Log.info("Ended editing textfield")
             onEndedEditing?()
         }
 

--- a/Convos/Shared Views/QRCodeView.swift
+++ b/Convos/Shared Views/QRCodeView.swift
@@ -29,7 +29,8 @@ struct QRCodeView: View {
             foregroundColor: UIColor(foregroundColor),
             backgroundColor: UIColor(backgroundColor),
         )
-        Logger.info("Generating QR code for:\n \(url.absoluteString)")
+        Log.info("Generating QR code for:")
+        Log.info(url.absoluteString)
         return await QRCodeGenerator.generate(from: url.absoluteString, options: options)
     }
 

--- a/Convos/Utilities/Log.swift
+++ b/Convos/Utilities/Log.swift
@@ -1,0 +1,21 @@
+import ConvosCore
+import Foundation
+
+/// Convos app logging wrapper - uses "Convos" namespace
+enum Log {
+    static func debug(_ message: String, file: String = #file, function: String = #function, line: Int = #line) {
+        ConvosLog.debug(message, namespace: "Convos", file: file, function: function, line: line)
+    }
+
+    static func info(_ message: String, file: String = #file, function: String = #function, line: Int = #line) {
+        ConvosLog.info(message, namespace: "Convos", file: file, function: function, line: line)
+    }
+
+    static func warning(_ message: String, file: String = #file, function: String = #function, line: Int = #line) {
+        ConvosLog.warning(message, namespace: "Convos", file: file, function: function, line: line)
+    }
+
+    static func error(_ message: String, file: String = #file, function: String = #function, line: Int = #line) {
+        ConvosLog.error(message, namespace: "Convos", file: file, function: function, line: line)
+    }
+}

--- a/Convos/_Archive/Convos Client/Auth/Passkey/PasskeyAuthService.swift
+++ b/Convos/_Archive/Convos Client/Auth/Passkey/PasskeyAuthService.swift
@@ -41,7 +41,7 @@ class PasskeyAuthService: AuthServiceProtocol {
         do {
             try refreshAuthState()
         } catch {
-            Logger.error("Error refreshing auth state: \(error)")
+            Log.error("Error refreshing auth state: \(error)")
         }
     }
 

--- a/Convos/_Archive/Convos Client/Auth/Passkey/PasskeyIdentityStore.swift
+++ b/Convos/_Archive/Convos Client/Auth/Passkey/PasskeyIdentityStore.swift
@@ -25,7 +25,7 @@ extension String {
 extension Data {
     func coseToSec1PublicKey() -> Data? {
         guard let decoded = try? CBORDecoder(input: bytes).decodeItem() else {
-            Logger.info("Failed to decode CBOR")
+            Log.info("Failed to decode CBOR")
             return nil
         }
 
@@ -54,7 +54,7 @@ extension Data {
         }
 
         guard let map = coseMap else {
-            Logger.info("COSE structure is not a valid map")
+            Log.info("COSE structure is not a valid map")
             return nil
         }
 
@@ -65,7 +65,7 @@ extension Data {
               case let CBOR.byteString(xBytes) = xVal,
               case let CBOR.byteString(yBytes) = yVal,
               xBytes.count == 32, yBytes.count == 32 else {
-            Logger.info("Missing or invalid x/y values")
+            Log.info("Missing or invalid x/y values")
             return nil
         }
 

--- a/Convos/_Archive/Convos Client/Auth/Passkey/PasskeySigningKey.swift
+++ b/Convos/_Archive/Convos Client/Auth/Passkey/PasskeySigningKey.swift
@@ -67,7 +67,7 @@ final class PasskeySigningKey: SigningKey {
         let sec1Key = try P256.Signing.PublicKey(x963Representation: publicKey)
         let signature = try P256.Signing.ECDSASignature(derRepresentation: assertion.signature)
         let isValid = sec1Key.isValidSignature(signature, for: verificationData)
-        Logger.info("Internal signing validation check returned `isValid`: \(isValid)")
+        Log.info("Internal signing validation check returned `isValid`: \(isValid)")
 
         return SignedData(
             rawData: assertion.signature,

--- a/Convos/_Archive/Convos Client/Auth/Turnkey/TurnkeyAccountsService.swift
+++ b/Convos/_Archive/Convos Client/Auth/Turnkey/TurnkeyAccountsService.swift
@@ -102,14 +102,14 @@ class TurnkeyAccountsService: AuthAccountsServiceProtocol {
 //            disableOtpEmailAuth: nil
 //        )
 //
-//        Logger.info("Create sub org response: \(subOrgResponse)")
+//        Log.info("Create sub org response: \(subOrgResponse)")
 //        guard
 //            case let .json(body) = subOrgResponse.body,
 //            let subOrgResult = body.activity.result.createSubOrganizationResult else {
 //            throw TurnkeyAccountsServiceError.failedCreatingSubOrg
 //        }
 //
-//        Logger.info("Created sub org: \(subOrgResult.subOrganizationId) users: \(subOrgResult.rootUserIds ?? [])")
+//        Log.info("Created sub org: \(subOrgResult.subOrganizationId) users: \(subOrgResult.rootUserIds ?? [])")
 
         let otrWalletId: String
         let otrWalletAddress: String
@@ -128,7 +128,7 @@ class TurnkeyAccountsService: AuthAccountsServiceProtocol {
                 mnemonicLength: nil
             )
 
-            Logger.info("Added wallet: \(response)")
+            Log.info("Added wallet: \(response)")
             guard
                 case let .json(body) = response.body,
                 let walletResult = body.activity.result.createWalletResult,

--- a/Convos/_Archive/Convos Client/Auth/Turnkey/TurnkeyAuthService.swift
+++ b/Convos/_Archive/Convos Client/Auth/Turnkey/TurnkeyAuthService.swift
@@ -27,7 +27,7 @@ fileprivate extension SignRawPayloadResult {
 
     var signedData: SignedData {
         guard let rawSignature else {
-            Logger.error("Failed getting raw signature from SignRawPayloadResult")
+            Log.error("Failed getting raw signature from SignRawPayloadResult")
             return SignedData(rawData: Data())
         }
         return SignedData(rawData: rawSignature)
@@ -61,7 +61,7 @@ extension SessionUser.UserWallet.WalletAccount: @retroactive SigningKey {
             )
             return result.signedData
         } catch {
-            Logger.error("Error signing message: \(error)")
+            Log.error("Error signing message: \(error)")
             throw error
         }
     }
@@ -248,7 +248,7 @@ final class TurnkeyAuthService: AuthServiceProtocol {
         do {
             return try processAuthFlow(for: wallet)
         } catch {
-            Logger.error("Error processing auth state: \(error)")
+            Log.error("Error processing auth state: \(error)")
             return .unauthorized
         }
     }
@@ -260,12 +260,12 @@ final class TurnkeyAuthService: AuthServiceProtocol {
 
     private func validateWallet(for user: SessionUser) -> SessionUser.UserWallet? {
         guard let wallet = user.defaultWallet else {
-            Logger.error("Default Wallet not found for Turnkey user, unauthorized")
+            Log.error("Default Wallet not found for Turnkey user, unauthorized")
             return nil
         }
 
         if user.wallets.count > 1 {
-            Logger.warning("Multiple wallets found for Turnkey user, using default")
+            Log.warning("Multiple wallets found for Turnkey user, using default")
         }
 
         return wallet
@@ -281,7 +281,7 @@ final class TurnkeyAuthService: AuthServiceProtocol {
             do {
                 try migration.performMigration(for: userIdentifier)
             } catch {
-                Logger.error("Failed performing migration for user \(userIdentifier): \(error)")
+                Log.error("Failed performing migration for user \(userIdentifier): \(error)")
                 return .migrating(migration)
             }
         }
@@ -321,7 +321,7 @@ final class TurnkeyAuthService: AuthServiceProtocol {
         }
 
         if wallet.accounts.count > 1 {
-            Logger.warning("Multiple wallet accounts found for Turnkey user, using the first one")
+            Log.warning("Multiple wallet accounts found for Turnkey user, using the first one")
         }
 
         let databaseKey = try account.databaseKey
@@ -368,7 +368,7 @@ final class TurnkeyAuthService: AuthServiceProtocol {
 
             try await turnkey.createSession(jwt: jwt)
         } catch let error as TurnkeyRequestError {
-            Logger.error("Failed to stamp login code \(error.statusCode ?? 0): \(error.fullMessage)")
+            Log.error("Failed to stamp login code \(error.statusCode ?? 0): \(error.fullMessage)")
             throw error
         }
     }

--- a/ConvosAppClip/ConvosAppClipApp.swift
+++ b/ConvosAppClip/ConvosAppClipApp.swift
@@ -10,23 +10,17 @@ struct ConvosAppClipApp: App {
 
     init() {
         let environment = ConfigManager.shared.currentEnvironment
-        Logger.configure(environment: environment)
+        // Configure logging (automatically disabled in production)
+        ConvosLog.configure(environment: environment)
 
-        switch environment {
-        case .production:
-            Logger.Default.configureForProduction(true)
-        default:
-            Logger.Default.configureForProduction(false)
-        }
-
-        Logger.info("App starting with environment: \(environment)")
+        Log.info("App starting with environment: \(environment)")
 
         // Configure Firebase BEFORE creating ConvosClient
         // This prevents a race condition where SessionManager tries to use AppCheck before it's configured
         if let url = ConfigManager.shared.currentEnvironment.firebaseConfigURL {
             FirebaseHelperCore.configure(with: url)
         } else {
-            Logger.error("Missing Firebase plist URL for current environment")
+            Log.error("Missing Firebase plist URL for current environment")
         }
 
         let convos: ConvosClient = .client(environment: environment)

--- a/ConvosCore/Package.resolved
+++ b/ConvosCore/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "07ce7641289264b1ff59c786c980fd11c05bae4df945f9bd024d640fdfa68885",
+  "originHash" : "f0a3eeb34441daf2aab90e82f31149b6f5a468fb416efe6ab52907d9c8efc16f",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -170,6 +170,15 @@
       "state" : {
         "revision" : "8c0c0a8b49e080e54e5e328cc552821ff07cd341",
         "version" : "1.2.1"
+      }
+    },
+    {
+      "identity" : "swift-log",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-log",
+      "state" : {
+        "revision" : "ce592ae52f982c847a4efc0dd881cc9eb32d29f2",
+        "version" : "1.6.4"
       }
     },
     {

--- a/ConvosCore/Package.swift
+++ b/ConvosCore/Package.swift
@@ -20,7 +20,8 @@ let package = Package(
         .package(url: "https://github.com/tesseract-one/CSecp256k1.swift.git", from: "0.2.0"),
         .package(url: "https://github.com/SimplyDanny/SwiftLintPlugins", from: "0.61.0"),
         .package(url: "https://github.com/firebase/firebase-ios-sdk", from: "12.1.0"),
-        .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.31.1")
+        .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.31.1"),
+        .package(path: "../ConvosLogging")
     ],
     targets: [
         .target(
@@ -32,13 +33,14 @@ let package = Package(
                 .product(name: "FirebaseAppCheck", package: "firebase-ios-sdk"),
                 .product(name: "SwiftProtobuf", package: "swift-protobuf"),
                 .product(name: "CSecp256k1", package: "CSecp256k1.swift"),
+                .product(name: "ConvosLogging", package: "ConvosLogging"),
             ],
             swiftSettings: [
                 .swiftLanguageMode(.v5),
+                // Define DEBUG - will be active based on Xcode's SWIFT_ACTIVE_COMPILATION_CONDITIONS
                 .define("DEBUG", .when(configuration: .debug)),
-                // Define XCODE_BUILD for non-release configurations (Local, Dev)
-                // This helps distinguish Xcode builds from CI/Archive builds
-                .define("XCODE_BUILD", .when(configuration: .debug))
+                // Disable optimization for debug builds to enable proper debugging
+                .unsafeFlags(["-Onone"], .when(configuration: .debug)),
             ],
             plugins: [
                 .plugin(name: "SwiftLintBuildToolPlugin", package: "SwiftLintPlugins")

--- a/ConvosCore/Sources/ConvosCore/AppEnvironment+SecureStorage.swift
+++ b/ConvosCore/Sources/ConvosCore/AppEnvironment+SecureStorage.swift
@@ -8,7 +8,7 @@ public extension AppEnvironment {
         let sharedConfig = SharedAppConfiguration(environment: self)
 
         guard let data = try? JSONEncoder().encode(sharedConfig) else {
-            Logger.error("Failed to encode environment configuration")
+            Log.error("Failed to encode environment configuration")
             return
         }
 
@@ -29,9 +29,9 @@ public extension AppEnvironment {
         let status = SecItemAdd(keychainQuery as CFDictionary, nil)
 
         if status == errSecSuccess {
-            Logger.info("Environment configuration stored securely in Keychain")
+            Log.info("Environment configuration stored securely in Keychain")
         } else {
-            Logger.error("Failed to store environment configuration in Keychain: \(status)")
+            Log.error("Failed to store environment configuration in Keychain: \(status)")
         }
     }
 
@@ -59,10 +59,10 @@ public extension AppEnvironment {
         if status == errSecSuccess,
            let data = result as? Data,
            let sharedConfig = try? JSONDecoder().decode(SharedAppConfiguration.self, from: data) {
-            Logger.info("Environment configuration retrieved from Keychain")
+            Log.info("Environment configuration retrieved from Keychain")
             return sharedConfig.toAppEnvironment()
         } else if status != errSecItemNotFound {
-            Logger.error("Failed to retrieve environment configuration from Keychain: \(status)")
+            Log.error("Failed to retrieve environment configuration from Keychain: \(status)")
         }
 
         return nil

--- a/ConvosCore/Sources/ConvosCore/AppEnvironment.swift
+++ b/ConvosCore/Sources/ConvosCore/AppEnvironment.swift
@@ -87,15 +87,15 @@ public enum AppEnvironment: Sendable {
     var apiBaseURL: String {
         switch self {
         case .local(let config):
-            Logger.info("🌐 Using API URL from local config: \(config.apiBaseURL)")
+            Log.info("🌐 Using API URL from local config: \(config.apiBaseURL)")
             return config.apiBaseURL
         case .tests:
             return "http://localhost:4000/api/"
         case .dev(let config):
-            Logger.info("🌐 Using API URL from dev config: \(config.apiBaseURL)")
+            Log.info("🌐 Using API URL from dev config: \(config.apiBaseURL)")
             return config.apiBaseURL
         case .production(let config):
-            Logger.info("🌐 Using API URL from production config: \(config.apiBaseURL)")
+            Log.info("🌐 Using API URL from production config: \(config.apiBaseURL)")
             return config.apiBaseURL
         }
     }
@@ -138,13 +138,13 @@ public enum AppEnvironment: Sendable {
     public var apnsEnvironment: ApnsEnvironment {
         switch buildEnvironment {
         case .simulator:
-            Logger.info("Simulator build detected - using sandbox APNS")
+            Log.info("Simulator build detected - using sandbox APNS")
             return .sandbox
         case .development:
-            Logger.info("Development build detected (has embedded.mobileprovision) - using sandbox APNS")
+            Log.info("Development build detected (has embedded.mobileprovision) - using sandbox APNS")
             return .sandbox
         case .distribution:
-            Logger.info("Distribution build detected (TestFlight/App Store) - using production APNS")
+            Log.info("Distribution build detected (TestFlight/App Store) - using production APNS")
             return .production
         }
     }

--- a/ConvosCore/Sources/ConvosCore/Auth/Keychain/KeychainIdentityStore.swift
+++ b/ConvosCore/Sources/ConvosCore/Auth/Keychain/KeychainIdentityStore.swift
@@ -324,7 +324,7 @@ public final actor KeychainIdentityStore: KeychainIdentityStoreProtocol {
                 let identity = try JSONDecoder().decode(KeychainIdentity.self, from: data)
                 identities.append(identity)
             } catch {
-                Logger.error("Failed decoding identity: \(error)")
+                Log.error("Failed decoding identity: \(error)")
             }
         }
 

--- a/ConvosCore/Sources/ConvosCore/Device/DeviceRegistrationManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Device/DeviceRegistrationManager.swift
@@ -78,12 +78,12 @@ public actor DeviceRegistrationManager: DeviceRegistrationManagerProtocol {
     /// Protected by isRegistering flag to prevent concurrent registration attempts.
     public func registerDeviceIfNeeded() async {
         if case .tests = environment {
-            Logger.info("Skipping device registration for tests environment...")
+            Log.info("Skipping device registration for tests environment...")
             return
         }
 
         guard !isRegistering else {
-            Logger.info("Registration already in progress, skipping")
+            Log.info("Registration already in progress, skipping")
             return
         }
 
@@ -106,14 +106,14 @@ public actor DeviceRegistrationManager: DeviceRegistrationManagerProtocol {
         let shouldRegister = !hasEverRegistered || lastToken != pushToken
 
         guard shouldRegister else {
-            Logger.info("Device already registered with this token")
+            Log.info("Device already registered with this token")
             return
         }
 
         let reason = !hasEverRegistered ? "first time" : "token changed"
 
         do {
-            Logger.info("Registering device (\(reason), token: \(pushToken != nil ? "present" : "nil"))")
+            Log.info("Registering device (\(reason), token: \(pushToken != nil ? "present" : "nil"))")
 
             try await apiClient.registerDevice(deviceId: deviceId, pushToken: pushToken)
 
@@ -123,15 +123,15 @@ public actor DeviceRegistrationManager: DeviceRegistrationManagerProtocol {
 
             if let pushToken = pushToken {
                 UserDefaults.standard.set(pushToken, forKey: lastTokenKey)
-                Logger.info("Successfully registered device with push token")
+                Log.info("Successfully registered device with push token")
             } else {
                 // Clear lastToken when successfully registering with nil token
                 // This ensures we don't keep retrying with nil on every launch
                 UserDefaults.standard.removeObject(forKey: lastTokenKey)
-                Logger.info("Successfully registered device without push token")
+                Log.info("Successfully registered device without push token")
             }
         } catch {
-            Logger.error("Failed to register device: \(error). Will retry on next attempt.")
+            Log.error("Failed to register device: \(error). Will retry on next attempt.")
         }
     }
 
@@ -141,7 +141,7 @@ public actor DeviceRegistrationManager: DeviceRegistrationManagerProtocol {
         let deviceId = DeviceInfo.deviceIdentifier
         UserDefaults.standard.removeObject(forKey: "lastRegisteredDevicePushToken_\(deviceId)")
         UserDefaults.standard.removeObject(forKey: "hasRegisteredDevice_\(deviceId)")
-        Logger.info("Cleared device registration state")
+        Log.info("Cleared device registration state")
     }
 
     /// Returns true if this device has been registered at least once.
@@ -155,7 +155,7 @@ public actor DeviceRegistrationManager: DeviceRegistrationManagerProtocol {
     private func setupPushTokenObserver() {
         guard pushTokenObserver == nil else { return }
 
-        Logger.info("DeviceRegistrationManager: Setting up push token observer...")
+        Log.info("DeviceRegistrationManager: Setting up push token observer...")
         pushTokenObserver = NotificationCenter.default.addObserver(
             forName: .convosPushTokenDidChange,
             object: nil,
@@ -171,12 +171,12 @@ public actor DeviceRegistrationManager: DeviceRegistrationManagerProtocol {
         if let observer = pushTokenObserver {
             NotificationCenter.default.removeObserver(observer)
             pushTokenObserver = nil
-            Logger.info("DeviceRegistrationManager: Removed push token observer")
+            Log.info("DeviceRegistrationManager: Removed push token observer")
         }
     }
 
     private func handlePushTokenChange() async {
-        Logger.info("DeviceRegistrationManager: Push token changed, re-registering device...")
+        Log.info("DeviceRegistrationManager: Push token changed, re-registering device...")
         await registerDeviceIfNeeded()
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Exports.swift
+++ b/ConvosCore/Sources/ConvosCore/Exports.swift
@@ -1,0 +1,2 @@
+// Re-export ConvosLogging so all ConvosCore files and consumers automatically have access
+@_exported import ConvosLogging

--- a/ConvosCore/Sources/ConvosCore/FirebaseHelper.swift
+++ b/ConvosCore/Sources/ConvosCore/FirebaseHelper.swift
@@ -11,7 +11,7 @@ public enum FirebaseHelperCore {
             AppCheck.setAppCheckProviderFactory(AppAttestFactory())
         #endif
         FirebaseApp.configure(options: options)
-        Logger.info("Firebase configured for current environment: \(FirebaseApp.app()?.options.googleAppID ?? "undefined")")
+        Log.info("Firebase configured for current environment: \(FirebaseApp.app()?.options.googleAppID ?? "undefined")")
     }
 
     public static func getAppCheckToken(forceRefresh: Bool = false) async throws -> String {

--- a/ConvosCore/Sources/ConvosCore/Image Cache/ImageCache.swift
+++ b/ConvosCore/Sources/ConvosCore/Image Cache/ImageCache.swift
@@ -95,13 +95,13 @@ public final class ImageCache {
         let resizedImage = ImageCompression.resizeForCache(image)
 
         guard resizedImage.size.width > 0 && resizedImage.size.height > 0 else {
-            Logger.error("Failed to resize image for \(logContext): \(key) - invalid dimensions")
+            Log.error("Failed to resize image for \(logContext): \(key) - invalid dimensions")
             return
         }
 
         let cost = Int(resizedImage.size.width * resizedImage.size.height * 4)
         cache.setObject(resizedImage, forKey: key as NSString, cost: cost)
-        Logger.info("Successfully cached resized image for \(logContext): \(key)")
+        Log.info("Successfully cached resized image for \(logContext): \(key)")
     }
 }
 

--- a/ConvosCore/Sources/ConvosCore/Inboxes/CachedPushNotificationHandler.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/CachedPushNotificationHandler.swift
@@ -74,31 +74,31 @@ public actor CachedPushNotificationHandler {
         payload: PushNotificationPayload,
         timeout: TimeInterval = 25
     ) async throws -> DecodedNotificationContent? {
-        Logger.info("Processing push notification")
+        Log.info("Processing push notification")
 
         // Clean up old services before processing
         cleanupStaleServices()
 
         guard payload.isValid else {
-            Logger.info("Dropping notification without clientId (v1/legacy)")
+            Log.info("Dropping notification without clientId (v1/legacy)")
             return nil
         }
 
         guard let clientId = payload.clientId else {
-            Logger.info("Dropping notification without clientId")
+            Log.info("Dropping notification without clientId")
             return nil
         }
 
-        Logger.info("Processing v2 notification for clientId: \(clientId)")
+        Log.info("Processing v2 notification for clientId: \(clientId)")
         let inboxesRepository = InboxesRepository(databaseReader: databaseReader)
         guard let inbox = try? inboxesRepository.inbox(byClientId: clientId) else {
-            Logger.warning("No inbox found in database for clientId: \(clientId) - dropping notification")
+            Log.warning("No inbox found in database for clientId: \(clientId) - dropping notification")
             return nil
         }
         let inboxId = inbox.inboxId
-        Logger.info("Matched clientId \(clientId) to inboxId: \(inboxId)")
+        Log.info("Matched clientId \(clientId) to inboxId: \(inboxId)")
 
-        Logger.info("Processing for inbox: \(inboxId)")
+        Log.info("Processing for inbox: \(inboxId)")
 
         // Process with timeout
         return try await withTimeout(seconds: timeout, timeoutError: NotificationProcessingError.timeout) {
@@ -109,7 +109,7 @@ public actor CachedPushNotificationHandler {
 
     /// Cleans up all resources
     public func cleanup() {
-        Logger.info("Cleaning up \(messagingServices.count) messaging services")
+        Log.info("Cleaning up \(messagingServices.count) messaging services")
         messagingServices.values.forEach { $0.stop() }
         messagingServices.removeAll()
         lastAccessTime.removeAll()
@@ -125,7 +125,7 @@ public actor CachedPushNotificationHandler {
         }
 
         if !staleInboxIds.isEmpty {
-            Logger.info("Cleaning up \(staleInboxIds.count) stale messaging services")
+            Log.info("Cleaning up \(staleInboxIds.count) stale messaging services")
             for inboxId in staleInboxIds {
                 let removedService = messagingServices.removeValue(forKey: inboxId)
                 removedService?.stop()
@@ -141,11 +141,14 @@ public actor CachedPushNotificationHandler {
         lastAccessTime[inboxId] = Date()
 
         if let existing = messagingServices[inboxId] {
-            Logger.info("Reusing existing messaging service for inbox: \(inboxId)")
+            Log.info("Reusing existing messaging service for inbox: \(inboxId)")
             return existing
         }
 
-        Logger.info("Creating new messaging service for inbox: \(inboxId), clientId: \(clientId), with JWT: \(overrideJWTToken != nil)")
+        Log
+            .info(
+                "Creating new messaging service for inbox: \(inboxId), clientId: \(clientId), with JWT: \(overrideJWTToken != nil)"
+            )
         let messagingService = MessagingService.authorizedMessagingService(
             for: inboxId,
             clientId: clientId,

--- a/ConvosCore/Sources/ConvosCore/Inboxes/InboxStateManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/InboxStateManager.swift
@@ -130,11 +130,14 @@ public final class InboxStateManager: InboxStateManagerProtocol {
         // Check if we're already authorized with this inbox
         if case .ready(let currentClientId, let result) = currentState,
            result.client.inboxId == inboxId && currentClientId == clientId {
-            Logger.info("Already authorized with inbox \(inboxId) and clientId \(clientId), skipping reauthorization")
+            Log
+                .info(
+                    "Already authorized with inbox \(inboxId) and clientId \(clientId), skipping reauthorization"
+                )
             return result
         }
 
-        Logger.info("Reauthorizing with inbox \(inboxId)...")
+        Log.info("Reauthorizing with inbox \(inboxId)...")
 
         // Stop current inbox if running
         if case .ready = currentState {
@@ -156,11 +159,14 @@ public final class InboxStateManager: InboxStateManagerProtocol {
             case .ready(_, let result):
                 // Verify this is the inbox we requested
                 if result.client.inboxId == inboxId {
-                    Logger.info("Successfully reauthorized to inbox \(inboxId)")
+                    Log.info("Successfully reauthorized to inbox \(inboxId)")
                     return result
                 } else {
                     // This is the old inbox's ready state, keep waiting
-                    Logger.info("Waiting for correct inbox... current: \(result.client.inboxId), expected: \(inboxId)")
+                    Log
+                        .info(
+                            "Waiting for correct inbox... current: \(result.client.inboxId), expected: \(inboxId)"
+                        )
                     continue
                 }
             case .error(_, let error):

--- a/ConvosCore/Sources/ConvosCore/Inboxes/PushNotificationRegistrar.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/PushNotificationRegistrar.swift
@@ -42,12 +42,12 @@ public final class PushNotificationRegistrar {
                 await MainActor.run {
                     UIApplication.shared.registerForRemoteNotifications()
                 }
-                Logger.info("Notification authorization granted, registering for remote notifications")
+                Log.info("Notification authorization granted, registering for remote notifications")
             } else {
-                Logger.info("Notification authorization denied by user")
+                Log.info("Notification authorization denied by user")
             }
         } catch {
-            Logger.warning("Notification authorization failed: \(error)")
+            Log.warning("Notification authorization failed: \(error)")
         }
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Logging/Logger.swift
+++ b/ConvosCore/Sources/ConvosCore/Logging/Logger.swift
@@ -1,594 +1,98 @@
+import ConvosLogging
 import Foundation
-import os
+import Logging
 
-/// Structured logging system with file persistence and production filtering
+/// Unified logger that accepts a namespace parameter
 ///
-/// Logger provides leveled logging (debug, info, warning, error) with file-based
-/// persistence in the shared App Group container. Supports both main app and
-/// notification extension logging to a unified log file. Includes:
-/// - Automatic log rotation when file size exceeds limit
-/// - Production mode filtering to exclude sensitive data
-/// - Buffered writes for performance
-/// - Async log retrieval with tail support
-public enum Logger {
-    public enum LogLevel: Int, Comparable {
-        case debug = 0
-        case info = 1
-        case warning = 2
-        case error = 3
+/// This is the public API that both ConvosCore and Convos app use.
+/// Each module provides a convenience wrapper with its own namespace.
+public enum ConvosLog {
+    private static var _logger: Logging.Logger?
+    private static let queue: DispatchQueue = DispatchQueue(label: "com.convos.log")
 
-        public static func < (lhs: LogLevel, rhs: LogLevel) -> Bool {
-            return lhs.rawValue < rhs.rawValue
-        }
-
-        var emoji: String {
-            switch self {
-            case .debug: return "🔍"
-            case .info: return "ℹ️"
-            case .warning: return "⚠️"
-            case .error: return "❌"
-            }
+    private static var logger: Logging.Logger? {
+        queue.sync {
+            _logger
         }
     }
 
-    public protocol LoggerProtocol {
-        func log(_ message: String, level: LogLevel, file: String, function: String, line: Int)
-        var minimumLogLevel: LogLevel { get set }
-        func getLogs() -> String
-        func getLogsAsync(completion: @escaping (String) -> Void)
-        func clearLogs(completion: (() -> Void)?)
-        func flushPendingWrites()
-        func getAllLogs() async -> String
+    public static func debug(_ message: String, namespace: String, file: String = #file, function: String = #function, line: Int = #line) {
+        logger?.debug("[\(namespace)] \(message)", source: makeSource(file: file, function: function, line: line))
     }
 
-    public class Default: LoggerProtocol {
-        public static var shared: LoggerProtocol = Default()
+    public static func info(_ message: String, namespace: String, file: String = #file, function: String = #function, line: Int = #line) {
+        logger?.info("[\(namespace)] \(message)", source: makeSource(file: file, function: function, line: line))
+    }
 
-        public var minimumLogLevel: LogLevel = .info
-        private var isProduction: Bool = false
-        private var logFileURL: URL?
-        private var environment: AppEnvironment?
+    public static func warning(_ message: String, namespace: String, file: String = #file, function: String = #function, line: Int = #line) {
+        logger?.warning("[\(namespace)] \(message)", source: makeSource(file: file, function: function, line: line))
+    }
 
-        /// os.Logger for Console.app visibility (only used in local/dev)
-        private lazy var systemLogger: os.Logger = {
-            let bundleId = Bundle.main.bundleIdentifier ?? "org.convos.ios"
-            let isNSE = bundleId.contains(".NotificationService")
-            let subsystem = isNSE ? "org.convos.ios.NSE" : "org.convos.ios"
-            let category = isNSE ? "NotificationService" : "General"
+    public static func error(_ message: String, namespace: String, file: String = #file, function: String = #function, line: Int = #line) {
+        logger?.error("[\(namespace)] \(message)", source: makeSource(file: file, function: function, line: line))
+    }
 
-            #if DEBUG
-            print("Logger: Creating system logger with subsystem=\(subsystem), category=\(category)")
-            #endif
+    private static func makeSource(file: String, function: String, line: Int) -> String {
+        let fileName = (file as NSString).lastPathComponent
+        return "\(fileName):\(line) \(function)"
+    }
 
-            return os.Logger(subsystem: subsystem, category: category)
-        }()
-        private var shouldUseSystemLogger: Bool {
-            guard let environment = environment else {
-                #if DEBUG
-                print("Logger: shouldUseSystemLogger = false (no environment)")
-                #endif
-                return false
-            }
-            let result: Bool
-            switch environment {
-            case .local, .dev:
-                result = true
-            case .production, .tests:
-                result = false
-            }
-            #if DEBUG
-            print("Logger: shouldUseSystemLogger = \(result) (environment: \(environment.name))")
-            #endif
-            return result
-        }
+    // MARK: - Configuration
 
-        /// Configure the logger for production mode
-        public static func configureForProduction(_ isProduction: Bool) {
-            if let defaultLogger = shared as? Default {
-                defaultLogger.isProduction = isProduction
-                defaultLogger.prepare()
-            }
-        }
+    /// Configure the logging system with file-based handler
+    /// Call this once at app startup before using any loggers
+    /// Logging is automatically disabled in production environments
+    public static func configure(environment: AppEnvironment) {
+        queue.sync {
+            guard _logger == nil else { return }
 
-        /// Configure the logger with environment (for proper app group access)
-        public static func configure(environment: AppEnvironment) {
-            if let defaultLogger = shared as? Default {
-                defaultLogger.environment = environment
-                defaultLogger.prepare()
-            }
-        }
-
-        /// Configure both environment and production in a single prepare pass
-        public static func configure(environment: AppEnvironment, isProduction: Bool) {
-            if let defaultLogger = shared as? Default {
-                defaultLogger.environment = environment
-                defaultLogger.isProduction = isProduction
-                defaultLogger.prepare()
-            }
-        }
-        private let fileQueue: DispatchQueue = DispatchQueue(label: "com.convos.logger.file", qos: .utility)
-        private let readQueue: DispatchQueue = DispatchQueue(label: "com.convos.logger.read", qos: .utility)
-        private let maxLogFileSize: Int64 = 10 * 1024 * 1024 // 10MB
-        private let maxLogLines: Int = 1000 // Maximum lines to return for performance
-        private var logBuffer: [String] = []
-        private let bufferQueue: DispatchQueue = DispatchQueue(label: "com.convos.logger.buffer", qos: .utility)
-        private let bufferMaxSize: Int = 100 // Keep last 100 log entries in memory
-
-        // File handle optimization
-        private var fileHandle: FileHandle?
-        private var pendingWrites: [Data] = []
-        private let writeBatchSize: Int = 10 // Write in batches of 10
-        private var lastFileSizeCheck: Date = Date()
-        private let fileSizeCheckInterval: TimeInterval = 30 // Check file size every 30 seconds
-
-        public init() {}
-
-        deinit {
-            closeFileHandle()
-        }
-
-        private func prepare() {
-            // Idempotency: close any previously opened handle and reset state up-front
-            fileQueue.sync {
-                if let handle = self.fileHandle {
-                    try? handle.close()
-                }
-                self.fileHandle = nil
-                self.logFileURL = nil
-            }
-
-            // Get app group identifier from environment configuration
-            let appGroupIdentifier = getAppGroupIdentifier()
-            let isNSE = Bundle.main.bundlePath.hasSuffix(".appex")
-
-            #if DEBUG
-            print("Logger: Using app group identifier: \(appGroupIdentifier) (isNSE: \(isNSE))")
-            #endif
-
-            // Use shared container - no fallback since we always need app group sharing
-            guard let containerURL = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: appGroupIdentifier) else {
-                #if DEBUG
-                print("Logger: Failed to get shared container for app group: \(appGroupIdentifier)")
-                #endif
-                self.logFileURL = nil
-                self.fileHandle = nil
+            // never enable logging in production
+            guard !environment.isProduction else {
                 return
             }
 
-            // Create logs directory in shared container
-            let logsDirectory = containerURL.appendingPathComponent("Logs")
-
-            do {
-                try FileManager.default.createDirectory(at: logsDirectory, withIntermediateDirectories: true)
-
-                // Use single log file for both main app and NSE
-                let resolvedLogFileURL = logsDirectory.appendingPathComponent("convos.log")
-
-                #if DEBUG
-                print("Logger: Log file path: \(resolvedLogFileURL.path)")
-                #endif
-
-                // Only set after directory creation succeeds
-                self.logFileURL = resolvedLogFileURL
-
-                // Initialize file handle after URL is ready
-                self.initializeFileHandle()
-            } catch {
-                #if DEBUG
-                print("Logger: Failed to create logs directory: \(error)")
-                #endif
-                // Ensure consistent nil state on failure
-                self.logFileURL = nil
-                self.fileHandle = nil
+            // First, bootstrap the logging system factory
+            LoggingSystem.bootstrap { label in
+                // Use MultiplexLogHandler to send logs to both file and console
+                MultiplexLogHandler([
+                    FileLogHandler.makeHandler(label: label, appGroupIdentifier: environment.appGroupIdentifier),
+                    StreamLogHandler.standardOutput(label: label)
+                ])
             }
+
+            // Then create the logger (it will now use the FileLogHandler)
+            _logger = Logging.Logger(label: "convos")
         }
+    }
 
-        private func getAppGroupIdentifier() -> String {
-            // Use configured environment if available
-            if let environment = environment {
-                return environment.appGroupIdentifier
-            }
+    /// Get all logs from the shared log file
+    public static func getLogs(appGroupIdentifier: String = "group.org.convos.app") async -> String {
+        await FileLogHandler.getLogs(appGroupIdentifier: appGroupIdentifier)
+    }
 
-            // For NSE, try to get from stored configuration
-            if Bundle.main.bundlePath.hasSuffix(".appex") {
-                if let storedEnvironment = AppEnvironment.retrieveSecureConfigurationForNotificationExtension() {
-                    return storedEnvironment.appGroupIdentifier
-                }
-            }
-
-            // Fallback to default app group identifier
-            return "group.org.convos.app"
-        }
-
-        private func initializeFileHandle() {
-            guard let logFileURL = logFileURL else { return }
-
-            fileQueue.async {
-                do {
-                    // Create file if it doesn't exist
-                    if !FileManager.default.fileExists(atPath: logFileURL.path) {
-                        try "".write(to: logFileURL, atomically: true, encoding: .utf8)
-                    }
-
-                    // Open file handle for writing
-                    self.fileHandle = try FileHandle(forWritingTo: logFileURL)
-                    self.fileHandle?.seekToEndOfFile()
-                } catch {
-                    print("Failed to initialize file handle: \(error)")
-                }
-            }
-        }
-
-        private func closeFileHandle() {
-            fileQueue.async {
-                do {
-                    try self.fileHandle?.close()
-                    self.fileHandle = nil
-                } catch {
-                    print("Failed to close file handle: \(error)")
-                }
-            }
-        }
-
-        private func checkAndTruncateFileIfNeeded() {
-            guard let logFileURL = logFileURL else { return }
-
-            let now = Date()
-            guard now.timeIntervalSince(lastFileSizeCheck) > fileSizeCheckInterval else { return }
-
-            lastFileSizeCheck = now
-
-            do {
-                let fileAttributes = try FileManager.default.attributesOfItem(atPath: logFileURL.path)
-                let fileSize = fileAttributes[.size] as? Int64 ?? 0
-
-                if fileSize > maxLogFileSize {
-                    // Close current handle
-                    try fileHandle?.close()
-                    fileHandle = nil
-
-                    // Truncate file
-                    try "".write(to: logFileURL, atomically: true, encoding: .utf8)
-
-                    // Reopen handle
-                    fileHandle = try FileHandle(forWritingTo: logFileURL)
-                    fileHandle?.seekToEndOfFile()
-
-                    // Clear buffer since file was truncated
-                    self.bufferQueue.async {
-                        self.logBuffer.removeAll()
-                    }
-                }
-            } catch {
-                print("Failed to check/truncate file: \(error)")
-            }
-        }
-
-        public func log(_ message: String,
-                        level: LogLevel = .info,
-                        file: String = #file,
-                        function: String = #function,
-                        line: Int = #line) {
-            guard level >= minimumLogLevel else { return }
-            if isProduction {
-                if message.contains("token") ||
-                   message.contains("certificate") ||
-                   message.contains("key") ||
-                   message.contains("password") {
-                    return
-                }
-            }
-            let fileName = (file as NSString).lastPathComponent
-            let timestamp = ISO8601DateFormatter().string(from: Date())
-            let logMessage = "\(level.emoji) [\(timestamp)] [\(level)] [\(fileName):\(line)] \(function): \(message)"
-
-            // Bridge to os.Logger for Console.app visibility (local/dev only)
-            if shouldUseSystemLogger {
-                let osMessage = "\(level.emoji) [\(fileName):\(line)] \(function): \(message)"
-                switch level {
-                case .debug:
-                    systemLogger.debug("\(osMessage, privacy: .public)")
-                case .info:
-                    systemLogger.info("\(osMessage, privacy: .public)")
-                case .warning:
-                    systemLogger.warning("\(osMessage, privacy: .public)")
-                case .error:
-                    systemLogger.error("\(osMessage, privacy: .public)")
-                }
-            }
-
-            // Use both compilation condition and runtime check for maximum compatibility
-            #if DEBUG
-            print(logMessage)
-            #else
-            // Runtime check for debug mode when compilation condition isn't available
-            if !isProduction {
-                print(logMessage)
-            }
-            #endif
-
-            // Add to buffer for quick access
-            bufferQueue.async {
-                self.logBuffer.append(logMessage)
-                if self.logBuffer.count > self.bufferMaxSize {
-                    self.logBuffer.removeFirst()
-                }
-            }
-
-            // Write to file if not in production
-            if !isProduction, let logFileURL = logFileURL {
-                fileQueue.async {
-                    self.writeToFile(logMessage, to: logFileURL)
-                }
-            }
-        }
-
-        private func writeToFile(_ message: String, to url: URL) {
-            let logEntry = message + "\n"
-
-            guard let data = logEntry.data(using: .utf8) else { return }
-
-            // Check file size periodically (not on every write)
-            checkAndTruncateFileIfNeeded()
-
-            // Add to pending writes
-            pendingWrites.append(data)
-
-            // Write immediately if we have a batch or if it's been a while
-            if pendingWrites.count >= writeBatchSize {
-                flushPendingWritesInternal()
-            }
-        }
-
-        private func flushPendingWritesInternal() {
-            guard !pendingWrites.isEmpty else { return }
-
-            do {
-                // Combine all pending writes into one operation
-                let combinedData = pendingWrites.reduce(Data(), +)
-                pendingWrites.removeAll()
-
-                if let fileHandle = fileHandle {
-                    fileHandle.write(combinedData)
-                } else {
-                    // Fallback: write directly to file
-                    if let logFileURL = logFileURL {
-                        if FileManager.default.fileExists(atPath: logFileURL.path) {
-                            let handle = try FileHandle(forWritingTo: logFileURL)
-                            handle.seekToEndOfFile()
-                            handle.write(combinedData)
-                            handle.closeFile()
-                        } else {
-                            try combinedData.write(to: logFileURL)
-                        }
-                    }
-                }
-            } catch {
-                print("Failed to write to log file: \(error)")
-                // Reset file handle on error
-                fileHandle = nil
-            }
-        }
-
-        public func getLogs() -> String {
-            // First try to return from buffer for immediate response
-            let bufferLogs = bufferQueue.sync {
-                logBuffer.joined(separator: "\n")
-            }
-
-            // If buffer has content, return it immediately
-            if !bufferLogs.isEmpty {
-                return bufferLogs
-            }
-
-            // Fallback to file reading (synchronous but should be rare)
-            guard let logFileURL = logFileURL else { return "No log file available" }
-
-            do {
-                let logContent = try String(contentsOf: logFileURL, encoding: .utf8)
-                return logContent.isEmpty ? "No logs available" : logContent
-            } catch {
-                return "Failed to read logs: \(error.localizedDescription)"
-            }
-        }
-
-        public func getLogsAsync(completion: @escaping (String) -> Void) {
-            readQueue.async {
-                // First try buffer for immediate response
-                let bufferLogs = self.bufferQueue.sync {
-                    self.logBuffer.joined(separator: "\n")
-                }
-
-                // If buffer has recent logs, return them immediately
-                if !bufferLogs.isEmpty {
-                    completion(bufferLogs)
-                    return
-                }
-
-                // Otherwise read from file
-                guard let logFileURL = self.logFileURL else {
-                    completion("No log file available")
-                    return
-                }
-
-                do {
-                    let logContent = try String(contentsOf: logFileURL, encoding: .utf8)
-                    let result = logContent.isEmpty ? "No logs available" : logContent
-                    completion(result)
-                } catch {
-                    completion("Failed to read logs: \(error.localizedDescription)")
-                }
-            }
-        }
-
-        public func clearLogs(completion: (() -> Void)? = nil) {
-            guard let logFileURL = logFileURL else { return }
-
-            // Clear buffer immediately
-            bufferQueue.async {
-                self.logBuffer.removeAll()
-            }
-
-            fileQueue.async {
-                // Flush any pending writes first
-                self.flushPendingWritesInternal()
-
-                // Close and reopen file handle
-                do {
-                    try self.fileHandle?.close()
-                    self.fileHandle = nil
-
-                    // Clear file
-                    try "".write(to: logFileURL, atomically: true, encoding: .utf8)
-
-                    // Reopen handle
-                    self.fileHandle = try FileHandle(forWritingTo: logFileURL)
-                    self.fileHandle?.seekToEndOfFile()
-                } catch {
-                    print("Failed to clear logs: \(error)")
-                }
-                completion?()
-            }
-        }
-
-        /// Flushes any pending writes to disk. Call this when app goes to background.
-        public func flushPendingWrites() {
-            fileQueue.async {
-                self.flushPendingWritesInternal()
-            }
-        }
-
-        /// Get logs from shared log file (contains both main app and NSE logs)
-        public func getAllLogs() async -> String {
-            let appGroupIdentifier = getAppGroupIdentifier()
-            guard let containerURL = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: appGroupIdentifier) else {
-                return "Failed to get shared container for app group: \(appGroupIdentifier)"
-            }
-
-            let logsDirectory = containerURL.appendingPathComponent("Logs")
-            let logURL = logsDirectory.appendingPathComponent("convos.log")
-
-            var header = "Debug Info:\n"
-            header += "App Group: \(appGroupIdentifier)\n"
-            header += "Container URL: \(containerURL.path)\n"
-            header += "Log Path: \(logURL.path)\n"
-            header += "Log Exists: \(FileManager.default.fileExists(atPath: logURL.path))\n\n"
-
-            guard FileManager.default.fileExists(atPath: logURL.path) else {
-                return header + "=== LOGS ===\nFile does not exist\n"
-            }
-
-            let maxLogLines = self.maxLogLines
-            // Read last maxLogLines lines by tailing from end asynchronously
-            let tailed: String = await withCheckedContinuation { continuation in
-                readQueue.async {
-                    do {
-                        let handle = try FileHandle(forReadingFrom: logURL)
-                        defer { try? handle.close() }
-
-                        let chunkSize = 64 * 1024
-                        var chunks: [Data] = []
-                        var newlineCount: Int = 0
-                        let endOffset = try handle.seekToEnd()
-                        var position = endOffset
-
-                        func countNewlines(_ data: Data) -> Int {
-                            var c = 0
-                            for b in data where b == 0x0A { c += 1 }
-                            return c
-                        }
-
-                        while position > 0 {
-                            let readSize = position >= UInt64(chunkSize) ? chunkSize : Int(position)
-                            let target = position - UInt64(readSize)
-                            try handle.seek(toOffset: target)
-                            position = target
-                            let chunk = try handle.read(upToCount: readSize) ?? Data()
-                            chunks.append(chunk)
-                            newlineCount += countNewlines(chunk)
-                            if newlineCount >= maxLogLines { break }
-                            if position == 0 { break }
-                        }
-
-                        // Concatenate once in forward order
-                        var combined = Data()
-                        for c in chunks.reversed() { combined.append(c) }
-
-                        // If we have more than needed, find start index of last maxLogLines
-                        if newlineCount > maxLogLines {
-                            var needed = maxLogLines
-                            var idx = combined.count - 1
-                            let bytes = [UInt8](combined)
-                            while idx >= 0 && needed > 0 {
-                                if bytes[idx] == 0x0A { needed -= 1 }
-                                idx -= 1
-                            }
-                            let start = max(idx + 2, 0) // move to byte after the found newline
-                            combined = combined.subdata(in: start..<combined.count)
-                        }
-
-                        let result = String(data: combined, encoding: .utf8) ?? ""
-                        continuation.resume(returning: result.isEmpty ? "(Empty file)" : result)
-                    } catch {
-                        continuation.resume(returning: "Failed to read: \(error.localizedDescription)")
-                    }
-                }
-            }
-
-            return header + "=== LOGS ===\n" + tailed + "\n"
-        }
-
-        // getAllLogsAsync removed; use async getAllLogs() instead
+    /// Clear all logs
+    public static func clearLogs(appGroupIdentifier: String = "group.org.convos.app") {
+        FileLogHandler.clearLogs(appGroupIdentifier: appGroupIdentifier)
     }
 }
 
-public extension Logger {
+// MARK: - ConvosCore convenience wrapper
+
+/// ConvosCore logging wrapper - uses "ConvosCore" namespace
+enum Log {
     static func debug(_ message: String, file: String = #file, function: String = #function, line: Int = #line) {
-        Self.Default.shared.log(message, level: .debug, file: file, function: function, line: line)
+        ConvosLog.debug(message, namespace: "ConvosCore", file: file, function: function, line: line)
     }
 
     static func info(_ message: String, file: String = #file, function: String = #function, line: Int = #line) {
-        Self.Default.shared.log(message, level: .info, file: file, function: function, line: line)
+        ConvosLog.info(message, namespace: "ConvosCore", file: file, function: function, line: line)
     }
 
     static func warning(_ message: String, file: String = #file, function: String = #function, line: Int = #line) {
-        Self.Default.shared.log(message, level: .warning, file: file, function: function, line: line)
+        ConvosLog.warning(message, namespace: "ConvosCore", file: file, function: function, line: line)
     }
 
     static func error(_ message: String, file: String = #file, function: String = #function, line: Int = #line) {
-        Self.Default.shared.log(message, level: .error, file: file, function: function, line: line)
+        ConvosLog.error(message, namespace: "ConvosCore", file: file, function: function, line: line)
     }
-
-    static func getLogs() -> String {
-        return Self.Default.shared.getLogs()
-    }
-
-    static func getLogsAsync(completion: @escaping (String) -> Void) {
-        Self.Default.shared.getLogsAsync(completion: completion)
-    }
-
-    static func clearLogs(completion: (() -> Void)? = nil) {
-        Self.Default.shared.clearLogs(completion: completion)
-    }
-
-    static func flushPendingWrites() {
-        Self.Default.shared.flushPendingWrites()
-    }
-
-    /// Configure the logger with environment (for proper app group access)
-    static func configure(environment: AppEnvironment) {
-        Self.Default.configure(environment: environment)
-    }
-
-    /// Configure both environment and production in a single prepare pass
-    static func configure(environment: AppEnvironment, isProduction: Bool) {
-        Self.Default.configure(environment: environment, isProduction: isProduction)
-    }
-
-    /// Get logs from both main app and NSE
-    static func getAllLogs() async -> String {
-        return await (Self.Default.shared as? Default)?.getAllLogs() ?? "No logger"
-    }
-
-    // Removed legacy callback API; use async getAllLogs() instead
 }

--- a/ConvosCore/Sources/ConvosCore/Notifications/NotificationExtensionEnvironment.swift
+++ b/ConvosCore/Sources/ConvosCore/Notifications/NotificationExtensionEnvironment.swift
@@ -20,14 +20,14 @@ public struct NotificationExtensionEnvironment {
 
         // Retrieve the configuration stored by the main app
         guard let storedEnvironment = AppEnvironment.retrieveSecureConfigurationForNotificationExtension() else {
-            Logger.warning("No stored environment configuration found - main app should store config before NSE runs")
+            Log.warning("No stored environment configuration found - main app should store config before NSE runs")
             throw NotificationExtensionEnvironmentError.failedRetrievingSecureConfiguration
         }
 
         // Cache for future use
         cachedEnvironment = storedEnvironment
 
-        Logger.info("Environment configuration loaded and cached: \(storedEnvironment.name)")
+        Log.info("Environment configuration loaded and cached: \(storedEnvironment.name)")
         return storedEnvironment
     }
 
@@ -38,7 +38,7 @@ public struct NotificationExtensionEnvironment {
         let databaseManager = DatabaseManager(environment: environment)
         let identityStore = KeychainIdentityStore(accessGroup: environment.keychainAccessGroup)
 
-        Logger.info("Creating CachedPushNotificationHandler with environment: \(environment.name)")
+        Log.info("Creating CachedPushNotificationHandler with environment: \(environment.name)")
 
         CachedPushNotificationHandler.initialize(
             databaseReader: databaseManager.dbReader,

--- a/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
@@ -72,7 +72,7 @@ public final class SessionManager: SessionManagerProtocol {
                 guard !Task.isCancelled else { return }
                 await self.startMessagingServices(for: identities)
             } catch {
-                Logger.error("Error starting messaging services: \(error.localizedDescription)")
+                Log.error("Error starting messaging services: \(error.localizedDescription)")
             }
             guard !Task.isCancelled else { return }
             self.unusedInboxPrepTask = Task(priority: .background) { [weak self] in
@@ -102,7 +102,7 @@ public final class SessionManager: SessionManagerProtocol {
 
     private func startMessagingServices(for identities: [KeychainIdentity]) async {
         let inboxIds = identities.map { $0.inboxId }
-        Logger.info("Starting messaging services for inboxes: \(inboxIds)")
+        Log.info("Starting messaging services for inboxes: \(inboxIds)")
 
         var servicesToCreate: [KeychainIdentity] = []
 
@@ -131,7 +131,10 @@ public final class SessionManager: SessionManagerProtocol {
     }
 
     private func startMessagingService(for inboxId: String, clientId: String) -> AnyMessagingService {
-        Logger.info("Starting messaging service for inboxId: \(inboxId) clientId: \(clientId)")
+        Log
+            .info(
+                "Starting messaging service for inboxId: \(inboxId) clientId: \(clientId)"
+            )
         return MessagingService.authorizedMessagingService(
             for: inboxId,
             clientId: clientId,
@@ -165,7 +168,7 @@ public final class SessionManager: SessionManagerProtocol {
                     do {
                         try await self.deleteInbox(clientId: clientId)
                     } catch {
-                        Logger.error("Error deleting inbox from left conversation notification: \(error.localizedDescription)")
+                        Log.error("Error deleting inbox from left conversation notification: \(error.localizedDescription)")
                     }
                 }
             }
@@ -175,7 +178,7 @@ public final class SessionManager: SessionManagerProtocol {
                 guard let self else { return }
                 let conversationId = notification.userInfo?["conversationId"] as? String
                 self.setActiveConversationId(conversationId)
-                Logger.info("Active conversation changed to: \(conversationId ?? "none")")
+                Log.info("Active conversation changed to: \(conversationId ?? "none")")
             }
     }
 
@@ -221,9 +224,9 @@ public final class SessionManager: SessionManagerProtocol {
                     )
                     content.attachments = [attachment]
 
-                    Logger.info("Successfully added conversation image to explosion notification")
+                    Log.info("Successfully added conversation image to explosion notification")
                 } catch {
-                    Logger.warning("Failed to download or create notification attachment: \(error)")
+                    Log.warning("Failed to download or create notification attachment: \(error)")
                 }
             }
 
@@ -233,9 +236,9 @@ public final class SessionManager: SessionManagerProtocol {
                 trigger: nil // Immediate trigger
             )
             try await UNUserNotificationCenter.current().add(request)
-            Logger.info("Scheduled explosion notification for conversation: \(conversationId)")
+            Log.info("Scheduled explosion notification for conversation: \(conversationId)")
         } catch {
-            Logger.error("Failed to schedule explosion notification: \(error)")
+            Log.error("Failed to schedule explosion notification: \(error)")
         }
     }
 
@@ -268,11 +271,11 @@ public final class SessionManager: SessionManagerProtocol {
         }
 
         guard let service = service else {
-            Logger.error("Messaging service not found for clientId \(clientId)")
+            Log.error("Messaging service not found for clientId \(clientId)")
             throw SessionManagerError.inboxNotFound
         }
 
-        Logger.info("Stopping messaging service for clientId: \(clientId)")
+        Log.info("Stopping messaging service for clientId: \(clientId)")
         await service.stopAndDelete()
 
         // Delete from database
@@ -300,7 +303,7 @@ public final class SessionManager: SessionManagerProtocol {
 
         // Delete all from database
         let inboxWriter = InboxWriter(dbWriter: databaseWriter)
-        Logger.info("Deleting all inboxes from database")
+        Log.info("Deleting all inboxes from database")
         try await inboxWriter.deleteAll()
     }
 
@@ -358,13 +361,13 @@ public final class SessionManager: SessionManagerProtocol {
 
         // Don't display notification if we're in the conversations list
         guard let currentActiveConversationId else {
-            Logger.info("Suppressing notification from conversations list: \(conversationId)")
+            Log.info("Suppressing notification from conversations list: \(conversationId)")
             return false
         }
 
         // Don't display notification if it's for the currently active conversation
         if currentActiveConversationId == conversationId {
-            Logger.info("Suppressing notification for active conversation: \(conversationId)")
+            Log.info("Suppressing notification for active conversation: \(conversationId)")
             return false
         }
         return true
@@ -379,7 +382,7 @@ public final class SessionManager: SessionManagerProtocol {
                     .inboxId
             }
         } catch {
-            Logger.error("Failed to look up inboxId for conversationId \(conversationId): \(error)")
+            Log.error("Failed to look up inboxId for conversationId \(conversationId): \(error)")
             return nil
         }
     }

--- a/ConvosCore/Sources/ConvosCore/Storage/DatabaseManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/DatabaseManager.swift
@@ -72,7 +72,7 @@ public final class DatabaseManager: DatabaseManagerProtocol {
                 }
             }
 #if DEBUG
-            db.trace { Logger.info("\($0)") }
+            db.trace { Log.info("\($0)") }
 #endif
         }
 

--- a/ConvosCore/Sources/ConvosCore/Storage/Repositories/ConversationsRepository.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Repositories/ConversationsRepository.swift
@@ -21,7 +21,7 @@ final class ConversationsRepository: ConversationsRepositoryProtocol {
                 do {
                     return try db.composeAllConversations(consent: consent)
                 } catch {
-                    Logger.error("Error composing all conversations: \(error)")
+                    Log.error("Error composing all conversations: \(error)")
                     throw error
                 }
             }

--- a/ConvosCore/Sources/ConvosCore/Storage/Repositories/MessagesRepository.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Repositories/MessagesRepository.swift
@@ -40,7 +40,7 @@ class MessagesRepository: MessagesRepositoryProtocol {
         self.conversationIdSubject = .init(conversationId)
         conversationIdCancellable = conversationIdPublisher.sink { [weak self] conversationId in
             guard let self else { return }
-            Logger.info("Sending updated conversation id: \(conversationId)")
+            Log.info("Sending updated conversation id: \(conversationId)")
             conversationIdSubject.send(conversationId)
         }
     }
@@ -71,7 +71,7 @@ class MessagesRepository: MessagesRepositoryProtocol {
                             let messages = try db.composeMessages(for: conversationId)
                             return messages
                         } catch {
-                            Logger.error("Error in messages publisher: \(error)")
+                            Log.error("Error in messages publisher: \(error)")
                         }
                         return []
                     }
@@ -128,7 +128,7 @@ extension Array where Element == MessageWithDetails {
                             conversationId: conversation.id,
                             inboxId: update.initiatedByInboxId
                           ) else {
-                        Logger.error("Update message type is missing update object")
+                        Log.error("Update message type is missing update object")
                         return nil
                     }
                     let addedMembers = try ConversationMemberProfileWithRole.fetchAll(

--- a/ConvosCore/Sources/ConvosCore/Storage/Repositories/MyProfileRepository.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Repositories/MyProfileRepository.swift
@@ -61,7 +61,7 @@ class MyProfileRepository: MyProfileRepositoryProtocol {
 
         conversationIdCancellable = conversationIdPublisher.sink { [weak self] conversationId in
             guard let self else { return }
-            Logger.info("Updating conversation id to \(conversationId)")
+            Log.info("Updating conversation id to \(conversationId)")
             self.conversationIdSubject.send(conversationId)
             // Re-observe profile for the new conversation
             if case .ready(_, let result) = self.inboxStateManager.currentState {

--- a/ConvosCore/Sources/ConvosCore/Storage/States/ConversationsCountState.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/States/ConversationsCountState.swift
@@ -20,7 +20,7 @@ final class ConversationsCountState {
         do {
             self.count = try conversationsCountRepository.fetchCount()
         } catch {
-            Logger.error("Error fetching conversations count: \(error)")
+            Log.error("Error fetching conversations count: \(error)")
             self.count = 0
         }
         observe()

--- a/ConvosCore/Sources/ConvosCore/Storage/States/ConversationsState.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/States/ConversationsState.swift
@@ -14,7 +14,7 @@ final class ConversationsState {
         do {
             self.conversations = try conversationsRepository.fetchAll()
         } catch {
-            Logger.error("Error fetching conversations: \(error)")
+            Log.error("Error fetching conversations: \(error)")
             self.conversations = []
         }
         observe()

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationConsentWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationConsentWriter.swift
@@ -39,7 +39,7 @@ class ConversationConsentWriter: ConversationConsentWriterProtocol {
                     consent: .allowed
                 )
                 try updatedConversation.save(db)
-                Logger.info("Updated conversation consent state to allowed")
+                Log.info("Updated conversation consent state to allowed")
             }
         }
     }
@@ -55,7 +55,7 @@ class ConversationConsentWriter: ConversationConsentWriterProtocol {
                     consent: .denied
                 )
                 try updatedConversation.save(db)
-                Logger.info("Updated conversation consent state to denied")
+                Log.info("Updated conversation consent state to denied")
             }
         }
     }
@@ -79,7 +79,7 @@ class ConversationConsentWriter: ConversationConsentWriterProtocol {
                         try await self.databaseWriter.write { db in
                             let updatedConversation = dbConversation.with(consent: .denied)
                             try updatedConversation.save(db)
-                            Logger.info("Updated conversation \(dbConversation.id) consent state to denied")
+                            Log.info("Updated conversation \(dbConversation.id) consent state to denied")
                         }
                     } catch {
                         await errorCollector.append(error)

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationMetadataWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationMetadataWriter.swift
@@ -60,7 +60,7 @@ final class ConversationMetadataWriter: ConversationMetadataWriterProtocol {
             }
             let updatedConversation = localConversation.with(name: truncatedName)
             try updatedConversation.save(db)
-            Logger.info("Updated local conversation name for \(conversationId): \(truncatedName)")
+            Log.info("Updated local conversation name for \(conversationId): \(truncatedName)")
             return updatedConversation
         }
 
@@ -71,7 +71,7 @@ final class ConversationMetadataWriter: ConversationMetadataWriterProtocol {
             imageURL: updatedConversation.imageURLString
         )
 
-        Logger.info("Updated conversation name for \(conversationId): \(truncatedName)")
+        Log.info("Updated conversation name for \(conversationId): \(truncatedName)")
     }
 
     func updateExpiresAt(_ expiresAt: Date, for conversationId: String) async throws {
@@ -96,7 +96,7 @@ final class ConversationMetadataWriter: ConversationMetadataWriterProtocol {
             // We continue anyway since not sending explode as a custom content type just means
             // the push notification will fail to display. The next time the app is active
             // expiresAt for the conversation will be updated.
-            Logger.error("Failed sending explode as custom content type: \(error.localizedDescription)")
+            Log.error("Failed sending explode as custom content type: \(error.localizedDescription)")
         }
 
         let updatedConversation = try await databaseWriter.write { db in
@@ -106,7 +106,7 @@ final class ConversationMetadataWriter: ConversationMetadataWriterProtocol {
             }
             let updatedConversation = localConversation.with(expiresAt: expiresAt)
             try updatedConversation.save(db)
-            Logger.info("Updated local conversation expiresAt for \(conversationId): \(expiresAt)")
+            Log.info("Updated local conversation expiresAt for \(conversationId): \(expiresAt)")
             return updatedConversation
         }
 
@@ -117,7 +117,7 @@ final class ConversationMetadataWriter: ConversationMetadataWriterProtocol {
             imageURL: updatedConversation.imageURLString
         )
 
-        Logger.info("Updated conversation expiresAt for \(conversationId): \(expiresAt)")
+        Log.info("Updated conversation expiresAt for \(conversationId): \(expiresAt)")
     }
 
     func updateDescription(_ description: String, for conversationId: String) async throws {
@@ -137,7 +137,7 @@ final class ConversationMetadataWriter: ConversationMetadataWriterProtocol {
             }
             let updatedConversation = localConversation.with(description: description)
             try updatedConversation.save(db)
-            Logger.info("Updated local conversation description for \(conversationId): \(description)")
+            Log.info("Updated local conversation description for \(conversationId): \(description)")
             return updatedConversation
         }
 
@@ -148,7 +148,7 @@ final class ConversationMetadataWriter: ConversationMetadataWriterProtocol {
             imageURL: updatedConversation.imageURLString
         )
 
-        Logger.info("Updated conversation description for \(conversationId): \(description)")
+        Log.info("Updated conversation description for \(conversationId): \(description)")
     }
 
     func updateImage(_ image: UIImage, for conversation: Conversation) async throws {
@@ -170,7 +170,7 @@ final class ConversationMetadataWriter: ConversationMetadataWriterProtocol {
                 try await self.updateImageUrl(uploadedURL, for: conversation.id)
                 ImageCache.shared.setImage(resizedImage, for: conversation)
             } catch {
-                Logger.error("Failed updating conversation image URL: \(error.localizedDescription)")
+                Log.error("Failed updating conversation image URL: \(error.localizedDescription)")
             }
         }
     }
@@ -192,7 +192,7 @@ final class ConversationMetadataWriter: ConversationMetadataWriterProtocol {
             }
             let updatedConversation = localConversation.with(imageURLString: imageURL)
             try updatedConversation.save(db)
-            Logger.info("Updated local conversation image for \(conversationId): \(imageURL)")
+            Log.info("Updated local conversation image for \(conversationId): \(imageURL)")
             return updatedConversation
         }
 
@@ -203,7 +203,7 @@ final class ConversationMetadataWriter: ConversationMetadataWriterProtocol {
             imageURL: updatedConversation.imageURLString
         )
 
-        Logger.info("Updated conversation image for \(conversationId): \(imageURL)")
+        Log.info("Updated conversation image for \(conversationId): \(imageURL)")
     }
 
     // MARK: - Member Management
@@ -228,11 +228,11 @@ final class ConversationMetadataWriter: ConversationMetadataWriterProtocol {
                     createdAt: Date()
                 )
                 try conversationMember.save(db)
-                Logger.info("Added local conversation member \(memberInboxId) to \(conversationId)")
+                Log.info("Added local conversation member \(memberInboxId) to \(conversationId)")
             }
         }
 
-        Logger.info("Added members to conversation \(conversationId): \(memberInboxIds)")
+        Log.info("Added members to conversation \(conversationId): \(memberInboxIds)")
     }
 
     func removeMembers(_ memberInboxIds: [String], from conversationId: String) async throws {
@@ -251,11 +251,11 @@ final class ConversationMetadataWriter: ConversationMetadataWriterProtocol {
                     .filter(DBConversationMember.Columns.conversationId == conversationId)
                     .filter(DBConversationMember.Columns.inboxId == memberInboxId)
                     .deleteAll(db)
-                Logger.info("Removed local conversation member \(memberInboxId) from \(conversationId)")
+                Log.info("Removed local conversation member \(memberInboxId) from \(conversationId)")
             }
         }
 
-        Logger.info("Removed members from conversation \(conversationId): \(memberInboxIds)")
+        Log.info("Removed members from conversation \(conversationId): \(memberInboxIds)")
     }
 
     // MARK: - Admin Management
@@ -277,11 +277,11 @@ final class ConversationMetadataWriter: ConversationMetadataWriterProtocol {
                 .fetchOne(db) {
                 let updatedMember = member.with(role: .admin)
                 try updatedMember.save(db)
-                Logger.info("Updated local member \(memberInboxId) role to admin in \(conversationId)")
+                Log.info("Updated local member \(memberInboxId) role to admin in \(conversationId)")
             }
         }
 
-        Logger.info("Promoted \(memberInboxId) to admin in conversation \(conversationId)")
+        Log.info("Promoted \(memberInboxId) to admin in conversation \(conversationId)")
     }
 
     func demoteFromAdmin(_ memberInboxId: String, in conversationId: String) async throws {
@@ -300,11 +300,11 @@ final class ConversationMetadataWriter: ConversationMetadataWriterProtocol {
                 .fetchOne(db) {
                 let updatedMember = member.with(role: .member)
                 try updatedMember.save(db)
-                Logger.info("Updated local member \(memberInboxId) role to member in \(conversationId)")
+                Log.info("Updated local member \(memberInboxId) role to member in \(conversationId)")
             }
         }
 
-        Logger.info("Demoted \(memberInboxId) from admin in conversation \(conversationId)")
+        Log.info("Demoted \(memberInboxId) from admin in conversation \(conversationId)")
     }
 
     func promoteToSuperAdmin(_ memberInboxId: String, in conversationId: String) async throws {
@@ -323,11 +323,11 @@ final class ConversationMetadataWriter: ConversationMetadataWriterProtocol {
                 .fetchOne(db) {
                 let updatedMember = member.with(role: .superAdmin)
                 try updatedMember.save(db)
-                Logger.info("Updated local member \(memberInboxId) role to superAdmin in \(conversationId)")
+                Log.info("Updated local member \(memberInboxId) role to superAdmin in \(conversationId)")
             }
         }
 
-        Logger.info("Promoted \(memberInboxId) to super admin in conversation \(conversationId)")
+        Log.info("Promoted \(memberInboxId) to super admin in conversation \(conversationId)")
     }
 
     func demoteFromSuperAdmin(_ memberInboxId: String, in conversationId: String) async throws {
@@ -346,11 +346,11 @@ final class ConversationMetadataWriter: ConversationMetadataWriterProtocol {
                 .fetchOne(db) {
                 let updatedMember = member.with(role: .admin)
                 try updatedMember.save(db)
-                Logger.info("Updated local member \(memberInboxId) role to admin in \(conversationId)")
+                Log.info("Updated local member \(memberInboxId) role to admin in \(conversationId)")
             }
         }
 
-        Logger.info("Demoted \(memberInboxId) from super admin in conversation \(conversationId)")
+        Log.info("Demoted \(memberInboxId) from super admin in conversation \(conversationId)")
     }
 }
 

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/InboxWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/InboxWriter.swift
@@ -36,7 +36,7 @@ struct InboxWriter {
                 // INVARIANT: For a given inboxId, the clientId must never change
                 // If they don't match, this is a data corruption bug that must be caught
                 if existingInbox.clientId != clientId {
-                    Logger.error("""
+                    Log.error("""
                         ClientId mismatch detected!
                         InboxId: \(inboxId)
                         Existing clientId: \(existingInbox.clientId)

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/IncomingMessageWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/IncomingMessageWriter.swift
@@ -38,27 +38,27 @@ class IncomingMessageWriter: IncomingMessageWriterProtocol {
             // @jarodl temporary, this should happen somewhere else more explicitly
             let wasRemovedFromConversation = message.update?.removedInboxIds.contains(conversation.inboxId) ?? false
 
-            Logger.info("Storing incoming message \(message.id) localId \(message.clientMessageId)")
+            Log.info("Storing incoming message \(message.id) localId \(message.clientMessageId)")
             // see if this message has a local version
             if let localMessage = try DBMessage
                 .filter(DBMessage.Columns.id == message.id)
                 .filter(DBMessage.Columns.clientMessageId != message.id)
                 .fetchOne(db) {
                 // keep using the same local id
-                Logger.info("Found local message \(localMessage.clientMessageId) for incoming message \(message.id)")
+                Log.info("Found local message \(localMessage.clientMessageId) for incoming message \(message.id)")
                 let updatedMessage = message.with(
                     clientMessageId: localMessage.clientMessageId
                 )
                 try updatedMessage.save(db)
-                Logger.info(
+                Log.info(
                     "Updated incoming message with local message \(localMessage.clientMessageId)"
                 )
             } else {
                 do {
                     try message.save(db)
-                    Logger.info("Saved incoming message: \(message.id)")
+                    Log.info("Saved incoming message: \(message.id)")
                 } catch {
-                    Logger.error("Failed saving incoming message \(message.id): \(error)")
+                    Log.error("Failed saving incoming message \(message.id): \(error)")
                     throw error
                 }
             }

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/InviteWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/InviteWriter.swift
@@ -33,7 +33,7 @@ class InviteWriter: InviteWriterProtocol {
                 .fetchOne(db)
         }
         if let existingInvite {
-            Logger.info("Existing invite found for conversation: \(conversation.id), \(existingInvite)")
+            Log.info("Existing invite found for conversation: \(conversation.id), \(existingInvite)")
             return existingInvite.hydrateInvite()
         }
 
@@ -45,7 +45,7 @@ class InviteWriter: InviteWriterProtocol {
             expiresAfterUse: expiresAfterUse,
             privateKey: privateKey
         )
-        Logger.info("Generated URL slug: \(urlSlug)")
+        Log.info("Generated URL slug: \(urlSlug)")
 
         let dbInvite = DBInvite(
             creatorInboxId: conversation.inboxId,

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/MyProfileWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/MyProfileWriter.swift
@@ -65,7 +65,7 @@ class MyProfileWriter: MyProfileWriterProtocol {
             let member = Member(inboxId: inboxId)
             try member.save(db)
             if let foundProfile = try MemberProfile.fetchOne(db, conversationId: conversationId, inboxId: inboxId) {
-                Logger.info("Found profile: \(foundProfile)")
+                Log.info("Found profile: \(foundProfile)")
                 return foundProfile
             } else {
                 let profile = MemberProfile(
@@ -107,7 +107,7 @@ class MyProfileWriter: MyProfileWriterProtocol {
         ImageCache.shared.setImage(resizedImage, for: uploadedURL)
 
         try await databaseWriter.write { db in
-            Logger.info("Updated avatar for profile: \(updatedProfile)")
+            Log.info("Updated avatar for profile: \(updatedProfile)")
             try updatedProfile.save(db)
         }
     }

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/OutgoingMessageWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/OutgoingMessageWriter.swift
@@ -71,27 +71,27 @@ class OutgoingMessageWriter: OutgoingMessageWriterProtocol {
             )
 
             try localMessage.save(db)
-            Logger.info("Saved local message with local id: \(localMessage.clientMessageId)")
+            Log.info("Saved local message with local id: \(localMessage.clientMessageId)")
         }
 
         do {
-            Logger.info("Sending local message with local id: \(clientMessageId)")
+            Log.info("Sending local message with local id: \(clientMessageId)")
             try await sender.publish()
             sentMessageSubject.send(text)
-            Logger.info("Sent local message with local id: \(clientMessageId)")
+            Log.info("Sent local message with local id: \(clientMessageId)")
         } catch {
-            Logger.error("Failed sending message")
+            Log.error("Failed sending message")
             do {
                 try await databaseWriter.write { db in
                     guard let localMessage = try DBMessage.fetchOne(db, key: clientMessageId) else {
-                        Logger.warning("Local message not found after failing to send")
+                        Log.warning("Local message not found after failing to send")
                         return
                     }
 
                     try localMessage.with(status: .failed).save(db)
                 }
             } catch {
-                Logger.error("Failed updating failed message status: \(error.localizedDescription)")
+                Log.error("Failed updating failed message status: \(error.localizedDescription)")
             }
 
             throw error

--- a/ConvosCore/Sources/ConvosCore/Storage/XMTP DB Representations/DecodedMessage+DBRepresentation.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/XMTP DB Representations/DecodedMessage+DBRepresentation.swift
@@ -109,7 +109,7 @@ extension XMTPiOS.DecodedMessage {
                 update: nil
             )
         default:
-            Logger.error("Unhandled contentType \(contentReply.contentType)")
+            Log.error("Unhandled contentType \(contentReply.contentType)")
             return DBMessageComponents(
                 messageType: .reply,
                 contentType: .text,
@@ -183,7 +183,7 @@ extension XMTPiOS.DecodedMessage {
                         do {
                             oldCustomValue = try ConversationCustomMetadata.fromCompactString($0.oldValue)
                         } catch {
-                            Logger.error("Failed to decode old custom metadata: \(error)")
+                            Log.error("Failed to decode old custom metadata: \(error)")
                             oldCustomValue = nil
                         }
                     } else {
@@ -195,7 +195,7 @@ extension XMTPiOS.DecodedMessage {
                         do {
                             newCustomValue = try ConversationCustomMetadata.fromCompactString($0.newValue)
                         } catch {
-                            Logger.error("Failed to decode new custom metadata: \(error)")
+                            Log.error("Failed to decode new custom metadata: \(error)")
                             newCustomValue = nil
                         }
                     } else {
@@ -277,7 +277,7 @@ extension XMTPiOS.DecodedMessage {
             throw DecodedMessageDBRepresentationError.mismatchedContentType
         }
 
-        Logger.info("Received explode settings: \(explodeSettings)")
+        Log.info("Received explode settings: \(explodeSettings)")
         let update = DBMessage.Update(
             initiatedByInboxId: senderInboxId,
             addedInboxIds: [],

--- a/ConvosCore/Sources/ConvosCore/Syncing/StreamProcessor.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/StreamProcessor.swift
@@ -81,7 +81,7 @@ actor StreamProcessor: StreamProcessorProtocol {
         apiClient: any ConvosAPIClientProtocol
     ) async throws {
         guard let group = conversation as? XMTPiOS.Group else {
-            Logger.warning("Passed type other than Group")
+            Log.warning("Passed type other than Group")
             return
         }
         try await processConversation(group, client: client, apiClient: apiClient)
@@ -105,7 +105,7 @@ actor StreamProcessor: StreamProcessorProtocol {
             }
         }
 
-        Logger.info("Syncing conversation: \(conversation.id)")
+        Log.info("Syncing conversation: \(conversation.id)")
         try await conversationWriter.storeWithLatestMessages(
             conversation: conversation,
             inboxId: client.inboxId
@@ -130,7 +130,7 @@ actor StreamProcessor: StreamProcessorProtocol {
             guard let conversation = try await client.conversationsProvider.findConversation(
                 conversationId: message.conversationId
             ) else {
-                Logger.error("Conversation not found for message")
+                Log.error("Conversation not found for message")
                 return
             }
 
@@ -141,14 +141,14 @@ actor StreamProcessor: StreamProcessorProtocol {
                         message: message,
                         client: client
                     )
-                    Logger.info("Processed potential join request: \(message.id)")
+                    Log.info("Processed potential join request: \(message.id)")
                 } catch {
-                    Logger.error("Failed processing join request: \(error)")
+                    Log.error("Failed processing join request: \(error)")
                 }
             case .group(let conversation):
                 do {
                     guard try await shouldProcessConversation(conversation, client: client) else {
-                        Logger.warning("Received invalid group message, skipping...")
+                        Log.warning("Received invalid group message, skipping...")
                         return
                     }
 
@@ -166,13 +166,13 @@ actor StreamProcessor: StreamProcessorProtocol {
                         try await localStateWriter.setUnread(true, for: conversation.id)
                     }
 
-                    Logger.info("Processed message: \(message.id)")
+                    Log.info("Processed message: \(message.id)")
                 } catch {
-                    Logger.error("Failed processing group message: \(error.localizedDescription)")
+                    Log.error("Failed processing group message: \(error.localizedDescription)")
                 }
             }
         } catch {
-            Logger.warning("Stopped processing message from error: \(error.localizedDescription)")
+            Log.warning("Stopped processing message from error: \(error.localizedDescription)")
         }
     }
 
@@ -224,7 +224,7 @@ actor StreamProcessor: StreamProcessorProtocol {
         // This is a defensive check - the device should already be registered on app launch,
         // but we want to ensure it's registered before we attempt topic subscription
         guard let deviceManager = deviceRegistrationManager else {
-            Logger.warning("DeviceRegistrationManager not available, skipping topic subscription")
+            Log.warning("DeviceRegistrationManager not available, skipping topic subscription")
             return
         }
 
@@ -232,7 +232,7 @@ actor StreamProcessor: StreamProcessorProtocol {
         let welcomeTopic = client.installationId.xmtpWelcomeTopicFormat
 
         guard let identity = try? await identityStore.identity(for: client.inboxId) else {
-            Logger.warning("Identity not found, skipping push notification subscription")
+            Log.warning("Identity not found, skipping push notification subscription")
             return
         }
 
@@ -245,9 +245,9 @@ actor StreamProcessor: StreamProcessorProtocol {
                 clientId: identity.clientId,
                 topics: [conversationTopic, welcomeTopic]
             )
-            Logger.info("Subscribed to push topics \(context): \(conversationTopic), \(welcomeTopic)")
+            Log.info("Subscribed to push topics \(context): \(conversationTopic), \(welcomeTopic)")
         } catch {
-            Logger.warning("Failed subscribing to topics \(context): \(error)")
+            Log.warning("Failed subscribing to topics \(context): \(error)")
         }
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Syncing/SyncingManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/SyncingManager.swift
@@ -84,7 +84,7 @@ actor SyncingManager: SyncingManagerProtocol {
         }
 
         guard syncTask == nil else {
-            Logger.info("Sync already in progress, ignoring redundant start() call")
+            Log.info("Sync already in progress, ignoring redundant start() call")
             return
         }
 
@@ -110,15 +110,15 @@ actor SyncingManager: SyncingManagerProtocol {
             // Get the last sync time for logging and join requests
             let lastSyncedAt = await self.getLastSyncedAt(for: client.inboxId)
             if let lastSyncedAt {
-                Logger.info("Starting, last synced \(lastSyncedAt.relativeShort()) ago...")
+                Log.info("Starting, last synced \(lastSyncedAt.relativeShort()) ago...")
             } else {
-                Logger.info("Syncing for the first time...")
+                Log.info("Syncing for the first time...")
             }
 
             // Perform the initial sync
             do {
                 let count = try await client.conversationsProvider.syncAllConversations(consentStates: consentStates)
-                Logger.info("syncAllConversations returned count: \(count)")
+                Log.info("syncAllConversations returned count: \(count)")
 
                 // we need to list all the conversations that have been updated since `lastSyncedAt` and then list
                 // messages since `lastSyncedAt`, then process the conversation + messages
@@ -134,7 +134,7 @@ actor SyncingManager: SyncingManagerProtocol {
                             consentStates: consentStates,
                             orderBy: .lastActivity
                         )
-                    Logger.info("Found \(updatedConversations.count) conversations since last sync, processing...")
+                    Log.info("Found \(updatedConversations.count) conversations since last sync, processing...")
                     try await withThrowingTaskGroup { [weak self] group in
                         for conversation in updatedConversations {
                             group.addTask {
@@ -151,7 +151,7 @@ actor SyncingManager: SyncingManagerProtocol {
                         }
                     }
                 } catch {
-                    Logger.error("Error catching up on missed conversation updates: \(error.localizedDescription)")
+                    Log.error("Error catching up on missed conversation updates: \(error.localizedDescription)")
                     throw error
                 }
 
@@ -162,7 +162,7 @@ actor SyncingManager: SyncingManagerProtocol {
                 // Only update timestamp after successful sync
                 await self.setLastSyncedAt(syncStartTime, for: client.inboxId)
             } catch {
-                Logger.error("Error syncing all conversations: \(error.localizedDescription)")
+                Log.error("Error syncing all conversations: \(error.localizedDescription)")
                 // attempt to process join requests anyway
                 _ = await joinRequestsManager.processJoinRequests(since: lastSyncedAt, client: client)
                 // Don't update timestamp on failure - keep the old one
@@ -174,7 +174,7 @@ actor SyncingManager: SyncingManagerProtocol {
     }
 
     func stop() async {
-        Logger.info("Stopping...")
+        Log.info("Stopping...")
 
         // Cancel and wait for sync tasks to complete
         // This ensures no database operations are in-flight before cleanup
@@ -218,7 +218,7 @@ actor SyncingManager: SyncingManagerProtocol {
                     try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
                 }
 
-                Logger.info("Starting message stream (attempt \(retryCount + 1))")
+                Log.info("Starting message stream (attempt \(retryCount + 1))")
 
                 // Stream messages - the loop will exit when onClose is called and continuation.finish() happens
                 var isFirstMessage = true
@@ -226,7 +226,7 @@ actor SyncingManager: SyncingManagerProtocol {
                     type: .all,
                     consentStates: consentStates,
                     onClose: {
-                        Logger.info("Message stream closed via onClose callback")
+                        Log.info("Message stream closed via onClose callback")
                     }
                 ) {
                     // Check cancellation
@@ -249,13 +249,13 @@ actor SyncingManager: SyncingManagerProtocol {
 
                 // Stream ended (onClose was called and continuation finished)
                 retryCount += 1
-                Logger.info("Message stream ended...")
+                Log.info("Message stream ended...")
             } catch is CancellationError {
-                Logger.info("Message stream cancelled")
+                Log.info("Message stream cancelled")
                 break
             } catch {
                 retryCount += 1
-                Logger.error("Message stream error: \(error)")
+                Log.error("Message stream error: \(error)")
             }
         }
     }
@@ -270,14 +270,14 @@ actor SyncingManager: SyncingManagerProtocol {
                     try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
                 }
 
-                Logger.info("Starting conversation stream (attempt \(retryCount + 1))")
+                Log.info("Starting conversation stream (attempt \(retryCount + 1))")
 
                 // Stream conversations - the loop will exit when onClose is called
                 var isFirstConversation = true
                 for try await conversation in client.conversationsProvider.stream(
                     type: .groups,
                     onClose: {
-                        Logger.info("Conversation stream closed via onClose callback")
+                        Log.info("Conversation stream closed via onClose callback")
                     }
                 ) {
                     guard case .group(let conversation) = conversation else {
@@ -303,13 +303,13 @@ actor SyncingManager: SyncingManagerProtocol {
 
                 // Stream ended (onClose was called and continuation finished)
                 retryCount += 1
-                Logger.info("Conversation stream ended, will retry...")
+                Log.info("Conversation stream ended, will retry...")
             } catch is CancellationError {
-                Logger.info("Conversation stream cancelled")
+                Log.info("Conversation stream cancelled")
                 break
             } catch {
                 retryCount += 1
-                Logger.error("Conversation stream error: \(error)")
+                Log.error("Conversation stream error: \(error)")
             }
         }
     }

--- a/ConvosCore/Tests/ConvosCoreTests/ConversationStateMachineTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ConversationStateMachineTests.swift
@@ -638,7 +638,7 @@ struct ConversationStateMachineTests {
             return
         }
 
-        Logger.info("Fetched invite URL: \(invite.urlSlug)")
+        Log.info("Fetched invite URL: \(invite.urlSlug)")
 
         // Setup joiner messaging service and state machine
         let joinerMessagingService = await unusedInboxCache.consumeOrCreateMessagingService(
@@ -755,11 +755,11 @@ struct ConversationStateMachineTests {
 
         inviterInboxId = inboxId
 
-        Logger.info("Fetched invite URL: \(invite.urlSlug)")
+        Log.info("Fetched invite URL: \(invite.urlSlug)")
 
         // Stop inviter's messaging service (simulating offline)
         inviterMessagingService.stop()
-        Logger.info("Inviter went offline")
+        Log.info("Inviter went offline")
 
         // Setup joiner messaging service and state machine
         let joinerMessagingService = await unusedInboxCache.consumeOrCreateMessagingService(
@@ -801,7 +801,7 @@ struct ConversationStateMachineTests {
             startsStreamingServices: true
         )
 
-        Logger.info("Inviter came back online")
+        Log.info("Inviter came back online")
 
         // Wait for joiner to reach ready state (join should be processed automatically)
         var joinerConversationId: String?

--- a/ConvosLogging/Package.resolved
+++ b/ConvosLogging/Package.resolved
@@ -1,0 +1,14 @@
+{
+  "pins" : [
+    {
+      "identity" : "swift-log",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-log",
+      "state" : {
+        "revision" : "ce592ae52f982c847a4efc0dd881cc9eb32d29f2",
+        "version" : "1.6.4"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/ConvosLogging/Package.swift
+++ b/ConvosLogging/Package.swift
@@ -1,0 +1,27 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "ConvosLogging",
+    platforms: [
+        .iOS(.v16),
+        .macOS(.v13)
+    ],
+    products: [
+        .library(
+            name: "ConvosLogging",
+            targets: ["ConvosLogging"]
+        )
+    ],
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-log", from: "1.6.0")
+    ],
+    targets: [
+        .target(
+            name: "ConvosLogging",
+            dependencies: [
+                .product(name: "Logging", package: "swift-log")
+            ]
+        )
+    ]
+)

--- a/ConvosLogging/Sources/ConvosLogging/FileLogHandler.swift
+++ b/ConvosLogging/Sources/ConvosLogging/FileLogHandler.swift
@@ -1,0 +1,334 @@
+import Foundation
+import Logging
+
+/// Simple file-based log handler that writes to a shared app group container
+///
+/// Features:
+/// - Writes to shared app group for access from main app and extensions
+/// - Automatic log rotation at 50MB (increased from 10MB for better debugging)
+/// - Thread-safe file operations
+/// - Cross-process safe using NSFileCoordinator (prevents corruption between main app and extensions)
+/// - No duplicate console logging (relies on swift-log's built-in console output)
+public struct FileLogHandler: LogHandler {
+    // thread-safe state storage
+    private final class State {
+        private let lock: NSLock = NSLock()
+        private var _logLevel: Logging.Logger.Level = .info
+        private var _metadata: Logging.Logger.Metadata = [:]
+
+        var logLevel: Logging.Logger.Level {
+            get { lock.withLock { _logLevel } }
+            set { lock.withLock { _logLevel = newValue } }
+        }
+
+        var metadata: Logging.Logger.Metadata {
+            get { lock.withLock { _metadata } }
+            set { lock.withLock { _metadata = newValue } }
+        }
+
+        subscript(metadataKey key: String) -> Logging.Logger.Metadata.Value? {
+            get { lock.withLock { _metadata[key] } }
+            set { lock.withLock { _metadata[key] = newValue } }
+        }
+    }
+
+    private let state: State = State()
+
+    public var logLevel: Logging.Logger.Level {
+        get { state.logLevel }
+        set { state.logLevel = newValue }
+    }
+
+    public var metadata: Logging.Logger.Metadata {
+        get { state.metadata }
+        set { state.metadata = newValue }
+    }
+
+    private let label: String
+    private let fileURL: URL?
+    private static let queue: DispatchQueue = DispatchQueue(label: "com.convos.logging.file", qos: .utility)
+    private static let maxFileSize: Int64 = 50 * 1024 * 1024 // 50MB
+
+    public init(label: String, appGroupIdentifier: String) {
+        self.label = label
+
+        // get shared container
+        guard let containerURL = FileManager.default.containerURL(
+            forSecurityApplicationGroupIdentifier: appGroupIdentifier
+        ) else {
+            print("❌ FileLogHandler: Failed to access app group container: \(appGroupIdentifier)")
+            self.fileURL = nil
+            return
+        }
+
+        let logsDirectory = containerURL.appendingPathComponent("Logs")
+
+        // create logs directory
+        do {
+            try FileManager.default.createDirectory(
+                at: logsDirectory,
+                withIntermediateDirectories: true
+            )
+        } catch {
+            print("❌ FileLogHandler: Failed to create logs directory: \(error)")
+        }
+
+        self.fileURL = logsDirectory.appendingPathComponent("convos.log")
+        print("✅ FileLogHandler initialized for label '\(label)' at: \(self.fileURL?.path ?? "nil")")
+    }
+
+    public subscript(metadataKey key: String) -> Logging.Logger.Metadata.Value? {
+        get { state[metadataKey: key] }
+        set { state[metadataKey: key] = newValue }
+    }
+
+    // swiftlint:disable:next function_parameter_count
+    public func log(
+        level: Logging.Logger.Level,
+        message: Logging.Logger.Message,
+        metadata: Logging.Logger.Metadata?,
+        source: String,
+        file: String,
+        function: String,
+        line: UInt
+    ) {
+        let timestamp = ISO8601DateFormatter().string(from: Date())
+        let fileName = (file as NSString).lastPathComponent
+
+        // combine metadata
+        var effectiveMetadata = self.metadata
+        if let metadata = metadata {
+            effectiveMetadata.merge(metadata) { _, new in new }
+        }
+
+        // format message (no label since namespace is in the message)
+        var logMessage = "[\(timestamp)] [\(level)] [\(fileName):\(line)] \(message)"
+
+        if !effectiveMetadata.isEmpty {
+            let metadataString = effectiveMetadata
+                .map { "\($0.key)=\($0.value)" }
+                .joined(separator: " ")
+            logMessage += " [\(metadataString)]"
+        }
+
+        writeToFile(logMessage)
+    }
+
+    private func writeToFile(_ message: String) {
+        guard let fileURL = fileURL else { return }
+
+        Self.queue.async {
+            do {
+                let logEntry = message + "\n"
+                guard let data = logEntry.data(using: .utf8) else { return }
+
+                // use NSFileCoordinator for cross-process coordination
+                let coordinator = NSFileCoordinator()
+                var coordinationError: NSError?
+
+                coordinator.coordinate(writingItemAt: fileURL, options: [], error: &coordinationError) { coordinatedURL in
+                    do {
+                        // check file size and rotate if needed
+                        if FileManager.default.fileExists(atPath: coordinatedURL.path) {
+                            let attributes = try FileManager.default.attributesOfItem(atPath: coordinatedURL.path)
+                            let fileSize = (attributes[.size] as? NSNumber)?.int64Value ?? 0
+
+                            if fileSize > Self.maxFileSize {
+                                // rotate: keep last 25% of file
+                                let keepSize = Self.maxFileSize / 4
+                                let handle = try FileHandle(forReadingFrom: coordinatedURL)
+                                defer { try? handle.close() }
+
+                                let endOffset = try handle.seekToEnd()
+                                let startOffset = max(0, endOffset - UInt64(keepSize))
+                                try handle.seek(toOffset: startOffset)
+
+                                let truncatedData = try handle.readToEnd() ?? Data()
+
+                                // write atomically to temporary file, then replace
+                                let tempURL = coordinatedURL.deletingLastPathComponent()
+                                    .appendingPathComponent(".\(coordinatedURL.lastPathComponent).tmp")
+                                try truncatedData.write(to: tempURL, options: .atomic)
+                                try FileManager.default.replaceItemAt(
+                                    coordinatedURL,
+                                    withItemAt: tempURL,
+                                    backupItemName: nil,
+                                    options: []
+                                )
+                            }
+                        }
+
+                        // append log message
+                        if let handle = try? FileHandle(forWritingTo: coordinatedURL) {
+                            defer { try? handle.close() }
+                            try handle.seekToEnd()
+                            try handle.write(contentsOf: data)
+                        } else {
+                            // file doesn't exist, create it
+                            try data.write(to: coordinatedURL, options: .atomic)
+                        }
+                    } catch {
+                        print("Failed to write log during coordination: \(error)")
+                    }
+                }
+
+                if let error = coordinationError {
+                    print("Failed to coordinate file access: \(error)")
+                }
+            } catch {
+                // fallback to print if file writing fails
+                print("Failed to write log: \(error)")
+            }
+        }
+    }
+}
+
+// MARK: - Factory methods
+
+public extension FileLogHandler {
+    /// Create a log handler for the main app or extensions
+    static func makeHandler(
+        label: String,
+        appGroupIdentifier: String = "group.org.convos.app"
+    ) -> FileLogHandler {
+        FileLogHandler(label: label, appGroupIdentifier: appGroupIdentifier)
+    }
+}
+
+// MARK: - Log retrieval
+
+public extension FileLogHandler {
+    /// Read all logs from the shared log file
+    static func getLogs(
+        appGroupIdentifier: String = "group.org.convos.app",
+        maxLines: Int = 5000  // increased from 1000 for better debugging
+    ) async -> String {
+        // clamp maxLines to prevent crashes with invalid values
+        let safeMaxLines = max(1, maxLines)
+
+        guard let containerURL = FileManager.default.containerURL(
+            forSecurityApplicationGroupIdentifier: appGroupIdentifier
+        ) else {
+            return "Failed to access app group container"
+        }
+
+        let logURL = containerURL
+            .appendingPathComponent("Logs")
+            .appendingPathComponent("convos.log")
+
+        guard FileManager.default.fileExists(atPath: logURL.path) else {
+            return "No logs available"
+        }
+
+        return await withCheckedContinuation { continuation in
+            DispatchQueue.global(qos: .utility).async {
+                // use NSFileCoordinator for cross-process safe reading
+                let coordinator = NSFileCoordinator()
+                var coordinationError: NSError?
+
+                coordinator.coordinate(readingItemAt: logURL, options: [], error: &coordinationError) { coordinatedURL in
+                    do {
+                        let handle = try FileHandle(forReadingFrom: coordinatedURL)
+                        defer { try? handle.close() }
+
+                        // read from end to get most recent logs
+                        let endOffset = try handle.seekToEnd()
+
+                        // if file is empty, return early
+                        if endOffset == 0 {
+                            continuation.resume(returning: "No logs yet")
+                            return
+                        }
+
+                        // read in chunks from end
+                        let chunkSize = 64 * 1024
+                        var chunks: [Data] = []
+                        var newlineCount = 0
+                        var position = endOffset
+
+                        while position > 0 && newlineCount < safeMaxLines {
+                            let readSize = min(chunkSize, Int(position))
+                            position -= UInt64(readSize)
+
+                            try handle.seek(toOffset: position)
+                            if let chunk = try handle.read(upToCount: readSize) {
+                                chunks.append(chunk)
+                                newlineCount += chunk.filter { $0 == 0x0A }.count
+                            }
+                        }
+
+                        // combine chunks in correct order
+                        var combined = Data()
+                        for chunk in chunks.reversed() {
+                            combined.append(chunk)
+                        }
+
+                        // extract last maxLines if we read too much
+                        if newlineCount > safeMaxLines {
+                            let bytes = [UInt8](combined)
+                            var needed = safeMaxLines
+                            var idx = bytes.count - 1
+
+                            while idx >= 0 && needed > 0 {
+                                if bytes[idx] == 0x0A {
+                                    needed -= 1
+                                }
+                                idx -= 1
+                            }
+
+                            let start = max(0, idx + 2)
+                            combined = combined.subdata(in: start..<combined.count)
+                        }
+
+                        let logs = String(data: combined, encoding: .utf8) ?? "Failed to decode logs"
+                        continuation.resume(returning: logs.isEmpty ? "No logs yet" : logs)
+                    } catch {
+                        continuation.resume(returning: "Failed to read logs: \(error.localizedDescription)")
+                    }
+                }
+
+                if let error = coordinationError {
+                    continuation.resume(returning: "Failed to coordinate file access: \(error)")
+                }
+            }
+        }
+    }
+
+    /// Clear all logs
+    ///
+    /// - Note: This operation is asynchronous and will complete on a background queue.
+    ///   It is safe to call from any thread, including the logging queue itself.
+    static func clearLogs(appGroupIdentifier: String = "group.org.convos.app") {
+        guard let containerURL = FileManager.default.containerURL(
+            forSecurityApplicationGroupIdentifier: appGroupIdentifier
+        ) else {
+            return
+        }
+
+        let logURL = containerURL
+            .appendingPathComponent("Logs")
+            .appendingPathComponent("convos.log")
+
+        Self.queue.async {
+            // use NSFileCoordinator for cross-process safe clearing
+            let coordinator = NSFileCoordinator()
+            var coordinationError: NSError?
+
+            coordinator.coordinate(writingItemAt: logURL, options: [], error: &coordinationError) { coordinatedURL in
+                do {
+                    if FileManager.default.fileExists(atPath: coordinatedURL.path) {
+                        let handle = try FileHandle(forWritingTo: coordinatedURL)
+                        defer { try? handle.close() }
+                        try handle.truncate(atOffset: 0)
+                    }
+                } catch {
+                    print("Failed to clear logs during coordination: \(error)")
+                }
+            }
+
+            if let error = coordinationError {
+                print("Failed to coordinate file access for clearing: \(error)")
+            }
+        }
+    }
+}

--- a/NotificationService/Log.swift
+++ b/NotificationService/Log.swift
@@ -1,0 +1,21 @@
+import ConvosCore
+import Foundation
+
+/// Notification service logging wrapper - uses "Convos" namespace
+enum Log {
+    static func debug(_ message: String, file: String = #file, function: String = #function, line: Int = #line) {
+        ConvosLog.debug(message, namespace: "NotificationService", file: file, function: function, line: line)
+    }
+
+    static func info(_ message: String, file: String = #file, function: String = #function, line: Int = #line) {
+        ConvosLog.info(message, namespace: "NotificationService", file: file, function: function, line: line)
+    }
+
+    static func warning(_ message: String, file: String = #file, function: String = #function, line: Int = #line) {
+        ConvosLog.warning(message, namespace: "NotificationService", file: file, function: function, line: line)
+    }
+
+    static func error(_ message: String, file: String = #file, function: String = #function, line: Int = #line) {
+        ConvosLog.error(message, namespace: "NotificationService", file: file, function: function, line: line)
+    }
+}


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Add XMTP logs to the Debug menu by routing all app logging through `ConvosLog`/`Log` and enabling non‑production XMTP persistent logging with hourly rotation and maxFiles=10, with file rotation at 50MB in `FileLogHandler`
Introduce `ConvosLogging` and replace `Logger.*` with `Log.*` across the app, centralize logging via `ConvosLog.configure(environment:)`, add `FileLogHandler` that writes to an app group with 50MB rotation, and update the Debug export view to share multiple log files including XMTP logs.

#### 📍Where to Start
Start with logging setup in `ConvosLog` and the new file handler in [ConvosCore/Sources/ConvosCore/Logging/Logger.swift](https://github.com/ephemeraHQ/convos-ios/pull/215/files#diff-96fd716e05d64110e15d9b5597d6408097084b797aeb30def9d5a1516bb52c4c), then review `FileLogHandler` in [ConvosLogging/Sources/ConvosLogging/FileLogHandler.swift](https://github.com/ephemeraHQ/convos-ios/pull/215/files#diff-af5255cf717f86f32011cf760f290467a0c4e4f10f008f715e21da5d80b594fe).

----
<!-- Macroscope's review summary starts here -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized b0337fd. 33 files reviewed, 123 issues evaluated, 119 issues filtered, 1 comment posted</summary>

### 🗂️ Filtered Issues
<details>
<summary>Convos/Conversation Creation/NewConversationViewModel.swift — 0 comments posted, 8 evaluated, 7 filtered</summary>

- [line 163](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/Convos/Conversation Creation/NewConversationViewModel.swift#L163): Potential retain cycle between `self` and `joinConversationTask` during task execution. The Task closure captures `[weak self]`, but `guard let self else { return }` at line 163 promotes a strong reference, and `self` is then used throughout the task. Because `self` strongly retains `joinConversationTask` (assigned at line 162) and the task closure strongly retains `self`, a cycle exists until the task exits. If the awaited operation never returns (hangs) or the task is stuck, this becomes a leak. Mitigate by not promoting to strong `self` for the entire task, clearing `joinConversationTask` on all completion paths, or scoping strong captures only within `MainActor.run` blocks. <b>[ Low confidence ]</b>
- [line 168](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/Convos/Conversation Creation/NewConversationViewModel.swift#L168): Cancellation race can still invoke `handleJoinSuccess()` if the task is cancelled after the `guard !Task.isCancelled` check but before `MainActor.run` executes. The check at line 168 is not atomic with the subsequent call at lines 170–172, so a cancellation signaled in that window allows the success handler to run on a cancelled task. Re-check cancellation inside the `MainActor.run` block or use `Task.checkCancellation()` immediately before invoking handlers. <b>[ Low confidence ]</b>
- [line 175](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/Convos/Conversation Creation/NewConversationViewModel.swift#L175): Cancellation race in error path mirrors the success-path issue. After catching at line 173, the check at line 175 is not atomic with `MainActor.run` at lines 176–178. A cancellation signaled in that window can still invoke `handleJoinError(_:)` on a cancelled task. Re-check inside `MainActor.run` or use `Task.checkCancellation()` immediately before invoking the handler. <b>[ Already posted ]</b>
- [line 185](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/Convos/Conversation Creation/NewConversationViewModel.swift#L185): `newConversationTask?.cancel()` and `joinConversationTask?.cancel()` are called, but their completion is not awaited before starting `conversationStateManager.delete()`. This can cause races/interleaving between cleanup of those tasks and the deletion operation, potentially leaving state inconsistent or double-applying effects. <b>[ Out of scope ]</b>
- [line 187](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/Convos/Conversation Creation/NewConversationViewModel.swift#L187): `Task { ... }` is launched in a fire-and-forget manner and its handle is not stored or awaited. Multiple calls to `deleteConversation()` can create concurrent deletion tasks, and there is no mutual-exclusion or idempotence guard. This can cause double-application of `conversationStateManager.delete()` and race conditions with other state changes. <b>[ Out of scope ]</b>
- [line 188](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/Convos/Conversation Creation/NewConversationViewModel.swift#L188): Using `[weak self]` with `guard let self else { return }` can silently skip deletion if `self` is deallocated after scheduling the task. This contradicts the log `"Deleting conversation"` and can leave the conversation undeleted despite the user action. <b>[ Out of scope ]</b>
- [line 350](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/Convos/Conversation Creation/NewConversationViewModel.swift#L350): The `Publishers.Merge` chain guarded by `.first()` may never emit, leaving UI state (`messagesTopBarTrailingItem`, `shouldConfirmDeletingConversation`, `untitledConversationPlaceholder`) and permission checks never applied. If no message is sent and `messagesPublisher` never publishes an array containing an element with `showsInMessagesList == true`, the sink is never invoked and these states remain unset. Provide a fallback path (e.g., initial state setup, timeout, or an immediate emission) to ensure all inputs reach a defined terminal state. <b>[ Low confidence ]</b>
</details>

<details>
<summary>Convos/Conversation Detail/ConversationInfoView.swift — 0 comments posted, 1 evaluated, 1 filtered</summary>

- [line 304](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/Convos/Conversation Detail/ConversationInfoView.swift#L304): The `.task { ... }` on the "Debug info" `Section` (lines 304–312) can run multiple times as the view reappears or re-evaluates, potentially spawning concurrent `exportDebugLogs()` operations and racing updates to `exportedLogsURL`. There is no guard to ensure at-most-once execution, no cancellation coordination, and no re-entrancy protection. This can cause duplicate work, flickering of the ShareLink visibility, and nondeterministic final `exportedLogsURL` value. Add an id/phase guard, a state flag, or use `.task(id:)` with a stable id to avoid concurrent re-entry, and ensure only one export runs at a time. <b>[ Already posted ]</b>
</details>

<details>
<summary>Convos/ConvosApp.swift — 0 comments posted, 2 evaluated, 2 filtered</summary>

- [line 37](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/Convos/ConvosApp.swift#L37): In `init()`, when `ConfigManager.shared.currentEnvironment.firebaseConfigURL` is `nil`, the code only logs `Log.error("Missing Firebase plist URL for current environment")` and proceeds to create `ConvosClient` and start the session. The preceding comment explicitly states Firebase must be configured before `SessionManager` uses AppCheck to avoid a race. Proceeding without configuration can cause runtime failures or undefined behavior in `SessionManager`/AppCheck. Consider failing fast (e.g., assert/terminate pre-effect), providing a safe fallback, or gating `ConvosClient` initialization behind successful Firebase configuration. <b>[ Low confidence ]</b>
- [line 107](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/Convos/ConvosApp.swift#L107): `runDataWipeMigrationSync` marks the migration as completed (`UserDefaults` key `data_wipe_migration_v1_completed`) even if one or more deletions fail. Errors are logged in the catch blocks, but the code unconditionally sets `defaults.set(true, forKey: migrationKey)` and calls `synchronize()` afterward. This can leave undeleted files behind while suppressing future attempts to clean them, resulting in inconsistent state. Consider only marking completion after verifying all deletions succeeded, or track per-file success and retry failures. <b>[ Low confidence ]</b>
</details>

<details>
<summary>Convos/DeepLinking/DeepLinkHandler.swift — 0 comments posted, 3 evaluated, 3 filtered</summary>

- [line 11](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/Convos/DeepLinking/DeepLinkHandler.swift#L11): `url.scheme` comparison is case-sensitive, which can incorrectly reject valid deep links where the scheme is uppercase or mixed case (schemes are case-insensitive by RFC). The expression `url.scheme == "https" ? ... : url.scheme == ConfigManager.shared.appUrlScheme` will fail for inputs like `"HTTPS"` or custom scheme `"MyApp"`. Normalize `scheme` (e.g., lowercasing) before comparison. <b>[ Out of scope ]</b>
- [line 20](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/Convos/DeepLinking/DeepLinkHandler.swift#L20): `destination(for:)` only checks that `convosInviteCode` is non-nil (`guard let inviteCode = url.convosInviteCode`) but does not validate that it is non-empty. If `convosInviteCode` can return an empty string, the function will emit `.joinConversation(inviteCode: "")`, propagating an invalid invite code and deferring failure downstream. Add an explicit non-empty check (e.g., `!inviteCode.isEmpty`). <b>[ Out of scope ]</b>
- [line 35](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/Convos/DeepLinking/DeepLinkHandler.swift#L35): `isValidHost(_:)` compares `host` to `ConfigManager.shared.associatedDomain` using case-sensitive equality. Hostnames are case-insensitive; valid links with uppercase or mixed-case hosts (e.g., `EXAMPLE.com`) will be rejected. Normalize casing (e.g., lowercasing) and possibly handle canonical forms (punycode) before comparison. <b>[ Out of scope ]</b>
</details>

<details>
<summary>Convos/_Archive/Convos Client/Auth/Passkey/PasskeyAuthService.swift — 0 comments posted, 1 evaluated, 1 filtered</summary>

- [line 44](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/Convos/_Archive/Convos Client/Auth/Passkey/PasskeyAuthService.swift#L44): If `refreshAuthState()` throws in `init`, the catch block only logs (`Log.error`) and leaves `authStateSubject` at `.unknown`. This violates the service’s state invariants by not reaching a defined terminal state (e.g., `.unauthorized`) on error, causing subscribers to remain in an indeterminate state and potentially blocking downstream flows. Set a fallback state (e.g., `authStateSubject.send(.unauthorized)`) in the catch. <b>[ Low confidence ]</b>
</details>

<details>
<summary>Convos/_Archive/Convos Client/Auth/Turnkey/TurnkeyAccountsService.swift — 0 comments posted, 2 evaluated, 2 filtered</summary>

- [line 173](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/Convos/_Archive/Convos Client/Auth/Turnkey/TurnkeyAccountsService.swift#L173): After creating a wallet or account, the code relies on `turnkey.refreshUser()` and then reads `turnkey.user?.otrWallet?.accounts` without verifying it corresponds to the specific wallet just created (`otrWalletId`). If the refreshed `user.otrWallet` does not point to the newly created or previously selected wallet (e.g., multiple wallets present, default selection changes, or a stale/async update), the subsequent lookup `accounts.first(where: { $0.address == otrWalletAddress })` may fail even though the operation succeeded, causing an erroneous `TurnkeyAccountsServiceError.failedCreatingAccount`. Instead, use `otrWalletId` to select the wallet deterministically or fetch accounts directly by `walletId`. <b>[ Low confidence ]</b>
- [line 189](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/Convos/_Archive/Convos Client/Auth/Turnkey/TurnkeyAccountsService.swift#L189): Errors from `try account.databaseKey` (and from upstream `client.*` calls) are propagated as arbitrary errors rather than being mapped to `TurnkeyAccountsServiceError`. This creates inconsistent error contracts: some failure modes are normalized to `TurnkeyAccountsServiceError` while others leak underlying errors, making callers handle heterogeneous error types unpredictably. Normalize or wrap thrown errors to maintain a consistent service error contract. <b>[ Low confidence ]</b>
</details>

<details>
<summary>Convos/_Archive/Convos Client/Auth/Turnkey/TurnkeyAuthService.swift — 0 comments posted, 4 evaluated, 4 filtered</summary>

- [line 276](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/Convos/_Archive/Convos Client/Auth/Turnkey/TurnkeyAuthService.swift#L276): When `state` is `.migrating`, `handleMigrationIfNeeded(for:)` silently bypasses migration and proceeds with normal auth flow if `wallet.accounts.count != 1` due to the early `guard` returning `nil`. This can violate the migration contract: the caller (`authState`) treats `nil` as "continue auth", so the system may proceed while still in a migrating state, leaving migration incomplete or inconsistent. Consider returning `.migrating(migration)` (or another blocking state) when the wallet has zero or multiple accounts, or explicitly handling/logging this case to avoid silently skipping migration. <b>[ Out of scope ]</b>
- [line 352](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/Convos/_Archive/Convos Client/Auth/Turnkey/TurnkeyAuthService.swift#L352): `turnkey.createKeyPair()` is called outside the `do { ... } catch let error as TurnkeyRequestError { ... }` block, so any `TurnkeyRequestError` thrown by `turnkey.createKeyPair()` will escape without logging, unlike errors from `client.stampLogin(...)` or `turnkey.createSession(jwt:)`. This creates inconsistent observability across error paths. <b>[ Out of scope ]</b>
- [line 352](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/Convos/_Archive/Convos Client/Auth/Turnkey/TurnkeyAuthService.swift#L352): `turnkey.createKeyPair()` acquires a cryptographic key resource, but if `client.stampLogin(...)` or `turnkey.createSession(jwt:)` fails, there is no paired cleanup or rollback to dispose of the newly created key. This risks orphaned keys or resource leakage depending on `createKeyPair()` semantics. <b>[ Out of scope ]</b>
- [line 359](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/Convos/_Archive/Convos Client/Auth/Turnkey/TurnkeyAuthService.swift#L359): Calling `client.stampLogin(..., invalidateExisting: true)` may invalidate an existing session before a new session is successfully created. If server-side semantics apply invalidation early or on partial success, and `createSession(jwt:)` then fails, the user can be left without a valid session. There is no compensating recovery or rollback. <b>[ Out of scope ]</b>
</details>

<details>
<summary>ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift — 0 comments posted, 13 evaluated, 13 filtered</summary>

- [line 107](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift#L107): `pushToken` is checked with `token.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty` to decide `apnsEnv` and `pushTokenType`, but the original `pushToken` value (which may be empty or whitespace-only) is still sent in the request body (`RegisterDeviceRequest`). This can yield an inconsistent payload where `pushToken` is a non-nil empty/whitespace string while `pushTokenType` and `apnsEnv` are `nil`, potentially causing server-side misinterpretation. Normalize `pushToken` before constructing the body (trim and either use the trimmed value or set it to `nil` when empty) so all related fields are consistent. <b>[ Out of scope ]</b>
- [line 193](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift#L193): `Task.sleep(nanoseconds:)` is called with `UInt64(delay * 1_000_000_000)` where `delay` is a `TimeInterval` from `TimeInterval.calculateExponentialBackoff(for:)`. If `delay` is negative, `NaN`, `infinite`, or large enough that the Double-to-UInt64 conversion overflows, this will trap at runtime. Add guards to ensure `delay` is finite, non-negative, and within `UInt64.max / 1_000_000_000` before converting, or clamp to a safe maximum. <b>[ Low confidence ]</b>
- [line 208](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift#L208): The decoded JWT `token` from `AuthResponse` is not validated for non-empty content before being saved to the keychain and returned. If the backend responds with an empty string (or only whitespace), the client will store and propagate an unusable token, causing downstream authentication failures without a clear, early error. Validate `authResponse.token` and fail fast (e.g., throw `APIError.authenticationFailed` or a specific error) if it is empty. <b>[ Low confidence ]</b>
- [line 231](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift#L231): `overrideJWTToken` is used without validation. If it is an empty or whitespace-only string, the code still sets the `X-Convos-AuthToken` header, which can yield a malformed/invalid auth header instead of omitting it to trigger re-authentication. Add a non-empty check (trimmed) before setting the header. <b>[ Low confidence ]</b>
- [line 239](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift#L239): `keychainJWT` is used without validation. If `retrieveString` returns an empty or whitespace-only string, the code still sets `X-Convos-AuthToken`, leading to an invalid/misleading auth header rather than omitting it to trigger re-authentication as intended when no token is present. <b>[ Already posted ]</b>
- [line 341](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift#L341): `acl` parameter is accepted (`uploadAttachment(data:filename:contentType:acl:)`) but never used: it is neither forwarded to the presign request (missing `acl` in `queryParameters`) nor set as an upload header (e.g., `x-amz-acl`). For S3/S3-compatible presigned PUTs, required headers must match the signature; omitting `x-amz-acl` when the server signed with it will cause 403 failures. This also silently discards caller intent, violating the method’s external contract. <b>[ Low confidence ]</b>
- [line 354](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift#L354): Sensitive information is logged: the full presigned URL (`Log.info("Getting presigned URL from: ...")` and `Log.info("Uploading to S3: ...")`). Presigned URLs embed object keys and time-limited credentials/signatures. Logging them risks credential leakage and unintended exposure of private object paths. <b>[ Low confidence ]</b>
- [line 373](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift#L373): The returned `publicURL` is inferred by stripping the query from the presigned URL (`scheme://host + path`) and is returned as a "public" URL without verifying accessibility. Combined with the ignored `acl`, the object may remain private, making the returned URL unusable. This is a contract/semantics bug: the function claims success and returns a URL that may not be publicly readable. <b>[ Low confidence ]</b>
- [line 383](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift#L383): For presigned uploads, the code unconditionally uses HTTP `PUT` (`s3Request.httpMethod = "PUT"`). If the presign endpoint returns a POST/multipart form upload URL (common for S3), this path will fail (405/403). There is no method/type indicator in `PresignedResponse` to select the correct upload strategy. <b>[ Low confidence ]</b>
- [line 401](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift#L401): Strict status check `s3HttpResponse.statusCode == 200` rejects other success codes (e.g., 201, 202, 204) returned by some S3-compatible services for PUT uploads. This yields false negatives and throws `APIError.serverError(nil)` even though the upload succeeded. <b>[ Low confidence ]</b>
- [line 422](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift#L422): The `contentType` is hardcoded to `"image/jpeg"` while `data` and `filename` are unconstrained. If a PNG or non-image is passed (reachable via the public API), the wrong MIME type will be sent, causing misinterpretation, broken display, or validation failures on the server/storage layer. Derive content type from the data/filename or make it a parameter with validation. <b>[ Low confidence ]</b>
- [line 423](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift#L423): ACL is hardcoded to `"public-read"`, making every upload publicly accessible without validation or explicit opt-in. This can unintentionally expose sensitive content, especially since inputs are unconstrained. Make ACL configurable with a safe default (e.g., private), or enforce explicit opt-in for public access. <b>[ Low confidence ]</b>
- [line 429](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift#L429): If `afterUpload(uploadedURL)` throws, the function propagates the error but does not roll back or delete the already uploaded attachment. This leaves an orphaned, publicly readable resource, violating single paired cleanup and potentially causing inconsistent state and resource leaks. Add a failure-path cleanup (e.g., delete the uploaded object) or transactional handling around the upload and post-upload action. <b>[ Already posted ]</b>
</details>

<details>
<summary>ConvosCore/Sources/ConvosCore/FirebaseHelper.swift — 0 comments posted, 3 evaluated, 3 filtered</summary>

- [line 7](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/ConvosCore/Sources/ConvosCore/FirebaseHelper.swift#L7): `FirebaseOptions(contentsOfFile:)` failing (e.g., bad `optionsURL` or non-file URL) leads to an early `return` with no error or log. This silently leaves Firebase unconfigured, causing downstream calls (e.g., `getAppCheckToken`) to fail without a clear cause. Provide a visible failure outcome (log or throw) so every input reaches a defined terminal state. <b>[ Out of scope ]</b>
- [line 11](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/ConvosCore/Sources/ConvosCore/FirebaseHelper.swift#L11): `AppAttestProvider` is selected unconditionally for non-simulator builds via `AppAttestFactory`. On platforms/devices where App Attest is unavailable (e.g., iOS < 14, or macCatalyst), creating/using `AppAttestProvider` can fail at runtime. Provide availability checks and a fallback (e.g., `DeviceCheckProvider`) to avoid runtime failures. <b>[ Out of scope ]</b>
- [line 13](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/ConvosCore/Sources/ConvosCore/FirebaseHelper.swift#L13): No guard for already-configured `FirebaseApp`. If `configure(with:)` is called after Firebase was previously configured elsewhere, `AppCheck.setAppCheckProviderFactory(...)` will run after initialization, which Firebase docs caution against (factory must be set before app initialization). This can lead to inconsistent AppCheck behavior or ignored provider settings. Add a check like `if FirebaseApp.app() == nil` before setting the factory and configuring, or handle reconfiguration explicitly. <b>[ Out of scope ]</b>
</details>

<details>
<summary>ConvosCore/Sources/ConvosCore/Image Cache/ImageCache.swift — 0 comments posted, 2 evaluated, 2 filtered</summary>

- [line 102](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/ConvosCore/Sources/ConvosCore/Image Cache/ImageCache.swift#L102): `cacheImage(_:key:cache:logContext:)` computes NSCache `cost` using `UIImage.size` in points (`resizedImage.size.width * resizedImage.size.height * 4`) rather than pixels and ignores `image.scale`. This underestimates memory usage on Retina screens, leading to mis-enforced cache limits and potential memory pressure or premature/late evictions. <b>[ Already posted ]</b>
- [line 102](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/ConvosCore/Sources/ConvosCore/Image Cache/ImageCache.swift#L102): `Int(resizedImage.size.width * resizedImage.size.height * 4)` truncates fractional point-area to an integer and still ignores `image.scale`. This further skews NSCache cost. Use pixel count (`width * scale` and `height * scale`) and an integer computation to avoid truncation. <b>[ Out of scope ]</b>
</details>

<details>
<summary>ConvosCore/Sources/ConvosCore/Inboxes/ConversationStateMachine.swift — 0 comments posted, 21 evaluated, 20 filtered</summary>

- [line 327](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/ConvosCore/Sources/ConvosCore/Inboxes/ConversationStateMachine.swift#L327): No rollback/cleanup is performed if `prepareConversation()` succeeds but subsequent `publish()` or `processConversation(...)` fails. This can leave an orphaned optimistic conversation or duplicated local state. Add a `do/catch` with compensating actions (e.g., cancel/abort/delete the optimistic conversation) to preserve invariants on failure. <b>[ Out of scope ]</b>
- [line 331](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/ConvosCore/Sources/ConvosCore/Inboxes/ConversationStateMachine.swift#L331): If any of the awaited operations (`inboxStateManager.waitForInboxReadyResult()`, `client.prepareConversation()`, `optimisticConversation.publish()`, or `streamProcessor.processConversation(...)`) throws, the function exits without emitting a failure/terminal state. Since `emitStateChange(.creating)` was already called, the state machine can be left stuck in `creating` with no visible outcome. Add error handling to emit an explicit failure state or rollback before rethrowing. <b>[ Out of scope ]</b>
- [line 343](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/ConvosCore/Sources/ConvosCore/Inboxes/ConversationStateMachine.swift#L343): The `conversationId` used in the ready state is captured from `optimisticConversation.id` before publish and processing. If `publish()` or `processConversation(...)` assigns/reconciles a canonical ID (e.g., server-assigned different from the optimistic ID), the emitted ready state may expose a stale/non-canonical ID. Retrieve and emit the canonicalized ID after publish/processing. <b>[ Out of scope ]</b>
- [line 383](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/ConvosCore/Sources/ConvosCore/Inboxes/ConversationStateMachine.swift#L383): `try? await identityStore.identity(for: existingConversation.inboxId)` swallows errors and sets `existingIdentity` to `nil` on any failure. The subsequent guard deletes the existing conversation when `existingConversation != nil` and `existingIdentity == nil`. This can wrongly delete a valid conversation if the identity lookup failed transiently (e.g., I/O error), leading to data loss. Use explicit error handling and avoid destructive actions on ambiguous `nil` caused by exceptions. <b>[ Low confidence ]</b>
- [line 402](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/ConvosCore/Sources/ConvosCore/Inboxes/ConversationStateMachine.swift#L402): `prevInboxReady` is obtained before `await inboxStateManager.delete()`, and after reauthorization, in the `hasJoined` path, `cleanUpPreviousConversationIfNeeded` is called with `prevInboxReady.client` and `prevInboxReady.apiClient`. If `delete()` tears down or invalidates those clients, using them post-delete is a use-after-release risk and can cause crashes or undefined behavior. Ensure cleanup is done before deletion or that the cleanup uses still-valid handles. <b>[ Low confidence ]</b>
- [line 402](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/ConvosCore/Sources/ConvosCore/Inboxes/ConversationStateMachine.swift#L402): In the `existingConversation.hasJoined == false` branch, `prevInboxReady` is obtained but never cleaned up before returning to a validated state and enqueuing `.join`. This can leak resources from the previous inbox authorization until some later point, violating single paired cleanup and leak avoidance requirements. <b>[ Already posted ]</b>
- [line 456](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/ConvosCore/Sources/ConvosCore/Inboxes/ConversationStateMachine.swift#L456): When creating a placeholder for a new conversation, the `ConversationReadyResult` is constructed with `origin: .joined` before an actual join occurs: `let placeholder = ConversationReadyResult(conversationId: conversationId, origin: .joined)`. This mislabels the state and can break downstream contract semantics (e.g., UI or logic that treats `.joined` as fully ready) causing incorrect behavior. <b>[ Low confidence ]</b>
- [line 482](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/ConvosCore/Sources/ConvosCore/Inboxes/ConversationStateMachine.swift#L482): Comment contradicts implementation: the code claims to validate that the hex conversion succeeded and produced a valid inbox ID, but only checks `isEmpty`. This mismatch creates uncertainty about whether additional validation is required, and allows malformed non-empty IDs to proceed to `newConversation` where they may fail later. <b>[ Out of scope ]</b>
- [line 487](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/ConvosCore/Sources/ConvosCore/Inboxes/ConversationStateMachine.swift#L487): No rollback/cleanup for newly created conversation on failure. If `prepare` or `publish` throws, any resources or partial state associated with `dm` may be left dangling. The function only cleans up the previous conversation and does not attempt to cancel or delete the newly created one when an error occurs before streaming. <b>[ Out of scope ]</b>
- [line 487](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/ConvosCore/Sources/ConvosCore/Inboxes/ConversationStateMachine.swift#L487): Early errors (e.g., `newConversation`, `prepare`, `publish`, or slug conversion) throw without emitting an error state. Since `.joining` was emitted earlier, a thrown error here can leave the state machine stuck unless the caller catches and translates the error into a state change. The function handles stream errors internally but not pre-stream errors. <b>[ Out of scope ]</b>
- [line 504](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/ConvosCore/Sources/ConvosCore/Inboxes/ConversationStateMachine.swift#L504): `streamConversationsTask` is assigned but never cleared to `nil` after completion, potentially retaining a finished `Task` and associated resources longer than necessary. Consider setting it to `nil` when the task completes or on terminal state transitions. <b>[ Out of scope ]</b>
- [line 508](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/ConvosCore/Sources/ConvosCore/Inboxes/ConversationStateMachine.swift#L508): The stream wait has no real timeout and can hang indefinitely. The `.else` branch logs `"timed out"` only if the stream completes without a match; it does not enforce a time limit. If the stream never closes and no matching conversation appears, the task stays pending and the state remains `.joining` forever. <b>[ Out of scope ]</b>
- [line 512](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/ConvosCore/Sources/ConvosCore/Inboxes/ConversationStateMachine.swift#L512): Errors thrown while fetching `group.inviteTag` inside the predicate abort the entire stream and transition to `.error`. Depending on desired behavior, failing to obtain a tag for a particular element might be better treated as a non-match rather than a fatal error for the whole join process. <b>[ Out of scope ]</b>
- [line 515](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/ConvosCore/Sources/ConvosCore/Inboxes/ConversationStateMachine.swift#L515): Cancellation path drops execution silently without emitting any terminal state or cleanup. After finding a matching conversation, if `Task.isCancelled` is true, the closure returns without calling `emitStateChange`, leaving the state potentially stuck in `.joining` and not performing any finalization. <b>[ Out of scope ]</b>
- [line 592](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/ConvosCore/Sources/ConvosCore/Inboxes/ConversationStateMachine.swift#L592): Cleanup failure is swallowed and the transition continues, which can leave resources and server/client-side state associated with `previousResult.conversationId` dangling. The `catch` at lines `592-594` only logs via `Log.error` and does not retry, compensate, or mark the conversation as needing later cleanup, creating a reachable leak path when `cleanUp(...)` throws. <b>[ Low confidence ]</b>
- [line 604](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/ConvosCore/Sources/ConvosCore/Inboxes/ConversationStateMachine.swift#L604): `client.conversationsProvider.findConversation(conversationId:)` is called with `try await` and any error will abort `cleanUp(...)` before push-unsubscribe and database deletions run. This yields partial cleanup and inconsistent state (e.g., remaining push topic subscription and DB records) when the conversation lookup fails (network/server errors). Wrap this call in `do/catch` and continue with local cleanup on failure, similar to the unsubscribe path. <b>[ Already posted ]</b>
- [line 605](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/ConvosCore/Sources/ConvosCore/Inboxes/ConversationStateMachine.swift#L605): `try await externalConversation?.updateConsentState(state: .denied)` will propagate errors when the conversation exists, aborting the remainder of cleanup. This can leave push topic subscriptions and DB records intact if the consent update fails. Given the function already tolerates remote unsubscribe failures, this remote consent update should also be contained in `do/catch` to ensure local cleanup proceeds. <b>[ Already posted ]</b>
- [line 651](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/ConvosCore/Sources/ConvosCore/Inboxes/ConversationStateMachine.swift#L651): The final `databaseWriter.write { ... fetchCount ... }` block can throw and cause `cleanUp(...)` to report failure even after successful local cleanup. Since it only logs a warning about zero conversations, errors in this non-essential observability path should be contained so the function does not fail post-cleanup. Consider using a read-only access or `do/catch` to avoid turning logging into a cleanup failure. <b>[ Low confidence ]</b>
- [line 685](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/ConvosCore/Sources/ConvosCore/Inboxes/ConversationStateMachine.swift#L685): No validation for empty or malformed topics: `conversationTopic` and `welcomeTopic` are derived from `conversationId` and `client.installationId` without checks. If either source is an empty string or maps to an empty/invalid topic via `.xmtpGroupTopicFormat` or `.xmtpWelcomeTopicFormat`, the API may receive invalid topics, yielding a failed or partial subscription with only generic logging. Validate non-empty and well-formed topics before invoking `subscribeToTopics`, and handle a zero-topic case explicitly. <b>[ Low confidence ]</b>
- [line 685](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/ConvosCore/Sources/ConvosCore/Inboxes/ConversationStateMachine.swift#L685): Possible duplicate topic subscription: `topics: [conversationTopic, welcomeTopic]` is sent without deduplication. If `conversationTopic` equals `welcomeTopic` (reachable if `conversationId` equals or maps to the same topic as `client.installationId`), this can cause a double-application effect or an API-level error. Ensure uniqueness before calling `subscribeToTopics` (e.g., build a `Set` and convert back to `Array`). <b>[ Low confidence ]</b>
</details>

<details>
<summary>ConvosCore/Sources/ConvosCore/Logging/Logger.swift — 0 comments posted, 2 evaluated, 2 filtered</summary>

- [line 55](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/ConvosCore/Sources/ConvosCore/Logging/Logger.swift#L55): `configure(environment:)` calls `LoggingSystem.bootstrap { ... }` (lines `55-61`) guarded only by `_logger == nil`. `swift-log`’s `LoggingSystem.bootstrap` is a global, one-time initializer; calling it after any other component has already bootstrapped the system (even if `_logger` here is still `nil`) triggers a runtime precondition failure. This makes `ConvosLog.configure` unsafe in mixed environments where another bootstrap may have occurred earlier. The local `_logger` guard does not prevent the global double-bootstrap. <b>[ Low confidence ]</b>
- [line 68](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/ConvosCore/Sources/ConvosCore/Logging/Logger.swift#L68): `getLogs(appGroupIdentifier:)` (lines `68-71`) and `clearLogs(appGroupIdentifier:)` (lines `73-76`) default to `"group.org.convos.app"` and do not use or refer to the `appGroupIdentifier` configured in `configure(environment:)`. If the app configured a different app group identifier, these operations will target the wrong container, leading to missing logs or clearing the wrong location. The module no longer stores the configured environment/app group, creating a contract mismatch between configuration and retrieval/clear operations. <b>[ Low confidence ]</b>
</details>

<details>
<summary>ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift — 0 comments posted, 12 evaluated, 12 filtered</summary>

- [line 58](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift#L58): `initializationTask = Task { [weak self] in ... }` uses `[weak self]` but then immediately `guard let self else { return }`, creating a strong reference to `self` for the remainder of the task. If `await self.deviceRegistrationManager.startObservingPushTokenChanges()` suspends for a long time or never completes, `SessionManager` may be retained indefinitely. There is no visible cancellation on deinit, nor a timeout. This is a lifecycle/leak risk and violates single paired cleanup for long-lived async work started in init. <b>[ Low confidence ]</b>
- [line 128](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift#L128): Existing entries in `self.messagingServices` are overwritten without teardown or duplication checks. In `serviceQueue.sync` the code assigns `self.messagingServices[identity.clientId] = service` for each `identity`, but does not stop or release any pre-existing service for the same `clientId`. If an existing service is running, this causes resource leaks and potentially two services operating for the same client, violating single paired cleanup and at-most-once effects. <b>[ Out of scope ]</b>
- [line 128](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift#L128): Silent overwrite when `identities` contains duplicate `clientId`s. The loop in `serviceQueue.sync` writes `messagingServices[identity.clientId] = service` for each item without checking for duplicates or enforcing uniqueness. Later duplicates will overwrite earlier services without warning or error, violating sequence constraints (uniqueness) and leading to inconsistent state. <b>[ Out of scope ]</b>
- [line 145](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift#L145): `startMessagingService(for:clientId:)` unconditionally creates and starts a messaging service with `startsStreamingServices: true` via `MessagingService.authorizedMessagingService(...)` and returns it, with no guard against prior starts for the same `inboxId`/`clientId`. If called multiple times with the same identifiers, this can start duplicate streaming services, leading to duplicated message consumption, race conditions, and resource leaks. There is no idempotency check, deduplication, or teardown of any previously started service, and no visibility of a single paired cleanup on any early/alternate path. <b>[ Already posted ]</b>
- [line 149](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift#L149): `observe()` can be called multiple times without a guard, leading to multiple registrations of the same `NotificationCenter` observers and repeated callback execution for each notification. Add an idempotence check (e.g., a `hasObserved` flag) to prevent duplicate registrations or remove existing observers before re-adding. <b>[ Out of scope ]</b>
- [line 150](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift#L150): `NotificationCenter` observers created in `observe()` (`leftConversationObserver` at lines 150–174 and `activeConversationObserver` at lines 176–183) have no visible paired removal within this code object. Without guaranteed teardown, observers can leak and continue delivering callbacks after the intended lifecycle, violating single paired cleanup and potentially causing double-handling if `observe()` is called more than once. Ensure observers are removed exactly once (e.g., in `deinit` or a dedicated `stopObserving()`), and guard against repeated registration (e.g., an idempotent flag). <b>[ Out of scope ]</b>
- [line 217](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift#L217): Temporary file created for the notification attachment at `let tempFileURL = ...; try cachedImageData.write(to: tempFileURL)` is never cleaned up. `UNNotificationAttachment` references the file URL; after delivery there’s no cleanup path here, so repeated notifications can accumulate files in the temporary directory, causing storage growth. Ensure deletion after the notification is delivered or use a managed cache directory with periodic cleanup. <b>[ Low confidence ]</b>
- [line 269](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift#L269): Potential deadlock: calling `serviceQueue.sync { ... }` from within `deleteInbox` can deadlock if `deleteInbox` is invoked while already executing on `serviceQueue` (serial queue). `DispatchQueue.sync` on the same serial queue will block forever. Add a guard to avoid calling `sync` from the same queue, or use `async` with proper synchronization, or refactor to use actors. <b>[ Out of scope ]</b>
- [line 270](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift#L270): Non-atomic removal and stop can violate uniqueness/mutual-exclusion: the service is removed from `messagingServices` inside `serviceQueue.sync`, then `await service.stopAndDelete()` runs outside the queue’s critical section. Another thread can create a new service for the same `clientId` before the old one fully stops, leading to overlapping lifecycle operations and potential resource races. Consider performing a guarded state transition (e.g., mark-as-deleting) and prevent recreation until stop completes, or perform stop under coordinated serialization. <b>[ Out of scope ]</b>
- [line 290](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift#L290): `messagingServices` is cleared (lines 290–294) before `messagingService.stopAndDelete()` tasks (lines 296–301) actually complete. If any service fails to stop/delete or hangs, the manager has already dropped its references, leaving a potentially running background service with no owner/cleanup path and no rollback to restore `messagingServices`. This can cause orphaned work, inconsistent state (manager appears empty while services are still active), and leaks. Move removal until after successful stops, or implement rollback/error reporting for failures. <b>[ Out of scope ]</b>
- [line 290](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift#L290): Potential deadlock: `serviceQueue.sync(flags: .barrier)` (line 290) will deadlock if `deleteAllInboxes()` is invoked while already executing on `serviceQueue` (calling `.sync` on the same queue). There is no visible guard preventing re-entry from `serviceQueue`. Use `.async(flags: .barrier)` with a completion or ensure calls are never made from `serviceQueue` (and enforce via assertions/guards). <b>[ Out of scope ]</b>
- [line 360](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift#L360): Potential deadlock: calling `serviceQueue.sync { activeConversationId }` inside an `async` function can deadlock if `shouldDisplayNotification(for:)` is invoked while already executing on `serviceQueue` (or if `serviceQueue` targets the current executing queue). GCD `sync` on the same serial queue will block forever. Replace with a non-blocking, re-entrancy-safe approach (e.g., ensure reads occur off-queue, use `serviceQueue.sync` only from other queues, or adopt an actor/lock or `serviceQueue.sync` guarded by `DispatchQueue.isCurrent`/use `serviceQueue.sync` on a dedicated queue that never calls this function). <b>[ Low confidence ]</b>
</details>

<details>
<summary>ConvosCore/Sources/ConvosCore/Storage/Repositories/ConversationsRepository.swift — 0 comments posted, 1 evaluated, 1 filtered</summary>

- [line 29](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/ConvosCore/Sources/ConvosCore/Storage/Repositories/ConversationsRepository.swift#L29): `replaceError(with: [])` on the observation publisher at line 29 causes the stream to emit an empty array and then complete on the first database error. This permanently stops further conversation updates after any transient failure in `ValueObservation`/database access, which is likely unintended for a live-updating repository publisher. <b>[ Low confidence ]</b>
</details>

<details>
<summary>ConvosCore/Sources/ConvosCore/Storage/Repositories/MessagesRepository.swift — 0 comments posted, 4 evaluated, 4 filtered</summary>

- [line 108](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/ConvosCore/Sources/ConvosCore/Storage/Repositories/MessagesRepository.swift#L108): Constructed `MessageReaction` instances set `date: Date()` (current time) rather than a timestamp derived from the database reaction record. This can yield incorrect ordering and non-canonical values in emitted artifacts, violating the requirement to use canonicalized values from the source. <b>[ Low confidence ]</b>
- [line 119](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/ConvosCore/Sources/ConvosCore/Storage/Repositories/MessagesRepository.swift#L119): In `.original` with `.attachments`, attachment URLs are built using `compactMap { URL(string: urlString) }`. Invalid URL strings are silently dropped, resulting in silent data loss in the produced `MessageContent.attachments`. Provide validation with explicit error handling/logging, or propagate a failure/fallback rather than silently removing entries. <b>[ Low confidence ]</b>
- [line 171](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/ConvosCore/Sources/ConvosCore/Storage/Repositories/MessagesRepository.swift#L171): `composeMessages(from:in:)` drops all messages with `messageType == .reply` without emitting any value or logging. The `switch` over `contentType` only `break`s and then the function falls through to `return nil`, silently discarding reply messages. This violates the requirement to provide a defined terminal state and avoid silent acceptance/loss for reachable inputs. <b>[ Low confidence ]</b>
- [line 182](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/ConvosCore/Sources/ConvosCore/Storage/Repositories/MessagesRepository.swift#L182): `composeMessages(from:in:)` drops all `.reaction` messages even when `contentType == .emoji`. The branch `case .reaction` allows `.emoji` via `break`, but does not construct or return an `AnyMessage`, and the function falls through to `return nil`. This silently discards valid reaction messages. <b>[ Already posted ]</b>
</details>

<details>
<summary>ConvosCore/Sources/ConvosCore/Storage/Repositories/MyProfileRepository.swift — 0 comments posted, 2 evaluated, 2 filtered</summary>

- [line 65](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/ConvosCore/Sources/ConvosCore/Storage/Repositories/MyProfileRepository.swift#L65): Unsynchronized cross-thread access to `conversationIdSubject`: `send` is called in the `conversationIdPublisher.sink` (line `65`) while reads of `.value` occur in `handleInboxStateChange` (outside this snippet). `CurrentValueSubject` is not thread-safe for concurrent `send`/`value` access without external synchronization. This can cause data races or undefined behavior. Use a serial queue/lock or ensure both operations occur on the same scheduler. <b>[ Already posted ]</b>
- [line 67](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/ConvosCore/Sources/ConvosCore/Storage/Repositories/MyProfileRepository.swift#L67): Possible data race on `cancellables` due to unsynchronized access from multiple Combine callbacks. `conversationIdPublisher.sink` (lines `62-70`) can call `startObservingProfile(...)` (which clears and mutates `cancellables`) concurrently with the inbox state observer callback (set up earlier in the initializer) that also calls `startObservingProfile(...)`. `Set<AnyCancellable>` is not thread-safe; concurrent `removeAll()`/`store(in:)` without serialization can crash or corrupt state. Ensure both code paths deliver on the same serial scheduler (e.g., main queue) or guard mutations behind a lock/serial queue. <b>[ Already posted ]</b>
</details>

<details>
<summary>ConvosCore/Sources/ConvosCore/Storage/States/ConversationsCountState.swift — 0 comments posted, 2 evaluated, 2 filtered</summary>

- [line 21](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/ConvosCore/Sources/ConvosCore/Storage/States/ConversationsCountState.swift#L21): No validation of the fetched `count` from `conversationsCountRepository.fetchCount()` (line `21`). If a negative value is returned, `self.count` can become negative, leading to inconsistent state and incorrect `isEmpty` semantics (negative counts are treated as non-empty). Consider clamping to `>= 0` or rejecting invalid values. <b>[ Out of scope ]</b>
- [line 21](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/ConvosCore/Sources/ConvosCore/Storage/States/ConversationsCountState.swift#L21): `self.count` is set synchronously during `init` (lines `21` and `24`) without enforcing main-thread execution. If `ConversationsCountState` is initialized off the main thread, observers of the `@Observable` `count` may be notified from a background thread, while subsequent updates in `observe()` are marshaled to the main thread via `.receive(on: DispatchQueue.main)`. This creates inconsistent thread affinity and can cause UI updates off the main thread. <b>[ Out of scope ]</b>
</details>

<details>
<summary>ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationConsentWriter.swift — 0 comments posted, 5 evaluated, 5 filtered</summary>

- [line 33](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationConsentWriter.swift#L33): Remote consent update and local DB write are performed sequentially without atomicity or compensation. If `client.update(consent:for:)` succeeds but `databaseWriter.write` fails, the function throws, leaving a remote state change without the corresponding local persistence. This violates post-effect invariants (consistency between remote and local) and can occur on both `join` and `delete`. Consider making the operations transactional, adding retries, or compensating/rolling back the remote change on local failure. <b>[ Low confidence ]</b>
- [line 35](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationConsentWriter.swift#L35): If the local conversation does not exist (`fetchOne(db)` returns `nil`), `join` updates remote consent but does not persist any local change or provide a fallback (e.g., insert/upsert). This leads to an inconsistent state where remote is `.allowed` but local remains absent/unknown, with no visible outcome or error for this reachable case. <b>[ Already posted ]</b>
- [line 49](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationConsentWriter.swift#L49): `delete` has the same non-atomic side-effect ordering as `join`: if `client.update(consent: .denied, for:)` succeeds but `databaseWriter.write` fails, the function throws after remote state has changed, leaving remote/local inconsistency. <b>[ Low confidence ]</b>
- [line 75](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationConsentWriter.swift#L75): `deleteAll` launches one task per conversation with `withTaskGroup` and no concurrency limit. Large inboxes can spawn very many tasks, overwhelming the `client` or database writer, causing timeouts, throttling, or resource exhaustion. Consider bounding concurrency (e.g., using a semaphore or chunking) or using structured concurrency with limited parallelism. <b>[ Low confidence ]</b>
- [line 78](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationConsentWriter.swift#L78): In `deleteAll`, remote update and local DB write are performed in the same `do` block per task. If the DB write fails after the remote succeeds, the error is collected and later thrown, but the remote change remains applied, leaving partial state. There is no rollback or reconciliation, violating post-effect consistency invariants across aggregated failure paths. <b>[ Low confidence ]</b>
</details>

<details>
<summary>ConvosCore/Sources/ConvosCore/Storage/Writers/InviteWriter.swift — 0 comments posted, 3 evaluated, 3 filtered</summary>

- [line 29](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/ConvosCore/Sources/ConvosCore/Storage/Writers/InviteWriter.swift#L29): Database errors are silently swallowed when checking for an existing invite. The outer `try? await databaseWriter.read { ... }` (line 29) and the inner `try?` around `fetchOne` (line 30) cause any thrown database error to be coerced to `nil`. This can incorrectly proceed as if no invite exists, masking real DB failures and leading to inconsistent behavior (e.g., unnecessary invite generation or duplicate entries if later write succeeds). Replace `try?` with proper error handling and return/propagate the error. <b>[ Out of scope ]</b>
- [line 57](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/ConvosCore/Sources/ConvosCore/Storage/Writers/InviteWriter.swift#L57): Potential race condition between the existence check and insert leads to duplicate invites or unhandled unique constraint violations. The code first reads for an existing invite (lines 29–35) and then inserts a new `DBInvite` (lines 57–75) without enforcing atomicity or handling conflicts. Concurrent calls can both observe 'no invite' and both insert. If a unique DB constraint exists, `save` may throw and the method will fail; if not, duplicates will be created. Use a single upsert with a unique constraint, or perform the check-and-insert within a transaction with conflict handling (e.g., `INSERT ... ON CONFLICT DO NOTHING` then fetch). <b>[ Out of scope ]</b>
- [line 73](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/ConvosCore/Sources/ConvosCore/Storage/Writers/InviteWriter.swift#L73): Errors during `MemberProfile` insertion are silently ignored. The `try? memberProfile.insert(db, onConflict: .ignore)` (line 73) swallows any error (e.g., I/O, schema, constraint other than conflict), potentially leading to partial/incorrect state without visibility. If insert is optional, explicitly document and log failures; otherwise, handle/propagate errors. <b>[ Out of scope ]</b>
</details>

<details>
<summary>ConvosCore/Sources/ConvosCore/Storage/Writers/MyProfileWriter.swift — 0 comments posted, 4 evaluated, 4 filtered</summary>

- [line 84](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/ConvosCore/Sources/ConvosCore/Storage/Writers/MyProfileWriter.swift#L84): When removing the avatar (`avatar == nil`), only the object-based cache entry is removed (`removeImage(for: profile.hydrateProfile())`). Any previously cached URL-based image remains in `urlCache`, leaving stale entries that can be served by URL lookups and wasting memory. Similarly, when setting a new avatar, old URL cache entries are not cleared. <b>[ Low confidence ]</b>
- [line 90](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/ConvosCore/Sources/ConvosCore/Storage/Writers/MyProfileWriter.swift#L90): `update(avatar:conversationId:)` performs an optimistic cache update for the object (`ImageCache.shared.setImage(avatarImage, for: profile.hydrateProfile())`) before the upload succeeds. If `uploadAttachment` throws, the method exits with an error but the cache remains updated, leaving UI showing an avatar that wasn’t persisted and no rollback is performed. <b>[ Low confidence ]</b>
- [line 92](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/ConvosCore/Sources/ConvosCore/Storage/Writers/MyProfileWriter.swift#L92): `update(avatar:conversationId:)` computes `resizedImage = ImageCompression.resizeForCache(avatarImage)` but uploads `avatarImage.jpegData(...)`. This increases upload size and bandwidth compared to using the resized image and may cause longer uploads; if quality/size constraints exist, this is a runtime inefficiency and potential policy violation. <b>[ Code style ]</b>
- [line 107](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/ConvosCore/Sources/ConvosCore/Storage/Writers/MyProfileWriter.swift#L107): Using `ImageCache.shared.setImage(resizedImage, for: uploadedURL)` relies on the URL-based cache method, which does not publish `cacheUpdateSubject` updates. Views or components depending on cache update notifications will not refresh when the URL-based image is cached, causing UI to miss the new avatar until a manual refresh or re-fetch. <b>[ Low confidence ]</b>
</details>

<details>
<summary>ConvosCore/Sources/ConvosCore/Storage/Writers/OutgoingMessageWriter.swift — 0 comments posted, 2 evaluated, 2 filtered</summary>

- [line 53](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/ConvosCore/Sources/ConvosCore/Storage/Writers/OutgoingMessageWriter.swift#L53): The database write closure captures `self` weakly and silently returns if `self` is deallocated: `try await databaseWriter.write { [weak self] db in guard let self else { return } ... }`. This can cause the local message record to not be saved while the send continues, leading to inconsistent behavior (message may be published without any local DB row). If `self` must be alive to proceed, capture strongly or fail early; otherwise explicitly handle the missing-save case (e.g., abort sending, surface an error). <b>[ Low confidence ]</b>
- [line 77](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/ConvosCore/Sources/ConvosCore/Storage/Writers/OutgoingMessageWriter.swift#L77): On successful publish, the local `DBMessage` status remains `.unpublished` and is never updated to a sent/published state. This leaves the database in an inconsistent state (message actually sent but recorded as unpublished). The success path at lines `77-82` should persist a status transition (e.g., `.sent`/`.published`) for the `clientMessageId`, mirroring the failure path which marks `.failed`. <b>[ Low confidence ]</b>
</details>

<details>
<summary>ConvosCore/Sources/ConvosCore/Syncing/InviteJoinRequestsManager.swift — 0 comments posted, 7 evaluated, 7 filtered</summary>

- [line 96](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/ConvosCore/Sources/ConvosCore/Syncing/InviteJoinRequestsManager.swift#L96): Duplicate logging for `InviteJoinRequestError.invalidSignature`: `processJoinRequest` logs an error on verification failures (e.g., at `Log.error("Exception during signature verification...")` and `Log.error("Signature verification failed...")`), then throws `invalidSignature`. `processJoinRequestSafely` catches `InviteJoinRequestError.invalidSignature` and logs again via `Log.error("Invalid signature in join request from \(message.senderInboxId)")`. This double-logs the same event, causing duplicated side effects and noisy logs. <b>[ Low confidence ]</b>
- [line 101](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/ConvosCore/Sources/ConvosCore/Syncing/InviteJoinRequestsManager.swift#L101): Duplicate logging for `InviteJoinRequestError.conversationNotFound`: Inside `processJoinRequest`, a missing or not-allowed conversation logs `Log.warning("Conversation \(conversationId) not found...")` before throwing `conversationNotFound`. The wrapper `processJoinRequestSafely` then catches `conversationNotFound` and logs again with `Log.error("Conversation \(id) not found...")`. This double-logs the same event with mismatched severity. <b>[ Already posted ]</b>
- [line 105](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/ConvosCore/Sources/ConvosCore/Syncing/InviteJoinRequestsManager.swift#L105): Duplicate logging for `InviteJoinRequestError.invalidConversationType`: `processJoinRequest` logs `Log.warning("Expected Group but found DM...")` then throws `invalidConversationType`. The wrapper catches `invalidConversationType` and logs `Log.error("Join request targets a DM instead of a group")`. This produces duplicate log entries for the same condition with inconsistent severity. <b>[ Already posted ]</b>
- [line 139](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/ConvosCore/Sources/ConvosCore/Syncing/InviteJoinRequestsManager.swift#L139): DMs with non-invite text or expired invites are never terminally handled, causing repeated reprocessing on each sync: for `invalidInviteFormat` (lines where `SignedInvite.fromURLSafeSlug` fails) and for `expired`/`expiredConversation` guards, the code throws without calling `blockDMConversation` or updating consent state. The wrapper swallows these with a nil return. In the calling loop (`processMessages`), only successful results update the DM consent to `.allowed`, so these DMs remain in a state that will be retried indefinitely, leading to repeated CPU/log churn. <b>[ Low confidence ]</b>
- [line 275](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/ConvosCore/Sources/ConvosCore/Syncing/InviteJoinRequestsManager.swift#L275): `withTaskGroup` at `processJoinRequests` spawns one task per DM without any concurrency limit (`line 275`). If `dms` is large, this can cause unbounded parallel work leading to resource exhaustion, rate limiting, or timeouts on `processMessages(for:client:)`. Add a limiter (e.g., `withTaskGroup` plus manual gating or a semaphore) or use a bounded concurrency approach to prevent runtime failures. <b>[ Out of scope ]</b>
- [line 329](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/ConvosCore/Sources/ConvosCore/Syncing/InviteJoinRequestsManager.swift#L329): `processMessages(for:client:)` returns a `JoinRequestResult` only after calling `dm.updateConsentState(state: .allowed)` succeeds. If `updateConsentState` throws, the function throws and the successfully processed join request result is lost, and the DM’s consent state remains `.unknown`. This can cause the same DM to be reprocessed later, potentially duplicating side effects from `processJoinRequestSafely` while never surfacing the result. Consider committing the processing result independently of consent-state update (e.g., return the result even if the consent update fails, and handle/update consent in a best-effort step with its own error reporting and retry), or perform the consent update before irreversible side effects. <b>[ Low confidence ]</b>
- [line 342](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/ConvosCore/Sources/ConvosCore/Syncing/InviteJoinRequestsManager.swift#L342): `blockDMConversation` returns silently when `findConversation` fails (`lines 342–346`). This leaves the DM unblocked with no visible outcome on this failure path, violating the function’s intent to "block" the conversation. Log the failure and/or propagate an error so callers have a defined terminal state and can avoid repeated reprocessing. <b>[ Out of scope ]</b>
</details>

<details>
<summary>ConvosCore/Sources/ConvosCore/Syncing/SyncingManager.swift — 0 comments posted, 3 evaluated, 3 filtered</summary>

- [line 181](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/ConvosCore/Sources/ConvosCore/Syncing/SyncingManager.swift#L181): Sequentially cancelling and then immediately awaiting each task (`messageStreamTask`, `conversationStreamTask`, `syncTask`) can deadlock if any one task’s completion depends (directly or indirectly) on another task being cancelled first. In the current order, `messageStreamTask` is cancelled and awaited before `conversationStreamTask` and `syncTask` are cancelled. If `messageStreamTask` waits for `conversationStreamTask` to cancel/finish, `stop()` will hang. Correct approach: cancel all non-nil tasks first, then await all of them. <b>[ Low confidence ]</b>
- [line 183](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/ConvosCore/Sources/ConvosCore/Syncing/SyncingManager.swift#L183): `stop()` can hang indefinitely if any cancelled task does not cooperatively observe cancellation and complete. The method awaits each `task.value` with no timeout, fallback, or external cancellation. In realistic conditions (e.g., blocking I/O or a loop that doesn’t check for cancellation), the actor will remain suspended forever, preventing shutdown from reaching observer cleanup. <b>[ Already posted ]</b>
- [line 218](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/ConvosCore/Sources/ConvosCore/Syncing/SyncingManager.swift#L218): `runMessageStream` exponential backoff converts a `TimeInterval` to nanoseconds via `UInt64(delay * 1_000_000_000)` (`line 218`). Without a maximum cap, large `retryCount` can yield values that overflow `UInt64` or produce excessively long sleeps, causing runtime malfunction or near-hangs. Cap the backoff and guard against overflow before calling `Task.sleep`. <b>[ Out of scope ]</b>
</details>

<details>
<summary>ConvosLogging/Sources/ConvosLogging/FileLogHandler.swift — 0 comments posted, 15 evaluated, 14 filtered</summary>

- [line 24](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/ConvosLogging/Sources/ConvosLogging/FileLogHandler.swift#L24): Compound read-modify-write on `metadata` is not atomic and can lose updates under concurrency. Callers can `get` `metadata` (line 24), mutate the returned `Logging.Logger.Metadata` copy, then `set` it (line 26). Concurrent operations doing the same can overwrite each other, resulting in lost key changes despite each individual `get`/`set` being lock-protected. Prefer exposing atomic per-key updates (the subscript) or provide an atomic mutation API (e.g., `updateMetadata(_:)` taking a closure executed under the lock) to avoid lost updates. <b>[ Low confidence ]</b>
- [line 37](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/ConvosLogging/Sources/ConvosLogging/FileLogHandler.swift#L37): Concurrent access to `state.logLevel` via the public `logLevel` getter/setter is not synchronized. In typical `swift-log` usage, `LogHandler` instances are called from multiple threads; unsynchronized reads/writes can cause data races, torn values, or inconsistent logging behavior. Ensure `state` provides thread-safe access (e.g., via an actor, lock, atomic) or guard access here. <b>[ Already posted ]</b>
- [line 42](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/ConvosLogging/Sources/ConvosLogging/FileLogHandler.swift#L42): Concurrent access to `state.metadata` via the public `metadata` getter/setter is not synchronized. `swift-log` expects `LogHandler.metadata` to be safely readable/writable across threads; unsynchronized dictionary mutations can cause races and runtime crashes. Ensure `state` provides thread-safe access (e.g., via an actor, lock, atomic copy-on-write discipline) or add synchronization here. <b>[ Already posted ]</b>
- [line 56](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/ConvosLogging/Sources/ConvosLogging/FileLogHandler.swift#L56): On failure to get the app group container (`FileManager.default.containerURL(forSecurityApplicationGroupIdentifier:)` returning `nil`), the initializer logs and returns with `fileURL` set to `nil`, leaving the `FileLogHandler` instance partially initialized and potentially unusable. If downstream code assumes `fileURL` is non-`nil` without guarding, it will crash or misbehave. The initializer should either be `throw`ing, set an explicit disabled state with guaranteed guards, or provide a fallback. As-is, there is no explicit, enforced invariant that the handler is operational after init. <b>[ Low confidence ]</b>
- [line 73](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/ConvosLogging/Sources/ConvosLogging/FileLogHandler.swift#L73): If `createDirectory(at:withIntermediateDirectories:)` throws (e.g., permission denied or `Logs` exists as a file), the code only logs the error but still sets `fileURL` to `logsDirectory/appendingPathComponent("convos.log")`. This can leave `fileURL` pointing under a non-existent or invalid directory, causing later I/O failures. The initializer should either early-return with `fileURL = nil`, verify the directory exists after creation, or handle the specific error (e.g., when `Logs` is a file). <b>[ Already posted ]</b>
- [line 118](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/ConvosLogging/Sources/ConvosLogging/FileLogHandler.swift#L118): Logs are silently dropped when `fileURL` is `nil`. The guard `guard let fileURL = fileURL else { return }` causes early return with no fallback (e.g., printing to stdout), so any call to `log(...)` while the handler is not configured with a valid `fileURL` results in lost logs. <b>[ Low confidence ]</b>
- [line 118](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/ConvosLogging/Sources/ConvosLogging/FileLogHandler.swift#L118): Logs are silently dropped when `appGroupIdentifier` is invalid or the shared container cannot be created. In `init`, failure sets `self.fileURL = nil` (lines `56`–`61`), and in `writeToFile(_:)` the guard `guard let fileURL = fileURL else { return }` (line `118`) exits without any fallback. If this handler is the only configured `LogHandler`, all logs are lost at runtime. Provide a fallback (e.g., write to a non-shared app sandbox path or `print`) so that every input reaches a visible terminal outcome. <b>[ Low confidence ]</b>
- [line 129](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/ConvosLogging/Sources/ConvosLogging/FileLogHandler.swift#L129): `NSFileCoordinator` is created with `options: []` (line `129`) while a replace operation (`FileManager.default.replaceItemAt`) is performed later (lines `152`–`157`). When replacing a file, coordination should use `.forReplacing` to accurately inform other coordinators/presenters of the operation type. Using generic write coordination can lead to improper conflict handling under concurrent access by other processes, risking write contention or corruption. <b>[ Low confidence ]</b>
- [line 129](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/ConvosLogging/Sources/ConvosLogging/FileLogHandler.swift#L129): `NSFileCoordinator` is used with `options: []` while the code may replace the file during rotation. Coordinating a replacement typically uses `.forReplacing` to inform other coordinators of the intent. Using empty options can increase the chance of coordination conflicts or denied access in multi-process scenarios. <b>[ Low confidence ]</b>
- [line 162](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/ConvosLogging/Sources/ConvosLogging/FileLogHandler.swift#L162): Potential data loss: the branch `if let handle = try? FileHandle(forWritingTo: coordinatedURL) { ... } else { /* file doesn't exist, create it */ try data.write(to: coordinatedURL, options: .atomic) }` assumes failure to open the `FileHandle` means the file doesn't exist. In reality, `FileHandle(forWritingTo:)` can fail for other reasons (e.g., permissions, file is busy). In the `else` branch, `Data.write(to:)` with `.atomic` will replace the existing file contents, truncating previous logs and keeping only the single new entry. This can silently destroy log history when the file exists but the handle open fails. <b>[ Already posted ]</b>
- [line 190](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/ConvosLogging/Sources/ConvosLogging/FileLogHandler.swift#L190): `FileLogHandler.makeHandler(label:appGroupIdentifier:)` provides a default `appGroupIdentifier` but performs no validation. If an invalid or missing app group is supplied, the returned handler may fail later when used. The factory itself does not surface errors or fallback, creating a silent failure window. <b>[ Low confidence ]</b>
- [line 279](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/ConvosLogging/Sources/ConvosLogging/FileLogHandler.swift#L279): The backward trimming index computation can start the slice at `start = bytes.count` when the last selected line is a trailing empty line (due to `idx` landing on the final newline). While valid, this amplifies the empty-output issue and can also risk starting in the middle of a multi-byte UTF-8 sequence if `idx` calculation ever goes off-by-one. The current loop decrements `idx` after detecting the needed newline, then uses `start = idx + 2`. An off-by-one in edge cases would produce a slice beginning mid-codepoint, causing `String(data:combined, encoding:.utf8)` to fail and return the fallback "Failed to decode logs" unnecessarily. Ensure `start` is computed at a confirmed newline boundary and guard against `start == combined.count` if you intend to preserve prior content. <b>[ Low confidence ]</b>
- [line 284](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/ConvosLogging/Sources/ConvosLogging/FileLogHandler.swift#L284): When trimming to the last `safeMaxLines` lines, the slice can be empty if the file ends with a trailing newline and the last selected line is the trailing empty line. In that case `logs.isEmpty` leads to returning "No logs yet" even though the file may contain many logs. This produces a misleading visible outcome for valid inputs. Consider avoiding the empty-line special-case or detecting whether the file contained prior non-empty content before returning the fallback. <b>[ Low confidence ]</b>
- [line 313](https://github.com/ephemeraHQ/convos-ios/blob/b0337fdc3317c9ebc74439c37cb0a269fdc7470b/ConvosLogging/Sources/ConvosLogging/FileLogHandler.swift#L313): `NSFileCoordinator` is used to claim "cross-process safe clearing" (see comment at line 313), but coordination only prevents races with other parties that also participate in file coordination (use `NSFileCoordinator`/`NSFilePresenter`). If other writers append to `convos.log` using plain `FileHandle`/`FileManager` without coordination, this method can truncate concurrently with their writes, causing interleaved/partially lost data. The implementation does not enforce or verify that all writers of `convos.log` use coordination, so the cross-process safety guarantee is not actually provided. This is a runtime race/data-loss risk under concurrent non-coordinated writers. <b>[ Low confidence ]</b>
</details>


</details><!-- Macroscope's review summary ends here -->
<!-- Macroscope's pull request summary ends here -->