### PR TITLE
XMTP Read Receipts

### DIFF
--- a/Convos.xcodeproj/project.pbxproj
+++ b/Convos.xcodeproj/project.pbxproj
@@ -190,6 +190,8 @@
 				"Conversation Detail/ConversationMemberView.swift",
 				"Conversation Detail/ConversationShareView.swift",
 				"Conversation Detail/ConversationView.swift",
+				"Conversation Detail/ConversationViewModel+ReadReceipts.swift",
+				"Conversation Detail/ConversationViewModel+TypingIndicators.swift",
 				"Conversation Detail/ConversationViewModel.swift",
 				"Conversation Detail/ExplodeButton.swift",
 				"Conversation Detail/Messages/ConversationIndicatorView.swift",

--- a/Convos.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Convos.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "8525519bbe8a9428a092b43e0d86549df75d7d6da42008a66a61bef5933e2542",
+  "originHash" : "c40fcb5279ffcf05994801de5933e258d72c7e21e5c777ef54ffb951d4469a38",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -150,8 +150,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/xmtp/libxmtp.git",
       "state" : {
-        "branch" : "ios-4.9.0-dev.6ecd439",
-        "revision" : "297e684d07e78f87da617be80565359c315ba6f0"
+        "branch" : "ios-4.9.0-dev.88ddfad",
+        "revision" : "899650a4189207ca2df515bf46beb549da07ff46"
       }
     },
     {

--- a/Convos/App Settings/CustomizeSettingsView.swift
+++ b/Convos/App Settings/CustomizeSettingsView.swift
@@ -48,6 +48,14 @@ struct CustomizeSettingsView: View {
                     isOn: $defaults.includeInfoWithInvites,
                     toggleAccessibilityIdentifier: "customize-include-info-toggle"
                 )
+
+                customizeToggleRow(
+                    symbolName: "eye",
+                    title: "Read receipts",
+                    subtitle: "Let others know when you've read their messages",
+                    isOn: $defaults.sendReadReceipts,
+                    toggleAccessibilityIdentifier: "read-receipts-toggle"
+                )
             }
 
             Section {

--- a/Convos/App Settings/GlobalConvoDefaults.swift
+++ b/Convos/App Settings/GlobalConvoDefaults.swift
@@ -67,6 +67,18 @@ final class GlobalConvoDefaults: @unchecked Sendable {
         }
     }
 
