### PR TITLE
Use appData field for Conversation metadata

### DIFF
--- a/Convos.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Convos.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "f9c6b86a3c4ca98ea2dcf9ea8afd1fafa6c8137e22ac59f582328440f4aa3a81",
+  "originHash" : "e61b9523aef68a79bed1ae798af6c9f57e9d5f11b49b1ca817dbb55ebc1eea87",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -267,8 +267,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/xmtp/xmtp-ios.git",
       "state" : {
-        "revision" : "c11139ef40f2ad46d268da4761b0486f42201b07",
-        "version" : "4.6.1-dev.c11139e"
+        "revision" : "b8379b8e823d72709124ceef1ff21492931b83a6",
+        "version" : "4.6.0-dev.b8379b8"
       }
     }
   ],

--- a/ConvosCore/Package.swift
+++ b/ConvosCore/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/groue/GRDB.swift.git", exact: "7.5.0"),
-        .package(url: "https://github.com/xmtp/xmtp-ios.git", exact: "4.6.1-dev.c11139e"),
+        .package(url: "https://github.com/xmtp/xmtp-ios.git", exact: "4.6.0-dev.b8379b8"),
         .package(url: "https://github.com/tesseract-one/CSecp256k1.swift.git", from: "0.2.0"),
         .package(url: "https://github.com/SimplyDanny/SwiftLintPlugins", from: "0.62.2"),
         .package(url: "https://github.com/firebase/firebase-ios-sdk", from: "12.1.0"),

--- a/ConvosCore/Sources/ConvosCore/Inboxes/ConversationStateMachine.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/ConversationStateMachine.swift
@@ -323,7 +323,9 @@ public actor ConversationStateMachine {
             // Don't emit error state - the cancelling method already handled state transition
         } catch {
             Log.error("Failed state transition \(_state) -> \(action): \(error.localizedDescription)")
-            emitStateChange(.error(error))
+            let displayableError: Error = (error is DisplayError ? error :
+                                            ConversationStateMachineError.stateMachineError(error))
+            emitStateChange(.error(displayableError))
         }
     }
 

