### PR TITLE
Add Convos Vault plan: multi-device key sync via hidden conversation

### DIFF
--- a/docs/plans/convos-vault.md
+++ b/docs/plans/convos-vault.md
@@ -57,32 +57,48 @@ On non-Apple platforms (Android, web), the Vault key must be presented to the us
 
 ### 2. Pairing a second device
 
-The user opens Vault settings on the first device and taps "Pair Device":
+The main device (Device A) initiates pairing from Vault settings:
 
-1. The Vault is unlocked temporarily
-2. A fresh invite tag is generated with a 30-second expiry (not stored in conversation metadata permanently)
-3. A QR code is displayed containing the invite slug
-4. A random 6-digit confirmation code is displayed on screen
+1. Device A shows a QR code containing its Vault info (inbox address or rendezvous identifier)
+2. Device B (new device) scans the QR code
+3. Device B generates a random 6-digit confirmation code and displays it on screen
+4. Device A prompts: "Enter the code shown on your new device"
+5. The owner reads the code off Device B's screen and types it into Device A
+6. Device A verifies the code
+7. Device A adds Device B's inbox to the Vault conversation
+8. The Vault is re-locked
 
-The invite can only be redeemed once. After the device joins (or the invite expires), the invite tag is invalidated and the Vault is re-locked.
+The 6-digit code proves the Device A owner has physical access to Device B's screen. Even if someone else scans the QR, Device A's owner won't enter their code — they know which device they're pairing with. This is the same pattern as Bluetooth pairing.
 
-### 3. Second device joins
+The QR code is not a standard conversation invite — it establishes a temporary connection between the two devices. Device B never joins the Vault directly by scanning. Instead, Device A adds Device B after the code is confirmed. This means no one enters the Vault without Device A's explicit approval.
 
-The new device installs Convos and selects "Pair with existing device":
+### 3. Key exchange after pairing
 
-1. Creates its own XMTP inbox (fresh key pair) — this is the device's Vault identity
-2. Scans the QR code using the device camera
-3. Joins the Vault conversation via the invite
-4. Is prompted to enter the 6-digit code displayed on the first device
-5. Sends the code as a message to the Vault for verification
+Once Device B is added to the Vault:
 
-### 4. First device confirms
+1. Device A sends a `DeviceKeyBundle` message containing all existing conversation private keys
+2. If Device B had its own conversations, Device B also sends a `DeviceKeyBundle` with its keys (see Vault Merging below)
+3. Both devices import each other's keys and call `Client.create()` for each new conversation inbox
+4. Both devices are now installations on all conversations
 
-The first device sees the join request with the confirmation code. It either auto-verifies or prompts the user to confirm the code matches. Once confirmed:
+### 4. Vault merging
 
-1. A `DeviceKeyBundle` message is sent containing all existing conversation private keys
-2. The new device receives this, imports all keys, and calls `Client.create()` for each conversation inbox
-3. The new device is now a second installation on every existing conversation
+When Device B already has its own Vault (from prior independent use), pairing requires merging:
+
+**Prerequisite:** Device B must be the sole member of its own Vault before pairing. If Device B's Vault has other devices (C, D), those must be removed first. This prevents devices silently migrating into a new Vault without individual pairing ceremonies.
+
+The app should check this and show an error: "Remove all other devices from your Vault before pairing with another device."
+
+**Merge flow:**
+
+1. Pairing completes — Device B is added to Device A's Vault
+2. Device B sends its `DeviceKeyBundle` (its conversation keys) to Device A's Vault
+3. Device A imports Device B's keys
+4. Device B's old Vault is abandoned (deleted locally, the conversation remains on XMTP but is no longer tracked)
+5. Device B updates its iCloud Keychain (or manual backup) to store Device A's Vault key, replacing its old Vault key
+6. Device A's Vault is now the single Vault for both devices
+
+After merging, if the owner wants to re-add devices C and D, they pair each one individually with Device A using the standard pairing flow.
 
 ### 5. Ongoing sync
 
@@ -182,7 +198,7 @@ Keys accumulate as messages in the Vault. When the device comes back online, it 
 
 ## Open Questions
 
-1. **Bidirectional verification**: Should pairing require both devices to confirm codes from each other's screens (like Bluetooth pairing), or is the one-way 6-digit code sufficient?
-2. **Key rotation**: Should conversation keys in the Vault be rotatable? If a device is compromised and removed, can existing conversation keys be rotated?
-3. **Maximum devices**: Should there be a limit on linked devices?
-4. **Vault conversation expiry**: The Vault conversation should probably not have an expiry timer. Need to ensure the explode/expiry system exempts it.
+1. **Key rotation**: Should conversation keys in the Vault be rotatable? If a device is compromised and removed, can existing conversation keys be rotated?
+2. **Maximum devices**: Should there be a limit on linked devices?
+3. **Vault conversation expiry**: The Vault conversation should probably not have an expiry timer. Need to ensure the explode/expiry system exempts it.
+4. **Temporary channel for pairing**: What mechanism establishes the connection between devices before Device B is added to the Vault? Options include a temporary DM, a relay via XMTP inbox addresses, or a lightweight signaling channel.

