### PR TITLE
Fix missing video thumbnails in reply UI

### DIFF
--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/ReplyComposerBar.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/ReplyComposerBar.swift
@@ -1,3 +1,4 @@
+import AVFoundation
 import ConvosCore
 import SwiftUI
 
@@ -78,7 +79,12 @@ struct ReplyComposerBar: View {
                     .foregroundStyle(.colorTextSecondary)
                     .frame(width: 40, height: 40)
             } else if let attachment {
-                ReplyPhotoThumbnail(attachmentKey: attachment.key, shouldBlur: shouldBlurAttachment, isVideo: isVideo)
+                ReplyPhotoThumbnail(
+                    attachmentKey: attachment.key,
+                    thumbnailData: attachment.thumbnailData,
+                    shouldBlur: shouldBlurAttachment,
+                    isVideo: isVideo
+                )
             }
 
             VStack(alignment: .leading, spacing: 2.0) {
@@ -125,6 +131,7 @@ struct ReplyComposerBar: View {
 
 private struct ReplyPhotoThumbnail: View {
     let attachmentKey: String
+    let thumbnailData: Data?
     let shouldBlur: Bool
     var isVideo: Bool = false
 
@@ -133,11 +140,17 @@ private struct ReplyPhotoThumbnail: View {
     private static let loader: RemoteAttachmentLoader = RemoteAttachmentLoader()
     private static let thumbnailSize: CGFloat = 40.0
 
-    init(attachmentKey: String, shouldBlur: Bool, isVideo: Bool = false) {
+    init(attachmentKey: String, thumbnailData: Data?, shouldBlur: Bool, isVideo: Bool = false) {
         self.attachmentKey = attachmentKey
+        self.thumbnailData = thumbnailData
         self.shouldBlur = shouldBlur
         self.isVideo = isVideo
-        _loadedImage = State(initialValue: ImageCache.shared.image(for: attachmentKey))
+
+        if isVideo, let thumbnailData, let thumb = UIImage(data: thumbnailData) {
+            _loadedImage = State(initialValue: thumb)
+        } else {
+            _loadedImage = State(initialValue: ImageCache.shared.image(for: attachmentKey))
+        }
     }
 
     var body: some View {
@@ -171,6 +184,20 @@ private struct ReplyPhotoThumbnail: View {
                 return
             }
             do {
+                if isVideo {
+                    let loaded = try await Self.loader.loadAttachmentData(from: attachmentKey)
+                    let tempURL = FileManager.default.temporaryDirectory.appendingPathComponent("reply-thumb-\(UUID().uuidString).mp4")
+                    try loaded.data.write(to: tempURL)
+                    defer { try? FileManager.default.removeItem(at: tempURL) }
+                    let asset = AVURLAsset(url: tempURL)
+                    let thumbnail = try await VideoCompressionService().generateThumbnail(for: asset)
+                    if let image = UIImage(data: thumbnail) {
+                        ImageCache.shared.cacheImage(image, for: attachmentKey, storageTier: .persistent)
+                        loadedImage = image
+                    }
+                    return
+                }
+
                 let data = try await Self.loader.loadImageData(from: attachmentKey)
                 if let image = UIImage(data: data) {
                     loadedImage = image

--- a/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/ReplyReferenceView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/ReplyReferenceView.swift
@@ -1,3 +1,4 @@
+import AVFoundation
 import ConvosCore
 import ConvosLogging
 import SwiftUI
@@ -334,8 +335,20 @@ private struct ReplyReferencePhotoPreview: View {
                 loadedImage = cachedImage
                 return
             }
-            guard !isVideo else { return }
             do {
+                if isVideo {
+                    let loaded = try await Self.loader.loadAttachmentData(from: attachmentKey)
+                    let tempURL = FileManager.default.temporaryDirectory.appendingPathComponent("reply-ref-thumb-\(UUID().uuidString).mp4")
+                    try loaded.data.write(to: tempURL)
+                    defer { try? FileManager.default.removeItem(at: tempURL) }
+                    let asset = AVURLAsset(url: tempURL)
+                    let thumbnail = try await VideoCompressionService().generateThumbnail(for: asset)
+                    if let image = UIImage(data: thumbnail) {
+                        ImageCache.shared.cacheImage(image, for: attachmentKey, storageTier: .persistent)
+                        loadedImage = image
+                    }
+                    return
+                }
                 let data = try await Self.loader.loadImageData(from: attachmentKey)
                 if let image = UIImage(data: data) {
                     loadedImage = image


### PR DESCRIPTION
## Summary
- fix missing video thumbnails in the reply composer bar
- fix missing fallback thumbnails in the reply parent reference view
- generate a local thumbnail from the video attachment when embedded thumbnail data is unavailable

## Root cause
`ReplyComposerBar` only tried to load the attachment as an image, which works for photos but not for videos. `ReplyReferenceView` already used embedded `thumbnailData` for videos, but if that payload was missing it had no fallback and rendered an empty placeholder.

## Validation
- `xcodebuild build -project Convos.xcodeproj -scheme "Convos (Dev)"` succeeded
- built and ran on physical device
- verified on device after install/launch


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix missing video thumbnails in reply composer and reference preview
> - [`ReplyPhotoThumbnail`](https://github.com/xmtplabs/convos-ios/pull/678/files#diff-c384af5f710dda8910b74dc2480e663c70ca285473aa20d1097176bb403f7303) now generates a video thumbnail by writing attachment data to a temp file, creating an `AVURLAsset`, and calling `VideoCompressionService` to produce a `UIImage`, which is then cached persistently.
> - [`ReplyReferencePhotoPreview`](https://github.com/xmtplabs/convos-ios/pull/678/files#diff-f4aab767e0ecfbed5f31ebb3412661186732e367192eeca828fff854a6d6dcf8) applies the same approach so reply reference previews render video thumbnails instead of showing nothing.
> - If `thumbnailData` is already available for a video, it is used immediately without generating a new thumbnail.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 28ba34c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->