--- a/ConvosCore/Sources/ConvosCore/Protobuf Models/conversation_custom_metadata.pb.swift
+++ b/ConvosCore/Sources/ConvosCore/Protobuf Models/conversation_custom_metadata.pb.swift
@@ -34,8 +34,6 @@ public struct ConversationCustomMetadata: Sendable {
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
-  public var description_p: String = String()
-
   public var tag: String = String()
 
   public var profiles: [ConversationProfile] = []
@@ -95,7 +93,7 @@ public struct ConversationProfile: Sendable {
 
 extension ConversationCustomMetadata: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = "ConversationCustomMetadata"
-  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}description\0\u{1}tag\0\u{1}profiles\0\u{1}expiresAtUnix\0")
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\u{2}tag\0\u{1}profiles\0\u{1}expiresAtUnix\0")
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -103,7 +101,6 @@ extension ConversationCustomMetadata: SwiftProtobuf.Message, SwiftProtobuf._Mess
       // allocates stack space for every case branch when no optimizations are
       // enabled. https://github.com/apple/swift-protobuf/issues/1034
       switch fieldNumber {
-      case 1: try { try decoder.decodeSingularStringField(value: &self.description_p) }()
       case 2: try { try decoder.decodeSingularStringField(value: &self.tag) }()
       case 3: try { try decoder.decodeRepeatedMessageField(value: &self.profiles) }()
       case 4: try { try decoder.decodeSingularSFixed64Field(value: &self._expiresAtUnix) }()
@@ -117,9 +114,6 @@ extension ConversationCustomMetadata: SwiftProtobuf.Message, SwiftProtobuf._Mess
     // allocates stack space for every if/case branch local when no optimizations
     // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
     // https://github.com/apple/swift-protobuf/issues/1182
-    if !self.description_p.isEmpty {
-      try visitor.visitSingularStringField(value: self.description_p, fieldNumber: 1)
-    }
     if !self.tag.isEmpty {
       try visitor.visitSingularStringField(value: self.tag, fieldNumber: 2)
     }
@@ -133,7 +127,6 @@ extension ConversationCustomMetadata: SwiftProtobuf.Message, SwiftProtobuf._Mess
   }
 
   public static func ==(lhs: ConversationCustomMetadata, rhs: ConversationCustomMetadata) -> Bool {
-    if lhs.description_p != rhs.description_p {return false}
     if lhs.tag != rhs.tag {return false}
     if lhs.profiles != rhs.profiles {return false}
     if lhs._expiresAtUnix != rhs._expiresAtUnix {return false}

--- a/ConvosCore/Sources/ConvosCore/Protobuf Models/proto/conversation_custom_metadata.proto
+++ b/ConvosCore/Sources/ConvosCore/Protobuf Models/proto/conversation_custom_metadata.proto
@@ -9,10 +9,9 @@ syntax = "proto3";
 //
 // Expected size for 5-member group: ~200-300 bytes (40-60% smaller than unoptimized)
 message ConversationCustomMetadata {
-    string description = 1;
-    string tag = 2;
-    repeated ConversationProfile profiles = 3;
-    optional sfixed64 expiresAtUnix = 4;
+    string tag = 1;
+    repeated ConversationProfile profiles = 2;
+    optional sfixed64 expiresAtUnix = 3;
 }
 
 // ConversationProfile represents a participant in the conversation

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/ConversationUpdate.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/ConversationUpdate.swift
@@ -7,12 +7,12 @@ public struct ConversationUpdate: Hashable, Codable, Sendable {
                  description = "description",
                  image = "group_image_url_square",
                  expiresAt = "expiresAt",
-                 custom = "custom",
+                 metadata = "app_data",
                  unknown
 
             var showsInMessagesList: Bool {
                 switch self {
-                case .custom, .expiresAt, .unknown:
+                case .expiresAt, .unknown, .metadata:
                     false
                 default:
                     true

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationMetadataWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationMetadataWriter.swift
@@ -128,7 +128,7 @@ final class ConversationMetadataWriter: ConversationMetadataWriterProtocol {
             throw ConversationMetadataError.conversationNotFound(conversationId: conversationId)
         }
 
-        try await group.updateCustomDescription(description: description)
+        try await group.updateDescription(description: description)
 
         let updatedConversation = try await databaseWriter.write { db in
             guard let localConversation = try DBConversation

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationWriter.swift
@@ -191,7 +191,7 @@ class ConversationWriter: ConversationWriterProtocol {
         return ConversationMetadata(
             kind: .group,
             name: try conversation.name(),
-            description: try conversation.customDescription,
+            description: try conversation.description(),
             imageURLString: try conversation.imageUrl(),
             expiresAt: try conversation.expiresAt,
             debugInfo: debugInfo


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Store and manage Conversation metadata in `XMTPiOS.Group` appData with 8 KB enforcement and update storage, parsing, and event handling accordingly
Move Conversation metadata from description to appData, add size checks, update read/write paths, adjust proto by removing `description`, and route description to the native field with updated change emission.

#### 📍Where to Start
Start with the `XMTPiOS.Group` metadata helpers and getters in [ConversationCustomMetadataExtensions.swift](https://github.com/ephemeraHQ/convos-ios/pull/235/files#diff-f6ec8bb948cb457536011eb22cc2734f19a7751684b198c15f6f11208832c563), then follow event handling in [DecodedMessage+DBRepresentation.swift](https://github.com/ephemeraHQ/convos-ios/pull/235/files#diff-506364f62b39595ed5e23f0dcfed112f9c4cf3e1f1fd7b263dbe1e386dbf2934).

----
<!-- Macroscope's review summary starts here -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized b2c4c14. 9 files reviewed, 22 issues evaluated, 22 issues filtered, 0 comments posted</summary>

### 🗂️ Filtered Issues
<details>
<summary>ConvosCore/Sources/ConvosCore/Protobuf Models/ConversationCustomMetadataExtensions.swift — 0 comments posted, 11 evaluated, 11 filtered</summary>

- [line 56](https://github.com/ephemeraHQ/convos-ios/blob/b2c4c14a87eaea437ccdcb0d15d2d68eba74d6e9/ConvosCore/Sources/ConvosCore/Protobuf Models/ConversationCustomMetadataExtensions.swift#L56): In `var description: String`, the `.appDataLimitExceeded(limit, actualSize)` case formats sizes as `actualSize / 1024` and `limit / 1024` with integer division. If `actualSize` or `limit` are smaller than 1024, this will report `0kb`, and generally it will silently truncate rather than rounding, producing misleading output. Use floating-point division and formatting (e.g., dividing by `1024.0` and formatting to a sensible precision) or explicitly label bytes. <b>[ Low confidence ]</b>
- [line 83](https://github.com/ephemeraHQ/convos-ios/blob/b2c4c14a87eaea437ccdcb0d15d2d68eba74d6e9/ConvosCore/Sources/ConvosCore/Protobuf Models/ConversationCustomMetadataExtensions.swift#L83): The logic for `currentCustomMetadata` was changed from parsing `description()` via `ConversationCustomMetadata.parseDescriptionField(_:)` to parsing `appData()` via `ConversationCustomMetadata.parseAppData(_:)` without a fallback path. For existing conversations where custom metadata resides only in the description field, this change will return empty metadata, causing silent data loss and behavior changes. Consider maintaining backward compatibility by attempting `parseAppData(_:)` first and, on absence or parse failure, falling back to `parseDescriptionField(_:)`, with clear precedence and error reporting. <b>[ Low confidence ]</b>
- [line 85](https://github.com/ephemeraHQ/convos-ios/blob/b2c4c14a87eaea437ccdcb0d15d2d68eba74d6e9/ConvosCore/Sources/ConvosCore/Protobuf Models/ConversationCustomMetadataExtensions.swift#L85): The getter `currentCustomMetadata` now catches `XMTPiOS.GenericError.GroupError(message: _)` and returns `ConversationCustomMetadata.init()` instead of propagating the error. This silently masks a recoverable/diagnostic error and changes the externally visible contract of a `get throws` accessor from “throws on group-related errors” to “returns an empty metadata object.” Callers that rely on thrown errors for control flow or logging will no longer receive them, leading to ambiguous state and silent failure. Consider preserving the error (rethrow), or returning a typed failure result, or at minimum logging and distinguishing between “no metadata” and “error retrieving metadata.” <b>[ Low confidence ]</b>
- [line 85](https://github.com/ephemeraHQ/convos-ios/blob/b2c4c14a87eaea437ccdcb0d15d2d68eba74d6e9/ConvosCore/Sources/ConvosCore/Protobuf Models/ConversationCustomMetadataExtensions.swift#L85): `currentCustomMetadata` swallows `XMTPiOS.GenericError.GroupError` from `self.appData()` and returns an empty `ConversationCustomMetadata`. Callers like `updateExpiresAt`, `ensureInviteTag`, and `updateProfile` then proceed with a read-modify-write using this empty baseline, which can silently clobber/overwrite existing app data if the read failed (e.g., transient error). This loses fields not explicitly updated and violates atomic read-modify-write semantics under error conditions. <b>[ Low confidence ]</b>
- [line 122](https://github.com/ephemeraHQ/convos-ios/blob/b2c4c14a87eaea437ccdcb0d15d2d68eba74d6e9/ConvosCore/Sources/ConvosCore/Protobuf Models/ConversationCustomMetadataExtensions.swift#L122): `generateSecureRandomString(length:)` is documented as generating a "cryptographically secure random string" but maps random bytes to characters with `Int(byte) % charactersCount`, which introduces modulo bias. The inline comment even states it's acceptable for non-cryptographic identifiers, contradicting the docstring. This creates ambiguity about the security properties of the output and can violate callers’ expectations relying on cryptographic uniformity. <b>[ Low confidence ]</b>
- [line 167](https://github.com/ephemeraHQ/convos-ios/blob/b2c4c14a87eaea437ccdcb0d15d2d68eba74d6e9/ConvosCore/Sources/ConvosCore/Protobuf Models/ConversationCustomMetadataExtensions.swift#L167): `updateProfile(_:)` throws `ConversationCustomMetadataError.invalidInboxIdHex(profile.inboxId)` when `profile.conversationProfile` is `nil` (line 167). This error is unrelated to the actual failure (missing `conversationProfile`) and misattributes the cause to an invalid inbox ID hex. This yields misleading failures and makes diagnosis and handling incorrect. The thrown error should reflect the missing or invalid `conversationProfile` rather than inbox ID formatting. <b>[ Out of scope ]</b>
- [line 171](https://github.com/ephemeraHQ/convos-ios/blob/b2c4c14a87eaea437ccdcb0d15d2d68eba74d6e9/ConvosCore/Sources/ConvosCore/Protobuf Models/ConversationCustomMetadataExtensions.swift#L171): Contract/behavior change in `XMTPiOS.Group` extension: replacing `updateDescription(description: customMetadata.toCompactString())` with `updateMetadata(customMetadata)` (diff lines +171–+172) may stop updating the conversation description and instead update a distinct metadata field. If any downstream logic/UI expects the description string to reflect the compact metadata, this change can lead to stale or missing updates, breaking external behavior and parity with previous contract. <b>[ Low confidence ]</b>
- [line 262](https://github.com/ephemeraHQ/convos-ios/blob/b2c4c14a87eaea437ccdcb0d15d2d68eba74d6e9/ConvosCore/Sources/ConvosCore/Protobuf Models/ConversationCustomMetadataExtensions.swift#L262): The initializer in `extension ConversationCustomMetadata` was changed from `init(description: String, profiles: [ConversationProfile])` to `init(profiles: [ConversationProfile])` while the doc comments still state "Create metadata with description and profiles" (duplicated). The implementation no longer sets or accepts `description`, which is a contract change and silently drops any description value. Newly created instances will have the default `description` (likely empty or nil), potentially breaking callers that expect a non-empty description or rely on it downstream. <b>[ Low confidence ]</b>
- [line 343](https://github.com/ephemeraHQ/convos-ios/blob/b2c4c14a87eaea437ccdcb0d15d2d68eba74d6e9/ConvosCore/Sources/ConvosCore/Protobuf Models/ConversationCustomMetadataExtensions.swift#L343): Documentation contradicts implementation: comments state the parser "returns ConversationCustomMetadata with either decoded data or plain text description", but the implementation now returns an empty `ConversationCustomMetadata` on decode failure instead of a plain text description. This creates uncertainty about the intended contract. <b>[ Low confidence ]</b>
- [line 347](https://github.com/ephemeraHQ/convos-ios/blob/b2c4c14a87eaea437ccdcb0d15d2d68eba74d6e9/ConvosCore/Sources/ConvosCore/Protobuf Models/ConversationCustomMetadataExtensions.swift#L347): `parseAppData(_:)` makes decode failure indistinguishable from absent/empty input. Both nil/empty `appDataString` and invalid compact metadata result in `ConversationCustomMetadata()` with no way to differentiate error vs. no data. This can break downstream invariants and error handling by suppressing a recoverable/diagnosable condition. <b>[ Low confidence ]</b>
- [line 356](https://github.com/ephemeraHQ/convos-ios/blob/b2c4c14a87eaea437ccdcb0d15d2d68eba74d6e9/ConvosCore/Sources/ConvosCore/Protobuf Models/ConversationCustomMetadataExtensions.swift#L356): The new `parseAppData(_:)` silently drops non-decodable input and returns an empty `ConversationCustomMetadata` instead of preserving the plain text in `description`. Previously `parseDescriptionField(_:)` fell back to `ConversationCustomMetadata(description: descriptionField)`. This is a contract-breaking behavioral change that causes silent data loss for any `appDataString` that is not valid compact metadata. <b>[ Already posted ]</b>
</details>

<details>
<summary>ConvosCore/Sources/ConvosCore/Protobuf Models/proto/conversation_custom_metadata.proto — 0 comments posted, 3 evaluated, 3 filtered</summary>

- [line 11](https://github.com/ephemeraHQ/convos-ios/blob/b2c4c14a87eaea437ccdcb0d15d2d68eba74d6e9/ConvosCore/Sources/ConvosCore/Protobuf Models/proto/conversation_custom_metadata.proto#L11): Removed field `description` without reserving its field number and name in `ConversationCustomMetadata`. Without `reserved 1;` and `reserved "description";`, future reuse of field number 1 or the name `description` can cause hard-to-diagnose compatibility issues, and currently `tag` reuses number `1`, mapping old `description` data to `tag`. <b>[ Low confidence ]</b>
- [line 12](https://github.com/ephemeraHQ/convos-ios/blob/b2c4c14a87eaea437ccdcb0d15d2d68eba74d6e9/ConvosCore/Sources/ConvosCore/Protobuf Models/proto/conversation_custom_metadata.proto#L12): Backward-incompatible renumbering and removal in `ConversationCustomMetadata`: field numbers were reassigned (`tag` moved from `2` to `1`, `profiles` from `3` to `2`, `expiresAtUnix` from `4` to `3`) and `description` (formerly `1`) was removed. Existing serialized messages will be misinterpreted: old `description` bytes will be read as `tag` (`1`), old `tag` (`2`) will be parsed as `profiles` messages, and old `expiresAtUnix` (`4`) will be dropped. This breaks wire compatibility and can cause silent data loss/corruption when reading previously stored/sent data. <b>[ Already posted ]</b>
- [line 13](https://github.com/ephemeraHQ/convos-ios/blob/b2c4c14a87eaea437ccdcb0d15d2d68eba74d6e9/ConvosCore/Sources/ConvosCore/Protobuf Models/proto/conversation_custom_metadata.proto#L13): Type change on field number `2`: previously `string tag = 2;` is now `repeated ConversationProfile profiles = 2;`. Both are length-delimited, so old wire data for `tag` will be parsed as embedded `ConversationProfile` messages, leading to silent misinterpretation/data loss rather than a clear error. <b>[ Already posted ]</b>
</details>

<details>
<summary>ConvosCore/Sources/ConvosCore/Storage/Models/ConversationUpdate.swift — 0 comments posted, 2 evaluated, 2 filtered</summary>

- [line 10](https://github.com/ephemeraHQ/convos-ios/blob/b2c4c14a87eaea437ccdcb0d15d2d68eba74d6e9/ConvosCore/Sources/ConvosCore/Storage/Models/ConversationUpdate.swift#L10): Renaming the case from `custom` to `metadata` with raw value `"app_data"` changes the decoding contract. Existing persisted or incoming data using the previous raw value `"custom"` will now fail to decode (or decode to no case) under synthesized `Decodable`, causing runtime `DecodingError.dataCorrupted`. This can break backward compatibility and lead to message/update drops or crashes depending on error handling. <b>[ Low confidence ]</b>
- [line 11](https://github.com/ephemeraHQ/convos-ios/blob/b2c4c14a87eaea437ccdcb0d15d2d68eba74d6e9/ConvosCore/Sources/ConvosCore/Storage/Models/ConversationUpdate.swift#L11): `Field` conforms to `Codable` via raw `String` values, but the presence of case `unknown` does not provide a fallback during decoding. Swift’s synthesized `Decodable` for raw-representable enums uses `init(rawValue:)` and throws `DecodingError.dataCorrupted` for any unrecognized string. As a result, any server/client value not matching one of the declared raw values will cause decoding to fail instead of mapping to `.unknown`, creating a runtime failure path when handling new/unknown fields. <b>[ Out of scope ]</b>
</details>

<details>
<summary>ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationMetadataWriter.swift — 0 comments posted, 2 evaluated, 2 filtered</summary>

- [line 131](https://github.com/ephemeraHQ/convos-ios/blob/b2c4c14a87eaea437ccdcb0d15d2d68eba74d6e9/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationMetadataWriter.swift#L131): Side-effect ordering can leave the system in an inconsistent state if the local conversation record is missing or DB write fails. The code invokes the remote `group.updateDescription(description:)` at line 131 before verifying/updating the local record inside `databaseWriter.write { ... }` (lines 134–140). If `DBConversation.fetchOne(db, key:)` returns `nil` or `save(db)` throws, the function throws `ConversationMetadataError.conversationNotFound(conversationId:)` after the remote description was already changed, leaving remote and local states diverged with no compensating action. Consider validating existence (or upserting) locally before the remote call, or adding a compensating rollback/fix-up path. <b>[ Low confidence ]</b>
- [line 144](https://github.com/ephemeraHQ/convos-ios/blob/b2c4c14a87eaea437ccdcb0d15d2d68eba74d6e9/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationMetadataWriter.swift#L144): Partial commit on failure of `inviteWriter.update`. The function performs two prior side effects successfully — remote `group.updateDescription(description:)` (line 131) and local DB save (lines 134–140) — then calls `inviteWriter.update(...)` (lines 144–149). If this last call throws, the function exits with an error after applying the first two effects, leaving invites stale relative to the updated conversation description with no retry/compensation. This violates at-most-once/atomicity across related effects and can leave the system in a mixed state. Consider reordering, wrapping related updates in a transactional/unit-of-work pattern with compensation, or tolerating/handling eventual consistency explicitly (e.g., queue a retry). <b>[ Low confidence ]</b>
</details>

<details>
<summary>ConvosCore/Sources/ConvosCore/Storage/XMTP DB Representations/DecodedMessage+DBRepresentation.swift — 0 comments posted, 4 evaluated, 4 filtered</summary>

- [line 181](https://github.com/ephemeraHQ/convos-ios/blob/b2c4c14a87eaea437ccdcb0d15d2d68eba74d6e9/ConvosCore/Sources/ConvosCore/Storage/XMTP DB Representations/DecodedMessage+DBRepresentation.swift#L181): `description` changes are emitted without checking `hasOldValue`/`hasNewValue`, passing `$0.oldValue`/`$0.newValue` directly. If either flag is false, protobuf-style accessors typically return an empty string default, so the update will contain empty strings instead of `nil`, conflating "unset" with "set to empty" and changing normalization semantics compared to other branches (which use `nil` for missing). This can mislead downstream consumers that distinguish `nil` from empty. <b>[ Low confidence ]</b>
- [line 188](https://github.com/ephemeraHQ/convos-ios/blob/b2c4c14a87eaea437ccdcb0d15d2d68eba74d6e9/ConvosCore/Sources/ConvosCore/Storage/XMTP DB Representations/DecodedMessage+DBRepresentation.swift#L188): When `descriptionChanged` is false for the `description` field, the code emits a `DBMessage.Update.MetadataChange` with `field` set to `unknown` and both values `nil`. This introduces a spurious no-op change entry instead of filtering it out, potentially confusing downstream consumers and violating the expectation that emitted changes represent real deltas. <b>[ Already posted ]</b>
- [line 235](https://github.com/ephemeraHQ/convos-ios/blob/b2c4c14a87eaea437ccdcb0d15d2d68eba74d6e9/ConvosCore/Sources/ConvosCore/Storage/XMTP DB Representations/DecodedMessage+DBRepresentation.swift#L235): In the `metadata` branch, if both `expiresAt` and other custom fields change within the same underlying change item, the code prioritizes `expiresAt` and returns a single change, silently suppressing the other changes. This can cause partial updates to be recorded, losing change details and violating data-conversion completeness. <b>[ Low confidence ]</b>
- [line 245](https://github.com/ephemeraHQ/convos-ios/blob/b2c4c14a87eaea437ccdcb0d15d2d68eba74d6e9/ConvosCore/Sources/ConvosCore/Storage/XMTP DB Representations/DecodedMessage+DBRepresentation.swift#L245): When handling `metadata` field changes where `expiresAt` did not change, the code emits a `DBMessage.Update.MetadataChange` with `field` set to `ConversationUpdate.MetadataChange.Field.metadata.rawValue` and both `oldValue`/`newValue` set to `nil`, discarding the actual old/new values of the changed custom metadata. This silently loses information during data conversion, making the downstream artifact less informative. <b>[ Low confidence ]</b>
</details>


</details><!-- Macroscope's review summary ends here -->
<!-- Macroscope's pull request summary ends here -->