### PR TITLE
Add inline reply and mark-as-read notification actions

### DIFF
--- a/Convos/ConvosAppDelegate.swift
+++ b/Convos/ConvosAppDelegate.swift
@@ -15,6 +15,7 @@ class ConvosAppDelegate: NSObject, UIApplicationDelegate, @preconcurrency UNUser
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
         SentryConfiguration.configure()
         UNUserNotificationCenter.current().delegate = self
+        registerNotificationCategories()
         application.registerForRemoteNotifications()
         leftConversationObserver = NotificationCenter.default.addObserver(
             forName: .leftConversationNotification, object: nil, queue: .main
@@ -23,6 +24,28 @@ class ConvosAppDelegate: NSObject, UIApplicationDelegate, @preconcurrency UNUser
             Task { await self?.clearDeliveredNotifications(for: conversationId) }
         }
         return true
+    }
+
+    private func registerNotificationCategories() {
+        let replyAction = UNTextInputNotificationAction(
+            identifier: NotificationAction.replyIdentifier,
+            title: "Reply",
+            options: [],
+            textInputButtonTitle: "Send",
+            textInputPlaceholder: "Type a reply..."
+        )
+        let markReadAction = UNNotificationAction(
+            identifier: NotificationAction.markReadIdentifier,
+            title: "Mark as Read",
+            options: []
+        )
+        let messageCategory = UNNotificationCategory(
+            identifier: NotificationAction.messageCategoryIdentifier,
+            actions: [replyAction, markReadAction],
+            intentIdentifiers: [],
+            options: []
+        )
+        UNUserNotificationCenter.current().setNotificationCategories([messageCategory])
     }
 
     func application(_ application: UIApplication,
@@ -94,14 +117,11 @@ class ConvosAppDelegate: NSObject, UIApplicationDelegate, @preconcurrency UNUser
         return [.banner]
     }
 
