### PR TITLE
Fix outgoing voice memo bubble invisible in dark mode

### DIFF
--- a/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/VoiceMemoBubble.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/VoiceMemoBubble.swift
@@ -119,18 +119,18 @@ struct VoiceMemoBubbleContent: View {
                         .font(.system(size: 16))
                 }
             }
-            .foregroundStyle(isOutgoing ? .white : .colorTextPrimary)
+            .foregroundStyle(isOutgoing ? .colorTextPrimaryInverted : .colorTextPrimary)
             .frame(width: 36, height: 36)
             .background(
-                isOutgoing ? Color.white.opacity(0.2) : .colorFillMinimal,
+                isOutgoing ? Color.colorTextPrimaryInverted.opacity(0.2) : .colorFillMinimal,
                 in: Circle()
             )
 
             VoiceMemoWaveformView(
                 levels: displayLevels,
                 progress: displayProgress,
-                playedColor: isOutgoing ? .white : .colorTextPrimary,
-                unplayedColor: isOutgoing ? .white.opacity(0.3) : .colorTextSecondary.opacity(0.3)
+                playedColor: isOutgoing ? .colorTextPrimaryInverted : .colorTextPrimary,
+                unplayedColor: isOutgoing ? .colorTextPrimaryInverted.opacity(0.3) : .colorTextSecondary.opacity(0.3)
             )
             .frame(height: 24)
             .frame(maxWidth: .infinity)
@@ -138,7 +138,7 @@ struct VoiceMemoBubbleContent: View {
 
             Text(displayDuration)
                 .font(.caption.monospacedDigit())
-                .foregroundStyle(isOutgoing ? .white.opacity(0.7) : .colorTextSecondary)
+                .foregroundStyle(isOutgoing ? .colorTextPrimaryInverted.opacity(0.7) : .colorTextSecondary)
                 .frame(minWidth: 32, alignment: .trailing)
         }
         .padding(DesignConstants.Spacing.step3x)


### PR DESCRIPTION
## Problem

In dark mode, outgoing voice memo bubbles have invisible play/pause icons, waveform, and duration labels.

## Root Cause

`VoiceMemoBubbleContent` used hardcoded `.white` for the foreground colors on outgoing messages. In light mode the outgoing bubble (`colorBubble`) is black, so white-on-black works. But `colorBubble` flips to white in dark mode, making white foreground content invisible.

## Fix

Replace hardcoded `.white` with `.colorTextPrimaryInverted`, which flips between white (light mode) and black (dark mode) along with the bubble background. Same pattern used by `MessageBubble`, `MessageContainer`, and `FileAttachmentBubble`.

Affected elements:
- Play/pause icon foreground
- Play/pause circle background (was `Color.white.opacity(0.2)`)
- Waveform played/unplayed colors
- Duration label

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix outgoing voice memo bubble invisible in dark mode
> Replaces hardcoded `white` color references in the outgoing state of `VoiceMemoBubbleContent` with `colorTextPrimaryInverted`, which adapts correctly to dark mode. Affected elements include the play/pause icon, its circular background, the waveform played/unplayed colors, and the duration text in [VoiceMemoBubble.swift](https://github.com/xmtplabs/convos-ios/pull/669/files#diff-8a0d69fffce67fba794f951a8fae1cb903bb8a2e5e3be308063ce8962d6fe634).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f8c5742.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->