### PR TITLE
Cache images to disk

### DIFF
--- a/Convos/Debug View/DebugView.swift
+++ b/Convos/Debug View/DebugView.swift
@@ -254,13 +254,13 @@ extension DebugViewSection {
         }
     }
 
-    private func testSentryMessage() {
+    func testSentryMessage() {
         let message = "Test message from local development - \(Date())"
         SentrySDK.capture(message: message)
         Log.info("Sent Sentry test message: \(message)")
     }
 
-    private func testSentryError() {
+    func testSentryError() {
         let error = NSError(
             domain: "com.convos.debug",
             code: 999,
@@ -274,7 +274,7 @@ extension DebugViewSection {
         Log.info("Sent Sentry test error")
     }
 
-    private func testSentryException() {
+    func testSentryException() {
         let exception = NSException(
             name: .init("TestException"),
             reason: "Test exception from local debug view",
@@ -287,7 +287,7 @@ extension DebugViewSection {
         Log.info("Sent Sentry test exception")
     }
 
-    private func testSentryWithBreadcrumbs() {
+    func testSentryWithBreadcrumbs() {
         let crumb1 = Breadcrumb(level: .info, category: "navigation")
         crumb1.message = "User navigated to Debug view"
         crumb1.data = ["screen": "DebugView"]

--- a/Convos/Shared Views/AvatarView.swift
+++ b/Convos/Shared Views/AvatarView.swift
@@ -36,9 +36,9 @@ struct AvatarView: View {
     @MainActor
     private func loadImage() async {
         // First check object cache for instant updates
-        if let cachedObjectImage = ImageCache.shared.image(for: cacheableObject) {
+        if let cachedObjectImage = await ImageCache.shared.imageAsync(for: cacheableObject) {
             cachedImage = cachedObjectImage
-            return
+            return // Early return to avoid redundant URL cache check
         }
 
         guard let imageURL else {
@@ -46,9 +46,10 @@ struct AvatarView: View {
             return
         }
 
-        // Check URL-based cache
-        if let existingImage = ImageCache.shared.image(for: imageURL) {
+        // Check URL-based cache (only if object cache was empty)
+        if let existingImage = await ImageCache.shared.imageAsync(for: imageURL) {
             cachedImage = existingImage
+            return // Early return to avoid network request if URL cache has the image
         }
 
         isLoading = true
@@ -97,7 +98,7 @@ struct ConversationAvatarView: View {
             // Fall back to URL-based loading with conversation object for cache awareness
             AvatarView(
                 imageURL: conversation.imageURL,
-                fallbackName: conversation.displayName,
+                fallbackName: "",
                 cacheableObject: conversation,
                 placeholderImage: conversationImage
             )

--- a/ConvosCore/Sources/ConvosCore/Extensions/ImageCacheableExtensions.swift
+++ b/ConvosCore/Sources/ConvosCore/Extensions/ImageCacheableExtensions.swift
@@ -8,6 +8,6 @@ extension Profile: ImageCacheable {
 
 extension Conversation: ImageCacheable {
     public var imageCacheIdentifier: String {
-        id
+        clientConversationId
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Image Cache/ImageCache.swift
+++ b/ConvosCore/Sources/ConvosCore/Image Cache/ImageCache.swift
@@ -1,6 +1,24 @@
 import Combine
+import CryptoKit
+import Foundation
 import Observation
+import os
 import SwiftUI
+
+// MARK: - Image Format
+
+/// Image format for caching
+public enum ImageFormat: Sendable {
+    case jpg
+    case png
+
+    var fileExtension: String {
+        switch self {
+        case .jpg: return ".jpg"
+        case .png: return ".png"
+        }
+    }
+}
 
 // MARK: - ImageCacheable Protocol
 
@@ -10,16 +28,46 @@ public protocol ImageCacheable {
     var imageCacheIdentifier: String { get }
 }
 
+// MARK: - Cache Configuration
+
+/// Configuration for image cache limits and sizes
+private struct CacheConfiguration {
+    /// Maximum size of disk cache in bytes (500MB)
+    static let maxDiskCacheSize: Int = 500 * 1024 * 1024
+
+    /// Maximum number of images in the main memory cache
+    static let memoryCacheCountLimit: Int = 400
+
+    /// Maximum total cost (in bytes) for the main memory cache (200MB)
+    static let memoryCacheTotalCostLimit: Int = 200 * 1024 * 1024
+
+    /// Maximum number of images in the URL memory cache
+    static let urlCacheCountLimit: Int = 200
+
+    /// Maximum total cost (in bytes) for the URL memory cache (100MB)
+    static let urlCacheTotalCostLimit: Int = 100 * 1024 * 1024
+}
+
 // MARK: - Generic Image Cache
 
 /// Smart reactive image cache that stores images for any ImageCacheable object with instant updates.
+/// Supports three-tier caching: memory → disk → network
 /// When a new image is uploaded for an object, all views showing that object update instantly.
 @Observable
-public final class ImageCache {
+public final class ImageCache: @unchecked Sendable {
     public static let shared: ImageCache = ImageCache()
 
     private let cache: NSCache<NSString, UIImage>
     private let urlCache: NSCache<NSString, UIImage>
+
+    // Disk cache properties
+    private let diskCacheURL: URL
+    private let diskCacheQueue: DispatchQueue
+    private let fileManager: FileManager
+    private let maxDiskCacheSize: Int = CacheConfiguration.maxDiskCacheSize
+
+    // Cleanup coordination
+    private let cleanupLock: OSAllocatedUnfairLock<Task<Void, Never>?> = OSAllocatedUnfairLock(initialState: nil)
 
     /// Publisher for specific cache updates by identifier
     private let cacheUpdateSubject: PassthroughSubject<String, Never> = PassthroughSubject<String, Never>()
@@ -31,51 +79,203 @@ public final class ImageCache {
 
     private init() {
         cache = NSCache<NSString, UIImage>()
-        cache.countLimit = 400
-        cache.totalCostLimit = 200 * 1024 * 1024 // 200MB total
+        cache.countLimit = CacheConfiguration.memoryCacheCountLimit
+        cache.totalCostLimit = CacheConfiguration.memoryCacheTotalCostLimit
 
         urlCache = NSCache<NSString, UIImage>()
-        urlCache.countLimit = 200
-        urlCache.totalCostLimit = 100 * 1024 * 1024 // 100MB for URL cache
+        urlCache.countLimit = CacheConfiguration.urlCacheCountLimit
+        urlCache.totalCostLimit = CacheConfiguration.urlCacheTotalCostLimit
+
+        // Setup disk cache
+        fileManager = FileManager.default
+        diskCacheQueue = DispatchQueue(label: "com.convos.imagecache.disk", qos: .utility)
+
+        // Create disk cache directory
+        let cacheDir = fileManager.urls(for: .cachesDirectory, in: .userDomainMask)[0]
+        diskCacheURL = cacheDir.appendingPathComponent("ImageCache", isDirectory: true)
+
+        do {
+            try fileManager.createDirectory(at: diskCacheURL, withIntermediateDirectories: true)
+        } catch {
+            Log.error("Failed to create disk cache directory: \(error)")
+            // Fallback: Memory-only caching will still work, but disk operations will fail gracefully
+        }
+
+        // Clean up disk cache on init if needed
+        scheduleCleanupIfNeeded()
     }
 
     // MARK: - Generic Cache Methods
 
-        /// Get cached image for any ImageCacheable object
+    /// Get cached image for any ImageCacheable object (synchronous, memory only)
     public func image(for object: any ImageCacheable) -> UIImage? {
         return cache.object(forKey: object.imageCacheIdentifier as NSString)
     }
 
-    /// Set cached image for any ImageCacheable object
+    /// Get cached image for any ImageCacheable object (async, checks memory → disk)
+    public func imageAsync(for object: any ImageCacheable) async -> UIImage? {
+        let identifier = object.imageCacheIdentifier
+
+        // Check memory first
+        if let memoryImage = cache.object(forKey: identifier as NSString) {
+            return memoryImage
+        }
+
+        // Check disk (default to JPEG for object-based cache)
+        if let diskImage = await loadImageFromDisk(identifier: identifier, imageFormat: .jpg) {
+            // Populate memory cache (image is already compressed/resized from disk)
+            cacheImageInMemory(diskImage, key: identifier, cache: cache, logContext: "Object cache (from disk)")
+            return diskImage
+        }
+
+        return nil
+    }
+
+    /// Set cached image for any ImageCacheable object (saves to both memory and disk)
     public func setImage(_ image: UIImage, for object: any ImageCacheable) {
         let identifier = object.imageCacheIdentifier
-        cacheImage(image, key: identifier, cache: cache, logContext: "Object cache")
+        cacheImage(image, key: identifier, cache: cache, logContext: "Object cache", imageFormat: .jpg)
+
+        // Save to disk asynchronously (default to JPEG for object-based cache)
+        Task {
+            await saveImageToDisk(image, identifier: identifier, imageFormat: .jpg)
+        }
+
         cacheUpdateSubject.send(identifier)
     }
 
-    /// Remove cached image for any ImageCacheable object
+    /// Resize, cache, and return JPEG data for upload in one pass
+    /// This optimizes the common pattern of resizing, caching, and uploading images
+    /// - Parameters:
+    ///   - image: The original UIImage to resize and cache
+    ///   - object: The ImageCacheable object to cache the image for
+    /// - Returns: JPEG data ready for upload, or nil if compression fails
+    public func resizeCacheAndGetData(_ image: UIImage, for object: any ImageCacheable) -> Data? {
+        let identifier = object.imageCacheIdentifier
+
+        // Resize and compress to JPEG in one pass
+        guard let jpegData = ImageCompression.resizeAndCompressToJPEG(image, compressionQuality: 0.8) else {
+            Log.error("Failed to resize and compress image for upload: \(identifier)")
+            return nil
+        }
+
+        // Reconstruct UIImage and cache asynchronously to avoid blocking
+        // This allows the method to return the JPEG data immediately for upload
+        Task {
+            guard let resizedImage = UIImage(data: jpegData) else {
+                Log.error("Failed to create UIImage from compressed data for caching: \(identifier)")
+                return
+            }
+
+            // Cache the resized image in memory
+            let cost = memoryCost(for: resizedImage)
+            cache.setObject(resizedImage, forKey: identifier as NSString, cost: cost)
+            Log.info("Successfully cached resized image for upload: \(identifier)")
+
+            // Notify immediately after memory cache (consistent with other methods)
+            cacheUpdateSubject.send(identifier)
+
+            // Save pre-compressed JPEG data directly to disk to avoid double compression
+            await saveDataToDisk(jpegData, identifier: identifier, imageFormat: .jpg)
+        }
+
+        return jpegData
+    }
+
+    /// Remove cached image for any ImageCacheable object (removes from both memory and disk)
     public func removeImage(for object: any ImageCacheable) {
         let identifier = object.imageCacheIdentifier
         cache.removeObject(forKey: identifier as NSString)
+
+        // Remove from disk asynchronously
+        Task {
+            await removeImageFromDisk(identifier: identifier)
+        }
+
         cacheUpdateSubject.send(identifier)
     }
 
     // MARK: - Identifier-based Methods
 
-    /// Get cached image by identifier
-    public func image(for identifier: String) -> UIImage? {
+    /// Get cached image by identifier (synchronous, memory only)
+    public func image(for identifier: String, imageFormat: ImageFormat = .jpg) -> UIImage? {
         return cache.object(forKey: identifier as NSString)
     }
 
-    /// Cache image by identifier
-    public func cacheImage(_ image: UIImage, for identifier: String) {
-        cacheImage(image, key: identifier, cache: cache, logContext: "Identifier cache")
+    /// Get cached image by identifier (async, checks memory → disk)
+    public func imageAsync(for identifier: String, imageFormat: ImageFormat = .jpg) async -> UIImage? {
+        // Check memory first
+        if let memoryImage = cache.object(forKey: identifier as NSString) {
+            return memoryImage
+        }
+
+        // Check disk
+        if let diskImage = await loadImageFromDisk(identifier: identifier, imageFormat: imageFormat) {
+            // Populate memory cache (image is already compressed/resized from disk)
+            cacheImageInMemory(diskImage, key: identifier, cache: cache, logContext: "Identifier cache (from disk)")
+            return diskImage
+        }
+
+        return nil
+    }
+
+    /// Cache image by identifier (saves to both memory and disk)
+    public func cacheImage(_ image: UIImage, for identifier: String, imageFormat: ImageFormat = .jpg) {
+        cacheImage(image, key: identifier, cache: cache, logContext: "Identifier cache", imageFormat: imageFormat)
+
+        // Save to disk asynchronously
+        Task {
+            await saveImageToDisk(image, identifier: identifier, imageFormat: imageFormat)
+        }
+
         cacheUpdateSubject.send(identifier)
     }
 
-    /// Remove cached image by identifier
+    /// Resize, cache, and return JPEG data for upload in one pass (identifier-based)
+    /// This optimizes the common pattern of resizing, caching, and uploading images
+    /// - Parameters:
+    ///   - image: The original UIImage to resize and cache
+    ///   - identifier: The identifier string to cache the image for
+    /// - Returns: JPEG data ready for upload, or nil if compression fails
+    public func resizeCacheAndGetData(_ image: UIImage, for identifier: String) -> Data? {
+        // Resize and compress to JPEG in one pass
+        guard let jpegData = ImageCompression.resizeAndCompressToJPEG(image, compressionQuality: 0.8) else {
+            Log.error("Failed to resize and compress image for upload: \(identifier)")
+            return nil
+        }
+
+        // Reconstruct UIImage and cache asynchronously to avoid blocking
+        // This allows the method to return the JPEG data immediately for upload
+        Task {
+            guard let resizedImage = UIImage(data: jpegData) else {
+                Log.error("Failed to create UIImage from compressed data for caching: \(identifier)")
+                return
+            }
+
+            // Cache the resized image in memory
+            let cost = memoryCost(for: resizedImage)
+            cache.setObject(resizedImage, forKey: identifier as NSString, cost: cost)
+            Log.info("Successfully cached resized image for upload: \(identifier)")
+
+            // Notify immediately after memory cache (consistent with other methods)
+            cacheUpdateSubject.send(identifier)
+
+            // Save pre-compressed JPEG data directly to disk to avoid double compression
+            await saveDataToDisk(jpegData, identifier: identifier, imageFormat: .jpg)
+        }
+
+        return jpegData
+    }
+
+    /// Remove cached image by identifier (removes from both memory and disk)
     public func removeImage(for identifier: String) {
         cache.removeObject(forKey: identifier as NSString)
+
+        // Remove from disk asynchronously
+        Task {
+            await removeImageFromDisk(identifier: identifier)
+        }
+
         cacheUpdateSubject.send(identifier)
     }
 
@@ -85,23 +285,373 @@ public final class ImageCache {
         return urlCache.object(forKey: url.absoluteString as NSString)
     }
 
+    /// Get cached image by URL (async, checks memory → disk)
+    public func imageAsync(for url: URL) async -> UIImage? {
+        let urlString = url.absoluteString
+
+        // Check memory first
+        if let memoryImage = urlCache.object(forKey: urlString as NSString) {
+            return memoryImage
+        }
+
+        // Check disk (using URL string as identifier, default to JPEG)
+        if let diskImage = await loadImageFromDisk(identifier: urlString, imageFormat: .jpg) {
+            // Populate memory cache (image is already compressed/resized from disk)
+            cacheImageInMemory(diskImage, key: urlString, cache: urlCache, logContext: "URL cache (from disk)")
+            return diskImage
+        }
+
+        return nil
+    }
+
     public func setImage(_ image: UIImage, for url: String) {
-        cacheImage(image, key: url, cache: urlCache, logContext: "URL cache")
+        cacheImage(image, key: url, cache: urlCache, logContext: "URL cache", imageFormat: .jpg)
+
+        // Save to disk asynchronously (default to JPEG for URL-based cache)
+        Task {
+            await saveImageToDisk(image, identifier: url, imageFormat: .jpg)
+        }
+
+        cacheUpdateSubject.send(url)
+    }
+
+    // MARK: - Disk Cache Methods
+
+    /// Load image from disk cache
+    private func loadImageFromDisk(identifier: String, imageFormat: ImageFormat) async -> UIImage? {
+        var fileURL = self.diskCacheURL.appendingPathComponent(self.sanitizedFilename(for: identifier, fileExtension: imageFormat.fileExtension))
+        let formatName = imageFormat == .png ? "PNG" : "JPEG"
+
+        return await withCheckedContinuation { continuation in
+            self.diskCacheQueue.async { [weak self] in
+                guard let self else {
+                    continuation.resume(returning: nil)
+                    return
+                }
+
+                guard self.fileManager.fileExists(atPath: fileURL.path) else {
+                    continuation.resume(returning: nil)
+                    return
+                }
+
+                do {
+                    let data = try Data(contentsOf: fileURL)
+                    if let image = UIImage(data: data) {
+                        // Update file access date for LRU cleanup
+                        var resourceValues = URLResourceValues()
+                        resourceValues.contentAccessDate = Date()
+                        try? fileURL.setResourceValues(resourceValues)
+                        Log.info("Successfully loaded \(formatName) image from disk: \(identifier)")
+                        continuation.resume(returning: image)
+                    } else {
+                        Log.error("Failed to decode image from disk: \(identifier)")
+                        continuation.resume(returning: nil)
+                    }
+                } catch {
+                    Log.error("Failed to load image from disk: \(identifier) - \(error)")
+                    continuation.resume(returning: nil)
+                }
+            }
+        }
+    }
+
+    /// Save pre-compressed data directly to disk cache (avoids double compression)
+    /// - Parameters:
+    ///   - data: The image data to save
+    ///   - identifier: The cache identifier
+    ///   - imageFormat: The image format (default: .jpg)
+    private func saveDataToDisk(_ data: Data, identifier: String, imageFormat: ImageFormat = .jpg) async {
+        let fileURL = self.diskCacheURL.appendingPathComponent(self.sanitizedFilename(for: identifier, fileExtension: imageFormat.fileExtension))
+        let formatName = imageFormat == .png ? "PNG" : "JPEG"
+
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            self.diskCacheQueue.async { [weak self] in
+                guard let self else {
+                    continuation.resume()
+                    return
+                }
+
+                do {
+                    try data.write(to: fileURL, options: .atomic)
+                    Log.info("Successfully saved image data to disk: \(identifier) (\(data.count) bytes, format: \(formatName))")
+                    // Trigger cleanup if needed
+                    self.scheduleCleanupIfNeeded()
+                } catch {
+                    Log.error("Failed to save image data to disk: \(identifier) - \(error)")
+                }
+
+                continuation.resume()
+            }
+        }
+    }
+
+    /// Save image to disk cache
+    private func saveImageToDisk(_ image: UIImage, identifier: String, imageFormat: ImageFormat = .jpg) async {
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            self.diskCacheQueue.async { [weak self] in
+                guard let self else {
+                    continuation.resume()
+                    return
+                }
+
+                let data: Data?
+                switch imageFormat {
+                case .png:
+                    data = ImageCompression.resizeAndCompressToPNG(image)
+                case .jpg:
+                    data = ImageCompression.resizeAndCompressToJPEG(image, compressionQuality: 0.8)
+                }
+
+                guard let imageData = data else {
+                    Log.error("Failed to resize and compress image for disk: \(identifier)")
+                    continuation.resume()
+                    return
+                }
+
+                let fileURL = self.diskCacheURL.appendingPathComponent(self.sanitizedFilename(for: identifier, fileExtension: imageFormat.fileExtension))
+
+                do {
+                    try imageData.write(to: fileURL, options: .atomic)
+                    let formatName = imageFormat == .png ? "PNG" : "JPEG"
+                    Log.info("Successfully saved image to disk: \(identifier) (\(imageData.count) bytes, format: \(formatName))")
+                    // Trigger cleanup if needed
+                    self.scheduleCleanupIfNeeded()
+                } catch {
+                    Log.error("Failed to save image to disk: \(identifier) - \(error)")
+                }
+
+                continuation.resume()
+            }
+        }
+    }
+
+    /// Remove image from disk cache
+    /// Removes both PNG and JPEG versions if they exist (for backward compatibility)
+    private func removeImageFromDisk(identifier: String) async {
+        let pngURL = self.diskCacheURL.appendingPathComponent(self.sanitizedFilename(for: identifier, fileExtension: ".png"))
+        let jpgURL = self.diskCacheURL.appendingPathComponent(self.sanitizedFilename(for: identifier, fileExtension: ".jpg"))
+
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            self.diskCacheQueue.async { [weak self] in
+                guard let self else {
+                    continuation.resume()
+                    return
+                }
+
+                // Remove PNG if it exists
+                if self.fileManager.fileExists(atPath: pngURL.path) {
+                    do {
+                        try self.fileManager.removeItem(at: pngURL)
+                        Log.info("Successfully removed PNG image from disk: \(identifier)")
+                    } catch {
+                        if (error as NSError).code != NSFileNoSuchFileError {
+                            Log.error("Failed to remove PNG image from disk: \(identifier) - \(error)")
+                        }
+                    }
+                }
+
+                // Remove JPEG if it exists
+                if self.fileManager.fileExists(atPath: jpgURL.path) {
+                    do {
+                        try self.fileManager.removeItem(at: jpgURL)
+                        Log.info("Successfully removed JPEG image from disk: \(identifier)")
+                    } catch {
+                        // Ignore error if file doesn't exist
+                        if (error as NSError).code != NSFileNoSuchFileError {
+                            Log.error("Failed to remove JPEG image from disk: \(identifier) - \(error)")
+                        }
+                    }
+                }
+
+                continuation.resume()
+            }
+        }
+    }
+
+    /// Schedule cleanup if not already scheduled (coalesces multiple concurrent requests)
+    private func scheduleCleanupIfNeeded() {
+        _ = cleanupLock.withLock { (task: inout Task<Void, Never>?) -> Task<Void, Never>? in
+            guard task == nil else { return task }
+
+            task = Task {
+                await cleanupDiskCacheIfNeeded()
+                // Clear the task when done
+                _ = cleanupLock.withLock { (t: inout Task<Void, Never>?) -> Task<Void, Never>? in
+                    t = nil
+                    return nil
+                }
+            }
+
+            return task
+        }
+    }
+
+    /// Clean up disk cache if it exceeds size limit (LRU - removes oldest accessed files)
+    /// Processes files in batches to avoid memory pressure with large caches
+    private func cleanupDiskCacheIfNeeded() async {
+        struct CachedFileInfo {
+            let url: URL
+            let size: Int
+            let date: Date
+        }
+
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            self.diskCacheQueue.async { [weak self] in
+                guard let self else {
+                    continuation.resume()
+                    return
+                }
+
+                do {
+                    let resourceKeys: [URLResourceKey] = [.fileSizeKey, .contentAccessDateKey]
+                    let fileURLs = try self.fileManager.contentsOfDirectory(
+                        at: self.diskCacheURL,
+                        includingPropertiesForKeys: resourceKeys,
+                        options: .skipsHiddenFiles
+                    )
+
+                    // Process files in batches to avoid loading all metadata into memory at once
+                    let batchSize = 100
+                    var totalSize = 0
+                    var batch: [CachedFileInfo] = []
+                    batch.reserveCapacity(batchSize)
+
+                    // First pass: Calculate total size in batches
+                    for i in stride(from: 0, to: fileURLs.count, by: batchSize) {
+                        let endIndex = min(i + batchSize, fileURLs.count)
+                        batch.removeAll(keepingCapacity: true)
+
+                        for j in i..<endIndex {
+                            let fileURL = fileURLs[j]
+                            let resourceValues = try fileURL.resourceValues(forKeys: Set(resourceKeys))
+                            let size = resourceValues.fileSize ?? 0
+
+                            totalSize += size
+                        }
+                    }
+
+                    // Second pass: If cleanup needed, collect oldest files in batches
+                    if totalSize > self.maxDiskCacheSize {
+                        var oldestFiles: [CachedFileInfo] = []
+
+                        // Collect all files in batches
+                        for i in stride(from: 0, to: fileURLs.count, by: batchSize) {
+                            let endIndex = min(i + batchSize, fileURLs.count)
+                            batch.removeAll(keepingCapacity: true)
+
+                            // Process batch
+                            for j in i..<endIndex {
+                                let fileURL = fileURLs[j]
+                                let resourceValues = try fileURL.resourceValues(forKeys: Set(resourceKeys))
+                                let size = resourceValues.fileSize ?? 0
+                                let date = resourceValues.contentAccessDate ?? Date.distantPast
+
+                                batch.append(CachedFileInfo(url: fileURL, size: size, date: date))
+                            }
+
+                            // Merge batch with oldestFiles
+                            oldestFiles.append(contentsOf: batch)
+                        }
+
+                        // Sort by date (oldest first) once at the end
+                        oldestFiles.sort { $0.date < $1.date }
+
+                        // Delete oldest files until we're under the limit
+                        var removedSize = 0
+                        for file in oldestFiles {
+                            guard totalSize - removedSize > self.maxDiskCacheSize else { break }
+
+                            do {
+                                try self.fileManager.removeItem(at: file.url)
+                                removedSize += file.size
+                                Log.info("Removed old cached image from disk: \(file.url.lastPathComponent)")
+                            } catch {
+                                Log.error("Failed to remove cached image: \(file.url.lastPathComponent) - \(error)")
+                            }
+                        }
+
+                        Log.info("Disk cache cleanup: removed \(removedSize) bytes")
+                    }
+                } catch {
+                    Log.error("Failed to cleanup disk cache: \(error)")
+                }
+
+                continuation.resume()
+            }
+        }
+    }
+
+    /// Sanitize identifier to create a valid filename
+    /// - Parameters:
+    ///   - identifier: The cache identifier
+    ///   - extension: File extension (default: ".jpg")
+    /// - Returns: Sanitized filename with extension
+    private func sanitizedFilename(for identifier: String, fileExtension: String = ".jpg") -> String {
+        // Use SHA256 hash for consistent, filesystem-safe filenames
+        let data = Data(identifier.utf8)
+        let hashData = data.sha256Hash()
+        let hashString = hashData.map { String(format: "%02x", $0) }.joined()
+        return hashString + fileExtension
     }
 
     // MARK: - Private Methods
 
-    private func cacheImage(_ image: UIImage, key: String, cache: NSCache<NSString, UIImage>, logContext: String) {
-        let resizedImage = ImageCompression.resizeForCache(image)
+    /// Calculates memory cost in bytes for an image based on pixel dimensions
+    /// Uses CGImage pixel dimensions (not UIImage point dimensions) to account for scale factor
+    /// - Parameter image: The UIImage to calculate cost for
+    /// - Returns: Memory cost in bytes (width * height * 4 bytes per pixel for RGBA)
+    private func memoryCost(for image: UIImage) -> Int {
+        guard let cgImage = image.cgImage else {
+            // Fallback to point-based calculation if CGImage is unavailable
+            // Account for scale factor to get pixel dimensions (scale^2 for area)
+            let scale = image.scale > 0 ? image.scale : 1.0
+            return Int(image.size.width * image.size.height * scale * scale * 4)
+        }
+        // Use pixel dimensions (accounts for scale factor: 1x, 2x, 3x)
+        return cgImage.width * cgImage.height * 4
+    }
+
+    /// Cache image in memory without compression (for images already processed, e.g., loaded from disk)
+    private func cacheImageInMemory(_ image: UIImage, key: String, cache: NSCache<NSString, UIImage>, logContext: String) {
+        guard image.size.width > 0 && image.size.height > 0 else {
+            Log.error("Invalid image dimensions for \(logContext): \(key)")
+            return
+        }
+
+        let cost = memoryCost(for: image)
+        cache.setObject(image, forKey: key as NSString, cost: cost)
+        Log.info("Successfully cached image for \(logContext): \(key)")
+    }
+
+    /// Resize, compress, and cache image in memory (for new/original images)
+    private func cacheImage(_ image: UIImage, key: String, cache: NSCache<NSString, UIImage>, logContext: String, imageFormat: ImageFormat = .jpg) {
+        let compressedData: Data?
+        switch imageFormat {
+        case .png:
+            compressedData = ImageCompression.resizeAndCompressToPNG(image)
+        case .jpg:
+            compressedData = ImageCompression.resizeAndCompressToJPEG(image, compressionQuality: 0.8)
+        }
+
+        guard let imageData = compressedData else {
+            Log.error("Failed to resize and compress image for \(logContext): \(key)")
+            return
+        }
+
+        guard let resizedImage = UIImage(data: imageData) else {
+            Log.error("Failed to create UIImage from compressed data for \(logContext): \(key)")
+            return
+        }
 
         guard resizedImage.size.width > 0 && resizedImage.size.height > 0 else {
             Log.error("Failed to resize image for \(logContext): \(key) - invalid dimensions")
             return
         }
 
-        let cost = Int(resizedImage.size.width * resizedImage.size.height * 4)
+        let cost = memoryCost(for: resizedImage)
         cache.setObject(resizedImage, forKey: key as NSString, cost: cost)
-        Log.info("Successfully cached resized image for \(logContext): \(key)")
+        let formatName = imageFormat == .png ? "PNG" : "JPEG"
+        Log.info("Successfully cached resized image for \(logContext): \(key) (format: \(formatName))")
     }
 }
 

--- a/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
@@ -208,7 +208,7 @@ public final class SessionManager: SessionManagerProtocol {
                 "notificationType": "explosion"
             ]
 
-            if let cachedImage = ImageCache.shared.image(for: conversation),
+            if let cachedImage = await ImageCache.shared.imageAsync(for: conversation),
                let cachedImageData = cachedImage.jpegData(compressionQuality: 1.0) {
                 do {
                     let tempDirectory = FileManager.default.temporaryDirectory

--- a/ConvosCore/Sources/ConvosCore/Storage/Hydration/DBConversationDetails+Conversation.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Hydration/DBConversationDetails+Conversation.swift
@@ -28,6 +28,7 @@ extension DBConversationDetails {
 
         return Conversation(
             id: conversation.id,
+            clientConversationId: conversation.clientConversationId,
             inboxId: conversation.inboxId,
             clientId: conversation.clientId,
             creator: creator,

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/Conversation.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/Conversation.swift
@@ -5,6 +5,7 @@ import GRDB
 
 public struct Conversation: Codable, Hashable, Identifiable, Sendable {
     public let id: String
+    let clientConversationId: String
     public let inboxId: String
     public let clientId: String
     public let creator: ConversationMember

--- a/ConvosCore/Sources/ConvosCore/Storage/Repositories/Mocks/MockConversationsRepository.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Repositories/Mocks/MockConversationsRepository.swift
@@ -4,6 +4,7 @@ import Foundation
 extension Conversation {
     public static func mock(
         id: String = UUID().uuidString,
+        clientConversationId: String = UUID().uuidString,
         creator: ConversationMember = .mock(),
         date: Date = Date(),
         consent: Consent = .allowed,
@@ -17,6 +18,7 @@ extension Conversation {
     ) -> Self {
         .init(
             id: id,
+            clientConversationId: clientConversationId,
             inboxId: UUID().uuidString,
             clientId: UUID().uuidString,
             creator: creator,
@@ -42,6 +44,7 @@ extension Conversation {
     public static func empty(id: String = "") -> Self {
         .init(
             id: id,
+            clientConversationId: id,
             inboxId: "",
             clientId: "",
             creator: .empty(isCurrentUser: true),

--- a/ConvosCore/Sources/ConvosCore/Utilities/ImageCompression.swift
+++ b/ConvosCore/Sources/ConvosCore/Utilities/ImageCompression.swift
@@ -1,44 +1,377 @@
+import CoreGraphics
+import ImageIO
 import UIKit
 
 struct ImageCompression {
     static let cacheOptimizedSize: CGFloat = 500
 
-    /// Resizes image for cache storage with optimal dimensions (500×500px default)
+    /// Resizes and compresses image to JPEG data in a single pass for optimal performance
+    /// This avoids creating an intermediate UIImage, reducing memory usage and improving speed
     /// - Parameters:
-    ///   - image: The original UIImage to resize
-    ///   - maxSize: Maximum dimensions (default: 500×500px for cache optimization)
-    /// - Returns: Resized UIImage
-    static func resizeForCache(
+    ///   - image: The original UIImage to resize and compress
+    ///   - maxSize: Maximum dimensions in points (default: 500×500pt for cache optimization)
+    ///   - compressionQuality: JPEG compression quality (0.0-1.0, default: 0.8)
+    /// - Returns: JPEG data of the resized and compressed image, or nil if compression fails
+    static func resizeAndCompressToJPEG(
         _ image: UIImage,
-        maxSize: CGSize = CGSize(width: cacheOptimizedSize, height: cacheOptimizedSize)
-    ) -> UIImage {
-        let size = image.size
-
-        // If image is already smaller than max size, return as-is
-        if size.width <= maxSize.width && size.height <= maxSize.height {
-            return image
+        maxSize: CGSize = CGSize(width: cacheOptimizedSize, height: cacheOptimizedSize),
+        compressionQuality: CGFloat = 0.8
+    ) -> Data? {
+        // Create JPEG data directly from resized image using Core Graphics
+        // This avoids creating an intermediate UIImage
+        guard let cgImage = image.cgImage else {
+            return nil
         }
 
-        // Calculate scale factor to fit within max size while maintaining aspect ratio
-        let widthRatio = maxSize.width / size.width
-        let heightRatio = maxSize.height / size.height
-        let scaleFactor = min(widthRatio, heightRatio)
+        // Work in pixel space: CGImage dimensions are in pixels, not points
+        // UIImage.size is in points and doesn't account for scale factor
+        let pixelWidth = CGFloat(cgImage.width)
+        let pixelHeight = CGFloat(cgImage.height)
 
-        let newSize = CGSize(
-            width: size.width * scaleFactor,
-            height: size.height * scaleFactor
+        // Convert maxSize from points to pixels using image scale
+        // Use scale of 1.0 if image.scale is 0 (can happen with some images)
+        let imageScale = image.scale > 0 ? image.scale : 1.0
+        let maxPixelWidth = maxSize.width * imageScale
+        let maxPixelHeight = maxSize.height * imageScale
+
+        // Calculate target size in pixels
+        let targetPixelSize: CGSize
+        if pixelWidth <= maxPixelWidth && pixelHeight <= maxPixelHeight {
+            // Image is already small enough, use original pixel size
+            targetPixelSize = CGSize(width: pixelWidth, height: pixelHeight)
+        } else {
+            // Calculate scale factor to fit within max size while maintaining aspect ratio
+            let widthRatio = maxPixelWidth / pixelWidth
+            let heightRatio = maxPixelHeight / pixelHeight
+            let scaleFactor = min(widthRatio, heightRatio)
+
+            targetPixelSize = CGSize(
+                width: pixelWidth * scaleFactor,
+                height: pixelHeight * scaleFactor
+            )
+        }
+
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+        let bitmapInfo = CGBitmapInfo(rawValue: CGImageAlphaInfo.premultipliedLast.rawValue)
+
+        // Create context with pixel dimensions (CGContext works in pixels, not points)
+        guard let context = CGContext(
+            data: nil,
+            width: Int(targetPixelSize.width),
+            height: Int(targetPixelSize.height),
+            bitsPerComponent: 8,
+            bytesPerRow: 0,
+            space: colorSpace,
+            bitmapInfo: bitmapInfo.rawValue
+        ) else {
+            return nil
+        }
+
+        // Set high-quality rendering
+        context.interpolationQuality = .high
+        context.setShouldAntialias(true)
+        context.setAllowsAntialiasing(true)
+
+        // Apply orientation transform to respect EXIF orientation data
+        // This ensures images from cameras display correctly
+        let orientation = image.imageOrientation
+        context.saveGState()
+
+        // Calculate the transform and adjusted drawing rect based on orientation
+        // Use pixel dimensions for both source and target
+        let (transform, drawingRect) = orientationTransformAndRect(
+            orientation: orientation,
+            imageSize: CGSize(width: pixelWidth, height: pixelHeight),
+            targetSize: targetPixelSize
         )
 
-        // Create resized image with scale 1.0 to get exact pixel dimensions (not logical points)
-        let format = UIGraphicsImageRendererFormat()
-        format.scale = 1.0 // Force 1x scale to get exact pixel dimensions
+        context.concatenate(transform)
 
-        let renderer = UIGraphicsImageRenderer(size: newSize, format: format)
-        return renderer.image { context in
-            context.cgContext.interpolationQuality = .high
-            context.cgContext.setShouldAntialias(true)
-            context.cgContext.setAllowsAntialiasing(true)
-            image.draw(in: CGRect(origin: .zero, size: newSize))
+        // Draw the image scaled to target size with proper orientation
+        context.draw(cgImage, in: drawingRect)
+
+        context.restoreGState()
+
+        // Get the resized image from context
+        guard let resizedCGImage = context.makeImage() else {
+            return nil
+        }
+
+        // Use ImageIO to compress directly to JPEG data without creating UIImage
+        // This is more memory-efficient than using UIImage.jpegData()
+        let mutableData = NSMutableData()
+        guard let destination = CGImageDestinationCreateWithData(mutableData, "public.jpeg" as CFString, 1, nil) else {
+            return nil
+        }
+
+        // Set JPEG compression quality
+        let options: [CFString: Any] = [
+            kCGImageDestinationLossyCompressionQuality: compressionQuality
+        ]
+
+        CGImageDestinationAddImage(destination, resizedCGImage, options as CFDictionary)
+        guard CGImageDestinationFinalize(destination) else {
+            return nil
+        }
+
+        return mutableData as Data
+    }
+
+    /// Resizes and compresses image to PNG data in a single pass for optimal performance
+    /// This preserves alpha channel and is lossless, making it ideal for images with transparency
+    /// - Parameters:
+    ///   - image: The original UIImage to resize and compress
+    ///   - maxSize: Maximum dimensions in points (default: 500×500pt for cache optimization)
+    /// - Returns: PNG data of the resized and compressed image, or nil if compression fails
+    static func resizeAndCompressToPNG(
+        _ image: UIImage,
+        maxSize: CGSize = CGSize(width: cacheOptimizedSize, height: cacheOptimizedSize)
+    ) -> Data? {
+        // Create PNG data directly from resized image using Core Graphics
+        // This avoids creating an intermediate UIImage
+        guard let cgImage = image.cgImage else {
+            return nil
+        }
+
+        // Work in pixel space: CGImage dimensions are in pixels, not points
+        // UIImage.size is in points and doesn't account for scale factor
+        let pixelWidth = CGFloat(cgImage.width)
+        let pixelHeight = CGFloat(cgImage.height)
+
+        // Convert maxSize from points to pixels using image scale
+        // Use scale of 1.0 if image.scale is 0 (can happen with some images)
+        let imageScale = image.scale > 0 ? image.scale : 1.0
+        let maxPixelWidth = maxSize.width * imageScale
+        let maxPixelHeight = maxSize.height * imageScale
+
+        // Calculate target size in pixels
+        let targetPixelSize: CGSize
+        if pixelWidth <= maxPixelWidth && pixelHeight <= maxPixelHeight {
+            // Image is already small enough, use original pixel size
+            targetPixelSize = CGSize(width: pixelWidth, height: pixelHeight)
+        } else {
+            // Calculate scale factor to fit within max size while maintaining aspect ratio
+            let widthRatio = maxPixelWidth / pixelWidth
+            let heightRatio = maxPixelHeight / pixelHeight
+            let scaleFactor = min(widthRatio, heightRatio)
+
+            targetPixelSize = CGSize(
+                width: pixelWidth * scaleFactor,
+                height: pixelHeight * scaleFactor
+            )
+        }
+
+        // Use RGB color space with alpha channel support
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+        let bitmapInfo = CGBitmapInfo(rawValue: CGImageAlphaInfo.premultipliedLast.rawValue)
+
+        // Create context with pixel dimensions (CGContext works in pixels, not points)
+        guard let context = CGContext(
+            data: nil,
+            width: Int(targetPixelSize.width),
+            height: Int(targetPixelSize.height),
+            bitsPerComponent: 8,
+            bytesPerRow: 0,
+            space: colorSpace,
+            bitmapInfo: bitmapInfo.rawValue
+        ) else {
+            return nil
+        }
+
+        // Set high-quality rendering
+        context.interpolationQuality = .high
+        context.setShouldAntialias(true)
+        context.setAllowsAntialiasing(true)
+
+        // Apply orientation transform to respect EXIF orientation data
+        // This ensures images from cameras display correctly
+        let orientation = image.imageOrientation
+        context.saveGState()
+
+        // Calculate the transform and adjusted drawing rect based on orientation
+        // Use pixel dimensions for both source and target
+        let (transform, drawingRect) = orientationTransformAndRect(
+            orientation: orientation,
+            imageSize: CGSize(width: pixelWidth, height: pixelHeight),
+            targetSize: targetPixelSize
+        )
+
+        context.concatenate(transform)
+
+        // Draw the image scaled to target size with proper orientation
+        context.draw(cgImage, in: drawingRect)
+
+        context.restoreGState()
+
+        // Get the resized image from context
+        guard let resizedCGImage = context.makeImage() else {
+            return nil
+        }
+
+        // Use ImageIO to compress directly to PNG data without creating UIImage
+        // PNG is lossless and preserves alpha channel
+        let mutableData = NSMutableData()
+        guard let destination = CGImageDestinationCreateWithData(mutableData, "public.png" as CFString, 1, nil) else {
+            return nil
+        }
+
+        // PNG compression options (lossless)
+        let options: [CFString: Any] = [:]
+
+        CGImageDestinationAddImage(destination, resizedCGImage, options as CFDictionary)
+        guard CGImageDestinationFinalize(destination) else {
+            return nil
+        }
+
+        return mutableData as Data
+    }
+
+    /// Checks if an image has transparency (alpha channel)
+    /// - Parameter image: The UIImage to check
+    /// - Returns: true if the image has transparency, false otherwise
+    static func hasTransparency(_ image: UIImage) -> Bool {
+        guard let cgImage = image.cgImage else {
+            return false
+        }
+
+        let alphaInfo = cgImage.alphaInfo
+
+        // Check if the image format supports alpha
+        switch alphaInfo {
+        case .none, .noneSkipFirst, .noneSkipLast:
+            return false
+        case .first, .last, .premultipliedFirst, .premultipliedLast, .alphaOnly:
+            // Format supports alpha, but we need to check if there are actually transparent pixels
+            return checkForTransparentPixels(cgImage: cgImage)
+        @unknown default:
+            // For unknown formats, assume no transparency to be safe
+            return false
+        }
+    }
+
+    /// Checks if a CGImage actually contains transparent pixels
+    /// - Parameter cgImage: The CGImage to check
+    /// - Returns: true if transparent pixels are found, false otherwise
+    private static func checkForTransparentPixels(cgImage: CGImage) -> Bool {
+        let width = cgImage.width
+        let height = cgImage.height
+
+        // Sample a subset of pixels to check for transparency (for performance)
+        // For QR codes, we can be more thorough since they're typically small
+        let sampleStep = max(1, min(width, height) / 50) // Sample every Nth pixel, or all if small
+
+        // Rasterize into a known RGBA bitmap format to avoid byte order issues
+        // Use premultipliedLast (RGBA) format where alpha is always at offset 3
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+        let bitmapInfo = CGBitmapInfo(rawValue: CGImageAlphaInfo.premultipliedLast.rawValue)
+
+        guard let context = CGContext(
+            data: nil,
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bytesPerRow: 0,
+            space: colorSpace,
+            bitmapInfo: bitmapInfo.rawValue
+        ) else {
+            return false
+        }
+
+        // Draw the image into the context
+        context.draw(cgImage, in: CGRect(x: 0, y: 0, width: width, height: height))
+
+        // Get the bitmap data from the context
+        guard let data = context.data else {
+            return false
+        }
+
+        let bytesPerPixel = 4 // RGBA = 4 bytes per pixel
+        let bytesPerRow = context.bytesPerRow
+
+        // Sample pixels to check for transparency
+        // In RGBA format, alpha is always at offset 3 (last byte)
+        for y in stride(from: 0, to: height, by: sampleStep) {
+            for x in stride(from: 0, to: width, by: sampleStep) {
+                let pixelOffset = y * bytesPerRow + x * bytesPerPixel + 3 // Alpha is at offset 3 in RGBA
+                guard pixelOffset < bytesPerRow * height else { continue }
+
+                let alpha = data.advanced(by: pixelOffset).assumingMemoryBound(to: UInt8.self).pointee
+                // If we find any pixel with alpha < 255, the image has transparency
+                if alpha < 255 {
+                    return true
+                }
+            }
+        }
+
+        return false
+    }
+
+    /// Calculates the transform and drawing rect needed to apply UIImage orientation
+    /// - Parameters:
+    ///   - orientation: The UIImage orientation
+    ///   - imageSize: The original image size in pixels
+    ///   - targetSize: The target size for the resized image in pixels
+    /// - Returns: A tuple containing the CGAffineTransform and the drawing rect (in pixels)
+    private static func orientationTransformAndRect(
+        orientation: UIImage.Orientation,
+        imageSize: CGSize,
+        targetSize: CGSize
+    ) -> (transform: CGAffineTransform, rect: CGRect) {
+        let width = targetSize.width
+        let height = targetSize.height
+
+        switch orientation {
+        case .up:
+            // No transformation needed
+            return (.identity, CGRect(origin: .zero, size: targetSize))
+
+        case .upMirrored:
+            // Flip horizontally
+            var transform = CGAffineTransform(translationX: width, y: 0)
+            transform = transform.scaledBy(x: -1, y: 1)
+            return (transform, CGRect(origin: .zero, size: targetSize))
+
+        case .down:
+            // Rotate 180 degrees
+            var transform = CGAffineTransform(translationX: width, y: height)
+            transform = transform.rotated(by: .pi)
+            return (transform, CGRect(origin: .zero, size: targetSize))
+
+        case .downMirrored:
+            // Flip vertically
+            var transform = CGAffineTransform(translationX: 0, y: height)
+            transform = transform.scaledBy(x: 1, y: -1)
+            return (transform, CGRect(origin: .zero, size: targetSize))
+
+        case .left:
+            // Rotate 90 degrees counterclockwise (swap width/height)
+            var transform = CGAffineTransform(translationX: 0, y: width)
+            transform = transform.rotated(by: -.pi / 2)
+            return (transform, CGRect(origin: .zero, size: CGSize(width: height, height: width)))
+
+        case .leftMirrored:
+            // Rotate 90 degrees counterclockwise and flip horizontally
+            var transform = CGAffineTransform(translationX: height, y: width)
+            transform = transform.scaledBy(x: -1, y: 1)
+            transform = transform.rotated(by: -.pi / 2)
+            return (transform, CGRect(origin: .zero, size: CGSize(width: height, height: width)))
+
+        case .right:
+            // Rotate 90 degrees clockwise (swap width/height)
+            var transform = CGAffineTransform(translationX: height, y: 0)
+            transform = transform.rotated(by: .pi / 2)
+            return (transform, CGRect(origin: .zero, size: CGSize(width: height, height: width)))
+
+        case .rightMirrored:
+            // Rotate 90 degrees clockwise and flip horizontally
+            var transform = CGAffineTransform(translationX: height, y: 0)
+            transform = transform.scaledBy(x: -1, y: 1)
+            transform = transform.rotated(by: .pi / 2)
+            return (transform, CGRect(origin: .zero, size: CGSize(width: height, height: width)))
+
+        @unknown default:
+            // Fallback to no transformation for unknown orientations
+            return (.identity, CGRect(origin: .zero, size: targetSize))
         }
     }
 }


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Add disk-backed image caching and modify UI and writers to use async ImageCache reads in [ImageCache.swift](https://github.com/ephemeraHQ/convos-ios/pull/230/files#diff-9c43db5e1255cd76ef671f19b4a4c7a02209590452cefbe49fbee60b9884b12b)
Introduce disk persistence, async retrieval, and LRU cleanup in `ImageCache`; switch avatar and notification flows to `imageAsync`; key conversation images by `clientConversationId`; add single-pass JPEG/PNG compression utilities and cache QR codes as PNG.

#### 📍Where to Start
Start with the `ImageCache` initialization and async retrieval paths in [ImageCache.swift](https://github.com/ephemeraHQ/convos-ios/pull/230/files#diff-9c43db5e1255cd76ef671f19b4a4c7a02209590452cefbe49fbee60b9884b12b).

----
<!-- Macroscope's review summary starts here -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized fdaef0d. 12 files reviewed, 37 issues evaluated, 35 issues filtered, 1 comment posted</summary>

### 🗂️ Filtered Issues
<details>
<summary>Convos/Debug View/DebugView.swift — 0 comments posted, 3 evaluated, 3 filtered</summary>

- [line 257](https://github.com/ephemeraHQ/convos-ios/blob/fdaef0d69638a6d25bce0086ba4165334e0e2ab0/Convos/Debug View/DebugView.swift#L257): `testSentryMessage()` was changed from `private` to internal, making it callable from outside the extension’s file/module scope. In production builds or from unintended callers, this can emit Sentry events when invoked, creating noisy telemetry and side effects. There is no guard against environment or Sentry initialization state here. <b>[ Low confidence ]</b>
- [line 263](https://github.com/ephemeraHQ/convos-ios/blob/fdaef0d69638a6d25bce0086ba4165334e0e2ab0/Convos/Debug View/DebugView.swift#L263): `testSentryError()` was changed from `private` to internal, exposing a method that emits an error event to Sentry. When invoked outside intended debug contexts, this can generate misleading telemetry and side effects. No environment checks are present. <b>[ Low confidence ]</b>
- [line 277](https://github.com/ephemeraHQ/convos-ios/blob/fdaef0d69638a6d25bce0086ba4165334e0e2ab0/Convos/Debug View/DebugView.swift#L277): `testSentryException()` was changed from `private` to internal, exposing a method that emits an exception event to Sentry. If invoked in production or by unintended callers, it can produce misleading telemetry and side effects. No environment gating is implemented. <b>[ Low confidence ]</b>
</details>

<details>
<summary>Convos/Shared Views/AvatarView.swift — 0 comments posted, 2 evaluated, 2 filtered</summary>

- [line 16](https://github.com/ephemeraHQ/convos-ios/blob/fdaef0d69638a6d25bce0086ba4165334e0e2ab0/Convos/Shared Views/AvatarView.swift#L16): Using `placeholderImage ?? cachedImage` in `AvatarView` means that when `placeholderImage` is non-nil, it will always be chosen and the loaded/cached image in `cachedImage` will never be displayed. This silently prevents transitioning from a placeholder to the real image, causing the avatar to remain stuck on the placeholder even after successful network/cache load. <b>[ Low confidence ]</b>
- [line 101](https://github.com/ephemeraHQ/convos-ios/blob/fdaef0d69638a6d25bce0086ba4165334e0e2ab0/Convos/Shared Views/AvatarView.swift#L101): In `ConversationAvatarView`, `fallbackName` is set to an empty string (`""`). When neither `conversation.imageURL` nor `conversationImage` is available (the else branch uses `MonogramView(text: "")`), and even when the `AvatarView` shows the monogram, this change results in an empty monogram instead of using `conversation.displayName`. This is an externally visible regression in fallback behavior. <b>[ Low confidence ]</b>
</details>

<details>
<summary>ConvosCore/Sources/ConvosCore/Extensions/ImageCacheableExtensions.swift — 0 comments posted, 1 evaluated, 1 filtered</summary>

- [line 11](https://github.com/ephemeraHQ/convos-ios/blob/fdaef0d69638a6d25bce0086ba4165334e0e2ab0/ConvosCore/Sources/ConvosCore/Extensions/ImageCacheableExtensions.swift#L11): Changing `Conversation.imageCacheIdentifier` from `id` to `clientConversationId` alters the cache key used across memory and disk caches. Any previously cached images keyed by `id` will no longer be retrievable, leading to silent cache misses and orphaned disk entries. If `clientConversationId` is not globally unique or can change over time, this also risks key collisions and stale cache behavior. This is an externally visible contract change for `ImageCacheable` that affects `imageAsync(for:)`, which now looks up using the new key. <b>[ Low confidence ]</b>
</details>

<details>
<summary>ConvosCore/Sources/ConvosCore/Image Cache/ImageCache.swift — 0 comments posted, 7 evaluated, 6 filtered</summary>

- [line 67](https://github.com/ephemeraHQ/convos-ios/blob/fdaef0d69638a6d25bce0086ba4165334e0e2ab0/ConvosCore/Sources/ConvosCore/Image Cache/ImageCache.swift#L67): `maxDiskCacheSize` is taken directly from `CacheConfiguration.maxDiskCacheSize` without validation. If this value is zero or negative, cleanup will run and potentially remove all cached files even when the cache may be intentionally disabled or misconfigured. Add a lower-bound guard (e.g., treat non-positive as no-op or clamp to minimum) to avoid aggressive deletion due to bad config. <b>[ Low confidence ]</b>
- [line 201](https://github.com/ephemeraHQ/convos-ios/blob/fdaef0d69638a6d25bce0086ba4165334e0e2ab0/ConvosCore/Sources/ConvosCore/Image Cache/ImageCache.swift#L201): Misleading parameter `imageFormat` in `image(for identifier: String, imageFormat: ImageFormat = .jpg)` is unused. The function is memory-only and ignores `imageFormat`, which suggests format influences retrieval. This contradicts the visible signature/contract and can cause confusion or incorrect usage paths expecting format-sensitive behavior. <b>[ Low confidence ]</b>
- [line 214](https://github.com/ephemeraHQ/convos-ios/blob/fdaef0d69638a6d25bce0086ba4165334e0e2ab0/ConvosCore/Sources/ConvosCore/Image Cache/ImageCache.swift#L214): `image(for identifier: String, imageFormat: ImageFormat = .jpg) -> UIImage?` ignores its `imageFormat` parameter and always returns the memory-cached image for the identifier regardless of format. This creates contract inconsistency with `imageAsync(for:imageFormat:)`, which honors the format for disk reads. If the same `identifier` is used to cache different formats at different times (e.g., PNG with transparency vs. JPEG), callers may request a specific format but receive whichever image happens to be in memory, leading to incorrect rendering (e.g., lost alpha). Consider either removing the `imageFormat` parameter from the synchronous method or ensuring memory-tier caches are segregated by format or validated against the requested format. <b>[ Low confidence ]</b>
- [line 307](https://github.com/ephemeraHQ/convos-ios/blob/fdaef0d69638a6d25bce0086ba4165334e0e2ab0/ConvosCore/Sources/ConvosCore/Image Cache/ImageCache.swift#L307): API asymmetry for URL-based caching can cause cache misses. `image(for url: URL)` and `imageAsync(for url: URL)` use `url.absoluteString` as the key, but the setter is `setImage(_ image: UIImage, for url: String)` which requires callers to pass an exact matching string. Different string representations of the same `URL` (e.g., differing percent-encoding, trailing slashes, or relative vs. absolute) will lead to keys that don’t match, resulting in missed reads. Provide a `setImage(_:for url: URL)` overload that uses the same normalization (`url.absoluteString`) or standardize on one type. <b>[ Low confidence ]</b>
- [line 546](https://github.com/ephemeraHQ/convos-ios/blob/fdaef0d69638a6d25bce0086ba4165334e0e2ab0/ConvosCore/Sources/ConvosCore/Image Cache/ImageCache.swift#L546): `removedSize` accounting can be incorrect when entries represent directories or when `fileSize` is unavailable (`resourceValues.fileSize` is `nil`), because size defaults to `0`. Deleting such a URL may remove non-trivial data while `removedSize` stays low, causing inaccurate logs and possibly continuing deletions longer than necessary. Consider skipping directories, computing actual sizes, or updating `totalSize` by re-stat after deletions. <b>[ Low confidence ]</b>
- [line 553](https://github.com/ephemeraHQ/convos-ios/blob/fdaef0d69638a6d25bce0086ba4165334e0e2ab0/ConvosCore/Sources/ConvosCore/Image Cache/ImageCache.swift#L553): The implementation explicitly contradicts its comments about memory usage. Despite stating "Processes files in batches to avoid memory pressure", it accumulates all `CachedFileInfo` entries into `oldestFiles` and sorts the entire collection (`oldestFiles.append(contentsOf: batch)` then `oldestFiles.sort`). For very large caches, this can cause high memory usage and potential OOM. Process incrementally: either select candidates with a bounded heap, or delete while iterating without storing all entries. <b>[ Low confidence ]</b>
</details>

<details>
<summary>ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift — 0 comments posted, 1 evaluated, 1 filtered</summary>

- [line 217](https://github.com/ephemeraHQ/convos-ios/blob/fdaef0d69638a6d25bce0086ba4165334e0e2ab0/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift#L217): Temporary file created for the `UNNotificationAttachment` is never deleted, causing a disk leak. The function writes the cached image to `tempFileURL` (`Data.write(to:)` at line `217`) and uses it to create an attachment, but there is no corresponding cleanup on success or failure paths. If attachment creation or request scheduling succeeds or fails, the file remains in the temporary directory. Add explicit removal of `tempFileURL` after the notification is scheduled (or after attachment creation when safe), and ensure cleanup occurs on all paths, including the `catch` block. A typical fix is to call `try? FileManager.default.removeItem(at: tempFileURL)` in a `defer` or after `UNUserNotificationCenter.current().add(request)` completes successfully. <b>[ Out of scope ]</b>
</details>

<details>
<summary>ConvosCore/Sources/ConvosCore/Storage/Repositories/Mocks/MockConversationsRepository.swift — 0 comments posted, 2 evaluated, 2 filtered</summary>

- [line 25](https://github.com/ephemeraHQ/convos-ios/blob/fdaef0d69638a6d25bce0086ba4165334e0e2ab0/ConvosCore/Sources/ConvosCore/Storage/Repositories/Mocks/MockConversationsRepository.swift#L25): Parameter `date` in `Conversation.mock(...)` is ignored. The initializer sets `createdAt` to `Date()` instead of the passed `date`, so callers cannot control the conversation's creation timestamp. Replace `createdAt: Date()` with `createdAt: date` to honor the parameter. <b>[ Out of scope ]</b>
- [line 51](https://github.com/ephemeraHQ/convos-ios/blob/fdaef0d69638a6d25bce0086ba4165334e0e2ab0/ConvosCore/Sources/ConvosCore/Storage/Repositories/Mocks/MockConversationsRepository.swift#L51): `Conversation.empty(...)` sets `createdAt` to `.distantFuture`. Any relative-time logic that computes `referenceDate.timeIntervalSince(createdAt)` (e.g., `Date.relativeShort(to:)`) will yield negative values, producing outputs like "-1h" or "-2w" and potentially breaking code that assumes non-future creation dates. Use a past or present timestamp (e.g., `.distantPast` or `.init()`) for drafts, or explicitly handle future dates in consumers. <b>[ Out of scope ]</b>
</details>

<details>
<summary>ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationMetadataWriter.swift — 0 comments posted, 2 evaluated, 2 filtered</summary>

- [line 158](https://github.com/ephemeraHQ/convos-ios/blob/fdaef0d69638a6d25bce0086ba4165334e0e2ab0/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationMetadataWriter.swift#L158): The shift to asynchronous caching via `ImageCache.shared.resizeCacheAndGetData(_, for:)` in both `updateImage(_:, for:)` (lines `158`–`165`) and `update(avatar:conversationId:)` (lines `91`–`96`) alters contract timing compared to prior synchronous `setImage` usage. Callers may immediately attempt to read from the cache after invocation and observe a miss until the `Task` completes, causing transient UI inconsistencies. Additionally, `Conversation.imageCacheIdentifier` was changed to `clientConversationId` (from `id`) elsewhere, which can orphan previously cached entries keyed by `id`. Consider documenting the timing change, ensuring consumers rely on `cacheUpdateSubject` before reading, and migrating/cleaning old cache keys to avoid stale disk entries. <b>[ Low confidence ]</b>
- [line 171](https://github.com/ephemeraHQ/convos-ios/blob/fdaef0d69638a6d25bce0086ba4165334e0e2ab0/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationMetadataWriter.swift#L171): In `updateImage(_:, for:)` (lines `167`–`176`), errors thrown inside the closure passed to `uploadAttachmentAndExecute` are caught and only logged (`Log.error`), without propagation or compensating actions. If the upload succeeds but `updateImageUrl` fails, the system may end up with an uploaded image whose URL is not reflected in the conversation metadata or local database, leaving inconsistent state. Consider propagating the error or implementing rollback/retry to maintain consistency. <b>[ Low confidence ]</b>
</details>

<details>
<summary>ConvosCore/Sources/ConvosCore/Storage/Writers/MyProfileWriter.swift — 0 comments posted, 1 evaluated, 1 filtered</summary>

- [line 85](https://github.com/ephemeraHQ/convos-ios/blob/fdaef0d69638a6d25bce0086ba4165334e0e2ab0/ConvosCore/Sources/ConvosCore/Storage/Writers/MyProfileWriter.swift#L85): In `update(avatar:conversationId:)`, when `avatar` is `nil` (lines `82`–`88`), the code removes the cached image and updates the remote profile via `group.updateProfile(updatedProfile)` but returns without persisting the `avatar: nil` change to the local database. This creates a local/remote state inconsistency where the remote profile has no avatar but the local `MemberProfile` may still hold the old `avatar` URL. You should save the updated profile to the database in the `nil` branch (mirroring the non-nil branch) before returning. <b>[ Already posted ]</b>
</details>

<details>
<summary>ConvosCore/Sources/ConvosCore/Utilities/ImageCompression.swift — 0 comments posted, 9 evaluated, 9 filtered</summary>

- [line 22](https://github.com/ephemeraHQ/convos-ios/blob/fdaef0d69638a6d25bce0086ba4165334e0e2ab0/ConvosCore/Sources/ConvosCore/Utilities/ImageCompression.swift#L22): `UIImage` instances backed only by `CIImage` will have `image.cgImage == nil`, causing the function to return `nil` for otherwise valid inputs. This is a reachable case (e.g., images created via Core Image). To avoid silent failure, render the `CIImage` to a `CGImage` using a `CIContext` fallback when `cgImage` is nil. <b>[ Low confidence ]</b>
- [line 60](https://github.com/ephemeraHQ/convos-ios/blob/fdaef0d69638a6d25bce0086ba4165334e0e2ab0/ConvosCore/Sources/ConvosCore/Utilities/ImageCompression.swift#L60): `CGContext` is created with `width: Int(targetPixelSize.width)` and `height: Int(targetPixelSize.height)`. If either target dimension is between 0 and 1 pixel (due to small `maxSize`, large downscale, or fractional computation), truncation to `Int` yields 0, causing `CGContext` creation to fail and the function to return `nil`. Clamp to at least 1 pixel and round (e.g., `max(1, Int(round(...)))`). <b>[ Already posted ]</b>
- [line 60](https://github.com/ephemeraHQ/convos-ios/blob/fdaef0d69638a6d25bce0086ba4165334e0e2ab0/ConvosCore/Sources/ConvosCore/Utilities/ImageCompression.swift#L60): `maxSize` is not validated for non-positive values, and `targetPixelSize` can become zero or negative. This flows into `CGContext` creation with `width`/`height` as `Int(targetPixelSize.width/height)` (lines `60`-`61`), which will fail and return `nil`. While this avoids a crash, it yields unexpected failure for reachable inputs (e.g., `maxSize` of `0` or negative). Enforce minimum dimensions (>= 1) and non-negative max size before creating the context, or clamp the computed `targetPixelSize` to at least 1×1 pixels. The same issue exists in `resizeAndCompressToPNG`. <b>[ Already posted ]</b>
- [line 60](https://github.com/ephemeraHQ/convos-ios/blob/fdaef0d69638a6d25bce0086ba4165334e0e2ab0/ConvosCore/Sources/ConvosCore/Utilities/ImageCompression.swift#L60): Rounding/truncation when converting `targetPixelSize` from `CGFloat` to `Int` can introduce off-by-one distortion or unintended aspect bias. Using `Int` truncation may slightly shrink one or both dimensions, degrading output quality. Prefer rounding to nearest (`Int(round(...))`) and ensuring consistent aspect by computing the second dimension from the first via the original ratio after rounding. <b>[ Already posted ]</b>
- [line 108](https://github.com/ephemeraHQ/convos-ios/blob/fdaef0d69638a6d25bce0086ba4165334e0e2ab0/ConvosCore/Sources/ConvosCore/Utilities/ImageCompression.swift#L108): `compressionQuality` is documented as 0.0–1.0 but is not validated. Passing values outside this range (including NaN) can lead to undefined or driver-specific behavior in ImageIO. Add a guard to clamp or reject out-of-range values before constructing the destination options. <b>[ Low confidence ]</b>
- [line 109](https://github.com/ephemeraHQ/convos-ios/blob/fdaef0d69638a6d25bce0086ba4165334e0e2ab0/ConvosCore/Sources/ConvosCore/Utilities/ImageCompression.swift#L109): `compressionQuality` in `resizeAndCompressToJPEG` is not validated. Values outside `[0.0, 1.0]` are reachable and can lead to undefined or default behavior in ImageIO (`kCGImageDestinationLossyCompressionQuality` at line `109`). Clamp or validate the quality to the supported range to ensure predictable output. <b>[ Low confidence ]</b>
- [line 261](https://github.com/ephemeraHQ/convos-ios/blob/fdaef0d69638a6d25bce0086ba4165334e0e2ab0/ConvosCore/Sources/ConvosCore/Utilities/ImageCompression.swift#L261): `checkForTransparentPixels(cgImage:)` samples every `sampleStep` pixels instead of scanning all pixels. This can return `false` (no transparency) when transparent pixels exist but fall between the sampling strides, especially on larger images where `sampleStep` grows (line 261). This is a logical false-negative that violates the intended semantics of `hasTransparency(_:)`, which claims to detect whether an image "has transparency". <b>[ Low confidence ]</b>
- [line 276](https://github.com/ephemeraHQ/convos-ios/blob/fdaef0d69638a6d25bce0086ba4165334e0e2ab0/ConvosCore/Sources/ConvosCore/Utilities/ImageCompression.swift#L276): `checkForTransparentPixels(cgImage:)` returns `false` when the `CGContext` cannot be created (line 276) or when `context.data` is `nil` (line 285). These are operational failures (e.g., memory pressure) but they are treated as "no transparency" rather than error states, causing silent false negatives and violating caller expectations that `false` strictly means "no transparent pixels present". <b>[ Low confidence ]</b>
- [line 320](https://github.com/ephemeraHQ/convos-ios/blob/fdaef0d69638a6d25bce0086ba4165334e0e2ab0/ConvosCore/Sources/ConvosCore/Utilities/ImageCompression.swift#L320): Potential off-by-one/cropping due to fractional pixel sizes: `targetSize` (derived from `targetPixelSize`) can contain fractional values, but the `CGContext` is created with `Int(targetPixelSize.width/height)` (truncating). The transforms and `drawingRect` here use `targetSize.width`/`height` directly, which may be larger than the actual bitmap by up to almost 1 pixel. This can cause subtle clipping or empty borders on some orientations/scales. To avoid this, round `targetPixelSize` to integers first and use those exact integer dimensions consistently for both the context creation and for all transform/drawing calculations (including the swapped sizes in 90° rotations). <b>[ Low confidence ]</b>
</details>

<details>
<summary>ConvosCore/Sources/ConvosCore/Utilities/QRCodeGenerator.swift — 1 comment posted, 9 evaluated, 8 filtered</summary>

- [line 98](https://github.com/ephemeraHQ/convos-ios/blob/fdaef0d69638a6d25bce0086ba4165334e0e2ab0/ConvosCore/Sources/ConvosCore/Utilities/QRCodeGenerator.swift#L98): The `scale` parameter is effectively ignored throughout. `OptionsHashKey` hard-sets `scale` to `3.0`, the cache key uses normalized scale, and rendering uses `normalizedScale` set to `3.0` when creating the `UIImage`. As a result, passing a custom `scale` (including via `pregenerate(from:scale:)`) does not affect cache keys or output image DPI. This is a contract mismatch and can lead to unexpected caching collisions or incorrect expectations about image scale. <b>[ Low confidence ]</b>
- [line 178](https://github.com/ephemeraHQ/convos-ios/blob/fdaef0d69638a6d25bce0086ba4165334e0e2ab0/ConvosCore/Sources/ConvosCore/Utilities/QRCodeGenerator.swift#L178): `centerSpaceSize` is documented as 0.0–1.0 but there is no validation; out-of-range values are passed to `filter.centerSpaceSize`, potentially producing invalid or failed output (`outputImage == nil`). Clamp or validate the value. <b>[ Out of scope ]</b>
- [line 179](https://github.com/ephemeraHQ/convos-ios/blob/fdaef0d69638a6d25bce0086ba4165334e0e2ab0/ConvosCore/Sources/ConvosCore/Utilities/QRCodeGenerator.swift#L179): `correctionLevel` accepts arbitrary strings and is passed directly to `filter.correctionLevel`. Invalid values (not one of "L","M","Q","H") can cause `outputImage` to be `nil`, silently failing. Validate and normalize (uppercase) the input or provide a safe default. <b>[ Out of scope ]</b>
- [line 188](https://github.com/ephemeraHQ/convos-ios/blob/fdaef0d69638a6d25bce0086ba4165334e0e2ab0/ConvosCore/Sources/ConvosCore/Utilities/QRCodeGenerator.swift#L188): `Options.scale` is documented as "The scale factor to use for rendering" but `generate(from:options:)` now hard-codes `normalizedScale = 3.0` and uses it for both `targetPixelSize` and the resulting `UIImage`'s `scale`, ignoring the caller-provided `options.scale`. This is an externally visible behavior change and contradicts the documented contract, making passed `scale` values ineffective. <b>[ Low confidence ]</b>
- [line 192](https://github.com/ephemeraHQ/convos-ios/blob/fdaef0d69638a6d25bce0086ba4165334e0e2ab0/ConvosCore/Sources/ConvosCore/Utilities/QRCodeGenerator.swift#L192): `baseSize` can be zero, leading to `scaleFactor = targetPixelSize / baseSize` dividing by zero and yielding `infinite` or `nan`. This makes `createCGImage` likely fail and the function returns `nil` unpredictably. Guard `baseSize > 0` before computing the scale, or early-return with a clear failure. Involved code: `let baseSize = max(outputExtent.width, outputExtent.height)` and `let scaleFactor = targetPixelSize / baseSize`. <b>[ Out of scope ]</b>
- [line 221](https://github.com/ephemeraHQ/convos-ios/blob/fdaef0d69638a6d25bce0086ba4165334e0e2ab0/ConvosCore/Sources/ConvosCore/Utilities/QRCodeGenerator.swift#L221): `generate(from:options:) async` uses `Task { ... }` rather than `Task.detached`. This inherits the current actor and can execute heavy Core Image work on the main actor if called from UI, causing UI jank or deadlocks. Use `Task.detached(priority:)` or ensure rendering executes off the main actor (e.g., with `@Sendable` work on a background executor). <b>[ Low confidence ]</b>
- [line 258](https://github.com/ephemeraHQ/convos-ios/blob/fdaef0d69638a6d25bce0086ba4165334e0e2ab0/ConvosCore/Sources/ConvosCore/Utilities/QRCodeGenerator.swift#L258): `clearFromCache(string:options:)` calls `ImageCache.shared.removeImage(for:)` without specifying an `imageFormat`, while generation and retrieval now consistently use `.png`. If `removeImage(for:)` only clears memory or a default format, the PNG on disk may remain and be reloaded by `imageAsync(for:imageFormat:)`, causing cache entries to persist unexpectedly after a clear. <b>[ Low confidence ]</b>
- [line 263](https://github.com/ephemeraHQ/convos-ios/blob/fdaef0d69638a6d25bce0086ba4165334e0e2ab0/ConvosCore/Sources/ConvosCore/Utilities/QRCodeGenerator.swift#L263): `clearFromCacheAllModes(string:)` uses `Options.qrCodeLight`/`qrCodeDark` which are defined with `backgroundColor: .clear`, while `pregenerate(from:)` uses `backgroundColor: .white` and `.black`. This mismatch means `clearFromCacheAllModes` may not clear images generated by `pregenerate`, violating caller expectations based on the function’s documentation and name. <b>[ Out of scope ]</b>
</details>


</details><!-- Macroscope's review summary ends here -->
<!-- Macroscope's pull request summary ends here -->