-    // Handle notification taps
+    // Handle notification taps and actions
     func userNotificationCenter(_ center: UNUserNotificationCenter,
                                 didReceive response: UNNotificationResponse) async {
-        Log.debug("Notification tapped")
-
         let conversationId = response.notification.request.content.threadIdentifier
 
-        // Check if this is an explosion notification tap
         if response.notification.request.content.userInfo["isExplosion"] as? Bool == true {
             Log.info("Explosion notification tapped")
             DispatchQueue.main.async {
@@ -115,30 +135,47 @@ class ConvosAppDelegate: NSObject, UIApplicationDelegate, @preconcurrency UNUser
         }
 
         guard !conversationId.isEmpty else {
-            Log.warning("Notification tapped but conversationId is empty")
+            Log.warning("Notification received but conversationId is empty")
             return
         }
 
+        switch response.actionIdentifier {
+        case NotificationAction.replyIdentifier:
+            await handleNotificationReply(response: response, conversationId: conversationId)
+
+        case NotificationAction.markReadIdentifier:
+            await clearDeliveredNotifications(for: conversationId)
+
+        default:
+            await handleNotificationTap(conversationId: conversationId)
+        }
+    }
+
+    private func handleNotificationReply(response: UNNotificationResponse, conversationId: String) async {
+        guard let textResponse = response as? UNTextInputNotificationResponse else { return }
+        let replyText = textResponse.userText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !replyText.isEmpty else { return }
+
+        Log.info("Sending notification reply to conversation \(conversationId)")
+        do {
+            try await session?.sendNotificationReply(text: replyText, conversationId: conversationId)
+            await clearDeliveredNotifications(for: conversationId)
+        } catch {
+            Log.error("Failed to send notification reply: \(error)")
+        }
+    }
+
+    private func handleNotificationTap(conversationId: String) async {
         guard let session = session,
               let inboxId = await session.inboxId(for: conversationId) else {
-            Log
-                .warning(
-                    "Notification tapped but could not find inboxId for conversationId: \(conversationId)"
-                )
+            Log.warning("Notification tapped but could not find inboxId for conversationId: \(conversationId)")
             return
         }
 
-        // Wake the inbox for this conversation when notification is tapped
-        // This ensures the inbox is ready when the user opens the conversation
         await session.wakeInboxForNotification(conversationId: conversationId)
-
-        // Clear all delivered notifications for this conversation
         await clearDeliveredNotifications(for: conversationId)
 
-        Log
-            .info(
-                "Handling conversation notification tap for inboxId: \(inboxId), conversationId: \(conversationId)"
-            )
+        Log.info("Handling conversation notification tap for inboxId: \(inboxId), conversationId: \(conversationId)")
         DispatchQueue.main.async {
             NotificationCenter.default.post(
                 name: .conversationNotificationTapped,

--- a/ConvosCore/Sources/ConvosCore/Inboxes/MessagingService+PushNotifications.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/MessagingService+PushNotifications.swift
@@ -387,12 +387,39 @@ extension MessagingService {
             return .droppedMessage
         }
 
+        let avatarData = await loadSenderAvatarData(
+            senderInboxId: decodedMessage.senderInboxId,
+            conversationId: conversationId
+        )
+
         return .init(
             title: notificationTitle,
             body: body,
             conversationId: conversationId,
-            userInfo: userInfo
+            userInfo: userInfo,
+            senderAvatarData: avatarData
         )
+    }
+
+    private func loadSenderAvatarData(
+        senderInboxId: String,
+        conversationId: String
+    ) async -> Data? {
+        do {
+            guard let profile = try await databaseReader.read({ db in
+                try DBMemberProfile.fetchOne(db, conversationId: conversationId, inboxId: senderInboxId)
+            }) else { return nil }
+
+            guard let ref = profile.encryptedImageRef,
+                  let params = EncryptedImageParams(encryptedRef: ref, groupKey: profile.avatarKey) else {
+                return nil
+            }
+
+            return try await EncryptedImageLoader.loadAndDecrypt(params: params)
+        } catch {
+            Log.debug("Could not load sender avatar for notification: \(error)")
+            return nil
+        }
     }
 
     private func getSenderDisplayName(

--- a/ConvosCore/Sources/ConvosCore/Inboxes/MockInboxesService.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/MockInboxesService.swift
@@ -30,6 +30,8 @@ public final class MockInboxesService: SessionManagerProtocol {
     public func notifyChangesInDatabase() {
     }
 
+    public func sendNotificationReply(text: String, conversationId: String) async throws {}
+
     public func inboxId(for conversationId: String) async -> String? {
         "mock-inbox-id"
     }

--- a/ConvosCore/Sources/ConvosCore/Notifications/NotificationAction.swift
+++ b/ConvosCore/Sources/ConvosCore/Notifications/NotificationAction.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+public enum NotificationAction {
+    public static let replyIdentifier: String = "com.convos.action.reply"
+    public static let markReadIdentifier: String = "com.convos.action.markRead"
+    public static let messageCategoryIdentifier: String = "com.convos.category.message"
+}

--- a/ConvosCore/Sources/ConvosCore/Notifications/PushNotificationPayload.swift
+++ b/ConvosCore/Sources/ConvosCore/Notifications/PushNotificationPayload.swift
@@ -9,13 +9,15 @@ public struct DecodedNotificationContent: @unchecked Sendable {
     public let conversationId: String?
     public let isDroppedMessage: Bool
     public let userInfo: [AnyHashable: Any]
+    public let senderAvatarData: Data?
 
-    init(title: String?, body: String, conversationId: String?, userInfo: [AnyHashable: Any]) {
+    init(title: String?, body: String, conversationId: String?, userInfo: [AnyHashable: Any], senderAvatarData: Data? = nil) {
         self.title = title
         self.body = body
         self.conversationId = conversationId
         self.isDroppedMessage = false
         self.userInfo = userInfo
+        self.senderAvatarData = senderAvatarData
     }
 
     init(isDroppedMessage: Bool, userInfo: [AnyHashable: Any]) {
@@ -24,6 +26,7 @@ public struct DecodedNotificationContent: @unchecked Sendable {
         self.conversationId = nil
         self.isDroppedMessage = isDroppedMessage
         self.userInfo = userInfo
+        self.senderAvatarData = nil
     }
 
     static var droppedMessage: DecodedNotificationContent {

--- a/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
@@ -560,6 +560,12 @@ public final class SessionManager: SessionManagerProtocol, @unchecked Sendable {
             for: conversation.clientId,
             inboxId: conversation.inboxId
         )
+        await service.inboxStateManager.ensureForeground()
+        for _ in 0..<20 {
+            if case .ready = service.inboxStateManager.currentState { break }
+            try await Task.sleep(for: .milliseconds(100))
+        }
+
         let writer = service.messageWriter(
             for: conversationId,
             backgroundUploadManager: platformProviders.backgroundUploadManager

--- a/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
@@ -539,6 +539,35 @@ public final class SessionManager: SessionManagerProtocol, @unchecked Sendable {
         Log.info("Deleted orphaned inbox: clientId=\(clientId), inboxId=\(inboxId)")
     }
 
+    // MARK: - Notification Actions
+
+    public func sendNotificationReply(text: String, conversationId: String) async throws {
+        guard let conversation = try await databaseReader.read({ db in
+            try DBConversation
+                .filter(DBConversation.Columns.id == conversationId)
+                .fetchOne(db)
+        }) else {
+            Log.error("Cannot reply: conversation \(conversationId) not found")
+            return
+        }
+
+        await wakeInboxForNotification(
+            clientId: conversation.clientId,
+            inboxId: conversation.inboxId
+        )
+
+        let service = try await messagingService(
+            for: conversation.clientId,
+            inboxId: conversation.inboxId
+        )
+        let writer = service.messageWriter(
+            for: conversationId,
+            backgroundUploadManager: platformProviders.backgroundUploadManager
+        )
+        try await writer.send(text: text)
+        Log.info("Sent notification reply to conversation \(conversationId)")
+    }
+
     // MARK: Helpers
 
     public func inboxId(for conversationId: String) async -> String? {

--- a/ConvosCore/Sources/ConvosCore/Sessions/SessionManagerProtocol.swift
+++ b/ConvosCore/Sources/ConvosCore/Sessions/SessionManagerProtocol.swift
@@ -64,8 +64,9 @@ public protocol SessionManagerProtocol: AnyObject, Sendable {
     func isInboxAwake(clientId: String) async -> Bool
     func isInboxSleeping(clientId: String) async -> Bool
 
-    // MARK: Helpers
+    // MARK: Notification Actions
 
+    func sendNotificationReply(text: String, conversationId: String) async throws
     func inboxId(for conversationId: String) async -> String?
 
     // MARK: Debug

--- a/NotificationService/NotificationService.swift
+++ b/NotificationService/NotificationService.swift
@@ -170,7 +170,30 @@ extension DecodedNotificationContent {
             content.threadIdentifier = conversationId
         }
         content.categoryIdentifier = NotificationAction.messageCategoryIdentifier
+
+        if let avatarData = senderAvatarData,
+           let attachment = Self.createAvatarAttachment(from: avatarData) {
+            content.attachments = [attachment]
+        }
+
         return content
+    }
+
+    private static func createAvatarAttachment(from imageData: Data) -> UNNotificationAttachment? {
+        let fileURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathExtension("jpg")
+        do {
+            try imageData.write(to: fileURL)
+            return try UNNotificationAttachment(
+                identifier: "sender-avatar",
+                url: fileURL,
+                options: [UNNotificationAttachmentOptionsTypeHintKey: "public.jpeg"]
+            )
+        } catch {
+            try? FileManager.default.removeItem(at: fileURL)
+            return nil
+        }
     }
 }
 

--- a/NotificationService/NotificationService.swift
+++ b/NotificationService/NotificationService.swift
@@ -169,6 +169,7 @@ extension DecodedNotificationContent {
         if let conversationId {
             content.threadIdentifier = conversationId
         }
+        content.categoryIdentifier = NotificationAction.messageCategoryIdentifier
         return content
     }
 }

--- a/NotificationService/NotificationService.swift
+++ b/NotificationService/NotificationService.swift
@@ -1,6 +1,7 @@
 import ConvosCore
 import ConvosCoreiOS
 import Foundation
+import Intents
 import UserNotifications
 import XMTPiOS
 
@@ -171,29 +172,40 @@ extension DecodedNotificationContent {
         }
         content.categoryIdentifier = NotificationAction.messageCategoryIdentifier
 
-        if let avatarData = senderAvatarData,
-           let attachment = Self.createAvatarAttachment(from: avatarData) {
-            content.attachments = [attachment]
+        let senderHandle = INPersonHandle(value: conversationId ?? "unknown", type: .unknown)
+        var avatarImage: INImage?
+        if let avatarData = senderAvatarData {
+            avatarImage = INImage(imageData: avatarData)
+        }
+        let sender = INPerson(
+            personHandle: senderHandle,
+            nameComponents: nil,
+            displayName: title,
+            image: avatarImage,
+            contactIdentifier: nil,
+            customIdentifier: conversationId
+        )
+
+        let intent = INSendMessageIntent(
+            recipients: nil,
+            outgoingMessageType: .outgoingMessageText,
+            content: body,
+            speakableGroupName: nil,
+            conversationIdentifier: conversationId,
+            serviceName: nil,
+            sender: sender,
+            attachments: nil
+        )
+
+        let interaction = INInteraction(intent: intent, response: nil)
+        interaction.direction = .incoming
+        interaction.donate(completion: nil)
+
+        if let updatedContent = try? content.updating(from: intent) as? UNMutableNotificationContent {
+            return updatedContent
         }
 
         return content
-    }
-
-    private static func createAvatarAttachment(from imageData: Data) -> UNNotificationAttachment? {
-        let fileURL = FileManager.default.temporaryDirectory
-            .appendingPathComponent(UUID().uuidString)
-            .appendingPathExtension("jpg")
-        do {
-            try imageData.write(to: fileURL)
-            return try UNNotificationAttachment(
-                identifier: "sender-avatar",
-                url: fileURL,
-                options: [UNNotificationAttachmentOptionsTypeHintKey: "public.jpeg"]
-            )
-        } catch {
-            try? FileManager.default.removeItem(at: fileURL)
-            return nil
-        }
     }
 }
 


### PR DESCRIPTION
## Changes

Adds two notification actions to message push notifications:

### 1. Inline Reply
Users can reply directly from the notification banner or lock screen via a `UNTextInputNotificationAction`. The reply is sent through the existing messaging pipeline — wakes the correct inbox, gets a message writer, and sends.

### 2. Mark as Read
Clears all delivered notifications for the conversation from the notification center.

### Implementation

- **`NotificationAction`** constants in ConvosCore define identifiers shared between the main app and NSE
- **NSE** sets `categoryIdentifier` on all decoded message notifications
- **App delegate** registers the category at launch and routes action responses
- **`SessionManager.sendNotificationReply`** handles the inbox wake → message write → send flow

### Files changed
- `ConvosCore/Notifications/NotificationAction.swift` (new)
- `ConvosCore/Sessions/SessionManager.swift`
- `ConvosCore/Sessions/SessionManagerProtocol.swift`
- `ConvosCore/Inboxes/MockInboxesService.swift`
- `Convos/ConvosAppDelegate.swift`
- `NotificationService/NotificationService.swift`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add inline reply and mark-as-read actions to push notifications
> - Registers a `UNNotificationCategory` with Reply and Mark as Read actions on launch via a new `registerNotificationCategories()` helper in [ConvosAppDelegate.swift](https://github.com/xmtplabs/convos-ios/pull/644/files#diff-b60017894e41cfae5972dc1a8e7a570c0e178450b755274f727901dd3ab2976e).
> - Inline replies extract the typed text from `UNTextInputNotificationResponse` and send it via `SessionManager.sendNotificationReply(text:conversationId:)`, which wakes the inbox and obtains a message writer before sending.
> - Mark-as-read clears delivered notifications for the thread; normal taps retain existing behavior via the new `handleNotificationTap` helper.
> - Notification content now includes sender avatar data (fetched and decrypted from `DBMemberProfile`) and is backed by an `INSendMessageIntent`, enabling system-level messaging UI in the notification.
> - Behavioral Change: all push notifications now carry a `categoryIdentifier` and an `INSendMessageIntent` donation, which may affect how iOS groups or displays them.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6f17c52.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->