### PR TITLE
Render removed convo name/description as 'removed' instead of empty quotes

### DIFF
--- a/ConvosCore/Sources/ConvosCore/Mocks/ModelMocks.swift
+++ b/ConvosCore/Sources/ConvosCore/Mocks/ModelMocks.swift
@@ -249,6 +249,9 @@ public extension ConversationUpdate {
         } else if let metadataChange = metadataChanges.first,
                   metadataChange.field == .name,
                   let updatedName = metadataChange.newValue {
+            if updatedName.isEmpty {
+                return "\(creatorDisplayName) removed the convo name"
+            }
             return "\(creatorDisplayName) changed the convo name to \"\(updatedName)\""
         } else if let metadataChange = metadataChanges.first,
                   metadataChange.field == .image,
@@ -257,6 +260,9 @@ public extension ConversationUpdate {
         } else if let metadataChange = metadataChanges.first,
                   metadataChange.field == .description,
                   let newValue = metadataChange.newValue {
+            if newValue.isEmpty {
+                return "\(creatorDisplayName) removed the convo description"
+            }
             return "\(creatorDisplayName) changed the convo description to \"\(newValue)\""
         } else if let metadataChange = metadataChanges.first,
                   metadataChange.field == .expiresAt,

--- a/ConvosCore/Tests/ConvosCoreTests/ConversationUpdateTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ConversationUpdateTests.swift
@@ -87,4 +87,56 @@ struct ConversationUpdateTests {
         let update = update(addedMembers: [])
         #expect(update.addedVerifiedAssistant == false)
     }
+
+    // MARK: - summary for metadata changes
+
+    private func metadataUpdate(
+        creator: ConversationMember,
+        field: ConversationUpdate.MetadataChange.Field,
+        oldValue: String? = nil,
+        newValue: String?
+    ) -> ConversationUpdate {
+        ConversationUpdate(
+            creator: creator,
+            addedMembers: [],
+            removedMembers: [],
+            metadataChanges: [
+                .init(field: field, oldValue: oldValue, newValue: newValue)
+            ]
+        )
+    }
+
+    @Test("summary uses 'changed the convo name to' for a non-empty new name")
+    func summaryRenamesToNonEmptyName() {
+        let update = metadataUpdate(creator: creator, field: .name, newValue: "Fam")
+        #expect(update.summary == "You changed the convo name to \"Fam\"")
+    }
+
+    @Test("summary says 'removed the convo name' when the new name is empty")
+    func summaryClearsName() {
+        // Regression: clearing the name field used to render
+        // `You changed the convo name to ""`. It should read
+        // `You removed the convo name` instead.
+        let update = metadataUpdate(creator: creator, field: .name, newValue: "")
+        #expect(update.summary == "You removed the convo name")
+    }
+
+    @Test("summary attributes the rename to the other member when not current user")
+    func summaryRenamesByOtherMember() {
+        let alice = ConversationMember.mock(isCurrentUser: false, name: "Alice")
+        let update = metadataUpdate(creator: alice, field: .name, newValue: "")
+        #expect(update.summary == "Alice removed the convo name")
+    }
+
+    @Test("summary uses 'changed the convo description to' for a non-empty new description")
+    func summaryRenamesDescriptionToNonEmpty() {
+        let update = metadataUpdate(creator: creator, field: .description, newValue: "plans for the weekend")
+        #expect(update.summary == "You changed the convo description to \"plans for the weekend\"")
+    }
+
+    @Test("summary says 'removed the convo description' when the new description is empty")
+    func summaryClearsDescription() {
+        let update = metadataUpdate(creator: creator, field: .description, newValue: "")
+        #expect(update.summary == "You removed the convo description")
+    }
 }


### PR DESCRIPTION
Clearing the conversation name (or description) used to render as
`You changed the convo name to ""` in the messages list, because
`ConversationUpdate.summary` only guarded against a nil `newValue`,
not an empty string. When the user clears the name field,
`ConversationViewModel.onConversationNameEndedEditing` publishes a
metadata change with an empty-string `newValue`, which is the
intentional 'removed' signal.

This change treats an empty `newValue` for the `.name` and
`.description` fields as removal:

    You changed the convo name to "Fam"     // unchanged
    You removed the convo name                 // was: "You changed the convo name to \"\""
    You changed the convo description to "…" // unchanged
    You removed the convo description          // was: "… description to \"\""

Covered by five new `ConversationUpdateTests` cases:
  - summaryRenamesToNonEmptyName
  - summaryClearsName                  (regression)
  - summaryRenamesByOtherMember        (attribution on clear)
  - summaryRenamesDescriptionToNonEmpty
  - summaryClearsDescription

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show 'removed' instead of empty quotes for cleared conversation name/description
> When a conversation's name or description is cleared (set to an empty string), `ConversationUpdate.summary` now returns "You removed the convo name/description" instead of composing a rename with empty quotes. Tests are added in [ConversationUpdateTests.swift](https://github.com/xmtplabs/convos-ios/pull/676/files#diff-09d605204924d2ae7292f534431cc98a9caa64b20cabb574911547428085d669) covering both clearing and renaming to non-empty values, for both the current user and other members.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f8ca4d7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->