### PR TITLE
Upload symbols to ASC

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -90,6 +90,7 @@ workflows:
         inputs:
         - bundle_id: org.convos.ios-preview
         - app_id: '6748622252'
+        - upload_symbols: 'yes'
     - save-spm-cache@1: {}
     meta:
       bitrise.io:
@@ -172,6 +173,7 @@ workflows:
         inputs:
         - app_id: '6744776535'
         - bundle_id: org.convos.ios
+        - upload_symbols: 'yes'
     - save-spm-cache@1: {}
     meta:
       bitrise.io:


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Enable symbol upload to App Store Connect for iOS preview (app_id 6748622252) and production (app_id 6744776535) workflows in [bitrise.yml](https://github.com/ephemeraHQ/convos-ios/pull/217/files#diff-61d1ee831cb1df242161a7d23171914a1d5d628c7659b52db957d80a9394bd68)
Add `upload_symbols: "yes"` to two Bitrise workflow steps for bundle IDs `org.convos.ios-preview` and `org.convos.ios` in [bitrise.yml](https://github.com/ephemeraHQ/convos-ios/pull/217/files#diff-61d1ee831cb1df242161a7d23171914a1d5d628c7659b52db957d80a9394bd68).

#### 📍Where to Start
Start with the modified workflow steps in [bitrise.yml](https://github.com/ephemeraHQ/convos-ios/pull/217/files#diff-61d1ee831cb1df242161a7d23171914a1d5d628c7659b52db957d80a9394bd68), focusing on the inputs near the `bundle_id` entries for `org.convos.ios-preview` and `org.convos.ios`.

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 3759224.
<!-- Macroscope's review summary ends here -->

<!-- Macroscope's pull request summary ends here -->