### PR TITLE
Add video message support (send, receive, inline playback)

### DIFF
--- a/Convos.xcodeproj/project.pbxproj
+++ b/Convos.xcodeproj/project.pbxproj
@@ -1417,6 +1417,7 @@
 				INFOPLIST_FILE = ConvosAppClip/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "Convos Dev";
 				INFOPLIST_KEY_NSCameraUsageDescription = "To join a convo, scan its QR code";
+				INFOPLIST_KEY_NSMicrophoneUsageDescription = "To record video messages with audio";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -1462,6 +1463,7 @@
 				INFOPLIST_FILE = ConvosAppClip/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "Convos Dev";
 				INFOPLIST_KEY_NSCameraUsageDescription = "To join a convo, scan its QR code";
+				INFOPLIST_KEY_NSMicrophoneUsageDescription = "To record video messages with audio";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -1702,6 +1704,7 @@
 				INFOPLIST_KEY_CFBundleDisplayName = Convos;
 				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_NSCameraUsageDescription = "Scan a convo code to join a convo instantly. You can use your Camera app, too.";
+				INFOPLIST_KEY_NSMicrophoneUsageDescription = "To record video messages with audio";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
@@ -1746,6 +1749,7 @@
 				INFOPLIST_KEY_CFBundleDisplayName = Convos;
 				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_NSCameraUsageDescription = "Scan a convo code to join a convo instantly. You can use your Camera app, too.";
+				INFOPLIST_KEY_NSMicrophoneUsageDescription = "To record video messages with audio";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
@@ -1986,6 +1990,7 @@
 				INFOPLIST_KEY_CFBundleDisplayName = Convos;
 				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_NSCameraUsageDescription = "Scan a convo code to join a convo instantly. You can use your Camera app, too.";
+				INFOPLIST_KEY_NSMicrophoneUsageDescription = "To record video messages with audio";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
@@ -2084,6 +2089,7 @@
 				INFOPLIST_FILE = ConvosAppClip/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "Convos Dev";
 				INFOPLIST_KEY_NSCameraUsageDescription = "To join a convo, scan its QR code";
+				INFOPLIST_KEY_NSMicrophoneUsageDescription = "To record video messages with audio";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;

--- a/Convos.xcodeproj/project.pbxproj
+++ b/Convos.xcodeproj/project.pbxproj
@@ -278,6 +278,8 @@
 				"Shared Views/PulsingCircleView.swift",
 				"Shared Views/QRCodeView.swift",
 				"Shared Views/QuickEditView.swift",
+				"Shared Views/SelectedMediaAttachment.swift",
+				"Shared Views/VideoPlayerView.swift",
 				"Shared Views/RelativeDateLabel.swift",
 				"Shared Views/UIViewPreview.swift",
 				"Shared Views/ViewModifiers.swift",

--- a/Convos.xcodeproj/project.pbxproj
+++ b/Convos.xcodeproj/project.pbxproj
@@ -278,7 +278,8 @@
 				"Shared Views/PulsingCircleView.swift",
 				"Shared Views/QRCodeView.swift",
 				"Shared Views/QuickEditView.swift",
-				"Shared Views/SelectedMediaAttachment.swift",
+
+				"Shared Views/VideoFile.swift",
 				"Shared Views/VideoPlayerView.swift",
 				"Shared Views/RelativeDateLabel.swift",
 				"Shared Views/UIViewPreview.swift",

