### PR TITLE
Fix received videos showing as 'Failed to load'

### DIFF
--- a/ConvosCore/Sources/ConvosCore/Storage/XMTP DB Representations/DecodedMessage+DBRepresentation.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/XMTP DB Representations/DecodedMessage+DBRepresentation.swift
@@ -1,6 +1,7 @@
 import ConvosAppData
 import Foundation
 import GRDB
+import UniformTypeIdentifiers
 import XMTPiOS
 
 extension Character {
@@ -283,13 +284,19 @@ extension XMTPiOS.DecodedMessage {
             throw DecodedMessageDBRepresentationError.mismatchedContentType
         }
         let storedAttachments = remoteAttachments.map { attachment in
+            let inferredMimeType: String? = attachment.filename.flatMap { filename in
+                let ext = (filename as NSString).pathExtension.lowercased()
+                guard !ext.isEmpty else { return nil }
+                return UTType(filenameExtension: ext)?.preferredMIMEType
+            }
             let stored = StoredRemoteAttachment(
                 url: attachment.url,
                 contentDigest: attachment.contentDigest,
                 secret: attachment.secret,
                 salt: attachment.salt,
                 nonce: attachment.nonce,
-                filename: attachment.filename
+                filename: attachment.filename,
+                mimeType: inferredMimeType
             )
             return (try? stored.toJSON()) ?? attachment.url
         }
@@ -309,13 +316,19 @@ extension XMTPiOS.DecodedMessage {
         guard let remoteAttachment = content as? RemoteAttachment else {
             throw DecodedMessageDBRepresentationError.mismatchedContentType
         }
+        let inferredMimeType: String? = remoteAttachment.filename.flatMap { filename in
+            let ext = (filename as NSString).pathExtension.lowercased()
+            guard !ext.isEmpty else { return nil }
+            return UTType(filenameExtension: ext)?.preferredMIMEType
+        }
         let stored = StoredRemoteAttachment(
             url: remoteAttachment.url,
             contentDigest: remoteAttachment.contentDigest,
             secret: remoteAttachment.secret,
             salt: remoteAttachment.salt,
             nonce: remoteAttachment.nonce,
-            filename: remoteAttachment.filename
+            filename: remoteAttachment.filename,
+            mimeType: inferredMimeType
         )
         let json = (try? stored.toJSON()) ?? remoteAttachment.url
         return DBMessageComponents(


### PR DESCRIPTION
## Problem

Users report that received video messages show "Failed to load" instead of playing.

## Root Cause

When incoming `RemoteAttachment` messages are stored in the database, the `StoredRemoteAttachment` JSON is created without a `mimeType` field. The XMTP `RemoteAttachment` type doesn't expose mimeType directly (it's inside the encrypted content).

Without `mimeType`, `HydratedAttachment.mediaType` defaults to `.image`. The UI then tries to load the video data as a `UIImage`, which fails, showing the error placeholder.

Outgoing videos work because `OutgoingMessageWriter` explicitly sets `mimeType: "video/mp4"` when creating the `StoredRemoteAttachment`.

## Fix

Infer `mimeType` from the `RemoteAttachment.filename` extension using `UTType` when storing both single and multi remote attachments. A file named `video_123.mp4` gets `mimeType: "video/mp4"`, which makes `HydratedAttachment.mediaType` return `.video`, triggering the correct video loading and playback path.

## Note

Existing messages already stored without mimeType will continue to show as failed. A migration or lazy-fix could be added to re-infer mimeType from the stored JSON's filename field on next load.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix received videos showing as 'Failed to load' by inferring MIME type from filename extension
> Remote attachments stored without a MIME type were failing to render. Now infers MIME type from the filename extension using `UTType(filenameExtension:).preferredMIMEType` in both `handleRemoteAttachmentContent` and `handleMultiRemoteAttachmentContent`, passing the result to `StoredRemoteAttachment`. If the extension is absent or unrecognized, `mimeType` remains `nil`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 69df767.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->