### PR TITLE
Add explode option to invite preview from convos button

### DIFF
--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -45,6 +45,8 @@ struct ConversationView<MessagesBottomBar: View>: View {
             isVideoAttachment: viewModel.selectedVideoURL != nil,
             composerLinkPreview: viewModel.pastedLinkPreview,
             pendingInviteURL: viewModel.pendingInvite?.fullURL,
+            pendingInviteExplodeDuration: viewModel.pendingInvite?.explodeDuration,
+            onSetInviteExplodeDuration: { duration in viewModel.setInviteExplodeDuration(duration) },
             sendButtonEnabled: viewModel.sendButtonEnabled,
             profileImage: $viewModel.myProfileViewModel.profileImage,
             onboardingCoordinator: onboardingCoordinator,

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -8,10 +8,34 @@ import UserNotifications
 
 struct PendingInvite {
     let code: String
-    let fullURL: String
+    var fullURL: String
     let range: Range<String.Index>
     var linkedConversationClientId: String?
     var linkedConversationInboxId: String?
+    var linkedConversationId: String?
+    var explodeDuration: ExplodeDuration?
+}
+
+enum ExplodeDuration: CaseIterable {
+    case oneHour
+    case oneDay
+    case oneWeek
+
+    var label: String {
+        switch self {
+        case .oneHour: return "1 hour"
+        case .oneDay: return "1 day"
+        case .oneWeek: return "1 week"
+        }
+    }
+
+    var timeInterval: TimeInterval {
+        switch self {
+        case .oneHour: return 3600
+        case .oneDay: return 86400
+        case .oneWeek: return 604800
+        }
+    }
 }
 
 @MainActor
@@ -64,6 +88,8 @@ class ConversationViewModel {
     private var convosButtonCancellable: AnyCancellable?
     @ObservationIgnored
     private var convosButtonTask: Task<Void, Never>?
+    @ObservationIgnored
+    private var explodeDurationTask: Task<Void, Never>?
     @ObservationIgnored
     private var photoPreferencesCancellable: AnyCancellable?
     @ObservationIgnored
@@ -354,6 +380,7 @@ class ConversationViewModel {
         explodeTask?.cancel()
         assistantJoinTask?.cancel()
         convosButtonTask?.cancel()
+        explodeDurationTask?.cancel()
     }
 
     // MARK: - Init
@@ -1499,6 +1526,47 @@ extension UNUserNotificationCenter {
     }
 }
 
+// MARK: - Linked Conversation Explosion
+
+extension ConversationViewModel {
+    func setInviteExplodeDuration(_ duration: ExplodeDuration?) {
+        explodeDurationTask?.cancel()
+        pendingInvite?.explodeDuration = duration
+        guard let duration,
+              let clientId = pendingInvite?.linkedConversationClientId,
+              let inboxId = pendingInvite?.linkedConversationInboxId,
+              let conversationId = pendingInvite?.linkedConversationId else { return }
+        explodeDurationTask = Task { [weak self] in
+            guard let self else { return }
+            let newURL = await scheduleLinkedConversationExplosion(
+                duration: duration, clientId: clientId, inboxId: inboxId, conversationId: conversationId
+            )
+            guard !Task.isCancelled, let newURL else { return }
+            await MainActor.run {
+                self.pendingInvite?.fullURL = newURL
+            }
+        }
+    }
+
+    func scheduleLinkedConversationExplosion(
+        duration: ExplodeDuration, clientId: String, inboxId: String, conversationId: String
+    ) async -> String? {
+        do {
+            let messagingService = try await session.messagingService(for: clientId, inboxId: inboxId)
+            let explosionWriter = messagingService.conversationExplosionWriter()
+            let metadataWriter = messagingService.conversationMetadataWriter()
+            let expiresAt = Date().addingTimeInterval(duration.timeInterval)
+            try await explosionWriter.scheduleExplosion(conversationId: conversationId, expiresAt: expiresAt)
+            Log.info("Scheduled explosion for linked conversation \(conversationId) in \(duration.label)")
+            let updatedInvite = try await metadataWriter.refreshInvite(for: conversationId)
+            return updatedInvite?.inviteURLString
+        } catch {
+            Log.error("Failed to schedule explosion for linked conversation: \(error)")
+            return nil
+        }
+    }
+}
+
 // MARK: - Invite URL Detection
 
 extension ConversationViewModel {
@@ -1572,7 +1640,8 @@ extension ConversationViewModel {
                         fullURL: urlString,
                         range: emptyRange,
                         linkedConversationClientId: clientId,
-                        linkedConversationInboxId: convo.inboxId
+                        linkedConversationInboxId: convo.inboxId,
+                        linkedConversationId: convo.id
                     )
                     self.convosButtonCancellable = nil
                 }

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Cells/MessageInviteContainerView.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Cells/MessageInviteContainerView.swift
@@ -101,18 +101,25 @@ struct MessageInviteView: View {
             .clipped()
             .background(.colorBackgroundInverted)
 
-            VStack(alignment: .leading, spacing: 2.0) {
-                Text(title)
-                    .lineLimit(2)
-                    .multilineTextAlignment(.leading)
-                    .foregroundStyle(.black)
-                    .font(.callout.weight(.bold))
-                    .fontWeight(.bold)
-                    .truncationMode(.tail)
-                Text(description)
-                    .font(.subheadline)
-                    .multilineTextAlignment(.leading)
-                    .foregroundStyle(.colorTextSecondary)
+            HStack {
+                VStack(alignment: .leading, spacing: 2.0) {
+                    Text(title)
+                        .lineLimit(2)
+                        .multilineTextAlignment(.leading)
+                        .foregroundStyle(.black)
+                        .font(.callout.weight(.bold))
+                        .fontWeight(.bold)
+                        .truncationMode(.tail)
+                    Text(description)
+                        .font(.subheadline)
+                        .multilineTextAlignment(.leading)
+                        .foregroundStyle(.colorTextSecondary)
+                }
+
+                if let expiresAt = invite.conversationExpiresAt, expiresAt > Date() {
+                    Spacer()
+                    ExplosionCountdownBadge(expiresAt: expiresAt)
+                }
             }
             .padding(.vertical, DesignConstants.Spacing.step3x)
             .padding(.horizontal, DesignConstants.Spacing.step4x)

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesBottomBar.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesBottomBar.swift
@@ -15,6 +15,8 @@ struct MessagesBottomBar<BottomBarContent: View>: View {
     var isVideoAttachment: Bool = false
     var composerLinkPreview: LinkPreview?
     var pendingInviteURL: String?
+    var pendingInviteExplodeDuration: ExplodeDuration?
+    var onSetInviteExplodeDuration: ((ExplodeDuration?) -> Void)?
     let sendButtonEnabled: Bool
     @Binding var profileImage: UIImage?
     @Binding var isPhotoPickerPresented: Bool
@@ -181,6 +183,8 @@ struct MessagesBottomBar<BottomBarContent: View>: View {
                 isVideoAttachment: isVideoAttachment,
                 composerLinkPreview: composerLinkPreview,
                 pendingInviteURL: pendingInviteURL,
+                pendingInviteExplodeDuration: pendingInviteExplodeDuration,
+                onSetInviteExplodeDuration: onSetInviteExplodeDuration,
                 sendButtonEnabled: sendButtonEnabled,
                 focusState: $focusState,
                 animateAvatarForQuickname: onboardingCoordinator.shouldAnimateAvatarForQuicknameSetup,

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesInputView.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesInputView.swift
@@ -13,6 +13,8 @@ struct MessagesInputView: View {
     var isVideoAttachment: Bool = false
     var composerLinkPreview: LinkPreview?
     var pendingInviteURL: String?
+    var pendingInviteExplodeDuration: ExplodeDuration?
+    var onSetInviteExplodeDuration: ((ExplodeDuration?) -> Void)?
     let sendButtonEnabled: Bool
     @FocusState.Binding var focusState: MessagesViewInputFocus?
     let animateAvatarForQuickname: Bool
@@ -209,13 +211,17 @@ struct MessagesInputView: View {
     @ViewBuilder
     private func inviteAttachmentPreview(url: String) -> some View {
         ZStack(alignment: .topTrailing) {
-            ComposerInvitePreviewCard(inviteURL: url)
-                .clipShape(.rect(cornerRadius: DesignConstants.Spacing.step4x))
-                .scaleEffect(isPoofingInvite ? 1.3 : 1.0)
-                .blur(radius: isPoofingInvite ? 12.0 : 0.0)
-                .opacity(isPoofingInvite ? 0.0 : 1.0)
-                .accessibilityLabel("Invite attachment preview")
-                .accessibilityIdentifier("invite-attachment-preview")
+            ComposerInvitePreviewCard(
+                inviteURL: url,
+                explodeDuration: pendingInviteExplodeDuration,
+                onSetExplodeDuration: onSetInviteExplodeDuration
+            )
+            .clipShape(.rect(cornerRadius: DesignConstants.Spacing.step4x))
+            .scaleEffect(isPoofingInvite ? 1.3 : 1.0)
+            .blur(radius: isPoofingInvite ? 12.0 : 0.0)
+            .opacity(isPoofingInvite ? 0.0 : 1.0)
+            .accessibilityLabel("Invite attachment preview")
+            .accessibilityIdentifier("invite-attachment-preview")
 
             Button {
                 withAnimation(.easeOut(duration: 0.2)) {
@@ -404,6 +410,8 @@ private struct ComposerImageAreaModifier: ViewModifier {
 
 private struct ComposerInvitePreviewCard: View {
     let inviteURL: String
+    var explodeDuration: ExplodeDuration?
+    var onSetExplodeDuration: ((ExplodeDuration?) -> Void)?
 
     @State private var ogTitle: String?
     @State private var cachedImage: UIImage?
@@ -443,16 +451,27 @@ private struct ComposerInvitePreviewCard: View {
             .clipped()
             .background(.colorBackgroundMedia)
 
-            VStack(alignment: .leading, spacing: 2.0) {
-                Text(displayTitle)
-                    .font(.callout.weight(.medium))
-                    .foregroundStyle(.colorTextPrimary)
-                    .lineLimit(2)
-                    .truncationMode(.tail)
-                Text("You're invited")
-                    .font(.caption)
-                    .foregroundStyle(.colorTextSecondary)
-                    .lineLimit(1)
+            HStack {
+                VStack(alignment: .leading, spacing: 2.0) {
+                    Text(displayTitle)
+                        .font(.callout.weight(.medium))
+                        .foregroundStyle(.colorTextPrimary)
+                        .lineLimit(2)
+                        .truncationMode(.tail)
+                    Text("You're invited")
+                        .font(.caption)
+                        .foregroundStyle(.colorTextSecondary)
+                        .lineLimit(1)
+                }
+
+                Spacer()
+
+                if let explodeDuration {
+                    ExplodeCountdownBadge(duration: explodeDuration)
+                        .onTapGesture {}
+                } else if onSetExplodeDuration != nil {
+                    explodeMenu
+                }
             }
             .padding(.horizontal, DesignConstants.Spacing.step4x)
             .padding(.vertical, DesignConstants.Spacing.step3x)
@@ -463,6 +482,28 @@ private struct ComposerInvitePreviewCard: View {
         .task {
             await fetchMetadata()
         }
+    }
+
+    @ViewBuilder
+    private var explodeMenu: some View {
+        Menu {
+            Section("Explode in") {
+                ForEach(ExplodeDuration.allCases, id: \.self) { duration in
+                    Button {
+                        onSetExplodeDuration?(duration)
+                    } label: {
+                        Text(duration.label)
+                    }
+                }
+            }
+        } label: {
+            Image(systemName: "ellipsis")
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundStyle(.colorTextSecondary)
+                .frame(width: 28, height: 28)
+                .contentShape(Rectangle())
+        }
+        .accessibilityIdentifier("invite-explode-menu")
     }
 
     private func fetchMetadata() async {
@@ -536,5 +577,22 @@ private struct ComposerInvitePreviewCard: View {
             onClearInvite: { pendingInviteURLPreview = nil }
         )
         .padding(DesignConstants.Spacing.step2x)
+    }
+}
+
+struct ExplodeCountdownBadge: View {
+    let duration: ExplodeDuration
+
+    var body: some View {
+        HStack(spacing: 2) {
+            Image(systemName: "burst")
+                .font(.system(size: 10, weight: .semibold))
+            Text(duration.label)
+                .font(.caption2.weight(.semibold))
+        }
+        .foregroundStyle(.colorCaution)
+        .padding(.horizontal, 6)
+        .padding(.vertical, 3)
+        .background(.colorCaution.opacity(0.15), in: Capsule())
     }
 }

--- a/Convos/Conversation Detail/Messages/MessagesView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesView.swift
@@ -22,6 +22,8 @@ struct MessagesView<BottomBarContent: View>: View {
     var isVideoAttachment: Bool = false
     var composerLinkPreview: LinkPreview?
     var pendingInviteURL: String?
+    var pendingInviteExplodeDuration: ExplodeDuration?
+    var onSetInviteExplodeDuration: ((ExplodeDuration?) -> Void)?
     let sendButtonEnabled: Bool
     @Binding var profileImage: UIImage?
     let onboardingCoordinator: ConversationOnboardingCoordinator
@@ -118,6 +120,8 @@ struct MessagesView<BottomBarContent: View>: View {
                 isVideoAttachment: isVideoAttachment,
                 composerLinkPreview: composerLinkPreview,
                 pendingInviteURL: pendingInviteURL,
+                pendingInviteExplodeDuration: pendingInviteExplodeDuration,
+                onSetInviteExplodeDuration: onSetInviteExplodeDuration,
                 sendButtonEnabled: sendButtonEnabled,
                 profileImage: $profileImage,
                 isPhotoPickerPresented: $isPhotoPickerPresented,

--- a/ConvosCore/Sources/ConvosCore/Mocks/MockConversationMetadataWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Mocks/MockConversationMetadataWriter.swift
@@ -74,4 +74,8 @@ public final class MockConversationMetadataWriter: ConversationMetadataWriterPro
     public func unlockConversation(for conversationId: String) async throws {
         unlockedConversations.append(conversationId)
     }
+
+    public func refreshInvite(for conversationId: String) async throws -> Invite? {
+        nil
+    }
 }

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationMetadataWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationMetadataWriter.swift
@@ -22,6 +22,7 @@ public protocol ConversationMetadataWriterProtocol: Sendable {
     func updateIncludeInfoInPublicPreview(_ enabled: Bool, for conversationId: String) async throws
     func lockConversation(for conversationId: String) async throws
     func unlockConversation(for conversationId: String) async throws
+    func refreshInvite(for conversationId: String) async throws -> Invite?
 }
 
 // MARK: - Conversation Metadata Errors
@@ -631,5 +632,18 @@ final class ConversationMetadataWriter: ConversationMetadataWriterProtocol, @unc
 
         Log.info("Unlocked conversation \(conversationId)")
         QAEvent.emit(.conversation, "unlocked", ["id": conversationId])
+    }
+
+    func refreshInvite(for conversationId: String) async throws -> Invite? {
+        guard let conversation = try await databaseWriter.read({ db in
+            try DBConversation.fetchOne(db, key: conversationId)
+        }) else { return nil }
+
+        return try await inviteWriter.update(
+            for: conversationId,
+            name: conversation.includeInfoInPublicPreview ? conversation.name : nil,
+            description: conversation.includeInfoInPublicPreview ? conversation.description : nil,
+            imageURL: conversation.includeInfoInPublicPreview ? conversation.publicImageURLString : nil
+        )
     }
 }


### PR DESCRIPTION
## Summary

Adds an explode timer option to the invite preview card that appears when generating an invite from the convos button in the message input bar.

## How it works

### Setting the timer
- A `...` menu button appears to the right of "Pop into this convo" in the invite preview card
- Tapping it shows a context menu titled "Explodes in" with options: **1 hour**, **1 day**, **1 week**
- When a duration is selected, the `...` button is replaced with an **explode countdown badge** (red burst icon + duration label)

### On send
- When the invite message is sent with an explode duration set, the **linked conversation** is scheduled to explode after the chosen duration
- Uses the existing `ConversationExplosionWriter.scheduleExplosion` infrastructure

## Files changed

| File | Change |
|------|--------|
| `ConversationViewModel.swift` | `ExplodeDuration` enum, `explodeDuration` on `PendingInvite`, schedule explosion on send |
| `MessagesInputView.swift` | Explode menu + countdown badge in `ComposerInvitePreviewCard`, `ExplodeCountdownBadge` view |
| `MessagesBottomBar.swift` | Thread explode duration props |
| `MessagesView.swift` | Thread explode duration props |
| `ConversationView.swift` | Pass explode duration and callback from ViewModel |

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add explode duration selector to invite preview in conversation composer
> - Adds an explode duration picker to the `ComposerInvitePreviewCard` in the composer's invite attachment preview, letting users choose one of three durations (1 hour, 1 day, 1 week) via an overflow menu.
> - When a duration is selected, `ConversationViewModel.setInviteExplodeDuration(_:)` schedules the linked conversation to explode and refreshes the invite URL in the composer if an updated URL is returned.
> - Invite messages in the thread now show an `ExplosionCountdownBadge` when the invite has a future expiration time.
> - Adds `refreshInvite(for:)` to `ConversationMetadataWriterProtocol` to support fetching an updated invite after scheduling explosion.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f53e09b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->