### PR TITLE
Fix incoming video aspect ratio using thumbnail dimensions

### DIFF
--- a/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
@@ -564,6 +564,9 @@ private struct AttachmentPlaceholder: View {
                 isLoading = false
                 isLoadingVideo = true
                 videoLoadFailed = false
+                if attachment.width == nil {
+                    onDimensionsLoaded(Int(thumb.size.width), Int(thumb.size.height))
+                }
             }
 
             do {


### PR DESCRIPTION
## Problem

Incoming videos sometimes display at the wrong aspect ratio (defaulting to 4:3) instead of their actual dimensions.

## Root Cause

Incoming `RemoteAttachment` messages from XMTP don't carry `mediaWidth`/`mediaHeight` — those fields are only available on outgoing videos (where we set them from the compressed video metadata). The `StoredRemoteAttachment` JSON for incoming videos has `null` for both dimensions.

Without dimensions, `HydratedAttachment.aspectRatio` returns `nil`, and the placeholder defaults to 4:3.

## Fix

After decoding the video thumbnail in the attachment view, call `onDimensionsLoaded` with the thumbnail's width and height. The thumbnail is generated from the video's first frame, so it has the same aspect ratio as the video.

This persists the dimensions to `AttachmentLocalState` in the database, so subsequent renders (scrolling back, reopening the conversation) use the correct ratio immediately without re-loading the thumbnail.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix video attachment aspect ratio by falling back to thumbnail dimensions
> In [MessagesGroupItemView.swift](https://github.com/xmtplabs/convos-ios/pull/665/files#diff-34b33cae925fe553d357af97d04319b8de2de329c1903afe72c915e36aa98774), when a video attachment has a thumbnail but no stored width, `onDimensionsLoaded` is now called with the thumbnail's pixel dimensions from `UIImage.size`. This prevents incorrectly sized video placeholders when width metadata is missing.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f6853b9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->