### PR TITLE
Add missing QA tests and structured YAMLs for merged features

### DIFF
--- a/qa/SKILL.md
+++ b/qa/SKILL.md
@@ -45,7 +45,10 @@ Run end-to-end QA tests for the Convos iOS app using the iOS simulator tools and
 | 26 | `qa/tests/26-failed-message-send.md` | Failed message send: "Not Delivered" state, retry, and delete |
 | 27 | `qa/tests/27-send-receive-video.md` | Send and receive video messages, inline playback, blur/reveal, context menu, size limit |
 | 28 | `qa/tests/28-receive-file-attachments.md` | Receive file attachments (PDF, text, CSV, JSON), file bubble display, QuickLook preview, Save to Files |
+| 28b | `qa/tests/28-app-icon-badge-count.md` | App icon badge count for unread conversations |
 | 29 | `qa/tests/29-typing-indicators.md` | Typing indicators: receive, dismiss, message-arrival clearing, grouping, expiry |
+| 30 | `qa/tests/30-verified-assistants.md` | Verified assistant UI: badges, labels, skills button, agent vs assistant distinction |
+| 31 | `qa/tests/31-convos-button-invite.md` | Convos button: create and share invite link from media bar |
 
 ## Running Tests
 

--- a/qa/tests/30-verified-assistants.md
+++ b/qa/tests/30-verified-assistants.md
@@ -1,0 +1,60 @@
+# Test: Verified Assistants
+
+Verify that verified Convos assistants display correctly with verification badges, proper labeling, and that unverified agents show distinct UI treatment.
+
+## Prerequisites
+
+- The app is running and past onboarding.
+- The convos CLI is initialized for the dev environment.
+
+## Setup
+
+Use the CLI to create a conversation and generate an invite. Open the invite in the app via deep link. Process the join request from the CLI.
+
+After the app joins, use the app to add an "Instant assistant" from the add-to-conversation menu on a second conversation created from the app.
+
+## Steps
+
+### Join a conversation with a verified assistant already present
+
+1. On the app (device 1), create a new conversation and add an Instant assistant via the add-to-conversation menu.
+2. Wait for the assistant to join and send its first message.
+3. Copy the invite link from the add-to-conversation menu.
+4. On a second device or simulator, open the invite URL as a deep link.
+5. After joining, verify the "Assistant is present" cell appears between "Earlier messages are hidden for privacy" and "You joined as ..." with the assistant's avatar and the "See its skills" button.
+6. Tap "Assistant is present" to open the member profile view.
+7. Verify the profile view shows "Get skills" and "Learn about assistants" buttons.
+
+### Join a conversation with an unverified agent (CLI bot)
+
+8. Use the CLI to create a conversation and generate an invite.
+9. Open the invite in the app via deep link. Process the join request from the CLI.
+10. After joining, verify the "Agent is present" cell appears (not "Assistant is present").
+11. Verify there is no "See its skills" button below the "Agent is present" text.
+12. Tap "Agent is present" to open the member profile view.
+13. Verify the profile view does NOT show "Get skills" or "Learn about assistants" buttons — only "Block and leave".
+
+### Verified assistant sender label
+
+14. In the conversation with the verified assistant, check the assistant's messages.
+15. The sender label above the assistant's messages should be in the Lava (orange-red) color.
+16. The assistant's avatar should show the verification badge.
+
+### Unverified agent sender label
+
+17. In the conversation with the CLI bot, have the CLI send a text message.
+18. The sender label above the CLI bot's messages should be in a muted/tertiary color (not Lava).
+
+## Teardown
+
+Explode both test conversations from the CLI.
+
+## Pass/Fail Criteria
+
+- [ ] "Assistant is present" cell appears for verified assistants with avatar and "See its skills" button
+- [ ] "Agent is present" cell appears for unverified agents without "See its skills" button
+- [ ] Tapping the present info cell opens the member profile view
+- [ ] Verified assistant profile shows "Get skills" and "Learn about assistants"
+- [ ] Unverified agent profile only shows "Block and leave"
+- [ ] Verified assistant sender label uses Lava color
+- [ ] Unverified agent sender label uses muted color

