### PR TITLE
Refactor: centralize MediaType semantics for attachment extensibility

### DIFF
--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -1,3 +1,4 @@
+import ConvosCore
 import SwiftUI
 
 struct ConversationView<MessagesBottomBar: View>: View {
@@ -311,6 +312,10 @@ struct ConversationView<MessagesBottomBar: View>: View {
                 PhotosInfoSheet()
             }
         )
+        .onDisappear {
+            VoiceMemoPlayer.shared.stop()
+            viewModel.voiceMemoRecorder.cancelRecording()
+        }
     }
 }
 

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -3,6 +3,7 @@ import Combine
 import ConvosCore
 import ConvosCoreiOS
 import Observation
+import SwiftUI
 import UIKit
 import UserNotifications
 
@@ -847,17 +848,21 @@ extension ConversationViewModel {
 
     func onVoiceMemoTapped() {
         guard case .idle = voiceMemoRecorder.state else { return }
-        do {
-            try voiceMemoRecorder.startRecording()
-        } catch {
-            Log.error("Failed to start voice memo recording: \(error)")
+        withAnimation(.bouncy(duration: 0.4, extraBounce: 0.01)) {
+            do {
+                try voiceMemoRecorder.startRecording()
+            } catch {
+                Log.error("Failed to start voice memo recording: \(error)")
+            }
         }
     }
 
     func sendVoiceMemo() {
         guard case .recorded(let url, let duration) = voiceMemoRecorder.state else { return }
         let levels = voiceMemoRecorder.audioLevels
-        voiceMemoRecorder.resetState()
+        withAnimation(.bouncy(duration: 0.4, extraBounce: 0.01)) {
+            voiceMemoRecorder.resetState()
+        }
 
         let messageWriter = cachedMessageWriter
         let replyTarget = replyingToMessage

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Data Source/DefaultMessagesLayoutDelegate.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Data Source/DefaultMessagesLayoutDelegate.swift
@@ -85,7 +85,18 @@ final class DefaultMessagesLayoutDelegate: MessagesLayoutDelegate {
         return height
     }
 
-    private func attachmentHeight(for attachment: HydratedAttachment, width: CGFloat) -> CGFloat {
+    private func estimatedAttachmentHeight(for attachment: HydratedAttachment, width: CGFloat) -> CGFloat {
+        switch attachment.mediaType {
+        case .audio:
+            return 44.0
+        case .file:
+            return 60.0
+        case .image, .video, .unknown:
+            return imageAttachmentHeight(for: attachment, width: width)
+        }
+    }
+
+    private func imageAttachmentHeight(for attachment: HydratedAttachment, width: CGFloat) -> CGFloat {
         guard let w = attachment.width, let h = attachment.height, w > 0, h > 0 else {
             return width * 0.75
         }
@@ -95,17 +106,11 @@ final class DefaultMessagesLayoutDelegate: MessagesLayoutDelegate {
     private func messageHeight(for message: AnyMessage, width: CGFloat) -> CGFloat {
         var height: CGFloat
         switch message.content {
-        case .attachment(let attachment) where attachment.mediaType == .audio:
-            height = 44.0
         case .attachment(let attachment):
-            height = attachmentHeight(for: attachment, width: width)
+            height = estimatedAttachmentHeight(for: attachment, width: width)
         case .attachments(let attachments):
             guard let first = attachments.first else { return 50.0 }
-            if first.mediaType == .audio {
-                height = 44.0
-            } else {
-                height = attachmentHeight(for: first, width: width)
-            }
+            height = estimatedAttachmentHeight(for: first, width: width)
         case .emoji:
             height = 80.0
         case .text:

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesBottomBar.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesBottomBar.swift
@@ -152,10 +152,14 @@ struct MessagesBottomBar<BottomBarContent: View>: View {
                 .frame(minHeight: 52)
                 .clipShape(.capsule)
                 .glassEffect(.regular.interactive(), in: .capsule)
+                .glassEffectID("media", in: namespace)
+                .glassEffectTransition(.matchedGeometry)
         } else if case .recorded(let url, let duration) = voiceMemoRecorder.state {
             HStack(spacing: DesignConstants.Spacing.step2x) {
                 Button {
-                    voiceMemoRecorder.cancelRecording()
+                    withAnimation(.bouncy(duration: 0.4, extraBounce: 0.01)) {
+                        voiceMemoRecorder.cancelRecording()
+                    }
                 } label: {
                     Image(systemName: "xmark")
                         .font(.system(size: 14, weight: .semibold))
@@ -176,6 +180,8 @@ struct MessagesBottomBar<BottomBarContent: View>: View {
                 .frame(minHeight: 52)
                 .clipShape(.capsule)
                 .glassEffect(.regular.interactive(), in: .capsule)
+                .glassEffectID("media", in: namespace)
+                .glassEffectTransition(.matchedGeometry)
             }
         } else {
             normalInputView

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/ReplyComposerBar.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/ReplyComposerBar.swift
@@ -62,12 +62,12 @@ struct ReplyComposerBar: View {
     }
 
     private func replyLabel(for attachment: HydratedAttachment) -> String {
-        switch attachment.mediaType {
-        case .video: return "Video"
-        case .audio: return "Audio"
-        case .file: return attachment.filename ?? "File"
-        default: return "Photo"
+        if attachment.mediaType == .file, let filename = attachment.filename {
+            return filename
         }
+        return attachment.mediaType.previewLabel
+            .replacingOccurrences(of: "a ", with: "")
+            .capitalized
     }
 
     var body: some View {

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/VoiceMemoRecordingView.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/VoiceMemoRecordingView.swift
@@ -44,7 +44,9 @@ struct VoiceMemoRecordingView: View {
                 .frame(minWidth: 36, alignment: .trailing)
 
             Button {
-                recorder.stopRecording()
+                withAnimation(.bouncy(duration: 0.4, extraBounce: 0.01)) {
+                    recorder.stopRecording()
+                }
             } label: {
                 Image(systemName: "stop.fill")
                     .font(.system(size: 14))

--- a/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/ReplyReferenceView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/ReplyReferenceView.swift
@@ -34,12 +34,10 @@ struct ReplyReferenceView: View {
     }
 
     private func replyLabel(for attachment: HydratedAttachment) -> String {
-        switch attachment.mediaType {
-        case .video: return "video"
-        case .audio: return "audio"
-        case .file: return attachment.filename ?? "file"
-        default: return "photo"
+        if attachment.mediaType == .file, let filename = attachment.filename {
+            return filename
         }
+        return attachment.mediaType.previewLabel.replacingOccurrences(of: "a ", with: "")
     }
 
     private var parentAttachment: HydratedAttachment? {

--- a/ConvosCore/Sources/ConvosCore/Storage/Hydration/DBMessage+MessagePreview.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Hydration/DBMessage+MessagePreview.swift
@@ -106,71 +106,72 @@ extension DBLastMessageWithSource {
     }
 
     static func attachmentsPreviewString(attachmentUrls: [String], count: Int) -> String {
-        var hasVideo = false
-        var hasAudio = false
-        var hasFile = false
+        var hasNonImage = false
+        var primaryType: MediaType = .image
         var filename: String?
 
         for url in attachmentUrls {
-            if let stored = try? StoredRemoteAttachment.fromJSON(url) {
-                classifyStoredAttachment(stored, hasVideo: &hasVideo, hasAudio: &hasAudio, hasFile: &hasFile, filename: &filename)
-            } else if url.hasPrefix("file://") {
-                classifyFileURL(url, hasVideo: &hasVideo, hasAudio: &hasAudio, hasFile: &hasFile, filename: &filename)
+            let classified = classifyAttachment(url)
+            if classified.mediaType != .image {
+                hasNonImage = true
+                primaryType = classified.mediaType
+            }
+            if classified.filename != nil {
+                filename = classified.filename
             }
         }
 
         if count <= 1 {
-            if hasAudio { return "a voice memo" }
-            if hasFile, let filename { return filename }
-            if hasFile { return "a file" }
-            if hasVideo { return "a video" }
-            return "a photo"
+            if primaryType == .file, let filename { return filename }
+            return primaryType.previewLabel
         }
-        if hasFile || hasVideo || hasAudio { return "\(count) attachments" }
+        if hasNonImage { return "\(count) attachments" }
         return "\(count) photos"
     }
 
-    private static func classifyStoredAttachment(
-        _ stored: StoredRemoteAttachment,
-        hasVideo: inout Bool,
-        hasAudio: inout Bool,
-        hasFile: inout Bool,
-        filename: inout String?
-    ) {
-        if stored.mimeType?.hasPrefix("video/") == true {
-            hasVideo = true
-        } else if stored.mimeType?.hasPrefix("audio/") == true {
-            hasAudio = true
-        } else if let mime = stored.mimeType, !mime.hasPrefix("image/") {
-            hasFile = true
-            filename = stored.filename
-        } else if let fn = stored.filename {
-            let ext = (fn as NSString).pathExtension.lowercased()
-            if !ext.isEmpty, let utType = UTType(filenameExtension: ext), !utType.conforms(to: .image) {
-                hasFile = true
-                filename = fn
-            }
+    private static func classifyAttachment(_ url: String) -> (mediaType: MediaType, filename: String?) {
+        if let stored = try? StoredRemoteAttachment.fromJSON(url) {
+            return classifyStoredAttachment(stored)
+        } else if url.hasPrefix("file://") {
+            return classifyFileURL(url)
         }
+        return (.image, nil)
     }
 
-    private static func classifyFileURL(
-        _ url: String,
-        hasVideo: inout Bool,
-        hasAudio: inout Bool,
-        hasFile: inout Bool,
-        filename: inout String?
-    ) {
-        guard let fn = extractFilenameFromURL(url) else { return }
-        let ext = (fn as NSString).pathExtension.lowercased()
-        guard !ext.isEmpty, let utType = UTType(filenameExtension: ext) else { return }
-        if utType.conforms(to: .movie) || utType.conforms(to: .video) {
-            hasVideo = true
-        } else if utType.conforms(to: .audio) {
-            hasAudio = true
-        } else if !utType.conforms(to: .image) {
-            hasFile = true
-            filename = fn
+    private static func classifyStoredAttachment(_ stored: StoredRemoteAttachment) -> (mediaType: MediaType, filename: String?) {
+        if stored.mimeType?.hasPrefix("video/") == true {
+            return (.video, stored.filename)
+        } else if stored.mimeType?.hasPrefix("audio/") == true {
+            return (.audio, stored.filename)
+        } else if let mime = stored.mimeType, !mime.hasPrefix("image/") {
+            return (.file, stored.filename)
+        } else if let fn = stored.filename {
+            let ext = (fn as NSString).pathExtension.lowercased()
+            if !ext.isEmpty, let utType = UTType(filenameExtension: ext) {
+                if utType.conforms(to: .movie) || utType.conforms(to: .video) {
+                    return (.video, fn)
+                } else if utType.conforms(to: .audio) {
+                    return (.audio, fn)
+                } else if !utType.conforms(to: .image) {
+                    return (.file, fn)
+                }
+            }
         }
+        return (.image, stored.filename)
+    }
+
+    private static func classifyFileURL(_ url: String) -> (mediaType: MediaType, filename: String?) {
+        guard let fn = extractFilenameFromURL(url) else { return (.image, nil) }
+        let ext = (fn as NSString).pathExtension.lowercased()
+        guard !ext.isEmpty, let utType = UTType(filenameExtension: ext) else { return (.image, fn) }
+        if utType.conforms(to: .movie) || utType.conforms(to: .video) {
+            return (.video, fn)
+        } else if utType.conforms(to: .audio) {
+            return (.audio, fn)
+        } else if !utType.conforms(to: .image) {
+            return (.file, fn)
+        }
+        return (.image, fn)
     }
 
     private static func extractFilenameFromURL(_ url: String) -> String? {

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/HydratedAttachment.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/HydratedAttachment.swift
@@ -6,6 +6,20 @@ public enum MediaType: String, Codable, Sendable {
     case audio
     case file
     case unknown
+
+    public var previewLabel: String {
+        switch self {
+        case .image: return "a photo"
+        case .video: return "a video"
+        case .audio: return "a voice memo"
+        case .file: return "a file"
+        case .unknown: return "an attachment"
+        }
+    }
+
+    public var isFullBleed: Bool {
+        self == .image || self == .video
+    }
 }
 
 public struct HydratedAttachment: Hashable, Codable, Sendable {

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/MessageContent.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/MessageContent.swift
@@ -69,9 +69,9 @@ public enum MessageContent: Hashable, Codable, Sendable {
     public var isFullBleedAttachment: Bool {
         switch self {
         case .attachment(let attachment):
-            attachment.mediaType == .image || attachment.mediaType == .video
+            attachment.mediaType.isFullBleed
         case .attachments(let attachments):
-            attachments.first.map { $0.mediaType == .image || $0.mediaType == .video } ?? false
+            attachments.first?.mediaType.isFullBleed ?? false
         default:
             false
         }

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/OutgoingMessageWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/OutgoingMessageWriter.swift
@@ -417,35 +417,50 @@ actor OutgoingMessageWriter: OutgoingMessageWriterProtocol {
         eagerUploads.removeValue(forKey: trackingKey)
     }
 
-    // MARK: - Video
+    // MARK: - File Attachment Upload (shared by video, voice memo, and future types)
 
-    func sendVideo(at fileURL: URL, replyToMessageId: String? = nil) async throws -> String {
-        let compressionService = VideoCompressionService()
-        let compressed = try await compressionService.compressVideo(at: fileURL)
+    struct AttachmentUploadParams {
+        let dataURL: URL
+        let filename: String
+        let mimeType: String
+        var width: Int?
+        var height: Int?
+        var duration: Double?
+        var thumbnailData: Data?
+        var waveformLevels: [Float]?
+        var mediaTypeLabel: String = "attachment"
+    }
 
+    private func sendFileAttachment(
+        params: AttachmentUploadParams,
+        replyToMessageId: String?
+    ) async throws -> String {
         let clientMessageId = UUID().uuidString
-        let filename = "video_\(Int(Date().timeIntervalSince1970))_\(UUID().uuidString.prefix(8)).mp4"
-        let localCacheURL = try photoService.localCacheURL(for: filename)
+        let localCacheURL = try photoService.localCacheURL(for: params.filename)
 
         try FileManager.default.createDirectory(
             at: localCacheURL.deletingLastPathComponent(),
             withIntermediateDirectories: true
         )
-        try FileManager.default.copyItem(at: compressed.fileURL, to: localCacheURL)
+        try FileManager.default.copyItem(at: params.dataURL, to: localCacheURL)
 
         let trackingKey = localCacheURL.absoluteString
 
-        if let thumbnailImage = ImageType(data: compressed.thumbnail) {
+        if let thumbnailData = params.thumbnailData, let thumbnailImage = ImageType(data: thumbnailData) {
             ImageCacheContainer.shared.cacheImage(thumbnailImage, for: trackingKey, storageTier: .persistent)
         }
 
         try await attachmentLocalStateWriter.saveWithDimensions(
             attachmentKey: trackingKey,
             conversationId: conversationId,
-            width: compressed.width,
-            height: compressed.height,
-            mimeType: compressed.mimeType
+            width: params.width ?? 0,
+            height: params.height ?? 0,
+            mimeType: params.mimeType
         )
+
+        if let waveformLevels = params.waveformLevels {
+            try? await attachmentLocalStateWriter.saveWaveformLevels(waveformLevels, for: trackingKey)
+        }
 
         var replyContext: ReplyContext?
         if let replyToMessageId {
@@ -460,11 +475,11 @@ actor OutgoingMessageWriter: OutgoingMessageWriterProtocol {
         do {
             let inboxReady = try await inboxStateManager.waitForInboxReadyResult()
 
-            let videoData = try Data(contentsOf: compressed.fileURL)
+            let fileData = try Data(contentsOf: params.dataURL)
             let attachment = Attachment(
-                filename: filename,
-                mimeType: "video/mp4",
-                data: videoData
+                filename: params.filename,
+                mimeType: params.mimeType,
+                data: fileData
             )
 
             let encrypted = try RemoteAttachment.encodeEncrypted(
@@ -473,7 +488,7 @@ actor OutgoingMessageWriter: OutgoingMessageWriterProtocol {
             )
 
             let presignedURLs = try await inboxReady.apiClient.getPresignedUploadURL(
-                filename: filename,
+                filename: params.filename,
                 contentType: "application/octet-stream"
             )
 
@@ -498,12 +513,10 @@ actor OutgoingMessageWriter: OutgoingMessageWriterProtocol {
             guard result.success else {
                 tracker.setStage(.failed, for: trackingKey)
                 try? await markMessageFailed(clientMessageId: clientMessageId)
-                throw result.error ?? PhotoAttachmentError.uploadFailed("Video upload failed")
+                throw result.error ?? PhotoAttachmentError.uploadFailed("\(params.mediaTypeLabel) upload failed")
             }
 
             tracker.setStage(.publishing, for: trackingKey)
-
-            let thumbnailBase64 = compressed.thumbnail.base64EncodedString()
 
             let storedAttachment = StoredRemoteAttachment(
                 url: presignedURLs.assetURL,
@@ -511,28 +524,27 @@ actor OutgoingMessageWriter: OutgoingMessageWriterProtocol {
                 secret: encrypted.secret,
                 salt: encrypted.salt,
                 nonce: encrypted.nonce,
-                filename: filename,
-                mimeType: "video/mp4",
-                mediaWidth: compressed.width,
-                mediaHeight: compressed.height,
-                mediaDuration: compressed.duration,
-                thumbnailDataBase64: thumbnailBase64
+                filename: params.filename,
+                mimeType: params.mimeType,
+                mediaWidth: params.width,
+                mediaHeight: params.height,
+                mediaDuration: params.duration,
+                thumbnailDataBase64: params.thumbnailData?.base64EncodedString()
             )
 
             let messageId = try await publishAttachment(
                 storedAttachment: storedAttachment,
                 clientMessageId: clientMessageId,
                 trackingKey: trackingKey,
-                thumbnailImage: ImageType(data: compressed.thumbnail),
+                thumbnailImage: params.thumbnailData.flatMap { ImageType(data: $0) },
                 inboxReady: inboxReady,
                 replyContext: replyContext,
-                mediaType: "video"
+                mediaType: params.mediaTypeLabel
             )
 
             try? FileManager.default.removeItem(at: encryptedFileURL)
-            try? FileManager.default.removeItem(at: compressed.fileURL)
 
-            QAEvent.emit(.message, "sent", ["id": messageId, "conversation": conversationId, "type": "video"])
+            QAEvent.emit(.message, "sent", ["id": messageId, "conversation": conversationId, "type": params.mediaTypeLabel])
 
             return trackingKey
         } catch {
@@ -540,6 +552,28 @@ actor OutgoingMessageWriter: OutgoingMessageWriterProtocol {
             try? await markMessageFailed(clientMessageId: clientMessageId)
             throw error
         }
+    }
+
+    // MARK: - Video
+
+    func sendVideo(at fileURL: URL, replyToMessageId: String? = nil) async throws -> String {
+        let compressionService = VideoCompressionService()
+        let compressed = try await compressionService.compressVideo(at: fileURL)
+
+        let params = AttachmentUploadParams(
+            dataURL: compressed.fileURL,
+            filename: "video_\(Int(Date().timeIntervalSince1970))_\(UUID().uuidString.prefix(8)).mp4",
+            mimeType: "video/mp4",
+            width: compressed.width,
+            height: compressed.height,
+            duration: compressed.duration,
+            thumbnailData: compressed.thumbnail,
+            mediaTypeLabel: "video"
+        )
+
+        let trackingKey = try await sendFileAttachment(params: params, replyToMessageId: replyToMessageId)
+        try? FileManager.default.removeItem(at: compressed.fileURL)
+        return trackingKey
     }
 
     private func publishAttachment(
@@ -635,118 +669,16 @@ actor OutgoingMessageWriter: OutgoingMessageWriterProtocol {
     // MARK: - Voice Memo
 
     func sendVoiceMemo(at fileURL: URL, duration: TimeInterval, waveformLevels: [Float]? = nil, replyToMessageId: String? = nil) async throws -> String {
-        let clientMessageId = UUID().uuidString
-        let filename = "voice_memo_\(Int(Date().timeIntervalSince1970))_\(UUID().uuidString.prefix(8)).m4a"
-        let localCacheURL = try photoService.localCacheURL(for: filename)
-
-        try FileManager.default.createDirectory(
-            at: localCacheURL.deletingLastPathComponent(),
-            withIntermediateDirectories: true
-        )
-        try FileManager.default.copyItem(at: fileURL, to: localCacheURL)
-
-        let trackingKey = localCacheURL.absoluteString
-
-        try await attachmentLocalStateWriter.saveWithDimensions(
-            attachmentKey: trackingKey,
-            conversationId: conversationId,
-            width: 0,
-            height: 0,
-            mimeType: "audio/m4a"
+        let params = AttachmentUploadParams(
+            dataURL: fileURL,
+            filename: "voice_memo_\(Int(Date().timeIntervalSince1970))_\(UUID().uuidString.prefix(8)).m4a",
+            mimeType: "audio/m4a",
+            duration: duration,
+            waveformLevels: waveformLevels,
+            mediaTypeLabel: "voice_memo"
         )
 
-        if let waveformLevels {
-            try? await attachmentLocalStateWriter.saveWaveformLevels(waveformLevels, for: trackingKey)
-        }
-
-        var replyContext: ReplyContext?
-        if let replyToMessageId {
-            replyContext = try await resolveReplyContext(parentClientMessageId: replyToMessageId)
-        }
-
-        try await savePhotoToDatabase(clientMessageId: clientMessageId, localCacheURL: localCacheURL, replyContext: replyContext)
-
-        let tracker = PhotoUploadProgressTracker.shared
-        tracker.setStage(.preparing, for: trackingKey)
-
-        do {
-            let inboxReady = try await inboxStateManager.waitForInboxReadyResult()
-
-            let audioData = try Data(contentsOf: fileURL)
-            let attachment = Attachment(
-                filename: filename,
-                mimeType: "audio/m4a",
-                data: audioData
-            )
-
-            let encrypted = try RemoteAttachment.encodeEncrypted(
-                content: attachment,
-                codec: AttachmentCodec()
-            )
-
-            let presignedURLs = try await inboxReady.apiClient.getPresignedUploadURL(
-                filename: filename,
-                contentType: "application/octet-stream"
-            )
-
-            guard let uploadURL = URL(string: presignedURLs.uploadURL) else {
-                throw PhotoAttachmentError.invalidURL
-            }
-
-            let taskId = UUID().uuidString
-            let encryptedFileURL = try saveToTemp(data: encrypted.payload, taskId: taskId)
-
-            tracker.setProgress(stage: .uploading, percentage: 0, for: trackingKey)
-
-            try await backgroundUploadManager.startUpload(
-                fileURL: encryptedFileURL,
-                uploadURL: uploadURL,
-                contentType: "application/octet-stream",
-                taskId: taskId
-            )
-
-            let result = await backgroundUploadManager.waitForCompletion(taskId: taskId)
-
-            guard result.success else {
-                tracker.setStage(.failed, for: trackingKey)
-                try? await markMessageFailed(clientMessageId: clientMessageId)
-                throw result.error ?? PhotoAttachmentError.uploadFailed("Voice memo upload failed")
-            }
-
-            tracker.setStage(.publishing, for: trackingKey)
-
-            let storedAttachment = StoredRemoteAttachment(
-                url: presignedURLs.assetURL,
-                contentDigest: encrypted.digest,
-                secret: encrypted.secret,
-                salt: encrypted.salt,
-                nonce: encrypted.nonce,
-                filename: filename,
-                mimeType: "audio/m4a",
-                mediaDuration: duration
-            )
-
-            let messageId = try await publishAttachment(
-                storedAttachment: storedAttachment,
-                clientMessageId: clientMessageId,
-                trackingKey: trackingKey,
-                thumbnailImage: nil,
-                inboxReady: inboxReady,
-                replyContext: replyContext,
-                mediaType: "voice_memo"
-            )
-
-            try? FileManager.default.removeItem(at: encryptedFileURL)
-
-            QAEvent.emit(.message, "sent", ["id": messageId, "conversation": conversationId, "type": "voice_memo"])
-        } catch {
-            Log.error("Failed to send voice memo: \(error)")
-            tracker.setStage(.failed, for: trackingKey)
-            try? await markMessageFailed(clientMessageId: clientMessageId)
-            throw error
-        }
-
-        return trackingKey
+        return try await sendFileAttachment(params: params, replyToMessageId: replyToMessageId)
     }
 
     // MARK: - Replies


### PR DESCRIPTION
## Summary

Centralizes attachment-type-specific logic into the `MediaType` enum so adding a new MIME type requires fewer touchpoints.

## What changed

### `MediaType` now owns its semantics
- `previewLabel`: returns human-readable label ('a photo', 'a video', 'a voice memo', 'a file')
- `isFullBleed`: only image/video are full-bleed (determines grouping, layout padding, avatar placement)

### Simplified classification
**Before**: `attachmentsPreviewString` used three mutable booleans (`hasVideo`, `hasAudio`, `hasFile`) threaded through two classify methods. Adding audio required touching both methods and the string builder.

**After**: Single `classifyAttachment` returns `(mediaType: MediaType, filename: String?)`. Preview string derives from `mediaType.previewLabel`.

### Simplified reply labels
**Before**: Each reply view had its own `switch attachment.mediaType` with duplicated strings.

**After**: Both `ReplyComposerBar` and `ReplyReferenceView` derive from `MediaType.previewLabel`.

### Simplified layout height estimation
**Before**: Special-cased `.audio` with duplicate checks in two `case` branches.

**After**: Single `estimatedAttachmentHeight(for:width:)` switches on `MediaType` once.

## Adding a new MIME type now requires:
1. Add a case to `MediaType` (with `previewLabel` and `isFullBleed`)
2. Add height estimate in `estimatedAttachmentHeight`
3. Add the bubble view in `MessagesGroupItemView`

Everything else (preview strings, reply labels, grouping, layout) derives automatically.

## Stacked on
- #664 (voice memos)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Centralize attachment MediaType semantics and add bouncy animations to voice memo recording
> - Adds `previewLabel` and `isFullBleed` computed properties to the `MediaType` enum in [HydratedAttachment.swift](https://github.com/xmtplabs/convos-ios/pull/666/files#diff-f67104b33c234ffc26e7bc5339386b8f6a0fae89f625cdbf3be8d453964977c9), replacing duplicated classification logic across reply labels, preview strings, and layout delegates.
> - Consolidates video and voice memo upload logic into a shared `sendFileAttachment` helper in [OutgoingMessageWriter.swift](https://github.com/xmtplabs/convos-ios/pull/666/files#diff-2ba8cf409a96f2eb22ac537fb59817aae89c4fdf4a953c1683a27be30a6107b6), reducing duplication while preserving behavior.
> - Standardizes attachment preview text in conversation lists and reply composers to use `mediaType.previewLabel`; file attachments show their filename when available.
> - Updates message cell height estimates: audio attachments return 44pt, file attachments 60pt, image/video use aspect-ratio-based height.
> - Wraps voice memo start, stop, send, and discard actions in `withAnimation(.bouncy)` and adds matched-geometry transitions to the recording/review UI in [MessagesBottomBar.swift](https://github.com/xmtplabs/convos-ios/pull/666/files#diff-b66861cd8ab11a6d499676511b14e2fba66afdb7467461c01255f35000b416a2); `ConversationView` now stops playback and cancels recording on disappear.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3749403.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->