### PR TITLE
Fix list selection complexity

### DIFF
--- a/Convos/Conversation Creation/NewConversationViewModel.swift
+++ b/Convos/Conversation Creation/NewConversationViewModel.swift
@@ -2,14 +2,6 @@ import Combine
 import ConvosCore
 import SwiftUI
 
-@MainActor
-protocol NewConversationsViewModelDelegate: AnyObject {
-    func newConversationsViewModel(
-        _ viewModel: NewConversationViewModel,
-        attemptedJoiningExistingConversationWithId conversationId: String
-    )
-}
-
 // MARK: - Error Types
 
 struct IdentifiableError: Identifiable {
@@ -33,7 +25,6 @@ class NewConversationViewModel: Identifiable {
     let session: any SessionManagerProtocol
     let conversationViewModel: ConversationViewModel
     let qrScannerViewModel: QRScannerViewModel
-    private weak var delegate: NewConversationsViewModelDelegate?
     private(set) var messagesTopBarTrailingItem: MessagesViewTopBarTrailingItem = .scan
     private(set) var messagesTopBarTrailingItemEnabled: Bool = false
     private(set) var messagesTextFieldEnabled: Bool = false
@@ -78,7 +69,6 @@ class NewConversationViewModel: Identifiable {
         autoCreateConversation: Bool = false,
         showingFullScreenScanner: Bool = false,
         allowsDismissingScanner: Bool = true,
-        delegate: NewConversationsViewModelDelegate? = nil
     ) async -> NewConversationViewModel {
         let messagingService = await session.addInbox()
         return NewConversationViewModel(
@@ -87,7 +77,6 @@ class NewConversationViewModel: Identifiable {
             autoCreateConversation: autoCreateConversation,
             showingFullScreenScanner: showingFullScreenScanner,
             allowsDismissingScanner: allowsDismissingScanner,
-            delegate: delegate
         )
     }
 
@@ -98,7 +87,6 @@ class NewConversationViewModel: Identifiable {
         autoCreateConversation: Bool = false,
         showingFullScreenScanner: Bool = false,
         allowsDismissingScanner: Bool = true,
-        delegate: NewConversationsViewModelDelegate? = nil
     ) {
         self.session = session
         self.qrScannerViewModel = QRScannerViewModel()
@@ -106,7 +94,6 @@ class NewConversationViewModel: Identifiable {
         self.startedWithFullscreenScanner = showingFullScreenScanner
         self.showingFullScreenScanner = showingFullScreenScanner
         self.allowsDismissingScanner = allowsDismissingScanner
-        self.delegate = delegate
 
         let conversationStateManager = messagingService.conversationStateManager()
         self.conversationStateManager = conversationStateManager


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Drive conversations list selection via `ConversationsViewModel.selectedConversationId` to fix list selection complexity
Replace delegate-based selection with a single ID source of truth in `ConversationsViewModel`, add `updateSelectionState()` to derive and update `selectedConversationViewModel`, mark reads, post `.activeConversationChanged` only on ID change, and clear selection when the conversation disappears; remove `NewConversationsViewModelDelegate` and its usages.

#### 📍Where to Start
Start with `updateSelectionState()` and the `selectedConversationId` binding in [Convos/Conversations List/ConversationsViewModel.swift](https://github.com/ephemeraHQ/convos-ios/pull/248/files#diff-e9ac0abeb6f4ab9d1335cf93b09f18a543936af17c742b0f60b5f57e26c07fce).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized af2be2f.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->