+    var sendReadReceipts: Bool {
+        get {
+            access(keyPath: \.sendReadReceipts)
+            return UserDefaults.standard.object(forKey: Constant.sendReadReceiptsKey) as? Bool ?? true
+        }
+        set {
+            withMutation(keyPath: \.sendReadReceipts) {
+                UserDefaults.standard.set(newValue, forKey: Constant.sendReadReceiptsKey)
+            }
+        }
+    }
+
     func reset() {
         withMutation(keyPath: \.autoRevealPhotos) {
             UserDefaults.standard.removeObject(forKey: Constant.autoRevealPhotosKey)
@@ -83,6 +95,9 @@ final class GlobalConvoDefaults: @unchecked Sendable {
         withMutation(keyPath: \.assistantInviteCode) {
             UserDefaults.standard.removeObject(forKey: Constant.assistantInviteCodeKey)
         }
+        withMutation(keyPath: \.sendReadReceipts) {
+            UserDefaults.standard.removeObject(forKey: Constant.sendReadReceiptsKey)
+        }
     }
 
     private enum Constant {
@@ -91,5 +106,6 @@ final class GlobalConvoDefaults: @unchecked Sendable {
         static let assistantsEnabledKey: String = "globalAssistantsEnabled"
         static let assistantCodeUnlockedKey: String = "globalAssistantCodeUnlocked"
         static let assistantInviteCodeKey: String = "globalAssistantInviteCode"
+        static let sendReadReceiptsKey: String = "globalSendReadReceipts"
     }
 }

--- a/Convos/Conversation Detail/ConversationInfoView.swift
+++ b/Convos/Conversation Detail/ConversationInfoView.swift
@@ -268,6 +268,22 @@ struct ConversationInfoView: View {
 
             FeatureRowItem(
                 imageName: nil,
+                symbolName: "eye",
+                title: "Read receipts",
+                subtitle: "Let others know you've read"
+            ) {
+                Toggle("", isOn: Binding(
+                    get: { viewModel.sendReadReceipts },
+                    set: { viewModel.setSendReadReceipts($0) }
+                ))
+                .labelsHidden()
+                .accessibilityLabel("Read receipts")
+                .accessibilityValue(viewModel.sendReadReceipts ? "on" : "off")
+                .accessibilityIdentifier("convo-read-receipts-toggle")
+            }
+
+            FeatureRowItem(
+                imageName: nil,
                 symbolName: "eye.circle.fill",
                 title: "Reveal mode",
                 subtitle: "Blur incoming pics"

--- a/Convos/Conversation Detail/ConversationInfoView.swift
+++ b/Convos/Conversation Detail/ConversationInfoView.swift
@@ -277,10 +277,17 @@ struct ConversationInfoView: View {
                     set: { viewModel.setSendReadReceipts($0) }
                 ))
                 .labelsHidden()
-                .accessibilityLabel("Read receipts")
-                .accessibilityValue(viewModel.sendReadReceipts ? "on" : "off")
-                .accessibilityIdentifier("convo-read-receipts-toggle")
+                .allowsHitTesting(false)
             }
+            .contentShape(Rectangle())
+            .onTapGesture {
+                viewModel.setSendReadReceipts(!viewModel.sendReadReceipts)
+            }
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel("Read receipts")
+            .accessibilityValue(viewModel.sendReadReceipts ? "on" : "off")
+            .accessibilityAddTraits(.isButton)
+            .accessibilityIdentifier("convo-read-receipts-toggle")
 
             FeatureRowItem(
                 imageName: nil,

--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -175,6 +175,8 @@ struct ConversationView<MessagesBottomBar: View>: View {
         }
         .animation(.easeOut, value: viewModel.explodeState)
         .dynamicTypeSize(...DynamicTypeSize.xxxLarge)
+        .onAppear { viewModel.onConversationAppeared() }
+        .onDisappear { viewModel.onConversationDisappeared() }
         .selfSizingSheet(isPresented: $viewModel.presentingConversationForked) {
             ConversationForkedInfoView {
                 viewModel.leaveConvo()

--- a/Convos/Conversation Detail/ConversationViewModel+ReadReceipts.swift
+++ b/Convos/Conversation Detail/ConversationViewModel+ReadReceipts.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+extension ConversationViewModel {
+    func onConversationAppeared() {
+        isViewingConversation = true
+        sendReadReceiptIfNeeded()
+    }
+
+    func onConversationDisappeared() {
+        isViewingConversation = false
+        pendingReadReceiptTask?.cancel()
+        pendingReadReceiptTask = nil
+    }
+
+    func sendReadReceiptIfNeeded() {
+        guard isViewingConversation else { return }
+        guard !conversation.isDraft, !conversation.isPendingInvite else { return }
+        guard sendReadReceipts else { return }
+
+        let debounceInterval: TimeInterval = 1
+        if let lastSent = lastReadReceiptSentAt, Date().timeIntervalSince(lastSent) < debounceInterval {
+            guard pendingReadReceiptTask == nil else { return }
+            let delay = debounceInterval - Date().timeIntervalSince(lastSent)
+            let conversationId = conversation.id
+            pendingReadReceiptTask = Task { [weak self] in
+                try? await Task.sleep(for: .seconds(delay))
+                guard !Task.isCancelled else { return }
+                await self?.sendReadReceipt(for: conversationId)
+                self?.pendingReadReceiptTask = nil
+            }
+            return
+        }
+
+        let conversationId = conversation.id
+        Task { [weak self] in
+            await self?.sendReadReceipt(for: conversationId)
+        }
+    }
+
+    func sendReadReceipt(for conversationId: String) async {
+        lastReadReceiptSentAt = Date()
+        do {
+            try await readReceiptWriter.sendReadReceipt(for: conversationId)
+        } catch {
+            Log.warning("Failed to send read receipt: \(error.localizedDescription)")
+        }
+    }
+}

--- a/Convos/Conversation Detail/ConversationViewModel+TypingIndicators.swift
+++ b/Convos/Conversation Detail/ConversationViewModel+TypingIndicators.swift
@@ -150,8 +150,10 @@ extension ConversationViewModel {
                 isLastGroupSentByCurrentUser: lastGroup.isLastGroupSentByCurrentUser,
                 showsTypingIndicator: true,
                 allTypingMembers: [typer],
+                readByProfiles: lastGroup.readByProfiles,
                 onlyVisibleToSender: lastGroup.onlyVisibleToSender,
-                isLastGroupBeforeOtherMembers: lastGroup.isLastGroupBeforeOtherMembers
+                isLastGroupBeforeOtherMembers: lastGroup.isLastGroupBeforeOtherMembers,
+                voiceMemoTranscripts: lastGroup.voiceMemoTranscripts
             )
             updated[lastIndex] = .messages(updatedGroup)
             return updated

--- a/Convos/Conversation Detail/ConversationViewModel+TypingIndicators.swift
+++ b/Convos/Conversation Detail/ConversationViewModel+TypingIndicators.swift
@@ -83,8 +83,9 @@ extension ConversationViewModel {
         typingThrottleDate = nil
         typingResetTask?.cancel()
         typingResetTask = nil
+        pendingTypingIndicatorTask?.cancel()
         let conversationId = conversation.id
-        Task { [weak self] in
+        pendingTypingIndicatorTask = Task { [weak self] in
             guard let self else { return }
             try? await self.messagingService.sendTypingIndicator(isTyping: false, for: conversationId)
         }
@@ -110,7 +111,6 @@ extension ConversationViewModel {
         }
 
         typingThrottleDate = now
-        isTypingSent = true
 
         typingResetTask?.cancel()
         typingResetTask = Task { [weak self] in
@@ -121,10 +121,15 @@ extension ConversationViewModel {
             }
         }
 
+        pendingTypingIndicatorTask?.cancel()
         let conversationId = conversation.id
-        Task { [weak self] in
+        pendingTypingIndicatorTask = Task { [weak self] in
             guard let self else { return }
             try? await self.messagingService.sendTypingIndicator(isTyping: true, for: conversationId)
+            guard !Task.isCancelled else { return }
+            await MainActor.run { [weak self] in
+                self?.isTypingSent = true
+            }
         }
     }
 

--- a/Convos/Conversation Detail/ConversationViewModel+TypingIndicators.swift
+++ b/Convos/Conversation Detail/ConversationViewModel+TypingIndicators.swift
@@ -1,0 +1,186 @@
+import ConvosCore
+import Foundation
+import Observation
+
+extension ConversationViewModel {
+    func setupTypingIndicatorHandler() {
+        let manager = typingIndicatorManager
+        Task {
+            await messagingService.inboxStateManager.setTypingIndicatorHandler { conversationId, senderInboxId, isTyping in
+                Task { @MainActor in
+                    manager.handleTypingEvent(
+                        conversationId: conversationId,
+                        senderInboxId: senderInboxId,
+                        isTyping: isTyping
+                    )
+                }
+            }
+        }
+    }
+
+    func observeTypingIndicators(_ manager: TypingIndicatorManager) {
+        withObservationTracking {
+            _ = manager.typingMembersByConversation[conversation.id]
+        } onChange: { [weak self] in
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                self.updateTypingMembers(from: manager)
+                self.observeTypingIndicators(manager)
+            }
+        }
+        updateTypingMembers(from: manager)
+    }
+
+    func updateTypingMembers(from manager: TypingIndicatorManager) {
+        let typerInboxIds = manager.typers(for: conversation.id)
+        let members = conversation.members.filter { member in
+            typerInboxIds.contains { $0.inboxId == member.profile.inboxId }
+        }
+        typingMembers = members
+    }
+
+    func clearTypingForNewMessages(old: [MessagesListItemType], new: [MessagesListItemType]) {
+        let oldLastId = old.lastMessageId
+        let newLastId = new.lastMessageId
+        guard oldLastId != newLastId,
+              let lastItem = new.last,
+              case .messages(let group) = lastItem,
+              !group.sender.isCurrentUser else { return }
+        typingIndicatorManager.handleMessageReceived(
+            conversationId: conversation.id,
+            senderInboxId: group.sender.profile.inboxId
+        )
+        updateTypingMembers(from: typingIndicatorManager)
+    }
+
+    func scheduleVoiceMemoTranscriptionsIfNeeded(in items: [MessagesListItemType]) {
+        let service = voiceMemoTranscriptionService
+        guard service.hasSpeechPermission() else { return }
+        let conversationId = conversation.id
+        for item in items {
+            guard case .messages(let group) = item else { continue }
+            for message in group.messages {
+                guard !message.senderIsCurrentUser else { continue }
+                guard let attachment = message.content.primaryVoiceMemoAttachment else { continue }
+                let messageId = message.messageId
+                let attachmentKey = attachment.key
+                let mimeType = attachment.mimeType ?? "audio/m4a"
+                Task.detached(priority: .utility) {
+                    await service.enqueueIfNeeded(
+                        messageId: messageId,
+                        conversationId: conversationId,
+                        attachmentKey: attachmentKey,
+                        mimeType: mimeType
+                    )
+                }
+            }
+        }
+    }
+
+    func stopTyping() {
+        guard isTypingSent else { return }
+        isTypingSent = false
+        typingThrottleDate = nil
+        typingResetTask?.cancel()
+        typingResetTask = nil
+        let conversationId = conversation.id
+        Task { [weak self] in
+            guard let self else { return }
+            try? await self.messagingService.sendTypingIndicator(isTyping: false, for: conversationId)
+        }
+    }
+
+    func handleTextChanged() {
+        if messageText.isEmpty {
+            stopTyping()
+            return
+        }
+
+        let now = Date()
+        if let lastSent = typingThrottleDate, now.timeIntervalSince(lastSent) < Self.typingThrottleInterval {
+            typingResetTask?.cancel()
+            typingResetTask = Task { [weak self] in
+                try? await Task.sleep(for: .seconds(Self.typingResetInterval))
+                guard !Task.isCancelled else { return }
+                await MainActor.run { [weak self] in
+                    self?.stopTyping()
+                }
+            }
+            return
+        }
+
+        typingThrottleDate = now
+        isTypingSent = true
+
+        typingResetTask?.cancel()
+        typingResetTask = Task { [weak self] in
+            try? await Task.sleep(for: .seconds(Self.typingResetInterval))
+            guard !Task.isCancelled else { return }
+            await MainActor.run { [weak self] in
+                self?.stopTyping()
+            }
+        }
+
+        let conversationId = conversation.id
+        Task { [weak self] in
+            guard let self else { return }
+            try? await self.messagingService.sendTypingIndicator(isTyping: true, for: conversationId)
+        }
+    }
+
+    var messagesWithTypingIndicator: [MessagesListItemType] {
+        guard !typingMembers.isEmpty else { return messages }
+
+        if typingMembers.count == 1 {
+            return messagesWithSingleTyper(typingMembers[0])
+        }
+        return messagesWithMultipleTypers(typingMembers)
+    }
+
+    func messagesWithSingleTyper(_ typer: ConversationMember) -> [MessagesListItemType] {
+        if let lastIndex = messages.lastIndex(where: { if case .messages = $0 { return true }; return false }),
+           case .messages(let lastGroup) = messages[lastIndex],
+           lastGroup.sender.profile.inboxId == typer.profile.inboxId {
+            var updated = messages
+            let updatedGroup = MessagesGroup(
+                id: lastGroup.id,
+                sender: lastGroup.sender,
+                messages: lastGroup.rawMessages,
+                isLastGroup: lastGroup.isLastGroup,
+                isLastGroupSentByCurrentUser: lastGroup.isLastGroupSentByCurrentUser,
+                showsTypingIndicator: true,
+                allTypingMembers: [typer],
+                onlyVisibleToSender: lastGroup.onlyVisibleToSender,
+                isLastGroupBeforeOtherMembers: lastGroup.isLastGroupBeforeOtherMembers
+            )
+            updated[lastIndex] = .messages(updatedGroup)
+            return updated
+        }
+
+        let typingGroup = MessagesGroup(
+            id: "typing-indicator",
+            sender: typer,
+            messages: [],
+            isLastGroup: false,
+            isLastGroupSentByCurrentUser: false,
+            showsTypingIndicator: true
+        )
+        return messages + [.messages(typingGroup)]
+    }
+
+    func messagesWithMultipleTypers(_ typers: [ConversationMember]) -> [MessagesListItemType] {
+        let typingGroup = MessagesGroup(
+            id: "typing-indicator-multi",
+            sender: typers[0],
+            messages: [],
+            isLastGroup: false,
+            isLastGroupSentByCurrentUser: false,
+            showsTypingIndicator: true,
+            allTypingMembers: typers
+        )
+        return messages + [.messages(typingGroup)]
+    }
+
+    static let typingThrottleInterval: TimeInterval = 5
+    static let typingResetInterval: TimeInterval = 10
+}

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -326,6 +326,7 @@ class ConversationViewModel {
 
     var autoRevealPhotos: Bool = false
     var sendReadReceipts: Bool = true
+    private(set) var isViewingConversation: Bool = false
 
     private static let hasShownPhotosInfoSheetKey: String = "hasShownPhotosInfoSheet"
     private var hasShownPhotosInfoSheet: Bool {
@@ -519,7 +520,6 @@ class ConversationViewModel {
         observe()
         loadPhotoPreferences()
         observeTypingIndicators(typingIndicatorManager)
-        sendReadReceiptIfNeeded()
 
         if conversation.isPendingInvite {
             onboardingCoordinator.isWaitingForInviteAcceptance = true
@@ -594,7 +594,6 @@ class ConversationViewModel {
         observeTypingIndicators(typingIndicatorManager)
         registerInlineAttachmentRecovery()
         scheduleVoiceMemoTranscriptionsIfNeeded(in: messages)
-        sendReadReceiptIfNeeded()
 
         self.editingConversationName = conversation.name ?? ""
         self.editingDescription = conversation.description ?? ""
@@ -1885,7 +1884,17 @@ extension ConversationViewModel {
 
     // MARK: - Read Receipts
 
+    func onConversationAppeared() {
+        isViewingConversation = true
+        sendReadReceiptIfNeeded()
+    }
+
+    func onConversationDisappeared() {
+        isViewingConversation = false
+    }
+
     private func sendReadReceiptIfNeeded() {
+        guard isViewingConversation else { return }
         guard !conversation.isDraft, !conversation.isPendingInvite else { return }
         guard sendReadReceipts else { return }
 

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -76,6 +76,7 @@ class ConversationViewModel {
     private let metadataWriter: any ConversationMetadataWriterProtocol
     private let explosionWriter: any ConversationExplosionWriterProtocol
     private let reactionWriter: any ReactionWriterProtocol
+    private let readReceiptWriter: any ReadReceiptWriterProtocol
     private let conversationRepository: any ConversationRepositoryProtocol
     private var messagesListRepository: any MessagesListRepositoryProtocol
     private let photoPreferencesRepository: any PhotoPreferencesRepositoryProtocol
@@ -97,6 +98,8 @@ class ConversationViewModel {
     private var photoPreferencesCancellable: AnyCancellable?
     @ObservationIgnored
     private var observedPhotoPreferencesConversationId: String?
+    @ObservationIgnored
+    private var lastReadReceiptSentAt: Date?
 
     // MARK: - Public
 
@@ -471,6 +474,7 @@ class ConversationViewModel {
         self.metadataWriter = conversationStateManager.conversationMetadataWriter
         self.explosionWriter = messagingService.conversationExplosionWriter()
         self.reactionWriter = messagingService.reactionWriter()
+        self.readReceiptWriter = messagingService.readReceiptWriter()
 
         let myProfileWriter = conversationStateManager.myProfileWriter
         let myProfileRepository = conversationRepository.myProfileRepository
@@ -510,6 +514,7 @@ class ConversationViewModel {
         observe()
         loadPhotoPreferences()
         observeTypingIndicators(typingIndicatorManager)
+        sendReadReceiptIfNeeded()
 
         if conversation.isPendingInvite {
             onboardingCoordinator.isWaitingForInviteAcceptance = true
@@ -553,6 +558,7 @@ class ConversationViewModel {
         self.metadataWriter = conversationStateManager.conversationMetadataWriter
         self.explosionWriter = messagingService.conversationExplosionWriter()
         self.reactionWriter = messagingService.reactionWriter()
+        self.readReceiptWriter = messagingService.readReceiptWriter()
 
         let myProfileWriter = conversationStateManager.myProfileWriter
         let myProfileRepository = conversationStateManager.draftConversationRepository.myProfileRepository
@@ -583,6 +589,7 @@ class ConversationViewModel {
         observeTypingIndicators(typingIndicatorManager)
         registerInlineAttachmentRecovery()
         scheduleVoiceMemoTranscriptionsIfNeeded(in: messages)
+        sendReadReceiptIfNeeded()
 
         self.editingConversationName = conversation.name ?? ""
         self.editingDescription = conversation.description ?? ""
@@ -615,6 +622,7 @@ class ConversationViewModel {
                 self.clearTypingForNewMessages(old: self.messages, new: messages)
                 self.messages = messages
                 self.scheduleVoiceMemoTranscriptionsIfNeeded(in: messages)
+                self.sendReadReceiptIfNeeded()
             }
             .store(in: &cancellables)
 
@@ -1843,6 +1851,28 @@ extension ConversationViewModel {
                     )
                     self.convosButtonCancellable = nil
                 }
+        }
+    }
+
+    // MARK: - Read Receipts
+
+    private func sendReadReceiptIfNeeded() {
+        guard !conversation.isDraft, !conversation.isPendingInvite else { return }
+        guard GlobalConvoDefaults.shared.sendReadReceipts else { return }
+
+        if let lastSent = lastReadReceiptSentAt, Date().timeIntervalSince(lastSent) < 5 {
+            return
+        }
+
+        lastReadReceiptSentAt = Date()
+        let conversationId = conversation.id
+
+        Task {
+            do {
+                try await readReceiptWriter.sendReadReceipt(for: conversationId)
+            } catch {
+                Log.warning("Failed to send read receipt: \(error.localizedDescription)")
+            }
         }
     }
 }

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -1918,14 +1918,12 @@ extension ConversationViewModel {
         }
     }
 
-    private func sendReadReceipt(for conversationId: String) {
+    private func sendReadReceipt(for conversationId: String) async {
         lastReadReceiptSentAt = Date()
-        Task {
-            do {
-                try await readReceiptWriter.sendReadReceipt(for: conversationId)
-            } catch {
-                Log.warning("Failed to send read receipt: \(error.localizedDescription)")
-            }
+        do {
+            try await readReceiptWriter.sendReadReceipt(for: conversationId)
+        } catch {
+            Log.warning("Failed to send read receipt: \(error.localizedDescription)")
         }
     }
 }

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -39,13 +39,14 @@ enum ExplodeDuration: CaseIterable {
     }
 }
 
+// swiftlint:disable type_body_length
 @MainActor
 @Observable
 class ConversationViewModel {
     // MARK: - Private
 
     private let session: any SessionManagerProtocol
-    private let messagingService: any MessagingServiceProtocol
+    let messagingService: any MessagingServiceProtocol
     private let conversationStateManager: any ConversationStateManagerProtocol
     private let outgoingMessageWriter: any OutgoingMessageWriterProtocol
     private let backgroundUploadManager: any BackgroundUploadManagerProtocol
@@ -76,15 +77,15 @@ class ConversationViewModel {
     private let metadataWriter: any ConversationMetadataWriterProtocol
     private let explosionWriter: any ConversationExplosionWriterProtocol
     private let reactionWriter: any ReactionWriterProtocol
-    private let readReceiptWriter: any ReadReceiptWriterProtocol
+    let readReceiptWriter: any ReadReceiptWriterProtocol
     private let conversationRepository: any ConversationRepositoryProtocol
     private var messagesListRepository: any MessagesListRepositoryProtocol
     private let photoPreferencesRepository: any PhotoPreferencesRepositoryProtocol
     private let photoPreferencesWriter: any PhotoPreferencesWriterProtocol
     private let attachmentLocalStateWriter: any AttachmentLocalStateWriterProtocol
-    private let voiceMemoTranscriptionService: any VoiceMemoTranscriptionServicing
+    let voiceMemoTranscriptionService: any VoiceMemoTranscriptionServicing
     private let applyGlobalDefaultsForNewConversation: Bool
-    private let typingIndicatorManager: TypingIndicatorManager
+    let typingIndicatorManager: TypingIndicatorManager
 
     @ObservationIgnored
     private var cancellables: Set<AnyCancellable> = []
@@ -99,9 +100,9 @@ class ConversationViewModel {
     @ObservationIgnored
     private var observedPhotoPreferencesConversationId: String?
     @ObservationIgnored
-    private var lastReadReceiptSentAt: Date?
+    var lastReadReceiptSentAt: Date?
     @ObservationIgnored
-    private var pendingReadReceiptTask: Task<Void, Never>?
+    var pendingReadReceiptTask: Task<Void, Never>?
     @ObservationIgnored
     private var lastMessageCountForReadReceipt: Int = 0
 
@@ -222,14 +223,14 @@ class ConversationViewModel {
         previousMessageTextLength = 0
     }
 
-    private(set) var typingMembers: [ConversationMember] = []
+    var typingMembers: [ConversationMember] = []
 
     @ObservationIgnored
-    private var isTypingSent: Bool = false
+    var isTypingSent: Bool = false
     @ObservationIgnored
-    private var typingResetTask: Task<Void, Never>?
+    var typingResetTask: Task<Void, Never>?
     @ObservationIgnored
-    private var typingThrottleDate: Date?
+    var typingThrottleDate: Date?
 
     var selectedAttachmentImage: UIImage? {
         didSet {
@@ -326,7 +327,7 @@ class ConversationViewModel {
 
     var autoRevealPhotos: Bool = false
     var sendReadReceipts: Bool = true
-    private(set) var isViewingConversation: Bool = false
+    var isViewingConversation: Bool = false
 
     private static let hasShownPhotosInfoSheetKey: String = "hasShownPhotosInfoSheet"
     private var hasShownPhotosInfoSheet: Bool {
@@ -1882,240 +1883,5 @@ extension ConversationViewModel {
                 }
         }
     }
-
-    // MARK: - Read Receipts
-
-    func onConversationAppeared() {
-        isViewingConversation = true
-        sendReadReceiptIfNeeded()
-    }
-
-    func onConversationDisappeared() {
-        isViewingConversation = false
-        pendingReadReceiptTask?.cancel()
-        pendingReadReceiptTask = nil
-    }
-
-    private func sendReadReceiptIfNeeded() {
-        guard isViewingConversation else { return }
-        guard !conversation.isDraft, !conversation.isPendingInvite else { return }
-        guard sendReadReceipts else { return }
-
-        let debounceInterval: TimeInterval = 1
-        if let lastSent = lastReadReceiptSentAt, Date().timeIntervalSince(lastSent) < debounceInterval {
-            guard pendingReadReceiptTask == nil else { return }
-            let delay = debounceInterval - Date().timeIntervalSince(lastSent)
-            let conversationId = conversation.id
-            pendingReadReceiptTask = Task { [weak self] in
-                try? await Task.sleep(for: .seconds(delay))
-                guard !Task.isCancelled else { return }
-                await self?.sendReadReceipt(for: conversationId)
-                self?.pendingReadReceiptTask = nil
-            }
-            return
-        }
-
-        let conversationId = conversation.id
-        Task { [weak self] in
-            await self?.sendReadReceipt(for: conversationId)
-        }
-    }
-
-    private func sendReadReceipt(for conversationId: String) async {
-        lastReadReceiptSentAt = Date()
-        do {
-            try await readReceiptWriter.sendReadReceipt(for: conversationId)
-        } catch {
-            Log.warning("Failed to send read receipt: \(error.localizedDescription)")
-        }
-    }
 }
-
-// MARK: - Typing Indicators
-
-extension ConversationViewModel {
-    fileprivate func setupTypingIndicatorHandler() {
-        let manager = typingIndicatorManager
-        Task {
-            await messagingService.inboxStateManager.setTypingIndicatorHandler { conversationId, senderInboxId, isTyping in
-                Task { @MainActor in
-                    manager.handleTypingEvent(
-                        conversationId: conversationId,
-                        senderInboxId: senderInboxId,
-                        isTyping: isTyping
-                    )
-                }
-            }
-        }
-    }
-
-    func observeTypingIndicators(_ manager: TypingIndicatorManager) {
-        withObservationTracking {
-            _ = manager.typingMembersByConversation[conversation.id]
-        } onChange: { [weak self] in
-            Task { @MainActor [weak self] in
-                guard let self else { return }
-                self.updateTypingMembers(from: manager)
-                self.observeTypingIndicators(manager)
-            }
-        }
-        updateTypingMembers(from: manager)
-    }
-
-    fileprivate func updateTypingMembers(from manager: TypingIndicatorManager) {
-        let typerInboxIds = manager.typers(for: conversation.id)
-        let members = conversation.members.filter { member in
-            typerInboxIds.contains { $0.inboxId == member.profile.inboxId }
-        }
-        typingMembers = members
-    }
-
-    fileprivate func clearTypingForNewMessages(old: [MessagesListItemType], new: [MessagesListItemType]) {
-        let oldLastId = old.lastMessageId
-        let newLastId = new.lastMessageId
-        guard oldLastId != newLastId,
-              let lastItem = new.last,
-              case .messages(let group) = lastItem,
-              !group.sender.isCurrentUser else { return }
-        typingIndicatorManager.handleMessageReceived(
-            conversationId: conversation.id,
-            senderInboxId: group.sender.profile.inboxId
-        )
-        updateTypingMembers(from: typingIndicatorManager)
-    }
-
-    fileprivate func scheduleVoiceMemoTranscriptionsIfNeeded(in items: [MessagesListItemType]) {
-        let service = voiceMemoTranscriptionService
-        // Only auto-enqueue once the user has granted speech recognition permission.
-        // Before that point, the row shows a "Tap to transcribe" affordance and the
-        // user kicks off the very first transcription manually (which is what causes
-        // iOS to surface the permission prompt).
-        guard service.hasSpeechPermission() else { return }
-        let conversationId = conversation.id
-        for item in items {
-            guard case .messages(let group) = item else { continue }
-            for message in group.messages {
-                guard !message.senderIsCurrentUser else { continue }
-                guard let attachment = message.content.primaryVoiceMemoAttachment else { continue }
-                let messageId = message.messageId
-                let attachmentKey = attachment.key
-                let mimeType = attachment.mimeType ?? "audio/m4a"
-                Task.detached(priority: .utility) {
-                    await service.enqueueIfNeeded(
-                        messageId: messageId,
-                        conversationId: conversationId,
-                        attachmentKey: attachmentKey,
-                        mimeType: mimeType
-                    )
-                }
-            }
-        }
-    }
-
-    func stopTyping() {
-        guard isTypingSent else { return }
-        isTypingSent = false
-        typingThrottleDate = nil
-        typingResetTask?.cancel()
-        typingResetTask = nil
-        let conversationId = conversation.id
-        Task { [weak self] in
-            guard let self else { return }
-            try? await self.messagingService.sendTypingIndicator(isTyping: false, for: conversationId)
-        }
-    }
-
-    fileprivate func handleTextChanged() {
-        if messageText.isEmpty {
-            stopTyping()
-            return
-        }
-
-        let now = Date()
-        if let lastSent = typingThrottleDate, now.timeIntervalSince(lastSent) < Self.typingThrottleInterval {
-            typingResetTask?.cancel()
-            typingResetTask = Task { [weak self] in
-                try? await Task.sleep(for: .seconds(Self.typingResetInterval))
-                guard !Task.isCancelled else { return }
-                await MainActor.run { [weak self] in
-                    self?.stopTyping()
-                }
-            }
-            return
-        }
-
-        typingThrottleDate = now
-        isTypingSent = true
-
-        typingResetTask?.cancel()
-        typingResetTask = Task { [weak self] in
-            try? await Task.sleep(for: .seconds(Self.typingResetInterval))
-            guard !Task.isCancelled else { return }
-            await MainActor.run { [weak self] in
-                self?.stopTyping()
-            }
-        }
-
-        let conversationId = conversation.id
-        Task { [weak self] in
-            guard let self else { return }
-            try? await self.messagingService.sendTypingIndicator(isTyping: true, for: conversationId)
-        }
-    }
-
-    var messagesWithTypingIndicator: [MessagesListItemType] {
-        guard !typingMembers.isEmpty else { return messages }
-
-        if typingMembers.count == 1 {
-            return messagesWithSingleTyper(typingMembers[0])
-        }
-        return messagesWithMultipleTypers(typingMembers)
-    }
-
-    fileprivate func messagesWithSingleTyper(_ typer: ConversationMember) -> [MessagesListItemType] {
-        if let lastIndex = messages.lastIndex(where: { if case .messages = $0 { return true }; return false }),
-           case .messages(let lastGroup) = messages[lastIndex],
-           lastGroup.sender.profile.inboxId == typer.profile.inboxId {
-            var updated = messages
-            let updatedGroup = MessagesGroup(
-                id: lastGroup.id,
-                sender: lastGroup.sender,
-                messages: lastGroup.rawMessages,
-                isLastGroup: lastGroup.isLastGroup,
-                isLastGroupSentByCurrentUser: lastGroup.isLastGroupSentByCurrentUser,
-                showsTypingIndicator: true,
-                allTypingMembers: [typer],
-                onlyVisibleToSender: lastGroup.onlyVisibleToSender,
-                isLastGroupBeforeOtherMembers: lastGroup.isLastGroupBeforeOtherMembers
-            )
-            updated[lastIndex] = .messages(updatedGroup)
-            return updated
-        }
-
-        let typingGroup = MessagesGroup(
-            id: "typing-indicator",
-            sender: typer,
-            messages: [],
-            isLastGroup: false,
-            isLastGroupSentByCurrentUser: false,
-            showsTypingIndicator: true
-        )
-        return messages + [.messages(typingGroup)]
-    }
-
-    fileprivate func messagesWithMultipleTypers(_ typers: [ConversationMember]) -> [MessagesListItemType] {
-        let typingGroup = MessagesGroup(
-            id: "typing-indicator-multi",
-            sender: typers[0],
-            messages: [],
-            isLastGroup: false,
-            isLastGroupSentByCurrentUser: false,
-            showsTypingIndicator: true,
-            allTypingMembers: typers
-        )
-        return messages + [.messages(typingGroup)]
-    }
-
-    fileprivate static let typingThrottleInterval: TimeInterval = 5
-    fileprivate static let typingResetInterval: TimeInterval = 10
-}
+// swiftlint:enable type_body_length

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -325,6 +325,7 @@ class ConversationViewModel {
     private var assistantJoinTaskId: String?
 
     var autoRevealPhotos: Bool = false
+    var sendReadReceipts: Bool = true
 
     private static let hasShownPhotosInfoSheetKey: String = "hasShownPhotosInfoSheet"
     private var hasShownPhotosInfoSheet: Bool {
@@ -608,6 +609,9 @@ class ConversationViewModel {
                 let prefs = try await photoPreferencesRepository.preferences(for: conversation.id)
                 let defaultAutoReveal: Bool = applyGlobalDefaultsForNewConversation ? GlobalConvoDefaults.shared.autoRevealPhotos : false
                 setAutoRevealPhotosLocally(prefs?.autoReveal ?? defaultAutoReveal)
+                let readReceiptsPref = prefs?.sendReadReceipts ?? GlobalConvoDefaults.shared.sendReadReceipts
+                sendReadReceipts = readReceiptsPref
+                messagesListRepository.sendReadReceipts = readReceiptsPref
             } catch {
                 Log.error("Error loading photo preferences: \(error)")
             }
@@ -676,6 +680,9 @@ class ConversationViewModel {
             .sink { [weak self] prefs in
                 guard let self else { return }
                 setAutoRevealPhotosLocally(prefs?.autoReveal ?? defaultAutoRevealForNewConversation)
+                let readReceiptsPref = prefs?.sendReadReceipts ?? GlobalConvoDefaults.shared.sendReadReceipts
+                sendReadReceipts = readReceiptsPref
+                messagesListRepository.sendReadReceipts = readReceiptsPref
             }
     }
 
@@ -691,6 +698,19 @@ class ConversationViewModel {
 
     private func setAutoRevealPhotosLocally(_ autoReveal: Bool) {
         autoRevealPhotos = autoReveal
+    }
+
+    func setSendReadReceipts(_ value: Bool) {
+        sendReadReceipts = value
+        messagesListRepository.sendReadReceipts = value
+        Task { [weak self] in
+            guard let self else { return }
+            do {
+                try await photoPreferencesWriter.setSendReadReceipts(value, for: conversation.id)
+            } catch {
+                Log.error("Error setting sendReadReceipts: \(error)")
+            }
+        }
     }
 
     private func setAutoRevealPhotosPersisted(_ autoReveal: Bool) {
@@ -1867,7 +1887,7 @@ extension ConversationViewModel {
 
     private func sendReadReceiptIfNeeded() {
         guard !conversation.isDraft, !conversation.isPendingInvite else { return }
-        guard GlobalConvoDefaults.shared.sendReadReceipts else { return }
+        guard sendReadReceipts else { return }
 
         let debounceInterval: TimeInterval = 1
         if let lastSent = lastReadReceiptSentAt, Date().timeIntervalSince(lastSent) < debounceInterval {

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -646,11 +646,16 @@ class ConversationViewModel {
             .sink { [weak self] conversation in
                 guard let self else { return }
                 let previousId = self.conversation.id
+                let wasViewingConversation = self.isViewingConversation
                 self.conversation = conversation
                 self.loadConversationImage(for: conversation)
                 if conversation.id != previousId {
                     self.observePhotoPreferences(for: conversation.id)
                     self.loadPhotoPreferences()
+                    if wasViewingConversation {
+                        self.isViewingConversation = true
+                        self.sendReadReceiptIfNeeded()
+                    }
                 }
             }
             .store(in: &cancellables)

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -230,6 +230,8 @@ class ConversationViewModel {
     @ObservationIgnored
     var typingResetTask: Task<Void, Never>?
     @ObservationIgnored
+    var pendingTypingIndicatorTask: Task<Void, Never>?
+    @ObservationIgnored
     var typingThrottleDate: Date?
 
     var selectedAttachmentImage: UIImage? {
@@ -409,6 +411,7 @@ class ConversationViewModel {
     deinit {
         voiceMemoPlaybackTask?.cancel()
         pendingReadReceiptTask?.cancel()
+        pendingTypingIndicatorTask?.cancel()
         loadConversationImageTask?.cancel()
         explodeTask?.cancel()
         assistantJoinTask?.cancel()

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -407,6 +407,7 @@ class ConversationViewModel {
 
     deinit {
         voiceMemoPlaybackTask?.cancel()
+        pendingReadReceiptTask?.cancel()
         loadConversationImageTask?.cancel()
         explodeTask?.cancel()
         assistantJoinTask?.cancel()
@@ -1891,6 +1892,8 @@ extension ConversationViewModel {
 
     func onConversationDisappeared() {
         isViewingConversation = false
+        pendingReadReceiptTask?.cancel()
+        pendingReadReceiptTask = nil
     }
 
     private func sendReadReceiptIfNeeded() {

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -100,6 +100,10 @@ class ConversationViewModel {
     private var observedPhotoPreferencesConversationId: String?
     @ObservationIgnored
     private var lastReadReceiptSentAt: Date?
+    @ObservationIgnored
+    private var pendingReadReceiptTask: Task<Void, Never>?
+    @ObservationIgnored
+    private var lastMessageCountForReadReceipt: Int = 0
 
     // MARK: - Public
 
@@ -620,9 +624,14 @@ class ConversationViewModel {
             .sink { [weak self] messages in
                 guard let self else { return }
                 self.clearTypingForNewMessages(old: self.messages, new: messages)
+                let messageCount = messages.countMessages
+                let messagesChanged = messageCount != self.lastMessageCountForReadReceipt
+                self.lastMessageCountForReadReceipt = messageCount
                 self.messages = messages
                 self.scheduleVoiceMemoTranscriptionsIfNeeded(in: messages)
-                self.sendReadReceiptIfNeeded()
+                if messagesChanged {
+                    self.sendReadReceiptIfNeeded()
+                }
             }
             .store(in: &cancellables)
 
@@ -1860,13 +1869,28 @@ extension ConversationViewModel {
         guard !conversation.isDraft, !conversation.isPendingInvite else { return }
         guard GlobalConvoDefaults.shared.sendReadReceipts else { return }
 
-        if let lastSent = lastReadReceiptSentAt, Date().timeIntervalSince(lastSent) < 5 {
+        let debounceInterval: TimeInterval = 1
+        if let lastSent = lastReadReceiptSentAt, Date().timeIntervalSince(lastSent) < debounceInterval {
+            guard pendingReadReceiptTask == nil else { return }
+            let delay = debounceInterval - Date().timeIntervalSince(lastSent)
+            let conversationId = conversation.id
+            pendingReadReceiptTask = Task { [weak self] in
+                try? await Task.sleep(for: .seconds(delay))
+                guard !Task.isCancelled else { return }
+                await self?.sendReadReceipt(for: conversationId)
+                self?.pendingReadReceiptTask = nil
+            }
             return
         }
 
-        lastReadReceiptSentAt = Date()
         let conversationId = conversation.id
+        Task { [weak self] in
+            await self?.sendReadReceipt(for: conversationId)
+        }
+    }
 
+    private func sendReadReceipt(for conversationId: String) {
+        lastReadReceiptSentAt = Date()
         Task {
             do {
                 try await readReceiptWriter.sendReadReceipt(for: conversationId)

--- a/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/ReadReceiptAvatarsView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/ReadReceiptAvatarsView.swift
@@ -15,7 +15,7 @@ struct ReadReceiptAvatarsView: View {
 
     private var avatarStack: some View {
         HStack(spacing: DesignConstants.Spacing.stepX) {
-            ForEach(profiles) { profile in
+            ForEach(profiles, id: \.self) { profile in
                 ProfileAvatarView(
                     profile: profile,
                     profileImage: nil,

--- a/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/ReadReceiptAvatarsView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/ReadReceiptAvatarsView.swift
@@ -1,0 +1,40 @@
+import ConvosCore
+import SwiftUI
+
+struct ReadReceiptAvatarsView: View {
+    let profiles: [Profile]
+
+    var body: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: DesignConstants.Spacing.stepX) {
+                ForEach(profiles) { profile in
+                    ProfileAvatarView(
+                        profile: profile,
+                        profileImage: nil,
+                        useSystemPlaceholder: false
+                    )
+                    .frame(width: 16, height: 16)
+                }
+            }
+        }
+        .frame(maxWidth: 120)
+        .mask(
+            HStack(spacing: 0) {
+                LinearGradient(
+                    gradient: Gradient(colors: [.clear, .black]),
+                    startPoint: .leading,
+                    endPoint: .trailing
+                )
+                .frame(width: DesignConstants.Spacing.stepX)
+                Rectangle().fill(.black)
+                LinearGradient(
+                    gradient: Gradient(colors: [.black, .clear]),
+                    startPoint: .leading,
+                    endPoint: .trailing
+                )
+                .frame(width: DesignConstants.Spacing.stepX)
+            }
+        )
+        .accessibilityIdentifier("read-receipt-avatars")
+    }
+}

--- a/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/ReadReceiptAvatarsView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/ReadReceiptAvatarsView.swift
@@ -4,37 +4,69 @@ import SwiftUI
 struct ReadReceiptAvatarsView: View {
     let profiles: [Profile]
 
-    var body: some View {
-        ScrollView(.horizontal, showsIndicators: false) {
-            HStack(spacing: DesignConstants.Spacing.stepX) {
-                ForEach(profiles) { profile in
-                    ProfileAvatarView(
-                        profile: profile,
-                        profileImage: nil,
-                        useSystemPlaceholder: false
-                    )
-                    .frame(width: 16, height: 16)
-                }
+    @State private var contentWidth: CGFloat = 0
+
+    private let avatarSize: CGFloat = 16
+    private let maxWidth: CGFloat = 120
+
+    private var needsScrolling: Bool {
+        contentWidth > maxWidth
+    }
+
+    private var avatarStack: some View {
+        HStack(spacing: DesignConstants.Spacing.stepX) {
+            ForEach(profiles) { profile in
+                ProfileAvatarView(
+                    profile: profile,
+                    profileImage: nil,
+                    useSystemPlaceholder: false
+                )
+                .frame(width: avatarSize, height: avatarSize)
             }
         }
-        .frame(maxWidth: 120)
-        .mask(
-            HStack(spacing: 0) {
-                LinearGradient(
-                    gradient: Gradient(colors: [.clear, .black]),
-                    startPoint: .leading,
-                    endPoint: .trailing
+    }
+
+    var body: some View {
+        Group {
+            if needsScrolling {
+                ScrollView(.horizontal, showsIndicators: false) {
+                    avatarStack
+                }
+                .scrollBounceBehavior(.basedOnSize)
+                .frame(width: maxWidth)
+                .mask(
+                    HStack(spacing: 0) {
+                        Rectangle().fill(.black)
+                        LinearGradient(
+                            colors: [.black, .black.opacity(0)],
+                            startPoint: .leading,
+                            endPoint: .trailing
+                        )
+                        .frame(width: DesignConstants.Spacing.step2x)
+                    }
                 )
-                .frame(width: DesignConstants.Spacing.stepX)
-                Rectangle().fill(.black)
-                LinearGradient(
-                    gradient: Gradient(colors: [.black, .clear]),
-                    startPoint: .leading,
-                    endPoint: .trailing
-                )
-                .frame(width: DesignConstants.Spacing.stepX)
+            } else {
+                avatarStack
             }
+        }
+        .background(
+            avatarStack
+                .fixedSize()
+                .hidden()
+                .background(GeometryReader { geo in
+                    Color.clear.preference(key: AvatarContentWidthKey.self, value: geo.size.width)
+                })
         )
+        .onPreferenceChange(AvatarContentWidthKey.self) { width in
+            contentWidth = width
+        }
         .accessibilityIdentifier("read-receipt-avatars")
+    }
+}
+
+private struct AvatarContentWidthKey: PreferenceKey {
+    nonisolated(unsafe) static var defaultValue: CGFloat = 0
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = max(value, nextValue())
     }
 }

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupView.swift
@@ -294,7 +294,13 @@ struct MessagesGroupView: View {
             .foregroundStyle(.colorTextSecondary)
             .zIndex(-1)
             .id("sent-status-\(message.differenceIdentifier)")
-            .accessibilityLabel(group.onlyVisibleToSender ? "Only visible to you" : (group.readByProfiles.isEmpty ? "Message sent" : "Message read by \(group.readByProfiles.count) members"))
+            .accessibilityLabel(
+                group.onlyVisibleToSender
+                    ? "Only visible to you"
+                    : (group.readByProfiles.isEmpty
+                        ? "Message sent"
+                        : "Message read by \(group.readByProfiles.count) \(group.readByProfiles.count == 1 ? "member" : "members")")
+            )
         }
     }
 

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupView.swift
@@ -275,6 +275,10 @@ struct MessagesGroupView: View {
                         useSystemPlaceholder: false
                     )
                     .frame(width: 16, height: 16)
+                } else if !group.readByProfiles.isEmpty {
+                    Text("Read")
+                        .font(.caption)
+                    ReadReceiptAvatarsView(profiles: group.readByProfiles)
                 } else {
                     Text("Sent")
                         .font(.caption)
@@ -290,7 +294,7 @@ struct MessagesGroupView: View {
             .foregroundStyle(.colorTextSecondary)
             .zIndex(-1)
             .id("sent-status-\(message.differenceIdentifier)")
-            .accessibilityLabel(group.onlyVisibleToSender ? "Only visible to you" : "Message sent")
+            .accessibilityLabel(group.onlyVisibleToSender ? "Only visible to you" : (group.readByProfiles.isEmpty ? "Message sent" : "Message read by \(group.readByProfiles.count) members"))
         }
     }
 

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessagesListRepository.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessagesListRepository.swift
@@ -9,18 +9,13 @@ protocol MessagesListRepositoryProtocol {
     var conversationMessagesListPublisher: AnyPublisher<(String, [MessagesListItemType]), Never> { get }
 
     func startObserving()
-
-    /// Fetches the initial page of messages (most recent messages)
     func fetchInitial() throws -> [MessagesListItemType]
-
-    /// Fetches previous (older) messages
-    /// Results are delivered through the messagesListPublisher
     func fetchPrevious() throws
 
-    /// Indicates if there are more messages to load
     var hasMoreMessages: Bool { get }
 
     var currentOtherMemberCount: Int { get set }
+    var sendReadReceipts: Bool { get set }
 }
 
 @MainActor
@@ -29,7 +24,7 @@ final class MessagesListRepository: MessagesListRepositoryProtocol {
 
     private let messagesRepository: any MessagesRepositoryProtocol
     private let transcriptRepository: any VoiceMemoTranscriptRepositoryProtocol
-    private let conversationIdSubject: CurrentValueSubject<String, Never>
+    private let conversationId: String
     /// Returns whether the user has granted on-device speech recognition permission.
     /// Used to suppress the synthetic "Tap to transcribe" affordance once the user
     /// has authorized transcription — from that point forward, voice memos with no
@@ -50,10 +45,10 @@ final class MessagesListRepository: MessagesListRepositoryProtocol {
     }
 
     var conversationMessagesListPublisher: AnyPublisher<(String, [MessagesListItemType]), Never> {
-        messagesRepository.conversationMessagesPublisher
-            .map { [weak self] conversationId, messages in
-                let processedMessages = self?.processMessages(messages, conversationId: conversationId) ?? []
-                return (conversationId, processedMessages)
+        messagesRepository.conversationMessagesResultPublisher
+            .map { [weak self] result in
+                let processedMessages = self?.processMessages(result.messages, readReceipts: result.readReceipts, memberProfiles: result.memberProfiles) ?? []
+                return (result.conversationId, processedMessages)
             }
             .handleEvents(receiveOutput: { [weak self] _, processedMessages in
                 self?.messagesListSubject.send(processedMessages)
@@ -73,44 +68,47 @@ final class MessagesListRepository: MessagesListRepositoryProtocol {
     ) {
         self.messagesRepository = messagesRepository
         self.transcriptRepository = transcriptRepository
-        self.conversationIdSubject = .init(conversationId)
+        self.conversationId = conversationId
         self.speechPermissionProvider = speechPermissionProvider
     }
 
     func startObserving() {
         guard !hasStartedObserving else { return }
         hasStartedObserving = true
-        messagesRepository.messagesPublisher
-            .map { [weak self] messages in
-                self?.processMessages(messages, conversationId: self?.conversationIdSubject.value) ?? []
+        messagesRepository.conversationMessagesResultPublisher
+            .map { [weak self] result in
+                self?.processMessages(result.messages, readReceipts: result.readReceipts, memberProfiles: result.memberProfiles) ?? []
             }
             .sink { [weak self] processedMessages in
                 self?.messagesListSubject.send(processedMessages)
             }
             .store(in: &cancellables)
 
-        conversationMessagesListPublisher
-            .map(\ .0)
-            .removeDuplicates()
-            .sink { [weak self] conversationId in
-                self?.handleConversationIdChanged(conversationId)
+        transcriptCancellable = transcriptRepository.transcriptsPublisher(in: conversationId)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] transcripts in
+                guard let self else { return }
+                self.storedTranscripts = transcripts
+                let reprocessed = self.processMessages(
+                    self.lastRawMessages,
+                    readReceipts: self.lastReadReceipts,
+                    memberProfiles: self.lastMemberProfiles
+                )
+                self.messagesListSubject.send(reprocessed)
             }
-            .store(in: &cancellables)
-
-        observeTranscripts(for: conversationIdSubject.value)
     }
 
     // MARK: - Public Methods
 
     func fetchInitial() throws -> [MessagesListItemType] {
-        let messages = try messagesRepository.fetchInitial()
+        let result = try messagesRepository.fetchInitialResult()
         // Seed the stored transcripts synchronously so the very first list
         // emission already carries any persisted transcripts. Otherwise the
         // transcripts publisher subscription in startObserving() lags behind
         // the initial fetch by one run loop, causing transcript rows to
         // "animate in" a moment after the conversation opens.
-        storedTranscripts = (try? transcriptRepository.fetchAllTranscripts(in: conversationIdSubject.value)) ?? [:]
-        return processMessages(messages, conversationId: conversationIdSubject.value)
+        storedTranscripts = (try? transcriptRepository.fetchAllTranscripts(in: conversationId)) ?? [:]
+        return processMessages(result.messages, readReceipts: result.readReceipts, memberProfiles: result.memberProfiles)
     }
 
     func fetchPrevious() throws {
@@ -124,14 +122,28 @@ final class MessagesListRepository: MessagesListRepositoryProtocol {
 
     // MARK: - Private Methods
 
-    private func processMessages(_ messages: [AnyMessage], conversationId: String?) -> [MessagesListItemType] {
+    private var lastReadReceipts: [ReadReceiptEntry] = []
+    private var lastMemberProfiles: [String: MemberProfileInfo] = [:]
+    private var lastOtherMemberCount: Int = 0
+    private var lastReadByProfiles: [Profile] = []
+    var sendReadReceipts: Bool = true
+
+    private func processMessages(_ messages: [AnyMessage], readReceipts: [ReadReceiptEntry] = [], memberProfiles: [String: MemberProfileInfo] = [:]) -> [MessagesListItemType] {
         lastRawMessages = messages
-        let transcripts = synthesizeTranscriptItems(messages: messages, conversationId: conversationId)
+        lastReadReceipts = readReceipts
+        lastMemberProfiles = memberProfiles
+        lastOtherMemberCount = currentOtherMemberCount
+        let transcripts = synthesizeTranscriptItems(messages: messages)
         let items = MessagesListProcessor.process(
             messages,
-            otherMemberCount: currentOtherMemberCount,
-            voiceMemoTranscripts: transcripts
+            voiceMemoTranscripts: transcripts,
+            readReceipts: readReceipts,
+            memberProfiles: memberProfiles,
+            currentOtherMemberCount: currentOtherMemberCount,
+            sendReadReceipts: sendReadReceipts,
+            previousReadByProfiles: lastReadByProfiles
         )
+        lastReadByProfiles = Self.extractReadByProfiles(from: items)
         scheduleAssistantJoinDismissIfNeeded(items)
         return items
     }
@@ -144,11 +156,9 @@ final class MessagesListRepository: MessagesListRepositoryProtocol {
     /// scheduler auto-enqueues these messages, so the row should stay hidden until
     /// the writer flips it to `.pending`.
     private func synthesizeTranscriptItems(
-        messages: [AnyMessage],
-        conversationId: String?
+        messages: [AnyMessage]
     ) -> [String: VoiceMemoTranscriptListItem] {
         let permissionGranted = speechPermissionProvider()
-        let effectiveConversationId = conversationId ?? conversationIdSubject.value
         var result: [String: VoiceMemoTranscriptListItem] = [:]
         for message in messages {
             guard let attachment = message.content.primaryVoiceMemoAttachment else { continue }
@@ -171,7 +181,7 @@ final class MessagesListRepository: MessagesListRepositoryProtocol {
             }
             let item = VoiceMemoTranscriptListItem(
                 parentMessageId: message.messageId,
-                conversationId: effectiveConversationId,
+                conversationId: conversationId,
                 attachmentKey: attachment.key,
                 mimeType: attachment.mimeType,
                 senderDisplayName: message.sender.profile.displayName,
@@ -185,23 +195,13 @@ final class MessagesListRepository: MessagesListRepositoryProtocol {
         return result
     }
 
-    private func handleConversationIdChanged(_ conversationId: String) {
-        guard conversationIdSubject.value != conversationId else { return }
-        conversationIdSubject.send(conversationId)
-        storedTranscripts = (try? transcriptRepository.fetchAllTranscripts(in: conversationId)) ?? [:]
-        observeTranscripts(for: conversationId)
-    }
-
-    private func observeTranscripts(for conversationId: String) {
-        transcriptCancellable?.cancel()
-        transcriptCancellable = transcriptRepository.transcriptsPublisher(in: conversationId)
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] transcripts in
-                guard let self else { return }
-                self.storedTranscripts = transcripts
-                let reprocessed = self.processMessages(self.lastRawMessages, conversationId: self.conversationIdSubject.value)
-                self.messagesListSubject.send(reprocessed)
+    private static func extractReadByProfiles(from items: [MessagesListItemType]) -> [Profile] {
+        for item in items.reversed() {
+            if case .messages(let group) = item, group.isLastGroupSentByCurrentUser {
+                return group.readByProfiles
             }
+        }
+        return []
     }
 
     private func scheduleAssistantJoinDismissIfNeeded(_ items: [MessagesListItemType]) {
@@ -218,7 +218,7 @@ final class MessagesListRepository: MessagesListRepositoryProtocol {
             .delay(for: .seconds(remaining), scheduler: DispatchQueue.main)
             .sink { [weak self] _ in
                 guard let self else { return }
-                let reprocessed = self.processMessages(self.lastRawMessages, conversationId: self.conversationIdSubject.value)
+                let reprocessed = self.processMessages(self.lastRawMessages, readReceipts: self.lastReadReceipts, memberProfiles: self.lastMemberProfiles)
                 self.scheduleAssistantJoinDismissIfNeeded(reprocessed)
                 self.messagesListSubject.send(reprocessed)
             }

--- a/ConvosCore/Package.resolved
+++ b/ConvosCore/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "71fc4f0a471170157f392192c900a8a7ad94ed62bd37ed05387c05a3a3b85a2e",
+  "originHash" : "7c6d0a4d8597a0087af595254774acfe939ff220ea3024cfa0bb6cf4ef51dbf0",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -141,8 +141,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/xmtp/libxmtp.git",
       "state" : {
-        "branch" : "ios-4.9.0-dev.6ecd439",
-        "revision" : "297e684d07e78f87da617be80565359c315ba6f0"
+        "branch" : "ios-4.10.0-dev.8fcbbde",
+        "revision" : "4e93ec9f7608e785b1ab7ebaf043c4def8322b2c"
       }
     },
     {
@@ -195,8 +195,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log",
       "state" : {
-        "revision" : "bc386b95f2a16ccd0150a8235e7c69eab2b866ca",
-        "version" : "1.8.0"
+        "revision" : "8c0f217f01000dd30f60d6e536569ad4e74291f9",
+        "version" : "1.11.0"
       }
     },
     {

--- a/ConvosCore/Package.resolved
+++ b/ConvosCore/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "7c6d0a4d8597a0087af595254774acfe939ff220ea3024cfa0bb6cf4ef51dbf0",
+  "originHash" : "579cd1d748e9b32204ec97c5a2a168f00af764e485cc3f70870e0129ee45605b",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -141,8 +141,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/xmtp/libxmtp.git",
       "state" : {
-        "branch" : "ios-4.10.0-dev.8fcbbde",
-        "revision" : "4e93ec9f7608e785b1ab7ebaf043c4def8322b2c"
+        "branch" : "ios-4.9.0-dev.88ddfad",
+        "revision" : "899650a4189207ca2df515bf46beb549da07ff46"
       }
     },
     {

--- a/ConvosCore/Package.swift
+++ b/ConvosCore/Package.swift
@@ -23,7 +23,7 @@ let package = Package(
         .package(url: "https://github.com/groue/GRDB.swift.git", exact: "7.5.0"),
         .package(
             url: "https://github.com/xmtp/libxmtp.git",
-            revision: "ios-4.10.0-dev.8fcbbde"
+            revision: "ios-4.9.0-dev.88ddfad"
         ),
         .package(url: "https://github.com/tesseract-one/CSecp256k1.swift.git", from: "0.2.0"),
         .package(url: "https://github.com/firebase/firebase-ios-sdk", from: "12.1.0"),

--- a/ConvosCore/Package.swift
+++ b/ConvosCore/Package.swift
@@ -23,7 +23,7 @@ let package = Package(
         .package(url: "https://github.com/groue/GRDB.swift.git", exact: "7.5.0"),
         .package(
             url: "https://github.com/xmtp/libxmtp.git",
-            revision: "ios-4.9.0-dev.6ecd439"
+            revision: "ios-4.10.0-dev.8fcbbde"
         ),
         .package(url: "https://github.com/tesseract-one/CSecp256k1.swift.git", from: "0.2.0"),
         .package(url: "https://github.com/firebase/firebase-ios-sdk", from: "12.1.0"),

--- a/ConvosCore/Sources/ConvosCore/Inboxes/ConversationStateMachine.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/ConversationStateMachine.swift
@@ -678,6 +678,7 @@ public actor ConversationStateMachine {
         let text = try invite.toURLSafeSlug()
         _ = try await dm.prepare(text: text)
         try await dm.publish()
+
         Log.info("[PERF] NewConversation.joinRequestSent")
         QAEvent.emit(.invite, "join_request_sent")
 

--- a/ConvosCore/Sources/ConvosCore/Inboxes/InboxStateMachine.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/InboxStateMachine.swift
@@ -1111,7 +1111,8 @@ public actor InboxStateMachine: InboxStateManagerProtocol {
                 ProfileSnapshotCodec(),
                 JoinRequestCodec(),
                 AssistantJoinRequestCodec(),
-                TypingIndicatorCodec()
+                TypingIndicatorCodec(),
+                ReadReceiptCodec()
             ],
             dbEncryptionKey: keys.databaseKey,
             dbDirectory: environment.defaultDatabasesDirectory,

--- a/ConvosCore/Sources/ConvosCore/Inboxes/InboxStateMachine.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/InboxStateMachine.swift
@@ -1116,9 +1116,7 @@ public actor InboxStateMachine: InboxStateManagerProtocol {
             ],
             dbEncryptionKey: keys.databaseKey,
             dbDirectory: environment.defaultDatabasesDirectory,
-            deviceSyncEnabled: false,
-            maxDbPoolSize: 10,
-            minDbPoolSize: 3
+            deviceSyncEnabled: false
         )
     }
 

--- a/ConvosCore/Sources/ConvosCore/Inboxes/InboxStateMachine.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/InboxStateMachine.swift
@@ -1116,7 +1116,9 @@ public actor InboxStateMachine: InboxStateManagerProtocol {
             ],
             dbEncryptionKey: keys.databaseKey,
             dbDirectory: environment.defaultDatabasesDirectory,
-            deviceSyncEnabled: false
+            deviceSyncEnabled: false,
+            maxDbPoolSize: 10,
+            minDbPoolSize: 3
         )
     }
 

--- a/ConvosCore/Sources/ConvosCore/Inboxes/MessagingService+PushNotifications.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/MessagingService+PushNotifications.swift
@@ -360,6 +360,11 @@ extension MessagingService {
             return .droppedMessage
         }
 
+        if let contentType = try? decodedMessage.encodedContent.type,
+           contentType == ContentTypeReadReceipt {
+            return .droppedMessage
+        }
+
         let dbConversation = try await storeConversation(group, inboxId: currentInboxId)
 
         _ = try await messageWriter.store(message: decodedMessage, for: dbConversation)

--- a/ConvosCore/Sources/ConvosCore/Inboxes/MessagingService+PushNotifications.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/MessagingService+PushNotifications.swift
@@ -361,6 +361,7 @@ extension MessagingService {
         }
 
         if decodedMessage.isReadReceipt {
+            await persistReadReceiptInNSE(decodedMessage, conversationId: conversationId)
             return .droppedMessage
         }
 
@@ -634,6 +635,38 @@ extension MessagingService {
             return "\(minutes) minute\(minutes == 1 ? "" : "s")"
         } else {
             return "less than a minute"
+        }
+    }
+
+    // MARK: - Read Receipt Processing
+
+    private func persistReadReceiptInNSE(
+        _ message: DecodedMessage,
+        conversationId: String
+    ) async {
+        let senderInboxId = message.senderInboxId
+        guard !senderInboxId.isEmpty else { return }
+        let sentAtNs = message.sentAtNs
+        do {
+            try await databaseWriter.write { db in
+                let existing = try DBConversationReadReceipt
+                    .filter(Column("conversationId") == conversationId && Column("inboxId") == senderInboxId)
+                    .fetchOne(db)
+                if let existing, existing.readAtNs >= sentAtNs {
+                    // Newer (or equal) read receipt already stored; skip so an
+                    // out-of-order delivery can't roll the timestamp backwards.
+                    return
+                }
+                let receipt = DBConversationReadReceipt(
+                    conversationId: conversationId,
+                    inboxId: senderInboxId,
+                    readAtNs: sentAtNs
+                )
+                try receipt.save(db, onConflict: .replace)
+            }
+            Log.debug("NSE: Stored read receipt from \(senderInboxId) in \(conversationId)")
+        } catch {
+            Log.warning("NSE: Failed to store read receipt: \(error.localizedDescription)")
         }
     }
 

--- a/ConvosCore/Sources/ConvosCore/Inboxes/MessagingService+PushNotifications.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/MessagingService+PushNotifications.swift
@@ -360,8 +360,7 @@ extension MessagingService {
             return .droppedMessage
         }
 
-        if let contentType = try? decodedMessage.encodedContent.type,
-           contentType == ContentTypeReadReceipt {
+        if decodedMessage.isReadReceipt {
             return .droppedMessage
         }
 

--- a/ConvosCore/Sources/ConvosCore/Messaging/MessagingService.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/MessagingService.swift
@@ -170,6 +170,11 @@ final class MessagingService: MessagingServiceProtocol, @unchecked Sendable {
                        databaseWriter: databaseWriter)
     }
 
+    func readReceiptWriter() -> any ReadReceiptWriterProtocol {
+        ReadReceiptWriter(inboxStateManager: inboxStateManager,
+                          databaseWriter: databaseWriter)
+    }
+
     func replyWriter() -> any ReplyMessageWriterProtocol {
         ReplyMessageWriter(inboxStateManager: inboxStateManager,
                            databaseWriter: databaseWriter)

--- a/ConvosCore/Sources/ConvosCore/Messaging/MessagingServiceProtocol.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/MessagingServiceProtocol.swift
@@ -40,6 +40,7 @@ public protocol MessagingServiceProtocol: AnyObject, Sendable {
         backgroundUploadManager: any BackgroundUploadManagerProtocol
     ) -> any OutgoingMessageWriterProtocol
     func reactionWriter() -> any ReactionWriterProtocol
+    func readReceiptWriter() -> any ReadReceiptWriterProtocol
     func replyWriter() -> any ReplyMessageWriterProtocol
 
     func conversationMetadataWriter() -> any ConversationMetadataWriterProtocol

--- a/ConvosCore/Sources/ConvosCore/Messaging/XMTPClientProvider.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/XMTPClientProvider.swift
@@ -44,6 +44,7 @@ public struct SendableXMTPOperations: Sendable {
 public protocol MessageSender {
     func sendExplode(expiresAt: Date) async throws
     func sendTypingIndicator(isTyping: Bool) async throws
+    func sendReadReceipt() async throws
     func prepare(text: String) async throws -> String
     func prepare(remoteAttachment: RemoteAttachment) async throws -> String
     func prepare(reply: Reply) async throws -> String
@@ -248,6 +249,13 @@ extension XMTPiOS.Client: XMTPClientProvider {
 }
 
 extension XMTPiOS.Conversation: MessageSender {
+    public func sendReadReceipt() async throws {
+        try await send(
+            content: ReadReceipt(),
+            options: .init(contentType: ReadReceiptCodec().contentType)
+        )
+    }
+
     public func sendExplode(expiresAt: Date) async throws {
         Log.info("Sending ExplodeSettings message with expiresAt: \(expiresAt) (\(expiresAt.timeIntervalSince1970))")
         let codec = ExplodeSettingsCodec()

--- a/ConvosCore/Sources/ConvosCore/Mocks/MockMessageSender.swift
+++ b/ConvosCore/Sources/ConvosCore/Mocks/MockMessageSender.swift
@@ -15,6 +15,9 @@ public final class MockMessageSender: MessageSender, @unchecked Sendable {
     public func sendTypingIndicator(isTyping: Bool) async throws {
     }
 
+    public func sendReadReceipt() async throws {
+    }
+
     public func prepare(text: String) async throws -> String {
         let messageId = UUID().uuidString
         preparedMessages.append(messageId)

--- a/ConvosCore/Sources/ConvosCore/Mocks/MockMessagingService.swift
+++ b/ConvosCore/Sources/ConvosCore/Mocks/MockMessagingService.swift
@@ -22,6 +22,7 @@ public final class MockMessagingService: MessagingServiceProtocol, @unchecked Se
     private let _conversationPermissionsRepository: any ConversationPermissionsRepositoryProtocol
     private let _outgoingMessageWriter: any OutgoingMessageWriterProtocol
     private let _reactionWriter: any ReactionWriterProtocol
+    private let _readReceiptWriter: any ReadReceiptWriterProtocol
     private let _replyWriter: any ReplyMessageWriterProtocol
 
     // MARK: - Initialization
@@ -37,6 +38,7 @@ public final class MockMessagingService: MessagingServiceProtocol, @unchecked Se
         conversationPermissionsRepository: (any ConversationPermissionsRepositoryProtocol)? = nil,
         outgoingMessageWriter: (any OutgoingMessageWriterProtocol)? = nil,
         reactionWriter: (any ReactionWriterProtocol)? = nil,
+        readReceiptWriter: (any ReadReceiptWriterProtocol)? = nil,
         replyWriter: (any ReplyMessageWriterProtocol)? = nil
     ) {
         self._inboxStateManager = inboxStateManager ?? MockInboxStateManager()
@@ -49,6 +51,7 @@ public final class MockMessagingService: MessagingServiceProtocol, @unchecked Se
         self._conversationPermissionsRepository = conversationPermissionsRepository ?? MockConversationPermissionsRepository()
         self._outgoingMessageWriter = outgoingMessageWriter ?? MockOutgoingMessageWriter()
         self._reactionWriter = reactionWriter ?? MockReactionWriter()
+        self._readReceiptWriter = readReceiptWriter ?? MockReadReceiptWriter()
         self._replyWriter = replyWriter ?? MockReplyMessageWriter()
     }
 
@@ -91,6 +94,10 @@ public final class MockMessagingService: MessagingServiceProtocol, @unchecked Se
 
     public func reactionWriter() -> any ReactionWriterProtocol {
         _reactionWriter
+    }
+
+    public func readReceiptWriter() -> any ReadReceiptWriterProtocol {
+        _readReceiptWriter
     }
 
     public func replyWriter() -> any ReplyMessageWriterProtocol {

--- a/ConvosCore/Sources/ConvosCore/Mocks/MockReadReceiptWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Mocks/MockReadReceiptWriter.swift
@@ -1,4 +1,3 @@
-import Combine
 import Foundation
 
 public final class MockReadReceiptWriter: ReadReceiptWriterProtocol, @unchecked Sendable {
@@ -8,17 +7,5 @@ public final class MockReadReceiptWriter: ReadReceiptWriterProtocol, @unchecked 
 
     public func sendReadReceipt(for conversationId: String) async throws {
         sentReadReceipts.append(conversationId)
-    }
-
-    public func fetchReadMemberInboxIds(
-        for conversationId: String,
-        afterNs messageDateNs: Int64,
-        excludingInboxId: String
-    ) async throws -> [String] {
-        []
-    }
-
-    public func readReceiptsPublisher(for conversationId: String) -> AnyPublisher<[ReadReceiptEntry], Error> {
-        Just([]).setFailureType(to: Error.self).eraseToAnyPublisher()
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Mocks/MockReadReceiptWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Mocks/MockReadReceiptWriter.swift
@@ -1,3 +1,4 @@
+import Combine
 import Foundation
 
 public final class MockReadReceiptWriter: ReadReceiptWriterProtocol, @unchecked Sendable {
@@ -15,5 +16,9 @@ public final class MockReadReceiptWriter: ReadReceiptWriterProtocol, @unchecked 
         excludingInboxId: String
     ) async throws -> [String] {
         []
+    }
+
+    public func readReceiptsPublisher(for conversationId: String) -> AnyPublisher<[ReadReceiptEntry], Error> {
+        Just([]).setFailureType(to: Error.self).eraseToAnyPublisher()
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Mocks/MockReadReceiptWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Mocks/MockReadReceiptWriter.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+public final class MockReadReceiptWriter: ReadReceiptWriterProtocol, @unchecked Sendable {
+    public var sentReadReceipts: [String] = []
+
+    public init() {}
+
+    public func sendReadReceipt(for conversationId: String) async throws {
+        sentReadReceipts.append(conversationId)
+    }
+
+    public func fetchReadMemberInboxIds(
+        for conversationId: String,
+        afterNs messageDateNs: Int64,
+        excludingInboxId: String
+    ) async throws -> [String] {
+        []
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Mocks/MockRepositories.swift
+++ b/ConvosCore/Sources/ConvosCore/Mocks/MockRepositories.swift
@@ -136,13 +136,13 @@ public final class MockMessagesRepository: MessagesRepositoryProtocol, @unchecke
     }
 
     public var conversationMessagesResultPublisher: AnyPublisher<ConversationMessagesResult, Never> {
-        Just(ConversationMessagesResult(conversationId: conversationId, messages: mockMessages, readReceipts: []))
+        Just(ConversationMessagesResult(conversationId: conversationId, messages: mockMessages, readReceipts: [], memberProfiles: [:]))
             .eraseToAnyPublisher()
     }
 
     public func fetchInitialResult() throws -> ConversationMessagesResult {
         let messages = try fetchInitial()
-        return ConversationMessagesResult(conversationId: conversationId, messages: messages, readReceipts: [])
+        return ConversationMessagesResult(conversationId: conversationId, messages: messages, readReceipts: [], memberProfiles: [:])
     }
 }
 

--- a/ConvosCore/Sources/ConvosCore/Mocks/MockRepositories.swift
+++ b/ConvosCore/Sources/ConvosCore/Mocks/MockRepositories.swift
@@ -202,6 +202,7 @@ public final class MockPhotoPreferencesRepository: PhotoPreferencesRepositoryPro
 public final class MockPhotoPreferencesWriter: PhotoPreferencesWriterProtocol, @unchecked Sendable {
     public var autoRevealValues: [String: Bool] = [:]
     public var hasRevealedFirstValues: [String: Bool] = [:]
+    public var sendReadReceiptsValues: [String: Bool?] = [:]
 
     public init() {}
 
@@ -211,6 +212,10 @@ public final class MockPhotoPreferencesWriter: PhotoPreferencesWriterProtocol, @
 
     public func setHasRevealedFirst(_ hasRevealedFirst: Bool, for conversationId: String) async throws {
         hasRevealedFirstValues[conversationId] = hasRevealedFirst
+    }
+
+    public func setSendReadReceipts(_ sendReadReceipts: Bool?, for conversationId: String) async throws {
+        sendReadReceiptsValues[conversationId] = sendReadReceipts
     }
 }
 

--- a/ConvosCore/Sources/ConvosCore/Mocks/MockRepositories.swift
+++ b/ConvosCore/Sources/ConvosCore/Mocks/MockRepositories.swift
@@ -135,8 +135,14 @@ public final class MockMessagesRepository: MessagesRepositoryProtocol, @unchecke
         hasMoreMessages = false
     }
 
-    public var conversationMessagesPublisher: AnyPublisher<ConversationMessages, Never> {
-        Just((conversationId, mockMessages)).eraseToAnyPublisher()
+    public var conversationMessagesResultPublisher: AnyPublisher<ConversationMessagesResult, Never> {
+        Just(ConversationMessagesResult(conversationId: conversationId, messages: mockMessages, readReceipts: []))
+            .eraseToAnyPublisher()
+    }
+
+    public func fetchInitialResult() throws -> ConversationMessagesResult {
+        let messages = try fetchInitial()
+        return ConversationMessagesResult(conversationId: conversationId, messages: messages, readReceipts: [])
     }
 }
 

--- a/ConvosCore/Sources/ConvosCore/Storage/Database Models/DBConversationMember.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Database Models/DBConversationMember.swift
@@ -20,7 +20,7 @@ struct DBConversationMember: Codable, FetchableRecord, PersistableRecord, Hashab
     let role: MemberRole
     let consent: Consent
     let createdAt: Date
-    let invitedByInboxId: String?
+    var invitedByInboxId: String?
 
     static let memberForeignKey: ForeignKey = ForeignKey([Columns.inboxId], to: [DBMember.Columns.inboxId])
     static let conversationForeignKey: ForeignKey = ForeignKey([Columns.conversationId], to: [DBConversation.Columns.id])

--- a/ConvosCore/Sources/ConvosCore/Storage/Database Models/DBConversationReadReceipt.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Database Models/DBConversationReadReceipt.swift
@@ -1,0 +1,15 @@
+import Foundation
+import GRDB
+
+struct DBConversationReadReceipt: Codable, FetchableRecord, PersistableRecord, Sendable {
+    static let databaseTableName: String = "conversation_read_receipts"
+
+    var conversationId: String
+    var inboxId: String
+    var readAtNs: Int64
+
+    static let memberProfile = belongsTo(DBMemberProfile.self, using: ForeignKey(
+        ["inboxId", "conversationId"],
+        to: ["inboxId", "conversationId"]
+    ))
+}

--- a/ConvosCore/Sources/ConvosCore/Storage/Database Models/DBConversationReadReceipt.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Database Models/DBConversationReadReceipt.swift
@@ -8,8 +8,11 @@ struct DBConversationReadReceipt: Codable, FetchableRecord, PersistableRecord, S
     var inboxId: String
     var readAtNs: Int64
 
-    static let memberProfile = belongsTo(DBMemberProfile.self, using: ForeignKey(
-        ["inboxId", "conversationId"],
-        to: ["inboxId", "conversationId"]
-    ))
+    static let memberProfile: BelongsToAssociation<DBConversationReadReceipt, DBMemberProfile> = belongsTo(
+        DBMemberProfile.self,
+        using: ForeignKey(
+            ["inboxId", "conversationId"],
+            to: ["inboxId", "conversationId"]
+        )
+    )
 }

--- a/ConvosCore/Sources/ConvosCore/Storage/Database Models/DBPhotoPreferences.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Database Models/DBPhotoPreferences.swift
@@ -9,12 +9,14 @@ struct DBPhotoPreferences: FetchableRecord, PersistableRecord, Codable, Hashable
         static let autoReveal: Column = Column(CodingKeys.autoReveal)
         static let hasRevealedFirst: Column = Column(CodingKeys.hasRevealedFirst)
         static let updatedAt: Column = Column(CodingKeys.updatedAt)
+        static let sendReadReceipts: Column = Column(CodingKeys.sendReadReceipts)
     }
 
     let conversationId: String
     var autoReveal: Bool
     var hasRevealedFirst: Bool
     var updatedAt: Date
+    var sendReadReceipts: Bool?
 
     static let conversation: BelongsToAssociation<DBPhotoPreferences, DBConversation> = belongsTo(DBConversation.self)
 }
@@ -25,7 +27,8 @@ extension DBPhotoPreferences {
             conversationId: conversationId,
             autoReveal: autoReveal,
             hasRevealedFirst: hasRevealedFirst,
-            updatedAt: Date()
+            updatedAt: Date(),
+            sendReadReceipts: sendReadReceipts
         )
     }
 
@@ -34,7 +37,18 @@ extension DBPhotoPreferences {
             conversationId: conversationId,
             autoReveal: autoReveal,
             hasRevealedFirst: hasRevealedFirst,
-            updatedAt: Date()
+            updatedAt: Date(),
+            sendReadReceipts: sendReadReceipts
+        )
+    }
+
+    func with(sendReadReceipts: Bool?) -> DBPhotoPreferences {
+        DBPhotoPreferences(
+            conversationId: conversationId,
+            autoReveal: autoReveal,
+            hasRevealedFirst: hasRevealedFirst,
+            updatedAt: Date(),
+            sendReadReceipts: sendReadReceipts
         )
     }
 
@@ -43,7 +57,8 @@ extension DBPhotoPreferences {
             conversationId: conversationId,
             autoReveal: false,
             hasRevealedFirst: false,
-            updatedAt: Date()
+            updatedAt: Date(),
+            sendReadReceipts: nil
         )
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/MessagesGroup.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/MessagesGroup.swift
@@ -103,6 +103,7 @@ extension MessagesGroup: Hashable {
         hasher.combine(isLastGroup)
         hasher.combine(isLastGroupSentByCurrentUser)
         hasher.combine(showsTypingIndicator)
+        hasher.combine(allTypingMembers)
         hasher.combine(readByProfiles)
         hasher.combine(onlyVisibleToSender)
         hasher.combine(isLastGroupBeforeOtherMembers)

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/MessagesGroup.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/MessagesGroup.swift
@@ -8,6 +8,7 @@ public struct MessagesGroup: Identifiable, Equatable, Sendable {
     public var isLastGroupSentByCurrentUser: Bool
     public let showsTypingIndicator: Bool
     public let allTypingMembers: [ConversationMember]
+    public let readByProfiles: [Profile]
     public var onlyVisibleToSender: Bool = false
     public var isLastGroupBeforeOtherMembers: Bool = false
     /// Display-time transcript rows keyed by parent message id. Populated by
@@ -35,6 +36,7 @@ public struct MessagesGroup: Identifiable, Equatable, Sendable {
         isLastGroupSentByCurrentUser: Bool,
         showsTypingIndicator: Bool = false,
         allTypingMembers: [ConversationMember] = [],
+        readByProfiles: [Profile] = [],
         onlyVisibleToSender: Bool = false,
         isLastGroupBeforeOtherMembers: Bool = false,
         voiceMemoTranscripts: [String: VoiceMemoTranscriptListItem] = [:]
@@ -46,6 +48,7 @@ public struct MessagesGroup: Identifiable, Equatable, Sendable {
         self.isLastGroupSentByCurrentUser = isLastGroupSentByCurrentUser
         self.showsTypingIndicator = showsTypingIndicator
         self.allTypingMembers = allTypingMembers
+        self.readByProfiles = readByProfiles
         self.onlyVisibleToSender = onlyVisibleToSender
         self.isLastGroupBeforeOtherMembers = isLastGroupBeforeOtherMembers
         self.voiceMemoTranscripts = voiceMemoTranscripts
@@ -59,6 +62,7 @@ public struct MessagesGroup: Identifiable, Equatable, Sendable {
         isLastGroupSentByCurrentUser: Bool,
         showsTypingIndicator: Bool = false,
         allTypingMembers: [ConversationMember] = [],
+        readByProfiles: [Profile] = [],
         onlyVisibleToSender: Bool = false,
         isLastGroupBeforeOtherMembers: Bool = false,
         voiceMemoTranscripts: [String: VoiceMemoTranscriptListItem] = [:]
@@ -70,6 +74,7 @@ public struct MessagesGroup: Identifiable, Equatable, Sendable {
         self.isLastGroupSentByCurrentUser = isLastGroupSentByCurrentUser
         self.showsTypingIndicator = showsTypingIndicator
         self.allTypingMembers = allTypingMembers
+        self.readByProfiles = readByProfiles
         self.onlyVisibleToSender = onlyVisibleToSender
         self.isLastGroupBeforeOtherMembers = isLastGroupBeforeOtherMembers
         self.voiceMemoTranscripts = voiceMemoTranscripts
@@ -83,6 +88,7 @@ public struct MessagesGroup: Identifiable, Equatable, Sendable {
         lhs.isLastGroupSentByCurrentUser == rhs.isLastGroupSentByCurrentUser &&
         lhs.showsTypingIndicator == rhs.showsTypingIndicator &&
         lhs.allTypingMembers == rhs.allTypingMembers &&
+        lhs.readByProfiles == rhs.readByProfiles &&
         lhs.onlyVisibleToSender == rhs.onlyVisibleToSender &&
         lhs.isLastGroupBeforeOtherMembers == rhs.isLastGroupBeforeOtherMembers &&
         lhs.voiceMemoTranscripts == rhs.voiceMemoTranscripts
@@ -97,6 +103,7 @@ extension MessagesGroup: Hashable {
         hasher.combine(isLastGroup)
         hasher.combine(isLastGroupSentByCurrentUser)
         hasher.combine(showsTypingIndicator)
+        hasher.combine(readByProfiles)
         hasher.combine(onlyVisibleToSender)
         hasher.combine(isLastGroupBeforeOtherMembers)
         hasher.combine(voiceMemoTranscripts)

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/MessagesListItemType.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/MessagesListItemType.swift
@@ -168,6 +168,15 @@ public enum MessagesListItemType: Identifiable, Equatable, Hashable, Sendable {
 }
 
 extension Array where Element == MessagesListItemType {
+    public var countMessages: Int {
+        reduce(0) { count, item in
+            if case .messages(let group) = item {
+                return count + group.messages.count
+            }
+            return count
+        }
+    }
+
     public var lastMessageId: String? {
         for item in reversed() {
             if let id = item.lastMessageId {

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/MessagesListProcessor.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/MessagesListProcessor.swift
@@ -216,13 +216,13 @@ public final class MessagesListProcessor: Sendable {
                GlobalConvoDefaults.shared.sendReadReceipts {
                 let msgDateNs = Int64(lastMsg.date.timeIntervalSince1970 * 1_000_000_000)
                 let senderInboxId = group.sender.profile.inboxId
-                let readInboxIds = Set(
-                    readReceipts
-                        .filter { $0.readAtNs >= msgDateNs && $0.inboxId != senderInboxId }
-                        .map(\.inboxId)
-                )
-                if !readInboxIds.isEmpty {
-                    let profiles: [Profile] = readInboxIds.compactMap { inboxId in
+                var seen = Set<String>()
+                let sortedInboxIds = readReceipts
+                    .filter { $0.readAtNs >= msgDateNs && $0.inboxId != senderInboxId }
+                    .sorted { $0.readAtNs != $1.readAtNs ? $0.readAtNs > $1.readAtNs : $0.inboxId < $1.inboxId }
+                    .compactMap { seen.insert($0.inboxId).inserted ? $0.inboxId : nil }
+                if !sortedInboxIds.isEmpty {
+                    let profiles: [Profile] = sortedInboxIds.compactMap { inboxId in
                         if let info = memberProfiles[inboxId] {
                             return Profile(inboxId: info.inboxId, name: info.name, avatar: info.avatar)
                         }

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/MessagesListProcessor.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/MessagesListProcessor.swift
@@ -8,14 +8,18 @@ public final class MessagesListProcessor: Sendable {
         voiceMemoTranscripts: [String: VoiceMemoTranscriptListItem] = [:],
         readReceipts: [ReadReceiptEntry] = [],
         memberProfiles: [String: MemberProfileInfo] = [:],
-        currentOtherMemberCount: Int = 0
+        currentOtherMemberCount: Int = 0,
+        sendReadReceipts: Bool = true,
+        previousReadByProfiles: [Profile] = []
     ) -> [MessagesListItemType] {
         return processMessages(
             messages,
             voiceMemoTranscripts: voiceMemoTranscripts,
             readReceipts: readReceipts,
             memberProfiles: memberProfiles,
-            currentOtherMemberCount: currentOtherMemberCount
+            currentOtherMemberCount: currentOtherMemberCount,
+            sendReadReceipts: sendReadReceipts,
+            previousReadByProfiles: previousReadByProfiles
         )
     }
 
@@ -25,7 +29,9 @@ public final class MessagesListProcessor: Sendable {
         voiceMemoTranscripts: [String: VoiceMemoTranscriptListItem] = [:],
         readReceipts: [ReadReceiptEntry] = [],
         memberProfiles: [String: MemberProfileInfo] = [:],
-        currentOtherMemberCount: Int = 0
+        currentOtherMemberCount: Int = 0,
+        sendReadReceipts: Bool = true,
+        previousReadByProfiles: [Profile] = []
     ) -> [MessagesListItemType] {
         guard !messages.isEmpty else { return [] }
 
@@ -213,23 +219,35 @@ public final class MessagesListProcessor: Sendable {
             if let lastMsg = group.messages.last,
                lastMsg.status == .published,
                !readReceipts.isEmpty,
-               GlobalConvoDefaults.shared.sendReadReceipts {
+               sendReadReceipts {
                 let msgDateNs = Int64(lastMsg.date.timeIntervalSince1970 * 1_000_000_000)
                 let senderInboxId = group.sender.profile.inboxId
-                var seen = Set<String>()
-                let sortedInboxIds = readReceipts
-                    .filter { $0.readAtNs >= msgDateNs && $0.inboxId != senderInboxId }
-                    .sorted { $0.readAtNs != $1.readAtNs ? $0.readAtNs > $1.readAtNs : $0.inboxId < $1.inboxId }
-                    .compactMap { seen.insert($0.inboxId).inserted ? $0.inboxId : nil }
-                if !sortedInboxIds.isEmpty {
-                    let profiles: [Profile] = sortedInboxIds.compactMap { inboxId in
-                        if let info = memberProfiles[inboxId] {
-                            return Profile(inboxId: info.inboxId, name: info.name, avatar: info.avatar)
-                        }
-                        return messages.lazy
-                            .compactMap { $0.sender.profile.inboxId == inboxId ? $0.sender.profile : nil }
-                            .first
+                let currentReaderInboxIds = Set(
+                    readReceipts
+                        .filter { $0.readAtNs >= msgDateNs && $0.inboxId != senderInboxId }
+                        .map(\.inboxId)
+                )
+
+                let resolveProfile: (String) -> Profile? = { inboxId in
+                    if let info = memberProfiles[inboxId] {
+                        return Profile(inboxId: info.inboxId, name: info.name, avatar: info.avatar)
                     }
+                    return messages.lazy
+                        .compactMap { $0.sender.profile.inboxId == inboxId ? $0.sender.profile : nil }
+                        .first
+                }
+
+                if !currentReaderInboxIds.isEmpty {
+                    var kept = previousReadByProfiles.filter { currentReaderInboxIds.contains($0.inboxId) }
+                    let keptIds = Set(kept.map(\.inboxId))
+                    let newInboxIds = currentReaderInboxIds.subtracting(keptIds)
+                        .sorted { lhs, rhs in
+                            let lhsNs = readReceipts.first { $0.inboxId == lhs }?.readAtNs ?? 0
+                            let rhsNs = readReceipts.first { $0.inboxId == rhs }?.readAtNs ?? 0
+                            return lhsNs != rhsNs ? lhsNs > rhsNs : lhs < rhs
+                        }
+                    let newProfiles = newInboxIds.compactMap(resolveProfile)
+                    let profiles: [Profile] = kept + newProfiles
                     group = MessagesGroup(
                         id: group.id,
                         sender: group.sender,

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/MessagesListProcessor.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/MessagesListProcessor.swift
@@ -5,27 +5,27 @@ public final class MessagesListProcessor: Sendable {
 
     public static func process(
         _ messages: [AnyMessage],
-        otherMemberCount: Int = 0,
         voiceMemoTranscripts: [String: VoiceMemoTranscriptListItem] = [:],
         readReceipts: [ReadReceiptEntry] = [],
-        memberProfiles: [String: MemberProfileInfo] = [:]
+        memberProfiles: [String: MemberProfileInfo] = [:],
+        currentOtherMemberCount: Int = 0
     ) -> [MessagesListItemType] {
         return processMessages(
             messages,
-            otherMemberCount: otherMemberCount,
             voiceMemoTranscripts: voiceMemoTranscripts,
             readReceipts: readReceipts,
-            memberProfiles: memberProfiles
+            memberProfiles: memberProfiles,
+            currentOtherMemberCount: currentOtherMemberCount
         )
     }
 
     // swiftlint:disable:next cyclomatic_complexity function_body_length
     private static func processMessages(
         _ messages: [AnyMessage],
-        otherMemberCount: Int = 0,
         voiceMemoTranscripts: [String: VoiceMemoTranscriptListItem] = [:],
         readReceipts: [ReadReceiptEntry] = [],
-        memberProfiles: [String: MemberProfileInfo] = [:]
+        memberProfiles: [String: MemberProfileInfo] = [:],
+        currentOtherMemberCount: Int = 0
     ) -> [MessagesListItemType] {
         guard !messages.isEmpty else { return [] }
 
@@ -33,7 +33,7 @@ public final class MessagesListProcessor: Sendable {
 
         var lastAssistantJoinIndex: Int?
         var agentJoinedAfterAssistantRequest = false
-        var trackedMemberCount: Int = otherMemberCount
+        var trackedMemberCount: Int = currentOtherMemberCount
 
         for i in 0..<messageCount {
             let content = messages[i].content

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/MessagesListProcessor.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/MessagesListProcessor.swift
@@ -6,12 +6,14 @@ public final class MessagesListProcessor: Sendable {
     public static func process(
         _ messages: [AnyMessage],
         otherMemberCount: Int = 0,
-        voiceMemoTranscripts: [String: VoiceMemoTranscriptListItem] = [:]
+        voiceMemoTranscripts: [String: VoiceMemoTranscriptListItem] = [:],
+        readReceipts: [ReadReceiptEntry] = []
     ) -> [MessagesListItemType] {
         return processMessages(
             messages,
             otherMemberCount: otherMemberCount,
-            voiceMemoTranscripts: voiceMemoTranscripts
+            voiceMemoTranscripts: voiceMemoTranscripts,
+            readReceipts: readReceipts
         )
     }
 
@@ -19,7 +21,8 @@ public final class MessagesListProcessor: Sendable {
     private static func processMessages(
         _ messages: [AnyMessage],
         otherMemberCount: Int = 0,
-        voiceMemoTranscripts: [String: VoiceMemoTranscriptListItem] = [:]
+        voiceMemoTranscripts: [String: VoiceMemoTranscriptListItem] = [:],
+        readReceipts: [ReadReceiptEntry] = []
     ) -> [MessagesListItemType] {
         guard !messages.isEmpty else { return [] }
 
@@ -203,6 +206,39 @@ public final class MessagesListProcessor: Sendable {
 
         if let lcui = lastCUGroupIdx, case .messages(var group) = items[lcui] {
             group.isLastGroupSentByCurrentUser = true
+
+            if let lastMsg = group.messages.last,
+               lastMsg.status == .published,
+               !readReceipts.isEmpty {
+                let msgDateNs = Int64(lastMsg.date.timeIntervalSince1970 * 1_000_000_000)
+                let senderInboxId = group.sender.profile.inboxId
+                let readInboxIds = Set(
+                    readReceipts
+                        .filter { $0.readAtNs >= msgDateNs && $0.inboxId != senderInboxId }
+                        .map(\.inboxId)
+                )
+                if !readInboxIds.isEmpty {
+                    let profiles = readInboxIds.compactMap { inboxId in
+                        messages.lazy
+                            .compactMap { $0.sender.profile.inboxId == inboxId ? $0.sender.profile : nil }
+                            .first
+                    }
+                    group = MessagesGroup(
+                        id: group.id,
+                        sender: group.sender,
+                        messages: group.rawMessages,
+                        isLastGroup: group.isLastGroup,
+                        isLastGroupSentByCurrentUser: true,
+                        showsTypingIndicator: group.showsTypingIndicator,
+                        allTypingMembers: group.allTypingMembers,
+                        readByProfiles: profiles,
+                        onlyVisibleToSender: group.onlyVisibleToSender,
+                        isLastGroupBeforeOtherMembers: group.isLastGroupBeforeOtherMembers,
+                        voiceMemoTranscripts: group.voiceMemoTranscripts
+                    )
+                }
+            }
+
             items[lcui] = .messages(group)
         }
 

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/MessagesListProcessor.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/MessagesListProcessor.swift
@@ -7,13 +7,15 @@ public final class MessagesListProcessor: Sendable {
         _ messages: [AnyMessage],
         otherMemberCount: Int = 0,
         voiceMemoTranscripts: [String: VoiceMemoTranscriptListItem] = [:],
-        readReceipts: [ReadReceiptEntry] = []
+        readReceipts: [ReadReceiptEntry] = [],
+        memberProfiles: [String: MemberProfileInfo] = [:]
     ) -> [MessagesListItemType] {
         return processMessages(
             messages,
             otherMemberCount: otherMemberCount,
             voiceMemoTranscripts: voiceMemoTranscripts,
-            readReceipts: readReceipts
+            readReceipts: readReceipts,
+            memberProfiles: memberProfiles
         )
     }
 
@@ -22,7 +24,8 @@ public final class MessagesListProcessor: Sendable {
         _ messages: [AnyMessage],
         otherMemberCount: Int = 0,
         voiceMemoTranscripts: [String: VoiceMemoTranscriptListItem] = [:],
-        readReceipts: [ReadReceiptEntry] = []
+        readReceipts: [ReadReceiptEntry] = [],
+        memberProfiles: [String: MemberProfileInfo] = [:]
     ) -> [MessagesListItemType] {
         guard !messages.isEmpty else { return [] }
 
@@ -209,7 +212,8 @@ public final class MessagesListProcessor: Sendable {
 
             if let lastMsg = group.messages.last,
                lastMsg.status == .published,
-               !readReceipts.isEmpty {
+               !readReceipts.isEmpty,
+               GlobalConvoDefaults.shared.sendReadReceipts {
                 let msgDateNs = Int64(lastMsg.date.timeIntervalSince1970 * 1_000_000_000)
                 let senderInboxId = group.sender.profile.inboxId
                 let readInboxIds = Set(
@@ -218,8 +222,11 @@ public final class MessagesListProcessor: Sendable {
                         .map(\.inboxId)
                 )
                 if !readInboxIds.isEmpty {
-                    let profiles = readInboxIds.compactMap { inboxId in
-                        messages.lazy
+                    let profiles: [Profile] = readInboxIds.compactMap { inboxId in
+                        if let info = memberProfiles[inboxId] {
+                            return Profile(inboxId: info.inboxId, name: info.name, avatar: info.avatar)
+                        }
+                        return messages.lazy
                             .compactMap { $0.sender.profile.inboxId == inboxId ? $0.sender.profile : nil }
                             .first
                     }

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/MessagesListProcessor.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/MessagesListProcessor.swift
@@ -238,7 +238,10 @@ public final class MessagesListProcessor: Sendable {
                 }
 
                 if !currentReaderInboxIds.isEmpty {
-                    var kept = previousReadByProfiles.filter { currentReaderInboxIds.contains($0.inboxId) }
+                    let keptInboxIds = previousReadByProfiles
+                        .map(\.inboxId)
+                        .filter { currentReaderInboxIds.contains($0) }
+                    let kept = keptInboxIds.compactMap(resolveProfile)
                     let keptIds = Set(kept.map(\.inboxId))
                     let newInboxIds = currentReaderInboxIds.subtracting(keptIds)
                         .sorted { lhs, rhs in

--- a/ConvosCore/Sources/ConvosCore/Storage/Repositories/MessagesRepository.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Repositories/MessagesRepository.swift
@@ -7,6 +7,19 @@ public struct ConversationMessagesResult: Sendable {
     public let conversationId: String
     public let messages: [AnyMessage]
     public let readReceipts: [ReadReceiptEntry]
+    public let memberProfiles: [String: MemberProfileInfo]
+}
+
+public struct MemberProfileInfo: Sendable {
+    public let inboxId: String
+    public let name: String?
+    public let avatar: String?
+
+    public init(inboxId: String, name: String?, avatar: String?) {
+        self.inboxId = inboxId
+        self.name = name
+        self.avatar = avatar
+    }
 }
 
 public protocol MessagesRepositoryProtocol {
@@ -181,7 +194,7 @@ class MessagesRepository: MessagesRepositoryProtocol {
 
         return try dbReader.read { [weak self] db in
             guard let self else {
-                return ConversationMessagesResult(conversationId: self?.conversationId ?? "", messages: [], readReceipts: [])
+                return ConversationMessagesResult(conversationId: self?.conversationId ?? "", messages: [], readReceipts: [], memberProfiles: [:])
             }
 
             let currentSeenIds = self.stateQueue.sync { self._seenMessageIds }
@@ -207,10 +220,13 @@ class MessagesRepository: MessagesRepositoryProtocol {
                 .fetchAll(db)
                 .map { ReadReceiptEntry(inboxId: $0.inboxId, readAtNs: $0.readAtNs) }
 
+            let profiles = try Self.fetchMemberProfiles(db, conversationId: self.conversationId)
+
             return ConversationMessagesResult(
                 conversationId: self.conversationId,
                 messages: messages,
-                readReceipts: readReceipts
+                readReceipts: readReceipts,
+                memberProfiles: profiles
             )
         }
     }
@@ -278,7 +294,7 @@ class MessagesRepository: MessagesRepositoryProtocol {
         )
         .map { [weak self] conversationId, limit -> AnyPublisher<ConversationMessagesResult, Never> in
             guard let self else {
-                return Just(ConversationMessagesResult(conversationId: conversationId, messages: [], readReceipts: []))
+                return Just(ConversationMessagesResult(conversationId: conversationId, messages: [], readReceipts: [], memberProfiles: [:]))
                     .eraseToAnyPublisher()
             }
 
@@ -322,23 +338,37 @@ class MessagesRepository: MessagesRepositoryProtocol {
                             .fetchAll(db)
                             .map { ReadReceiptEntry(inboxId: $0.inboxId, readAtNs: $0.readAtNs) }
 
+                        let profiles = try MessagesRepository.fetchMemberProfiles(db, conversationId: conversationId)
+
                         return ConversationMessagesResult(
                             conversationId: conversationId,
                             messages: messages,
-                            readReceipts: readReceipts
+                            readReceipts: readReceipts,
+                            memberProfiles: profiles
                         )
                     } catch {
                         Log.error("Error in messages publisher: \(error)")
                     }
-                    return ConversationMessagesResult(conversationId: conversationId, messages: [], readReceipts: [])
+                    return ConversationMessagesResult(conversationId: conversationId, messages: [], readReceipts: [], memberProfiles: [:])
                 }
                 .publisher(in: dbReader)
-                .replaceError(with: ConversationMessagesResult(conversationId: conversationId, messages: [], readReceipts: []))
+                .replaceError(with: ConversationMessagesResult(conversationId: conversationId, messages: [], readReceipts: [], memberProfiles: [:]))
                 .eraseToAnyPublisher()
         }
         .switchToLatest()
         .eraseToAnyPublisher()
     }()
+
+    static func fetchMemberProfiles(_ db: Database, conversationId: String) throws -> [String: MemberProfileInfo] {
+        let rows = try DBMemberProfile
+            .filter(DBMemberProfile.Columns.conversationId == conversationId)
+            .fetchAll(db)
+        var result: [String: MemberProfileInfo] = [:]
+        for row in rows {
+            result[row.inboxId] = MemberProfileInfo(inboxId: row.inboxId, name: row.name, avatar: row.avatar)
+        }
+        return result
+    }
 }
 
 extension Array where Element == DBMessage {

--- a/ConvosCore/Sources/ConvosCore/Storage/Repositories/MessagesRepository.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Repositories/MessagesRepository.swift
@@ -3,29 +3,26 @@ import Foundation
 import GRDB
 import UniformTypeIdentifiers
 
-public typealias ConversationMessages = (conversationId: String, messages: [AnyMessage])
+public struct ConversationMessagesResult: Sendable {
+    public let conversationId: String
+    public let messages: [AnyMessage]
+    public let readReceipts: [ReadReceiptEntry]
+}
 
 public protocol MessagesRepositoryProtocol {
     var messagesPublisher: AnyPublisher<[AnyMessage], Never> { get }
-    var conversationMessagesPublisher: AnyPublisher<ConversationMessages, Never> { get }
+    var conversationMessagesResultPublisher: AnyPublisher<ConversationMessagesResult, Never> { get }
 
-    /// Fetches the initial page of messages (most recent messages)
-    /// Resets the pagination cursor to fetch only the latest messages
     func fetchInitial() throws -> [AnyMessage]
-
-    /// Fetches previous (older) messages by increasing the limit
-    /// Each call increases the limit by the page size
-    /// Results are delivered through the publisher
+    func fetchInitialResult() throws -> ConversationMessagesResult
     func fetchPrevious() throws
 
-    /// Indicates if there are more messages to load
-    /// Automatically set to false when fetchPrevious returns fewer messages than the page size
     var hasMoreMessages: Bool { get }
 }
 
 extension MessagesRepositoryProtocol {
     var messagesPublisher: AnyPublisher<[AnyMessage], Never> {
-        conversationMessagesPublisher
+        conversationMessagesResultPublisher
             .map { $0.messages }
             .eraseToAnyPublisher()
     }
@@ -173,6 +170,51 @@ class MessagesRepository: MessagesRepositoryProtocol {
         return result
     }
 
+    func fetchInitialResult() throws -> ConversationMessagesResult {
+        stateQueue.sync(flags: .barrier) {
+            self._hasMoreMessages = true
+            self._seenMessageIds.removeAll()
+            self._hasCompletedInitialLoad = false
+        }
+
+        currentLimit = pageSize
+
+        return try dbReader.read { [weak self] db in
+            guard let self else {
+                return ConversationMessagesResult(conversationId: self?.conversationId ?? "", messages: [], readReceipts: [])
+            }
+
+            let currentSeenIds = self.stateQueue.sync { self._seenMessageIds }
+
+            let (messages, updatedSeenIds) = try db.composeMessages(
+                for: self.conversationId,
+                limit: self.currentLimit,
+                seenMessageIds: currentSeenIds,
+                isInitialLoad: true,
+                isPaginating: false
+            )
+
+            self.stateQueue.sync(flags: .barrier) {
+                self._seenMessageIds = updatedSeenIds
+                self._hasCompletedInitialLoad = true
+                if messages.count < self.pageSize {
+                    self._hasMoreMessages = false
+                }
+            }
+
+            let readReceipts = try DBConversationReadReceipt
+                .filter(DBConversationReadReceipt.Columns.conversationId == self.conversationId)
+                .fetchAll(db)
+                .map { ReadReceiptEntry(inboxId: $0.inboxId, readAtNs: $0.readAtNs) }
+
+            return ConversationMessagesResult(
+                conversationId: self.conversationId,
+                messages: messages,
+                readReceipts: readReceipts
+            )
+        }
+    }
+
     func fetchPrevious() throws {
         // Capture the current conversation ID and calculate target limit before any async operations
         // This prevents race conditions with conversation changes
@@ -227,34 +269,26 @@ class MessagesRepository: MessagesRepositoryProtocol {
         currentLimit = targetLimit
     }
 
-    lazy var conversationMessagesPublisher: AnyPublisher<ConversationMessages, Never> = {
+    lazy var conversationMessagesResultPublisher: AnyPublisher<ConversationMessagesResult, Never> = {
         let dbReader = dbReader
         let stateQueue = stateQueue
-        // Combine both conversation ID and limit changes
         return Publishers.CombineLatest(
             conversationIdSubject.removeDuplicates(),
             currentLimitSubject.removeDuplicates()
         )
-        .map { [weak self] conversationId, limit -> AnyPublisher<ConversationMessages, Never> in
+        .map { [weak self] conversationId, limit -> AnyPublisher<ConversationMessagesResult, Never> in
             guard let self else {
-                return Just((conversationId, [])).eraseToAnyPublisher()
+                return Just(ConversationMessagesResult(conversationId: conversationId, messages: [], readReceipts: []))
+                    .eraseToAnyPublisher()
             }
 
-            // Capture unsafe self reference for use in @Sendable tracking closure.
-            // This is safe because:
-            // 1. The outer closure already has a weak self guard
-            // 2. GRDB's ValueObservation is bound to the lifecycle of this publisher
-            // 3. The publisher is invalidated when self is deallocated
             nonisolated(unsafe) let unsafeSelf = self
 
             return ValueObservation
                 .tracking { db in
                     do {
-                        // Fetch all local states to force GRDB tracking on that table,
-                        // ensuring reveal/hide changes trigger re-emission
                         let allLocalStates = try AttachmentLocalState.fetchAll(db)
 
-                        // Get current state safely
                         let currentState = stateQueue.sync { () -> LoadingState in
                             LoadingState(
                                 seenIds: unsafeSelf._seenMessageIds,
@@ -283,15 +317,23 @@ class MessagesRepository: MessagesRepositoryProtocol {
                             }
                         }
 
-                        return messages
+                        let readReceipts = try DBConversationReadReceipt
+                            .filter(DBConversationReadReceipt.Columns.conversationId == conversationId)
+                            .fetchAll(db)
+                            .map { ReadReceiptEntry(inboxId: $0.inboxId, readAtNs: $0.readAtNs) }
+
+                        return ConversationMessagesResult(
+                            conversationId: conversationId,
+                            messages: messages,
+                            readReceipts: readReceipts
+                        )
                     } catch {
                         Log.error("Error in messages publisher: \(error)")
                     }
-                    return []
+                    return ConversationMessagesResult(conversationId: conversationId, messages: [], readReceipts: [])
                 }
                 .publisher(in: dbReader)
-                .replaceError(with: [])
-                .map { (conversationId, $0) }
+                .replaceError(with: ConversationMessagesResult(conversationId: conversationId, messages: [], readReceipts: []))
                 .eraseToAnyPublisher()
         }
         .switchToLatest()

--- a/ConvosCore/Sources/ConvosCore/Storage/Repositories/PhotoPreferencesRepository.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Repositories/PhotoPreferencesRepository.swift
@@ -6,6 +6,7 @@ public struct PhotoPreferences: Hashable, Sendable {
     public let conversationId: String
     public let autoReveal: Bool
     public let hasRevealedFirst: Bool
+    public let sendReadReceipts: Bool?
 
     public var shouldBlurPhotos: Bool {
         !hasRevealedFirst || !autoReveal
@@ -33,7 +34,8 @@ public final class PhotoPreferencesRepository: PhotoPreferencesRepositoryProtoco
                     PhotoPreferences(
                         conversationId: dbPrefs.conversationId,
                         autoReveal: dbPrefs.autoReveal,
-                        hasRevealedFirst: dbPrefs.hasRevealedFirst
+                        hasRevealedFirst: dbPrefs.hasRevealedFirst,
+                        sendReadReceipts: dbPrefs.sendReadReceipts
                     )
                 }
         }
@@ -49,7 +51,8 @@ public final class PhotoPreferencesRepository: PhotoPreferencesRepositoryProtoco
                         PhotoPreferences(
                             conversationId: dbPrefs.conversationId,
                             autoReveal: dbPrefs.autoReveal,
-                            hasRevealedFirst: dbPrefs.hasRevealedFirst
+                            hasRevealedFirst: dbPrefs.hasRevealedFirst,
+                            sendReadReceipts: dbPrefs.sendReadReceipts
                         )
                     }
             }

--- a/ConvosCore/Sources/ConvosCore/Storage/SharedDatabaseMigrator.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/SharedDatabaseMigrator.swift
@@ -451,6 +451,7 @@ extension SharedDatabaseMigrator {
                 t.column("conversationId", .text).notNull()
                     .references("conversation", onDelete: .cascade)
                 t.column("inboxId", .text).notNull()
+                    .references("member", onDelete: .cascade)
                 t.column("readAtNs", .integer).notNull()
                 t.primaryKey(["conversationId", "inboxId"])
             }
@@ -458,6 +459,7 @@ extension SharedDatabaseMigrator {
                 INSERT INTO conversation_read_receipts_new
                 SELECT r.* FROM conversation_read_receipts r
                 INNER JOIN conversation c ON r.conversationId = c.id
+                INNER JOIN member m ON r.inboxId = m.inboxId
             """)
             try db.drop(table: "conversation_read_receipts")
             try db.rename(table: "conversation_read_receipts_new", to: "conversation_read_receipts")

--- a/ConvosCore/Sources/ConvosCore/Storage/SharedDatabaseMigrator.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/SharedDatabaseMigrator.swift
@@ -440,6 +440,12 @@ extension SharedDatabaseMigrator {
             )
         }
 
+        migrator.registerMigration("addSendReadReceiptsToPhotoPreferences") { db in
+            try db.alter(table: "photoPreferences") { t in
+                t.add(column: "sendReadReceipts", .boolean)
+            }
+        }
+
         return migrator
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Storage/SharedDatabaseMigrator.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/SharedDatabaseMigrator.swift
@@ -446,6 +446,27 @@ extension SharedDatabaseMigrator {
             }
         }
 
+        migrator.registerMigration("addReadReceiptsCascadeDelete") { db in
+            try db.create(table: "conversation_read_receipts_new") { t in
+                t.column("conversationId", .text).notNull()
+                    .references("conversation", onDelete: .cascade)
+                t.column("inboxId", .text).notNull()
+                t.column("readAtNs", .integer).notNull()
+                t.primaryKey(["conversationId", "inboxId"])
+            }
+            try db.execute(sql: """
+                INSERT INTO conversation_read_receipts_new
+                SELECT * FROM conversation_read_receipts
+            """)
+            try db.drop(table: "conversation_read_receipts")
+            try db.rename(table: "conversation_read_receipts_new", to: "conversation_read_receipts")
+            try db.create(
+                index: "idx_read_receipts_conversation",
+                on: "conversation_read_receipts",
+                columns: ["conversationId"]
+            )
+        }
+
         return migrator
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Storage/SharedDatabaseMigrator.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/SharedDatabaseMigrator.swift
@@ -456,7 +456,8 @@ extension SharedDatabaseMigrator {
             }
             try db.execute(sql: """
                 INSERT INTO conversation_read_receipts_new
-                SELECT * FROM conversation_read_receipts
+                SELECT r.* FROM conversation_read_receipts r
+                INNER JOIN conversation c ON r.conversationId = c.id
             """)
             try db.drop(table: "conversation_read_receipts")
             try db.rename(table: "conversation_read_receipts_new", to: "conversation_read_receipts")

--- a/ConvosCore/Sources/ConvosCore/Storage/SharedDatabaseMigrator.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/SharedDatabaseMigrator.swift
@@ -426,6 +426,20 @@ extension SharedDatabaseMigrator {
             try db.create(index: "voiceMemoTranscript_attachmentKey", on: "voiceMemoTranscript", columns: ["attachmentKey"])
         }
 
+        migrator.registerMigration("createConversationReadReceipts") { db in
+            try db.create(table: "conversation_read_receipts") { t in
+                t.column("conversationId", .text).notNull()
+                t.column("inboxId", .text).notNull()
+                t.column("readAtNs", .integer).notNull()
+                t.primaryKey(["conversationId", "inboxId"])
+            }
+            try db.create(
+                index: "idx_read_receipts_conversation",
+                on: "conversation_read_receipts",
+                columns: ["conversationId"]
+            )
+        }
+
         return migrator
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationWriter.swift
@@ -18,7 +18,8 @@ extension DecodedMessage {
 
     var isReadReceipt: Bool {
         guard let contentType = try? encodedContent.type else { return false }
-        return contentType == ContentTypeReadReceipt
+        return contentType.authorityID == ContentTypeReadReceipt.authorityID
+            && contentType.typeID == ContentTypeReadReceipt.typeID
     }
 }
 

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationWriter.swift
@@ -15,6 +15,11 @@ extension DecodedMessage {
         return contentType.authorityID == ContentTypeTypingIndicator.authorityID
             && contentType.typeID == ContentTypeTypingIndicator.typeID
     }
+
+    var isReadReceipt: Bool {
+        guard let contentType = try? encodedContent.type else { return false }
+        return contentType == ContentTypeReadReceipt
+    }
 }
 
 enum ConversationWriterError: Error {
@@ -268,9 +273,9 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
             try await fetchAndStoreLatestMessages(for: conversation, dbConversation: dbConversation)
         }
 
-        // Store last message (skip profile messages which aren't stored as DB messages)
+        // Store last message (skip profile messages and read receipts which aren't stored as DB messages)
         let lastMessage = try await conversation.lastMessage()
-        if let lastMessage, !lastMessage.isProfileMessage, !lastMessage.isTypingIndicator {
+        if let lastMessage, !lastMessage.isProfileMessage, !lastMessage.isTypingIndicator, !lastMessage.isReadReceipt {
             let result = try await messageWriter.store(
                 message: lastMessage,
                 for: dbConversation
@@ -611,6 +616,10 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
         let myInboxId = dbConversation.inboxId
         for message in messages {
             guard !message.isProfileMessage, !message.isTypingIndicator else { continue }
+            if message.isReadReceipt {
+                await storeReadReceipt(message, conversationId: conversation.id)
+                continue
+            }
             Log.debug("Catching up with message sent at: \(message.sentAt.nanosecondsSince1970)")
             let result = try await messageWriter.store(message: message, for: dbConversation)
             if result.contentType.marksConversationAsUnread,
@@ -622,6 +631,21 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
 
         if marksConversationAsUnread {
             try await localStateWriter.setUnread(true, for: conversation.id)
+        }
+    }
+
+    private func storeReadReceipt(_ message: DecodedMessage, conversationId: String) async {
+        do {
+            try await databaseWriter.write { db in
+                let receipt = DBConversationReadReceipt(
+                    conversationId: conversationId,
+                    inboxId: message.senderInboxId,
+                    readAtNs: message.sentAtNs
+                )
+                try receipt.save(db, onConflict: .replace)
+            }
+        } catch {
+            Log.warning("Failed to store read receipt during catch-up: \(error.localizedDescription)")
         }
     }
 

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationWriter.swift
@@ -638,10 +638,20 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
     private func storeReadReceipt(_ message: DecodedMessage, conversationId: String) async {
         do {
             try await databaseWriter.write { db in
+                let senderInboxId = message.senderInboxId
+                let sentAtNs = message.sentAtNs
+                let existing = try DBConversationReadReceipt
+                    .filter(Column("conversationId") == conversationId && Column("inboxId") == senderInboxId)
+                    .fetchOne(db)
+                if let existing, existing.readAtNs >= sentAtNs {
+                    // Newer (or equal) read receipt already stored; skip so an
+                    // out-of-order catch-up can't roll the timestamp backwards.
+                    return
+                }
                 let receipt = DBConversationReadReceipt(
                     conversationId: conversationId,
-                    inboxId: message.senderInboxId,
-                    readAtNs: message.sentAtNs
+                    inboxId: senderInboxId,
+                    readAtNs: sentAtNs
                 )
                 try receipt.save(db, onConflict: .replace)
             }

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/PhotoPreferencesWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/PhotoPreferencesWriter.swift
@@ -4,6 +4,7 @@ import GRDB
 public protocol PhotoPreferencesWriterProtocol: Sendable {
     func setAutoReveal(_ autoReveal: Bool, for conversationId: String) async throws
     func setHasRevealedFirst(_ hasRevealedFirst: Bool, for conversationId: String) async throws
+    func setSendReadReceipts(_ sendReadReceipts: Bool?, for conversationId: String) async throws
 }
 
 public final class PhotoPreferencesWriter: PhotoPreferencesWriterProtocol, Sendable {
@@ -22,6 +23,12 @@ public final class PhotoPreferencesWriter: PhotoPreferencesWriterProtocol, Senda
     public func setHasRevealedFirst(_ hasRevealedFirst: Bool, for conversationId: String) async throws {
         try await updatePreferences(for: conversationId) { prefs in
             prefs.with(hasRevealedFirst: hasRevealedFirst)
+        }
+    }
+
+    public func setSendReadReceipts(_ sendReadReceipts: Bool?, for conversationId: String) async throws {
+        try await updatePreferences(for: conversationId) { prefs in
+            prefs.with(sendReadReceipts: sendReadReceipts)
         }
     }
 

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/ReadReceiptWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/ReadReceiptWriter.swift
@@ -1,6 +1,12 @@
+import Combine
 import Foundation
 import GRDB
 import XMTPiOS
+
+public struct ReadReceiptEntry: Sendable {
+    public let inboxId: String
+    public let readAtNs: Int64
+}
 
 public protocol ReadReceiptWriterProtocol: Sendable {
     func sendReadReceipt(for conversationId: String) async throws
@@ -9,6 +15,7 @@ public protocol ReadReceiptWriterProtocol: Sendable {
         afterNs messageDateNs: Int64,
         excludingInboxId: String
     ) async throws -> [String]
+    func readReceiptsPublisher(for conversationId: String) -> AnyPublisher<[ReadReceiptEntry], Error>
 }
 
 enum ReadReceiptWriterError: Error {
@@ -65,6 +72,18 @@ final class ReadReceiptWriter: ReadReceiptWriterProtocol, Sendable {
                 .asRequest(of: String.self)
                 .fetchAll(db)
         }
+    }
+
+    func readReceiptsPublisher(for conversationId: String) -> AnyPublisher<[ReadReceiptEntry], Error> {
+        let observation = ValueObservation.tracking { db in
+            try DBConversationReadReceipt
+                .filter(DBConversationReadReceipt.Columns.conversationId == conversationId)
+                .fetchAll(db)
+                .map { ReadReceiptEntry(inboxId: $0.inboxId, readAtNs: $0.readAtNs) }
+        }
+        return observation
+            .publisher(in: databaseWriter, scheduling: .immediate)
+            .eraseToAnyPublisher()
     }
 }
 

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/ReadReceiptWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/ReadReceiptWriter.swift
@@ -1,4 +1,3 @@
-import Combine
 import Foundation
 import GRDB
 import XMTPiOS
@@ -10,12 +9,6 @@ public struct ReadReceiptEntry: Sendable {
 
 public protocol ReadReceiptWriterProtocol: Sendable {
     func sendReadReceipt(for conversationId: String) async throws
-    func fetchReadMemberInboxIds(
-        for conversationId: String,
-        afterNs messageDateNs: Int64,
-        excludingInboxId: String
-    ) async throws -> [String]
-    func readReceiptsPublisher(for conversationId: String) -> AnyPublisher<[ReadReceiptEntry], Error>
 }
 
 enum ReadReceiptWriterError: Error {
@@ -56,34 +49,6 @@ final class ReadReceiptWriter: ReadReceiptWriterProtocol, Sendable {
         }
 
         Log.info("Sent read receipt for conversation \(conversationId)")
-    }
-
-    func fetchReadMemberInboxIds(
-        for conversationId: String,
-        afterNs messageDateNs: Int64,
-        excludingInboxId: String
-    ) async throws -> [String] {
-        try await databaseWriter.read { db in
-            try DBConversationReadReceipt
-                .filter(DBConversationReadReceipt.Columns.conversationId == conversationId)
-                .filter(DBConversationReadReceipt.Columns.readAtNs >= messageDateNs)
-                .filter(DBConversationReadReceipt.Columns.inboxId != excludingInboxId)
-                .select(DBConversationReadReceipt.Columns.inboxId)
-                .asRequest(of: String.self)
-                .fetchAll(db)
-        }
-    }
-
-    func readReceiptsPublisher(for conversationId: String) -> AnyPublisher<[ReadReceiptEntry], Error> {
-        let observation = ValueObservation.tracking { db in
-            try DBConversationReadReceipt
-                .filter(DBConversationReadReceipt.Columns.conversationId == conversationId)
-                .fetchAll(db)
-                .map { ReadReceiptEntry(inboxId: $0.inboxId, readAtNs: $0.readAtNs) }
-        }
-        return observation
-            .publisher(in: databaseWriter, scheduling: .immediate)
-            .eraseToAnyPublisher()
     }
 }
 

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/ReadReceiptWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/ReadReceiptWriter.swift
@@ -1,0 +1,75 @@
+import Foundation
+import GRDB
+import XMTPiOS
+
+public protocol ReadReceiptWriterProtocol: Sendable {
+    func sendReadReceipt(for conversationId: String) async throws
+    func fetchReadMemberInboxIds(
+        for conversationId: String,
+        afterNs messageDateNs: Int64,
+        excludingInboxId: String
+    ) async throws -> [String]
+}
+
+enum ReadReceiptWriterError: Error {
+    case missingClientProvider
+    case conversationNotFound
+}
+
+final class ReadReceiptWriter: ReadReceiptWriterProtocol, Sendable {
+    private let inboxStateManager: any InboxStateManagerProtocol
+    private let databaseWriter: any DatabaseWriter
+
+    init(
+        inboxStateManager: any InboxStateManagerProtocol,
+        databaseWriter: any DatabaseWriter
+    ) {
+        self.inboxStateManager = inboxStateManager
+        self.databaseWriter = databaseWriter
+    }
+
+    func sendReadReceipt(for conversationId: String) async throws {
+        let inboxReady = try await inboxStateManager.waitForInboxReadyResult()
+        guard let conversation = try await inboxReady.client.conversationsProvider
+            .findConversation(conversationId: conversationId) else {
+            throw ReadReceiptWriterError.conversationNotFound
+        }
+
+        nonisolated(unsafe) let unsafeConversation = conversation
+        try await unsafeConversation.sendReadReceipt()
+
+        let sentAtNs = Int64(Date().timeIntervalSince1970 * 1_000_000_000)
+        try await databaseWriter.write { db in
+            let receipt = DBConversationReadReceipt(
+                conversationId: conversationId,
+                inboxId: inboxReady.client.inboxId,
+                readAtNs: sentAtNs
+            )
+            try receipt.save(db, onConflict: .replace)
+        }
+
+        Log.info("Sent read receipt for conversation \(conversationId)")
+    }
+
+    func fetchReadMemberInboxIds(
+        for conversationId: String,
+        afterNs messageDateNs: Int64,
+        excludingInboxId: String
+    ) async throws -> [String] {
+        try await databaseWriter.read { db in
+            try DBConversationReadReceipt
+                .filter(DBConversationReadReceipt.Columns.conversationId == conversationId)
+                .filter(DBConversationReadReceipt.Columns.readAtNs >= messageDateNs)
+                .filter(DBConversationReadReceipt.Columns.inboxId != excludingInboxId)
+                .select(DBConversationReadReceipt.Columns.inboxId)
+                .asRequest(of: String.self)
+                .fetchAll(db)
+        }
+    }
+}
+
+extension DBConversationReadReceipt {
+    enum Columns: String, ColumnExpression {
+        case conversationId, inboxId, readAtNs
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Storage/XMTP DB Representations/DecodedMessage+DBRepresentation.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/XMTP DB Representations/DecodedMessage+DBRepresentation.swift
@@ -67,6 +67,8 @@ extension XMTPiOS.DecodedMessage {
             components = try handleExplodeSettingsContent()
         case ContentTypeAssistantJoinRequest:
             components = try handleAssistantJoinRequestContent()
+        case ContentTypeReadReceipt:
+            throw DecodedMessageDBRepresentationError.unsupportedContentType
         default:
             throw DecodedMessageDBRepresentationError.unsupportedContentType
         }

--- a/ConvosCore/Sources/ConvosCore/Syncing/StreamProcessor.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/StreamProcessor.swift
@@ -228,6 +228,10 @@ actor StreamProcessor: StreamProcessorProtocol {
                         return
                     }
 
+                    if await processReadReceipt(message, conversationId: conversation.id) {
+                        return
+                    }
+
                     let result = try await messageWriter.store(message: message, for: dbConversation)
 
                     // Mark unread if needed
@@ -263,6 +267,34 @@ actor StreamProcessor: StreamProcessorProtocol {
     private func handleInviteJoinError(_ error: InviteJoinError, senderInboxId: String) async {
         Log.info("Received InviteJoinError (\(error.errorType.rawValue)) for inviteTag: \(error.inviteTag) from \(senderInboxId)")
         await inviteJoinErrorHandler?.handleInviteJoinError(error)
+    }
+
+    // MARK: - Read Receipts
+
+    private func processReadReceipt(_ message: DecodedMessage, conversationId: String) async -> Bool {
+        guard let contentType = try? message.encodedContent.type,
+              contentType == ContentTypeReadReceipt else {
+            return false
+        }
+
+        let senderInboxId = message.senderInboxId
+        let sentAtNs = message.sentAtNs
+        Log.info("Received read receipt from \(senderInboxId) for conversation \(conversationId)")
+
+        do {
+            try await databaseWriter.write { db in
+                let receipt = DBConversationReadReceipt(
+                    conversationId: conversationId,
+                    inboxId: senderInboxId,
+                    readAtNs: sentAtNs
+                )
+                try receipt.save(db, onConflict: .replace)
+            }
+        } catch {
+            Log.warning("Failed to store read receipt: \(error.localizedDescription)")
+        }
+
+        return true
     }
 
     // MARK: - Profile Messages

--- a/ConvosCore/Sources/ConvosCore/Syncing/StreamProcessor.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/StreamProcessor.swift
@@ -228,7 +228,7 @@ actor StreamProcessor: StreamProcessorProtocol {
                         return
                     }
 
-                    if await processReadReceipt(message, conversationId: conversation.id) {
+                    if await processReadReceipt(message, conversationId: conversation.id, currentInboxId: params.client.inboxId) {
                         return
                     }
 
@@ -271,13 +271,18 @@ actor StreamProcessor: StreamProcessorProtocol {
 
     // MARK: - Read Receipts
 
-    private func processReadReceipt(_ message: DecodedMessage, conversationId: String) async -> Bool {
+    private func processReadReceipt(_ message: DecodedMessage, conversationId: String, currentInboxId: String) async -> Bool {
         guard let contentType = try? message.encodedContent.type,
               contentType == ContentTypeReadReceipt else {
             return false
         }
 
         let senderInboxId = message.senderInboxId
+
+        guard senderInboxId != currentInboxId else {
+            return true
+        }
+
         let sentAtNs = message.sentAtNs
         Log.info("Received read receipt from \(senderInboxId) for conversation \(conversationId)")
 

--- a/ConvosCore/Sources/ConvosCore/Syncing/StreamProcessor.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/StreamProcessor.swift
@@ -272,8 +272,7 @@ actor StreamProcessor: StreamProcessorProtocol {
     // MARK: - Read Receipts
 
     private func processReadReceipt(_ message: DecodedMessage, conversationId: String, currentInboxId: String) async -> Bool {
-        guard let contentType = try? message.encodedContent.type,
-              contentType == ContentTypeReadReceipt else {
+        guard message.isReadReceipt else {
             return false
         }
 

--- a/ConvosCore/Sources/ConvosCore/Syncing/StreamProcessor.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/StreamProcessor.swift
@@ -287,6 +287,14 @@ actor StreamProcessor: StreamProcessorProtocol {
 
         do {
             try await databaseWriter.write { db in
+                let existing = try DBConversationReadReceipt
+                    .filter(Column("conversationId") == conversationId && Column("inboxId") == senderInboxId)
+                    .fetchOne(db)
+                if let existing, existing.readAtNs >= sentAtNs {
+                    // Newer (or equal) read receipt already stored; ignore this one so an
+                    // out-of-order delivery can't roll the timestamp backwards.
+                    return
+                }
                 let receipt = DBConversationReadReceipt(
                     conversationId: conversationId,
                     inboxId: senderInboxId,

--- a/ConvosCore/Tests/ConvosCoreTests/MessagesListProcessorBenchmarkTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/MessagesListProcessorBenchmarkTests.swift
@@ -333,7 +333,7 @@ struct MessagesListProcessorBenchmarkTests {
         var times: [Double] = []
         for _ in 0..<100 {
             let start = CFAbsoluteTimeGetCurrent()
-            let result = MessagesListProcessor.process(messages, otherMemberCount: 0)
+            let result = MessagesListProcessor.process(messages, currentOtherMemberCount: 0)
             let elapsed = (CFAbsoluteTimeGetCurrent() - start) * 1_000_000
             times.append(elapsed)
             #expect(!result.isEmpty)

--- a/ConvosCore/Tests/ConvosCoreTests/MessagesListProcessorTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/MessagesListProcessorTests.swift
@@ -594,7 +594,7 @@ struct MessagesListProcessorOnlyVisibleTests {
         let messages = [
             makeMessage(id: "1", sender: currentUser, text: "Talking to myself", date: now),
         ]
-        let result = MessagesListProcessor.process(messages, otherMemberCount: 0)
+        let result = MessagesListProcessor.process(messages, currentOtherMemberCount: 0)
         let g = groups(from: result)
         #expect(g[0].onlyVisibleToSender == true)
     }
@@ -605,7 +605,7 @@ struct MessagesListProcessorOnlyVisibleTests {
         let messages = [
             makeMessage(id: "1", sender: currentUser, text: "Hello everyone", date: now),
         ]
-        let result = MessagesListProcessor.process(messages, otherMemberCount: 2)
+        let result = MessagesListProcessor.process(messages, currentOtherMemberCount: 2)
         let g = groups(from: result)
         #expect(g[0].onlyVisibleToSender == false)
     }
@@ -616,7 +616,7 @@ struct MessagesListProcessorOnlyVisibleTests {
         let messages = [
             makeMessage(id: "1", sender: otherUser, text: "I'm here", date: now),
         ]
-        let result = MessagesListProcessor.process(messages, otherMemberCount: 0)
+        let result = MessagesListProcessor.process(messages, currentOtherMemberCount: 0)
         let g = groups(from: result)
         #expect(g[0].onlyVisibleToSender == false)
     }
@@ -630,7 +630,7 @@ struct MessagesListProcessorOnlyVisibleTests {
             makeUpdate(id: "join", date: now.addingTimeInterval(10), addedMembers: [newMember]),
             makeMessage(id: "2", sender: currentUser, text: "Not alone", date: now.addingTimeInterval(20)),
         ]
-        let result = MessagesListProcessor.process(messages, otherMemberCount: 0)
+        let result = MessagesListProcessor.process(messages, currentOtherMemberCount: 0)
         let g = groups(from: result)
 
         #expect(g[0].onlyVisibleToSender == true)
@@ -647,7 +647,7 @@ struct MessagesListProcessorOnlyVisibleTests {
             makeUpdate(id: "join", date: now.addingTimeInterval(10), addedMembers: [newMember]),
             makeMessage(id: "3", sender: currentUser, text: "After join", date: now.addingTimeInterval(20)),
         ]
-        let result = MessagesListProcessor.process(messages, otherMemberCount: 0)
+        let result = MessagesListProcessor.process(messages, currentOtherMemberCount: 0)
         let g = groups(from: result)
 
         let onlyVisibleGroups = g.filter { $0.onlyVisibleToSender }

--- a/ConvosCore/Tests/ConvosCoreTests/MessagesRepositoryBenchmarkTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/MessagesRepositoryBenchmarkTests.swift
@@ -581,7 +581,6 @@ struct MessagesRepositoryBenchmarkTests {
                         DBConversationMember.Columns.createdAt,
                     ])
                     .including(required: DBConversationMember.memberProfile)
-                            .including(optional: DBConversationMember.inviterProfile)
                     .including(optional: DBConversationMember.inviterProfile)
                     .asRequest(of: DBConversationMemberProfileWithRole.self)
                     .fetchAll(db)

--- a/ConvosCore/Tests/ConvosCoreTests/MessagesRepositoryBenchmarkTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/MessagesRepositoryBenchmarkTests.swift
@@ -335,6 +335,7 @@ struct MessagesRepositoryBenchmarkTests {
                             .forKey("conversationCreator")
                             .select([DBConversationMember.Columns.role, DBConversationMember.Columns.createdAt])
                             .including(required: DBConversationMember.memberProfile)
+                            .including(optional: DBConversationMember.inviterProfile)
                     )
                     .including(required: DBConversation.localState)
                     .including(
@@ -342,6 +343,7 @@ struct MessagesRepositoryBenchmarkTests {
                             .forKey("conversationMembers")
                             .select([DBConversationMember.Columns.role, DBConversationMember.Columns.createdAt])
                             .including(required: DBConversationMember.memberProfile)
+                            .including(optional: DBConversationMember.inviterProfile)
                     )
                     .asRequest(of: DBConversationDetails.self)
                     .fetchOne(db)
@@ -479,6 +481,7 @@ struct MessagesRepositoryBenchmarkTests {
                             .forKey("messageSender")
                             .select([DBConversationMember.Columns.role, DBConversationMember.Columns.createdAt])
                             .including(required: DBConversationMember.memberProfile)
+                            .including(optional: DBConversationMember.inviterProfile)
                     )
                     .including(optional: DBMessage.sourceMessage)
                     .asRequest(of: MessageWithDetailsLite.self)
@@ -496,6 +499,7 @@ struct MessagesRepositoryBenchmarkTests {
                             .forKey("messageSender")
                             .select([DBConversationMember.Columns.role, DBConversationMember.Columns.createdAt])
                             .including(required: DBConversationMember.memberProfile)
+                            .including(optional: DBConversationMember.inviterProfile)
                     )
                     .asRequest(of: MessageSenderOnly.self)
                     .fetchAll(db)
@@ -556,6 +560,7 @@ struct MessagesRepositoryBenchmarkTests {
                             .forKey("conversationCreator")
                             .select([DBConversationMember.Columns.role, DBConversationMember.Columns.createdAt])
                             .including(required: DBConversationMember.memberProfile)
+                            .including(optional: DBConversationMember.inviterProfile)
                     )
                     .including(required: DBConversation.localState)
                     .including(
@@ -563,6 +568,7 @@ struct MessagesRepositoryBenchmarkTests {
                             .forKey("conversationMembers")
                             .select([DBConversationMember.Columns.role, DBConversationMember.Columns.createdAt])
                             .including(required: DBConversationMember.memberProfile)
+                            .including(optional: DBConversationMember.inviterProfile)
                     )
                     .asRequest(of: DBConversationDetails.self)
                     .fetchOne(db)
@@ -570,8 +576,13 @@ struct MessagesRepositoryBenchmarkTests {
 
                 _ = try DBConversationMember
                     .filter(DBConversationMember.Columns.conversationId == conversationId)
-                    .select([DBConversationMember.Columns.role, DBConversationMember.Columns.createdAt])
+                    .select([
+                        DBConversationMember.Columns.role,
+                        DBConversationMember.Columns.createdAt,
+                    ])
                     .including(required: DBConversationMember.memberProfile)
+                            .including(optional: DBConversationMember.inviterProfile)
+                    .including(optional: DBConversationMember.inviterProfile)
                     .asRequest(of: DBConversationMemberProfileWithRole.self)
                     .fetchAll(db)
                 let t2 = CFAbsoluteTimeGetCurrent()
@@ -586,6 +597,7 @@ struct MessagesRepositoryBenchmarkTests {
                             .forKey("messageSender")
                             .select([DBConversationMember.Columns.role, DBConversationMember.Columns.createdAt])
                             .including(required: DBConversationMember.memberProfile)
+                            .including(optional: DBConversationMember.inviterProfile)
                     )
                     .including(all: DBMessage.reactions)
                     .including(optional: DBMessage.sourceMessage)
@@ -604,6 +616,7 @@ struct MessagesRepositoryBenchmarkTests {
                             .forKey("messageSender")
                             .select([DBConversationMember.Columns.role, DBConversationMember.Columns.createdAt])
                             .including(required: DBConversationMember.memberProfile)
+                            .including(optional: DBConversationMember.inviterProfile)
                     )
                     .including(optional: DBMessage.sourceMessage)
                     .asRequest(of: MessageWithDetailsLite.self)

--- a/ConvosCore/Tests/ConvosCoreTests/SyncingManagerTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/SyncingManagerTests.swift
@@ -286,6 +286,9 @@ class TestableMockMessageSender: MessageSender {
     func sendTypingIndicator(isTyping: Bool) async throws {
     }
 
+    func sendReadReceipt() async throws {
+    }
+
     func prepare(text: String) async throws -> String {
         ""
     }

--- a/ConvosInvites/Package.swift
+++ b/ConvosInvites/Package.swift
@@ -25,7 +25,7 @@ let package = Package(
         .package(url: "https://github.com/tesseract-one/CSecp256k1.swift.git", from: "0.2.0"),
         .package(
             url: "https://github.com/xmtp/libxmtp.git",
-            revision: "ios-4.10.0-dev.8fcbbde"
+            revision: "ios-4.9.0-dev.88ddfad"
         ),
         .package(path: "../ConvosAppData"),
     ],

--- a/ConvosInvites/Package.swift
+++ b/ConvosInvites/Package.swift
@@ -25,7 +25,7 @@ let package = Package(
         .package(url: "https://github.com/tesseract-one/CSecp256k1.swift.git", from: "0.2.0"),
         .package(
             url: "https://github.com/xmtp/libxmtp.git",
-            revision: "ios-4.9.0-dev.6ecd439"
+            revision: "ios-4.10.0-dev.8fcbbde"
         ),
         .package(path: "../ConvosAppData"),
     ],

--- a/ConvosProfiles/Package.swift
+++ b/ConvosProfiles/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
         .package(path: "../ConvosAppData"),
         .package(
             url: "https://github.com/xmtp/libxmtp.git",
-            revision: "ios-4.10.0-dev.8fcbbde"
+            revision: "ios-4.9.0-dev.88ddfad"
         ),
     ],
     targets: [

--- a/ConvosProfiles/Package.swift
+++ b/ConvosProfiles/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
         .package(path: "../ConvosAppData"),
         .package(
             url: "https://github.com/xmtp/libxmtp.git",
-            revision: "ios-4.9.0-dev.6ecd439"
+            revision: "ios-4.10.0-dev.8fcbbde"
         ),
     ],
     targets: [

--- a/docs/investigations/xmtp-read-receipts.md
+++ b/docs/investigations/xmtp-read-receipts.md
@@ -1,82 +1,111 @@
-# XMTP Read Receipts Investigation
+# XMTP Read Receipts — Implementation Plan
 
-## What XMTP Provides
+## Overview
+
+Add read receipt support to Convos. When a user opens a conversation or receives a new message while viewing it, we send a read receipt. The last message sent by the current user shows "Read" with a horizontally scrolling list of profile avatars of members who have seen it (replacing the current "Sent" + checkmark). Users can opt out of both sending and seeing read receipts.
+
+## XMTP SDK API
 
 ### ReadReceiptCodec
-- Located at `XMTPiOS/Codecs/ReadReceiptCodec.swift`
 - Content type: `xmtp.org/readReceipt:1.0`
-- `ReadReceipt` is an empty struct — no payload, just the message existence + sender + timestamp
-- `shouldPush` returns `false` — no push notifications for read receipts
-- Fallback is `nil` — the message is not expected to be displayed
-- Read receipts must be filtered out and not shown to users as messages
+- `ReadReceipt` is an empty struct — timestamp is the message's `sentAt`
+- `shouldPush` returns `false`
+- Fallback is `nil` — must be filtered from visible messages
 
-### Sending a Read Receipt
-Send via regular `conversation.send()`:
+### Sending
 ```swift
-Client.register(codec: ReadReceiptCodec())
 try await conversation.send(
     content: ReadReceipt(),
     options: .init(contentType: ReadReceiptCodec().contentType)
 )
 ```
 
-### Querying Read Times
+### Querying
 ```swift
 let lastReadTimes: [String: Int64] = try conversation.getLastReadTimes()
 // Returns: [inboxId: sentAtNs] for each member's most recent read receipt
 ```
 
-This is built into the XMTP SDK at the FFI level — no manual message scanning needed.
+## DB Schema
 
-### Key Docs Notes (from docs.xmtp.org)
-- **Opt-out**: Best practice is to provide users with the option to opt out of sending read receipts
-- **Display**: Read receipt indicator should be displayed under the message it's associated with, can include a timestamp
-- **Filtering**: Read receipts are empty messages — must filter them out so they don't render as visible messages
-- **Timestamp comparison**: The read receipt timestamp indicates "everything up to this time was read" — compare message timestamps to determine which messages have been read
-- **No push**: `shouldPush` is false, so properly configured notification servers won't send push for read receipts
+New table: `conversation_read_receipts`
+```sql
+CREATE TABLE conversation_read_receipts (
+    conversationId TEXT NOT NULL,
+    inboxId TEXT NOT NULL,
+    readAtNs INTEGER NOT NULL,
+    PRIMARY KEY (conversationId, inboxId)
+);
+CREATE INDEX idx_read_receipts_conversation ON conversation_read_receipts(conversationId);
+```
 
-## Implementation Plan
+One row per member per conversation. Updated when a new read receipt is received (upsert with max timestamp). To find who has read a message: `WHERE conversationId = ? AND readAtNs >= message.dateNs AND inboxId != currentUserInboxId`.
+
+This optimizes for the primary use case (who read the last sent message) while supporting future per-message queries with the same schema.
+
+## Implementation
 
 ### Phase 1: Infrastructure
+
 1. **Register `ReadReceiptCodec`** in `InboxStateMachine.swift` codecs array
-2. **Handle in `DecodedMessage+DBRepresentation.swift`**: Add `ContentTypeReadReceipt` case — skip storing as a visible message (return early or use a non-visible content type)
-3. **Handle in `StreamProcessor`**: When receiving a read receipt, update local state rather than storing a message
-4. **Handle in `IncomingMessageWriter`**: Skip read receipt messages (don't store in message table)
+2. **Skip in `DecodedMessage+DBRepresentation.swift`**: Add `ContentTypeReadReceipt` case, throw or return early (don't store as a visible message)
+3. **Skip in `StreamProcessor.processMessage`**: Detect read receipt content type before calling `messageWriter.store()`, extract sender + timestamp, write to `conversation_read_receipts` instead
+4. **Skip in NSE**: Drop read receipt messages in `MessagingService+PushNotifications.swift` (return `.droppedMessage`)
+5. **DB migration**: Add `conversation_read_receipts` table
 
 ### Phase 2: Sending Read Receipts
-1. **Add `sendReadReceipt()` to `MessageSender` protocol** (or a separate protocol)
-2. **Trigger when user views a conversation**: When `MessagesViewController` appears / messages are displayed
-3. **Debounce**: Don't send on every message — send when the user opens/focuses a conversation, or periodically while viewing
-4. **Store locally**: Track last sent read receipt timestamp per conversation to avoid redundant sends
+
+1. **Add `sendReadReceipt` to `MessageSender` protocol** (or on `ConversationSender`)
+2. **Trigger on conversation open**: When `MessagesViewController` appears and messages load
+3. **Trigger on new incoming message**: When a message arrives while the conversation is active (`activeConversationId` matches)
+4. **Debounce**: Don't re-send if we already sent one within the last N seconds for the same conversation
+5. **Respect opt-out**: Check `GlobalConvoDefaults.sendReadReceipts` before sending
 
 ### Phase 3: Displaying Read Status
-1. **Store read times in DB**: New table or column — `conversation_read_receipts(conversationId, inboxId, readAtNs)`
-2. **Update `MessageStatus`**: Add `.read` status or a separate "read by" indicator
-3. **UI**: Show read indicators on messages (e.g., "Read" or profile avatars of readers under the last read message)
 
-### Phase 4: Real-time Updates
-1. **Stream processing**: Update read receipt state when receiving read receipt messages via stream
-2. **Polling fallback**: Periodically call `getLastReadTimes()` to sync state
+1. **New model**: `ReadReceipt` or extend `ConversationMember` with read status
+2. **Query at display time**: For the last message sent by current user, fetch members from `conversation_read_receipts` where `readAtNs >= message.dateNs`
+3. **UI in `MessagesGroupView`**: Replace "Sent" + checkmark with "Read" + horizontally scrolling avatar list
+   - ScrollView with profile avatars (same size as current checkmark, ~16pt)
+   - Max width capped, gradient fade on edges (same pattern as reactions HStack)
+   - Only shows on the last message sent by current user (`isLastGroupSentByCurrentUser`)
+   - Exclude current user from avatar list
+   - If no one has read it yet, show "Sent" + checkmark (existing behavior)
+4. **Respect opt-out**: If user has opted out, always show "Sent" (never "Read")
 
-## Key Decisions Needed
-- **Groups vs DMs**: Read receipts in groups show who has read up to what point. Do we show this for all groups or just DMs?
-- **Privacy**: Should read receipts be opt-in/opt-out per user?
-- **UI treatment**: iMessage-style "Read" text? Profile avatar bubbles under last read message? Both?
-- **Frequency**: How often to send read receipts? On open? On scroll? Throttled?
-- **Storage**: Do we need a new DB table for read receipt state, or can we use `getLastReadTimes()` on demand?
+### Phase 4: Settings
 
-## Effort Estimate
-- Phase 1 (infra): Small — register codec, skip in message pipeline
-- Phase 2 (sending): Medium — protocol addition, trigger logic, debouncing
-- Phase 3 (display): Medium-Large — DB schema, UI changes, message status updates
-- Phase 4 (real-time): Small — stream handler addition
+1. **Add to `GlobalConvoDefaults`**: `sendReadReceipts: Bool` (default `true`)
+2. **Add to `CustomizeSettingsView`**: Toggle row with appropriate icon/description
+3. **When disabled**: Stop sending read receipts AND hide "Read" status (show "Sent" instead)
 
 ## Files to Modify
-- `ConvosCore/Sources/ConvosCore/Inboxes/InboxStateMachine.swift` (register codec)
-- `ConvosCore/Sources/ConvosCore/Storage/XMTP DB Representations/DecodedMessage+DBRepresentation.swift` (handle content type)
-- `ConvosCore/Sources/ConvosCore/Syncing/StreamProcessor.swift` (process read receipts)
-- `ConvosCore/Sources/ConvosCore/Storage/Writers/IncomingMessageWriter.swift` (skip storing)
-- `ConvosCore/Sources/ConvosCore/Messaging/XMTPClientProvider.swift` (send method)
-- New: DB migration for read receipt storage
-- New: Read receipt repository/writer
-- UI: Message status views
+
+### ConvosCore
+- `InboxStateMachine.swift` — register codec
+- `DecodedMessage+DBRepresentation.swift` — handle content type (skip)
+- `StreamProcessor.swift` — intercept read receipts, write to DB
+- `SharedDatabaseMigrator.swift` — new migration
+- `MessagingService+PushNotifications.swift` — drop in NSE
+- `XMTPClientProvider.swift` — add `sendReadReceipt` to protocol
+- New: `DBConversationReadReceipt.swift` — GRDB model
+- New: `ReadReceiptWriter.swift` — write read receipts to DB
+- New: `ReadReceiptRepository.swift` — query read receipts for UI
+
+### Main App
+- `MessagesGroupView.swift` — read status UI (replace "Sent" section)
+- `GlobalConvoDefaults.swift` — add `sendReadReceipts` setting
+- `CustomizeSettingsView.swift` — add toggle
+- `ConversationViewModel.swift` or `MessagesViewController.swift` — trigger sending
+- New: `ReadReceiptAvatarsView.swift` — scrolling avatar list with gradient fade
+
+## Key Decisions
+- **One table, not per-message**: `conversation_read_receipts` stores latest read timestamp per member per conversation — works for both "who read the last message" and future "who read message X"
+- **Agents included**: Agents/assistants send read receipts and appear in the avatar list
+- **Opt-out is both**: Disabling read receipts stops sending AND hides others' read status
+- **Send frequency**: On conversation open + on each new incoming message while viewing
+- **Default on**: `sendReadReceipts` defaults to `true`
+
+## QA Testing
+- Use two simulators + CLI tool for multi-member testing
+- Test sending, receiving, display, opt-out, and edge cases

--- a/docs/investigations/xmtp-read-receipts.md
+++ b/docs/investigations/xmtp-read-receipts.md
@@ -1,0 +1,82 @@
+# XMTP Read Receipts Investigation
+
+## What XMTP Provides
+
+### ReadReceiptCodec
+- Located at `XMTPiOS/Codecs/ReadReceiptCodec.swift`
+- Content type: `xmtp.org/readReceipt:1.0`
+- `ReadReceipt` is an empty struct — no payload, just the message existence + sender + timestamp
+- `shouldPush` returns `false` — no push notifications for read receipts
+- Fallback is `nil` — the message is not expected to be displayed
+- Read receipts must be filtered out and not shown to users as messages
+
+### Sending a Read Receipt
+Send via regular `conversation.send()`:
+```swift
+Client.register(codec: ReadReceiptCodec())
+try await conversation.send(
+    content: ReadReceipt(),
+    options: .init(contentType: ReadReceiptCodec().contentType)
+)
+```
+
+### Querying Read Times
+```swift
+let lastReadTimes: [String: Int64] = try conversation.getLastReadTimes()
+// Returns: [inboxId: sentAtNs] for each member's most recent read receipt
+```
+
+This is built into the XMTP SDK at the FFI level — no manual message scanning needed.
+
+### Key Docs Notes (from docs.xmtp.org)
+- **Opt-out**: Best practice is to provide users with the option to opt out of sending read receipts
+- **Display**: Read receipt indicator should be displayed under the message it's associated with, can include a timestamp
+- **Filtering**: Read receipts are empty messages — must filter them out so they don't render as visible messages
+- **Timestamp comparison**: The read receipt timestamp indicates "everything up to this time was read" — compare message timestamps to determine which messages have been read
+- **No push**: `shouldPush` is false, so properly configured notification servers won't send push for read receipts
+
+## Implementation Plan
+
+### Phase 1: Infrastructure
+1. **Register `ReadReceiptCodec`** in `InboxStateMachine.swift` codecs array
+2. **Handle in `DecodedMessage+DBRepresentation.swift`**: Add `ContentTypeReadReceipt` case — skip storing as a visible message (return early or use a non-visible content type)
+3. **Handle in `StreamProcessor`**: When receiving a read receipt, update local state rather than storing a message
+4. **Handle in `IncomingMessageWriter`**: Skip read receipt messages (don't store in message table)
+
+### Phase 2: Sending Read Receipts
+1. **Add `sendReadReceipt()` to `MessageSender` protocol** (or a separate protocol)
+2. **Trigger when user views a conversation**: When `MessagesViewController` appears / messages are displayed
+3. **Debounce**: Don't send on every message — send when the user opens/focuses a conversation, or periodically while viewing
+4. **Store locally**: Track last sent read receipt timestamp per conversation to avoid redundant sends
+
+### Phase 3: Displaying Read Status
+1. **Store read times in DB**: New table or column — `conversation_read_receipts(conversationId, inboxId, readAtNs)`
+2. **Update `MessageStatus`**: Add `.read` status or a separate "read by" indicator
+3. **UI**: Show read indicators on messages (e.g., "Read" or profile avatars of readers under the last read message)
+
+### Phase 4: Real-time Updates
+1. **Stream processing**: Update read receipt state when receiving read receipt messages via stream
+2. **Polling fallback**: Periodically call `getLastReadTimes()` to sync state
+
+## Key Decisions Needed
+- **Groups vs DMs**: Read receipts in groups show who has read up to what point. Do we show this for all groups or just DMs?
+- **Privacy**: Should read receipts be opt-in/opt-out per user?
+- **UI treatment**: iMessage-style "Read" text? Profile avatar bubbles under last read message? Both?
+- **Frequency**: How often to send read receipts? On open? On scroll? Throttled?
+- **Storage**: Do we need a new DB table for read receipt state, or can we use `getLastReadTimes()` on demand?
+
+## Effort Estimate
+- Phase 1 (infra): Small — register codec, skip in message pipeline
+- Phase 2 (sending): Medium — protocol addition, trigger logic, debouncing
+- Phase 3 (display): Medium-Large — DB schema, UI changes, message status updates
+- Phase 4 (real-time): Small — stream handler addition
+
+## Files to Modify
+- `ConvosCore/Sources/ConvosCore/Inboxes/InboxStateMachine.swift` (register codec)
+- `ConvosCore/Sources/ConvosCore/Storage/XMTP DB Representations/DecodedMessage+DBRepresentation.swift` (handle content type)
+- `ConvosCore/Sources/ConvosCore/Syncing/StreamProcessor.swift` (process read receipts)
+- `ConvosCore/Sources/ConvosCore/Storage/Writers/IncomingMessageWriter.swift` (skip storing)
+- `ConvosCore/Sources/ConvosCore/Messaging/XMTPClientProvider.swift` (send method)
+- New: DB migration for read receipt storage
+- New: Read receipt repository/writer
+- UI: Message status views

--- a/qa/SKILL.md
+++ b/qa/SKILL.md
@@ -50,6 +50,7 @@ Run end-to-end QA tests for the Convos iOS app using the iOS simulator tools and
 | 30 | `qa/tests/30-verified-assistants.md` | Verified assistant UI: badges, labels, skills button, agent vs assistant distinction |
 | 31 | `qa/tests/31-convos-button-invite.md` | Convos button: create and share invite link from media bar |
 | 32 | `qa/tests/32-voice-memo-transcription.md` | Voice memo transcription: receive voice memo, on-device transcript appears, expand/collapse, persistence across relaunch, retry on failure |
+| 33 | `qa/tests/33-read-receipts.md` | Read receipts: send on view, display avatars, opt-out setting |
 
 ## Running Tests
 

--- a/qa/tests/33-read-receipts.md
+++ b/qa/tests/33-read-receipts.md
@@ -1,0 +1,115 @@
+# Test: Read Receipts
+
+Verify that read receipts are sent when viewing a conversation, received from other members, and displayed correctly as a scrolling avatar list replacing the "Sent" indicator.
+
+## Prerequisites
+
+- The app is built and installed.
+- Two simulators are available (Device A and Device B), each running a separate Convos identity.
+- The convos CLI is initialized for the dev environment.
+
+## Setup
+
+### Create a conversation with three members
+
+1. Use the CLI to create a conversation named "Read Receipt Test" and generate an invite URL.
+2. Open the invite URL on Device A via deep link. Wait for Device A to send the join request.
+3. Process the join request from the CLI so Device A is admitted.
+4. Generate a new invite URL from the CLI for the same conversation.
+5. Open the new invite URL on Device B via deep link. Wait for Device B to send the join request.
+6. Process the join request from the CLI so Device B is admitted.
+7. Wait for both devices to show the conversation with all three members.
+
+The conversation now has three participants: CLI member, Device A user, Device B user.
+
+## Steps
+
+### Verify "Sent" status shows by default
+
+1. On Device A, send a text message like "Hello everyone".
+2. Verify the message shows "Sent" with a checkmark icon below it (the existing behavior before anyone has read it).
+
+### Verify read receipt is sent on conversation open
+
+3. On Device B, open the conversation (it should already be open from setup, but navigate away and back if needed to trigger a fresh open).
+4. Wait a few seconds for the read receipt to be sent and propagated.
+5. On Device A, verify the "Sent" label on the last sent message changes to "Read".
+6. Verify a profile avatar for Device B's member appears next to the "Read" label.
+
+### Verify read receipt from CLI member
+
+7. Use the CLI to send a text message to the conversation (e.g., "Message from CLI").
+8. Wait for the message to appear on Device A.
+9. The "Read" indicator on Device A's last sent message ("Hello everyone") should now show both Device B's avatar AND the CLI member's avatar (since the CLI sent a message after Device A's message, implying the CLI has seen it — though the CLI may not send read receipts, so this depends on whether the CLI supports read receipts).
+
+Note: If the CLI does not send read receipts, only Device B's avatar will show. The key verification is that at least one avatar appears.
+
+### Send a new message and verify fresh read status
+
+10. On Device A, send another message like "Second message".
+11. Verify it shows "Sent" with checkmark (no one has read it yet).
+12. On Device B, the conversation is still open — a new incoming message should trigger Device B to send another read receipt.
+13. Wait a few seconds for propagation.
+14. On Device A, verify the "Second message" now shows "Read" with Device B's avatar.
+15. Verify the previous message ("Hello everyone") no longer shows "Sent" or "Read" — only the last sent message shows read status.
+
+### Verify scrolling avatar list
+
+16. If more members have read the message, verify the avatar list scrolls horizontally and is capped at a max width with gradient fade on both sides (matching the reactions HStack pattern).
+
+Note: With only two other members, the scroll/gradient may not be visible. The key check is that the avatar HStack is present and properly laid out.
+
+### Verify opt-out stops sending and showing
+
+17. On Device A, navigate to App Settings > Customize.
+18. Find and disable the "Read receipts" toggle.
+19. Navigate back to the conversation.
+20. On Device B, send a new message to the conversation (e.g., "Can you see this?").
+21. Wait for it to appear on Device A.
+22. On Device B, verify that Device A's read status does NOT update — Device A should not have sent a read receipt.
+23. On Device A, send a message (e.g., "Opt-out test").
+24. On Device B, navigate away from and back into the conversation to trigger a read receipt.
+25. On Device A, verify the last sent message shows "Sent" with checkmark, NOT "Read" — because Device A has opted out of seeing read receipts too.
+
+### Re-enable read receipts
+
+26. On Device A, navigate to App Settings > Customize.
+27. Re-enable the "Read receipts" toggle.
+28. Navigate back to the conversation.
+29. On Device B, send another message to the conversation.
+30. Wait for it to appear on Device A, which should trigger a read receipt send.
+31. On Device A, verify the last sent message now shows "Read" with Device B's avatar again.
+
+### Verify read receipts don't appear on non-last messages
+
+32. On Device A, send three messages in quick succession: "One", "Two", "Three".
+33. On Device B, navigate away and back to the conversation.
+34. Wait for propagation.
+35. On Device A, verify only "Three" (the last sent message) shows "Read" — "One" and "Two" should not show any read status.
+
+### Verify "only visible to you" takes precedence
+
+36. If the conversation has no other human members who have joined (edge case), the "only visible to you" state should still show when applicable, not "Read".
+
+## Teardown
+
+Explode the conversation via CLI to clean up. Shut down and delete Device B simulator.
+
+## Pass/Fail Criteria
+
+- [ ] Message shows "Sent" with checkmark when no one has read it
+- [ ] "Sent" changes to "Read" when another member opens the conversation
+- [ ] Profile avatar(s) of members who read the message appear next to "Read"
+- [ ] Read status only shows on the last message sent by the current user
+- [ ] New messages reset to "Sent" until read by others
+- [ ] Disabling read receipts stops sending read receipts to others
+- [ ] Disabling read receipts hides "Read" status (shows "Sent" instead)
+- [ ] Re-enabling read receipts restores both sending and display
+- [ ] Read receipt messages are not displayed as visible messages in the conversation
+- [ ] No app-level errors in logs during the test
+
+## Accessibility Improvements Needed
+
+- The "Read" label should have an accessibility label like "Message read by N members"
+- The scrolling avatar list should have an accessibility identifier like "read-receipt-avatars"
+- The read receipts setting toggle should have an accessibility identifier like "read-receipts-toggle"


### PR DESCRIPTION
## Summary

Implements XMTP read receipts — sending, receiving, displaying, and per-conversation/global opt-out.

Stacked on #587.

## Changes

### Infrastructure (Phase 1)
- Register `ReadReceiptCodec` in XMTP client codecs
- DB migration `createConversationReadReceipts` — `(conversationId, inboxId, readAtNs)` composite PK
- `DBConversationReadReceipt` GRDB model
- `StreamProcessor.processReadReceipt()` intercepts incoming read receipts and writes to DB
- `DecodedMessage+DBRepresentation` throws `unsupportedContentType` for read receipts (prevents storing as messages)
- NSE drops read receipt push notifications

### Sending (Phase 2)
- `ReadReceiptWriterProtocol` + `ReadReceiptWriter` — sends via XMTP, stores locally
- `ConversationViewModel` triggers on conversation open and on new incoming messages
- 1-second debounce with deferred scheduling (coalesces rapid messages, never drops)
- Skips draft/pending-invite conversations
- Guards against infinite loops via `lastMessageCountForReadReceipt`

### Display (Phase 3)
- `MessagesRepository` fetches read receipts inside GRDB `ValueObservation.tracking` (auto-fires on table changes)
- `ConversationMessagesResult` bundles messages + read receipts + member profiles
- `MessagesListProcessor` resolves `readByProfiles` on last sent message group
- `ReadReceiptAvatarsView` — horizontal avatar list (plain HStack when fits, ScrollView with gradient on overflow)
- Shows "Read" + avatars when read, "Sent" + checkmark otherwise

### Settings (Phase 4)
- `GlobalConvoDefaults.sendReadReceipts` toggle (default: on)
- Global toggle in Customize Settings: "Read receipts" / "Let others know when you've read their messages"
- Per-conversation toggle in conversation info personal preferences section
- Per-conversation stored in `photoPreferences.sendReadReceipts` (nullable, falls back to global)
- Opt-out disables both sending AND displaying read status

### Bug Fixes
- Skip read receipts in `ConversationWriter` catch-up and `lastMessage()` store paths
- Resolve reader profiles from `memberProfiles` (not just message sender profiles)
- Fix "only visible to you" using current member count instead of building from updates
- Fix `ReadReceiptAvatarsView` layout (GeometryReader + PreferenceKey pattern)
- Fix debounce dropping receipts (defer instead of skip)
- Fix read receipt infinite loop/storm between devices
- Address PR review feedback from #585 and #587

## Testing
- QA test 27 written (`qa/tests/27-read-receipts.md`)
- 0 SwiftLint violations
- Builds successfully

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add XMTP read receipts with per-conversation opt-out and avatar display
> - Sends read receipts over XMTP when a conversation is viewed, with a 1s debounce and lifecycle-aware cancellation via `ConversationViewModel+ReadReceipts`.
> - Stores incoming read receipts in a new `conversation_read_receipts` DB table (with cascade deletes) and intercepts them in the stream processor and push notification handler so they never appear as regular messages.
> - Adds `readByProfiles` to `MessagesGroup` and renders a `ReadReceiptAvatarsView` below the last outgoing message group, with an accessible label announcing the reader count.
> - Exposes a global Read receipts toggle in app settings (`GlobalConvoDefaults.sendReadReceipts`, default `true`) and a per-conversation toggle in `ConversationInfoView`; preference is persisted in `DBPhotoPreferences`.
> - Enriches `MessagesRepository` and `MessagesListRepository` to emit `ConversationMessagesResult` (messages + read receipts + member profiles) on every update.
> - Risk: `MessagesListRepository` no longer supports runtime conversation ID changes; it is now bound to a fixed ID at construction time.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 01487de.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->