### PR TITLE
Update DM one-pager with simplified design

### DIFF
--- a/docs/plans/dm-from-group.md
+++ b/docs/plans/dm-from-group.md
@@ -151,3 +151,22 @@ Yes. Each intent creates a separate fresh identity, so you can have multiple pen
 3. **"Not interested" action**: Yes — tapping "Not interested" blocks future DM intents from that person. You can always change your mind by sending them an intent yourself.
 
 4. **Multiple pending intents**: Yes — you can signal intent to multiple people at the same time.
+
+---
+
+# Open Questions
+
+## DM intent discoverability
+
+The faint green glow on someone's avatar may not be visible enough — you only see it if that person is actively chatting in the group.
+
+**Constraints:**
+- No badge or dismissable notification
+- Should not feel like a "request" or intrusive
+
+**Ideas to explore:**
+1. **Sort members list** by who most recently sent a DM intent (one tap away from message list)
+2. **Temporary element** when re-entering the convo that teaches you to look at members list, then auto-dismisses
+3. **Info island treatment** — where it shows "11 people", show something like "New DM request" with motion design that draws attention then removes itself
+
+**Current approach:** Ship with the green glow, learn from usage, iterate.

--- a/docs/plans/dm-from-group.md
+++ b/docs/plans/dm-from-group.md
@@ -1,0 +1,153 @@
+# DMs
+
+Today we're introducing private DMs from within group conversations, so you can take a conversation one-on-one without anyone knowing you did.
+
+---
+
+## Meet someone, then meet again
+
+You meet people in group convos. Sometimes you want to connect with them privately. On other apps, sliding into someone's DMs means they see your profile, your history, your identity. On Convos, starting a DM means starting fresh — a new identity for both of you, no strings attached to the group where you met.
+
+## Consent goes both ways
+
+You can't just DM someone. You signal that you're open to it, they decide if they want to connect. No one gets added to a conversation they didn't agree to. And because the person who accepts creates the DM, they're in control — they decide when it explodes.
+
+## Ephemeral by design
+
+The connection between your group identity and your DM identity is temporary. Once the signal expires, there's no trace linking the two. You showed up how you chose in the group, you show up how you choose in the DM.
+
+---
+
+# How DMs work
+
+## Signaling intent
+
+When you want to DM someone you've met in a group:
+
+- Long-press their avatar in the message list
+- Tap "Open to DM"
+- A faint green circle appears around your avatar (from their perspective)
+
+Behind the scenes, your client creates a fresh inbox — your new identity for this DM. A signal is sent to the other person via XMTP containing your new inbox ID and a short-lived tag. This signal is allowed through because you're already in a trusted conversation together.
+
+## Accepting
+
+When someone signals they're open to a DM with you:
+
+- You see a faint green circle around their avatar in the message list and on their profile sheet
+- Tap it to see: "<Name> is open to a DM"
+- Tap "Accept" or "Not interested"
+
+If you accept, your client creates your fresh identity, creates the DM conversation, adds their inbox ID, and locks the conversation so no one else can join. You're the creator — you control when this DM explodes.
+
+If you tap "Not interested," future DM intents from this person are blocked. You can always change your mind later by sending them a DM intent yourself.
+
+## The DM appears
+
+Once accepted:
+
+- The DM shows up in both your home lists immediately
+- The green circle around their avatar becomes solid (no longer faint)
+- Tapping the solid green circle takes you to the DM
+- When the original signal expires, the green circle disappears — the ephemeral link between identities dissolves
+
+## Fresh identities
+
+Both people get new identities for the DM. There's no connection to your group identity visible to anyone — not the other person, not other group members, not Convos. You decide how to show up in the DM: new name, new photo, or the same as before.
+
+## They're in control
+
+The person who accepts the DM request is the creator. They have super admin powers. When they decide the DM has run its course, they can explode it — destroying all messages and both identities cryptographically.
+
+---
+
+# Who cares
+
+Group chats are where you meet people. But sometimes you want a private sidebar without broadcasting that you're having one. Traditional messaging apps make this awkward, they reveal your full identity and creates a permanent connection.
+
+Convos DMs are different. They're initiated with mutual consent, built on fresh identities, and leave no trace connecting back to how you met.
+
+---
+
+# Technical notes
+
+## The DMIntent message
+
+When you signal intent to DM, your client sends a custom XMTP content type:
+
+- **Your new inbox ID**: The fresh identity you'll use for the DM
+- **A DM tag**: A random identifier to correlate your request with the conversation you're added to
+- **Expiration**: This is a disappearing message (7 days) — when it expires, the green circle goes away
+
+This message is delivered because your existing inbox ID (from the group) already has approved consent state with the recipient.
+
+## Conversation creation
+
+When the other person accepts:
+
+1. They create a new inbox (their fresh DM identity)
+2. They create a new XMTP conversation (they're super admin)
+3. They add your inbox ID to the conversation
+4. They set the DM tag in conversation metadata
+5. They lock the conversation (no additional members allowed)
+
+## Verification
+
+When you're added to the DM conversation:
+
+1. Your client syncs the new conversation
+2. Checks if the conversation's DM tag matches the tag from your DMIntent
+3. If it matches, the DM is revealed in your home list
+4. If it doesn't match, the conversation is rejected (someone tried to add you to an unrelated convo)
+
+## Expiration and the green circle
+
+- The solid green circle persists while the DMIntent message exists
+- Once the disappearing message expires, the circle goes away
+- The DM itself remains — only the visual indicator of "how you connected" dissolves
+- This ensures the link between group identity and DM identity is ephemeral
+
+## Locking the conversation
+
+XMTP group permissions are set so:
+
+- Only the two inbox IDs can be members
+- No one can add additional members
+- The creator (accepter) retains super admin for explode control
+
+---
+
+# FAQ
+
+**What if I signal intent but they never see it?**
+The disappearing message expires and the faint green circle goes away. You can signal again whenever you want.
+
+**Can I DM someone I'm not in a group with?**
+Not with this flow. This is specifically for connecting with people you've already met in a conversation. No requests box, ever.
+
+**Do they see my group identity when I signal intent?**
+They see your avatar and name from the group — that's how they know who's reaching out. But the DM itself uses your fresh identity.
+
+**Can I change my name/photo for the DM?**
+Yes. When you signal intent, a new inbox is created. You can choose to use your quickname, or not, once the DM starts.
+
+**Can the other person see that I signaled intent to others?**
+No. The DMIntent is sent via private XMTP DM between your group identities. No one else in the group can see it.
+
+**What if I tapped "Not interested" but changed my mind?**
+Send them a DM intent yourself. That unblocks them and signals you're now open to connecting.
+
+**Can I signal intent to multiple people?**
+Yes. Each intent creates a separate fresh identity, so you can have multiple pending requests at once.
+
+---
+
+# Decisions
+
+1. **Green circle on profile sheet**: Yes — the DM status indicator appears both in the message list and on the profile sheet.
+
+2. **DMIntent expiration**: 7 days. Long enough to catch people who don't check the app daily, short enough to feel ephemeral.
+
+3. **"Not interested" action**: Yes — tapping "Not interested" blocks future DM intents from that person. You can always change your mind by sending them an intent yourself.
+
+4. **Multiple pending intents**: Yes — you can signal intent to multiple people at the same time.

--- a/docs/plans/dm-from-group.md
+++ b/docs/plans/dm-from-group.md
@@ -107,18 +107,19 @@ The select members list is private — it is never shared with the group or any 
 
 Profiles are stored per-conversation per-member in the `memberProfile` table. The `ConversationWriter` also writes profiles to XMTP appData as a best-effort fallback for older clients. The authoritative source is always the `ProfileUpdate`/`ProfileSnapshot` messages — appData is only used to fill gaps for members that haven't sent a profile message yet.
 
-## The DMRequest message
+## The convo_request message
 
-A new custom XMTP content type (`convos.org/dm_request`) sent via the 1:1 DM back channel between the two members' group inbox IDs — the same mechanism used for invite join requests. This keeps DM requests out of the group message history entirely.
+A new custom XMTP content type (`convos.org/convo_request`) sent via the 1:1 back channel between the two members' group inbox IDs — the same mechanism used for invite join requests. This keeps convo requests out of the group message history entirely.
 
 The message contains:
 
-- **Your new inbox ID**: The fresh identity you'll use for the DM
-- **A DM tag**: A random identifier to correlate your request with the conversation you're added to
+- **Your new inbox ID**: The fresh identity you'll use for the new conversation
+- **A convo tag**: A random identifier to correlate your request with the conversation you're added to
 - **The origin conversation ID**: So the receiver's client can look up DM settings for that group
-- **Expiration**: This is a disappearing message. When it expires, the context linking the DM to the original convo disappears
+- **Invite slug** (optional): If present, the receiver joins an existing group via this invite (group spinoff). If absent, the receiver creates a new 1:1 conversation (DM).
+- **Expiration**: This is a disappearing message. When it expires, the context linking the new conversation to the original group disappears
 
-This message is delivered because both members' group inbox IDs already have an XMTP DM channel between them (used for join request processing). The DM request is processed silently by the receiver's client — not displayed as a chat message.
+This message is delivered because both members' group inbox IDs already have an XMTP DM channel between them (used for join request processing). The convo request is processed silently by the receiver's client — not displayed as a chat message.
 
 ## Conversation creation
 
@@ -161,52 +162,60 @@ XMTP group permissions are set so:
 
 # Group spinoffs
 
-> **Status: deferred.** Group spinoffs will be implemented after DMs ship. The design below outlines the direction but has open questions that need to be resolved before building.
+> **Status: deferred.** Group spinoffs will be implemented after DMs ship. The design below is fully specified.
 
 The DM flow generalizes to starting a new group with a subset of members from an existing conversation — without the rest knowing.
 
+## UI flow
+
+1. In conversation settings, below the "X members" row, a button reads **"Spinoff new Convo"** with footer text "Invite members to a new Convo"
+2. Tapping opens a member picker showing all members except the current user
+3. The user selects one or more members (minimum 1) and taps **"Pop up new convo"**
+4. The sender is taken to a `ConversationView` for the new group. A toast above the messages input bar (same style as quickname UI) shows "✓ invites sent" and auto-dismisses
+
 ## How it works
 
-1. In the member list, select multiple members
-2. Your client creates a fresh inbox and a new XMTP group
-3. Sends a `GroupInviteRequest` through the back channel to each selected member individually
-4. Each recipient's client checks DM settings independently, creates a fresh inbox, and joins the group if approved
+1. The sender's client creates a fresh inbox and a new XMTP group (sender is super admin)
+2. Generates an invite for the new group
+3. Sends a `convo_request` through the back channel to each selected member individually, including the invite slug
+4. Each recipient's client checks `allows_dms` settings independently, creates a fresh inbox, and joins via the invite if approved
+5. The sender (as super admin) processes join requests as recipients join
 
-The sender creates the group immediately — no waiting for acceptance. Recipients join asynchronously as they come online and process the request.
+The sender creates the group immediately — no waiting for acceptance. Recipients join asynchronously as they come online and process the request. The sender sees the conversation view as they would when creating any new conversation (no pending member indicators).
+
+## Permissions
+
+- **Sender**: super admin of the spinoff group
+- **Invited members**: join as admins (can add more people later)
+- The group is not locked — members can add others after joining
+
+## Conversation naming
+
+The UI displays "[origin convo name] spinoff" if no name has been set. This is a client-side display convention, not stored as the XMTP group name. There is no visible link back to the origin conversation.
 
 ## Reuses the DM infrastructure
 
-- **Same back channel**: 1:1 DM channel between group inbox IDs (used for join requests and DM requests)
-- **Same consent logic**: `allowsDMs` setting controls reachability for both DMs and group spinoffs
+Both DMs and group spinoffs use a single content type: `convos.org/convo_request`. The message includes an optional invite slug:
+
+- **DM (1:1)**: No invite slug. The receiver creates the conversation.
+- **Group spinoff**: Includes an invite slug. The receiver joins the sender's existing group via the invite.
+
+Other shared infrastructure:
+- **Same back channel**: 1:1 DM channel between group inbox IDs (used for join requests and convo requests)
+- **Same consent logic**: `allows_dms` setting controls reachability for both DMs and group spinoffs. Only recipients need the flag enabled; the sender does not.
 - **Same fresh identities**: Everyone gets a new inbox for the new group
 - **Same select members filtering**: If a recipient only allows DMs from select members, the group invite is filtered the same way
 
 ## Differences from DMs
 
 - The sender creates the group upfront (not the receiver)
-- The group is not locked — members could add others later
+- The group is not locked — members can add others later
 - Each invited member receives their own back channel message and decides independently
 - Members who don't accept (or have DMs off) simply never join — no one knows they were invited
 
-## The GroupInviteRequest message
+## Abuse prevention
 
-Sent through the back channel to each invitee. Could reuse the `DMRequest` content type with additional fields, or be a separate content type — to be decided during implementation.
-
-Contents:
-
-- **Sender's new inbox ID**: Their fresh identity for the new group
-- **Conversation ID**: The new group's XMTP conversation ID (to join)
-- **Origin conversation ID**: Which group the invite came from (for consent checks)
-- **Expiration**: Disappearing message, same as DM requests
-
-## Open questions
-
-- **UI entry point**: How do users enter multi-select mode in the member list? Dedicated button? Long-press?
-- **Admin permissions**: Is the sender super admin of the spinoff group? What permission level do joiners get?
-- **Conversation naming**: Does the spinoff group get a default name? Any visible link back to the origin?
-- **Pending state**: What does the sender see while waiting for others to join? Placeholder members?
-- **Sender's DM flag**: Does the sender need `allows_dms` enabled, or only recipients?
-- **Abuse prevention**: Can someone spam invites to all members of a large group? Rate limiting needed?
+The `allows_dms` filtering on the receiving end gates all convo requests. If a member has DMs off, spinoff invites from that conversation are silently ignored. No additional rate limiting is needed.
 
 ---
 

--- a/docs/plans/dm-from-group.md
+++ b/docs/plans/dm-from-group.md
@@ -122,12 +122,14 @@ This message is delivered because both members' group inbox IDs already have an 
 
 ## Conversation creation
 
+DM conversations are standard XMTP group conversations — there is no special "DM" conversation type. The only difference is the entry point: instead of being created from an invite link, they're created from within an existing group. Once created, they look and behave like any other conversation.
+
 When the receiver's client processes the request:
 
-1. Creates a new inbox (their fresh DM identity)
-2. Creates a new XMTP conversation (they're super admin)
+1. Creates a new inbox (their fresh identity for this conversation)
+2. Creates a new XMTP group conversation (they're super admin)
 3. Adds the sender's new inbox ID to the conversation
-4. Sets the DM tag in conversation metadata
+4. Sets the DM tag in conversation metadata (for origin context display)
 5. Locks the conversation (no additional members allowed)
 6. Sets consent state based on their DM settings
 

--- a/docs/plans/dm-from-group.md
+++ b/docs/plans/dm-from-group.md
@@ -59,7 +59,7 @@ The sender doesn't know whether they were auto-approved or silently ignored.
 Once the DM is created:
 
 - It shows up in both home lists immediately
-- Context is shown: "From [display name] in [convo name]" for the receiver, or "To [display name] in [convo name]" for the sender
+- In the conversations list, the sender label area (where the member name normally appears) shows origin context: "[display name] from [convo name]". The origin conversation's image may also be shown alongside the convo name for visual recognition
 - This context expires when the DM request message expires
 
 ---
@@ -159,6 +159,8 @@ XMTP group permissions are set so:
 
 # Group spinoffs
 
+> **Status: deferred.** Group spinoffs will be implemented after DMs ship. The design below outlines the direction but has open questions that need to be resolved before building.
+
 The DM flow generalizes to starting a new group with a subset of members from an existing conversation — without the rest knowing.
 
 ## How it works
@@ -186,12 +188,23 @@ The sender creates the group immediately — no waiting for acceptance. Recipien
 
 ## The GroupInviteRequest message
 
-Sent through the back channel to each invitee:
+Sent through the back channel to each invitee. Could reuse the `DMRequest` content type with additional fields, or be a separate content type — to be decided during implementation.
+
+Contents:
 
 - **Sender's new inbox ID**: Their fresh identity for the new group
 - **Conversation ID**: The new group's XMTP conversation ID (to join)
 - **Origin conversation ID**: Which group the invite came from (for consent checks)
 - **Expiration**: Disappearing message, same as DM requests
+
+## Open questions
+
+- **UI entry point**: How do users enter multi-select mode in the member list? Dedicated button? Long-press?
+- **Admin permissions**: Is the sender super admin of the spinoff group? What permission level do joiners get?
+- **Conversation naming**: Does the spinoff group get a default name? Any visible link back to the origin?
+- **Pending state**: What does the sender see while waiting for others to join? Placeholder members?
+- **Sender's DM flag**: Does the sender need `allows_dms` enabled, or only recipients?
+- **Abuse prevention**: Can someone spam invites to all members of a large group? Rate limiting needed?
 
 ---
 

--- a/docs/plans/dm-from-group.md
+++ b/docs/plans/dm-from-group.md
@@ -28,7 +28,7 @@ In any conversation, you can toggle "Allow DMs" in settings:
 - **From everyone**: Anyone in this convo can DM you (default when enabled)
 - **From select members**: Only specific people you choose can DM you
 
-Your `allowsDMs` flag is stored in your profile metadata for the group. Everyone can see who has DMs enabled, but they can't see if someone only allows select members.
+When you toggle this setting, your client sends a `ProfileUpdate` message to the group with the updated `allows_dms` field. Everyone can see who has DMs enabled, but they can't see if someone only allows select members.
 
 ## Sending a DM
 
@@ -39,7 +39,7 @@ When you want to DM someone:
 
 The "Send DM" button only appears if they have DMs enabled for this convo.
 
-Behind the scenes, your client creates a fresh inbox (your new identity for this DM) and sends a DM request to the other person via XMTP as a disappearing message, so the tie to the original convo is ephemeral.
+Behind the scenes, your client creates a fresh inbox (your new identity for this DM) and sends a DM request as a disappearing message through the 1:1 back channel between your group inbox IDs (the same channel used for join requests), so the tie to the original convo is ephemeral.
 
 ## Receiving a DM request
 
@@ -76,21 +76,48 @@ Convos DMs are different. They're initiated with mutual consent, filtered by you
 
 ## Profile metadata
 
-The `allowsDMs` flag is stored in the user's Profile in the group's custom metadata:
+The `allowsDMs` flag is a field on the `ProfileUpdate` message type (see PR #552). When a member enables or disables DMs, their client sends a `ProfileUpdate` with the updated `allows_dms` field. This follows the same infrastructure used for name and avatar updates:
 
-- Everyone in the group can read this flag
+- The flag is included in `ProfileSnapshot` messages, so new joiners immediately know who has DMs enabled
+- Everyone in the group can read this flag (it's in the profile data)
 - Used to conditionally show the "Send DM" button
 - Does not reveal whether the user has a select members list
 
+The select members list is private — it is never shared with the group or any other member. See "Select members list" below for storage.
+
+### Proto changes
+
+```protobuf
+message ProfileUpdate {
+    optional string name = 1;
+    optional EncryptedProfileImageRef encrypted_image = 2;
+    MemberKind member_kind = 3;
+    optional bool allows_dms = 4;  // new
+}
+
+message MemberProfile {
+    bytes inbox_id = 1;
+    optional string name = 2;
+    optional EncryptedProfileImageRef encrypted_image = 3;
+    MemberKind member_kind = 4;
+    optional bool allows_dms = 5;  // new
+}
+```
+
+Old clients ignore the `allows_dms` field (protobuf forward compatibility). Members on old clients will appear as DMs-disabled (field absent = false).
+
 ## The DMRequest message
 
-When you send a DM request, your client sends a custom XMTP content type:
+A new custom XMTP content type (`convos.org/dm_request`) sent via the 1:1 DM back channel between the two members' group inbox IDs — the same mechanism used for invite join requests. This keeps DM requests out of the group message history entirely.
+
+The message contains:
 
 - **Your new inbox ID**: The fresh identity you'll use for the DM
 - **A DM tag**: A random identifier to correlate your request with the conversation you're added to
+- **The origin conversation ID**: So the receiver's client can look up DM settings for that group
 - **Expiration**: This is a disappearing message. When it expires, the context linking the DM to the original convo disappears
 
-This message is delivered because your existing inbox ID (from the group) already has approved consent state with the recipient.
+This message is delivered because both members' group inbox IDs already have an XMTP DM channel between them (used for join request processing). The DM request is processed silently by the receiver's client — not displayed as a chat message.
 
 ## Conversation creation
 
@@ -98,17 +125,23 @@ When the receiver's client processes the request:
 
 1. Creates a new inbox (their fresh DM identity)
 2. Creates a new XMTP conversation (they're super admin)
-3. Adds the sender's inbox ID to the conversation
+3. Adds the sender's new inbox ID to the conversation
 4. Sets the DM tag in conversation metadata
 5. Locks the conversation (no additional members allowed)
 6. Sets consent state based on their DM settings
+
+## Select members list
+
+The select members list is stored as a self-addressed XMTP message — you send it to your own inbox ID's DM channel. XMTP encryption means only your installations can read it.
+
+Each message contains a conversation ID and the list of allowed inbox IDs. When you update the list, send a new message. On new device or reinstall, read the latest per conversation.
 
 ## Consent logic
 
 The consent check happens on the receiver's device:
 
 - If "From everyone": consent is set to approved immediately
-- If "From select members": consent is approved only if sender is in the list
+- If "From select members": checks the local select members list (stored in GRDB, never shared). Approved only if sender is in the list
 - If not approved, the conversation exists but won't surface notifications or appear prominently
 
 The sender has no way to know which path was taken.
@@ -120,6 +153,44 @@ XMTP group permissions are set so:
 - Only the two inbox IDs can be members
 - No one can add additional members
 - The creator (receiver) retains super admin for explode control
+
+---
+
+# Group spinoffs
+
+The DM flow generalizes to starting a new group with a subset of members from an existing conversation — without the rest knowing.
+
+## How it works
+
+1. In the member list, select multiple members
+2. Your client creates a fresh inbox and a new XMTP group
+3. Sends a `GroupInviteRequest` through the back channel to each selected member individually
+4. Each recipient's client checks DM settings independently, creates a fresh inbox, and joins the group if approved
+
+The sender creates the group immediately — no waiting for acceptance. Recipients join asynchronously as they come online and process the request.
+
+## Reuses the DM infrastructure
+
+- **Same back channel**: 1:1 DM channel between group inbox IDs (used for join requests and DM requests)
+- **Same consent logic**: `allowsDMs` setting controls reachability for both DMs and group spinoffs
+- **Same fresh identities**: Everyone gets a new inbox for the new group
+- **Same select members filtering**: If a recipient only allows DMs from select members, the group invite is filtered the same way
+
+## Differences from DMs
+
+- The sender creates the group upfront (not the receiver)
+- The group is not locked — members could add others later
+- Each invited member receives their own back channel message and decides independently
+- Members who don't accept (or have DMs off) simply never join — no one knows they were invited
+
+## The GroupInviteRequest message
+
+Sent through the back channel to each invitee:
+
+- **Sender's new inbox ID**: Their fresh identity for the new group
+- **Conversation ID**: The new group's XMTP conversation ID (to join)
+- **Origin conversation ID**: Which group the invite came from (for consent checks)
+- **Expiration**: Disappearing message, same as DM requests
 
 ---
 
@@ -146,11 +217,13 @@ Yes. When you send a DM request, a new inbox is created. You can choose to use y
 
 1. **Allow DMs toggle**: Per-conversation setting with three states: off, everyone, select members.
 
-2. **Profile metadata**: The `allowsDMs` flag is public within the group. Select members list is private.
+2. **Profile messages for `allowsDMs`**: The flag is a field on `ProfileUpdate` / `MemberProfile` (PR #552's profile message infrastructure). It flows through the existing codec, snapshot, and GRDB persistence pipeline. No new content type needed for the flag itself.
 
-3. **Silent filtering**: Senders don't know if they're on the approved list. No rejection notification.
+3. **Select members list is private**: Synced across your devices via self-addressed XMTP messages. Never shared with the group. The sender cannot determine whether they're on someone's list.
 
-4. **Context expiration**: The link between DM and origin convo is ephemeral, tied to the DM request message lifetime.
+4. **Silent filtering**: Senders don't know if they're on the approved list. No rejection notification.
+
+5. **Context expiration**: The link between DM and origin convo is ephemeral, tied to the DM request message lifetime.
 
 ---
 

--- a/docs/plans/dm-from-group.md
+++ b/docs/plans/dm-from-group.md
@@ -76,35 +76,36 @@ Convos DMs are different. They're initiated with mutual consent, filtered by you
 
 ## Profile metadata
 
-The `allowsDMs` flag is a field on the `ProfileUpdate` message type (see PR #552). When a member enables or disables DMs, their client sends a `ProfileUpdate` with the updated `allows_dms` field. This follows the same infrastructure used for name and avatar updates:
+Profile data is transmitted via two custom XMTP content types defined in the `ConvosProfiles` package:
 
-- The flag is included in `ProfileSnapshot` messages, so new joiners immediately know who has DMs enabled
+- **`convos.org/profile_update`** — sent by a member when they change their own profile (name, avatar, or metadata). The sender's inbox ID is implicit from the XMTP message envelope.
+- **`convos.org/profile_snapshot`** — sent by the member who adds new members to a group. Contains all current member profiles so new joiners have everyone's data immediately (solves the MLS forward secrecy gap where new members can't decrypt older messages).
+
+Both message types include a `metadata` map (`map<string, MetadataValue>`) that supports typed key-value pairs (string, number, or bool). This map is already used for agent attestation fields and is the extension point for new profile features.
+
+### How `allows_dms` works
+
+The `allows_dms` flag uses the existing `metadata` map on `ProfileUpdate` and `MemberProfile` — no proto schema changes needed:
+
+```
+metadata["allows_dms"] = MetadataValue(bool_value: true)
+```
+
+When a member toggles their DM setting, their client sends a `ProfileUpdate` with the updated metadata. The flag flows through the existing pipeline:
+
+- Persisted in `DBMemberProfile.metadata` (GRDB)
+- Included in `ProfileSnapshot` messages, so new joiners immediately know who has DMs enabled
 - Everyone in the group can read this flag (it's in the profile data)
 - Used to conditionally show the "Send DM" button
 - Does not reveal whether the user has a select members list
 
+Old clients ignore unknown metadata keys (the map is additive). Members on old clients will appear as DMs-disabled (key absent = false).
+
 The select members list is private — it is never shared with the group or any other member. See "Select members list" below for storage.
 
-### Proto changes
+### Profile architecture reference
 
-```protobuf
-message ProfileUpdate {
-    optional string name = 1;
-    optional EncryptedProfileImageRef encrypted_image = 2;
-    MemberKind member_kind = 3;
-    optional bool allows_dms = 4;  // new
-}
-
-message MemberProfile {
-    bytes inbox_id = 1;
-    optional string name = 2;
-    optional EncryptedProfileImageRef encrypted_image = 3;
-    MemberKind member_kind = 4;
-    optional bool allows_dms = 5;  // new
-}
-```
-
-Old clients ignore the `allows_dms` field (protobuf forward compatibility). Members on old clients will appear as DMs-disabled (field absent = false).
+Profiles are stored per-conversation per-member in the `memberProfile` table. The `ConversationWriter` also writes profiles to XMTP appData as a best-effort fallback for older clients. The authoritative source is always the `ProfileUpdate`/`ProfileSnapshot` messages — appData is only used to fill gaps for members that haven't sent a profile message yet.
 
 ## The DMRequest message
 


### PR DESCRIPTION
Replace intent/accept flow with per-convo "Allow DMs" toggle (off/everyone/select members). Removes green circle UI, adds silent filtering so senders never know if they're approved. Ephemeral context shows origin conversation. Inline member picker for select members management.

Updated Notion doc and local one-pager with new flow.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add planning document for private DMs initiated from group conversations
> Adds [dm-from-group.md](https://github.com/xmtplabs/convos-ios/pull/398/files#diff-2b6ffceaf45165f1bddaac921cf1ac8197edf470ddd376e336e565ee5836243b), a design document covering the UX flow, XMTP content types, consent logic, identity creation, and conversation lifecycle for private DMs started from group chats.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 61975d4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->