### PR TITLE
Revoke other installations on restore and persist installationId

### DIFF
--- a/ConvosCore/Sources/ConvosCore/Inboxes/InboxStateMachine.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/InboxStateMachine.swift
@@ -50,6 +50,10 @@ public struct InboxReadyResult: @unchecked Sendable {
 
 typealias AnySyncingManager = (any SyncingManagerProtocol)
 typealias AnyInviteJoinRequestsManager = (any InviteJoinRequestsManagerProtocol)
+typealias RevokeInstallationsHandler = (
+    _ client: any XMTPClientProvider,
+    _ signingKey: any SigningKey
+) async throws -> Void
 
 // swiftlint:disable type_body_length
 
@@ -107,6 +111,7 @@ public actor InboxStateMachine: InboxStateManagerProtocol {
     private let apiClient: any ConvosAPIClientProtocol
     private let networkMonitor: any NetworkMonitorProtocol
     private let appLifecycle: any AppLifecycleProviding
+    private let revokeInstallationsHandler: RevokeInstallationsHandler
     private var requestDeviceSyncAfterAuthorize: Bool = false
 
     private var currentTask: Task<Void, Never>?
@@ -276,7 +281,10 @@ public actor InboxStateMachine: InboxStateManagerProtocol {
         overrideJWTToken: String? = nil,
         environment: AppEnvironment,
         appLifecycle: any AppLifecycleProviding,
-        apiClient: (any ConvosAPIClientProtocol)? = nil
+        apiClient: (any ConvosAPIClientProtocol)? = nil,
+        revokeInstallationsHandler: @escaping RevokeInstallationsHandler = { client, signingKey in
+            try await client.revokeAllOtherInstallations(signingKey: signingKey)
+        }
     ) {
         let initialState: State = .idle(clientId: clientId)
         self.initialClientId = clientId
@@ -290,6 +298,7 @@ public actor InboxStateMachine: InboxStateManagerProtocol {
         self.overrideJWTToken = overrideJWTToken ?? environment.defaultOverrideJWTToken
         self.environment = environment
         self.appLifecycle = appLifecycle
+        self.revokeInstallationsHandler = revokeInstallationsHandler
 
         // Use provided API client or create a new one
         if let apiClient {
@@ -697,6 +706,25 @@ public actor InboxStateMachine: InboxStateManagerProtocol {
             } catch {
                 Log.warning("Device sync request failed (non-fatal): \(error)")
             }
+        }
+
+        do {
+            let identity = try await identityStore.identity(for: result.client.inboxId)
+            try await revokeInstallationsHandler(result.client, identity.keys.signingKey)
+            Log.info("Revoked all other installations for inbox: \(result.client.inboxId)")
+        } catch {
+            Log.warning("Failed to revoke other installations for inbox \(result.client.inboxId) (non-fatal): \(error)")
+        }
+
+        do {
+            let inboxWriter = InboxWriter(dbWriter: databaseWriter)
+            _ = try await inboxWriter.save(
+                inboxId: result.client.inboxId,
+                clientId: clientId,
+                installationId: result.client.installationId
+            )
+        } catch {
+            Log.warning("Failed to persist installationId for inbox \(result.client.inboxId) (non-fatal): \(error)")
         }
 
         await syncingManager?.start(with: result.client, apiClient: result.apiClient)

--- a/ConvosCore/Sources/ConvosCore/Inboxes/InboxStateMachine.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/InboxStateMachine.swift
@@ -708,12 +708,17 @@ public actor InboxStateMachine: InboxStateManagerProtocol {
             }
         }
 
-        do {
-            let identity = try await identityStore.identity(for: result.client.inboxId)
-            try await revokeInstallationsHandler(result.client, identity.keys.signingKey)
-            Log.info("Revoked all other installations for inbox: \(result.client.inboxId)")
-        } catch {
-            Log.warning("Failed to revoke other installations for inbox \(result.client.inboxId) (non-fatal): \(error)")
+        let storedInstallationId: String? = try? await databaseWriter.read { db in
+            try DBInbox.fetchOne(db, id: result.client.inboxId)?.installationId
+        }
+        if let storedInstallationId, storedInstallationId != result.client.installationId {
+            do {
+                let identity = try await identityStore.identity(for: result.client.inboxId)
+                try await revokeInstallationsHandler(result.client, identity.keys.signingKey)
+                Log.info("Revoked all other installations for inbox: \(result.client.inboxId)")
+            } catch {
+                Log.warning("Failed to revoke other installations for inbox \(result.client.inboxId) (non-fatal): \(error)")
+            }
         }
 
         do {

--- a/ConvosCore/Sources/ConvosCore/Inboxes/InboxStateMachine.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/InboxStateMachine.swift
@@ -708,17 +708,30 @@ public actor InboxStateMachine: InboxStateManagerProtocol {
             }
         }
 
-        let storedInstallationId: String? = try? await databaseWriter.read { db in
-            try DBInbox.fetchOne(db, id: result.client.inboxId)?.installationId
-        }
-        if let storedInstallationId, storedInstallationId != result.client.installationId {
-            do {
-                let identity = try await identityStore.identity(for: result.client.inboxId)
-                try await revokeInstallationsHandler(result.client, identity.keys.signingKey)
-                Log.info("Revoked all other installations for inbox: \(result.client.inboxId)")
-            } catch {
-                Log.warning("Failed to revoke other installations for inbox \(result.client.inboxId) (non-fatal): \(error)")
+        let storedInstallationId: String?
+        do {
+            storedInstallationId = try await databaseWriter.read { db in
+                try DBInbox.fetchOne(db, id: result.client.inboxId)?.installationId
             }
+        } catch {
+            Log.warning("Failed to read stored installationId for inbox \(result.client.inboxId), skipping revocation check (non-fatal): \(error)")
+            storedInstallationId = nil
+        }
+
+        if let storedInstallationId {
+            if storedInstallationId != result.client.installationId {
+                do {
+                    let identity = try await identityStore.identity(for: result.client.inboxId)
+                    try await revokeInstallationsHandler(result.client, identity.keys.signingKey)
+                    Log.info("Revoked all other installations for inbox: \(result.client.inboxId)")
+                } catch {
+                    Log.warning("Failed to revoke other installations for inbox \(result.client.inboxId) (non-fatal): \(error)")
+                }
+            } else {
+                Log.debug("Skipping installation revocation for inbox \(result.client.inboxId) because installationId is unchanged")
+            }
+        } else {
+            Log.debug("Skipping installation revocation for inbox \(result.client.inboxId) because no stored installationId was found")
         }
 
         do {
@@ -729,7 +742,7 @@ public actor InboxStateMachine: InboxStateManagerProtocol {
                 installationId: result.client.installationId
             )
         } catch {
-            Log.warning("Failed to persist installationId for inbox \(result.client.inboxId) (non-fatal): \(error)")
+            Log.error("Failed to persist installationId for inbox \(result.client.inboxId) (non-fatal): \(error)")
         }
 
         await syncingManager?.start(with: result.client, apiClient: result.apiClient)

--- a/ConvosCore/Sources/ConvosCore/Messaging/XMTPClientProvider.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/XMTPClientProvider.swift
@@ -139,6 +139,7 @@ public protocol XMTPClientProvider: AnyObject {
     func revokeInstallations(
         signingKey: SigningKey, installationIds: [String]
     ) async throws
+    func revokeAllOtherInstallations(signingKey: SigningKey) async throws
     func requestDeviceSync() async throws
     func deleteLocalDatabase() throws
     func reconnectLocalDatabase() async throws

--- a/ConvosCore/Sources/ConvosCore/Mocks/MockXMTPClientProvider.swift
+++ b/ConvosCore/Sources/ConvosCore/Mocks/MockXMTPClientProvider.swift
@@ -69,6 +69,10 @@ public final class MockXMTPClientProvider: XMTPClientProvider, @unchecked Sendab
         // No-op for mock
     }
 
+    public func revokeAllOtherInstallations(signingKey: any SigningKey) async throws {
+        // No-op for mock
+    }
+
     public func requestDeviceSync() async throws {
         // No-op for mock
     }

--- a/ConvosCore/Sources/ConvosCore/Storage/Database Models/DBInbox.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Database Models/DBInbox.swift
@@ -19,6 +19,7 @@ struct DBInbox: Codable, FetchableRecord, PersistableRecord, Identifiable, Hasha
         static let sharedToVault: Column = Column(CodingKeys.sharedToVault)
         static let vaultSyncState: Column = Column(CodingKeys.vaultSyncState)
         static let vaultSyncAttempts: Column = Column(CodingKeys.vaultSyncAttempts)
+        static let installationId: Column = Column(CodingKeys.installationId)
     }
 
     var id: String { inboxId }
@@ -29,6 +30,7 @@ struct DBInbox: Codable, FetchableRecord, PersistableRecord, Identifiable, Hasha
     var sharedToVault: Bool
     var vaultSyncState: VaultSyncState
     var vaultSyncAttempts: Int
+    var installationId: String?
 
     init(
         inboxId: String,
@@ -37,7 +39,8 @@ struct DBInbox: Codable, FetchableRecord, PersistableRecord, Identifiable, Hasha
         isVault: Bool = false,
         sharedToVault: Bool = false,
         vaultSyncState: VaultSyncState = .none,
-        vaultSyncAttempts: Int = 0
+        vaultSyncAttempts: Int = 0,
+        installationId: String? = nil
     ) {
         self.inboxId = inboxId
         self.clientId = clientId
@@ -46,6 +49,7 @@ struct DBInbox: Codable, FetchableRecord, PersistableRecord, Identifiable, Hasha
         self.sharedToVault = sharedToVault
         self.vaultSyncState = vaultSyncState
         self.vaultSyncAttempts = vaultSyncAttempts
+        self.installationId = installationId
     }
 
     static let conversations: HasManyAssociation<DBInbox, DBConversation> = hasMany(

--- a/ConvosCore/Sources/ConvosCore/Storage/Hydration/DBInbox+Inbox.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Hydration/DBInbox+Inbox.swift
@@ -6,7 +6,8 @@ extension DBInbox {
             inboxId: inboxId,
             clientId: clientId,
             createdAt: createdAt,
-            isVault: isVault
+            isVault: isVault,
+            installationId: installationId
         )
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/Inbox.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/Inbox.swift
@@ -6,11 +6,19 @@ public struct Inbox: Codable, Hashable, Identifiable {
     public let clientId: String
     public let createdAt: Date
     public let isVault: Bool
+    public let installationId: String?
 
-    public init(inboxId: String, clientId: String, createdAt: Date = Date(), isVault: Bool = false) {
+    public init(
+        inboxId: String,
+        clientId: String,
+        createdAt: Date = Date(),
+        isVault: Bool = false,
+        installationId: String? = nil
+    ) {
         self.inboxId = inboxId
         self.clientId = clientId
         self.createdAt = createdAt
         self.isVault = isVault
+        self.installationId = installationId
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Storage/SharedDatabaseMigrator.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/SharedDatabaseMigrator.swift
@@ -427,6 +427,12 @@ extension SharedDatabaseMigrator {
             }
         }
 
+        migrator.registerMigration("addInstallationIdToInbox") { db in
+            try db.alter(table: "inbox") { t in
+                t.add(column: "installationId", .text)
+            }
+        }
+
         return migrator
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/InboxWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/InboxWriter.swift
@@ -63,8 +63,11 @@ struct InboxWriter {
                     )
                 }
 
-                guard let installationId,
-                      existingInbox.installationId != installationId else {
+                guard let installationId else {
+                    return existingInbox
+                }
+
+                guard existingInbox.installationId != installationId else {
                     return existingInbox
                 }
 

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/InboxWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/InboxWriter.swift
@@ -32,7 +32,12 @@ struct InboxWriter {
     }
 
     @discardableResult
-    func save(inboxId: String, clientId: String, isVault: Bool = false) async throws -> DBInbox {
+    func save(
+        inboxId: String,
+        clientId: String,
+        installationId: String? = nil,
+        isVault: Bool = false
+    ) async throws -> DBInbox {
         try await dbWriter.write { db in
             if isVault {
                 let existingVault = try DBInbox
@@ -57,14 +62,24 @@ struct InboxWriter {
                         newClientId: clientId
                     )
                 }
-                return existingInbox
+
+                guard let installationId,
+                      existingInbox.installationId != installationId else {
+                    return existingInbox
+                }
+
+                var updatedInbox = existingInbox
+                updatedInbox.installationId = installationId
+                try updatedInbox.update(db)
+                return updatedInbox
             }
 
             let inbox = DBInbox(
                 inboxId: inboxId,
                 clientId: clientId,
                 createdAt: Date(),
-                isVault: isVault
+                isVault: isVault,
+                installationId: installationId
             )
             try inbox.insert(db)
             return inbox

--- a/ConvosCore/Tests/ConvosCoreTests/InboxStateMachineTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/InboxStateMachineTests.swift
@@ -134,15 +134,13 @@ struct InboxStateMachineTests {
         try? await fixtures.cleanup()
     }
 
-    @Test("Register revokes other installations and persists installationId")
-    func testRegisterRevokesInstallationsAndPersistsInstallationId() async throws {
+    @Test("Register does not revoke and persists installationId")
+    func testRegisterDoesNotRevokeAndPersistsInstallationId() async throws {
         actor RevocationTracker {
             var callCount = 0
-            var lastInstallationId: String?
 
-            func record(installationId: String) {
+            func record() {
                 callCount += 1
-                lastInstallationId = installationId
             }
         }
 
@@ -163,8 +161,8 @@ struct InboxStateMachineTests {
             overrideJWTToken: "test-jwt-token",
             environment: .tests,
             appLifecycle: testAppLifecycle,
-            revokeInstallationsHandler: { client, _ in
-                await revocationTracker.record(installationId: client.installationId)
+            revokeInstallationsHandler: { _, _ in
+                await revocationTracker.record()
             }
         )
 
@@ -185,8 +183,7 @@ struct InboxStateMachineTests {
             return
         }
 
-        #expect(await revocationTracker.callCount == 1)
-        #expect(await revocationTracker.lastInstallationId == result.client.installationId)
+        #expect(await revocationTracker.callCount == 0)
 
         let dbInbox = try await fixtures.databaseManager.dbReader.read { db in
             try DBInbox
@@ -199,7 +196,77 @@ struct InboxStateMachineTests {
         try? await fixtures.cleanup()
     }
 
-    @Test("Revocation failure is non-fatal during ready transition")
+    @Test("Authorize revokes when installationId changed (restore scenario)")
+    func testAuthorizeRevokesOnInstallationIdChange() async throws {
+        actor RevocationTracker {
+            var callCount = 0
+
+            func record() {
+                callCount += 1
+            }
+        }
+
+        let fixtures = TestFixtures()
+
+        let (client, clientId, _) = try await fixtures.createClient()
+
+        let inboxWriter = InboxWriter(dbWriter: fixtures.databaseManager.dbWriter)
+        _ = try await inboxWriter.save(
+            inboxId: client.inboxId,
+            clientId: clientId,
+            installationId: "old-installation-from-previous-device"
+        )
+
+        try? client.deleteLocalDatabase()
+
+        let revocationTracker = RevocationTracker()
+        let mockInvites = MockInvitesRepository()
+        let networkMonitor = NetworkMonitor()
+
+        let stateMachine = InboxStateMachine(
+            clientId: clientId,
+            identityStore: fixtures.identityStore,
+            invitesRepository: mockInvites,
+            databaseWriter: fixtures.databaseManager.dbWriter,
+            syncingManager: nil,
+            networkMonitor: networkMonitor,
+            overrideJWTToken: "test-jwt-token",
+            environment: .tests,
+            appLifecycle: testAppLifecycle,
+            revokeInstallationsHandler: { _, _ in
+                await revocationTracker.record()
+            }
+        )
+
+        await stateMachine.authorize(inboxId: client.inboxId, clientId: clientId)
+
+        let state = try await waitForState(stateMachine, timeout: 30) { state in
+            if case .ready = state { return true }
+            if case .error = state { return true }
+            return false
+        }
+
+        guard case .ready(_, let result) = state else {
+            if case .error(_, let error) = state {
+                Issue.record("Authorization failed: \(error)")
+            }
+            Issue.record("Did not reach ready state")
+            try? await fixtures.cleanup()
+            return
+        }
+
+        #expect(await revocationTracker.callCount == 1)
+
+        let dbInbox = try await fixtures.databaseManager.dbReader.read { db in
+            try DBInbox.fetchOne(db, id: client.inboxId)
+        }
+        #expect(dbInbox?.installationId == result.client.installationId)
+
+        try? result.client.deleteLocalDatabase()
+        try? await fixtures.cleanup()
+    }
+
+    @Test("Revocation failure is non-fatal during restore")
     func testRevocationFailureDoesNotBlockReadyState() async throws {
         enum TestRevocationError: Error {
             case expected
@@ -215,7 +282,17 @@ struct InboxStateMachineTests {
 
         let fixtures = TestFixtures()
 
-        let clientId = ClientId.generate().value
+        let (client, clientId, _) = try await fixtures.createClient()
+
+        let inboxWriter = InboxWriter(dbWriter: fixtures.databaseManager.dbWriter)
+        _ = try await inboxWriter.save(
+            inboxId: client.inboxId,
+            clientId: clientId,
+            installationId: "old-installation-from-previous-device"
+        )
+
+        try? client.deleteLocalDatabase()
+
         let mockSync = MockSyncingManager()
         let mockInvites = MockInvitesRepository()
         let networkMonitor = NetworkMonitor()
@@ -237,7 +314,7 @@ struct InboxStateMachineTests {
             }
         )
 
-        await stateMachine.register(clientId: clientId)
+        await stateMachine.authorize(inboxId: client.inboxId, clientId: clientId)
 
         let state = try await waitForState(stateMachine, timeout: 30) { state in
             if case .ready = state { return true }
@@ -247,7 +324,7 @@ struct InboxStateMachineTests {
 
         guard case .ready(_, let result) = state else {
             if case .error(_, let error) = state {
-                Issue.record("Registration failed after revocation error: \(error)")
+                Issue.record("Authorization failed after revocation error: \(error)")
             }
             Issue.record("Did not reach ready state")
             try? await fixtures.cleanup()

--- a/ConvosCore/Tests/ConvosCoreTests/InboxStateMachineTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/InboxStateMachineTests.swift
@@ -209,10 +209,11 @@ struct InboxStateMachineTests {
         let fixtures = TestFixtures()
 
         let (client, clientId, _) = try await fixtures.createClient()
+        let inboxId = client.inboxId
 
         let inboxWriter = InboxWriter(dbWriter: fixtures.databaseManager.dbWriter)
         _ = try await inboxWriter.save(
-            inboxId: client.inboxId,
+            inboxId: inboxId,
             clientId: clientId,
             installationId: "old-installation-from-previous-device"
         )
@@ -238,7 +239,7 @@ struct InboxStateMachineTests {
             }
         )
 
-        await stateMachine.authorize(inboxId: client.inboxId, clientId: clientId)
+        await stateMachine.authorize(inboxId: inboxId, clientId: clientId)
 
         let state = try await waitForState(stateMachine, timeout: 30) { state in
             if case .ready = state { return true }
@@ -258,11 +259,95 @@ struct InboxStateMachineTests {
         #expect(await revocationTracker.callCount == 1)
 
         let dbInbox = try await fixtures.databaseManager.dbReader.read { db in
-            try DBInbox.fetchOne(db, id: client.inboxId)
+            try DBInbox.fetchOne(db, id: inboxId)
         }
         #expect(dbInbox?.installationId == result.client.installationId)
 
         try? result.client.deleteLocalDatabase()
+        try? await fixtures.cleanup()
+    }
+
+    @Test("Authorize with unchanged installationId does not revoke")
+    func testAuthorizeWithSameInstallationIdDoesNotRevoke() async throws {
+        actor RevocationTracker {
+            var callCount = 0
+
+            func record() {
+                callCount += 1
+            }
+        }
+
+        let fixtures = TestFixtures()
+
+        let clientId = ClientId.generate().value
+        let mockInvites = MockInvitesRepository()
+        let networkMonitor = NetworkMonitor()
+        let revocationTracker = RevocationTracker()
+
+        let stateMachine = InboxStateMachine(
+            clientId: clientId,
+            identityStore: fixtures.identityStore,
+            invitesRepository: mockInvites,
+            databaseWriter: fixtures.databaseManager.dbWriter,
+            syncingManager: nil,
+            networkMonitor: networkMonitor,
+            overrideJWTToken: "test-jwt-token",
+            environment: .tests,
+            appLifecycle: testAppLifecycle,
+            revokeInstallationsHandler: { _, _ in
+                await revocationTracker.record()
+            }
+        )
+
+        await stateMachine.register(clientId: clientId)
+
+        let registerState = try await waitForState(stateMachine, timeout: 30) { state in
+            if case .ready = state { return true }
+            if case .error = state { return true }
+            return false
+        }
+
+        guard case .ready(_, let registerResult) = registerState else {
+            if case .error(_, let error) = registerState {
+                Issue.record("Registration failed: \(error)")
+            }
+            Issue.record("Did not reach ready state")
+            try? await fixtures.cleanup()
+            return
+        }
+
+        await stateMachine.stop()
+        _ = try await waitForState(stateMachine, timeout: 10) { state in
+            if case .idle = state { return true }
+            return false
+        }
+
+        await stateMachine.authorize(inboxId: registerResult.client.inboxId, clientId: clientId)
+
+        let authorizeState = try await waitForState(stateMachine, timeout: 30) { state in
+            if case .ready = state { return true }
+            if case .error = state { return true }
+            return false
+        }
+
+        guard case .ready(_, let authorizeResult) = authorizeState else {
+            if case .error(_, let error) = authorizeState {
+                Issue.record("Authorization failed: \(error)")
+            }
+            Issue.record("Did not reach ready state after authorize")
+            try? registerResult.client.deleteLocalDatabase()
+            try? await fixtures.cleanup()
+            return
+        }
+
+        #expect(await revocationTracker.callCount == 0)
+
+        let dbInbox = try await fixtures.databaseManager.dbReader.read { db in
+            try DBInbox.fetchOne(db, id: registerResult.client.inboxId)
+        }
+        #expect(dbInbox?.installationId == authorizeResult.client.installationId)
+
+        try? authorizeResult.client.deleteLocalDatabase()
         try? await fixtures.cleanup()
     }
 

--- a/ConvosCore/Tests/ConvosCoreTests/InboxStateMachineTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/InboxStateMachineTests.swift
@@ -134,6 +134,133 @@ struct InboxStateMachineTests {
         try? await fixtures.cleanup()
     }
 
+    @Test("Register revokes other installations and persists installationId")
+    func testRegisterRevokesInstallationsAndPersistsInstallationId() async throws {
+        actor RevocationTracker {
+            var callCount = 0
+            var lastInstallationId: String?
+
+            func record(installationId: String) {
+                callCount += 1
+                lastInstallationId = installationId
+            }
+        }
+
+        let fixtures = TestFixtures()
+
+        let clientId = ClientId.generate().value
+        let mockInvites = MockInvitesRepository()
+        let networkMonitor = NetworkMonitor()
+        let revocationTracker = RevocationTracker()
+
+        let stateMachine = InboxStateMachine(
+            clientId: clientId,
+            identityStore: fixtures.identityStore,
+            invitesRepository: mockInvites,
+            databaseWriter: fixtures.databaseManager.dbWriter,
+            syncingManager: nil,
+            networkMonitor: networkMonitor,
+            overrideJWTToken: "test-jwt-token",
+            environment: .tests,
+            appLifecycle: testAppLifecycle,
+            revokeInstallationsHandler: { client, _ in
+                await revocationTracker.record(installationId: client.installationId)
+            }
+        )
+
+        await stateMachine.register(clientId: clientId)
+
+        let state = try await waitForState(stateMachine, timeout: 30) { state in
+            if case .ready = state { return true }
+            if case .error = state { return true }
+            return false
+        }
+
+        guard case .ready(_, let result) = state else {
+            if case .error(_, let error) = state {
+                Issue.record("Registration failed: \(error)")
+            }
+            Issue.record("Did not reach ready state")
+            try? await fixtures.cleanup()
+            return
+        }
+
+        #expect(await revocationTracker.callCount == 1)
+        #expect(await revocationTracker.lastInstallationId == result.client.installationId)
+
+        let dbInbox = try await fixtures.databaseManager.dbReader.read { db in
+            try DBInbox
+                .filter(DBInbox.Columns.clientId == clientId)
+                .fetchOne(db)
+        }
+        #expect(dbInbox?.installationId == result.client.installationId)
+
+        try? result.client.deleteLocalDatabase()
+        try? await fixtures.cleanup()
+    }
+
+    @Test("Revocation failure is non-fatal during ready transition")
+    func testRevocationFailureDoesNotBlockReadyState() async throws {
+        enum TestRevocationError: Error {
+            case expected
+        }
+
+        actor RevocationTracker {
+            var callCount = 0
+
+            func record() {
+                callCount += 1
+            }
+        }
+
+        let fixtures = TestFixtures()
+
+        let clientId = ClientId.generate().value
+        let mockSync = MockSyncingManager()
+        let mockInvites = MockInvitesRepository()
+        let networkMonitor = NetworkMonitor()
+        let revocationTracker = RevocationTracker()
+
+        let stateMachine = InboxStateMachine(
+            clientId: clientId,
+            identityStore: fixtures.identityStore,
+            invitesRepository: mockInvites,
+            databaseWriter: fixtures.databaseManager.dbWriter,
+            syncingManager: mockSync,
+            networkMonitor: networkMonitor,
+            overrideJWTToken: "test-jwt-token",
+            environment: .tests,
+            appLifecycle: testAppLifecycle,
+            revokeInstallationsHandler: { _, _ in
+                await revocationTracker.record()
+                throw TestRevocationError.expected
+            }
+        )
+
+        await stateMachine.register(clientId: clientId)
+
+        let state = try await waitForState(stateMachine, timeout: 30) { state in
+            if case .ready = state { return true }
+            if case .error = state { return true }
+            return false
+        }
+
+        guard case .ready(_, let result) = state else {
+            if case .error(_, let error) = state {
+                Issue.record("Registration failed after revocation error: \(error)")
+            }
+            Issue.record("Did not reach ready state")
+            try? await fixtures.cleanup()
+            return
+        }
+
+        #expect(await revocationTracker.callCount == 1)
+        #expect(await mockSync.isStarted)
+
+        try? result.client.deleteLocalDatabase()
+        try? await fixtures.cleanup()
+    }
+
     // MARK: - Authorization Tests
 
     @Test("Authorize with existing identity reaches ready state")

--- a/ConvosCore/Tests/ConvosCoreTests/InboxWriterTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/InboxWriterTests.swift
@@ -62,6 +62,33 @@ struct InboxWriterTests {
         try? await fixtures.cleanup()
     }
 
+    @Test("Save updates installationId for existing inbox")
+    func testSaveUpdatesInstallationId() async throws {
+        let fixtures = TestFixtures()
+        let inboxWriter = InboxWriter(dbWriter: fixtures.databaseManager.dbWriter)
+
+        let inboxId = "test-inbox-id"
+        let clientId = ClientId.generate().value
+
+        _ = try await inboxWriter.save(inboxId: inboxId, clientId: clientId)
+
+        let installationId = "installation-123"
+        let updatedInbox = try await inboxWriter.save(
+            inboxId: inboxId,
+            clientId: clientId,
+            installationId: installationId
+        )
+
+        #expect(updatedInbox.installationId == installationId)
+
+        let dbInbox = try await fixtures.databaseManager.dbReader.read { db in
+            try DBInbox.fetchOne(db, id: inboxId)
+        }
+        #expect(dbInbox?.installationId == installationId)
+
+        try? await fixtures.cleanup()
+    }
+
     @Test("Save throws error when clientId doesn't match (invariant violation)")
     func testSaveThrowsOnClientIdMismatch() async throws {
         let fixtures = TestFixtures()

--- a/ConvosCore/Tests/ConvosCoreTests/SyncingManagerTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/SyncingManagerTests.swift
@@ -82,6 +82,9 @@ class TestableMockClient: XMTPClientProvider, @unchecked Sendable {
     func revokeInstallations(signingKey: any SigningKey, installationIds: [String]) async throws {
     }
 
+    func revokeAllOtherInstallations(signingKey: any SigningKey) async throws {
+    }
+
     func requestDeviceSync() async throws {
     }
 


### PR DESCRIPTION
## Summary
- add `revokeAllOtherInstallations(signingKey:)` to `XMTPClientProvider`
- invoke revocation when `InboxStateMachine` reaches ready **only if the stored `installationId` differs** from the current client (restore detection) — non-fatal warning on failure
- persist current `client.installationId` to inbox storage for diagnostics/future flows
- add GRDB migration `addInstallationIdToInbox`
- thread `installationId` through `DBInbox`/`Inbox` hydration and `InboxWriter.save(...)`
- add tests for writer persistence + state-machine revocation/non-fatal behavior

## Why
This is PR2 from `docs/plans/icloud-backup-pr-briefings.md`: enforce single-device installation validity after restore, while recording installation identity in local storage.

## Stack
- Base branch: `vault-key-sync` (PR #591)
- Head branch: `vault-installation-revocation`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Revoke other installations on restore and persist installationId to inbox
> - On `InboxStateMachine` reaching ready, compares the stored `installationId` in the DB to the current client's `installationId`; if they differ, calls `revokeAllOtherInstallations(signingKey:)` to invalidate stale installations.
> - Adds `installationId` as a nullable column to the `inbox` table via a new migration, and threads the field through `DBInbox`, `Inbox`, and `InboxWriter`.
> - Extends `XMTPClientProvider` with a new `revokeAllOtherInstallations(signingKey:)` protocol requirement, implemented as a no-op in mocks.
> - Revocation and persistence failures are logged but non-fatal — the state machine still transitions to ready.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e697bc3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->