--- a/docs/plans/convos-vault.md
+++ b/docs/plans/convos-vault.md
@@ -59,18 +59,21 @@ On non-Apple platforms (Android, web), the Vault key must be presented to the us
 
 The main device (Device A) initiates pairing from Vault settings:
 
-1. Device A shows a QR code containing its Vault info (inbox address or rendezvous identifier)
+1. Device A taps "Pair Device" — this generates a standard Convos invite for the Vault (short-lived, 30-second expiry, single-use) and displays the QR code
 2. Device B (new device) scans the QR code
 3. Device B generates a random 6-digit confirmation code and displays it on screen
-4. Device A prompts: "Enter the code shown on your new device"
-5. The owner reads the code off Device B's screen and types it into Device A
-6. Device A verifies the code
-7. Device A adds Device B's inbox to the Vault conversation
-8. The Vault is re-locked
+4. Device B sends a join request via DM (the standard invite join flow) — the join request includes Device B's inbox ID and the 6-digit code
+5. Device A receives the join request and prompts: "Enter the code shown on your new device"
+6. The owner reads the code off Device B's screen and types it into Device A
+7. Device A matches the entered code against the code in the join request — this confirms the correct inbox ID to add
+8. Device A adds Device B to the Vault conversation
+9. The invite tag is invalidated and the Vault is re-locked
 
-The 6-digit code proves the Device A owner has physical access to Device B's screen. Even if someone else scans the QR, Device A's owner won't enter their code — they know which device they're pairing with. This is the same pattern as Bluetooth pairing.
+**Reuses the existing invite system:** The QR code is a standard Convos invite slug. The join request travels via DM, the same as any conversation invite. The only addition is the 6-digit confirmation code embedded in the join request, which Device A must verify before accepting.
 
-The QR code is not a standard conversation invite — it establishes a temporary connection between the two devices. Device B never joins the Vault directly by scanning. Instead, Device A adds Device B after the code is confirmed. This means no one enters the Vault without Device A's explicit approval.
+**Why the code is in the join request:** Multiple join requests could arrive if others also scanned the QR. The 6-digit code ties the confirmation to a specific request, ensuring Device A adds the correct inbox ID.
+
+**Security model:** The 6-digit code proves Device A's owner has physical access to Device B's screen. Even if someone else scans the QR, Device A's owner won't enter their code. Device B is never added to the Vault without Device A explicitly confirming the code match.
 
 ### 3. Key exchange after pairing
 
@@ -201,4 +204,4 @@ Keys accumulate as messages in the Vault. When the device comes back online, it 
 1. **Key rotation**: Should conversation keys in the Vault be rotatable? If a device is compromised and removed, can existing conversation keys be rotated?
 2. **Maximum devices**: Should there be a limit on linked devices?
 3. **Vault conversation expiry**: The Vault conversation should probably not have an expiry timer. Need to ensure the explode/expiry system exempts it.
-4. **Temporary channel for pairing**: What mechanism establishes the connection between devices before Device B is added to the Vault? Options include a temporary DM, a relay via XMTP inbox addresses, or a lightweight signaling channel.
+

--- a/docs/plans/convos-vault.md
+++ b/docs/plans/convos-vault.md
@@ -59,7 +59,7 @@ On non-Apple platforms (Android, web), the Vault key must be presented to the us
 
 The main device (Device A) initiates pairing from Vault settings:
 
-1. Device A taps "Pair Device" — this generates a standard Convos invite for the Vault (short-lived, 30-second expiry, single-use) and displays the QR code
+1. Device A taps "Pair Device" — this generates a standard Convos invite for the Vault (60-second expiry, single-use) and displays the QR code
 2. Device B (new device) scans the QR code
 3. Device B generates a random 6-digit confirmation code and displays it on screen
 4. Device B sends a join request via DM (the standard invite join flow) — the join request includes Device B's inbox ID and the 6-digit code
@@ -74,6 +74,8 @@ The main device (Device A) initiates pairing from Vault settings:
 **Why the code is in the join request:** Multiple join requests could arrive if others also scanned the QR. The 6-digit code ties the confirmation to a specific request, ensuring Device A adds the correct inbox ID.
 
 **Security model:** The 6-digit code proves Device A's owner has physical access to Device B's screen. Even if someone else scans the QR, Device A's owner won't enter their code. Device B is never added to the Vault without Device A explicitly confirming the code match.
+
+**Timing:** The entire pairing flow — scanning the QR, generating and displaying the code, entering the code on Device A, and verification — must complete within the 60-second invite expiry. If the invite expires before the code is confirmed, pairing fails and Device A must generate a new invite.
 
 ### 3. Key exchange after pairing
 

--- a/docs/plans/convos-vault.md
+++ b/docs/plans/convos-vault.md
@@ -51,7 +51,9 @@ When a user installs Convos for the first time:
 - The device's profile display name is set to the device name (e.g., "Jarod's iPhone")
 - The Vault is locked immediately
 
-The Vault's private key is stored in iCloud Keychain by default, syncing automatically across the user's Apple devices.
+The Vault's private key is stored in iCloud Keychain by default on Apple devices, syncing automatically across the user's Apple devices.
+
+On non-Apple platforms (Android, web), the Vault key must be presented to the user for manual backup during setup. This could be a mnemonic phrase or a copyable key string. The app should block progression until the user confirms they've saved it, since there is no platform-level key sync equivalent to iCloud Keychain.
 
 ### 2. Pairing a second device
 
