### PR TITLE
Improve delete all flow

### DIFF
--- a/Convos/App Settings/AppSettingsView.swift
+++ b/Convos/App Settings/AppSettingsView.swift
@@ -24,6 +24,7 @@ struct ConvosToolbarButton: View {
 // swiftlint:disable force_unwrapping
 
 struct AppSettingsView: View {
+    @Bindable var viewModel: AppSettingsViewModel
     @Bindable var quicknameViewModel: QuicknameSettingsViewModel
     let onDeleteAllData: () -> Void
     @State private var showingDeleteAllDataConfirmation: Bool = false
@@ -161,16 +162,15 @@ struct AppSettingsView: View {
                     } label: {
                         Text("Delete all app data")
                     }
-                    .confirmationDialog("", isPresented: $showingDeleteAllDataConfirmation) {
-                        Button("Delete", role: .destructive) {
-                            quicknameViewModel.delete()
-                            onDeleteAllData()
-                            dismiss()
-                        }
-
-                        Button("Cancel") {
-                            showingDeleteAllDataConfirmation = false
-                        }
+                    .selfSizingSheet(isPresented: $showingDeleteAllDataConfirmation) {
+                        DeleteAllDataView(
+                            viewModel: viewModel,
+                            onComplete: {
+                                dismiss()
+                                onDeleteAllData()
+                            }
+                        )
+                        .interactiveDismissDisabled(viewModel.isDeleting)
                     }
                 }
             }
@@ -208,6 +208,10 @@ struct AppSettingsView: View {
 #Preview {
     let quicknameViewModel = QuicknameSettingsViewModel.shared
     NavigationStack {
-        AppSettingsView(quicknameViewModel: quicknameViewModel) {}
+        AppSettingsView(
+            viewModel: .mock,
+            quicknameViewModel: quicknameViewModel,
+            onDeleteAllData: {}
+        )
     }
 }

--- a/Convos/App Settings/AppSettingsViewModel.swift
+++ b/Convos/App Settings/AppSettingsViewModel.swift
@@ -1,0 +1,50 @@
+import ConvosCore
+import Foundation
+import Observation
+
+@MainActor
+@Observable
+final class AppSettingsViewModel {
+    // MARK: - State
+
+    private(set) var isDeleting: Bool = false
+    private(set) var deletionProgress: InboxDeletionProgress?
+    private(set) var deletionError: Error?
+
+    // MARK: - Dependencies
+
+    private let session: any SessionManagerProtocol
+
+    init(session: any SessionManagerProtocol) {
+        self.session = session
+    }
+
+    // MARK: - Actions
+
+    func deleteAllData(onComplete: @escaping () -> Void) {
+        guard !isDeleting else { return }
+        isDeleting = true
+        deletionError = nil
+        deletionProgress = nil
+
+        QuicknameSettingsViewModel.shared.delete()
+
+        Task {
+            do {
+                for try await progress in session.deleteAllInboxesWithProgress() {
+                    deletionProgress = progress
+                }
+                onComplete()
+            } catch {
+                deletionError = error
+                isDeleting = false
+            }
+        }
+    }
+}
+
+extension AppSettingsViewModel {
+    static var mock: AppSettingsViewModel {
+        AppSettingsViewModel(session: MockInboxesService())
+    }
+}

--- a/Convos/App Settings/DeleteAllDataView.swift
+++ b/Convos/App Settings/DeleteAllDataView.swift
@@ -1,0 +1,103 @@
+import ConvosCore
+import SwiftUI
+
+struct DeleteAllDataView: View {
+    @Environment(\.dismiss) var dismiss: DismissAction
+    @Bindable var viewModel: AppSettingsViewModel
+    let onComplete: () -> Void
+
+    var title: String {
+        "Delete everything?"
+    }
+
+    var subtitle: String {
+        "This will permanently delete all conversations on this device, as well as your Quickname."
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: DesignConstants.Spacing.step4x) {
+            Text(title)
+                .font(.system(.largeTitle))
+                .fontWeight(.bold)
+            Text(subtitle)
+                .font(.body)
+                .foregroundStyle(.colorTextSecondary)
+
+            if let error = viewModel.deletionError {
+                Text("\(error.localizedDescription). Try again.")
+                    .font(.subheadline)
+                    .foregroundStyle(.colorTextSecondary)
+                    .padding(.vertical, DesignConstants.Spacing.stepX)
+            }
+
+            VStack(spacing: DesignConstants.Spacing.step4x) {
+                HoldToDeleteButton(
+                    isDeleting: viewModel.isDeleting,
+                    onDelete: { deleteAllData() }
+                )
+                .hoverEffect(.lift)
+
+                Button {
+                    dismiss()
+                } label: {
+                    Text("Cancel")
+                }
+                .convosButtonStyle(.text)
+                .disabled(viewModel.isDeleting)
+                .hoverEffect(.lift)
+            }
+
+            .padding(.top, DesignConstants.Spacing.step4x)
+        }
+        .padding([.leading, .top, .trailing], DesignConstants.Spacing.step10x)
+    }
+
+    private func deleteAllData() {
+        viewModel.deleteAllData(onComplete: onComplete)
+    }
+}
+
+// MARK: - Hold To Delete Button
+
+private struct HoldToDeleteButton: View {
+    let isDeleting: Bool
+    let onDelete: () -> Void
+
+    private var buttonConfig: HoldToConfirmStyleConfig {
+        var config = HoldToConfirmStyleConfig.default
+        config.duration = 3.0
+        config.backgroundColor = .colorCaution
+        return config
+    }
+
+    var body: some View {
+        Button {
+            onDelete()
+        } label: {
+            textView
+                .foregroundStyle(.white)
+                .frame(maxWidth: .infinity)
+        }
+        .disabled(isDeleting)
+        .buttonStyle(HoldToConfirmPrimitiveStyle(config: buttonConfig))
+    }
+
+    private var textView: some View {
+        ZStack {
+            Text("Hold to delete")
+                .opacity(isDeleting ? 0 : 1)
+
+            Text("Deleting...")
+                .opacity(isDeleting ? 1 : 0)
+        }
+        .animation(.easeInOut(duration: 0.2), value: isDeleting)
+    }
+}
+
+#Preview {
+    let viewModel = AppSettingsViewModel(session: ConvosClient.mock().session)
+    DeleteAllDataView(
+        viewModel: viewModel,
+        onComplete: {}
+    )
+}

