### PR TITLE
Fix quickname on join

### DIFF
--- a/Convos/Conversation Creation/NewConversationViewModel.swift
+++ b/Convos/Conversation Creation/NewConversationViewModel.swift
@@ -290,6 +290,8 @@ class NewConversationViewModel: Identifiable {
             conversationViewModel.startOnboarding()
             if result.origin == .joined {
                 conversationViewModel.inviteWasAccepted()
+            } else {
+                conversationViewModel.isWaitingForInviteAcceptance = false
             }
             conversationViewModel.showsInfoView = true
             messagesTopBarTrailingItemEnabled = true
@@ -367,6 +369,7 @@ class NewConversationViewModel: Identifiable {
             messagesTopBarTrailingItem = .share
             shouldConfirmDeletingConversation = false
             conversationViewModel.untitledConversationPlaceholder = "Untitled"
+            conversationViewModel.inviteWasAccepted()
         }
         .store(in: &cancellables)
     }

--- a/Convos/Conversation Detail/ConversationOnboardingCoordinator.swift
+++ b/Convos/Conversation Detail/ConversationOnboardingCoordinator.swift
@@ -385,10 +385,13 @@ final class ConversationOnboardingCoordinator {
         // No longer waiting for invite
         isWaitingForInviteAcceptance = false
 
-        // If we're idle (not in an active flow), start notification flow
-        if case .idle = state {
+        // If we're not in an active flow, start notification flow
+        switch state {
+        case .idle, .started:
             // Start notification flow, then quickname
             await startNotificationFlow(for: clientId)
+        default:
+            break
         }
     }
 

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -251,7 +251,6 @@ class ConversationViewModel {
     }
 
     func inviteWasAccepted() {
-        isWaitingForInviteAcceptance = false
         Task { @MainActor in
             await onboardingCoordinator.inviteWasAccepted(for: conversation.clientId)
         }


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Fix quickname on join by clearing `ConversationViewModel.isWaitingForInviteAcceptance` when creation is not `.joined` and trigger invite acceptance via `NewConversationViewModel.sharePublisher`
Update `NewConversationViewModel.creationReadyState` to unset `isWaitingForInviteAcceptance` when origin is not `.joined`, forward invite acceptance from `sharePublisher` to `ConversationViewModel`, and allow `ConversationOnboardingCoordinator.inviteWasAccepted` to start notifications when state is `.idle` or `.started`.

#### 📍Where to Start
Start with `creationReadyState` handling in [NewConversationViewModel.swift](https://github.com/ephemeraHQ/convos-ios/pull/244/files#diff-bc0af06ca6587e88461a662416743a0ef38cc55d66fc169caad65a62fb3abe47), then review `inviteWasAccepted` in [ConversationViewModel.swift](https://github.com/ephemeraHQ/convos-ios/pull/244/files#diff-d056b0b131534648b6d13cddafd053be956f5d23d035ad2538db85a8cc370d8d) and [ConversationOnboardingCoordinator.swift](https://github.com/ephemeraHQ/convos-ios/pull/244/files#diff-cfdcd58edc9cdb689c4014d4562251b351c87c7f4a586d344060839e97af7f6f).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized c54590f.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->