### PR TITLE
Fix delete all data leaving orphaned conversations

### DIFF
--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/InboxWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/InboxWriter.swift
@@ -112,8 +112,19 @@ struct InboxWriter {
     }
 
     func deleteAll() async throws {
-        _ = try await dbWriter.write { db in
-            try DBInbox.deleteAll(db)
+        try await dbWriter.write { db in
+            try db.execute(sql: "DELETE FROM message")
+            try db.execute(sql: "DELETE FROM attachmentLocalState")
+            try db.execute(sql: "DELETE FROM conversationLocalState")
+            try db.execute(sql: "DELETE FROM invite")
+            try db.execute(sql: "DELETE FROM conversation_members")
+            try db.execute(sql: "DELETE FROM memberProfile")
+            try db.execute(sql: "DELETE FROM photoPreferences")
+            try db.execute(sql: "DELETE FROM pendingPhotoUpload")
+            try db.execute(sql: "DELETE FROM conversation")
+            try db.execute(sql: "DELETE FROM member")
+            try db.execute(sql: "DELETE FROM vaultDevice")
+            try db.execute(sql: "DELETE FROM inbox")
         }
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/InboxWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/InboxWriter.swift
@@ -113,18 +113,43 @@ struct InboxWriter {
 
     func deleteAll() async throws {
         try await dbWriter.write { db in
-            try db.execute(sql: "DELETE FROM message")
-            try db.execute(sql: "DELETE FROM attachmentLocalState")
-            try db.execute(sql: "DELETE FROM conversationLocalState")
-            try db.execute(sql: "DELETE FROM invite")
-            try db.execute(sql: "DELETE FROM conversation_members")
-            try db.execute(sql: "DELETE FROM memberProfile")
-            try db.execute(sql: "DELETE FROM photoPreferences")
-            try db.execute(sql: "DELETE FROM pendingPhotoUpload")
-            try db.execute(sql: "DELETE FROM conversation")
-            try db.execute(sql: "DELETE FROM member")
-            try db.execute(sql: "DELETE FROM vaultDevice")
-            try db.execute(sql: "DELETE FROM inbox")
+            // Delete children before parents to respect foreign keys.
+            //
+            // Dependency graph (child → parent):
+            //   message → conversation
+            //   attachmentLocalState → conversation
+            //   conversationLocalState → conversation
+            //   invite → conversation_members  (FK: creatorInboxId + conversationId)
+            //   conversation_members → conversation, member
+            //   memberProfile → conversation, member
+            //   conversation → (no app-level parents)
+            //   member → (no app-level parents)
+            //   inbox, vaultDevice, photoPreferences, pendingPhotoUpload → independent
+            //
+            // Cascades are set on FKs, but we still delete children first for
+            // defensive safety if cascades are ever removed.
+            let tables = [
+                "message",
+                "attachmentLocalState",
+                "conversationLocalState",
+                "invite",
+                "conversation_members",
+                "memberProfile",
+                "photoPreferences",
+                "pendingPhotoUpload",
+                "conversation",
+                "member",
+                "vaultDevice",
+                "inbox",
+            ]
+            for table in tables {
+                do {
+                    try db.execute(sql: "DELETE FROM \(table)")
+                } catch {
+                    Log.error("deleteAll: failed to delete from \(table): \(error)")
+                    throw error
+                }
+            }
         }
     }
 }

--- a/ConvosCore/Tests/ConvosCoreTests/InboxWriterTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/InboxWriterTests.swift
@@ -167,4 +167,110 @@ struct InboxWriterTests {
 
         try? await fixtures.cleanup()
     }
+
+    @Test("deleteAll removes data from all tables")
+    func testDeleteAllRemovesAllData() async throws {
+        let fixtures = TestFixtures()
+        let db = fixtures.databaseManager.dbWriter
+
+        let inboxWriter = InboxWriter(dbWriter: db)
+        _ = try await inboxWriter.save(inboxId: "inbox-1", clientId: "client-1")
+
+        try await db.write { db in
+            let conversation = DBConversation(
+                id: "conv-1",
+                inboxId: "inbox-1",
+                clientId: "client-1",
+                clientConversationId: "conv-1",
+                inviteTag: "",
+                creatorId: "inbox-1",
+                kind: .group,
+                consent: .allowed,
+                createdAt: Date(),
+                name: nil,
+                description: nil,
+                imageURLString: nil,
+                publicImageURLString: nil,
+                includeInfoInPublicPreview: false,
+                expiresAt: nil,
+                debugInfo: .empty,
+                isLocked: false,
+                imageSalt: nil,
+                imageNonce: nil,
+                imageEncryptionKey: nil,
+                imageLastRenewed: nil,
+                isUnused: false
+            )
+            try conversation.save(db)
+
+            let member = DBMember(inboxId: "inbox-1")
+            try member.save(db)
+
+            let memberProfile = DBMemberProfile(
+                conversationId: "conv-1",
+                inboxId: "inbox-1",
+                name: "Test",
+                avatar: nil
+            )
+            try memberProfile.save(db)
+
+            let localState = ConversationLocalState(
+                conversationId: "conv-1",
+                isPinned: false,
+                isUnread: false,
+                isUnreadUpdatedAt: Date(),
+                isMuted: false,
+                pinnedOrder: nil,
+                isActive: true
+            )
+            try localState.save(db)
+
+            let conversationMember = DBConversationMember(
+                conversationId: "conv-1",
+                inboxId: "inbox-1",
+                role: .superAdmin,
+                consent: .allowed,
+                createdAt: Date(),
+                invitedByInboxId: nil
+            )
+            try conversationMember.save(db)
+
+            // invite references conversation_members via composite FK
+            // (creatorInboxId + conversationId). This exercises the FK ordering
+            // in deleteAll: invite must be deleted before conversation_members
+            // (or cascade must fire) to avoid constraint violations.
+            let invite = DBInvite(
+                creatorInboxId: "inbox-1",
+                conversationId: "conv-1",
+                urlSlug: "test-slug",
+                expiresAt: nil,
+                expiresAfterUse: false
+            )
+            try invite.save(db)
+        }
+
+        try await inboxWriter.deleteAll()
+
+        let counts = try await fixtures.databaseManager.dbReader.read { db in
+            (
+                inbox: try DBInbox.fetchCount(db),
+                conversation: try DBConversation.fetchCount(db),
+                member: try DBMember.fetchCount(db),
+                memberProfile: try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM memberProfile") ?? 0,
+                localState: try ConversationLocalState.fetchCount(db),
+                conversationMembers: try DBConversationMember.fetchCount(db),
+                invite: try DBInvite.fetchCount(db)
+            )
+        }
+
+        #expect(counts.inbox == 0)
+        #expect(counts.conversation == 0)
+        #expect(counts.member == 0)
+        #expect(counts.memberProfile == 0)
+        #expect(counts.localState == 0)
+        #expect(counts.conversationMembers == 0)
+        #expect(counts.invite == 0)
+
+        try? await fixtures.cleanup()
+    }
 }


### PR DESCRIPTION
## Summary

"Delete all data" in app settings only deleted `inbox` rows from GRDB. All other tables — conversations, messages, members, profiles, invites, local state, etc. — were left behind because there are no foreign key cascades from `inbox` to `conversation`.

This caused "ghost" conversations to reappear after deleting all data and relaunching the app.

## Fix

`InboxWriter.deleteAll()` now deletes all rows from every GRDB table in dependency order within a single write transaction:

```
message → attachmentLocalState → conversationLocalState → invite →
conversation_members → memberProfile → photoPreferences →
pendingPhotoUpload → conversation → member → vaultDevice → inbox
```

## Testing

- InboxWriter tests pass
- Manual: delete all data → relaunch → no conversations visible

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `InboxWriter.deleteAll` leaving orphaned conversations by deleting all related tables
> Previously, `deleteAll` only deleted rows from the `DBInbox` table, leaving orphaned records in related tables. Now it deletes rows across all dependent tables in child-to-parent order (messages, attachments, local state, invites, members, conversations, etc.) within a single write transaction, aborting and rethrowing on the first failure.
>
> - Behavioral Change: `deleteAll` now clears 12 tables instead of 1; any failure in an intermediate table aborts the entire operation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 827fb05.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->