--- a/Convos/Shared Views/HoldToConfirmButton.swift
+++ b/Convos/Shared Views/HoldToConfirmButton.swift
@@ -1,0 +1,129 @@
+import SwiftUI
+
+// MARK: - Hold To Confirm Style Config
+
+struct HoldToConfirmStyleConfig {
+    // Timing
+    var duration: TimeInterval = 2.0
+    var maxDistance: CGFloat = 20.0
+
+    // Colors
+    var backgroundColor: Color = .colorOrange
+    var pressedOverlayColor: Color = .black
+    var pressedOverlayOpacity: Double = 0.15
+    var progressIndicatorColor: Color = .white
+    var progressIndicatorStrokeColor: Color = .white.opacity(0.3)
+
+    // Layout
+    var verticalPadding: CGFloat = DesignConstants.Spacing.step4x
+    var horizontalPadding: CGFloat = DesignConstants.Spacing.step3x
+    var progressIndicatorPadding: CGFloat = DesignConstants.Spacing.step3x
+    var progressIndicatorStrokeWidth: CGFloat = 1.0
+
+    // Progress indicator
+    var showProgressIndicator: Bool = true
+
+    static let `default`: HoldToConfirmStyleConfig = .init()
+}
+
+// MARK: - Hold To Confirm Primitive Style
+
+struct HoldToConfirmPrimitiveStyle: PrimitiveButtonStyle {
+    var config: HoldToConfirmStyleConfig = .default
+
+    // Convenience initializer for just duration
+    init(duration: TimeInterval) {
+        self.config = HoldToConfirmStyleConfig(duration: duration)
+    }
+
+    init(config: HoldToConfirmStyleConfig = .default) {
+        self.config = config
+    }
+
+    @Environment(\.isEnabled) private var isEnabled: Bool
+
+    func makeBody(configuration: Configuration) -> some View {
+        HoldToConfirmBody(
+            config: config,
+            isEnabled: isEnabled,
+            trigger: configuration.trigger,
+            label: { configuration.label }
+        )
+    }
+
+    private struct HoldToConfirmBody<Label: View>: View {
+        let config: HoldToConfirmStyleConfig
+        let isEnabled: Bool
+        let trigger: () -> Void
+        @ViewBuilder var label: () -> Label
+
+        @State private var isPressing: Bool = false
+        @State private var pressStartDate: Date?
+        @State private var didFire: Bool = false
+        @State private var frozenProgress: Double = 0
+
+        var body: some View {
+            TimelineView(.animation(paused: !isPressing)) { context in
+                let currentProgress: Double = {
+                    if let start = pressStartDate {
+                        return min(1.0, context.date.timeIntervalSince(start) / config.duration)
+                    }
+                    return frozenProgress
+                }()
+
+                label()
+                    .padding(.vertical, config.verticalPadding)
+                    .background(
+                        Capsule()
+                            .fill(config.backgroundColor)
+                            .overlay(
+                                config.pressedOverlayColor
+                                    .opacity(currentProgress > 0.0 ? config.pressedOverlayOpacity : 0.0),
+                                in: Capsule()
+                            )
+                    )
+                    .overlay(alignment: .leading) {
+                        if config.showProgressIndicator {
+                            HStack {
+                                Circle()
+                                    .stroke(config.progressIndicatorStrokeColor, lineWidth: config.progressIndicatorStrokeWidth)
+                                    .overlay(
+                                        Circle()
+                                            .fill(config.progressIndicatorColor)
+                                            .scaleEffect(currentProgress)
+                                    )
+                                Spacer()
+                            }
+                            .padding(config.progressIndicatorPadding)
+                            .opacity(isEnabled && currentProgress > 0.0 ? 1.0 : 0.0)
+                        }
+                    }
+            }
+            .onLongPressGesture(
+                minimumDuration: config.duration,
+                maximumDistance: config.maxDistance,
+                perform: {
+                    guard !didFire else { return }
+                    didFire = true
+                    frozenProgress = 1.0
+                    pressStartDate = nil
+                    trigger()
+                },
+                onPressingChanged: { pressing in
+                    isPressing = pressing
+                    if pressing {
+                        didFire = false
+                        pressStartDate = Date()
+                        frozenProgress = 0
+                    } else if !didFire {
+                        // Released early - animate back to zero
+                        withAnimation(.easeOut(duration: 0.18)) {
+                            frozenProgress = 0
+                        }
+                        pressStartDate = nil
+                    }
+                }
+            )
+        }
+    }
+}

