### PR TITLE
Fix incoming video aspect ratio when no thumbnail or stored dimensions

### DIFF
--- a/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
@@ -607,6 +607,9 @@ private struct AttachmentPlaceholder: View {
 
             do {
                 let videoURL = try await resolveVideoURL(for: attachment.key)
+                if attachment.width == nil {
+                    await loadVideoDimensionsIfPossible(from: videoURL)
+                }
                 let player = AVPlayer(url: videoURL)
                 await player.seek(to: .zero)
                 inlinePlayer = player
@@ -666,6 +669,27 @@ private struct AttachmentPlaceholder: View {
         }
 
         isLoading = false
+    }
+
+    /// Reads the natural video dimensions from a decrypted local video file and
+    /// reports them via `onDimensionsLoaded` so the aspect ratio is persisted for
+    /// future renders. This is the fallback for incoming videos that arrive without
+    /// sender-provided dimensions (e.g. inline attachments from clients that do not
+    /// populate `StoredRemoteAttachment.mediaWidth`/`mediaHeight`, or remote
+    /// attachments without an accompanying thumbnail).
+    private func loadVideoDimensionsIfPossible(from videoURL: URL) async {
+        let service = VideoCompressionService()
+        do {
+            let size = try await service.loadVideoDimensions(from: videoURL)
+            let width = Int(size.width.rounded())
+            let height = Int(size.height.rounded())
+            guard width > 0, height > 0 else { return }
+            await MainActor.run {
+                onDimensionsLoaded(width, height)
+            }
+        } catch {
+            Log.warning("Failed to read video dimensions: \(error)")
+        }
     }
 
     private func resolveVideoURL(for key: String) async throws -> URL {

--- a/ConvosCore/Sources/ConvosCore/Messaging/VideoCompressionService.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/VideoCompressionService.swift
@@ -45,6 +45,7 @@ public struct CompressedVideo: Sendable {
 public protocol VideoCompressionServiceProtocol: Sendable {
     func compressVideo(at sourceURL: URL) async throws -> CompressedVideo
     func generateThumbnail(for asset: AVAsset) async throws -> Data
+    func loadVideoDimensions(from url: URL) async throws -> CGSize
 }
 
 public final class VideoCompressionService: VideoCompressionServiceProtocol, Sendable {
@@ -115,6 +116,20 @@ public final class VideoCompressionService: VideoCompressionServiceProtocol, Sen
             thumbnail: thumbnail,
             mimeType: "video/mp4"
         )
+    }
+
+    /// Loads the natural video dimensions from a local or remote URL, accounting for
+    /// the track's preferred transform so rotated portrait videos return portrait
+    /// dimensions (width < height).
+    public func loadVideoDimensions(from url: URL) async throws -> CGSize {
+        let asset = AVURLAsset(url: url)
+        guard let videoTrack = try await asset.loadTracks(withMediaType: .video).first else {
+            throw VideoCompressionError.invalidAsset
+        }
+        let naturalSize = try await videoTrack.load(.naturalSize)
+        let transform = try await videoTrack.load(.preferredTransform)
+        let transformedSize = naturalSize.applying(transform)
+        return CGSize(width: abs(transformedSize.width), height: abs(transformedSize.height))
     }
 
     public func generateThumbnail(for asset: AVAsset) async throws -> Data {

--- a/ConvosCore/Tests/ConvosCoreTests/VideoMessageTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/VideoMessageTests.swift
@@ -182,6 +182,19 @@ struct VideoMessageTests {
         #expect(VideoCompressionService.maxFileSizeBytes == 25 * 1024 * 1024)
     }
 
+    @Test("loadVideoDimensions throws for a non-video URL")
+    func testLoadVideoDimensionsInvalidAsset() async throws {
+        let tempURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("not-a-video-\(UUID().uuidString).mp4")
+        try Data("this is not a video".utf8).write(to: tempURL)
+        defer { try? FileManager.default.removeItem(at: tempURL) }
+
+        let service = VideoCompressionService()
+        await #expect(throws: (any Error).self) {
+            try await service.loadVideoDimensions(from: tempURL)
+        }
+    }
+
     // MARK: - Attachments Preview String
 
     @Test("Single photo attachment shows 'a photo'")


### PR DESCRIPTION
The previous fix for incoming video aspect ratio only ran when the
attachment had a thumbnail — it decoded the thumbnail and forwarded its
dimensions via onDimensionsLoaded. That covered outgoing videos (which
the iOS sender always compresses and thumbnails) and remote attachments
with a sender-provided thumbnail, but it missed two real cases:

1. Inline video attachments from clients that don't populate
   StoredRemoteAttachment.mediaWidth / mediaHeight / thumbnailDataBase64
   (e.g. the convos CLI's send-attachment command for files under 1 MB.
2. Remote video attachments that arrive without a thumbnail.

For both cases HydratedAttachment.width / height stayed nil forever,
aspectRatio returned nil, and the bubble fell back to a 4:3 placeholder.
Sending a 360x640 portrait video from the CLI reproduced this as a
squat landscape rectangle instead of the expected tall portrait frame.

Fix: once the decrypted video file is available on disk, read the
natural video dimensions from the file itself and feed them through
the same onDimensionsLoaded path the thumbnail branch already uses.
VideoCompressionService gains a loadVideoDimensions(from:) helper that
reuses the existing AVURLAsset + preferredTransform logic (so rotated
portrait captures return portrait dimensions). AttachmentPlaceholder
calls it only when attachment.width is still nil after the thumbnail
branch, so there's no extra AVAsset work when dimensions are already
available.

Verified on simulator by sending /tmp/test-cat.mp4 (360x640) via the
convos CLI: bubble now renders as 9:16 portrait and the dimensions
persist to AttachmentLocalState for subsequent renders.
EOF
)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix incoming video aspect ratio when no thumbnail or stored dimensions
> - Adds `loadVideoDimensions(from:)` to `VideoCompressionService` that reads a video track's `naturalSize` and `preferredTransform` via AVFoundation, returning the correct dimensions accounting for rotation.
> - In `MessagesGroupItemView`, when a video attachment has no pre-populated width/height, the view now calls this method after resolving the local/remote URL and reports results via `onDimensionsLoaded` on the main actor.
> - Adds a test asserting `loadVideoDimensions` throws `invalidAsset` for non-video data.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 05ffd40.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->