### PR TITLE
Update pre-signed upload URL to API v2

### DIFF
--- a/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift
+++ b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift
@@ -346,7 +346,7 @@ final class ConvosAPIClient: ConvosAPIClientProtocol, Sendable {
 
         // Step 1: Get presigned URL from Convos API
         let presignedRequest = try authenticatedRequest(
-            for: "v1/attachments/presigned",
+            for: "v2/attachments/presigned",
             method: "GET",
             queryParameters: ["contentType": contentType, "filename": filename]
         )

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/MyProfileWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/MyProfileWriter.swift
@@ -91,13 +91,13 @@ class MyProfileWriter: MyProfileWriterProtocol {
 
         let resizedImage = ImageCompression.resizeForCache(avatarImage)
 
-        guard let compressedImageData = avatarImage.jpegData(compressionQuality: 0.8) else {
+        guard let compressedImageData = resizedImage.jpegData(compressionQuality: 0.8) else {
             throw MyProfileWriterError.imageCompressionFailed
         }
 
         let uploadedURL = try await inboxReady.apiClient.uploadAttachment(
             data: compressedImageData,
-            filename: "profile-\(UUID().uuidString).jpg",
+            filename: "p-\(UUID().uuidString).jpg",
             contentType: "image/jpeg",
             acl: "public-read"
         )


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Route attachment presigned URL requests to API v2 and compress avatar uploads from resized image in `ConvosCore.API.ConvosAPIClient.uploadAttachment` and `ConvosCore.Storage.Writers.MyProfileWriter.avatar`
Switch the presigned URL endpoint to `v2/attachments/presigned` in `ConvosCore.API.ConvosAPIClient.uploadAttachment` and change avatar JPEG compression to use the resized image with filenames starting `p-` in `ConvosCore.Storage.Writers.MyProfileWriter.avatar`.

#### 📍Where to Start
Start with `uploadAttachment` in [ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift](https://github.com/ephemeraHQ/convos-ios/pull/224/files#diff-d9c911c02b64ae370c51a1048b35e6e5dfc05805b43efd9be61a31fa422500b8), then review the avatar update logic in [ConvosCore/Sources/ConvosCore/Storage/Writers/MyProfileWriter.swift](https://github.com/ephemeraHQ/convos-ios/pull/224/files#diff-f3ce93052543335859b22b5d9723929fba25b7e4d7dec7508ee0f6c4d9970747).

----
<!-- Macroscope's review summary starts here -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 60fe74d. 2 files reviewed, 7 issues evaluated, 7 issues filtered, 0 comments posted</summary>

### 🗂️ Filtered Issues
<details>
<summary>ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift — 0 comments posted, 4 evaluated, 4 filtered</summary>

- [line 342](https://github.com/ephemeraHQ/convos-ios/blob/60fe74dd54f01d3eac836513a069d0af1b2de68d/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift#L342): The `acl` parameter is accepted (`"public-read"` by default) but never used. It is not forwarded in `authenticatedRequest` query parameters (line `351`) nor applied as an S3 header (e.g., `x-amz-acl`) during the PUT (line `384`). This can lead to returning a URL for an object that remains private, violating the function’s apparent contract. Either include `acl` in the presign request and/or set the required S3 header per the presigned constraints, or remove the parameter if ACL is server-controlled. <b>[ Out of scope ]</b>
- [line 354](https://github.com/ephemeraHQ/convos-ios/blob/60fe74dd54f01d3eac836513a069d0af1b2de68d/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift#L354): Sensitive data is logged, including the full presigned S3 URL (`Log.info` at `354` and `361`), request headers (`389`), and error response body (`403`). Presigned URLs contain credentials/signatures; logging them risks leakage and misuse. Avoid logging full URLs or redact query parameters and sensitive headers, especially in production. <b>[ Out of scope ]</b>
- [line 373](https://github.com/ephemeraHQ/convos-ios/blob/60fe74dd54f01d3eac836513a069d0af1b2de68d/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift#L373): The code constructs and returns `publicURL` by stripping query parameters from the presigned URL (`scheme://host + path`) and assumes it is publicly accessible (`407`, `408`). Without applying `acl` or verifying accessibility, callers may receive an unusable URL (403/404 when fetched). Either enforce/accessibility (apply ACL per presign requirements) or return the presigned URL for authenticated access, or verify/readability before returning. <b>[ Out of scope ]</b>
- [line 385](https://github.com/ephemeraHQ/convos-ios/blob/60fe74dd54f01d3eac836513a069d0af1b2de68d/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift#L385): `s3Request.httpBody = data` sends the entire attachment in-memory (line `385`). For large files this can cause high memory usage and potential OOM. Prefer streaming upload APIs (e.g., `uploadTask` with `InputStream` or `URLSession.shared.upload(for:from:)`) to avoid buffering the entire payload. <b>[ Out of scope ]</b>
</details>

<details>
<summary>ConvosCore/Sources/ConvosCore/Storage/Writers/MyProfileWriter.swift — 0 comments posted, 3 evaluated, 3 filtered</summary>

- [line 85](https://github.com/ephemeraHQ/convos-ios/blob/60fe74dd54f01d3eac836513a069d0af1b2de68d/ConvosCore/Sources/ConvosCore/Storage/Writers/MyProfileWriter.swift#L85): Avatar removal path does not persist the change to the local database. After setting `updatedProfile = profile.with(avatar: nil)` and calling `group.updateProfile(updatedProfile)`, the function returns without saving `updatedProfile` to the DB, leaving local state inconsistent with the remote profile. <b>[ Out of scope ]</b>
- [line 90](https://github.com/ephemeraHQ/convos-ios/blob/60fe74dd54f01d3eac836513a069d0af1b2de68d/ConvosCore/Sources/ConvosCore/Storage/Writers/MyProfileWriter.swift#L90): Pre-upload cache mutation can leave stale/duplicate entries and inconsistent UI on failure paths. The code sets `ImageCache.shared.setImage(avatarImage, for: profile.hydrateProfile())` before compression and upload. If compression (`jpegData`) or upload throws, the function exits with the cache entry still set under the pre-upload key and no persisted/profile change, with no cleanup. After success, a second cache entry is set for `uploadedURL` without clearing the pre-upload key, potentially leaking redundant cache entries. <b>[ Low confidence ]</b>
- [line 105](https://github.com/ephemeraHQ/convos-ios/blob/60fe74dd54f01d3eac836513a069d0af1b2de68d/ConvosCore/Sources/ConvosCore/Storage/Writers/MyProfileWriter.swift#L105): Remote update is performed before persisting the local DB change in the non-nil avatar path. If the database write fails after `group.updateProfile(updatedProfile)` succeeds, local and remote states diverge with no rollback or retry. <b>[ Low confidence ]</b>
</details>


</details><!-- Macroscope's review summary ends here -->
<!-- Macroscope's pull request summary ends here -->