### PR TITLE
Fix convo info button width

### DIFF
--- a/Convos/Conversation Detail/Messages/ConversationInfoButton.swift
+++ b/Convos/Conversation Detail/Messages/ConversationInfoButton.swift
@@ -18,81 +18,87 @@ struct ConversationInfoButton<InfoView: View>: View {
     let onExplodeNow: () -> Void
     @ViewBuilder let infoView: () -> InfoView
 
-    @State private var progress: CGFloat = 0.0
+    @State private var isExpanded: Bool = false
     @State private var showingExplodeConfirmation: Bool = false
     @Namespace private var namespace: Namespace.ID
 
     var body: some View {
-        PrimarySecondaryContainerView(
-            progress: progress,
-            primaryProperties: .init(
-                cornerRadius: 26.0,
-                padding: DesignConstants.Spacing.step2x,
-                fixedSizeHorizontal: false
-            ),
-            secondaryProperties: .init(
-                cornerRadius: 40.0,
-                padding: DesignConstants.Spacing.step6x,
-                fixedSizeHorizontal: true
-            )
-        ) {
-            ConversationToolbarButton(
-                conversation: conversation,
-                conversationImage: $conversationImage,
-                conversationName: conversationName,
-                placeholderName: untitledConversationPlaceholder,
-                subtitle: subtitle,
-                action: onConversationInfoTapped
-            )
-        } secondaryContent: {
-            VStack(spacing: DesignConstants.Spacing.step4x) {
-                QuickEditView(
-                    placeholderText: conversationName.isEmpty ? placeholderName : conversationName,
-                    text: $conversationName,
-                    image: $conversationImage,
-                    focusState: $focusState,
-                    focused: .conversationName,
-                    onSubmit: onConversationNameEndedEditing,
-                    onSettings: onConversationSettings)
+        GlassEffectContainer {
+            ZStack {
+                if !isExpanded {
+                    ConversationToolbarButton(
+                        conversation: conversation,
+                        conversationImage: $conversationImage,
+                        conversationName: conversationName,
+                        placeholderName: untitledConversationPlaceholder,
+                        subtitle: subtitle,
+                        action: onConversationInfoTapped
+                    )
+                    .fixedSize(horizontal: false, vertical: true)
+                    .clipShape(.capsule)
+                    .glassEffect(.regular.interactive(), in: .capsule)
+                    .glassEffectID("convoInfo", in: namespace)
+                    .glassEffectTransition(.matchedGeometry)
+                }
 
-                if showsExplodeNowButton {
-                    Button {
-                        showingExplodeConfirmation = true
-                    } label: {
-                        Text("Explode now")
-                    }
-                    .buttonStyle(RoundedDestructiveButtonStyle(fullWidth: true))
-                    .confirmationDialog(
-                        "",
-                        isPresented: $showingExplodeConfirmation
-                    ) {
-                        Button("Explode", role: .destructive) {
-                            onExplodeNow()
-                        }
+                if isExpanded {
+                    VStack(spacing: DesignConstants.Spacing.step4x) {
+                        QuickEditView(
+                            placeholderText: conversationName.isEmpty ? placeholderName : conversationName,
+                            text: $conversationName,
+                            image: $conversationImage,
+                            focusState: $focusState,
+                            focused: .conversationName,
+                            onSubmit: onConversationNameEndedEditing,
+                            onSettings: onConversationSettings
+                        )
 
-                        Button("Cancel") {
-                            showingExplodeConfirmation = false
+                        if showsExplodeNowButton {
+                            Button {
+                                showingExplodeConfirmation = true
+                            } label: {
+                                Text("Explode now")
+                            }
+                            .buttonStyle(RoundedDestructiveButtonStyle(fullWidth: true))
+                            .confirmationDialog(
+                                "",
+                                isPresented: $showingExplodeConfirmation
+                            ) {
+                                Button("Explode", role: .destructive) {
+                                    onExplodeNow()
+                                }
+
+                                Button("Cancel") {
+                                    showingExplodeConfirmation = false
+                                }
+                            }
                         }
                     }
+                    .frame(maxWidth: 320.0)
+                    .padding(DesignConstants.Spacing.step6x)
+                    .clipShape(.rect(cornerRadius: 40.0))
+                    .glassEffect(.regular.interactive(), in: .rect(cornerRadius: 40.0))
+                    .glassEffectID("convoEditor", in: namespace)
+                    .glassEffectTransition(.matchedGeometry)
                 }
             }
-            .matchedTransitionSource(
-                id: "convo-info-transition-source",
-                in: namespace
-            )
-            .sheet(isPresented: $presentingConversationSettings) {
-                infoView()
-                    .navigationTransition(
-                        .zoom(
-                            sourceID: "convo-info-transition-source",
-                            in: namespace
-                        )
+        }
+        .matchedTransitionSource(
+            id: "convo-info-transition-source",
+            in: namespace
+        )
+        .sheet(isPresented: $presentingConversationSettings) {
+            infoView()
+                .navigationTransition(
+                    .zoom(
+                        sourceID: "convo-info-transition-source",
+                        in: namespace
                     )
-            }
+                )
         }
         .onChange(of: focusCoordinator?.currentFocus) { _, newValue in
-            withAnimation(.bouncy(duration: 0.5, extraBounce: 0.2)) {
-                progress = newValue == .conversationName ? 1.0 : 0.0
+            withAnimation(.bouncy(duration: 0.4, extraBounce: 0.01)) {
+                isExpanded = newValue == .conversationName ? true : false
             }
         }
     }

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesBottomBar.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesBottomBar.swift
@@ -21,7 +21,6 @@ struct MessagesBottomBar: View {
     let onDisplayNameEndedEditing: () -> Void
     let onProfileSettings: () -> Void
 
-    @State private var progress: CGFloat = 0.0
     @State private var isExpanded: Bool = false
     @Namespace private var namespace: Namespace.ID
 

--- a/Convos/Shared Views/ConversationToolbarButton.swift
+++ b/Convos/Shared Views/ConversationToolbarButton.swift
@@ -49,7 +49,7 @@ struct ConversationToolbarButton: View {
                 VStack(alignment: .leading, spacing: 0.0) {
                     Text(title)
                         .lineLimit(1)
-                        .frame(maxWidth: 180.0)
+                        .frame(maxWidth: 140.0)
                         .font(.callout.weight(.medium))
                         .truncationMode(.tail)
                         .foregroundStyle(.colorTextPrimary)
@@ -61,7 +61,7 @@ struct ConversationToolbarButton: View {
                 }
                 .padding(.horizontal, DesignConstants.Spacing.step2x)
             }
-            .compositingGroup()
+            .padding(DesignConstants.Spacing.step2x)
         }
     }
 }


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Fix ConversationInfoButton width by replacing progress-driven layout with isExpanded-gated GlassEffectContainer and constraining expanded panel to maxWidth 320 in [ConversationInfoButton.swift](https://github.com/ephemeraHQ/convos-ios/pull/246/files#diff-585831cea6307764b478722706a9ab364ebd7942d89fbb5f99d6cdd20f392ca6)
Switch the ConversationInfoButton to an `isExpanded` state with matched geometry IDs, render a collapsed capsule toolbar button and an expanded editor panel (maxWidth 320), and adjust expansion timing. Reduce `ConversationToolbarButton` title `Text` `maxWidth` to 140 and add internal padding. Remove unused `progress` state from `MessagesBottomBar`.

#### 📍Where to Start
Start with the `ConversationInfoButton` view in [ConversationInfoButton.swift](https://github.com/ephemeraHQ/convos-ios/pull/246/files#diff-585831cea6307764b478722706a9ab364ebd7942d89fbb5f99d6cdd20f392ca6) to review the new `isExpanded` gating and container transitions.

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 54e4689.
<!-- Macroscope's review summary ends here -->
<!-- Macroscope's pull request summary ends here -->