### PR TITLE
Fix 'See its skills' button showing on unverified agent joins

### DIFF
--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Cells/MessagesListItemTypeCell.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Cells/MessagesListItemTypeCell.swift
@@ -76,9 +76,9 @@ class MessagesListItemTypeCell: UICollectionViewCell {
                         )
                             .id(update.differenceIdentifier)
                             .padding(.top, DesignConstants.Spacing.step4x)
-                            .padding(.bottom, update.addedAgent ? DesignConstants.Spacing.step3x : DesignConstants.Spacing.step4x)
+                            .padding(.bottom, update.addedVerifiedAssistant ? DesignConstants.Spacing.step3x : DesignConstants.Spacing.step4x)
                             .padding(.horizontal, DesignConstants.Spacing.step4x)
-                        if update.addedAgent {
+                        if update.addedVerifiedAssistant {
                             AssistantJoinedInfoView()
                                 .padding(.horizontal, DesignConstants.Spacing.step4x)
                         }

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessagesListView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessagesListView.swift
@@ -72,7 +72,7 @@ struct MessagesListView: View {
                                         }
                                     )
                                         .padding(.vertical, DesignConstants.Spacing.stepX)
-                                    if update.addedAgent {
+                                    if update.addedVerifiedAssistant {
                                         AssistantJoinedInfoView()
                                     }
                                 }

