### PR TITLE
Add clipboard image paste support in composer

### DIFF
--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesBottomBar.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesBottomBar.swift
@@ -118,9 +118,7 @@ struct MessagesBottomBar<BottomBarContent: View>: View {
                 messagesTextFieldEnabled: messagesTextFieldEnabled,
                 onProfilePhotoTap: onProfilePhotoTap,
                 onSendMessage: onSendMessage,
-                onImagePasted: { image in
-                    selectedAttachmentImage = image
-                }
+                onImagePasted: { selectedAttachmentImage = $0 }
             )
             .opacity(messagesTextFieldEnabled ? 1.0 : 0.4)
             .fixedSize(horizontal: false, vertical: true)

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesBottomBar.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesBottomBar.swift
@@ -117,7 +117,10 @@ struct MessagesBottomBar<BottomBarContent: View>: View {
                 animateAvatarForQuickname: onboardingCoordinator.shouldAnimateAvatarForQuicknameSetup,
                 messagesTextFieldEnabled: messagesTextFieldEnabled,
                 onProfilePhotoTap: onProfilePhotoTap,
-                onSendMessage: onSendMessage
+                onSendMessage: onSendMessage,
+                onImagePasted: { image in
+                    selectedAttachmentImage = image
+                }
             )
             .opacity(messagesTextFieldEnabled ? 1.0 : 0.4)
             .fixedSize(horizontal: false, vertical: true)

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesInputView.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesInputView.swift
@@ -17,6 +17,7 @@ struct MessagesInputView: View {
     private let focused: MessagesViewInputFocus = .message
     let onProfilePhotoTap: () -> Void
     let onSendMessage: () -> Void
+    let onImagePasted: (UIImage) -> Void
 
     private let attachmentPreviewSize: CGFloat = 80.0
     @State private var isPoofing: Bool = false
@@ -69,27 +70,21 @@ struct MessagesInputView: View {
                 .accessibilityLabel("Edit your profile")
                 .accessibilityIdentifier("profile-avatar-button")
 
-                Group {
-                    TextField(
-                        "Chat as \(profile.displayName)",
-                        text: $messageText,
-                        axis: .vertical
-                    )
-                    .focused($focusState, equals: focused)
-                    .font(.callout)
-                    .foregroundStyle(.colorTextPrimary)
-                    .tint(.colorTextPrimary)
-                    .frame(minHeight: Self.defaultHeight, maxHeight: 170.0, alignment: .center)
-                    .padding(.leading, DesignConstants.Spacing.step2x)
-                    .padding(.trailing, DesignConstants.Spacing.step3x)
-                    .disabled(!messagesTextFieldEnabled)
-                    .accessibilityLabel("Message input")
-                    .accessibilityIdentifier("message-text-field")
-                }
-                .onSubmit {
-                    onSendMessage()
-                    focusState = .message
-                }
+                ComposerTextView(
+                    text: $messageText,
+                    placeholder: "Chat as \(profile.displayName)",
+                    isEnabled: messagesTextFieldEnabled,
+                    maxHeight: 170.0,
+                    onSubmit: {
+                        onSendMessage()
+                        focusState = .message
+                    },
+                    onImagePasted: onImagePasted
+                )
+                .focused($focusState, equals: focused)
+                .frame(minHeight: Self.defaultHeight, alignment: .center)
+                .padding(.leading, DesignConstants.Spacing.step2x)
+                .padding(.trailing, DesignConstants.Spacing.step3x)
                 .frame(maxHeight: .infinity, alignment: .center)
 
                 Button {
@@ -204,7 +199,8 @@ struct MessagesInputView: View {
             animateAvatarForQuickname: animateAvatarForQuickname,
             messagesTextFieldEnabled: true,
             onProfilePhotoTap: {},
-            onSendMessage: {}
+            onSendMessage: {},
+            onImagePasted: { _ in }
         )
         .padding(DesignConstants.Spacing.step2x)
     }

--- a/Convos/Shared Views/ComposerTextView.swift
+++ b/Convos/Shared Views/ComposerTextView.swift
@@ -38,7 +38,7 @@ struct ComposerTextView: UIViewRepresentable {
         uiView.isEditable = isEnabled
         uiView.isSelectable = isEnabled
 
-        if uiView.text != text {
+        if uiView.text != text, !uiView.isPasting {
             uiView.text = text
             uiView.invalidateIntrinsicContentSize()
         }
@@ -108,12 +108,15 @@ struct ComposerTextView: UIViewRepresentable {
 
 final class ComposerUITextView: UITextView {
     var onImagePasted: ((UIImage) -> Void)?
+    private(set) var isPasting: Bool = false
 
     override func paste(_ sender: Any?) {
         let pasteboard = UIPasteboard.general
 
         if pasteboard.hasImages, let image = pasteboard.image {
+            isPasting = true
             onImagePasted?(image)
+            isPasting = false
             return
         }
 

--- a/Convos/Shared Views/ComposerTextView.swift
+++ b/Convos/Shared Views/ComposerTextView.swift
@@ -34,6 +34,7 @@ struct ComposerTextView: UIViewRepresentable {
         context.coordinator.isUpdating = true
         defer { context.coordinator.isUpdating = false }
 
+        context.coordinator.parent = self
         uiView.onImagePasted = onImagePasted
         uiView.isEditable = isEnabled
         uiView.isSelectable = isEnabled
@@ -59,7 +60,7 @@ struct ComposerTextView: UIViewRepresentable {
     }
 
     final class Coordinator: NSObject, UITextViewDelegate {
-        let parent: ComposerTextView
+        var parent: ComposerTextView
         var isUpdating: Bool = false
         private var placeholderLabel: UILabel?
 

--- a/Convos/Shared Views/ComposerTextView.swift
+++ b/Convos/Shared Views/ComposerTextView.swift
@@ -1,0 +1,129 @@
+import SwiftUI
+import UIKit
+
+struct ComposerTextView: UIViewRepresentable {
+    @Binding var text: String
+    let placeholder: String
+    let isEnabled: Bool
+    let maxHeight: CGFloat
+    let onSubmit: () -> Void
+    let onImagePasted: (UIImage) -> Void
+
+    func makeUIView(context: Context) -> ComposerUITextView {
+        let textView = ComposerUITextView()
+        textView.delegate = context.coordinator
+        textView.onImagePasted = onImagePasted
+        textView.font = UIFont.preferredFont(forTextStyle: .callout)
+        textView.textColor = UIColor(.colorTextPrimary)
+        textView.tintColor = UIColor(.colorTextPrimary)
+        textView.backgroundColor = .clear
+        textView.textContainerInset = .zero
+        textView.textContainer.lineFragmentPadding = 0
+        textView.isScrollEnabled = false
+        textView.isEditable = true
+        textView.isSelectable = true
+        textView.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        textView.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        textView.accessibilityLabel = "Message input"
+        textView.accessibilityIdentifier = "message-text-field"
+        context.coordinator.setupPlaceholder(in: textView, placeholder: placeholder)
+        return textView
+    }
+
+    func updateUIView(_ uiView: ComposerUITextView, context: Context) {
+        context.coordinator.isUpdating = true
+        defer { context.coordinator.isUpdating = false }
+
+        uiView.onImagePasted = onImagePasted
+        uiView.isEditable = isEnabled
+        uiView.isSelectable = isEnabled
+
+        if uiView.text != text {
+            uiView.text = text
+            uiView.invalidateIntrinsicContentSize()
+        }
+
+        context.coordinator.updatePlaceholder(in: uiView, text: text, placeholder: placeholder)
+    }
+
+    func sizeThatFits(_ proposal: ProposedViewSize, uiView: ComposerUITextView, context: Context) -> CGSize? {
+        let maxWidth = proposal.width ?? UIView.layoutFittingExpandedSize.width
+        let fittingSize = uiView.sizeThatFits(CGSize(width: maxWidth, height: CGFloat.greatestFiniteMagnitude))
+        let clampedHeight = min(fittingSize.height, maxHeight)
+        uiView.isScrollEnabled = fittingSize.height > maxHeight
+        return CGSize(width: maxWidth, height: clampedHeight)
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(parent: self)
+    }
+
+    final class Coordinator: NSObject, UITextViewDelegate {
+        let parent: ComposerTextView
+        var isUpdating: Bool = false
+        private var placeholderLabel: UILabel?
+
+        init(parent: ComposerTextView) {
+            self.parent = parent
+        }
+
+        func setupPlaceholder(in textView: UITextView, placeholder: String) {
+            let label = UILabel()
+            label.text = placeholder
+            label.font = textView.font
+            label.textColor = UIColor.tertiaryLabel
+            label.translatesAutoresizingMaskIntoConstraints = false
+            label.isAccessibilityElement = false
+            textView.addSubview(label)
+            NSLayoutConstraint.activate([
+                label.leadingAnchor.constraint(equalTo: textView.leadingAnchor),
+                label.topAnchor.constraint(equalTo: textView.topAnchor),
+            ])
+            placeholderLabel = label
+            label.isHidden = !textView.text.isEmpty
+        }
+
+        func updatePlaceholder(in textView: UITextView, text: String, placeholder: String) {
+            placeholderLabel?.text = placeholder
+            placeholderLabel?.font = textView.font
+            placeholderLabel?.isHidden = !text.isEmpty
+        }
+
+        func textViewDidChange(_ textView: UITextView) {
+            guard !isUpdating else { return }
+            parent.text = textView.text
+            placeholderLabel?.isHidden = !textView.text.isEmpty
+            textView.invalidateIntrinsicContentSize()
+        }
+
+        func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
+            if text == "\n" {
+                parent.onSubmit()
+                return false
+            }
+            return true
+        }
+    }
+}
+
+final class ComposerUITextView: UITextView {
+    var onImagePasted: ((UIImage) -> Void)?
+
+    override func paste(_ sender: Any?) {
+        let pasteboard = UIPasteboard.general
+
+        if pasteboard.hasImages, let image = pasteboard.image {
+            onImagePasted?(image)
+            return
+        }
+
+        super.paste(sender)
+    }
+
+    override func canPerformAction(_ action: Selector, withSender sender: Any?) -> Bool {
+        if action == #selector(paste(_:)) {
+            return UIPasteboard.general.hasImages || UIPasteboard.general.hasStrings
+        }
+        return super.canPerformAction(action, withSender: sender)
+    }
+}

--- a/docs/plans/clipboard-image-paste.md
+++ b/docs/plans/clipboard-image-paste.md
@@ -1,0 +1,97 @@
+# Plan: Clipboard Image Paste in Composer
+
+## Goal
+
+Allow users to paste images from the system clipboard into the message composer. Reuses the entire existing JPEG send pipeline with no changes to compression, upload, or rendering.
+
+## Current State Assessment
+
+### What works today
+
+- Composer supports selecting a single image from Photos (`MessagesBottomBar` + `.photosPicker(..., matching: .images)`)
+- Selected media is stored as `selectedAttachmentImage: UIImage?` in the conversation view model
+- Outgoing photo pipeline (`OutgoingMessageWriter` + `PhotoAttachmentService`) supports one attachment and background upload
+- Static photo compression targets ~1MB (`targetBytes: 1_000_000`) with a hard failure if resized JPEG is still above 10MB (`maxBytes: 10_000_000`)
+- Eager upload starts automatically when `selectedAttachmentImage` changes (via `onPhotoSelected`)
+
+### What is missing
+
+- No clipboard paste handling exists anywhere in the composer (no paste hooks, no custom input delegate)
+- The composer uses a SwiftUI `TextField` which has no paste interception API on iOS
+
+## Scope
+
+- Paste JPEG/PNG/HEIC from clipboard into composer
+- Reuse existing `UIImage` attachment model and JPEG send pipeline — no pipeline changes
+- Reuse existing eager upload, background upload, and rendering paths
+- Validate pasted image can produce a `UIImage` before accepting
+
+### Out of scope
+
+- GIF / animated image support (separate plan: `docs/plans/gif-support.md`)
+- Multi-attachment
+- Any changes to the send pipeline, compression, or rendering
+
+## Size Limits
+
+Static images go through the existing compression pipeline, so limits are already enforced:
+- `compressForPhotoAttachment` resizes to max 2048px dimension, targets ~1MB output
+- Hard reject if resized image at quality 1.0 exceeds 10MB
+
+No new limit infrastructure needed.
+
+## Implementation
+
+### Phase 1: Paste input mechanism
+
+The composer uses a SwiftUI `TextField` with `.vertical` axis. SwiftUI does not provide reliable paste interception on iOS (`.onPasteCommand` is macOS/Catalyst only, `UIPasteControl` requires a system button tap).
+
+The recommended approach is a **`UITextView` subclass wrapped in `UIViewRepresentable`** that overrides `paste(_:)`. The codebase already uses this pattern (`LinkTextView` is a `UITextView` subclass in `Convos/Shared Views/`).
+
+Implementation:
+- Create a composer-specific `UITextView` wrapper that intercepts `paste(_:)`
+- On paste, check `UIPasteboard.general` for image types (`public.image`, `public.png`, `public.jpeg`)
+- If image data is present, convert to `UIImage` and set as `selectedAttachmentImage`
+- If only text is present, insert text normally
+- If both image and text are on clipboard, prefer image (text can still be typed separately)
+- Replace the current SwiftUI `TextField` in `MessagesInputView` with this wrapper
+- Preserve all existing TextField behavior: placeholder, focus, multiline growth, on-submit
+
+Likely files:
+- New: `Convos/Shared Views/ComposerTextView.swift` (UITextView subclass + UIViewRepresentable)
+- Modified: `Convos/Conversation Detail/Messages/.../MessagesInputView.swift` (swap TextField)
+- Modified: `Convos/Conversation Detail/Messages/.../MessagesBottomBar.swift` (wire paste callback)
+
+### Phase 2: Validation and UX
+
+- Validate pasted image can produce a `UIImage` before accepting
+- If `UIImage(data:)` returns nil, discard silently (corrupt/unsupported data)
+- Existing eager upload flow handles the rest — `onPhotoSelected` is already called when `selectedAttachmentImage` changes
+- Text draft is preserved when image paste fails
+
+### Phase 3: QA
+
+- Paste JPEG from clipboard → appears in composer preview → sends successfully
+- Paste PNG from clipboard → same flow
+- Paste screenshot (PNG) → same flow
+- Paste image from Safari/web → same flow
+- Paste text only → inserts text normally
+- Paste image when attachment already exists → replaces previous attachment
+- Paste image, remove it, type text, send → text-only message
+- Copy image from Photos app, paste into composer → works
+- Hardware keyboard ⌘V and edit menu "Paste" both work
+- Regression: photo picker flow unchanged
+- Regression: text input behavior (multiline, submit, placeholder) unchanged
+
+## Risks and Mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| `UITextView` wrapper doesn't match `TextField` behavior (placeholder, focus, growth) | Follow existing `LinkTextView` pattern; match current styling and layout precisely |
+| `FocusState` integration with UIKit text view | Use `UIViewRepresentable` coordinator to bridge `becomeFirstResponder`/`resignFirstResponder` with SwiftUI focus |
+| Edit menu "Paste" differs from ⌘V behavior | Both go through `paste(_:)` override on `UITextView` — single code path |
+
+## Suggested PR Stack
+
+1. Plan PR (this document)
+2. `ComposerTextView` wrapper + paste handling + validation


### PR DESCRIPTION
Allow users to paste images from the system clipboard into the message composer using ⌘V or the Edit menu.

## How it works

1. A `ComposerTextView` (`UITextView` subclass wrapped in `UIViewRepresentable`) replaces the SwiftUI `TextField` in the composer
2. It overrides `paste(_:)` to check `UIPasteboard.general` for image content
3. If an image is found, it sets `selectedAttachmentImage` which triggers the existing eager upload flow
4. If only text is on the clipboard, paste behaves normally

## What's unchanged

- No changes to the send pipeline, compression, upload, or rendering
- Photo picker flow unchanged
- All existing attachment preview/removal UX preserved

## Plan

See `docs/plans/clipboard-image-paste.md` for full details.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enable clipboard image paste in message composer
> - Replaces the SwiftUI `TextField` with a custom `ComposerTextView` wrapping `UITextView`
> - The `UITextView` subclass intercepts paste operations, checks the clipboard for images, and invokes `onImagePasted` with the `UIImage`
> - Pasted images populate `selectedAttachmentImage`; text paste works normally
> - Pressing return triggers send; placeholder and focus behavior are preserved
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4937396.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->