### PR TITLE
Align SwiftLint to the version CI is running: 0.62.2

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -87,7 +87,7 @@ explicit_type_interface:
   excluded:
     - local
 
-swiftlint_version: 0.61.0
+swiftlint_version: 0.62.2
 
 implicit_return:
   included:

--- a/Convos.xcodeproj/project.pbxproj
+++ b/Convos.xcodeproj/project.pbxproj
@@ -2118,7 +2118,7 @@
 			repositoryURL = "https://github.com/SimplyDanny/SwiftLintPlugins";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 0.61.0;
+				minimumVersion = 0.62.2;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Convos.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Convos.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "100286ff199e535f29a2d79d4d45cd41e51e55eb73eea3d2bf574ca02d2204f9",
+  "originHash" : "f9c6b86a3c4ca98ea2dcf9ea8afd1fafa6c8137e22ac59f582328440f4aa3a81",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -249,8 +249,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SimplyDanny/SwiftLintPlugins",
       "state" : {
-        "revision" : "6166499ede0efe43c3809f101d2c3cd409e2b77a",
-        "version" : "0.61.0"
+        "revision" : "ecafb5b056cb7995324f0d310a61f30661d00cad",
+        "version" : "0.62.2"
       }
     },
     {

--- a/ConvosCore/Package.resolved
+++ b/ConvosCore/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "9678d571caf92bf79cef3bcf82b819140e5045d2de468f574c5c0e68f4d2b7c7",
+  "originHash" : "833c5b6a6e4d9172803d56986d084c0fe33d0f1f0c51e3cf9a5f9c4dd18ab0c1",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -240,8 +240,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SimplyDanny/SwiftLintPlugins",
       "state" : {
-        "revision" : "6166499ede0efe43c3809f101d2c3cd409e2b77a",
-        "version" : "0.61.0"
+        "revision" : "ecafb5b056cb7995324f0d310a61f30661d00cad",
+        "version" : "0.62.2"
       }
     },
     {

--- a/ConvosCore/Package.swift
+++ b/ConvosCore/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
         .package(url: "https://github.com/groue/GRDB.swift.git", exact: "7.5.0"),
         .package(url: "https://github.com/xmtp/xmtp-ios.git", exact: "4.6.1-dev.c11139e"),
         .package(url: "https://github.com/tesseract-one/CSecp256k1.swift.git", from: "0.2.0"),
-        .package(url: "https://github.com/SimplyDanny/SwiftLintPlugins", from: "0.61.0"),
+        .package(url: "https://github.com/SimplyDanny/SwiftLintPlugins", from: "0.62.2"),
         .package(url: "https://github.com/firebase/firebase-ios-sdk", from: "12.1.0"),
         .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.31.1"),
         .package(url: "https://github.com/getsentry/sentry-cocoa.git", from: "8.57.1"),


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Align SwiftLint configuration and plugin to version 0.62.2 across .swiftlint.yml, Xcode project, and SwiftPM
Update SwiftLint version references to 0.62.2 in [/.swiftlint.yml](https://github.com/ephemeraHQ/convos-ios/pull/225/files#diff-7109ad4ca9c6e705a8da290e7cb2898a679b0f8f1f4712d082dee256230d6a1f), [Convos.xcodeproj/project.pbxproj](https://github.com/ephemeraHQ/convos-ios/pull/225/files#diff-d58364582ce5ff189bf9f87c20898db7df50a681e6e9df35dca291d7b9373da7), and SwiftPM dependencies. Refresh related `Package.resolved` files.

#### 📍Where to Start
Start with the version bump in [/.swiftlint.yml](https://github.com/ephemeraHQ/convos-ios/pull/225/files#diff-7109ad4ca9c6e705a8da290e7cb2898a679b0f8f1f4712d082dee256230d6a1f), then verify the `minimumVersion` in [Convos.xcodeproj/project.pbxproj](https://github.com/ephemeraHQ/convos-ios/pull/225/files#diff-d58364582ce5ff189bf9f87c20898db7df50a681e6e9df35dca291d7b9373da7) and the SwiftPM dependency in [ConvosCore/Package.swift](https://github.com/ephemeraHQ/convos-ios/pull/225/files#diff-a2bdca0eaceddfb5e4fbd6afdf3047a9c23f261d60140456b61baada4a24caa3).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 1c2e3bd.
<!-- Macroscope's review summary ends here -->

<!-- Macroscope's pull request summary ends here -->