### PR TITLE
Fix missing thumbnail in reply reference for video messages

### DIFF
--- a/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/ReplyReferenceView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/ReplyReferenceView.swift
@@ -251,8 +251,13 @@ private struct ReplyReferencePhotoPreview: View {
         self.onReveal = onReveal
         self.onHide = onHide
 
-        if isVideo, let thumbnailData, let thumb = UIImage(data: thumbnailData) {
-            _loadedImage = State(initialValue: thumb)
+        if isVideo, let thumbnailData {
+            if let thumb = UIImage(data: thumbnailData) {
+                _loadedImage = State(initialValue: thumb)
+            } else {
+                Log.warning("Video thumbnail data failed to decode for attachment: \(attachmentKey)")
+                _loadedImage = State(initialValue: ImageCache.shared.image(for: attachmentKey))
+            }
         } else {
             _loadedImage = State(initialValue: ImageCache.shared.image(for: attachmentKey))
         }

--- a/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/ReplyReferenceView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/ReplyReferenceView.swift
@@ -106,6 +106,7 @@ struct ReplyReferenceView: View {
                 ReplyReferencePhotoPreview(
                     attachmentKey: attachment.key,
                     isVideo: attachment.mediaType == .video,
+                    thumbnailData: attachment.thumbnailData,
                     parentMessage: parentMessage,
                     shouldBlur: shouldBlurAttachment,
                     onReveal: { onPhotoRevealed?(attachment.key) },
@@ -221,6 +222,7 @@ struct ReplyReferenceView: View {
 private struct ReplyReferencePhotoPreview: View {
     let attachmentKey: String
     let isVideo: Bool
+    let thumbnailData: Data?
     let parentMessage: Message
     let shouldBlur: Bool
     let onReveal: () -> Void
@@ -235,6 +237,7 @@ private struct ReplyReferencePhotoPreview: View {
     init(
         attachmentKey: String,
         isVideo: Bool = false,
+        thumbnailData: Data? = nil,
         parentMessage: Message,
         shouldBlur: Bool,
         onReveal: @escaping () -> Void,
@@ -242,11 +245,17 @@ private struct ReplyReferencePhotoPreview: View {
     ) {
         self.attachmentKey = attachmentKey
         self.isVideo = isVideo
+        self.thumbnailData = thumbnailData
         self.parentMessage = parentMessage
         self.shouldBlur = shouldBlur
         self.onReveal = onReveal
         self.onHide = onHide
-        _loadedImage = State(initialValue: ImageCache.shared.image(for: attachmentKey))
+
+        if isVideo, let thumbnailData, let thumb = UIImage(data: thumbnailData) {
+            _loadedImage = State(initialValue: thumb)
+        } else {
+            _loadedImage = State(initialValue: ImageCache.shared.image(for: attachmentKey))
+        }
     }
 
     @State private var instanceID: UUID = UUID()
@@ -319,6 +328,7 @@ private struct ReplyReferencePhotoPreview: View {
                 loadedImage = cachedImage
                 return
             }
+            guard !isVideo else { return }
             do {
                 let data = try await Self.loader.loadImageData(from: attachmentKey)
                 if let image = UIImage(data: data) {


### PR DESCRIPTION
## Problem

When replying to a video message, the reply reference preview shows a gray placeholder instead of the video thumbnail.

## Root Cause

`ReplyReferencePhotoPreview` uses `RemoteAttachmentLoader.loadImageData` to fetch the preview image. For videos, this downloads the entire encrypted video file, decrypts it, and tries to create a `UIImage` from video data — which fails silently, leaving the placeholder visible.

## Fix

Use the video's embedded thumbnail (`HydratedAttachment.thumbnailData`, stored as base64 in `StoredRemoteAttachment.thumbnailDataBase64`) for the preview image instead of downloading the full video. Skip the remote attachment download entirely for video replies since only the thumbnail is needed.

Changes:
- Add `thumbnailData` parameter to `ReplyReferencePhotoPreview`
- Initialize `loadedImage` from thumbnail data for videos
- Skip `loadImageData` call for video attachments in the async task

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix missing thumbnail in reply reference for video messages
> - `ReplyReferenceView` now forwards `attachment.thumbnailData` to `ReplyReferencePhotoPreview` when the attachment is a video.
> - `ReplyReferencePhotoPreview` accepts an optional `thumbnailData: Data?` parameter and decodes it immediately as the initial image for video attachments, skipping any remote image fetch.
> - If the thumbnail data cannot be decoded, it falls back to the image cache and logs a warning.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8559f50.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->