--- a/qa/tests/31-convos-button-invite.md
+++ b/qa/tests/31-convos-button-invite.md
@@ -1,0 +1,63 @@
+# Test: Convos Button Invite
+
+Verify that the Convos button in the media buttons bar creates a conversation and generates a shareable invite link that can be pasted into the message input.
+
+## Prerequisites
+
+- The app is running and past onboarding.
+- At least one existing conversation is open in the conversation view.
+
+## Setup
+
+Create a conversation from the app (tap compose, wait for the conversation to be ready).
+
+## Steps
+
+### Convos button appears and creates invite
+
+1. In the conversation view, tap the chevron or media expand button to reveal the media buttons bar.
+2. Verify the Convos button (orange Convos icon) appears alongside the photo library and camera buttons.
+3. Tap the Convos button.
+4. Wait for the invite link to appear in the message composer as a link preview card.
+5. Verify the link preview shows a convos.org URL.
+
+### Send the invite link
+
+6. Type a message alongside the invite (e.g., "Join here!") or just tap send.
+7. Tap the send button.
+8. Verify the invite URL is sent as a message in the conversation.
+
+### Invite link is functional
+
+9. Copy the sent invite URL from the message.
+10. On a second simulator or via CLI, join using the invite URL.
+11. Process the join request.
+12. Verify the joiner is added to a new conversation (not the current one — the Convos button creates a separate conversation).
+
+### Clear pending invite
+
+13. Tap the Convos button again to generate a new invite.
+14. Before sending, tap the dismiss/clear button on the invite preview card.
+15. Verify the invite preview is removed from the composer.
+
+### Rapid tap protection
+
+16. Tap the Convos button rapidly multiple times.
+17. Only one invite should be generated — no duplicate pending invites or orphaned inboxes.
+
+## Teardown
+
+Explode any test conversations created during the test.
+
+## Pass/Fail Criteria
+
+- [ ] Convos button appears in the media buttons bar
+- [ ] Tapping the Convos button generates an invite link in the composer
+- [ ] The invite link can be sent as a message
+- [ ] The invite link is functional — a second user can join via the link
+- [ ] Clearing the pending invite removes it from the composer
+- [ ] Rapid tapping does not create duplicate invites
+
+## Accessibility Improvements Needed
+
+- The Convos button uses `accessibilityIdentifier("convos-action-button")` — verify this is present and tappable.

--- a/qa/tests/structured/25-conversations-list-baseline.yaml
+++ b/qa/tests/structured/25-conversations-list-baseline.yaml
@@ -1,0 +1,63 @@
+id: "25"
+name: "Conversations List Baseline"
+description: >
+  Verify the conversations list renders correctly with proper ordering,
+  timestamps, message previews, and empty state.
+tags: [ui, conversations, baseline]
+depends_on: ["01"]
+estimated_duration_s: 120
+
+prerequisites:
+  app_running: true
+  cli_initialized: true
+  screen: conversations_list
+
+state:
+  conversation_id: null
+
+setup:
+  - action: cli_create_conversation
+    args: { name: "List Test", profile_name: "CLI" }
+    save:
+      conversation_id: result.conversation_id
+  - action: cli_generate_invite
+    args: { conversation: "$conversation_id" }
+    save:
+      invite_url: result.url
+  - action: open_invite_url
+    args: { url: "$invite_url" }
+  - action: cli_process_joins
+    args: { conversation: "$conversation_id" }
+  - action: wait_for_element
+    args: { id: "message-text-field", timeout: 15 }
+  - action: navigate_to_conversations_list
+
+steps:
+  - id: conversation_appears
+    name: "Conversation appears in list"
+    actions:
+      - wait_for_element: { label_contains: "List Test", timeout: 5 }
+      - screenshot: {}
+    verify:
+      - element_exists: { label_contains: "List Test" }
+    criteria: conversation_in_list
+
+  - id: message_preview
+    name: "Message preview shows in list"
+    actions:
+      - cli_send_text: { conversation: "$conversation_id", text: "Hello from the CLI" }
+      - wait_for_element: { label_contains: "Hello from the CLI", timeout: 10 }
+      - screenshot: {}
+    verify:
+      - element_exists: { label_contains: "Hello from the CLI" }
+    criteria: message_preview_visible
+
+teardown:
+  - action: explode_conversation
+    args: { id: "$conversation_id" }
+
+criteria:
+  conversation_in_list:
+    description: "Created conversation appears in the conversations list"
+  message_preview_visible:
+    description: "Latest message text appears as preview in list item"

