### PR TITLE
Add file attachment receiving and display

### DIFF
--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -532,6 +532,7 @@ class ConversationViewModel {
         observe()
         loadPhotoPreferences()
         observeTypingIndicators(typingIndicatorManager)
+        registerInlineAttachmentRecovery()
 
         self.editingConversationName = conversation.name ?? ""
         self.editingDescription = conversation.description ?? ""
@@ -928,7 +929,8 @@ extension ConversationViewModel {
     }
 
     private func registerInlineAttachmentRecovery() {
-        Task {
+        Task { [weak self] in
+            guard let messagingService = self?.messagingService else { return }
             guard let result = try? await messagingService.inboxStateManager.waitForInboxReadyResult() else { return }
             await InlineAttachmentRecovery.shared.setProvider(result.client.conversationsProvider)
         }

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -474,6 +474,7 @@ class ConversationViewModel {
             onboardingCoordinator.isWaitingForInviteAcceptance = true
         }
         startOnboarding()
+        registerInlineAttachmentRecovery()
     }
 
     // Alternative initializer for draft conversations with pre-loaded dependencies
@@ -923,6 +924,13 @@ extension ConversationViewModel {
             } catch {
                 Log.error("Failed to retry message: \(error.localizedDescription)")
             }
+        }
+    }
+
+    private func registerInlineAttachmentRecovery() {
+        Task {
+            guard let result = try? await messagingService.inboxStateManager.waitForInboxReadyResult() else { return }
+            await InlineAttachmentRecovery.shared.setProvider(result.client.conversationsProvider)
         }
     }
 

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Cells/MessagesListItemTypeCell.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Cells/MessagesListItemTypeCell.swift
@@ -95,6 +95,7 @@ class MessagesListItemTypeCell: UICollectionViewCell {
                         onPhotoRevealed: config.onPhotoRevealed,
                         onPhotoHidden: config.onPhotoHidden,
                         onPhotoDimensionsLoaded: config.onPhotoDimensionsLoaded,
+                        onOpenFile: config.onOpenFile,
                         onRetryMessage: config.onRetryMessage,
                         onDeleteMessage: config.onDeleteMessage
                     )

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Data Source/CellFactory.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Data Source/CellFactory.swift
@@ -15,6 +15,7 @@ struct CellConfig {
     let onRetryAssistantJoin: () -> Void
     let onPhotoDimensionsLoaded: (String, Int, Int) -> Void
     let onTapUpdateMember: (ConversationMember) -> Void
+    let onOpenFile: ((HydratedAttachment) -> Void)?
     let onRetryMessage: (AnyMessage) -> Void
     let onDeleteMessage: (AnyMessage) -> Void
     let onCopyInviteLink: () -> Void

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Data Source/DefaultMessagesLayoutDelegate.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Data Source/DefaultMessagesLayoutDelegate.swift
@@ -56,9 +56,9 @@ final class DefaultMessagesLayoutDelegate: MessagesLayoutDelegate {
         var childCount: Int = 0
 
         for (index, message) in group.messages.enumerated() {
-            let isAttachment = message.content.isAttachment
+            let isFullBleed = message.content.isFullBleedAttachment
 
-            if index == 0 && !group.sender.isCurrentUser && !isAttachment {
+            if index == 0 && !group.sender.isCurrentUser && !isFullBleed {
                 height += 17.0
                 childCount += 1
             }

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Data Source/MessagesCollectionDataSource.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Data Source/MessagesCollectionDataSource.swift
@@ -16,6 +16,7 @@ protocol MessagesCollectionDataSource: UICollectionViewDataSource, MessagesLayou
     var onPhotoDimensionsLoaded: ((String, Int, Int) -> Void)? { get set }
     var onAgentOutOfCredits: (() -> Void)? { get set }
     var onTapUpdateMember: ((ConversationMember) -> Void)? { get set }
+    var onOpenFile: ((HydratedAttachment) -> Void)? { get set }
     var onRetryMessage: ((AnyMessage) -> Void)? { get set }
     var onDeleteMessage: ((AnyMessage) -> Void)? { get set }
     var onRetryAssistantJoin: (() -> Void)? { get set }

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Data Source/MessagesCollectionViewDataSource.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Data Source/MessagesCollectionViewDataSource.swift
@@ -24,6 +24,7 @@ final class MessagesCollectionViewDataSource: NSObject {
     var onPhotoDimensionsLoaded: ((String, Int, Int) -> Void)?
     var onAgentOutOfCredits: (() -> Void)?
     var onTapUpdateMember: ((ConversationMember) -> Void)?
+    var onOpenFile: ((HydratedAttachment) -> Void)?
     var onRetryMessage: ((AnyMessage) -> Void)?
     var onDeleteMessage: ((AnyMessage) -> Void)?
     var onRetryAssistantJoin: (() -> Void)?
@@ -99,6 +100,9 @@ extension MessagesCollectionViewDataSource: UICollectionViewDataSource {
             },
             onTapUpdateMember: { [weak self] member in
                 self?.onTapUpdateMember?(member)
+            },
+            onOpenFile: { [weak self] attachment in
+                self?.onOpenFile?(attachment)
             },
             onRetryMessage: { [weak self] message in
                 self?.onRetryMessage?(message)

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/MessagesViewController.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/MessagesViewController.swift
@@ -3,6 +3,7 @@ import ConvosCore
 import DifferenceKit
 import Foundation
 import Observation
+import QuickLook
 import SwiftUI
 import UIKit
 
@@ -192,6 +193,7 @@ final class MessagesViewController: UIViewController {
     var onCopyInviteLink: (() -> Void)?
     var onConvoCode: (() -> Void)?
     var onInviteAssistant: (() -> Void)?
+    private var filePreviewURL: URL?
     var hasAssistant: Bool = false {
         didSet { dataSource.hasAssistant = hasAssistant }
     }

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/MessagesViewController.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/MessagesViewController.swift
@@ -858,6 +858,70 @@ extension MessagesViewController: KeyboardListenerDelegate {
     }
 }
 
+// MARK: - File Attachment QuickLook
+
+extension MessagesViewController: QLPreviewControllerDataSource {
+    private func openFileAttachment(_ attachment: HydratedAttachment) {
+        Task {
+            do {
+                let fileURL = try await loadFileForPreview(attachment)
+                let previewController = QLPreviewController()
+                filePreviewURL = fileURL
+                previewController.dataSource = self
+                present(previewController, animated: true)
+            } catch {
+                Log.error("Failed to open file attachment: \(error)")
+                let alert = UIAlertController(
+                    title: "File Unavailable",
+                    message: "This file is no longer available on this device.",
+                    preferredStyle: .alert
+                )
+                let okAction = UIAlertAction(title: "OK", style: .default)
+                alert.addAction(okAction)
+                present(alert, animated: true)
+            }
+        }
+    }
+
+    private func loadFileForPreview(_ attachment: HydratedAttachment) async throws -> URL {
+        let filename = attachment.filename ?? "attachment"
+
+        if attachment.key.hasPrefix("file://") {
+            let path = String(attachment.key.dropFirst("file://".count))
+            let sourceURL = URL(fileURLWithPath: path)
+            let tempURL = FileManager.default.temporaryDirectory
+                .appendingPathComponent("preview_\(UUID().uuidString)")
+                .appendingPathComponent(filename)
+            try FileManager.default.createDirectory(
+                at: tempURL.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            try FileManager.default.copyItem(at: sourceURL, to: tempURL)
+            return tempURL
+        }
+
+        let loader = RemoteAttachmentLoader()
+        let loaded = try await loader.loadAttachmentData(from: attachment.key)
+        let tempURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("preview_\(UUID().uuidString)")
+            .appendingPathComponent(filename)
+        try FileManager.default.createDirectory(
+            at: tempURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try loaded.data.write(to: tempURL)
+        return tempURL
+    }
+
+    func numberOfPreviewItems(in controller: QLPreviewController) -> Int {
+        filePreviewURL != nil ? 1 : 0
+    }
+
+    func previewController(_ controller: QLPreviewController, previewItemAt index: Int) -> any QLPreviewItem {
+        (filePreviewURL ?? URL(fileURLWithPath: "")) as NSURL
+    }
+}
+
 // MARK: - UIGestureRecognizerDelegate
 
 extension MessagesViewController: UIGestureRecognizerDelegate {

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/MessagesViewController.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/MessagesViewController.swift
@@ -889,15 +889,34 @@ extension MessagesViewController: QLPreviewControllerDataSource {
         if attachment.key.hasPrefix("file://") {
             let path = String(attachment.key.dropFirst("file://".count))
             let sourceURL = URL(fileURLWithPath: path)
-            let tempURL = FileManager.default.temporaryDirectory
-                .appendingPathComponent("preview_\(UUID().uuidString)")
-                .appendingPathComponent(filename)
-            try FileManager.default.createDirectory(
-                at: tempURL.deletingLastPathComponent(),
-                withIntermediateDirectories: true
-            )
-            try FileManager.default.copyItem(at: sourceURL, to: tempURL)
-            return tempURL
+
+            if FileManager.default.fileExists(atPath: path) {
+                let tempURL = FileManager.default.temporaryDirectory
+                    .appendingPathComponent("preview_\(UUID().uuidString)")
+                    .appendingPathComponent(filename)
+                try FileManager.default.createDirectory(
+                    at: tempURL.deletingLastPathComponent(),
+                    withIntermediateDirectories: true
+                )
+                try FileManager.default.copyItem(at: sourceURL, to: tempURL)
+                return tempURL
+            }
+
+            let messageId = extractMessageId(from: sourceURL)
+            if let messageId {
+                let data = try await InlineAttachmentRecovery.shared.recoverData(messageId: messageId)
+                let tempURL = FileManager.default.temporaryDirectory
+                    .appendingPathComponent("preview_\(UUID().uuidString)")
+                    .appendingPathComponent(filename)
+                try FileManager.default.createDirectory(
+                    at: tempURL.deletingLastPathComponent(),
+                    withIntermediateDirectories: true
+                )
+                try data.write(to: tempURL)
+                return tempURL
+            }
+
+            throw CocoaError(.fileReadNoSuchFile, userInfo: [NSFilePathErrorKey: path])
         }
 
         let loader = RemoteAttachmentLoader()
@@ -911,6 +930,14 @@ extension MessagesViewController: QLPreviewControllerDataSource {
         )
         try loaded.data.write(to: tempURL)
         return tempURL
+    }
+
+    private func extractMessageId(from fileURL: URL) -> String? {
+        let filename = fileURL.lastPathComponent
+        guard let underscoreIndex = filename.firstIndex(of: "_") else { return nil }
+        let messageId = String(filename[filename.startIndex..<underscoreIndex])
+        guard !messageId.isEmpty else { return nil }
+        return messageId
     }
 
     func numberOfPreviewItems(in controller: QLPreviewController) -> Int {

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/MessagesViewController.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/MessagesViewController.swift
@@ -356,6 +356,9 @@ final class MessagesViewController: UIViewController {
         dataSource.onTapUpdateMember = { [weak self] member in
             self?.onTapUpdateMember?(member)
         }
+        dataSource.onOpenFile = { [weak self] attachment in
+            self?.openFileAttachment(attachment)
+        }
         dataSource.onRetryMessage = { [weak self] message in
             self?.onRetryMessage?(message)
         }

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/MessagesViewController.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/MessagesViewController.swift
@@ -868,6 +868,7 @@ extension MessagesViewController: QLPreviewControllerDataSource {
                 let previewController = QLPreviewController()
                 filePreviewURL = fileURL
                 previewController.dataSource = self
+                previewController.delegate = self
                 present(previewController, animated: true)
             } catch {
                 Log.error("Failed to open file attachment: \(error)")
@@ -946,6 +947,15 @@ extension MessagesViewController: QLPreviewControllerDataSource {
 
     func previewController(_ controller: QLPreviewController, previewItemAt index: Int) -> any QLPreviewItem {
         (filePreviewURL ?? URL(fileURLWithPath: "")) as NSURL
+    }
+}
+
+extension MessagesViewController: @preconcurrency QLPreviewControllerDelegate {
+    func previewControllerDidDismiss(_ controller: QLPreviewController) {
+        if let url = filePreviewURL {
+            try? FileManager.default.removeItem(at: url.deletingLastPathComponent())
+        }
+        filePreviewURL = nil
     }
 }
 

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/ReplyComposerBar.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/ReplyComposerBar.swift
@@ -52,6 +52,19 @@ struct ReplyComposerBar: View {
         attachment?.mediaType == .video
     }
 
+    private var isFile: Bool {
+        attachment?.mediaType == .file
+    }
+
+    private func replyLabel(for attachment: HydratedAttachment) -> String {
+        switch attachment.mediaType {
+        case .video: return "Video"
+        case .audio: return "Audio"
+        case .file: return attachment.filename ?? "File"
+        default: return "Photo"
+        }
+    }
+
     var body: some View {
         HStack(spacing: DesignConstants.Spacing.step2x) {
             if let attachment {

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessageContextMenu/MessageContextMenuOverlay.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessageContextMenu/MessageContextMenuOverlay.swift
@@ -82,9 +82,7 @@ struct MessageContextMenuOverlay: View {
         return shouldBlurPhotos && !photoAttachment.isRevealed
     }
 
-    private var windowSafeTop: CGFloat {
-        (UIApplication.shared.connectedScenes.first as? UIWindowScene)?.windows.first?.safeAreaInsets.top ?? 0
-    }
+    private var windowSafeTop: CGFloat { (UIApplication.shared.connectedScenes.first as? UIWindowScene)?.windows.first?.safeAreaInsets.top ?? 0 }
 
     var body: some View {
         if let message = state.presentedMessage {
@@ -765,8 +763,8 @@ private func saveVideoToPhotoLibrary(key: String) {
     Task {
         do {
             let videoURL: URL
-            let isLocalFile = key.hasPrefix("file://")
-            if isLocalFile {
+            var isTempFile = false
+            if key.hasPrefix("file://") {
                 let path = String(key.dropFirst("file://".count))
                 if FileManager.default.fileExists(atPath: path) {
                     videoURL = URL(fileURLWithPath: path)
@@ -776,6 +774,7 @@ private func saveVideoToPhotoLibrary(key: String) {
                         .appendingPathComponent("save_video_\(UUID().uuidString).mp4")
                     try data.write(to: tempURL)
                     videoURL = tempURL
+                    isTempFile = true
                 }
             } else {
                 let loader = RemoteAttachmentLoader()
@@ -784,10 +783,11 @@ private func saveVideoToPhotoLibrary(key: String) {
                     .appendingPathComponent("save_video_\(UUID().uuidString).mp4")
                 try loaded.data.write(to: tempURL)
                 videoURL = tempURL
+                isTempFile = true
             }
 
             defer {
-                if !isLocalFile {
+                if isTempFile {
                     try? FileManager.default.removeItem(at: videoURL)
                 }
             }
@@ -816,6 +816,7 @@ private func loadFileToTempURL(key: String, filename: String?) async throws -> U
         let fullFilename = fileURL.lastPathComponent
         if let underscoreIndex = fullFilename.firstIndex(of: "_") {
             let messageId = String(fullFilename[fullFilename.startIndex..<underscoreIndex])
+            guard !messageId.isEmpty else { throw CocoaError(.fileReadNoSuchFile) }
             let data = try await InlineAttachmentRecovery.shared.recoverData(messageId: messageId)
             let tempURL = FileManager.default.temporaryDirectory
                 .appendingPathComponent("share_\(UUID().uuidString)_\(name)")

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessageContextMenu/MessageContextMenuOverlay.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessageContextMenu/MessageContextMenuOverlay.swift
@@ -436,21 +436,11 @@ struct MessageContextMenuOverlay: View {
                 )
 
             case .attachment(let attachment):
-                ContextMenuPhotoPreview(
-                    attachmentKey: attachment.key, isOutgoing: state.isOutgoing,
-                    profile: message.sender.profile, shouldBlur: shouldBlurPhoto,
-                    cornerRadius: state.isReplyParent ? DesignConstants.CornerRadius.regular : (appeared ? C.photoCornerRadius : 0),
-                    showSenderLabel: !state.isReplyParent, isReplyParent: state.isReplyParent
-                )
+                contextMenuAttachmentPreview(attachment)
 
             case .attachments(let attachments):
                 if let attachment = attachments.first {
-                    ContextMenuPhotoPreview(
-                        attachmentKey: attachment.key, isOutgoing: state.isOutgoing,
-                        profile: message.sender.profile, shouldBlur: shouldBlurPhoto,
-                        cornerRadius: state.isReplyParent ? DesignConstants.CornerRadius.regular : (appeared ? C.photoCornerRadius : 0),
-                        showSenderLabel: !state.isReplyParent, isReplyParent: state.isReplyParent
-                    )
+                    contextMenuAttachmentPreview(attachment)
                 }
 
             case .invite(let invite):
@@ -674,6 +664,25 @@ struct MessageContextMenuOverlay: View {
         static let defaultReactions: [String] = ["❤️", "👍", "👎", "😂", "😮", "🤔"]
     }
     // swiftlint:enable type_name
+    @ViewBuilder
+    private func contextMenuAttachmentPreview(_ attachment: HydratedAttachment) -> some View {
+        let profile = message?.sender.profile ?? Profile(inboxId: "", conversationId: "", name: nil, avatar: nil)
+        if attachment.mediaType == .file {
+            FileAttachmentBubble(
+                attachment: attachment,
+                style: state.bubbleStyle,
+                isOutgoing: state.isOutgoing,
+                profile: profile
+            )
+        } else {
+            ContextMenuPhotoPreview(
+                attachmentKey: attachment.key, isOutgoing: state.isOutgoing,
+                profile: profile, shouldBlur: shouldBlurPhoto,
+                cornerRadius: state.isReplyParent ? DesignConstants.CornerRadius.regular : (appeared ? C.photoCornerRadius : 0),
+                showSenderLabel: !state.isReplyParent, isReplyParent: state.isReplyParent
+            )
+        }
+    }
 }
 
 // MARK: - Context Menu Photo Preview

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessageContextMenu/MessageContextMenuOverlay.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessageContextMenu/MessageContextMenuOverlay.swift
@@ -744,6 +744,16 @@ private struct ContextMenuPhotoPreview: View {
 
 // MARK: - Save Attachment Helper
 
+private func recoverInlineAttachmentData(fromPath path: String) async throws -> Data {
+    let fileURL = URL(fileURLWithPath: path)
+    let filename = fileURL.lastPathComponent
+    guard let underscoreIndex = filename.firstIndex(of: "_") else {
+        throw CocoaError(.fileReadNoSuchFile, userInfo: [NSFilePathErrorKey: path])
+    }
+    let messageId = String(filename[filename.startIndex..<underscoreIndex])
+    return try await InlineAttachmentRecovery.shared.recoverData(messageId: messageId)
+}
+
 private func saveAttachmentToPhotoLibrary(key: String) {
     guard let image = ImageCache.shared.image(for: key) else { return }
     PHPhotoLibrary.shared().performChanges {
@@ -758,7 +768,15 @@ private func saveVideoToPhotoLibrary(key: String) {
             let isLocalFile = key.hasPrefix("file://")
             if isLocalFile {
                 let path = String(key.dropFirst("file://".count))
-                videoURL = URL(fileURLWithPath: path)
+                if FileManager.default.fileExists(atPath: path) {
+                    videoURL = URL(fileURLWithPath: path)
+                } else {
+                    let data = try await recoverInlineAttachmentData(fromPath: path)
+                    let tempURL = FileManager.default.temporaryDirectory
+                        .appendingPathComponent("save_video_\(UUID().uuidString).mp4")
+                    try data.write(to: tempURL)
+                    videoURL = tempURL
+                }
             } else {
                 let loader = RemoteAttachmentLoader()
                 let loaded = try await loader.loadAttachmentData(from: key)
@@ -779,6 +797,82 @@ private func saveVideoToPhotoLibrary(key: String) {
             }
         } catch {
             Log.error("Failed to save video to photo library: \(error)")
+        }
+    }
+}
+
+// MARK: - File Save/Share Helpers
+
+private func loadFileToTempURL(key: String, filename: String?) async throws -> URL {
+    let name = filename ?? "attachment"
+
+    if key.hasPrefix("file://") {
+        let path = String(key.dropFirst("file://".count))
+        if FileManager.default.fileExists(atPath: path) {
+            return URL(fileURLWithPath: path)
+        }
+
+        let fileURL = URL(fileURLWithPath: path)
+        let fullFilename = fileURL.lastPathComponent
+        if let underscoreIndex = fullFilename.firstIndex(of: "_") {
+            let messageId = String(fullFilename[fullFilename.startIndex..<underscoreIndex])
+            let data = try await InlineAttachmentRecovery.shared.recoverData(messageId: messageId)
+            let tempURL = FileManager.default.temporaryDirectory
+                .appendingPathComponent("share_\(UUID().uuidString)_\(name)")
+            try data.write(to: tempURL)
+            return tempURL
+        }
+
+        throw CocoaError(.fileReadNoSuchFile, userInfo: [NSFilePathErrorKey: path])
+    }
+
+    let loader = RemoteAttachmentLoader()
+    let loaded = try await loader.loadAttachmentData(from: key)
+    let tempURL = FileManager.default.temporaryDirectory
+        .appendingPathComponent("share_\(UUID().uuidString)_\(name)")
+    try loaded.data.write(to: tempURL)
+    return tempURL
+}
+
+private func saveFileToFiles(key: String, filename: String?) {
+    Task { @MainActor in
+        do {
+            let tempURL = try await loadFileToTempURL(key: key, filename: filename)
+            let picker = UIDocumentPickerViewController(forExporting: [tempURL])
+            picker.shouldShowFileExtensions = true
+            guard let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+                  let root = scene.keyWindow?.rootViewController else { return }
+            var presenter = root
+            while let presented = presenter.presentedViewController {
+                presenter = presented
+            }
+            presenter.present(picker, animated: true)
+        } catch {
+            Log.error("Failed to save file: \(error)")
+        }
+    }
+}
+
+private func shareFile(key: String, filename: String?) {
+    Task { @MainActor in
+        do {
+            let tempURL = try await loadFileToTempURL(key: key, filename: filename)
+            let activityVC = UIActivityViewController(activityItems: [tempURL], applicationActivities: nil)
+            guard let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+                  let root = scene.keyWindow?.rootViewController else { return }
+            var presenter = root
+            while let presented = presenter.presentedViewController {
+                presenter = presented
+            }
+            activityVC.popoverPresentationController?.sourceView = presenter.view
+            activityVC.popoverPresentationController?.sourceRect = CGRect(
+                x: presenter.view.bounds.midX,
+                y: presenter.view.bounds.midY,
+                width: 0, height: 0
+            )
+            presenter.present(activityVC, animated: true)
+        } catch {
+            Log.error("Failed to share file: \(error)")
         }
     }
 }

--- a/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/FileAttachmentBubble.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/FileAttachmentBubble.swift
@@ -26,7 +26,7 @@ struct FileAttachmentBubble: View {
 
     var body: some View {
         MessageContainer(style: style, isOutgoing: isOutgoing) {
-            HStack(spacing: DesignConstants.Spacing.step3x) {
+            HStack(spacing: DesignConstants.Spacing.step2x) {
                 fileIcon
                     .frame(width: 44, height: 44)
                     .accessibilityIdentifier("file-attachment-icon")
@@ -45,7 +45,8 @@ struct FileAttachmentBubble: View {
                         .accessibilityIdentifier("file-attachment-subtitle")
                 }
             }
-            .padding(DesignConstants.Spacing.step3x)
+            .padding(.horizontal, DesignConstants.Spacing.step3x)
+            .padding(.vertical, DesignConstants.Spacing.step2x)
         }
         .accessibilityIdentifier("file-attachment-bubble")
         .accessibilityLabel("File: \(displayFilename)")

--- a/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/FileAttachmentBubble.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/FileAttachmentBubble.swift
@@ -1,0 +1,126 @@
+import ConvosCore
+import SwiftUI
+import UniformTypeIdentifiers
+
+struct FileAttachmentBubble: View {
+    let attachment: HydratedAttachment
+    let style: MessageBubbleType
+    let isOutgoing: Bool
+    let profile: Profile
+
+    private var textColor: Color {
+        isOutgoing ? .colorTextPrimaryInverted : .colorTextPrimary
+    }
+
+    private var secondaryTextColor: Color {
+        isOutgoing ? .colorTextPrimaryInverted.opacity(0.7) : .secondary
+    }
+
+    private var iconBackground: Color {
+        isOutgoing ? .white.opacity(0.2) : .colorFillMinimal
+    }
+
+    private var iconForeground: Color {
+        isOutgoing ? .colorTextPrimaryInverted.opacity(0.8) : .secondary
+    }
+
+    var body: some View {
+        MessageContainer(style: style, isOutgoing: isOutgoing) {
+            HStack(spacing: DesignConstants.Spacing.step3x) {
+                fileIcon
+                    .frame(width: 44, height: 44)
+                    .accessibilityIdentifier("file-attachment-icon")
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(displayFilename)
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(textColor)
+                        .lineLimit(2)
+                        .accessibilityIdentifier("file-attachment-filename")
+
+                    Text(subtitleText)
+                        .font(.caption)
+                        .foregroundStyle(secondaryTextColor)
+                        .lineLimit(1)
+                        .accessibilityIdentifier("file-attachment-subtitle")
+                }
+            }
+            .padding(DesignConstants.Spacing.step3x)
+        }
+        .accessibilityIdentifier("file-attachment-bubble")
+        .accessibilityLabel("File: \(displayFilename)")
+    }
+
+    private var displayFilename: String {
+        attachment.filename ?? "Unknown file"
+    }
+
+    private var subtitleText: String {
+        var parts: [String] = []
+        if let label = attachment.fileTypeLabel {
+            parts.append(label)
+        } else if let ext = attachment.filenameExtension {
+            parts.append(ext.uppercased())
+        }
+        if let size = attachment.fileSize {
+            parts.append(ByteCountFormatter.string(fromByteCount: Int64(size), countStyle: .file))
+        }
+        if parts.isEmpty {
+            return "File"
+        }
+        return parts.joined(separator: " · ")
+    }
+
+    @ViewBuilder
+    private var fileIcon: some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: 8)
+                .fill(iconBackground)
+            Image(systemName: fileIconSymbol)
+                .font(.system(size: 20))
+                .foregroundStyle(iconForeground)
+        }
+    }
+
+    private var fileIconSymbol: String {
+        if let ext = attachment.filenameExtension {
+            switch ext {
+            case "pdf":
+                return "doc.text.fill"
+            case "txt", "rtf", "rtfd":
+                return "doc.plaintext.fill"
+            case "md", "markdown":
+                return "doc.text.fill"
+            case "csv":
+                return "tablecells.fill"
+            case "json", "yaml", "yml", "xml":
+                return "curlybraces"
+            case "html", "htm":
+                return "globe"
+            case "zip", "tar", "gz", "rar", "7z":
+                return "doc.zipper"
+            case "swift", "py", "js", "ts", "rb", "go", "rs", "java", "kt", "c", "cpp", "h", "m", "cs":
+                return "chevron.left.forwardslash.chevron.right"
+            case "doc", "docx":
+                return "doc.text.fill"
+            case "xls", "xlsx", "numbers":
+                return "tablecells.fill"
+            case "ppt", "pptx", "key", "keynote":
+                return "rectangle.fill.on.rectangle.angled.fill"
+            default:
+                break
+            }
+        }
+
+        if let mimeType = attachment.mimeType {
+            if mimeType.hasPrefix("text/") { return "doc.plaintext.fill" }
+            if mimeType.hasPrefix("application/json") { return "curlybraces" }
+            if mimeType.hasPrefix("application/pdf") { return "doc.text.fill" }
+            if mimeType.contains("spreadsheet") || mimeType.contains("csv") { return "tablecells.fill" }
+            if mimeType.contains("presentation") { return "rectangle.fill.on.rectangle.angled.fill" }
+            if mimeType.contains("word") || mimeType.contains("document") { return "doc.text.fill" }
+        }
+
+        return "doc.fill"
+    }
+}

--- a/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/ReplyReferenceView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/ReplyReferenceView.swift
@@ -89,9 +89,11 @@ struct ReplyReferenceView: View {
                     .foregroundStyle(.tertiary)
             }
             .padding(.leading, isOutgoing ? 0.0 : DesignConstants.Spacing.step3x)
-            .padding(.trailing, isOutgoing ? (DesignConstants.Spacing.step4x + DesignConstants.Spacing.step3x) : 0.0)
+            .padding(.trailing, isOutgoing ? DesignConstants.Spacing.step3x : 0.0)
 
-            if let attachment = parentAttachment {
+            if let attachment = parentAttachment, attachment.mediaType == .file {
+                ReplyReferenceFileBubble(attachment: attachment)
+            } else if let attachment = parentAttachment {
                 ReplyReferencePhotoPreview(
                     attachmentKey: attachment.key,
                     isVideo: attachment.mediaType == .video,
@@ -100,11 +102,9 @@ struct ReplyReferenceView: View {
                     onReveal: { onPhotoRevealed?(attachment.key) },
                     onHide: { onPhotoHidden?(attachment.key) }
                 )
-                .padding(.trailing, isOutgoing ? DesignConstants.Spacing.step4x : 0.0)
             } else if let emoji = parentEmoji {
                 Text(emoji)
                     .font(.largeTitle)
-                    .padding(.trailing, isOutgoing ? DesignConstants.Spacing.step4x : 0.0)
             } else if let invite = parentInvite {
                 if let onTapInvite {
                     let tapAction = { onTapInvite(invite) }
@@ -112,10 +112,8 @@ struct ReplyReferenceView: View {
                         ReplyReferenceInvitePreview(invite: invite)
                     }
                     .buttonStyle(.plain)
-                    .padding(.trailing, isOutgoing ? DesignConstants.Spacing.step4x : 0.0)
                 } else {
                     ReplyReferenceInvitePreview(invite: invite)
-                        .padding(.trailing, isOutgoing ? DesignConstants.Spacing.step4x : 0.0)
                 }
             } else if let preview = parentLinkPreview {
                 ReplyReferenceLinkPreview(preview: preview)
@@ -134,7 +132,6 @@ struct ReplyReferenceView: View {
                             .layoutPriority(-1)
                     }
                 }
-                .padding(.trailing, isOutgoing ? DesignConstants.Spacing.step4x : 0.0)
             }
         }
         .padding(.top, DesignConstants.Spacing.stepX)
@@ -467,5 +464,43 @@ private struct ReplyReferenceLinkPreview: View {
                 }
             }
         }
+    }
+}
+
+// MARK: - File Reply Preview
+
+private struct ReplyReferenceFileBubble: View {
+    let attachment: HydratedAttachment
+
+    var body: some View {
+        HStack(spacing: DesignConstants.Spacing.step2x) {
+            ZStack {
+                RoundedRectangle(cornerRadius: 6)
+                    .fill(Color.colorFillMinimal)
+                Image(systemName: "doc.fill")
+                    .font(.system(size: 20))
+                    .foregroundStyle(.secondary)
+            }
+            .frame(width: 40, height: 40)
+
+            VStack(alignment: .leading, spacing: 1) {
+                Text(attachment.filename ?? "File")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.primary)
+                    .lineLimit(1)
+                if let label = attachment.fileTypeLabel {
+                    Text(label)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+            }
+        }
+        .padding(.horizontal, DesignConstants.Spacing.step3x)
+        .padding(.vertical, DesignConstants.Spacing.step2x)
+        .background(
+            RoundedRectangle(cornerRadius: 10)
+                .fill(Color.colorFillMinimal)
+        )
     }
 }

--- a/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/ReplyReferenceView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/ReplyReferenceView.swift
@@ -32,6 +32,15 @@ struct ReplyReferenceView: View {
         }
     }
 
+    private func replyLabel(for attachment: HydratedAttachment) -> String {
+        switch attachment.mediaType {
+        case .video: return "video"
+        case .audio: return "audio"
+        case .file: return attachment.filename ?? "file"
+        default: return "photo"
+        }
+    }
+
     private var parentAttachment: HydratedAttachment? {
         switch parentMessage.content {
         case .attachment(let attachment):

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
@@ -551,7 +551,15 @@ private struct AttachmentPlaceholder: View {
                 let videoURL: URL
                 if attachment.key.hasPrefix("file://") {
                     let path = String(attachment.key.dropFirst("file://".count))
-                    videoURL = URL(fileURLWithPath: path)
+                    if FileManager.default.fileExists(atPath: path) {
+                        videoURL = URL(fileURLWithPath: path)
+                    } else {
+                        let data = try await recoverInlineAttachmentData(from: path)
+                        let tempURL = FileManager.default.temporaryDirectory
+                            .appendingPathComponent("video_\(UUID().uuidString).mp4")
+                        try data.write(to: tempURL)
+                        videoURL = tempURL
+                    }
                 } else if let cached = await VideoURLCache.shared.url(for: attachment.key) {
                     videoURL = cached
                 } else {
@@ -591,8 +599,11 @@ private struct AttachmentPlaceholder: View {
 
             if attachment.key.hasPrefix("file://") {
                 let path = String(attachment.key.dropFirst("file://".count))
-                let url = URL(fileURLWithPath: path)
-                imageData = try Data(contentsOf: url)
+                if FileManager.default.fileExists(atPath: path) {
+                    imageData = try Data(contentsOf: URL(fileURLWithPath: path))
+                } else {
+                    imageData = try await recoverInlineAttachmentData(from: path)
+                }
             } else if attachment.key.hasPrefix("{") {
                 imageData = try await Self.loader.loadImageData(from: attachment.key)
             } else if let url = URL(string: attachment.key) {
@@ -795,6 +806,16 @@ struct PhotoSenderLabel: View {
         onPhotoDimensionsLoaded: { _, _, _ in }
     )
     .padding()
+}
+
+private func recoverInlineAttachmentData(from path: String) async throws -> Data {
+    let fileURL = URL(fileURLWithPath: path)
+    let filename = fileURL.lastPathComponent
+    guard let underscoreIndex = filename.firstIndex(of: "_") else {
+        throw CocoaError(.fileReadNoSuchFile, userInfo: [NSFilePathErrorKey: path])
+    }
+    let messageId = String(filename[filename.startIndex..<underscoreIndex])
+    return try await InlineAttachmentRecovery.shared.recoverData(messageId: messageId)
 }
 
 // swiftlint:disable force_unwrapping

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
@@ -40,7 +40,7 @@ struct MessagesGroupItemView: View {
                     onPhotoRevealed: onPhotoRevealed,
                     onPhotoHidden: onPhotoHidden
                 )
-                .padding(.leading, !message.sender.isCurrentUser && message.content.isAttachment
+                .padding(.leading, !message.sender.isCurrentUser && message.content.isFullBleedAttachment
                     ? DesignConstants.Spacing.step4x
                     : 0.0)
             }

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
@@ -43,6 +43,7 @@ struct MessagesGroupItemView: View {
                 .padding(.leading, !message.sender.isCurrentUser && message.content.isFullBleedAttachment
                     ? DesignConstants.Spacing.step4x
                     : 0.0)
+                .padding(.trailing, trailingPadding)
             }
             messageContent
         }

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
@@ -14,6 +14,7 @@ struct MessagesGroupItemView: View {
     let onPhotoRevealed: (String) -> Void
     let onPhotoHidden: (String) -> Void
     let onPhotoDimensionsLoaded: (String, Int, Int) -> Void
+    var onOpenFile: ((HydratedAttachment) -> Void)?
     var omitTrailingPadding: Bool = false
 
     @State private var isAppearing: Bool = true
@@ -216,18 +217,35 @@ struct MessagesGroupItemView: View {
     private func attachmentView(for attachment: HydratedAttachment) -> some View {
         let isBlurred = attachment.isHiddenByOwner || (!message.sender.isCurrentUser && shouldBlurPhotos && !attachment.isRevealed)
 
-        VideoTapAttachmentView(
-            attachment: attachment,
-            message: message,
-            isOutgoing: message.sender.isCurrentUser,
-            profile: message.sender.profile,
-            shouldBlurPhotos: shouldBlurPhotos,
-            isBlurred: isBlurred,
-            onPhotoRevealed: onPhotoRevealed,
-            onPhotoDimensionsLoaded: onPhotoDimensionsLoaded,
-            onReply: onReply
-        )
-        .id(message.messageId)
+        if attachment.mediaType == .file {
+            let fileTapAction: () -> Void = { onOpenFile?(attachment) }
+            FileAttachmentBubble(
+                attachment: attachment,
+                style: bubbleType,
+                isOutgoing: message.sender.isCurrentUser,
+                profile: message.sender.profile
+            )
+            .messageGesture(
+                message: message,
+                bubbleStyle: bubbleType,
+                onSingleTap: fileTapAction,
+                onReply: onReply
+            )
+            .id(message.messageId)
+        } else {
+            VideoTapAttachmentView(
+                attachment: attachment,
+                message: message,
+                isOutgoing: message.sender.isCurrentUser,
+                profile: message.sender.profile,
+                shouldBlurPhotos: shouldBlurPhotos,
+                isBlurred: isBlurred,
+                onPhotoRevealed: onPhotoRevealed,
+                onPhotoDimensionsLoaded: onPhotoDimensionsLoaded,
+                onReply: onReply
+            )
+            .id(message.messageId)
+        }
     }
 }
 

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
@@ -549,28 +549,7 @@ private struct AttachmentPlaceholder: View {
             }
 
             do {
-                let videoURL: URL
-                if attachment.key.hasPrefix("file://") {
-                    let path = String(attachment.key.dropFirst("file://".count))
-                    if FileManager.default.fileExists(atPath: path) {
-                        videoURL = URL(fileURLWithPath: path)
-                    } else {
-                        let data = try await recoverInlineAttachmentData(from: path)
-                        let tempURL = FileManager.default.temporaryDirectory
-                            .appendingPathComponent("video_\(UUID().uuidString).mp4")
-                        try data.write(to: tempURL)
-                        videoURL = tempURL
-                    }
-                } else if let cached = await VideoURLCache.shared.url(for: attachment.key) {
-                    videoURL = cached
-                } else {
-                    let loaded = try await Self.loader.loadAttachmentData(from: attachment.key)
-                    let tempURL = FileManager.default.temporaryDirectory
-                        .appendingPathComponent("video_\(UUID().uuidString).mp4")
-                    try loaded.data.write(to: tempURL)
-                    await VideoURLCache.shared.set(tempURL, for: attachment.key)
-                    videoURL = tempURL
-                }
+                let videoURL = try await resolveVideoURL(for: attachment.key)
                 let player = AVPlayer(url: videoURL)
                 await player.seek(to: .zero)
                 inlinePlayer = player
@@ -630,6 +609,29 @@ private struct AttachmentPlaceholder: View {
         }
 
         isLoading = false
+    }
+
+    private func resolveVideoURL(for key: String) async throws -> URL {
+        if key.hasPrefix("file://") {
+            let path = String(key.dropFirst("file://".count))
+            if FileManager.default.fileExists(atPath: path) {
+                return URL(fileURLWithPath: path)
+            }
+            let data = try await recoverInlineAttachmentData(from: path)
+            let tempURL = FileManager.default.temporaryDirectory
+                .appendingPathComponent("video_\(UUID().uuidString).mp4")
+            try data.write(to: tempURL)
+            return tempURL
+        }
+        if let cached = await VideoURLCache.shared.url(for: key) {
+            return cached
+        }
+        let loaded = try await Self.loader.loadAttachmentData(from: key)
+        let tempURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("video_\(UUID().uuidString).mp4")
+        try loaded.data.write(to: tempURL)
+        await VideoURLCache.shared.set(tempURL, for: key)
+        return tempURL
     }
 
     private var loadingPlaceholder: some View {

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupView.swift
@@ -12,6 +12,7 @@ struct MessagesGroupView: View {
     let onPhotoRevealed: (String) -> Void
     let onPhotoHidden: (String) -> Void
     let onPhotoDimensionsLoaded: (String, Int, Int) -> Void
+    var onOpenFile: ((HydratedAttachment) -> Void)?
     var onRetryMessage: ((AnyMessage) -> Void)?
     var onDeleteMessage: ((AnyMessage) -> Void)?
 
@@ -171,6 +172,7 @@ struct MessagesGroupView: View {
                         onPhotoRevealed: onPhotoRevealed,
                         onPhotoHidden: onPhotoHidden,
                         onPhotoDimensionsLoaded: onPhotoDimensionsLoaded,
+                        onOpenFile: onOpenFile,
                         omitTrailingPadding: isFailed
                     )
                     .zIndex(100)

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupView.swift
@@ -143,7 +143,7 @@ struct MessagesGroupView: View {
         VStack(alignment: .leading, spacing: DesignConstants.Spacing.stepX) {
             ForEach(Array(group.allMessages.enumerated()), id: \.element.messageId) { index, message in
                 let isReply: Bool = if case .reply = message { true } else { false }
-                let isFullWidthAttachment: Bool = message.content.isAttachment
+                let isFullWidthAttachment: Bool = message.content.isFullBleedAttachment
 
                 if index == 0 && !group.sender.isCurrentUser && !isFullWidthAttachment && !isReply {
                     senderLabel

--- a/ConvosCore/Sources/ConvosCore/Messaging/InlineAttachmentRecovery.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/InlineAttachmentRecovery.swift
@@ -48,7 +48,9 @@ public actor InlineAttachmentRecovery {
         }
         let dir = cacheDir.appendingPathComponent("InlineAttachments", isDirectory: true)
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
-        let safeFilename = "\(messageId)_\(filename)".replacingOccurrences(of: "/", with: "_")
+        let safeFilename = "\(messageId)_\(filename)"
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "..", with: "_")
         let fileURL = dir.appendingPathComponent(safeFilename)
         try data.write(to: fileURL, options: .atomic)
     }

--- a/ConvosCore/Sources/ConvosCore/Messaging/InlineAttachmentRecovery.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/InlineAttachmentRecovery.swift
@@ -1,0 +1,55 @@
+import Foundation
+import XMTPiOS
+
+public enum InlineAttachmentRecoveryError: Error {
+    case messageNotFound
+    case notAnAttachment
+    case noProviderAvailable
+}
+
+public actor InlineAttachmentRecovery {
+    public static let shared: InlineAttachmentRecovery = .init()
+
+    private var provider: (any ConversationsProvider)?
+
+    private init() {}
+
+    public func setProvider(_ provider: (any ConversationsProvider)?) {
+        self.provider = provider
+    }
+
+    public func recoverData(messageId: String) throws -> Data {
+        guard let provider else {
+            throw InlineAttachmentRecoveryError.noProviderAvailable
+        }
+
+        guard let decoded = try provider.findMessage(messageId: messageId) else {
+            throw InlineAttachmentRecoveryError.messageNotFound
+        }
+
+        let content = try decoded.content() as Any
+
+        if let attachment = content as? Attachment {
+            try resave(data: attachment.data, messageId: messageId, filename: attachment.filename)
+            return attachment.data
+        }
+
+        if let reply = content as? Reply, let attachment = reply.content as? Attachment {
+            try resave(data: attachment.data, messageId: messageId, filename: attachment.filename)
+            return attachment.data
+        }
+
+        throw InlineAttachmentRecoveryError.notAnAttachment
+    }
+
+    private func resave(data: Data, messageId: String, filename: String) throws {
+        guard let cacheDir = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first else {
+            return
+        }
+        let dir = cacheDir.appendingPathComponent("InlineAttachments", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let safeFilename = "\(messageId)_\(filename)".replacingOccurrences(of: "/", with: "_")
+        let fileURL = dir.appendingPathComponent(safeFilename)
+        try data.write(to: fileURL, options: .atomic)
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Messaging/XMTPClientProvider.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/XMTPClientProvider.swift
@@ -110,6 +110,8 @@ public protocol ConversationsProvider {
 
     func findOrCreateDm(with peerInboxId: String) async throws -> Dm
 
+    func findMessage(messageId: String) throws -> XMTPiOS.DecodedMessage?
+
     func sync() async throws
     func syncAllConversations(consentStates: [ConsentState]?) async throws -> GroupSyncSummary
     func streamAllMessages(

--- a/ConvosCore/Sources/ConvosCore/Mocks/MockXMTPClientProvider.swift
+++ b/ConvosCore/Sources/ConvosCore/Mocks/MockXMTPClientProvider.swift
@@ -144,6 +144,10 @@ public final class MockConversationsProvider: ConversationsProvider, @unchecked 
         // No-op for mock
     }
 
+    public func findMessage(messageId: String) throws -> DecodedMessage? {
+        nil
+    }
+
     public func syncAllConversations(consentStates: [ConsentState]?) async throws -> GroupSyncSummary {
         GroupSyncSummary(numEligible: 0, numSynced: 0)
     }

--- a/ConvosCore/Sources/ConvosCore/Storage/Hydration/DBMessage+MessagePreview.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Hydration/DBMessage+MessagePreview.swift
@@ -1,4 +1,5 @@
 import Foundation
+import UniformTypeIdentifiers
 
 extension DBLastMessageWithSource {
     func hydrateMessagePreview(
@@ -105,13 +106,71 @@ extension DBLastMessageWithSource {
     }
 
     static func attachmentsPreviewString(attachmentUrls: [String], count: Int) -> String {
-        let hasVideo = attachmentUrls.contains { url in
-            guard let stored = try? StoredRemoteAttachment.fromJSON(url) else { return false }
-            return stored.mimeType?.hasPrefix("video/") == true
+        var hasVideo = false
+        var hasFile = false
+        var filename: String?
+
+        for url in attachmentUrls {
+            if let stored = try? StoredRemoteAttachment.fromJSON(url) {
+                classifyStoredAttachment(stored, hasVideo: &hasVideo, hasFile: &hasFile, filename: &filename)
+            } else if url.hasPrefix("file://") {
+                classifyFileURL(url, hasVideo: &hasVideo, hasFile: &hasFile, filename: &filename)
+            }
         }
+
         if count <= 1 {
-            return hasVideo ? "a video" : "a photo"
+            if hasFile, let filename { return filename }
+            if hasFile { return "a file" }
+            if hasVideo { return "a video" }
+            return "a photo"
         }
-        return hasVideo ? "\(count) attachments" : "\(count) photos"
+        if hasFile || hasVideo { return "\(count) attachments" }
+        return "\(count) photos"
+    }
+
+    private static func classifyStoredAttachment(
+        _ stored: StoredRemoteAttachment,
+        hasVideo: inout Bool,
+        hasFile: inout Bool,
+        filename: inout String?
+    ) {
+        if stored.mimeType?.hasPrefix("video/") == true {
+            hasVideo = true
+        } else if let mime = stored.mimeType, !mime.hasPrefix("image/") {
+            hasFile = true
+            filename = stored.filename
+        } else if let fn = stored.filename {
+            let ext = (fn as NSString).pathExtension.lowercased()
+            if !ext.isEmpty, let utType = UTType(filenameExtension: ext), !utType.conforms(to: .image) {
+                hasFile = true
+                filename = fn
+            }
+        }
+    }
+
+    private static func classifyFileURL(
+        _ url: String,
+        hasVideo: inout Bool,
+        hasFile: inout Bool,
+        filename: inout String?
+    ) {
+        guard let fn = extractFilenameFromURL(url) else { return }
+        let ext = (fn as NSString).pathExtension.lowercased()
+        guard !ext.isEmpty, let utType = UTType(filenameExtension: ext) else { return }
+        if utType.conforms(to: .movie) || utType.conforms(to: .video) {
+            hasVideo = true
+        } else if !utType.conforms(to: .image) {
+            hasFile = true
+            filename = fn
+        }
+    }
+
+    private static func extractFilenameFromURL(_ url: String) -> String? {
+        guard let parsed = URL(string: url) else { return nil }
+        let lastComponent = parsed.lastPathComponent
+        if let range = lastComponent.range(of: "_") {
+            return String(lastComponent[range.upperBound...])
+        }
+        return lastComponent
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/HydratedAttachment.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/HydratedAttachment.swift
@@ -18,6 +18,27 @@ public struct HydratedAttachment: Hashable, Codable, Sendable {
     public let duration: Double?
     public let thumbnailDataBase64: String?
     public let fileSize: Int?
+    public let filename: String?
+
+    public var filenameExtension: String? {
+        guard let filename else { return nil }
+        let ext = (filename as NSString).pathExtension.lowercased()
+        return ext.isEmpty ? nil : ext
+    }
+
+    public var fileTypeLabel: String? {
+        guard mediaType == .file else { return nil }
+        if let ext = filenameExtension {
+            return ext.uppercased()
+        }
+        if let mimeType {
+            let components = mimeType.split(separator: "/")
+            if components.count == 2 {
+                return String(components[1]).uppercased()
+            }
+        }
+        return nil
+    }
 
     public var mediaType: MediaType {
         guard let mimeType else { return .image }
@@ -46,7 +67,8 @@ public struct HydratedAttachment: Hashable, Codable, Sendable {
         mimeType: String? = nil,
         duration: Double? = nil,
         thumbnailDataBase64: String? = nil,
-        fileSize: Int? = nil
+        fileSize: Int? = nil,
+        filename: String? = nil
     ) {
         self.key = key
         self.isRevealed = isRevealed
@@ -57,5 +79,6 @@ public struct HydratedAttachment: Hashable, Codable, Sendable {
         self.duration = duration
         self.thumbnailDataBase64 = thumbnailDataBase64
         self.fileSize = fileSize
+        self.filename = filename
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/MessageContent.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/MessageContent.swift
@@ -65,4 +65,15 @@ public enum MessageContent: Hashable, Codable, Sendable {
             false
         }
     }
+
+    public var isFullBleedAttachment: Bool {
+        switch self {
+        case .attachment(let attachment):
+            attachment.mediaType != .file
+        case .attachments(let attachments):
+            attachments.first.map { $0.mediaType != .file } ?? false
+        default:
+            false
+        }
+    }
 }

--- a/ConvosCore/Sources/ConvosCore/Storage/Repositories/MessagesRepository.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Repositories/MessagesRepository.swift
@@ -804,12 +804,15 @@ private func hydrateAttachment(key: String, localState: AttachmentLocalState?) -
     var width: Int? = localState?.width
     var height: Int? = localState?.height
 
+    var filename: String?
+
     if let stored = try? StoredRemoteAttachment.fromJSON(key) {
         if mimeType == nil { mimeType = stored.mimeType }
         if width == nil { width = stored.mediaWidth }
         if height == nil { height = stored.mediaHeight }
         duration = stored.mediaDuration
         thumbnailDataBase64 = stored.thumbnailDataBase64
+        filename = stored.filename
     }
 
     return HydratedAttachment(
@@ -820,6 +823,7 @@ private func hydrateAttachment(key: String, localState: AttachmentLocalState?) -
         height: height,
         mimeType: mimeType,
         duration: duration,
-        thumbnailDataBase64: thumbnailDataBase64
+        thumbnailDataBase64: thumbnailDataBase64,
+        filename: filename
     )
 }

--- a/ConvosCore/Sources/ConvosCore/Storage/Repositories/MessagesRepository.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Repositories/MessagesRepository.swift
@@ -1,6 +1,7 @@
 import Combine
 import Foundation
 import GRDB
+import UniformTypeIdentifiers
 
 public typealias ConversationMessages = (conversationId: String, messages: [AnyMessage])
 
@@ -813,6 +814,17 @@ private func hydrateAttachment(key: String, localState: AttachmentLocalState?) -
         duration = stored.mediaDuration
         thumbnailDataBase64 = stored.thumbnailDataBase64
         filename = stored.filename
+    } else if key.hasPrefix("file://"), let url = URL(string: key) {
+        let name = url.lastPathComponent
+        if let underscoreIndex = name.firstIndex(of: "_") {
+            filename = String(name[name.index(after: underscoreIndex)...])
+        } else {
+            filename = name
+        }
+        if mimeType == nil, let ext = filename.flatMap({ ($0 as NSString).pathExtension.lowercased() }),
+           !ext.isEmpty, let utType = UTType(filenameExtension: ext) {
+            mimeType = utType.preferredMIMEType
+        }
     }
 
     return HydratedAttachment(

--- a/ConvosCore/Sources/ConvosCore/Storage/Repositories/MessagesRepository.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Repositories/MessagesRepository.swift
@@ -814,7 +814,8 @@ private func hydrateAttachment(key: String, localState: AttachmentLocalState?) -
         duration = stored.mediaDuration
         thumbnailDataBase64 = stored.thumbnailDataBase64
         filename = stored.filename
-    } else if key.hasPrefix("file://"), let url = URL(string: key) {
+    } else if key.hasPrefix("file://") {
+        let url = URL(fileURLWithPath: String(key.dropFirst(7)))
         let name = url.lastPathComponent
         if let underscoreIndex = name.firstIndex(of: "_") {
             filename = String(name[name.index(after: underscoreIndex)...])

--- a/ConvosCore/Sources/ConvosCore/Storage/Repositories/MessagesRepository.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Repositories/MessagesRepository.swift
@@ -815,7 +815,7 @@ private func hydrateAttachment(key: String, localState: AttachmentLocalState?) -
         thumbnailDataBase64 = stored.thumbnailDataBase64
         filename = stored.filename
     } else if key.hasPrefix("file://") {
-        let url = URL(fileURLWithPath: String(key.dropFirst(7)))
+        let url = URL(string: key) ?? URL(fileURLWithPath: String(key.dropFirst(7)))
         let name = url.lastPathComponent
         if let underscoreIndex = name.firstIndex(of: "_") {
             filename = String(name[name.index(after: underscoreIndex)...])

--- a/ConvosCore/Tests/ConvosCoreTests/SyncingManagerTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/SyncingManagerTests.swift
@@ -198,6 +198,10 @@ class TestableMockConversations: ConversationsProvider, @unchecked Sendable {
         nil
     }
 
+    func findMessage(messageId: String) throws -> DecodedMessage? {
+        nil
+    }
+
     func findOrCreateDm(with peerInboxId: String) async throws -> XMTPiOS.Dm {
         fatalError("not implemented in test mock")
     }

--- a/docs/plans/file-attachments.md
+++ b/docs/plans/file-attachments.md
@@ -1,0 +1,416 @@
+# Generic File Attachment Support — Investigation
+
+## Context
+
+AI Assistants (agents) need to send users files beyond photos and videos — PDFs, documents, spreadsheets, code, Markdown, CSVs, etc. The app currently only renders image and video attachments. Any other MIME type silently falls through to a failed/empty state.
+
+This document investigates what it would take to:
+1. Render inline previews for generic files in the messages list
+2. Let users open/view files in a full-screen preview
+3. Let users save files to the iOS Files app or share them
+
+## Current State
+
+### What Works Today (Protocol Layer)
+
+The XMTP protocol is **fully content-type agnostic**. The `Attachment` type is just `{filename, mimeType, data}` — no image-specific logic. Both `AttachmentCodec` (inline ≤1MB) and `RemoteAttachmentCodec` (encrypted + uploaded) work with any file type.
+
+The CLI already supports sending any file: `convos conversation send-attachment <id> ./report.pdf`
+
+### What Blocks Generic Files Today (App Layer)
+
+| Layer | File | Issue |
+|-------|------|-------|
+| **Message decoding** | `DecodedMessage+DBRepresentation.swift` | No longer blocks — `image/` MIME guard was removed for video support |
+| **DB model** | `StoredRemoteAttachment` | Already stores `mimeType`, `filename`. Works for any type. |
+| **Hydration** | `MessagesRepository` → `hydrateAttachment()` | `MediaType` enum already has `.file` case. `HydratedAttachment` carries `mimeType` and `filename`. |
+| **UI rendering** | `AttachmentPlaceholder` in `MessagesGroupItemView.swift` | Only renders `UIImage` or `AVPlayer`. No file preview path. Falls through to loading/error state for PDFs, etc. |
+| **Message preview** | `DBMessage+MessagePreview.swift` | `attachmentsPreviewString` returns "a photo" or "a video". No "a file" / "a document" case. |
+| **Context menu** | `MessageContextMenuOverlay.swift` | Save action only handles images and videos. No "Save to Files" or "Open In..." |
+| **Reply views** | `ReplyComposerBar.swift`, `ReplyReferenceView.swift` | Only render photo/video thumbnails. No file icon/name for generic files. |
+
+### What We Get for Free
+
+- `HydratedAttachment.mediaType` already returns `.file` for non-image/video MIME types
+- `StoredRemoteAttachment` already round-trips `mimeType` and `filename` through JSON
+- `RemoteAttachmentLoader.loadAttachmentData()` returns `LoadedAttachment(data, mimeType, filename)` — works for any file
+- The `AttachmentLocalState` DB table already has a `mimeType` column (added for video)
+- `MediaType` enum already has `.audio`, `.file`, `.unknown` cases
+
+## Investigation: File Preview Rendering
+
+### Option A: QLThumbnailGenerator for Message Bubbles
+
+iOS's `QLThumbnailGenerator` can generate thumbnail images for most file types — PDFs, Office docs, iWork docs, text files, source code, and more. It falls back to a system file-type icon for unsupported formats.
+
+```swift
+import QuickLookThumbnailing
+
+let request = QLThumbnailGenerator.Request(
+    fileAt: localFileURL,
+    size: CGSize(width: 120, height: 160),
+    scale: UIScreen.main.scale,
+    representationTypes: [.thumbnail, .icon]
+)
+
+let thumbnail = try await QLThumbnailGenerator.shared.generateBestRepresentation(for: request)
+let image = thumbnail.uiImage
+```
+
+**Pros:**
+- Automatic support for 20+ file types without custom rendering
+- Native iOS quality — same thumbnails as Files app
+- Generates both content thumbnails (first page of PDF) and type icons (fallback)
+
+**Cons:**
+- Requires file on local disk — must download + decrypt first
+- Async operation — adds latency to first render
+- No thumbnail for many programmatic file types (.json, .yaml, .csv — renders as text icon only)
+
+**Recommendation:** Use for the inline message bubble preview. The flow would be:
+1. Show placeholder with file icon + filename + file size while loading
+2. Download + decrypt file to temp directory
+3. Generate thumbnail via `QLThumbnailGenerator`
+4. Display thumbnail image in bubble (similar to photo treatment but smaller, with filename overlay)
+
+### Option B: Custom Renderers Per File Type
+
+Build custom inline previews for specific high-value types:
+- **PDF:** First page via `PDFKit` (`PDFDocument` → `PDFPage.thumbnail()`)
+- **Markdown:** Render to `AttributedString` and show styled preview text
+- **Code/Text:** Show first N lines in monospace font
+- **CSV:** Show mini table view with first few rows
+
+**Pros:** Richer, more useful previews
+**Cons:** Significant dev effort per type, maintenance burden
+
+**Recommendation:** Not for V1. Start with QLThumbnailGenerator and add custom renderers for high-value types later.
+
+### Option C: Sender-Generated Thumbnails (like video)
+
+The sender generates a thumbnail and embeds it as base64 in the `StoredRemoteAttachment` metadata, same as video thumbnails today.
+
+**Pros:** Instant display, no download needed for preview
+**Cons:** Only works for app-sent files (agents use CLI, which doesn't generate thumbnails). Adds message size.
+
+**Recommendation:** Use as an optimization layer on top of Option A. If `thumbnailDataBase64` exists, use it immediately; otherwise fall back to QLThumbnailGenerator after download.
+
+### Recommended Approach: Hybrid (A + C)
+
+1. **Immediate render:** File icon + filename + size badge (from metadata in `StoredRemoteAttachment`)
+2. **If thumbnail exists in metadata:** Show it immediately (like video thumbnails)
+3. **After download:** Generate QLThumbnail and cache it (replaces icon)
+4. **Cache thumbnails** in `ImageCache` with `.persistent` tier so they survive app restarts
+
+## Investigation: Full-Screen File Viewing
+
+### SwiftUI `.quickLookPreview()` Modifier
+
+The simplest approach — SwiftUI's built-in QuickLook integration:
+
+```swift
+@State private var previewURL: URL?
+
+view
+    .quickLookPreview($previewURL)
+```
+
+When `previewURL` is set, iOS presents a full-screen `QLPreviewController` modally. Supports:
+- PDF (with page navigation, search, markup)
+- Office docs (Word, Excel, PowerPoint)
+- iWork docs (Pages, Numbers, Keynote)
+- Images, videos, audio
+- Text, RTF, HTML, CSV
+- 3D models (USDZ)
+
+The user gets native iOS file viewing with share, markup, and print built in.
+
+**Flow:**
+1. User taps file attachment bubble
+2. If file not yet downloaded: show loading spinner, download + decrypt, save to temp with correct filename/extension
+3. Set `previewURL` → system presents QLPreviewController
+4. User can share from within QuickLook (share button in toolbar)
+
+**Key detail:** The temp file MUST have the correct file extension (e.g., `.pdf`, not `.bin`) for QuickLook to render it properly. Use `UTType(mimeType:)?.preferredFilenameExtension` to derive the extension from MIME type.
+
+### UIDocumentInteractionController (Alternative)
+
+More control than QuickLook — shows "Open In..." menu with compatible apps. But it's UIKit-only and mostly superseded by `UIActivityViewController`.
+
+**Recommendation:** Use `.quickLookPreview()` for V1. It's the standard iOS pattern and requires minimal code.
+
+## Investigation: Save to Files / Share
+
+### Option 1: Share Sheet via UIActivityViewController
+
+Present a share sheet with the file URL. The system automatically offers:
+- Save to Files
+- AirDrop
+- Mail, Messages
+- Third-party apps (Slack, Google Drive, etc.)
+
+This is what the QuickLook share button already does, so we get it for free with `.quickLookPreview()`.
+
+### Option 2: Direct "Save to Files" via UIDocumentPickerViewController
+
+```swift
+let picker = UIDocumentPickerViewController(forExporting: [fileURL])
+picker.shouldShowFileExtensions = true
+present(picker, animated: true)
+```
+
+This opens the Files app picker directly, letting the user choose where to save.
+
+### Option 3: Context Menu Actions
+
+Add to the long-press context menu:
+- **"Save to Files"** — Opens document picker for save location
+- **"Share"** — Opens share sheet
+- **"Open"** — Opens in QuickLook
+
+**Recommendation:** For V1:
+- Tap → QuickLook preview (which has built-in share)
+- Context menu → "Save to Files" + "Share" + "Open"
+
+## Investigation: Message List Preview Text
+
+Currently `attachmentsPreviewString` returns "a photo" or "a video". For files, we should show the filename:
+
+```swift
+static func attachmentsPreviewString(attachmentUrls: [String], count: Int) -> String {
+    // ... existing photo/video logic ...
+    
+    // For generic files, show filename
+    if let stored = try? StoredRemoteAttachment.fromJSON(attachmentUrls.first ?? ""),
+       let filename = stored.filename {
+        return count <= 1 ? filename : "\(count) files"
+    }
+    return count <= 1 ? "a file" : "\(count) files"
+}
+```
+
+## Data Model Changes Required
+
+### StoredRemoteAttachment — Needs One Addition
+
+The existing fields cover most file metadata:
+- `filename` — Already present
+- `mimeType` — Already present (added for video)
+- `mediaWidth`/`mediaHeight` — N/A for files, already optional
+- `thumbnailDataBase64` — Can be reused for file thumbnails
+
+One addition needed:
+- `fileSize: Int64?` — Original file size in bytes (for display in bubble). Not currently stored. The XMTP `RemoteAttachment.contentLength` is the *encrypted* payload size, not the original.
+
+### HydratedAttachment — Two Fields Need Hydration
+
+- `filename: String?` — Currently NOT hydrated from `StoredRemoteAttachment`. Must be added to `hydrateAttachment()` in `MessagesRepository`. Critical for determining file type when `mimeType` is nil.
+- `fileSize: Int?` — Already defined on `HydratedAttachment` but never populated. Should be hydrated from `StoredRemoteAttachment.fileSize` once that field exists.
+
+### filename Hydration Path
+
+Currently in `MessagesRepository.hydrateAttachment()`:
+
+```swift
+private func hydrateAttachment(key: String, localState: AttachmentLocalState?) -> HydratedAttachment {
+    // ... existing code extracts mimeType, duration, thumbnailDataBase64, width, height
+    // filename is NOT extracted — needs to be added:
+    var filename: String? = nil
+    if let stored = try? StoredRemoteAttachment.fromJSON(key) {
+        filename = stored.filename
+        // ... existing extractions
+    }
+    // For file:// URLs, derive from path
+    if filename == nil, key.hasPrefix("file://") {
+        filename = URL(string: key)?.lastPathComponent
+    }
+}
+```
+
+### AttachmentLocalState — No Changes
+
+Already has `mimeType` column.
+
+## UI Design: File Attachment Bubble
+
+### Proposed Layout (Compact)
+
+```
+┌─────────────────────────────────┐
+│  ┌────┐                        │
+│  │ 📄 │  report.pdf            │
+│  │    │  245 KB · PDF          │
+│  └────┘                        │
+└─────────────────────────────────┘
+```
+
+For files with thumbnails (after QLThumbnailGenerator):
+
+```
+┌─────────────────────────────────┐
+│  ┌────────┐                    │
+│  │ thumb  │  report.pdf        │
+│  │ nail   │  245 KB · PDF      │
+│  └────────┘                    │
+└─────────────────────────────────┘
+```
+
+### Components:
+- **File icon or thumbnail:** 48×64pt area. SF Symbol `doc.fill` initially, replaced by QLThumbnail after download.
+- **Filename:** Primary text, truncated with ellipsis.
+- **Subtitle:** File size + file type label (derived from MIME type or extension).
+- **Background:** Rounded rectangle matching message bubble style.
+- **Sender avatar:** Same position as photo/video messages.
+
+### File Type to Icon Mapping
+
+Use SF Symbols for instant rendering before thumbnail loads:
+
+| MIME Type | SF Symbol | Label |
+|-----------|-----------|-------|
+| `application/pdf` | `doc.fill` | PDF |
+| `text/plain` | `doc.text.fill` | Text |
+| `text/markdown` | `doc.text.fill` | Markdown |
+| `text/csv` | `tablecells.fill` | CSV |
+| `text/html` | `globe` | HTML |
+| `application/json` | `curlybraces` | JSON |
+| `application/zip` | `doc.zipper` | ZIP |
+| `application/vnd.openxmlformats-officedocument.wordprocessingml.document` | `doc.fill` | Word |
+| `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet` | `tablecells.fill` | Excel |
+| `application/vnd.openxmlformats-officedocument.presentationml.presentation` | `rectangle.fill.on.rectangle.angled.fill` | PowerPoint |
+| `audio/*` | `waveform` | Audio |
+| (default) | `doc.fill` | File |
+
+## Implementation Layers (Estimated Effort)
+
+### Layer 1: Receive & Display (Core — ~2 days)
+
+1. Add `filename` hydration to `hydrateAttachment()` in `MessagesRepository`
+2. Add `fileSize` hydration from `StoredRemoteAttachment` metadata
+3. Create `FileAttachmentBubble` SwiftUI view (icon + filename + size)
+4. Route `MediaType.file` in `AttachmentPlaceholder` to `FileAttachmentBubble` instead of photo path
+5. Update `attachmentsPreviewString` for conversation list ("report.pdf" instead of "a photo")
+6. Update reply views to show file icon + filename instead of photo thumbnail
+
+### Layer 2: Download & Preview (Core — ~2 days)
+
+1. Download + decrypt file via `RemoteAttachmentLoader.loadAttachmentData()`
+2. Save to temp directory with correct file extension
+3. Present via `.quickLookPreview()` on tap
+4. Add download progress indicator to bubble
+5. Cache downloaded files in `VideoURLCache`-style actor (reuse for repeat opens)
+
+### Layer 3: Thumbnails (Polish — ~1 day)
+
+1. After download, generate thumbnail via `QLThumbnailGenerator`
+2. Cache thumbnail in `ImageCache` with persistent tier
+3. Replace file icon with thumbnail in bubble
+4. For sender-generated thumbnails (future), display from `thumbnailDataBase64`
+
+### Layer 4: Context Menu & Save (Polish — ~1 day)
+
+1. Add "Save to Files" context menu action (UIDocumentPickerViewController)
+2. Add "Share" context menu action (UIActivityViewController)
+3. Add "Open" context menu action (QuickLook)
+4. Handle file-specific context menu (no "Blur/Reveal" for files)
+
+### Layer 5: Conversation List & Notifications (Polish — ~0.5 day)
+
+1. Update preview text: show filename for file attachments
+2. Update push notification text for file messages
+
+### Total Estimated Effort: ~6.5 days
+
+## Critical Finding: MIME Type Not Available at Receive Time
+
+When a `RemoteAttachment` arrives via XMTP, we only get `{url, contentDigest, secret, salt, nonce, filename}`. The `mimeType` is inside the encrypted payload — only available after download and decryption.
+
+For **sender-side** (our app sending video), we embed `mimeType` into `StoredRemoteAttachment` during send. But for **receiver-side** (files from agents/CLI), `StoredRemoteAttachment.mimeType` will be `nil`.
+
+**Implication:** We must derive media type from the `filename` extension:
+
+```swift
+import UniformTypeIdentifiers
+
+extension HydratedAttachment {
+    var mediaType: MediaType {
+        // Check explicit mimeType first (sender-set)
+        if let mimeType {
+            if mimeType.hasPrefix("image/") { return .image }
+            if mimeType.hasPrefix("video/") { return .video }
+            if mimeType.hasPrefix("audio/") { return .audio }
+            return .file
+        }
+        
+        // Fall back to filename extension
+        if let filename = self.filename,
+           let ext = filename.split(separator: ".").last,
+           let utType = UTType(filenameExtension: String(ext)) {
+            if utType.conforms(to: .image) { return .image }
+            if utType.conforms(to: .movie) || utType.conforms(to: .video) { return .video }
+            if utType.conforms(to: .audio) { return .audio }
+            return .file
+        }
+        
+        // No mimeType, no filename → assume image (backward compat)
+        return .image
+    }
+}
+```
+
+This also means `filename` MUST be hydrated from `StoredRemoteAttachment` to `HydratedAttachment` — it currently isn't.
+
+After the file is downloaded and decrypted, we get the actual `mimeType` from the `Attachment` payload. At that point, we should update `AttachmentLocalState.mimeType` so subsequent renders use the authoritative MIME type.
+
+### Inline Attachments (≤1MB from CLI)
+
+For inline `ContentTypeAttachment` messages, the attachment `data` is decoded immediately and saved to `Caches/InlineAttachments/{messageId}_{filename}`. The `attachmentUrls` array stores a `file://` URL (not JSON).
+
+The `Attachment.mimeType` IS available at decode time but is **not currently stored** — only the file URL is saved. The filename preserves the original extension, so we can derive type from extension.
+
+However, for correctness we should store the mimeType in `AttachmentLocalState` at decode time for inline attachments:
+
+```swift
+// In handleAttachmentContent():
+let fileURL = try Self.saveInlineAttachment(data: attachment.data, messageId: id, filename: attachment.filename)
+// NEW: Also save mimeType for inline attachments
+// (needs to be done post-save in StreamProcessor since we don't have conversationId here)
+```
+
+### Two Attachment Key Formats
+
+| Format | Source | Example |
+|--------|--------|---------|
+| `file://...` URL | Inline attachments (≤1MB), just-sent photos/videos | `file:///var/.../Caches/InlineAttachments/msgId_report.pdf` |
+| JSON string | Remote attachments (>1MB) | `{"url":"https://...","contentDigest":"...","filename":"report.pdf",...}` |
+
+The UI code checks `attachment.key.hasPrefix("file://")` to distinguish these. For `file://` keys, it reads data directly. For JSON keys, it uses `RemoteAttachmentLoader` to download + decrypt.
+
+## Key Questions to Resolve Before Implementation
+
+1. **File size limit:** Currently 25MB for video. Same limit for files? The XMTP `RemoteAttachment` has no inherent limit, but S3 presigned URLs and upload may have constraints.
+
+2. **Blur/reveal for files:** Should files from non-contacts be blurred like photos? Files don't have visual content to blur — could show "File from unknown sender" with a reveal button. Or skip blur entirely for files (only apply to visual media).
+
+3. **Inline vs. remote threshold:** CLI sends inline (≤1MB) or remote (>1MB). Our app always sends remote for photos/video. For files, do we want to support inline `ContentTypeAttachment` receiving? Currently `handleAttachmentContent()` saves inline attachments to `Caches/InlineAttachments/` — this already works.
+
+4. **Audio files:** `MediaType.audio` is already defined. Should audio get its own playback treatment (waveform + play button) or be treated as a generic file? iMessage shows audio as inline waveform players.
+
+5. **Agent thumbnail generation:** Should the agent SDK / CLI be enhanced to generate and embed thumbnails for files it sends? This would give instant previews without download.
+
+6. **File caching strategy:** Downloaded files can be large. Should they persist across sessions (Application Support) or be treated as temp (Caches, OS can purge)? Videos currently use temp directory.
+
+## Appendix: MIME Types Agents Are Likely to Send
+
+Based on common AI assistant use cases:
+
+| Category | Types | Priority |
+|----------|-------|----------|
+| Documents | PDF, DOCX, TXT, RTF | High |
+| Data | CSV, JSON, XML, YAML | High |
+| Code | .py, .swift, .js, .ts, .html, .css | Medium |
+| Markdown | .md | High |
+| Spreadsheets | XLSX, Numbers | Medium |
+| Presentations | PPTX, Keynote | Low |
+| Archives | ZIP, TAR.GZ | Low |
+| Audio | MP3, WAV, M4A | Medium (separate feature) |

--- a/qa/SKILL.md
+++ b/qa/SKILL.md
@@ -44,6 +44,7 @@ Run end-to-end QA tests for the Convos iOS app using the iOS simulator tools and
 | 25 | `qa/tests/25-conversations-list-baseline.md` | Conversations list baseline for UICollectionView migration - captures all UI states and interactions |
 | 26 | `qa/tests/26-failed-message-send.md` | Failed message send: "Not Delivered" state, retry, and delete |
 | 27 | `qa/tests/27-send-receive-video.md` | Send and receive video messages, inline playback, blur/reveal, context menu, size limit |
+| 28 | `qa/tests/28-receive-file-attachments.md` | Receive file attachments (PDF, text, CSV, JSON), file bubble display, QuickLook preview, Save to Files |
 | 29 | `qa/tests/29-typing-indicators.md` | Typing indicators: receive, dismiss, message-arrival clearing, grouping, expiry |
 
 ## Running Tests
@@ -75,6 +76,7 @@ Recommended order:
 16. **17-swipe-actions** — tests mark read/unread swipe actions
 17. **20-send-receive-photos** — tests photo send/receive, blur/reveal, context menu
 18. **27-send-receive-video** — tests video send/receive, inline playback, blur/reveal
+19. **28-receive-file-attachments** — tests receiving file attachments from CLI, file bubble UI, QuickLook
 19. **19-profile-photo** — tests profile and group photos
 20. **15-performance** — performance baselines (run last, non-destructive)
 21. **18-delete-all-data** — wipes all data (run very last, destructive)

--- a/qa/tests/28-receive-file-attachments.md
+++ b/qa/tests/28-receive-file-attachments.md
@@ -1,0 +1,132 @@
+# Test: Receive File Attachments
+
+Verify that generic file attachments (PDF, text, CSV, JSON, etc.) sent from
+the CLI are received and displayed correctly in the app. Files should render
+as compact message bubbles with a file type icon, filename, type label, and
+file size — matching the iMessage file attachment design. Tapping a file should
+open it in QuickLook for full-screen viewing. Context menu should offer Save to
+Files and Share options.
+
+## Prerequisites
+
+- The app is running and past onboarding.
+- The convos CLI is initialized for the dev environment.
+
+## Setup
+
+1. Reset the CLI and re-initialize for dev.
+2. Create test files on disk:
+   - `/tmp/test-document.pdf` — a small valid PDF
+   - `/tmp/test-notes.txt` — a plain text file
+   - `/tmp/test-data.csv` — a CSV file with a few rows
+   - `/tmp/test-config.json` — a small JSON file
+3. Create a conversation via CLI named "File Test" with profile name "Agent".
+4. Generate an invite and open it as a deep link in the app.
+5. Process the join request from the CLI.
+
+## Steps
+
+### Receive a PDF from CLI
+
+6. Send the PDF from CLI: `convos conversation send-attachment <id> /tmp/test-document.pdf`.
+7. Wait for the message to appear in the app.
+8. Verify the file bubble shows:
+   - A file type icon on the left (PDF icon or generic document icon)
+   - Filename "test-document.pdf" (bold)
+   - Type label "PDF Document" and file size below the filename
+   - The bubble fits within the standard message bubble area
+9. Verify the sender avatar appears in the correct position.
+
+### Receive a text file from CLI
+
+10. Send the text file: `convos conversation send-attachment <id> /tmp/test-notes.txt`.
+11. Verify the file bubble shows the filename "test-notes.txt", type label, and size.
+
+### Receive a CSV from CLI
+
+12. Send the CSV: `convos conversation send-attachment <id> /tmp/test-data.csv`.
+13. Verify the file bubble shows "test-data.csv" with appropriate type and size.
+
+### Receive a JSON file from CLI
+
+14. Send the JSON: `convos conversation send-attachment <id> /tmp/test-config.json`.
+15. Verify the file bubble shows "test-config.json" with appropriate type and size.
+
+### Tap file to open in QuickLook
+
+16. Tap the PDF file bubble.
+17. Verify a full-screen QuickLook preview opens showing the PDF content.
+18. Verify the QuickLook toolbar has a share button.
+19. Dismiss QuickLook (tap Done or swipe down).
+
+### Tap text file to open in QuickLook
+
+20. Tap the text file bubble.
+21. Verify QuickLook opens and displays the text content.
+22. Dismiss QuickLook.
+
+### File context menu
+
+23. Long-press the PDF file bubble.
+24. Verify context menu shows: Reply, Save to Files, Share.
+25. Dismiss the context menu.
+
+### Save to Files
+
+26. Long-press the PDF file bubble again.
+27. Tap "Save to Files".
+28. Verify the iOS document picker opens for choosing a save location.
+29. Dismiss the picker.
+
+### Share file
+
+30. Long-press the PDF file bubble.
+31. Tap "Share".
+32. Verify the standard iOS share sheet opens with the file.
+33. Dismiss the share sheet.
+
+### Conversation list preview
+
+34. Navigate back to the conversations list.
+35. Verify the preview text shows the filename (e.g., "test-config.json") or
+    "sent a file" for the most recent message.
+
+### Incoming file blurred by default
+
+36. Open the conversation and verify the file bubbles from the CLI user
+    follow the same blur/reveal treatment as photos and videos.
+37. If blurred, tap to reveal and verify the file bubble content becomes visible.
+
+### Photo and video still work
+
+38. Send a photo from the app (or verify existing photos in conversation still
+    render correctly).
+39. Verify file messages don't break photo/video rendering.
+
+## Teardown
+
+Explode the conversation via CLI.
+
+## Pass/Fail Criteria
+
+- [ ] PDF sent from CLI appears as file bubble with icon, filename, type, size
+- [ ] Text file sent from CLI appears as file bubble with correct metadata
+- [ ] CSV file sent from CLI appears as file bubble with correct metadata
+- [ ] JSON file sent from CLI appears as file bubble with correct metadata
+- [ ] File bubble layout matches iMessage style (icon left, text right, within bubble)
+- [ ] Tapping file opens QuickLook full-screen preview
+- [ ] QuickLook shows correct file content (PDF renders, text displays)
+- [ ] QuickLook can be dismissed
+- [ ] Context menu shows Reply, Save to Files, Share
+- [ ] Save to Files opens document picker
+- [ ] Share opens standard share sheet
+- [ ] Conversation list shows filename or "sent a file" for file messages
+- [ ] File messages respect blur/reveal privacy treatment
+- [ ] Existing photo/video messages still render correctly
+
+## Accessibility Identifiers Needed
+
+- `file-attachment-bubble` — the file bubble container
+- `file-attachment-icon` — the file type icon/thumbnail
+- `file-attachment-filename` — the filename text
+- `file-attachment-subtitle` — the type label and size text

--- a/qa/tests/28-receive-file-attachments.md
+++ b/qa/tests/28-receive-file-attachments.md
@@ -91,12 +91,6 @@ Files and Share options.
 35. Verify the preview text shows the filename (e.g., "test-config.json") or
     "sent a file" for the most recent message.
 
-### Incoming file blurred by default
-
-36. Open the conversation and verify the file bubbles from the CLI user
-    follow the same blur/reveal treatment as photos and videos.
-37. If blurred, tap to reveal and verify the file bubble content becomes visible.
-
 ### Photo and video still work
 
 38. Send a photo from the app (or verify existing photos in conversation still
@@ -121,7 +115,6 @@ Explode the conversation via CLI.
 - [ ] Save to Files opens document picker
 - [ ] Share opens standard share sheet
 - [ ] Conversation list shows filename or "sent a file" for file messages
-- [ ] File messages respect blur/reveal privacy treatment
 - [ ] Existing photo/video messages still render correctly
 
 ## Accessibility Identifiers Needed

--- a/qa/tests/structured/28-receive-file-attachments.yaml
+++ b/qa/tests/structured/28-receive-file-attachments.yaml
@@ -1,0 +1,295 @@
+id: "28"
+name: "Receive File Attachments"
+description: >
+  Verify that generic file attachments (PDF, text, CSV, JSON) sent from
+  the CLI are received and displayed correctly as compact file bubbles
+  matching the iMessage design: file type icon on the left, filename and
+  type/size on the right, within the message bubble. Tapping opens
+  QuickLook for full-screen viewing. Context menu offers Save to Files
+  and Share.
+tags: [messaging, files, attachments, core]
+depends_on: ["20"]
+estimated_duration_s: 300
+
+prerequisites:
+  app_running: true
+  cli_initialized: true
+  shared_conversation: false
+  screen: conversations_list
+
+state:
+  conversation_id: null
+  invite_url: null
+
+setup:
+  - action: cli_reset
+    note: >
+      convos reset && convos init --env dev --force
+  - action: create_test_files
+    note: >
+      Create test files on disk:
+
+      # PDF
+      python3 -c "
+      import struct
+      pdf = b'%PDF-1.4\n1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj\n2 0 obj<</Type/Pages/Kids[3 0 R]/Count 1>>endobj\n3 0 obj<</Type/Page/Parent 2 0 R/MediaBox[0 0 612 792]/Contents 4 0 R/Resources<</Font<</F1 5 0 R>>>>>>endobj\n4 0 obj<</Length 44>>stream\nBT /F1 24 Tf 100 700 Td (Hello from Agent!) Tj ET\nendstream\nendobj\n5 0 obj<</Type/Font/Subtype/Type1/BaseFont/Helvetica>>endobj\nxref\n0 6\ntrailer<</Size 6/Root 1 0 R>>\nstartxref\n0\n%%EOF'
+      open('/tmp/test-document.pdf','wb').write(pdf)
+      "
+
+      # Text
+      echo "Hello, this is a plain text document sent by an AI assistant.\nIt contains multiple lines of text.\nLine 3." > /tmp/test-notes.txt
+
+      # CSV
+      printf "name,age,city\nAlice,30,NYC\nBob,25,London\nCharlie,35,Tokyo\n" > /tmp/test-data.csv
+
+      # JSON
+      echo '{"name": "Assistant Config", "version": "1.0", "features": ["chat", "files", "code"]}' > /tmp/test-config.json
+  - action: cli_create_conversation
+    args: { name: "File Test", profile_name: "Agent" }
+    save:
+      conversation_id: result.conversation_id
+  - action: cli_generate_invite
+    args: { conversation: "$conversation_id" }
+    save:
+      invite_url: result.invite_url
+  - action: open_deep_link
+    args: { url: "$invite_url" }
+  - action: cli_process_joins
+    args: { conversation: "$conversation_id", watch: true, timeout: 30 }
+  - action: wait_for_element
+    args: { id: "message-text-field", timeout: 15 }
+
+steps:
+  - id: receive_pdf
+    name: "Receive a PDF from CLI"
+    actions:
+      - cli_send_attachment:
+          conversation: "$conversation_id"
+          path: "/tmp/test-document.pdf"
+      - wait_for_element: { id: "file-attachment-bubble", timeout: 30 }
+      - screenshot: {}
+    verify:
+      - element_exists: { id: "file-attachment-bubble" }
+      - element_exists: { id: "file-attachment-filename" }
+      - visual_check: >
+          File bubble shows a PDF-style icon on the left, filename
+          "test-document.pdf" in bold, and a type/size subtitle. The
+          bubble fits within the standard message area. Sender avatar
+          is visible.
+    criteria: pdf_displays_as_file_bubble
+    note: >
+      The CLI auto-detects mime type as application/pdf. The file is small
+      enough to send inline (under 1MB). The app should display it as a
+      compact file bubble, not as a photo placeholder.
+
+  - id: receive_text_file
+    name: "Receive a text file from CLI"
+    actions:
+      - cli_send_attachment:
+          conversation: "$conversation_id"
+          path: "/tmp/test-notes.txt"
+      - wait_for_element: { id: "file-attachment-bubble", timeout: 30 }
+      - screenshot: {}
+    verify:
+      - element_exists: { id: "file-attachment-bubble" }
+      - visual_check: >
+          Text file bubble shows a document icon, filename "test-notes.txt",
+          and type/size subtitle.
+    criteria: text_file_displays_as_file_bubble
+
+  - id: receive_csv_file
+    name: "Receive a CSV file from CLI"
+    actions:
+      - cli_send_attachment:
+          conversation: "$conversation_id"
+          path: "/tmp/test-data.csv"
+      - wait_for_element: { id: "file-attachment-bubble", timeout: 30 }
+      - screenshot: {}
+    verify:
+      - element_exists: { id: "file-attachment-bubble" }
+      - visual_check: >
+          CSV file bubble shows a spreadsheet-style icon, filename
+          "test-data.csv", and type/size subtitle.
+    criteria: csv_file_displays_as_file_bubble
+
+  - id: receive_json_file
+    name: "Receive a JSON file from CLI"
+    actions:
+      - cli_send_attachment:
+          conversation: "$conversation_id"
+          path: "/tmp/test-config.json"
+      - wait_for_element: { id: "file-attachment-bubble", timeout: 30 }
+      - screenshot: {}
+    verify:
+      - element_exists: { id: "file-attachment-bubble" }
+      - visual_check: >
+          JSON file bubble shows a code-style icon, filename
+          "test-config.json", and type/size subtitle.
+    criteria: json_file_displays_as_file_bubble
+
+  - id: tap_pdf_opens_quicklook
+    name: "Tap PDF to open in QuickLook"
+    actions:
+      - scroll_to: { id: "file-attachment-filename", label_contains: "test-document.pdf" }
+      - tap: { id: "file-attachment-bubble" }
+        note: Tap the PDF file bubble
+      - wait: { seconds: 3 }
+      - screenshot: {}
+    verify:
+      - visual_check: >
+          A full-screen QuickLook preview opens showing the PDF content
+          (the text "Hello from Agent!" should be visible). A share button
+          and Done button are in the toolbar.
+    criteria: tap_opens_quicklook_pdf
+    note: >
+      The file must be downloaded and decrypted first, then saved to a temp
+      file with the correct .pdf extension for QuickLook to render it.
+      A loading indicator should show during download.
+
+  - id: dismiss_quicklook
+    name: "Dismiss QuickLook"
+    actions:
+      - tap: { label: "Done" }
+        note: Tap Done button in QuickLook toolbar
+      - wait_for_element: { id: "message-text-field", timeout: 5 }
+    verify:
+      - element_exists: { id: "message-text-field" }
+    criteria: quicklook_dismissable
+
+  - id: tap_text_file_quicklook
+    name: "Tap text file to open in QuickLook"
+    actions:
+      - scroll_to: { id: "file-attachment-filename", label_contains: "test-notes.txt" }
+      - tap: { id: "file-attachment-bubble" }
+      - wait: { seconds: 3 }
+      - screenshot: {}
+    verify:
+      - visual_check: >
+          QuickLook displays the text content: "Hello, this is a plain text
+          document sent by an AI assistant."
+    criteria: tap_opens_quicklook_text
+    actions_after:
+      - tap: { label: "Done" }
+
+  - id: file_context_menu
+    name: "File context menu shows correct options"
+    actions:
+      - scroll_to: { id: "file-attachment-filename", label_contains: "test-document.pdf" }
+      - long_press: { id: "file-attachment-bubble", duration: 0.5 }
+      - screenshot: {}
+    verify:
+      - element_exists: { label: "Reply" }
+      - element_exists: { label: "Save to Files" }
+      - element_exists: { label: "Share" }
+    criteria: file_context_menu_correct
+    note: >
+      File context menu should show Reply, Save to Files, and Share. It should
+      NOT show Blur/Reveal (files don't have visual content to blur) or Save
+      (which is for saving images to Photos).
+
+  - id: dismiss_context_menu
+    name: "Dismiss context menu"
+    actions:
+      - key: { code: 41 }
+    verify: []
+    criteria: context_menu_dismissable
+
+  - id: save_to_files
+    name: "Save to Files from context menu"
+    actions:
+      - long_press: { id: "file-attachment-bubble", duration: 0.5 }
+      - tap: { label: "Save to Files" }
+      - wait: { seconds: 2 }
+      - screenshot: {}
+    verify:
+      - visual_check: >
+          The iOS document picker (Files) opens showing the file ready
+          to save. The filename is preserved (test-document.pdf).
+    criteria: save_to_files_works
+    actions_after:
+      - tap: { label: "Cancel" }
+        note: Dismiss the document picker
+
+  - id: share_file
+    name: "Share file from context menu"
+    actions:
+      - long_press: { id: "file-attachment-bubble", duration: 0.5 }
+      - tap: { label: "Share" }
+      - wait: { seconds: 2 }
+      - screenshot: {}
+    verify:
+      - visual_check: >
+          The standard iOS share sheet opens with the file. AirDrop, Messages,
+          and other share targets are visible.
+    criteria: share_file_works
+    actions_after:
+      - tap: { label: "Close" }
+        note: Dismiss share sheet
+
+  - id: conversation_list_preview
+    name: "Conversation list shows file preview"
+    actions:
+      - navigate_back: {}
+      - wait_for_element: { label_contains: "File Test", timeout: 10 }
+      - screenshot: {}
+    verify:
+      - visual_check: >
+          The conversation list entry for "File Test" shows a preview that
+          includes the filename (e.g., "test-config.json") or "sent a file"
+          rather than "sent a photo".
+    criteria: list_preview_shows_filename
+
+  - id: photo_video_still_work
+    name: "Photo and video messages still render correctly"
+    actions:
+      - navigate_to_conversation: { label: "File Test" }
+      - cli_send_attachment:
+          conversation: "$conversation_id"
+          path: "/tmp/test-photo.jpg"
+          note: >
+            If a test photo exists at /tmp/test-photo.jpg, send it. Otherwise
+            skip this step — the goal is to verify that file support doesn't
+            break existing photo rendering.
+      - wait: { seconds: 5 }
+      - screenshot: {}
+    verify:
+      - visual_check: >
+          If a photo was sent, it renders as a full-bleed image (not as a
+          file bubble). File messages and photo messages coexist correctly.
+    criteria: photos_still_render_correctly
+    note: >
+      This is a regression check. Photos should continue to render as
+      full-width images with blur/reveal treatment, not as file bubbles.
+
+teardown:
+  - action: explode_conversation
+    args: { id: "$conversation_id" }
+    optional: true
+
+criteria:
+  pdf_displays_as_file_bubble:
+    description: "PDF from CLI renders as compact file bubble with icon, filename, type, size"
+  text_file_displays_as_file_bubble:
+    description: "Text file from CLI renders as compact file bubble"
+  csv_file_displays_as_file_bubble:
+    description: "CSV file from CLI renders as compact file bubble"
+  json_file_displays_as_file_bubble:
+    description: "JSON file from CLI renders as compact file bubble"
+  tap_opens_quicklook_pdf:
+    description: "Tapping PDF file bubble opens full-screen QuickLook preview"
+  quicklook_dismissable:
+    description: "QuickLook preview can be dismissed"
+  tap_opens_quicklook_text:
+    description: "Tapping text file opens QuickLook showing text content"
+  file_context_menu_correct:
+    description: "File context menu shows Reply, Save to Files, Share"
+  context_menu_dismissable:
+    description: "Context menu can be dismissed"
+  save_to_files_works:
+    description: "Save to Files opens document picker with correct filename"
+  share_file_works:
+    description: "Share opens standard iOS share sheet with the file"
+  list_preview_shows_filename:
+    description: "Conversation list shows filename or 'sent a file' for file messages"
+  photos_still_render_correctly:
+    description: "Photo/video messages still render as images, not file bubbles"

--- a/qa/tests/structured/28-receive-file-attachments.yaml
+++ b/qa/tests/structured/28-receive-file-attachments.yaml
@@ -37,13 +37,20 @@ setup:
       "
 
       # Text
-      echo "Hello, this is a plain text document sent by an AI assistant.\nIt contains multiple lines of text.\nLine 3." > /tmp/test-notes.txt
+      printf "Hello, this is a plain text document sent by an AI assistant.\nIt contains multiple lines of text.\nLine 3.\n" > /tmp/test-notes.txt
 
       # CSV
       printf "name,age,city\nAlice,30,NYC\nBob,25,London\nCharlie,35,Tokyo\n" > /tmp/test-data.csv
 
       # JSON
       echo '{"name": "Assistant Config", "version": "1.0", "features": ["chat", "files", "code"]}' > /tmp/test-config.json
+
+      # Test photo for backward compatibility check
+      python3 -c "
+      from PIL import Image
+      img = Image.new('RGB', (200, 200), color='red')
+      img.save('/tmp/test-photo.jpg', 'JPEG')
+      " 2>/dev/null || true
   - action: cli_create_conversation
     args: { name: "File Test", profile_name: "Agent" }
     save:


### PR DESCRIPTION
## Summary

Files (PDF, text, CSV, JSON, etc.) sent from CLI now render as compact file bubbles with QuickLook preview, Save to Files, Share, and proper reply/context menu support.

### File Bubbles
- `FileAttachmentBubble` renders inside `MessageContainer` for proper bubble background and alignment
- File type icon mapped by extension (PDF→doc.text.fill, CSV→tablecells.fill, JSON→curlybraces, etc.)
- Bold filename + type label subtitle
- Adapts icon colors for outgoing (white) vs incoming (gray)

### File Preview
- Tap file bubble → QuickLook (`QLPreviewController`) with clean filename
- Context menu: Save to Files (`UIDocumentPickerViewController`) and Share (`UIActivityViewController`)

### Reply Support
- Reply composer bar shows filename with doc icon thumbnail
- Reply reference shows compact file bubble with icon + filename + type label

### Data Model
- `HydratedAttachment`: filename, filenameExtension, fileTypeLabel, fileSize
- `MediaType.file` case with UTType-based classification
- Derive mimeType from filename extension when not set

### Inline Attachment Recovery
- `InlineAttachmentRecovery` actor re-decodes from XMTP local store when cached `file://` paths are stale (after app reinstall)
- Uses `ConversationsProvider.findMessage()` for local XMTP SQLite lookup (no network)

### Tests
- 13 new tests for file attachment data model and preview strings

### QA
- Structured QA test 28: receive-file-attachments

Stacked on #593 (video messages)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add file attachment receiving and display with QuickLook preview and save/share actions
> - Renders non-image/video attachments as a dedicated `FileAttachmentBubble` in message threads, reply references, and the context menu overlay, with icons based on file extension or MIME type.
> - Tapping a file bubble presents a `QLPreviewController` (QuickLook) for in-app preview; supports local files, inline attachment recovery, and remote downloads, with temp file cleanup on dismissal.
> - Adds "Save to Files" (via `UIDocumentPickerViewController`) and "Share" (via `UIActivityViewController`) to the file attachment context menu.
> - Introduces `InlineAttachmentRecovery` to fetch raw attachment bytes by `messageId` from the conversations provider when the original local file is missing.
> - Updates conversation list preview text to show `"a file"` or the filename for single file attachments, and `"X attachments"` for mixed-type groups.
> - Adds `filename` and `filenameExtension` to `HydratedAttachment` and `isFullBleedAttachment` to `MessageContent` to distinguish file attachments from images/videos in layout and spacing logic.
> - Behavioral Change: local inline attachments with a missing file now attempt async recovery rather than failing silently; `mediaType` for local file URLs may change from the previous image default to a type inferred from the file extension.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a6da4a5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->