### PR TITLE
Improve delete all flow

### DIFF
--- a/Convos/App Settings/DeleteAllDataView.swift
+++ b/Convos/App Settings/DeleteAllDataView.swift
@@ -1,0 +1,84 @@
+import ConvosCore
+import SwiftUI
+
+struct DeleteAllDataView: View {
+    @Environment(\.dismiss) var dismiss: DismissAction
+    @Bindable var viewModel: AppSettingsViewModel
+    let onComplete: () -> Void
+
+    var title: String {
+        "Delete everything?"
+    }
+
+    var subtitle: String {
+        "This will permanently delete all conversations on this device, as well as your Quickname."
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: DesignConstants.Spacing.step4x) {
+            Text(title)
+                .font(.system(.largeTitle))
+                .fontWeight(.bold)
+            Text(subtitle)
+                .font(.body)
+                .foregroundStyle(.colorTextSecondary)
+
+            if let error = viewModel.deletionError {
+                Text("\(error.localizedDescription). Try again.")
+                    .font(.subheadline)
+                    .foregroundStyle(.colorTextSecondary)
+                    .padding(.vertical, DesignConstants.Spacing.stepX)
+            }
+
+            VStack(spacing: DesignConstants.Spacing.step4x) {
+                Button {
+                    deleteAllData()
+                } label: {
+                    Text("Delete all data")
+                }
+                .convosButtonStyle(.rounded(fullWidth: true, backgroundColor: .colorCaution))
+                .disabled(viewModel.isDeleting)
+                .hoverEffect(.lift)
+
+                Button {
+                    dismiss()
+                } label: {
+                    Text("Cancel")
+                }
+                .convosButtonStyle(.text)
+                .disabled(viewModel.isDeleting)
+                .hoverEffect(.lift)
+            }
+
+            .padding(.top, DesignConstants.Spacing.step4x)
+        }
+        .padding([.leading, .top, .trailing], DesignConstants.Spacing.step10x)
+    }
+
+    private var progressMessage: String {
+        guard let currentStep = viewModel.deletionProgress else { return "" }
+
+        switch currentStep {
+        case .clearingDeviceRegistration:
+            return "Clearing settings..."
+        case let .stoppingServices(completed, total):
+            return "Stopping services (\(completed)/\(total))..."
+        case .deletingFromDatabase:
+            return "Deleting database..."
+        case .completed:
+            return ""
+        }
+    }
+
+    private func deleteAllData() {
+        viewModel.deleteAllData(onComplete: onComplete)
+    }
+}
+
+#Preview {
+    let viewModel = AppSettingsViewModel(session: ConvosClient.mock().session)
+    DeleteAllDataView(
+        viewModel: viewModel,
+        onComplete: {}
+    )
+}


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Add DeleteAllDataView to App Settings to improve delete all flow and wire primary action to `AppSettingsViewModel.deleteAllData(onComplete:)` in [DeleteAllDataView.swift](https://github.com/ephemeraHQ/convos-ios/pull/236/files#diff-59783c89324b831f3b853ac4025c7be639aaa442779f2397f3109f1059ec2fc8)
Introduce a SwiftUI confirmation screen with title, subtitle, progress messaging, error display from `AppSettingsViewModel.deletionError`, and two actions: a primary delete button calling `AppSettingsViewModel.deleteAllData(onComplete:)` and a cancel button that dismisses; buttons bind disabled state to `AppSettingsViewModel.isDeleting` and apply `convosButtonStyle`.

#### 📍Where to Start
Start with the `DeleteAllDataView` body and `deleteAllData()` helper in [DeleteAllDataView.swift](https://github.com/ephemeraHQ/convos-ios/pull/236/files#diff-59783c89324b831f3b853ac4025c7be639aaa442779f2397f3109f1059ec2fc8).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 85b064f.
<!-- Macroscope's review summary ends here -->

<!-- Macroscope's pull request summary ends here -->