### PR TITLE
Fix verified assistant briefly showing as unverified

### DIFF
--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -27,9 +27,9 @@ struct ConversationView<MessagesBottomBar: View>: View {
             && GlobalConvoDefaults.shared.assistantsEnabled
     }
 
-    var body: some View {
+    private var messagesView: some View {
         @Bindable var onboardingCoordinator = viewModel.onboardingCoordinator
-        MessagesView(
+        return MessagesView(
             conversation: viewModel.conversation,
             messages: viewModel.messages,
             invite: viewModel.invite,
@@ -148,6 +148,10 @@ struct ConversationView<MessagesBottomBar: View>: View {
                 .padding(.horizontal, DesignConstants.Spacing.step4x)
             }
         )
+    }
+
+    var body: some View {
+        messagesView
         .onChange(of: viewModel.selectedAttachmentImage) { oldValue, newValue in
             if let image = newValue {
                 viewModel.onPhotoSelected(image)

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationWriter.swift
@@ -391,7 +391,7 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
                     conversationId: dbConversation.id,
                     inboxId: profile.inboxId
                 )
-                if existing?.name != nil || existing?.avatar != nil {
+                if existing?.name != nil || existing?.avatar != nil || existing?.memberKind != nil {
                     return
                 }
                 let member = DBMember(inboxId: profile.inboxId)


### PR DESCRIPTION
## Problem

When a verified assistant sends a message, it briefly flashes as "unverified" before showing as verified again.

## Root Cause

When a message arrives via the stream, `StreamProcessor.processMessage` calls `conversationWriter.store()` which re-syncs the conversation. During this sync, `saveConversationToDatabase` writes member profiles from XMTP appData (the `ConversationCustomMetadata` protobuf). These appData profiles don't include `memberKind`, so the save overwrites the existing profile row, resetting `memberKind` from `.verifiedConvos` back to `nil` (`.unverified`).

The guard only checked for existing `name` or `avatar` before skipping the write. If the assistant had no name/avatar in appData but was already verified via profile messages, the write would proceed and clear the verified status.

Shortly after, `processProfileMessagesFromHistory` runs and re-verifies the assistant, restoring the verified status — but the brief unverified state was already rendered.

## Fix

Add `existing?.memberKind != nil` to the guard that decides whether to skip overwriting a profile from appData. This preserves the verified `memberKind` across conversation syncs.

Also extracts `messagesView` from `ConversationView.body` to fix a type-checker timeout (101ms > 100ms limit).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix verified assistant briefly showing as unverified by preserving `memberKind` in profile writes
> In [`ConversationWriter.store`](https://github.com/xmtplabs/convos-ios/pull/658/files#diff-113bfd0c28b1a3b561f19e4574a0937082fe5c92a262e57573eee7728940a726), the early-return condition that skips writing member profile data now also triggers when the existing `DBMemberProfile` has a non-nil `memberKind`. Previously, a profile with `memberKind` already set could be overwritten with a version missing that field, causing a verified assistant to momentarily appear unverified.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7b0c464.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->