### PR TITLE
Add balloon sway animation

### DIFF
--- a/Convos/App Settings/AppSettingsView.swift
+++ b/Convos/App Settings/AppSettingsView.swift
@@ -14,6 +14,7 @@ struct ConvosToolbarButton: View {
                     .renderingMode(.template)
                     .foregroundStyle(.colorFillPrimary)
                     .frame(width: 16.0, height: 20.0)
+                    .balloonSway()
                     .frame(width: 24.0, height: 24.0)
 
                 Text("Convos")

--- a/Convos/Design System/Animation/BalloonSwayModifier.swift
+++ b/Convos/Design System/Animation/BalloonSwayModifier.swift
@@ -1,0 +1,29 @@
+import SwiftUI
+
+struct BalloonSwayModifier: ViewModifier {
+    var motionManager: DeviceMotionManager = .shared
+
+    func body(content: Content) -> some View {
+        content
+            .rotationEffect(
+                .degrees(motionManager.rollAngle),
+                anchor: Constant.circleCenter
+            )
+            .onAppear {
+                motionManager.startUpdates()
+            }
+            .onDisappear {
+                motionManager.stopUpdates()
+            }
+    }
+
+    private enum Constant {
+        static let circleCenter: UnitPoint = .init(x: 0.5, y: 0.4)
+    }
+}
+
+extension View {
+    func balloonSway() -> some View {
+        modifier(BalloonSwayModifier())
+    }
+}

--- a/Convos/Design System/Animation/DeviceMotionManager.swift
+++ b/Convos/Design System/Animation/DeviceMotionManager.swift
@@ -1,0 +1,83 @@
+import CoreMotion
+import Foundation
+import Observation
+
+@MainActor
+@Observable
+final class DeviceMotionManager {
+    static let shared: DeviceMotionManager = .init()
+
+    private(set) var rollAngle: Double = 0.0
+
+    private let motionManager: CMMotionManager = .init()
+    private var activeListenerCount: Int = 0
+    private var idleSwayPhase: Double = 0.0
+    private var idleSwayTimer: Timer?
+
+    private var isDeviceMotionAvailable: Bool { motionManager.isDeviceMotionAvailable }
+
+    private init() {}
+
+    func startUpdates() {
+        activeListenerCount += 1
+        guard activeListenerCount == 1 else { return }
+
+        #if targetEnvironment(simulator)
+        startIdleSway()
+        #else
+        if isDeviceMotionAvailable {
+            stopIdleSway()
+            startDeviceMotion()
+        } else {
+            startIdleSway()
+        }
+        #endif
+    }
+
+    func stopUpdates() {
+        activeListenerCount -= 1
+        guard activeListenerCount <= 0 else { return }
+        activeListenerCount = 0
+
+        motionManager.stopDeviceMotionUpdates()
+        startIdleSway()
+    }
+
+    private func startDeviceMotion() {
+        motionManager.deviceMotionUpdateInterval = Constant.updateInterval
+        motionManager.startDeviceMotionUpdates(using: .xArbitraryZVertical, to: .main) { [weak self] motion, _ in
+            Task { @MainActor [weak self] in
+                guard let self, let gravity = motion?.gravity else { return }
+                let rawAngle: Double = asin(max(-1, min(1, gravity.x))) * (180.0 / .pi)
+                let clamped: Double = max(-Constant.maxAngle, min(Constant.maxAngle, rawAngle))
+                self.rollAngle = self.rollAngle * (1 - Constant.smoothingFactor) + clamped * Constant.smoothingFactor
+            }
+        }
+    }
+
+    private func startIdleSway() {
+        guard idleSwayTimer == nil else { return }
+        idleSwayTimer = Timer.scheduledTimer(withTimeInterval: Constant.updateInterval, repeats: true) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                self.idleSwayPhase += Constant.idleSwaySpeed
+                self.rollAngle = sin(self.idleSwayPhase) * Constant.idleSwayPrimaryAmplitude
+                    + sin(self.idleSwayPhase * 0.7) * Constant.idleSwaySecondaryAmplitude
+            }
+        }
+    }
+
+    private func stopIdleSway() {
+        idleSwayTimer?.invalidate()
+        idleSwayTimer = nil
+    }
+
+    private enum Constant {
+        static let updateInterval: TimeInterval = 1.0 / 30.0
+        static let maxAngle: Double = 30.0
+        static let smoothingFactor: Double = 0.12
+        static let idleSwaySpeed: Double = 0.03
+        static let idleSwayPrimaryAmplitude: Double = 20.0
+        static let idleSwaySecondaryAmplitude: Double = 10.0
+    }
+}


### PR DESCRIPTION
## Summary

The balloon icon in the conversations toolbar now responds to device tilt via CoreMotion. When the user tilts the phone, the balloon smoothly sways following gravity (±30° max). On simulator, an idle sway keeps the animation running for preview purposes.

## Implementation

- **DeviceMotionManager**: Singleton observable class wrapping CMMotionManager, reads `gravity.x` via device motion updates at 30Hz
- **BalloonSwayModifier**: ViewModifier applying rotationEffect anchored at the circle center, manages motion manager lifecycle
- **Exponential smoothing**: Applies 0.12 factor for floaty feel (~280ms lag to 63% of target angle)
- **Reference counting**: Stops motion updates when no listeners are active to preserve battery

## Test Plan

- [x] Build on device and tilt phone left/right — balloon sways smoothly
- [x] Run on simulator — idle sway animation plays 
- [x] Lint passes (0 violations)