--- a/Convos/Shared Views/ShatteringText.swift
+++ b/Convos/Shared Views/ShatteringText.swift
@@ -1,0 +1,119 @@
+import SwiftUI
+
+// MARK: - Shattering Text Animation Config
+
+struct ShatteringTextAnimationConfig {
+    var letterHorizontalRange: ClosedRange<Double> = 25...50
+    var letterVerticalRange: ClosedRange<Double> = 15...35
+    var letterRotationRange: ClosedRange<Double> = 15...45
+    var letterScaleRange: ClosedRange<Double> = 2.0...5.0
+    var letterBlurRadius: CGFloat = 5
+    var letterAnimationResponse: Double = 0.7
+    var letterAnimationDamping: Double = 0.3
+    var letterStaggerDelay: Double = 0.03
+
+    static let `default`: ShatteringTextAnimationConfig = .init()
+}
+
+// MARK: - Shattering Text
+
+struct ShatteringText: View {
+    let text: String
+    let isExploded: Bool
+    var config: ShatteringTextAnimationConfig = .default
+
+    @State private var letterOffsets: [CGSize] = []
+    @State private var letterRotations: [Double] = []
+    @State private var letterScales: [Double] = []
+
+    var body: some View {
+        ZStack {
+            // Regular text when not exploded
+            Text(text)
+                .opacity(isExploded ? 0 : 1)
+                .animation(.easeOut(duration: 0.1), value: isExploded)
+
+            // Shattered letters
+            HStack(spacing: 0) {
+                ForEach(Array(text.enumerated()), id: \.offset) { index, character in
+                    let delay = Double(index) * config.letterStaggerDelay
+                    let springAnimation = Animation
+                        .spring(response: config.letterAnimationResponse, dampingFraction: config.letterAnimationDamping)
+                        .delay(delay)
+                    // Use easeOut for opacity to prevent bounce-back visibility
+                    let opacityAnimation = Animation
+                        .easeOut(duration: config.letterAnimationResponse * 0.6)
+                        .delay(delay)
+
+                    Text(String(character))
+                        .offset(isExploded && index < letterOffsets.count ? letterOffsets[index] : .zero)
+                        .rotationEffect(.degrees(isExploded && index < letterRotations.count ? letterRotations[index] : 0))
+                        .scaleEffect(isExploded && index < letterScales.count ? letterScales[index] : 1)
+                        .blur(radius: isExploded ? config.letterBlurRadius : 0)
+                        .animation(isExploded ? springAnimation : .none, value: isExploded)
+                        .opacity(isExploded ? 0.0 : 1.0)
+                        .animation(isExploded ? opacityAnimation : .none, value: isExploded)
+                }
+            }
+            .opacity(isExploded ? 1.0 : 0.0)
+            .animation(.none, value: isExploded)
+        }
+        .task(id: text) { generateRandomValues() }
+    }
+
+    private func generateRandomValues() {
+        let letterCount = text.count
+        let centerIndex = Double(letterCount - 1) / 2.0
+
+        // swiftlint:disable:next unused_enumerated
+        letterOffsets = text.enumerated().map { i, _ in
+            // Calculate position relative to center: -1 (leftmost) to +1 (rightmost)
+            let normalizedPosition = centerIndex > 0
+            ? (Double(i) - centerIndex) / centerIndex
+            : 0
+
+            // Horizontal: letters fly outward from center
+            let horizontalDistance = normalizedPosition * Double.random(in: config.letterHorizontalRange)
+
+            // Vertical: alternate up/down based on odd/even index
+            let verticalDirection = i.isMultiple(of: 2) ? -1.0 : 1.0
+            let verticalDistance = verticalDirection * Double.random(in: config.letterVerticalRange)
+
+            return CGSize(width: horizontalDistance, height: verticalDistance)
+        }
+
+        // swiftlint:disable:next unused_enumerated
+        letterRotations = text.enumerated().map { i, _ in
+            let centerIndex = Double(text.count - 1) / 2.0
+            let direction = Double(i) < centerIndex ? -1.0 : 1.0
+            return direction * Double.random(in: config.letterRotationRange)
+        }
+
+        letterScales = text.map { _ in
+            Double.random(in: config.letterScaleRange)
+        }
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+    struct PreviewWrapper: View {
+        @State private var isExploded: Bool = false
+
+        var body: some View {
+            VStack(spacing: DesignConstants.Spacing.step5x) {
+                ShatteringText(text: "Exploding...", isExploded: isExploded)
+                    .font(.headline)
+
+                Button(isExploded ? "Reset" : "Shatter") {
+                    isExploded.toggle()
+                }
+                .buttonStyle(.borderedProminent)
+            }
+            .padding(44)
+        }
+    }
+
+    return PreviewWrapper()
+}

--- a/ConvosCore/Sources/ConvosCore/Inboxes/InboxStateMachine.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/InboxStateMachine.swift
@@ -293,6 +293,24 @@ public actor InboxStateMachine {
         enqueueAction(.delete)
     }
 
+    /// Wait for the deletion process to complete
+    /// Returns when the state machine reaches .idle or .stopping state after deletion
+    public func waitForDeletionComplete() async {
+        for await state in stateSequence {
+            switch state {
+            case .idle, .stopping:
+                // Deletion complete
+                return
+            case .error:
+                // Deletion failed, but still complete
+                return
+            default:
+                // Still processing, continue waiting
+                continue
+            }
+        }
+    }
+
     // MARK: - Private
 
     private func enqueueAction(_ action: Action) {

--- a/ConvosCore/Sources/ConvosCore/Inboxes/InboxStateManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/InboxStateManager.swift
@@ -11,6 +11,7 @@ public protocol InboxStateManagerProtocol: AnyObject {
     func waitForInboxReadyResult() async throws -> InboxReadyResult
     func reauthorize(inboxId: String, clientId: String) async throws -> InboxReadyResult
     func delete() async throws
+    func waitForDeletionComplete() async
 
     func addObserver(_ observer: InboxStateObserver)
     func removeObserver(_ observer: InboxStateObserver)
@@ -120,6 +121,14 @@ public final class InboxStateManager: InboxStateManagerProtocol {
             throw InboxStateError.inboxNotReady
         }
         await stateMachine.stopAndDelete()
+        await stateMachine.waitForDeletionComplete()
+    }
+
+    public func waitForDeletionComplete() async {
+        guard let stateMachine = stateMachine else {
+            return
+        }
+        await stateMachine.waitForDeletionComplete()
     }
 
     public func reauthorize(inboxId: String, clientId: String) async throws -> InboxReadyResult {

--- a/ConvosCore/Sources/ConvosCore/Inboxes/MockInboxesService.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/MockInboxesService.swift
@@ -4,6 +4,25 @@ import Foundation
 public final class MockInboxesService: SessionManagerProtocol {
     private let mockMessagingService: MockMessagingService = MockMessagingService()
 
+    public func deleteAllInboxesWithProgress() -> AsyncThrowingStream<InboxDeletionProgress, any Error> {
+        AsyncThrowingStream { continuation in
+            Task {
+                // Simulate deletion progress
+                continuation.yield(.clearingDeviceRegistration)
+                try? await Task.sleep(for: .milliseconds(200))
+                // Simulate stopping 1 service
+                continuation.yield(.stoppingServices(completed: 0, total: 1))
+                try? await Task.sleep(for: .milliseconds(300))
+                continuation.yield(.stoppingServices(completed: 1, total: 1))
+                try? await Task.sleep(for: .milliseconds(200))
+                continuation.yield(.deletingFromDatabase)
+                try? await Task.sleep(for: .milliseconds(200))
+                continuation.yield(.completed)
+                continuation.finish()
+            }
+        }
+    }
+
     public func shouldDisplayNotification(for conversationId: String) async -> Bool {
         true
     }

--- a/ConvosCore/Sources/ConvosCore/Messaging/MessagingService.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/MessagingService.swift
@@ -82,6 +82,10 @@ final class MessagingService: MessagingServiceProtocol {
         await authorizationOperation.stopAndDelete()
     }
 
+    func waitForDeletionComplete() async {
+        await inboxStateManager.waitForDeletionComplete()
+    }
+
     // MARK: My Profile
 
     func myProfileWriter() -> any MyProfileWriterProtocol {

--- a/ConvosCore/Sources/ConvosCore/Messaging/MessagingServiceProtocol.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/MessagingServiceProtocol.swift
@@ -24,6 +24,7 @@ public protocol MessagingServiceProtocol: AnyObject {
     func stop()
     func stopAndDelete()
     func stopAndDelete() async
+    func waitForDeletionComplete() async
 
     func myProfileWriter() -> any MyProfileWriterProtocol
 

--- a/ConvosCore/Sources/ConvosCore/Mocks/MockInboxStateManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Mocks/MockInboxStateManager.swift
@@ -36,6 +36,11 @@ public final class MockInboxStateManager: InboxStateManagerProtocol, @unchecked 
         notifyObservers()
     }
 
+    public func waitForDeletionComplete() async {
+        currentState = .idle(clientId: currentState.clientId)
+        notifyObservers()
+    }
+
     public func addObserver(_ observer: any InboxStateObserver) {
         observers.removeAll { $0.observer == nil }
         observers.append(WeakStateObserver(observer: observer))

--- a/ConvosCore/Sources/ConvosCore/Mocks/MockMessagingService.swift
+++ b/ConvosCore/Sources/ConvosCore/Mocks/MockMessagingService.swift
@@ -48,6 +48,8 @@ public final class MockMessagingService: MessagingServiceProtocol, @unchecked Se
 
     public func stopAndDelete() async {}
 
+    public func waitForDeletionComplete() async {}
+
     public var inboxStateManager: any InboxStateManagerProtocol {
         _inboxStateManager
     }

--- a/ConvosCore/Sources/ConvosCore/Sessions/SessionManagerProtocol.swift
+++ b/ConvosCore/Sources/ConvosCore/Sessions/SessionManagerProtocol.swift
@@ -1,12 +1,21 @@
 import Combine
 import Foundation
 
+/// Progress events for inbox deletion
+public enum InboxDeletionProgress: Sendable, Equatable {
+    case clearingDeviceRegistration
+    case stoppingServices(completed: Int, total: Int)
+    case deletingFromDatabase
+    case completed
+}
+
 public protocol SessionManagerProtocol: AnyObject {
     // MARK: Inbox Management
 
     func addInbox() async -> AnyMessagingService
     func deleteInbox(clientId: String) async throws
     func deleteAllInboxes() async throws
+    func deleteAllInboxesWithProgress() -> AsyncThrowingStream<InboxDeletionProgress, Error>
 
     // MARK: Messaging Services
 


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Replace destructive confirmation dialog with a non-dismissible self-sizing sheet and hold-to-delete flow for deleting all app data in `AppSettingsView`
Introduce `AppSettingsViewModel` to manage delete-all progress and errors, present `DeleteAllDataView` via a sheet with a 3-second hold-to-delete button, route session deletion through `SessionManagerProtocol.deleteAllInboxesWithProgress()`, and add `waitForDeletionComplete()` across inbox and messaging layers.

#### 📍Where to Start
Start with the delete-all flow entry in `AppSettingsView` and its view model: [AppSettingsView.swift](https://github.com/ephemeraHQ/convos-ios/pull/237/files#diff-30e98d39613710cf0f912b477ed30a8638995959caa9cb2e9facdc10e1c3f8b9) and [AppSettingsViewModel.swift](https://github.com/ephemeraHQ/convos-ios/pull/237/files#diff-3a627072f76047fb7949e53f112514e7b27e2cbd1afab64e799c6b6f403f15ef). Then review the progress stream in [SessionManager.swift](https://github.com/ephemeraHQ/convos-ios/pull/237/files#diff-047bb043999d66a7809a8ab86918296f5f449652df54267763f6ec8da0a71ca7).

----
<!-- Macroscope's review summary starts here -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized fd192c3. 17 files reviewed, 6 issues evaluated, 4 issues filtered, 1 comment posted</summary>

### 🗂️ Filtered Issues
<details>
<summary>Convos/App Settings/AppSettingsView.swift — 0 comments posted, 1 evaluated, 1 filtered</summary>

- [line 166](https://github.com/ephemeraHQ/convos-ios/blob/fd192c360aafa12309d08f9a910971e6b75627bd/Convos/App Settings/AppSettingsView.swift#L166): The refactored code removes the `quicknameViewModel.delete()` call that was present in the old confirmation dialog. The old code explicitly deleted the quickname when the user confirmed deletion, but the new `DeleteAllDataView` only calls `viewModel.deleteAllData(onComplete:)` without any reference to `quicknameViewModel`. Unless `AppSettingsViewModel.deleteAllData` internally handles quickname deletion, the quickname data will no longer be deleted when the user chooses to delete all app data, despite the UI stating "This will permanently delete all conversations on this device, as well as your Quickname." <b>[ Already posted ]</b>
</details>

<details>
<summary>Convos/App Settings/AppSettingsViewModel.swift — 0 comments posted, 1 evaluated, 1 filtered</summary>

- [line 37](https://github.com/ephemeraHQ/convos-ios/blob/fd192c360aafa12309d08f9a910971e6b75627bd/Convos/App Settings/AppSettingsViewModel.swift#L37): In `deleteAllData()`, `isDeleting` is set to `true` at the start but is never set back to `false` on successful completion. It is only reset to `false` in the `catch` block on error. This means after a successful deletion, `isDeleting` will remain `true` indefinitely, causing the `guard !isDeleting else { return }` check to prevent any future delete attempts, and the UI will incorrectly show a loading/deleting state. <b>[ Already posted ]</b>
</details>

<details>
<summary>ConvosCore/Sources/ConvosCore/Inboxes/InboxStateMachine.swift — 0 comments posted, 1 evaluated, 1 filtered</summary>

- [line 298](https://github.com/ephemeraHQ/convos-ios/blob/fd192c360aafa12309d08f9a910971e6b75627bd/ConvosCore/Sources/ConvosCore/Inboxes/InboxStateMachine.swift#L298): The method `waitForDeletionComplete()` may hang indefinitely if called when a deletion has not been initiated. If the state machine is in a state like `.ready` and no `stopAndDelete()` action is queued, the method will wait forever for a state transition to `.idle`, `.stopping`, or `.error` that may never occur. Consider adding a timeout or checking that a deletion is in progress before waiting. <b>[ Already posted ]</b>
</details>

<details>
<summary>ConvosCore/Sources/ConvosCore/Inboxes/InboxStateManager.swift — 0 comments posted, 1 evaluated, 1 filtered</summary>

- [line 134](https://github.com/ephemeraHQ/convos-ios/blob/fd192c360aafa12309d08f9a910971e6b75627bd/ConvosCore/Sources/ConvosCore/Inboxes/InboxStateManager.swift#L134): The `waitForDeletionComplete()` method in `InboxStateManager` (line 134-139) silently returns when `stateMachine` is nil, which could mislead callers into thinking deletion completed successfully when in fact the state machine reference was lost and no waiting occurred. Callers relying on this method to confirm deletion completion may proceed incorrectly. <b>[ Low confidence ]</b>
</details>


</details><!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->