### PR TITLE
Fix conversations not marked as read after viewing

### DIFF
--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesMediaInputView.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesMediaInputView.swift
@@ -33,7 +33,7 @@ struct MessagesMediaButtonsView: View {
             .accessibilityLabel("Camera")
             .accessibilityIdentifier("camera-button")
 
-            // TODO: Convos action button (hidden until feature is ready)
+            // Convos action button (hidden until feature is ready)
             // Button {
             //     onConvosAction()
             // } label: {

--- a/Convos/Conversations List/ConversationsViewModel.swift
+++ b/Convos/Conversations List/ConversationsViewModel.swift
@@ -64,6 +64,9 @@ final class ConversationsViewModel {
                 markConversationAsRead(conversation)
             }
         } else {
+            if let previousViewModel = selectedConversationViewModel {
+                markConversationAsRead(previousViewModel.conversation)
+            }
             updateSelectionTask?.cancel()
             selectedConversationViewModel = nil
         }

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationWriter.swift
@@ -535,17 +535,18 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
 
         // Store messages and track if conversation should be marked unread
         var marksConversationAsUnread = false
+        let myInboxId = dbConversation.inboxId
         for message in messages {
             guard !message.isProfileMessage else { continue }
             Log.debug("Catching up with message sent at: \(message.sentAt.nanosecondsSince1970)")
             let result = try await messageWriter.store(message: message, for: dbConversation)
-            if result.contentType.marksConversationAsUnread {
+            if result.contentType.marksConversationAsUnread,
+               message.senderInboxId != myInboxId {
                 marksConversationAsUnread = true
             }
             Log.debug("Saved caught up message sent at: \(message.sentAt.nanosecondsSince1970)")
         }
 
-        // Update unread status if needed
         if marksConversationAsUnread {
             try await localStateWriter.setUnread(true, for: conversation.id)
         }


### PR DESCRIPTION
## Summary

Conversations were incorrectly showing as unread after being viewed. Two issues identified and fixed:

### 1. No mark-as-read on deselection

When navigating back from a conversation to the conversations list, the previously viewed conversation was never explicitly marked as read. If any code path marked it unread while viewing (e.g., race between notification delivery and stream processing), it would stay unread.

**Fix:** Call `markConversationAsRead` for the previous conversation when selection changes to `nil` in `ConversationsViewModel.updateSelectionState()`.

### 2. ConversationWriter catch-up didn't check sender

`fetchAndStoreLatestMessages` marked conversations unread for all incoming messages including the user's own messages. The `StreamProcessor` already had a sender check (`message.senderInboxId != params.client.inboxId`) but this parallel path didn't.

**Fix:** Added sender check so only messages from other users mark conversations as unread — matching `StreamProcessor`'s existing logic.

## Test plan

QA verified with 5 scenarios on a fresh simulator:

| Test | Result |
|------|--------|
| Receive messages while viewing conversation, go back | ✅ No unread indicator |
| Receive message while NOT viewing | ✅ Unread indicator appears |
| Open unread conversation, go back | ✅ Marked as read |
| Send own message, go back | ✅ Stays read |
| 5 rapid concurrent messages while viewing, immediate back | ✅ Stays read |

All 473 ConvosCore unit tests pass.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix conversations not marked as read after viewing
> - When the selected conversation is cleared in `ConversationsViewModel.updateSelectionState`, the previously selected conversation is now explicitly marked as read before being deselected.
> - In [`ConversationWriter.catchUpWithHistory`](https://github.com/xmtplabs/convos-ios/pull/653/files#diff-113bfd0c28b1a3b561f19e4574a0937082fe5c92a262e57573eee7728940a726), messages sent by the current user no longer mark the conversation as unread during history catch-up; only messages from other senders with qualifying content types trigger the unread state.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5a34ecc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->