### PR TITLE
Add reset onboarding option in debug menu

### DIFF
--- a/Convos/Conversation Detail/ConversationOnboardingCoordinator.swift
+++ b/Convos/Conversation Detail/ConversationOnboardingCoordinator.swift
@@ -178,6 +178,13 @@ final class ConversationOnboardingCoordinator {
         set { UserDefaults.standard.set(newValue, forKey: hasSeenAddAsQuicknameKey)}
     }
 
+    // Only used in Debug builds
+    func reset() {
+        hasSeenAddAsQuickname = false
+        hasCompletedOnboarding = false
+        hasShownQuicknameEditor = false
+    }
+
     // MARK: - Dependencies
 
     private let notificationCenter: NotificationCenterProtocol

--- a/Convos/Debug View/DebugView.swift
+++ b/Convos/Debug View/DebugView.swift
@@ -185,9 +185,9 @@ struct DebugViewSection: View {
                         .foregroundStyle(.colorTextPrimary)
                 }
                 Button {
-                    resetUserDefaults()
+                    resetOnboarding()
                 } label: {
-                    Text("Reset User Defaults")
+                    Text("Reset Onboarding")
                         .foregroundStyle(.colorTextPrimary)
                 }
             }
@@ -248,10 +248,9 @@ extension DebugViewSection {
         await manager.registerDeviceIfNeeded()
     }
 
-    private func resetUserDefaults() {
-        if let appDomain = Bundle.main.bundleIdentifier {
-            UserDefaults.standard.removePersistentDomain(forName: appDomain)
-        }
+    private func resetOnboarding() {
+        QuicknameSettings.delete()
+        ConversationOnboardingCoordinator().reset()
     }
 
     func testSentryMessage() {


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Add a debug-only "Reset Onboarding" button in [DebugView.swift](https://github.com/ephemeraHQ/convos-ios/pull/242/files#diff-c45ca903f9cc34fa316deb294404f56695ab7914c8a43563ade3081b646368aa) that calls `ConversationOnboardingCoordinator.reset` to clear onboarding and quickname flags
Introduce `ConversationOnboardingCoordinator.reset` to set `hasSeenAddAsQuickname`, `hasCompletedOnboarding`, and `hasShownQuicknameEditor` to `false`, and update the debug view to replace full UserDefaults wipe with a scoped onboarding reset.

#### 📍Where to Start
Start with the `reset` method in [ConversationOnboardingCoordinator.swift](https://github.com/ephemeraHQ/convos-ios/pull/242/files#diff-cfdcd58edc9cdb689c4014d4562251b351c87c7f4a586d344060839e97af7f6f), then review the button action wiring in [DebugView.swift](https://github.com/ephemeraHQ/convos-ios/pull/242/files#diff-c45ca903f9cc34fa316deb294404f56695ab7914c8a43563ade3081b646368aa).

----
<!-- Macroscope's review summary starts here -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized e71d704. 2 files reviewed, 4 issues evaluated, 4 issues filtered, 0 comments posted</summary>

### 🗂️ Filtered Issues
<details>
<summary>Convos/Conversation Detail/ConversationOnboardingCoordinator.swift — 0 comments posted, 3 evaluated, 3 filtered</summary>

- [line 336](https://github.com/ephemeraHQ/convos-ios/blob/e71d70458a8e2199217fd4cae4c7d2feed19689c/Convos/Conversation Detail/ConversationOnboardingCoordinator.swift#L336): In `startNotificationFlow(for:)`, when authorization is already granted (`.authorized`, `.provisional`, `.ephemeral`) and `isWaitingForInviteAcceptance` is `true`, the code neither transitions `state` nor calls `handleStateChange()`. Because `start(for:)` sets `state = .started` just before calling `startNotificationFlow(for:)`, this branch leaves the coordinator stuck in `.started` with no UI progression and no autodismiss task, while `showOnboardingView` remains true. This is a hang/stuck flow. A concrete fix is to either transition to the next expected state (e.g., start quickname or notification completion) or explicitly complete, and call `handleStateChange()`. <b>[ Out of scope ]</b>
- [line 341](https://github.com/ephemeraHQ/convos-ios/blob/e71d70458a8e2199217fd4cae4c7d2feed19689c/Convos/Conversation Detail/ConversationOnboardingCoordinator.swift#L341): `startNotificationFlow(for:)` clears `shouldShowQuicknameAfterNotifications` and `pendingClientId` in the already-authorized branch (and `@unknown default`) even when `isWaitingForInviteAcceptance` is `true`. Those flags are the only signals used later to continue into the quickname flow from `.notificationsEnabled` (see the autodismiss path) or after permission requests. Clearing them prevents the intended "notifications first, then quickname" continuation, causing the quickname flow to be silently skipped. <b>[ Out of scope ]</b>
- [line 471](https://github.com/ephemeraHQ/convos-ios/blob/e71d70458a8e2199217fd4cae4c7d2feed19689c/Convos/Conversation Detail/ConversationOnboardingCoordinator.swift#L471): Inconsistent gating on `isWaitingForInviteAcceptance` when deciding to proceed to quickname after notifications: (a) In the `.notificationsEnabled` autodismiss path, it proceeds if `shouldShowQuicknameAfterNotifications` and `pendingClientId` are set, regardless of `isWaitingForInviteAcceptance` (lines 259–266). (b) In `requestNotificationPermission()`, it requires `!isWaitingForInviteAcceptance` in addition to the flags (lines 471–477). This inconsistency causes divergent behavior depending on which path is taken, violating contract parity and making the quickname continuation flaky. <b>[ Low confidence ]</b>
</details>

<details>
<summary>Convos/Debug View/DebugView.swift — 0 comments posted, 1 evaluated, 1 filtered</summary>

- [line 253](https://github.com/ephemeraHQ/convos-ios/blob/e71d70458a8e2199217fd4cae4c7d2feed19689c/Convos/Debug View/DebugView.swift#L253): resetOnboarding constructs a fresh `ConversationOnboardingCoordinator` and calls `reset()` on it: `ConversationOnboardingCoordinator().reset()` (line 253). If `hasSeenAddAsQuickname`, `hasCompletedOnboarding`, and `hasShownQuicknameEditor` are stored as instance-backed state, resetting a new, short-lived instance will not affect the coordinator state used elsewhere nor any persisted onboarding flags. This can result in a no-op where the user's onboarding is not actually reset, despite the debug action indicating otherwise. To ensure effect, `reset()` must operate on shared/persisted storage (e.g., `UserDefaults`/shared store/static), or the call site must target the live/shared coordinator instance. <b>[ Low confidence ]</b>
</details>


</details><!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->