### PR TITLE
Shorten collapsed composer placeholder

### DIFF
--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesBottomBar.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesBottomBar.swift
@@ -280,6 +280,7 @@ struct MessagesBottomBar<BottomBarContent: View>: View {
                 focusState: $focusState,
                 animateAvatarForQuickname: onboardingCoordinator.shouldAnimateAvatarForQuicknameSetup,
                 messagesTextFieldEnabled: messagesTextFieldEnabled,
+                isCollapsed: !isMessageInputFocused,
                 onProfilePhotoTap: onProfilePhotoTap,
                 onSendMessage: onSendMessage,
                 onClearInvite: onClearInvite,

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesInputView.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesInputView.swift
@@ -19,6 +19,7 @@ struct MessagesInputView: View {
     @FocusState.Binding var focusState: MessagesViewInputFocus?
     let animateAvatarForQuickname: Bool
     let messagesTextFieldEnabled: Bool
+    let isCollapsed: Bool
     private let focused: MessagesViewInputFocus = .message
     let onProfilePhotoTap: () -> Void
     let onSendMessage: () -> Void
@@ -99,7 +100,7 @@ struct MessagesInputView: View {
     private var messageTextField: some View {
         Group {
             TextField(
-                "Chat as \(profile.displayName)",
+                isCollapsed ? "Chat" : "Chat as \(profile.displayName)",
                 text: $messageText,
                 axis: .vertical
             )
@@ -572,6 +573,7 @@ private struct ComposerInvitePreviewCard: View {
             focusState: $focusState,
             animateAvatarForQuickname: animateAvatarForQuickname,
             messagesTextFieldEnabled: true,
+            isCollapsed: true,
             onProfilePhotoTap: {},
             onSendMessage: {},
             onClearInvite: { pendingInviteURLPreview = nil }


### PR DESCRIPTION
## Summary
- use `Chat` as the placeholder when the composer is collapsed and media buttons are visible
- keep `Chat as <displayName>` when the composer is expanded

## Validation
- `xcodebuild build -project Convos.xcodeproj -scheme "Convos (Dev)"` succeeded
- built and launched on simulator


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Shorten `MessagesInputView` placeholder text when composer is collapsed
> When the message input is not focused, `MessagesInputView` now receives `isCollapsed: true` from [MessagesBottomBar.swift](https://github.com/xmtplabs/convos-ios/pull/679/files#diff-b66861cd8ab11a6d499676511b14e2fba66afdb7467461c01255f35000b416a2). The placeholder shortens to "Chat" in the collapsed state and shows the full "Chat as <displayName>" when focused.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f1a3716.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->