### PR TITLE
Explode Notifications

### DIFF
--- a/Convos/Conversation Detail/ConversationInfoView.swift
+++ b/Convos/Conversation Detail/ConversationInfoView.swift
@@ -90,7 +90,7 @@ struct ConversationInfoView: View {
                             .frame(width: 160.0, height: 160.0)
 
                             VStack(spacing: DesignConstants.Spacing.step2x) {
-                                Text(viewModel.conversationName.isEmpty ? "Untitled" : viewModel.conversationName)
+                                Text(viewModel.conversationName.orUntitled)
                                     .font(.largeTitle.weight(.semibold))
                                     .foregroundStyle(.colorTextPrimary)
                                 if !viewModel.conversationDescription.isEmpty {

--- a/Convos/Conversation Detail/Messages/ConversationInfoButton.swift
+++ b/Convos/Conversation Detail/Messages/ConversationInfoButton.swift
@@ -12,6 +12,8 @@ struct ConversationInfoButton<InfoView: View>: View {
     @FocusState.Binding var focusState: MessagesViewInputFocus?
     let focusCoordinator: FocusCoordinator?
     let showsExplodeNowButton: Bool
+    let isExploding: Bool
+    let explodeError: String?
     let onConversationInfoTapped: () -> Void
     let onConversationNameEndedEditing: () -> Void
     let onConversationSettings: () -> Void
@@ -58,22 +60,32 @@ struct ConversationInfoButton<InfoView: View>: View {
                         )
 
                         if showsExplodeNowButton {
-                            Button {
-                                showingExplodeConfirmation = true
-                            } label: {
-                                Text("Explode now")
-                            }
-                            .buttonStyle(RoundedDestructiveButtonStyle(fullWidth: true))
-                            .confirmationDialog(
-                                "",
-                                isPresented: $showingExplodeConfirmation
-                            ) {
-                                Button("Explode", role: .destructive) {
-                                    onExplodeNow()
+                            VStack(spacing: DesignConstants.Spacing.step2x) {
+                                Button {
+                                    showingExplodeConfirmation = true
+                                } label: {
+                                    Text(isExploding ? "Exploding..." : "Explode now")
+                                }
+                                .buttonStyle(RoundedDestructiveButtonStyle(fullWidth: true))
+                                .disabled(isExploding)
+                                .confirmationDialog(
+                                    "",
+                                    isPresented: $showingExplodeConfirmation
+                                ) {
+                                    Button("Explode", role: .destructive) {
+                                        onExplodeNow()
+                                    }
+
+                                    Button("Cancel") {
+                                        showingExplodeConfirmation = false
+                                    }
                                 }
 
-                                Button("Cancel") {
-                                    showingExplodeConfirmation = false
+                                if let explodeError {
+                                    Text(explodeError)
+                                        .font(.caption)
+                                        .foregroundColor(.red)
+                                        .multilineTextAlignment(.center)
                                 }
                             }
                         }
@@ -137,6 +149,8 @@ struct ConversationInfoButton<InfoView: View>: View {
         focusState: $focusState,
         focusCoordinator: focusCoordinator,
         showsExplodeNowButton: true,
+        isExploding: false,
+        explodeError: nil,
         onConversationInfoTapped: {
             focusCoordinator?.moveFocus(to: .conversationName)
         },

--- a/Convos/Conversations List/ConversationsViewModel.swift
+++ b/Convos/Conversations List/ConversationsViewModel.swift
@@ -293,6 +293,8 @@ final class ConversationsViewModel {
                     Log.info("Left conversation notification received for conversation: \(conversationId)")
                     if selectedConversation?.id == conversationId {
                         selectedConversation = nil
+                        selectedConversationId = nil
+                        selectedConversationViewModel = nil
                     }
                     if newConversationViewModel?.conversationViewModel.conversation.id == conversationId {
                         newConversationViewModel = nil
@@ -305,6 +307,7 @@ final class ConversationsViewModel {
             .publisher(for: .explosionNotificationTapped)
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
+                self?.selectedConversation = nil
                 self?.presentingExplodeInfo = true
             }
             .store(in: &cancellables)

--- a/Convos/ConvosApp.swift
+++ b/Convos/ConvosApp.swift
@@ -7,7 +7,7 @@ import XMTPiOS
 struct ConvosApp: App {
     @UIApplicationDelegateAdaptor(ConvosAppDelegate.self) private var appDelegate: ConvosAppDelegate
 
-    let session: any SessionManagerProtocol
+    private let convos: ConvosClient
     let conversationsViewModel: ConversationsViewModel
     let quicknameViewModel: QuicknameSettingsViewModel = .shared
 
@@ -44,10 +44,9 @@ struct ConvosApp: App {
             }
         }
 
-        let convos: ConvosClient = .client(environment: environment)
-        self.session = convos.session
-        self.conversationsViewModel = .init(session: session)
-        appDelegate.session = session
+        self.convos = .client(environment: environment)
+        self.conversationsViewModel = .init(session: convos.session)
+        appDelegate.session = convos.session
     }
 
     var body: some Scene {

--- a/Convos/Shared Views/ConversationPresenter.swift
+++ b/Convos/Shared Views/ConversationPresenter.swift
@@ -81,6 +81,8 @@ private struct ConversationInfoButtonWrapper: View {
             focusState: $focusState,
             focusCoordinator: focusCoordinator,
             showsExplodeNowButton: viewModel.showsExplodeNowButton,
+            isExploding: viewModel.isExploding,
+            explodeError: viewModel.explodeError,
             onConversationInfoTapped: { viewModel.onConversationInfoTap(focusCoordinator: focusCoordinator) },
             onConversationNameEndedEditing: {
                 viewModel.onConversationNameEndedEditing(

--- a/ConvosCore/Sources/ConvosCore/AppEnvironment.swift
+++ b/ConvosCore/Sources/ConvosCore/AppEnvironment.swift
@@ -87,15 +87,15 @@ public enum AppEnvironment: Sendable {
     var apiBaseURL: String {
         switch self {
         case .local(let config):
-            Log.info("🌐 Using API URL from local config: \(config.apiBaseURL)")
+            Log.info("Using API URL from local config: \(config.apiBaseURL)")
             return config.apiBaseURL
         case .tests:
             return "http://localhost:4000/api/"
         case .dev(let config):
-            Log.info("🌐 Using API URL from dev config: \(config.apiBaseURL)")
+            Log.info("Using API URL from dev config: \(config.apiBaseURL)")
             return config.apiBaseURL
         case .production(let config):
-            Log.info("🌐 Using API URL from production config: \(config.apiBaseURL)")
+            Log.info("Using API URL from production config: \(config.apiBaseURL)")
             return config.apiBaseURL
         }
     }

--- a/ConvosCore/Sources/ConvosCore/ConvosClient+App.swift
+++ b/ConvosCore/Sources/ConvosCore/ConvosClient+App.swift
@@ -13,8 +13,15 @@ extension ConvosClient {
             environment: environment,
             identityStore: identityStore
         )
-        return .init(sessionManager: sessionManager,
-                     databaseManager: databaseManager,
-                     environment: environment)
+        let expiredConversationsWorker = ExpiredConversationsWorker(
+            databaseReader: databaseReader,
+            sessionManager: sessionManager
+        )
+        return .init(
+            sessionManager: sessionManager,
+            databaseManager: databaseManager,
+            environment: environment,
+            expiredConversationsWorker: expiredConversationsWorker
+        )
     }
 }

--- a/ConvosCore/Sources/ConvosCore/ConvosClient.swift
+++ b/ConvosCore/Sources/ConvosCore/ConvosClient.swift
@@ -13,6 +13,7 @@ public final class ConvosClient {
     private let sessionManager: any SessionManagerProtocol
     private let databaseManager: any DatabaseManagerProtocol
     private let environment: AppEnvironment
+    public let expiredConversationsWorker: ExpiredConversationsWorkerProtocol?
 
     var databaseWriter: any DatabaseWriter {
         databaseManager.dbWriter
@@ -35,24 +36,34 @@ public final class ConvosClient {
             environment: .tests,
             identityStore: identityStore
         )
-        return .init(sessionManager: sessionManager,
-                     databaseManager: databaseManager,
-                     environment: .tests)
+        return .init(
+            sessionManager: sessionManager,
+            databaseManager: databaseManager,
+            environment: .tests,
+            expiredConversationsWorker: nil
+        )
     }
 
     public static func mock() -> ConvosClient {
         let databaseManager = MockDatabaseManager.previews
         let sessionManager = MockInboxesService()
-        return .init(sessionManager: sessionManager,
-                     databaseManager: databaseManager,
-                     environment: .tests)
+        return .init(
+            sessionManager: sessionManager,
+            databaseManager: databaseManager,
+            environment: .tests,
+            expiredConversationsWorker: nil
+        )
     }
 
-    internal init(sessionManager: any SessionManagerProtocol,
-                  databaseManager: any DatabaseManagerProtocol,
-                  environment: AppEnvironment) {
+    internal init(
+        sessionManager: any SessionManagerProtocol,
+        databaseManager: any DatabaseManagerProtocol,
+        environment: AppEnvironment,
+        expiredConversationsWorker: ExpiredConversationsWorkerProtocol?
+    ) {
         self.sessionManager = sessionManager
         self.databaseManager = databaseManager
         self.environment = environment
+        self.expiredConversationsWorker = expiredConversationsWorker
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Custom Content Types/ExplodeSettingsCodec.swift
+++ b/ConvosCore/Sources/ConvosCore/Custom Content Types/ExplodeSettingsCodec.swift
@@ -61,6 +61,8 @@ public struct ExplodeSettingsCodec: ContentCodec {
     }
 
     public func shouldPush(content: ExplodeSettings) throws -> Bool {
+        // Push to ensure all devices (including offline ones) receive the message
+        // But the notification will be silently dropped (not shown to user)
         true
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Extensions/String+Conversation.swift
+++ b/ConvosCore/Sources/ConvosCore/Extensions/String+Conversation.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+public extension Optional where Wrapped == String {
+    /// Returns the string if it's non-nil and non-empty, otherwise returns "Untitled"
+    var orUntitled: String {
+        guard let self, !self.isEmpty else {
+            return "Untitled"
+        }
+        return self
+    }
+}
+
+public extension String {
+    /// Returns "Untitled" if the string is empty, otherwise returns the string itself
+    var orUntitled: String {
+        (isEmpty ? nil : self).orUntitled
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Inboxes/InboxStateMachine.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/InboxStateMachine.swift
@@ -240,7 +240,7 @@ public actor InboxStateMachine {
         )
 
         // Set custom XMTP host if provided
-        Log.info("🔧 XMTP Configuration:")
+        Log.info("XMTP Configuration:")
 
         // @lourou: Enable XMTP v4 d14n when ready
         // if let gatewayUrl = environment.gatewayUrl {
@@ -263,11 +263,11 @@ public actor InboxStateMachine {
 
         // Log the actual XMTPEnvironment.customLocalAddress after setting
         if let customHost = environment.customLocalAddress {
-            Log.info("🌐 Setting XMTPEnvironment.customLocalAddress = \(customHost)")
+            Log.info("Setting XMTPEnvironment.customLocalAddress = \(customHost)")
             XMTPEnvironment.customLocalAddress = customHost
-            Log.info("🌐 Actual XMTPEnvironment.customLocalAddress = \(XMTPEnvironment.customLocalAddress ?? "nil")")
+            Log.info("Actual XMTPEnvironment.customLocalAddress = \(XMTPEnvironment.customLocalAddress ?? "nil")")
         } else {
-            Log.info("🌐 Using default XMTP endpoints")
+            Log.info("Using default XMTP endpoints")
         }
     }
 
@@ -851,7 +851,7 @@ public actor InboxStateMachine {
         // } else {
 
         // Direct XMTP v3 connection: we specify env and isSecure
-        Log.info("🔗 Using direct XMTP connection with env: \(environment.xmtpEnv)")
+        Log.info("Using direct XMTP connection with env: \(environment.xmtpEnv)")
         let apiOptions: ClientOptions.Api = .init(
             env: environment.xmtpEnv,
             isSecure: environment.isSecure,

--- a/ConvosCore/Sources/ConvosCore/Messaging/MockMessagingService.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/MockMessagingService.swift
@@ -591,15 +591,12 @@ public class MockConversationMetadataWriter: ConversationMetadataWriterProtocol 
 
 class MockConversationPermissionsRepository: ConversationPermissionsRepositoryProtocol {
     func addAdmin(memberInboxId: String, to conversationId: String) async throws {
-        // @lourou
     }
 
     func removeAdmin(memberInboxId: String, from conversationId: String) async throws {
-        // @lourou
     }
 
     func addSuperAdmin(memberInboxId: String, to conversationId: String) async throws {
-        // @lourou
     }
 
     func removeSuperAdmin(memberInboxId: String, from conversationId: String) async throws {

--- a/ConvosCore/Sources/ConvosCore/Messaging/XMTPClientProvider.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/XMTPClientProvider.swift
@@ -196,10 +196,14 @@ extension XMTPiOS.Client: XMTPClientProvider {
 
 extension XMTPiOS.Conversation: MessageSender {
     public func sendExplode(expiresAt: Date) async throws {
+        Log.info("Sending ExplodeSettings message with expiresAt: \(expiresAt) (\(expiresAt.timeIntervalSince1970))")
+        let codec = ExplodeSettingsCodec()
+        Log.info("ExplodeSettings shouldPush: \(try codec.shouldPush(content: ExplodeSettings(expiresAt: expiresAt)))")
         try await send(
             content: ExplodeSettings(expiresAt: expiresAt),
-            options: .init(contentType: ExplodeSettingsCodec().contentType)
+            options: .init(contentType: codec.contentType)
         )
+        Log.info("ExplodeSettings message sent successfully")
     }
 
     public func prepare(text: String) async throws -> String {

--- a/ConvosCore/Sources/ConvosCore/Mocks/ModelMocks.swift
+++ b/ConvosCore/Sources/ConvosCore/Mocks/ModelMocks.swift
@@ -38,6 +38,7 @@ public extension Conversation {
             imageURL: nil,
             isDraft: id.hasPrefix("draft-"),
             invite: nil,
+            expiresAt: nil,
             debugInfo: DBConversation.DebugInfo.empty
         )
     }

--- a/ConvosCore/Sources/ConvosCore/Notifications/NotificationConstants.swift
+++ b/ConvosCore/Sources/ConvosCore/Notifications/NotificationConstants.swift
@@ -24,6 +24,7 @@ struct NotificationConstants {
         static let pushTokenDidChange: String = "convosPushTokenDidChange"
         static let explosionNotificationTapped: String = "explosionNotificationTapped"
         static let conversationNotificationTapped: String = "conversationNotificationTapped"
+        static let conversationExpired: String = "conversationExpired"
     }
 }
 
@@ -31,4 +32,5 @@ extension Notification.Name {
     public static let convosPushTokenDidChange: Notification.Name = Notification.Name(NotificationConstants.AppNotifications.pushTokenDidChange)
     public static let explosionNotificationTapped: Notification.Name = Notification.Name(NotificationConstants.AppNotifications.explosionNotificationTapped)
     public static let conversationNotificationTapped: Notification.Name = Notification.Name(NotificationConstants.AppNotifications.conversationNotificationTapped)
+    public static let conversationExpired: Notification.Name = Notification.Name(NotificationConstants.AppNotifications.conversationExpired)
 }

--- a/ConvosCore/Sources/ConvosCore/Storage/Hydration/DBConversationDetails+Conversation.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Hydration/DBConversationDetails+Conversation.swift
@@ -47,6 +47,7 @@ extension DBConversationDetails {
             imageURL: imageURL,
             isDraft: conversation.isDraft,
             invite: conversationInvite?.hydrateInvite(),
+            expiresAt: conversation.expiresAt,
             debugInfo: conversation.debugInfo
         )
     }

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/Conversation.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/Conversation.swift
@@ -24,6 +24,7 @@ public struct Conversation: Codable, Hashable, Identifiable, Sendable {
     public let imageURL: URL?
     public let isDraft: Bool
     public let invite: Invite?
+    public let expiresAt: Date?
     public let debugInfo: DBConversation.DebugInfo
 }
 
@@ -41,10 +42,7 @@ public extension Conversation {
     }
 
     var displayName: String {
-        guard let name, !name.isEmpty else {
-            return "Untitled"
-        }
-        return name
+        name.orUntitled
     }
 
     var memberNamesString: String {

--- a/ConvosCore/Sources/ConvosCore/Storage/Repositories/ConversationsRepository.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Repositories/ConversationsRepository.swift
@@ -56,6 +56,7 @@ fileprivate extension Database {
         let dbConversationDetails = try DBConversation
             .filter(!DBConversation.Columns.id.like("draft-%"))
             .filter(consent.contains(DBConversation.Columns.consent))
+            .filter(DBConversation.Columns.expiresAt == nil || DBConversation.Columns.expiresAt > Date())
             .detailedConversationQuery()
             .fetchAll(self)
         return try dbConversationDetails.composeConversations(from: self)

--- a/ConvosCore/Sources/ConvosCore/Storage/Repositories/Mocks/MockConversationsRepository.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Repositories/Mocks/MockConversationsRepository.swift
@@ -37,6 +37,7 @@ extension Conversation {
             imageURL: nil,
             isDraft: false,
             invite: .mock(),
+            expiresAt: Date(),
             debugInfo: .empty
         )
     }
@@ -63,6 +64,7 @@ extension Conversation {
             imageURL: nil,
             isDraft: true,
             invite: nil,
+            expiresAt: Date(),
             debugInfo: .empty
         )
     }

--- a/ConvosCore/Sources/ConvosCore/Storage/Workers/ExpiredConversationsWorker.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Workers/ExpiredConversationsWorker.swift
@@ -1,0 +1,151 @@
+import Foundation
+import GRDB
+import UIKit
+
+public protocol ExpiredConversationsWorkerProtocol {}
+
+final class ExpiredConversationsWorker: ExpiredConversationsWorkerProtocol {
+    private let sessionManager: SessionManagerProtocol
+    private let databaseReader: DatabaseReader
+    private var observers: [NSObjectProtocol] = []
+
+    init(
+        databaseReader: DatabaseReader,
+        sessionManager: SessionManagerProtocol
+    ) {
+        self.databaseReader = databaseReader
+        self.sessionManager = sessionManager
+        setupObservers()
+        checkForExpiredConversations()
+    }
+
+    deinit {
+        Log.warning("ExpiredConversationsWorker deinit - removing observers")
+        observers.forEach { NotificationCenter.default.removeObserver($0) }
+    }
+
+    private func setupObservers() {
+        let center = NotificationCenter.default
+
+        observers.append(center.addObserver(
+            forName: UIApplication.didBecomeActiveNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            self?.checkForExpiredConversations()
+        })
+
+        observers.append(center.addObserver(
+            forName: .conversationExpired,
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            Log.info("ExpiredConversationsWorker received .conversationExpired notification")
+            if let conversationId = notification.userInfo?["conversationId"] as? String {
+                self?.handleExpiredConversation(conversationId: conversationId)
+            } else {
+                self?.checkForExpiredConversations()
+            }
+        })
+
+        observers.append(center.addObserver(
+            forName: .explosionNotificationTapped,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            self?.checkForExpiredConversations()
+        })
+    }
+
+    private func checkForExpiredConversations() {
+        Task { [weak self] in
+            guard let self else { return }
+            await self.queryAndProcessExpiredConversations()
+        }
+    }
+
+    private func handleExpiredConversation(conversationId: String) {
+        Task { [weak self] in
+            guard let self else { return }
+            await self.processExpiredConversationById(conversationId)
+        }
+    }
+
+    private func processExpiredConversationById(_ conversationId: String) async {
+        do {
+            let conversation = try await databaseReader.read { db -> ExpiredConversation? in
+                guard let row = try DBConversation.fetchOne(db, key: conversationId) else {
+                    Log.warning("Conversation not found for expiration: \(conversationId)")
+                    return nil
+                }
+                return ExpiredConversation(
+                    conversationId: row.id,
+                    clientId: row.clientId,
+                    inboxId: row.inboxId
+                )
+            }
+            if let conversation {
+                await cleanupExpiredConversation(conversation)
+            }
+        } catch {
+            Log.error("Failed to fetch expired conversation \(conversationId): \(error)")
+        }
+    }
+
+    private func queryAndProcessExpiredConversations() async {
+        do {
+            let expiredConversations = try await databaseReader.read { db in
+                try db.fetchExpiredConversations()
+            }
+            guard !expiredConversations.isEmpty else { return }
+            await processExpiredConversations(expiredConversations)
+        } catch {
+            Log.error("Failed to query expired conversations: \(error)")
+        }
+    }
+
+    private func processExpiredConversations(_ conversations: [ExpiredConversation]) async {
+        for conversation in conversations {
+            await cleanupExpiredConversation(conversation)
+        }
+    }
+
+    private func cleanupExpiredConversation(_ conversation: ExpiredConversation) async {
+        Log.info("Cleaning up expired conversation: \(conversation.conversationId), posting leftConversationNotification")
+
+        await MainActor.run {
+            NotificationCenter.default.post(
+                name: .leftConversationNotification,
+                object: nil,
+                userInfo: [
+                    "conversationId": conversation.conversationId,
+                    "clientId": conversation.clientId,
+                    "inboxId": conversation.inboxId
+                ]
+            )
+        }
+    }
+}
+
+struct ExpiredConversation {
+    let conversationId: String
+    let clientId: String
+    let inboxId: String
+}
+
+fileprivate extension Database {
+    func fetchExpiredConversations() throws -> [ExpiredConversation] {
+        let rows = try DBConversation
+            .filter(DBConversation.Columns.expiresAt != nil)
+            .filter(DBConversation.Columns.expiresAt <= Date())
+            .fetchAll(self)
+
+        return rows.map { row in
+            ExpiredConversation(
+                conversationId: row.id,
+                clientId: row.clientId,
+                inboxId: row.inboxId
+            )
+        }
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Syncing/InviteJoinRequestsManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/InviteJoinRequestsManager.swift
@@ -207,7 +207,9 @@ class InviteJoinRequestsManager: InviteJoinRequestsManagerProtocol {
         switch conversation {
         case .group(let group):
             Log.info("Adding \(senderInboxId) to group \(group.id)...")
+
             try await group.add(members: [senderInboxId])
+
             let conversationName = try? group.name()
             return JoinRequestResult(
                 conversationId: group.id,


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Add conversation “explode” flow that sends `ExplodeSettings` with a 20s timeout, updates `expiresAt`, denies group consent, removes members, and posts explosion notifications across UI and background workers
Implements a stateful explode action from the conversation view model, wires UI disabled/error states, posts distinct explosion notifications, excludes expired conversations from queries, and adds a worker to clean up expired threads; also persists and processes `expiresAt` via incoming messages and streaming handlers.

#### 📍Where to Start
Start with the explode entry point `ConversationViewModel.explodeConvo()` in [ConversationViewModel.swift](https://github.com/ephemeraHQ/convos-ios/pull/219/files#diff-b82b1a141f7e3950a1be2924e959e9271da1f9cc7679b7e23df75da55f011419), then follow explosion handling through push handling in [MessagingService+PushNotifications.swift](https://github.com/ephemeraHQ/convos-ios/pull/219/files#diff-e3600c561fc30fca5b793ab019a6c9384b2f81973531eff39d65eba919fddf4b) and stream processing in [StreamProcessor.swift](https://github.com/ephemeraHQ/convos-ios/pull/219/files#diff-f78e6097ff7047f6d74818393ba23110c801e841158bb8edeaee24ec74566791).

<!-- Macroscope's changelog starts here -->
#### Changes since #219 opened

- Removed time-window validation for explode settings and refactored processing to decode settings earlier in the message handling pipeline [3d8c9a7]
- Modified expired conversation processing to handle conversations without `expiresAt` field and post notifications when conversations expire [3d8c9a7]
- Moved `expiredConversationsWorker` storage and lifecycle management from `ConvosAppDelegate` to `ConvosApp` [3d8c9a7]
- Added `profileImage` computed property to `ConversationViewModel` and fixed timing issue in profile image retrieval during display name editing [3d8c9a7]
- Updated dependency resolution file [e9777db]
- Converted `ExpiredConversationsWorker` from explicit startup to automatic initialization pattern [1723eea]
- Refactored `ConvosApp` to retain `ConvosClient` instance instead of `SessionManagerProtocol` and `ExpiredConversationsWorkerProtocol` instances [8b2f51c]
<!-- Macroscope's changelog ends here -->

----
<!-- Macroscope's review summary starts here -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized a8f7806. 28 files reviewed, 54 issues evaluated, 53 issues filtered, 0 comments posted</summary>

### 🗂️ Filtered Issues
<details>
<summary>Convos/Conversation Detail/ConversationViewModel.swift — 0 comments posted, 7 evaluated, 7 filtered</summary>

- [line 113](https://github.com/ephemeraHQ/convos-ios/blob/a8f7806f16a0cfee25b977bda33d5ed95fc113fa/Convos/Conversation Detail/ConversationViewModel.swift#L113): Global mutable state `isExploding` is declared at file scope. Without actor isolation or synchronization, concurrent access from multiple tasks/threads can race, and the single shared variable couples all `ConversationViewModel` users, causing cross-talk between unrelated conversations. This can manifest as incorrect UI state or nondeterministic behavior when multiple view models are active. <b>[ Low confidence ]</b>
- [line 114](https://github.com/ephemeraHQ/convos-ios/blob/a8f7806f16a0cfee25b977bda33d5ed95fc113fa/Convos/Conversation Detail/ConversationViewModel.swift#L114): Global mutable state `explodeError` is declared at file scope. As a shared optional `String` without actor isolation or synchronization, it can race under concurrent access and may leak error state across different `ConversationViewModel` instances, causing unrelated screens to show stale errors. <b>[ Low confidence ]</b>
- [line 395](https://github.com/ephemeraHQ/convos-ios/blob/a8f7806f16a0cfee25b977bda33d5ed95fc113fa/Convos/Conversation Detail/ConversationViewModel.swift#L395): Cancellation race in onTapInvite: after checking `guard !Task.isCancelled` (line 395), the code calls `viewModel.joinConversation(...)` (line 396) without another cancellation check or passing cancellation to the join. If the task is cancelled between the check and the call, the join still executes. Consider a second `Task.isCancelled` check immediately before joining, or making `joinConversation` cooperatively cancel using a `Task` handle or `CancellationError` propagation. <b>[ Low confidence ]</b>
- [line 483](https://github.com/ephemeraHQ/convos-ios/blob/a8f7806f16a0cfee25b977bda33d5ed95fc113fa/Convos/Conversation Detail/ConversationViewModel.swift#L483): `sendExplode(expiresAt:)` is invoked (line 483) before validating that `xmtpConversation` is a group. If `xmtpConversation` is not a group, the code later throws `ExplodeConvoError.notGroupConversation` (lines 487–489), but by then the explode message may already have been sent, causing a side effect on a non-group conversation and leaving local state partially updated only via the error path. This violates atomicity and can produce inconsistent external vs. local state. <b>[ Low confidence ]</b>
- [line 483](https://github.com/ephemeraHQ/convos-ios/blob/a8f7806f16a0cfee25b977bda33d5ed95fc113fa/Convos/Conversation Detail/ConversationViewModel.swift#L483): explodeConvo sends the explode message before validating that the target conversation is a group. At lines 483–485, `xmtpConversation.sendExplode` is invoked, and only afterwards (line 487) a `guard case .group(let group) = xmtpConversation` enforces the group constraint. This can apply the side effect to a non-group conversation and then throw `notGroupConversation`, surfacing an error while the explode was already attempted. The check for group type should occur before performing `sendExplode` so no side-effect is applied on an invalid target. <b>[ Low confidence ]</b>
- [line 509](https://github.com/ephemeraHQ/convos-ios/blob/a8f7806f16a0cfee25b977bda33d5ed95fc113fa/Convos/Conversation Detail/ConversationViewModel.swift#L509): Behavioral regression and misleading log: the previous path deleted the inbox (`session.deleteInbox`) after explosion, but the new code removed that call while leaving the log `"Explode complete, inbox deletion triggered"` (line 509). This breaks contract parity (missing side effect) and emits a log that explicitly contradicts the actual behavior, creating operational confusion and potential stale local state. <b>[ Low confidence ]</b>
- [line 510](https://github.com/ephemeraHQ/convos-ios/blob/a8f7806f16a0cfee25b977bda33d5ed95fc113fa/Convos/Conversation Detail/ConversationViewModel.swift#L510): explodeConvo no longer deletes the inbox but still logs "Explode complete, inbox deletion triggered" (line 510). The previous implementation (per diff) called `session.deleteInbox(clientId:)`; that call is now removed, yet the log implies deletion occurs. This is a visible contract change and a misleading log that can cause incorrect assumptions by callers/observers. If inbox deletion is intended to happen, it must be performed; otherwise, update logs and any dependent flows to reflect the new behavior and ensure downstream consumers rely on the correct terminal state. <b>[ Low confidence ]</b>
</details>

<details>
<summary>Convos/Conversation Detail/Messages/ConversationInfoButton.swift — 0 comments posted, 2 evaluated, 1 filtered</summary>

- [line 75](https://github.com/ephemeraHQ/convos-ios/blob/a8f7806f16a0cfee25b977bda33d5ed95fc113fa/Convos/Conversation Detail/Messages/ConversationInfoButton.swift#L75): The destructive confirmation action `Button("Explode", role: .destructive)` in the `.confirmationDialog` is always enabled and calls `onExplodeNow()` even when `isExploding` is true. This allows a user to open the dialog when not exploding, then the state flips to exploding before they confirm, and tapping "Explode" will re-trigger the action, violating at-most-once semantics and potentially double-applying side effects. The main trigger button is disabled via `.disabled(isExploding)`, but the confirm button lacks an equivalent guard, creating an inconsistent contract and a race window. Add a guard inside the confirm action and/or disable/hide the confirm button when `isExploding` is true, and ensure idempotency (e.g., no-ops when already exploding). <b>[ Low confidence ]</b>
</details>

<details>
<summary>Convos/Conversations List/ConversationsViewModel.swift — 0 comments posted, 3 evaluated, 3 filtered</summary>

- [line 286](https://github.com/ephemeraHQ/convos-ios/blob/a8f7806f16a0cfee25b977bda33d5ed95fc113fa/Convos/Conversations List/ConversationsViewModel.swift#L286): The NotificationCenter observer created with `addObserver(forName:object:queue:using:)` is registered at line 286 and stored in `leftConversationObserver`, but there is no corresponding removal in this code path. Block-based observers are retained by NotificationCenter until explicitly removed via `removeObserver(_:)`. If not removed (e.g., in `deinit`), this causes a long-lived observer and closure to be retained, resulting in a memory leak and unnecessary notification handling. Although `self` is captured weakly (avoiding use-after-free), the observer itself will leak and continue to execute a `Task` on every matching notification. <b>[ Low confidence ]</b>
- [line 309](https://github.com/ephemeraHQ/convos-ios/blob/a8f7806f16a0cfee25b977bda33d5ed95fc113fa/Convos/Conversations List/ConversationsViewModel.swift#L309): On `.explosionNotificationTapped` (lines 306–313), only `selectedConversation` is set to `nil`, but `selectedConversationId` and `selectedConversationViewModel` are not cleared. This diverges from the `leftConversationNotification` path where all three are cleared together. Unless other code guarantees synchronization when `selectedConversation` changes, this can leave a stale `selectedConversationId` or `selectedConversationViewModel` that no longer matches `selectedConversation`, leading to inconsistent state and potential UI or logic errors. <b>[ Low confidence ]</b>
- [line 336](https://github.com/ephemeraHQ/convos-ios/blob/a8f7806f16a0cfee25b977bda33d5ed95fc113fa/Convos/Conversations List/ConversationsViewModel.swift#L336): Selection state may become inconsistent when the selected conversation disappears from the repository. At lines 336–340, if `_selectedConversationId` is no longer present in `conversations`, only `selectedConversationId` is cleared (`selectedConversationId = nil`). Unlike the `leftConversationNotification` path (lines 294–301) where `selectedConversation`, `selectedConversationId`, and `selectedConversationViewModel` are all nulled, this path does not explicitly clear `selectedConversation` or `selectedConversationViewModel`. Unless the `selectedConversationId` setter guarantees clearing the other properties, this can leave stale `selectedConversation`/`selectedConversationViewModel` referencing a non-existent conversation, causing inconsistent UI state or logic that assumes alignment between these fields. <b>[ Already posted ]</b>
</details>

<details>
<summary>Convos/ConvosApp.swift — 0 comments posted, 2 evaluated, 2 filtered</summary>

- [line 40](https://github.com/ephemeraHQ/convos-ios/blob/a8f7806f16a0cfee25b977bda33d5ed95fc113fa/Convos/ConvosApp.swift#L40): Firebase configuration may be skipped but initialization proceeds anyway, contradicting the stated intent to configure it before creating `ConvosClient`. The comment says configuring Firebase first "prevents SessionManager trying to use AppCheck before it's configured", yet in non-test environments where `firebaseConfigURL` is `nil`, the code only logs an error and continues to create the client (`self.convos = .client(...)`). This risks downstream runtime failures if `SessionManager` assumes Firebase/AppCheck is set up. Either fail fast before constructing the client, provide a safe fallback path that guarantees SessionManager won't touch AppCheck, or ensure the client/session can operate without Firebase. <b>[ Low confidence ]</b>
- [line 115](https://github.com/ephemeraHQ/convos-ios/blob/a8f7806f16a0cfee25b977bda33d5ed95fc113fa/Convos/ConvosApp.swift#L115): Migration marks completion even if the wipe only partially succeeds or is entirely skipped. After attempting deletions in the Documents directory and database files, the code unconditionally sets `UserDefaults` key `"data_wipe_migration_v1_0_completed"` to `true` (and also when `documentsDirectory` is `nil`). This can leave the app in an inconsistent state (partially wiped data) while preventing the migration from retrying on next launch. Consider marking completion only after verifying all required deletions succeeded, or persisting per-step status and retrying failures. <b>[ Low confidence ]</b>
</details>

<details>
<summary>Convos/ConvosAppDelegate.swift — 0 comments posted, 2 evaluated, 2 filtered</summary>

- [line 42](https://github.com/ephemeraHQ/convos-ios/blob/a8f7806f16a0cfee25b977bda33d5ed95fc113fa/Convos/ConvosAppDelegate.swift#L42): Fragile type check for `userInfo["isExplosion"]` assumes a `Bool`. APNs/NSE payloads often encode values as `String` or `NSNumber`. If `isExplosion` arrives as, e.g., "true" or 1, the cast fails and the explosion path won't trigger. Result: foreground explosions may be misclassified as regular notifications (no sound and potentially suppressed if `session.shouldDisplayNotification` returns false). Accept multiple representations (Bool/String/NSNumber) or normalize the value before branching. <b>[ Low confidence ]</b>
- [line 73](https://github.com/ephemeraHQ/convos-ios/blob/a8f7806f16a0cfee25b977bda33d5ed95fc113fa/Convos/ConvosAppDelegate.swift#L73): Contract change for explosion taps: previously the posted notification guaranteed a `userInfo` containing `"inboxId"`, `"conversationId"`, and `"notificationType"`. Now it forwards `response.notification.request.content.userInfo` as-is. Observers relying on those guaranteed keys may crash or misbehave when payloads omit or rename them. Either preserve the prior guaranteed keys (merge/normalize) or version/document the change and update all observers. <b>[ Low confidence ]</b>
</details>

<details>
<summary>Convos/Profile/MyProfileViewModel.swift — 0 comments posted, 1 evaluated, 1 filtered</summary>

- [line 125](https://github.com/ephemeraHQ/convos-ios/blob/a8f7806f16a0cfee25b977bda33d5ed95fc113fa/Convos/Profile/MyProfileViewModel.swift#L125): In `onEndedEditing(for:)`, the Quickname save block passes `profileImage` into `.with(profileImage: profileImage)` after the property `self.profileImage` was set to `nil` above. The `if let profileImage { ... }` creates a shadowed local constant only within that block; outside it, `profileImage` refers to the class property, which has just been cleared. As a result, even when a new image was chosen and updated, the saved Quickname will always receive `nil` for `profileImage`. Capture the image to a temporary variable that outlives the `if let` scope (before clearing the property), or reorder so you pass the correct image into Quickname saving. <b>[ Already posted ]</b>
</details>

<details>
<summary>ConvosCore/Sources/ConvosCore/Inboxes/InboxStateMachine.swift — 0 comments posted, 2 evaluated, 2 filtered</summary>

- [line 267](https://github.com/ephemeraHQ/convos-ios/blob/a8f7806f16a0cfee25b977bda33d5ed95fc113fa/ConvosCore/Sources/ConvosCore/Inboxes/InboxStateMachine.swift#L267): Initializer mutates process-wide global `XMTPEnvironment.customLocalAddress` from within an actor, introducing shared global side effects that can race or conflict with other components. If multiple instances or threads access/modify this global concurrently, behavior is non-deterministic (ordering/race) and cross-instance interference occurs. Move this configuration to a single, process-initialization point with proper synchronization (e.g., once-only setup) or provide a thread-safe API in `XMTPEnvironment` to encapsulate mutation. <b>[ Low confidence ]</b>
- [line 270](https://github.com/ephemeraHQ/convos-ios/blob/a8f7806f16a0cfee25b977bda33d5ed95fc113fa/ConvosCore/Sources/ConvosCore/Inboxes/InboxStateMachine.swift#L270): `XMTPEnvironment.customLocalAddress` is only set when `environment.customLocalAddress` is non-nil, but it is never cleared when `environment.customLocalAddress` is nil. This allows a stale value from a prior initialization to persist and affect subsequent instances, leading to cross-instance configuration bleed (e.g., misrouting traffic to an old host). Explicitly set `XMTPEnvironment.customLocalAddress = nil` in the `else` branch to restore defaults. <b>[ Low confidence ]</b>
</details>

<details>
<summary>ConvosCore/Sources/ConvosCore/Inboxes/MessagingService+PushNotifications.swift — 0 comments posted, 5 evaluated, 5 filtered</summary>

- [line 204](https://github.com/ephemeraHQ/convos-ios/blob/a8f7806f16a0cfee25b977bda33d5ed95fc113fa/ConvosCore/Sources/ConvosCore/Inboxes/MessagingService+PushNotifications.swift#L204): Regression: group messages from self are no longer explicitly dropped. Previously, a pre-switch guard dropped any message where `decodedMessage.senderInboxId == currentInboxId`. The new code adds this check only inside the `.dm` case (lines 172–175) and not for `.group`, so a user may receive notifications for their own group messages unless `handleGroupMessage` independently reimplements this filter. To preserve prior behavior and avoid self-notifications, add the self-check for group messages before invoking `handleGroupMessage` or within it, guaranteed on all paths. <b>[ Low confidence ]</b>
- [line 205](https://github.com/ephemeraHQ/convos-ios/blob/a8f7806f16a0cfee25b977bda33d5ed95fc113fa/ConvosCore/Sources/ConvosCore/Inboxes/MessagingService+PushNotifications.swift#L205): Contract parity risk in group handling: previously, the `.group` branch explicitly (a) persisted the conversation via `storeConversation`, (b) persisted the message via `IncomingMessageWriter.store`, and (c) dropped non-text content by checking `decodedMessage.encodedContent.type == ContentTypeText`. The new code delegates all handling to `handleGroupMessage` without ensuring these behaviors remain. If `handleGroupMessage` does not replicate text-only filtering, persistence ordering, and drop semantics, external behavior changes (e.g., notifications for non-text messages, missed or duplicated persistence) may occur. Ensure `handleGroupMessage` enforces the same filters and side effects atomically, or document and intentionally migrate the contract. <b>[ Low confidence ]</b>
- [line 223](https://github.com/ephemeraHQ/convos-ios/blob/a8f7806f16a0cfee25b977bda33d5ed95fc113fa/ConvosCore/Sources/ConvosCore/Inboxes/MessagingService+PushNotifications.swift#L223): Self-sender suppression is bypassed for explode-settings messages. The code returns early to `handleExplodeSettingsMessage(...)` before checking `decodedMessage.senderInboxId == currentInboxId`, so messages that carry explode settings authored by the current user can produce notifications for their own action. The self-sender check should occur before the explode-settings branch (or `handleExplodeSettingsMessage` must guarantee suppression for self-sent messages). <b>[ Low confidence ]</b>
- [line 283](https://github.com/ephemeraHQ/convos-ios/blob/a8f7806f16a0cfee25b977bda33d5ed95fc113fa/ConvosCore/Sources/ConvosCore/Inboxes/MessagingService+PushNotifications.swift#L283): The code unconditionally overrides potential existing entries in `userInfo` by setting `explosionUserInfo["isExplosion"] = true` and `explosionUserInfo["clientId"] = currentInboxId`. If callers upstream already provided these keys with different meanings/values, this silently clobbers them, causing data loss or incorrect routing/behavior for consumers that rely on the original values. Prefer using namespaced keys, checking for presence before overwriting, or explicitly documenting/renaming keys to avoid collision. <b>[ Low confidence ]</b>
- [line 286](https://github.com/ephemeraHQ/convos-ios/blob/a8f7806f16a0cfee25b977bda33d5ed95fc113fa/ConvosCore/Sources/ConvosCore/Inboxes/MessagingService+PushNotifications.swift#L286): The change hardcodes the notification `title` and `body` to "💥 \(conversationName) 💥" and "A convo exploded", replacing previously used variables (e.g., `notificationTitle`/`notificationBody`). This is an externally visible contract change that can break localization, formatting expectations, or downstream features relying on specific content structure. If other code or UI analytics expect the prior values, this leads to incorrect runtime behavior, not just presentation differences. <b>[ Low confidence ]</b>
</details>

<details>
<summary>ConvosCore/Sources/ConvosCore/Messaging/MockMessagingService.swift — 0 comments posted, 3 evaluated, 3 filtered</summary>

- [line 593](https://github.com/ephemeraHQ/convos-ios/blob/a8f7806f16a0cfee25b977bda33d5ed95fc113fa/ConvosCore/Sources/ConvosCore/Messaging/MockMessagingService.swift#L593): `addAdmin(memberInboxId:to:)` has an empty body but is declared `async throws`. It returns successfully without effect or validation and without throwing on error conditions. Callers will observe a successful completion while no admin is added, violating the expected contract and creating silent state inconsistency. <b>[ Low confidence ]</b>
- [line 596](https://github.com/ephemeraHQ/convos-ios/blob/a8f7806f16a0cfee25b977bda33d5ed95fc113fa/ConvosCore/Sources/ConvosCore/Messaging/MockMessagingService.swift#L596): `removeAdmin(memberInboxId:from:)` has an empty body while being `async throws`. It completes without effect and without throwing, so callers believe the admin was removed when nothing happened, causing silent divergence between expected and actual state. <b>[ Low confidence ]</b>
- [line 599](https://github.com/ephemeraHQ/convos-ios/blob/a8f7806f16a0cfee25b977bda33d5ed95fc113fa/ConvosCore/Sources/ConvosCore/Messaging/MockMessagingService.swift#L599): `addSuperAdmin(memberInboxId:to:)` has an empty body while being `async throws`. It returns successfully without performing any state change or validation, misleading callers into believing a super admin was granted when no change occurred. <b>[ Low confidence ]</b>
</details>

<details>
<summary>ConvosCore/Sources/ConvosCore/Messaging/XMTPClientProvider.swift — 0 comments posted, 1 evaluated, 1 filtered</summary>

- [line 201](https://github.com/ephemeraHQ/convos-ios/blob/a8f7806f16a0cfee25b977bda33d5ed95fc113fa/ConvosCore/Sources/ConvosCore/Messaging/XMTPClientProvider.swift#L201): Logging line uses a throwing call inside string interpolation: `Log.info("ExplodeSettings shouldPush: \(try codec.shouldPush(content: ExplodeSettings(expiresAt: expiresAt)))")`. If `codec.shouldPush(...)` throws for any reason, the error will propagate and abort `sendExplode` before calling `send(content:options:)`. This introduces a new externally observable failure mode where a non-essential logging computation prevents sending the message, breaking contract parity with a behavior that should remain best-effort. Use `try?` (and log fallback) or compute outside logging with explicit error handling to avoid aborting the send. <b>[ Low confidence ]</b>
</details>

<details>
<summary>ConvosCore/Sources/ConvosCore/Mocks/ModelMocks.swift — 0 comments posted, 2 evaluated, 2 filtered</summary>

- [line 18](https://github.com/ephemeraHQ/convos-ios/blob/a8f7806f16a0cfee25b977bda33d5ed95fc113fa/ConvosCore/Sources/ConvosCore/Mocks/ModelMocks.swift#L18): If the caller passes an empty `members` array, `creator` is synthesized via `.mock(isCurrentUser: true)` and thus is not included in `members` (which remains empty). This creates an inconsistent `Conversation` where `creator` is not among `members`. If downstream logic assumes the creator is a participant, this violates an invariant and can cause incorrect behavior during tests/previews. <b>[ Out of scope ]</b>
- [line 32](https://github.com/ephemeraHQ/convos-ios/blob/a8f7806f16a0cfee25b977bda33d5ed95fc113fa/ConvosCore/Sources/ConvosCore/Mocks/ModelMocks.swift#L32): When `members` contains exactly two entries and both have `isCurrentUser == false`, `kind` becomes `.dm` but `otherMember` is computed as `mockMembers.first(where: { !$0.isCurrentUser })`, which returns the first element. Since `creator` also becomes the first element (no current user present), `otherMember` equals `creator`. In a 2-member DM, `otherMember` should be the other participant (the second element), not the creator. This yields an inconsistent DM conversation. <b>[ Out of scope ]</b>
</details>

<details>
<summary>ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift — 0 comments posted, 8 evaluated, 8 filtered</summary>

- [line 98](https://github.com/ephemeraHQ/convos-ios/blob/a8f7806f16a0cfee25b977bda33d5ed95fc113fa/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift#L98): `deinit` cancels tasks and removes observers but does not stop any active `messagingServices`. If `SessionManager` is deallocated without prior explicit deletion of inboxes, underlying services may continue running or hold resources until they detect owner loss (if ever), leading to potential leaks or dangling background work. A paired cleanup (stop/tear down all services) is missing in `deinit`. <b>[ Low confidence ]</b>
- [line 154](https://github.com/ephemeraHQ/convos-ios/blob/a8f7806f16a0cfee25b977bda33d5ed95fc113fa/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift#L154): `leftConversationNotification` handler now requires both `conversationId` and `clientId` in `userInfo` (`guard let conversationId ... , let clientId ... else { return }`). This makes deletion of the inbox contingent on `conversationId` being present. If a valid notification arrives without `conversationId` (but with `clientId`), the handler returns early: it will neither clear `activeConversationId` nor delete the inbox. Previously, deletion did not depend on `conversationId`. This can leave stale state and resources (messaging service and DB row) undeleted. <b>[ Low confidence ]</b>
- [line 160](https://github.com/ephemeraHQ/convos-ios/blob/a8f7806f16a0cfee25b977bda33d5ed95fc113fa/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift#L160): Potential deadlock: the notification handler runs on the `.main` queue, and it calls `serviceQueue.sync { ... }` (lines with `serviceQueue.sync`). If `serviceQueue` is (or targets) the main queue, this will synchronously dispatch onto the same queue, causing a deadlock. There is no visible guard or invariant here ensuring `serviceQueue` is distinct from the main queue. Consider asserting/guaranteeing `serviceQueue` is a non-main serial queue or switching to `async` when called from main. <b>[ Low confidence ]</b>
- [line 167](https://github.com/ephemeraHQ/convos-ios/blob/a8f7806f16a0cfee25b977bda33d5ed95fc113fa/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift#L167): The previous behavior scheduled a local “explosion” notification (including optional image attachment). That entire notification flow (`scheduleExplosionNotification` and its call site) was removed. This is an externally visible behavior change: explosion events no longer generate a local notification. If clients or UX rely on that notification, this is a contract/behavior regression. <b>[ Low confidence ]</b>
- [line 168](https://github.com/ephemeraHQ/convos-ios/blob/a8f7806f16a0cfee25b977bda33d5ed95fc113fa/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift#L168): Inbox deletion runs unconditionally for every `.leftConversationNotification` (lines starting the Task that calls `deleteInbox(clientId:)`). If this notification is used for both ordinary 'leave' and 'explosion' events, the code will delete the entire inbox even on an ordinary leave. The log message says "Deleted inbox after explosion", but there is no check to distinguish explosion from a simple leave. This can cause unintended destructive side effects if non-explosion leaves are expected not to delete the inbox. <b>[ Already posted ]</b>
- [line 209](https://github.com/ephemeraHQ/convos-ios/blob/a8f7806f16a0cfee25b977bda33d5ed95fc113fa/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift#L209): Possible deadlock: `serviceQueue.sync { ... }` is invoked from an `async` public API without guarding against being called while already executing on `serviceQueue`. If `deleteInbox(clientId:)` is ever invoked from work already on `serviceQueue`, the synchronous dispatch to the same queue will deadlock. Add a precondition/guard to avoid calling from `serviceQueue`, or use reentrant-safe access (e.g., `dispatchPrecondition`, `serviceQueue.async` + awaiting a continuation, or make the storage an actor). <b>[ Low confidence ]</b>
- [line 221](https://github.com/ephemeraHQ/convos-ios/blob/a8f7806f16a0cfee25b977bda33d5ed95fc113fa/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift#L221): Partial cleanup leaves inconsistent state if the database deletion fails: the service is removed from `messagingServices` (and potentially already stopped), but `InboxWriter.delete(clientId:)` can throw, leaving persistent data undeleted. There is no rollback or compensating action, and callers receive a thrown error after in-memory state has been irrevocably changed. If atomic semantics are required, this violates them; otherwise, at least log/escalate and document the partial-failure behavior, or stage changes (e.g., stop service but defer removal from registry until DB deletion succeeds, or mark as 'deleting' to block new use while allowing a retry). <b>[ Low confidence ]</b>
- [line 222](https://github.com/ephemeraHQ/convos-ios/blob/a8f7806f16a0cfee25b977bda33d5ed95fc113fa/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift#L222): Race on concurrent invocations for the same `clientId`: both calls proceed independently. The first call removes the service and awaits `stopAndDelete()`. A second concurrent call will find no service and still proceed to `try await inboxWriter.delete(clientId:)`. If `delete(clientId:)` is not idempotent, the second call can fail with an error (e.g., 'not found'), causing flaky behavior. Consider guarding with a per-client lock, de-duplicating in-flight deletes, or making the DB delete idempotent and treating missing rows as success. <b>[ Low confidence ]</b>
</details>

<details>
<summary>ConvosCore/Sources/ConvosCore/Storage/Models/Conversation.swift — 0 comments posted, 1 evaluated, 1 filtered</summary>

- [line 45](https://github.com/ephemeraHQ/convos-ios/blob/a8f7806f16a0cfee25b977bda33d5ed95fc113fa/ConvosCore/Sources/ConvosCore/Storage/Models/Conversation.swift#L45): `displayName` previously returned "Untitled" when `name` was `nil` OR an empty string. It now delegates to `name.orUntitled`. If `orUntitled` only substitutes on `nil` and not on empty strings, `displayName` will return an empty string instead of "Untitled" for `name == ""`, changing externally visible behavior. This is a contract-parity regression unless `orUntitled` preserves the exact prior semantics (nil OR empty -> "Untitled"). <b>[ Low confidence ]</b>
</details>

<details>
<summary>ConvosCore/Sources/ConvosCore/Storage/Repositories/Mocks/MockConversationsRepository.swift — 0 comments posted, 1 evaluated, 1 filtered</summary>

- [line 25](https://github.com/ephemeraHQ/convos-ios/blob/a8f7806f16a0cfee25b977bda33d5ed95fc113fa/ConvosCore/Sources/ConvosCore/Storage/Repositories/Mocks/MockConversationsRepository.swift#L25): Parameter `date` is accepted but never used. `createdAt` is set to `Date()` instead of the provided `date`, so callers cannot control the creation time and will get non-deterministic values. Replace `createdAt: Date()` with `createdAt: date`. <b>[ Out of scope ]</b>
</details>

<details>
<summary>ConvosCore/Sources/ConvosCore/Storage/Workers/ExpiredConversationsWorker.swift — 0 comments posted, 6 evaluated, 6 filtered</summary>

- [line 60](https://github.com/ephemeraHQ/convos-ios/blob/a8f7806f16a0cfee25b977bda33d5ed95fc113fa/ConvosCore/Sources/ConvosCore/Storage/Workers/ExpiredConversationsWorker.swift#L60): No reentrancy/in-flight guard exists around `checkForExpiredConversations()` and `queryAndProcessExpiredConversations()`. Multiple notifications in quick succession (e.g., `didBecomeActive`, `.conversationExpired`, `.explosionNotificationTapped`) can spawn overlapping `Task`s that each fetch and process the same expired rows, causing duplicate `leftConversationNotification` emissions. There is no serialization, debounce, or at-most-once processing gate. <b>[ Low confidence ]</b>
- [line 61](https://github.com/ephemeraHQ/convos-ios/blob/a8f7806f16a0cfee25b977bda33d5ed95fc113fa/ConvosCore/Sources/ConvosCore/Storage/Workers/ExpiredConversationsWorker.swift#L61): Race condition: the worker may process the same conversation concurrently from multiple triggers, leading to duplicate `leftConversationNotification` posts. `checkForExpiredConversations` and `handleExpiredConversation` each spawn uncoordinated `Task`s; there is no synchronization or in-flight tracking. Overlapping invocations (e.g., multiple `UIApplication.didBecomeActive` firings, `.conversationExpired` and batch processing running together) can simultaneously process the same conversation and double-emit the notification. <b>[ Low confidence ]</b>
- [line 87](https://github.com/ephemeraHQ/convos-ios/blob/a8f7806f16a0cfee25b977bda33d5ed95fc113fa/ConvosCore/Sources/ConvosCore/Storage/Workers/ExpiredConversationsWorker.swift#L87): `processExpiredConversationById(_:)` cleans up any conversation that exists without verifying it is actually expired. In the `.conversationExpired` path, if a notification is posted erroneously or prematurely, this code will still call `cleanupExpiredConversation` for a non-expired conversation because it only checks that `DBConversation.fetchOne` returns a row and never validates `row.expiresAt <= Date()`. This can lead to incorrect removal/left-notification for active conversations. <b>[ Low confidence ]</b>
- [line 87](https://github.com/ephemeraHQ/convos-ios/blob/a8f7806f16a0cfee25b977bda33d5ed95fc113fa/ConvosCore/Sources/ConvosCore/Storage/Workers/ExpiredConversationsWorker.swift#L87): The single-conversation path does not validate that the conversation is actually expired before triggering cleanup. In `processExpiredConversationById`, after fetching the row, the code immediately constructs `ExpiredConversation` and calls `cleanupExpiredConversation` without checking `row.expiresAt` or comparing it to `Date()`. This diverges from the batch path which explicitly filters `expiresAt <= Date()`. As a result, a `.conversationExpired` notification with a valid `conversationId` for a non-expired conversation will still cause a leftConversationNotification to be posted, prematurely cleaning up a non-expired conversation. <b>[ Low confidence ]</b>
- [line 95](https://github.com/ephemeraHQ/convos-ios/blob/a8f7806f16a0cfee25b977bda33d5ed95fc113fa/ConvosCore/Sources/ConvosCore/Storage/Workers/ExpiredConversationsWorker.swift#L95): Expired conversations are never marked as processed in storage, so the same conversations will be reprocessed and `leftConversationNotification` re-posted repeatedly on every trigger (e.g., app becomes active, `.explosionNotificationTapped`, or subsequent `.conversationExpired` without id). The query `fetchExpiredConversations()` filters only by `expiresAt <= Date()` and `cleanupExpiredConversation` performs no DB mutation. This violates at-most-once semantics and can lead to duplicate side effects. <b>[ Low confidence ]</b>
- [line 108](https://github.com/ephemeraHQ/convos-ios/blob/a8f7806f16a0cfee25b977bda33d5ed95fc113fa/ConvosCore/Sources/ConvosCore/Storage/Workers/ExpiredConversationsWorker.swift#L108): No at-most-once semantics for expired conversation processing. The batch path (`queryAndProcessExpiredConversations` -> `processExpiredConversations` -> `cleanupExpiredConversation`) emits `leftConversationNotification` but never updates persistent state to mark the conversation as handled (e.g., clearing `expiresAt`, deleting, or writing a processed flag). Combined with repeated triggers (e.g., app becoming active, `.explosionNotificationTapped`, or repeated queries), the same expired conversations will be processed and notifications posted repeatedly, causing duplicated side effects. <b>[ Low confidence ]</b>
</details>

<details>
<summary>ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationMetadataWriter.swift — 0 comments posted, 3 evaluated, 3 filtered</summary>

- [line 85](https://github.com/ephemeraHQ/convos-ios/blob/a8f7806f16a0cfee25b977bda33d5ed95fc113fa/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationMetadataWriter.swift#L85): Remote side-effect (`group.updateExpiresAt(date:)`) is performed before verifying the local record exists. If the local conversation is missing in the database, the code still updates the remote group (lines 80–86) and only afterwards attempts to fetch and update the local record (lines 87–95). When `DBConversation.fetchOne` returns `nil`, the function throws `conversationNotFound`, leaving the remote state updated while the local store remains unchanged. This is a reachable, partial-state outcome with no compensation or rollback path. <b>[ Low confidence ]</b>
- [line 97](https://github.com/ephemeraHQ/convos-ios/blob/a8f7806f16a0cfee25b977bda33d5ed95fc113fa/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationMetadataWriter.swift#L97): `inviteWriter.update(...)` is executed after remote and local updates and is allowed to throw (lines 97–102). If a caller retries on error, this function will re-apply `group.updateExpiresAt` and the DB save. Without explicit idempotency guarantees or guards, this can lead to double-application of earlier effects and inconsistent at-most-once semantics. <b>[ Already posted ]</b>
- [line 97](https://github.com/ephemeraHQ/convos-ios/blob/a8f7806f16a0cfee25b977bda33d5ed95fc113fa/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationMetadataWriter.swift#L97): No transactional boundary or compensating action across multiple side-effects: (1) remote update via `group.updateExpiresAt` (line 85), (2) local DB update (lines 87–95), and (3) `inviteWriter.update` (lines 97–102). If any step after (1) fails, the function throws after prior effects have been committed, leaving the system in a partial state. This violates the single paired cleanup / no partial-application invariant for multi-effect operations. <b>[ Already posted ]</b>
</details>

<details>
<summary>ConvosCore/Sources/ConvosCore/Storage/Writers/IncomingMessageWriter.swift — 0 comments posted, 3 evaluated, 3 filtered</summary>

- [line 127](https://github.com/ephemeraHQ/convos-ios/blob/a8f7806f16a0cfee25b977bda33d5ed95fc113fa/ConvosCore/Sources/ConvosCore/Storage/Writers/IncomingMessageWriter.swift#L127): processExplodeSettings conflates "conversation not found" with "already expired". When `DBConversation.fetchOne` returns nil (no conversation with `conversationId`), the closure returns `false`, which then logs "conversation already expired" and returns `.alreadyExpired`. This hides a real error/pathological state and misleads callers and logs. Distinguish not-found from already-expired and handle/log accordingly. <b>[ Low confidence ]</b>
- [line 144](https://github.com/ephemeraHQ/convos-ios/blob/a8f7806f16a0cfee25b977bda33d5ed95fc113fa/ConvosCore/Sources/ConvosCore/Storage/Writers/IncomingMessageWriter.swift#L144): processExplodeSettings posts `.conversationExpired` notification immediately after setting `expiresAt`, without checking whether `settings.expiresAt` is in the future. If a future/scheduled expiration is provided (reachable input), this emits a premature "expired" event, violating contract and causing inconsistent state (DB shows future expiration while observers are told it already expired). Gate the notification on `settings.expiresAt <= Date()` or schedule appropriately. <b>[ Low confidence ]</b>
- [line 155](https://github.com/ephemeraHQ/convos-ios/blob/a8f7806f16a0cfee25b977bda33d5ed95fc113fa/ConvosCore/Sources/ConvosCore/Storage/Writers/IncomingMessageWriter.swift#L155): processExplodeSettings maps any database write error (catch block) to `.alreadyExpired`. This collapses a genuine failure into an idempotent-looking outcome, hiding operational errors from callers and making retries/alerting impossible. Return a distinct error or at least log and surface failure to the caller instead of signaling `.alreadyExpired`. <b>[ Low confidence ]</b>
</details>

<details>
<summary>ConvosCore/Sources/ConvosCore/Syncing/StreamProcessor.swift — 0 comments posted, 2 evaluated, 2 filtered</summary>

- [line 233](https://github.com/ephemeraHQ/convos-ios/blob/a8f7806f16a0cfee25b977bda33d5ed95fc113fa/ConvosCore/Sources/ConvosCore/Syncing/StreamProcessor.swift#L233): Using a fixed request `identifier` pattern `"explosion-\(conversationId)"` can cause silent replacement of prior notifications for the same `conversationId`. UNUserNotificationCenter treats identifiers as unique keys; adding another request with the same identifier replaces the previous pending/delivered notification instead of creating a new one. If multiple explosions can occur per conversation, this loses history and violates at-most-once/duplicate handling expectations. Consider making the identifier unique per event (e.g., append a timestamp/UUID) while still using `threadIdentifier` for grouping. <b>[ Low confidence ]</b>
- [line 239](https://github.com/ephemeraHQ/convos-ios/blob/a8f7806f16a0cfee25b977bda33d5ed95fc113fa/ConvosCore/Sources/ConvosCore/Syncing/StreamProcessor.swift#L239): No authorization/settings check before calling `UNUserNotificationCenter.current().add(request)`. If notifications are denied or not authorized, the system will drop the notification silently without throwing, and this function returns successfully with no visible outcome. Callers and logs will not reflect that the notification was never shown. Consider checking `getNotificationSettings`/`requestAuthorization` and logging or adapting behavior (e.g., in-app hint) when delivery is impossible. <b>[ Low confidence ]</b>
</details>


</details><!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->