### PR TITLE
Fix archive build: type-check timeout in ReplyReferenceView

### DIFF
--- a/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/ReplyReferenceView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/ReplyReferenceView.swift
@@ -249,51 +249,62 @@ private struct ReplyReferencePhotoPreview: View {
         contextMenuState.isReplyParent && contextMenuState.sourceID == instanceID
     }
 
+    private var imageContent: some View {
+        Image(uiImage: loadedImage ?? UIImage())
+            .resizable()
+            .aspectRatio(contentMode: .fit)
+            .frame(maxHeight: Self.maxHeight)
+            .scaleEffect(shouldBlur ? 1.65 : 1.0)
+            .blur(radius: shouldBlur ? 96 : 0)
+            .background(shouldBlur ? Color.colorBackgroundSurfaceless : .clear)
+            .overlay { videoPlayOverlay }
+            .opacity(isSourceForContextMenu ? 0 : 1.0)
+            .clipShape(RoundedRectangle(cornerRadius: DesignConstants.CornerRadius.regular))
+            .contentShape(RoundedRectangle(cornerRadius: DesignConstants.CornerRadius.regular))
+            .onTapGesture {
+                if shouldBlur { onReveal() }
+            }
+            .overlay { longPressOverlay }
+    }
+
+    @ViewBuilder
+    private var videoPlayOverlay: some View {
+        if isVideo, !shouldBlur {
+            Image(systemName: "play.fill")
+                .font(.system(size: 20))
+                .foregroundStyle(.white)
+                .shadow(color: .black.opacity(0.3), radius: 2, x: 0, y: 1)
+        }
+    }
+
+    private var longPressOverlay: some View {
+        GeometryReader { geometry in
+            Color.clear
+                .contentShape(Rectangle())
+                .onLongPressGesture(minimumDuration: 0.5) {
+                    UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+                    let frame = geometry.frame(in: .global)
+                    contextMenuState.presentReplyParent(
+                        message: .message(parentMessage, .existing),
+                        bubbleFrame: frame,
+                        sourceID: instanceID
+                    )
+                }
+        }
+    }
+
+    private var placeholder: some View {
+        RoundedRectangle(cornerRadius: DesignConstants.CornerRadius.regular)
+            .fill(.quaternary)
+            .frame(width: 60.0, height: Self.maxHeight)
+    }
+
     var body: some View {
         Group {
-            if let image = loadedImage {
-                Image(uiImage: image)
-                    .resizable()
-                    .aspectRatio(contentMode: .fit)
-                    .frame(maxHeight: Self.maxHeight)
-                    .scaleEffect(shouldBlur ? 1.65 : 1.0)
-                    .blur(radius: shouldBlur ? 96 : 0)
-                    .background(shouldBlur ? Color.colorBackgroundSurfaceless : .clear)
-                    .overlay {
-                        if isVideo, !shouldBlur {
-                            Image(systemName: "play.fill")
-                                .font(.system(size: 20))
-                                .foregroundStyle(.white)
-                                .shadow(color: .black.opacity(0.3), radius: 2, x: 0, y: 1)
-                        }
-                    }
-                    .opacity(isSourceForContextMenu ? 0 : 1.0)
-                    .clipShape(RoundedRectangle(cornerRadius: DesignConstants.CornerRadius.regular))
-                    .contentShape(RoundedRectangle(cornerRadius: DesignConstants.CornerRadius.regular))
-                    .onTapGesture {
-                        if shouldBlur {
-                            onReveal()
-                        }
-                    }
-                    .overlay {
-                        GeometryReader { geometry in
-                            Color.clear
-                                .contentShape(Rectangle())
-                                .onLongPressGesture(minimumDuration: 0.5) {
-                                    UIImpactFeedbackGenerator(style: .medium).impactOccurred()
-                                    let frame = geometry.frame(in: .global)
-                                    contextMenuState.presentReplyParent(
-                                        message: .message(parentMessage, .existing),
-                                        bubbleFrame: frame,
-                                        sourceID: instanceID
-                                    )
-                                }
-                        }
-                    }
+            if loadedImage != nil {
+                imageContent
             } else {
-                RoundedRectangle(cornerRadius: DesignConstants.CornerRadius.regular)
-                    .fill(.quaternary)
-                    .frame(width: 60.0, height: Self.maxHeight)
+                placeholder
             }
         }
         .task {


### PR DESCRIPTION
The `body` property in `ReplyReferenceAttachmentPreview` took 147ms to type-check, exceeding the 100ms limit in release/archive builds. This broke the CI archive step.

Fix: extract the monolithic body into four smaller computed properties (`imageContent`, `videoPlayOverlay`, `longPressOverlay`, `placeholder`) to reduce type inference complexity.

No behavioral changes — pure refactor for compiler performance.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix type-check timeout in `ReplyReferencePhotoPreview` by splitting body into computed views
> Refactors the `ReplyReferencePhotoPreview` view in [ReplyReferenceView.swift](https://github.com/xmtplabs/convos-ios/pull/655/files#diff-f4aab767e0ecfbed5f31ebb3412661186732e367192eeca828fff854a6d6dcf8) to resolve a compiler type-check timeout that was breaking archive builds. The monolithic `body` is split into `imageContent`, `videoPlayOverlay`, `longPressOverlay`, and `placeholder` computed properties, with `body` delegating to each. Logic and runtime behavior are unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c158130.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->