### PR TITLE
Add force re-upload from cache for expired assets

### DIFF
--- a/Convos/App Settings/AppSettingsViewModel.swift
+++ b/Convos/App Settings/AppSettingsViewModel.swift
@@ -13,7 +13,7 @@ final class AppSettingsViewModel {
 
     // MARK: - Dependencies
 
-    private let session: any SessionManagerProtocol
+    let session: any SessionManagerProtocol
 
     init(session: any SessionManagerProtocol) {
         self.session = session

--- a/Convos/App Settings/AppSettingsViewModel.swift
+++ b/Convos/App Settings/AppSettingsViewModel.swift
@@ -13,7 +13,7 @@ final class AppSettingsViewModel {
 
     // MARK: - Dependencies
 
-    let session: any SessionManagerProtocol
+    private let session: any SessionManagerProtocol
 
     init(session: any SessionManagerProtocol) {
         self.session = session

--- a/Convos/Debug View/DebugAssetRenewalView.swift
+++ b/Convos/Debug View/DebugAssetRenewalView.swift
@@ -148,7 +148,7 @@ private struct AssetRow: View {
             .disabled(asset.key == nil)
 
             let renewAction = {
-                Task { await renewSingleAsset() }
+                _ = Task { await renewSingleAsset() }
             }
             Button(action: renewAction) {
                 Label("Renew Asset", systemImage: "arrow.clockwise")
@@ -156,7 +156,7 @@ private struct AssetRow: View {
             .disabled(isRenewing || asset.key == nil)
 
             let reuploadAction = {
-                Task { await forceReuploadFromCache() }
+                _ = Task { await forceReuploadFromCache() }
             }
             Button(action: reuploadAction) {
                 Label("Force Re-upload from Cache", systemImage: "arrow.up.circle")

--- a/Convos/Debug View/DebugAssetRenewalView.swift
+++ b/Convos/Debug View/DebugAssetRenewalView.swift
@@ -153,7 +153,7 @@ private struct AssetRow: View {
             Button(action: renewAction) {
                 Label("Renew Asset", systemImage: "arrow.clockwise")
             }
-            .disabled(isRenewing || asset.key == nil)
+            .disabled(isRenewing || isReuploading || asset.key == nil)
 
             let reuploadAction = {
                 _ = Task { await forceReuploadFromCache() }
@@ -161,7 +161,7 @@ private struct AssetRow: View {
             Button(action: reuploadAction) {
                 Label("Force Re-upload from Cache", systemImage: "arrow.up.circle")
             }
-            .disabled(isReuploading)
+            .disabled(isRenewing || isReuploading)
         }
     }
 

--- a/Convos/Debug View/DebugAssetRenewalView.swift
+++ b/Convos/Debug View/DebugAssetRenewalView.swift
@@ -147,16 +147,18 @@ private struct AssetRow: View {
             }
             .disabled(asset.key == nil)
 
-            Button {
+            let renewAction = {
                 Task { await renewSingleAsset() }
-            } label: {
+            }
+            Button(action: renewAction) {
                 Label("Renew Asset", systemImage: "arrow.clockwise")
             }
             .disabled(isRenewing || asset.key == nil)
 
-            Button {
+            let reuploadAction = {
                 Task { await forceReuploadFromCache() }
-            } label: {
+            }
+            Button(action: reuploadAction) {
                 Label("Force Re-upload from Cache", systemImage: "arrow.up.circle")
             }
             .disabled(isReuploading)

--- a/Convos/Debug View/DebugAssetRenewalView.swift
+++ b/Convos/Debug View/DebugAssetRenewalView.swift
@@ -103,6 +103,7 @@ private struct AssetRow: View {
     let onRenewalComplete: (String) -> Void
 
     @State private var isRenewing: Bool = false
+    @State private var isReuploading: Bool = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
@@ -113,7 +114,7 @@ private struct AssetRow: View {
 
                 Spacer()
 
-                if isRenewing {
+                if isRenewing || isReuploading {
                     ProgressView()
                         .scaleEffect(0.8)
                 }
@@ -152,6 +153,13 @@ private struct AssetRow: View {
                 Label("Renew Asset", systemImage: "arrow.clockwise")
             }
             .disabled(isRenewing || asset.key == nil)
+
+            Button {
+                Task { await forceReuploadFromCache() }
+            } label: {
+                Label("Force Re-upload from Cache", systemImage: "arrow.up.circle")
+            }
+            .disabled(isReuploading)
         }
     }
 
@@ -184,6 +192,24 @@ private struct AssetRow: View {
         } else {
             onRenewalComplete("Renewal failed. Check logs.")
         }
+    }
+
+    private func forceReuploadFromCache() async {
+        guard !isReuploading else { return }
+        isReuploading = true
+
+        do {
+            let success = try await session.forceReuploadAssetFromCache(asset)
+            if success {
+                onRenewalComplete("Re-uploaded from cache successfully")
+            } else {
+                onRenewalComplete("Image not found in cache")
+            }
+        } catch {
+            onRenewalComplete("Re-upload failed: \(error.localizedDescription)")
+        }
+
+        isReuploading = false
     }
 }
 

--- a/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient+Models.swift
+++ b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient+Models.swift
@@ -197,10 +197,17 @@ public struct AssetRenewalResult: Sendable {
     public let renewed: Int
     public let failed: Int
     public let expiredKeys: [String]
+    public let renewedKeys: [String]
 
-    public init(renewed: Int, failed: Int, expiredKeys: [String]) {
+    public init(
+        renewed: Int,
+        failed: Int,
+        expiredKeys: [String],
+        renewedKeys: [String] = []
+    ) {
         self.renewed = renewed
         self.failed = failed
         self.expiredKeys = expiredKeys
+        self.renewedKeys = renewedKeys
     }
 }

--- a/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift
+++ b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift
@@ -528,10 +528,15 @@ final class ConvosAPIClient: ConvosAPIClientProtocol, Sendable {
             .filter { !$0.success && $0.error == "not_found" }
             .map { $0.key }
 
+        let renewedKeys = response.results
+            .filter(\.success)
+            .map(\.key)
+
         return AssetRenewalResult(
             renewed: response.renewed,
             failed: response.failed,
-            expiredKeys: expiredKeys
+            expiredKeys: expiredKeys,
+            renewedKeys: renewedKeys
         )
     }
 

--- a/ConvosCore/Sources/ConvosCore/API/MockAPIClient.swift
+++ b/ConvosCore/Sources/ConvosCore/API/MockAPIClient.swift
@@ -77,7 +77,12 @@ final class MockAPIClient: ConvosAPIClientProtocol, Sendable {
     // MARK: - Asset Renewal
 
     func renewAssetsBatch(assetKeys: [String]) async throws -> AssetRenewalResult {
-        AssetRenewalResult(renewed: assetKeys.count, failed: 0, expiredKeys: [])
+        AssetRenewalResult(
+            renewed: assetKeys.count,
+            failed: 0,
+            expiredKeys: [],
+            renewedKeys: assetKeys
+        )
     }
 
     func requestAgentJoin(slug: String, instructions: String) async throws -> ConvosAPI.AgentJoinResponse {

--- a/ConvosCore/Sources/ConvosCore/Assets/AssetRenewalManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Assets/AssetRenewalManager.swift
@@ -87,6 +87,7 @@ public actor AssetRenewalManager {
             var totalRenewed = 0
             var totalFailed = 0
             var allExpiredKeys: [String] = []
+            var allRenewedKeys: [String] = []
 
             for batch in assetKeys.chunked(into: Self.batchSize) {
                 do {
@@ -94,6 +95,7 @@ public actor AssetRenewalManager {
                     totalRenewed += result.renewed
                     totalFailed += result.failed
                     allExpiredKeys.append(contentsOf: result.expiredKeys)
+                    allRenewedKeys.append(contentsOf: result.renewedKeys)
 
                     let renewedKeySet = Set(result.renewedKeys)
                     let renewedAssets = renewedKeySet.compactMap { keyToAsset[$0] }
@@ -119,7 +121,7 @@ public actor AssetRenewalManager {
 
             Log.info("Asset renewal: \(totalRenewed) renewed, \(totalFailed) failed")
 
-            return AssetRenewalResult(renewed: totalRenewed, failed: totalFailed, expiredKeys: allExpiredKeys)
+            return AssetRenewalResult(renewed: totalRenewed, failed: totalFailed, expiredKeys: allExpiredKeys, renewedKeys: allRenewedKeys)
         } catch {
             Log.error("Asset renewal failed: \(error.localizedDescription)")
             return nil

--- a/ConvosCore/Sources/ConvosCore/Assets/AssetRenewalManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Assets/AssetRenewalManager.swift
@@ -44,7 +44,7 @@ public actor AssetRenewalManager {
                 await recoveryHandler.handleExpiredAsset(asset)
             }
 
-            if result.renewed > 0 {
+            if result.renewedKeys.contains(key) {
                 do {
                     try await recordRenewalInDatabase(for: [asset])
                 } catch {
@@ -95,10 +95,8 @@ public actor AssetRenewalManager {
                     totalFailed += result.failed
                     allExpiredKeys.append(contentsOf: result.expiredKeys)
 
-                    let batchExpiredSet = Set(result.expiredKeys)
-                    let renewedAssets = batch
-                        .filter { !batchExpiredSet.contains($0) }
-                        .compactMap { keyToAsset[$0] }
+                    let renewedKeySet = Set(result.renewedKeys)
+                    let renewedAssets = renewedKeySet.compactMap { keyToAsset[$0] }
 
                     for expiredKey in result.expiredKeys {
                         if let asset = keyToAsset[expiredKey] {

--- a/ConvosCore/Sources/ConvosCore/Assets/AssetRenewalManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Assets/AssetRenewalManager.swift
@@ -41,7 +41,7 @@ public actor AssetRenewalManager {
             let result = try await apiClient.renewAssetsBatch(assetKeys: [key])
 
             if result.expiredKeys.contains(key) {
-                await recoveryHandler.handleExpiredAsset(asset)
+                _ = await recoveryHandler.handleExpiredAsset(asset)
             }
 
             if result.renewedKeys.contains(key) {
@@ -100,7 +100,7 @@ public actor AssetRenewalManager {
 
                     for expiredKey in result.expiredKeys {
                         if let asset = keyToAsset[expiredKey] {
-                            await recoveryHandler.handleExpiredAsset(asset)
+                            _ = await recoveryHandler.handleExpiredAsset(asset)
                         }
                     }
 

--- a/ConvosCore/Sources/ConvosCore/Assets/DeferredAssetRecoveryQueue.swift
+++ b/ConvosCore/Sources/ConvosCore/Assets/DeferredAssetRecoveryQueue.swift
@@ -1,23 +1,47 @@
 import Foundation
 
 public actor DeferredAssetRecoveryQueue {
-    private var assetsByURL: [String: RenewableAsset] = [:]
+    public struct Entry: Sendable {
+        public let asset: RenewableAsset
+        public let retryCount: Int
+
+        public init(asset: RenewableAsset, retryCount: Int) {
+            self.asset = asset
+            self.retryCount = retryCount
+        }
+    }
+
+    private var entriesByURL: [String: Entry] = [:]
     private var orderedURLs: [String] = []
+    private var isProcessing: Bool = false
 
     public init() {}
 
-    public func enqueue(_ asset: RenewableAsset) {
-        if assetsByURL[asset.url] == nil {
+    public func enqueue(_ asset: RenewableAsset, retryCount: Int = 0) {
+        let entry = Entry(asset: asset, retryCount: retryCount)
+        if entriesByURL[asset.url] == nil {
             orderedURLs.append(asset.url)
         }
-        assetsByURL[asset.url] = asset
+        entriesByURL[asset.url] = entry
     }
 
-    public func drain() -> [RenewableAsset] {
-        let assets = orderedURLs.compactMap { assetsByURL[$0] }
+    public func nextBatchForProcessing() -> [Entry]? {
+        guard !isProcessing else { return nil }
+
+        let entries = orderedURLs.compactMap { entriesByURL[$0] }
+        guard !entries.isEmpty else { return nil }
+
+        isProcessing = true
         orderedURLs.removeAll()
-        assetsByURL.removeAll()
-        return assets
+        entriesByURL.removeAll()
+        return entries
+    }
+
+    public func finishProcessing(requeue: [Entry]) {
+        for entry in requeue {
+            enqueue(entry.asset, retryCount: entry.retryCount)
+        }
+        isProcessing = false
     }
 
     public var count: Int {

--- a/ConvosCore/Sources/ConvosCore/Assets/DeferredAssetRecoveryQueue.swift
+++ b/ConvosCore/Sources/ConvosCore/Assets/DeferredAssetRecoveryQueue.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+public actor DeferredAssetRecoveryQueue {
+    private var assetsByURL: [String: RenewableAsset] = [:]
+    private var orderedURLs: [String] = []
+
+    public init() {}
+
+    public func enqueue(_ asset: RenewableAsset) {
+        if assetsByURL[asset.url] == nil {
+            orderedURLs.append(asset.url)
+        }
+        assetsByURL[asset.url] = asset
+    }
+
+    public func drain() -> [RenewableAsset] {
+        let assets = orderedURLs.compactMap { assetsByURL[$0] }
+        orderedURLs.removeAll()
+        assetsByURL.removeAll()
+        return assets
+    }
+
+    public var count: Int {
+        orderedURLs.count
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Assets/ExpiredAssetRecoveryHandler.swift
+++ b/ConvosCore/Sources/ConvosCore/Assets/ExpiredAssetRecoveryHandler.swift
@@ -1,16 +1,89 @@
 import Foundation
 import GRDB
 
-public struct ExpiredAssetRecoveryHandler: Sendable {
+public struct ExpiredAssetRecoveryHandler: @unchecked Sendable {
     private let databaseWriter: any DatabaseWriter
+    private let imageCache: (any ImageCacheProtocol)?
+    private let myProfileWriter: (any MyProfileWriterProtocol)?
+    private let conversationMetadataWriter: (any ConversationMetadataWriterProtocol)?
 
-    public init(databaseWriter: any DatabaseWriter) {
+    public init(
+        databaseWriter: any DatabaseWriter,
+        imageCache: (any ImageCacheProtocol)? = nil,
+        myProfileWriter: (any MyProfileWriterProtocol)? = nil,
+        conversationMetadataWriter: (any ConversationMetadataWriterProtocol)? = nil
+    ) {
         self.databaseWriter = databaseWriter
+        self.imageCache = imageCache
+        self.myProfileWriter = myProfileWriter
+        self.conversationMetadataWriter = conversationMetadataWriter
     }
 
     public func handleExpiredAsset(_ asset: RenewableAsset) async {
-        Log.warning("Asset expired and cannot be renewed: \(asset.url) - clearing URL")
+        // Try to recover from cache first
+        if await attemptRecoveryFromCache(asset) {
+            return
+        }
+
+        // Fall back to clearing the URL
+        Log.warning("Asset expired and cannot be recovered: \(asset.url) - clearing URL")
         await clearAssetUrl(asset)
+    }
+
+    private func attemptRecoveryFromCache(_ asset: RenewableAsset) async -> Bool {
+        guard let imageCache else {
+            Log.info("No image cache available for recovery")
+            return false
+        }
+
+        // Try to get image from cache using the URL
+        guard let url = URL(string: asset.url),
+              let cachedImage = imageCache.image(for: url) else {
+            Log.info("Image not found in cache for \(asset.url)")
+            return false
+        }
+
+        do {
+            switch asset {
+            case let .profileAvatar(_, conversationId, _):
+                guard let myProfileWriter else {
+                    Log.info("No profile writer available for recovery")
+                    return false
+                }
+
+                try await myProfileWriter.update(avatar: cachedImage, conversationId: conversationId)
+                Log.info("Auto-recovered profile avatar for conversation \(conversationId)")
+                return true
+
+            case let .groupImage(_, conversationId):
+                guard let conversationMetadataWriter else {
+                    Log.info("No conversation metadata writer available for recovery")
+                    return false
+                }
+
+                guard let conversation = try await fetchConversation(id: conversationId) else {
+                    Log.warning("Cannot recover group image - conversation not found: \(conversationId)")
+                    return false
+                }
+
+                try await conversationMetadataWriter.updateImage(cachedImage, for: conversation)
+                Log.info("Auto-recovered group image for conversation \(conversationId)")
+                return true
+            }
+        } catch {
+            Log.error("Failed to recover asset from cache: \(error.localizedDescription)")
+            return false
+        }
+    }
+
+    private func fetchConversation(id: String) async throws -> Conversation? {
+        try await databaseWriter.read { db in
+            try DBConversation
+                .filter(DBConversation.Columns.id == id)
+                .detailedConversationQuery()
+                .fetchOne(db)?
+                .hydrateConversation()
+        }
     }
 
     private func clearAssetUrl(_ asset: RenewableAsset) async {

--- a/ConvosCore/Sources/ConvosCore/Assets/ExpiredAssetRecoveryHandler.swift
+++ b/ConvosCore/Sources/ConvosCore/Assets/ExpiredAssetRecoveryHandler.swift
@@ -1,7 +1,7 @@
 import Foundation
 import GRDB
 
-public struct ExpiredAssetRecoveryHandler: @unchecked Sendable {
+public struct ExpiredAssetRecoveryHandler: Sendable {
     private let databaseWriter: any DatabaseWriter
     private let imageCache: (any ImageCacheProtocol)?
     private let myProfileWriter: (any MyProfileWriterProtocol)?
@@ -22,21 +22,26 @@ public struct ExpiredAssetRecoveryHandler: @unchecked Sendable {
         self.onRecoveryDeferred = onRecoveryDeferred
     }
 
-    public func handleExpiredAsset(_ asset: RenewableAsset) async {
-        let outcome = await attemptRecoveryFromCache(asset)
+    public func handleExpiredAsset(
+        _ asset: RenewableAsset,
+        cachedImage: ImageType? = nil
+    ) async -> RecoveryResult {
+        let outcome = await attemptRecoveryFromCache(asset, cachedImage: cachedImage)
 
         switch outcome {
         case .recovered:
-            return
+            return .recovered
         case .deferred:
             guard let onRecoveryDeferred else {
                 Log.warning("Asset recovery deferred but no deferred handler configured: \(asset.url)")
                 await clearExpiredAsset(asset)
-                return
+                return .cleared
             }
             await onRecoveryDeferred(asset)
+            return .deferred
         case .notRecoverable:
             await clearExpiredAsset(asset)
+            return .cleared
         }
     }
 
@@ -45,16 +50,25 @@ public struct ExpiredAssetRecoveryHandler: @unchecked Sendable {
         await clearAssetUrl(asset)
     }
 
-    private func attemptRecoveryFromCache(_ asset: RenewableAsset) async -> RecoveryOutcome {
-        guard let imageCache else {
-            Log.info("No image cache available for recovery")
-            return .notRecoverable
-        }
+    private func attemptRecoveryFromCache(
+        _ asset: RenewableAsset,
+        cachedImage: ImageType?
+    ) async -> RecoveryOutcome {
+        let cachedImageToUse: ImageType
 
-        // Try to get image from cache using the URL string as identifier
-        guard let cachedImage = imageCache.image(for: asset.url) else {
-            Log.info("Image not found in cache for \(asset.url)")
-            return .notRecoverable
+        if let cachedImage {
+            cachedImageToUse = cachedImage
+        } else {
+            guard let imageCache else {
+                Log.info("No image cache available for recovery")
+                return .notRecoverable
+            }
+
+            guard let cachedImage = imageCache.image(for: asset.url) else {
+                Log.info("Image not found in cache for \(asset.url)")
+                return .notRecoverable
+            }
+            cachedImageToUse = cachedImage
         }
 
         do {
@@ -65,7 +79,7 @@ public struct ExpiredAssetRecoveryHandler: @unchecked Sendable {
                     return .deferred
                 }
 
-                try await myProfileWriter.update(avatar: cachedImage, conversationId: conversationId)
+                try await myProfileWriter.update(avatar: cachedImageToUse, conversationId: conversationId)
                 Log.info("Auto-recovered profile avatar for conversation \(conversationId)")
                 return .recovered
 
@@ -80,7 +94,7 @@ public struct ExpiredAssetRecoveryHandler: @unchecked Sendable {
                     return .notRecoverable
                 }
 
-                try await conversationMetadataWriter.updateImage(cachedImage, for: conversation)
+                try await conversationMetadataWriter.updateImage(cachedImageToUse, for: conversation)
                 Log.info("Auto-recovered group image for conversation \(conversationId)")
                 return .recovered
             }
@@ -138,6 +152,12 @@ public struct ExpiredAssetRecoveryHandler: @unchecked Sendable {
         } catch {
             Log.error("Failed to clear asset URL: \(error.localizedDescription)")
         }
+    }
+
+    public enum RecoveryResult: Sendable {
+        case recovered
+        case deferred
+        case cleared
     }
 
     private enum RecoveryOutcome {

--- a/ConvosCore/Sources/ConvosCore/Assets/ExpiredAssetRecoveryHandler.swift
+++ b/ConvosCore/Sources/ConvosCore/Assets/ExpiredAssetRecoveryHandler.swift
@@ -34,20 +34,19 @@ public struct ExpiredAssetRecoveryHandler: Sendable {
         case .deferred:
             guard let onRecoveryDeferred else {
                 Log.warning("Asset recovery deferred but no deferred handler configured: \(asset.url)")
-                await clearExpiredAsset(asset)
-                return .cleared
+                return await clearExpiredAsset(asset)
             }
             await onRecoveryDeferred(asset)
             return .deferred
         case .notRecoverable:
-            await clearExpiredAsset(asset)
-            return .cleared
+            return await clearExpiredAsset(asset)
         }
     }
 
-    private func clearExpiredAsset(_ asset: RenewableAsset) async {
+    private func clearExpiredAsset(_ asset: RenewableAsset) async -> RecoveryResult {
         Log.warning("Asset expired and cannot be recovered: \(asset.url) - clearing URL")
-        await clearAssetUrl(asset)
+        let didClear = await clearAssetUrl(asset)
+        return didClear ? .cleared : .clearFailed
     }
 
     private func attemptRecoveryFromCache(
@@ -114,12 +113,11 @@ public struct ExpiredAssetRecoveryHandler: Sendable {
         }
     }
 
-    private func clearAssetUrl(_ asset: RenewableAsset) async {
+    private func clearAssetUrl(_ asset: RenewableAsset) async -> Bool {
         do {
             try await databaseWriter.write { db in
                 switch asset {
                 case let .profileAvatar(url, _, _, _):
-                    // Clear ALL profiles with this avatar URL (same person may appear in multiple conversations)
                     let profiles = try DBMemberProfile
                         .filter(DBMemberProfile.Columns.avatar == url)
                         .fetchAll(db)
@@ -134,7 +132,6 @@ public struct ExpiredAssetRecoveryHandler: Sendable {
                     }
 
                 case let .groupImage(url, _, _):
-                    // Clear ALL conversations with this image URL (unlikely to have duplicates, but for consistency)
                     let conversations = try DBConversation
                         .filter(DBConversation.Columns.imageURLString == url)
                         .fetchAll(db)
@@ -149,8 +146,10 @@ public struct ExpiredAssetRecoveryHandler: Sendable {
                     }
                 }
             }
+            return true
         } catch {
             Log.error("Failed to clear asset URL: \(error.localizedDescription)")
+            return false
         }
     }
 
@@ -158,6 +157,7 @@ public struct ExpiredAssetRecoveryHandler: Sendable {
         case recovered
         case deferred
         case cleared
+        case clearFailed
     }
 
     private enum RecoveryOutcome {

--- a/ConvosCore/Sources/ConvosCore/Assets/ExpiredAssetRecoveryHandler.swift
+++ b/ConvosCore/Sources/ConvosCore/Assets/ExpiredAssetRecoveryHandler.swift
@@ -6,72 +6,87 @@ public struct ExpiredAssetRecoveryHandler: @unchecked Sendable {
     private let imageCache: (any ImageCacheProtocol)?
     private let myProfileWriter: (any MyProfileWriterProtocol)?
     private let conversationMetadataWriter: (any ConversationMetadataWriterProtocol)?
+    private let onRecoveryDeferred: (@Sendable (RenewableAsset) async -> Void)?
 
     public init(
         databaseWriter: any DatabaseWriter,
         imageCache: (any ImageCacheProtocol)? = nil,
         myProfileWriter: (any MyProfileWriterProtocol)? = nil,
-        conversationMetadataWriter: (any ConversationMetadataWriterProtocol)? = nil
+        conversationMetadataWriter: (any ConversationMetadataWriterProtocol)? = nil,
+        onRecoveryDeferred: (@Sendable (RenewableAsset) async -> Void)? = nil
     ) {
         self.databaseWriter = databaseWriter
         self.imageCache = imageCache
         self.myProfileWriter = myProfileWriter
         self.conversationMetadataWriter = conversationMetadataWriter
+        self.onRecoveryDeferred = onRecoveryDeferred
     }
 
     public func handleExpiredAsset(_ asset: RenewableAsset) async {
-        // Try to recover from cache first
-        if await attemptRecoveryFromCache(asset) {
-            return
-        }
+        let outcome = await attemptRecoveryFromCache(asset)
 
-        // Fall back to clearing the URL
+        switch outcome {
+        case .recovered:
+            return
+        case .deferred:
+            guard let onRecoveryDeferred else {
+                Log.warning("Asset recovery deferred but no deferred handler configured: \(asset.url)")
+                await clearExpiredAsset(asset)
+                return
+            }
+            await onRecoveryDeferred(asset)
+        case .notRecoverable:
+            await clearExpiredAsset(asset)
+        }
+    }
+
+    private func clearExpiredAsset(_ asset: RenewableAsset) async {
         Log.warning("Asset expired and cannot be recovered: \(asset.url) - clearing URL")
         await clearAssetUrl(asset)
     }
 
-    private func attemptRecoveryFromCache(_ asset: RenewableAsset) async -> Bool {
+    private func attemptRecoveryFromCache(_ asset: RenewableAsset) async -> RecoveryOutcome {
         guard let imageCache else {
             Log.info("No image cache available for recovery")
-            return false
+            return .notRecoverable
         }
 
         // Try to get image from cache using the URL string as identifier
         guard let cachedImage = imageCache.image(for: asset.url) else {
             Log.info("Image not found in cache for \(asset.url)")
-            return false
+            return .notRecoverable
         }
 
         do {
             switch asset {
             case let .profileAvatar(_, conversationId, _, _):
                 guard let myProfileWriter else {
-                    Log.info("No profile writer available for recovery")
-                    return false
+                    Log.info("Deferring profile avatar recovery until writer is available")
+                    return .deferred
                 }
 
                 try await myProfileWriter.update(avatar: cachedImage, conversationId: conversationId)
                 Log.info("Auto-recovered profile avatar for conversation \(conversationId)")
-                return true
+                return .recovered
 
             case let .groupImage(_, conversationId, _):
                 guard let conversationMetadataWriter else {
-                    Log.info("No conversation metadata writer available for recovery")
-                    return false
+                    Log.info("Deferring group image recovery until writer is available")
+                    return .deferred
                 }
 
                 guard let conversation = try await fetchConversation(id: conversationId) else {
                     Log.warning("Cannot recover group image - conversation not found: \(conversationId)")
-                    return false
+                    return .notRecoverable
                 }
 
                 try await conversationMetadataWriter.updateImage(cachedImage, for: conversation)
                 Log.info("Auto-recovered group image for conversation \(conversationId)")
-                return true
+                return .recovered
             }
         } catch {
             Log.error("Failed to recover asset from cache: \(error.localizedDescription)")
-            return false
+            return .notRecoverable
         }
     }
 
@@ -123,5 +138,11 @@ public struct ExpiredAssetRecoveryHandler: @unchecked Sendable {
         } catch {
             Log.error("Failed to clear asset URL: \(error.localizedDescription)")
         }
+    }
+
+    private enum RecoveryOutcome {
+        case recovered
+        case deferred
+        case notRecoverable
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Assets/ExpiredAssetRecoveryHandler.swift
+++ b/ConvosCore/Sources/ConvosCore/Assets/ExpiredAssetRecoveryHandler.swift
@@ -36,16 +36,15 @@ public struct ExpiredAssetRecoveryHandler: @unchecked Sendable {
             return false
         }
 
-        // Try to get image from cache using the URL
-        guard let url = URL(string: asset.url),
-              let cachedImage = imageCache.image(for: url) else {
+        // Try to get image from cache using the URL string as identifier
+        guard let cachedImage = imageCache.image(for: asset.url) else {
             Log.info("Image not found in cache for \(asset.url)")
             return false
         }
 
         do {
             switch asset {
-            case let .profileAvatar(_, conversationId, _):
+            case let .profileAvatar(_, conversationId, _, _):
                 guard let myProfileWriter else {
                     Log.info("No profile writer available for recovery")
                     return false
@@ -55,7 +54,7 @@ public struct ExpiredAssetRecoveryHandler: @unchecked Sendable {
                 Log.info("Auto-recovered profile avatar for conversation \(conversationId)")
                 return true
 
-            case let .groupImage(_, conversationId):
+            case let .groupImage(_, conversationId, _):
                 guard let conversationMetadataWriter else {
                     Log.info("No conversation metadata writer available for recovery")
                     return false

--- a/ConvosCore/Sources/ConvosCore/Inboxes/MockInboxesService.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/MockInboxesService.swift
@@ -135,11 +135,18 @@ public final class MockInboxesService: SessionManagerProtocol {
 
     public func makeAssetRenewalManager() async -> AssetRenewalManager {
         let dbManager = MockDatabaseManager.shared
-        let recoveryHandler = ExpiredAssetRecoveryHandler(databaseWriter: dbManager.dbWriter)
+        let recoveryHandler = ExpiredAssetRecoveryHandler(
+            databaseWriter: dbManager.dbWriter,
+            imageCache: ImageCacheContainer.shared
+        )
         return AssetRenewalManager(
             databaseWriter: dbManager.dbWriter,
             apiClient: MockAPIClient(),
             recoveryHandler: recoveryHandler
         )
+    }
+
+    public func forceReuploadAssetFromCache(_ asset: RenewableAsset) async throws -> Bool {
+        false
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
@@ -32,7 +32,6 @@ public final class SessionManager: SessionManagerProtocol, @unchecked Sendable {
     private var assetRenewalTask: Task<Void, Never>?
 
     private let deferredAssetRecoveryQueue: DeferredAssetRecoveryQueue = DeferredAssetRecoveryQueue()
-    private var deferredAssetRecoveryProcessingTask: Task<Void, Never>?
 
     private let databaseWriter: any DatabaseWriter
     private let databaseReader: any DatabaseReader
@@ -138,7 +137,6 @@ public final class SessionManager: SessionManagerProtocol, @unchecked Sendable {
         unusedInboxPrepTask?.cancel()
         foregroundObserverTask?.cancel()
         assetRenewalTask?.cancel()
-        deferredAssetRecoveryProcessingTask?.cancel()
         if let leftConversationObserver {
             NotificationCenter.default.removeObserver(leftConversationObserver)
         }
@@ -546,26 +544,34 @@ public final class SessionManager: SessionManagerProtocol, @unchecked Sendable {
     }
 
     private func scheduleDeferredAssetRecoveryProcessingIfNeeded() async {
-        guard deferredAssetRecoveryProcessingTask == nil else { return }
+        guard let queuedEntries = await deferredAssetRecoveryQueue.nextBatchForProcessing() else {
+            return
+        }
 
-        let queuedCount = await deferredAssetRecoveryQueue.count
-        guard queuedCount > 0 else { return }
-
-        deferredAssetRecoveryProcessingTask = Task(priority: .utility) { [weak self] in
+        Task(priority: .utility) { [weak self] in
             guard let self, !Task.isCancelled else { return }
-            await self.processDeferredAssetRecoveries()
-            self.deferredAssetRecoveryProcessingTask = nil
+            await self.processDeferredAssetRecoveries(queuedEntries)
         }
     }
 
-    private func processDeferredAssetRecoveries() async {
-        let queuedAssets = await deferredAssetRecoveryQueue.drain()
-        guard !queuedAssets.isEmpty else { return }
+    private func processDeferredAssetRecoveries(_ queuedEntries: [DeferredAssetRecoveryQueue.Entry]) async {
+        guard !queuedEntries.isEmpty else {
+            await deferredAssetRecoveryQueue.finishProcessing(requeue: [])
+            return
+        }
 
-        Log.info("Processing \(queuedAssets.count) deferred asset recovery item(s)")
+        Log.info("Processing \(queuedEntries.count) deferred asset recovery item(s)")
 
-        for asset in queuedAssets {
-            guard !Task.isCancelled else { return }
+        var entriesToRequeue: [DeferredAssetRecoveryQueue.Entry] = []
+
+        for (index, entry) in queuedEntries.enumerated() {
+            guard !Task.isCancelled else {
+                let remaining = queuedEntries[index...]
+                entriesToRequeue.append(contentsOf: remaining)
+                break
+            }
+
+            let asset = entry.asset
 
             do {
                 let didRecover = try await forceReuploadAssetFromCache(asset)
@@ -573,12 +579,23 @@ public final class SessionManager: SessionManagerProtocol, @unchecked Sendable {
                 guard !didRecover else { continue }
 
                 let clearOnlyRecoveryHandler = ExpiredAssetRecoveryHandler(databaseWriter: databaseWriter)
-                await clearOnlyRecoveryHandler.handleExpiredAsset(asset)
+                _ = await clearOnlyRecoveryHandler.handleExpiredAsset(asset)
             } catch {
-                Log.warning("Deferred asset recovery failed for \(asset.url), re-queuing: \(error.localizedDescription)")
-                await deferredAssetRecoveryQueue.enqueue(asset)
+                let nextRetryCount = entry.retryCount + 1
+                guard nextRetryCount <= Constant.maxDeferredRecoveryRetries else {
+                    Log.warning("Deferred asset recovery exhausted retries for \(asset.url). Clearing URL.")
+                    let clearOnlyRecoveryHandler = ExpiredAssetRecoveryHandler(databaseWriter: databaseWriter)
+                    _ = await clearOnlyRecoveryHandler.handleExpiredAsset(asset)
+                    continue
+                }
+
+                Log.warning("Deferred asset recovery failed for \(asset.url), re-queuing (attempt \(nextRetryCount)): \(error.localizedDescription)")
+                entriesToRequeue.append(.init(asset: asset, retryCount: nextRetryCount))
             }
         }
+
+        await deferredAssetRecoveryQueue.finishProcessing(requeue: entriesToRequeue)
+        await scheduleDeferredAssetRecoveryProcessingIfNeeded()
     }
 
     // MARK: - Asset Renewal
@@ -586,7 +603,11 @@ public final class SessionManager: SessionManagerProtocol, @unchecked Sendable {
     public func makeAssetRenewalManager() async -> AssetRenewalManager {
         let recoveryHandler = ExpiredAssetRecoveryHandler(
             databaseWriter: databaseWriter,
-            imageCache: ImageCacheContainer.shared
+            imageCache: ImageCacheContainer.shared,
+            onRecoveryDeferred: { [weak self] asset in
+                guard let self else { return }
+                await self.enqueueDeferredAssetRecovery(asset)
+            }
         )
         return AssetRenewalManager(
             databaseWriter: databaseWriter,
@@ -596,13 +617,16 @@ public final class SessionManager: SessionManagerProtocol, @unchecked Sendable {
     }
 
     public func forceReuploadAssetFromCache(_ asset: RenewableAsset) async throws -> Bool {
-        // Get clientId and inboxId for the asset
+        guard let cachedImage = ImageCacheContainer.shared.image(for: asset.url) else {
+            Log.info("Image not found in cache for re-upload: \(asset.url)")
+            return false
+        }
+
         let clientId: String
         let inboxId: String
 
         switch asset {
         case let .profileAvatar(_, conversationId, assetInboxId, _):
-            // Look up clientId from conversation
             guard let conv = try await databaseReader.read({ db in
                 try DBConversation.fetchOne(db, key: conversationId)
             }) else {
@@ -612,7 +636,6 @@ public final class SessionManager: SessionManagerProtocol, @unchecked Sendable {
             inboxId = assetInboxId
 
         case let .groupImage(_, conversationId, _):
-            // Look up both clientId and inboxId from conversation
             guard let conv = try await databaseReader.read({ db in
                 try DBConversation.fetchOne(db, key: conversationId)
             }) else {
@@ -622,10 +645,8 @@ public final class SessionManager: SessionManagerProtocol, @unchecked Sendable {
             inboxId = conv.inboxId
         }
 
-        // Get the messaging service (this wakes the inbox if needed)
         let service = try await messagingService(for: clientId, inboxId: inboxId)
 
-        // Create writers with the service's inboxStateManager
         let myProfileWriter = MyProfileWriter(
             inboxStateManager: service.inboxStateManager,
             databaseWriter: databaseWriter
@@ -640,7 +661,6 @@ public final class SessionManager: SessionManagerProtocol, @unchecked Sendable {
             databaseWriter: databaseWriter
         )
 
-        // Create recovery handler with full capabilities
         let recoveryHandler = ExpiredAssetRecoveryHandler(
             databaseWriter: databaseWriter,
             imageCache: ImageCacheContainer.shared,
@@ -648,14 +668,11 @@ public final class SessionManager: SessionManagerProtocol, @unchecked Sendable {
             conversationMetadataWriter: conversationMetadataWriter
         )
 
-        // Check if image is in cache
-        guard ImageCacheContainer.shared.image(for: asset.url) != nil else {
-            Log.info("Image not found in cache for re-upload: \(asset.url)")
-            return false
-        }
+        let recoveryResult = await recoveryHandler.handleExpiredAsset(asset, cachedImage: cachedImage)
+        return recoveryResult == .recovered
+    }
 
-        // Perform the re-upload
-        await recoveryHandler.handleExpiredAsset(asset)
-        return true
+    private enum Constant {
+        static let maxDeferredRecoveryRetries: Int = 3
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
@@ -531,11 +531,76 @@ public final class SessionManager: SessionManagerProtocol, @unchecked Sendable {
     // MARK: - Asset Renewal
 
     public func makeAssetRenewalManager() async -> AssetRenewalManager {
-        let recoveryHandler = ExpiredAssetRecoveryHandler(databaseWriter: databaseWriter)
+        let recoveryHandler = ExpiredAssetRecoveryHandler(
+            databaseWriter: databaseWriter,
+            imageCache: ImageCacheContainer.shared
+        )
         return AssetRenewalManager(
             databaseWriter: databaseWriter,
             apiClient: apiClient,
             recoveryHandler: recoveryHandler
         )
+    }
+
+    public func forceReuploadAssetFromCache(_ asset: RenewableAsset) async throws -> Bool {
+        // Get clientId and inboxId for the asset
+        let (clientId, inboxId): (String, String) = try await {
+            switch asset {
+            case let .profileAvatar(_, conversationId, inboxId):
+                // Look up clientId from conversation
+                guard let conv = try await databaseReader.read({ db in
+                    try DBConversation.fetchOne(db, key: conversationId)
+                }) else {
+                    throw SessionManagerError.inboxNotFound
+                }
+                return (conv.clientId, inboxId)
+
+            case let .groupImage(_, conversationId):
+                // Look up both clientId and inboxId from conversation
+                guard let conv = try await databaseReader.read({ db in
+                    try DBConversation.fetchOne(db, key: conversationId)
+                }) else {
+                    throw SessionManagerError.inboxNotFound
+                }
+                return (conv.clientId, conv.inboxId)
+            }
+        }()
+
+        // Get the messaging service (this wakes the inbox if needed)
+        let service = try await messagingService(for: clientId, inboxId: inboxId)
+
+        // Create writers with the service's inboxStateManager
+        let myProfileWriter = MyProfileWriter(
+            inboxStateManager: service.inboxStateManager,
+            databaseWriter: databaseWriter
+        )
+        let inviteWriter = InviteWriter(
+            identityStore: identityStore,
+            databaseWriter: databaseWriter
+        )
+        let conversationMetadataWriter = ConversationMetadataWriter(
+            inboxStateManager: service.inboxStateManager,
+            inviteWriter: inviteWriter,
+            databaseWriter: databaseWriter
+        )
+
+        // Create recovery handler with full capabilities
+        let recoveryHandler = ExpiredAssetRecoveryHandler(
+            databaseWriter: databaseWriter,
+            imageCache: ImageCacheContainer.shared,
+            myProfileWriter: myProfileWriter,
+            conversationMetadataWriter: conversationMetadataWriter
+        )
+
+        // Check if image is in cache
+        guard let url = URL(string: asset.url),
+              ImageCacheContainer.shared.image(for: url) != nil else {
+            Log.info("Image not found in cache for re-upload: \(asset.url)")
+            return false
+        }
+
+        // Perform the re-upload
+        await recoveryHandler.handleExpiredAsset(asset)
+        return true
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
@@ -544,27 +544,30 @@ public final class SessionManager: SessionManagerProtocol, @unchecked Sendable {
 
     public func forceReuploadAssetFromCache(_ asset: RenewableAsset) async throws -> Bool {
         // Get clientId and inboxId for the asset
-        let (clientId, inboxId): (String, String) = try await {
-            switch asset {
-            case let .profileAvatar(_, conversationId, inboxId):
-                // Look up clientId from conversation
-                guard let conv = try await databaseReader.read({ db in
-                    try DBConversation.fetchOne(db, key: conversationId)
-                }) else {
-                    throw SessionManagerError.inboxNotFound
-                }
-                return (conv.clientId, inboxId)
+        let clientId: String
+        let inboxId: String
 
-            case let .groupImage(_, conversationId):
-                // Look up both clientId and inboxId from conversation
-                guard let conv = try await databaseReader.read({ db in
-                    try DBConversation.fetchOne(db, key: conversationId)
-                }) else {
-                    throw SessionManagerError.inboxNotFound
-                }
-                return (conv.clientId, conv.inboxId)
+        switch asset {
+        case let .profileAvatar(_, conversationId, assetInboxId, _):
+            // Look up clientId from conversation
+            guard let conv = try await databaseReader.read({ db in
+                try DBConversation.fetchOne(db, key: conversationId)
+            }) else {
+                throw SessionManagerError.inboxNotFound
             }
-        }()
+            clientId = conv.clientId
+            inboxId = assetInboxId
+
+        case let .groupImage(_, conversationId, _):
+            // Look up both clientId and inboxId from conversation
+            guard let conv = try await databaseReader.read({ db in
+                try DBConversation.fetchOne(db, key: conversationId)
+            }) else {
+                throw SessionManagerError.inboxNotFound
+            }
+            clientId = conv.clientId
+            inboxId = conv.inboxId
+        }
 
         // Get the messaging service (this wakes the inbox if needed)
         let service = try await messagingService(for: clientId, inboxId: inboxId)
@@ -593,8 +596,7 @@ public final class SessionManager: SessionManagerProtocol, @unchecked Sendable {
         )
 
         // Check if image is in cache
-        guard let url = URL(string: asset.url),
-              ImageCacheContainer.shared.image(for: url) != nil else {
+        guard ImageCacheContainer.shared.image(for: asset.url) != nil else {
             Log.info("Image not found in cache for re-upload: \(asset.url)")
             return false
         }

--- a/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
@@ -665,7 +665,11 @@ public final class SessionManager: SessionManagerProtocol, @unchecked Sendable {
             databaseWriter: databaseWriter,
             imageCache: ImageCacheContainer.shared,
             myProfileWriter: myProfileWriter,
-            conversationMetadataWriter: conversationMetadataWriter
+            conversationMetadataWriter: conversationMetadataWriter,
+            onRecoveryDeferred: { [weak self] asset in
+                guard let self else { return }
+                await self.enqueueDeferredAssetRecovery(asset)
+            }
         )
 
         let recoveryResult = await recoveryHandler.handleExpiredAsset(asset, cachedImage: cachedImage)

--- a/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
@@ -31,6 +31,9 @@ public final class SessionManager: SessionManagerProtocol, @unchecked Sendable {
     private var foregroundObserverTask: Task<Void, Never>?
     private var assetRenewalTask: Task<Void, Never>?
 
+    private let deferredAssetRecoveryQueue: DeferredAssetRecoveryQueue = DeferredAssetRecoveryQueue()
+    private var deferredAssetRecoveryProcessingTask: Task<Void, Never>?
+
     private let databaseWriter: any DatabaseWriter
     private let databaseReader: any DatabaseReader
     private let environment: AppEnvironment
@@ -112,7 +115,14 @@ public final class SessionManager: SessionManagerProtocol, @unchecked Sendable {
             guard !Task.isCancelled else { return }
             self.assetRenewalTask = Task(priority: .utility) { [weak self] in
                 guard let self, !Task.isCancelled else { return }
-                let recoveryHandler = ExpiredAssetRecoveryHandler(databaseWriter: self.databaseWriter)
+                let recoveryHandler = ExpiredAssetRecoveryHandler(
+                    databaseWriter: self.databaseWriter,
+                    imageCache: ImageCacheContainer.shared,
+                    onRecoveryDeferred: { [weak self] asset in
+                        guard let self else { return }
+                        await self.enqueueDeferredAssetRecovery(asset)
+                    }
+                )
                 let renewalManager = AssetRenewalManager(
                     databaseWriter: self.databaseWriter,
                     apiClient: self.apiClient,
@@ -128,6 +138,7 @@ public final class SessionManager: SessionManagerProtocol, @unchecked Sendable {
         unusedInboxPrepTask?.cancel()
         foregroundObserverTask?.cancel()
         assetRenewalTask?.cancel()
+        deferredAssetRecoveryProcessingTask?.cancel()
         if let leftConversationObserver {
             NotificationCenter.default.removeObserver(leftConversationObserver)
         }
@@ -144,6 +155,7 @@ public final class SessionManager: SessionManagerProtocol, @unchecked Sendable {
             for await _ in foregroundNotifications {
                 guard let self else { return }
                 self.notificationChangeReporter.notifyChangesInDatabase()
+                await self.scheduleDeferredAssetRecoveryProcessingIfNeeded()
             }
         }
 
@@ -525,6 +537,47 @@ public final class SessionManager: SessionManagerProtocol, @unchecked Sendable {
         } catch {
             Log.error("Failed to look up inboxId for conversationId \(conversationId): \(error)")
             return nil
+        }
+    }
+
+    private func enqueueDeferredAssetRecovery(_ asset: RenewableAsset) async {
+        await deferredAssetRecoveryQueue.enqueue(asset)
+        await scheduleDeferredAssetRecoveryProcessingIfNeeded()
+    }
+
+    private func scheduleDeferredAssetRecoveryProcessingIfNeeded() async {
+        guard deferredAssetRecoveryProcessingTask == nil else { return }
+
+        let queuedCount = await deferredAssetRecoveryQueue.count
+        guard queuedCount > 0 else { return }
+
+        deferredAssetRecoveryProcessingTask = Task(priority: .utility) { [weak self] in
+            guard let self, !Task.isCancelled else { return }
+            await self.processDeferredAssetRecoveries()
+            self.deferredAssetRecoveryProcessingTask = nil
+        }
+    }
+
+    private func processDeferredAssetRecoveries() async {
+        let queuedAssets = await deferredAssetRecoveryQueue.drain()
+        guard !queuedAssets.isEmpty else { return }
+
+        Log.info("Processing \(queuedAssets.count) deferred asset recovery item(s)")
+
+        for asset in queuedAssets {
+            guard !Task.isCancelled else { return }
+
+            do {
+                let didRecover = try await forceReuploadAssetFromCache(asset)
+
+                guard !didRecover else { continue }
+
+                let clearOnlyRecoveryHandler = ExpiredAssetRecoveryHandler(databaseWriter: databaseWriter)
+                await clearOnlyRecoveryHandler.handleExpiredAsset(asset)
+            } catch {
+                Log.warning("Deferred asset recovery failed for \(asset.url), re-queuing: \(error.localizedDescription)")
+                await deferredAssetRecoveryQueue.enqueue(asset)
+            }
         }
     }
 

--- a/ConvosCore/Sources/ConvosCore/Sessions/SessionManagerProtocol.swift
+++ b/ConvosCore/Sources/ConvosCore/Sessions/SessionManagerProtocol.swift
@@ -76,4 +76,8 @@ public protocol SessionManagerProtocol: AnyObject, Sendable {
     // MARK: Asset Renewal
 
     func makeAssetRenewalManager() async -> AssetRenewalManager
+
+    /// Attempts to re-upload an expired asset from the local cache.
+    /// Returns true if the re-upload succeeded, false if the image wasn't in cache.
+    func forceReuploadAssetFromCache(_ asset: RenewableAsset) async throws -> Bool
 }

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationWriter.swift
@@ -356,6 +356,11 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
             )
             try localState.insert(db, onConflict: .ignore)
 
+            let existingProfiles = try DBMemberProfile
+                .filter(DBMemberProfile.Columns.conversationId == dbConversation.id)
+                .fetchAll(db)
+            let existingProfilesByInboxId = Dictionary(uniqueKeysWithValues: existingProfiles.map { ($0.inboxId, $0) })
+
             // Delete old members
             try DBMemberProfile
                 .filter(DBMemberProfile.Columns.conversationId == dbConversation.id)
@@ -366,7 +371,13 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
             try memberProfiles.forEach { profile in
                 let member = DBMember(inboxId: profile.inboxId)
                 try member.save(db)
-                try profile.save(db)
+
+                let existingProfile = existingProfilesByInboxId[profile.inboxId]
+                let profileToSave = Self.preservingAvatarLastRenewed(
+                    incomingProfile: profile,
+                    existingProfile: existingProfile
+                )
+                try profileToSave.save(db)
             }
 
             return (actualClientConversationId, oldImageURL)
@@ -454,6 +465,19 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
         }
 
         return (actualClientConversationId, oldImageURL)
+    }
+
+    static func preservingAvatarLastRenewed(
+        incomingProfile: DBMemberProfile,
+        existingProfile: DBMemberProfile?
+    ) -> DBMemberProfile {
+        guard let existingProfile,
+              incomingProfile.avatar != nil,
+              existingProfile.avatar == incomingProfile.avatar else {
+            return incomingProfile.with(avatarLastRenewed: nil)
+        }
+
+        return incomingProfile.with(avatarLastRenewed: existingProfile.avatarLastRenewed)
     }
 
     private func saveMembers(_ dbMembers: [DBConversationMember], in db: Database) throws {

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/MyProfileWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/MyProfileWriter.swift
@@ -1,7 +1,7 @@
 import Foundation
 import GRDB
 
-public protocol MyProfileWriterProtocol {
+public protocol MyProfileWriterProtocol: Sendable {
     func update(displayName: String, conversationId: String) async throws
     func update(avatar: ImageType?, conversationId: String) async throws
 }
@@ -10,7 +10,7 @@ enum MyProfileWriterError: Error {
     case imageCompressionFailed
 }
 
-class MyProfileWriter: MyProfileWriterProtocol {
+class MyProfileWriter: MyProfileWriterProtocol, @unchecked Sendable {
     private let inboxStateManager: any InboxStateManagerProtocol
     private let databaseWriter: any DatabaseWriter
 

--- a/ConvosCore/Tests/ConvosCoreTests/Assets/AssetRenewalManagerTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/Assets/AssetRenewalManagerTests.swift
@@ -284,6 +284,63 @@ struct AssetRenewalManagerTests {
         #expect(conversation?.imageLastRenewed != nil)
     }
 
+    @Test("Batch renewal can over-record timestamps when non-expired failures exist")
+    func testBatchRenewalCanOverRecordTimestampsForUnknownFailures() async throws {
+        let fixtures = try await makeTestFixtures()
+        fixtures.mockAPI.renewResult = AssetRenewalResult(
+            renewed: 1,
+            failed: 2,
+            expiredKeys: ["avatar-1.bin"]
+        )
+
+        try await fixtures.dbWriter.write { db in
+            try DBInbox(inboxId: "inbox-1", clientId: "client-1", createdAt: Date()).insert(db)
+            try DBMember(inboxId: "inbox-1").insert(db)
+            try makeDBConversation(id: "convo-1", inboxId: "inbox-1", clientId: "client-1").insert(db)
+            try makeDBConversation(id: "convo-2", inboxId: "inbox-1", clientId: "client-1").insert(db)
+            try makeDBConversation(
+                id: "convo-3",
+                inboxId: "inbox-1",
+                clientId: "client-1",
+                kind: .group,
+                imageURL: "https://example.com/group.bin"
+            ).insert(db)
+
+            try DBMemberProfile(
+                conversationId: "convo-1",
+                inboxId: "inbox-1",
+                name: "Avatar 1",
+                avatar: "https://example.com/avatar-1.bin",
+                avatarLastRenewed: nil
+            ).insert(db)
+
+            try DBMemberProfile(
+                conversationId: "convo-2",
+                inboxId: "inbox-1",
+                name: "Avatar 2",
+                avatar: "https://example.com/avatar-2.bin",
+                avatarLastRenewed: nil
+            ).insert(db)
+        }
+
+        let result = await fixtures.manager.forceRenewal()
+
+        let renewedProfilesCount = try await fixtures.dbWriter.read { db in
+            try DBMemberProfile
+                .filter(DBMemberProfile.Columns.avatarLastRenewed != nil)
+                .fetchCount(db)
+        }
+        let renewedConversationsCount = try await fixtures.dbWriter.read { db in
+            try DBConversation
+                .filter(DBConversation.Columns.imageLastRenewed != nil)
+                .fetchCount(db)
+        }
+        let timestampedAssetCount = renewedProfilesCount + renewedConversationsCount
+
+        #expect(result?.renewed == 1)
+        #expect(timestampedAssetCount > (result?.renewed ?? 0))
+    }
+
     @Test("Batch renewal handles API error gracefully")
     func testBatchRenewalHandlesApiError() async throws {
         let fixtures = try await makeTestFixtures()

--- a/ConvosCore/Tests/ConvosCoreTests/Assets/AssetRenewalManagerTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/Assets/AssetRenewalManagerTests.swift
@@ -99,7 +99,12 @@ struct AssetRenewalManagerTests {
     @Test("renewSingleAsset records timestamp in database on success")
     func testRenewSingleAssetRecordsTimestamp() async throws {
         let fixtures = try await makeTestFixtures()
-        fixtures.mockAPI.renewResult = AssetRenewalResult(renewed: 1, failed: 0, expiredKeys: [])
+        fixtures.mockAPI.renewResult = AssetRenewalResult(
+            renewed: 1,
+            failed: 0,
+            expiredKeys: [],
+            renewedKeys: ["avatar.bin"]
+        )
 
         try await fixtures.dbWriter.write { db in
             try DBInbox(inboxId: "inbox-1", clientId: "client-1", createdAt: Date()).insert(db)
@@ -213,7 +218,12 @@ struct AssetRenewalManagerTests {
     @Test("Batch renewal records timestamps for renewed assets")
     func testBatchRenewalRecordsTimestamps() async throws {
         let fixtures = try await makeTestFixtures()
-        fixtures.mockAPI.renewResult = AssetRenewalResult(renewed: 2, failed: 0, expiredKeys: [])
+        fixtures.mockAPI.renewResult = AssetRenewalResult(
+            renewed: 2,
+            failed: 0,
+            expiredKeys: [],
+            renewedKeys: ["avatar.bin", "group.bin"]
+        )
 
         try await fixtures.dbWriter.write { db in
             try DBInbox(inboxId: "inbox-1", clientId: "client-1", createdAt: Date()).insert(db)
@@ -250,7 +260,12 @@ struct AssetRenewalManagerTests {
     @Test("Batch renewal does not record timestamps for expired assets")
     func testBatchRenewalSkipsExpiredAssets() async throws {
         let fixtures = try await makeTestFixtures()
-        fixtures.mockAPI.renewResult = AssetRenewalResult(renewed: 1, failed: 1, expiredKeys: ["avatar.bin"])
+        fixtures.mockAPI.renewResult = AssetRenewalResult(
+            renewed: 1,
+            failed: 1,
+            expiredKeys: ["avatar.bin"],
+            renewedKeys: ["group.bin"]
+        )
 
         try await fixtures.dbWriter.write { db in
             try DBInbox(inboxId: "inbox-1", clientId: "client-1", createdAt: Date()).insert(db)
@@ -284,13 +299,14 @@ struct AssetRenewalManagerTests {
         #expect(conversation?.imageLastRenewed != nil)
     }
 
-    @Test("Batch renewal can over-record timestamps when non-expired failures exist")
-    func testBatchRenewalCanOverRecordTimestampsForUnknownFailures() async throws {
+    @Test("Batch renewal records timestamps only for explicitly renewed keys")
+    func testBatchRenewalRecordsOnlyExplicitlyRenewedKeys() async throws {
         let fixtures = try await makeTestFixtures()
         fixtures.mockAPI.renewResult = AssetRenewalResult(
             renewed: 1,
             failed: 2,
-            expiredKeys: ["avatar-1.bin"]
+            expiredKeys: ["avatar-1.bin"],
+            renewedKeys: ["avatar-2.bin"]
         )
 
         try await fixtures.dbWriter.write { db in
@@ -325,20 +341,29 @@ struct AssetRenewalManagerTests {
 
         let result = await fixtures.manager.forceRenewal()
 
-        let renewedProfilesCount = try await fixtures.dbWriter.read { db in
+        let renewedAvatar1 = try await fixtures.dbWriter.read { db in
             try DBMemberProfile
-                .filter(DBMemberProfile.Columns.avatarLastRenewed != nil)
-                .fetchCount(db)
+                .filter(DBMemberProfile.Columns.avatar == "https://example.com/avatar-1.bin")
+                .fetchOne(db)?
+                .avatarLastRenewed
         }
-        let renewedConversationsCount = try await fixtures.dbWriter.read { db in
+        let renewedAvatar2 = try await fixtures.dbWriter.read { db in
+            try DBMemberProfile
+                .filter(DBMemberProfile.Columns.avatar == "https://example.com/avatar-2.bin")
+                .fetchOne(db)?
+                .avatarLastRenewed
+        }
+        let renewedGroupImage = try await fixtures.dbWriter.read { db in
             try DBConversation
-                .filter(DBConversation.Columns.imageLastRenewed != nil)
-                .fetchCount(db)
+                .filter(DBConversation.Columns.id == "convo-3")
+                .fetchOne(db)?
+                .imageLastRenewed
         }
-        let timestampedAssetCount = renewedProfilesCount + renewedConversationsCount
 
         #expect(result?.renewed == 1)
-        #expect(timestampedAssetCount > (result?.renewed ?? 0))
+        #expect(renewedAvatar1 == nil)
+        #expect(renewedAvatar2 != nil)
+        #expect(renewedGroupImage == nil)
     }
 
     @Test("Batch renewal handles API error gracefully")
@@ -371,7 +396,12 @@ struct AssetRenewalManagerTests {
     @Test("Records renewal for all profiles with same URL")
     func testRecordsRenewalForAllProfilesWithSameURL() async throws {
         let fixtures = try await makeTestFixtures()
-        fixtures.mockAPI.renewResult = AssetRenewalResult(renewed: 1, failed: 0, expiredKeys: [])
+        fixtures.mockAPI.renewResult = AssetRenewalResult(
+            renewed: 1,
+            failed: 0,
+            expiredKeys: [],
+            renewedKeys: ["shared-avatar.bin"]
+        )
         let sharedAvatarURL = "https://example.com/shared-avatar.bin"
 
         try await fixtures.dbWriter.write { db in

--- a/ConvosCore/Tests/ConvosCoreTests/Assets/ExpiredAssetRecoveryHandlerTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/Assets/ExpiredAssetRecoveryHandlerTests.swift
@@ -1,0 +1,130 @@
+@testable import ConvosCore
+import Combine
+import Foundation
+import GRDB
+import Testing
+
+#if os(macOS)
+import AppKit
+
+@Suite("ExpiredAssetRecoveryHandler Tests", .serialized)
+struct ExpiredAssetRecoveryHandlerTests {
+    @Test("Defers recovery when cache exists but writers are unavailable")
+    func testDefersRecoveryWhenWritersUnavailable() async throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        let deferredFlag = DeferredFlag()
+        let avatarURL = "https://example.com/avatar.bin"
+
+        try await dbManager.dbWriter.write { db in
+            try DBInbox(inboxId: "inbox-1", clientId: "client-1", createdAt: Date()).insert(db)
+            try DBMember(inboxId: "inbox-1").insert(db)
+            try makeConversation(id: "convo-1", inboxId: "inbox-1", clientId: "client-1").insert(db)
+            try DBMemberProfile(
+                conversationId: "convo-1",
+                inboxId: "inbox-1",
+                name: "Test",
+                avatar: avatarURL,
+                avatarLastRenewed: nil
+            ).insert(db)
+        }
+
+        let cache = TestImageCache(imagesByIdentifier: [avatarURL: NSImage(size: .init(width: 1, height: 1))])
+        let handler = ExpiredAssetRecoveryHandler(
+            databaseWriter: dbManager.dbWriter,
+            imageCache: cache,
+            onRecoveryDeferred: { _ in
+                await deferredFlag.markDeferred()
+            }
+        )
+
+        let asset = RenewableAsset.profileAvatar(
+            url: avatarURL,
+            conversationId: "convo-1",
+            inboxId: "inbox-1",
+            lastRenewed: nil
+        )
+
+        await handler.handleExpiredAsset(asset)
+
+        #expect(await deferredFlag.wasDeferred == true)
+
+        let profile = try await dbManager.dbWriter.read { db in
+            try DBMemberProfile.fetchOne(db, conversationId: "convo-1", inboxId: "inbox-1")
+        }
+        #expect(profile?.avatar == avatarURL)
+    }
+}
+
+private actor DeferredFlag {
+    private(set) var wasDeferred: Bool = false
+
+    func markDeferred() {
+        wasDeferred = true
+    }
+}
+
+private final class TestImageCache: ImageCacheProtocol, @unchecked Sendable {
+    private let imagesByIdentifier: [String: NSImage]
+
+    init(imagesByIdentifier: [String: NSImage]) {
+        self.imagesByIdentifier = imagesByIdentifier
+    }
+
+    func loadImage(for object: any ImageCacheable) async -> NSImage? { nil }
+    func image(for object: any ImageCacheable) -> NSImage? { nil }
+    func imageAsync(for object: any ImageCacheable) async -> NSImage? { nil }
+    func removeImage(for object: any ImageCacheable) {}
+
+    func prepareForUpload(_ image: NSImage, for object: any ImageCacheable) -> Data? { nil }
+    func cacheAfterUpload(_ image: NSImage, for object: any ImageCacheable, url: String) {}
+    func cacheAfterUpload(_ image: NSImage, for identifier: String, url: String) {}
+    func cacheAfterUpload(_ imageData: Data, for identifier: String, url: String) {}
+
+    func image(for identifier: String, imageFormat: ImageFormat) -> NSImage? {
+        imagesByIdentifier[identifier]
+    }
+
+    func imageAsync(for identifier: String, imageFormat: ImageFormat) async -> NSImage? {
+        imagesByIdentifier[identifier]
+    }
+
+    func cacheImage(_ image: NSImage, for identifier: String, imageFormat: ImageFormat) {}
+    func removeImage(for identifier: String) {}
+    func hasURLChanged(_ url: String?, for identifier: String) async -> Bool { false }
+
+    var cacheUpdates: AnyPublisher<String, Never> {
+        Empty().eraseToAnyPublisher()
+    }
+}
+
+private func makeConversation(
+    id: String,
+    inboxId: String,
+    clientId: String
+) -> DBConversation {
+    DBConversation(
+        id: id,
+        inboxId: inboxId,
+        clientId: clientId,
+        clientConversationId: id,
+        inviteTag: "invite-\(id)",
+        creatorId: inboxId,
+        kind: .group,
+        consent: .allowed,
+        createdAt: Date(),
+        name: nil,
+        description: nil,
+        imageURLString: nil,
+        publicImageURLString: nil,
+        includeInfoInPublicPreview: false,
+        expiresAt: nil,
+        debugInfo: .empty,
+        isLocked: false,
+        imageSalt: nil,
+        imageNonce: nil,
+        imageEncryptionKey: nil,
+        imageLastRenewed: nil,
+        isUnused: false
+    )
+}
+#endif

--- a/ConvosCore/Tests/ConvosCoreTests/Assets/ExpiredAssetRecoveryHandlerTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/Assets/ExpiredAssetRecoveryHandlerTests.swift
@@ -54,6 +54,126 @@ struct ExpiredAssetRecoveryHandlerTests {
         }
         #expect(profile?.avatar == avatarURL)
     }
+
+    @Test("Recovers profile avatar when cache and profile writer are available")
+    func testRecoversProfileAvatarWhenWriterAvailable() async throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        let avatarURL = "https://example.com/avatar-recover.bin"
+        let profileWriter = TestMyProfileWriter()
+
+        try await dbManager.dbWriter.write { db in
+            try DBInbox(inboxId: "inbox-1", clientId: "client-1", createdAt: Date()).insert(db)
+            try DBMember(inboxId: "inbox-1").insert(db)
+            try makeConversation(id: "convo-1", inboxId: "inbox-1", clientId: "client-1").insert(db)
+            try DBMemberProfile(
+                conversationId: "convo-1",
+                inboxId: "inbox-1",
+                name: "Test",
+                avatar: avatarURL,
+                avatarLastRenewed: nil
+            ).insert(db)
+        }
+
+        let cache = TestImageCache(imagesByIdentifier: [avatarURL: NSImage(size: .init(width: 2, height: 2))])
+        let handler = ExpiredAssetRecoveryHandler(
+            databaseWriter: dbManager.dbWriter,
+            imageCache: cache,
+            myProfileWriter: profileWriter
+        )
+
+        let asset = RenewableAsset.profileAvatar(
+            url: avatarURL,
+            conversationId: "convo-1",
+            inboxId: "inbox-1",
+            lastRenewed: nil
+        )
+
+        let result = await handler.handleExpiredAsset(asset)
+
+        #expect(result == .recovered)
+        #expect(await profileWriter.updatedConversationIds == ["convo-1"])
+    }
+
+    @Test("Clears group image when writer exists but target conversation cannot be loaded")
+    func testClearsGroupImageWhenConversationMissing() async throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        let imageURL = "https://example.com/group-image.bin"
+        let conversationWriter = TestConversationMetadataWriter()
+
+        try await dbManager.dbWriter.write { db in
+            try DBInbox(inboxId: "inbox-1", clientId: "client-1", createdAt: Date()).insert(db)
+            try DBMember(inboxId: "inbox-1").insert(db)
+            try makeConversation(id: "convo-1", inboxId: "inbox-1", clientId: "client-1")
+                .with(imageURLString: imageURL, imageSalt: Data([1]), imageNonce: Data([2]), imageEncryptionKey: Data([3]))
+                .insert(db)
+        }
+
+        let cache = TestImageCache(imagesByIdentifier: [imageURL: NSImage(size: .init(width: 3, height: 3))])
+        let handler = ExpiredAssetRecoveryHandler(
+            databaseWriter: dbManager.dbWriter,
+            imageCache: cache,
+            conversationMetadataWriter: conversationWriter
+        )
+
+        let asset = RenewableAsset.groupImage(
+            url: imageURL,
+            conversationId: "missing-conversation",
+            lastRenewed: nil
+        )
+
+        let result = await handler.handleExpiredAsset(asset)
+
+        #expect(result == .cleared)
+        #expect(await conversationWriter.updateImageCount == 0)
+
+        let conversation = try await dbManager.dbWriter.read { db in
+            try DBConversation.fetchOne(db, key: "convo-1")
+        }
+        #expect(conversation?.imageURLString == nil)
+        #expect(conversation?.imageSalt == nil)
+        #expect(conversation?.imageNonce == nil)
+        #expect(conversation?.imageEncryptionKey == nil)
+    }
+
+    @Test("Defers group image recovery when cache exists but conversation metadata writer is unavailable")
+    func testDefersGroupImageRecoveryWhenWriterUnavailable() async throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        let deferredFlag = DeferredFlag()
+        let imageURL = "https://example.com/group-deferred.bin"
+
+        try await dbManager.dbWriter.write { db in
+            try DBInbox(inboxId: "inbox-1", clientId: "client-1", createdAt: Date()).insert(db)
+            try DBMember(inboxId: "inbox-1").insert(db)
+            try makeConversation(id: "convo-1", inboxId: "inbox-1", clientId: "client-1")
+                .with(imageURLString: imageURL, imageSalt: Data([1]), imageNonce: Data([2]), imageEncryptionKey: Data([3]))
+                .insert(db)
+        }
+
+        let cache = TestImageCache(imagesByIdentifier: [imageURL: NSImage(size: .init(width: 4, height: 4))])
+        let handler = ExpiredAssetRecoveryHandler(
+            databaseWriter: dbManager.dbWriter,
+            imageCache: cache,
+            onRecoveryDeferred: { _ in
+                await deferredFlag.markDeferred()
+            }
+        )
+
+        let asset = RenewableAsset.groupImage(
+            url: imageURL,
+            conversationId: "convo-1",
+            lastRenewed: nil
+        )
+
+        let result = await handler.handleExpiredAsset(asset)
+
+        #expect(result == .deferred)
+        #expect(await deferredFlag.wasDeferred == true)
+
+        let conversation = try await dbManager.dbWriter.read { db in
+            try DBConversation.fetchOne(db, key: "convo-1")
+        }
+        #expect(conversation?.imageURLString == imageURL)
+    }
 }
 
 private actor DeferredFlag {
@@ -62,6 +182,40 @@ private actor DeferredFlag {
     func markDeferred() {
         wasDeferred = true
     }
+}
+
+private actor TestMyProfileWriter: MyProfileWriterProtocol {
+    private(set) var updatedConversationIds: [String] = []
+
+    func update(displayName: String, conversationId: String) async throws {}
+
+    func update(avatar: ImageType?, conversationId: String) async throws {
+        guard avatar != nil else { return }
+        updatedConversationIds.append(conversationId)
+    }
+}
+
+private actor TestConversationMetadataWriter: ConversationMetadataWriterProtocol {
+    private(set) var updateImageCount: Int = 0
+
+    func updateName(_ name: String, for conversationId: String) async throws {}
+    func updateDescription(_ description: String, for conversationId: String) async throws {}
+    func updateImageUrl(_ imageURL: String, for conversationId: String) async throws {}
+    func addMembers(_ memberInboxIds: [String], to conversationId: String) async throws {}
+    func removeMembers(_ memberInboxIds: [String], from conversationId: String) async throws {}
+    func promoteToAdmin(_ memberInboxId: String, in conversationId: String) async throws {}
+    func demoteFromAdmin(_ memberInboxId: String, in conversationId: String) async throws {}
+    func promoteToSuperAdmin(_ memberInboxId: String, in conversationId: String) async throws {}
+    func demoteFromSuperAdmin(_ memberInboxId: String, in conversationId: String) async throws {}
+
+    func updateImage(_ image: ImageType, for conversation: Conversation) async throws {
+        updateImageCount += 1
+    }
+
+    func updateExpiresAt(_ expiresAt: Date, for conversationId: String) async throws {}
+    func updateIncludeInfoInPublicPreview(_ enabled: Bool, for conversationId: String) async throws {}
+    func lockConversation(for conversationId: String) async throws {}
+    func unlockConversation(for conversationId: String) async throws {}
 }
 
 private final class TestImageCache: ImageCacheProtocol, @unchecked Sendable {

--- a/ConvosCore/Tests/ConvosCoreTests/Assets/ExpiredAssetRecoveryHandlerTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/Assets/ExpiredAssetRecoveryHandlerTests.swift
@@ -44,8 +44,9 @@ struct ExpiredAssetRecoveryHandlerTests {
             lastRenewed: nil
         )
 
-        await handler.handleExpiredAsset(asset)
+        let result = await handler.handleExpiredAsset(asset)
 
+        #expect(result == .deferred)
         #expect(await deferredFlag.wasDeferred == true)
 
         let profile = try await dbManager.dbWriter.read { db in

--- a/ConvosCore/Tests/ConvosCoreTests/Assets/ExpiredAssetRecoveryHandlerTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/Assets/ExpiredAssetRecoveryHandlerTests.swift
@@ -90,6 +90,12 @@ private final class TestImageCache: ImageCacheProtocol, @unchecked Sendable {
 
     func cacheImage(_ image: NSImage, for identifier: String, imageFormat: ImageFormat) {}
     func removeImage(for identifier: String) {}
+
+    func cacheData(_ data: Data, for identifier: String, storageTier: ImageStorageTier) {}
+    func cacheImage(_ image: NSImage, for identifier: String, storageTier: ImageStorageTier) {}
+    func removePersistentImages(for identifiers: [String]) {}
+    func removeAllPersistentImages() {}
+
     func hasURLChanged(_ url: String?, for identifier: String) async -> Bool { false }
 
     var cacheUpdates: AnyPublisher<String, Never> {

--- a/ConvosCore/Tests/ConvosCoreTests/AvatarRenewalPreservationTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/AvatarRenewalPreservationTests.swift
@@ -1,0 +1,82 @@
+@testable import ConvosCore
+import Foundation
+import Testing
+
+@Suite("Avatar Renewal Preservation Tests")
+struct AvatarRenewalPreservationTests {
+    @Test("Preserves avatarLastRenewed when avatar URL is unchanged")
+    func testPreservesLastRenewedWhenAvatarUnchanged() {
+        let renewedAt = Date().addingTimeInterval(-3600)
+        let existing = DBMemberProfile(
+            conversationId: "convo-1",
+            inboxId: "inbox-1",
+            name: "Existing",
+            avatar: "https://example.com/a.bin",
+            avatarLastRenewed: renewedAt
+        )
+        let incoming = DBMemberProfile(
+            conversationId: "convo-1",
+            inboxId: "inbox-1",
+            name: "Incoming",
+            avatar: "https://example.com/a.bin",
+            avatarLastRenewed: nil
+        )
+
+        let result = ConversationWriter.preservingAvatarLastRenewed(
+            incomingProfile: incoming,
+            existingProfile: existing
+        )
+
+        #expect(result.avatarLastRenewed == renewedAt)
+    }
+
+    @Test("Clears avatarLastRenewed when avatar URL changes")
+    func testClearsLastRenewedWhenAvatarChanges() {
+        let existing = DBMemberProfile(
+            conversationId: "convo-1",
+            inboxId: "inbox-1",
+            name: "Existing",
+            avatar: "https://example.com/a.bin",
+            avatarLastRenewed: Date()
+        )
+        let incoming = DBMemberProfile(
+            conversationId: "convo-1",
+            inboxId: "inbox-1",
+            name: "Incoming",
+            avatar: "https://example.com/b.bin",
+            avatarLastRenewed: Date()
+        )
+
+        let result = ConversationWriter.preservingAvatarLastRenewed(
+            incomingProfile: incoming,
+            existingProfile: existing
+        )
+
+        #expect(result.avatarLastRenewed == nil)
+    }
+
+    @Test("Clears avatarLastRenewed when incoming avatar is nil")
+    func testClearsLastRenewedWhenIncomingAvatarNil() {
+        let existing = DBMemberProfile(
+            conversationId: "convo-1",
+            inboxId: "inbox-1",
+            name: "Existing",
+            avatar: "https://example.com/a.bin",
+            avatarLastRenewed: Date()
+        )
+        let incoming = DBMemberProfile(
+            conversationId: "convo-1",
+            inboxId: "inbox-1",
+            name: "Incoming",
+            avatar: nil,
+            avatarLastRenewed: Date()
+        )
+
+        let result = ConversationWriter.preservingAvatarLastRenewed(
+            incomingProfile: incoming,
+            existingProfile: existing
+        )
+
+        #expect(result.avatarLastRenewed == nil)
+    }
+}

--- a/ConvosCore/Tests/ConvosCoreTests/DeferredAssetRecoveryQueueTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/DeferredAssetRecoveryQueueTests.swift
@@ -4,8 +4,8 @@ import Testing
 
 @Suite("DeferredAssetRecoveryQueue Tests")
 struct DeferredAssetRecoveryQueueTests {
-    @Test("Enqueue deduplicates by asset URL")
-    func testEnqueueDeduplicatesByURL() async {
+    @Test("Enqueue deduplicates by asset URL with last-write wins")
+    func testEnqueueDeduplicatesByURLLastWriteWins() async {
         let queue = DeferredAssetRecoveryQueue()
 
         let first = RenewableAsset.profileAvatar(
@@ -25,10 +25,21 @@ struct DeferredAssetRecoveryQueueTests {
         await queue.enqueue(second)
 
         #expect(await queue.count == 1)
+
+        let batch = await queue.nextBatchForProcessing()
+        #expect(batch?.count == 1)
+        if case let .profileAvatar(_, conversationId, inboxId, _) = batch?.first?.asset {
+            #expect(conversationId == "convo-2")
+            #expect(inboxId == "inbox-2")
+        } else {
+            Issue.record("Expected profile avatar entry")
+        }
+
+        await queue.finishProcessing(requeue: [])
     }
 
-    @Test("Drain returns queued assets and clears queue")
-    func testDrainClearsQueue() async {
+    @Test("Processing batch drains queue and finish resets processing lock")
+    func testBatchProcessingLifecycle() async {
         let queue = DeferredAssetRecoveryQueue()
 
         let avatar = RenewableAsset.profileAvatar(
@@ -46,9 +57,18 @@ struct DeferredAssetRecoveryQueueTests {
         await queue.enqueue(avatar)
         await queue.enqueue(groupImage)
 
-        let drained = await queue.drain()
-
-        #expect(drained.count == 2)
+        let firstBatch = await queue.nextBatchForProcessing()
+        #expect(firstBatch?.count == 2)
         #expect(await queue.count == 0)
+
+        let secondBatch = await queue.nextBatchForProcessing()
+        #expect(secondBatch == nil)
+
+        await queue.finishProcessing(requeue: [])
+
+        await queue.enqueue(avatar)
+        let thirdBatch = await queue.nextBatchForProcessing()
+        #expect(thirdBatch?.count == 1)
+        await queue.finishProcessing(requeue: [])
     }
 }

--- a/ConvosCore/Tests/ConvosCoreTests/DeferredAssetRecoveryQueueTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/DeferredAssetRecoveryQueueTests.swift
@@ -1,0 +1,54 @@
+@testable import ConvosCore
+import Foundation
+import Testing
+
+@Suite("DeferredAssetRecoveryQueue Tests")
+struct DeferredAssetRecoveryQueueTests {
+    @Test("Enqueue deduplicates by asset URL")
+    func testEnqueueDeduplicatesByURL() async {
+        let queue = DeferredAssetRecoveryQueue()
+
+        let first = RenewableAsset.profileAvatar(
+            url: "https://example.com/a.bin",
+            conversationId: "convo-1",
+            inboxId: "inbox-1",
+            lastRenewed: nil
+        )
+        let second = RenewableAsset.profileAvatar(
+            url: "https://example.com/a.bin",
+            conversationId: "convo-2",
+            inboxId: "inbox-2",
+            lastRenewed: nil
+        )
+
+        await queue.enqueue(first)
+        await queue.enqueue(second)
+
+        #expect(await queue.count == 1)
+    }
+
+    @Test("Drain returns queued assets and clears queue")
+    func testDrainClearsQueue() async {
+        let queue = DeferredAssetRecoveryQueue()
+
+        let avatar = RenewableAsset.profileAvatar(
+            url: "https://example.com/a.bin",
+            conversationId: "convo-1",
+            inboxId: "inbox-1",
+            lastRenewed: nil
+        )
+        let groupImage = RenewableAsset.groupImage(
+            url: "https://example.com/g.bin",
+            conversationId: "convo-1",
+            lastRenewed: nil
+        )
+
+        await queue.enqueue(avatar)
+        await queue.enqueue(groupImage)
+
+        let drained = await queue.drain()
+
+        #expect(drained.count == 2)
+        #expect(await queue.count == 0)
+    }
+}

--- a/docs/plans/asset-renewal-assessment.md
+++ b/docs/plans/asset-renewal-assessment.md
@@ -1,0 +1,224 @@
+# Asset Renewal Assessment Plan (Deep Findings)
+
+> Status: in progress
+> Branch: `asset-reupload`
+> Owner: TBD
+> Last updated: 2026-02-24
+
+## Purpose
+
+Validate (with reproducible evidence) the deep findings from review before implementing fixes.
+
+---
+
+## Tracking
+
+| Finding | Severity | Hypothesis | Status | Evidence | Verdict |
+|---|---|---|---|---|---|
+| F1: Compile regression in asset recovery path | blocker | API/enum drift caused compile failure | done | `swift test --package-path ConvosCore --filter AssetRenewalURLCollectorTests` fails in `ExpiredAssetRecoveryHandler` + `SessionManager`; `rg` confirms stale enum destructuring call sites | confirmed |
+| F2: Batch renewal marks failed keys as renewed | high | non-`not_found` failures still get timestamps | not started |  |  |
+| F3: `avatarLastRenewed` lost during conversation sync | high | member profile rows are recreated without preserving timestamp | not started |  |  |
+| F4: Startup path cannot auto re-upload expired assets | medium | startup recovery handler lacks cache/writers | not started |  |  |
+| F5: Test coverage gaps around recovery/integration | medium | missing tests fail to protect core recovery behavior | not started |  |  |
+
+---
+
+## Phase 0 — Baseline snapshot
+
+### Objective
+Capture current branch/build state and establish a reproducible baseline.
+
+### Commands
+
+```bash
+git rev-parse --short HEAD
+git status --short
+swift test --package-path ConvosCore --filter AssetRenewalURLCollectorTests
+```
+
+### Evidence to record
+- Commit SHA
+- Dirty files
+- Build/test output summary (errors and key lines)
+
+### Result
+- Status: ☑ done
+- Notes:
+  - Commit SHA: `fbbbc703`
+  - Dirty files at snapshot:
+    - `.claude/settings.local.json`
+    - `docs/plans/asset-renewal-assessment.md`
+  - Baseline command `swift test --package-path ConvosCore --filter AssetRenewalURLCollectorTests` fails with compile errors in:
+    - `ConvosCore/Sources/ConvosCore/Assets/ExpiredAssetRecoveryHandler.swift`
+    - `ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift`
+
+---
+
+## Phase 1 — F1 Compile regression assessment
+
+### Hypothesis
+`ExpiredAssetRecoveryHandler` and call sites are out of sync with current `RenewableAsset` shape and `ImageCacheProtocol` API.
+
+### Steps
+1. Compile ConvosCore and collect all errors touching:
+   - `ConvosCore/Sources/ConvosCore/Assets/ExpiredAssetRecoveryHandler.swift`
+   - `ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift`
+2. Group each error into root cause bucket:
+   - enum tuple arity mismatch
+   - image cache API mismatch
+   - stale call-site destructuring
+3. Confirm impacted files via search:
+
+```bash
+rg -n "\\.profileAvatar\\(|\\.groupImage\\(" ConvosCore/Sources/ConvosCore
+```
+
+### Evidence to record
+- Error list by bucket
+- File+line list of required updates
+
+### Initial evidence (captured)
+- `SessionManager.swift`
+  - ambiguous expression in `forceReuploadAssetFromCache` tuple initialization
+  - `ImageCacheContainer.shared.image(for: url)` uses unsupported URL overload
+- `ExpiredAssetRecoveryHandler.swift`
+  - `imageCache.image(for: url)` uses unsupported URL overload
+  - enum tuple pattern arity mismatch for `.profileAvatar` and `.groupImage`
+
+### Verdict
+- Confirmed? ☑ yes
+- Why:
+  - Compile is currently blocked by concrete API/enum mismatch errors in both recovery and re-upload call paths.
+  - `rg` confirms stale enum destructuring patterns in:
+    - `ConvosCore/Sources/ConvosCore/Assets/ExpiredAssetRecoveryHandler.swift`
+    - `ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift`
+
+---
+
+## Phase 2 — F2 Renewal timestamp correctness assessment
+
+### Hypothesis
+Batch logic records timestamps for keys that failed renewal with errors other than `not_found`.
+
+### Steps
+1. Add/adjust test in `ConvosCore/Tests/ConvosCoreTests/Assets/AssetRenewalManagerTests.swift`:
+   - mixed results per key: success + `not_found` + `internal_error`
+2. Assert timestamp updates only for true successes.
+3. Run targeted test.
+
+### Suggested test scenario matrix
+
+| Key | API outcome | Expected timestamp update |
+|---|---|---|
+| k1 | success | yes |
+| k2 | not_found | no |
+| k3 | internal_error | no |
+
+### Evidence to record
+- Failing test (current behavior)
+- Expected vs actual key-level outcome table
+
+### Verdict template
+- Confirmed? ☐ yes ☐ no ☐ partial
+- Why:
+
+---
+
+## Phase 3 — F3 Profile timestamp preservation assessment
+
+### Hypothesis
+Conversation sync/store path drops `avatarLastRenewed` due to profile delete/reinsert flow.
+
+### Steps
+1. Add regression test (ConversationWriter path):
+   - seed `DBMemberProfile.avatarLastRenewed` with non-nil
+   - run store/sync flow for same conversation/profile/avatar
+   - verify `avatarLastRenewed` remains unchanged
+2. Trace where loss happens if test fails.
+
+### Evidence to record
+- Before/after DB values for `avatarLastRenewed`
+- Exact writer path where reset occurs
+
+### Verdict template
+- Confirmed? ☐ yes ☐ no ☐ partial
+- Why:
+
+---
+
+## Phase 4 — F4 Auto re-upload startup path assessment
+
+### Hypothesis
+Startup renewal cannot auto-reupload because recovery handler is instantiated without image cache and metadata writers.
+
+### Steps
+1. Document current dependency wiring:
+   - startup path (`SessionManager` initialization task)
+   - debug/manual path (`forceReuploadAssetFromCache`)
+2. Validate behavior with expired key simulation:
+   - when startup handler lacks cache/writers
+   - when manual path injects full dependencies
+
+### Dependency matrix
+
+| Path | imageCache | myProfileWriter | conversationMetadataWriter | Expected behavior |
+|---|---|---|---|---|
+| Startup task |  |  |  | clear URL fallback |
+| Manual force reupload |  |  |  | cache re-upload possible |
+
+### Evidence to record
+- Source references (file+line)
+- Behavior outcome for each path
+
+### Verdict template
+- Confirmed? ☐ yes ☐ no ☐ partial
+- Why:
+
+---
+
+## Phase 5 — F5 Coverage gap assessment
+
+### Hypothesis
+Current tests do not cover recovery handler behavior and startup integration enough to prevent regressions.
+
+### Steps
+1. Inventory current tests in:
+   - `AssetRenewalManagerTests.swift`
+   - `AssetRenewalURLCollectorTests.swift`
+2. Map each finding to existing coverage and missing tests.
+3. Propose a minimum guardrail suite.
+
+### Coverage matrix template
+
+| Risk | Existing tests | Missing tests |
+|---|---|---|
+| Compile drift on enum/image cache API |  |  |
+| Per-key renewal success accounting |  |  |
+| Profile timestamp preservation |  |  |
+| Expired asset recovery paths |  |  |
+| Startup integration behavior |  |  |
+
+### Verdict template
+- Confirmed gaps? ☐ yes ☐ no ☐ partial
+- Why:
+
+---
+
+## Final output expected from assessment
+
+1. For each finding (F1-F5):
+   - reproducible steps
+   - evidence
+   - confirmed verdict
+2. Ranked remediation order with dependencies.
+3. Test plan for preventing recurrence.
+
+---
+
+## Recommended remediation order (after assessment)
+
+1. Fix F1 compile breakages.
+2. Fix F2 per-key renewal accounting.
+3. Fix F3 timestamp preservation for member profiles.
+4. Address F4 startup recovery wiring policy.
+5. Implement F5 regression tests.

--- a/docs/plans/asset-renewal-assessment.md
+++ b/docs/plans/asset-renewal-assessment.md
@@ -15,11 +15,11 @@ Validate (with reproducible evidence) the deep findings from review before imple
 
 | Finding | Severity | Hypothesis | Status | Evidence | Verdict |
 |---|---|---|---|---|---|
-| F1: Compile regression in asset recovery path | blocker | API/enum drift caused compile failure | done | fixed by updating enum destructuring + cache identifier lookups; `swift test --package-path ConvosCore --filter AssetRenewalURLCollectorTests` now builds/runs | confirmed |
-| F2: Batch renewal marks failed keys as renewed | high | non-`not_found` failures still get timestamps | done | added test `testBatchRenewalCanOverRecordTimestampsForUnknownFailures` proving timestamped assets can exceed `result.renewed` | confirmed |
-| F3: `avatarLastRenewed` lost during conversation sync | high | member profile rows are recreated without preserving timestamp | done | static trace: profile rows are deleted/reinserted in `ConversationWriter`, and XMTP profile mapping initializes `avatarLastRenewed` as nil | confirmed |
+| F1: Compile regression in asset recovery path | blocker | API/enum drift caused compile failure | done | fixed by updating enum destructuring + cache identifier lookups; `swift test --package-path ConvosCore --filter AssetRenewalURLCollectorTests` now builds/runs | confirmed + fixed |
+| F2: Batch renewal marks failed keys as renewed | high | non-`not_found` failures still get timestamps | done | added/updated test `testBatchRenewalRecordsOnlyExplicitlyRenewedKeys`; introduced `renewedKeys` in `AssetRenewalResult` and use it in manager | confirmed + fixed |
+| F3: `avatarLastRenewed` lost during conversation sync | high | member profile rows are recreated without preserving timestamp | done | fixed in `ConversationWriter` via preservation helper; added `AvatarRenewalPreservationTests` | confirmed + fixed |
 | F4: Startup path cannot auto re-upload expired assets | medium | startup recovery handler lacks cache/writers | done | `SessionManager` startup injects only `databaseWriter`; manual path injects cache + profile/group writers | confirmed |
-| F5: Test coverage gaps around recovery/integration | medium | missing tests fail to protect core recovery behavior | done | inventory shows no direct tests for `ExpiredAssetRecoveryHandler` or startup renewal wiring behavior | confirmed |
+| F5: Test coverage gaps around recovery/integration | medium | missing tests fail to protect core recovery behavior | done | added manager/accounting tests + avatar renewal preservation tests; recovery/startup integration tests still missing | confirmed (partially addressed) |
 
 
 ---
@@ -121,19 +121,19 @@ Batch logic records timestamps for keys that failed renewal with errors other th
 | k3 | internal_error | no |
 
 ### Evidence recorded
-- Added test in `ConvosCore/Tests/ConvosCoreTests/Assets/AssetRenewalManagerTests.swift`:
-  - `testBatchRenewalCanOverRecordTimestampsForUnknownFailures`
-- Test setup:
-  - API result: `renewed: 1`, `failed: 2`, `expiredKeys: ["avatar-1.bin"]`
-  - Assets under test: profile avatar 1, profile avatar 2, group image
-- Observed outcome:
-  - `result.renewed == 1`
-  - `timestampedAssetCount > result.renewed` (timestamps written to more assets than explicitly renewed)
+- Initial repro test showed over-record risk when renewal success was inferred by `batch - expiredKeys`.
+- Fix implemented:
+  - `AssetRenewalResult` now carries `renewedKeys` (derived from backend `results.success`).
+  - `AssetRenewalManager` records timestamps using `renewedKeys` only.
+- Verification test:
+  - `testBatchRenewalRecordsOnlyExplicitlyRenewedKeys`
+  - Scenario: one explicit renewed key, one expired key, one unknown failure key.
+  - Observed: only explicit renewed key gets timestamp.
 
 ### Verdict
 - Confirmed? ☑ yes
 - Why:
-  - Current logic treats `batch - expiredKeys` as renewed, which includes unknown failures that are not in `expiredKeys`.
+  - The bug existed under inferred-success logic and is now corrected with key-level success accounting.
 
 ---
 
@@ -150,18 +150,22 @@ Conversation sync/store path drops `avatarLastRenewed` due to profile delete/rei
 2. Trace where loss happens if test fails.
 
 ### Evidence recorded
-- `ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationWriter.swift`
-  - member profiles are deleted per conversation before re-save:
-    - `DBMemberProfile.filter(...conversationId...).deleteAll(db)`
-  - then profiles are re-saved from `memberProfiles` input.
-- `ConvosCore/Sources/ConvosCore/Invites & Custom Metadata/XMTPGroup+CustomMetadata.swift`
-  - `memberProfiles` mapping creates `DBMemberProfile` without passing `avatarLastRenewed` (defaults to nil).
-- There is explicit preservation logic for `conversation.imageLastRenewed` but no equivalent for `memberProfile.avatarLastRenewed`.
+- Initial issue:
+  - `ConversationWriter` deleted and recreated `DBMemberProfile` rows per conversation.
+  - Incoming profiles from XMTP mapping had `avatarLastRenewed` defaulting to nil.
+- Fix implemented:
+  - Added `ConversationWriter.preservingAvatarLastRenewed(incomingProfile:existingProfile:)`.
+  - During save, existing profile rows are fetched first and `avatarLastRenewed` is preserved only when avatar URL is unchanged.
+- Tests added:
+  - `AvatarRenewalPreservationTests`
+    - preserves when URL unchanged
+    - clears when URL changes
+    - clears when incoming avatar is nil
 
 ### Verdict
 - Confirmed? ☑ yes
 - Why:
-  - Conversation sync path structurally recreates profile rows with no carry-over of `avatarLastRenewed`, so renewal timestamps are dropped.
+  - Issue reproduced by code path analysis and fixed with explicit preservation logic plus focused tests.
 
 ---
 
@@ -215,8 +219,8 @@ Current tests do not cover recovery handler behavior and startup integration eno
 | Risk | Existing tests | Missing tests |
 |---|---|---|
 | Compile drift on enum/image cache API | `AssetRenewalManagerTests`, `AssetRenewalURLCollectorTests` compile indirectly | Direct tests for `ExpiredAssetRecoveryHandler` pattern matching/cache lookup API usage |
-| Per-key renewal success accounting | `AssetRenewalManagerTests` includes stale/expired/success paths | Per-key API result mapping test once API returns explicit success keys |
-| Profile timestamp preservation | none | Regression test for `avatarLastRenewed` preservation through conversation sync |
+| Per-key renewal success accounting | `AssetRenewalManagerTests` now includes explicit renewed-key accounting test | Additional integration coverage across API client parsing + manager path |
+| Profile timestamp preservation | `AvatarRenewalPreservationTests` | Full integration test through `ConversationWriter.store` + DB migration state |
 | Expired asset recovery paths | none | Unit tests for recovery success/fallback clear-url logic |
 | Startup integration behavior | none | Integration test validating startup renewal dependency injection behavior |
 

--- a/docs/plans/asset-renewal-assessment.md
+++ b/docs/plans/asset-renewal-assessment.md
@@ -18,8 +18,8 @@ Validate (with reproducible evidence) the deep findings from review before imple
 | F1: Compile regression in asset recovery path | blocker | API/enum drift caused compile failure | done | fixed by updating enum destructuring + cache identifier lookups; `swift test --package-path ConvosCore --filter AssetRenewalURLCollectorTests` now builds/runs | confirmed + fixed |
 | F2: Batch renewal marks failed keys as renewed | high | non-`not_found` failures still get timestamps | done | added/updated test `testBatchRenewalRecordsOnlyExplicitlyRenewedKeys`; introduced `renewedKeys` in `AssetRenewalResult` and use it in manager | confirmed + fixed |
 | F3: `avatarLastRenewed` lost during conversation sync | high | member profile rows are recreated without preserving timestamp | done | fixed in `ConversationWriter` via preservation helper; added `AvatarRenewalPreservationTests` | confirmed + fixed |
-| F4: Startup path cannot auto re-upload expired assets | medium | startup recovery handler lacks cache/writers | done | `SessionManager` startup injects only `databaseWriter`; manual path injects cache + profile/group writers | confirmed |
-| F5: Test coverage gaps around recovery/integration | medium | missing tests fail to protect core recovery behavior | done | added manager/accounting tests + avatar renewal preservation tests; recovery/startup integration tests still missing | confirmed (partially addressed) |
+| F4: Startup path cannot auto re-upload expired assets | medium | startup recovery handler lacks cache/writers | done | implemented deferred queue: startup now defers recoverable assets, foreground processes queue with full writers | confirmed + fixed |
+| F5: Test coverage gaps around recovery/integration | medium | missing tests fail to protect core recovery behavior | done | added manager/accounting tests + avatar preservation + deferred queue/handler tests; startup integration still candidate for future hardening | confirmed (mostly addressed) |
 
 
 ---
@@ -184,21 +184,27 @@ Startup renewal cannot auto-reupload because recovery handler is instantiated wi
 
 ### Dependency matrix
 
-| Path | imageCache | myProfileWriter | conversationMetadataWriter | Expected behavior |
+| Path | imageCache | myProfileWriter | conversationMetadataWriter | Behavior |
 |---|---|---|---|---|
-| Startup task | no | no | no | clear URL fallback |
-| Manual force reupload | yes | yes | yes | cache re-upload possible |
+| Startup renewal task | yes | no | no | cache hits are deferred into queue |
+| Foreground deferred processing | yes | yes | yes | queued assets are re-uploaded via existing force path |
+| Manual force reupload | yes | yes | yes | immediate cache re-upload |
 
 ### Evidence recorded
-- Startup path wiring (`SessionManager` init task):
-  - `let recoveryHandler = ExpiredAssetRecoveryHandler(databaseWriter: self.databaseWriter)`
-- Manual path wiring (`forceReuploadAssetFromCache`):
-  - injects `ImageCacheContainer.shared`, `MyProfileWriter`, and `ConversationMetadataWriter`.
+- Added `DeferredAssetRecoveryQueue` actor for deduped queuing by URL.
+- Startup recovery handler now receives:
+  - `imageCache: ImageCacheContainer.shared`
+  - `onRecoveryDeferred` callback to enqueue recoverable assets.
+- `SessionManager` foreground observer now triggers deferred queue processing.
+- Queue processing uses full writer path (`forceReuploadAssetFromCache`), and falls back to clear URL if unrecoverable.
+- Tests added:
+  - `DeferredAssetRecoveryQueueTests`
+  - `ExpiredAssetRecoveryHandlerTests`
 
 ### Verdict
 - Confirmed? ☑ yes
 - Why:
-  - Expired assets in startup renewal path cannot be re-uploaded from cache because required dependencies are not injected.
+  - Initial gap was real, and Option B deferred recovery is now implemented to avoid startup inbox wake while still auto-recovering when app is foregrounded.
 
 ---
 
@@ -218,16 +224,16 @@ Current tests do not cover recovery handler behavior and startup integration eno
 
 | Risk | Existing tests | Missing tests |
 |---|---|---|
-| Compile drift on enum/image cache API | `AssetRenewalManagerTests`, `AssetRenewalURLCollectorTests` compile indirectly | Direct tests for `ExpiredAssetRecoveryHandler` pattern matching/cache lookup API usage |
-| Per-key renewal success accounting | `AssetRenewalManagerTests` now includes explicit renewed-key accounting test | Additional integration coverage across API client parsing + manager path |
-| Profile timestamp preservation | `AvatarRenewalPreservationTests` | Full integration test through `ConversationWriter.store` + DB migration state |
-| Expired asset recovery paths | none | Unit tests for recovery success/fallback clear-url logic |
-| Startup integration behavior | none | Integration test validating startup renewal dependency injection behavior |
+| Compile drift on enum/image cache API | `AssetRenewalManagerTests`, `AssetRenewalURLCollectorTests`, `ExpiredAssetRecoveryHandlerTests` | Full integration regression across `SessionManager` startup task wiring |
+| Per-key renewal success accounting | `AssetRenewalManagerTests` explicit renewed-key accounting | API-decoding integration test with mixed server results |
+| Profile timestamp preservation | `AvatarRenewalPreservationTests` | End-to-end `ConversationWriter.store` integration path test |
+| Expired asset recovery paths | `ExpiredAssetRecoveryHandlerTests` (defer behavior) | Explicit fallback-clear path test when cache miss/no writers/no queue callback |
+| Startup integration behavior | Deferred queue unit tests + handler defer test | Full startup-to-foreground integration test in `SessionManager` |
 
 ### Verdict
-- Confirmed gaps? ☑ yes
+- Confirmed gaps? ☑ partial
 - Why:
-  - Current coverage is strong for collector and manager basics, but weak around recovery handler and end-to-end startup recovery behavior.
+  - Coverage now exists for key unit behaviors, but a full startup/foreground integration regression test is still pending.
 
 ---
 

--- a/docs/plans/asset-renewal-assessment.md
+++ b/docs/plans/asset-renewal-assessment.md
@@ -15,11 +15,12 @@ Validate (with reproducible evidence) the deep findings from review before imple
 
 | Finding | Severity | Hypothesis | Status | Evidence | Verdict |
 |---|---|---|---|---|---|
-| F1: Compile regression in asset recovery path | blocker | API/enum drift caused compile failure | done | `swift test --package-path ConvosCore --filter AssetRenewalURLCollectorTests` fails in `ExpiredAssetRecoveryHandler` + `SessionManager`; `rg` confirms stale enum destructuring call sites | confirmed |
-| F2: Batch renewal marks failed keys as renewed | high | non-`not_found` failures still get timestamps | not started |  |  |
-| F3: `avatarLastRenewed` lost during conversation sync | high | member profile rows are recreated without preserving timestamp | not started |  |  |
-| F4: Startup path cannot auto re-upload expired assets | medium | startup recovery handler lacks cache/writers | not started |  |  |
-| F5: Test coverage gaps around recovery/integration | medium | missing tests fail to protect core recovery behavior | not started |  |  |
+| F1: Compile regression in asset recovery path | blocker | API/enum drift caused compile failure | done | fixed by updating enum destructuring + cache identifier lookups; `swift test --package-path ConvosCore --filter AssetRenewalURLCollectorTests` now builds/runs | confirmed |
+| F2: Batch renewal marks failed keys as renewed | high | non-`not_found` failures still get timestamps | done | added test `testBatchRenewalCanOverRecordTimestampsForUnknownFailures` proving timestamped assets can exceed `result.renewed` | confirmed |
+| F3: `avatarLastRenewed` lost during conversation sync | high | member profile rows are recreated without preserving timestamp | done | static trace: profile rows are deleted/reinserted in `ConversationWriter`, and XMTP profile mapping initializes `avatarLastRenewed` as nil | confirmed |
+| F4: Startup path cannot auto re-upload expired assets | medium | startup recovery handler lacks cache/writers | done | `SessionManager` startup injects only `databaseWriter`; manual path injects cache + profile/group writers | confirmed |
+| F5: Test coverage gaps around recovery/integration | medium | missing tests fail to protect core recovery behavior | done | inventory shows no direct tests for `ExpiredAssetRecoveryHandler` or startup renewal wiring behavior | confirmed |
+
 
 ---
 
@@ -88,10 +89,15 @@ rg -n "\\.profileAvatar\\(|\\.groupImage\\(" ConvosCore/Sources/ConvosCore
 ### Verdict
 - Confirmed? ☑ yes
 - Why:
-  - Compile is currently blocked by concrete API/enum mismatch errors in both recovery and re-upload call paths.
-  - `rg` confirms stale enum destructuring patterns in:
+  - Compile was blocked by concrete API/enum mismatch errors in both recovery and re-upload call paths.
+  - `rg` confirmed stale enum destructuring patterns in:
     - `ConvosCore/Sources/ConvosCore/Assets/ExpiredAssetRecoveryHandler.swift`
     - `ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift`
+  - Applied fix:
+    - switched cache lookup to identifier-based `image(for: asset.url)`
+    - updated enum case destructuring to include `lastRenewed`
+    - simplified ambiguous async tuple construction in `SessionManager.forceReuploadAssetFromCache`
+  - Re-check: `swift test --package-path ConvosCore --filter AssetRenewalURLCollectorTests` passes.
 
 ---
 
@@ -114,13 +120,20 @@ Batch logic records timestamps for keys that failed renewal with errors other th
 | k2 | not_found | no |
 | k3 | internal_error | no |
 
-### Evidence to record
-- Failing test (current behavior)
-- Expected vs actual key-level outcome table
+### Evidence recorded
+- Added test in `ConvosCore/Tests/ConvosCoreTests/Assets/AssetRenewalManagerTests.swift`:
+  - `testBatchRenewalCanOverRecordTimestampsForUnknownFailures`
+- Test setup:
+  - API result: `renewed: 1`, `failed: 2`, `expiredKeys: ["avatar-1.bin"]`
+  - Assets under test: profile avatar 1, profile avatar 2, group image
+- Observed outcome:
+  - `result.renewed == 1`
+  - `timestampedAssetCount > result.renewed` (timestamps written to more assets than explicitly renewed)
 
-### Verdict template
-- Confirmed? ☐ yes ☐ no ☐ partial
+### Verdict
+- Confirmed? ☑ yes
 - Why:
+  - Current logic treats `batch - expiredKeys` as renewed, which includes unknown failures that are not in `expiredKeys`.
 
 ---
 
@@ -136,13 +149,19 @@ Conversation sync/store path drops `avatarLastRenewed` due to profile delete/rei
    - verify `avatarLastRenewed` remains unchanged
 2. Trace where loss happens if test fails.
 
-### Evidence to record
-- Before/after DB values for `avatarLastRenewed`
-- Exact writer path where reset occurs
+### Evidence recorded
+- `ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationWriter.swift`
+  - member profiles are deleted per conversation before re-save:
+    - `DBMemberProfile.filter(...conversationId...).deleteAll(db)`
+  - then profiles are re-saved from `memberProfiles` input.
+- `ConvosCore/Sources/ConvosCore/Invites & Custom Metadata/XMTPGroup+CustomMetadata.swift`
+  - `memberProfiles` mapping creates `DBMemberProfile` without passing `avatarLastRenewed` (defaults to nil).
+- There is explicit preservation logic for `conversation.imageLastRenewed` but no equivalent for `memberProfile.avatarLastRenewed`.
 
-### Verdict template
-- Confirmed? ☐ yes ☐ no ☐ partial
+### Verdict
+- Confirmed? ☑ yes
 - Why:
+  - Conversation sync path structurally recreates profile rows with no carry-over of `avatarLastRenewed`, so renewal timestamps are dropped.
 
 ---
 
@@ -163,16 +182,19 @@ Startup renewal cannot auto-reupload because recovery handler is instantiated wi
 
 | Path | imageCache | myProfileWriter | conversationMetadataWriter | Expected behavior |
 |---|---|---|---|---|
-| Startup task |  |  |  | clear URL fallback |
-| Manual force reupload |  |  |  | cache re-upload possible |
+| Startup task | no | no | no | clear URL fallback |
+| Manual force reupload | yes | yes | yes | cache re-upload possible |
 
-### Evidence to record
-- Source references (file+line)
-- Behavior outcome for each path
+### Evidence recorded
+- Startup path wiring (`SessionManager` init task):
+  - `let recoveryHandler = ExpiredAssetRecoveryHandler(databaseWriter: self.databaseWriter)`
+- Manual path wiring (`forceReuploadAssetFromCache`):
+  - injects `ImageCacheContainer.shared`, `MyProfileWriter`, and `ConversationMetadataWriter`.
 
-### Verdict template
-- Confirmed? ☐ yes ☐ no ☐ partial
+### Verdict
+- Confirmed? ☑ yes
 - Why:
+  - Expired assets in startup renewal path cannot be re-uploaded from cache because required dependencies are not injected.
 
 ---
 
@@ -192,15 +214,16 @@ Current tests do not cover recovery handler behavior and startup integration eno
 
 | Risk | Existing tests | Missing tests |
 |---|---|---|
-| Compile drift on enum/image cache API |  |  |
-| Per-key renewal success accounting |  |  |
-| Profile timestamp preservation |  |  |
-| Expired asset recovery paths |  |  |
-| Startup integration behavior |  |  |
+| Compile drift on enum/image cache API | `AssetRenewalManagerTests`, `AssetRenewalURLCollectorTests` compile indirectly | Direct tests for `ExpiredAssetRecoveryHandler` pattern matching/cache lookup API usage |
+| Per-key renewal success accounting | `AssetRenewalManagerTests` includes stale/expired/success paths | Per-key API result mapping test once API returns explicit success keys |
+| Profile timestamp preservation | none | Regression test for `avatarLastRenewed` preservation through conversation sync |
+| Expired asset recovery paths | none | Unit tests for recovery success/fallback clear-url logic |
+| Startup integration behavior | none | Integration test validating startup renewal dependency injection behavior |
 
-### Verdict template
-- Confirmed gaps? ☐ yes ☐ no ☐ partial
+### Verdict
+- Confirmed gaps? ☑ yes
 - Why:
+  - Current coverage is strong for collector and manager basics, but weak around recovery handler and end-to-end startup recovery behavior.
 
 ---
 


### PR DESCRIPTION
Add force re-upload from cache for expired assets

Adds manual re-upload capability for expired assets from the debug view:
- Enhanced ExpiredAssetRecoveryHandler with optional cache recovery support
- Added forceReuploadAssetFromCache to SessionManagerProtocol
- Implemented in SessionManager with proper writer initialization
- Wired through debug view hierarchy with context menu action

Fix asset reupload compile regressions and start assessment log

Assess renewal accounting and document asset renewal findings

Fix renewal timestamp accounting using explicit renewed keys

Preserve avatar renewal timestamps during conversation sync

Defer expired asset recovery from startup via queued foreground processing

Add tests for deferred asset recovery queue and handler behavior

Update assessment log with deferred recovery implementation status

Update recovery handler test cache stub for latest image cache protocol

Harden deferred asset recovery flow with capped retries and serialized processing

Expand deferred recovery tests for queue semantics and defer result

Align app settings and debug asset view with project style conventions

Add group image recovery-path coverage for expired asset handler

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Recover expired assets from cache in `ExpiredAssetRecoveryHandler` with deferred processing
> - `ExpiredAssetRecoveryHandler.handleExpiredAsset` now attempts to recover assets from cache using `MyProfileWriter` or `ConversationMetadataWriter`, defers processing when writers are unavailable via `DeferredAssetRecoveryQueue`, and only clears URLs as a last resort
> - `SessionManager` processes deferred assets in background on app foreground with retry logic (max 3 attempts), and exposes `forceReuploadAssetFromCache` to manually trigger cache recovery for a specific asset
> - `AssetRenewalResult` includes `renewedKeys` field to track which keys were successfully renewed, fixing timestamp updates to only apply to explicitly renewed assets
> - `ConversationWriter.store` preserves `avatarLastRenewed` when avatar URLs remain unchanged during conversation sync
> - Debug UI adds "Force Re-upload from Cache" action in [DebugAssetRenewalView.swift](https://github.com/xmtplabs/convos-ios/pull/530/files#diff-dc6963b7b7c05e4d1391c82ad5d93851ddaa86b706c4e8686922c3d3427ac57d)
> - Behavioral Change: expired assets are now recovered from cache when possible instead of being cleared immediately
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized f83030c. 13 files reviewed, 8 issues evaluated, 7 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> <details>
> <summary>Convos/Debug View/DebugAssetRenewalView.swift — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 164](https://github.com/xmtplabs/convos-ios/blob/f83030c7ac3c26672253bbc57bb7a3cc9e698f80/Convos/Debug View/DebugAssetRenewalView.swift#L164): The "Force Re-upload from Cache" button's `.disabled(isReuploading)` modifier doesn't account for when `isRenewing` is true, and similarly the renew button doesn't check `isReuploading`. This allows both operations to run concurrently on the same asset, potentially causing race conditions or inconsistent state when both `renewSingleAsset()` and `forceReuploadFromCache()` execute simultaneously. <b>[ Low confidence ]</b>
> </details>
>
> <details>
> <summary>ConvosCore/Sources/ConvosCore/Assets/AssetRenewalManager.swift — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 122](https://github.com/xmtplabs/convos-ios/blob/f83030c7ac3c26672253bbc57bb7a3cc9e698f80/ConvosCore/Sources/ConvosCore/Assets/AssetRenewalManager.swift#L122): In `performRenewal`, the returned `AssetRenewalResult` at line 122 does not include accumulated `renewedKeys`. While `allExpiredKeys` is properly accumulated across batches, there is no corresponding `allRenewedKeys` accumulation. The result uses the default empty array for `renewedKeys`, meaning callers of `forceRenewal()` will always receive an empty `renewedKeys` array even when assets were successfully renewed. This is inconsistent with how `expiredKeys` is handled and could break callers that depend on knowing which keys were renewed. <b>[ Out of scope ]</b>
> </details>
>
> <details>
> <summary>ConvosCore/Sources/ConvosCore/Assets/ExpiredAssetRecoveryHandler.swift — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 152](https://github.com/xmtplabs/convos-ios/blob/f83030c7ac3c26672253bbc57bb7a3cc9e698f80/ConvosCore/Sources/ConvosCore/Assets/ExpiredAssetRecoveryHandler.swift#L152): The `clearAssetUrl` method swallows database write errors silently (lines 152-154), but `handleExpiredAsset` returns `.cleared` regardless of whether the clear operation succeeded (lines 37-38, 43-44). This could mislead callers into believing the asset URL was cleared when the database write actually failed. <b>[ Out of scope ]</b>
> </details>
>
> <details>
> <summary>ConvosCore/Sources/ConvosCore/Inboxes/MockInboxesService.swift — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 138](https://github.com/xmtplabs/convos-ios/blob/f83030c7ac3c26672253bbc57bb7a3cc9e698f80/ConvosCore/Sources/ConvosCore/Inboxes/MockInboxesService.swift#L138): In `makeAssetRenewalManager`, the `ExpiredAssetRecoveryHandler` is created with `imageCache` but without `myProfileWriter`, `conversationMetadataWriter`, or `onRecoveryDeferred`. If `attemptRecoveryFromCache` finds a cached image but no writer is available, it returns `.deferred`. Since `onRecoveryDeferred` is nil, `handleExpiredAsset` will then clear the asset URL even though the cached image exists and recovery might have been possible with proper writers configured. This could result in unnecessary asset loss in mock scenarios. <b>[ Low confidence ]</b>
> </details>
>
> <details>
> <summary>ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift — 0 comments posted, 4 evaluated, 3 filtered</summary>
>
> - [line 569](https://github.com/xmtplabs/convos-ios/blob/f83030c7ac3c26672253bbc57bb7a3cc9e698f80/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift#L569): In `processDeferredAssetRecoveries`, when `forceReuploadAssetFromCache` returns `false` because the recovery handler inside it already returned `.cleared` (meaning the asset URL was already cleared in the database), the code at lines 569-570 creates another `ExpiredAssetRecoveryHandler` and calls `handleExpiredAsset` again. This results in redundant database operations attempting to clear an already-cleared asset URL. While not a crash, this wastes database writes. <b>[ Low confidence ]</b>
> - [line 617](https://github.com/xmtplabs/convos-ios/blob/f83030c7ac3c26672253bbc57bb7a3cc9e698f80/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift#L617): In `forceReuploadAssetFromCache` for `.profileAvatar` assets (line 617-624), the code uses `assetInboxId` from the `RenewableAsset` tuple to obtain the messaging service. If the `RenewableAsset.profileAvatar` was created for another user's cached avatar (not the current user's profile), this would attempt to get a service for an inbox that doesn't belong to us. The call to `messagingService(for:inboxId:)` would fail, causing retries until exhaustion and eventual clearing of a URL that may have been legitimate. This depends on whether `AssetRenewalURLCollector` only collects the current user's avatars. <b>[ Low confidence ]</b>
> - [line 652](https://github.com/xmtplabs/convos-ios/blob/f83030c7ac3c26672253bbc57bb7a3cc9e698f80/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift#L652): The `ExpiredAssetRecoveryHandler` created in `forceReuploadAssetFromCache` at lines 652-657 does not include an `onRecoveryDeferred` callback. If for any reason the recovery returns `.deferred` (though currently the writers are provided so this shouldn't happen), the handler will fall through to clearing the asset with a warning log rather than properly deferring it for later processing. <b>[ Low confidence ]</b>
> </details>
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->