### PR TITLE
Store invite payload as bytes in protobuf

### DIFF
--- a/ConvosCore/Sources/ConvosCore/Protobuf Models/conversation_custom_metadata.pb.swift
+++ b/ConvosCore/Sources/ConvosCore/Protobuf Models/conversation_custom_metadata.pb.swift
@@ -22,6 +22,13 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 }
 
 /// ConversationCustomMetadata stores custom metadata for XMTP conversations
+///
+/// Encoding optimizations for compact storage:
+/// - inboxId: Hex-decoded bytes (32 bytes) instead of hex string (64 chars) - saves ~32 bytes per member
+/// - expiresAt: Unix sfixed64 (8 bytes) instead of protobuf Timestamp (10-16 bytes)
+/// - DEFLATE compression applied if size >100 bytes (typically 20-40% reduction)
+///
+/// Expected size for 5-member group: ~200-300 bytes (40-60% smaller than unoptimized)
 public struct ConversationCustomMetadata: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
@@ -33,7 +40,6 @@ public struct ConversationCustomMetadata: Sendable {
 
   public var profiles: [ConversationProfile] = []
 
-  /// Unix timestamp in seconds (compact encoding)
   public var expiresAtUnix: Int64 {
     get {return _expiresAtUnix ?? 0}
     set {_expiresAtUnix = newValue}
@@ -56,7 +62,7 @@ public struct ConversationProfile: Sendable {
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
-  /// Hex-decoded for compactness (~32 bytes instead of ~64 chars)
+  /// XMTP inbox ID as hex-decoded bytes
   public var inboxID: Data = Data()
 
   public var name: String {

--- a/ConvosCore/Sources/ConvosCore/Protobuf Models/proto/invite.proto
+++ b/ConvosCore/Sources/ConvosCore/Protobuf Models/proto/invite.proto
@@ -30,8 +30,11 @@ message InvitePayload {
 
 // SignedInvite represents an invite with its cryptographic signature
 message SignedInvite {
-    // The invite payload containing the actual invite data
-    InvitePayload payload = 1;
+    // The invite payload containing the actual invite data, stored as bytes
+    // to preserve the exact serialization that was signed. This ensures signatures
+    // remain valid even if the protobuf schema changes (since protobuf serialization
+    // is not canonical).
+    bytes payload = 1;
 
     // The cryptographic signature (typically 65 bytes for ECDSA with recovery)
     bytes signature = 2;

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationWriter.swift
@@ -60,7 +60,7 @@ class ConversationWriter: ConversationWriterProtocol {
         let draftConversationId = draftConversationId ?? DBConversation.generateDraftConversationId()
 
         // Create the draft conversation and necessary records
-        let creatorInboxId = signedInvite.payload.creatorInboxIdString
+        let creatorInboxId = signedInvite.invitePayload.creatorInboxIdString
 
         // validate that the invite contains a non-empty creator inbox ID
         guard !creatorInboxId.isEmpty else {
@@ -78,7 +78,7 @@ class ConversationWriter: ConversationWriterProtocol {
                 inboxId: inboxId,
                 clientId: inbox.clientId,
                 clientConversationId: draftConversationId,
-                inviteTag: signedInvite.payload.tag,
+                inviteTag: signedInvite.invitePayload.tag,
                 creatorId: creatorInboxId,
                 kind: .group,
                 consent: .allowed,

--- a/ConvosCore/Sources/ConvosCore/Syncing/InviteJoinRequestsManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/InviteJoinRequestsManager.swift
@@ -152,7 +152,7 @@ class InviteJoinRequestsManager: InviteJoinRequestsManagerProtocol {
             throw InviteJoinRequestError.expiredConversation
         }
 
-        let creatorInboxId = signedInvite.payload.creatorInboxIdString
+        let creatorInboxId = signedInvite.invitePayload.creatorInboxIdString
 
         // validate that the invite contains a non-empty creator inbox ID
         guard !creatorInboxId.isEmpty else {
@@ -190,7 +190,7 @@ class InviteJoinRequestsManager: InviteJoinRequestsManagerProtocol {
         }
 
         let privateKey: Data = identity.keys.privateKey.secp256K1.bytes
-        let conversationTokenBytes = signedInvite.payload.conversationToken
+        let conversationTokenBytes = signedInvite.invitePayload.conversationToken
         let conversationId = try InviteConversationToken.decodeConversationTokenBytes(
             conversationTokenBytes,
             creatorInboxId: client.inboxId,
@@ -241,7 +241,7 @@ class InviteJoinRequestsManager: InviteJoinRequestsManagerProtocol {
             }
 
             // Check if this invite matches our target conversation
-            if invite.payload.tag == inviteTag {
+            if invite.invitePayload.tag == inviteTag {
                 return true
             }
         }

--- a/ConvosCore/Tests/ConvosCoreTests/InviteProtobufExtensionsTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/InviteProtobufExtensionsTests.swift
@@ -45,14 +45,14 @@ struct InviteProtobufExtensionsTests {
         let signature = try payload.sign(with: privateKey)
 
         var signedInvite = SignedInvite()
-        signedInvite.payload = payload
+        try signedInvite.setPayload(payload)
         signedInvite.signature = signature
 
         let encoded = try signedInvite.toURLSafeSlug()
         let decoded = try SignedInvite.fromURLSafeSlug(encoded)
 
-        #expect(decoded.payload.tag == "test123")
-        #expect(decoded.payload.conversationToken == conversationTokenBytes)
+        #expect(decoded.invitePayload.tag == "test123")
+        #expect(decoded.invitePayload.conversationToken == conversationTokenBytes)
         #expect(decoded.signature == signature)
     }
 
@@ -81,18 +81,18 @@ struct InviteProtobufExtensionsTests {
         let signature = try payload.sign(with: privateKey)
 
         var signedInvite = SignedInvite()
-        signedInvite.payload = payload
+        try signedInvite.setPayload(payload)
         signedInvite.signature = signature
 
         let encoded = try signedInvite.toURLSafeSlug()
         let decoded = try SignedInvite.fromURLSafeSlug(encoded)
 
-        #expect(decoded.payload.name == "My Group Chat")
-        #expect(decoded.payload.description_p == "A group chat for testing")
-        #expect(decoded.payload.imageURL == "https://example.com/group.jpg")
-        #expect(decoded.payload.expiresAtUnix == 1735689600)
-        #expect(decoded.payload.conversationExpiresAtUnix == 1767225600)
-        #expect(decoded.payload.expiresAfterUse == true)
+        #expect(decoded.invitePayload.name == "My Group Chat")
+        #expect(decoded.invitePayload.description_p == "A group chat for testing")
+        #expect(decoded.invitePayload.imageURL == "https://example.com/group.jpg")
+        #expect(decoded.invitePayload.expiresAtUnix == 1735689600)
+        #expect(decoded.invitePayload.conversationExpiresAtUnix == 1767225600)
+        #expect(decoded.invitePayload.expiresAfterUse == true)
     }
 
     // MARK: - Compression Tests
@@ -118,7 +118,7 @@ struct InviteProtobufExtensionsTests {
         let signature = try payload.sign(with: privateKey)
 
         var signedInvite = SignedInvite()
-        signedInvite.payload = payload
+        try signedInvite.setPayload(payload)
         signedInvite.signature = signature
 
         let protobufData = try signedInvite.serializedData()
@@ -132,8 +132,8 @@ struct InviteProtobufExtensionsTests {
 
         // Should decode correctly
         let decoded = try SignedInvite.fromURLSafeSlug(encoded)
-        #expect(decoded.payload.name == payload.name)
-        #expect(decoded.payload.description_p == payload.description_p)
+        #expect(decoded.invitePayload.name == payload.name)
+        #expect(decoded.invitePayload.description_p == payload.description_p)
     }
 
     @Test("Uncompressed invite decoding (backward compatibility)")
@@ -155,7 +155,7 @@ struct InviteProtobufExtensionsTests {
         let signature = try payload.sign(with: privateKey)
 
         var signedInvite = SignedInvite()
-        signedInvite.payload = payload
+        try signedInvite.setPayload(payload)
         signedInvite.signature = signature
 
         // Create truly uncompressed slug by encoding protobuf directly
@@ -170,7 +170,7 @@ struct InviteProtobufExtensionsTests {
 
         let uncompressedSlug = protobufData.base64URLEncoded()
         let decoded = try SignedInvite.fromURLSafeSlug(uncompressedSlug)
-        #expect(decoded.payload.tag == "test")
+        #expect(decoded.invitePayload.tag == "test")
     }
 
     // MARK: - Signature Tests
@@ -194,7 +194,7 @@ struct InviteProtobufExtensionsTests {
         let signature = try payload.sign(with: privateKey)
 
         var signedInvite = SignedInvite()
-        signedInvite.payload = payload
+        try signedInvite.setPayload(payload)
         signedInvite.signature = signature
 
         // Signature should be 65 bytes (64 + recovery ID)
@@ -243,7 +243,9 @@ struct InviteProtobufExtensionsTests {
     @Test("Invalid signature length throws error")
     func invalidSignatureLengthThrowsError() throws {
         var signedInvite = SignedInvite()
-        signedInvite.payload.tag = "test"
+        var payload = InvitePayload()
+        payload.tag = "test"
+        try signedInvite.setPayload(payload)
         signedInvite.signature = Data([1, 2, 3]) // Invalid length
 
         #expect {
@@ -267,7 +269,7 @@ struct InviteProtobufExtensionsTests {
         let signature = try payload.sign(with: privateKey)
 
         var signedInvite = SignedInvite()
-        signedInvite.payload = payload
+        try signedInvite.setPayload(payload)
         signedInvite.signature = signature
 
         let originalPublicKey = try signedInvite.recoverSignerPublicKey()
@@ -302,7 +304,7 @@ struct InviteProtobufExtensionsTests {
         let signature = try payload.sign(with: privateKey)
 
         var signedInvite = SignedInvite()
-        signedInvite.payload = payload
+        try signedInvite.setPayload(payload)
         signedInvite.signature = signature
 
         let recoveredPublicKey = try signedInvite.recoverSignerPublicKey()
@@ -325,13 +327,13 @@ struct InviteProtobufExtensionsTests {
         let signature = try payload.sign(with: privateKey)
 
         var signedInvite = SignedInvite()
-        signedInvite.payload = payload
+        try signedInvite.setPayload(payload)
         signedInvite.signature = signature
 
         let encoded = try signedInvite.toURLSafeSlug()
         let decoded = try SignedInvite.fromURLSafeSlug(encoded)
 
-        #expect(decoded.payload.creatorInboxIdString == inboxIdHex)
+        #expect(decoded.invitePayload.creatorInboxIdString == inboxIdHex)
     }
 
     // MARK: - Expiration Tests
@@ -351,7 +353,7 @@ struct InviteProtobufExtensionsTests {
         let signature = try payload.sign(with: privateKey)
 
         var signedInvite = SignedInvite()
-        signedInvite.payload = payload
+        try signedInvite.setPayload(payload)
         signedInvite.signature = signature
 
         #expect(signedInvite.hasExpired == true)
@@ -372,7 +374,7 @@ struct InviteProtobufExtensionsTests {
         let signature = try payload.sign(with: privateKey)
 
         var signedInvite = SignedInvite()
-        signedInvite.payload = payload
+        try signedInvite.setPayload(payload)
         signedInvite.signature = signature
 
         #expect(signedInvite.hasExpired == false)
@@ -393,7 +395,7 @@ struct InviteProtobufExtensionsTests {
         let signature = try payload.sign(with: privateKey)
 
         var signedInvite = SignedInvite()
-        signedInvite.payload = payload
+        try signedInvite.setPayload(payload)
         signedInvite.signature = signature
 
         #expect(signedInvite.conversationHasExpired == true)
@@ -415,7 +417,7 @@ struct InviteProtobufExtensionsTests {
         let signature = try payload.sign(with: privateKey)
 
         var signedInvite = SignedInvite()
-        signedInvite.payload = payload
+        try signedInvite.setPayload(payload)
         signedInvite.signature = signature
 
         #expect(signedInvite.name == "Test Name")
@@ -434,7 +436,7 @@ struct InviteProtobufExtensionsTests {
         let signature = try payload.sign(with: privateKey)
 
         var signedInvite = SignedInvite()
-        signedInvite.payload = payload
+        try signedInvite.setPayload(payload)
         signedInvite.signature = signature
 
         #expect(signedInvite.name == nil)
@@ -457,14 +459,14 @@ struct InviteProtobufExtensionsTests {
         let signature = try payload.sign(with: privateKey)
 
         var signedInvite = SignedInvite()
-        signedInvite.payload = payload
+        try signedInvite.setPayload(payload)
         signedInvite.signature = signature
 
         let code = try signedInvite.toURLSafeSlug()
 
         // Parse as raw code
         let decoded = try SignedInvite.fromInviteCode(code)
-        #expect(decoded.payload.tag == "test")
+        #expect(decoded.invitePayload.tag == "test")
     }
 
     @Test("Parse invite code with whitespace")
@@ -478,7 +480,7 @@ struct InviteProtobufExtensionsTests {
         let signature = try payload.sign(with: privateKey)
 
         var signedInvite = SignedInvite()
-        signedInvite.payload = payload
+        try signedInvite.setPayload(payload)
         signedInvite.signature = signature
 
         let code = try signedInvite.toURLSafeSlug()
@@ -487,7 +489,7 @@ struct InviteProtobufExtensionsTests {
         let codeWithWhitespace = "  \n\(code)\n  "
 
         let decoded = try SignedInvite.fromInviteCode(codeWithWhitespace)
-        #expect(decoded.payload.tag == "test")
+        #expect(decoded.invitePayload.tag == "test")
     }
 
     // MARK: - Error Handling Tests
@@ -560,13 +562,13 @@ struct InviteProtobufExtensionsTests {
         let signature = try payload.sign(with: privateKey)
 
         var signedInvite = SignedInvite()
-        signedInvite.payload = payload
+        try signedInvite.setPayload(payload)
         signedInvite.signature = signature
 
         let encoded = try signedInvite.toURLSafeSlug()
         let decoded = try SignedInvite.fromURLSafeSlug(encoded)
 
-        #expect(decoded.payload.tag.count == 1000)
+        #expect(decoded.invitePayload.tag.count == 1000)
     }
 
     @Test("Special characters in name and description")
@@ -582,14 +584,14 @@ struct InviteProtobufExtensionsTests {
         let signature = try payload.sign(with: privateKey)
 
         var signedInvite = SignedInvite()
-        signedInvite.payload = payload
+        try signedInvite.setPayload(payload)
         signedInvite.signature = signature
 
         let encoded = try signedInvite.toURLSafeSlug()
         let decoded = try SignedInvite.fromURLSafeSlug(encoded)
 
-        #expect(decoded.payload.name == "Group 🎉 with emoji")
-        #expect(decoded.payload.description_p == "Description\nwith\nnewlines\tand\ttabs")
+        #expect(decoded.invitePayload.name == "Group 🎉 with emoji")
+        #expect(decoded.invitePayload.description_p == "Description\nwith\nnewlines\tand\ttabs")
     }
 
     // MARK: - Decompression Bomb Protection


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Store `SignedInvite.payload` as bytes and update invite accessors and conversation flows to read from `SignedInvite.invitePayload` across core inbox, sync, and storage
Convert `SignedInvite.payload` to bytes and add `SignedInvite.invitePayload` for deserialization; switch invite field accessors and conversation matching to use `invitePayload`; update signature recovery to hash raw payload bytes; adjust join request creation and DB filters to read tags and creator inbox IDs from `invitePayload`.

#### 📍Where to Start
Start with the schema change in [invite.proto](https://github.com/ephemeraHQ/convos-ios/pull/222/files#diff-26f958bae2b10778a1e5bb7537dec350c554b6384fe600dd87ff6c6e6926371d), then review `SignedInvite` extensions in [InviteProtobufExtensions.swift](https://github.com/ephemeraHQ/convos-ios/pull/222/files#diff-35655bc1017b3f3504490e666da39af0d85c800649e8cf17d216a24ddfeb5795).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 136c106.
<!-- Macroscope's review summary ends here -->

<!-- Macroscope's pull request summary ends here -->