### PR TITLE
Fix CI: cross-platform jpegData for macOS compilation

### DIFF
--- a/ConvosCore/Sources/ConvosCore/Shared/ImageType.swift
+++ b/ConvosCore/Sources/ConvosCore/Shared/ImageType.swift
@@ -5,3 +5,15 @@ public typealias ImageType = NSImage
 import UIKit
 public typealias ImageType = UIImage
 #endif
+
+extension ImageType {
+    func crossPlatformJPEGData(compressionQuality: CGFloat = 0.8) -> Data? {
+        #if os(macOS)
+        guard let tiffData = tiffRepresentation,
+              let bitmap = NSBitmapImageRep(data: tiffData) else { return nil }
+        return bitmap.representation(using: .jpeg, properties: [.compressionFactor: compressionQuality])
+        #else
+        return jpegData(compressionQuality: compressionQuality)
+        #endif
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/OutgoingMessageWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/OutgoingMessageWriter.swift
@@ -1009,7 +1009,7 @@ actor OutgoingMessageWriter: OutgoingMessageWriterProtocol {
             mediaWidth: nil,
             mediaHeight: nil,
             mediaDuration: nil,
-            thumbnailDataBase64: thumbnailImage.flatMap { $0.jpegData(compressionQuality: 0.5)?.base64EncodedString() }
+            thumbnailDataBase64: thumbnailImage.flatMap { $0.crossPlatformJPEGData(compressionQuality: 0.5)?.base64EncodedString() }
         )
 
         let messageId = try await publishAttachment(


### PR DESCRIPTION
ConvosCore tests run on macOS via `swift test`, where `ImageType` is `NSImage`. `NSImage` has no `jpegData(compressionQuality:)` method, causing compilation failure in `OutgoingMessageWriter` (video thumbnail encoding).

Adds `crossPlatformJPEGData(compressionQuality:)` extension on `ImageType` that uses `NSBitmapImageRep` on macOS and `jpegData` on iOS.

This has been breaking CI integration tests for weeks.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix macOS compilation by adding `crossPlatformJPEGData` to `ImageType`
> `jpegData(compressionQuality:)` is not available on macOS, causing CI failures. Adds a `crossPlatformJPEGData(compressionQuality:)` method to `ImageType` in [ImageType.swift](https://github.com/xmtplabs/convos-ios/pull/656/files#diff-2af8a797b18d365c0e344641d84014159df10ebcb6084b7055e334b4e411ef21) that uses `NSBitmapImageRep` on macOS and delegates to `jpegData` on other platforms. Updates [OutgoingMessageWriter.swift](https://github.com/xmtplabs/convos-ios/pull/656/files#diff-2ba8cf409a96f2eb22ac537fb59817aae89c4fdf4a953c1683a27be30a6107b6) to use this method when encoding video thumbnails.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cc2ea5d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->