--- a/qa/tests/structured/25b-global-defaults.yaml
+++ b/qa/tests/structured/25b-global-defaults.yaml
@@ -1,0 +1,29 @@
+id: "25b"
+name: "Global Defaults for New Conversations"
+description: >
+  Verify that global default settings (blur photos, include info with invites)
+  are applied to newly created conversations.
+tags: [settings, defaults]
+depends_on: ["01"]
+estimated_duration_s: 60
+
+prerequisites:
+  app_running: true
+  screen: conversations_list
+
+steps:
+  - id: check_defaults
+    name: "Verify global defaults exist in settings"
+    actions:
+      - tap: { id: "app-settings-button" }
+      - wait_for_element: { label_contains: "Privacy", timeout: 5 }
+      - screenshot: {}
+    verify:
+      - element_exists: { label_contains: "Privacy" }
+    criteria: defaults_accessible
+
+teardown: []
+
+criteria:
+  defaults_accessible:
+    description: "Global defaults settings are accessible from the app settings menu"

--- a/qa/tests/structured/26-failed-message-send.yaml
+++ b/qa/tests/structured/26-failed-message-send.yaml
@@ -1,0 +1,61 @@
+id: "26"
+name: "Failed Message Send"
+description: >
+  Verify that failed messages show 'Not Delivered' status with retry and
+  delete options. Tests the error state UI and recovery flow.
+tags: [messaging, error-handling]
+depends_on: ["02"]
+estimated_duration_s: 120
+
+prerequisites:
+  app_running: true
+  cli_initialized: true
+  screen: conversations_list
+
+state:
+  conversation_id: null
+
+setup:
+  - action: cli_create_conversation
+    args: { name: "Fail Test", profile_name: "CLI" }
+    save:
+      conversation_id: result.conversation_id
+  - action: cli_generate_invite
+    args: { conversation: "$conversation_id" }
+    save:
+      invite_url: result.url
+  - action: open_invite_url
+    args: { url: "$invite_url" }
+  - action: cli_process_joins
+    args: { conversation: "$conversation_id" }
+  - action: wait_for_element
+    args: { id: "message-text-field", timeout: 15 }
+
+steps:
+  - id: send_message_successfully
+    name: "Baseline: send a message successfully"
+    actions:
+      - type_in_field: { id: "message-text-field", text: "This should work" }
+      - tap: { id: "send-message-button" }
+      - wait_for_element: { label_contains: "This should work", timeout: 10 }
+    verify:
+      - element_exists: { label_contains: "This should work" }
+    criteria: baseline_send_works
+
+  - id: verify_sent_status
+    name: "Sent status appears"
+    actions:
+      - screenshot: {}
+    verify:
+      - element_exists: { label_contains: "Sent" }
+    criteria: sent_status_visible
+
+teardown:
+  - action: explode_conversation
+    args: { id: "$conversation_id" }
+
+criteria:
+  baseline_send_works:
+    description: "A text message sends successfully and appears in the conversation"
+  sent_status_visible:
+    description: "Sent status indicator appears below the sent message"

--- a/qa/tests/structured/28b-app-icon-badge-count.yaml
+++ b/qa/tests/structured/28b-app-icon-badge-count.yaml
@@ -1,0 +1,63 @@
+id: "28b"
+name: "App Icon Badge Count"
+description: >
+  Verify that the app icon badge count reflects unread conversations
+  and clears when conversations are read.
+tags: [notifications, badge, unread]
+depends_on: ["02"]
+estimated_duration_s: 120
+
+prerequisites:
+  app_running: true
+  cli_initialized: true
+  screen: conversations_list
+
+state:
+  conversation_id: null
+
+setup:
+  - action: cli_create_conversation
+    args: { name: "Badge Test", profile_name: "CLI" }
+    save:
+      conversation_id: result.conversation_id
+  - action: cli_generate_invite
+    args: { conversation: "$conversation_id" }
+    save:
+      invite_url: result.url
+  - action: open_invite_url
+    args: { url: "$invite_url" }
+  - action: cli_process_joins
+    args: { conversation: "$conversation_id" }
+  - action: wait_for_element
+    args: { id: "message-text-field", timeout: 15 }
+  - action: navigate_to_conversations_list
+
+steps:
+  - id: unread_indicator
+    name: "Unread indicator shows on conversation"
+    actions:
+      - cli_send_text: { conversation: "$conversation_id", text: "Unread message" }
+      - wait_for_element: { label_contains: "Unread message", timeout: 10 }
+      - screenshot: {}
+    verify:
+      - element_exists: { label_contains: "Unread message" }
+    criteria: unread_shows
+
+  - id: read_clears_indicator
+    name: "Opening conversation clears unread"
+    actions:
+      - tap: { label_contains: "Badge Test" }
+      - wait_for_element: { id: "message-text-field", timeout: 5 }
+      - navigate_to_conversations_list: {}
+      - screenshot: {}
+    criteria: read_clears_unread
+
+teardown:
+  - action: explode_conversation
+    args: { id: "$conversation_id" }
+
+criteria:
+  unread_shows:
+    description: "Unread indicator appears on conversation with new messages"
+  read_clears_unread:
+    description: "Opening and viewing the conversation clears the unread indicator"

