### PR TITLE
Update to latest RC of xmtp-ios

### DIFF
--- a/Convos.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Convos.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "c0d2a22500c9e4d8102df408342490e39c95bbaf0a6483004ea4cc88ca98640f",
+  "originHash" : "56db735fae57074e3a8c280200c96a842e21da459801c61458832a434ba3ef48",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -267,8 +267,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/xmtp/xmtp-ios.git",
       "state" : {
-        "revision" : "e5ba3acf0c0913e3be77546b85aa7620aa42e3a0",
-        "version" : "4.5.3"
+        "revision" : "159d3be954bc08dfdc1a9abd4560cac019d778a7",
+        "version" : "4.6.1-rc3"
       }
     }
   ],

--- a/ConvosCore/Package.resolved
+++ b/ConvosCore/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "f0a3eeb34441daf2aab90e82f31149b6f5a468fb416efe6ab52907d9c8efc16f",
+  "originHash" : "9f9b62d8a77572dcbc5a0910e6bde1406913408f6dd21185f6b3617b7b8c77fd",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -249,8 +249,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/xmtp/xmtp-ios.git",
       "state" : {
-        "revision" : "e5ba3acf0c0913e3be77546b85aa7620aa42e3a0",
-        "version" : "4.5.3"
+        "revision" : "159d3be954bc08dfdc1a9abd4560cac019d778a7",
+        "version" : "4.6.1-rc3"
       }
     }
   ],

--- a/ConvosCore/Package.swift
+++ b/ConvosCore/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/groue/GRDB.swift.git", exact: "7.5.0"),
-        .package(url: "https://github.com/xmtp/xmtp-ios.git", exact: "4.5.3"),
+        .package(url: "https://github.com/xmtp/xmtp-ios.git", exact: "4.6.1-rc3"),
         .package(url: "https://github.com/tesseract-one/CSecp256k1.swift.git", from: "0.2.0"),
         .package(url: "https://github.com/SimplyDanny/SwiftLintPlugins", from: "0.61.0"),
         .package(url: "https://github.com/firebase/firebase-ios-sdk", from: "12.1.0"),

--- a/ConvosCore/Sources/ConvosCore/Messaging/MockMessagingService.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/MockMessagingService.swift
@@ -273,8 +273,8 @@ class MockConversations: ConversationsProvider {
         }
     }
 
-    func syncAllConversations(consentStates: [XMTPiOS.ConsentState]?) async throws -> UInt32 {
-        0
+    func syncAllConversations(consentStates: [XMTPiOS.ConsentState]?) async throws -> GroupSyncSummary {
+        .init(numEligible: 0, numSynced: 0)
     }
 
     func sync() async throws {

--- a/ConvosCore/Sources/ConvosCore/Messaging/XMTPClientProvider.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/XMTPClientProvider.swift
@@ -65,7 +65,7 @@ public protocol ConversationsProvider {
     -> XMTPiOS.Conversation?
 
     func sync() async throws
-    func syncAllConversations(consentStates: [XMTPiOS.ConsentState]?) async throws -> UInt32
+    func syncAllConversations(consentStates: [ConsentState]?) async throws -> GroupSyncSummary
     func streamAllMessages(
         type: XMTPiOS.ConversationFilterType,
         consentStates: [XMTPiOS.ConsentState]?,


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Update `xmtp-ios` dependency to exact `4.6.1-rc3` and change `ConversationsProvider.syncAllConversations` to return `GroupSyncSummary` in [XMTPClientProvider.swift](https://github.com/ephemeraHQ/convos-ios/pull/221/files#diff-319627da6df510b09c2b33daf23ed1daf3897db8bf58aafff6904071ea610cc0)
Align code with the latest RC by switching consent types to `ConsentState`, updating sync methods to return `GroupSyncSummary`, and removing initial full sync logic from `SyncingManager` while keeping stream tasks.

#### 📍Where to Start
Start with the protocol and signature changes in `ConversationsProvider.syncAllConversations` in [XMTPClientProvider.swift](https://github.com/ephemeraHQ/convos-ios/pull/221/files#diff-319627da6df510b09c2b33daf23ed1daf3897db8bf58aafff6904071ea610cc0), then review `SyncingManager.start` in [SyncingManager.swift](https://github.com/ephemeraHQ/convos-ios/pull/221/files#diff-ba2362cf646b78283a1af17654ea8d2c18f6b1cb686a78e7761e10f1b0328101).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 906b489.
<!-- Macroscope's review summary ends here -->

<!-- Macroscope's pull request summary ends here -->