### PR TITLE
Self-heal missing invite tags

### DIFF
--- a/Convos/Conversation Detail/ConversationInfoView.swift
+++ b/Convos/Conversation Detail/ConversationInfoView.swift
@@ -80,6 +80,9 @@ struct ConversationInfoView: View {
     @State private var showingFullInfo: Bool = false
     @State private var presentingShareView: Bool = false
     @State private var exportedLogsURL: URL?
+    @State private var metadataDebugText: String = "Loading…"
+    @State private var showingRestoreInviteTagAlert: Bool = false
+    @State private var restoreInviteTagText: String = ""
 
     private let maxMembersToShow: Int = 6
     private var displayedMembers: [ConversationMember] {
@@ -412,6 +415,19 @@ struct ConversationInfoView: View {
                         } label: {
                             Text("Remote commit log")
                         }
+                        NavigationLink {
+                            DebugLogsTextView(logs: metadataDebugText)
+                                .task {
+                                    metadataDebugText = await viewModel.conversationMetadataDebugText()
+                                }
+                        } label: {
+                            Text("Metadata")
+                        }
+                        Button {
+                            showingRestoreInviteTagAlert = true
+                        } label: {
+                            Text("Restore invite tag")
+                        }
                         if let url = exportedLogsURL {
                             ShareLink(item: url) {
                                 HStack {
@@ -441,6 +457,27 @@ struct ConversationInfoView: View {
                         }
                     }
                 }
+            }
+            .alert("Restore invite tag", isPresented: $showingRestoreInviteTagAlert) {
+                TextField("Invite tag", text: $restoreInviteTagText)
+                Button("Cancel", role: .cancel) {
+                    restoreInviteTagText = ""
+                }
+                Button("Restore") {
+                    let expectedTag = restoreInviteTagText
+                    restoreInviteTagText = ""
+                    Task {
+                        do {
+                            try await viewModel.restoreInviteTagIfMissing(expectedTag)
+                            metadataDebugText = await viewModel.conversationMetadataDebugText()
+                        } catch {
+                            let refreshedDebugText = await viewModel.conversationMetadataDebugText()
+                            metadataDebugText = "Restore failed: \(error.localizedDescription)\n\n\(refreshedDebugText)"
+                        }
+                    }
+                }
+            } message: {
+                Text("Only use this if you know the expected invite tag for this convo.")
             }
             .scrollContentBackground(.hidden)
             .background(.colorBackgroundRaisedSecondary)
@@ -539,7 +576,7 @@ struct ConversationInfoView: View {
 }
 
 struct DebugLogsTextView: View {
-    @State var logs: String
+    let logs: String
     var body: some View {
         VStack {
             ScrollView {

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -1336,6 +1336,43 @@ extension ConversationViewModel {
     }
 
     @MainActor
+    func conversationMetadataDebugText() async -> String {
+        do {
+            let messagingService = try await session.messagingService(
+                for: conversation.clientId,
+                inboxId: conversation.inboxId
+            )
+            let inboxResult = try await messagingService.inboxStateManager.waitForInboxReadyResult()
+            let client = inboxResult.client
+            return try await client.conversationMetadataDebugInfo(
+                conversationId: conversation.id,
+                clientConversationId: conversation.clientConversationId
+            ).debugText
+        } catch {
+            return metadataDebugFallbackText(reason: error.localizedDescription)
+        }
+    }
+
+    @MainActor
+    func restoreInviteTagIfMissing(_ expectedTag: String) async throws {
+        let trimmedTag = expectedTag.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedTag.isEmpty else { return }
+
+        let messagingService = try await session.messagingService(
+            for: conversation.clientId,
+            inboxId: conversation.inboxId
+        )
+        let inboxResult = try await messagingService.inboxStateManager.waitForInboxReadyResult()
+        let client = inboxResult.client
+        guard let xmtpConversation = try await client.conversation(with: conversation.id),
+              case .group(let group) = xmtpConversation else {
+            throw NSError(domain: "ConversationViewModel", code: 1, userInfo: [NSLocalizedDescriptionKey: "XMTP group not found"])
+        }
+
+        try await group.restoreInviteTagIfMissing(trimmedTag)
+    }
+
+    @MainActor
     func exportDebugLogs() async throws -> URL {
         let environment = ConfigManager.shared.currentEnvironment
 
@@ -1364,6 +1401,14 @@ extension ConversationViewModel {
                 conversationDebugInfo: debugInfoURL
             )
         }.value
+    }
+
+    private func metadataDebugFallbackText(reason: String) -> String {
+        [
+            "conversationId: \(conversation.id)",
+            "clientConversationId: \(conversation.clientConversationId)",
+            "error: \(reason)"
+        ].joined(separator: "\n")
     }
 
     private func withThrowingTimeout<T: Sendable>(

--- a/ConvosAppData/Sources/ConvosAppData/ConversationCustomMetadata+Debug.swift
+++ b/ConvosAppData/Sources/ConvosAppData/ConversationCustomMetadata+Debug.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+public struct ConversationCustomMetadataDebugSnapshot: Sendable {
+    public let rawAppData: String?
+    public let rawAppDataByteCount: Int
+    public let parsedMetadata: ConversationCustomMetadata
+    public let roundTripEncodedMetadata: String?
+    public let parseLooksLossless: Bool
+
+    public init(rawAppData: String?) {
+        self.rawAppData = rawAppData
+        rawAppDataByteCount = rawAppData?.utf8.count ?? 0
+        parsedMetadata = ConversationCustomMetadata.parseAppData(rawAppData)
+        roundTripEncodedMetadata = try? parsedMetadata.toCompactString()
+        parseLooksLossless = rawAppData == roundTripEncodedMetadata
+    }
+
+    public var debugText: String {
+        [
+            "rawAppDataByteCount: \(rawAppDataByteCount)",
+            "rawAppData:",
+            rawAppData ?? "<nil>",
+            "",
+            "parsedMetadata:",
+            String(describing: parsedMetadata),
+            "",
+            "roundTripEncodedMetadata:",
+            roundTripEncodedMetadata ?? "<encoding failed>",
+            "",
+            "parseLooksLossless: \(parseLooksLossless)"
+        ].joined(separator: "\n")
+    }
+}

--- a/ConvosCore/Package.swift
+++ b/ConvosCore/Package.swift
@@ -74,6 +74,7 @@ let package = Package(
             name: "ConvosCoreTests",
             dependencies: [
                 "ConvosCore",
+                "ConvosAppData",
                 .target(name: "ConvosCoreiOS", condition: .when(platforms: [.iOS])),
                 "ConvosProfiles",
             ]

--- a/ConvosCore/Sources/ConvosCore/Invites & Custom Metadata/ConversationCustomMetadataError.swift
+++ b/ConvosCore/Sources/ConvosCore/Invites & Custom Metadata/ConversationCustomMetadataError.swift
@@ -7,6 +7,7 @@ enum ConversationCustomMetadataError: Error, LocalizedError {
     case invalidLength(Int)
     case invalidInboxIdHex(String)
     case appDataLimitExceeded(limit: Int, actualSize: Int)
+    case invalidInviteTag(String)
     case metadataUpdateFailed
 
     var errorDescription: String? {
@@ -19,6 +20,8 @@ enum ConversationCustomMetadataError: Error, LocalizedError {
             return "Failed to convert MemberProfile to ConversationProfile - invalid inbox ID hex: \(inboxId)"
         case let .appDataLimitExceeded(limit, actualSize):
             return "Conversation metadata exceeds \(limit) byte limit: \(actualSize) bytes"
+        case .invalidInviteTag(let tag):
+            return "Invalid invite tag: \(tag)"
         case .metadataUpdateFailed:
             return "Failed to update conversation metadata after multiple retries"
         }
@@ -34,6 +37,7 @@ extension ConversationCustomMetadataError: DisplayError {
         case .randomGenerationFailed: return "Security error"
         case .invalidLength: return "Invalid data"
         case .invalidInboxIdHex: return "Invalid profile"
+        case .invalidInviteTag: return "Invalid invite tag"
         case .metadataUpdateFailed: return "Update failed"
         }
     }
@@ -48,6 +52,8 @@ extension ConversationCustomMetadataError: DisplayError {
             return "Invalid data length: \(length)"
         case .invalidInboxIdHex:
             return "Invalid member profile identifier"
+        case .invalidInviteTag:
+            return "Invalid invite tag format"
         case .metadataUpdateFailed:
             return "Failed to update conversation. Please try again."
         }

--- a/ConvosCore/Sources/ConvosCore/Invites & Custom Metadata/XMTPGroup+CustomMetadata.swift
+++ b/ConvosCore/Sources/ConvosCore/Invites & Custom Metadata/XMTPGroup+CustomMetadata.swift
@@ -250,7 +250,7 @@ extension XMTPiOS.Group {
             guard metadata.tag.isEmpty else { return }
             metadata.tag = expectedTag
         } verify: { metadata in
-            metadata.tag == expectedTag
+            !metadata.tag.isEmpty
         }
     }
 

--- a/ConvosCore/Sources/ConvosCore/Invites & Custom Metadata/XMTPGroup+CustomMetadata.swift
+++ b/ConvosCore/Sources/ConvosCore/Invites & Custom Metadata/XMTPGroup+CustomMetadata.swift
@@ -243,12 +243,19 @@ extension XMTPiOS.Group {
     /// - Throws: `ConversationCustomMetadataError.metadataUpdateFailed` if all retries exhausted
     public func restoreInviteTagIfMissing(_ expectedTag: String) async throws {
         guard !expectedTag.isEmpty else { return }
+        guard Self.isValidInviteTag(expectedTag) else {
+            throw ConversationCustomMetadataError.invalidInviteTag(expectedTag)
+        }
         try await atomicUpdateMetadata(operation: "restoreInviteTagIfMissing") { metadata in
             guard metadata.tag.isEmpty else { return }
             metadata.tag = expectedTag
         } verify: { metadata in
             metadata.tag == expectedTag
         }
+    }
+
+    private static func isValidInviteTag(_ tag: String) -> Bool {
+        tag.range(of: "^[A-Za-z0-9]{10}$", options: .regularExpression) != nil
     }
 
     private func atomicUpdateMetadata(
@@ -292,6 +299,13 @@ extension XMTPiOS.Group {
     }
 
     func updateMetadata(_ metadata: ConversationCustomMetadata) async throws {
+        if let currentTag = try? inviteTag,
+           !currentTag.isEmpty,
+           metadata.tag.isEmpty {
+            Log.error("[MetadataDebug] updateMetadata refusing to clear invite tag for groupId=\(id)")
+            throw ConversationCustomMetadataError.metadataUpdateFailed
+        }
+
         let encodedMetadata = try metadata.toCompactString()
         let byteCount = encodedMetadata.lengthOfBytes(using: .utf8)
         guard byteCount <= Self.appDataByteLimit else {

--- a/ConvosCore/Sources/ConvosCore/Invites & Custom Metadata/XMTPGroup+CustomMetadata.swift
+++ b/ConvosCore/Sources/ConvosCore/Invites & Custom Metadata/XMTPGroup+CustomMetadata.swift
@@ -52,7 +52,7 @@ extension XMTPiOS.Group {
 
     public func updateExpiresAt(date: Date) async throws {
         let expiresAtUnix = Int64(date.timeIntervalSince1970)
-        try await atomicUpdateMetadata { metadata in
+        try await atomicUpdateMetadata(operation: "updateExpiresAt") { metadata in
             metadata.expiresAtUnix = expiresAtUnix
         } verify: { metadata in
             metadata.hasExpiresAtUnix && metadata.expiresAtUnix == expiresAtUnix
@@ -76,7 +76,7 @@ extension XMTPiOS.Group {
         }
 
         let newKey = try ImageEncryption.generateGroupKey()
-        try await atomicUpdateMetadata { metadata in
+        try await atomicUpdateMetadata(operation: "ensureImageEncryptionKey") { metadata in
             if !metadata.hasImageEncryptionKey {
                 metadata.imageEncryptionKey = newKey
             }
@@ -102,7 +102,7 @@ extension XMTPiOS.Group {
     }
 
     public func updateEncryptedGroupImage(_ encryptedRef: EncryptedImageRef) async throws {
-        try await atomicUpdateMetadata { metadata in
+        try await atomicUpdateMetadata(operation: "updateEncryptedGroupImage") { metadata in
             metadata.encryptedGroupImage = encryptedRef
         } verify: { metadata in
             metadata.hasEncryptedGroupImage &&
@@ -121,7 +121,7 @@ extension XMTPiOS.Group {
         guard existingTag.isEmpty else { return }
 
         let newTag = try generateSecureRandomString(length: 10)
-        try await atomicUpdateMetadata { metadata in
+        try await atomicUpdateMetadata(operation: "ensureInviteTag") { metadata in
             if metadata.tag.isEmpty {
                 metadata.tag = newTag
             }
@@ -135,7 +135,7 @@ extension XMTPiOS.Group {
     public func rotateInviteTag() async throws {
         let oldTag = try inviteTag
         let newTag = try generateSecureRandomString(length: 10)
-        try await atomicUpdateMetadata { metadata in
+        try await atomicUpdateMetadata(operation: "rotateInviteTag") { metadata in
             metadata.tag = newTag
         } verify: { metadata in
             metadata.tag != oldTag && !metadata.tag.isEmpty
@@ -213,7 +213,7 @@ extension XMTPiOS.Group {
         guard let conversationProfile = profile.conversationProfile else {
             throw ConversationCustomMetadataError.invalidInboxIdHex(profile.inboxId)
         }
-        try await atomicUpdateMetadata { metadata in
+        try await atomicUpdateMetadata(operation: "updateProfile") { metadata in
             metadata.upsertProfile(conversationProfile)
         } verify: { metadata in
             metadata.findProfile(inboxId: profile.inboxId) == conversationProfile
@@ -241,17 +241,43 @@ extension XMTPiOS.Group {
     ///   - modify: Closure to modify the metadata
     ///   - verify: Closure to verify the modification persisted
     /// - Throws: `ConversationCustomMetadataError.metadataUpdateFailed` if all retries exhausted
+    public func restoreInviteTagIfMissing(_ expectedTag: String) async throws {
+        guard !expectedTag.isEmpty else { return }
+        try await atomicUpdateMetadata(operation: "restoreInviteTagIfMissing") { metadata in
+            guard metadata.tag.isEmpty else { return }
+            metadata.tag = expectedTag
+        } verify: { metadata in
+            metadata.tag == expectedTag
+        }
+    }
+
     private func atomicUpdateMetadata(
+        operation: String,
         maxRetries: Int = 3,
         modify: (inout ConversationCustomMetadata) -> Void,
         verify: (ConversationCustomMetadata) -> Bool
     ) async throws {
         for attempt in 0..<maxRetries {
-            var metadata = try currentCustomMetadata
+            let beforeAppData = try appData()
+            let beforeMetadata = ConversationCustomMetadata.parseAppData(beforeAppData)
+            var metadata = beforeMetadata
             modify(&metadata)
+
+            Log.info(
+                "[MetadataDebug] operation=\(operation) groupId=\(id) attempt=\(attempt + 1) beforeTag=\(beforeMetadata.tag) afterTag=\(metadata.tag) beforeBytes=\(beforeAppData.utf8.count)"
+            )
+            if !beforeMetadata.tag.isEmpty && metadata.tag.isEmpty {
+                Log.error("[MetadataDebug] operation=\(operation) cleared invite tag for groupId=\(id)")
+                throw ConversationCustomMetadataError.metadataUpdateFailed
+            }
+
             try await updateMetadata(metadata)
 
-            let finalMetadata = try currentCustomMetadata
+            let finalAppData = try appData()
+            let finalMetadata = ConversationCustomMetadata.parseAppData(finalAppData)
+            Log.info(
+                "[MetadataDebug] operation=\(operation) groupId=\(id) finalTag=\(finalMetadata.tag) finalBytes=\(finalAppData.utf8.count)"
+            )
             if verify(finalMetadata) {
                 return
             }
@@ -259,7 +285,7 @@ extension XMTPiOS.Group {
             if attempt < maxRetries - 1 {
                 let delayMs = UInt64(50_000_000 * (attempt + 1))
                 try await Task.sleep(nanoseconds: delayMs)
-                Log.warning("Metadata update verification failed, retrying (attempt \(attempt + 1)/\(maxRetries))")
+                Log.warning("Metadata update verification failed, retrying (operation=\(operation), attempt \(attempt + 1)/\(maxRetries))")
             }
         }
         throw ConversationCustomMetadataError.metadataUpdateFailed

--- a/ConvosCore/Sources/ConvosCore/Messaging/XMTPClientProvider+MetadataDebug.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/XMTPClientProvider+MetadataDebug.swift
@@ -1,0 +1,47 @@
+import ConvosAppData
+import Foundation
+import XMTPiOS
+
+public struct ConversationMetadataDebugInfo: Sendable {
+    public let conversationId: String
+    public let clientConversationId: String
+    public let xmtpInviteTag: String
+    public let xmtpExpiresAtDescription: String
+    public let snapshot: ConversationCustomMetadataDebugSnapshot
+
+    public var debugText: String {
+        [
+            "conversationId: \(conversationId)",
+            "clientConversationId: \(clientConversationId)",
+            "xmtpInviteTag: \(xmtpInviteTag)",
+            "xmtpExpiresAt: \(xmtpExpiresAtDescription)",
+            "",
+            snapshot.debugText
+        ].joined(separator: "\n")
+    }
+}
+
+public extension XMTPClientProvider {
+    func conversationMetadataDebugInfo(
+        conversationId: String,
+        clientConversationId: String
+    ) async throws -> ConversationMetadataDebugInfo {
+        guard let xmtpConversation = try await conversation(with: conversationId),
+              case .group(let group) = xmtpConversation else {
+            throw XMTPClientProviderError.conversationNotFound(id: conversationId)
+        }
+
+        let rawAppData = try group.appData()
+        let snapshot = ConversationCustomMetadataDebugSnapshot(rawAppData: rawAppData)
+        let xmtpInviteTag = (try? group.inviteTag) ?? "<error>"
+        let xmtpExpiresAtDescription = (try? group.expiresAt)?.description ?? "<nil>"
+
+        return ConversationMetadataDebugInfo(
+            conversationId: conversationId,
+            clientConversationId: clientConversationId,
+            xmtpInviteTag: xmtpInviteTag,
+            xmtpExpiresAtDescription: xmtpExpiresAtDescription,
+            snapshot: snapshot
+        )
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationWriter.swift
@@ -235,12 +235,10 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
         if let preservedInviteTag = saveResult.preservedInviteTag,
            (try conversation.inviteTag).isEmpty {
             Log.warning("[MetadataDebug] preserving local invite tag and attempting self-heal for groupId=\(conversation.id) tag=\(preservedInviteTag)")
-            Task {
-                do {
-                    try await conversation.restoreInviteTagIfMissing(preservedInviteTag)
-                } catch {
-                    Log.error("[MetadataDebug] failed self-heal for groupId=\(conversation.id): \(error.localizedDescription)")
-                }
+            do {
+                try await conversation.restoreInviteTagIfMissing(preservedInviteTag)
+            } catch {
+                Log.error("[MetadataDebug] failed self-heal for groupId=\(conversation.id): \(error.localizedDescription)")
             }
         }
 

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationWriter.swift
@@ -226,11 +226,23 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
         // like "draft-XXX" instead of the XMTP group ID) so cache notifications match
         // the ID that ViewModels subscribe to.
         // Also returns the old image URL for cache invalidation.
-        let (actualClientConversationId, oldImageURL) = try await saveConversationToDatabase(
+        let saveResult = try await saveConversationToDatabase(
             dbConversation: dbConversation,
             dbMembers: dbMembers,
             memberProfiles: memberProfiles
         )
+
+        if let preservedInviteTag = saveResult.preservedInviteTag,
+           (try conversation.inviteTag).isEmpty {
+            Log.warning("[MetadataDebug] preserving local invite tag and attempting self-heal for groupId=\(conversation.id) tag=\(preservedInviteTag)")
+            Task {
+                do {
+                    try await conversation.restoreInviteTagIfMissing(preservedInviteTag)
+                } catch {
+                    Log.error("[MetadataDebug] failed self-heal for groupId=\(conversation.id): \(error.localizedDescription)")
+                }
+            }
+        }
 
         // Prefetch encrypted profile images in background
         prefetchEncryptedImages(profiles: memberProfiles, group: conversation)
@@ -238,9 +250,9 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
         // Prefetch encrypted group image in background (invalidate old URL if changed)
         // Use actualClientConversationId to match the ID that ViewModels subscribe to
         prefetchEncryptedGroupImage(
-            cacheId: actualClientConversationId,
+            cacheId: saveResult.clientConversationId,
             group: conversation,
-            oldImageURL: oldImageURL != metadata.imageURLString ? oldImageURL : nil
+            oldImageURL: saveResult.oldImageURL != metadata.imageURLString ? saveResult.oldImageURL : nil
         )
 
         do {
@@ -352,20 +364,26 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
         )
     }
 
+    private struct ConversationSaveResult {
+        let clientConversationId: String
+        let oldImageURL: String?
+        let preservedInviteTag: String?
+    }
+
     /// Returns the actual clientConversationId used (may differ from input if a local draft exists),
     /// and the old image URL for cache invalidation purposes.
     private func saveConversationToDatabase(
         dbConversation: DBConversation,
         dbMembers: [DBConversationMember],
         memberProfiles: [DBMemberProfile]
-    ) async throws -> (clientConversationId: String, oldImageURL: String?) {
+    ) async throws -> ConversationSaveResult {
         try await databaseWriter.write { [self] db in
             let creator = DBMember(inboxId: dbConversation.creatorId)
             try creator.save(db)
 
             // Save conversation (handle local conversation updates)
             // This also handles imageLastRenewed preservation inside the transaction
-            let (actualClientConversationId, oldImageURL) = try self.saveConversation(dbConversation, in: db)
+            let saveResult = try self.saveConversation(dbConversation, in: db)
 
             // Save local state
             let localState = ConversationLocalState(
@@ -405,7 +423,7 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
                 try profile.save(db)
             }
 
-            return (actualClientConversationId, oldImageURL)
+            return saveResult
         }
     }
 
@@ -416,10 +434,11 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
     private func saveConversation(
         _ dbConversation: DBConversation,
         in db: Database
-    ) throws -> (clientConversationId: String, oldImageURL: String?) {
+    ) throws -> ConversationSaveResult {
         let firstTimeSeeingConversationExpired: Bool
         let actualClientConversationId: String
         let oldImageURL: String?
+        let preservedInviteTag: String?
 
         // Fetch current conversation state inside the transaction to avoid race conditions
         // with concurrent asset renewal that might update imageLastRenewed
@@ -437,11 +456,40 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
         // Apply the preserved timestamp
         var conversationToSave = dbConversation.with(imageLastRenewed: imageLastRenewed)
 
-        if !dbConversation.inviteTag.isEmpty,
-           let localConversation = try DBConversation
-            .filter(DBConversation.Columns.inviteTag == dbConversation.inviteTag)
-            .filter(DBConversation.Columns.clientConversationId != dbConversation.clientConversationId)
-            .fetchOne(db) {
+        if dbConversation.inviteTag.isEmpty,
+           let existingConversation,
+           !existingConversation.inviteTag.isEmpty {
+            conversationToSave = conversationToSave.with(inviteTag: existingConversation.inviteTag)
+            Log.warning(
+                "[MetadataDebug] preserving existing local invite tag for conversationId=\(dbConversation.id) preservedTag=\(existingConversation.inviteTag)"
+            )
+            preservedInviteTag = existingConversation.inviteTag
+        } else {
+            preservedInviteTag = nil
+        }
+
+        let existingConversationByTag: DBConversation?
+        if !dbConversation.inviteTag.isEmpty {
+            existingConversationByTag = try DBConversation
+                .filter(DBConversation.Columns.inviteTag == dbConversation.inviteTag)
+                .filter(DBConversation.Columns.id != dbConversation.id)
+                .fetchOne(db)
+        } else {
+            existingConversationByTag = nil
+        }
+
+        let conversationSaveLog: String = "Conversation save attempt. " +
+            "incomingId=\(dbConversation.id) " +
+            "incomingClientConversationId=\(dbConversation.clientConversationId) " +
+            "incomingInviteTag=\(dbConversation.inviteTag) " +
+            "hasExistingById=\(existingConversation != nil) " +
+            "existingByIdClientConversationId=\(existingConversation?.clientConversationId ?? "nil") " +
+            "existingByIdInviteTag=\(existingConversation?.inviteTag ?? "nil") " +
+            "existingByTagId=\(existingConversationByTag?.id ?? "nil") " +
+            "existingByTagClientConversationId=\(existingConversationByTag?.clientConversationId ?? "nil")"
+        Log.info(conversationSaveLog)
+
+        if let localConversation = existingConversationByTag {
             // Prefer draft IDs for stability (image caching, default emoji)
             let preferredClientConversationId: String
             if DBConversation.isDraft(id: dbConversation.clientConversationId) {
@@ -482,6 +530,23 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
             if let existingExpiresAt = existingConversation.expiresAt, updatedConversation.expiresAt == nil {
                 updatedConversation = updatedConversation.with(expiresAt: existingExpiresAt)
             }
+            if !updatedConversation.inviteTag.isEmpty,
+               let conflictingConversation = try DBConversation
+                .filter(DBConversation.Columns.inviteTag == updatedConversation.inviteTag)
+                .filter(DBConversation.Columns.id != updatedConversation.id)
+                .fetchOne(db) {
+                Log.error(
+                    "Invite tag collision before save. " +
+                        "incomingId=\(updatedConversation.id) " +
+                        "incomingClientConversationId=\(updatedConversation.clientConversationId) " +
+                        "incomingInviteTag=\(updatedConversation.inviteTag) " +
+                        "existingId=\(existingConversation.id) " +
+                        "existingClientConversationId=\(existingConversation.clientConversationId) " +
+                        "conflictingId=\(conflictingConversation.id) " +
+                        "conflictingClientConversationId=\(conflictingConversation.clientConversationId) " +
+                        "conflictingIsUnused=\(conflictingConversation.isUnused)"
+                )
+            }
             try updatedConversation.save(db)
             firstTimeSeeingConversationExpired = updatedConversation.isExpired && updatedConversation.expiresAt != existingConversation.expiresAt
             actualClientConversationId = preferredClientConversationId
@@ -495,7 +560,11 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
             Log.debug("Encountered expired conversation for the first time.")
         }
 
-        return (actualClientConversationId, oldImageURL)
+        return ConversationSaveResult(
+            clientConversationId: actualClientConversationId,
+            oldImageURL: oldImageURL,
+            preservedInviteTag: preservedInviteTag
+        )
     }
 
     private func saveMembers(_ dbMembers: [DBConversationMember], in db: Database) throws {

--- a/ConvosCore/Tests/ConvosCoreTests/InviteTagSelfHealingTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/InviteTagSelfHealingTests.swift
@@ -1,0 +1,87 @@
+@testable import ConvosAppData
+@testable import ConvosCore
+import Foundation
+import GRDB
+import Testing
+import XMTPiOS
+
+@Suite("Invite Tag Self-Healing Tests")
+struct InviteTagSelfHealingTests {
+    private enum TestError: Error {
+        case missingClients
+    }
+
+    @Test("Store preserves local invite tag when incoming XMTP metadata tag is empty")
+    func preservesLocalInviteTagWhenIncomingTagIsEmpty() async throws {
+        let fixtures = TestFixtures()
+        try await fixtures.createTestClients()
+
+        guard let clientA = fixtures.clientA as? Client,
+              let clientB = fixtures.clientB,
+              let clientIdA = fixtures.clientIdA else {
+            throw TestError.missingClients
+        }
+
+        let inboxIdA = clientA.inboxID
+        try await fixtures.databaseManager.dbWriter.write { db in
+            try DBInbox(inboxId: inboxIdA, clientId: clientIdA, createdAt: Date()).insert(db)
+        }
+
+        let group = try await clientA.conversations.newGroup(
+            with: [clientB.inboxId],
+            name: "Test Group",
+            imageUrl: "",
+            description: ""
+        )
+        try await group.ensureInviteTag()
+        let originalTag = try group.inviteTag
+
+        let conversationWriter = ConversationWriter(
+            identityStore: fixtures.identityStore,
+            databaseWriter: fixtures.databaseManager.dbWriter,
+            messageWriter: MockIncomingMessageWriter()
+        )
+
+        _ = try await conversationWriter.store(conversation: group, inboxId: inboxIdA)
+
+        var emptyMetadata = ConversationCustomMetadata()
+        emptyMetadata.name = "Test Group"
+        let encodedEmptyMetadata = try emptyMetadata.toCompactString()
+        try await group.updateAppData(appData: encodedEmptyMetadata)
+
+        _ = try await conversationWriter.store(conversation: group, inboxId: inboxIdA)
+
+        let storedConversation = try await fixtures.databaseManager.dbReader.read { db in
+            try DBConversation.fetchOne(db, id: group.id)
+        }
+
+        #expect(storedConversation?.inviteTag == originalTag)
+        #expect(try group.inviteTag == originalTag)
+
+        try? await fixtures.cleanup()
+    }
+
+    @Test("restoreInviteTagIfMissing rejects invalid invite tag format")
+    func restoreInviteTagRejectsInvalidFormat() async throws {
+        let fixtures = TestFixtures()
+        try await fixtures.createTestClients()
+
+        guard let clientA = fixtures.clientA as? Client,
+              let clientB = fixtures.clientB else {
+            throw TestError.missingClients
+        }
+
+        let group = try await clientA.conversations.newGroup(
+            with: [clientB.inboxId],
+            name: "Test Group",
+            imageUrl: "",
+            description: ""
+        )
+
+        await #expect(throws: ConversationCustomMetadataError.self) {
+            try await group.restoreInviteTagIfMissing("bad-tag")
+        }
+
+        try? await fixtures.cleanup()
+    }
+}

--- a/ConvosCore/Tests/ConvosCoreTests/InviteTagSelfHealingTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/InviteTagSelfHealingTests.swift
@@ -1,9 +1,9 @@
-@testable import ConvosAppData
+import ConvosAppData
 @testable import ConvosCore
 import Foundation
 import GRDB
 import Testing
-import XMTPiOS
+@preconcurrency import XMTPiOS
 
 @Suite("Invite Tag Self-Healing Tests")
 struct InviteTagSelfHealingTests {
@@ -44,10 +44,9 @@ struct InviteTagSelfHealingTests {
 
         _ = try await conversationWriter.store(conversation: group, inboxId: inboxIdA)
 
-        var emptyMetadata = ConversationCustomMetadata()
-        emptyMetadata.name = "Test Group"
-        let encodedEmptyMetadata = try emptyMetadata.toCompactString()
-        try await group.updateAppData(appData: encodedEmptyMetadata)
+        let metadataWithoutTag = ConversationCustomMetadata()
+        let encodedCleared = try metadataWithoutTag.toCompactString()
+        try await group.updateAppData(appData: encodedCleared)
 
         _ = try await conversationWriter.store(conversation: group, inboxId: inboxIdA)
 


### PR DESCRIPTION
## Summary
- add convo metadata debug inspection and invite tag restore tooling
- preserve trusted local invite tags when incoming XMTP metadata goes empty and attempt self-heal
- keep metadata write logging and reject metadata writes that would clear a non-empty invite tag

## Testing
- swiftlint on changed files
- xcodebuild build -project Convos.xcodeproj -scheme "Convos (Dev)" -destination "platform=iOS Simulator,name=convos-media-invite-bug-1" -derivedDataPath .derivedData
- xcodebuild build -project Convos.xcodeproj -scheme "Convos (Dev)" -destination id=00008120-000E5DEC2663C01E -derivedDataPath .derivedData
- installed and launched on device


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Self-heal missing invite tags on XMTP conversations
> - When saving a conversation, [`ConversationWriter`](https://github.com/xmtplabs/convos-ios/pull/682/files#diff-113bfd0c28b1a3b561f19e4574a0937082fe5c92a262e57573eee7728940a726) now preserves a locally-stored invite tag if the incoming XMTP data has an empty tag, then calls `restoreInviteTagIfMissing` on the remote group after save.
> - [`XMTPGroup+CustomMetadata`](https://github.com/xmtplabs/convos-ios/pull/682/files#diff-531b5042f2639e0a548e07f4a8bbe3b6e8a8ed4a8e2c9b643211b6d00ba5ec85) adds `restoreInviteTagIfMissing(_:)`, which validates a strict alphanumeric 10-character format and sets the tag only when the current remote tag is empty.
> - Metadata update methods now guard against accidentally clearing a non-empty invite tag, throwing an error instead of silently overwriting.
> - A 'Restore invite tag' action and a 'Metadata' debug view are added to `ConversationInfoView` for manual recovery and inspection.
> - Behavioral Change: any metadata update that would clear an existing invite tag now fails with an error rather than succeeding silently.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized aa8cec7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->