### PR TITLE
Fix voice memo transcripts in new conversation flow

### DIFF
--- a/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/VoiceMemoBubble.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/VoiceMemoBubble.swift
@@ -15,9 +15,7 @@ struct VoiceMemoAttachmentView: View {
     let onReply: (AnyMessage) -> Void
 
     @State private var player: VoiceMemoPlayer = .shared
-    @State private var audioData: Data?
     @State private var isLoading: Bool = false
-    @State private var playTrigger: Int = 0
 
     var body: some View {
         MessageContainer(style: bubbleType, isOutgoing: message.sender.isCurrentUser) {
@@ -32,36 +30,8 @@ struct VoiceMemoAttachmentView: View {
         .messageGesture(
             message: message,
             bubbleStyle: bubbleType,
-            onSingleTap: { playTrigger += 1 },
             onReply: onReply
         )
-        .onChange(of: playTrigger) {
-            Task { await togglePlayback() }
-        }
-    }
-
-    private func togglePlayback() async {
-        if let data = audioData {
-            do {
-                try player.togglePlayback(data: data, messageId: message.messageId)
-            } catch {
-                Log.error("Failed to play voice memo: \(error)")
-            }
-            return
-        }
-
-        guard !isLoading else { return }
-        isLoading = true
-        do {
-            let loaded = try await sharedAttachmentLoader.loadAttachmentData(from: attachment.key)
-            audioData = loaded.data
-            try await MainActor.run {
-                try player.play(data: loaded.data, messageId: message.messageId)
-            }
-        } catch {
-            Log.error("Failed to load voice memo: \(error)")
-        }
-        isLoading = false
     }
 }
 

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessagesListRepository.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessagesListRepository.swift
@@ -29,7 +29,7 @@ final class MessagesListRepository: MessagesListRepositoryProtocol {
 
     private let messagesRepository: any MessagesRepositoryProtocol
     private let transcriptRepository: any VoiceMemoTranscriptRepositoryProtocol
-    private let conversationId: String
+    private let conversationIdSubject: CurrentValueSubject<String, Never>
     /// Returns whether the user has granted on-device speech recognition permission.
     /// Used to suppress the synthetic "Tap to transcribe" affordance once the user
     /// has authorized transcription — from that point forward, voice memos with no
@@ -52,7 +52,7 @@ final class MessagesListRepository: MessagesListRepositoryProtocol {
     var conversationMessagesListPublisher: AnyPublisher<(String, [MessagesListItemType]), Never> {
         messagesRepository.conversationMessagesPublisher
             .map { [weak self] conversationId, messages in
-                let processedMessages = self?.processMessages(messages) ?? []
+                let processedMessages = self?.processMessages(messages, conversationId: conversationId) ?? []
                 return (conversationId, processedMessages)
             }
             .handleEvents(receiveOutput: { [weak self] _, processedMessages in
@@ -73,7 +73,7 @@ final class MessagesListRepository: MessagesListRepositoryProtocol {
     ) {
         self.messagesRepository = messagesRepository
         self.transcriptRepository = transcriptRepository
-        self.conversationId = conversationId
+        self.conversationIdSubject = .init(conversationId)
         self.speechPermissionProvider = speechPermissionProvider
     }
 
@@ -82,21 +82,22 @@ final class MessagesListRepository: MessagesListRepositoryProtocol {
         hasStartedObserving = true
         messagesRepository.messagesPublisher
             .map { [weak self] messages in
-                self?.processMessages(messages) ?? []
+                self?.processMessages(messages, conversationId: self?.conversationIdSubject.value) ?? []
             }
             .sink { [weak self] processedMessages in
                 self?.messagesListSubject.send(processedMessages)
             }
             .store(in: &cancellables)
 
-        transcriptCancellable = transcriptRepository.transcriptsPublisher(in: conversationId)
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] transcripts in
-                guard let self else { return }
-                self.storedTranscripts = transcripts
-                let reprocessed = self.processMessages(self.lastRawMessages)
-                self.messagesListSubject.send(reprocessed)
+        conversationMessagesListPublisher
+            .map(\ .0)
+            .removeDuplicates()
+            .sink { [weak self] conversationId in
+                self?.handleConversationIdChanged(conversationId)
             }
+            .store(in: &cancellables)
+
+        observeTranscripts(for: conversationIdSubject.value)
     }
 
     // MARK: - Public Methods
@@ -108,8 +109,8 @@ final class MessagesListRepository: MessagesListRepositoryProtocol {
         // transcripts publisher subscription in startObserving() lags behind
         // the initial fetch by one run loop, causing transcript rows to
         // "animate in" a moment after the conversation opens.
-        storedTranscripts = (try? transcriptRepository.fetchAllTranscripts(in: conversationId)) ?? [:]
-        return processMessages(messages)
+        storedTranscripts = (try? transcriptRepository.fetchAllTranscripts(in: conversationIdSubject.value)) ?? [:]
+        return processMessages(messages, conversationId: conversationIdSubject.value)
     }
 
     func fetchPrevious() throws {
@@ -123,9 +124,9 @@ final class MessagesListRepository: MessagesListRepositoryProtocol {
 
     // MARK: - Private Methods
 
-    private func processMessages(_ messages: [AnyMessage]) -> [MessagesListItemType] {
+    private func processMessages(_ messages: [AnyMessage], conversationId: String?) -> [MessagesListItemType] {
         lastRawMessages = messages
-        let transcripts = synthesizeTranscriptItems(messages: messages)
+        let transcripts = synthesizeTranscriptItems(messages: messages, conversationId: conversationId)
         let items = MessagesListProcessor.process(
             messages,
             otherMemberCount: currentOtherMemberCount,
@@ -143,9 +144,11 @@ final class MessagesListRepository: MessagesListRepositoryProtocol {
     /// scheduler auto-enqueues these messages, so the row should stay hidden until
     /// the writer flips it to `.pending`.
     private func synthesizeTranscriptItems(
-        messages: [AnyMessage]
+        messages: [AnyMessage],
+        conversationId: String?
     ) -> [String: VoiceMemoTranscriptListItem] {
         let permissionGranted = speechPermissionProvider()
+        let effectiveConversationId = conversationId ?? conversationIdSubject.value
         var result: [String: VoiceMemoTranscriptListItem] = [:]
         for message in messages {
             guard let attachment = message.content.primaryVoiceMemoAttachment else { continue }
@@ -168,7 +171,7 @@ final class MessagesListRepository: MessagesListRepositoryProtocol {
             }
             let item = VoiceMemoTranscriptListItem(
                 parentMessageId: message.messageId,
-                conversationId: conversationId,
+                conversationId: effectiveConversationId,
                 attachmentKey: attachment.key,
                 mimeType: attachment.mimeType,
                 senderDisplayName: message.sender.profile.displayName,
@@ -180,6 +183,25 @@ final class MessagesListRepository: MessagesListRepositoryProtocol {
             result[message.messageId] = item
         }
         return result
+    }
+
+    private func handleConversationIdChanged(_ conversationId: String) {
+        guard conversationIdSubject.value != conversationId else { return }
+        conversationIdSubject.send(conversationId)
+        storedTranscripts = (try? transcriptRepository.fetchAllTranscripts(in: conversationId)) ?? [:]
+        observeTranscripts(for: conversationId)
+    }
+
+    private func observeTranscripts(for conversationId: String) {
+        transcriptCancellable?.cancel()
+        transcriptCancellable = transcriptRepository.transcriptsPublisher(in: conversationId)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] transcripts in
+                guard let self else { return }
+                self.storedTranscripts = transcripts
+                let reprocessed = self.processMessages(self.lastRawMessages, conversationId: self.conversationIdSubject.value)
+                self.messagesListSubject.send(reprocessed)
+            }
     }
 
     private func scheduleAssistantJoinDismissIfNeeded(_ items: [MessagesListItemType]) {
@@ -196,7 +218,7 @@ final class MessagesListRepository: MessagesListRepositoryProtocol {
             .delay(for: .seconds(remaining), scheduler: DispatchQueue.main)
             .sink { [weak self] _ in
                 guard let self else { return }
-                let reprocessed = self.processMessages(self.lastRawMessages)
+                let reprocessed = self.processMessages(self.lastRawMessages, conversationId: self.conversationIdSubject.value)
                 self.scheduleAssistantJoinDismissIfNeeded(reprocessed)
                 self.messagesListSubject.send(reprocessed)
             }


### PR DESCRIPTION
## Summary
- fix transcript observation in the new conversation/draft flow by tracking conversation ID changes in MessagesListRepository
- resubscribe transcript observation and reseed stored transcripts when the draft conversation becomes a real conversation
- keep voice memo playback on the existing outer single-tap gesture path, which is the reliable tap handler under the gesture overlay

## Root cause
MessagesListRepository pinned transcript state to the conversation ID it received at init time. In the new conversation flow, that starts as a draft conversation ID and later switches to the real conversation ID after creation. Message observation already followed the conversation ID change, but transcript observation did not, so transcript rows, retries, and auto-transcription could stay attached to the stale draft conversation.

## Validation
- xcodebuild build -project Convos.xcodeproj -scheme "Convos (Dev)" succeeded
- built and ran on physical device
- verified voice memo playback still works after keeping the outer tap handler


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix voice memo transcripts in new conversation flow
> - Removes audio playback logic from [`VoiceMemoAttachmentView`](https://github.com/xmtplabs/convos-ios/pull/677/files#diff-8a0d69fffce67fba794f951a8fae1cb903bb8a2e5e3be308063ce8962d6fe634), which now only renders content and forwards reply gestures.
> - Updates [`MessagesListRepository`](https://github.com/xmtplabs/convos-ios/pull/677/files#diff-71dd69ab8fe7508011640a2d654b7a4b05f7da5527c887b56188a72eb5ad2255) to track the active conversation ID via a `CurrentValueSubject`, so transcript observation and message synthesis switch correctly when the conversation changes.
> - `synthesizeTranscriptItems` now uses the effective current conversation ID when constructing `VoiceMemoTranscriptListItem`, fixing incorrect or missing transcripts in new conversation flows.
> - Behavioral Change: tapping a voice memo bubble no longer triggers playback from `VoiceMemoAttachmentView`; playback must now be handled elsewhere.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 57e4af5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->