### PR TITLE
Silent notifications when the app is in the foreground

### DIFF
--- a/Convos/ConvosAppDelegate.swift
+++ b/Convos/ConvosAppDelegate.swift
@@ -36,21 +36,7 @@ class ConvosAppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCent
     // Handle notifications when app is in foreground
     func userNotificationCenter(_ center: UNUserNotificationCenter,
                                 willPresent notification: UNNotification) async -> UNNotificationPresentationOptions {
-        // Check if we should display this notification based on the active conversation
-        let conversationId = notification.request.content.threadIdentifier
-
-        if !conversationId.isEmpty,
-           let session = session {
-            let shouldDisplay = await session.shouldDisplayNotification(for: conversationId)
-            if !shouldDisplay {
-                return []
-            }
-        }
-
-        // Show notification banner when app is in foreground
-        // NSE processes all notifications regardless of app state
-        Log.info("App in foreground - showing notification banner")
-        return [.banner]
+        return []
     }
 
     // Handle notification taps


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Suppress foreground notification banners by making `ConvosAppDelegate.userNotificationCenter(_:willPresent:)` always return an empty presentation option set in [ConvosAppDelegate.swift](https://github.com/ephemeraHQ/convos-ios/pull/257/files#diff-b60017894e41cfae5972dc1a8e7a570c0e178450b755274f727901dd3ab2976e)
Replaces conditional presentation logic with a constant empty `UNNotificationPresentationOptions` return in `ConvosAppDelegate.userNotificationCenter(_:willPresent:)`, removing logging and previous `.banner` presentation.

#### 📍Where to Start
Start with `ConvosAppDelegate.userNotificationCenter(_:willPresent:)` in [ConvosAppDelegate.swift](https://github.com/ephemeraHQ/convos-ios/pull/257/files#diff-b60017894e41cfae5972dc1a8e7a570c0e178450b755274f727901dd3ab2976e).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 8720e7e.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->