--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -15,6 +15,7 @@ struct ConversationView<MessagesBottomBar: View>: View {
     @State private var showingLockedInfo: Bool = false
     @State private var showingProcessingPowerInfo: Bool = false
     @State private var showingFullInfo: Bool = false
+    @State private var showingAssistantsInfo: Bool = false
     @State private var scrollOverscrollAmount: CGFloat = 0.0
     @State private var didReleasePastThreshold: Bool = false
     @Environment(\.dismiss) private var dismiss: DismissAction
@@ -44,7 +45,6 @@ struct ConversationView<MessagesBottomBar: View>: View {
             isVideoAttachment: viewModel.selectedVideoURL != nil,
             composerLinkPreview: viewModel.pastedLinkPreview,
             pendingInviteURL: viewModel.pendingInvite?.fullURL,
->>>>>>> 6f02b89c (Show video badge on composer attachment preview)
             sendButtonEnabled: viewModel.sendButtonEnabled,
             profileImage: $viewModel.myProfileViewModel.profileImage,
             onboardingCoordinator: onboardingCoordinator,
@@ -246,6 +246,10 @@ struct ConversationView<MessagesBottomBar: View>: View {
         }
         .selfSizingSheet(isPresented: $showingProcessingPowerInfo) {
             AssistantProcessingPowerInfoView()
+                .padding(.top, 20)
+        }
+        .selfSizingSheet(isPresented: $showingAssistantsInfo) {
+            AssistantsInfoView()
                 .padding(.top, 20)
         }
         .sheet(item: $viewModel.presentingProfileForMember) { member in

--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -41,8 +41,10 @@ struct ConversationView<MessagesBottomBar: View>: View {
             displayName: $viewModel.myProfileViewModel.editingDisplayName,
             messageText: $viewModel.messageText,
             selectedAttachmentImage: $viewModel.selectedAttachmentImage,
+            isVideoAttachment: viewModel.selectedVideoURL != nil,
             composerLinkPreview: viewModel.pastedLinkPreview,
             pendingInviteURL: viewModel.pendingInvite?.fullURL,
+>>>>>>> 6f02b89c (Show video badge on composer attachment preview)
             sendButtonEnabled: viewModel.sendButtonEnabled,
             profileImage: $viewModel.myProfileViewModel.profileImage,
             onboardingCoordinator: onboardingCoordinator,
@@ -82,11 +84,8 @@ struct ConversationView<MessagesBottomBar: View>: View {
             onPhotoRevealed: viewModel.onPhotoRevealed(_:),
             onPhotoHidden: viewModel.onPhotoHidden(_:),
             onPhotoDimensionsLoaded: viewModel.onPhotoDimensionsLoaded(_:width:height:),
-<<<<<<< HEAD
-=======
             onVideoSelected: viewModel.onVideoSelected(_:),
             onAboutAssistants: { showingAssistantsInfo = true },
->>>>>>> 0555dd80 (Implement video message sending and playback)
             onAgentOutOfCredits: { showingProcessingPowerInfo = true },
             onTapUpdateMember: { viewModel.presentingProfileForMember = $0 },
             onRetryMessage: viewModel.retryMessage(_:),

--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -82,6 +82,11 @@ struct ConversationView<MessagesBottomBar: View>: View {
             onPhotoRevealed: viewModel.onPhotoRevealed(_:),
             onPhotoHidden: viewModel.onPhotoHidden(_:),
             onPhotoDimensionsLoaded: viewModel.onPhotoDimensionsLoaded(_:width:height:),
+<<<<<<< HEAD
+=======
+            onVideoSelected: viewModel.onVideoSelected(_:),
+            onAboutAssistants: { showingAssistantsInfo = true },
+>>>>>>> 0555dd80 (Implement video message sending and playback)
             onAgentOutOfCredits: { showingProcessingPowerInfo = true },
             onTapUpdateMember: { viewModel.presentingProfileForMember = $0 },
             onRetryMessage: viewModel.retryMessage(_:),

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -734,16 +734,14 @@ extension ConversationViewModel {
 
     func onVideoSelected(_ url: URL) {
         selectedVideoURL = url
-        let service = VideoCompressionService()
         Task {
             do {
+                let service = VideoCompressionService()
                 let asset = AVURLAsset(url: url)
                 let thumbnailData = try await service.generateThumbnail(for: asset)
-                await MainActor.run {
-                    self.selectedVideoThumbnail = UIImage(data: thumbnailData)
-                    self.selectedAttachmentImage = self.selectedVideoThumbnail
-                    self.onPhotoAttached()
-                }
+                self.selectedVideoThumbnail = UIImage(data: thumbnailData)
+                self.selectedAttachmentImage = self.selectedVideoThumbnail
+                self.onPhotoAttached()
             } catch {
                 Log.error("Failed to generate video thumbnail: \(error)")
             }

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -763,11 +763,8 @@ extension ConversationViewModel {
         let prevAttachmentImage = selectedAttachmentImage
         let eagerUploadKey = currentEagerUploadKey
         let prevInviteURL = pendingInvite?.fullURL
-<<<<<<< HEAD
         let prevLinkURL = pastedLinkPreview?.url
-=======
         let prevVideoURL = selectedVideoURL
->>>>>>> 0555dd80 (Implement video message sending and playback)
 
         messageText = ""
         replyingToMessage = nil
@@ -789,7 +786,7 @@ extension ConversationViewModel {
 
                 if let videoURL = prevVideoURL {
                     isSendingPhoto = true
-                    let key = try await messageWriter.sendVideo(at: videoURL, replyToMessageId: replyTarget?.base.id)
+                    let key = try await messageWriter.sendVideo(at: videoURL, replyToMessageId: replyTarget?.messageId)
                     photoTrackingKey = key
                 } else if prevAttachmentImage != nil {
                     isSendingPhoto = true

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -1,3 +1,4 @@
+import AVFoundation
 import Combine
 import ConvosCore
 import ConvosCoreiOS
@@ -181,6 +182,8 @@ class ConversationViewModel {
             }
         }
     }
+    var selectedVideoURL: URL?
+    var selectedVideoThumbnail: UIImage?
     private(set) var currentEagerUploadKey: String?
     var canRemoveMembers: Bool {
         conversation.creator.isCurrentUser
@@ -729,6 +732,24 @@ extension ConversationViewModel {
         onDisplayNameEndedEditing(focusCoordinator: focusCoordinator, context: .editProfile)
     }
 
+    func onVideoSelected(_ url: URL) {
+        selectedVideoURL = url
+        let service = VideoCompressionService()
+        Task {
+            do {
+                let asset = AVURLAsset(url: url)
+                let thumbnailData = try await service.generateThumbnail(for: asset)
+                await MainActor.run {
+                    self.selectedVideoThumbnail = UIImage(data: thumbnailData)
+                    self.selectedAttachmentImage = self.selectedVideoThumbnail
+                    self.onPhotoAttached()
+                }
+            } catch {
+                Log.error("Failed to generate video thumbnail: \(error)")
+            }
+        }
+    }
+
     func onSendMessage(focusCoordinator: FocusCoordinator) {
         let hasText = !messageText.isEmpty
         let hasAttachment = selectedAttachmentImage != nil
@@ -744,11 +765,17 @@ extension ConversationViewModel {
         let prevAttachmentImage = selectedAttachmentImage
         let eagerUploadKey = currentEagerUploadKey
         let prevInviteURL = pendingInvite?.fullURL
+<<<<<<< HEAD
         let prevLinkURL = pastedLinkPreview?.url
+=======
+        let prevVideoURL = selectedVideoURL
+>>>>>>> 0555dd80 (Implement video message sending and playback)
 
         messageText = ""
         replyingToMessage = nil
         selectedAttachmentImage = nil
+        selectedVideoURL = nil
+        selectedVideoThumbnail = nil
         currentEagerUploadKey = nil
         pendingInvite = nil
         pastedLinkPreview = nil
@@ -762,7 +789,11 @@ extension ConversationViewModel {
             do {
                 let photoTrackingKey: String?
 
-                if prevAttachmentImage != nil {
+                if let videoURL = prevVideoURL {
+                    isSendingPhoto = true
+                    let key = try await messageWriter.sendVideo(at: videoURL)
+                    photoTrackingKey = key
+                } else if prevAttachmentImage != nil {
                     isSendingPhoto = true
                     if let trackingKey = eagerUploadKey {
                         photoTrackingKey = trackingKey

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -750,7 +750,7 @@ extension ConversationViewModel {
 
     func onSendMessage(focusCoordinator: FocusCoordinator) {
         let hasText = !messageText.isEmpty
-        let hasAttachment = selectedAttachmentImage != nil
+        let hasAttachment = selectedAttachmentImage != nil || selectedVideoURL != nil
         let hasInvite = pendingInvite != nil
         let hasLinkPreview = pastedLinkPreview != nil
 
@@ -789,7 +789,7 @@ extension ConversationViewModel {
 
                 if let videoURL = prevVideoURL {
                     isSendingPhoto = true
-                    let key = try await messageWriter.sendVideo(at: videoURL)
+                    let key = try await messageWriter.sendVideo(at: videoURL, replyToMessageId: replyTarget?.base.id)
                     photoTrackingKey = key
                 } else if prevAttachmentImage != nil {
                     isSendingPhoto = true

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -782,67 +782,94 @@ extension ConversationViewModel {
             guard let self else { return }
 
             do {
-                let photoTrackingKey: String?
+                let photoTrackingKey = try await sendAttachmentIfNeeded(
+                    videoURL: prevVideoURL,
+                    attachmentImage: prevAttachmentImage,
+                    eagerUploadKey: eagerUploadKey,
+                    replyTarget: replyTarget,
+                    messageWriter: messageWriter
+                )
 
-                if let videoURL = prevVideoURL {
-                    isSendingPhoto = true
-                    let key = try await messageWriter.sendVideo(at: videoURL, replyToMessageId: replyTarget?.messageId)
-                    photoTrackingKey = key
-                } else if prevAttachmentImage != nil {
-                    isSendingPhoto = true
-                    if let trackingKey = eagerUploadKey {
-                        photoTrackingKey = trackingKey
-                        if let replyTarget {
-                            try await messageWriter.sendEagerPhotoReply(trackingKey: trackingKey, toMessageWithClientId: replyTarget.messageId)
-                        } else {
-                            try await messageWriter.sendEagerPhoto(trackingKey: trackingKey)
-                        }
-                    } else if let attachmentImage = prevAttachmentImage {
-                        let key = try await messageWriter.startEagerUpload(image: attachmentImage)
-                        photoTrackingKey = key
-                        if let replyTarget {
-                            try await messageWriter.sendEagerPhotoReply(trackingKey: key, toMessageWithClientId: replyTarget.messageId)
-                        } else {
-                            try await messageWriter.sendEagerPhoto(trackingKey: key)
-                        }
-                    } else {
-                        photoTrackingKey = nil
-                    }
-                } else {
-                    photoTrackingKey = nil
-                }
-
-                if let inviteURL = prevInviteURL {
-                    let inviteIsReply = replyTarget != nil && !hasAttachment && !hasText
-                    if inviteIsReply, let replyTarget {
-                        try await messageWriter.sendReply(text: inviteURL, afterPhoto: photoTrackingKey, toMessageWithClientId: replyTarget.messageId)
-                    } else {
-                        try await messageWriter.send(text: inviteURL, afterPhoto: photoTrackingKey)
-                    }
-                }
-
-                if let linkURL = prevLinkURL {
-                    let linkIsReply = replyTarget != nil && !hasAttachment && !hasText && !hasInvite
-                    if linkIsReply, let replyTarget {
-                        try await messageWriter.sendReply(text: linkURL, afterPhoto: photoTrackingKey, toMessageWithClientId: replyTarget.messageId)
-                    } else {
-                        try await messageWriter.send(text: linkURL, afterPhoto: photoTrackingKey)
-                    }
-                }
-
-                if hasText {
-                    let textIsReply = replyTarget != nil && !hasAttachment
-                    if textIsReply, let replyTarget {
-                        try await messageWriter.sendReply(text: prevMessageText, afterPhoto: photoTrackingKey, toMessageWithClientId: replyTarget.messageId)
-                    } else {
-                        try await messageWriter.send(text: prevMessageText, afterPhoto: photoTrackingKey)
-                    }
-                }
+                try await sendTextAndLinksIfNeeded(
+                    text: hasText ? prevMessageText : nil,
+                    inviteURL: prevInviteURL,
+                    linkURL: prevLinkURL,
+                    photoTrackingKey: photoTrackingKey,
+                    replyTarget: replyTarget,
+                    messageWriter: messageWriter
+                )
             } catch {
                 Log.error("Error sending message: \(error)")
             }
 
             isSendingPhoto = false
+        }
+    }
+
+    private func sendAttachmentIfNeeded(
+        videoURL: URL?,
+        attachmentImage: UIImage?,
+        eagerUploadKey: String?,
+        replyTarget: AnyMessage?,
+        messageWriter: any OutgoingMessageWriterProtocol
+    ) async throws -> String? {
+        if let videoURL {
+            isSendingPhoto = true
+            return try await messageWriter.sendVideo(at: videoURL, replyToMessageId: replyTarget?.messageId)
+        } else if attachmentImage != nil {
+            isSendingPhoto = true
+            if let trackingKey = eagerUploadKey {
+                if let replyTarget {
+                    try await messageWriter.sendEagerPhotoReply(trackingKey: trackingKey, toMessageWithClientId: replyTarget.messageId)
+                } else {
+                    try await messageWriter.sendEagerPhoto(trackingKey: trackingKey)
+                }
+                return trackingKey
+            } else if let image = attachmentImage {
+                let key = try await messageWriter.startEagerUpload(image: image)
+                if let replyTarget {
+                    try await messageWriter.sendEagerPhotoReply(trackingKey: key, toMessageWithClientId: replyTarget.messageId)
+                } else {
+                    try await messageWriter.sendEagerPhoto(trackingKey: key)
+                }
+                return key
+            }
+        }
+        return nil
+    }
+
+    private func sendTextAndLinksIfNeeded(
+        text: String?,
+        inviteURL: String?,
+        linkURL: String?,
+        photoTrackingKey: String?,
+        replyTarget: AnyMessage?,
+        messageWriter: any OutgoingMessageWriterProtocol
+    ) async throws {
+        let hasAttachment = photoTrackingKey != nil
+
+        if let inviteURL {
+            if replyTarget != nil && !hasAttachment && text == nil, let replyTarget {
+                try await messageWriter.sendReply(text: inviteURL, afterPhoto: photoTrackingKey, toMessageWithClientId: replyTarget.messageId)
+            } else {
+                try await messageWriter.send(text: inviteURL, afterPhoto: photoTrackingKey)
+            }
+        }
+
+        if let linkURL {
+            if replyTarget != nil && !hasAttachment && text == nil && inviteURL == nil, let replyTarget {
+                try await messageWriter.sendReply(text: linkURL, afterPhoto: photoTrackingKey, toMessageWithClientId: replyTarget.messageId)
+            } else {
+                try await messageWriter.send(text: linkURL, afterPhoto: photoTrackingKey)
+            }
+        }
+
+        if let text {
+            if replyTarget != nil && !hasAttachment, let replyTarget {
+                try await messageWriter.sendReply(text: text, afterPhoto: photoTrackingKey, toMessageWithClientId: replyTarget.messageId)
+            } else {
+                try await messageWriter.send(text: text, afterPhoto: photoTrackingKey)
+            }
         }
     }
 

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -184,6 +184,7 @@ class ConversationViewModel {
     }
     var selectedVideoURL: URL?
     var selectedVideoThumbnail: UIImage?
+    private var videoThumbnailTask: Task<Void, Never>?
     private(set) var currentEagerUploadKey: String?
     var canRemoveMembers: Bool {
         conversation.creator.isCurrentUser
@@ -734,11 +735,13 @@ extension ConversationViewModel {
 
     func onVideoSelected(_ url: URL) {
         selectedVideoURL = url
-        Task {
+        videoThumbnailTask?.cancel()
+        videoThumbnailTask = Task {
             do {
                 let service = VideoCompressionService()
                 let asset = AVURLAsset(url: url)
                 let thumbnailData = try await service.generateThumbnail(for: asset)
+                guard !Task.isCancelled, self.selectedVideoURL == url else { return }
                 self.selectedVideoThumbnail = UIImage(data: thumbnailData)
                 self.selectedAttachmentImage = self.selectedVideoThumbnail
                 self.onPhotoAttached()

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/CameraPickerView.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/CameraPickerView.swift
@@ -3,6 +3,7 @@ import UIKit
 
 struct CameraPickerView: UIViewControllerRepresentable {
     let onImageCaptured: (UIImage) -> Void
+    let onVideoCaptured: ((URL) -> Void)?
 
     static var isAvailable: Bool {
         UIImagePickerController.isSourceTypeAvailable(.camera)
@@ -11,7 +12,7 @@ struct CameraPickerView: UIViewControllerRepresentable {
     @Environment(\.dismiss) private var dismiss: DismissAction
 
     func makeCoordinator() -> Coordinator {
-        Coordinator(onImageCaptured: onImageCaptured, dismiss: dismiss)
+        Coordinator(onImageCaptured: onImageCaptured, onVideoCaptured: onVideoCaptured, dismiss: dismiss)
     }
 
     func makeUIViewController(context: Context) -> UIViewController {
@@ -24,6 +25,9 @@ struct CameraPickerView: UIViewControllerRepresentable {
         }
         let picker = UIImagePickerController()
         picker.sourceType = .camera
+        picker.mediaTypes = onVideoCaptured != nil ? ["public.image", "public.movie"] : ["public.image"]
+        picker.videoMaximumDuration = 60
+        picker.videoQuality = .typeHigh
         picker.delegate = context.coordinator
         return picker
     }
@@ -32,10 +36,12 @@ struct CameraPickerView: UIViewControllerRepresentable {
 
     final class Coordinator: NSObject, UIImagePickerControllerDelegate, UINavigationControllerDelegate {
         let onImageCaptured: (UIImage) -> Void
+        let onVideoCaptured: ((URL) -> Void)?
         let dismiss: DismissAction
 
-        init(onImageCaptured: @escaping (UIImage) -> Void, dismiss: DismissAction) {
+        init(onImageCaptured: @escaping (UIImage) -> Void, onVideoCaptured: ((URL) -> Void)?, dismiss: DismissAction) {
             self.onImageCaptured = onImageCaptured
+            self.onVideoCaptured = onVideoCaptured
             self.dismiss = dismiss
         }
 
@@ -43,7 +49,10 @@ struct CameraPickerView: UIViewControllerRepresentable {
             _: UIImagePickerController,
             didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey: Any]
         ) {
-            if let image = info[.originalImage] as? UIImage {
+            if let mediaType = info[.mediaType] as? String, mediaType == "public.movie",
+               let videoURL = info[.mediaURL] as? URL {
+                onVideoCaptured?(videoURL)
+            } else if let image = info[.originalImage] as? UIImage {
                 onImageCaptured(image)
             }
             dismiss()

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesBottomBar.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesBottomBar.swift
@@ -116,11 +116,18 @@ struct MessagesBottomBar<BottomBarContent: View>: View {
             }
         }
         .fullScreenCover(isPresented: $isCameraPresented) {
-            CameraPickerView { image in
-                selectedAttachmentImage = image
-                isCameraPresented = false
-                focusCoordinator.moveFocus(to: .message)
-            }
+            CameraPickerView(
+                onImageCaptured: { image in
+                    selectedAttachmentImage = image
+                    isCameraPresented = false
+                    focusCoordinator.moveFocus(to: .message)
+                },
+                onVideoCaptured: { url in
+                    onVideoSelected(url)
+                    isCameraPresented = false
+                    focusCoordinator.moveFocus(to: .message)
+                }
+            )
             .ignoresSafeArea()
         }
     }

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesBottomBar.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesBottomBar.swift
@@ -13,8 +13,10 @@ struct MessagesBottomBar<BottomBarContent: View>: View {
     let emptyDisplayNamePlaceholder: String = "Somebody"
     @Binding var messageText: String
     @Binding var selectedAttachmentImage: UIImage?
+    var isVideoAttachment: Bool = false
     var composerLinkPreview: LinkPreview?
     var pendingInviteURL: String?
+>>>>>>> 6f02b89c (Show video badge on composer attachment preview)
     let sendButtonEnabled: Bool
     @Binding var profileImage: UIImage?
     @Binding var isPhotoPickerPresented: Bool
@@ -170,8 +172,10 @@ struct MessagesBottomBar<BottomBarContent: View>: View {
                 emptyDisplayNamePlaceholder: emptyDisplayNamePlaceholder,
                 messageText: $messageText,
                 selectedAttachmentImage: $selectedAttachmentImage,
+                isVideoAttachment: isVideoAttachment,
                 composerLinkPreview: composerLinkPreview,
                 pendingInviteURL: pendingInviteURL,
+>>>>>>> 6f02b89c (Show video badge on composer attachment preview)
                 sendButtonEnabled: sendButtonEnabled,
                 focusState: $focusState,
                 animateAvatarForQuickname: onboardingCoordinator.shouldAnimateAvatarForQuicknameSetup,

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesBottomBar.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesBottomBar.swift
@@ -1,6 +1,7 @@
 import ConvosCore
 import PhotosUI
 import SwiftUI
+import UniformTypeIdentifiers
 
 enum MessagesViewInputFocus: Hashable {
     case message, displayName, conversationName
@@ -26,6 +27,7 @@ struct MessagesBottomBar<BottomBarContent: View>: View {
     let onClearInvite: () -> Void
     let onClearLinkPreview: () -> Void
     let onDisplayNameEndedEditing: () -> Void
+    let onVideoSelected: (URL) -> Void
     let onProfileSettings: () -> Void
     let onBaseHeightChanged: (CGFloat) -> Void
     @ViewBuilder let bottomBarContent: () -> BottomBarContent
@@ -92,12 +94,19 @@ struct MessagesBottomBar<BottomBarContent: View>: View {
                 }
             }
         }
-        .photosPicker(isPresented: $isPhotoPickerPresented, selection: $selectedPhoto, matching: .images)
+        .photosPicker(isPresented: $isPhotoPickerPresented, selection: $selectedPhoto, matching: .any(of: [.images, .videos]))
         .onChange(of: selectedPhoto) { _, newValue in
             Task {
-                if let newValue,
-                   let data = try? await newValue.loadTransferable(type: Data.self),
-                   let image = UIImage(data: data) {
+                guard let newValue else { return }
+
+                if let videoFile = try? await newValue.loadTransferable(type: VideoFile.self) {
+                    onVideoSelected(videoFile.url)
+                    selectedPhoto = nil
+                    didSelectPhotoThisSession = true
+                    isPhotoPickerPresented = false
+                    focusCoordinator.moveFocus(to: .message)
+                } else if let data = try? await newValue.loadTransferable(type: Data.self),
+                          let image = UIImage(data: data) {
                     selectedAttachmentImage = image
                     selectedPhoto = nil
                     didSelectPhotoThisSession = true
@@ -213,6 +222,21 @@ struct MessagesBottomBar<BottomBarContent: View>: View {
     }
 }
 
+struct VideoFile: Transferable {
+    let url: URL
+
+    static var transferRepresentation: some TransferRepresentation {
+        FileRepresentation(contentType: .movie) { video in
+            SentTransferredFile(video.url)
+        } importing: { received in
+            let tempDir = FileManager.default.temporaryDirectory
+            let outputURL = tempDir.appendingPathComponent("video_\(UUID().uuidString).mov")
+            try FileManager.default.copyItem(at: received.file, to: outputURL)
+            return VideoFile(url: outputURL)
+        }
+    }
+}
+
 #Preview {
     @Previewable @State var profile: Profile = .mock()
     @Previewable @State var profileName: String = ""
@@ -287,6 +311,7 @@ struct MessagesBottomBar<BottomBarContent: View>: View {
             onDisplayNameEndedEditing: {
                 focusCoordinator.endEditing(for: .displayName)
             },
+            onVideoSelected: { _ in },
             onProfileSettings: {},
             onBaseHeightChanged: { height in
                 bottomBarHeight = height

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesBottomBar.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesBottomBar.swift
@@ -1,7 +1,6 @@
 import ConvosCore
 import PhotosUI
 import SwiftUI
-import UniformTypeIdentifiers
 
 enum MessagesViewInputFocus: Hashable {
     case message, displayName, conversationName
@@ -223,21 +222,6 @@ struct MessagesBottomBar<BottomBarContent: View>: View {
         .glassEffect(.regular.interactive(), in: .rect(cornerRadius: 40.0))
         .glassEffectID("profileEditor", in: namespace)
         .glassEffectTransition(.matchedGeometry)
-    }
-}
-
-struct VideoFile: Transferable {
-    let url: URL
-
-    static var transferRepresentation: some TransferRepresentation {
-        FileRepresentation(contentType: .movie) { video in
-            SentTransferredFile(video.url)
-        } importing: { received in
-            let tempDir = FileManager.default.temporaryDirectory
-            let outputURL = tempDir.appendingPathComponent("video_\(UUID().uuidString).mov")
-            try FileManager.default.copyItem(at: received.file, to: outputURL)
-            return VideoFile(url: outputURL)
-        }
     }
 }
 

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesBottomBar.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesBottomBar.swift
@@ -15,7 +15,6 @@ struct MessagesBottomBar<BottomBarContent: View>: View {
     var isVideoAttachment: Bool = false
     var composerLinkPreview: LinkPreview?
     var pendingInviteURL: String?
->>>>>>> 6f02b89c (Show video badge on composer attachment preview)
     let sendButtonEnabled: Bool
     @Binding var profileImage: UIImage?
     @Binding var isPhotoPickerPresented: Bool
@@ -174,7 +173,6 @@ struct MessagesBottomBar<BottomBarContent: View>: View {
                 isVideoAttachment: isVideoAttachment,
                 composerLinkPreview: composerLinkPreview,
                 pendingInviteURL: pendingInviteURL,
->>>>>>> 6f02b89c (Show video badge on composer attachment preview)
                 sendButtonEnabled: sendButtonEnabled,
                 focusState: $focusState,
                 animateAvatarForQuickname: onboardingCoordinator.shouldAnimateAvatarForQuicknameSetup,

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesInputView.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesInputView.swift
@@ -10,6 +10,7 @@ struct MessagesInputView: View {
     let emptyDisplayNamePlaceholder: String
     @Binding var messageText: String
     @Binding var selectedAttachmentImage: UIImage?
+    var isVideoAttachment: Bool = false
     var composerLinkPreview: LinkPreview?
     var pendingInviteURL: String?
     let sendButtonEnabled: Bool
@@ -156,8 +157,18 @@ struct MessagesInputView: View {
                 .scaleEffect(isPoofing ? 1.3 : 1.0)
                 .blur(radius: isPoofing ? 12.0 : 0.0)
                 .opacity(isPoofing ? 0.0 : 1.0)
-                .accessibilityLabel("Attachment preview")
+                .accessibilityLabel(isVideoAttachment ? "Video attachment preview" : "Attachment preview")
                 .accessibilityIdentifier("attachment-preview-image")
+                .overlay(alignment: .bottomLeading) {
+                    if isVideoAttachment {
+                        Image(systemName: "video.fill")
+                            .font(.system(size: 16.0, weight: .bold))
+                            .foregroundStyle(.white)
+                            .shadow(color: .black.opacity(0.5), radius: 2, x: 0, y: 1)
+                            .padding(.bottom, DesignConstants.Spacing.step2x)
+                            .padding(.leading, DesignConstants.Spacing.step2x)
+                    }
+                }
 
             Button {
                 withAnimation(.easeOut(duration: 0.2)) {

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesInputView.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesInputView.swift
@@ -167,6 +167,7 @@ struct MessagesInputView: View {
                             .shadow(color: .black.opacity(0.5), radius: 2, x: 0, y: 1)
                             .padding(.bottom, DesignConstants.Spacing.step2x)
                             .padding(.leading, DesignConstants.Spacing.step2x)
+                            .accessibilityHidden(true)
                     }
                 }
 

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesMediaInputView.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesMediaInputView.swift
@@ -50,11 +50,17 @@ struct MessagesMediaButtonsView: View {
             // .accessibilityLabel("Convos")
             // .accessibilityIdentifier("convos-action-button")
         }
+<<<<<<< HEAD
         .padding(.horizontal, DesignConstants.Spacing.step2x)
     }
 
     private enum Constant {
         static let buttonSize: CGFloat = 32.0
+=======
+        .buttonStyle(.plain)
+        .accessibilityLabel("Photo and video library")
+        .accessibilityIdentifier("photo-picker-button")
+>>>>>>> 0555dd80 (Implement video message sending and playback)
     }
 }
 

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesMediaInputView.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesMediaInputView.swift
@@ -51,8 +51,8 @@ struct MessagesMediaButtonsView: View {
             // .accessibilityIdentifier("convos-action-button")
         }
         .buttonStyle(.plain)
-        .accessibilityLabel("Photo and video library")
-        .accessibilityIdentifier("photo-picker-button")
+        .accessibilityLabel("Media buttons")
+        .accessibilityIdentifier("media-buttons")
         .padding(.horizontal, DesignConstants.Spacing.step2x)
     }
 

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesMediaInputView.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesMediaInputView.swift
@@ -50,17 +50,14 @@ struct MessagesMediaButtonsView: View {
             // .accessibilityLabel("Convos")
             // .accessibilityIdentifier("convos-action-button")
         }
-<<<<<<< HEAD
+        .buttonStyle(.plain)
+        .accessibilityLabel("Photo and video library")
+        .accessibilityIdentifier("photo-picker-button")
         .padding(.horizontal, DesignConstants.Spacing.step2x)
     }
 
     private enum Constant {
         static let buttonSize: CGFloat = 32.0
-=======
-        .buttonStyle(.plain)
-        .accessibilityLabel("Photo and video library")
-        .accessibilityIdentifier("photo-picker-button")
->>>>>>> 0555dd80 (Implement video message sending and playback)
     }
 }
 

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/ReplyComposerBar.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/ReplyComposerBar.swift
@@ -16,8 +16,10 @@ struct ReplyComposerBar: View {
             return String(text.prefix(50))
         case .emoji(let emoji):
             return emoji
-        case .attachment, .attachments:
-            return "Photo"
+        case .attachment(let attachment):
+            return attachment.mediaType == .video ? "Video" : "Photo"
+        case .attachments(let attachments):
+            return attachments.first?.mediaType == .video ? "Video" : "Photo"
         case .invite:
             return "Invite"
         case .linkPreview(let preview):
@@ -46,10 +48,14 @@ struct ReplyComposerBar: View {
         return shouldBlurPhotos && !attachment.isRevealed
     }
 
+    private var isVideo: Bool {
+        attachment?.mediaType == .video
+    }
+
     var body: some View {
         HStack(spacing: DesignConstants.Spacing.step2x) {
             if let attachment {
-                ReplyPhotoThumbnail(attachmentKey: attachment.key, shouldBlur: shouldBlurAttachment)
+                ReplyPhotoThumbnail(attachmentKey: attachment.key, shouldBlur: shouldBlurAttachment, isVideo: isVideo)
             }
 
             VStack(alignment: .leading, spacing: 2.0) {
@@ -97,15 +103,17 @@ struct ReplyComposerBar: View {
 private struct ReplyPhotoThumbnail: View {
     let attachmentKey: String
     let shouldBlur: Bool
+    var isVideo: Bool = false
 
     @State private var loadedImage: UIImage?
 
     private static let loader: RemoteAttachmentLoader = RemoteAttachmentLoader()
     private static let thumbnailSize: CGFloat = 40.0
 
-    init(attachmentKey: String, shouldBlur: Bool) {
+    init(attachmentKey: String, shouldBlur: Bool, isVideo: Bool = false) {
         self.attachmentKey = attachmentKey
         self.shouldBlur = shouldBlur
+        self.isVideo = isVideo
         _loadedImage = State(initialValue: ImageCache.shared.image(for: attachmentKey))
     }
 
@@ -119,6 +127,14 @@ private struct ReplyPhotoThumbnail: View {
                     .blur(radius: shouldBlur ? 8 : 0)
                     .opacity(shouldBlur ? 0.5 : 1.0)
                     .clipShape(RoundedRectangle(cornerRadius: 8.0))
+                    .overlay {
+                        if isVideo, !shouldBlur {
+                            Image(systemName: "play.fill")
+                                .font(.system(size: 12))
+                                .foregroundStyle(.white)
+                                .shadow(color: .black.opacity(0.3), radius: 2, x: 0, y: 1)
+                        }
+                    }
             } else {
                 RoundedRectangle(cornerRadius: 8.0)
                     .fill(.quaternary)

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessageContextMenu/MessageContextMenuOverlay.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessageContextMenu/MessageContextMenuOverlay.swift
@@ -750,7 +750,8 @@ private func saveVideoToPhotoLibrary(key: String) {
     Task {
         do {
             let videoURL: URL
-            if key.hasPrefix("file://") {
+            let isLocalFile = key.hasPrefix("file://")
+            if isLocalFile {
                 let path = String(key.dropFirst("file://".count))
                 videoURL = URL(fileURLWithPath: path)
             } else {
@@ -762,11 +763,14 @@ private func saveVideoToPhotoLibrary(key: String) {
                 videoURL = tempURL
             }
 
+            defer {
+                if !isLocalFile {
+                    try? FileManager.default.removeItem(at: videoURL)
+                }
+            }
+
             try await PHPhotoLibrary.shared().performChanges {
                 PHAssetChangeRequest.creationRequestForAssetFromVideo(atFileURL: videoURL)
-            }
-            if !key.hasPrefix("file://") {
-                try? FileManager.default.removeItem(at: videoURL)
             }
         } catch {
             Log.error("Failed to save video to photo library: \(error)")

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessageContextMenu/MessageContextMenuOverlay.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessageContextMenu/MessageContextMenuOverlay.swift
@@ -741,11 +741,8 @@ private struct ContextMenuPhotoPreview: View {
 
 private func saveAttachmentToPhotoLibrary(key: String) {
     guard let image = ImageCache.shared.image(for: key) else { return }
-    PHPhotoLibrary.requestAuthorization(for: .addOnly) { status in
-        guard status == .authorized || status == .limited else { return }
-        PHPhotoLibrary.shared().performChanges {
-            PHAssetChangeRequest.creationRequestForAsset(from: image)
-        }
+    PHPhotoLibrary.shared().performChanges {
+        PHAssetChangeRequest.creationRequestForAsset(from: image)
     }
 }
 
@@ -765,21 +762,14 @@ private func saveVideoToPhotoLibrary(key: String) {
                 videoURL = tempURL
             }
 
-            PHPhotoLibrary.requestAuthorization(for: .addOnly) { status in
-                guard status == .authorized || status == .limited else { return }
-                PHPhotoLibrary.shared().performChanges {
-                    PHAssetChangeRequest.creationRequestForAssetFromVideo(atFileURL: videoURL)
-                } completionHandler: { _, error in
-                    if let error {
-                        Log.error("Failed to save video to photo library: \(error)")
-                    }
-                    if !key.hasPrefix("file://") {
-                        try? FileManager.default.removeItem(at: videoURL)
-                    }
-                }
+            try await PHPhotoLibrary.shared().performChanges {
+                PHAssetChangeRequest.creationRequestForAssetFromVideo(atFileURL: videoURL)
+            }
+            if !key.hasPrefix("file://") {
+                try? FileManager.default.removeItem(at: videoURL)
             }
         } catch {
-            Log.error("Failed to load video for save: \(error)")
+            Log.error("Failed to save video to photo library: \(error)")
         }
     }
 }

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessageContextMenu/MessageContextMenuOverlay.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessageContextMenu/MessageContextMenuOverlay.swift
@@ -549,7 +549,11 @@ struct MessageContextMenuOverlay: View {
 
                 if let attachment = photoAttachment {
                     let saveAction = {
-                        saveAttachmentToPhotoLibrary(key: attachment.key)
+                        if attachment.mediaType == .video {
+                            saveVideoToPhotoLibrary(key: attachment.key)
+                        } else {
+                            saveAttachmentToPhotoLibrary(key: attachment.key)
+                        }
                         dismissMenu()
                     }
                     ContextMenuRow(icon: "square.and.arrow.down", title: "Save", action: saveAction)
@@ -733,7 +737,7 @@ private struct ContextMenuPhotoPreview: View {
     }
 }
 
-// MARK: - Save Photo Helper
+// MARK: - Save Attachment Helper
 
 private func saveAttachmentToPhotoLibrary(key: String) {
     guard let image = ImageCache.shared.image(for: key) else { return }
@@ -741,6 +745,27 @@ private func saveAttachmentToPhotoLibrary(key: String) {
         guard status == .authorized || status == .limited else { return }
         PHPhotoLibrary.shared().performChanges {
             PHAssetChangeRequest.creationRequestForAsset(from: image)
+        }
+    }
+}
+
+private func saveVideoToPhotoLibrary(key: String) {
+    Task {
+        do {
+            let loader = RemoteAttachmentLoader()
+            let loaded = try await loader.loadAttachmentData(from: key)
+            let tempURL = FileManager.default.temporaryDirectory
+                .appendingPathComponent("save_video_\(UUID().uuidString).mp4")
+            try loaded.data.write(to: tempURL)
+
+            PHPhotoLibrary.requestAuthorization(for: .addOnly) { status in
+                guard status == .authorized || status == .limited else { return }
+                PHPhotoLibrary.shared().performChanges {
+                    PHAssetChangeRequest.creationRequestForAssetFromVideo(atFileURL: tempURL)
+                }
+            }
+        } catch {
+            Log.error("Failed to save video to photo library: \(error)")
         }
     }
 }

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessageContextMenu/MessageContextMenuOverlay.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessageContextMenu/MessageContextMenuOverlay.swift
@@ -752,20 +752,34 @@ private func saveAttachmentToPhotoLibrary(key: String) {
 private func saveVideoToPhotoLibrary(key: String) {
     Task {
         do {
-            let loader = RemoteAttachmentLoader()
-            let loaded = try await loader.loadAttachmentData(from: key)
-            let tempURL = FileManager.default.temporaryDirectory
-                .appendingPathComponent("save_video_\(UUID().uuidString).mp4")
-            try loaded.data.write(to: tempURL)
+            let videoURL: URL
+            if key.hasPrefix("file://") {
+                let path = String(key.dropFirst("file://".count))
+                videoURL = URL(fileURLWithPath: path)
+            } else {
+                let loader = RemoteAttachmentLoader()
+                let loaded = try await loader.loadAttachmentData(from: key)
+                let tempURL = FileManager.default.temporaryDirectory
+                    .appendingPathComponent("save_video_\(UUID().uuidString).mp4")
+                try loaded.data.write(to: tempURL)
+                videoURL = tempURL
+            }
 
             PHPhotoLibrary.requestAuthorization(for: .addOnly) { status in
                 guard status == .authorized || status == .limited else { return }
                 PHPhotoLibrary.shared().performChanges {
-                    PHAssetChangeRequest.creationRequestForAssetFromVideo(atFileURL: tempURL)
+                    PHAssetChangeRequest.creationRequestForAssetFromVideo(atFileURL: videoURL)
+                } completionHandler: { _, error in
+                    if let error {
+                        Log.error("Failed to save video to photo library: \(error)")
+                    }
+                    if !key.hasPrefix("file://") {
+                        try? FileManager.default.removeItem(at: videoURL)
+                    }
                 }
             }
         } catch {
-            Log.error("Failed to save video to photo library: \(error)")
+            Log.error("Failed to load video for save: \(error)")
         }
     }
 }

--- a/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/ReplyReferenceView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/ReplyReferenceView.swift
@@ -19,8 +19,10 @@ struct ReplyReferenceView: View {
             return String(text.prefix(80))
         case .emoji(let emoji):
             return emoji
-        case .attachment, .attachments:
-            return "photo"
+        case .attachment(let attachment):
+            return attachment.mediaType == .video ? "video" : "photo"
+        case .attachments(let attachments):
+            return attachments.first?.mediaType == .video ? "video" : "photo"
         case .invite:
             return "invite"
         case .linkPreview(let preview):
@@ -92,6 +94,7 @@ struct ReplyReferenceView: View {
             if let attachment = parentAttachment {
                 ReplyReferencePhotoPreview(
                     attachmentKey: attachment.key,
+                    isVideo: attachment.mediaType == .video,
                     parentMessage: parentMessage,
                     shouldBlur: shouldBlurAttachment,
                     onReveal: { onPhotoRevealed?(attachment.key) },
@@ -211,6 +214,7 @@ struct ReplyReferenceView: View {
 
 private struct ReplyReferencePhotoPreview: View {
     let attachmentKey: String
+    let isVideo: Bool
     let parentMessage: Message
     let shouldBlur: Bool
     let onReveal: () -> Void
@@ -224,12 +228,14 @@ private struct ReplyReferencePhotoPreview: View {
 
     init(
         attachmentKey: String,
+        isVideo: Bool = false,
         parentMessage: Message,
         shouldBlur: Bool,
         onReveal: @escaping () -> Void,
         onHide: @escaping () -> Void
     ) {
         self.attachmentKey = attachmentKey
+        self.isVideo = isVideo
         self.parentMessage = parentMessage
         self.shouldBlur = shouldBlur
         self.onReveal = onReveal
@@ -253,6 +259,14 @@ private struct ReplyReferencePhotoPreview: View {
                     .scaleEffect(shouldBlur ? 1.65 : 1.0)
                     .blur(radius: shouldBlur ? 96 : 0)
                     .background(shouldBlur ? Color.colorBackgroundSurfaceless : .clear)
+                    .overlay {
+                        if isVideo, !shouldBlur {
+                            Image(systemName: "play.fill")
+                                .font(.system(size: 20))
+                                .foregroundStyle(.white)
+                                .shadow(color: .black.opacity(0.3), radius: 2, x: 0, y: 1)
+                        }
+                    }
                     .opacity(isSourceForContextMenu ? 0 : 1.0)
                     .clipShape(RoundedRectangle(cornerRadius: DesignConstants.CornerRadius.regular))
                     .contentShape(RoundedRectangle(cornerRadius: DesignConstants.CornerRadius.regular))

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
@@ -495,11 +495,18 @@ private struct AttachmentPlaceholder: View {
             }
 
             do {
-                let loaded = try await Self.loader.loadAttachmentData(from: attachment.key)
-                let tempURL = FileManager.default.temporaryDirectory
-                    .appendingPathComponent("video_\(UUID().uuidString).mp4")
-                try loaded.data.write(to: tempURL)
-                let player = AVPlayer(url: tempURL)
+                let videoURL: URL
+                if attachment.key.hasPrefix("file://") {
+                    let path = String(attachment.key.dropFirst("file://".count))
+                    videoURL = URL(fileURLWithPath: path)
+                } else {
+                    let loaded = try await Self.loader.loadAttachmentData(from: attachment.key)
+                    let tempURL = FileManager.default.temporaryDirectory
+                        .appendingPathComponent("video_\(UUID().uuidString).mp4")
+                    try loaded.data.write(to: tempURL)
+                    videoURL = tempURL
+                }
+                let player = AVPlayer(url: videoURL)
                 await player.seek(to: .zero)
                 inlinePlayer = player
                 isLoading = false

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
@@ -1,3 +1,4 @@
+import AVKit
 import ConvosCore
 import ConvosLogging
 import SwiftUI
@@ -297,7 +298,7 @@ private struct AttachmentPlaceholder: View {
     @State private var loadError: Error?
     @State private var videoLocalURL: URL?
     @State private var isDownloadingVideo: Bool = false
-    @State private var showFullScreenPlayer: Bool = false
+    @State private var inlinePlayer: AVPlayer?
     @Environment(\.messagePressed) private var isPressed: Bool
 
     private static let loader: RemoteAttachmentLoader = RemoteAttachmentLoader()
@@ -335,7 +336,14 @@ private struct AttachmentPlaceholder: View {
 
     var body: some View {
         Group {
-            if let image = loadedImage {
+            if let player = inlinePlayer {
+                InlineVideoPlayerView(player: player)
+                    .aspectRatio(placeholderAspectRatio, contentMode: .fit)
+                    .clipShape(RoundedRectangle(cornerRadius: isRegularWidth ? DesignConstants.CornerRadius.medium : 0))
+                    .frame(maxWidth: isRegularWidth ? Self.maxPhotoWidth : .infinity)
+                    .frame(maxWidth: .infinity, alignment: isRegularWidth ? (isOutgoing ? .trailing : .leading) : .leading)
+                    .padding(isRegularWidth ? (isOutgoing ? .trailing : .leading) : [], DesignConstants.Spacing.step4x)
+            } else if let image = loadedImage {
                 ZStack {
                     photoContent(image: image)
 
@@ -357,11 +365,6 @@ private struct AttachmentPlaceholder: View {
         .accessibilityLabel(isVideo ? "Video message" : "Photo message")
         .onChange(of: videoPlayTrigger) {
             handleVideoPlayTap()
-        }
-        .fullScreenCover(isPresented: $showFullScreenPlayer) {
-            if let url = videoLocalURL {
-                FullScreenVideoPlayer(url: url, isPresented: $showFullScreenPlayer)
-            }
         }
         .task {
             await loadAttachment()
@@ -411,8 +414,8 @@ private struct AttachmentPlaceholder: View {
     func handleVideoPlayTap() {
         guard isVideo, !shouldBlur else { return }
 
-        if videoLocalURL != nil {
-            showFullScreenPlayer = true
+        if let url = videoLocalURL {
+            startInlinePlayback(url: url)
             return
         }
 
@@ -425,12 +428,18 @@ private struct AttachmentPlaceholder: View {
                 try loaded.data.write(to: tempURL)
                 videoLocalURL = tempURL
                 isDownloadingVideo = false
-                showFullScreenPlayer = true
+                startInlinePlayback(url: tempURL)
             } catch {
                 isDownloadingVideo = false
                 Log.error("Failed to download video: \(error)")
             }
         }
+    }
+
+    private func startInlinePlayback(url: URL) {
+        let player = AVPlayer(url: url)
+        inlinePlayer = player
+        player.play()
     }
 
     @ViewBuilder

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
@@ -299,6 +299,7 @@ private struct AttachmentPlaceholder: View {
     @State private var loadError: Error?
     @State private var inlinePlayer: AVPlayer?
     @State private var isPlaying: Bool = false
+    @State private var isLoadingVideo: Bool = false
     @State private var instanceID: UUID = UUID()
     @Environment(\.messagePressed) private var isPressed: Bool
 
@@ -375,7 +376,12 @@ private struct AttachmentPlaceholder: View {
                     photoContent(image: image)
 
                     if isVideo, !shouldBlur {
-                        videoOverlay
+                        if isLoadingVideo {
+                            ProgressView()
+                                .tint(.white)
+                        } else {
+                            videoOverlay
+                        }
                     }
                 }
                 .clipShape(RoundedRectangle(cornerRadius: isRegularWidth ? DesignConstants.CornerRadius.medium : 0))
@@ -523,6 +529,7 @@ private struct AttachmentPlaceholder: View {
             if let thumbnailData = attachment.thumbnailData, let thumb = UIImage(data: thumbnailData) {
                 loadedImage = thumb
                 isLoading = false
+                isLoadingVideo = true
             }
 
             do {
@@ -541,9 +548,11 @@ private struct AttachmentPlaceholder: View {
                 await player.seek(to: .zero)
                 inlinePlayer = player
                 isLoading = false
+                isLoadingVideo = false
             } catch {
                 loadError = error
                 isLoading = false
+                isLoadingVideo = false
                 Log.error("Failed to load video: \(error)")
             }
             return

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
@@ -351,7 +351,7 @@ private struct AttachmentPlaceholder: View {
                         videoOverlay
                     }
 
-                    if !isPlaying, !showBlurOverlay {
+                    if !isPlaying {
                         PhotoSenderLabel(profile: profile, isOutgoing: isOutgoing)
                     }
                 }

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
@@ -296,9 +296,8 @@ private struct AttachmentPlaceholder: View {
     @State private var loadedImage: UIImage?
     @State private var isLoading: Bool = true
     @State private var loadError: Error?
-    @State private var videoLocalURL: URL?
-    @State private var isDownloadingVideo: Bool = false
     @State private var inlinePlayer: AVPlayer?
+    @State private var isPlaying: Bool = false
     @Environment(\.messagePressed) private var isPressed: Bool
 
     private static let loader: RemoteAttachmentLoader = RemoteAttachmentLoader()
@@ -337,12 +336,24 @@ private struct AttachmentPlaceholder: View {
     var body: some View {
         Group {
             if let player = inlinePlayer {
-                InlineVideoPlayerView(player: player)
-                    .aspectRatio(placeholderAspectRatio, contentMode: .fit)
-                    .clipShape(RoundedRectangle(cornerRadius: isRegularWidth ? DesignConstants.CornerRadius.medium : 0))
-                    .frame(maxWidth: isRegularWidth ? Self.maxPhotoWidth : .infinity)
-                    .frame(maxWidth: .infinity, alignment: isRegularWidth ? (isOutgoing ? .trailing : .leading) : .leading)
-                    .padding(isRegularWidth ? (isOutgoing ? .trailing : .leading) : [], DesignConstants.Spacing.step4x)
+                ZStack {
+                    InlineVideoPlayerView(player: player)
+
+                    if !isPlaying, !shouldBlur {
+                        videoOverlay
+                    }
+
+                    if !isPlaying {
+                        PhotoSenderLabel(profile: profile, isOutgoing: isOutgoing)
+                            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: isOutgoing ? .bottomTrailing : .topLeading)
+                    }
+                }
+                .aspectRatio(placeholderAspectRatio, contentMode: .fit)
+                .clipped()
+                .clipShape(RoundedRectangle(cornerRadius: isRegularWidth ? DesignConstants.CornerRadius.medium : 0))
+                .frame(maxWidth: isRegularWidth ? Self.maxPhotoWidth : .infinity)
+                .frame(maxWidth: .infinity, alignment: isRegularWidth ? (isOutgoing ? .trailing : .leading) : .leading)
+                .padding(isRegularWidth ? (isOutgoing ? .trailing : .leading) : [], DesignConstants.Spacing.step4x)
             } else if let image = loadedImage {
                 ZStack {
                     photoContent(image: image)
@@ -374,23 +385,18 @@ private struct AttachmentPlaceholder: View {
     @ViewBuilder
     private var videoOverlay: some View {
         ZStack {
-            if isDownloadingVideo {
-                ProgressView()
-                    .tint(.white)
-            } else {
-                Image(systemName: "play.fill")
-                    .font(.system(size: 36))
-                    .foregroundStyle(.white)
-                    .shadow(color: .black.opacity(0.3), radius: 4, x: 0, y: 2)
-                    .accessibilityIdentifier("video-play-button")
-            }
+            Image(systemName: "play.fill")
+                .font(.system(size: 36))
+                .foregroundStyle(.white)
+                .shadow(color: .black.opacity(0.3), radius: 4, x: 0, y: 2)
+                .accessibilityIdentifier("video-play-button")
         }
 
         if let duration = attachment.duration {
             VStack {
                 Spacer()
                 HStack {
-                    Spacer()
+                    if !isOutgoing { Spacer() }
                     Text(formatDuration(duration))
                         .font(.caption2.weight(.medium))
                         .foregroundStyle(.white)
@@ -398,9 +404,10 @@ private struct AttachmentPlaceholder: View {
                         .padding(.vertical, 2)
                         .background(.black.opacity(0.6))
                         .clipShape(RoundedRectangle(cornerRadius: 4))
-                        .padding(8)
                         .accessibilityIdentifier("video-duration-badge")
+                    if isOutgoing { Spacer() }
                 }
+                .padding(DesignConstants.Spacing.step4x)
             }
         }
     }
@@ -414,32 +421,16 @@ private struct AttachmentPlaceholder: View {
     func handleVideoPlayTap() {
         guard isVideo, !shouldBlur else { return }
 
-        if let url = videoLocalURL {
-            startInlinePlayback(url: url)
+        if let player = inlinePlayer {
+            if isPlaying {
+                player.pause()
+                isPlaying = false
+            } else {
+                player.play()
+                isPlaying = true
+            }
             return
         }
-
-        isDownloadingVideo = true
-        Task {
-            do {
-                let loaded = try await Self.loader.loadAttachmentData(from: attachment.key)
-                let tempURL = FileManager.default.temporaryDirectory
-                    .appendingPathComponent("video_\(UUID().uuidString).mp4")
-                try loaded.data.write(to: tempURL)
-                videoLocalURL = tempURL
-                isDownloadingVideo = false
-                startInlinePlayback(url: tempURL)
-            } catch {
-                isDownloadingVideo = false
-                Log.error("Failed to download video: \(error)")
-            }
-        }
-    }
-
-    private func startInlinePlayback(url: URL) {
-        let player = AVPlayer(url: url)
-        inlinePlayer = player
-        player.play()
     }
 
     @ViewBuilder
@@ -475,19 +466,35 @@ private struct AttachmentPlaceholder: View {
 
         let cacheKey = attachment.key
 
+        if isVideo {
+            if let thumbnailData = attachment.thumbnailData, let thumb = UIImage(data: thumbnailData) {
+                loadedImage = thumb
+                isLoading = false
+            }
+
+            do {
+                let loaded = try await Self.loader.loadAttachmentData(from: attachment.key)
+                let tempURL = FileManager.default.temporaryDirectory
+                    .appendingPathComponent("video_\(UUID().uuidString).mp4")
+                try loaded.data.write(to: tempURL)
+                let player = AVPlayer(url: tempURL)
+                await player.seek(to: .zero)
+                inlinePlayer = player
+                isLoading = false
+            } catch {
+                loadError = error
+                isLoading = false
+                Log.error("Failed to load video: \(error)")
+            }
+            return
+        }
+
         if let cachedImage = await ImageCache.shared.imageAsync(for: cacheKey) {
             loadedImage = cachedImage
             isLoading = false
             if attachment.width == nil {
                 onDimensionsLoaded(Int(cachedImage.size.width), Int(cachedImage.size.height))
             }
-            return
-        }
-
-        if isVideo, let thumbnailData = attachment.thumbnailData, let thumb = UIImage(data: thumbnailData) {
-            loadedImage = thumb
-            ImageCache.shared.cacheImage(thumb, for: cacheKey, storageTier: .persistent)
-            isLoading = false
             return
         }
 
@@ -499,10 +506,6 @@ private struct AttachmentPlaceholder: View {
                 let url = URL(fileURLWithPath: path)
                 imageData = try Data(contentsOf: url)
             } else if attachment.key.hasPrefix("{") {
-                if isVideo {
-                    isLoading = false
-                    return
-                }
                 imageData = try await Self.loader.loadImageData(from: attachment.key)
             } else if let url = URL(string: attachment.key) {
                 let (data, _) = try await URLSession.shared.data(from: url)

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
@@ -377,6 +377,12 @@ private struct AttachmentPlaceholder: View {
         .onChange(of: videoPlayTrigger) {
             handleVideoPlayTap()
         }
+        .onReceive(NotificationCenter.default.publisher(for: .AVPlayerItemDidPlayToEndTime)) { notification in
+            guard let finishedItem = notification.object as? AVPlayerItem,
+                  finishedItem === inlinePlayer?.currentItem
+            else { return }
+            isPlaying = false
+        }
         .task {
             await loadAttachment()
         }
@@ -426,7 +432,23 @@ private struct AttachmentPlaceholder: View {
                 player.pause()
                 isPlaying = false
             } else {
-                player.play()
+                let atEnd: Bool = {
+                    guard let item = player.currentItem,
+                          item.duration.seconds.isFinite
+                    else { return false }
+                    return CMTimeGetSeconds(player.currentTime()) >= item.duration.seconds - 0.1
+                }()
+
+                if atEnd {
+                    player.seek(to: .zero) { [weak player] finished in
+                        guard finished else { return }
+                        DispatchQueue.main.async {
+                            player?.play()
+                        }
+                    }
+                } else {
+                    player.play()
+                }
                 isPlaying = true
             }
             return

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
@@ -336,24 +336,36 @@ private struct AttachmentPlaceholder: View {
     var body: some View {
         Group {
             if let player = inlinePlayer {
-                ZStack {
+                ZStack(alignment: isOutgoing ? .bottomTrailing : .topLeading) {
                     InlineVideoPlayerView(player: player)
+                        .scaleEffect(showBlurOverlay ? 1.65 : 1.0)
+                        .blur(radius: showBlurOverlay ? blurRadius : 0)
+                        .opacity(showBlurOverlay ? blurOpacity : 1.0)
+
+                    if showBlurOverlay, !isOutgoing {
+                        PhotoBlurOverlayContent()
+                            .transition(.opacity)
+                    }
 
                     if !isPlaying, !shouldBlur {
                         videoOverlay
                     }
 
-                    if !isPlaying {
+                    if !isPlaying, !showBlurOverlay {
                         PhotoSenderLabel(profile: profile, isOutgoing: isOutgoing)
-                            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: isOutgoing ? .bottomTrailing : .topLeading)
                     }
                 }
                 .aspectRatio(placeholderAspectRatio, contentMode: .fit)
                 .clipped()
+                .overlay(alignment: isOutgoing ? .bottom : .top) {
+                    PhotoEdgeGradient(isOutgoing: isOutgoing)
+                }
+                .compositingGroup()
                 .clipShape(RoundedRectangle(cornerRadius: isRegularWidth ? DesignConstants.CornerRadius.medium : 0))
                 .frame(maxWidth: isRegularWidth ? Self.maxPhotoWidth : .infinity)
                 .frame(maxWidth: .infinity, alignment: isRegularWidth ? (isOutgoing ? .trailing : .leading) : .leading)
                 .padding(isRegularWidth ? (isOutgoing ? .trailing : .leading) : [], DesignConstants.Spacing.step4x)
+                .animation(.easeOut(duration: 0.25), value: showBlurOverlay)
             } else if let image = loadedImage {
                 ZStack {
                     photoContent(image: image)
@@ -376,6 +388,12 @@ private struct AttachmentPlaceholder: View {
         .accessibilityLabel(isVideo ? "Video message" : "Photo message")
         .onChange(of: videoPlayTrigger) {
             handleVideoPlayTap()
+        }
+        .onChange(of: shouldBlur) {
+            if shouldBlur, isPlaying {
+                inlinePlayer?.pause()
+                isPlaying = false
+            }
         }
         .onReceive(NotificationCenter.default.publisher(for: .AVPlayerItemDidPlayToEndTime)) { notification in
             guard let finishedItem = notification.object as? AVPlayerItem,

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
@@ -280,6 +280,19 @@ private struct VideoTapAttachmentView: View {
     }
 }
 
+private actor VideoURLCache {
+    static let shared: VideoURLCache = VideoURLCache()
+    private var cache: [String: URL] = [:]
+
+    func url(for key: String) -> URL? {
+        cache[key]
+    }
+
+    func set(_ url: URL, for key: String) {
+        cache[key] = url
+    }
+}
+
 private struct AttachmentPlaceholder: View {
     static let maxPhotoWidth: CGFloat = 430
     static let videoPlaybackStarted: Notification.Name = Notification.Name("AttachmentPlaceholder.videoPlaybackStarted")
@@ -304,7 +317,6 @@ private struct AttachmentPlaceholder: View {
     @Environment(\.messagePressed) private var isPressed: Bool
 
     private static let loader: RemoteAttachmentLoader = RemoteAttachmentLoader()
-    private static var videoURLCache: [String: URL] = [:]
 
     private var shouldBlur: Bool {
         if attachment.isHiddenByOwner { return true }
@@ -325,10 +337,6 @@ private struct AttachmentPlaceholder: View {
         return isPressed ? 80 : 96
     }
 
-    private var blurOpacity: Double {
-        1.0
-    }
-
     private var placeholderAspectRatio: CGFloat {
         attachment.aspectRatio ?? (4.0 / 3.0)
     }
@@ -344,7 +352,6 @@ private struct AttachmentPlaceholder: View {
                     InlineVideoPlayerView(player: player)
                         .scaleEffect(showBlurOverlay ? 1.65 : 1.0)
                         .blur(radius: showBlurOverlay ? blurRadius : 0)
-                        .opacity(showBlurOverlay ? blurOpacity : 1.0)
 
                     if showBlurOverlay, !isOutgoing {
                         PhotoBlurOverlayContent()
@@ -456,12 +463,17 @@ private struct AttachmentPlaceholder: View {
     }
 
     private func formatDuration(_ seconds: Double) -> String {
-        let mins = Int(seconds) / 60
-        let secs = Int(seconds) % 60
+        let totalSeconds = Int(seconds)
+        let hours = totalSeconds / 3600
+        let mins = (totalSeconds % 3600) / 60
+        let secs = totalSeconds % 60
+        if hours > 0 {
+            return String(format: "%d:%02d:%02d", hours, mins, secs)
+        }
         return String(format: "%d:%02d", mins, secs)
     }
 
-    func handleVideoPlayTap() {
+    private func handleVideoPlayTap() {
         guard isVideo, !shouldBlur else { return }
 
         if let player = inlinePlayer {
@@ -504,7 +516,6 @@ private struct AttachmentPlaceholder: View {
                 .aspectRatio(contentMode: .fit)
                 .scaleEffect(showBlurOverlay ? 1.65 : 1.0)
                 .blur(radius: showBlurOverlay ? blurRadius : 0)
-                .opacity(showBlurOverlay ? blurOpacity : 1.0)
 
             if showBlurOverlay, !isOutgoing {
                 PhotoBlurOverlayContent()
@@ -541,14 +552,14 @@ private struct AttachmentPlaceholder: View {
                 if attachment.key.hasPrefix("file://") {
                     let path = String(attachment.key.dropFirst("file://".count))
                     videoURL = URL(fileURLWithPath: path)
-                } else if let cached = Self.videoURLCache[attachment.key] {
+                } else if let cached = await VideoURLCache.shared.url(for: attachment.key) {
                     videoURL = cached
                 } else {
                     let loaded = try await Self.loader.loadAttachmentData(from: attachment.key)
                     let tempURL = FileManager.default.temporaryDirectory
                         .appendingPathComponent("video_\(UUID().uuidString).mp4")
                     try loaded.data.write(to: tempURL)
-                    Self.videoURLCache[attachment.key] = tempURL
+                    await VideoURLCache.shared.set(tempURL, for: attachment.key)
                     videoURL = tempURL
                 }
                 let player = AVPlayer(url: videoURL)

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
@@ -344,11 +344,13 @@ private struct AttachmentPlaceholder: View {
 
                     if showBlurOverlay, !isOutgoing {
                         PhotoBlurOverlayContent()
+                            .frame(maxWidth: .infinity, maxHeight: .infinity)
                             .transition(.opacity)
                     }
 
                     if !isPlaying, !shouldBlur {
                         videoOverlay
+                            .frame(maxWidth: .infinity, maxHeight: .infinity)
                     }
 
                     if !isPlaying {

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
@@ -313,6 +313,7 @@ private struct AttachmentPlaceholder: View {
     @State private var inlinePlayer: AVPlayer?
     @State private var isPlaying: Bool = false
     @State private var isLoadingVideo: Bool = false
+    @State private var videoLoadFailed: Bool = false
     @State private var instanceID: UUID = UUID()
     @Environment(\.messagePressed) private var isPressed: Bool
 
@@ -359,7 +360,7 @@ private struct AttachmentPlaceholder: View {
                             .transition(.opacity)
                     }
 
-                    if !isPlaying, !shouldBlur {
+                    if !isPlaying, !shouldBlur, !videoLoadFailed {
                         videoOverlay
                             .frame(maxWidth: .infinity, maxHeight: .infinity)
                     }
@@ -383,7 +384,7 @@ private struct AttachmentPlaceholder: View {
                 ZStack {
                     photoContent(image: image)
 
-                    if isVideo, !shouldBlur {
+                    if isVideo, !shouldBlur, !videoLoadFailed {
                         if isLoadingVideo {
                             ProgressView()
                                 .tint(.white)
@@ -492,17 +493,20 @@ private struct AttachmentPlaceholder: View {
                 }()
 
                 if atEnd {
+                    let id = instanceID
                     player.seek(to: .zero) { [weak player] finished in
                         guard finished else { return }
                         DispatchQueue.main.async {
                             player?.play()
                         }
                     }
+                    isPlaying = true
+                    NotificationCenter.default.post(name: Self.videoPlaybackStarted, object: id)
                 } else {
                     player.play()
+                    isPlaying = true
+                    NotificationCenter.default.post(name: Self.videoPlaybackStarted, object: instanceID)
                 }
-                isPlaying = true
-                NotificationCenter.default.post(name: Self.videoPlaybackStarted, object: instanceID)
             }
             return
         }
@@ -545,6 +549,7 @@ private struct AttachmentPlaceholder: View {
                 loadedImage = thumb
                 isLoading = false
                 isLoadingVideo = true
+                videoLoadFailed = false
             }
 
             do {
@@ -571,6 +576,7 @@ private struct AttachmentPlaceholder: View {
                 loadError = error
                 isLoading = false
                 isLoadingVideo = false
+                videoLoadFailed = true
                 Log.error("Failed to load video: \(error)")
             }
             return

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
@@ -304,6 +304,7 @@ private struct AttachmentPlaceholder: View {
     @Environment(\.messagePressed) private var isPressed: Bool
 
     private static let loader: RemoteAttachmentLoader = RemoteAttachmentLoader()
+    private static var videoURLCache: [String: URL] = [:]
 
     private var shouldBlur: Bool {
         if attachment.isHiddenByOwner { return true }
@@ -468,6 +469,9 @@ private struct AttachmentPlaceholder: View {
                 player.pause()
                 isPlaying = false
             } else {
+                try? AVAudioSession.sharedInstance().setCategory(.playback)
+                try? AVAudioSession.sharedInstance().setActive(true)
+
                 let atEnd: Bool = {
                     guard let item = player.currentItem,
                           item.duration.seconds.isFinite
@@ -537,11 +541,14 @@ private struct AttachmentPlaceholder: View {
                 if attachment.key.hasPrefix("file://") {
                     let path = String(attachment.key.dropFirst("file://".count))
                     videoURL = URL(fileURLWithPath: path)
+                } else if let cached = Self.videoURLCache[attachment.key] {
+                    videoURL = cached
                 } else {
                     let loaded = try await Self.loader.loadAttachmentData(from: attachment.key)
                     let tempURL = FileManager.default.temporaryDirectory
                         .appendingPathComponent("video_\(UUID().uuidString).mp4")
                     try loaded.data.write(to: tempURL)
+                    Self.videoURLCache[attachment.key] = tempURL
                     videoURL = tempURL
                 }
                 let player = AVPlayer(url: videoURL)

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
@@ -214,20 +214,20 @@ struct MessagesGroupItemView: View {
     private func attachmentView(for attachment: HydratedAttachment) -> some View {
         let isBlurred = attachment.isHiddenByOwner || (!message.sender.isCurrentUser && shouldBlurPhotos && !attachment.isRevealed)
 
-        AttachmentPlaceholder(
+        VideoTapAttachmentView(
             attachment: attachment,
+<<<<<<< HEAD
             isOutgoing: message.sender.isCurrentUser,
             profile: message.sender.profile,
-            shouldBlurPhotos: shouldBlurPhotos,
-            cornerRadius: 0,
-            onDimensionsLoaded: { width, height in
-                onPhotoDimensionsLoaded(attachment.key, width, height)
-            }
-        )
-        .messageGesture(
+=======
             message: message,
-            bubbleStyle: .normal,
-            onSingleTap: isBlurred ? { onPhotoRevealed(attachment.key) } : nil,
+            isOutgoing: message.base.sender.isCurrentUser,
+            profile: message.base.sender.profile,
+>>>>>>> 0555dd80 (Implement video message sending and playback)
+            shouldBlurPhotos: shouldBlurPhotos,
+            isBlurred: isBlurred,
+            onPhotoRevealed: onPhotoRevealed,
+            onPhotoDimensionsLoaded: onPhotoDimensionsLoaded,
             onReply: onReply
         )
         .id(message.messageId)
@@ -235,6 +235,49 @@ struct MessagesGroupItemView: View {
 }
 
 // MARK: - Attachment Views
+
+private struct VideoTapAttachmentView: View {
+    let attachment: HydratedAttachment
+    let message: AnyMessage
+    let isOutgoing: Bool
+    let profile: Profile
+    let shouldBlurPhotos: Bool
+    let isBlurred: Bool
+    let onPhotoRevealed: (String) -> Void
+    let onPhotoDimensionsLoaded: (String, Int, Int) -> Void
+    let onReply: (AnyMessage) -> Void
+
+    @State private var videoPlayTrigger: Bool = false
+
+    var body: some View {
+        AttachmentPlaceholder(
+            attachment: attachment,
+            isOutgoing: isOutgoing,
+            profile: profile,
+            shouldBlurPhotos: shouldBlurPhotos,
+            cornerRadius: 0,
+            videoPlayTrigger: $videoPlayTrigger,
+            onDimensionsLoaded: { width, height in
+                onPhotoDimensionsLoaded(attachment.key, width, height)
+            }
+        )
+        .messageGesture(
+            message: message,
+            bubbleStyle: .normal,
+            onSingleTap: singleTapAction,
+            onReply: onReply
+        )
+    }
+
+    private var singleTapAction: (() -> Void)? {
+        if isBlurred {
+            return { onPhotoRevealed(attachment.key) }
+        } else if attachment.mediaType == .video {
+            return { videoPlayTrigger.toggle() }
+        }
+        return nil
+    }
+}
 
 private struct AttachmentPlaceholder: View {
     static let maxPhotoWidth: CGFloat = 430
@@ -244,6 +287,7 @@ private struct AttachmentPlaceholder: View {
     let profile: Profile
     let shouldBlurPhotos: Bool
     var cornerRadius: CGFloat = 0
+    @Binding var videoPlayTrigger: Bool
     let onDimensionsLoaded: (Int, Int) -> Void
 
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass: UserInterfaceSizeClass?
@@ -251,6 +295,9 @@ private struct AttachmentPlaceholder: View {
     @State private var loadedImage: UIImage?
     @State private var isLoading: Bool = true
     @State private var loadError: Error?
+    @State private var videoLocalURL: URL?
+    @State private var isDownloadingVideo: Bool = false
+    @State private var showFullScreenPlayer: Bool = false
     @Environment(\.messagePressed) private var isPressed: Bool
 
     private static let loader: RemoteAttachmentLoader = RemoteAttachmentLoader()
@@ -282,14 +329,24 @@ private struct AttachmentPlaceholder: View {
         attachment.aspectRatio ?? (4.0 / 3.0)
     }
 
+    private var isVideo: Bool {
+        attachment.mediaType == .video
+    }
+
     var body: some View {
         Group {
             if let image = loadedImage {
-                photoContent(image: image)
-                    .clipShape(RoundedRectangle(cornerRadius: isRegularWidth ? DesignConstants.CornerRadius.medium : 0))
-                    .frame(maxWidth: isRegularWidth ? Self.maxPhotoWidth : .infinity)
-                    .frame(maxWidth: .infinity, alignment: isRegularWidth ? (isOutgoing ? .trailing : .leading) : .leading)
-                    .padding(isRegularWidth ? (isOutgoing ? .trailing : .leading) : [], DesignConstants.Spacing.step4x)
+                ZStack {
+                    photoContent(image: image)
+
+                    if isVideo, !shouldBlur {
+                        videoOverlay
+                    }
+                }
+                .clipShape(RoundedRectangle(cornerRadius: isRegularWidth ? DesignConstants.CornerRadius.medium : 0))
+                .frame(maxWidth: isRegularWidth ? Self.maxPhotoWidth : .infinity)
+                .frame(maxWidth: .infinity, alignment: isRegularWidth ? (isOutgoing ? .trailing : .leading) : .leading)
+                .padding(isRegularWidth ? (isOutgoing ? .trailing : .leading) : [], DesignConstants.Spacing.step4x)
             } else if isLoading {
                 loadingPlaceholder
             } else {
@@ -297,8 +354,82 @@ private struct AttachmentPlaceholder: View {
             }
         }
         .clipShape(RoundedRectangle(cornerRadius: cornerRadius))
+        .accessibilityLabel(isVideo ? "Video message" : "Photo message")
+        .onChange(of: videoPlayTrigger) {
+            handleVideoPlayTap()
+        }
+        .fullScreenCover(isPresented: $showFullScreenPlayer) {
+            if let url = videoLocalURL {
+                FullScreenVideoPlayer(url: url, isPresented: $showFullScreenPlayer)
+            }
+        }
         .task {
             await loadAttachment()
+        }
+    }
+
+    @ViewBuilder
+    private var videoOverlay: some View {
+        ZStack {
+            if isDownloadingVideo {
+                ProgressView()
+                    .tint(.white)
+            } else {
+                Image(systemName: "play.fill")
+                    .font(.system(size: 36))
+                    .foregroundStyle(.white)
+                    .shadow(color: .black.opacity(0.3), radius: 4, x: 0, y: 2)
+                    .accessibilityIdentifier("video-play-button")
+            }
+        }
+
+        if let duration = attachment.duration {
+            VStack {
+                Spacer()
+                HStack {
+                    Spacer()
+                    Text(formatDuration(duration))
+                        .font(.caption2.weight(.medium))
+                        .foregroundStyle(.white)
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(.black.opacity(0.6))
+                        .clipShape(RoundedRectangle(cornerRadius: 4))
+                        .padding(8)
+                        .accessibilityIdentifier("video-duration-badge")
+                }
+            }
+        }
+    }
+
+    private func formatDuration(_ seconds: Double) -> String {
+        let mins = Int(seconds) / 60
+        let secs = Int(seconds) % 60
+        return String(format: "%d:%02d", mins, secs)
+    }
+
+    func handleVideoPlayTap() {
+        guard isVideo, !shouldBlur else { return }
+
+        if videoLocalURL != nil {
+            showFullScreenPlayer = true
+            return
+        }
+
+        isDownloadingVideo = true
+        Task {
+            do {
+                let loaded = try await Self.loader.loadAttachmentData(from: attachment.key)
+                let tempURL = FileManager.default.temporaryDirectory
+                    .appendingPathComponent("video_\(UUID().uuidString).mp4")
+                try loaded.data.write(to: tempURL)
+                videoLocalURL = tempURL
+                isDownloadingVideo = false
+                showFullScreenPlayer = true
+            } catch {
+                isDownloadingVideo = false
+                Log.error("Failed to download video: \(error)")
+            }
         }
     }
 
@@ -344,6 +475,13 @@ private struct AttachmentPlaceholder: View {
             return
         }
 
+        if isVideo, let thumbnailData = attachment.thumbnailData, let thumb = UIImage(data: thumbnailData) {
+            loadedImage = thumb
+            ImageCache.shared.cacheImage(thumb, for: cacheKey, storageTier: .persistent)
+            isLoading = false
+            return
+        }
+
         do {
             let imageData: Data
 
@@ -352,6 +490,10 @@ private struct AttachmentPlaceholder: View {
                 let url = URL(fileURLWithPath: path)
                 imageData = try Data(contentsOf: url)
             } else if attachment.key.hasPrefix("{") {
+                if isVideo {
+                    isLoading = false
+                    return
+                }
                 imageData = try await Self.loader.loadImageData(from: attachment.key)
             } else if let url = URL(string: attachment.key) {
                 let (data, _) = try await URLSession.shared.data(from: url)

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
@@ -282,6 +282,7 @@ private struct VideoTapAttachmentView: View {
 
 private struct AttachmentPlaceholder: View {
     static let maxPhotoWidth: CGFloat = 430
+    static let videoPlaybackStarted: Notification.Name = Notification.Name("AttachmentPlaceholder.videoPlaybackStarted")
 
     let attachment: HydratedAttachment
     let isOutgoing: Bool
@@ -298,6 +299,7 @@ private struct AttachmentPlaceholder: View {
     @State private var loadError: Error?
     @State private var inlinePlayer: AVPlayer?
     @State private var isPlaying: Bool = false
+    @State private var instanceID: UUID = UUID()
     @Environment(\.messagePressed) private var isPressed: Bool
 
     private static let loader: RemoteAttachmentLoader = RemoteAttachmentLoader()
@@ -403,6 +405,14 @@ private struct AttachmentPlaceholder: View {
             else { return }
             isPlaying = false
         }
+        .onReceive(NotificationCenter.default.publisher(for: Self.videoPlaybackStarted)) { notification in
+            guard let senderID = notification.object as? UUID,
+                  senderID != instanceID,
+                  isPlaying
+            else { return }
+            inlinePlayer?.pause()
+            isPlaying = false
+        }
         .task {
             await loadAttachment()
         }
@@ -470,6 +480,7 @@ private struct AttachmentPlaceholder: View {
                     player.play()
                 }
                 isPlaying = true
+                NotificationCenter.default.post(name: Self.videoPlaybackStarted, object: instanceID)
             }
             return
         }

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
@@ -217,14 +217,9 @@ struct MessagesGroupItemView: View {
 
         VideoTapAttachmentView(
             attachment: attachment,
-<<<<<<< HEAD
+            message: message,
             isOutgoing: message.sender.isCurrentUser,
             profile: message.sender.profile,
-=======
-            message: message,
-            isOutgoing: message.base.sender.isCurrentUser,
-            profile: message.base.sender.profile,
->>>>>>> 0555dd80 (Implement video message sending and playback)
             shouldBlurPhotos: shouldBlurPhotos,
             isBlurred: isBlurred,
             onPhotoRevealed: onPhotoRevealed,

--- a/Convos/Conversation Detail/Messages/MessagesView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesView.swift
@@ -22,7 +22,6 @@ struct MessagesView<BottomBarContent: View>: View {
     var isVideoAttachment: Bool = false
     var composerLinkPreview: LinkPreview?
     var pendingInviteURL: String?
->>>>>>> 6f02b89c (Show video badge on composer attachment preview)
     let sendButtonEnabled: Bool
     @Binding var profileImage: UIImage?
     let onboardingCoordinator: ConversationOnboardingCoordinator
@@ -118,7 +117,6 @@ struct MessagesView<BottomBarContent: View>: View {
                 isVideoAttachment: isVideoAttachment,
                 composerLinkPreview: composerLinkPreview,
                 pendingInviteURL: pendingInviteURL,
->>>>>>> 6f02b89c (Show video badge on composer attachment preview)
                 sendButtonEnabled: sendButtonEnabled,
                 profileImage: $profileImage,
                 isPhotoPickerPresented: $isPhotoPickerPresented,

--- a/Convos/Conversation Detail/Messages/MessagesView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesView.swift
@@ -19,8 +19,10 @@ struct MessagesView<BottomBarContent: View>: View {
     @Binding var displayName: String
     @Binding var messageText: String
     @Binding var selectedAttachmentImage: UIImage?
+    var isVideoAttachment: Bool = false
     var composerLinkPreview: LinkPreview?
     var pendingInviteURL: String?
+>>>>>>> 6f02b89c (Show video badge on composer attachment preview)
     let sendButtonEnabled: Bool
     @Binding var profileImage: UIImage?
     let onboardingCoordinator: ConversationOnboardingCoordinator
@@ -113,8 +115,10 @@ struct MessagesView<BottomBarContent: View>: View {
                 displayName: $displayName,
                 messageText: $messageText,
                 selectedAttachmentImage: $selectedAttachmentImage,
+                isVideoAttachment: isVideoAttachment,
                 composerLinkPreview: composerLinkPreview,
                 pendingInviteURL: pendingInviteURL,
+>>>>>>> 6f02b89c (Show video badge on composer attachment preview)
                 sendButtonEnabled: sendButtonEnabled,
                 profileImage: $profileImage,
                 isPhotoPickerPresented: $isPhotoPickerPresented,

--- a/Convos/Conversation Detail/Messages/MessagesView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesView.swift
@@ -47,6 +47,8 @@ struct MessagesView<BottomBarContent: View>: View {
     let onPhotoRevealed: (String) -> Void
     let onPhotoHidden: (String) -> Void
     let onPhotoDimensionsLoaded: (String, Int, Int) -> Void
+    let onVideoSelected: (URL) -> Void
+    let onAboutAssistants: () -> Void
     let onAgentOutOfCredits: () -> Void
     let onTapUpdateMember: (ConversationMember) -> Void
     let onRetryMessage: (AnyMessage) -> Void
@@ -128,6 +130,7 @@ struct MessagesView<BottomBarContent: View>: View {
                 onClearInvite: onClearInvite,
                 onClearLinkPreview: onClearLinkPreview,
                 onDisplayNameEndedEditing: onDisplayNameEndedEditing,
+                onVideoSelected: onVideoSelected,
                 onProfileSettings: onProfileSettings,
                 onBaseHeightChanged: { height in
                     bottomBarHeight = height

--- a/Convos/Shared Views/SelectedMediaAttachment.swift
+++ b/Convos/Shared Views/SelectedMediaAttachment.swift
@@ -1,0 +1,7 @@
+import ConvosCore
+import UIKit
+
+enum SelectedMediaAttachment {
+    case image(UIImage)
+    case video(url: URL, thumbnail: UIImage)
+}

--- a/Convos/Shared Views/SelectedMediaAttachment.swift
+++ b/Convos/Shared Views/SelectedMediaAttachment.swift
@@ -1,7 +1,0 @@
-import ConvosCore
-import UIKit
-
-enum SelectedMediaAttachment {
-    case image(UIImage)
-    case video(url: URL, thumbnail: UIImage)
-}

--- a/Convos/Shared Views/VideoFile.swift
+++ b/Convos/Shared Views/VideoFile.swift
@@ -1,0 +1,18 @@
+import Foundation
+import SwiftUI
+import UniformTypeIdentifiers
+
+struct VideoFile: Transferable {
+    let url: URL
+
+    static var transferRepresentation: some TransferRepresentation {
+        FileRepresentation(contentType: .movie) { video in
+            SentTransferredFile(video.url)
+        } importing: { received in
+            let tempDir = FileManager.default.temporaryDirectory
+            let outputURL = tempDir.appendingPathComponent("video_\(UUID().uuidString).mov")
+            try FileManager.default.copyItem(at: received.file, to: outputURL)
+            return VideoFile(url: outputURL)
+        }
+    }
+}

--- a/Convos/Shared Views/VideoPlayerView.swift
+++ b/Convos/Shared Views/VideoPlayerView.swift
@@ -1,0 +1,40 @@
+import AVKit
+import SwiftUI
+
+struct FullScreenVideoPlayer: View {
+    let url: URL
+    @Binding var isPresented: Bool
+
+    @State private var player: AVPlayer?
+
+    var body: some View {
+        ZStack(alignment: .topLeading) {
+            Color.black.ignoresSafeArea()
+
+            if let player {
+                VideoPlayer(player: player)
+                    .ignoresSafeArea()
+            }
+
+            Button {
+                player?.pause()
+                isPresented = false
+            } label: {
+                Image(systemName: "xmark.circle.fill")
+                    .font(.title)
+                    .foregroundStyle(.white.opacity(0.8))
+                    .padding()
+            }
+        }
+        .onAppear {
+            let newPlayer = AVPlayer(url: url)
+            player = newPlayer
+            newPlayer.play()
+        }
+        .onDisappear {
+            player?.pause()
+            player = nil
+        }
+        .statusBarHidden()
+    }
+}

--- a/Convos/Shared Views/VideoPlayerView.swift
+++ b/Convos/Shared Views/VideoPlayerView.swift
@@ -1,40 +1,24 @@
-import AVKit
+import AVFoundation
 import SwiftUI
+import UIKit
 
-struct FullScreenVideoPlayer: View {
-    let url: URL
-    @Binding var isPresented: Bool
+struct InlineVideoPlayerView: UIViewRepresentable {
+    let player: AVPlayer
 
-    @State private var player: AVPlayer?
+    func makeUIView(context: Context) -> PlayerLayerView {
+        let view = PlayerLayerView()
+        view.playerLayer.player = player
+        view.playerLayer.videoGravity = .resizeAspectFill
+        return view
+    }
 
-    var body: some View {
-        ZStack(alignment: .topLeading) {
-            Color.black.ignoresSafeArea()
+    func updateUIView(_ uiView: PlayerLayerView, context: Context) {
+        uiView.playerLayer.player = player
+    }
 
-            if let player {
-                VideoPlayer(player: player)
-                    .ignoresSafeArea()
-            }
-
-            Button {
-                player?.pause()
-                isPresented = false
-            } label: {
-                Image(systemName: "xmark.circle.fill")
-                    .font(.title)
-                    .foregroundStyle(.white.opacity(0.8))
-                    .padding()
-            }
-        }
-        .onAppear {
-            let newPlayer = AVPlayer(url: url)
-            player = newPlayer
-            newPlayer.play()
-        }
-        .onDisappear {
-            player?.pause()
-            player = nil
-        }
-        .statusBarHidden()
+    final class PlayerLayerView: UIView {
+        override static var layerClass: AnyClass { AVPlayerLayer.self }
+        // swiftlint:disable:next force_cast
+        var playerLayer: AVPlayerLayer { layer as! AVPlayerLayer }
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Inboxes/ConversationStateMachine.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/ConversationStateMachine.swift
@@ -274,9 +274,9 @@ public actor ConversationStateMachine {
         await writer.cancelEagerUpload(trackingKey: trackingKey)
     }
 
-    func sendVideo(at fileURL: URL) async throws -> String {
+    func sendVideo(at fileURL: URL, replyToMessageId: String? = nil) async throws -> String {
         let writer = try await getOrCreateMessageWriter()
-        return try await writer.sendVideo(at: fileURL)
+        return try await writer.sendVideo(at: fileURL, replyToMessageId: replyToMessageId)
     }
 
     func sendReply(text: String, toMessageWithClientId parentClientMessageId: String) async throws {

--- a/ConvosCore/Sources/ConvosCore/Inboxes/ConversationStateMachine.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/ConversationStateMachine.swift
@@ -274,6 +274,11 @@ public actor ConversationStateMachine {
         await writer.cancelEagerUpload(trackingKey: trackingKey)
     }
 
+    func sendVideo(at fileURL: URL) async throws -> String {
+        let writer = try await getOrCreateMessageWriter()
+        return try await writer.sendVideo(at: fileURL)
+    }
+
     func sendReply(text: String, toMessageWithClientId parentClientMessageId: String) async throws {
         let writer = try await getOrCreateMessageWriter()
         try await writer.sendReply(text: text, toMessageWithClientId: parentClientMessageId)

--- a/ConvosCore/Sources/ConvosCore/Messaging/RemoteAttachmentLoader.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/RemoteAttachmentLoader.swift
@@ -8,25 +8,35 @@ public enum RemoteAttachmentLoaderError: Error {
     case notAnImage
 }
 
+public struct LoadedAttachment: Sendable {
+    public let data: Data
+    public let mimeType: String
+    public let filename: String?
+}
+
 public protocol RemoteAttachmentLoaderProtocol: Sendable {
     func loadImageData(from storedJSON: String) async throws -> Data
+    func loadAttachmentData(from storedJSON: String) async throws -> LoadedAttachment
 }
 
 public actor RemoteAttachmentLoader: RemoteAttachmentLoaderProtocol {
-    private var inFlightTasks: [String: Task<Data, Error>] = [:]
+    private var inFlightTasks: [String: Task<LoadedAttachment, Error>] = [:]
 
     public init() {}
 
     public func loadImageData(from storedJSON: String) async throws -> Data {
-        // Use hash as key for deduplication of in-flight requests
+        let loaded = try await loadAttachmentData(from: storedJSON)
+        return loaded.data
+    }
+
+    public func loadAttachmentData(from storedJSON: String) async throws -> LoadedAttachment {
         let requestKey = storedJSON.hash.description
 
-        // Check for existing in-flight request to avoid duplicate fetches
         if let existingTask = inFlightTasks[requestKey] {
             return try await existingTask.value
         }
 
-        let task = Task<Data, Error> {
+        let task = Task<LoadedAttachment, Error> {
             try await fetchAndDecrypt(storedJSON: storedJSON)
         }
 
@@ -42,7 +52,7 @@ public actor RemoteAttachmentLoader: RemoteAttachmentLoaderProtocol {
         }
     }
 
-    private func fetchAndDecrypt(storedJSON: String) async throws -> Data {
+    private func fetchAndDecrypt(storedJSON: String) async throws -> LoadedAttachment {
         let stored = try StoredRemoteAttachment.fromJSON(storedJSON)
 
         let remoteAttachment = try RemoteAttachment(
@@ -60,10 +70,10 @@ public actor RemoteAttachmentLoader: RemoteAttachmentLoaderProtocol {
 
         let attachment = try AttachmentCodec().decode(content: encodedContent)
 
-        guard attachment.mimeType.hasPrefix("image/") else {
-            throw RemoteAttachmentLoaderError.notAnImage
-        }
-
-        return attachment.data
+        return LoadedAttachment(
+            data: attachment.data,
+            mimeType: attachment.mimeType,
+            filename: attachment.filename
+        )
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Messaging/VideoCompressionService.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/VideoCompressionService.swift
@@ -49,7 +49,7 @@ public protocol VideoCompressionServiceProtocol: Sendable {
 
 public final class VideoCompressionService: VideoCompressionServiceProtocol, Sendable {
     public static let maxFileSizeBytes: Int64 = 25 * 1024 * 1024
-    private static let thumbnailMaxDimension: CGFloat = 200
+    private static let thumbnailMaxDimension: CGFloat = 400
 
     public init() {}
 

--- a/ConvosCore/Sources/ConvosCore/Messaging/VideoCompressionService.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/VideoCompressionService.swift
@@ -1,0 +1,152 @@
+import AVFoundation
+import Foundation
+#if os(macOS)
+import AppKit
+#else
+import UIKit
+#endif
+
+public enum VideoCompressionError: Error {
+    case exportSessionCreationFailed
+    case exportFailed(String)
+    case fileTooLarge(bytes: Int64, maxBytes: Int64)
+    case thumbnailGenerationFailed
+    case invalidAsset
+}
+
+public struct CompressedVideo: Sendable {
+    public let fileURL: URL
+    public let fileSize: Int64
+    public let duration: Double
+    public let width: Int
+    public let height: Int
+    public let thumbnail: Data
+    public let mimeType: String
+
+    public init(
+        fileURL: URL,
+        fileSize: Int64,
+        duration: Double,
+        width: Int,
+        height: Int,
+        thumbnail: Data,
+        mimeType: String
+    ) {
+        self.fileURL = fileURL
+        self.fileSize = fileSize
+        self.duration = duration
+        self.width = width
+        self.height = height
+        self.thumbnail = thumbnail
+        self.mimeType = mimeType
+    }
+}
+
+public protocol VideoCompressionServiceProtocol: Sendable {
+    func compressVideo(at sourceURL: URL) async throws -> CompressedVideo
+    func generateThumbnail(for asset: AVAsset) async throws -> Data
+}
+
+public final class VideoCompressionService: VideoCompressionServiceProtocol, Sendable {
+    public static let maxFileSizeBytes: Int64 = 25 * 1024 * 1024
+    private static let thumbnailMaxDimension: CGFloat = 200
+
+    public init() {}
+
+    public func compressVideo(at sourceURL: URL) async throws -> CompressedVideo {
+        let asset = AVURLAsset(url: sourceURL)
+
+        guard let videoTrack = try await asset.loadTracks(withMediaType: .video).first else {
+            throw VideoCompressionError.invalidAsset
+        }
+
+        let naturalSize = try await videoTrack.load(.naturalSize)
+        let transform = try await videoTrack.load(.preferredTransform)
+        let transformedSize = naturalSize.applying(transform)
+        let videoWidth = Int(abs(transformedSize.width))
+        let videoHeight = Int(abs(transformedSize.height))
+        let duration = try await asset.load(.duration)
+        let durationSeconds = CMTimeGetSeconds(duration)
+
+        let thumbnail = try await generateThumbnail(for: asset)
+
+        let outputURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("video_\(UUID().uuidString).mp4")
+
+        guard let exportSession = AVAssetExportSession(
+            asset: asset,
+            presetName: AVAssetExportPresetMediumQuality
+        ) else {
+            throw VideoCompressionError.exportSessionCreationFailed
+        }
+
+        exportSession.outputURL = outputURL
+        exportSession.outputFileType = .mp4
+        exportSession.shouldOptimizeForNetworkUse = true
+
+        await exportSession.export()
+
+        switch exportSession.status {
+        case .completed:
+            break
+        case .failed:
+            let errorMessage = exportSession.error?.localizedDescription ?? "unknown error"
+            throw VideoCompressionError.exportFailed(errorMessage)
+        case .cancelled:
+            throw VideoCompressionError.exportFailed("export cancelled")
+        default:
+            throw VideoCompressionError.exportFailed("unexpected status: \(exportSession.status.rawValue)")
+        }
+
+        let fileAttributes = try FileManager.default.attributesOfItem(atPath: outputURL.path)
+        let fileSize = fileAttributes[.size] as? Int64 ?? 0
+
+        if fileSize > Self.maxFileSizeBytes {
+            try? FileManager.default.removeItem(at: outputURL)
+            throw VideoCompressionError.fileTooLarge(bytes: fileSize, maxBytes: Self.maxFileSizeBytes)
+        }
+
+        return CompressedVideo(
+            fileURL: outputURL,
+            fileSize: fileSize,
+            duration: durationSeconds,
+            width: videoWidth,
+            height: videoHeight,
+            thumbnail: thumbnail,
+            mimeType: "video/mp4"
+        )
+    }
+
+    public func generateThumbnail(for asset: AVAsset) async throws -> Data {
+        let imageGenerator = AVAssetImageGenerator(asset: asset)
+        imageGenerator.appliesPreferredTrackTransform = true
+        imageGenerator.maximumSize = CGSize(
+            width: Self.thumbnailMaxDimension,
+            height: Self.thumbnailMaxDimension
+        )
+
+        let cgImage: CGImage
+        do {
+            let (image, _) = try await imageGenerator.image(at: .zero)
+            cgImage = image
+        } catch {
+            throw VideoCompressionError.thumbnailGenerationFailed
+        }
+
+        #if os(macOS)
+        let nsImage = NSImage(cgImage: cgImage, size: NSSize(width: cgImage.width, height: cgImage.height))
+        guard let tiffData = nsImage.tiffRepresentation,
+              let bitmap = NSBitmapImageRep(data: tiffData),
+              let jpegData = bitmap.representation(using: .jpeg, properties: [.compressionFactor: 0.7]) else {
+            throw VideoCompressionError.thumbnailGenerationFailed
+        }
+        return jpegData
+        #else
+        let uiImage = UIImage(cgImage: cgImage)
+        guard let jpegData = uiImage.jpegData(compressionQuality: 0.7) else {
+            throw VideoCompressionError.thumbnailGenerationFailed
+        }
+        return jpegData
+        #endif
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Mocks/MockConversationStateManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Mocks/MockConversationStateManager.swift
@@ -101,6 +101,7 @@ public final class MockConversationStateManager: ConversationStateManagerProtoco
 
     public func sendEagerPhoto(trackingKey: String) async throws {}
     public func cancelEagerUpload(trackingKey: String) async {}
+    public func sendVideo(at fileURL: URL) async throws -> String { UUID().uuidString }
     public func sendReply(text: String, toMessageWithClientId parentClientMessageId: String) async throws {}
     public func sendEagerPhotoReply(trackingKey: String, toMessageWithClientId parentClientMessageId: String) async throws {}
     public func sendReply(text: String, afterPhoto trackingKey: String?, toMessageWithClientId parentClientMessageId: String) async throws {}

--- a/ConvosCore/Sources/ConvosCore/Mocks/MockConversationStateManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Mocks/MockConversationStateManager.swift
@@ -101,7 +101,7 @@ public final class MockConversationStateManager: ConversationStateManagerProtoco
 
     public func sendEagerPhoto(trackingKey: String) async throws {}
     public func cancelEagerUpload(trackingKey: String) async {}
-    public func sendVideo(at fileURL: URL) async throws -> String { UUID().uuidString }
+    public func sendVideo(at fileURL: URL, replyToMessageId: String?) async throws -> String { UUID().uuidString }
     public func sendReply(text: String, toMessageWithClientId parentClientMessageId: String) async throws {}
     public func sendEagerPhotoReply(trackingKey: String, toMessageWithClientId parentClientMessageId: String) async throws {}
     public func sendReply(text: String, afterPhoto trackingKey: String?, toMessageWithClientId parentClientMessageId: String) async throws {}

--- a/ConvosCore/Sources/ConvosCore/Mocks/MockOutgoingMessageWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Mocks/MockOutgoingMessageWriter.swift
@@ -41,7 +41,7 @@ public final class MockOutgoingMessageWriter: OutgoingMessageWriterProtocol, @un
 
     public func cancelEagerUpload(trackingKey: String) async {}
 
-    public func sendVideo(at fileURL: URL) async throws -> String {
+    public func sendVideo(at fileURL: URL, replyToMessageId: String?) async throws -> String {
         sentImageCount += 1
         return UUID().uuidString
     }

--- a/ConvosCore/Sources/ConvosCore/Mocks/MockOutgoingMessageWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Mocks/MockOutgoingMessageWriter.swift
@@ -41,6 +41,11 @@ public final class MockOutgoingMessageWriter: OutgoingMessageWriterProtocol, @un
 
     public func cancelEagerUpload(trackingKey: String) async {}
 
+    public func sendVideo(at fileURL: URL) async throws -> String {
+        sentImageCount += 1
+        return UUID().uuidString
+    }
+
     public func sendReply(text: String, toMessageWithClientId parentClientMessageId: String) async throws {
         try await send(text: text)
     }

--- a/ConvosCore/Sources/ConvosCore/Mocks/MockRepositories.swift
+++ b/ConvosCore/Sources/ConvosCore/Mocks/MockRepositories.swift
@@ -230,9 +230,15 @@ public final class MockAttachmentLocalStateWriter: AttachmentLocalStateWriterPro
         conversationId: String,
         width: Int,
         height: Int
-    ) async throws {
-        // No-op for mock
-    }
+    ) async throws {}
+
+    public func saveWithDimensions(
+        attachmentKey: String,
+        conversationId: String,
+        width: Int,
+        height: Int,
+        mimeType: String?
+    ) async throws {}
 
     public func migrateKey(from oldKey: String, to newKey: String) async throws {
         if let conversationId = revealedAttachments.removeValue(forKey: oldKey) {

--- a/ConvosCore/Sources/ConvosCore/Storage/Database Models/AttachmentLocalState.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Database Models/AttachmentLocalState.swift
@@ -12,6 +12,7 @@ struct AttachmentLocalState: FetchableRecord, PersistableRecord, Codable, Hashab
         static let width: Column = Column(CodingKeys.width)
         static let height: Column = Column(CodingKeys.height)
         static let isHiddenByOwner: Column = Column(CodingKeys.isHiddenByOwner)
+        static let mimeType: Column = Column(CodingKeys.mimeType)
     }
 
     let attachmentKey: String
@@ -21,6 +22,7 @@ struct AttachmentLocalState: FetchableRecord, PersistableRecord, Codable, Hashab
     let width: Int?
     let height: Int?
     let isHiddenByOwner: Bool
+    let mimeType: String?
 
     static let conversationForeignKey: ForeignKey = ForeignKey([Columns.conversationId], to: [DBConversation.Columns.id])
     static let conversation: BelongsToAssociation<AttachmentLocalState, DBConversation> = belongsTo(DBConversation.self, using: conversationForeignKey)
@@ -32,7 +34,8 @@ struct AttachmentLocalState: FetchableRecord, PersistableRecord, Codable, Hashab
         revealedAt: Date? = nil,
         width: Int? = nil,
         height: Int? = nil,
-        isHiddenByOwner: Bool = false
+        isHiddenByOwner: Bool = false,
+        mimeType: String? = nil
     ) {
         self.attachmentKey = attachmentKey
         self.conversationId = conversationId
@@ -41,5 +44,6 @@ struct AttachmentLocalState: FetchableRecord, PersistableRecord, Codable, Hashab
         self.width = width
         self.height = height
         self.isHiddenByOwner = isHiddenByOwner
+        self.mimeType = mimeType
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Storage/Hydration/DBMessage+MessagePreview.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Hydration/DBMessage+MessagePreview.swift
@@ -11,7 +11,7 @@ extension DBLastMessageWithSource {
         let senderProfile = members.first { $0.memberProfile.inboxId == senderId }
         let senderName = isCurrentUser ? "You" : (senderProfile?.memberProfile.name ?? "Somebody")
         let attachmentsCount = attachmentUrls.count
-        let attachmentsString = attachmentsCount <= 1 ? "a photo" : "\(attachmentsCount) photos"
+        let attachmentsString = Self.attachmentsPreviewString(attachmentUrls: attachmentUrls, count: attachmentsCount)
 
         let otherMemberCount = members.filter { $0.memberProfile.inboxId != currentInboxId }.count
         let shouldShowSenderName = conversationKind == .group && otherMemberCount > 1
@@ -102,5 +102,16 @@ extension DBLastMessageWithSource {
             }
         }
         return .init(text: text, createdAt: date)
+    }
+
+    private static func attachmentsPreviewString(attachmentUrls: [String], count: Int) -> String {
+        let hasVideo = attachmentUrls.contains { url in
+            guard let stored = try? StoredRemoteAttachment.fromJSON(url) else { return false }
+            return stored.mimeType?.hasPrefix("video/") == true
+        }
+        if count <= 1 {
+            return hasVideo ? "a video" : "a photo"
+        }
+        return hasVideo ? "\(count) attachments" : "\(count) photos"
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Storage/Hydration/DBMessage+MessagePreview.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Hydration/DBMessage+MessagePreview.swift
@@ -104,7 +104,7 @@ extension DBLastMessageWithSource {
         return .init(text: text, createdAt: date)
     }
 
-    private static func attachmentsPreviewString(attachmentUrls: [String], count: Int) -> String {
+    static func attachmentsPreviewString(attachmentUrls: [String], count: Int) -> String {
         let hasVideo = attachmentUrls.contains { url in
             guard let stored = try? StoredRemoteAttachment.fromJSON(url) else { return false }
             return stored.mimeType?.hasPrefix("video/") == true

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/HydratedAttachment.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/HydratedAttachment.swift
@@ -1,22 +1,61 @@
 import Foundation
 
+public enum MediaType: String, Codable, Sendable {
+    case image
+    case video
+    case audio
+    case file
+    case unknown
+}
+
 public struct HydratedAttachment: Hashable, Codable, Sendable {
     public let key: String
     public let isRevealed: Bool
     public let isHiddenByOwner: Bool
     public let width: Int?
     public let height: Int?
+    public let mimeType: String?
+    public let duration: Double?
+    public let thumbnailDataBase64: String?
+    public let fileSize: Int?
+
+    public var mediaType: MediaType {
+        guard let mimeType else { return .image }
+        if mimeType.hasPrefix("image/") { return .image }
+        if mimeType.hasPrefix("video/") { return .video }
+        if mimeType.hasPrefix("audio/") { return .audio }
+        return .file
+    }
 
     public var aspectRatio: CGFloat? {
         guard let w = width, let h = height, h > 0 else { return nil }
         return CGFloat(w) / CGFloat(h)
     }
 
-    public init(key: String, isRevealed: Bool = false, isHiddenByOwner: Bool = false, width: Int? = nil, height: Int? = nil) {
+    public var thumbnailData: Data? {
+        guard let thumbnailDataBase64 else { return nil }
+        return Data(base64Encoded: thumbnailDataBase64)
+    }
+
+    public init(
+        key: String,
+        isRevealed: Bool = false,
+        isHiddenByOwner: Bool = false,
+        width: Int? = nil,
+        height: Int? = nil,
+        mimeType: String? = nil,
+        duration: Double? = nil,
+        thumbnailDataBase64: String? = nil,
+        fileSize: Int? = nil
+    ) {
         self.key = key
         self.isRevealed = isRevealed
         self.isHiddenByOwner = isHiddenByOwner
         self.width = width
         self.height = height
+        self.mimeType = mimeType
+        self.duration = duration
+        self.thumbnailDataBase64 = thumbnailDataBase64
+        self.fileSize = fileSize
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/StoredRemoteAttachment.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/StoredRemoteAttachment.swift
@@ -7,6 +7,11 @@ public struct StoredRemoteAttachment: Codable, Hashable, Sendable {
     public let salt: Data
     public let nonce: Data
     public let filename: String?
+    public let mimeType: String?
+    public let mediaWidth: Int?
+    public let mediaHeight: Int?
+    public let mediaDuration: Double?
+    public let thumbnailDataBase64: String?
 
     public init(
         url: String,
@@ -14,7 +19,12 @@ public struct StoredRemoteAttachment: Codable, Hashable, Sendable {
         secret: Data,
         salt: Data,
         nonce: Data,
-        filename: String?
+        filename: String?,
+        mimeType: String? = nil,
+        mediaWidth: Int? = nil,
+        mediaHeight: Int? = nil,
+        mediaDuration: Double? = nil,
+        thumbnailDataBase64: String? = nil
     ) {
         self.url = url
         self.contentDigest = contentDigest
@@ -22,6 +32,11 @@ public struct StoredRemoteAttachment: Codable, Hashable, Sendable {
         self.salt = salt
         self.nonce = nonce
         self.filename = filename
+        self.mimeType = mimeType
+        self.mediaWidth = mediaWidth
+        self.mediaHeight = mediaHeight
+        self.mediaDuration = mediaDuration
+        self.thumbnailDataBase64 = thumbnailDataBase64
     }
 
     public func toJSON() throws -> String {

--- a/ConvosCore/Sources/ConvosCore/Storage/Repositories/MessagesRepository.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Repositories/MessagesRepository.swift
@@ -343,14 +343,7 @@ extension Array where Element == DBMessage {
                     messageContent = .linkPreview(preview)
                 case .attachments:
                     let hydratedAttachments = dbMessage.attachmentUrls.map { key in
-                        let localState = attachmentLocalStates[key]
-                        return HydratedAttachment(
-                            key: key,
-                            isRevealed: localState?.isRevealed ?? false,
-                            isHiddenByOwner: localState?.isHiddenByOwner ?? false,
-                            width: localState?.width,
-                            height: localState?.height
-                        )
+                        hydrateAttachment(key: key, localState: attachmentLocalStates[key])
                     }
                     messageContent = .attachments(hydratedAttachments)
                 case .emoji:
@@ -447,14 +440,7 @@ extension Array where Element == DBMessage {
             replyContent = .emoji(dbMessage.emoji ?? "")
         case .attachments:
             replyContent = .attachments(dbMessage.attachmentUrls.map { key in
-                let localState = attachmentLocalStates[key]
-                return HydratedAttachment(
-                    key: key,
-                    isRevealed: localState?.isRevealed ?? false,
-                    isHiddenByOwner: localState?.isHiddenByOwner ?? false,
-                    width: localState?.width,
-                    height: localState?.height
-                )
+                hydrateAttachment(key: key, localState: attachmentLocalStates[key])
             })
         case .invite:
             if let invite = dbMessage.invite {
@@ -491,14 +477,7 @@ extension Array where Element == DBMessage {
             parentContent = .emoji(sourceDBMessage.emoji ?? "")
         case .attachments:
             parentContent = .attachments(sourceDBMessage.attachmentUrls.map { key in
-                let localState = attachmentLocalStates[key]
-                return HydratedAttachment(
-                    key: key,
-                    isRevealed: localState?.isRevealed ?? false,
-                    isHiddenByOwner: localState?.isHiddenByOwner ?? false,
-                    width: localState?.width,
-                    height: localState?.height
-                )
+                hydrateAttachment(key: key, localState: attachmentLocalStates[key])
             })
         case .invite:
             if let invite = sourceDBMessage.invite {
@@ -812,4 +791,31 @@ fileprivate extension Database {
         )
         return result
     }
+}
+
+private func hydrateAttachment(key: String, localState: AttachmentLocalState?) -> HydratedAttachment {
+    var mimeType: String? = localState?.mimeType
+    var duration: Double?
+    var thumbnailDataBase64: String?
+    var width: Int? = localState?.width
+    var height: Int? = localState?.height
+
+    if let stored = try? StoredRemoteAttachment.fromJSON(key) {
+        if mimeType == nil { mimeType = stored.mimeType }
+        if width == nil { width = stored.mediaWidth }
+        if height == nil { height = stored.mediaHeight }
+        duration = stored.mediaDuration
+        thumbnailDataBase64 = stored.thumbnailDataBase64
+    }
+
+    return HydratedAttachment(
+        key: key,
+        isRevealed: localState?.isRevealed ?? false,
+        isHiddenByOwner: localState?.isHiddenByOwner ?? false,
+        width: width,
+        height: height,
+        mimeType: mimeType,
+        duration: duration,
+        thumbnailDataBase64: thumbnailDataBase64
+    )
 }

--- a/ConvosCore/Sources/ConvosCore/Storage/SharedDatabaseMigrator.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/SharedDatabaseMigrator.swift
@@ -393,6 +393,12 @@ extension SharedDatabaseMigrator {
             }
         }
 
+        migrator.registerMigration("addMimeTypeToAttachmentLocalState") { db in
+            try db.alter(table: "attachmentLocalState") { t in
+                t.add(column: "mimeType", .text)
+            }
+        }
+
         return migrator
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/AttachmentLocalStateWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/AttachmentLocalStateWriter.swift
@@ -10,6 +10,13 @@ public protocol AttachmentLocalStateWriterProtocol: Sendable {
         width: Int,
         height: Int
     ) async throws
+    func saveWithDimensions(
+        attachmentKey: String,
+        conversationId: String,
+        width: Int,
+        height: Int,
+        mimeType: String?
+    ) async throws
     func migrateKey(from oldKey: String, to newKey: String) async throws
 }
 
@@ -33,7 +40,8 @@ public final class AttachmentLocalStateWriter: AttachmentLocalStateWriterProtoco
                 revealedAt: Date(),
                 width: existing?.width,
                 height: existing?.height,
-                isHiddenByOwner: false
+                isHiddenByOwner: false,
+                mimeType: existing?.mimeType
             )
             try record.save(db)
         }
@@ -52,7 +60,8 @@ public final class AttachmentLocalStateWriter: AttachmentLocalStateWriterProtoco
                 revealedAt: nil,
                 width: existing?.width,
                 height: existing?.height,
-                isHiddenByOwner: true
+                isHiddenByOwner: true,
+                mimeType: existing?.mimeType
             )
             try record.save(db)
         }
@@ -63,6 +72,22 @@ public final class AttachmentLocalStateWriter: AttachmentLocalStateWriterProtoco
         conversationId: String,
         width: Int,
         height: Int
+    ) async throws {
+        try await saveWithDimensions(
+            attachmentKey: attachmentKey,
+            conversationId: conversationId,
+            width: width,
+            height: height,
+            mimeType: nil
+        )
+    }
+
+    public func saveWithDimensions(
+        attachmentKey: String,
+        conversationId: String,
+        width: Int,
+        height: Int,
+        mimeType: String?
     ) async throws {
         try await databaseWriter.write { db in
             if let existing = try AttachmentLocalState
@@ -75,7 +100,8 @@ public final class AttachmentLocalStateWriter: AttachmentLocalStateWriterProtoco
                     revealedAt: existing.revealedAt,
                     width: width,
                     height: height,
-                    isHiddenByOwner: existing.isHiddenByOwner
+                    isHiddenByOwner: existing.isHiddenByOwner,
+                    mimeType: mimeType ?? existing.mimeType
                 )
                 try updated.update(db)
             } else {
@@ -86,7 +112,8 @@ public final class AttachmentLocalStateWriter: AttachmentLocalStateWriterProtoco
                     revealedAt: nil,
                     width: width,
                     height: height,
-                    isHiddenByOwner: false
+                    isHiddenByOwner: false,
+                    mimeType: mimeType
                 )
                 try record.insert(db)
             }
@@ -109,7 +136,8 @@ public final class AttachmentLocalStateWriter: AttachmentLocalStateWriterProtoco
                 revealedAt: existing.revealedAt,
                 width: existing.width,
                 height: existing.height,
-                isHiddenByOwner: existing.isHiddenByOwner
+                isHiddenByOwner: existing.isHiddenByOwner,
+                mimeType: existing.mimeType
             )
             try migrated.save(db)
 

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationStateManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationStateManager.swift
@@ -209,6 +209,10 @@ public final class ConversationStateManager: ConversationStateManagerProtocol, @
         await stateMachine.cancelEagerUpload(trackingKey: trackingKey)
     }
 
+    public func sendVideo(at fileURL: URL) async throws -> String {
+        try await stateMachine.sendVideo(at: fileURL)
+    }
+
     public func sendReply(text: String, toMessageWithClientId parentClientMessageId: String) async throws {
         try await stateMachine.sendReply(text: text, toMessageWithClientId: parentClientMessageId)
     }

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationStateManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationStateManager.swift
@@ -209,8 +209,8 @@ public final class ConversationStateManager: ConversationStateManagerProtocol, @
         await stateMachine.cancelEagerUpload(trackingKey: trackingKey)
     }
 
-    public func sendVideo(at fileURL: URL) async throws -> String {
-        try await stateMachine.sendVideo(at: fileURL)
+    public func sendVideo(at fileURL: URL, replyToMessageId: String?) async throws -> String {
+        try await stateMachine.sendVideo(at: fileURL, replyToMessageId: replyToMessageId)
     }
 
     public func sendReply(text: String, toMessageWithClientId parentClientMessageId: String) async throws {

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/OutgoingMessageWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/OutgoingMessageWriter.swift
@@ -81,6 +81,14 @@ actor OutgoingMessageWriter: OutgoingMessageWriterProtocol {
         var replyContext: ReplyContext?
     }
 
+    private struct QueuedVideoMessage {
+        let clientMessageId: String
+        let localCacheURL: URL
+        let filename: String
+        let trackingKey: String
+        var replyContext: ReplyContext?
+    }
+
     private struct QueuedEagerPhoto {
         let trackingKey: String
     }
@@ -88,6 +96,7 @@ actor OutgoingMessageWriter: OutgoingMessageWriterProtocol {
     private enum QueuedMessage {
         case text(QueuedTextMessage)
         case photo(QueuedPhotoMessage)
+        case video(QueuedVideoMessage)
         case eagerPhoto(QueuedEagerPhoto)
     }
 
@@ -676,6 +685,8 @@ actor OutgoingMessageWriter: OutgoingMessageWriterProtocol {
                     try await publishText(queued)
                 case .photo(let queued):
                     try await publishPhoto(queued)
+                case .video(let queued):
+                    try await publishVideo(queued)
                 case .eagerPhoto(let queued):
                     try await processEagerPhoto(trackingKey: queued.trackingKey)
                 }
@@ -683,6 +694,8 @@ actor OutgoingMessageWriter: OutgoingMessageWriterProtocol {
                 switch message {
                 case .photo(let queued):
                     await markPhotoFailed(trackingKey: queued.localCacheURL.absoluteString)
+                case .video(let queued):
+                    await markPhotoFailed(trackingKey: queued.trackingKey)
                 case .eagerPhoto(let queued):
                     await markPhotoFailed(trackingKey: queued.trackingKey)
                 case .text:
@@ -932,6 +945,87 @@ actor OutgoingMessageWriter: OutgoingMessageWriterProtocol {
         )
     }
 
+    private func publishVideo(_ queued: QueuedVideoMessage) async throws {
+        let tracker = PhotoUploadProgressTracker.shared
+        tracker.setStage(.preparing, for: queued.trackingKey)
+
+        let inboxReady = try await inboxStateManager.waitForInboxReadyResult()
+
+        let videoData = try Data(contentsOf: queued.localCacheURL)
+        let attachment = Attachment(
+            filename: queued.filename,
+            mimeType: "video/mp4",
+            data: videoData
+        )
+
+        let encrypted = try RemoteAttachment.encodeEncrypted(
+            content: attachment,
+            codec: AttachmentCodec()
+        )
+
+        let presignedURLs = try await inboxReady.apiClient.getPresignedUploadURL(
+            filename: queued.filename,
+            contentType: "application/octet-stream"
+        )
+
+        guard let uploadURL = URL(string: presignedURLs.uploadURL) else {
+            tracker.setStage(.failed, for: queued.trackingKey)
+            try? await markMessageFailed(clientMessageId: queued.clientMessageId)
+            throw PhotoAttachmentError.invalidURL
+        }
+
+        let taskId = UUID().uuidString
+        let encryptedFileURL = try saveToTemp(data: encrypted.payload, taskId: taskId)
+
+        tracker.setProgress(stage: .uploading, percentage: 0, for: queued.trackingKey)
+
+        try await backgroundUploadManager.startUpload(
+            fileURL: encryptedFileURL,
+            uploadURL: uploadURL,
+            contentType: "application/octet-stream",
+            taskId: taskId
+        )
+
+        let result = await backgroundUploadManager.waitForCompletion(taskId: taskId)
+
+        guard result.success else {
+            tracker.setStage(.failed, for: queued.trackingKey)
+            try? await markMessageFailed(clientMessageId: queued.clientMessageId)
+            throw result.error ?? PhotoAttachmentError.uploadFailed("Video upload failed")
+        }
+
+        tracker.setStage(.publishing, for: queued.trackingKey)
+
+        let thumbnailImage = ImageCacheContainer.shared.image(for: queued.trackingKey)
+
+        let storedAttachment = StoredRemoteAttachment(
+            url: presignedURLs.assetURL,
+            contentDigest: encrypted.digest,
+            secret: encrypted.secret,
+            salt: encrypted.salt,
+            nonce: encrypted.nonce,
+            filename: queued.filename,
+            mimeType: "video/mp4",
+            mediaWidth: nil,
+            mediaHeight: nil,
+            mediaDuration: nil,
+            thumbnailDataBase64: thumbnailImage.flatMap { $0.jpegData(compressionQuality: 0.5)?.base64EncodedString() }
+        )
+
+        let messageId = try await publishAttachment(
+            storedAttachment: storedAttachment,
+            clientMessageId: queued.clientMessageId,
+            trackingKey: queued.trackingKey,
+            thumbnailImage: thumbnailImage,
+            inboxReady: inboxReady,
+            replyContext: queued.replyContext,
+            mediaType: "video"
+        )
+
+        try? FileManager.default.removeItem(at: encryptedFileURL)
+        QAEvent.emit(.message, "sent", ["id": messageId, "conversation": conversationId, "type": "video_retry"])
+    }
+
     private func completeXMTPSend(
         queued: QueuedPhotoMessage,
         prepared: PreparedBackgroundUpload,
@@ -1153,30 +1247,47 @@ actor OutgoingMessageWriter: OutgoingMessageWriterProtocol {
         }
 
         guard FileManager.default.fileExists(atPath: localFileURL.path) else {
-            Log.error("Cannot retry photo: local file no longer exists at \(localFileURL.path)")
+            Log.error("Cannot retry attachment: local file no longer exists at \(localFileURL.path)")
             return
         }
 
-        guard let imageData = try? Data(contentsOf: localFileURL),
-              let image = ImageType(data: imageData) else {
-            Log.error("Cannot retry photo: failed to load image from \(localFileURL.path)")
-            return
-        }
+        let isVideo = localFileURL.pathExtension.lowercased() == "mp4"
+            || localFileURL.pathExtension.lowercased() == "mov"
 
         try await databaseWriter.write { db in
             try message.with(status: .unpublished).save(db)
         }
 
-        let filename = localFileURL.lastPathComponent
-        let queued = QueuedPhotoMessage(
-            clientMessageId: message.clientMessageId,
-            image: image,
-            localCacheURL: localFileURL,
-            filename: filename,
-            replyContext: replyContext
-        )
-        messageQueue.append(.photo(queued))
-        startProcessingIfNeeded()
+        if isVideo {
+            let filename = localFileURL.lastPathComponent
+            let trackingKey = localFileURL.absoluteString
+            let queued = QueuedVideoMessage(
+                clientMessageId: message.clientMessageId,
+                localCacheURL: localFileURL,
+                filename: filename,
+                trackingKey: trackingKey,
+                replyContext: replyContext
+            )
+            messageQueue.append(.video(queued))
+            startProcessingIfNeeded()
+        } else {
+            guard let imageData = try? Data(contentsOf: localFileURL),
+                  let image = ImageType(data: imageData) else {
+                Log.error("Cannot retry photo: failed to load image from \(localFileURL.path)")
+                return
+            }
+
+            let filename = localFileURL.lastPathComponent
+            let queued = QueuedPhotoMessage(
+                clientMessageId: message.clientMessageId,
+                image: image,
+                localCacheURL: localFileURL,
+                filename: filename,
+                replyContext: replyContext
+            )
+            messageQueue.append(.photo(queued))
+            startProcessingIfNeeded()
+        }
     }
 
     private func resolveLocalCacheURL(from storedJSON: String) -> URL? {

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/OutgoingMessageWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/OutgoingMessageWriter.swift
@@ -487,25 +487,6 @@ actor OutgoingMessageWriter: OutgoingMessageWriterProtocol {
 
         let thumbnailBase64 = compressed.thumbnail.base64EncodedString()
 
-        let remoteAttachment = try RemoteAttachment(
-            url: presignedURLs.assetURL,
-            contentDigest: encrypted.digest,
-            secret: encrypted.secret,
-            salt: encrypted.salt,
-            nonce: encrypted.nonce,
-            scheme: .https,
-            contentLength: nil,
-            filename: filename
-        )
-
-        guard let sender = try await inboxReady.client.messageSender(for: conversationId) else {
-            tracker.setStage(.failed, for: trackingKey)
-            try? await markMessageFailed(clientMessageId: clientMessageId)
-            throw OutgoingMessageWriterError.missingClientProvider
-        }
-
-        let messageId = try await sender.prepare(remoteAttachment: remoteAttachment)
-
         let storedAttachment = StoredRemoteAttachment(
             url: presignedURLs.assetURL,
             contentDigest: encrypted.digest,
@@ -519,35 +500,15 @@ actor OutgoingMessageWriter: OutgoingMessageWriterProtocol {
             mediaDuration: compressed.duration,
             thumbnailDataBase64: thumbnailBase64
         )
-        guard let json = try? storedAttachment.toJSON() else {
-            tracker.setStage(.failed, for: trackingKey)
-            throw PhotoAttachmentError.encryptionFailed
-        }
 
-        if let thumbnailImage = ImageType(data: compressed.thumbnail) {
-            ImageCacheContainer.shared.cacheImage(thumbnailImage, for: json, storageTier: .persistent)
-        }
-
-        let attachmentUrlsJSON = try JSONEncoder().encode([json])
-        let attachmentUrlsString = String(data: attachmentUrlsJSON, encoding: .utf8) ?? "[]"
-
-        try await databaseWriter.write { db in
-            try db.execute(
-                sql: "UPDATE message SET id = ?, attachmentUrls = ? WHERE id = ?",
-                arguments: [messageId, attachmentUrlsString, clientMessageId]
-            )
-        }
-
-        try await attachmentLocalStateWriter.migrateKey(from: trackingKey, to: json)
-
-        try await sender.publish()
-
-        ImageCacheContainer.shared.removeImage(for: trackingKey)
-
-        try? await markMessagePublished(messageId: messageId)
-        tracker.setStage(.completed, for: trackingKey)
-        sentMessageSubject.send(json)
-        markPhotoPublished(trackingKey: trackingKey)
+        let messageId = try await publishAttachment(
+            storedAttachment: storedAttachment,
+            clientMessageId: clientMessageId,
+            trackingKey: trackingKey,
+            thumbnailImage: ImageType(data: compressed.thumbnail),
+            inboxReady: inboxReady,
+            mediaType: "video"
+        )
 
         try? FileManager.default.removeItem(at: encryptedFileURL)
         try? FileManager.default.removeItem(at: compressed.fileURL)
@@ -555,6 +516,91 @@ actor OutgoingMessageWriter: OutgoingMessageWriterProtocol {
         QAEvent.emit(.message, "sent", ["id": messageId, "conversation": conversationId, "type": "video"])
 
         return trackingKey
+    }
+
+    private func publishAttachment(
+        storedAttachment: StoredRemoteAttachment,
+        clientMessageId: String,
+        trackingKey: String,
+        thumbnailImage: ImageType?,
+        inboxReady: InboxReadyResult,
+        replyContext: ReplyContext? = nil,
+        mediaType: String = "photo"
+    ) async throws -> String {
+        let tracker = PhotoUploadProgressTracker.shared
+
+        guard let json = try? storedAttachment.toJSON() else {
+            tracker.setStage(.failed, for: trackingKey)
+            throw PhotoAttachmentError.encryptionFailed
+        }
+
+        let remoteAttachment = try RemoteAttachment(
+            url: storedAttachment.url,
+            contentDigest: storedAttachment.contentDigest,
+            secret: storedAttachment.secret,
+            salt: storedAttachment.salt,
+            nonce: storedAttachment.nonce,
+            scheme: .https,
+            contentLength: nil,
+            filename: storedAttachment.filename
+        )
+
+        guard let sender = try await inboxReady.client.messageSender(for: conversationId) else {
+            tracker.setStage(.failed, for: trackingKey)
+            try? await markMessageFailed(clientMessageId: clientMessageId)
+            throw OutgoingMessageWriterError.missingClientProvider
+        }
+
+        do {
+            let messageId: String
+            if let replyContext {
+                let reply = Reply(reference: replyContext.parentDbId, content: remoteAttachment, contentType: ContentTypeRemoteAttachment)
+                messageId = try await sender.prepare(reply: reply)
+            } else {
+                messageId = try await sender.prepare(remoteAttachment: remoteAttachment)
+            }
+
+            if let thumbnailImage {
+                ImageCacheContainer.shared.cacheImage(thumbnailImage, for: json, storageTier: .persistent)
+            }
+
+            let attachmentUrlsJSON = try JSONEncoder().encode([json])
+            let attachmentUrlsString = String(data: attachmentUrlsJSON, encoding: .utf8) ?? "[]"
+
+            try await databaseWriter.write { db in
+                try db.execute(
+                    sql: """
+                        UPDATE message
+                        SET id = ?, attachmentUrls = ?
+                        WHERE id = ?
+                        """,
+                    arguments: [messageId, attachmentUrlsString, clientMessageId]
+                )
+                if replyContext != nil {
+                    try db.execute(
+                        sql: "UPDATE message SET sourceMessageId = ? WHERE sourceMessageId = ?",
+                        arguments: [messageId, clientMessageId]
+                    )
+                }
+            }
+
+            try await attachmentLocalStateWriter.migrateKey(from: trackingKey, to: json)
+
+            try await sender.publish()
+
+            ImageCacheContainer.shared.removeImage(for: trackingKey)
+
+            try? await markMessagePublished(messageId: messageId)
+            tracker.setStage(.completed, for: trackingKey)
+            sentMessageSubject.send(json)
+            markPhotoPublished(trackingKey: trackingKey)
+
+            return messageId
+        } catch {
+            tracker.setStage(.failed, for: trackingKey)
+            try? await markMessageFailed(clientMessageId: clientMessageId)
+            throw error
+        }
     }
 
     private func saveToTemp(data: Data, taskId: String) throws -> URL {
@@ -884,121 +930,42 @@ actor OutgoingMessageWriter: OutgoingMessageWriterProtocol {
         replyContext: ReplyContext? = nil
     ) async throws {
         let perfStart = CFAbsoluteTimeGetCurrent()
-        let tracker = PhotoUploadProgressTracker.shared
 
-        guard let sender = try await inboxReady.client.messageSender(for: conversationId) else {
-            tracker.setStage(.failed, for: trackingKey)
-            try await pendingUploadWriter.updateState(
-                taskId: prepared.taskId,
-                state: .failed,
-                errorMessage: "No message sender"
-            )
-            try? await markMessageFailed(clientMessageId: queued.clientMessageId)
-            throw OutgoingMessageWriterError.missingClientProvider
-        }
+        let storedAttachment = StoredRemoteAttachment(
+            url: prepared.assetURL,
+            contentDigest: prepared.contentDigest,
+            secret: prepared.encryptionSecret,
+            salt: prepared.encryptionSalt,
+            nonce: prepared.encryptionNonce,
+            filename: prepared.filename
+        )
 
-        let publishResult: (xmtpMessageId: String, storedJSON: String)
-
+        let messageId: String
         do {
-            let remoteAttachment = try RemoteAttachment(
-                url: prepared.assetURL,
-                contentDigest: prepared.contentDigest,
-                secret: prepared.encryptionSecret,
-                salt: prepared.encryptionSalt,
-                nonce: prepared.encryptionNonce,
-                scheme: .https,
-                contentLength: nil,
-                filename: prepared.filename
+            messageId = try await publishAttachment(
+                storedAttachment: storedAttachment,
+                clientMessageId: queued.clientMessageId,
+                trackingKey: trackingKey,
+                thumbnailImage: queued.image,
+                inboxReady: inboxReady,
+                replyContext: replyContext
             )
-
-            let messageId: String
-            if let replyContext {
-                let reply = Reply(reference: replyContext.parentDbId, content: remoteAttachment, contentType: ContentTypeRemoteAttachment)
-                messageId = try await sender.prepare(reply: reply)
-            } else {
-                messageId = try await sender.prepare(remoteAttachment: remoteAttachment)
-            }
-            Log.debug("Prepared photo message - XMTP id: \(messageId), clientMessageId: \(queued.clientMessageId)")
-
-            let storedAttachment = StoredRemoteAttachment(
-                url: remoteAttachment.url,
-                contentDigest: remoteAttachment.contentDigest,
-                secret: remoteAttachment.secret,
-                salt: remoteAttachment.salt,
-                nonce: remoteAttachment.nonce,
-                filename: remoteAttachment.filename
-            )
-            guard let json = try? storedAttachment.toJSON() else {
-                tracker.setStage(.failed, for: trackingKey)
-                try await pendingUploadWriter.updateState(
-                    taskId: prepared.taskId,
-                    state: .failed,
-                    errorMessage: "JSON encoding failed"
-                )
-                throw PhotoAttachmentError.encryptionFailed
-            }
-
-            ImageCacheContainer.shared.cacheImage(queued.image, for: json, storageTier: .persistent)
-
-            let attachmentUrlsJSON = try JSONEncoder().encode([json])
-            let attachmentUrlsString = String(data: attachmentUrlsJSON, encoding: .utf8) ?? "[]"
-
-            let oldAttachmentKey = queued.localCacheURL.absoluteString
-            Log.debug("[OutgoingMessageWriter] About to update DB. Old key: \(oldAttachmentKey.prefix(60))...")
-            Log.debug("[OutgoingMessageWriter] New key (storedJSON): \(json.prefix(80))...")
-
-            let clientMessageId = queued.clientMessageId
-            try await databaseWriter.write { db in
-                try db.execute(
-                    sql: """
-                        UPDATE message
-                        SET id = ?, attachmentUrls = ?
-                        WHERE id = ?
-                        """,
-                    arguments: [messageId, attachmentUrlsString, clientMessageId]
-                )
-                try db.execute(
-                    sql: "UPDATE message SET sourceMessageId = ? WHERE sourceMessageId = ?",
-                    arguments: [messageId, clientMessageId]
-                )
-                Log.debug("Updated photo message - id: \(messageId), clientMessageId: \(clientMessageId)")
-            }
-
-            try await attachmentLocalStateWriter.migrateKey(from: oldAttachmentKey, to: json)
-
-            try await sender.publish()
-
-            ImageCacheContainer.shared.removeImage(for: oldAttachmentKey)
-
-            publishResult = (xmtpMessageId: messageId, storedJSON: json)
         } catch {
-            tracker.setStage(.failed, for: trackingKey)
             Log.error("Failed publishing photo message: \(error)")
-            try await pendingUploadWriter.updateState(
+            try? await pendingUploadWriter.updateState(
                 taskId: prepared.taskId,
                 state: .failed,
                 errorMessage: error.localizedDescription
             )
-            try? await markMessageFailed(clientMessageId: queued.clientMessageId)
             throw error
         }
 
-        do {
-            try await markMessagePublished(messageId: publishResult.xmtpMessageId)
-        } catch {
-            Log.error("Failed to update photo message status after successful publish: \(error)")
-        }
         let perfElapsed = String(format: "%.0f", (CFAbsoluteTimeGetCurrent() - perfStart) * 1000)
-        Log.info("[PERF] message.publish_photo: \(perfElapsed)ms id=\(publishResult.xmtpMessageId)")
-        QAEvent.emit(.message, "sent", ["id": publishResult.xmtpMessageId, "conversation": conversationId, "type": "photo"])
+        Log.info("[PERF] message.publish_photo: \(perfElapsed)ms id=\(messageId)")
+        QAEvent.emit(.message, "sent", ["id": messageId, "conversation": conversationId, "type": "photo"])
 
         try? await pendingUploadWriter.delete(taskId: prepared.taskId)
         try? FileManager.default.removeItem(at: prepared.encryptedFileURL)
-
-        tracker.setStage(.completed, for: trackingKey)
-        sentMessageSubject.send(publishResult.storedJSON)
-
-        markPhotoPublished(trackingKey: trackingKey)
     }
 
     // MARK: - Status Updates

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/OutgoingMessageWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/OutgoingMessageWriter.swift
@@ -487,7 +487,7 @@ actor OutgoingMessageWriter: OutgoingMessageWriterProtocol {
 
         let thumbnailBase64 = compressed.thumbnail.base64EncodedString()
 
-        var remoteAttachment = try RemoteAttachment(
+        let remoteAttachment = try RemoteAttachment(
             url: presignedURLs.assetURL,
             contentDigest: encrypted.digest,
             secret: encrypted.secret,

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/OutgoingMessageWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/OutgoingMessageWriter.swift
@@ -25,7 +25,7 @@ public protocol OutgoingMessageWriterProtocol: Sendable {
 
     /// Send a video from a local file URL.
     /// Returns a tracking key for dependency management.
-    func sendVideo(at fileURL: URL) async throws -> String
+    func sendVideo(at fileURL: URL, replyToMessageId: String?) async throws -> String
 
     /// Send a text reply to an existing message.
     func sendReply(text: String, toMessageWithClientId parentClientMessageId: String) async throws
@@ -407,7 +407,7 @@ actor OutgoingMessageWriter: OutgoingMessageWriterProtocol {
 
     // MARK: - Video
 
-    func sendVideo(at fileURL: URL) async throws -> String {
+    func sendVideo(at fileURL: URL, replyToMessageId: String? = nil) async throws -> String {
         let compressionService = VideoCompressionService()
         let compressed = try await compressionService.compressVideo(at: fileURL)
 
@@ -435,87 +435,99 @@ actor OutgoingMessageWriter: OutgoingMessageWriterProtocol {
             mimeType: compressed.mimeType
         )
 
-        try await savePhotoToDatabase(clientMessageId: clientMessageId, localCacheURL: localCacheURL)
+        var replyContext: ReplyContext?
+        if let replyToMessageId {
+            replyContext = try await resolveReplyContext(parentClientMessageId: replyToMessageId)
+        }
+
+        try await savePhotoToDatabase(clientMessageId: clientMessageId, localCacheURL: localCacheURL, replyContext: replyContext)
 
         let tracker = PhotoUploadProgressTracker.shared
         tracker.setStage(.preparing, for: trackingKey)
 
-        let inboxReady = try await inboxStateManager.waitForInboxReadyResult()
+        do {
+            let inboxReady = try await inboxStateManager.waitForInboxReadyResult()
 
-        let videoData = try Data(contentsOf: compressed.fileURL)
-        let attachment = Attachment(
-            filename: filename,
-            mimeType: "video/mp4",
-            data: videoData
-        )
+            let videoData = try Data(contentsOf: compressed.fileURL)
+            let attachment = Attachment(
+                filename: filename,
+                mimeType: "video/mp4",
+                data: videoData
+            )
 
-        let encrypted = try RemoteAttachment.encodeEncrypted(
-            content: attachment,
-            codec: AttachmentCodec()
-        )
+            let encrypted = try RemoteAttachment.encodeEncrypted(
+                content: attachment,
+                codec: AttachmentCodec()
+            )
 
-        let presignedURLs = try await inboxReady.apiClient.getPresignedUploadURL(
-            filename: filename,
-            contentType: "application/octet-stream"
-        )
+            let presignedURLs = try await inboxReady.apiClient.getPresignedUploadURL(
+                filename: filename,
+                contentType: "application/octet-stream"
+            )
 
-        guard let uploadURL = URL(string: presignedURLs.uploadURL) else {
-            throw PhotoAttachmentError.invalidURL
-        }
+            guard let uploadURL = URL(string: presignedURLs.uploadURL) else {
+                throw PhotoAttachmentError.invalidURL
+            }
 
-        let taskId = UUID().uuidString
-        let encryptedFileURL = try saveToTemp(data: encrypted.payload, taskId: taskId)
+            let taskId = UUID().uuidString
+            let encryptedFileURL = try saveToTemp(data: encrypted.payload, taskId: taskId)
 
-        tracker.setProgress(stage: .uploading, percentage: 0, for: trackingKey)
+            tracker.setProgress(stage: .uploading, percentage: 0, for: trackingKey)
 
-        try await backgroundUploadManager.startUpload(
-            fileURL: encryptedFileURL,
-            uploadURL: uploadURL,
-            contentType: "application/octet-stream",
-            taskId: taskId
-        )
+            try await backgroundUploadManager.startUpload(
+                fileURL: encryptedFileURL,
+                uploadURL: uploadURL,
+                contentType: "application/octet-stream",
+                taskId: taskId
+            )
 
-        let result = await backgroundUploadManager.waitForCompletion(taskId: taskId)
+            let result = await backgroundUploadManager.waitForCompletion(taskId: taskId)
 
-        guard result.success else {
+            guard result.success else {
+                tracker.setStage(.failed, for: trackingKey)
+                try? await markMessageFailed(clientMessageId: clientMessageId)
+                throw result.error ?? PhotoAttachmentError.uploadFailed("Video upload failed")
+            }
+
+            tracker.setStage(.publishing, for: trackingKey)
+
+            let thumbnailBase64 = compressed.thumbnail.base64EncodedString()
+
+            let storedAttachment = StoredRemoteAttachment(
+                url: presignedURLs.assetURL,
+                contentDigest: encrypted.digest,
+                secret: encrypted.secret,
+                salt: encrypted.salt,
+                nonce: encrypted.nonce,
+                filename: filename,
+                mimeType: "video/mp4",
+                mediaWidth: compressed.width,
+                mediaHeight: compressed.height,
+                mediaDuration: compressed.duration,
+                thumbnailDataBase64: thumbnailBase64
+            )
+
+            let messageId = try await publishAttachment(
+                storedAttachment: storedAttachment,
+                clientMessageId: clientMessageId,
+                trackingKey: trackingKey,
+                thumbnailImage: ImageType(data: compressed.thumbnail),
+                inboxReady: inboxReady,
+                replyContext: replyContext,
+                mediaType: "video"
+            )
+
+            try? FileManager.default.removeItem(at: encryptedFileURL)
+            try? FileManager.default.removeItem(at: compressed.fileURL)
+
+            QAEvent.emit(.message, "sent", ["id": messageId, "conversation": conversationId, "type": "video"])
+
+            return trackingKey
+        } catch {
             tracker.setStage(.failed, for: trackingKey)
             try? await markMessageFailed(clientMessageId: clientMessageId)
-            throw result.error ?? PhotoAttachmentError.uploadFailed("Video upload failed")
+            throw error
         }
-
-        tracker.setStage(.publishing, for: trackingKey)
-
-        let thumbnailBase64 = compressed.thumbnail.base64EncodedString()
-
-        let storedAttachment = StoredRemoteAttachment(
-            url: presignedURLs.assetURL,
-            contentDigest: encrypted.digest,
-            secret: encrypted.secret,
-            salt: encrypted.salt,
-            nonce: encrypted.nonce,
-            filename: filename,
-            mimeType: "video/mp4",
-            mediaWidth: compressed.width,
-            mediaHeight: compressed.height,
-            mediaDuration: compressed.duration,
-            thumbnailDataBase64: thumbnailBase64
-        )
-
-        let messageId = try await publishAttachment(
-            storedAttachment: storedAttachment,
-            clientMessageId: clientMessageId,
-            trackingKey: trackingKey,
-            thumbnailImage: ImageType(data: compressed.thumbnail),
-            inboxReady: inboxReady,
-            mediaType: "video"
-        )
-
-        try? FileManager.default.removeItem(at: encryptedFileURL)
-        try? FileManager.default.removeItem(at: compressed.fileURL)
-
-        QAEvent.emit(.message, "sent", ["id": messageId, "conversation": conversationId, "type": "video"])
-
-        return trackingKey
     }
 
     private func publishAttachment(
@@ -576,12 +588,10 @@ actor OutgoingMessageWriter: OutgoingMessageWriterProtocol {
                         """,
                     arguments: [messageId, attachmentUrlsString, clientMessageId]
                 )
-                if replyContext != nil {
-                    try db.execute(
-                        sql: "UPDATE message SET sourceMessageId = ? WHERE sourceMessageId = ?",
-                        arguments: [messageId, clientMessageId]
-                    )
-                }
+                try db.execute(
+                    sql: "UPDATE message SET sourceMessageId = ? WHERE sourceMessageId = ?",
+                    arguments: [messageId, clientMessageId]
+                )
             }
 
             try await attachmentLocalStateWriter.migrateKey(from: trackingKey, to: json)

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/OutgoingMessageWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/OutgoingMessageWriter.swift
@@ -1,3 +1,4 @@
+import AVFoundation
 import Combine
 import Foundation
 import GRDB
@@ -21,6 +22,10 @@ public protocol OutgoingMessageWriterProtocol: Sendable {
     func cancelEagerUpload(trackingKey: String) async
 
     // MARK: - Replies
+
+    /// Send a video from a local file URL.
+    /// Returns a tracking key for dependency management.
+    func sendVideo(at fileURL: URL) async throws -> String
 
     /// Send a text reply to an existing message.
     func sendReply(text: String, toMessageWithClientId parentClientMessageId: String) async throws
@@ -398,6 +403,165 @@ actor OutgoingMessageWriter: OutgoingMessageWriterProtocol {
 
         await markPhotoFailed(trackingKey: trackingKey)
         eagerUploads.removeValue(forKey: trackingKey)
+    }
+
+    // MARK: - Video
+
+    func sendVideo(at fileURL: URL) async throws -> String {
+        let compressionService = VideoCompressionService()
+        let compressed = try await compressionService.compressVideo(at: fileURL)
+
+        let clientMessageId = UUID().uuidString
+        let filename = "video_\(Int(Date().timeIntervalSince1970))_\(UUID().uuidString.prefix(8)).mp4"
+        let localCacheURL = try photoService.localCacheURL(for: filename)
+
+        try FileManager.default.createDirectory(
+            at: localCacheURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try FileManager.default.copyItem(at: compressed.fileURL, to: localCacheURL)
+
+        let trackingKey = localCacheURL.absoluteString
+
+        if let thumbnailImage = ImageType(data: compressed.thumbnail) {
+            ImageCacheContainer.shared.cacheImage(thumbnailImage, for: trackingKey, storageTier: .persistent)
+        }
+
+        try await attachmentLocalStateWriter.saveWithDimensions(
+            attachmentKey: trackingKey,
+            conversationId: conversationId,
+            width: compressed.width,
+            height: compressed.height,
+            mimeType: compressed.mimeType
+        )
+
+        try await savePhotoToDatabase(clientMessageId: clientMessageId, localCacheURL: localCacheURL)
+
+        let tracker = PhotoUploadProgressTracker.shared
+        tracker.setStage(.preparing, for: trackingKey)
+
+        let inboxReady = try await inboxStateManager.waitForInboxReadyResult()
+
+        let videoData = try Data(contentsOf: compressed.fileURL)
+        let attachment = Attachment(
+            filename: filename,
+            mimeType: "video/mp4",
+            data: videoData
+        )
+
+        let encrypted = try RemoteAttachment.encodeEncrypted(
+            content: attachment,
+            codec: AttachmentCodec()
+        )
+
+        let presignedURLs = try await inboxReady.apiClient.getPresignedUploadURL(
+            filename: filename,
+            contentType: "application/octet-stream"
+        )
+
+        guard let uploadURL = URL(string: presignedURLs.uploadURL) else {
+            throw PhotoAttachmentError.invalidURL
+        }
+
+        let taskId = UUID().uuidString
+        let encryptedFileURL = try saveToTemp(data: encrypted.payload, taskId: taskId)
+
+        tracker.setProgress(stage: .uploading, percentage: 0, for: trackingKey)
+
+        try await backgroundUploadManager.startUpload(
+            fileURL: encryptedFileURL,
+            uploadURL: uploadURL,
+            contentType: "application/octet-stream",
+            taskId: taskId
+        )
+
+        let result = await backgroundUploadManager.waitForCompletion(taskId: taskId)
+
+        guard result.success else {
+            tracker.setStage(.failed, for: trackingKey)
+            try? await markMessageFailed(clientMessageId: clientMessageId)
+            throw result.error ?? PhotoAttachmentError.uploadFailed("Video upload failed")
+        }
+
+        tracker.setStage(.publishing, for: trackingKey)
+
+        let thumbnailBase64 = compressed.thumbnail.base64EncodedString()
+
+        var remoteAttachment = try RemoteAttachment(
+            url: presignedURLs.assetURL,
+            contentDigest: encrypted.digest,
+            secret: encrypted.secret,
+            salt: encrypted.salt,
+            nonce: encrypted.nonce,
+            scheme: .https,
+            contentLength: nil,
+            filename: filename
+        )
+
+        guard let sender = try await inboxReady.client.messageSender(for: conversationId) else {
+            tracker.setStage(.failed, for: trackingKey)
+            try? await markMessageFailed(clientMessageId: clientMessageId)
+            throw OutgoingMessageWriterError.missingClientProvider
+        }
+
+        let messageId = try await sender.prepare(remoteAttachment: remoteAttachment)
+
+        let storedAttachment = StoredRemoteAttachment(
+            url: presignedURLs.assetURL,
+            contentDigest: encrypted.digest,
+            secret: encrypted.secret,
+            salt: encrypted.salt,
+            nonce: encrypted.nonce,
+            filename: filename,
+            mimeType: "video/mp4",
+            mediaWidth: compressed.width,
+            mediaHeight: compressed.height,
+            mediaDuration: compressed.duration,
+            thumbnailDataBase64: thumbnailBase64
+        )
+        guard let json = try? storedAttachment.toJSON() else {
+            tracker.setStage(.failed, for: trackingKey)
+            throw PhotoAttachmentError.encryptionFailed
+        }
+
+        if let thumbnailImage = ImageType(data: compressed.thumbnail) {
+            ImageCacheContainer.shared.cacheImage(thumbnailImage, for: json, storageTier: .persistent)
+        }
+
+        let attachmentUrlsJSON = try JSONEncoder().encode([json])
+        let attachmentUrlsString = String(data: attachmentUrlsJSON, encoding: .utf8) ?? "[]"
+
+        try await databaseWriter.write { db in
+            try db.execute(
+                sql: "UPDATE message SET id = ?, attachmentUrls = ? WHERE id = ?",
+                arguments: [messageId, attachmentUrlsString, clientMessageId]
+            )
+        }
+
+        try await attachmentLocalStateWriter.migrateKey(from: trackingKey, to: json)
+
+        try await sender.publish()
+
+        ImageCacheContainer.shared.removeImage(for: trackingKey)
+
+        try? await markMessagePublished(messageId: messageId)
+        tracker.setStage(.completed, for: trackingKey)
+        sentMessageSubject.send(json)
+        markPhotoPublished(trackingKey: trackingKey)
+
+        try? FileManager.default.removeItem(at: encryptedFileURL)
+        try? FileManager.default.removeItem(at: compressed.fileURL)
+
+        QAEvent.emit(.message, "sent", ["id": messageId, "conversation": conversationId, "type": "video"])
+
+        return trackingKey
+    }
+
+    private func saveToTemp(data: Data, taskId: String) throws -> URL {
+        let tempDir = FileManager.default.temporaryDirectory
+        let fileURL = tempDir.appendingPathComponent("\(taskId).enc")
+        try data.write(to: fileURL)
+        return fileURL
     }
 
     // MARK: - Replies

--- a/ConvosCore/Sources/ConvosCore/Storage/XMTP DB Representations/DecodedMessage+DBRepresentation.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/XMTP DB Representations/DecodedMessage+DBRepresentation.swift
@@ -186,9 +186,6 @@ extension XMTPiOS.DecodedMessage {
             guard let attachment = contentReply.content as? Attachment else {
                 throw DecodedMessageDBRepresentationError.mismatchedContentType
             }
-            guard attachment.mimeType.hasPrefix("image/") else {
-                throw DecodedMessageDBRepresentationError.unsupportedContentType
-            }
             let fileURL = try Self.saveInlineAttachment(data: attachment.data, messageId: id, filename: attachment.filename)
             return DBMessageComponents(
                 messageType: .reply,
@@ -255,9 +252,6 @@ extension XMTPiOS.DecodedMessage {
         let content = try content() as Any
         guard let attachment = content as? Attachment else {
             throw DecodedMessageDBRepresentationError.mismatchedContentType
-        }
-        guard attachment.mimeType.hasPrefix("image/") else {
-            throw DecodedMessageDBRepresentationError.unsupportedContentType
         }
         let fileURL = try Self.saveInlineAttachment(data: attachment.data, messageId: id, filename: attachment.filename)
         return DBMessageComponents(

--- a/ConvosCore/Tests/ConvosCoreTests/VideoMessageTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/VideoMessageTests.swift
@@ -181,4 +181,66 @@ struct VideoMessageTests {
     func testMaxFileSize() {
         #expect(VideoCompressionService.maxFileSizeBytes == 25 * 1024 * 1024)
     }
+
+    // MARK: - Attachments Preview String
+
+    @Test("Single photo attachment shows 'a photo'")
+    func testPreviewStringSinglePhoto() {
+        let photoJSON = makePhotoJSON()
+        let result = DBLastMessageWithSource.attachmentsPreviewString(attachmentUrls: [photoJSON], count: 1)
+        #expect(result == "a photo")
+    }
+
+    @Test("Single video attachment shows 'a video'")
+    func testPreviewStringSingleVideo() {
+        let videoJSON = makeVideoJSON()
+        let result = DBLastMessageWithSource.attachmentsPreviewString(attachmentUrls: [videoJSON], count: 1)
+        #expect(result == "a video")
+    }
+
+    @Test("Multiple photos shows 'N photos'")
+    func testPreviewStringMultiplePhotos() {
+        let photoJSON = makePhotoJSON()
+        let result = DBLastMessageWithSource.attachmentsPreviewString(attachmentUrls: [photoJSON, photoJSON], count: 2)
+        #expect(result == "2 photos")
+    }
+
+    @Test("Mixed video and photo shows 'N attachments'")
+    func testPreviewStringMixedAttachments() {
+        let videoJSON = makeVideoJSON()
+        let photoJSON = makePhotoJSON()
+        let result = DBLastMessageWithSource.attachmentsPreviewString(attachmentUrls: [videoJSON, photoJSON], count: 2)
+        #expect(result == "2 attachments")
+    }
+
+    @Test("Non-JSON attachment key defaults to 'a photo'")
+    func testPreviewStringNonJSONKey() {
+        let result = DBLastMessageWithSource.attachmentsPreviewString(attachmentUrls: ["file://local/path"], count: 1)
+        #expect(result == "a photo")
+    }
+
+    private func makePhotoJSON() -> String {
+        let stored = StoredRemoteAttachment(
+            url: "https://example.com/photo.enc",
+            contentDigest: "abc",
+            secret: Data("s".utf8),
+            salt: Data("s".utf8),
+            nonce: Data("n".utf8),
+            filename: "photo.jpg"
+        )
+        return (try? stored.toJSON()) ?? ""
+    }
+
+    private func makeVideoJSON() -> String {
+        let stored = StoredRemoteAttachment(
+            url: "https://example.com/video.enc",
+            contentDigest: "abc",
+            secret: Data("s".utf8),
+            salt: Data("s".utf8),
+            nonce: Data("n".utf8),
+            filename: "video.mp4",
+            mimeType: "video/mp4"
+        )
+        return (try? stored.toJSON()) ?? ""
+    }
 }

--- a/ConvosCore/Tests/ConvosCoreTests/VideoMessageTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/VideoMessageTests.swift
@@ -1,0 +1,184 @@
+import Foundation
+import Testing
+@testable import ConvosCore
+
+@Suite("Video Message Tests")
+struct VideoMessageTests {
+    // MARK: - MediaType
+
+    @Test("MediaType from video mimeType")
+    func testMediaTypeVideo() {
+        let attachment = HydratedAttachment(key: "test", mimeType: "video/mp4")
+        #expect(attachment.mediaType == .video)
+    }
+
+    @Test("MediaType from video/quicktime mimeType")
+    func testMediaTypeVideoQuicktime() {
+        let attachment = HydratedAttachment(key: "test", mimeType: "video/quicktime")
+        #expect(attachment.mediaType == .video)
+    }
+
+    @Test("MediaType from image mimeType")
+    func testMediaTypeImage() {
+        let attachment = HydratedAttachment(key: "test", mimeType: "image/jpeg")
+        #expect(attachment.mediaType == .image)
+    }
+
+    @Test("MediaType defaults to image when nil")
+    func testMediaTypeDefaultsToImage() {
+        let attachment = HydratedAttachment(key: "test")
+        #expect(attachment.mediaType == .image)
+    }
+
+    @Test("MediaType audio")
+    func testMediaTypeAudio() {
+        let attachment = HydratedAttachment(key: "test", mimeType: "audio/mpeg")
+        #expect(attachment.mediaType == .audio)
+    }
+
+    @Test("MediaType file for unknown types")
+    func testMediaTypeFile() {
+        let attachment = HydratedAttachment(key: "test", mimeType: "application/pdf")
+        #expect(attachment.mediaType == .file)
+    }
+
+    // MARK: - HydratedAttachment properties
+
+    @Test("thumbnailData decodes base64")
+    func testThumbnailData() {
+        let originalData = Data("test thumbnail".utf8)
+        let base64 = originalData.base64EncodedString()
+        let attachment = HydratedAttachment(key: "test", thumbnailDataBase64: base64)
+        #expect(attachment.thumbnailData == originalData)
+    }
+
+    @Test("thumbnailData returns nil when no base64")
+    func testThumbnailDataNil() {
+        let attachment = HydratedAttachment(key: "test")
+        #expect(attachment.thumbnailData == nil)
+    }
+
+    @Test("aspectRatio computed from width and height")
+    func testAspectRatio() {
+        let attachment = HydratedAttachment(key: "test", width: 1920, height: 1080)
+        let expected = CGFloat(1920) / CGFloat(1080)
+        #expect(attachment.aspectRatio == expected)
+    }
+
+    @Test("aspectRatio nil when height is zero")
+    func testAspectRatioZeroHeight() {
+        let attachment = HydratedAttachment(key: "test", width: 100, height: 0)
+        #expect(attachment.aspectRatio == nil)
+    }
+
+    @Test("aspectRatio nil when dimensions missing")
+    func testAspectRatioNilDimensions() {
+        let attachment = HydratedAttachment(key: "test")
+        #expect(attachment.aspectRatio == nil)
+    }
+
+    @Test("duration stored on attachment")
+    func testDuration() {
+        let attachment = HydratedAttachment(key: "test", duration: 10.5)
+        #expect(attachment.duration == 10.5)
+    }
+
+    // MARK: - StoredRemoteAttachment video metadata
+
+    @Test("StoredRemoteAttachment round-trips video metadata through JSON")
+    func testStoredAttachmentVideoMetadata() throws {
+        let stored = StoredRemoteAttachment(
+            url: "https://example.com/video.enc",
+            contentDigest: "abc123",
+            secret: Data("secret".utf8),
+            salt: Data("salt".utf8),
+            nonce: Data("nonce".utf8),
+            filename: "video.mp4",
+            mimeType: "video/mp4",
+            mediaWidth: 568,
+            mediaHeight: 320,
+            mediaDuration: 10.0,
+            thumbnailDataBase64: "dGh1bWJuYWls"
+        )
+
+        let json = try stored.toJSON()
+        let decoded = try StoredRemoteAttachment.fromJSON(json)
+
+        #expect(decoded.mimeType == "video/mp4")
+        #expect(decoded.mediaWidth == 568)
+        #expect(decoded.mediaHeight == 320)
+        #expect(decoded.mediaDuration == 10.0)
+        #expect(decoded.thumbnailDataBase64 == "dGh1bWJuYWls")
+        #expect(decoded.filename == "video.mp4")
+    }
+
+    @Test("StoredRemoteAttachment backward compatible with photo-only JSON")
+    func testStoredAttachmentBackwardCompatible() throws {
+        let stored = StoredRemoteAttachment(
+            url: "https://example.com/photo.enc",
+            contentDigest: "abc123",
+            secret: Data("secret".utf8),
+            salt: Data("salt".utf8),
+            nonce: Data("nonce".utf8),
+            filename: "photo.jpg"
+        )
+
+        let json = try stored.toJSON()
+        let decoded = try StoredRemoteAttachment.fromJSON(json)
+
+        #expect(decoded.mimeType == nil)
+        #expect(decoded.mediaWidth == nil)
+        #expect(decoded.mediaHeight == nil)
+        #expect(decoded.mediaDuration == nil)
+        #expect(decoded.thumbnailDataBase64 == nil)
+    }
+
+    @Test("StoredRemoteAttachment decodes legacy JSON without video fields")
+    func testLegacyJSONDecoding() throws {
+        let legacyJSON = """
+        {"contentDigest":"abc","filename":"photo.jpg","nonce":"bm9uY2U=","salt":"c2FsdA==","secret":"c2VjcmV0","url":"https://example.com/photo.enc"}
+        """
+        let decoded = try StoredRemoteAttachment.fromJSON(legacyJSON)
+        #expect(decoded.mimeType == nil)
+        #expect(decoded.mediaWidth == nil)
+        #expect(decoded.mediaDuration == nil)
+    }
+
+    // MARK: - Hydration
+
+    @Test("hydrateAttachment extracts video metadata from StoredRemoteAttachment JSON key")
+    func testHydrateAttachmentFromJSON() throws {
+        let stored = StoredRemoteAttachment(
+            url: "https://example.com/video.enc",
+            contentDigest: "abc",
+            secret: Data("secret".utf8),
+            salt: Data("salt".utf8),
+            nonce: Data("nonce".utf8),
+            filename: "video.mp4",
+            mimeType: "video/mp4",
+            mediaWidth: 1280,
+            mediaHeight: 720,
+            mediaDuration: 15.5,
+            thumbnailDataBase64: "dGh1bWI="
+        )
+        let key = try stored.toJSON()
+
+        let hydrated = HydratedAttachment(
+            key: key,
+            mimeType: stored.mimeType,
+            duration: stored.mediaDuration,
+            thumbnailDataBase64: stored.thumbnailDataBase64
+        )
+
+        #expect(hydrated.mediaType == .video)
+        #expect(hydrated.duration == 15.5)
+        #expect(hydrated.thumbnailData == Data(base64Encoded: "dGh1bWI="))
+    }
+
+    // MARK: - VideoCompressionService
+
+    @Test("VideoCompressionService max file size is 25MB")
+    func testMaxFileSize() {
+        #expect(VideoCompressionService.maxFileSizeBytes == 25 * 1024 * 1024)
+    }
+}

--- a/docs/plans/video-messages.md
+++ b/docs/plans/video-messages.md
@@ -1,0 +1,181 @@
+# Video Messages
+
+## Problem
+
+Convos currently supports sending and receiving photos but not video. Users expect to share short video clips in a messaging app. The attachment system is also tightly coupled to images — hardcoded MIME type checks, image-only compression, and `UIImage`-specific display code. Adding video support requires generalizing the attachment pipeline to handle multiple media types, with an architecture that extends naturally to future content types (audio notes, files, etc.).
+
+## Goals
+
+- Send and receive video messages up to 25MB
+- Inline playback in the messages list (full-bleed, matching photo layout)
+- Instant thumbnail preview before video downloads
+- Progressive playback (play while downloading)
+- Generalize the attachment model with a `mimeType` field for future content types
+- Maintain backward compatibility with existing photo messages
+
+## Non-Goals
+
+- Audio notes, file attachments, or other content types (future work, but architecture should support them)
+- Video editing (trimming, filters) before send
+- Video recording from camera (use system picker only for v1)
+- Animated GIF support (separate feature)
+- Group video/photo albums in a single message (existing multi-attachment flow stays as-is)
+
+## Design
+
+### Size and Format Constraints
+
+- Maximum file size: 25MB after compression
+- Output format: H.264 in MP4 container (`video/mp4`)
+- Compression target: 720p, medium quality via `AVAssetExportSession`
+- Maximum duration: derived from size limit (roughly 30-60 seconds depending on content)
+- Thumbnail: 200px max dimension, JPEG, typically 5-15KB
+
+### Thumbnail Strategy
+
+Embed a base64-encoded thumbnail JPEG in the XMTP `RemoteAttachment` parameters map. The parameters map is a `map<string,string>` on the protobuf `EncodedContent` — it's extensible and available to the receiver without downloading the remote payload.
+
+Parameters added to `RemoteAttachment`:
+- `thumbnail`: base64-encoded JPEG data (5-15KB encoded, ~7-20KB as base64)
+- `thumbnailWidth`: pixel width as string
+- `thumbnailHeight`: pixel height as string
+- `mediaWidth`: full video width as string
+- `mediaHeight`: full video height as string
+- `mediaDuration`: duration in seconds as string (e.g., "14.5")
+- `mediaMimeType`: the MIME type of the remote payload (e.g., "video/mp4")
+
+This approach was chosen over alternatives because:
+- Available instantly — no extra network request for the thumbnail
+- Single upload — only the video goes to S3
+- Well within XMTP message size limits
+- Extensible — same pattern works for audio waveforms, file previews, etc.
+
+If we later decide to use `MultiRemoteAttachment` (thumbnail + video as separate entries), there is no conflict — the two approaches use different XMTP content types entirely (`remoteStaticAttachment` vs `multiRemoteStaticAttachment`), and the receiver can handle both.
+
+Note: these same parameters should also be added retroactively for photo messages (`mediaMimeType: "image/jpeg"`, `mediaWidth`, `mediaHeight`). This gives the receiver dimensions before downloading, enabling proper aspect-ratio placeholders. No thumbnail parameter is needed for photos since the photo itself is small enough to load quickly.
+
+### XMTP Transport
+
+No SDK changes required. The existing `RemoteAttachment` content type wraps an `Attachment(filename, mimeType, data)` — the inner `Attachment.mimeType` is set to `"video/mp4"` instead of `"image/jpeg"`. The encrypted payload is uploaded to S3 via the same presigned URL flow. The `contentLength` field on `RemoteAttachment` provides file size for download progress.
+
+### Data Model Changes
+
+#### `StoredRemoteAttachment` — add fields
+
+```
+mimeType: String?         // "video/mp4", "image/jpeg", etc.
+thumbnailData: String?    // base64 JPEG thumbnail (from parameters)
+mediaWidth: Int?          // full media dimensions
+mediaHeight: Int?
+mediaDuration: Double?    // seconds
+```
+
+These are populated from the `RemoteAttachment` parameters when the message is first received and stored, so they're available without re-parsing the XMTP message.
+
+#### `HydratedAttachment` — add fields
+
+```
+mimeType: String?         // "video/mp4", "image/jpeg", etc.
+duration: Double?         // seconds, for video/audio
+thumbnailKey: String?     // cache key or inline base64 for thumbnail
+fileSize: Int?            // bytes, for download progress UI
+```
+
+A computed `mediaType` property derives the category from `mimeType`:
+
+```swift
+enum MediaType { case image, video, audio, file, unknown }
+var mediaType: MediaType {
+    guard let mimeType else { return .unknown }
+    if mimeType.hasPrefix("image/") { return .image }
+    if mimeType.hasPrefix("video/") { return .video }
+    if mimeType.hasPrefix("audio/") { return .audio }
+    return .file
+}
+```
+
+#### DB migration
+
+Add a `mimeType TEXT` column to `AttachmentLocalState`. For existing rows, `mimeType` defaults to `NULL` which the app treats as `"image/jpeg"` (backward compatible).
+
+#### Message preview text
+
+`DBMessage+MessagePreview.swift` currently hardcodes "a photo" / "N photos". Change to derive from MIME type: "a video", "a photo", "a file", etc.
+
+### Sending Flow
+
+1. **Picker**: Change `PhotosPicker` filter from `.images` to `.any(of: [.images, .videos])`. After selection, inspect the `PhotosPickerItem.supportedContentTypes` to determine if it's image or video.
+
+2. **Video compression**: New `VideoCompressionService` (or extend to `MediaCompressionService`):
+   - Input: `URL` to the picked video file
+   - Use `AVAssetExportSession` with `AVAssetExportPresetMediumQuality`
+   - Output format: `.mp4`
+   - Check compressed size against 25MB limit; reject if over
+   - Extract thumbnail via `AVAssetImageGenerator` at time 0
+
+3. **Upload**: Reuse existing `PhotoAttachmentService` flow, generalized:
+   - Create `Attachment(filename: "video_<timestamp>.mp4", mimeType: "video/mp4", data: compressedData)`
+   - Encrypt via `RemoteAttachment.encodeEncrypted(content:codec:)`
+   - Upload encrypted payload to S3 via presigned URL
+   - Construct `RemoteAttachment` with thumbnail and media metadata in parameters
+
+4. **Eager upload**: Extend `OutgoingMessageWriter` with `startEagerUpload(videoURL:)` — begins compression + upload immediately when video is selected, before user taps Send. The existing eager upload infrastructure handles this.
+
+5. **Local preview**: Save the thumbnail and a local file URL for the video so the sending user sees the content immediately (same pattern as photo local cache).
+
+### Receiving Flow
+
+1. **`DecodedMessage+DBRepresentation`**: Remove the `guard attachment.mimeType.hasPrefix("image/")` checks (3 places). Accept any MIME type. Store `mimeType` in `StoredRemoteAttachment` JSON. Extract thumbnail/dimensions from `RemoteAttachment` parameters.
+
+2. **`RemoteAttachmentLoader`**: Rename to `AttachmentLoader` (or keep name, generalize internals). Remove the `guard attachment.mimeType.hasPrefix("image/")` check. For video, return the raw encrypted data URL for streaming rather than loading everything into memory.
+
+3. **Hydration**: `StoredRemoteAttachment` → `HydratedAttachment` populates `mimeType`, `duration`, `thumbnailKey`, `fileSize` from the stored JSON.
+
+### Display
+
+#### Inline Video in Messages List
+
+The messages list uses full-bleed media (edge-to-edge on iPhone, constrained width on iPad). Video follows the same layout as photos:
+
+- **Before download**: Show thumbnail at correct aspect ratio (from `mediaWidth`/`mediaHeight`). Overlay a play button and duration badge. The blur/reveal system applies to the thumbnail the same way it does for photos.
+- **On tap**: Begin streaming the video. The player replaces the thumbnail inline. Use `AVPlayer` with a custom `AVPlayerLayer` view. Loop playback. Tap again to pause. Show a subtle progress indicator if buffering.
+- **Progressive playback**: `AVPlayer` supports streaming from an HTTPS URL natively. However, the video is encrypted — we need to decrypt on-the-fly. Options:
+  - **Option 1**: Download + decrypt fully, then play from local file. Simpler but no progressive playback.
+  - **Option 2**: Stream-decrypt via a local HTTP proxy or custom `AVAssetResourceLoaderDelegate`. Complex but enables true streaming.
+  - For v1, Option 1 (download-then-play) is acceptable. Show download progress on the thumbnail. Once downloaded, playback is instant. Cache the decrypted file locally.
+
+If progressive playback from encrypted sources proves too complex for v1, fall back to download-then-play with a progress indicator. The thumbnail ensures the user sees something immediately regardless.
+
+#### Video Player Controls
+
+- Tap to play/pause
+- No scrubber for inline playback (keep it simple like iMessage)
+- Duration badge on thumbnail (e.g., "0:14")
+- Download progress ring overlaid on play button
+- Mute/unmute toggle (videos start muted by default in the feed)
+- Fullscreen option via long-press or dedicated button
+
+#### Blur/Reveal for Video
+
+Same as photos. The thumbnail is blurred when `shouldBlurPhotos` is true and not yet revealed. Tap to reveal shows the thumbnail; a second tap starts playback.
+
+### Backward Compatibility
+
+- Old clients that don't understand video will see the `RemoteAttachment` fallback text: "Can't display this content."
+- Old messages (photos without `mimeType` in parameters) continue to work — `nil` mimeType is treated as `"image/jpeg"`.
+- The `parameters` map is ignored by clients that don't know about the new keys — no breaking change.
+
+### Error Handling
+
+- Video too large after compression: show error "Video is too long. Try a shorter clip." with the size/duration limit.
+- Upload failure: same retry flow as photos (pending upload writer, background upload manager).
+- Download failure: show error state on the thumbnail with retry button.
+- Unsupported codec in received video: show generic "Can't play this video" with the filename.
+
+## Future Considerations
+
+- **Audio notes**: Same `RemoteAttachment` + parameters pattern. `mediaMimeType: "audio/m4a"`, `mediaDuration`, optional `waveform` base64 parameter. Display as waveform + play button.
+- **File attachments**: `mediaMimeType: "application/pdf"` etc. Display as file icon + name + size. Tap to download and open with system viewer.
+- **Larger videos via MultiRemoteAttachment**: If 25MB proves too limiting, could split video into chunks or use `MultiRemoteAttachment` with a low-res version + full-res version for adaptive quality.
+- **Camera capture**: Add "Record video" option alongside photo library picker.
+- **Video trimming**: In-app trim UI before send to help users stay under size limit.

--- a/qa/SKILL.md
+++ b/qa/SKILL.md
@@ -43,6 +43,7 @@ Run end-to-end QA tests for the Convos iOS app using the iOS simulator tools and
 | 23 | `qa/tests/23-pending-invites-home-view.md` | Pending invites appear in home view, filter, swipe/context restrictions, approval transition |
 | 25 | `qa/tests/25-conversations-list-baseline.md` | Conversations list baseline for UICollectionView migration - captures all UI states and interactions |
 | 26 | `qa/tests/26-failed-message-send.md` | Failed message send: "Not Delivered" state, retry, and delete |
+| 27 | `qa/tests/27-send-receive-video.md` | Send and receive video messages, inline playback, blur/reveal, context menu, size limit |
 
 ## Running Tests
 
@@ -72,9 +73,10 @@ Recommended order:
 15. **16-conversation-filters** — tests unread filter (needs conversations with mixed read states)
 16. **17-swipe-actions** — tests mark read/unread swipe actions
 17. **20-send-receive-photos** — tests photo send/receive, blur/reveal, context menu
-18. **19-profile-photo** — tests profile and group photos
-19. **15-performance** — performance baselines (run last, non-destructive)
-20. **18-delete-all-data** — wipes all data (run very last, destructive)
+18. **27-send-receive-video** — tests video send/receive, inline playback, blur/reveal
+19. **19-profile-photo** — tests profile and group photos
+20. **15-performance** — performance baselines (run last, non-destructive)
+21. **18-delete-all-data** — wipes all data (run very last, destructive)
 
 ### Reporting
 

--- a/qa/tests/27-send-receive-video.md
+++ b/qa/tests/27-send-receive-video.md
@@ -1,0 +1,101 @@
+# Test: Send and Receive Video Messages
+
+Verify end-to-end video messaging: selecting a video from the photo picker, sending with compression, receiving from CLI, thumbnail display with play button and duration badge, inline playback, blur/reveal for incoming video, context menu actions, size limit enforcement, and that existing photo messaging continues to work alongside video.
+
+## Prerequisites
+
+- The app is running and past onboarding.
+- The convos CLI is initialized for the dev environment.
+- The simulator photo library has at least one video and one photo.
+
+## Setup
+
+1. Reset the CLI and re-initialize for dev.
+2. Download a short test video and add it to the simulator photo library.
+3. Create a conversation via CLI named "Video Test" with profile name "CLI User".
+4. Generate an invite and open it as a deep link in the app.
+5. Process the join request from the CLI (per invite ordering rules in RULES.md).
+
+## Steps
+
+### Picker shows photos and videos
+
+6. Tap the media picker button (`photo-picker-button`). The system PhotosPicker should appear showing both photos and videos. Videos are distinguishable by a duration badge in the picker grid.
+
+### Send a video from the app
+
+7. Select a video from the picker. If "Pics are personal" education sheet appears, dismiss it.
+8. Verify a thumbnail preview appears in the composer (`attachment-preview-image`).
+9. Tap the send button. Verify the video message appears with a thumbnail, play button overlay, and duration badge. Check for `message.sent` event.
+
+### Remove video before sending
+
+10. Select another video from the picker.
+11. Tap the remove button (`remove-attachment-button`).
+12. Verify the preview disappears and the composer returns to text input.
+
+### Inline playback
+
+13. Tap the play button on the sent video. Verify inline playback starts (play button disappears).
+14. Tap the playing video to pause. Verify the play button reappears.
+
+### Receive a video from CLI
+
+15. Send a video from the CLI using `send-attachment` with `--mime-type video/mp4`.
+16. Verify the incoming video appears with a blurred thumbnail and "Tap to reveal" overlay. Check for `message.received` event.
+
+### Incoming video blur/reveal
+
+17. Verify the incoming video thumbnail is blurred (screenshot check).
+18. Tap to reveal. Dismiss "Reveal" education sheet if it appears.
+19. Verify the thumbnail is now clear with a play button and duration badge.
+20. Tap the play button to start playback on the revealed video.
+
+### Video context menu
+
+21. Long-press on the revealed incoming video. Verify Reply, Save, and Blur in context menu.
+22. Tap Blur. Verify the video returns to blurred state.
+23. Long-press the blurred video. Verify menu shows Reveal instead of Blur.
+
+### Own video context menu
+
+24. Long-press on the video sent from the app. Verify Reply, Save, and Blur (own videos start unblurred).
+
+### Photo still works
+
+25. Select and send a photo. Verify it renders as a full-width image (unchanged behavior).
+
+### Conversation list preview
+
+26. Navigate back to conversations list. Verify the preview text shows "a photo" or "a video" as appropriate for the most recent message.
+
+## Teardown
+
+Explode the conversation via CLI.
+
+## Pass/Fail Criteria
+
+- [ ] Photo picker shows both photos and videos
+- [ ] Video can be selected and sent with thumbnail preview in composer
+- [ ] Sent video displays thumbnail with play button and duration badge
+- [ ] `message.sent` event fires for video
+- [ ] Video attachment can be removed before sending
+- [ ] Tapping play button starts inline playback
+- [ ] Tapping playing video pauses it
+- [ ] Video from CLI appears in the app
+- [ ] `message.received` event fires for incoming video
+- [ ] Incoming video is blurred by default
+- [ ] Tapping blurred video reveals the thumbnail
+- [ ] Tapping revealed video starts inline playback
+- [ ] Context menu shows Reply, Save, Blur/Reveal for incoming video
+- [ ] Blur/Reveal toggles work from context menu
+- [ ] Own sent video context menu shows Reply, Save, Blur
+- [ ] Photo sending still works alongside video
+- [ ] Conversation list preview shows "a video" or "a photo" appropriately
+
+## Accessibility Improvements Needed
+
+- Video play button overlay needs `accessibilityIdentifier("video-play-button")`
+- Video duration badge needs `accessibilityIdentifier("video-duration-badge")`
+- Video messages should have a label distinguishing them from photos (e.g., "Video message" vs photo labels)
+- Inline video player play/pause state should be accessible

--- a/qa/tests/structured/27-send-receive-video.yaml
+++ b/qa/tests/structured/27-send-receive-video.yaml
@@ -1,0 +1,339 @@
+id: "26"
+name: "Send and Receive Video Messages"
+description: >
+  Verify end-to-end video messaging: selecting a video from the photo picker,
+  sending with compression, receiving from CLI, thumbnail display with play
+  button and duration badge, inline playback, blur/reveal for incoming video,
+  context menu actions, size limit enforcement, and that existing photo
+  messaging continues to work alongside video.
+tags: [messaging, video, photos, privacy, core]
+depends_on: ["20"]
+estimated_duration_s: 360
+
+prerequisites:
+  app_running: true
+  cli_initialized: true
+  shared_conversation: false
+  screen: conversations_list
+
+state:
+  conversation_id: null
+  invite_url: null
+
+setup:
+  - action: cli_reset
+    note: >
+      convos reset && convos init --env dev --force
+  - action: add_test_video_to_simulator
+    note: >
+      Download a short test video and add it to the simulator photo library:
+      curl -sL "https://test-videos.co.uk/vids/bigbuckbunny/mp4/h264/360/Big_Buck_Bunny_360_10s_1MB.mp4" -o /tmp/test-video.mp4
+      xcrun simctl addmedia $UDID /tmp/test-video.mp4
+      Also add a test photo if not already present:
+      curl -sL "https://picsum.photos/400/300" -o /tmp/test-photo.jpg
+      xcrun simctl addmedia $UDID /tmp/test-photo.jpg
+  - action: cli_create_conversation
+    args: { name: "Video Test", profile_name: "CLI User" }
+    save:
+      conversation_id: result.conversation_id
+  - action: cli_generate_invite
+    args: { conversation: "$conversation_id" }
+    save:
+      invite_url: result.invite_url
+  - action: open_deep_link
+    args: { url: "$invite_url" }
+  - action: cli_process_joins
+    args: { conversation: "$conversation_id", watch: true, timeout: 30 }
+  - action: wait_for_element
+    args: { id: "message-text-field", timeout: 15 }
+
+steps:
+  - id: picker_shows_videos
+    name: "Photo picker shows both photos and videos"
+    actions:
+      - tap: { id: "photo-picker-button" }
+      - wait_for_element: { label: "Photos", timeout: 10 }
+      - screenshot: {}
+    verify:
+      - visual_check: "System PhotosPicker is open and shows both photos and videos (videos have duration badges in the grid)"
+    criteria: picker_shows_photos_and_videos
+    note: >
+      The picker filter should be .any(of: [.images, .videos]) so both media
+      types appear. Videos are distinguishable by a duration badge in the
+      system picker grid. Dismiss the picker after visual verification.
+
+  - id: select_and_send_video
+    name: "Select a video and send it"
+    actions:
+      - tap_first_video: {}
+        note: >
+          Tap a video thumbnail in the picker (videos have a duration label
+          overlay). If "Pics are personal" education sheet appears, dismiss
+          with "Got it".
+      - dismiss_education_sheet: { button: "Got it" }
+      - wait_for_element: { id: "attachment-preview-image", timeout: 10 }
+      - screenshot: {}
+      - tap: { id: "send-message-button" }
+      - wait_for_element: { label: "Sent", timeout: 30 }
+    verify:
+      - element_exists: { id: "attachment-preview-image" }
+    expect_event: "message.sent"
+    criteria: video_sent_from_app
+    note: >
+      After selecting, a thumbnail preview should appear in the composer area
+      (same attachment-preview-image identifier as photos). The video is
+      compressed before upload, so the send may take longer than a photo.
+      After sending, the message should show a thumbnail with a play button
+      overlay and a duration badge (e.g., "0:10").
+
+  - id: sent_video_displays_correctly
+    name: "Sent video shows thumbnail with play button and duration"
+    actions:
+      - screenshot: {}
+    verify:
+      - visual_check: "Sent video message shows a thumbnail image with a play button overlay and a duration badge"
+      - element_exists: { id: "video-play-button" }
+      - element_exists: { id: "video-duration-badge" }
+    criteria: sent_video_has_thumbnail_and_controls
+    note: >
+      The video message in the conversation should display as a full-bleed
+      thumbnail (like photos) but with a centered play button and a duration
+      badge in the corner. The thumbnail is a still frame from the video.
+
+  - id: remove_video_before_send
+    name: "Remove video attachment before sending"
+    actions:
+      - tap: { id: "photo-picker-button" }
+      - wait_for_element: { label: "Photos", timeout: 10 }
+      - tap_first_video: {}
+      - dismiss_education_sheet: { button: "Got it" }
+      - wait_for_element: { id: "remove-attachment-button", timeout: 10 }
+      - tap: { id: "remove-attachment-button" }
+    verify:
+      - element_not_exists: { id: "attachment-preview-image" }
+    criteria: video_attachment_removable
+    note: >
+      Same flow as photos — selecting a video shows a preview with an X
+      button. Tapping the X removes the preview and returns to text input.
+
+  - id: inline_playback_tap_to_play
+    name: "Tap sent video to start inline playback"
+    actions:
+      - tap: { id: "video-play-button" }
+      - screenshot: {}
+    verify:
+      - visual_check: "Video is playing inline in the message — the play button is gone and the video frame is animating"
+      - element_not_exists: { id: "video-play-button" }
+    criteria: tap_plays_video_inline
+    note: >
+      Tapping the play button on a sent video should start inline playback.
+      The play button overlay disappears and the video plays within the
+      message bubble. No fullscreen player should appear.
+
+  - id: inline_playback_tap_to_pause
+    name: "Tap playing video to pause"
+    actions:
+      - tap: { label_contains: "Video message" }
+        note: Tap the video area to pause
+      - screenshot: {}
+    verify:
+      - visual_check: "Video is paused — the play button overlay has reappeared"
+      - element_exists: { id: "video-play-button" }
+    criteria: tap_pauses_video
+    note: >
+      Tapping a playing video should pause it and bring back the play button
+      overlay.
+
+  - id: receive_video_from_cli
+    name: "Receive a video from CLI"
+    actions:
+      - cli_send_attachment:
+          conversation: "$conversation_id"
+          path: "/tmp/test-video.mp4"
+          mime_type: "video/mp4"
+      - wait_for_element: { label_contains: "Tap to reveal", timeout: 30 }
+    verify:
+      - element_exists: { label_contains: "Tap to reveal" }
+    expect_event: "message.received"
+    criteria: video_received_from_cli
+    note: >
+      The CLI sends the video as a remote attachment with mime type video/mp4.
+      The app should display it as a blurred thumbnail with a reveal overlay,
+      same privacy treatment as incoming photos. The thumbnail and duration
+      metadata are embedded in the RemoteAttachment parameters.
+
+  - id: incoming_video_blurred
+    name: "Incoming video is blurred by default"
+    actions:
+      - screenshot: {}
+    verify:
+      - element_exists: { label_contains: "Tap to reveal" }
+      - visual_check: "Incoming video thumbnail is blurred and unrecognizable with a reveal overlay"
+    criteria: incoming_video_blurred
+    note: >
+      Same blur/reveal treatment as photos. The thumbnail should be blurred
+      with "Tap pic to reveal" or similar overlay text.
+
+  - id: reveal_incoming_video
+    name: "Tap to reveal incoming video"
+    actions:
+      - tap: { label_contains: "Tap to reveal" }
+      - dismiss_education_sheet: { button: "Got it" }
+      - screenshot: {}
+    verify:
+      - element_not_exists: { label_contains: "Tap to reveal" }
+      - visual_check: "Video thumbnail is now sharp and visible with a play button overlay and duration badge"
+    criteria: incoming_video_revealable
+    note: >
+      After revealing, the video thumbnail should be clear (not blurred) with
+      a play button overlay and duration badge. If the "Reveal" education
+      sheet appears (first-time reveal), dismiss it.
+
+  - id: play_revealed_incoming_video
+    name: "Tap revealed incoming video to play"
+    actions:
+      - tap: { id: "video-play-button" }
+      - screenshot: {}
+    verify:
+      - visual_check: "Incoming video is playing inline"
+    criteria: incoming_video_plays_inline
+    note: >
+      Tapping the play button on a revealed incoming video should start
+      inline playback. The video data may need to download first — a progress
+      indicator should show during download, then playback begins.
+
+  - id: video_context_menu_incoming
+    name: "Context menu for incoming video"
+    actions:
+      - long_press: { id: "video-play-button", duration: 0.5 }
+        note: Long-press on the incoming video area to open context menu
+      - screenshot: {}
+    verify:
+      - element_exists: { label: "Reply" }
+      - element_exists: { label: "Save" }
+      - element_exists: { label: "Blur" }
+    criteria: incoming_video_context_menu
+    note: >
+      The context menu for a revealed incoming video should show Reply, Save,
+      and Blur. Same options as photos. "Blur" because the video is currently
+      revealed.
+
+  - id: context_menu_blur_video
+    name: "Blur video via context menu"
+    actions:
+      - tap: { label: "Blur" }
+    verify:
+      - element_exists: { label_contains: "Tap to reveal" }
+    criteria: context_menu_blurs_video
+    note: >
+      Tapping "Blur" should re-blur the video thumbnail with the reveal
+      overlay.
+
+  - id: context_menu_shows_reveal
+    name: "Context menu shows Reveal for blurred video"
+    actions:
+      - long_press: { label_contains: "Tap to reveal", duration: 0.5 }
+      - screenshot: {}
+    verify:
+      - element_exists: { label: "Reveal" }
+    criteria: blurred_video_shows_reveal_option
+    note: >
+      After blurring via context menu, long-pressing the blurred video should
+      show "Reveal" instead of "Blur" in the context menu.
+    actions_after:
+      - key: { code: 41 }
+        note: Dismiss context menu with Escape
+
+  - id: own_video_context_menu
+    name: "Context menu for own sent video"
+    actions:
+      - scroll_to_own_video: {}
+        note: Scroll up to find the video sent by the app user earlier
+      - long_press: { label_contains: "Video message", duration: 0.5 }
+        note: Long-press on own sent video
+      - screenshot: {}
+    verify:
+      - element_exists: { label: "Reply" }
+      - element_exists: { label: "Save" }
+      - element_exists: { label: "Blur" }
+    criteria: own_video_context_menu
+    note: >
+      Own videos are never auto-blurred but the owner can manually blur.
+      Context menu should show Reply, Save, and Blur (not Reveal).
+    actions_after:
+      - key: { code: 41 }
+
+  - id: photo_still_works
+    name: "Photo sending still works alongside video"
+    actions:
+      - tap: { id: "photo-picker-button" }
+      - wait_for_element: { label: "Photos", timeout: 10 }
+      - tap_first_photo: {}
+      - dismiss_education_sheet: { button: "Got it" }
+      - wait_for_element: { id: "send-message-button", timeout: 5 }
+      - tap: { id: "send-message-button" }
+      - wait_for_element: { label: "Sent", timeout: 15 }
+    verify:
+      - element_exists: { label: "Sent" }
+    expect_event: "message.sent"
+    criteria: photo_sending_still_works
+    note: >
+      After adding video support, photo sending should be completely
+      unchanged. Select a photo, send it, verify it renders as a full-width
+      image.
+
+  - id: conversation_list_preview
+    name: "Conversation list shows appropriate preview text"
+    actions:
+      - tap: { id: "BackButton" }
+        note: Navigate back to conversations list
+      - wait_for_element: { id: "compose-button", timeout: 10 }
+      - find_elements: { pattern: "Video Test" }
+    verify:
+      - element_exists: { label_contains: "a photo" }
+        note: >
+          The last message was a photo, so the preview should say "a photo".
+          If the last message was a video, it should say "a video".
+    criteria: list_preview_text_correct
+    note: >
+      The conversation list preview text should differentiate between photo
+      and video messages. "a photo" for images, "a video" for videos.
+
+teardown:
+  - action: explode_conversation
+    args: { id: "$conversation_id" }
+    optional: true
+
+criteria:
+  picker_shows_photos_and_videos:
+    description: "Photo picker shows both photos and videos in the grid"
+  video_sent_from_app:
+    description: "Video can be selected from picker and sent successfully"
+  sent_video_has_thumbnail_and_controls:
+    description: "Sent video displays thumbnail with play button and duration badge"
+  video_attachment_removable:
+    description: "Video attachment can be removed from composer before sending"
+  tap_plays_video_inline:
+    description: "Tapping play button starts inline video playback"
+  tap_pauses_video:
+    description: "Tapping a playing video pauses playback"
+  video_received_from_cli:
+    description: "Video sent from CLI appears in the app"
+  incoming_video_blurred:
+    description: "Incoming video is blurred by default with reveal overlay"
+  incoming_video_revealable:
+    description: "Tapping blurred incoming video reveals the thumbnail"
+  incoming_video_plays_inline:
+    description: "Tapping revealed incoming video starts inline playback"
+  incoming_video_context_menu:
+    description: "Incoming video context menu shows Reply, Save, and Blur"
+  context_menu_blurs_video:
+    description: "Blur option in context menu re-blurs the video"
+  blurred_video_shows_reveal_option:
+    description: "Blurred video context menu shows Reveal instead of Blur"
+  own_video_context_menu:
+    description: "Own sent video context menu shows Reply, Save, and Blur"
+  photo_sending_still_works:
+    description: "Photo sending continues to work alongside video support"
+  list_preview_text_correct:
+    description: "Conversation list preview shows 'a video' or 'a photo' as appropriate"

--- a/qa/tests/structured/27-send-receive-video.yaml
+++ b/qa/tests/structured/27-send-receive-video.yaml
@@ -1,4 +1,4 @@
-id: "26"
+id: "27"
 name: "Send and Receive Video Messages"
 description: >
   Verify end-to-end video messaging: selecting a video from the photo picker,

--- a/qa/tests/structured/27-send-receive-video.yaml
+++ b/qa/tests/structured/27-send-receive-video.yaml
@@ -205,7 +205,7 @@ steps:
   - id: video_context_menu_incoming
     name: "Context menu for incoming video"
     actions:
-      - long_press: { id: "video-play-button", duration: 0.5 }
+      - long_press: { label_contains: "Video message", duration: 0.5 }
         note: Long-press on the incoming video area to open context menu
       - screenshot: {}
     verify:


### PR DESCRIPTION
## Summary

Adds video message support to the app, which was previously photo-only.

### Sending
- PhotosPicker now shows both photos and videos (`VideoFile` Transferable type)
- Video compression via `VideoCompressionService` (H.264, 25MB limit)
- Thumbnail generation (400px max dimension) embedded in XMTP message
- Video badge overlay on composer attachment preview

### Receiving
- Removed image-only MIME guards from message decoding
- `RemoteAttachmentLoader.loadAttachmentData()` returns typed `LoadedAttachment`
- Message preview shows "a video" vs "a photo"

### Inline Playback
- `InlineVideoPlayerView` (UIViewRepresentable with AVPlayerLayer) for reliable playback in collection view cells
- Tap to play/pause, auto-pause at end with replay support
- Only one video plays at a time (notification-based coordination)
- Blur treatment matching photos (scale 1.65x + blur radius 96)

### Reply Support
- Reply bar shows "Video" label with play button overlay on thumbnail
- Reply reference shows "video" text with play button overlay

### Architecture
- `VideoURLCache` actor for thread-safe video URL caching
- `publishAttachment()` shared helper extracted from send pipelines
- 5 new tests for `attachmentsPreviewString`

### QA
- Structured QA test 27: send-receive-video (17 criteria)

Stacked on `dev`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add video message support with inline playback, send, and receive
> - Adds end-to-end video messaging: users can select or record videos (up to 60s) via the photo picker or camera, which are compressed to MP4 (≤25MB), encrypted, and uploaded via the existing background upload pipeline.
> - Inline playback is supported in the message list via `AVPlayer`, with thumbnail preview, play/pause on tap, duration badge, and auto-pause when another video starts or the attachment is blurred.
> - Extends `HydratedAttachment`, `StoredRemoteAttachment`, and `AttachmentLocalState` with `mimeType`, `duration`, `thumbnailDataBase64`, and dimension fields; a new DB migration adds `mimeType` to the `attachmentLocalState` table.
> - Reply composer, reply reference view, and conversation list preview now distinguish between photo and video attachments in labels and thumbnails.
> - The 'Save' context menu action saves videos to the Photos library, handling both local file URLs and remotely downloaded data.
> - Risk: `DecodedMessage` no longer rejects non-image MIME types, so any non-image inline attachment (e.g. unexpected file types) will now be persisted as an attachment instead of throwing `unsupportedContentType`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized eb416be.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->