### PR TITLE
Fix voice memo playback observer and review composer controls

### DIFF
--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -393,7 +393,11 @@ class ConversationViewModel {
     @ObservationIgnored
     private var explodeTask: Task<Void, Never>?
 
+    @ObservationIgnored
+    private var voiceMemoPlaybackTask: Task<Void, Never>?
+
     deinit {
+        voiceMemoPlaybackTask?.cancel()
         loadConversationImageTask?.cancel()
         explodeTask?.cancel()
         assistantJoinTask?.cancel()
@@ -832,35 +836,43 @@ extension ConversationViewModel {
     }
 
     func setupVoiceMemoPlaybackObserver() {
+        NotificationCenter.default.removeObserver(self, name: .voiceMemoPlaybackRequested, object: nil)
         NotificationCenter.default.addObserver(
-            forName: .voiceMemoPlaybackRequested,
-            object: nil,
-            queue: .main
-        ) { [weak self] notification in
-            guard self != nil,
-                  let userInfo = notification.userInfo,
-                  let messageId = userInfo["messageId"] as? String,
-                  let attachmentKey = userInfo["attachmentKey"] as? String else { return }
+            self,
+            selector: #selector(handleVoiceMemoPlaybackRequested(_:)),
+            name: .voiceMemoPlaybackRequested,
+            object: nil
+        )
+    }
 
-            Task { @MainActor in
-                let player = VoiceMemoPlayer.shared
-                if player.currentlyPlayingMessageId == messageId {
-                    if player.state == .playing {
-                        player.pause()
-                        return
-                    } else if player.state == .paused {
-                        player.resume()
-                        return
-                    }
-                }
+    @objc
+    private func handleVoiceMemoPlaybackRequested(_ notification: Notification) {
+        guard let userInfo = notification.userInfo,
+              let messageId = userInfo["messageId"] as? String,
+              let attachmentKey = userInfo["attachmentKey"] as? String else { return }
 
-                do {
-                    let loader = RemoteAttachmentLoader()
-                    let loaded = try await loader.loadAttachmentData(from: attachmentKey)
-                    try player.play(data: loaded.data, messageId: messageId)
-                } catch {
-                    Log.error("Failed to play voice memo: \(error)")
+        voiceMemoPlaybackTask?.cancel()
+        voiceMemoPlaybackTask = Task { @MainActor in
+            let player = VoiceMemoPlayer.shared
+            if player.currentlyPlayingMessageId == messageId {
+                if player.state == .playing {
+                    player.pause()
+                    return
+                } else if player.state == .paused {
+                    player.resume()
+                    return
                 }
+            }
+
+            do {
+                let loader = RemoteAttachmentLoader()
+                let loaded = try await loader.loadAttachmentData(from: attachmentKey)
+                guard !Task.isCancelled else { return }
+                try player.play(data: loaded.data, messageId: messageId)
+            } catch is CancellationError {
+                return
+            } catch {
+                Log.error("Failed to play voice memo: \(error)")
             }
         }
     }

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/VoiceMemoReviewView.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/VoiceMemoReviewView.swift
@@ -24,7 +24,7 @@ struct VoiceMemoReviewView: View {
                     .font(.system(size: 14))
                     .foregroundStyle(.colorTextPrimary)
                     .frame(width: 32, height: 32)
-                    .background(.colorFillMinimal, in: Circle())
+                    .background(.colorFillTertiary, in: Circle())
             }
             .accessibilityLabel(isPlaying ? "Pause" : "Play")
             .accessibilityIdentifier("voice-memo-play-button")
@@ -47,9 +47,9 @@ struct VoiceMemoReviewView: View {
             } label: {
                 Image(systemName: "arrow.up")
                     .font(.system(size: 14, weight: .bold))
-                    .foregroundStyle(.white)
+                    .foregroundStyle(.colorTextPrimaryInverted)
                     .frame(width: 32, height: 32)
-                    .background(.colorTextPrimary, in: Circle())
+                    .background(.colorFillPrimary, in: Circle())
             }
             .accessibilityLabel("Send voice memo")
             .accessibilityIdentifier("voice-memo-send-button")


### PR DESCRIPTION
## Summary\n- dedupe the voice memo playback notification observer so tapping a playing memo reliably pauses/resumes\n- align the voice memo review send button with the composer send button styling\n- use  for the review play button background\n\n## Testing\n- xcodebuild build -project Convos.xcodeproj -scheme "Convos (Dev)" -destination "platform=iOS Simulator,name=convos-dev" -derivedDataPath .derivedData\n- verified pause/resume on an existing loaded voice memo in the simulator\n- verified a newly sent longer voice memo loads and plays in the simulator\n

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix voice memo playback observer and review composer controls in conversation view
> - Replaces the closure-based `NotificationCenter` observer in `setupVoiceMemoPlaybackObserver` with a selector-based registration, and adds a pre-emptive `removeObserver` call to prevent duplicate handlers on re-registration.
> - Introduces `handleVoiceMemoPlaybackRequested` to ensure only one playback task runs at a time; new requests cancel the previous task, and cancelled loads skip playback.
> - Cancels any in-flight `voiceMemoPlaybackTask` in `deinit` to prevent work tied to a deallocated instance.
> - Updates color tokens in [`VoiceMemoReviewView`](https://github.com/xmtplabs/convos-ios/pull/671/files#diff-46015fee134165ddc3fd0823cc6a8579021434338c0670c130903079118e3428): play/pause button background uses `.colorFillTertiary`, send button uses `.colorTextPrimaryInverted` foreground and `.colorFillPrimary` background.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f2617ca.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->