@@ -144,7 +146,13 @@ Since the Vault key is stored in iCloud Keychain, installing Convos on a new dev
 
 ### Lost all devices (different Apple ID / no iCloud Keychain)
 
-Unrecoverable in a trustless model. No server holds the keys. This is the fundamental tradeoff — the mitigation is that iCloud Keychain provides durable, automatic backup for the vast majority of users.
+If the user backed up their Vault key (manual backup on non-Apple platforms, or exported from settings):
+
+1. User installs Convos on a new device
+2. Enters their Vault key manually
+3. Same recovery flow as above — rebuild client, replay history, restore keys
+
+If no backup exists, this is unrecoverable in a trustless model. No server holds the keys.
 
 ## Future Extensions
 

--- a/docs/plans/convos-vault.md
+++ b/docs/plans/convos-vault.md
@@ -123,11 +123,14 @@ A new custom content type that replaces the current plain-text invite slug sent 
 |---|---|---|---|
 | `inviteSlug` | string | yes | The URL-safe encoded signed invite (same as current text message) |
 | `profile` | object | no | The joiner's profile (name, image) for display in join request UI |
-| `deviceName` | string | no | Device name for Vault pairing (e.g., "Jarod's iPad") |
-| `confirmationCode` | string | no | 6-digit code for Vault pairing verification |
-| `metadata` | map | no | Extensible key-value pairs for future use |
+| `metadata` | map | no | Extensible key-value pairs for context-specific data |
 
-For regular conversation joins, only `inviteSlug` is required (with optional `profile`). For Vault pairing, the join request also includes `deviceName` and `confirmationCode`.
+For regular conversation joins, only `inviteSlug` is required (with optional `profile`). For Vault pairing, the metadata map carries Vault-specific fields:
+
+| Metadata Key | Value | Description |
+|---|---|---|
+| `deviceName` | string | Device name (e.g., "Jarod's iPad") |
+| `confirmationCode` | string | 6-digit code for pairing verification |
 
 This is backward-compatible — existing join request processing checks for the invite slug and ignores unknown fields.
 

--- a/docs/plans/convos-vault.md
+++ b/docs/plans/convos-vault.md
@@ -201,9 +201,12 @@ A web app is just another device in the Vault. It creates an XMTP inbox, joins t
 
 Keys accumulate as messages in the Vault. When the device comes back online, it syncs the conversation and imports all missed keys. XMTP message persistence handles this naturally.
 
+## Resolved Design Decisions
+
+**Key rotation after device compromise:** Not needed. Revoking the compromised device's XMTP installations (via `revokeInstallations()`) for each conversation is sufficient. The compromised device is removed from the MLS group for every conversation, and MLS forward secrecy ensures it cannot decrypt any future messages. The private keys alone are useless without an active installation.
+
 ## Open Questions
 
-1. **Key rotation**: Should conversation keys in the Vault be rotatable? If a device is compromised and removed, can existing conversation keys be rotated?
-2. **Maximum devices**: Should there be a limit on linked devices?
-3. **Vault conversation expiry**: The Vault conversation should probably not have an expiry timer. Need to ensure the explode/expiry system exempts it.
+1. **Maximum devices**: Should there be a limit on linked devices?
+2. **Vault conversation expiry**: The Vault conversation should probably not have an expiry timer. Need to ensure the explode/expiry system exempts it.
 

--- a/docs/plans/convos-vault.md
+++ b/docs/plans/convos-vault.md
@@ -115,10 +115,28 @@ Whenever any linked device creates or joins a conversation:
 
 ## Custom Content Types
 
+### JoinRequest (phase 1 — prerequisite)
+
+A new custom content type that replaces the current plain-text invite slug sent via DM. The current join request is just the invite slug as a text message. A structured `JoinRequest` content type is more flexible and supports both regular conversation joins and Vault pairing.
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `inviteSlug` | string | yes | The URL-safe encoded signed invite (same as current text message) |
+| `profile` | object | no | The joiner's profile (name, image) for display in join request UI |
+| `deviceName` | string | no | Device name for Vault pairing (e.g., "Jarod's iPad") |
+| `confirmationCode` | string | no | 6-digit code for Vault pairing verification |
+| `metadata` | map | no | Extensible key-value pairs for future use |
+
+For regular conversation joins, only `inviteSlug` is required (with optional `profile`). For Vault pairing, the join request also includes `deviceName` and `confirmationCode`.
+
+This is backward-compatible — existing join request processing checks for the invite slug and ignores unknown fields.
+
+### Vault Content Types
+
 | Content Type | Purpose |
 |---|---|