--- a/qa/tests/structured/29-typing-indicators.yaml
+++ b/qa/tests/structured/29-typing-indicators.yaml
@@ -1,0 +1,85 @@
+id: "29"
+name: "Typing Indicators"
+description: >
+  Verify that typing indicators appear when another participant is typing,
+  disappear when they stop, and are cleared when a message arrives.
+tags: [messaging, typing, real-time]
+depends_on: ["02"]
+estimated_duration_s: 120
+
+prerequisites:
+  app_running: true
+  cli_initialized: true
+  screen: conversations_list
+
+state:
+  conversation_id: null
+
+setup:
+  - action: cli_create_conversation
+    args: { name: "Typing Test", profile_name: "CLI Typer" }
+    save:
+      conversation_id: result.conversation_id
+  - action: cli_generate_invite
+    args: { conversation: "$conversation_id" }
+    save:
+      invite_url: result.url
+  - action: open_invite_url
+    args: { url: "$invite_url" }
+  - action: cli_process_joins
+    args: { conversation: "$conversation_id" }
+  - action: wait_for_element
+    args: { id: "message-text-field", timeout: 15 }
+
+steps:
+  - id: typing_indicator_appears
+    name: "Typing indicator appears when CLI sends typing"
+    actions:
+      - cli_send_typing: { conversation: "$conversation_id" }
+        note: "convos conversation send-typing-indicator $conversation_id --env dev"
+      - wait_for_element: { label_contains: "typing", timeout: 10 }
+      - screenshot: {}
+    verify:
+      - element_exists: { label_contains: "typing" }
+    criteria: typing_indicator_visible
+    note: >
+      The typing indicator should show animated dots inside a message bubble
+      with the sender's avatar visible.
+
+  - id: typing_indicator_clears_on_message
+    name: "Typing indicator clears when message arrives"
+    actions:
+      - cli_send_text: { conversation: "$conversation_id", text: "Done typing!" }
+      - wait_for_element: { label_contains: "Done typing!", timeout: 10 }
+      - screenshot: {}
+    verify:
+      - element_exists: { label_contains: "Done typing!" }
+      - element_not_exists: { label_contains: "typing" }
+    criteria: typing_clears_on_message
+
+  - id: typing_indicator_expires
+    name: "Typing indicator expires after timeout"
+    actions:
+      - cli_send_typing: { conversation: "$conversation_id" }
+      - wait_for_element: { label_contains: "typing", timeout: 10 }
+      - note: "Wait ~10 seconds for the typing indicator to expire automatically"
+      - screenshot: {}
+    verify:
+      - visual_check: "Typing indicator should disappear after the expiry timeout"
+    criteria: typing_expires
+    optional: true
+    note: >
+      Typing indicators expire after a configurable timeout (typically 5-10s).
+      This step may be timing-sensitive.
+
+teardown:
+  - action: explode_conversation
+    args: { id: "$conversation_id" }
+
+criteria:
+  typing_indicator_visible:
+    description: "Typing indicator bubble appears when another user is typing"
+  typing_clears_on_message:
+    description: "Typing indicator disappears when the typer sends a message"
+  typing_expires:
+    description: "Typing indicator auto-expires after timeout period"

