### PR TITLE
Fix loading previous messages getting stuck after first attempt

### DIFF
--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/MessagesViewController.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/MessagesViewController.swift
@@ -429,6 +429,9 @@ final class MessagesViewController: UIViewController {
 
     private func loadPreviousMessages() {
         guard let onLoadPreviousMessages = onLoadPreviousMessages else { return }
+        // Don't set the loading flag if there are no more messages to load —
+        // the repository will no-op and we'd never clear the flag.
+        guard state?.hasLoadedAllMessages == false else { return }
         currentControllerActions.options.insert(.loadingPreviousMessages)
         onLoadPreviousMessages()
     }
@@ -509,8 +512,13 @@ extension MessagesViewController {
                                 animated: Bool = true,
                                 requiresIsolatedProcess: Bool,
                                 completion: (() -> Void)? = nil) {
-        if currentControllerActions.options.contains(.loadingPreviousMessages),
-           messages.contains(where: { $0.origin == .paginated }) {
+        // Clear the pagination loading flag whenever we receive a batch of messages.
+        // Previously this only cleared on messages with .paginated origin, but if the
+        // repository decides there are no more messages to load (totalCount <= limit),
+        // it returns without triggering a new publisher emission, leaving the flag
+        // stuck forever. Clearing on any update is safe because fetchPrevious has its
+        // own concurrency guard, and hasMoreMessages gates further pagination requests.
+        if currentControllerActions.options.contains(.loadingPreviousMessages) {
             currentControllerActions.options.remove(.loadingPreviousMessages)
         }
 

--- a/ConvosCore/Sources/ConvosCore/Storage/Repositories/MessagesRepository.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Repositories/MessagesRepository.swift
@@ -180,52 +180,51 @@ class MessagesRepository: MessagesRepositoryProtocol {
         let targetLimit = currentLimit + pageSize
 
         // Synchronously check and acquire the pagination lock
-        // This ensures only one pagination operation can proceed at a time
+        // This ensures only one pagination operation can proceed at a time.
+        // The flag is cleared from the ValueObservation closure once the
+        // publisher re-emits with the new limit, not here — otherwise the
+        // async observation would see a stale _isLoadingPrevious and mark
+        // paginated messages as .inserted / .existing instead of .paginated.
         let shouldProceed = stateQueue.sync { () -> Bool in
-            // Check if we can proceed with pagination
             guard !_isLoadingPrevious && _hasMoreMessages else {
                 return false
             }
-            // Atomically set the loading flag before any state changes
             _isLoadingPrevious = true
             return true
         }
 
-        // Early return if we shouldn't proceed (already loading or no more messages)
         guard shouldProceed else { return }
 
-        // Ensure we always reset the loading flag, even if the read throws
-        defer {
-            stateQueue.sync(flags: .barrier) {
-                self._isLoadingPrevious = false
-            }
-        }
-
-        // Increment the limit
-        currentLimit = targetLimit
-
-        // The publisher will automatically update with the new messages
-        try dbReader.read { [weak self] db in
-            guard let self else { return }
-
-            let totalCount = try DBMessage
+        // Check if there are more messages to load before bumping the limit.
+        // If not, clear the loading flag and bail out.
+        let totalCount = try dbReader.read { db in
+            try DBMessage
                 .filter(DBMessage.Columns.conversationId == capturedConversationId)
                 .filter(DBMessage.Columns.messageType != DBMessageType.reaction.rawValue)
                 .fetchCount(db)
-
-            self.stateQueue.sync(flags: .barrier) {
-                // Verify the conversation hasn't changed before updating state
-                // If it has changed, abort without updating state as this pagination
-                // was for the previous conversation
-                guard self.conversationId == capturedConversationId else {
-                    return
-                }
-
-                if totalCount <= targetLimit {
-                    self._hasMoreMessages = false
-                }
-            }
         }
+
+        let shouldBumpLimit = stateQueue.sync(flags: .barrier) { () -> Bool in
+            guard self.conversationId == capturedConversationId else {
+                self._isLoadingPrevious = false
+                return false
+            }
+            if totalCount <= currentLimit {
+                self._hasMoreMessages = false
+                self._isLoadingPrevious = false
+                return false
+            }
+            if totalCount <= targetLimit {
+                self._hasMoreMessages = false
+            }
+            return true
+        }
+
+        guard shouldBumpLimit else { return }
+
+        // Increment the limit. The publisher will re-emit with the new limit
+        // and the ValueObservation closure will clear _isLoadingPrevious.
+        currentLimit = targetLimit
     }
 
     lazy var conversationMessagesPublisher: AnyPublisher<ConversationMessages, Never> = {
@@ -273,9 +272,15 @@ class MessagesRepository: MessagesRepositoryProtocol {
                             isPaginating: currentState.isPaginating
                         )
 
-                        // Update seenMessageIds atomically
+                        // Update seenMessageIds atomically and clear the pagination flag.
+                        // Clearing here (after messages have been composed with the updated
+                        // limit) ensures origin is correctly set to .paginated for newly
+                        // loaded messages before the UI observes them.
                         stateQueue.sync(flags: .barrier) {
                             unsafeSelf._seenMessageIds = updatedSeenIds
+                            if currentState.isPaginating {
+                                unsafeSelf._isLoadingPrevious = false
+                            }
                         }
 
                         return messages


### PR DESCRIPTION
## Problem

Users report that 'load previous messages' (scrolling to the top of a conversation) stops working after the first attempt. The logs show multiple `Fetching previous messages` entries but the UI never shows new messages and subsequent scroll-to-top gestures are ignored.

## Root Cause

Two interacting bugs in `MessagesRepository.fetchPrevious()` and `MessagesViewController.loadPreviousMessages()`:

### Bug 1: `_isLoadingPrevious` race condition

`fetchPrevious()` sets `_isLoadingPrevious = true`, bumps `currentLimit`, then uses `defer` to clear the flag after the synchronous count read returns. But the `ValueObservation` triggered by bumping `currentLimit` runs **asynchronously** on its own thread, and may not read `_isLoadingPrevious` until after the `defer` has already cleared it.

When that happens, the new batch of messages gets:
```swift
LoadingState(isPaginating: false /* stale */)
```

Which makes `resolveOrigin()` assign `.inserted` or `.existing` instead of `.paginated` for the newly loaded messages. The UI's clearing logic:
```swift
if currentControllerActions.options.contains(.loadingPreviousMessages),
   messages.contains(where: { $0.origin == .paginated }) {
    currentControllerActions.options.remove(.loadingPreviousMessages)
}
```

...never matches, so the `.loadingPreviousMessages` flag stays set forever, and the scroll-to-top guard in `scrollViewDidScroll` blocks all future pagination attempts.

### Bug 2: Stuck flag when there's nothing to load

If the user scrolled to top when all messages were already loaded, the UI still set `loadingPreviousMessages` before calling into the repository. The repository would no-op (`_hasMoreMessages == false`) without triggering a new publisher emission, so the flag had no way to clear.

## Fix

1. **Clear `_isLoadingPrevious` from inside the `ValueObservation` closure**, after messages have been composed with the updated limit. This ensures `isPaginating` is read correctly before the flag flips.

2. **Check `totalCount` BEFORE bumping the limit** in `fetchPrevious()`. If there's nothing new to load, clear `_hasMoreMessages` and `_isLoadingPrevious` synchronously and return — avoiding an unnecessary publisher emission.

3. **Guard `loadPreviousMessages()` in the UI** with `state?.hasLoadedAllMessages == false` so the flag is never set when there's nothing to load.

4. **Remove the `.paginated` origin check** in `processUpdates()`'s flag clearing. With the race fixed, we can safely clear the flag on any message batch update. Added inline documentation explaining why.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix message pagination getting stuck after the first load attempt
> - In [`MessagesViewController`](https://github.com/xmtplabs/convos-ios/pull/672/files#diff-1427b816e5e93d8bc7ea882f5eabd9671135c6f9b9ebc6b0a6f7116a2f8a37c3), `loadPreviousMessages` now exits early when `hasLoadedAllMessages` is true, preventing the loading flag from being set unnecessarily.
> - `processUpdates` now clears the `.loadingPreviousMessages` flag on any messages update, not just when paginated items are present, fixing the stuck state.
> - In [`MessagesRepository`](https://github.com/xmtplabs/convos-ios/pull/672/files#diff-e28ef7ea258a8f4aa4b0f172d269bea58cfb2d103c92ec33a4eb24e1f49beb86), `fetchPrevious` checks `totalCount` before bumping the limit and sets `_hasMoreMessages=false` immediately when no additional messages exist.
> - The repository now clears `_isLoadingPrevious` inside the publisher after composing messages, ensuring `.paginated` origin is set before observers are notified.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f020290.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->