### PR TITLE
Fix empty reactions drawer sheet

### DIFF
--- a/Convos/Conversation Detail/Messages/Messages View Controller/Reactions/ReactionsDrawerView.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/Reactions/ReactionsDrawerView.swift
@@ -23,32 +23,30 @@ struct ReactionsDrawerView: View {
     }
 
     var body: some View {
-        GeometryReader { geometry in
-            let maxDrawerHeight: CGFloat = geometry.size.height * 0.7
-            VStack(alignment: .leading, spacing: DesignConstants.Spacing.step4x) {
-                Text("Reactions")
-                    .font(.system(.largeTitle))
-                    .fontWeight(.bold)
-                    .padding(.bottom, DesignConstants.Spacing.step2x)
+        VStack(alignment: .leading, spacing: DesignConstants.Spacing.step4x) {
+            Text("Reactions")
+                .font(.system(.largeTitle))
+                .fontWeight(.bold)
+                .padding(.bottom, DesignConstants.Spacing.step2x)
 
-                ScrollView {
-                    VStack(alignment: .leading, spacing: DesignConstants.Spacing.step4x) {
-                        ForEach(sortedReactions, id: \.id) { reaction in
-                            ReactionRowView(
-                                reaction: reaction,
-                                onRemove: reaction.sender.isCurrentUser ? { onRemoveReaction?(reaction) } : nil
-                            )
-                        }
+            ScrollView {
+                VStack(alignment: .leading, spacing: DesignConstants.Spacing.step4x) {
+                    ForEach(sortedReactions, id: \.id) { reaction in
+                        ReactionRowView(
+                            reaction: reaction,
+                            onRemove: reaction.sender.isCurrentUser ? { onRemoveReaction?(reaction) } : nil
+                        )
                     }
                 }
-                .scrollBounceBehavior(.basedOnSize)
-                .scrollIndicatorsFlash(onAppear: true)
-                .scrollContentBackground(.hidden)
             }
-            .padding([.leading, .top, .trailing], DesignConstants.Spacing.step10x)
-            .padding(.bottom, DesignConstants.Spacing.step3x)
-            .frame(minHeight: 160, maxHeight: maxDrawerHeight)
+            .scrollBounceBehavior(.basedOnSize)
+            .scrollIndicatorsFlash(onAppear: true)
+            .scrollContentBackground(.hidden)
+            .frame(minHeight: 120, idealHeight: 400, maxHeight: 600)
         }
+        .padding([.leading, .top, .trailing], DesignConstants.Spacing.step10x)
+        .padding(.bottom, DesignConstants.Spacing.step3x)
+        .frame(minHeight: 160)
     }
 }
 


### PR DESCRIPTION
## Problem

Tapping the reactions pill in the messages list opens a sheet that appears empty — the 'Reactions' title and reaction rows are not visible.

## Root Cause

`ReactionsDrawerView` used a `GeometryReader` as its root view. `GeometryReader` has no intrinsic size. When presented inside `selfSizingSheet` (which uses `.fixedSize(vertical: true)` and `.readHeight` to measure content height), the `GeometryReader` reported zero height, causing `.presentationDetents([.height(0)])` — resulting in an empty sheet.

This broke after recent rebases that merged several large PRs — the `GeometryReader` was likely added or reintroduced during conflict resolution.

## Fix

Remove the `GeometryReader` wrapper and use a fixed `maxHeight` (400pt) on the `ScrollView` instead. The `selfSizingSheet` can now correctly measure the content and set the appropriate presentation detent.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix empty reactions drawer sheet by replacing dynamic sizing with fixed constraints
> The `ReactionsDrawerView` was rendering empty because `GeometryReader` caused layout issues with the sheet presentation. Removes `GeometryReader` and replaces the 70%-of-available-height dynamic sizing with fixed `ScrollView` constraints (`minHeight: 120`, `idealHeight: 400`, `maxHeight: 600`) and an outer `minHeight: 160` on the view.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e6d2991.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->