### PR TITLE
Show invite code always in messages

### DIFF
--- a/Convos/Conversation Detail/Messages/Messages View Controller/Message Models/MessagesCollectionCell.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/Message Models/MessagesCollectionCell.swift
@@ -50,7 +50,7 @@ extension MessagesCollectionCell: Differentiable {
         case let .date(group):
             group.differenceIdentifier
         case let .invite(invite):
-            invite.hashValue
+            invite.differenceIdentifier
         case let .conversationInfo(conversation):
             conversation.id.hashValue
         }

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Cells/InviteCell.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Cells/InviteCell.swift
@@ -22,12 +22,17 @@ struct InviteView: View {
     var body: some View {
         VStack {
             Group {
-                if let inviteURL = invite.inviteURL {
+                if !invite.isEmpty,
+                   let inviteURL = invite.inviteURL {
                     QRCodeView(url: inviteURL, backgroundColor: .colorFillMinimal)
                         .frame(maxWidth: 220, maxHeight: 220)
                         .padding(DesignConstants.Spacing.step12x)
+                } else {
+                    EmptyView()
+                        .frame(width: 220, height: 220.0)
                 }
             }
+            .transition(.blurReplace)
             .background(.colorFillMinimal)
             .mask(RoundedRectangle(cornerRadius: 38.0))
         }

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/MessagesViewController.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/MessagesViewController.swift
@@ -366,9 +366,9 @@ extension MessagesViewController {
             return cells
         }
 
-        if conversation.creator.isCurrentUser && !invite.isEmpty {
+        if conversation.creator.isCurrentUser {
             cells.insert(.invite(invite), at: 0)
-        } else if !conversation.creator.isCurrentUser {
+        } else {
             cells.insert(.conversationInfo(conversation), at: 0)
         }
 

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/Invite.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/Invite.swift
@@ -20,6 +20,15 @@ public extension Invite {
         )
     }
 
+    static func empty(conversationId: String) -> Self {
+        .init(
+            conversationId: conversationId,
+            urlSlug: "",
+            expiresAt: nil,
+            expiresAfterUse: false
+        )
+    }
+
     var isEmpty: Bool {
         urlSlug.isEmpty
     }


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Always show an invite cell for creators in Messages and use `Invite.differenceIdentifier` for diffing in [MessagesViewController.swift](https://github.com/ephemeraHQ/convos-ios/pull/245/files#diff-1427b816e5e93d8bc7ea882f5eabd9671135c6f9b9ebc6b0a6f7116a2f8a37c3)
Update header insertion to always add `MessagesCell.invite` for creators, switch invite diffing to `Invite.differenceIdentifier`, and render a fixed 220x220 placeholder when the invite lacks a URL with a `.blurReplace` transition.

#### 📍Where to Start
Start with `MessagesViewController.processUpdates` in [MessagesViewController.swift](https://github.com/ephemeraHQ/convos-ios/pull/245/files#diff-1427b816e5e93d8bc7ea882f5eabd9671135c6f9b9ebc6b0a6f7116a2f8a37c3).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 2d3780f.
<!-- Macroscope's review summary ends here -->
<!-- Macroscope's pull request summary ends here -->