### PR TITLE
Temporarily disable sync all

### DIFF
--- a/ConvosCore/Sources/ConvosCore/Syncing/SyncingManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/SyncingManager.swift
@@ -302,8 +302,8 @@ actor SyncingManager: SyncingManagerProtocol {
         syncTask = Task { [weak self] in
             guard let self else { return }
             do {
-                try Task.checkCancellation()
-                _ = try await client.conversationsProvider.syncAllConversations(consentStates: consentStates)
+//                try Task.checkCancellation()
+//                _ = try await client.conversationsProvider.syncAllConversations(consentStates: consentStates)
                 try Task.checkCancellation()
                 // Check if pause was requested during starting and handle transition
                 await self.handleSyncCompleteTransition(params: params)


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Disable initial conversation sync in `SyncingManager.start` to temporarily pause sync-all during startup
Comments out the initial call to `client.conversationsProvider.syncAllConversations(consentStates:)` in `SyncingManager.start` after launching stream tasks, retaining the later `Task.checkCancellation()` and `handleSyncCompleteTransition(params:)` path in [SyncingManager.swift](https://github.com/ephemeraHQ/convos-ios/pull/223/files#diff-ba2362cf646b78283a1af17654ea8d2c18f6b1cb686a78e7761e10f1b0328101).

#### 📍Where to Start
Start in `SyncingManager.start` within [SyncingManager.swift](https://github.com/ephemeraHQ/convos-ios/pull/223/files#diff-ba2362cf646b78283a1af17654ea8d2c18f6b1cb686a78e7761e10f1b0328101), focusing on the startup sequence around the commented `client.conversationsProvider.syncAllConversations(consentStates:)` call.

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized df3bfa2.
<!-- Macroscope's review summary ends here -->
<!-- Macroscope's pull request summary ends here -->