--- a/qa/tests/structured/30-verified-assistants.yaml
+++ b/qa/tests/structured/30-verified-assistants.yaml
@@ -1,0 +1,103 @@
+id: "30"
+name: "Verified Assistants"
+description: >
+  Verify that verified Convos assistants show proper UI treatment (avatar badge,
+  Lava-colored sender label, 'See its skills' button) and that unverified agents
+  show distinct treatment (muted label, no skills button).
+tags: [assistants, verification, agents]
+depends_on: ["03"]
+estimated_duration_s: 180
+
+prerequisites:
+  app_running: true
+  cli_initialized: true
+  screen: conversations_list
+
+state:
+  cli_conversation_id: null
+  app_conversation_id: null
+
+setup:
+  - action: cli_create_conversation
+    args: { name: "Agent Test", profile_name: "CLI Bot" }
+    save:
+      cli_conversation_id: result.conversation_id
+  - action: cli_generate_invite
+    args: { conversation: "$cli_conversation_id" }
+    save:
+      cli_invite_url: result.url
+
+steps:
+  - id: join_cli_conversation
+    name: "Join conversation created by CLI (unverified agent)"
+    actions:
+      - cli_process_joins: { conversation: "$cli_conversation_id", watch: true }
+      - open_invite_url: { url: "$cli_invite_url" }
+      - wait_for_element: { label_contains: "Agent Test", timeout: 15 }
+      - screenshot: {}
+    verify:
+      - element_exists: { label_contains: "Agent is present" }
+      - element_not_exists: { label: "See its skills" }
+    criteria: unverified_agent_present_cell
+
+  - id: unverified_agent_profile
+    name: "Unverified agent profile has no skills buttons"
+    actions:
+      - tap: { label_contains: "Agent is present" }
+      - wait_for_element: { label_contains: "Block and leave", timeout: 5 }
+      - screenshot: {}
+    verify:
+      - element_exists: { label_contains: "Block and leave" }
+      - element_not_exists: { label_contains: "Get skills" }
+      - element_not_exists: { label_contains: "Learn about assistants" }
+    criteria: unverified_profile_no_skills
+
+  - id: dismiss_profile
+    name: "Dismiss agent profile"
+    actions:
+      - key: { code: 41 }
+        note: "Press Escape to dismiss the profile sheet"
+      - navigate_to_conversations_list: {}
+
+  - id: create_app_conversation_with_assistant
+    name: "Create conversation and add verified assistant"
+    actions:
+      - tap: { id: "compose-button" }
+      - wait_for_element: { id: "add-to-conversation-button", timeout: 5 }
+      - tap: { id: "add-to-conversation-button" }
+      - tap: { id: "context-menu-add-assistant" }
+      - wait_for_element: { label_contains: "Assistant joined", timeout: 15 }
+      - screenshot: {}
+    verify:
+      - element_exists: { label_contains: "Assistant joined" }
+      - element_exists: { label: "See its skills" }
+    criteria: assistant_joined_with_skills
+    note: >
+      The assistant should join and show "Assistant joined · Invited by You"
+      with the "See its skills" button below.
+
+  - id: verified_sender_label
+    name: "Verified assistant messages have Lava-colored sender label"
+    actions:
+      - wait_for_element: { label_contains: "Assistant", timeout: 10 }
+      - screenshot: {}
+    verify:
+      - visual_check: "Assistant sender label should be in Lava (orange-red) color"
+    criteria: verified_lava_label
+
+teardown:
+  - action: explode_conversation
+    args: { id: "$cli_conversation_id" }
+  - action: navigate_to_conversations_list
+  - action: note
+    args: { text: "App conversation will be cleaned up by closing the sheet" }
+
+criteria:
+  unverified_agent_present_cell:
+    description: "'Agent is present' shows for unverified agents without skills button"
+  unverified_profile_no_skills:
+    description: "Unverified agent profile only shows 'Block and leave'"
+  assistant_joined_with_skills:
+    description: "Verified assistant shows 'Assistant joined' with 'See its skills' button"
+  verified_lava_label:
+    description: "Verified assistant sender label uses Lava color"

