### PR TITLE
Change copy for the fork modal

### DIFF
--- a/Convos/Conversation Detail/ConversationForkedInfoView.swift
+++ b/Convos/Conversation Detail/ConversationForkedInfoView.swift
@@ -5,18 +5,41 @@ struct ConversationForkedInfoView: View {
     @Environment(\.dismiss) var dismiss: DismissAction
 
     var body: some View {
-        VStack(alignment: .leading, spacing: DesignConstants.Spacing.step4x) {
-            Text("Problem")
-                .font(.system(.largeTitle))
-                .fontWeight(.bold)
+        VStack(alignment: .leading, spacing: DesignConstants.Spacing.step6x) {
+            VStack(alignment: .leading, spacing: DesignConstants.Spacing.step2x) {
+                Text("Get a new room")
+                    .font(.system(.largeTitle))
+                    .fontWeight(.bold)
+                    .padding(.bottom, DesignConstants.Spacing.step4x)
 
-            Text("This convo is buggy on your device.\nPlease delete it and ask the person who invited you for a new invitation.")
-                .font(.body)
-                .foregroundStyle(.colorTextPrimary)
+                Text("A key is out of date, so this convo can’t continue correctly. Please delete it and start a new one.")
+                    .font(.body)
+                    .foregroundStyle(.colorTextPrimary)
 
-            Text("For privacy, Convos tracks zero app activity, including errors. Please screenshot this and tag @convosmessenger on social to let us know.")
-                .font(.body)
-                .foregroundStyle(.colorTextSecondary)
+                Text("All data remains securely encrypted.")
+                    .font(.body)
+                    .foregroundStyle(.colorTextSecondary)
+            }
+
+            VStack(alignment: .leading, spacing: DesignConstants.Spacing.step2x) {
+                Text("Current keys guarantee security")
+                    .font(.body)
+                    .foregroundStyle(.colorTextPrimary)
+
+                // swiftlint:disable:next line_length
+                Text("Convos constantly confirms that all participants hold up-to-date cryptographic keys. If a member’s keys aren’t current, they cannot decrypt new messages nor updates, so their experience is degraded.")
+                    .font(.body)
+                    .foregroundStyle(.colorTextSecondary)
+            }
+
+            VStack {
+                Text("For privacy, Convos tracks zero app activity, including errors. Please let us know by screenshotting this and tag @convosmessenger on social.")
+                    .font(.subheadline)
+                    .foregroundStyle(.colorTextSecondary)
+                    .padding(DesignConstants.Spacing.step4x)
+            }
+            .background(.colorFillMinimal)
+            .mask(RoundedRectangle(cornerRadius: DesignConstants.CornerRadius.mediumLarge))
 
             VStack(spacing: DesignConstants.Spacing.step2x) {
                 Button {
@@ -24,7 +47,7 @@ struct ConversationForkedInfoView: View {
                 } label: {
                     Text("Delete convo")
                 }
-                .convosButtonStyle(.rounded(fullWidth: true, backgroundColor: .colorCaution))
+                .convosButtonStyle(.rounded(fullWidth: true, backgroundColor: .colorBackgroundInverted))
             }
             .padding(.top, DesignConstants.Spacing.step4x)
 
@@ -37,9 +60,9 @@ struct ConversationForkedInfoView: View {
                 .convosButtonStyle(.text)
                 .frame(maxWidth: .infinity)
             }
-            .padding(.top, DesignConstants.Spacing.step4x)
         }
         .padding(DesignConstants.Spacing.step10x)
+        .background(.colorBackgroundPrimary)
     }
 }
 


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Update fork modal copy and layout in `ConversationForkedInfoView` to present "Get a new room" title, new explanatory sections, and revised spacing (outer step6x, inner step2x, overall padding step10x) with primary background and inverted delete button color
Reworks `ConversationForkedInfoView` layout with nested `VStack`s, applies primary background, updates title and body copy, adds a masked privacy info container, and switches the delete button to `.colorBackgroundInverted` while keeping dismiss as text style.

#### 📍Where to Start
Start with the `ConversationForkedInfoView` struct in [ConversationForkedInfoView.swift](https://github.com/ephemeraHQ/convos-ios/pull/226/files#diff-f551bf371178f5a50dc3db25e522faaf12c71d0d89a5ffe677416de0267c1182).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 097c649.
<!-- Macroscope's review summary ends here -->
<!-- Macroscope's pull request summary ends here -->