-| `DeviceKeyBundle` | Full export of all conversation private keys (sent during initial pairing) |
-| `DeviceKeyShare` | Single conversation key (sent when a new conversation is created or joined) |
+| `DeviceKeyBundle` | Full export of all conversation private keys + installation IDs (sent during initial pairing) |
+| `DeviceKeyShare` | Single conversation key + installation ID (sent when a new conversation is created or joined) |
 | `DeviceKeyRequest` | Request keys from other devices (e.g., after reinstall with recovery key) |
 
 All content types are XMTP custom content types, encrypted end-to-end by MLS. The key material is only readable by Vault members (the user's devices).

--- a/docs/plans/convos-vault.md
+++ b/docs/plans/convos-vault.md
@@ -62,11 +62,11 @@ The main device (Device A) initiates pairing from Vault settings:
 1. Device A taps "Pair Device" — this generates a standard Convos invite for the Vault (60-second expiry, single-use) and displays the QR code
 2. Device B (new device) scans the QR code
 3. Device B generates a random 6-digit confirmation code and displays it on screen
-4. Device B sends a join request via DM (the standard invite join flow) — the join request includes Device B's inbox ID and the 6-digit code
+4. Device B sends a join request via DM (the standard invite join flow) — the join request includes Device B's inbox ID, the 6-digit code, and the device name (e.g., "Jarod's iPad")
 5. Device A receives the join request and prompts: "Enter the code shown on your new device"
 6. The owner reads the code off Device B's screen and types it into Device A
 7. Device A matches the entered code against the code in the join request — this confirms the correct inbox ID to add
-8. Device A adds Device B to the Vault conversation
+8. Device A adds Device B to the Vault conversation — Device B's profile display name in the Vault is set to the device name from the join request
 9. The invite tag is invalidated and the Vault is re-locked
 
 **Reuses the existing invite system:** The QR code is a standard Convos invite slug. The join request travels via DM, the same as any conversation invite. The only addition is the 6-digit confirmation code embedded in the join request, which Device A must verify before accepting.

--- a/docs/plans/convos-vault.md
+++ b/docs/plans/convos-vault.md
@@ -175,26 +175,21 @@ Accessible from Settings → Convos Vault:
 
 User removes the lost device from the Vault on another device. The removed device's inbox is kicked from the group, preventing it from receiving future keys. Full compromise mitigation (revoking installations, key rotation) is out of scope for now — see Resolved Design Decisions.
 
-### Lost all devices (same Apple ID)
+### Lost all devices
 
-Since the Vault key is stored in iCloud Keychain, installing Convos on a new device signed into the same Apple ID will automatically recover the Vault key:
+**Important limitation:** XMTP history sync only works between active installations. It replicates messages from one live installation to another — it is not an archive that can be pulled from after the fact. If the user's only device is lost and no other installations are active, the Vault message history (and therefore all conversation keys) is unrecoverable, even if the user still has the Vault key.
 
-1. User installs Convos on a new device
-2. The Vault key is retrieved from iCloud Keychain
-3. The app creates a new installation on the Vault inbox using the recovered key (with `deviceSyncEnabled: true`)
-4. XMTP history sync replicates all Vault messages to the new installation — including all `DeviceKeyBundle` and `DeviceKeyShare` messages ever sent
-5. The app replays the synced messages to reconstruct the full set of conversation keys
-6. Creates installations for each conversation
+This means:
 
-### Lost all devices (different Apple ID / no iCloud Keychain)
+- **Multi-device users are protected.** As long as at least one device remains active, a new device can pair via the Vault and receive all keys.
+- **Single-device users lose everything if they lose that device.** The Vault key from iCloud Keychain lets them re-create an installation on the Vault inbox, but the message history containing the conversation keys will be empty.
 
-If the user backed up their Vault key (manual backup on non-Apple platforms, or exported from settings):
+Recovery with the Vault key (from iCloud Keychain or manual backup) only restores access to the Vault conversation itself — not the keys that were stored in it, since those were in messages that no active installation can provide.
 
-1. User installs Convos on a new device
-2. Enters their Vault key manually
-3. Same recovery flow as above — create installation, history sync, replay messages, restore keys
-
-If no backup exists, this is unrecoverable in a trustless model. No server holds the keys.
+Future mitigation options:
+- Encourage users to pair a second device (even an old phone or tablet) as an always-on backup
+- Explore XMTP archival/persistence features if they become available
+- Consider an optional encrypted cloud backup of the key bundle (opt-in, user-controlled encryption key)
 
 ## Future Extensions
 
@@ -207,7 +202,7 @@ The Vault can serve as a trustless purchase ledger:
 - Current balance is derived by replaying purchase and spend history
 - Deduplication by Apple transaction ID prevents double-counting
 - Apple's signature on each transaction prevents fabricated purchases
-- Balance survives reinstall (same recovery flow as key sync)
+- Balance survives reinstall as long as at least one device remains active (same limitation as key sync)
 - Balance syncs across devices automatically
 
 ### Preferences Sync

--- a/docs/plans/convos-vault.md
+++ b/docs/plans/convos-vault.md
@@ -228,8 +228,9 @@ Keys accumulate as messages in the Vault. When the device comes back online, it 
 
 **Installation ID tracking:** When a device shares a conversation key (via `DeviceKeyBundle` or `DeviceKeyShare`), it also includes the installation ID it created for that conversation. This builds a mapping of device → installation IDs per conversation, which is needed to selectively revoke a specific device's installations without affecting other devices. Selective revocation based on this mapping is a future phase — for now, removing a device from the Vault prevents it from receiving future keys.
 
+**Maximum devices:** 10, matching XMTP's maximum installation count per inbox. The Vault UI should enforce this limit and show an error when attempting to pair an 11th device.
+
 ## Open Questions
 
-1. **Maximum devices**: Should there be a limit on linked devices?
-2. **Vault conversation expiry**: The Vault conversation should probably not have an expiry timer. Need to ensure the explode/expiry system exempts it.
+1. **Vault conversation expiry**: The Vault conversation should probably not have an expiry timer. Need to ensure the explode/expiry system exempts it.
 

--- a/docs/plans/convos-vault.md
+++ b/docs/plans/convos-vault.md
@@ -173,7 +173,7 @@ Accessible from Settings → Convos Vault:
 
 ### Lost one device (other devices remain)
 
-User removes the lost device from the Vault on another device. The removed device's inbox is kicked from the group, preventing it from receiving future keys. In a future phase, the installation IDs tracked in the Vault will be used to selectively revoke the compromised device's installations across all conversations via `revokeInstallations()`.
+User removes the lost device from the Vault on another device. The removed device's inbox is kicked from the group, preventing it from receiving future keys. Full compromise mitigation (revoking installations, key rotation) is out of scope for now — see Resolved Design Decisions.
 
 ### Lost all devices (same Apple ID)
 
@@ -224,7 +224,7 @@ Keys accumulate as messages in the Vault. When the device comes back online, it 
 
 ## Resolved Design Decisions
 
-**Key rotation after device compromise:** Not needed. Revoking the compromised device's XMTP installations (via `revokeInstallations()`) for each conversation is sufficient. The compromised device is removed from the MLS group for every conversation, and MLS forward secrecy ensures it cannot decrypt any future messages. The private keys alone are useless without an active installation.
+**Device compromise is out of scope for now.** Revoking installations alone is not sufficient — an attacker with the private keys can call `Client.create()` to make new installations. Truly locking out a compromised device would require rotating conversation keys (generating new keys, migrating all members to new conversations, abandoning old inboxes). This is a significant feature that we'll address in a future phase if needed.
 
 **Installation ID tracking:** When a device shares a conversation key (via `DeviceKeyBundle` or `DeviceKeyShare`), it also includes the installation ID it created for that conversation. This builds a mapping of device → installation IDs per conversation, which is needed to selectively revoke a specific device's installations without affecting other devices. Selective revocation based on this mapping is a future phase — for now, removing a device from the Vault prevents it from receiving future keys.
 

--- a/docs/plans/convos-vault.md
+++ b/docs/plans/convos-vault.md
@@ -1,0 +1,167 @@
+# Convos Vault — Multi-Device Key Sync & Recovery
+
+## Overview
+
+Convos Vault is a hidden XMTP group conversation that acts as a secure, trustless channel for syncing private keys across a user's devices. It uses existing conversation primitives — messages, invites, locking, profiles, members — with dedicated content types and UI.
+
+Convos uses a per-conversation identity model: each conversation has its own secp256k1 private key and XMTP inbox. A user with 20 conversations has 20 separate private keys stored in their device keychain. Convos Vault solves the problem of making those keys available on multiple devices without any server ever having access to the key material.
+
+## Why not server-side sync?
+
+Convos is trustless by design. The Convos backend never has access to user private keys. Key material only travels through XMTP's end-to-end encrypted MLS protocol — the same trust model used for regular messages.
+
+## Why not XMTP multi-installation (addAccount)?
+
+XMTP supports associating multiple wallet identities with a single inbox via `addAccount`. However, Convos creates a separate XMTP inbox per conversation (for privacy), meaning there are N private keys to manage, not one. The `addAccount` flow doesn't scale to this model — each new conversation would require a new cross-device association ceremony. Instead, we sync the actual private keys through an encrypted channel that the user controls.
+
+## Architecture
+
+The Vault is a standard XMTP group conversation with:
+
+- Custom metadata flag (`conversationType: "vault"`) to filter it from the conversations list
+- Custom XMTP content types for key exchange
+- Locked by default (no new members can join without explicit user action)
+- Members represent devices, with profile display names as device names
+
+## Lifecycle
+
+### 1. First device install
+
+When a user installs Convos for the first time:
+
+- A Vault conversation is created automatically
+- The device is the sole member
+- The device's profile display name is set to the device name (e.g., "Jarod's iPhone")
+- The Vault is locked immediately
+
+The Vault's private key is the user's recovery key. It should be presented to the user once for backup (e.g., "Save your recovery key") and stored in iCloud Keychain as an additional safety net.
+
+### 2. Pairing a second device
+
+The user opens Vault settings on the first device and taps "Pair Device":
+
+1. The Vault is unlocked temporarily
+2. A fresh invite tag is generated with a 30-second expiry (not stored in conversation metadata permanently)
+3. A QR code is displayed containing the invite slug
+4. A random 6-digit confirmation code is displayed on screen
+
+The invite can only be redeemed once. After the device joins (or the invite expires), the invite tag is invalidated and the Vault is re-locked.
+
+### 3. Second device joins
+
+The new device installs Convos and selects "Pair with existing device":
+
+1. Creates its own XMTP inbox (fresh key pair) — this is the device's Vault identity
+2. Scans the QR code using the device camera
+3. Joins the Vault conversation via the invite
+4. Is prompted to enter the 6-digit code displayed on the first device
+5. Sends the code as a message to the Vault for verification
+
+### 4. First device confirms
+
+The first device sees the join request with the confirmation code. It either auto-verifies or prompts the user to confirm the code matches. Once confirmed:
+
+1. A `DeviceKeyBundle` message is sent containing all existing conversation private keys
+2. The new device receives this, imports all keys, and calls `Client.create()` for each conversation inbox
+3. The new device is now a second installation on every existing conversation
+
+### 5. Ongoing sync
+
+Whenever any linked device creates or joins a conversation:
+
+1. The new conversation's private key is sent to the Vault as a `DeviceKeyShare` message
+2. Other devices pick it up via normal XMTP message sync
+3. Each device imports the key and adds itself as an installation for that conversation
+
+## Custom Content Types
+
+| Content Type | Purpose |
+|---|---|
+| `DeviceKeyBundle` | Full export of all conversation private keys (sent during initial pairing) |
+| `DeviceKeyShare` | Single conversation key (sent when a new conversation is created or joined) |
+| `DeviceKeyRequest` | Request keys from other devices (e.g., after reinstall with recovery key) |
+
+All content types are XMTP custom content types, encrypted end-to-end by MLS. The key material is only readable by Vault members (the user's devices).
+
+## Locking
+
+The Vault stays locked by default:
+
+- No new members can join
+- The invite mechanism is disabled
+- Key sync messages flow freely between existing members
+
+When the user wants to add a device:
+
+- They explicitly unlock the Vault
+- A short-lived invite tag is generated
+- After the new device joins (or the invite expires), the Vault auto-locks
+
+This reuses the existing lock/unlock infrastructure.
+
+## Managing Devices
+
+Accessible from Settings → Convos Vault:
+
+- List of linked devices (members with profile display names as device names)
+- Last active timestamp per device
+- "Pair Device" button (unlocks Vault, generates invite)
+- Swipe to remove a device (removes from group, revokes XMTP installations for that inbox)
+- Device names are editable (profile display name updates)
+
+## Recovery
+
+### Lost one device (other devices remain)
+
+User removes the lost device from the Vault on another device. The removed device's inbox is kicked from the group, preventing it from receiving future keys. For conversation keys the lost device already had, those installations should be revoked via `revokeInstallations()`.
+
+### Lost all devices (recovery key available)
+
+1. User installs Convos on a new device
+2. Enters their recovery key (the Vault's private key)
+3. The app rebuilds the XMTP client for the Vault inbox and syncs message history
+4. Replays all `DeviceKeyBundle` and `DeviceKeyShare` messages to reconstruct the full set of conversation keys
+5. Creates installations for each conversation
+
+### Lost all devices (no recovery key)
+
+Unrecoverable in a trustless model. No server holds the keys. This is the fundamental tradeoff — the mitigation is encouraging users to:
+
+- Back up their recovery key
+- Link a second device early (which effectively serves as a backup)
+- Allow iCloud Keychain to store the Vault key
+
+## Future Extensions
+
+### Convos Credits (IAP)
+
+The Vault can serve as a trustless purchase ledger:
+
+- Credit purchases are recorded as messages in the Vault (including Apple's JWS-signed transaction data for verification)
+- Credit spends are recorded as messages
+- Current balance is derived by replaying purchase and spend history
+- Deduplication by Apple transaction ID prevents double-counting
+- Apple's signature on each transaction prevents fabricated purchases
+- Balance survives reinstall (same recovery flow as key sync)
+- Balance syncs across devices automatically
+
+### Preferences Sync
+
+Global preferences (like the reveal mode and include-info defaults) could be synced through the Vault rather than stored in local `UserDefaults`, giving cross-device consistency.
+
+## Web App Support
+
+A web app is just another device in the Vault. It creates an XMTP inbox, joins the Vault via QR pairing, receives keys, and stores them in Web Crypto API / IndexedDB. Its storage is less durable than iOS Keychain, so the web should be treated as a session device that can re-request keys from the Vault if storage is cleared.
+
+## Device Offline for Extended Period
+
+Keys accumulate as messages in the Vault. When the device comes back online, it syncs the conversation and imports all missed keys. XMTP message persistence handles this naturally.
+
+## Open Questions
+
+1. **Recovery key UX**: How and when to present the recovery key to the user? On first install? In settings? Should it be a mnemonic phrase or raw key?
+2. **iCloud Keychain for Vault key**: Should we automatically store the Vault private key in iCloud Keychain (syncs across Apple devices) as a safety net, or keep it fully manual?
+3. **Bidirectional verification**: Should pairing require both devices to confirm codes from each other's screens (like Bluetooth pairing), or is the one-way 6-digit code sufficient?
+4. **Key rotation**: Should conversation keys in the Vault be rotatable? If a device is compromised and removed, can existing conversation keys be rotated?
+5. **Maximum devices**: Should there be a limit on linked devices?
+6. **Vault conversation expiry**: The Vault conversation should probably not have an expiry timer. Need to ensure the explode/expiry system exempts it.

--- a/docs/plans/convos-vault.md
+++ b/docs/plans/convos-vault.md
@@ -140,7 +140,6 @@ This is backward-compatible — existing join request processing checks for the 
 |---|---|
 | `DeviceKeyBundle` | Full export of all conversation private keys + installation IDs (sent during initial pairing) |
 | `DeviceKeyShare` | Single conversation key + installation ID (sent when a new conversation is created or joined) |
-| `DeviceKeyRequest` | Request keys from other devices (e.g., after reinstall with recovery key) |
 
 All content types are XMTP custom content types, encrypted end-to-end by MLS. The key material is only readable by Vault members (the user's devices).
 
@@ -182,9 +181,10 @@ Since the Vault key is stored in iCloud Keychain, installing Convos on a new dev
 
 1. User installs Convos on a new device
 2. The Vault key is retrieved from iCloud Keychain
-3. The app rebuilds the XMTP client for the Vault inbox and syncs message history
-4. Replays all `DeviceKeyBundle` and `DeviceKeyShare` messages to reconstruct the full set of conversation keys
-5. Creates installations for each conversation
+3. The app creates a new installation on the Vault inbox using the recovered key (with `deviceSyncEnabled: true`)
+4. XMTP history sync replicates all Vault messages to the new installation — including all `DeviceKeyBundle` and `DeviceKeyShare` messages ever sent
+5. The app replays the synced messages to reconstruct the full set of conversation keys
+6. Creates installations for each conversation
 
 ### Lost all devices (different Apple ID / no iCloud Keychain)
 
@@ -192,7 +192,7 @@ If the user backed up their Vault key (manual backup on non-Apple platforms, or 
 
 1. User installs Convos on a new device
 2. Enters their Vault key manually
-3. Same recovery flow as above — rebuild client, replay history, restore keys
+3. Same recovery flow as above — create installation, history sync, replay messages, restore keys
 
 If no backup exists, this is unrecoverable in a trustless model. No server holds the keys.
 

--- a/docs/plans/convos-vault.md
+++ b/docs/plans/convos-vault.md
@@ -153,7 +153,7 @@ Accessible from Settings → Convos Vault:
 
 ### Lost one device (other devices remain)
 
-User removes the lost device from the Vault on another device. The removed device's inbox is kicked from the group, preventing it from receiving future keys. For conversation keys the lost device already had, those installations should be revoked via `revokeInstallations()`.
+User removes the lost device from the Vault on another device. The removed device's inbox is kicked from the group, preventing it from receiving future keys. In a future phase, the installation IDs tracked in the Vault will be used to selectively revoke the compromised device's installations across all conversations via `revokeInstallations()`.
 
 ### Lost all devices (same Apple ID)
 
@@ -204,6 +204,8 @@ Keys accumulate as messages in the Vault. When the device comes back online, it 
 ## Resolved Design Decisions
 
 **Key rotation after device compromise:** Not needed. Revoking the compromised device's XMTP installations (via `revokeInstallations()`) for each conversation is sufficient. The compromised device is removed from the MLS group for every conversation, and MLS forward secrecy ensures it cannot decrypt any future messages. The private keys alone are useless without an active installation.
+
+**Installation ID tracking:** When a device shares a conversation key (via `DeviceKeyBundle` or `DeviceKeyShare`), it also includes the installation ID it created for that conversation. This builds a mapping of device → installation IDs per conversation, which is needed to selectively revoke a specific device's installations without affecting other devices. Selective revocation based on this mapping is a future phase — for now, removing a device from the Vault prevents it from receiving future keys.
 
 ## Open Questions
 

--- a/docs/plans/convos-vault.md
+++ b/docs/plans/convos-vault.md
@@ -18,10 +18,27 @@ XMTP supports associating multiple wallet identities with a single inbox via `ad
 
 The Vault is a standard XMTP group conversation with:
 
-- Custom metadata flag (`conversationType: "vault"`) to filter it from the conversations list
+- A `conversationType` field in `ConversationCustomMetadata` (protobuf field 6) set to `"vault"` — this is how any device identifies the Vault after syncing its conversation list
 - Custom XMTP content types for key exchange
 - Locked by default (no new members can join without explicit user action)
 - Members represent devices, with profile display names as device names
+
+### Conversation type in custom metadata
+
+The Vault must be identifiable by any device that syncs the conversation, without prior local state. When a new device joins and pulls its conversation list, it reads `ConversationCustomMetadata.conversationType` to distinguish the Vault from regular conversations.
+
+```protobuf
+message ConversationCustomMetadata {
+    string tag = 1;
+    repeated ConversationProfile profiles = 2;
+    optional sfixed64 expiresAtUnix = 3;
+    optional bytes imageEncryptionKey = 4;
+    optional EncryptedImageRef encryptedGroupImage = 5;
+    optional string conversationType = 6;  // "vault" for Convos Vault
+}
+```
+
+The conversations list filters out any conversation where `conversationType == "vault"`. The Vault is only accessible through Settings → Convos Vault.
 
 ## Lifecycle
 

--- a/docs/plans/convos-vault.md
+++ b/docs/plans/convos-vault.md
@@ -51,7 +51,7 @@ When a user installs Convos for the first time:
 - The device's profile display name is set to the device name (e.g., "Jarod's iPhone")
 - The Vault is locked immediately
 
-The Vault's private key is the user's recovery key. It should be presented to the user once for backup (e.g., "Save your recovery key") and stored in iCloud Keychain as an additional safety net.
+The Vault's private key is stored in iCloud Keychain by default, syncing automatically across the user's Apple devices.
 
 ### 2. Pairing a second device
 
@@ -132,21 +132,19 @@ Accessible from Settings → Convos Vault:
 
 User removes the lost device from the Vault on another device. The removed device's inbox is kicked from the group, preventing it from receiving future keys. For conversation keys the lost device already had, those installations should be revoked via `revokeInstallations()`.
 
-### Lost all devices (recovery key available)
+### Lost all devices (same Apple ID)
+
+Since the Vault key is stored in iCloud Keychain, installing Convos on a new device signed into the same Apple ID will automatically recover the Vault key:
 
 1. User installs Convos on a new device
-2. Enters their recovery key (the Vault's private key)
+2. The Vault key is retrieved from iCloud Keychain
 3. The app rebuilds the XMTP client for the Vault inbox and syncs message history
 4. Replays all `DeviceKeyBundle` and `DeviceKeyShare` messages to reconstruct the full set of conversation keys
 5. Creates installations for each conversation
 
-### Lost all devices (no recovery key)
+### Lost all devices (different Apple ID / no iCloud Keychain)
 
-Unrecoverable in a trustless model. No server holds the keys. This is the fundamental tradeoff — the mitigation is encouraging users to:
-
-- Back up their recovery key
-- Link a second device early (which effectively serves as a backup)
-- Allow iCloud Keychain to store the Vault key
+Unrecoverable in a trustless model. No server holds the keys. This is the fundamental tradeoff — the mitigation is that iCloud Keychain provides durable, automatic backup for the vast majority of users.
 
 ## Future Extensions
 
@@ -176,9 +174,7 @@ Keys accumulate as messages in the Vault. When the device comes back online, it 
 
 ## Open Questions
 
-1. **Recovery key UX**: How and when to present the recovery key to the user? On first install? In settings? Should it be a mnemonic phrase or raw key?
-2. **iCloud Keychain for Vault key**: Should we automatically store the Vault private key in iCloud Keychain (syncs across Apple devices) as a safety net, or keep it fully manual?
-3. **Bidirectional verification**: Should pairing require both devices to confirm codes from each other's screens (like Bluetooth pairing), or is the one-way 6-digit code sufficient?
-4. **Key rotation**: Should conversation keys in the Vault be rotatable? If a device is compromised and removed, can existing conversation keys be rotated?
-5. **Maximum devices**: Should there be a limit on linked devices?
-6. **Vault conversation expiry**: The Vault conversation should probably not have an expiry timer. Need to ensure the explode/expiry system exempts it.
+1. **Bidirectional verification**: Should pairing require both devices to confirm codes from each other's screens (like Bluetooth pairing), or is the one-way 6-digit code sufficient?
+2. **Key rotation**: Should conversation keys in the Vault be rotatable? If a device is compromised and removed, can existing conversation keys be rotated?
+3. **Maximum devices**: Should there be a limit on linked devices?
+4. **Vault conversation expiry**: The Vault conversation should probably not have an expiry timer. Need to ensure the explode/expiry system exempts it.


### PR DESCRIPTION
Add Convos Vault plan: multi-device key sync via hidden conversation

Specify conversationType in ConversationCustomMetadata protobuf for Vault identification

Store Vault key in iCloud Keychain by default, update recovery flows

Add manual Vault key backup requirement for non-Apple platforms

Redesign pairing flow: Device A confirms code from Device B, add vault merging and multi-device edge case

Use standard invite system for Vault pairing with 6-digit code verification gate

Set Vault pairing invite expiry to 60 seconds for full flow

Resolve key rotation question: revokeInstallations + MLS forward secrecy is sufficient

Track installation IDs alongside shared keys, defer selective revocation to future phase

Include device name in pairing join request, use as Vault profile display name

Add JoinRequest custom content type as phase 1 prerequisite with optional profile, device name, and confirmation code

Move deviceName and confirmationCode to JoinRequest metadata map

Remove DeviceKeyRequest: XMTP history sync handles recovery by replaying Vault messages

Set 10 device max matching XMTP installation limit

Acknowledge device compromise limitation, defer to future phase

Correct recovery section: XMTP history sync requires active installation

History sync replicates between live installations, not from an
archive. Single-device users who lose their only device cannot recover
Vault message history even with the Vault key.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add design document for Convos Vault multi-device key sync via hidden XMPP conversation
> Adds [convos-vault.md](https://github.com/xmtplabs/convos-ios/pull/555/files#diff-34c271fa161d1b3a0e6139306b4bf2b487d7acfe3021067ea953ce7aafdf780e), a design plan for syncing end-to-end encryption keys across devices using a hidden XMTP "vault" conversation.
>
> - Defines the full device lifecycle: first install, pairing, key exchange, merge, and ongoing sync using custom XMTP content types (`JoinRequest`, `DeviceKeyBundle`, `DeviceKeyShare`)
> - Identifies the vault conversation via a `conversationType: "vault"` field in `ConversationCustomMetadata` protobuf
> - Covers recovery scenarios, offline behavior, locking, and device management
> - Documents resolved design decisions and one open question around key share expiry
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e7a7b29.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->