--- a/ConvosCore/Sources/ConvosCore/Mocks/ModelMocks.swift
+++ b/ConvosCore/Sources/ConvosCore/Mocks/ModelMocks.swift
@@ -108,7 +108,9 @@ public extension ConversationMember {
     static func mock(
         isCurrentUser: Bool = false,
         name: String? = nil,
-        role: MemberRole = .member
+        role: MemberRole = .member,
+        isAgent: Bool = false,
+        agentVerification: AgentVerification = .unverified
     ) -> ConversationMember {
         let profile = Profile.mock(
             inboxId: isCurrentUser ? "current-user" : "other-user-\(UUID().uuidString)",
@@ -118,7 +120,9 @@ public extension ConversationMember {
         return ConversationMember(
             profile: profile,
             role: isCurrentUser ? .admin : role,
-            isCurrentUser: isCurrentUser
+            isCurrentUser: isCurrentUser,
+            isAgent: isAgent,
+            agentVerification: agentVerification
         )
     }
 

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/ConversationUpdate.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/ConversationUpdate.swift
@@ -60,6 +60,14 @@ public struct ConversationUpdate: Hashable, Codable, Sendable {
         addedMembers.contains(where: \.isAgent)
     }
 
+    /// `true` when this update added at least one member that is a verified
+    /// Convos assistant. Used to gate UI affordances like the "See its skills"
+    /// button, which should only appear for verified assistants — never for
+    /// regular members or unverified agents.
+    public var addedVerifiedAssistant: Bool {
+        addedMembers.contains { $0.isAgent && $0.agentVerification.isConvosAssistant }
+    }
+
     var showsInMessagesList: Bool {
         guard metadataChanges.allSatisfy({ $0.field.showsInMessagesList }) else {
             return false

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/MessagesListProcessor.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/MessagesListProcessor.swift
@@ -36,7 +36,7 @@ public final class MessagesListProcessor: Sendable {
                 lastAssistantJoinIndex = i
                 agentJoinedAfterAssistantRequest = false
             case .update(let update):
-                if lastAssistantJoinIndex != nil, update.addedAgent {
+                if lastAssistantJoinIndex != nil, update.addedVerifiedAssistant {
                     agentJoinedAfterAssistantRequest = true
                 }
                 var added = 0

--- a/ConvosCore/Tests/ConvosCoreTests/ConversationUpdateTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ConversationUpdateTests.swift
@@ -1,0 +1,90 @@
+@testable import ConvosCore
+import Foundation
+import Testing
+
+@Suite("ConversationUpdate Tests")
+struct ConversationUpdateTests {
+    private let creator: ConversationMember = .mock(isCurrentUser: true, name: "Me")
+
+    private func update(addedMembers: [ConversationMember]) -> ConversationUpdate {
+        ConversationUpdate(
+            creator: creator,
+            addedMembers: addedMembers,
+            removedMembers: [],
+            metadataChanges: []
+        )
+    }
+
+    // MARK: - addedAgent
+
+    @Test("addedAgent is true when any added member is an agent")
+    func addedAgentTrueForUnverifiedAgent() {
+        let agent = ConversationMember.mock(name: "CLI Bot", isAgent: true, agentVerification: .unverified)
+        let update = update(addedMembers: [agent])
+        #expect(update.addedAgent == true)
+    }
+
+    @Test("addedAgent is true when added member is a verified Convos assistant")
+    func addedAgentTrueForVerifiedConvosAssistant() {
+        let agent = ConversationMember.mock(name: "Convos Assistant", isAgent: true, agentVerification: .verified(.convos))
+        let update = update(addedMembers: [agent])
+        #expect(update.addedAgent == true)
+    }
+
+    @Test("addedAgent is false when no added member is an agent")
+    func addedAgentFalseForRegularMembers() {
+        let regular = ConversationMember.mock(name: "Alice", isAgent: false)
+        let update = update(addedMembers: [regular])
+        #expect(update.addedAgent == false)
+    }
+
+    // MARK: - addedVerifiedAssistant
+
+    @Test("addedVerifiedAssistant is true only for verified Convos assistants")
+    func addedVerifiedAssistantTrueForConvosAssistant() {
+        let agent = ConversationMember.mock(name: "Convos Assistant", isAgent: true, agentVerification: .verified(.convos))
+        let update = update(addedMembers: [agent])
+        #expect(update.addedVerifiedAssistant == true)
+    }
+
+    @Test("addedVerifiedAssistant is false for unverified agents")
+    func addedVerifiedAssistantFalseForUnverifiedAgent() {
+        // This is the regression case: a CLI joiner advertises itself as
+        // memberKind=agent but has no Convos attestation. The "See its skills"
+        // button must NOT appear for these.
+        let agent = ConversationMember.mock(name: "CLI Bot", isAgent: true, agentVerification: .unverified)
+        let update = update(addedMembers: [agent])
+        #expect(update.addedVerifiedAssistant == false)
+    }
+
+    @Test("addedVerifiedAssistant is false for user-OAuth verified agents")
+    func addedVerifiedAssistantFalseForUserOAuthAgent() {
+        // OAuth-verified agents are not Convos assistants and should not get
+        // the "See its skills" affordance, which links to the Convos catalog.
+        let agent = ConversationMember.mock(name: "OAuth Agent", isAgent: true, agentVerification: .verified(.userOAuth))
+        let update = update(addedMembers: [agent])
+        #expect(update.addedVerifiedAssistant == false)
+    }
+
+    @Test("addedVerifiedAssistant is false for regular members")
+    func addedVerifiedAssistantFalseForRegularMembers() {
+        let regular = ConversationMember.mock(name: "Alice", isAgent: false)
+        let update = update(addedMembers: [regular])
+        #expect(update.addedVerifiedAssistant == false)
+    }
+
+    @Test("addedVerifiedAssistant is true when at least one added member is a verified Convos assistant")
+    func addedVerifiedAssistantTrueWithMixedMembers() {
+        let regular = ConversationMember.mock(name: "Alice", isAgent: false)
+        let unverified = ConversationMember.mock(name: "CLI Bot", isAgent: true, agentVerification: .unverified)
+        let verified = ConversationMember.mock(name: "Convos Assistant", isAgent: true, agentVerification: .verified(.convos))
+        let update = update(addedMembers: [regular, unverified, verified])
+        #expect(update.addedVerifiedAssistant == true)
+    }
+
+    @Test("addedVerifiedAssistant is false for empty added members")
+    func addedVerifiedAssistantFalseForEmpty() {
+        let update = update(addedMembers: [])
+        #expect(update.addedVerifiedAssistant == false)
+    }
+}

--- a/ConvosCore/Tests/ConvosCoreTests/MessagesListProcessorTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/MessagesListProcessorTests.swift
@@ -824,14 +824,15 @@ struct MessagesListProcessorAssistantJoinTests {
         #expect(ajItems.count == 1)
     }
 
-    @Test("Assistant join request hidden if agent joined after")
+    @Test("Assistant join request hidden if verified Convos assistant joined after")
     func hiddenAfterAgentJoined() {
         let now = Date()
         let agentMember = ConversationMember(
-            profile: Profile(inboxId: "agent-1", name: "Agent", avatar: nil, isAgent: true),
+            profile: Profile(inboxId: "agent-1", name: "Convos Assistant", avatar: nil, isAgent: true),
             role: .member,
             isCurrentUser: false,
-            isAgent: true
+            isAgent: true,
+            agentVerification: .verified(.convos)
         )
         let messages = [
             makeAssistantJoinRequest(id: "aj-1", date: now),
@@ -856,6 +857,45 @@ struct MessagesListProcessorAssistantJoinTests {
             return false
         }
         #expect(ajItems.count == 0)
+    }
+
+    @Test("Assistant join request stays visible if only an unverified agent joined after")
+    func stayVisibleAfterUnverifiedAgentJoined() {
+        // Regression coverage: a CLI joiner advertises itself as memberKind=agent
+        // but is not a verified Convos assistant. It must NOT dismiss the
+        // pending assistant join status — the user is still waiting for the
+        // real assistant.
+        let now = Date()
+        let unverifiedAgent = ConversationMember(
+            profile: Profile(inboxId: "cli-bot-1", name: "CLI Bot", avatar: nil, isAgent: true),
+            role: .member,
+            isCurrentUser: false,
+            isAgent: true,
+            agentVerification: .unverified
+        )
+        let messages = [
+            makeAssistantJoinRequest(id: "aj-1", date: now),
+            AnyMessage.message(Message(
+                id: "cli-bot-joined",
+                sender: otherUser,
+                source: .incoming,
+                status: .published,
+                content: .update(ConversationUpdate(
+                    creator: otherUser,
+                    addedMembers: [unverifiedAgent],
+                    removedMembers: [],
+                    metadataChanges: []
+                )),
+                date: now.addingTimeInterval(5),
+                reactions: []
+            ), .existing),
+        ]
+        let result = MessagesListProcessor.process(messages)
+        let ajItems = result.filter {
+            if case .assistantJoinStatus = $0 { return true }
+            return false
+        }
+        #expect(ajItems.count == 1)
     }
 
     @Test("Expired assistant join request is not shown")


### PR DESCRIPTION
The convos CLI (and other clients acting as agents) advertise themselves
with 'memberKind: agent' in their join requests. These members arrive as
`isAgent: true` but with no Convos attestation metadata, so they're
unverified. The previous logic in `ConversationUpdate.addedAgent` and
`MessagesListProcessor` treated any agent the same way, which caused
the orange 'See its skills' capsule — meant only for verified Convos
assistants — to appear below every CLI/agent joiner update.

This change introduces `ConversationUpdate.addedVerifiedAssistant`,
which is true only when at least one added member has
`agentVerification == .verified(.convos)`. The message list views
(SwiftUI + UICollectionView cell) now gate 'See its skills' on this
stricter check, and `MessagesListProcessor` uses it to decide whether
an assistant join request should be dismissed — an unverified CLI bot
joining must not retire a pending assistant join status.

Covered by:
- ConversationUpdateTests: addedAgent still broad, addedVerifiedAssistant
  true only for `.verified(.convos)`, false for unverified/userOAuth/
  regular members.
- MessagesListProcessorAssistantJoinTests: new regression test
  `stayVisibleAfterUnverifiedAgentJoined`; existing
  `hiddenAfterAgentJoined` updated to use a verified Convos assistant.

Manually verified on the iPhone 17 Pro simulator by reproducing the bug
with `convos conversations join` and confirming the 'See its skills'
capsule no longer renders after the fix.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix 'See its skills' button showing when an unverified agent joins a conversation
> - Adds `addedVerifiedAssistant` computed property to `ConversationUpdate` that returns `true` only when an added member is both an agent and has `agentVerification.isConvosAssistant == true`.
> - Replaces `addedAgent` checks with `addedVerifiedAssistant` in `MessagesListItemTypeCell`, `MessagesListView`, and `MessagesListProcessor` so the assistant-joined UI and skill button appear only for verified Convos assistants.
> - The pending assistant join request item is no longer dismissed when an unverified agent joins.
> - Adds unit tests covering the new `addedVerifiedAssistant` property and the updated `MessagesListProcessor` behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2229a18.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->