### PR TITLE
Add settings row for invite code sharing

### DIFF
--- a/Convos/App Settings/AssistantSettingsView.swift
+++ b/Convos/App Settings/AssistantSettingsView.swift
@@ -1,11 +1,15 @@
 import ConvosCore
 import SwiftUI
+import UIKit
 
 struct AssistantSettingsView: View {
     let session: any SessionManagerProtocol
 
     @Bindable private var defaults: GlobalConvoDefaults = .shared
     @State private var presentingCodeEntry: Bool = false
+    @State private var inviteCodeStatus: ConvosAPI.InviteCodeStatus?
+    @State private var inviteCodeStatusTask: Task<Void, Never>?
+    @State private var copiedInviteCode: Bool = false
 
     var body: some View {
         List {
@@ -53,6 +57,26 @@ struct AssistantSettingsView: View {
                 Text("Swipe up in new convos")
             }
 
+            if let inviteCodeStatus {
+                Section {
+                    Button(action: copyInviteCode) {
+                        HStack(alignment: .firstTextBaseline, spacing: DesignConstants.Spacing.stepX) {
+                            Text(inviteCodeStatus.code)
+                                .font(.body.monospaced())
+                                .foregroundStyle(.colorTextPrimary)
+                            Spacer()
+                            Text(remainingRedemptionsText(inviteCodeStatus.remainingRedemptions))
+                                .font(.footnote)
+                                .foregroundStyle(.colorTextSecondary)
+                        }
+                    }
+                    .accessibilityIdentifier("assistant-invite-code-row")
+                    .accessibilityLabel("Invite code \(inviteCodeStatus.code), \(remainingRedemptionsText(inviteCodeStatus.remainingRedemptions)). Tap to copy")
+                } footer: {
+                    Text(copiedInviteCode ? "Copied" : "Tap to copy your invite code")
+                }
+            }
+
             Section {
                 if let learnURL = URL(string: "https://learn.convos.org/assistants") {
                     Link(destination: learnURL) {
@@ -78,8 +102,58 @@ struct AssistantSettingsView: View {
             session: session,
             onUnlocked: {
                 defaults.assistantsEnabled = true
+                refreshInviteCodeStatus()
             }
         )
+        .task {
+            refreshInviteCodeStatus()
+        }
+        .onDisappear {
+            inviteCodeStatusTask?.cancel()
+        }
+    }
+
+    private func refreshInviteCodeStatus() {
+        inviteCodeStatusTask?.cancel()
+        guard let inviteCode = defaults.assistantInviteCode, !inviteCode.isEmpty else {
+            inviteCodeStatus = nil
+            return
+        }
+
+        inviteCodeStatusTask = Task {
+            do {
+                let status = try await session.fetchInviteCodeStatus(inviteCode)
+                guard !Task.isCancelled else { return }
+                await MainActor.run {
+                    inviteCodeStatus = status
+                }
+            } catch {
+                guard !Task.isCancelled else { return }
+                await MainActor.run {
+                    inviteCodeStatus = nil
+                }
+            }
+        }
+    }
+
+    private func copyInviteCode() {
+        guard let inviteCode = inviteCodeStatus?.code else { return }
+        UIPasteboard.general.string = inviteCode
+        copiedInviteCode = true
+        Task {
+            try? await Task.sleep(for: .seconds(2))
+            guard !Task.isCancelled else { return }
+            await MainActor.run {
+                copiedInviteCode = false
+            }
+        }
+    }
+
+    private func remainingRedemptionsText(_ remainingRedemptions: Int) -> String {
+        if remainingRedemptions == 1 {
+            return "1 redemption left"
+        }
+        return "\(remainingRedemptions) redemptions left"
     }
 }
 

--- a/Convos/App Settings/GlobalConvoDefaults.swift
+++ b/Convos/App Settings/GlobalConvoDefaults.swift
@@ -55,6 +55,18 @@ final class GlobalConvoDefaults: @unchecked Sendable {
         }
     }
 
+    var assistantInviteCode: String? {
+        get {
+            access(keyPath: \.assistantInviteCode)
+            return UserDefaults.standard.string(forKey: Constant.assistantInviteCodeKey)
+        }
+        set {
+            withMutation(keyPath: \.assistantInviteCode) {
+                UserDefaults.standard.set(newValue, forKey: Constant.assistantInviteCodeKey)
+            }
+        }
+    }
+
     func reset() {
         withMutation(keyPath: \.autoRevealPhotos) {
             UserDefaults.standard.removeObject(forKey: Constant.autoRevealPhotosKey)
@@ -68,6 +80,9 @@ final class GlobalConvoDefaults: @unchecked Sendable {
         withMutation(keyPath: \.assistantCodeUnlocked) {
             UserDefaults.standard.removeObject(forKey: Constant.assistantCodeUnlockedKey)
         }
+        withMutation(keyPath: \.assistantInviteCode) {
+            UserDefaults.standard.removeObject(forKey: Constant.assistantInviteCodeKey)
+        }
     }
 
     private enum Constant {
@@ -75,5 +90,6 @@ final class GlobalConvoDefaults: @unchecked Sendable {
         static let includeInfoWithInvitesKey: String = "globalIncludeInfoWithInvites"
         static let assistantsEnabledKey: String = "globalAssistantsEnabled"
         static let assistantCodeUnlockedKey: String = "globalAssistantCodeUnlocked"
+        static let assistantInviteCodeKey: String = "globalAssistantInviteCode"
     }
 }

--- a/Convos/App Settings/InviteCodeEntryView.swift
+++ b/Convos/App Settings/InviteCodeEntryView.swift
@@ -48,9 +48,10 @@ struct InviteCodeAlertModifier: ViewModifier {
         defer { isRedeeming = false }
 
         do {
-            try await session.redeemInviteCode(trimmed)
+            let inviteCode = try await session.redeemInviteCode(trimmed)
             await MainActor.run {
                 GlobalConvoDefaults.shared.assistantCodeUnlocked = true
+                GlobalConvoDefaults.shared.assistantInviteCode = inviteCode.code
                 code = ""
                 onUnlocked()
             }
@@ -63,6 +64,8 @@ struct InviteCodeAlertModifier: ViewModifier {
                     errorMessage = "Code must be 8 letters"
                 case .rateLimitExceeded:
                     errorMessage = "Too many attempts, try again later"
+                case .inviteCodeFullyRedeemed:
+                    errorMessage = "That invite code has already been fully redeemed"
                 default:
                     errorMessage = "Something went wrong, try again"
                 }

--- a/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient+Models.swift
+++ b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient+Models.swift
@@ -163,6 +163,50 @@ public enum ConvosAPI {
         }
     }
 
+    public struct InviteCodeStatusResponse: Codable, Sendable {
+        public let success: Bool
+        public let data: InviteCodeStatus
+
+        public init(success: Bool, data: InviteCodeStatus) {
+            self.success = success
+            self.data = data
+        }
+    }
+
+    public struct InviteCodeStatus: Codable, Sendable {
+        public let code: String
+        public let name: String?
+        public let maxRedemptions: Int
+        public let redemptionCount: Int
+        public let remainingRedemptions: Int
+
+        public init(code: String, name: String?, maxRedemptions: Int, redemptionCount: Int, remainingRedemptions: Int) {
+            self.code = code
+            self.name = name
+            self.maxRedemptions = maxRedemptions
+            self.redemptionCount = redemptionCount
+            self.remainingRedemptions = remainingRedemptions
+        }
+    }
+
+    public struct RedeemInviteCodeResponse: Codable, Sendable {
+        public let success: Bool
+        public let data: RedeemInviteCodeData
+
+        public init(success: Bool, data: RedeemInviteCodeData) {
+            self.success = success
+            self.data = data
+        }
+    }
+
+    public struct RedeemInviteCodeData: Codable, Sendable {
+        public let inviteCode: InviteCodeStatus
+
+        public init(inviteCode: InviteCodeStatus) {
+            self.inviteCode = inviteCode
+        }
+    }
+
     // MARK: - Common Error Response
 
     public struct ErrorResponse: Codable {

--- a/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift
+++ b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift
@@ -58,7 +58,8 @@ public protocol ConvosAPIClientProtocol: AnyObject, Sendable {
     func requestAgentJoin(slug: String, instructions: String, forceErrorCode: Int?) async throws -> ConvosAPI.AgentJoinResponse
 
     // Invite codes
-    func redeemInviteCode(_ code: String) async throws
+    func redeemInviteCode(_ code: String) async throws -> ConvosAPI.InviteCodeStatus
+    func fetchInviteCodeStatus(_ code: String) async throws -> ConvosAPI.InviteCodeStatus
 }
 
 extension ConvosAPIClientProtocol {
@@ -589,7 +590,7 @@ final class ConvosAPIClient: ConvosAPIClientProtocol, Sendable {
 
     // MARK: - Invite Codes
 
-    func redeemInviteCode(_ code: String) async throws {
+    func redeemInviteCode(_ code: String) async throws -> ConvosAPI.InviteCodeStatus {
         var request = try authenticatedRequest(for: "v2/invite-codes/redeem", method: "POST")
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
 
@@ -600,9 +601,30 @@ final class ConvosAPIClient: ConvosAPIClientProtocol, Sendable {
 
         switch httpResponse.statusCode {
         case 200...299:
-            return
+            let response = try JSONDecoder().decode(ConvosAPI.RedeemInviteCodeResponse.self, from: data)
+            return response.data.inviteCode
         case 409:
-            return
+            throw APIError.inviteCodeFullyRedeemed
+        case 404:
+            throw APIError.inviteCodeNotFound
+        case 422:
+            throw APIError.inviteCodeInvalidFormat
+        case 429:
+            throw APIError.rateLimitExceeded
+        default:
+            throw APIError.serverError(parseErrorMessage(from: data))
+        }
+    }
+
+    func fetchInviteCodeStatus(_ code: String) async throws -> ConvosAPI.InviteCodeStatus {
+        let normalised = code.uppercased().trimmingCharacters(in: .whitespacesAndNewlines)
+        let request = try authenticatedRequest(for: "v2/invite-codes/\(normalised)/status", method: "GET")
+        let (data, httpResponse) = try await performAuthenticatedRequest(request)
+
+        switch httpResponse.statusCode {
+        case 200...299:
+            let response = try JSONDecoder().decode(ConvosAPI.InviteCodeStatusResponse.self, from: data)
+            return response.data
         case 404:
             throw APIError.inviteCodeNotFound
         case 422:
@@ -648,6 +670,7 @@ public enum APIError: Error {
     case agentProvisionFailed
     case inviteCodeNotFound
     case inviteCodeInvalidFormat
+    case inviteCodeFullyRedeemed
 }
 
 extension APIError: DisplayError {
@@ -685,6 +708,8 @@ extension APIError: DisplayError {
             return "Code not found"
         case .inviteCodeInvalidFormat:
             return "Invalid code"
+        case .inviteCodeFullyRedeemed:
+            return "Code already used up"
         }
     }
 
@@ -722,6 +747,8 @@ extension APIError: DisplayError {
             return "No invite code found with that value."
         case .inviteCodeInvalidFormat:
             return "Code must be 8 letters."
+        case .inviteCodeFullyRedeemed:
+            return "That invite code has already been fully redeemed."
         }
     }
 }

--- a/ConvosCore/Sources/ConvosCore/API/MockAPIClient.swift
+++ b/ConvosCore/Sources/ConvosCore/API/MockAPIClient.swift
@@ -84,6 +84,11 @@ final class MockAPIClient: ConvosAPIClientProtocol, Sendable {
         .init(success: true, joined: true)
     }
 
-    func redeemInviteCode(_ code: String) async throws {
+    func redeemInviteCode(_ code: String) async throws -> ConvosAPI.InviteCodeStatus {
+        .init(code: "MOCKCODE", name: nil, maxRedemptions: 5, redemptionCount: 0, remainingRedemptions: 5)
+    }
+
+    func fetchInviteCodeStatus(_ code: String) async throws -> ConvosAPI.InviteCodeStatus {
+        .init(code: code.uppercased(), name: nil, maxRedemptions: 5, redemptionCount: 1, remainingRedemptions: 4)
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Inboxes/MockInboxesService.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/MockInboxesService.swift
@@ -93,7 +93,12 @@ public final class MockInboxesService: SessionManagerProtocol {
         return .init(success: true, joined: true)
     }
 
-    public func redeemInviteCode(_ code: String) async throws {
+    public func redeemInviteCode(_ code: String) async throws -> ConvosAPI.InviteCodeStatus {
+        .init(code: "MOCKCODE", name: nil, maxRedemptions: 5, redemptionCount: 0, remainingRedemptions: 5)
+    }
+
+    public func fetchInviteCodeStatus(_ code: String) async throws -> ConvosAPI.InviteCodeStatus {
+        .init(code: code.uppercased(), name: nil, maxRedemptions: 5, redemptionCount: 1, remainingRedemptions: 4)
     }
 
     public func conversationRepository(for conversationId: String, inboxId: String, clientId: String) async throws -> any ConversationRepositoryProtocol {

--- a/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
@@ -309,8 +309,12 @@ public final class SessionManager: SessionManagerProtocol, @unchecked Sendable {
         try await apiClient.requestAgentJoin(slug: slug, instructions: instructions, forceErrorCode: forceErrorCode)
     }
 
-    public func redeemInviteCode(_ code: String) async throws {
+    public func redeemInviteCode(_ code: String) async throws -> ConvosAPI.InviteCodeStatus {
         try await apiClient.redeemInviteCode(code)
+    }
+
+    public func fetchInviteCodeStatus(_ code: String) async throws -> ConvosAPI.InviteCodeStatus {
+        try await apiClient.fetchInviteCodeStatus(code)
     }
 
     public func conversationRepository(for conversationId: String, inboxId: String, clientId: String) async throws -> any ConversationRepositoryProtocol {

--- a/ConvosCore/Sources/ConvosCore/Sessions/SessionManagerProtocol.swift
+++ b/ConvosCore/Sources/ConvosCore/Sessions/SessionManagerProtocol.swift
@@ -27,7 +27,8 @@ public protocol SessionManagerProtocol: AnyObject, Sendable {
 
     func inviteRepository(for conversationId: String) -> any InviteRepositoryProtocol
     func requestAgentJoin(slug: String, instructions: String, forceErrorCode: Int?) async throws -> ConvosAPI.AgentJoinResponse
-    func redeemInviteCode(_ code: String) async throws
+    func redeemInviteCode(_ code: String) async throws -> ConvosAPI.InviteCodeStatus
+    func fetchInviteCodeStatus(_ code: String) async throws -> ConvosAPI.InviteCodeStatus
 
     func conversationRepository(
         for conversationId: String,


### PR DESCRIPTION
## Summary
- store the child invite code returned after redeeming an assistant invite code
- add client support for the new invite code status endpoint and fully-redeemed error
- show a dedicated invite-code row in Assistant Settings with remaining redemptions and tap-to-copy

## Testing
- swiftlint on touched files
- xcodebuild build -project Convos.xcodeproj -scheme "Convos (Dev)" -destination "platform=iOS Simulator,name=convos-jarod-invite-code-settings-row" -derivedDataPath .derivedData
- launched app in simulator and spot-checked settings UI

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add invite code status display and copy to Assistant settings
> - Adds a new section in [AssistantSettingsView](https://github.com/xmtplabs/convos-ios/pull/667/files#diff-82fc50156296f3bb62bf65904c0d188b4c869b6b0129f9da7aa6dc4355178c14) that fetches and displays the user's invite code with remaining redemptions, and allows tapping to copy the code to the clipboard.
> - Persists the invite code string in [GlobalConvoDefaults](https://github.com/xmtplabs/convos-ios/pull/667/files#diff-9b7426f539f4440e427de136137f59672b486a31c091ec181cb2696784327bf1) via a new `assistantInviteCode` UserDefaults-backed property, cleared on reset.
> - Extends `ConvosAPIClient` with a `fetchInviteCodeStatus` endpoint and updates `redeemInviteCode` to return decoded `InviteCodeStatus` instead of `Void`.
> - Adds `APIError.inviteCodeFullyRedeemed` for HTTP 409 responses, replacing the previous silent success path.
> - Behavioral Change: `redeemInviteCode` callers now receive an `InviteCodeStatus` return value; code that ignored the previous `Void` return is unaffected, but callers expecting `Void` will fail to compile.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5b1df04.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->