### PR TITLE
Voice memo support

### DIFF
--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -1,3 +1,4 @@
+import ConvosCore
 import SwiftUI
 
 struct ConversationView<MessagesBottomBar: View>: View {
@@ -311,6 +312,10 @@ struct ConversationView<MessagesBottomBar: View>: View {
                 PhotosInfoSheet()
             }
         )
+        .onDisappear {
+            VoiceMemoPlayer.shared.stop()
+            viewModel.voiceMemoRecorder.cancelRecording()
+        }
     }
 }
 

--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -117,6 +117,9 @@ struct ConversationView<MessagesBottomBar: View>: View {
                     didReleasePastThreshold = true
                 }
             },
+            onVoiceMemoTap: { viewModel.onVoiceMemoTapped() },
+            voiceMemoRecorder: viewModel.voiceMemoRecorder,
+            onSendVoiceMemo: { viewModel.sendVoiceMemo() },
             onConvosAction: { viewModel.onConvosButtonTapped() },
             bottomBarContent: {
                 VStack(spacing: DesignConstants.Spacing.step3x) {

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -232,6 +232,7 @@ class ConversationViewModel {
     var selectedVideoURL: URL?
     var selectedVideoThumbnail: UIImage?
     private var videoThumbnailTask: Task<Void, Never>?
+    var voiceMemoRecorder: VoiceMemoRecorder = VoiceMemoRecorder()
     private(set) var currentEagerUploadKey: String?
     var canRemoveMembers: Bool {
         conversation.creator.isCurrentUser
@@ -583,6 +584,7 @@ class ConversationViewModel {
     private func observe() {
         messagesListRepository.startObserving()
         setupTypingIndicatorHandler()
+        setupVoiceMemoPlaybackObserver()
         messagesListRepository.messagesListPublisher
             .dropFirst()
             .receive(on: DispatchQueue.main)
@@ -805,6 +807,72 @@ extension ConversationViewModel {
                 self.onPhotoAttached()
             } catch {
                 Log.error("Failed to generate video thumbnail: \(error)")
+            }
+        }
+    }
+
+    func setupVoiceMemoPlaybackObserver() {
+        NotificationCenter.default.addObserver(
+            forName: .voiceMemoPlaybackRequested,
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            guard self != nil,
+                  let userInfo = notification.userInfo,
+                  let messageId = userInfo["messageId"] as? String,
+                  let attachmentKey = userInfo["attachmentKey"] as? String else { return }
+
+            Task { @MainActor in
+                let player = VoiceMemoPlayer.shared
+                if player.currentlyPlayingMessageId == messageId {
+                    if player.state == .playing {
+                        player.pause()
+                        return
+                    } else if player.state == .paused {
+                        player.resume()
+                        return
+                    }
+                }
+
+                do {
+                    let loader = RemoteAttachmentLoader()
+                    let loaded = try await loader.loadAttachmentData(from: attachmentKey)
+                    try player.play(data: loaded.data, messageId: messageId)
+                } catch {
+                    Log.error("Failed to play voice memo: \(error)")
+                }
+            }
+        }
+    }
+
+    func onVoiceMemoTapped() {
+        guard case .idle = voiceMemoRecorder.state else { return }
+        do {
+            try voiceMemoRecorder.startRecording()
+        } catch {
+            Log.error("Failed to start voice memo recording: \(error)")
+        }
+    }
+
+    func sendVoiceMemo() {
+        guard case .recorded(let url, let duration) = voiceMemoRecorder.state else { return }
+        let levels = voiceMemoRecorder.audioLevels
+        voiceMemoRecorder.resetState()
+
+        let messageWriter = cachedMessageWriter
+        let replyTarget = replyingToMessage
+        replyingToMessage = nil
+
+        Task {
+            do {
+                _ = try await messageWriter.sendVoiceMemo(
+                    at: url,
+                    duration: duration,
+                    waveformLevels: levels.isEmpty ? nil : levels,
+                    replyToMessageId: replyTarget?.messageId
+                )
+            } catch {
+                Log.error("Error sending voice memo: \(error)")
             }
         }
     }

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -3,6 +3,7 @@ import Combine
 import ConvosCore
 import ConvosCoreiOS
 import Observation
+import SwiftUI
 import UIKit
 import UserNotifications
 
@@ -847,17 +848,21 @@ extension ConversationViewModel {
 
     func onVoiceMemoTapped() {
         guard case .idle = voiceMemoRecorder.state else { return }
-        do {
-            try voiceMemoRecorder.startRecording()
-        } catch {
-            Log.error("Failed to start voice memo recording: \(error)")
+        withAnimation(.bouncy(duration: 0.4, extraBounce: 0.01)) {
+            do {
+                try voiceMemoRecorder.startRecording()
+            } catch {
+                Log.error("Failed to start voice memo recording: \(error)")
+            }
         }
     }
 
     func sendVoiceMemo() {
         guard case .recorded(let url, let duration) = voiceMemoRecorder.state else { return }
         let levels = voiceMemoRecorder.audioLevels
-        voiceMemoRecorder.resetState()
+        withAnimation(.bouncy(duration: 0.4, extraBounce: 0.01)) {
+            voiceMemoRecorder.resetState()
+        }
 
         let messageWriter = cachedMessageWriter
         let replyTarget = replyingToMessage

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Data Source/DefaultMessagesLayoutDelegate.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Data Source/DefaultMessagesLayoutDelegate.swift
@@ -85,7 +85,18 @@ final class DefaultMessagesLayoutDelegate: MessagesLayoutDelegate {
         return height
     }
 
-    private func attachmentHeight(for attachment: HydratedAttachment, width: CGFloat) -> CGFloat {
+    private func estimatedAttachmentHeight(for attachment: HydratedAttachment, width: CGFloat) -> CGFloat {
+        switch attachment.mediaType {
+        case .audio:
+            return 44.0
+        case .file:
+            return 60.0
+        case .image, .video, .unknown:
+            return imageAttachmentHeight(for: attachment, width: width)
+        }
+    }
+
+    private func imageAttachmentHeight(for attachment: HydratedAttachment, width: CGFloat) -> CGFloat {
         guard let w = attachment.width, let h = attachment.height, w > 0, h > 0 else {
             return width * 0.75
         }
@@ -95,17 +106,11 @@ final class DefaultMessagesLayoutDelegate: MessagesLayoutDelegate {
     private func messageHeight(for message: AnyMessage, width: CGFloat) -> CGFloat {
         var height: CGFloat
         switch message.content {
-        case .attachment(let attachment) where attachment.mediaType == .audio:
-            height = 44.0
         case .attachment(let attachment):
-            height = attachmentHeight(for: attachment, width: width)
+            height = estimatedAttachmentHeight(for: attachment, width: width)
         case .attachments(let attachments):
             guard let first = attachments.first else { return 50.0 }
-            if first.mediaType == .audio {
-                height = 44.0
-            } else {
-                height = attachmentHeight(for: first, width: width)
-            }
+            height = estimatedAttachmentHeight(for: first, width: width)
         case .emoji:
             height = 80.0
         case .text:

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Data Source/DefaultMessagesLayoutDelegate.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Data Source/DefaultMessagesLayoutDelegate.swift
@@ -95,11 +95,17 @@ final class DefaultMessagesLayoutDelegate: MessagesLayoutDelegate {
     private func messageHeight(for message: AnyMessage, width: CGFloat) -> CGFloat {
         var height: CGFloat
         switch message.content {
+        case .attachment(let attachment) where attachment.mediaType == .audio:
+            height = 44.0
         case .attachment(let attachment):
             height = attachmentHeight(for: attachment, width: width)
         case .attachments(let attachments):
             guard let first = attachments.first else { return 50.0 }
-            height = attachmentHeight(for: first, width: width)
+            if first.mediaType == .audio {
+                height = 44.0
+            } else {
+                height = attachmentHeight(for: first, width: width)
+            }
         case .emoji:
             height = 80.0
         case .text:

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesBottomBar.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesBottomBar.swift
@@ -152,10 +152,14 @@ struct MessagesBottomBar<BottomBarContent: View>: View {
                 .frame(minHeight: 52)
                 .clipShape(.capsule)
                 .glassEffect(.regular.interactive(), in: .capsule)
+                .glassEffectID("media", in: namespace)
+                .glassEffectTransition(.matchedGeometry)
         } else if case .recorded(let url, let duration) = voiceMemoRecorder.state {
             HStack(spacing: DesignConstants.Spacing.step2x) {
                 Button {
-                    voiceMemoRecorder.cancelRecording()
+                    withAnimation(.bouncy(duration: 0.4, extraBounce: 0.01)) {
+                        voiceMemoRecorder.cancelRecording()
+                    }
                 } label: {
                     Image(systemName: "xmark")
                         .font(.system(size: 14, weight: .semibold))
@@ -176,6 +180,8 @@ struct MessagesBottomBar<BottomBarContent: View>: View {
                 .frame(minHeight: 52)
                 .clipShape(.capsule)
                 .glassEffect(.regular.interactive(), in: .capsule)
+                .glassEffectID("media", in: namespace)
+                .glassEffectTransition(.matchedGeometry)
             }
         } else {
             normalInputView

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesBottomBar.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesBottomBar.swift
@@ -31,6 +31,9 @@ struct MessagesBottomBar<BottomBarContent: View>: View {
     let onDisplayNameEndedEditing: () -> Void
     let onVideoSelected: (URL) -> Void
     let onProfileSettings: () -> Void
+    let onVoiceMemoTap: () -> Void
+    @Bindable var voiceMemoRecorder: VoiceMemoRecorder
+    let onSendVoiceMemo: () -> Void
     let onConvosAction: () -> Void
     let onBaseHeightChanged: (CGFloat) -> Void
     @ViewBuilder let bottomBarContent: () -> BottomBarContent
@@ -135,8 +138,52 @@ struct MessagesBottomBar<BottomBarContent: View>: View {
         }
     }
 
+    private var isVoiceMemoActive: Bool {
+        switch voiceMemoRecorder.state {
+        case .recording, .recorded: return true
+        case .idle: return false
+        }
+    }
+
     @ViewBuilder
     private var collapsedInputView: some View {
+        if case .recording = voiceMemoRecorder.state {
+            VoiceMemoRecordingView(recorder: voiceMemoRecorder)
+                .frame(minHeight: 52)
+                .clipShape(.capsule)
+                .glassEffect(.regular.interactive(), in: .capsule)
+        } else if case .recorded(let url, let duration) = voiceMemoRecorder.state {
+            HStack(spacing: DesignConstants.Spacing.step2x) {
+                Button {
+                    voiceMemoRecorder.cancelRecording()
+                } label: {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 14, weight: .semibold))
+                        .foregroundStyle(.colorTextSecondary)
+                        .frame(width: DesignConstants.Spacing.step12x, height: DesignConstants.Spacing.step12x)
+                }
+                .clipShape(.circle)
+                .glassEffect(.regular.interactive(), in: .circle)
+                .accessibilityLabel("Discard voice memo")
+                .accessibilityIdentifier("voice-memo-cancel-button")
+
+                VoiceMemoReviewView(
+                    audioURL: url,
+                    duration: duration,
+                    levels: voiceMemoRecorder.audioLevels,
+                    onSend: { onSendVoiceMemo() }
+                )
+                .frame(minHeight: 52)
+                .clipShape(.capsule)
+                .glassEffect(.regular.interactive(), in: .capsule)
+            }
+        } else {
+            normalInputView
+        }
+    }
+
+    @ViewBuilder
+    private var normalInputView: some View {
         HStack(alignment: .bottom, spacing: DesignConstants.Spacing.step2x) {
             if isMessageInputFocused {
                 Button {
@@ -163,6 +210,7 @@ struct MessagesBottomBar<BottomBarContent: View>: View {
                 MessagesMediaButtonsView(
                     isPhotoPickerPresented: $isPhotoPickerPresented,
                     isCameraPresented: $isCameraPresented,
+                    onVoiceMemoTap: onVoiceMemoTap,
                     onConvosAction: onConvosAction
                 )
                 .opacity(messagesTextFieldEnabled ? 1.0 : 0.4)
@@ -311,6 +359,9 @@ struct MessagesBottomBar<BottomBarContent: View>: View {
             },
             onVideoSelected: { _ in },
             onProfileSettings: {},
+            onVoiceMemoTap: {},
+            voiceMemoRecorder: VoiceMemoRecorder(),
+            onSendVoiceMemo: {},
             onConvosAction: {},
             onBaseHeightChanged: { height in
                 bottomBarHeight = height

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesBottomBar.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesBottomBar.swift
@@ -217,7 +217,12 @@ struct MessagesBottomBar<BottomBarContent: View>: View {
                     isPhotoPickerPresented: $isPhotoPickerPresented,
                     isCameraPresented: $isCameraPresented,
                     onVoiceMemoTap: onVoiceMemoTap,
-                    onConvosAction: onConvosAction
+                    onConvosAction: {
+                        withAnimation(.bouncy(duration: 0.4, extraBounce: 0.01)) {
+                            isMessageInputFocused = true
+                        }
+                        onConvosAction()
+                    }
                 )
                 .opacity(messagesTextFieldEnabled ? 1.0 : 0.4)
                 .frame(height: DesignConstants.Spacing.step12x)

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesBottomBar.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesBottomBar.swift
@@ -3,7 +3,7 @@ import PhotosUI
 import SwiftUI
 
 enum MessagesViewInputFocus: Hashable {
-    case message, displayName, conversationName
+    case message, displayName, conversationName, voiceMemoRecording
 }
 
 struct MessagesBottomBar<BottomBarContent: View>: View {
@@ -40,12 +40,14 @@ struct MessagesBottomBar<BottomBarContent: View>: View {
 
     @State private var quicknameSettings: QuicknameSettingsViewModel = .shared
 
+    @State private var voiceMemoKeyboardKeeperText: String = ""
     @State private var isExpanded: Bool = false
     @State private var isMessageInputFocused: Bool = false
     @State private var isImagePickerPresented: Bool = false
     @State private var isCameraPresented: Bool = false
     @State private var selectedPhoto: PhotosPickerItem?
     @State private var previousFocus: MessagesViewInputFocus?
+    @State private var voiceMemoReturnFocus: MessagesViewInputFocus?
     @State private var didSelectPhotoThisSession: Bool = false
     @Namespace private var namespace: Namespace.ID
 
@@ -56,6 +58,10 @@ struct MessagesBottomBar<BottomBarContent: View>: View {
     var body: some View {
         VStack(spacing: 0) {
             bottomBarContent()
+            VoiceMemoKeyboardFocusKeeper(
+                focusState: $focusState,
+                text: $voiceMemoKeyboardKeeperText
+            )
             GlassEffectContainer {
                 ZStack {
                     if !isExpanded {
@@ -80,7 +86,7 @@ struct MessagesBottomBar<BottomBarContent: View>: View {
 
             withAnimation(.bouncy(duration: 0.4, extraBounce: 0.01)) {
                 isExpanded = newValue == .displayName
-                isMessageInputFocused = newValue == .message
+                isMessageInputFocused = newValue == .message || newValue == .voiceMemoRecording
             }
         }
         .onChange(of: messageText) { _, _ in
@@ -88,6 +94,10 @@ struct MessagesBottomBar<BottomBarContent: View>: View {
             withAnimation(.bouncy(duration: 0.4, extraBounce: 0.01)) {
                 isMessageInputFocused = true
             }
+        }
+        .onChange(of: isVoiceMemoActive) { wasActive, isActive in
+            guard wasActive, !isActive else { return }
+            restoreVoiceMemoFocusIfNeeded()
         }
         .onChange(of: isPhotoPickerPresented) { _, newValue in
             if newValue {
@@ -143,6 +153,27 @@ struct MessagesBottomBar<BottomBarContent: View>: View {
         case .recording, .recorded: return true
         case .idle: return false
         }
+    }
+
+    private func startVoiceMemoRecording() {
+        if let currentFocus = focusCoordinator.currentFocus {
+            voiceMemoReturnFocus = currentFocus
+            focusCoordinator.moveFocus(to: .voiceMemoRecording)
+        } else {
+            voiceMemoReturnFocus = nil
+        }
+        onVoiceMemoTap()
+    }
+
+    private func restoreVoiceMemoFocusIfNeeded() {
+        guard focusCoordinator.currentFocus == .voiceMemoRecording,
+              let voiceMemoReturnFocus else {
+            self.voiceMemoReturnFocus = nil
+            return
+        }
+
+        focusCoordinator.moveFocus(to: voiceMemoReturnFocus)
+        self.voiceMemoReturnFocus = nil
     }
 
     @ViewBuilder
@@ -216,7 +247,7 @@ struct MessagesBottomBar<BottomBarContent: View>: View {
                 MessagesMediaButtonsView(
                     isPhotoPickerPresented: $isPhotoPickerPresented,
                     isCameraPresented: $isCameraPresented,
-                    onVoiceMemoTap: onVoiceMemoTap,
+                    onVoiceMemoTap: startVoiceMemoRecording,
                     onConvosAction: {
                         withAnimation(.bouncy(duration: 0.4, extraBounce: 0.01)) {
                             isMessageInputFocused = true

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesMediaInputView.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesMediaInputView.swift
@@ -7,7 +7,7 @@ struct MessagesMediaButtonsView: View {
     let onConvosAction: () -> Void
 
     var body: some View {
-        HStack(spacing: DesignConstants.Spacing.stepX) {
+        HStack(spacing: DesignConstants.Spacing.step2x) {
             Button {
                 isPhotoPickerPresented = true
             } label: {

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesMediaInputView.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesMediaInputView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct MessagesMediaButtonsView: View {
     @Binding var isPhotoPickerPresented: Bool
     @Binding var isCameraPresented: Bool
+    let onVoiceMemoTap: () -> Void
     let onConvosAction: () -> Void
 
     var body: some View {
@@ -32,6 +33,19 @@ struct MessagesMediaButtonsView: View {
             .buttonStyle(.plain)
             .accessibilityLabel("Camera")
             .accessibilityIdentifier("camera-button")
+
+            Button {
+                onVoiceMemoTap()
+            } label: {
+                Image(systemName: "waveform")
+                    .font(.system(size: 18.0, weight: .medium))
+                    .foregroundStyle(Color.colorTextSecondary)
+                    .frame(width: Constant.buttonSize, height: Constant.buttonSize)
+                    .contentShape(.circle)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Voice memo")
+            .accessibilityIdentifier("voice-memo-button")
 
             Button {
                 onConvosAction()
@@ -67,6 +81,7 @@ struct MessagesMediaButtonsView: View {
     MessagesMediaButtonsView(
         isPhotoPickerPresented: $isPhotoPickerPresented,
         isCameraPresented: $isCameraPresented,
+        onVoiceMemoTap: {},
         onConvosAction: {}
     )
     .padding()

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/ReplyComposerBar.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/ReplyComposerBar.swift
@@ -62,12 +62,12 @@ struct ReplyComposerBar: View {
     }
 
     private func replyLabel(for attachment: HydratedAttachment) -> String {
-        switch attachment.mediaType {
-        case .video: return "Video"
-        case .audio: return "Audio"
-        case .file: return attachment.filename ?? "File"
-        default: return "Photo"
+        if attachment.mediaType == .file, let filename = attachment.filename {
+            return filename
         }
+        return attachment.mediaType.previewLabel
+            .replacingOccurrences(of: "a ", with: "")
+            .capitalized
     }
 
     var body: some View {

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/ReplyComposerBar.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/ReplyComposerBar.swift
@@ -17,9 +17,10 @@ struct ReplyComposerBar: View {
         case .emoji(let emoji):
             return emoji
         case .attachment(let attachment):
-            return attachment.mediaType == .video ? "Video" : "Photo"
+            return replyLabel(for: attachment)
         case .attachments(let attachments):
-            return attachments.first?.mediaType == .video ? "Video" : "Photo"
+            if let first = attachments.first { return replyLabel(for: first) }
+            return "Photo"
         case .invite:
             return "Invite"
         case .linkPreview(let preview):
@@ -56,6 +57,10 @@ struct ReplyComposerBar: View {
         attachment?.mediaType == .file
     }
 
+    private var isAudio: Bool {
+        attachment?.mediaType == .audio
+    }
+
     private func replyLabel(for attachment: HydratedAttachment) -> String {
         switch attachment.mediaType {
         case .video: return "Video"
@@ -67,7 +72,12 @@ struct ReplyComposerBar: View {
 
     var body: some View {
         HStack(spacing: DesignConstants.Spacing.step2x) {
-            if let attachment {
+            if isAudio {
+                Image(systemName: "waveform")
+                    .font(.system(size: 14))
+                    .foregroundStyle(.colorTextSecondary)
+                    .frame(width: 40, height: 40)
+            } else if let attachment {
                 ReplyPhotoThumbnail(attachmentKey: attachment.key, shouldBlur: shouldBlurAttachment, isVideo: isVideo)
             }
 

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/VoiceMemoRecordingView.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/VoiceMemoRecordingView.swift
@@ -44,7 +44,9 @@ struct VoiceMemoRecordingView: View {
                 .frame(minWidth: 36, alignment: .trailing)
 
             Button {
-                recorder.stopRecording()
+                withAnimation(.bouncy(duration: 0.4, extraBounce: 0.01)) {
+                    recorder.stopRecording()
+                }
             } label: {
                 Image(systemName: "stop.fill")
                     .font(.system(size: 14))

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/VoiceMemoRecordingView.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/VoiceMemoRecordingView.swift
@@ -1,0 +1,72 @@
+import ConvosCore
+import SwiftUI
+
+struct VoiceMemoRecordingView: View {
+    @Bindable var recorder: VoiceMemoRecorder
+
+    private let barWidth: CGFloat = 2
+    private let barSpacing: CGFloat = 1.5
+
+    var body: some View {
+        HStack(spacing: DesignConstants.Spacing.step3x) {
+            Canvas { context, size in
+                let totalBarWidth = barWidth + barSpacing
+                let visibleBarCount = max(Int(size.width / totalBarWidth), 1)
+                let levels = recorder.audioLevels
+                let placeholderHeight: CGFloat = 2
+                let recordedCount = min(levels.count, visibleBarCount)
+                let startIndex = max(levels.count - visibleBarCount, 0)
+
+                for i in 0 ..< visibleBarCount {
+                    let x = CGFloat(i) * totalBarWidth
+
+                    let barIndex = i - (visibleBarCount - recordedCount)
+                    if barIndex >= 0, barIndex + startIndex < levels.count {
+                        let level = CGFloat(levels[startIndex + barIndex])
+                        let height = max(size.height * level, placeholderHeight)
+                        let y = (size.height - height) / 2
+                        let rect = CGRect(x: x, y: y, width: barWidth, height: height)
+                        let path = Path(roundedRect: rect, cornerRadius: barWidth / 2)
+                        context.fill(path, with: .color(.colorCaution))
+                    } else {
+                        let y = (size.height - placeholderHeight) / 2
+                        let rect = CGRect(x: x, y: y, width: barWidth, height: placeholderHeight)
+                        let path = Path(roundedRect: rect, cornerRadius: barWidth / 2)
+                        context.fill(path, with: .color(Color.colorCaution.opacity(0.3)))
+                    }
+                }
+            }
+            .frame(height: 24)
+
+            Text(formattedDuration(recorder.duration))
+                .font(.callout.monospacedDigit())
+                .foregroundStyle(.colorTextSecondary)
+                .frame(minWidth: 36, alignment: .trailing)
+
+            Button {
+                recorder.stopRecording()
+            } label: {
+                Image(systemName: "stop.fill")
+                    .font(.system(size: 14))
+                    .foregroundStyle(.white)
+                    .frame(width: 32, height: 32)
+                    .background(.colorCaution, in: Circle())
+            }
+            .accessibilityLabel("Stop recording")
+            .accessibilityIdentifier("voice-memo-stop-button")
+        }
+        .padding(.horizontal, DesignConstants.Spacing.step6x)
+        .padding(.vertical, DesignConstants.Spacing.step4x)
+    }
+
+    private func formattedDuration(_ duration: TimeInterval) -> String {
+        let minutes = Int(duration) / 60
+        let seconds = Int(duration) % 60
+        return String(format: "%d:%02d", minutes, seconds)
+    }
+}
+
+#Preview {
+    VoiceMemoRecordingView(recorder: VoiceMemoRecorder())
+        .padding()
+}

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/VoiceMemoRecordingView.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/VoiceMemoRecordingView.swift
@@ -68,7 +68,28 @@ struct VoiceMemoRecordingView: View {
     }
 }
 
+struct VoiceMemoKeyboardFocusKeeper: View {
+    @FocusState.Binding var focusState: MessagesViewInputFocus?
+    @Binding var text: String
+
+    init(focusState: FocusState<MessagesViewInputFocus?>.Binding, text: Binding<String>) {
+        _focusState = focusState
+        _text = text
+    }
+
+    var body: some View {
+        TextField("", text: $text)
+            .focused($focusState, equals: .voiceMemoRecording)
+            .frame(width: 1, height: 1)
+            .opacity(0.01)
+            .allowsHitTesting(false)
+            .accessibilityHidden(true)
+    }
+}
+
 #Preview {
+    @Previewable @FocusState var focusState: MessagesViewInputFocus?
+
     VoiceMemoRecordingView(recorder: VoiceMemoRecorder())
         .padding()
 }

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/VoiceMemoReviewView.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/VoiceMemoReviewView.swift
@@ -71,9 +71,9 @@ struct VoiceMemoReviewView: View {
                 if player == nil {
                     player = try AVAudioPlayer(contentsOf: audioURL)
                     player?.prepareToPlay()
+                    player?.currentTime = 0
                 }
                 if let player {
-                    player.currentTime = 0
                     guard player.play() else {
                         Log.error("Failed to play voice memo preview: playback returned false")
                         return

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/VoiceMemoReviewView.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/VoiceMemoReviewView.swift
@@ -72,7 +72,13 @@ struct VoiceMemoReviewView: View {
                     player = try AVAudioPlayer(contentsOf: audioURL)
                     player?.prepareToPlay()
                 }
-                player?.play()
+                if let player {
+                    player.currentTime = 0
+                    guard player.play() else {
+                        Log.error("Failed to play voice memo preview: playback returned false")
+                        return
+                    }
+                }
                 isPlaying = true
                 startProgressTimer()
             } catch {

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/VoiceMemoReviewView.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/VoiceMemoReviewView.swift
@@ -107,9 +107,7 @@ struct VoiceMemoReviewView: View {
                 if player.isPlaying {
                     self.playbackProgress = player.duration > 0 ? player.currentTime / player.duration : 0
                 } else {
-                    self.playbackTimer?.invalidate()
-                    self.isPlaying = false
-                    self.playbackProgress = 0
+                    self.stopPlayback()
                 }
             }
         }

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/VoiceMemoReviewView.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/VoiceMemoReviewView.swift
@@ -1,0 +1,130 @@
+import ConvosCore
+import SwiftUI
+
+struct VoiceMemoReviewView: View {
+    let audioURL: URL
+    let duration: TimeInterval
+    let levels: [Float]
+    let onSend: () -> Void
+
+    @State private var player: AVAudioPlayer?
+    @State private var isPlaying: Bool = false
+    @State private var playbackProgress: Double = 0
+    @State private var playbackTimer: Timer?
+    private var displayLevels: [Float] {
+        levels
+    }
+
+    var body: some View {
+        HStack(spacing: DesignConstants.Spacing.step3x) {
+            Button {
+                togglePlayback()
+            } label: {
+                Image(systemName: isPlaying ? "pause.fill" : "play.fill")
+                    .font(.system(size: 14))
+                    .foregroundStyle(.colorTextPrimary)
+                    .frame(width: 32, height: 32)
+                    .background(.colorFillMinimal, in: Circle())
+            }
+            .accessibilityLabel(isPlaying ? "Pause" : "Play")
+            .accessibilityIdentifier("voice-memo-play-button")
+
+            VoiceMemoWaveformView(
+                levels: displayLevels,
+                progress: playbackProgress
+            )
+            .frame(height: 24)
+            .animation(.linear(duration: 1.0 / 30.0), value: playbackProgress)
+
+            Text(formattedDuration(duration))
+                .font(.callout.monospacedDigit())
+                .foregroundStyle(.colorTextSecondary)
+                .frame(minWidth: 44, alignment: .trailing)
+
+            Button {
+                stopPlayback()
+                onSend()
+            } label: {
+                Image(systemName: "arrow.up")
+                    .font(.system(size: 14, weight: .bold))
+                    .foregroundStyle(.white)
+                    .frame(width: 32, height: 32)
+                    .background(.colorTextPrimary, in: Circle())
+            }
+            .accessibilityLabel("Send voice memo")
+            .accessibilityIdentifier("voice-memo-send-button")
+        }
+        .padding(.horizontal, DesignConstants.Spacing.step6x)
+        .padding(.vertical, DesignConstants.Spacing.step4x)
+        .onDisappear {
+            stopPlayback()
+        }
+    }
+
+    private func togglePlayback() {
+        if isPlaying {
+            player?.pause()
+            playbackTimer?.invalidate()
+            isPlaying = false
+        } else {
+            do {
+                if player == nil {
+                    player = try AVAudioPlayer(contentsOf: audioURL)
+                    player?.prepareToPlay()
+                }
+                player?.play()
+                isPlaying = true
+                startProgressTimer()
+            } catch {
+                Log.error("Failed to play voice memo preview: \(error)")
+            }
+        }
+    }
+
+    private func stopPlayback() {
+        playbackTimer?.invalidate()
+        playbackTimer = nil
+        player?.stop()
+        player = nil
+        isPlaying = false
+        playbackProgress = 0
+    }
+
+    private func startProgressTimer() {
+        playbackTimer = Timer.scheduledTimer(withTimeInterval: 1.0 / 30.0, repeats: true) { [self] _ in
+            Task { @MainActor in
+                guard let player = self.player else {
+                    self.playbackTimer?.invalidate()
+                    self.isPlaying = false
+                    return
+                }
+                if player.isPlaying {
+                    self.playbackProgress = player.duration > 0 ? player.currentTime / player.duration : 0
+                } else {
+                    self.playbackTimer?.invalidate()
+                    self.isPlaying = false
+                    self.playbackProgress = 0
+                }
+            }
+        }
+    }
+
+    private func formattedDuration(_ duration: TimeInterval) -> String {
+        let minutes = Int(duration) / 60
+        let seconds = Int(duration) % 60
+        return String(format: "%d:%02d", minutes, seconds)
+    }
+}
+
+import AVFoundation
+
+#Preview {
+    let levels: [Float] = (0 ..< 60).map { _ in Float.random(in: 0.05 ... 1.0) }
+    VoiceMemoReviewView(
+        audioURL: URL(fileURLWithPath: "/tmp/test.m4a"),
+        duration: 7,
+        levels: levels,
+        onSend: {}
+    )
+    .padding()
+}

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessageContextMenu/MessageContextMenuOverlay.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessageContextMenu/MessageContextMenuOverlay.swift
@@ -667,7 +667,17 @@ struct MessageContextMenuOverlay: View {
     @ViewBuilder
     private func contextMenuAttachmentPreview(_ attachment: HydratedAttachment) -> some View {
         let profile = message?.sender.profile ?? Profile(inboxId: "", conversationId: "", name: nil, avatar: nil)
-        if attachment.mediaType == .file {
+        if attachment.mediaType == .audio, let message {
+            MessageContainer(style: state.bubbleStyle, isOutgoing: state.isOutgoing) {
+                VoiceMemoBubbleContent(
+                    message: message,
+                    attachment: attachment,
+                    isOutgoing: state.isOutgoing,
+                    player: .shared,
+                    isLoading: false
+                )
+            }
+        } else if attachment.mediaType == .file {
             FileAttachmentBubble(
                 attachment: attachment,
                 style: state.bubbleStyle,

--- a/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/ReplyReferenceView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/ReplyReferenceView.swift
@@ -20,9 +20,10 @@ struct ReplyReferenceView: View {
         case .emoji(let emoji):
             return emoji
         case .attachment(let attachment):
-            return attachment.mediaType == .video ? "video" : "photo"
+            return replyLabel(for: attachment)
         case .attachments(let attachments):
-            return attachments.first?.mediaType == .video ? "video" : "photo"
+            if let first = attachments.first { return replyLabel(for: first) }
+            return "photo"
         case .invite:
             return "invite"
         case .linkPreview(let preview):
@@ -100,7 +101,9 @@ struct ReplyReferenceView: View {
             .padding(.leading, isOutgoing ? 0.0 : DesignConstants.Spacing.step3x)
             .padding(.trailing, isOutgoing ? DesignConstants.Spacing.step3x : 0.0)
 
-            if let attachment = parentAttachment, attachment.mediaType == .file {
+            if let attachment = parentAttachment, attachment.mediaType == .audio {
+                ReplyReferenceAudioPreview(attachment: attachment)
+            } else if let attachment = parentAttachment, attachment.mediaType == .file {
                 ReplyReferenceFileBubble(attachment: attachment)
             } else if let attachment = parentAttachment {
                 ReplyReferencePhotoPreview(
@@ -511,5 +514,60 @@ private struct ReplyReferenceFileBubble: View {
             RoundedRectangle(cornerRadius: 10)
                 .fill(Color.colorFillMinimal)
         )
+    }
+}
+
+private struct ReplyReferenceAudioPreview: View {
+    let attachment: HydratedAttachment
+
+    @State private var waveformLevels: [Float]?
+
+    private var durationText: String {
+        guard let duration = attachment.duration else { return "Audio" }
+        let minutes = Int(duration) / 60
+        let seconds = Int(duration) % 60
+        return String(format: "%d:%02d", minutes, seconds)
+    }
+
+    var body: some View {
+        HStack(spacing: DesignConstants.Spacing.step2x) {
+            Image(systemName: "waveform")
+                .font(.system(size: 10))
+                .foregroundStyle(.colorTextSecondary)
+
+            if let levels = waveformLevels {
+                VoiceMemoWaveformView(
+                    levels: levels,
+                    unplayedColor: .colorTextSecondary.opacity(0.4),
+                    barWidth: 1.5,
+                    barSpacing: 1
+                )
+                .frame(width: 60, height: 16)
+            }
+
+            Text(durationText)
+                .font(.caption2)
+                .foregroundStyle(.colorTextSecondary)
+        }
+        .padding(.horizontal, DesignConstants.Spacing.step3x)
+        .padding(.vertical, DesignConstants.Spacing.step2x)
+        .background(
+            RoundedRectangle(cornerRadius: 10)
+                .fill(Color.colorFillMinimal)
+        )
+        .task {
+            if let cached = attachment.waveformLevels {
+                waveformLevels = cached
+                return
+            }
+            do {
+                let loader = RemoteAttachmentLoader()
+                let loaded = try await loader.loadAttachmentData(from: attachment.key)
+                let levels = await VoiceMemoWaveformAnalyzer.analyzeLevels(from: loaded.data, sampleCount: 30)
+                await MainActor.run { waveformLevels = levels }
+            } catch {
+                Log.error("Failed to load reply audio waveform: \(error)")
+            }
+        }
     }
 }

--- a/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/ReplyReferenceView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/ReplyReferenceView.swift
@@ -34,12 +34,10 @@ struct ReplyReferenceView: View {
     }
 
     private func replyLabel(for attachment: HydratedAttachment) -> String {
-        switch attachment.mediaType {
-        case .video: return "video"
-        case .audio: return "audio"
-        case .file: return attachment.filename ?? "file"
-        default: return "photo"
+        if attachment.mediaType == .file, let filename = attachment.filename {
+            return filename
         }
+        return attachment.mediaType.previewLabel.replacingOccurrences(of: "a ", with: "")
     }
 
     private var parentAttachment: HydratedAttachment? {

--- a/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/VoiceMemoBubble.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/VoiceMemoBubble.swift
@@ -1,0 +1,180 @@
+import ConvosCore
+import SwiftUI
+
+extension Notification.Name {
+    static let voiceMemoPlaybackRequested: Notification.Name = .init("voiceMemoPlaybackRequested")
+}
+
+struct VoiceMemoAttachmentView: View {
+    let message: AnyMessage
+    let attachment: HydratedAttachment
+    let bubbleType: MessageBubbleType
+    let onReply: (AnyMessage) -> Void
+
+    @State private var player: VoiceMemoPlayer = .shared
+    @State private var audioData: Data?
+    @State private var isLoading: Bool = false
+    @State private var playTrigger: Int = 0
+
+    var body: some View {
+        MessageContainer(style: bubbleType, isOutgoing: message.sender.isCurrentUser) {
+            VoiceMemoBubbleContent(
+                message: message,
+                attachment: attachment,
+                isOutgoing: message.sender.isCurrentUser,
+                player: player,
+                isLoading: isLoading
+            )
+        }
+        .messageGesture(
+            message: message,
+            bubbleStyle: bubbleType,
+            onSingleTap: { playTrigger += 1 },
+            onReply: onReply
+        )
+        .onChange(of: playTrigger) {
+            Task { await togglePlayback() }
+        }
+    }
+
+    private func togglePlayback() async {
+        if let data = audioData {
+            do {
+                try player.togglePlayback(data: data, messageId: message.messageId)
+            } catch {
+                Log.error("Failed to play voice memo: \(error)")
+            }
+            return
+        }
+
+        guard !isLoading else { return }
+        isLoading = true
+        do {
+            let loader = RemoteAttachmentLoader()
+            let loaded = try await loader.loadAttachmentData(from: attachment.key)
+            audioData = loaded.data
+            try await MainActor.run {
+                try player.play(data: loaded.data, messageId: message.messageId)
+            }
+        } catch {
+            Log.error("Failed to load voice memo: \(error)")
+        }
+        isLoading = false
+    }
+}
+
+struct VoiceMemoBubbleContent: View {
+    let message: AnyMessage
+    let attachment: HydratedAttachment
+    let isOutgoing: Bool
+    let player: VoiceMemoPlayer
+    let isLoading: Bool
+
+    @State private var analyzedLevels: [Float]?
+
+    private var displayLevels: [Float] {
+        attachment.waveformLevels ?? analyzedLevels ?? Self.placeholderLevels
+    }
+
+    private var isCurrentlyPlaying: Bool {
+        player.currentlyPlayingMessageId == message.messageId
+    }
+
+    private var showPause: Bool {
+        isCurrentlyPlaying && player.state == .playing
+    }
+
+    private var displayDuration: String {
+        if isCurrentlyPlaying && player.duration > 0 {
+            return formatDuration(player.currentTime)
+        }
+        return formatDuration(attachment.duration ?? 0)
+    }
+
+    private var displayProgress: Double {
+        isCurrentlyPlaying ? player.progress : 0
+    }
+
+    var body: some View {
+        HStack(spacing: DesignConstants.Spacing.step3x) {
+            Group {
+                if isLoading {
+                    ProgressView()
+                        .scaleEffect(0.7)
+                } else {
+                    Image(systemName: showPause ? "pause.fill" : "play.fill")
+                        .font(.system(size: 16))
+                }
+            }
+            .foregroundStyle(isOutgoing ? .white : .colorTextPrimary)
+            .frame(width: 36, height: 36)
+            .background(
+                isOutgoing ? Color.white.opacity(0.2) : .colorFillMinimal,
+                in: Circle()
+            )
+
+            VoiceMemoWaveformView(
+                levels: displayLevels,
+                progress: displayProgress,
+                playedColor: isOutgoing ? .white : .colorTextPrimary,
+                unplayedColor: isOutgoing ? .white.opacity(0.3) : .colorTextSecondary.opacity(0.3)
+            )
+            .frame(height: 24)
+            .frame(maxWidth: .infinity)
+            .animation(.linear(duration: 1.0 / 30.0), value: displayProgress)
+
+            Text(displayDuration)
+                .font(.caption.monospacedDigit())
+                .foregroundStyle(isOutgoing ? .white.opacity(0.7) : .colorTextSecondary)
+                .frame(minWidth: 32, alignment: .trailing)
+        }
+        .padding(DesignConstants.Spacing.step3x)
+        .frame(width: 220)
+        .task(id: message.messageId) {
+            guard attachment.waveformLevels == nil, analyzedLevels == nil else { return }
+            await loadAndCacheWaveform()
+        }
+    }
+
+    private func loadAndCacheWaveform() async {
+        do {
+            let loader = RemoteAttachmentLoader()
+            let loaded = try await loader.loadAttachmentData(from: attachment.key)
+            let levels = await VoiceMemoWaveformAnalyzer.analyzeLevels(from: loaded.data)
+            await MainActor.run { analyzedLevels = levels }
+        } catch {
+            Log.error("Failed to analyze voice memo waveform: \(error)")
+        }
+    }
+
+    private func formatDuration(_ duration: TimeInterval) -> String {
+        let minutes = Int(duration) / 60
+        let seconds = Int(duration) % 60
+        return String(format: "%d:%02d", minutes, seconds)
+    }
+
+    private static let placeholderLevels: [Float] = Array(repeating: Float(0), count: 40)
+}
+
+#Preview {
+    VStack {
+        VoiceMemoBubbleContent(
+            message: .message(.mock(), .existing),
+            attachment: HydratedAttachment(key: "test", mimeType: "audio/m4a", duration: 7),
+            isOutgoing: true,
+            player: .shared,
+            isLoading: false
+        )
+        .background(.colorBubble, in: RoundedRectangle(cornerRadius: 16))
+
+        VoiceMemoBubbleContent(
+            message: .message(.mock(), .existing),
+            attachment: HydratedAttachment(key: "test2", mimeType: "audio/m4a", duration: 15),
+            isOutgoing: false,
+            player: .shared,
+            isLoading: false
+        )
+        .background(.colorBubbleIncoming, in: RoundedRectangle(cornerRadius: 16))
+    }
+    .padding()
+}

--- a/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/VoiceMemoBubble.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/VoiceMemoBubble.swift
@@ -5,6 +5,8 @@ extension Notification.Name {
     static let voiceMemoPlaybackRequested: Notification.Name = .init("voiceMemoPlaybackRequested")
 }
 
+private let sharedAttachmentLoader: RemoteAttachmentLoader = RemoteAttachmentLoader()
+
 struct VoiceMemoAttachmentView: View {
     let message: AnyMessage
     let attachment: HydratedAttachment
@@ -50,8 +52,7 @@ struct VoiceMemoAttachmentView: View {
         guard !isLoading else { return }
         isLoading = true
         do {
-            let loader = RemoteAttachmentLoader()
-            let loaded = try await loader.loadAttachmentData(from: attachment.key)
+            let loaded = try await sharedAttachmentLoader.loadAttachmentData(from: attachment.key)
             audioData = loaded.data
             try await MainActor.run {
                 try player.play(data: loaded.data, messageId: message.messageId)
@@ -138,8 +139,7 @@ struct VoiceMemoBubbleContent: View {
 
     private func loadAndCacheWaveform() async {
         do {
-            let loader = RemoteAttachmentLoader()
-            let loaded = try await loader.loadAttachmentData(from: attachment.key)
+            let loaded = try await sharedAttachmentLoader.loadAttachmentData(from: attachment.key)
             let levels = await VoiceMemoWaveformAnalyzer.analyzeLevels(from: loaded.data)
             await MainActor.run { analyzedLevels = levels }
         } catch {

--- a/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/VoiceMemoWaveformView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/VoiceMemoWaveformView.swift
@@ -1,0 +1,58 @@
+import SwiftUI
+
+struct VoiceMemoWaveformView: View {
+    let levels: [Float]
+    var progress: Double = 0
+    var playedColor: Color = .colorTextPrimary
+    var unplayedColor: Color = .colorTextSecondary.opacity(0.4)
+    var barWidth: CGFloat = 2
+    var barSpacing: CGFloat = 1.5
+
+    var body: some View {
+        Canvas { context, size in
+            let totalBarWidth = barWidth + barSpacing
+            let barCount = max(Int(size.width / totalBarWidth), 1)
+            let sampledLevels = resample(levels, to: barCount)
+            let progressBarIndex = Int(Double(barCount) * progress)
+
+            for index in 0 ..< barCount {
+                let level = index < sampledLevels.count ? CGFloat(sampledLevels[index]) : 0
+                let height = max(size.height * level, 2)
+                let x = CGFloat(index) * totalBarWidth
+                let y = (size.height - height) / 2
+                let rect = CGRect(x: x, y: y, width: barWidth, height: height)
+                let path = Path(roundedRect: rect, cornerRadius: barWidth / 2)
+                let color: Color = progress > 0 && index < progressBarIndex ? playedColor : unplayedColor
+                context.fill(path, with: .color(color))
+            }
+        }
+    }
+
+    private func resample(_ input: [Float], to count: Int) -> [Float] {
+        guard !input.isEmpty, count > 0 else {
+            return Array(repeating: 0, count: count)
+        }
+        if input.count == count { return input }
+        var result: [Float] = []
+        let step = Double(input.count) / Double(count)
+        for i in 0 ..< count {
+            let position = Double(i) * step
+            let index = Int(position)
+            if index >= input.count - 1 {
+                result.append(input[input.count - 1])
+            } else {
+                let fraction = Float(position - Double(index))
+                let interpolated = input[index] * (1 - fraction) + input[index + 1] * fraction
+                result.append(interpolated)
+            }
+        }
+        return result
+    }
+}
+
+#Preview {
+    let levels: [Float] = (0 ..< 80).map { _ in Float.random(in: 0.05 ... 1.0) }
+    VoiceMemoWaveformView(levels: levels, progress: 0.4)
+        .frame(height: 32)
+        .padding()
+}

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
@@ -217,7 +217,32 @@ struct MessagesGroupItemView: View {
     private func attachmentView(for attachment: HydratedAttachment) -> some View {
         let isBlurred = attachment.isHiddenByOwner || (!message.sender.isCurrentUser && shouldBlurPhotos && !attachment.isRevealed)
 
-        if attachment.mediaType == .file {
+        if attachment.mediaType == .audio {
+            let playAction: () -> Void = {
+                NotificationCenter.default.post(
+                    name: .voiceMemoPlaybackRequested,
+                    object: nil,
+                    userInfo: ["messageId": message.messageId, "attachmentKey": attachment.key]
+                )
+            }
+            MessageContainer(style: bubbleType, isOutgoing: message.sender.isCurrentUser) {
+                VoiceMemoBubbleContent(
+                    message: message,
+                    attachment: attachment,
+                    isOutgoing: message.sender.isCurrentUser,
+                    player: .shared,
+                    isLoading: false
+                )
+            }
+            .padding(.trailing, message.sender.isCurrentUser ? DesignConstants.Spacing.step4x : 0)
+            .messageGesture(
+                message: message,
+                bubbleStyle: bubbleType,
+                onSingleTap: playAction,
+                onReply: onReply
+            )
+            .id(message.messageId)
+        } else if attachment.mediaType == .file {
             let fileTapAction: () -> Void = { onOpenFile?(attachment) }
             FileAttachmentBubble(
                 attachment: attachment,

--- a/Convos/Conversation Detail/Messages/MessagesView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesView.swift
@@ -65,6 +65,9 @@ struct MessagesView<BottomBarContent: View>: View {
     let isAssistantEnabled: Bool
     let onBottomOverscrollChanged: (CGFloat) -> Void
     let onBottomOverscrollReleased: (CGFloat) -> Void
+    let onVoiceMemoTap: () -> Void
+    @Bindable var voiceMemoRecorder: VoiceMemoRecorder
+    let onSendVoiceMemo: () -> Void
     let onConvosAction: () -> Void
     @ViewBuilder let bottomBarContent: () -> BottomBarContent
 
@@ -139,6 +142,9 @@ struct MessagesView<BottomBarContent: View>: View {
                 onDisplayNameEndedEditing: onDisplayNameEndedEditing,
                 onVideoSelected: onVideoSelected,
                 onProfileSettings: onProfileSettings,
+                onVoiceMemoTap: onVoiceMemoTap,
+                voiceMemoRecorder: voiceMemoRecorder,
+                onSendVoiceMemo: onSendVoiceMemo,
                 onConvosAction: onConvosAction,
                 onBaseHeightChanged: { height in
                     bottomBarHeight = height

--- a/Convos/Shared Views/FocusCoordinator.swift
+++ b/Convos/Shared Views/FocusCoordinator.swift
@@ -103,19 +103,22 @@ final class FocusCoordinator {
             return previousFocus ?? defaultFocus ?? .message
 
         case (.displayName, .editProfile),
-            (.message, .editProfile):
+            (.message, .editProfile),
+            (.voiceMemoRecording, .editProfile):
             return .message
 
         case (.conversationName, .conversationSettings):
             // After editing conversation name in settings, move to message field (or default)
             return defaultFocus ?? .message
 
-        case (.message, .conversation):
+        case (.message, .conversation),
+            (.voiceMemoRecording, .conversation):
             // When sending a message, always re-focus the message field
             return .message
 
-        case (.message, _):
-            // Message field ends editing, go to default
+        case (.message, _),
+            (.voiceMemoRecording, _):
+            // Message field and voice memo keeper end editing, go to default
             return defaultFocus
 
         default:
@@ -288,9 +291,9 @@ final class FocusCoordinator {
     }
 
     private func updateFocusForSizeClassChange() {
-        // Only auto-adjust if we're currently at nil or .message
+        // Only auto-adjust if we're currently at nil, .message, or .voiceMemoRecording
         // Don't interrupt active editing of displayName or conversationName
-        guard currentFocus == nil || currentFocus == .message else {
+        guard currentFocus == nil || currentFocus == .message || currentFocus == .voiceMemoRecording else {
             return
         }
 

--- a/ConvosCore/Sources/ConvosCore/Inboxes/ConversationStateMachine.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/ConversationStateMachine.swift
@@ -279,6 +279,11 @@ public actor ConversationStateMachine {
         return try await writer.sendVideo(at: fileURL, replyToMessageId: replyToMessageId)
     }
 
+    func sendVoiceMemo(at fileURL: URL, duration: TimeInterval, waveformLevels: [Float]? = nil, replyToMessageId: String? = nil) async throws -> String {
+        let writer = try await getOrCreateMessageWriter()
+        return try await writer.sendVoiceMemo(at: fileURL, duration: duration, waveformLevels: waveformLevels, replyToMessageId: replyToMessageId)
+    }
+
     func sendReply(text: String, toMessageWithClientId parentClientMessageId: String) async throws {
         let writer = try await getOrCreateMessageWriter()
         try await writer.sendReply(text: text, toMessageWithClientId: parentClientMessageId)

--- a/ConvosCore/Sources/ConvosCore/Inboxes/MessagingService+PushNotifications.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/MessagingService+PushNotifications.swift
@@ -2,6 +2,7 @@ import Combine
 import ConvosProfiles
 import Foundation
 import GRDB
+import UniformTypeIdentifiers
 import UserNotifications
 @preconcurrency import XMTPiOS
 
@@ -462,11 +463,65 @@ extension MessagingService {
             return nil
 
         case ContentTypeRemoteAttachment, ContentTypeMultiRemoteAttachment:
-            return shouldShowSenderName ? "\(senderName) sent a photo" : "sent a photo"
+            let attachmentText = try attachmentNotificationText(for: decodedMessage)
+            return shouldShowSenderName ? "\(senderName) sent \(attachmentText)" : "sent \(attachmentText)"
 
         default:
             return nil
         }
+    }
+
+    private func attachmentNotificationText(for decodedMessage: DecodedMessage) throws -> String {
+        let content = try decodedMessage.content() as Any
+
+        if let attachment = content as? RemoteAttachment {
+            return attachmentPreviewLabel(for: attachment.filename)
+        }
+
+        if let attachments = content as? [RemoteAttachment] {
+            return attachmentsPreviewLabel(for: attachments)
+        }
+
+        return "an attachment"
+    }
+
+    private func attachmentsPreviewLabel(for attachments: [RemoteAttachment]) -> String {
+        guard attachments.count > 1 else {
+            return attachmentPreviewLabel(for: attachments.first?.filename)
+        }
+
+        let mediaTypes = attachments.map { mediaType(for: $0.filename) }
+        if let firstType = mediaTypes.first, mediaTypes.allSatisfy({ $0 == firstType }) {
+            switch firstType {
+            case .image: return "\(attachments.count) photos"
+            case .video: return "\(attachments.count) videos"
+            case .audio: return "\(attachments.count) voice memos"
+            case .file: return "\(attachments.count) files"
+            case .unknown: return "\(attachments.count) attachments"
+            }
+        }
+
+        return "\(attachments.count) attachments"
+    }
+
+    private func attachmentPreviewLabel(for filename: String?) -> String {
+        switch mediaType(for: filename) {
+        case .image: return "a photo"
+        case .video: return "a video"
+        case .audio: return "a voice memo"
+        case .file: return "a file"
+        case .unknown: return "an attachment"
+        }
+    }
+
+    private func mediaType(for filename: String?) -> MediaType {
+        guard let filename else { return .unknown }
+        let ext = (filename as NSString).pathExtension.lowercased()
+        guard !ext.isEmpty, let utType = UTType(filenameExtension: ext) else { return .unknown }
+        if utType.conforms(to: .image) { return .image }
+        if utType.conforms(to: .movie) || utType.conforms(to: .video) { return .video }
+        if utType.conforms(to: .audio) { return .audio }
+        return .file
     }
 
     private func getSourceMessageText(messageId: String, conversationId: String) async throws -> String? {

--- a/ConvosCore/Sources/ConvosCore/Messaging/VoiceMemoPlayer.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/VoiceMemoPlayer.swift
@@ -1,0 +1,120 @@
+import AVFoundation
+import Foundation
+
+public enum VoiceMemoPlaybackState: Sendable {
+    case idle
+    case loading
+    case playing
+    case paused
+}
+
+@MainActor
+@Observable
+public final class VoiceMemoPlayer: NSObject {
+    public static let shared: VoiceMemoPlayer = VoiceMemoPlayer()
+
+    public var state: VoiceMemoPlaybackState = .idle
+    public var currentTime: TimeInterval = 0
+    public var duration: TimeInterval = 0
+    public var progress: Double = 0
+    public var currentlyPlayingMessageId: String?
+
+    private var audioPlayer: AVAudioPlayer?
+    private var progressTimer: Timer?
+
+    private override init() {
+        super.init()
+    }
+
+    public func play(data: Data, messageId: String) throws {
+        stop()
+
+        let session = AVAudioSession.sharedInstance()
+        try session.setCategory(.playback, mode: .default)
+        try session.setActive(true)
+
+        let player = try AVAudioPlayer(data: data)
+        player.delegate = self
+        player.prepareToPlay()
+
+        audioPlayer = player
+        duration = player.duration
+        currentTime = 0
+        progress = 0
+        currentlyPlayingMessageId = messageId
+
+        guard player.play() else {
+            stop()
+            return
+        }
+        state = .playing
+
+        progressTimer = Timer.scheduledTimer(withTimeInterval: 1.0 / 30.0, repeats: true) { [weak self] _ in
+            Task { @MainActor in
+                self?.updateProgress()
+            }
+        }
+    }
+
+    public func pause() {
+        audioPlayer?.pause()
+        progressTimer?.invalidate()
+        progressTimer = nil
+        state = .paused
+    }
+
+    public func resume() {
+        guard audioPlayer != nil else { return }
+        audioPlayer?.play()
+        state = .playing
+        progressTimer?.invalidate()
+        progressTimer = Timer.scheduledTimer(withTimeInterval: 1.0 / 30.0, repeats: true) { [weak self] _ in
+            Task { @MainActor in
+                self?.updateProgress()
+            }
+        }
+    }
+
+    public func stop() {
+        progressTimer?.invalidate()
+        progressTimer = nil
+        audioPlayer?.stop()
+        audioPlayer = nil
+        state = .idle
+        currentTime = 0
+        progress = 0
+        currentlyPlayingMessageId = nil
+    }
+
+    public func togglePlayback(data: Data, messageId: String) throws {
+        if currentlyPlayingMessageId == messageId {
+            switch state {
+            case .playing:
+                pause()
+            case .paused:
+                resume()
+            default:
+                try play(data: data, messageId: messageId)
+            }
+        } else {
+            try play(data: data, messageId: messageId)
+        }
+    }
+
+    private func updateProgress() {
+        guard let player = audioPlayer else { return }
+        currentTime = player.currentTime
+        duration = player.duration
+        progress = player.duration > 0 ? player.currentTime / player.duration : 0
+    }
+}
+
+extension VoiceMemoPlayer: @preconcurrency AVAudioPlayerDelegate {
+    public func audioPlayerDidFinishPlaying(_ player: AVAudioPlayer, successfully flag: Bool) {
+        Task { @MainActor in self.stop() }
+    }
+
+    public func audioPlayerBeginInterruption(_ player: AVAudioPlayer) {
+        Task { @MainActor in self.pause() }
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Messaging/VoiceMemoRecorder.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/VoiceMemoRecorder.swift
@@ -1,0 +1,165 @@
+import AVFoundation
+import Combine
+import Foundation
+
+public enum VoiceMemoRecorderState: Sendable {
+    case idle
+    case recording
+    case recorded(URL, TimeInterval)
+}
+
+@MainActor
+@Observable
+public final class VoiceMemoRecorder: NSObject {
+    public var state: VoiceMemoRecorderState = .idle
+    public var duration: TimeInterval = 0
+    public var audioLevels: [Float] = []
+
+    private var audioRecorder: AVAudioRecorder?
+    private var levelTimer: Timer?
+    private var durationTimer: Timer?
+    private var recordingURL: URL?
+
+    private let maxDuration: TimeInterval = 300
+
+    public override init() {
+        super.init()
+    }
+
+    public func startRecording() throws {
+        guard case .idle = state else { return }
+
+        levelTimer?.invalidate()
+        durationTimer?.invalidate()
+
+        let session = AVAudioSession.sharedInstance()
+        try session.setCategory(.playAndRecord, mode: .default, options: [.defaultToSpeaker])
+        try session.setActive(true)
+
+        let filename = "voice_memo_\(Int(Date().timeIntervalSince1970)).m4a"
+        let tempDir = FileManager.default.temporaryDirectory
+        let url = tempDir.appendingPathComponent(filename)
+        recordingURL = url
+
+        let settings: [String: Any] = [
+            AVFormatIDKey: Int(kAudioFormatMPEG4AAC),
+            AVSampleRateKey: 44100.0,
+            AVNumberOfChannelsKey: 1,
+            AVEncoderAudioQualityKey: AVAudioQuality.high.rawValue,
+            AVEncoderBitRateKey: 64000,
+        ]
+
+        let recorder = try AVAudioRecorder(url: url, settings: settings)
+        recorder.delegate = self
+        recorder.isMeteringEnabled = true
+        guard recorder.record() else {
+            state = .idle
+            return
+        }
+        audioRecorder = recorder
+
+        duration = 0
+        audioLevels = []
+        state = .recording
+
+        levelTimer = Timer.scheduledTimer(withTimeInterval: 1.0 / 30.0, repeats: true) { [weak self] _ in
+            Task { @MainActor in
+                self?.sampleLevel()
+            }
+        }
+
+        durationTimer = Timer.scheduledTimer(withTimeInterval: 0.1, repeats: true) { [weak self] _ in
+            Task { @MainActor in
+                guard let self, let recorder = self.audioRecorder, recorder.isRecording else { return }
+                self.duration = recorder.currentTime
+                if self.duration >= self.maxDuration {
+                    self.stopRecording()
+                }
+            }
+        }
+    }
+
+    public func stopRecording() {
+        levelTimer?.invalidate()
+        levelTimer = nil
+        durationTimer?.invalidate()
+        durationTimer = nil
+
+        guard let recorder = audioRecorder else { return }
+        let finalDuration = recorder.currentTime
+
+        if recorder.isRecording {
+            recorder.stop()
+        }
+
+        if finalDuration < 1.0 {
+            cancelRecording()
+            return
+        }
+
+        if let url = recordingURL {
+            duration = finalDuration
+            state = .recorded(url, finalDuration)
+        }
+    }
+
+    public func resetState() {
+        levelTimer?.invalidate()
+        levelTimer = nil
+        durationTimer?.invalidate()
+        durationTimer = nil
+
+        audioRecorder?.stop()
+        audioRecorder = nil
+        recordingURL = nil
+        duration = 0
+        audioLevels = []
+        state = .idle
+    }
+
+    public func cancelRecording() {
+        levelTimer?.invalidate()
+        levelTimer = nil
+        durationTimer?.invalidate()
+        durationTimer = nil
+
+        audioRecorder?.stop()
+        audioRecorder = nil
+
+        if let url = recordingURL {
+            try? FileManager.default.removeItem(at: url)
+        }
+        recordingURL = nil
+        duration = 0
+        audioLevels = []
+        state = .idle
+    }
+
+    private func sampleLevel() {
+        guard let recorder = audioRecorder, recorder.isRecording else { return }
+        recorder.updateMeters()
+        let power = recorder.averagePower(forChannel: 0)
+        let normalized = normalizedPower(power)
+        audioLevels.append(normalized)
+    }
+
+    private func normalizedPower(_ power: Float) -> Float {
+        let minDb: Float = -50
+        let maxDb: Float = 0
+        let clampedPower = max(min(power, maxDb), minDb)
+        let normalized = (clampedPower - minDb) / (maxDb - minDb)
+        return normalized
+    }
+}
+
+extension VoiceMemoRecorder: @preconcurrency AVAudioRecorderDelegate {
+    public func audioRecorderDidFinishRecording(_ recorder: AVAudioRecorder, successfully flag: Bool) {
+        Task { @MainActor in
+            if !flag { self.cancelRecording() }
+        }
+    }
+
+    public func audioRecorderBeginInterruption(_ recorder: AVAudioRecorder) {
+        Task { @MainActor in self.stopRecording() }
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Messaging/VoiceMemoRecorder.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/VoiceMemoRecorder.swift
@@ -53,6 +53,10 @@ public final class VoiceMemoRecorder: NSObject {
         recorder.delegate = self
         recorder.isMeteringEnabled = true
         guard recorder.record() else {
+            if let url = recordingURL {
+                try? FileManager.default.removeItem(at: url)
+            }
+            recordingURL = nil
             state = .idle
             return
         }

--- a/ConvosCore/Sources/ConvosCore/Messaging/VoiceMemoRecorder.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/VoiceMemoRecorder.swift
@@ -103,6 +103,7 @@ public final class VoiceMemoRecorder: NSObject {
 
         if let url = recordingURL {
             duration = finalDuration
+            audioRecorder = nil
             state = .recorded(url, finalDuration)
         }
     }

--- a/ConvosCore/Sources/ConvosCore/Messaging/VoiceMemoWaveformAnalyzer.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/VoiceMemoWaveformAnalyzer.swift
@@ -1,0 +1,80 @@
+import AVFoundation
+import Foundation
+
+public enum VoiceMemoWaveformAnalyzer {
+    public static func analyzeLevels(from data: Data, sampleCount: Int = 40) async -> [Float] {
+        await Task.detached(priority: .userInitiated) {
+            computeLevels(from: data, sampleCount: sampleCount)
+        }.value
+    }
+
+    public static func analyzeLevels(from url: URL, sampleCount: Int = 40) async -> [Float] {
+        await Task.detached(priority: .userInitiated) {
+            guard let data = try? Data(contentsOf: url) else {
+                return Array(repeating: Float(0.1), count: sampleCount)
+            }
+            return computeLevels(from: data, sampleCount: sampleCount)
+        }.value
+    }
+
+    private static func computeLevels(from data: Data, sampleCount: Int) -> [Float] {
+        guard let audioFile = createAudioFile(from: data) else {
+            return Array(repeating: Float(0.1), count: sampleCount)
+        }
+
+        let frameCount = AVAudioFrameCount(audioFile.length)
+        guard frameCount > 0, let buffer = AVAudioPCMBuffer(
+            pcmFormat: audioFile.processingFormat,
+            frameCapacity: frameCount
+        ) else {
+            return Array(repeating: Float(0.1), count: sampleCount)
+        }
+
+        do {
+            try audioFile.read(into: buffer)
+        } catch {
+            return Array(repeating: Float(0.1), count: sampleCount)
+        }
+
+        guard let channelData = buffer.floatChannelData?[0] else {
+            return Array(repeating: Float(0.1), count: sampleCount)
+        }
+
+        let totalSamples = Int(buffer.frameLength)
+        let samplesPerBucket = max(totalSamples / sampleCount, 1)
+        var levels: [Float] = []
+
+        for i in 0 ..< sampleCount {
+            let start = i * samplesPerBucket
+            let end = min(start + samplesPerBucket, totalSamples)
+            guard start < end else {
+                levels.append(0.05)
+                continue
+            }
+
+            var sum: Float = 0
+            for j in start ..< end {
+                sum += abs(channelData[j])
+            }
+            let avg = sum / Float(end - start)
+            levels.append(max(avg, 0.05))
+        }
+
+        let referenceAmplitude: Float = 0.15
+        return levels.map { min($0 / referenceAmplitude, 1.0) }
+    }
+
+    private static func createAudioFile(from data: Data) -> AVAudioFile? {
+        let tempURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("waveform_\(UUID().uuidString).m4a")
+        do {
+            try data.write(to: tempURL)
+            let file = try AVAudioFile(forReading: tempURL)
+            try? FileManager.default.removeItem(at: tempURL)
+            return file
+        } catch {
+            try? FileManager.default.removeItem(at: tempURL)
+            return nil
+        }
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Mocks/MockConversationStateManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Mocks/MockConversationStateManager.swift
@@ -102,6 +102,7 @@ public final class MockConversationStateManager: ConversationStateManagerProtoco
     public func sendEagerPhoto(trackingKey: String) async throws {}
     public func cancelEagerUpload(trackingKey: String) async {}
     public func sendVideo(at fileURL: URL, replyToMessageId: String?) async throws -> String { UUID().uuidString }
+    public func sendVoiceMemo(at fileURL: URL, duration: TimeInterval, waveformLevels: [Float]?, replyToMessageId: String?) async throws -> String { UUID().uuidString }
     public func sendReply(text: String, toMessageWithClientId parentClientMessageId: String) async throws {}
     public func sendEagerPhotoReply(trackingKey: String, toMessageWithClientId parentClientMessageId: String) async throws {}
     public func sendReply(text: String, afterPhoto trackingKey: String?, toMessageWithClientId parentClientMessageId: String) async throws {}

--- a/ConvosCore/Sources/ConvosCore/Mocks/MockOutgoingMessageWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Mocks/MockOutgoingMessageWriter.swift
@@ -46,6 +46,10 @@ public final class MockOutgoingMessageWriter: OutgoingMessageWriterProtocol, @un
         return UUID().uuidString
     }
 
+    public func sendVoiceMemo(at fileURL: URL, duration: TimeInterval, waveformLevels: [Float]?, replyToMessageId: String?) async throws -> String {
+        return UUID().uuidString
+    }
+
     public func sendReply(text: String, toMessageWithClientId parentClientMessageId: String) async throws {
         try await send(text: text)
     }

--- a/ConvosCore/Sources/ConvosCore/Mocks/MockRepositories.swift
+++ b/ConvosCore/Sources/ConvosCore/Mocks/MockRepositories.swift
@@ -248,4 +248,7 @@ public final class MockAttachmentLocalStateWriter: AttachmentLocalStateWriterPro
 
     public func saveWaveformLevels(_ levels: [Float], for attachmentKey: String) async throws {
     }
+
+    public func saveDuration(_ duration: Double, for attachmentKey: String) async throws {
+    }
 }

--- a/ConvosCore/Sources/ConvosCore/Mocks/MockRepositories.swift
+++ b/ConvosCore/Sources/ConvosCore/Mocks/MockRepositories.swift
@@ -245,4 +245,7 @@ public final class MockAttachmentLocalStateWriter: AttachmentLocalStateWriterPro
             revealedAttachments[newKey] = conversationId
         }
     }
+
+    public func saveWaveformLevels(_ levels: [Float], for attachmentKey: String) async throws {
+    }
 }

--- a/ConvosCore/Sources/ConvosCore/Storage/Database Models/AttachmentLocalState.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Database Models/AttachmentLocalState.swift
@@ -14,6 +14,7 @@ struct AttachmentLocalState: FetchableRecord, PersistableRecord, Codable, Hashab
         static let isHiddenByOwner: Column = Column(CodingKeys.isHiddenByOwner)
         static let mimeType: Column = Column(CodingKeys.mimeType)
         static let waveformLevels: Column = Column(CodingKeys.waveformLevels)
+        static let duration: Column = Column(CodingKeys.duration)
     }
 
     let attachmentKey: String
@@ -25,6 +26,7 @@ struct AttachmentLocalState: FetchableRecord, PersistableRecord, Codable, Hashab
     let isHiddenByOwner: Bool
     let mimeType: String?
     let waveformLevels: String?
+    let duration: Double?
 
     static let conversationForeignKey: ForeignKey = ForeignKey([Columns.conversationId], to: [DBConversation.Columns.id])
     static let conversation: BelongsToAssociation<AttachmentLocalState, DBConversation> = belongsTo(DBConversation.self, using: conversationForeignKey)
@@ -38,7 +40,8 @@ struct AttachmentLocalState: FetchableRecord, PersistableRecord, Codable, Hashab
         height: Int? = nil,
         isHiddenByOwner: Bool = false,
         mimeType: String? = nil,
-        waveformLevels: String? = nil
+        waveformLevels: String? = nil,
+        duration: Double? = nil
     ) {
         self.attachmentKey = attachmentKey
         self.conversationId = conversationId
@@ -49,5 +52,6 @@ struct AttachmentLocalState: FetchableRecord, PersistableRecord, Codable, Hashab
         self.isHiddenByOwner = isHiddenByOwner
         self.mimeType = mimeType
         self.waveformLevels = waveformLevels
+        self.duration = duration
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Storage/Database Models/AttachmentLocalState.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Database Models/AttachmentLocalState.swift
@@ -13,6 +13,7 @@ struct AttachmentLocalState: FetchableRecord, PersistableRecord, Codable, Hashab
         static let height: Column = Column(CodingKeys.height)
         static let isHiddenByOwner: Column = Column(CodingKeys.isHiddenByOwner)
         static let mimeType: Column = Column(CodingKeys.mimeType)
+        static let waveformLevels: Column = Column(CodingKeys.waveformLevels)
     }
 
     let attachmentKey: String
@@ -23,6 +24,7 @@ struct AttachmentLocalState: FetchableRecord, PersistableRecord, Codable, Hashab
     let height: Int?
     let isHiddenByOwner: Bool
     let mimeType: String?
+    let waveformLevels: String?
 
     static let conversationForeignKey: ForeignKey = ForeignKey([Columns.conversationId], to: [DBConversation.Columns.id])
     static let conversation: BelongsToAssociation<AttachmentLocalState, DBConversation> = belongsTo(DBConversation.self, using: conversationForeignKey)
@@ -35,7 +37,8 @@ struct AttachmentLocalState: FetchableRecord, PersistableRecord, Codable, Hashab
         width: Int? = nil,
         height: Int? = nil,
         isHiddenByOwner: Bool = false,
-        mimeType: String? = nil
+        mimeType: String? = nil,
+        waveformLevels: String? = nil
     ) {
         self.attachmentKey = attachmentKey
         self.conversationId = conversationId
@@ -45,5 +48,6 @@ struct AttachmentLocalState: FetchableRecord, PersistableRecord, Codable, Hashab
         self.height = height
         self.isHiddenByOwner = isHiddenByOwner
         self.mimeType = mimeType
+        self.waveformLevels = waveformLevels
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Storage/Hydration/DBMessage+MessagePreview.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Hydration/DBMessage+MessagePreview.swift
@@ -106,71 +106,72 @@ extension DBLastMessageWithSource {
     }
 
     static func attachmentsPreviewString(attachmentUrls: [String], count: Int) -> String {
-        var hasVideo = false
-        var hasAudio = false
-        var hasFile = false
+        var hasNonImage = false
+        var primaryType: MediaType = .image
         var filename: String?
 
         for url in attachmentUrls {
-            if let stored = try? StoredRemoteAttachment.fromJSON(url) {
-                classifyStoredAttachment(stored, hasVideo: &hasVideo, hasAudio: &hasAudio, hasFile: &hasFile, filename: &filename)
-            } else if url.hasPrefix("file://") {
-                classifyFileURL(url, hasVideo: &hasVideo, hasAudio: &hasAudio, hasFile: &hasFile, filename: &filename)
+            let classified = classifyAttachment(url)
+            if classified.mediaType != .image {
+                hasNonImage = true
+                primaryType = classified.mediaType
+            }
+            if classified.filename != nil {
+                filename = classified.filename
             }
         }
 
         if count <= 1 {
-            if hasAudio { return "a voice memo" }
-            if hasFile, let filename { return filename }
-            if hasFile { return "a file" }
-            if hasVideo { return "a video" }
-            return "a photo"
+            if primaryType == .file, let filename { return filename }
+            return primaryType.previewLabel
         }
-        if hasFile || hasVideo || hasAudio { return "\(count) attachments" }
+        if hasNonImage { return "\(count) attachments" }
         return "\(count) photos"
     }
 
-    private static func classifyStoredAttachment(
-        _ stored: StoredRemoteAttachment,
-        hasVideo: inout Bool,
-        hasAudio: inout Bool,
-        hasFile: inout Bool,
-        filename: inout String?
-    ) {
-        if stored.mimeType?.hasPrefix("video/") == true {
-            hasVideo = true
-        } else if stored.mimeType?.hasPrefix("audio/") == true {
-            hasAudio = true
-        } else if let mime = stored.mimeType, !mime.hasPrefix("image/") {
-            hasFile = true
-            filename = stored.filename
-        } else if let fn = stored.filename {
-            let ext = (fn as NSString).pathExtension.lowercased()
-            if !ext.isEmpty, let utType = UTType(filenameExtension: ext), !utType.conforms(to: .image) {
-                hasFile = true
-                filename = fn
-            }
+    private static func classifyAttachment(_ url: String) -> (mediaType: MediaType, filename: String?) {
+        if let stored = try? StoredRemoteAttachment.fromJSON(url) {
+            return classifyStoredAttachment(stored)
+        } else if url.hasPrefix("file://") {
+            return classifyFileURL(url)
         }
+        return (.image, nil)
     }
 
-    private static func classifyFileURL(
-        _ url: String,
-        hasVideo: inout Bool,
-        hasAudio: inout Bool,
-        hasFile: inout Bool,
-        filename: inout String?
-    ) {
-        guard let fn = extractFilenameFromURL(url) else { return }
-        let ext = (fn as NSString).pathExtension.lowercased()
-        guard !ext.isEmpty, let utType = UTType(filenameExtension: ext) else { return }
-        if utType.conforms(to: .movie) || utType.conforms(to: .video) {
-            hasVideo = true
-        } else if utType.conforms(to: .audio) {
-            hasAudio = true
-        } else if !utType.conforms(to: .image) {
-            hasFile = true
-            filename = fn
+    private static func classifyStoredAttachment(_ stored: StoredRemoteAttachment) -> (mediaType: MediaType, filename: String?) {
+        if stored.mimeType?.hasPrefix("video/") == true {
+            return (.video, stored.filename)
+        } else if stored.mimeType?.hasPrefix("audio/") == true {
+            return (.audio, stored.filename)
+        } else if let mime = stored.mimeType, !mime.hasPrefix("image/") {
+            return (.file, stored.filename)
+        } else if let fn = stored.filename {
+            let ext = (fn as NSString).pathExtension.lowercased()
+            if !ext.isEmpty, let utType = UTType(filenameExtension: ext) {
+                if utType.conforms(to: .movie) || utType.conforms(to: .video) {
+                    return (.video, fn)
+                } else if utType.conforms(to: .audio) {
+                    return (.audio, fn)
+                } else if !utType.conforms(to: .image) {
+                    return (.file, fn)
+                }
+            }
         }
+        return (.image, stored.filename)
+    }
+
+    private static func classifyFileURL(_ url: String) -> (mediaType: MediaType, filename: String?) {
+        guard let fn = extractFilenameFromURL(url) else { return (.image, nil) }
+        let ext = (fn as NSString).pathExtension.lowercased()
+        guard !ext.isEmpty, let utType = UTType(filenameExtension: ext) else { return (.image, fn) }
+        if utType.conforms(to: .movie) || utType.conforms(to: .video) {
+            return (.video, fn)
+        } else if utType.conforms(to: .audio) {
+            return (.audio, fn)
+        } else if !utType.conforms(to: .image) {
+            return (.file, fn)
+        }
+        return (.image, fn)
     }
 
     private static func extractFilenameFromURL(_ url: String) -> String? {

--- a/ConvosCore/Sources/ConvosCore/Storage/Hydration/DBMessage+MessagePreview.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Hydration/DBMessage+MessagePreview.swift
@@ -107,35 +107,40 @@ extension DBLastMessageWithSource {
 
     static func attachmentsPreviewString(attachmentUrls: [String], count: Int) -> String {
         var hasVideo = false
+        var hasAudio = false
         var hasFile = false
         var filename: String?
 
         for url in attachmentUrls {
             if let stored = try? StoredRemoteAttachment.fromJSON(url) {
-                classifyStoredAttachment(stored, hasVideo: &hasVideo, hasFile: &hasFile, filename: &filename)
+                classifyStoredAttachment(stored, hasVideo: &hasVideo, hasAudio: &hasAudio, hasFile: &hasFile, filename: &filename)
             } else if url.hasPrefix("file://") {
-                classifyFileURL(url, hasVideo: &hasVideo, hasFile: &hasFile, filename: &filename)
+                classifyFileURL(url, hasVideo: &hasVideo, hasAudio: &hasAudio, hasFile: &hasFile, filename: &filename)
             }
         }
 
         if count <= 1 {
+            if hasAudio { return "a voice memo" }
             if hasFile, let filename { return filename }
             if hasFile { return "a file" }
             if hasVideo { return "a video" }
             return "a photo"
         }
-        if hasFile || hasVideo { return "\(count) attachments" }
+        if hasFile || hasVideo || hasAudio { return "\(count) attachments" }
         return "\(count) photos"
     }
 
     private static func classifyStoredAttachment(
         _ stored: StoredRemoteAttachment,
         hasVideo: inout Bool,
+        hasAudio: inout Bool,
         hasFile: inout Bool,
         filename: inout String?
     ) {
         if stored.mimeType?.hasPrefix("video/") == true {
             hasVideo = true
+        } else if stored.mimeType?.hasPrefix("audio/") == true {
+            hasAudio = true
         } else if let mime = stored.mimeType, !mime.hasPrefix("image/") {
             hasFile = true
             filename = stored.filename
@@ -151,6 +156,7 @@ extension DBLastMessageWithSource {
     private static func classifyFileURL(
         _ url: String,
         hasVideo: inout Bool,
+        hasAudio: inout Bool,
         hasFile: inout Bool,
         filename: inout String?
     ) {
@@ -159,6 +165,8 @@ extension DBLastMessageWithSource {
         guard !ext.isEmpty, let utType = UTType(filenameExtension: ext) else { return }
         if utType.conforms(to: .movie) || utType.conforms(to: .video) {
             hasVideo = true
+        } else if utType.conforms(to: .audio) {
+            hasAudio = true
         } else if !utType.conforms(to: .image) {
             hasFile = true
             filename = fn

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/HydratedAttachment.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/HydratedAttachment.swift
@@ -19,6 +19,7 @@ public struct HydratedAttachment: Hashable, Codable, Sendable {
     public let thumbnailDataBase64: String?
     public let fileSize: Int?
     public let filename: String?
+    public let waveformLevels: [Float]?
 
     public var filenameExtension: String? {
         guard let filename else { return nil }
@@ -68,7 +69,8 @@ public struct HydratedAttachment: Hashable, Codable, Sendable {
         duration: Double? = nil,
         thumbnailDataBase64: String? = nil,
         fileSize: Int? = nil,
-        filename: String? = nil
+        filename: String? = nil,
+        waveformLevels: [Float]? = nil
     ) {
         self.key = key
         self.isRevealed = isRevealed
@@ -80,5 +82,6 @@ public struct HydratedAttachment: Hashable, Codable, Sendable {
         self.thumbnailDataBase64 = thumbnailDataBase64
         self.fileSize = fileSize
         self.filename = filename
+        self.waveformLevels = waveformLevels
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/HydratedAttachment.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/HydratedAttachment.swift
@@ -6,6 +6,20 @@ public enum MediaType: String, Codable, Sendable {
     case audio
     case file
     case unknown
+
+    public var previewLabel: String {
+        switch self {
+        case .image: return "a photo"
+        case .video: return "a video"
+        case .audio: return "a voice memo"
+        case .file: return "a file"
+        case .unknown: return "an attachment"
+        }
+    }
+
+    public var isFullBleed: Bool {
+        self == .image || self == .video
+    }
 }
 
 public struct HydratedAttachment: Hashable, Codable, Sendable {

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/MessageContent.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/MessageContent.swift
@@ -69,9 +69,9 @@ public enum MessageContent: Hashable, Codable, Sendable {
     public var isFullBleedAttachment: Bool {
         switch self {
         case .attachment(let attachment):
-            attachment.mediaType == .image || attachment.mediaType == .video
+            attachment.mediaType.isFullBleed
         case .attachments(let attachments):
-            attachments.first.map { $0.mediaType == .image || $0.mediaType == .video } ?? false
+            attachments.first?.mediaType.isFullBleed ?? false
         default:
             false
         }

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/MessageContent.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/MessageContent.swift
@@ -69,9 +69,9 @@ public enum MessageContent: Hashable, Codable, Sendable {
     public var isFullBleedAttachment: Bool {
         switch self {
         case .attachment(let attachment):
-            attachment.mediaType != .file
+            attachment.mediaType == .image || attachment.mediaType == .video
         case .attachments(let attachments):
-            attachments.first.map { $0.mediaType != .file } ?? false
+            attachments.first.map { $0.mediaType == .image || $0.mediaType == .video } ?? false
         default:
             false
         }

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/MessagesListProcessor.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/MessagesListProcessor.swift
@@ -135,14 +135,14 @@ public final class MessagesListProcessor: Sendable {
             }
             isFirstVisible = false
 
-            let isAttachment = content.isAttachment
+            let isFullBleedAttachment = content.isFullBleedAttachment
             let senderId = msg.senderId
 
             if addedDateSeparator {
                 groupStartIndex = index
                 groupEndIndex = index
                 currentSenderId = senderId
-            } else if isAttachment {
+            } else if isFullBleedAttachment {
                 if groupStartIndex >= 0, currentSenderId != nil {
                     flush(
                         &items, messages, groupStartIndex, groupEndIndex,
@@ -180,7 +180,7 @@ public final class MessagesListProcessor: Sendable {
             }
 
             lastMessageDate = messageDate
-            lastWasAttachment = isAttachment
+            lastWasAttachment = isFullBleedAttachment
         }
 
         if groupStartIndex >= 0, currentSenderId != nil {

--- a/ConvosCore/Sources/ConvosCore/Storage/Repositories/MessagesRepository.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Repositories/MessagesRepository.swift
@@ -828,6 +828,13 @@ private func hydrateAttachment(key: String, localState: AttachmentLocalState?) -
         }
     }
 
+    var waveformLevels: [Float]?
+    if let levelsJSON = localState?.waveformLevels,
+       let data = levelsJSON.data(using: .utf8),
+       let decoded = try? JSONDecoder().decode([Float].self, from: data) {
+        waveformLevels = decoded
+    }
+
     return HydratedAttachment(
         key: key,
         isRevealed: localState?.isRevealed ?? false,
@@ -837,6 +844,7 @@ private func hydrateAttachment(key: String, localState: AttachmentLocalState?) -
         mimeType: mimeType,
         duration: duration,
         thumbnailDataBase64: thumbnailDataBase64,
-        filename: filename
+        filename: filename,
+        waveformLevels: waveformLevels
     )
 }

--- a/ConvosCore/Sources/ConvosCore/Storage/Repositories/MessagesRepository.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Repositories/MessagesRepository.swift
@@ -835,6 +835,10 @@ private func hydrateAttachment(key: String, localState: AttachmentLocalState?) -
         waveformLevels = decoded
     }
 
+    if duration == nil {
+        duration = localState?.duration
+    }
+
     return HydratedAttachment(
         key: key,
         isRevealed: localState?.isRevealed ?? false,

--- a/ConvosCore/Sources/ConvosCore/Storage/SharedDatabaseMigrator.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/SharedDatabaseMigrator.swift
@@ -405,6 +405,12 @@ extension SharedDatabaseMigrator {
             }
         }
 
+        migrator.registerMigration("addDurationToAttachmentLocalState") { db in
+            try db.alter(table: "attachmentLocalState") { t in
+                t.add(column: "duration", .double)
+            }
+        }
+
         return migrator
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Storage/SharedDatabaseMigrator.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/SharedDatabaseMigrator.swift
@@ -399,6 +399,12 @@ extension SharedDatabaseMigrator {
             }
         }
 
+        migrator.registerMigration("addWaveformLevelsToAttachmentLocalState") { db in
+            try db.alter(table: "attachmentLocalState") { t in
+                t.add(column: "waveformLevels", .text)
+            }
+        }
+
         return migrator
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/AttachmentLocalStateWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/AttachmentLocalStateWriter.swift
@@ -18,6 +18,7 @@ public protocol AttachmentLocalStateWriterProtocol: Sendable {
         mimeType: String?
     ) async throws
     func migrateKey(from oldKey: String, to newKey: String) async throws
+    func saveWaveformLevels(_ levels: [Float], for attachmentKey: String) async throws
 }
 
 public final class AttachmentLocalStateWriter: AttachmentLocalStateWriterProtocol, Sendable {
@@ -137,7 +138,8 @@ public final class AttachmentLocalStateWriter: AttachmentLocalStateWriterProtoco
                 width: existing.width,
                 height: existing.height,
                 isHiddenByOwner: existing.isHiddenByOwner,
-                mimeType: existing.mimeType
+                mimeType: existing.mimeType,
+                waveformLevels: existing.waveformLevels
             )
             try migrated.save(db)
 
@@ -146,6 +148,16 @@ public final class AttachmentLocalStateWriter: AttachmentLocalStateWriterProtoco
                 .deleteAll(db)
 
             Log.info("[AttachmentLocalState] Migrated from \(oldKey.prefix(30))... to \(newKey.prefix(30))... (dims: \(existing.width ?? -1)x\(existing.height ?? -1))")
+        }
+    }
+
+    public func saveWaveformLevels(_ levels: [Float], for attachmentKey: String) async throws {
+        let levelsJSON = String(data: try JSONEncoder().encode(levels), encoding: .utf8)
+        try await databaseWriter.write { db in
+            try db.execute(
+                sql: "UPDATE attachmentLocalState SET waveformLevels = ? WHERE attachmentKey = ?",
+                arguments: [levelsJSON, attachmentKey]
+            )
         }
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/AttachmentLocalStateWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/AttachmentLocalStateWriter.swift
@@ -154,10 +154,12 @@ public final class AttachmentLocalStateWriter: AttachmentLocalStateWriterProtoco
     public func saveWaveformLevels(_ levels: [Float], for attachmentKey: String) async throws {
         let levelsJSON = String(data: try JSONEncoder().encode(levels), encoding: .utf8)
         try await databaseWriter.write { db in
-            try db.execute(
-                sql: "UPDATE attachmentLocalState SET waveformLevels = ? WHERE attachmentKey = ?",
-                arguments: [levelsJSON, attachmentKey]
-            )
+            let count = try AttachmentLocalState
+                .filter(AttachmentLocalState.Columns.attachmentKey == attachmentKey)
+                .updateAll(db, AttachmentLocalState.Columns.waveformLevels.set(to: levelsJSON))
+            if count == 0 {
+                Log.error("[AttachmentLocalState] No record found for waveform levels save: \(attachmentKey.prefix(50))...")
+            }
         }
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/AttachmentLocalStateWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/AttachmentLocalStateWriter.swift
@@ -19,6 +19,7 @@ public protocol AttachmentLocalStateWriterProtocol: Sendable {
     ) async throws
     func migrateKey(from oldKey: String, to newKey: String) async throws
     func saveWaveformLevels(_ levels: [Float], for attachmentKey: String) async throws
+    func saveDuration(_ duration: Double, for attachmentKey: String) async throws
 }
 
 public final class AttachmentLocalStateWriter: AttachmentLocalStateWriterProtocol, Sendable {
@@ -139,7 +140,8 @@ public final class AttachmentLocalStateWriter: AttachmentLocalStateWriterProtoco
                 height: existing.height,
                 isHiddenByOwner: existing.isHiddenByOwner,
                 mimeType: existing.mimeType,
-                waveformLevels: existing.waveformLevels
+                waveformLevels: existing.waveformLevels,
+                duration: existing.duration
             )
             try migrated.save(db)
 
@@ -159,6 +161,17 @@ public final class AttachmentLocalStateWriter: AttachmentLocalStateWriterProtoco
                 .updateAll(db, AttachmentLocalState.Columns.waveformLevels.set(to: levelsJSON))
             if count == 0 {
                 Log.error("[AttachmentLocalState] No record found for waveform levels save: \(attachmentKey.prefix(50))...")
+            }
+        }
+    }
+
+    public func saveDuration(_ duration: Double, for attachmentKey: String) async throws {
+        try await databaseWriter.write { db in
+            let count = try AttachmentLocalState
+                .filter(AttachmentLocalState.Columns.attachmentKey == attachmentKey)
+                .updateAll(db, AttachmentLocalState.Columns.duration.set(to: duration))
+            if count == 0 {
+                Log.error("[AttachmentLocalState] No record found for duration save: \(attachmentKey.prefix(50))...")
             }
         }
     }

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationStateManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationStateManager.swift
@@ -213,6 +213,10 @@ public final class ConversationStateManager: ConversationStateManagerProtocol, @
         try await stateMachine.sendVideo(at: fileURL, replyToMessageId: replyToMessageId)
     }
 
+    public func sendVoiceMemo(at fileURL: URL, duration: TimeInterval, waveformLevels: [Float]? = nil, replyToMessageId: String?) async throws -> String {
+        try await stateMachine.sendVoiceMemo(at: fileURL, duration: duration, waveformLevels: waveformLevels, replyToMessageId: replyToMessageId)
+    }
+
     public func sendReply(text: String, toMessageWithClientId parentClientMessageId: String) async throws {
         try await stateMachine.sendReply(text: text, toMessageWithClientId: parentClientMessageId)
     }

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/OutgoingMessageWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/OutgoingMessageWriter.swift
@@ -27,6 +27,9 @@ public protocol OutgoingMessageWriterProtocol: Sendable {
     /// Returns a tracking key for dependency management.
     func sendVideo(at fileURL: URL, replyToMessageId: String?) async throws -> String
 
+    /// Send a voice memo from a local audio file URL.
+    func sendVoiceMemo(at fileURL: URL, duration: TimeInterval, waveformLevels: [Float]?, replyToMessageId: String?) async throws -> String
+
     /// Send a text reply to an existing message.
     func sendReply(text: String, toMessageWithClientId parentClientMessageId: String) async throws
 
@@ -627,6 +630,123 @@ actor OutgoingMessageWriter: OutgoingMessageWriterProtocol {
         let fileURL = tempDir.appendingPathComponent("\(taskId).enc")
         try data.write(to: fileURL)
         return fileURL
+    }
+
+    // MARK: - Voice Memo
+
+    func sendVoiceMemo(at fileURL: URL, duration: TimeInterval, waveformLevels: [Float]? = nil, replyToMessageId: String? = nil) async throws -> String {
+        let clientMessageId = UUID().uuidString
+        let filename = "voice_memo_\(Int(Date().timeIntervalSince1970))_\(UUID().uuidString.prefix(8)).m4a"
+        let localCacheURL = try photoService.localCacheURL(for: filename)
+
+        try FileManager.default.createDirectory(
+            at: localCacheURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try FileManager.default.copyItem(at: fileURL, to: localCacheURL)
+
+        let trackingKey = localCacheURL.absoluteString
+
+        try await attachmentLocalStateWriter.saveWithDimensions(
+            attachmentKey: trackingKey,
+            conversationId: conversationId,
+            width: 0,
+            height: 0,
+            mimeType: "audio/m4a"
+        )
+
+        if let waveformLevels {
+            try? await attachmentLocalStateWriter.saveWaveformLevels(waveformLevels, for: trackingKey)
+        }
+
+        var replyContext: ReplyContext?
+        if let replyToMessageId {
+            replyContext = try await resolveReplyContext(parentClientMessageId: replyToMessageId)
+        }
+
+        try await savePhotoToDatabase(clientMessageId: clientMessageId, localCacheURL: localCacheURL, replyContext: replyContext)
+
+        let tracker = PhotoUploadProgressTracker.shared
+        tracker.setStage(.preparing, for: trackingKey)
+
+        do {
+            let inboxReady = try await inboxStateManager.waitForInboxReadyResult()
+
+            let audioData = try Data(contentsOf: fileURL)
+            let attachment = Attachment(
+                filename: filename,
+                mimeType: "audio/m4a",
+                data: audioData
+            )
+
+            let encrypted = try RemoteAttachment.encodeEncrypted(
+                content: attachment,
+                codec: AttachmentCodec()
+            )
+
+            let presignedURLs = try await inboxReady.apiClient.getPresignedUploadURL(
+                filename: filename,
+                contentType: "application/octet-stream"
+            )
+
+            guard let uploadURL = URL(string: presignedURLs.uploadURL) else {
+                throw PhotoAttachmentError.invalidURL
+            }
+
+            let taskId = UUID().uuidString
+            let encryptedFileURL = try saveToTemp(data: encrypted.payload, taskId: taskId)
+
+            tracker.setProgress(stage: .uploading, percentage: 0, for: trackingKey)
+
+            try await backgroundUploadManager.startUpload(
+                fileURL: encryptedFileURL,
+                uploadURL: uploadURL,
+                contentType: "application/octet-stream",
+                taskId: taskId
+            )
+
+            let result = await backgroundUploadManager.waitForCompletion(taskId: taskId)
+
+            guard result.success else {
+                tracker.setStage(.failed, for: trackingKey)
+                try? await markMessageFailed(clientMessageId: clientMessageId)
+                throw result.error ?? PhotoAttachmentError.uploadFailed("Voice memo upload failed")
+            }
+
+            tracker.setStage(.publishing, for: trackingKey)
+
+            let storedAttachment = StoredRemoteAttachment(
+                url: presignedURLs.assetURL,
+                contentDigest: encrypted.digest,
+                secret: encrypted.secret,
+                salt: encrypted.salt,
+                nonce: encrypted.nonce,
+                filename: filename,
+                mimeType: "audio/m4a",
+                mediaDuration: duration
+            )
+
+            let messageId = try await publishAttachment(
+                storedAttachment: storedAttachment,
+                clientMessageId: clientMessageId,
+                trackingKey: trackingKey,
+                thumbnailImage: nil,
+                inboxReady: inboxReady,
+                replyContext: replyContext,
+                mediaType: "voice_memo"
+            )
+
+            try? FileManager.default.removeItem(at: encryptedFileURL)
+
+            QAEvent.emit(.message, "sent", ["id": messageId, "conversation": conversationId, "type": "voice_memo"])
+        } catch {
+            Log.error("Failed to send voice memo: \(error)")
+            tracker.setStage(.failed, for: trackingKey)
+            try? await markMessageFailed(clientMessageId: clientMessageId)
+            throw error
+        }
+
+        return trackingKey
     }
 
     // MARK: - Replies

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/OutgoingMessageWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/OutgoingMessageWriter.swift
@@ -2,6 +2,7 @@ import AVFoundation
 import Combine
 import Foundation
 import GRDB
+import UniformTypeIdentifiers
 @preconcurrency import XMTPiOS
 
 public protocol OutgoingMessageWriterProtocol: Sendable {
@@ -92,6 +93,16 @@ actor OutgoingMessageWriter: OutgoingMessageWriterProtocol {
         var replyContext: ReplyContext?
     }
 
+    private struct QueuedAudioMessage {
+        let clientMessageId: String
+        let localCacheURL: URL
+        let filename: String
+        let trackingKey: String
+        let mimeType: String
+        let duration: Double?
+        var replyContext: ReplyContext?
+    }
+
     private struct QueuedEagerPhoto {
         let trackingKey: String
     }
@@ -100,6 +111,7 @@ actor OutgoingMessageWriter: OutgoingMessageWriterProtocol {
         case text(QueuedTextMessage)
         case photo(QueuedPhotoMessage)
         case video(QueuedVideoMessage)
+        case audio(QueuedAudioMessage)
         case eagerPhoto(QueuedEagerPhoto)
     }
 
@@ -462,6 +474,10 @@ actor OutgoingMessageWriter: OutgoingMessageWriterProtocol {
             try? await attachmentLocalStateWriter.saveWaveformLevels(waveformLevels, for: trackingKey)
         }
 
+        if let duration = params.duration {
+            try? await attachmentLocalStateWriter.saveDuration(duration, for: trackingKey)
+        }
+
         var replyContext: ReplyContext?
         if let replyToMessageId {
             replyContext = try await resolveReplyContext(parentClientMessageId: replyToMessageId)
@@ -738,6 +754,8 @@ actor OutgoingMessageWriter: OutgoingMessageWriterProtocol {
                     try await publishPhoto(queued)
                 case .video(let queued):
                     try await publishVideo(queued)
+                case .audio(let queued):
+                    try await publishAudio(queued)
                 case .eagerPhoto(let queued):
                     try await processEagerPhoto(trackingKey: queued.trackingKey)
                 }
@@ -746,6 +764,8 @@ actor OutgoingMessageWriter: OutgoingMessageWriterProtocol {
                 case .photo(let queued):
                     await markPhotoFailed(trackingKey: queued.localCacheURL.absoluteString)
                 case .video(let queued):
+                    await markPhotoFailed(trackingKey: queued.trackingKey)
+                case .audio(let queued):
                     await markPhotoFailed(trackingKey: queued.trackingKey)
                 case .eagerPhoto(let queued):
                     await markPhotoFailed(trackingKey: queued.trackingKey)
@@ -1077,6 +1097,85 @@ actor OutgoingMessageWriter: OutgoingMessageWriterProtocol {
         QAEvent.emit(.message, "sent", ["id": messageId, "conversation": conversationId, "type": "video_retry"])
     }
 
+    private func publishAudio(_ queued: QueuedAudioMessage) async throws {
+        let tracker = PhotoUploadProgressTracker.shared
+        tracker.setStage(.preparing, for: queued.trackingKey)
+
+        let inboxReady = try await inboxStateManager.waitForInboxReadyResult()
+
+        let audioData = try Data(contentsOf: queued.localCacheURL)
+        let attachment = Attachment(
+            filename: queued.filename,
+            mimeType: queued.mimeType,
+            data: audioData
+        )
+
+        let encrypted = try RemoteAttachment.encodeEncrypted(
+            content: attachment,
+            codec: AttachmentCodec()
+        )
+
+        let presignedURLs = try await inboxReady.apiClient.getPresignedUploadURL(
+            filename: queued.filename,
+            contentType: "application/octet-stream"
+        )
+
+        guard let uploadURL = URL(string: presignedURLs.uploadURL) else {
+            tracker.setStage(.failed, for: queued.trackingKey)
+            try? await markMessageFailed(clientMessageId: queued.clientMessageId)
+            throw PhotoAttachmentError.invalidURL
+        }
+
+        let taskId = UUID().uuidString
+        let encryptedFileURL = try saveToTemp(data: encrypted.payload, taskId: taskId)
+
+        tracker.setProgress(stage: .uploading, percentage: 0, for: queued.trackingKey)
+
+        try await backgroundUploadManager.startUpload(
+            fileURL: encryptedFileURL,
+            uploadURL: uploadURL,
+            contentType: "application/octet-stream",
+            taskId: taskId
+        )
+
+        let result = await backgroundUploadManager.waitForCompletion(taskId: taskId)
+
+        guard result.success else {
+            tracker.setStage(.failed, for: queued.trackingKey)
+            try? await markMessageFailed(clientMessageId: queued.clientMessageId)
+            throw result.error ?? PhotoAttachmentError.uploadFailed("Audio upload failed")
+        }
+
+        tracker.setStage(.publishing, for: queued.trackingKey)
+
+        let storedAttachment = StoredRemoteAttachment(
+            url: presignedURLs.assetURL,
+            contentDigest: encrypted.digest,
+            secret: encrypted.secret,
+            salt: encrypted.salt,
+            nonce: encrypted.nonce,
+            filename: queued.filename,
+            mimeType: queued.mimeType,
+            mediaWidth: nil,
+            mediaHeight: nil,
+            mediaDuration: queued.duration,
+            thumbnailDataBase64: nil
+        )
+
+        let messageId = try await publishAttachment(
+            storedAttachment: storedAttachment,
+            clientMessageId: queued.clientMessageId,
+            trackingKey: queued.trackingKey,
+            thumbnailImage: nil,
+            inboxReady: inboxReady,
+            replyContext: queued.replyContext,
+            mediaType: "voice_memo"
+        )
+
+        try? FileManager.default.removeItem(at: encryptedFileURL)
+        QAEvent.emit(.message, "sent", ["id": messageId, "conversation": conversationId, "type": "voice_memo_retry"])
+    }
+
     private func completeXMTPSend(
         queued: QueuedPhotoMessage,
         prepared: PreparedBackgroundUpload,
@@ -1302,16 +1401,26 @@ actor OutgoingMessageWriter: OutgoingMessageWriterProtocol {
             return
         }
 
-        let isVideo = localFileURL.pathExtension.lowercased() == "mp4"
-            || localFileURL.pathExtension.lowercased() == "mov"
+        let localState = try await databaseWriter.read { db in
+            try AttachmentLocalState
+                .filter(AttachmentLocalState.Columns.attachmentKey == localFileURL.absoluteString)
+                .fetchOne(db)
+        }
+
+        let mediaType = detectRetryMediaType(
+            mimeType: localState?.mimeType,
+            filename: localFileURL.lastPathComponent
+        )
 
         try await databaseWriter.write { db in
             try message.with(status: .unpublished).save(db)
         }
 
-        if isVideo {
-            let filename = localFileURL.lastPathComponent
-            let trackingKey = localFileURL.absoluteString
+        let filename = localFileURL.lastPathComponent
+        let trackingKey = localFileURL.absoluteString
+
+        switch mediaType {
+        case .video:
             let queued = QueuedVideoMessage(
                 clientMessageId: message.clientMessageId,
                 localCacheURL: localFileURL,
@@ -1320,15 +1429,24 @@ actor OutgoingMessageWriter: OutgoingMessageWriterProtocol {
                 replyContext: replyContext
             )
             messageQueue.append(.video(queued))
-            startProcessingIfNeeded()
-        } else {
+        case .audio:
+            let queued = QueuedAudioMessage(
+                clientMessageId: message.clientMessageId,
+                localCacheURL: localFileURL,
+                filename: filename,
+                trackingKey: trackingKey,
+                mimeType: localState?.mimeType ?? "audio/m4a",
+                duration: localState?.duration,
+                replyContext: replyContext
+            )
+            messageQueue.append(.audio(queued))
+        case .image, .unknown:
             guard let imageData = try? Data(contentsOf: localFileURL),
                   let image = ImageType(data: imageData) else {
                 Log.error("Cannot retry photo: failed to load image from \(localFileURL.path)")
                 return
             }
 
-            let filename = localFileURL.lastPathComponent
             let queued = QueuedPhotoMessage(
                 clientMessageId: message.clientMessageId,
                 image: image,
@@ -1337,8 +1455,29 @@ actor OutgoingMessageWriter: OutgoingMessageWriterProtocol {
                 replyContext: replyContext
             )
             messageQueue.append(.photo(queued))
-            startProcessingIfNeeded()
+        case .file:
+            Log.error("Cannot retry attachment: unsupported file type for \(localFileURL.path)")
+            return
         }
+
+        startProcessingIfNeeded()
+    }
+
+    private func detectRetryMediaType(mimeType: String?, filename: String?) -> MediaType {
+        if let mimeType {
+            if mimeType.hasPrefix("image/") { return .image }
+            if mimeType.hasPrefix("video/") { return .video }
+            if mimeType.hasPrefix("audio/") { return .audio }
+            return .file
+        }
+
+        guard let filename else { return .unknown }
+        let ext = (filename as NSString).pathExtension.lowercased()
+        guard !ext.isEmpty, let utType = UTType(filenameExtension: ext) else { return .unknown }
+        if utType.conforms(to: .image) { return .image }
+        if utType.conforms(to: .movie) || utType.conforms(to: .video) { return .video }
+        if utType.conforms(to: .audio) { return .audio }
+        return .file
     }
 
     private func resolveLocalCacheURL(from storedJSON: String) -> URL? {

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/OutgoingMessageWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/OutgoingMessageWriter.swift
@@ -514,6 +514,7 @@ actor OutgoingMessageWriter: OutgoingMessageWriterProtocol {
 
             let taskId = UUID().uuidString
             let encryptedFileURL = try saveToTemp(data: encrypted.payload, taskId: taskId)
+            defer { try? FileManager.default.removeItem(at: encryptedFileURL) }
 
             tracker.setProgress(stage: .uploading, percentage: 0, for: trackingKey)
 
@@ -557,8 +558,6 @@ actor OutgoingMessageWriter: OutgoingMessageWriterProtocol {
                 replyContext: replyContext,
                 mediaType: params.mediaTypeLabel
             )
-
-            try? FileManager.default.removeItem(at: encryptedFileURL)
 
             QAEvent.emit(.message, "sent", ["id": messageId, "conversation": conversationId, "type": params.mediaTypeLabel])
 

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/OutgoingMessageWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/OutgoingMessageWriter.swift
@@ -417,35 +417,50 @@ actor OutgoingMessageWriter: OutgoingMessageWriterProtocol {
         eagerUploads.removeValue(forKey: trackingKey)
     }
 
-    // MARK: - Video
+    // MARK: - File Attachment Upload (shared by video, voice memo, and future types)
 
-    func sendVideo(at fileURL: URL, replyToMessageId: String? = nil) async throws -> String {
-        let compressionService = VideoCompressionService()
-        let compressed = try await compressionService.compressVideo(at: fileURL)
+    struct AttachmentUploadParams {
+        let dataURL: URL
+        let filename: String
+        let mimeType: String
+        var width: Int?
+        var height: Int?
+        var duration: Double?
+        var thumbnailData: Data?
+        var waveformLevels: [Float]?
+        var mediaTypeLabel: String = "attachment"
+    }
 
+    private func sendFileAttachment(
+        params: AttachmentUploadParams,
+        replyToMessageId: String?
+    ) async throws -> String {
         let clientMessageId = UUID().uuidString
-        let filename = "video_\(Int(Date().timeIntervalSince1970))_\(UUID().uuidString.prefix(8)).mp4"
-        let localCacheURL = try photoService.localCacheURL(for: filename)
+        let localCacheURL = try photoService.localCacheURL(for: params.filename)
 
         try FileManager.default.createDirectory(
             at: localCacheURL.deletingLastPathComponent(),
             withIntermediateDirectories: true
         )
-        try FileManager.default.copyItem(at: compressed.fileURL, to: localCacheURL)
+        try FileManager.default.copyItem(at: params.dataURL, to: localCacheURL)
 
         let trackingKey = localCacheURL.absoluteString
 
-        if let thumbnailImage = ImageType(data: compressed.thumbnail) {
+        if let thumbnailData = params.thumbnailData, let thumbnailImage = ImageType(data: thumbnailData) {
             ImageCacheContainer.shared.cacheImage(thumbnailImage, for: trackingKey, storageTier: .persistent)
         }
 
         try await attachmentLocalStateWriter.saveWithDimensions(
             attachmentKey: trackingKey,
             conversationId: conversationId,
-            width: compressed.width,
-            height: compressed.height,
-            mimeType: compressed.mimeType
+            width: params.width ?? 0,
+            height: params.height ?? 0,
+            mimeType: params.mimeType
         )
+
+        if let waveformLevels = params.waveformLevels {
+            try? await attachmentLocalStateWriter.saveWaveformLevels(waveformLevels, for: trackingKey)
+        }
 
         var replyContext: ReplyContext?
         if let replyToMessageId {
@@ -460,11 +475,11 @@ actor OutgoingMessageWriter: OutgoingMessageWriterProtocol {
         do {
             let inboxReady = try await inboxStateManager.waitForInboxReadyResult()
 
-            let videoData = try Data(contentsOf: compressed.fileURL)
+            let fileData = try Data(contentsOf: params.dataURL)
             let attachment = Attachment(
-                filename: filename,
-                mimeType: "video/mp4",
-                data: videoData
+                filename: params.filename,
+                mimeType: params.mimeType,
+                data: fileData
             )
 
             let encrypted = try RemoteAttachment.encodeEncrypted(
@@ -473,7 +488,7 @@ actor OutgoingMessageWriter: OutgoingMessageWriterProtocol {
             )
 
             let presignedURLs = try await inboxReady.apiClient.getPresignedUploadURL(
-                filename: filename,
+                filename: params.filename,
                 contentType: "application/octet-stream"
             )
 
@@ -498,12 +513,10 @@ actor OutgoingMessageWriter: OutgoingMessageWriterProtocol {
             guard result.success else {
                 tracker.setStage(.failed, for: trackingKey)
                 try? await markMessageFailed(clientMessageId: clientMessageId)
-                throw result.error ?? PhotoAttachmentError.uploadFailed("Video upload failed")
+                throw result.error ?? PhotoAttachmentError.uploadFailed("\(params.mediaTypeLabel) upload failed")
             }
 
             tracker.setStage(.publishing, for: trackingKey)
-
-            let thumbnailBase64 = compressed.thumbnail.base64EncodedString()
 
             let storedAttachment = StoredRemoteAttachment(
                 url: presignedURLs.assetURL,
@@ -511,28 +524,27 @@ actor OutgoingMessageWriter: OutgoingMessageWriterProtocol {
                 secret: encrypted.secret,
                 salt: encrypted.salt,
                 nonce: encrypted.nonce,
-                filename: filename,
-                mimeType: "video/mp4",
-                mediaWidth: compressed.width,
-                mediaHeight: compressed.height,
-                mediaDuration: compressed.duration,
-                thumbnailDataBase64: thumbnailBase64
+                filename: params.filename,
+                mimeType: params.mimeType,
+                mediaWidth: params.width,
+                mediaHeight: params.height,
+                mediaDuration: params.duration,
+                thumbnailDataBase64: params.thumbnailData?.base64EncodedString()
             )
 
             let messageId = try await publishAttachment(
                 storedAttachment: storedAttachment,
                 clientMessageId: clientMessageId,
                 trackingKey: trackingKey,
-                thumbnailImage: ImageType(data: compressed.thumbnail),
+                thumbnailImage: params.thumbnailData.flatMap { ImageType(data: $0) },
                 inboxReady: inboxReady,
                 replyContext: replyContext,
-                mediaType: "video"
+                mediaType: params.mediaTypeLabel
             )
 
             try? FileManager.default.removeItem(at: encryptedFileURL)
-            try? FileManager.default.removeItem(at: compressed.fileURL)
 
-            QAEvent.emit(.message, "sent", ["id": messageId, "conversation": conversationId, "type": "video"])
+            QAEvent.emit(.message, "sent", ["id": messageId, "conversation": conversationId, "type": params.mediaTypeLabel])
 
             return trackingKey
         } catch {
@@ -540,6 +552,27 @@ actor OutgoingMessageWriter: OutgoingMessageWriterProtocol {
             try? await markMessageFailed(clientMessageId: clientMessageId)
             throw error
         }
+    }
+
+    // MARK: - Video
+
+    func sendVideo(at fileURL: URL, replyToMessageId: String? = nil) async throws -> String {
+        let compressionService = VideoCompressionService()
+        let compressed = try await compressionService.compressVideo(at: fileURL)
+        defer { try? FileManager.default.removeItem(at: compressed.fileURL) }
+
+        let params = AttachmentUploadParams(
+            dataURL: compressed.fileURL,
+            filename: "video_\(Int(Date().timeIntervalSince1970))_\(UUID().uuidString.prefix(8)).mp4",
+            mimeType: "video/mp4",
+            width: compressed.width,
+            height: compressed.height,
+            duration: compressed.duration,
+            thumbnailData: compressed.thumbnail,
+            mediaTypeLabel: "video"
+        )
+
+        return try await sendFileAttachment(params: params, replyToMessageId: replyToMessageId)
     }
 
     private func publishAttachment(
@@ -635,118 +668,16 @@ actor OutgoingMessageWriter: OutgoingMessageWriterProtocol {
     // MARK: - Voice Memo
 
     func sendVoiceMemo(at fileURL: URL, duration: TimeInterval, waveformLevels: [Float]? = nil, replyToMessageId: String? = nil) async throws -> String {
-        let clientMessageId = UUID().uuidString
-        let filename = "voice_memo_\(Int(Date().timeIntervalSince1970))_\(UUID().uuidString.prefix(8)).m4a"
-        let localCacheURL = try photoService.localCacheURL(for: filename)
-
-        try FileManager.default.createDirectory(
-            at: localCacheURL.deletingLastPathComponent(),
-            withIntermediateDirectories: true
-        )
-        try FileManager.default.copyItem(at: fileURL, to: localCacheURL)
-
-        let trackingKey = localCacheURL.absoluteString
-
-        try await attachmentLocalStateWriter.saveWithDimensions(
-            attachmentKey: trackingKey,
-            conversationId: conversationId,
-            width: 0,
-            height: 0,
-            mimeType: "audio/m4a"
+        let params = AttachmentUploadParams(
+            dataURL: fileURL,
+            filename: "voice_memo_\(Int(Date().timeIntervalSince1970))_\(UUID().uuidString.prefix(8)).m4a",
+            mimeType: "audio/m4a",
+            duration: duration,
+            waveformLevels: waveformLevels,
+            mediaTypeLabel: "voice_memo"
         )
 
-        if let waveformLevels {
-            try? await attachmentLocalStateWriter.saveWaveformLevels(waveformLevels, for: trackingKey)
-        }
-
-        var replyContext: ReplyContext?
-        if let replyToMessageId {
-            replyContext = try await resolveReplyContext(parentClientMessageId: replyToMessageId)
-        }
-
-        try await savePhotoToDatabase(clientMessageId: clientMessageId, localCacheURL: localCacheURL, replyContext: replyContext)
-
-        let tracker = PhotoUploadProgressTracker.shared
-        tracker.setStage(.preparing, for: trackingKey)
-
-        do {
-            let inboxReady = try await inboxStateManager.waitForInboxReadyResult()
-
-            let audioData = try Data(contentsOf: fileURL)
-            let attachment = Attachment(
-                filename: filename,
-                mimeType: "audio/m4a",
-                data: audioData
-            )
-
-            let encrypted = try RemoteAttachment.encodeEncrypted(
-                content: attachment,
-                codec: AttachmentCodec()
-            )
-
-            let presignedURLs = try await inboxReady.apiClient.getPresignedUploadURL(
-                filename: filename,
-                contentType: "application/octet-stream"
-            )
-
-            guard let uploadURL = URL(string: presignedURLs.uploadURL) else {
-                throw PhotoAttachmentError.invalidURL
-            }
-
-            let taskId = UUID().uuidString
-            let encryptedFileURL = try saveToTemp(data: encrypted.payload, taskId: taskId)
-
-            tracker.setProgress(stage: .uploading, percentage: 0, for: trackingKey)
-
-            try await backgroundUploadManager.startUpload(
-                fileURL: encryptedFileURL,
-                uploadURL: uploadURL,
-                contentType: "application/octet-stream",
-                taskId: taskId
-            )
-
-            let result = await backgroundUploadManager.waitForCompletion(taskId: taskId)
-
-            guard result.success else {
-                tracker.setStage(.failed, for: trackingKey)
-                try? await markMessageFailed(clientMessageId: clientMessageId)
-                throw result.error ?? PhotoAttachmentError.uploadFailed("Voice memo upload failed")
-            }
-
-            tracker.setStage(.publishing, for: trackingKey)
-
-            let storedAttachment = StoredRemoteAttachment(
-                url: presignedURLs.assetURL,
-                contentDigest: encrypted.digest,
-                secret: encrypted.secret,
-                salt: encrypted.salt,
-                nonce: encrypted.nonce,
-                filename: filename,
-                mimeType: "audio/m4a",
-                mediaDuration: duration
-            )
-
-            let messageId = try await publishAttachment(
-                storedAttachment: storedAttachment,
-                clientMessageId: clientMessageId,
-                trackingKey: trackingKey,
-                thumbnailImage: nil,
-                inboxReady: inboxReady,
-                replyContext: replyContext,
-                mediaType: "voice_memo"
-            )
-
-            try? FileManager.default.removeItem(at: encryptedFileURL)
-
-            QAEvent.emit(.message, "sent", ["id": messageId, "conversation": conversationId, "type": "voice_memo"])
-        } catch {
-            Log.error("Failed to send voice memo: \(error)")
-            tracker.setStage(.failed, for: trackingKey)
-            try? await markMessageFailed(clientMessageId: clientMessageId)
-            throw error
-        }
-
-        return trackingKey
+        return try await sendFileAttachment(params: params, replyToMessageId: replyToMessageId)
     }
 
     // MARK: - Replies

--- a/docs/plans/voice-memos.md
+++ b/docs/plans/voice-memos.md
@@ -1,0 +1,178 @@
+# Voice Memos
+
+> **Status**: Draft
+> **Branch**: `jarod/voice-memos`
+
+## Overview
+
+Add voice memo recording and playback as a new remote attachment type. Voice memos use the existing XMTP remote attachment infrastructure (same as photos/videos) with an `audio/m4a` MIME type. The recording experience is inline in the message input bar, following iMessage's UX pattern.
+
+## UX Flow
+
+### Recording
+
+1. User taps the **waveform** icon (SF Symbol `waveform`) in the media buttons bar (after camera, before convos button)
+2. The bottom bar morphs to a full-width recording state:
+   - The expand/collapse button and media buttons container are hidden
+   - A live waveform animation shows audio levels
+   - The waveform marquees left as recording progresses
+   - Duration counter shows elapsed time (e.g., `0:05`)
+   - A red **stop** button (square in circle) on the right
+3. Tapping stop transitions to the **review** state
+
+### Review (after recording)
+
+The bottom bar shows:
+- **X** (cancel) button on the left — discards the recording
+- **Play/pause** button — preview the recording
+- Waveform visualization of the recorded audio
+- Duration label (e.g., `+ 0:07`)
+- **Send** button on the right (same as normal send)
+
+### Message Cell (sent/received)
+
+Inside our existing message container (MessageBubble):
+- **Play/pause** button on the left
+- Waveform visualization (static, shows playback progress)
+- Duration / elapsed time label
+- Context menu: "Save to Files" option
+
+### Reply Reference
+
+When a voice memo is the parent of a reply:
+- Small static waveform icon + "Voice memo" text
+- No play/pause button (just a visual indicator)
+
+## Architecture
+
+### Recording Service
+
+**New file**: `ConvosCore/Sources/ConvosCore/Messaging/VoiceMemoRecorder.swift`
+
+```swift
+actor VoiceMemoRecorder {
+    enum State { case idle, recording, recorded(URL, TimeInterval) }
+    
+    var state: State
+    var audioLevels: [Float]  // normalized 0-1, for waveform visualization
+    var duration: TimeInterval
+    
+    func startRecording() async throws
+    func stopRecording() async throws -> (url: URL, duration: TimeInterval)
+    func cancelRecording()
+}
+```
+
+Uses `AVAudioRecorder` with `.m4a` format (AAC codec). Publishes audio levels periodically for the waveform animation.
+
+### Sending
+
+Voice memos are sent as remote attachments — same flow as video:
+
+1. Record audio to a local `.m4a` file
+2. Read the file data into an XMTP `Attachment(filename:, mimeType: "audio/m4a", data:)`
+3. Encrypt with `RemoteAttachment.encodeEncrypted`
+4. Upload encrypted data to S3 via presigned URL
+5. Send the `RemoteAttachment` message via XMTP
+
+**New method on `OutgoingMessageWriterProtocol`:**
+```swift
+func sendVoiceMemo(at fileURL: URL, duration: TimeInterval, replyToMessageId: String?) async throws -> String
+```
+
+### Receiving / Playback
+
+**New file**: `ConvosCore/Sources/ConvosCore/Messaging/VoiceMemoPlayer.swift`
+
+```swift
+@Observable
+class VoiceMemoPlayer {
+    enum State { case idle, loading, playing, paused }
+    
+    var state: State
+    var currentTime: TimeInterval
+    var duration: TimeInterval
+    var progress: Double  // 0-1
+    
+    func play(url: URL) async throws
+    func pause()
+    func stop()
+}
+```
+
+Uses `AVAudioPlayer` for playback. The player is shared per conversation to ensure only one voice memo plays at a time.
+
+### Content Type Detection
+
+The existing `HydratedAttachment` model detects attachment types by MIME type. Add audio MIME type detection:
+
+```swift
+var isAudio: Bool {
+    mimeType?.hasPrefix("audio/") == true
+}
+```
+
+### DB / Models
+
+No new DB tables needed. Voice memos are stored as regular messages with remote attachment content type, same as photos and videos. The MIME type (`audio/m4a`) distinguishes them.
+
+The `MessageContent` enum may need a new case or the existing `.remoteAttachment` case handles it (with MIME-based rendering in the view layer).
+
+## Files to Create
+
+| File | Purpose |
+|------|---------|
+| `ConvosCore/.../Messaging/VoiceMemoRecorder.swift` | AVAudioRecorder wrapper |
+| `ConvosCore/.../Messaging/VoiceMemoPlayer.swift` | AVAudioPlayer wrapper |
+| `Convos/.../Views/VoiceMemoRecordingView.swift` | Recording state bottom bar |
+| `Convos/.../Views/VoiceMemoReviewView.swift` | Review state bottom bar |
+| `Convos/.../Messages List Items/VoiceMemoBubble.swift` | Message cell view |
+| `Convos/.../Messages List Items/VoiceMemoWaveformView.swift` | Reusable waveform visualization |
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `MessagesMediaInputView.swift` | Add waveform button after camera |
+| `MessagesBottomBar.swift` | Handle recording/review states, morph animation |
+| `MessagesInputView.swift` | Integrate recording state |
+| `ConversationViewModel.swift` | Recording state management, send voice memo |
+| `OutgoingMessageWriter.swift` | `sendVoiceMemo` method |
+| `MessagesGroupItemView.swift` | Render voice memo bubble |
+| `MessagesGroupView.swift` | Layout for voice memo messages |
+| `ReplyReferenceView.swift` | Voice memo reply preview |
+| `HydratedAttachment.swift` | Audio type detection |
+| `MessageContent.swift` | Voice memo content identification |
+
+## Audio Format
+
+- **Container**: M4A (MPEG-4 Audio)
+- **Codec**: AAC
+- **Sample rate**: 44100 Hz
+- **Channels**: 1 (mono)
+- **Bit rate**: 64 kbps (good quality for voice, small file size)
+- **Max duration**: 5 minutes (configurable)
+
+## Waveform Visualization
+
+Two modes:
+1. **Live recording**: Animated bars driven by `AVAudioRecorder.averagePower(forChannel:)`, sampled at ~60fps, marquees left as time progresses
+2. **Static playback**: Pre-computed from the audio file's amplitude data, with a progress overlay showing playback position
+
+The waveform is rendered as a series of vertical bars (`RoundedRectangle`) with varying heights based on audio levels.
+
+## Permissions
+
+Microphone access requires `NSMicrophoneUsageDescription` in Info.plist (already present for camera video recording).
+
+## Edge Cases
+
+| Scenario | Handling |
+|----------|----------|
+| App backgrounded during recording | Stop recording, transition to review state |
+| Phone call during recording | Stop recording via AVAudioSession interruption notification |
+| No microphone permission | Show system permission dialog on first tap, show error if denied |
+| Recording too short (< 1s) | Discard silently, stay in idle state |
+| Recording at max duration | Auto-stop, transition to review state |
+| Network failure during send | Same retry mechanism as photo/video attachments |
+| Received audio in unsupported format | Show "Unsupported audio" placeholder |

--- a/qa/tests/30-voice-memos.md
+++ b/qa/tests/30-voice-memos.md
@@ -1,0 +1,85 @@
+# Test: Voice Memos
+
+Verify that voice memos can be recorded, previewed, and sent as messages.
+
+## Prerequisites
+
+- The app is running and past onboarding on the primary simulator.
+- At least one conversation exists.
+- Microphone permission has been granted (or will be granted on first use).
+
+## Steps
+
+### Verify waveform button exists
+
+1. Open a conversation from the conversations list.
+2. If the media buttons are collapsed, tap the expand button to show them.
+3. Verify that a waveform button (SF Symbol "waveform") appears in the media buttons bar, after the camera icon and before the convos button.
+
+### Start recording
+
+4. Tap the waveform button to start recording.
+5. If a microphone permission dialog appears, grant permission.
+6. The bottom bar should morph to show the recording state:
+   - A live waveform animation showing audio levels
+   - A duration counter (e.g., "0:02") incrementing in real time
+   - A red stop button on the right
+
+### Stop recording
+
+7. Wait at least 2 seconds for a valid recording.
+8. Tap the red stop button.
+9. The bottom bar should transition to the review state:
+   - An X (cancel) button on the left
+   - A play/pause button
+   - A static waveform visualization
+   - The duration label showing the recorded length
+   - A send button (arrow up) on the right
+
+### Preview playback
+
+10. Tap the play button in the review state.
+11. The button should change to a pause icon and audio should play (if on a real device — simulator may not produce audible output but the state should change).
+12. Tap pause to stop playback.
+
+### Cancel recording
+
+13. Tap the X (cancel) button.
+14. The bottom bar should return to the normal input state with the text field and media buttons.
+15. No voice memo should be sent.
+
+### Record and send
+
+16. Tap the waveform button again to start a new recording.
+17. Record for at least 2 seconds, then tap stop.
+18. Tap the send button (arrow up) in the review state.
+19. The bottom bar should return to the normal input state.
+20. A voice memo message should appear in the messages list (it may appear as an attachment/remote attachment).
+
+### Short recording discard
+
+21. Tap the waveform button to start recording.
+22. Immediately tap the stop button (within 1 second).
+23. The recording should be discarded and the bar should return to idle state (no review state shown for recordings under 1 second).
+
+## Teardown
+
+No specific teardown needed.
+
+## Pass/Fail Criteria
+
+- [ ] Waveform button appears in media buttons bar after camera icon
+- [ ] Tapping waveform button starts recording (duration counter increments)
+- [ ] Stop button transitions to review state with play/cancel/send controls
+- [ ] Cancel button returns to normal input state without sending
+- [ ] Send button sends the voice memo as a message
+- [ ] Recordings under 1 second are discarded automatically
+- [ ] Recording state shows live waveform animation
+
+## Accessibility Improvements Needed
+
+- The waveform button should have `accessibilityIdentifier("voice-memo-button")` — verify it's findable
+- The stop button should have `accessibilityIdentifier("voice-memo-stop-button")`
+- The cancel button should have `accessibilityIdentifier("voice-memo-cancel-button")`
+- The send button should have `accessibilityIdentifier("voice-memo-send-button")`
+- The play button should have `accessibilityIdentifier("voice-memo-play-button")`


### PR DESCRIPTION
## Summary

Adds voice memo recording and sending as a new remote attachment type (`audio/m4a`). Uses the existing XMTP remote attachment infrastructure — same encrypt/upload/publish flow as photos and videos.

## What's included

### Recording (`VoiceMemoRecorder`)
- AVAudioRecorder wrapper with real-time audio level sampling at 30fps
- AAC codec, 44.1kHz mono, 64kbps
- Auto-stop at 5 min, discard if < 1 second
- Handles interruptions (phone calls, app backgrounding)

### UI Components
- **Waveform button** in media bar (SF Symbol `waveform`, after camera)
- **VoiceMemoRecordingView** — live waveform + duration + stop button
- **VoiceMemoReviewView** — cancel, play/pause preview, waveform, duration, send
- **VoiceMemoBubble** — message cell with play button, waveform, duration
- **VoiceMemoWaveformView** — reusable bar visualization with progress overlay

### Sending (`OutgoingMessageWriter.sendVoiceMemo`)
- Records to local .m4a → encrypts via RemoteAttachment → uploads to S3 → publishes XMTP message
- Same background upload flow as video messages

### Playback (`VoiceMemoPlayer`)
- Shared AVAudioPlayer singleton (one playback at a time per conversation)
- Play/pause/stop with progress tracking

## Still needed (follow-up)
- Wire recording/review states into MessagesBottomBar morph animation
- Integrate VoiceMemoBubble into MessagesGroupItemView for rendering
- Reply reference view for voice memo parents
- Save to Files action in context menu
- Full playback integration in bubble (download + decrypt + play)

## Files

6 new files, 11 modified files. See plan at `docs/plans/voice-memos.md`.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add voice memo recording, playback, and sending to conversation messages
> - Adds `VoiceMemoRecorder` and `VoiceMemoPlayer` singletons to manage AVAudioRecorder/AVAudioPlayer lifecycle, including metering, progress tracking, and interruption handling.
> - Integrates recording UI into `MessagesBottomBar`: tapping the waveform button shows a live `VoiceMemoRecordingView` (levels + timer), and after stopping shows `VoiceMemoReviewView` (playback + send).
> - Adds `VoiceMemoBubbleContent` and `VoiceMemoAttachmentView` for rendering sent voice memos in the message list with tap-to-play and waveform progress.
> - Extends `OutgoingMessageWriter` with `sendVoiceMemo` that uploads audio/m4a files through the shared `sendFileAttachment` path, persisting duration and waveform levels to `AttachmentLocalState`.
> - Adds two DB migrations to `attachmentLocalState` for `waveformLevels` (text) and `duration` (double) columns, and a `VoiceMemoWaveformAnalyzer` to compute normalized levels from audio data.
> - Updates reply previews, message list layout, context menus, push notification text, and message preview strings to handle the new `.audio` media type.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e4ee290.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->