### PR TITLE
Convos button: create and share invite link

### DIFF
--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -115,6 +115,7 @@ struct ConversationView<MessagesBottomBar: View>: View {
                     didReleasePastThreshold = true
                 }
             },
+            onConvosAction: { viewModel.onConvosButtonTapped() },
             bottomBarContent: {
                 VStack(spacing: DesignConstants.Spacing.step3x) {
                     if showPullToAddAssistant {

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -1556,7 +1556,7 @@ extension ConversationViewModel {
                 .first { $0.invite?.urlSlug.isEmpty == false }
                 .receive(on: DispatchQueue.main)
                 .sink { [weak self] convo in
-                    guard let self, let convoInvite = convo.invite else { return }
+                    guard let self, self.pendingInvite == nil, let convoInvite = convo.invite else { return }
                     let urlString = convoInvite.inviteURLString
                     let emptyRange = urlString.startIndex ..< urlString.startIndex
                     self.pendingInvite = PendingInvite(

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -62,6 +62,7 @@ class ConversationViewModel {
     private var cancellables: Set<AnyCancellable> = []
     @ObservationIgnored
     private var convosButtonCancellable: AnyCancellable?
+    private var convosButtonTask: Task<Void, Never>?
     @ObservationIgnored
     private var photoPreferencesCancellable: AnyCancellable?
     @ObservationIgnored
@@ -1520,8 +1521,9 @@ extension ConversationViewModel {
     }
 
     func onConvosButtonTapped() {
-        guard pendingInvite == nil else { return }
-        Task { [session] in
+        guard pendingInvite == nil, convosButtonTask == nil else { return }
+        convosButtonTask = Task { [session] in
+            defer { convosButtonTask = nil }
             let (messagingService, existingConversationId) = await session.addInbox()
             let clientId = messagingService.clientId
 

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -1521,21 +1521,34 @@ extension ConversationViewModel {
 
     func onConvosButtonTapped() {
         guard pendingInvite == nil else { return }
-        Task {
+        Task { [session] in
             let (messagingService, existingConversationId) = await session.addInbox()
-            guard !Task.isCancelled else { return }
+            let clientId = messagingService.clientId
+
+            guard !Task.isCancelled else {
+                try? await session.deleteInbox(clientId: clientId, inboxId: "")
+                return
+            }
 
             let stateManager: any ConversationStateManagerProtocol
             if let existingConversationId {
                 stateManager = messagingService.conversationStateManager(for: existingConversationId)
             } else {
                 stateManager = messagingService.conversationStateManager()
-                try? await stateManager.createConversation()
+                do {
+                    try await stateManager.createConversation()
+                } catch {
+                    Log.error("Failed to create conversation for Convos button: \(error)")
+                    try? await session.deleteInbox(clientId: clientId, inboxId: "")
+                    return
+                }
             }
 
-            guard !Task.isCancelled else { return }
+            guard !Task.isCancelled else {
+                try? await session.deleteInbox(clientId: clientId, inboxId: "")
+                return
+            }
 
-            let clientId = messagingService.clientId
             convosButtonCancellable = stateManager.draftConversationRepository.conversationPublisher
                 .compactMap { $0 }
                 .first { $0.invite?.urlSlug.isEmpty == false }

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -62,6 +62,7 @@ class ConversationViewModel {
     private var cancellables: Set<AnyCancellable> = []
     @ObservationIgnored
     private var convosButtonCancellable: AnyCancellable?
+    @ObservationIgnored
     private var convosButtonTask: Task<Void, Never>?
     @ObservationIgnored
     private var photoPreferencesCancellable: AnyCancellable?
@@ -352,6 +353,7 @@ class ConversationViewModel {
         loadConversationImageTask?.cancel()
         explodeTask?.cancel()
         assistantJoinTask?.cancel()
+        convosButtonTask?.cancel()
     }
 
     // MARK: - Init
@@ -1504,6 +1506,8 @@ extension ConversationViewModel {
         guard pendingInvite == nil else { return }
 
         if let result = InviteURLDetector.detectInviteURL(in: messageText) {
+            convosButtonTask?.cancel()
+            convosButtonCancellable?.cancel()
             pendingInvite = PendingInvite(code: result.code, fullURL: result.fullURL, range: result.range)
             messageText = InviteURLDetector.removeInviteURL(from: messageText, range: result.range)
         }
@@ -1515,7 +1519,11 @@ extension ConversationViewModel {
         if let clientId = invite.linkedConversationClientId {
             let inboxId = invite.linkedConversationInboxId ?? ""
             Task { [session] in
-                try? await session.deleteInbox(clientId: clientId, inboxId: inboxId)
+                do {
+                    try await session.deleteInbox(clientId: clientId, inboxId: inboxId)
+                } catch {
+                    Log.error("Failed to delete linked conversation inbox: \(error)")
+                }
             }
         }
     }

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -10,6 +10,8 @@ struct PendingInvite {
     let code: String
     let fullURL: String
     let range: Range<String.Index>
+    var linkedConversationClientId: String?
+    var linkedConversationInboxId: String?
 }
 
 @MainActor
@@ -58,6 +60,8 @@ class ConversationViewModel {
 
     @ObservationIgnored
     private var cancellables: Set<AnyCancellable> = []
+    @ObservationIgnored
+    private var convosButtonCancellable: AnyCancellable?
     @ObservationIgnored
     private var photoPreferencesCancellable: AnyCancellable?
     @ObservationIgnored
@@ -1505,6 +1509,50 @@ extension ConversationViewModel {
     }
 
     func clearPendingInvite() {
+        guard let invite = pendingInvite else { return }
         pendingInvite = nil
+        if let clientId = invite.linkedConversationClientId {
+            let inboxId = invite.linkedConversationInboxId ?? ""
+            Task { [session] in
+                try? await session.deleteInbox(clientId: clientId, inboxId: inboxId)
+            }
+        }
+    }
+
+    func onConvosButtonTapped() {
+        guard pendingInvite == nil else { return }
+        Task {
+            let (messagingService, existingConversationId) = await session.addInbox()
+            guard !Task.isCancelled else { return }
+
+            let stateManager: any ConversationStateManagerProtocol
+            if let existingConversationId {
+                stateManager = messagingService.conversationStateManager(for: existingConversationId)
+            } else {
+                stateManager = messagingService.conversationStateManager()
+                try? await stateManager.createConversation()
+            }
+
+            guard !Task.isCancelled else { return }
+
+            let clientId = messagingService.clientId
+            convosButtonCancellable = stateManager.draftConversationRepository.conversationPublisher
+                .compactMap { $0 }
+                .first { $0.invite?.urlSlug.isEmpty == false }
+                .receive(on: DispatchQueue.main)
+                .sink { [weak self] convo in
+                    guard let self, let convoInvite = convo.invite else { return }
+                    let urlString = convoInvite.inviteURLString
+                    let emptyRange = urlString.startIndex ..< urlString.startIndex
+                    self.pendingInvite = PendingInvite(
+                        code: convoInvite.urlSlug,
+                        fullURL: urlString,
+                        range: emptyRange,
+                        linkedConversationClientId: clientId,
+                        linkedConversationInboxId: convo.inboxId
+                    )
+                    self.convosButtonCancellable = nil
+                }
+        }
     }
 }

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesBottomBar.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesBottomBar.swift
@@ -29,6 +29,7 @@ struct MessagesBottomBar<BottomBarContent: View>: View {
     let onDisplayNameEndedEditing: () -> Void
     let onVideoSelected: (URL) -> Void
     let onProfileSettings: () -> Void
+    let onConvosAction: () -> Void
     let onBaseHeightChanged: (CGFloat) -> Void
     @ViewBuilder let bottomBarContent: () -> BottomBarContent
 
@@ -160,7 +161,7 @@ struct MessagesBottomBar<BottomBarContent: View>: View {
                 MessagesMediaButtonsView(
                     isPhotoPickerPresented: $isPhotoPickerPresented,
                     isCameraPresented: $isCameraPresented,
-                    onConvosAction: {}
+                    onConvosAction: onConvosAction
                 )
                 .opacity(messagesTextFieldEnabled ? 1.0 : 0.4)
                 .frame(height: DesignConstants.Spacing.step12x)
@@ -306,6 +307,7 @@ struct MessagesBottomBar<BottomBarContent: View>: View {
             },
             onVideoSelected: { _ in },
             onProfileSettings: {},
+            onConvosAction: {},
             onBaseHeightChanged: { height in
                 bottomBarHeight = height
             },

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesMediaInputView.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesMediaInputView.swift
@@ -33,22 +33,21 @@ struct MessagesMediaButtonsView: View {
             .accessibilityLabel("Camera")
             .accessibilityIdentifier("camera-button")
 
-            // Convos action button (hidden until feature is ready)
-            // Button {
-            //     onConvosAction()
-            // } label: {
-            //     Image("convosOrangeIcon")
-            //         .renderingMode(.template)
-            //         .resizable()
-            //         .scaledToFit()
-            //         .frame(height: 18)
-            //         .foregroundStyle(Color.colorTextSecondary)
-            //         .frame(width: Constant.buttonSize, height: Constant.buttonSize)
-            //         .contentShape(.circle)
-            // }
-            // .buttonStyle(.plain)
-            // .accessibilityLabel("Convos")
-            // .accessibilityIdentifier("convos-action-button")
+            Button {
+                onConvosAction()
+            } label: {
+                Image("convosOrangeIcon")
+                    .renderingMode(.template)
+                    .resizable()
+                    .scaledToFit()
+                    .frame(height: 18)
+                    .foregroundStyle(Color.colorTextSecondary)
+                    .frame(width: Constant.buttonSize, height: Constant.buttonSize)
+                    .contentShape(.circle)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Convos")
+            .accessibilityIdentifier("convos-action-button")
         }
         .buttonStyle(.plain)
         .accessibilityLabel("Media buttons")

--- a/Convos/Conversation Detail/Messages/MessagesView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesView.swift
@@ -63,6 +63,7 @@ struct MessagesView<BottomBarContent: View>: View {
     let isAssistantEnabled: Bool
     let onBottomOverscrollChanged: (CGFloat) -> Void
     let onBottomOverscrollReleased: (CGFloat) -> Void
+    let onConvosAction: () -> Void
     @ViewBuilder let bottomBarContent: () -> BottomBarContent
 
     @State private var bottomBarHeight: CGFloat = 0.0
@@ -134,6 +135,7 @@ struct MessagesView<BottomBarContent: View>: View {
                 onDisplayNameEndedEditing: onDisplayNameEndedEditing,
                 onVideoSelected: onVideoSelected,
                 onProfileSettings: onProfileSettings,
+                onConvosAction: onConvosAction,
                 onBaseHeightChanged: { height in
                     bottomBarHeight = height
                 },


### PR DESCRIPTION
## Summary

Stacked on #614. Re-enables the Convos icon button in the media buttons bar and wires it to create a new conversation and share its invite link.

## How it works

1. **Tap Convos button** → acquires an inbox via `session.addInbox()` and creates a new conversation through the conversation state manager
2. **Invite ready** → observes the draft conversation publisher for the invite URL, then sets it as a `pendingInvite` attachment in the current conversation's message bar
3. **Clear invite** → calls `session.deleteInbox()` to clean up the linked conversation

## Changes

- **`ConversationViewModel`**: `onConvosButtonTapped()` creates conversation and observes for invite; `clearPendingInvite()` deletes linked conversation; `PendingInvite` gains `linkedConversationClientId` and `linkedConversationInboxId`
- **`MessagesMediaButtonsView`**: Convos button re-enabled
- **`MessagesBottomBar`**, **`MessagesView`**, **`ConversationView`**: Thread `onConvosAction` callback

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Convos button to create and share a conversation invite link
> - Adds a Convos button to the message composer's media buttons bar in [MessagesMediaInputView.swift](https://github.com/xmtplabs/convos-ios/pull/615/files#diff-2ef425132cd324e2bdecf8896c7f1faefde0b87061f46c59e109b152dd6f68ed), propagating the action up through `MessagesView` and `MessagesBottomBar` to `ConversationViewModel`.
> - Tapping the button triggers `onConvosButtonTapped()`, which creates or opens an inbox via `session.addInbox()`, waits for a conversation with a non-empty invite `urlSlug`, then sets `pendingInvite` with the linked client and inbox identifiers.
> - Cancelling or clearing the pending invite deletes the linked inbox via `session.deleteInbox(clientId:inboxId:)` to avoid orphaned inboxes.
> - `PendingInvite` gains `linkedConversationClientId` and `linkedConversationInboxId` fields to track the associated inbox lifecycle.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 10fd49b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->