### PR TITLE
Add xmtp logs to notif extension

### DIFF
--- a/Convos/ConvosApp.swift
+++ b/Convos/ConvosApp.swift
@@ -22,6 +22,7 @@ struct ConvosApp: App {
                 logLevel: .debug,
                 rotationSchedule: .hourly,
                 maxFiles: 10,
+                customLogDirectory: environment.defaultXMTPLogsDirectoryURL,
                 processType: .main
             )
         }

--- a/Convos/Debug View/DebugView.swift
+++ b/Convos/Debug View/DebugView.swift
@@ -6,7 +6,8 @@ import XMTPiOS
 
 extension Client {
     static var logFileURLs: [URL]? {
-        let filePaths = getXMTPLogFilePaths(customLogDirectory: nil)
+        let customLogDirectory = ConfigManager.shared.currentEnvironment.defaultXMTPLogsDirectoryURL
+        let filePaths = getXMTPLogFilePaths(customLogDirectory: customLogDirectory)
         guard !filePaths.isEmpty else { return nil }
         return filePaths
             .map { URL(fileURLWithPath: $0) }

--- a/ConvosCore/Sources/ConvosCore/AppEnvironment.swift
+++ b/ConvosCore/Sources/ConvosCore/AppEnvironment.swift
@@ -209,6 +209,19 @@ public extension AppEnvironment {
         }
     }
 
+    var defaultXMTPLogsDirectoryURL: URL {
+        guard !isTestingEnvironment else {
+            return FileManager.default.temporaryDirectory
+        }
+
+        guard let groupUrl = FileManager.default.containerURL(
+            forSecurityApplicationGroupIdentifier: appGroupIdentifier
+        ) else {
+            fatalError("Failed getting container URL for group identifier: \(appGroupIdentifier)")
+        }
+        return groupUrl.appendingPathComponent("logs", isDirectory: true)
+    }
+
     var defaultDatabasesDirectoryURL: URL {
         guard !isTestingEnvironment else {
             return FileManager.default.temporaryDirectory

--- a/ConvosCore/Sources/ConvosCore/Inboxes/InboxStateMachine.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/InboxStateMachine.swift
@@ -871,7 +871,8 @@ public actor InboxStateMachine {
                 ExplodeSettingsCodec()
             ],
             dbEncryptionKey: keys.databaseKey,
-            dbDirectory: environment.defaultDatabasesDirectory
+            dbDirectory: environment.defaultDatabasesDirectory,
+            deviceSyncEnabled: false
         )
     }
 

--- a/NotificationService/NotificationService.swift
+++ b/NotificationService/NotificationService.swift
@@ -20,6 +20,7 @@ private let globalPushHandler: CachedPushNotificationHandler? = {
                 logLevel: .debug,
                 rotationSchedule: .hourly,
                 maxFiles: 10,
+                customLogDirectory: environment.defaultXMTPLogsDirectoryURL,
                 processType: .notificationExtension
             )
         }


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Route XMTP logs to the app group logs directory in the app and notification extension in non-production and disable device sync in newly built clients
Adds `AppEnvironment.defaultXMTPLogsDirectoryURL` and uses it to set `customLogDirectory` for `Client.activatePersistentLibXMTPLogWriter` in the app and notification extension for non-production. Updates the debug log enumeration to read from the app group logs directory. Sets `deviceSyncEnabled: false` in the client configuration builder.

#### 📍Where to Start
Start with the initialization in [Convos/ConvosApp.swift](https://github.com/ephemeraHQ/convos-ios/pull/251/files#diff-de23c5a6e10cb84b89d91ed62b707b654c28566f38cc339af8b3cbbf6e003014), then review `defaultXMTPLogsDirectoryURL` in [ConvosCore/Sources/ConvosCore/AppEnvironment.swift](https://github.com/ephemeraHQ/convos-ios/pull/251/files#diff-c41b4b73606649b51abcec3156d536e2b3978a8771275ac4be74dc15927c3580), and the notification extension setup in [NotificationService/NotificationService.swift](https://github.com/ephemeraHQ/convos-ios/pull/251/files#diff-cd6c8fdb4518bf3bbc5ee11b88947aa53f113197875ddb7ca91ee8dd4eb0eed4).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 02a2a74.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->