### PR TITLE
Fix photo picker dismiss

### DIFF
--- a/Convos/Conversation Detail/Messages/ConversationInfoButton.swift
+++ b/Convos/Conversation Detail/Messages/ConversationInfoButton.swift
@@ -105,6 +105,12 @@ struct ConversationInfoButton<InfoView: View>: View {
                 isExpanded = newValue == .conversationName ? true : false
             }
         }
+        .onChange(of: isImagePickerPresented) { _, newValue in
+            guard newValue == false else { return }
+            withAnimation(.bouncy(duration: 0.4, extraBounce: 0.01)) {
+                isExpanded = (focusCoordinator?.currentFocus == .conversationName)
+            }
+        }
     }
 }
 


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Add an `onChange` for `ConversationInfoButton.body` to re-evaluate and animate `isExpanded` when the photo picker dismisses in [ConversationInfoButton.swift](https://github.com/ephemeraHQ/convos-ios/pull/256/files#diff-d9521d4f71eaa69bb67fc5e04d6213ac6c46b9e0e7cfa25945eac68592ad8261)
Introduce an `onChange` handler tied to `isImagePickerPresented` that, on dismissal (`newValue == false`), triggers a bouncy animation and sets `isExpanded` based on `.conversationName` focus; retain the existing `onChange` for `focusCoordinator?.currentFocus` to avoid updates while the picker is shown.

#### 📍Where to Start
Start with the `body` view and its new `onChange(of: isImagePickerPresented)` handler in [ConversationInfoButton.swift](https://github.com/ephemeraHQ/convos-ios/pull/256/files#diff-d9521d4f71eaa69bb67fc5e04d6213ac6c46b9e0e7cfa25945eac68592ad8261).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 2007e2d.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->