### PR TITLE
Fix flaky VoiceMemoTranscriptionService tests under parallel load

### DIFF
--- a/ConvosCore/Tests/ConvosCoreTests/VoiceMemoTranscriptionServiceTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/VoiceMemoTranscriptionServiceTests.swift
@@ -26,7 +26,7 @@ struct VoiceMemoTranscriptionServiceTests {
             mimeType: "audio/m4a"
         )
 
-        try await waitUntil(timeout: .seconds(2)) { await writer.completedSnapshot().count == 1 }
+        try await waitUntil(timeout: .seconds(10)) { await writer.completedSnapshot().count == 1 }
 
         let pendingCount = await writer.pendingSnapshot().count
         let completed = await writer.completedSnapshot()
@@ -159,7 +159,7 @@ struct VoiceMemoTranscriptionServiceTests {
             mimeType: "audio/m4a"
         )
 
-        try await waitUntil(timeout: .seconds(2)) { await writer.completedSnapshot().count == 1 }
+        try await waitUntil(timeout: .seconds(10)) { await writer.completedSnapshot().count == 1 }
 
         let completed = await writer.completedSnapshot()
         let transcribeCalls = await transcriber.callCount()
@@ -190,7 +190,7 @@ struct VoiceMemoTranscriptionServiceTests {
             mimeType: "audio/m4a"
         )
 
-        try await waitUntil(timeout: .seconds(2)) { await writer.failedSnapshot().count == 1 }
+        try await waitUntil(timeout: .seconds(10)) { await writer.failedSnapshot().count == 1 }
 
         let failed = await writer.failedSnapshot()
         let pending = await writer.pendingSnapshot()
@@ -224,7 +224,7 @@ struct VoiceMemoTranscriptionServiceTests {
             mimeType: "audio/m4a"
         )
 
-        try await waitUntil(timeout: .seconds(2)) {
+        try await waitUntil(timeout: .seconds(10)) {
             await transcriber.cancelCallSnapshot().contains("msg-1")
         }
 
@@ -262,7 +262,7 @@ struct VoiceMemoTranscriptionServiceTests {
             mimeType: "audio/m4a"
         )
 
-        try await waitUntil(timeout: .seconds(2)) { await writer.permanentlyFailedSnapshot().count == 1 }
+        try await waitUntil(timeout: .seconds(10)) { await writer.permanentlyFailedSnapshot().count == 1 }
 
         let permanentlyFailed = await writer.permanentlyFailedSnapshot()
         let failed = await writer.failedSnapshot()
@@ -294,7 +294,7 @@ struct VoiceMemoTranscriptionServiceTests {
             mimeType: "audio/m4a"
         )
 
-        try await waitUntil(timeout: .seconds(2)) { await writer.permanentlyFailedSnapshot().count == 1 }
+        try await waitUntil(timeout: .seconds(10)) { await writer.permanentlyFailedSnapshot().count == 1 }
 
         let permanentlyFailed = await writer.permanentlyFailedSnapshot()
         let failed = await writer.failedSnapshot()
@@ -326,7 +326,7 @@ struct VoiceMemoTranscriptionServiceTests {
             mimeType: "audio/m4a"
         )
 
-        try await waitUntil(timeout: .seconds(2)) { await writer.failedSnapshot().count == 1 }
+        try await waitUntil(timeout: .seconds(10)) { await writer.failedSnapshot().count == 1 }
 
         let transcribeCalls = await transcriber.callCount()
         let failed = await writer.failedSnapshot()
@@ -365,7 +365,7 @@ struct VoiceMemoTranscriptionServiceTests {
         )
         _ = await (firstCall, secondCall)
 
-        try await waitUntil(timeout: .seconds(2)) { await writer.completedSnapshot().count == 1 }
+        try await waitUntil(timeout: .seconds(10)) { await writer.completedSnapshot().count == 1 }
 
         let transcribeCalls = await transcriber.callCount()
         let loadCalls = await attachmentLoader.callCount()


### PR DESCRIPTION
All eight `waitUntil(timeout: .seconds(2))` calls in
VoiceMemoTranscriptionServiceTests were too tight to survive the full
`swift test --package-path ConvosCore` run on a laptop. The transcription
happy-path actor chain completes in ~55 ms in isolation, but when 66
test suites run in parallel and the machine is under load, the dispatch
of `saveCompleted` can take longer than two seconds, causing
`TimeoutError()` and a red build.

Bumped every timeout in the file to `.seconds(10)` (matching the
default in `waitUntil`), which gives the pipeline enough slack on a
loaded machine while still catching real hangs. On a clean run the
suite now finishes in ~8 s instead of timing out at 2 s. Verified by
running `swift test --package-path ConvosCore` end-to-end: 561 tests,
66 suites, 0 failures.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix flaky `VoiceMemoTranscriptionService` tests by increasing async wait timeouts
> Increases the `waitUntil` timeout from 2 seconds to 10 seconds across all 8 tests in [VoiceMemoTranscriptionServiceTests.swift](https://github.com/xmtplabs/convos-ios/pull/675/files#diff-188a19245ea32abb955f66bd67c18b5f0592934c28b247efd60de130bee51f0e) to prevent false failures under parallel test load.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 22b75ab.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->