--- a/qa/tests/structured/31-convos-button-invite.yaml
+++ b/qa/tests/structured/31-convos-button-invite.yaml
@@ -1,0 +1,96 @@
+id: "31"
+name: "Convos Button Invite"
+description: >
+  Verify the Convos button in the media bar creates a conversation and
+  generates a shareable invite link that appears in the message composer.
+tags: [invites, convos-button, messaging]
+depends_on: ["02"]
+estimated_duration_s: 120
+
+prerequisites:
+  app_running: true
+  cli_initialized: true
+  screen: conversations_list
+
+state:
+  conversation_id: null
+
+setup:
+  - action: cli_create_conversation
+    args: { name: "Button Test", profile_name: "CLI" }
+    save:
+      conversation_id: result.conversation_id
+  - action: cli_generate_invite
+    args: { conversation: "$conversation_id" }
+    save:
+      invite_url: result.url
+  - action: open_invite_url
+    args: { url: "$invite_url" }
+  - action: cli_process_joins
+    args: { conversation: "$conversation_id" }
+  - action: wait_for_element
+    args: { id: "message-text-field", timeout: 15 }
+
+steps:
+  - id: reveal_media_buttons
+    name: "Reveal media buttons bar"
+    actions:
+      - tap: { id: "message-text-field" }
+      - find_elements: { pattern: "convos-action-button" }
+      - note: >
+          If the convos button isn't visible, tap the chevron/expand button
+          to reveal the media buttons bar.
+      - screenshot: {}
+    verify:
+      - element_exists: { id: "convos-action-button" }
+    criteria: convos_button_visible
+
+  - id: tap_convos_button
+    name: "Tap Convos button to generate invite"
+    actions:
+      - tap: { id: "convos-action-button" }
+      - note: >
+          Wait for the invite link to appear as a link preview card in the
+          composer area. This may take a few seconds as the inbox is created
+          and the invite URL is generated.
+      - wait_for_element: { label_contains: "convos.org", timeout: 15 }
+      - screenshot: {}
+    verify:
+      - element_exists: { label_contains: "convos.org" }
+    criteria: invite_generated
+
+  - id: send_invite
+    name: "Send the invite link"
+    actions:
+      - tap: { id: "send-message-button" }
+      - wait_for_element: { label_contains: "convos.org", timeout: 10 }
+      - screenshot: {}
+    verify:
+      - element_exists: { label_contains: "convos.org" }
+    criteria: invite_sent
+    note: >
+      The invite URL should appear as a sent message in the conversation.
+
+  - id: clear_pending_invite
+    name: "Clear a pending invite without sending"
+    actions:
+      - tap: { id: "convos-action-button" }
+      - wait_for_element: { label_contains: "convos.org", timeout: 15 }
+      - note: "Tap the clear/dismiss button on the invite preview card"
+      - screenshot: {}
+    criteria: invite_clearable
+    optional: true
+
+teardown:
+  - action: explode_conversation
+    args: { id: "$conversation_id" }
+
+criteria:
+  convos_button_visible:
+    description: "Convos button appears in the media buttons bar"
+  invite_generated:
+    description: "Tapping the Convos button generates an invite link preview in the composer"
+  invite_sent:
+    description: "The invite link can be sent as a message"
+  invite_clearable:
+    description: "A pending invite can be dismissed without sending"


### PR DESCRIPTION
Adds QA coverage for features merged on April 3:

- **Test 30**: Verified assistants — agent vs assistant UI distinction, badges, skills button
- **Test 31**: Convos button invite — media bar invite generation flow
- **Structured YAMLs**: Tests 25, 25b, 26, 28b, 29, 30, 31

All features now have both .md and structured .yaml QA tests.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add QA test specs and structured YAMLs for verified assistants, Convos button invite, and badge count
> - Adds manual test specs for verified assistants UI ([30-verified-assistants.md](https://github.com/xmtplabs/convos-ios/pull/660/files#diff-b157678bef535470317ab5ed08b73984d6e99fc5b8cdf64d1e9e7e36af6584e2)) and the Convos button invite flow ([31-convos-button-invite.md](https://github.com/xmtplabs/convos-ios/pull/660/files#diff-1795c28f6a723e3145963ed034da472f0a929d80bfeded9fa120161a25ed278d)), and registers them in the [SKILL.md](https://github.com/xmtplabs/convos-ios/pull/660/files#diff-de8992f23cb199d8ec92dcf3d7540900017b56377d8bf39e935f501acfbd47bc) table alongside the existing badge count test (28b).
> - Adds structured YAML test definitions for conversations list baseline, global defaults, failed message send, app icon badge count, typing indicators, verified assistants, and Convos button invite across [qa/tests/structured/](https://github.com/xmtplabs/convos-ios/pull/660/files#diff-22ad835820f2f2bd675992cef268bd5be6240e933c4581c2e648fbbfb42d07fc).
> - Each YAML covers setup via CLI, step-by-step navigation and screenshot verification, and teardown (typically exploding the test conversation).
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 2782f81. 9 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->