### PR TITLE
Remove early access gate

### DIFF
--- a/Convos/Conversations List/ConversationsViewModel.swift
+++ b/Convos/Conversations List/ConversationsViewModel.swift
@@ -87,9 +87,6 @@ final class ConversationsViewModel {
             if conversationsCount > 1 {
                 hasCreatedMoreThanOneConvo = true
             }
-            if conversationsCount > 0 {
-                hasEarlyAccess = true
-            }
         }
     }
 
@@ -106,20 +103,6 @@ final class ConversationsViewModel {
         }
         set {
             UserDefaults.standard.set(newValue, forKey: "hasCreatedMoreThanOneConvo")
-        }
-    }
-
-    private(set) var hasEarlyAccess: Bool {
-        get {
-            return true
-            UserDefaults.standard.bool(forKey: "hasEarlyAccess")
-        }
-        set {
-            // once a user has early access, don't reset it
-            guard newValue else {
-                return
-            }
-            UserDefaults.standard.set(newValue, forKey: "hasEarlyAccess")
         }
     }
 
@@ -160,26 +143,10 @@ final class ConversationsViewModel {
             if conversationsCount > 1 {
                 hasCreatedMoreThanOneConvo = true
             }
-            if conversationsCount > 0 {
-                hasEarlyAccess = true
-            }
         } catch {
             Log.error("Error fetching conversations: \(error)")
             self.conversations = []
             self.conversationsCount = 0
-        }
-        if !hasEarlyAccess {
-            newConversationViewModelTask = Task { [weak self] in
-                guard let self else { return }
-                let viewModel = await NewConversationViewModel.create(
-                    session: session,
-                    showingFullScreenScanner: true,
-                    allowsDismissingScanner: false
-                )
-                await MainActor.run {
-                    self.newConversationViewModel = viewModel
-                }
-            }
         }
         observe()
     }


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Remove the early-access gate by deleting `ConversationsViewModel.hasEarlyAccess` and its initialization logic in [ConversationsViewModel.swift](https://github.com/ephemeraHQ/convos-ios/pull/243/files#diff-e9ac0abeb6f4ab9d1335cf93b09f18a543936af17c742b0f60b5f57e26c07fce)
Delete the `ConversationsViewModel.hasEarlyAccess` property and remove initializer logic that created `newConversationViewModel` for the non-early-access path; keep `conversationsCount` `didSet` updating only `hasCreatedMoreThanOneConvo` when `conversationsCount > 1`.

#### 📍Where to Start
Start with the initializer and property definitions in [ConversationsViewModel.swift](https://github.com/ephemeraHQ/convos-ios/pull/243/files#diff-e9ac0abeb6f4ab9d1335cf93b09f18a543936af17c742b0f60b5f57e26c07fce), focusing on the removal of `hasEarlyAccess` and the init path that previously instantiated `newConversationViewModel`.

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized a2d9e5d.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->