### PR TITLE
Fix build config and sentry config for dev builds

### DIFF
--- a/Convos.xcodeproj/xcshareddata/xcschemes/Convos (Dev).xcscheme
+++ b/Convos.xcodeproj/xcshareddata/xcschemes/Convos (Dev).xcscheme
@@ -85,7 +85,7 @@
       buildConfiguration = "Debug">
    </AnalyzeAction>
    <ArchiveAction
-      buildConfiguration = "Release"
+      buildConfiguration = "Dev"
       revealArchiveInOrganizer = "YES">
    </ArchiveAction>
 </Scheme>

--- a/Convos.xcodeproj/xcshareddata/xcschemes/Convos (Local).xcscheme
+++ b/Convos.xcodeproj/xcshareddata/xcschemes/Convos (Local).xcscheme
@@ -92,7 +92,7 @@
       buildConfiguration = "Debug">
    </AnalyzeAction>
    <ArchiveAction
-      buildConfiguration = "Release"
+      buildConfiguration = "Local"
       revealArchiveInOrganizer = "YES">
    </ArchiveAction>
 </Scheme>

--- a/Convos/Config/SentryConfiguration.swift
+++ b/Convos/Config/SentryConfiguration.swift
@@ -41,12 +41,13 @@ enum SentryConfiguration {
         let environment = ConfigManager.shared.currentEnvironment
 
         switch environment {
-        case .local, .dev:
-            #if DEBUG
+        case .local:
+            // Local builds never use Sentry
             return false
-            #else
+        case .dev:
+            // Dev builds (TestFlight) use Sentry even with DEBUG flag
+            // This is intentional: Dev.xcconfig defines DEBUG for debugging Swift packages
             return true
-            #endif
         case .production, .tests:
             return false
         }


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Set dev and local archive schemes to use their matching configurations and force Sentry enablement in `SentryConfiguration.shouldEnableSentry` for `.dev` while disabling for `.local`
Update Xcode schemes to archive with `Dev` and `Local` configs, and change `SentryConfiguration.shouldEnableSentry` to always return `true` for `.dev` and `false` for `.local`, removing `#if DEBUG` logic in [SentryConfiguration.swift](https://github.com/ephemeraHQ/convos-ios/pull/218/files#diff-15bbfbfdd2b8a4f029aae8b275b6183bb831413fcc2676f124e8e7c8e43b1e01).

#### 📍Where to Start
Start with `SentryConfiguration.shouldEnableSentry` in [SentryConfiguration.swift](https://github.com/ephemeraHQ/convos-ios/pull/218/files#diff-15bbfbfdd2b8a4f029aae8b275b6183bb831413fcc2676f124e8e7c8e43b1e01).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized dabbdbb.
<!-- Macroscope's review summary ends here -->

<!-- Macroscope's pull request summary ends here -->