### PR TITLE
Allow assistants to set an emoji as an avatar

### DIFF
--- a/Convos/Profile/MyProfileViewModel.swift
+++ b/Convos/Profile/MyProfileViewModel.swift
@@ -1,5 +1,6 @@
 import Combine
 import ConvosCore
+import ConvosProfiles
 import SwiftUI
 
 @MainActor
@@ -11,6 +12,7 @@ class MyProfileViewModel {
     private var cancellables: Set<AnyCancellable> = []
     private var updateDisplayNameTask: Task<Void, Never>?
     private var updateImageTask: Task<Void, Never>?
+    private var updateMetadataTask: Task<Void, Never>?
     private var pendingUpdateCount: Int = 0
 
     var isEditingDisplayName: Bool = false
@@ -18,6 +20,7 @@ class MyProfileViewModel {
     var saveDisplayNameAsQuickname: Bool = false
 
     var profileImage: UIImage?
+    var editingEmoji: String = ""
 
     // Computed properties for display
     var displayName: String {
@@ -42,6 +45,7 @@ class MyProfileViewModel {
         setupMyProfileRepository()
 
         self.editingDisplayName = profile.name ?? ""
+        self.editingEmoji = profile.profileEmoji ?? ""
     }
 
     func cancelEditingDisplayName() {
@@ -57,6 +61,7 @@ class MyProfileViewModel {
             .sink { [weak self] profile in
                 self?.profileImage = ImageCache.shared.image(for: profile)
                 self?.profile = profile
+                self?.editingEmoji = profile.profileEmoji ?? ""
             }
             .store(in: &cancellables)
     }
@@ -91,6 +96,23 @@ class MyProfileViewModel {
         }
     }
 
+    private func update(profileMetadata: ProfileMetadata?, conversationId: String) {
+        updateMetadataTask?.cancel()
+        beginUpdate()
+        let displayNameTask = updateDisplayNameTask
+        nonisolated(unsafe) let unsafeWriter = myProfileWriter
+        updateMetadataTask = Task { [weak self] in
+            guard self != nil else { return }
+            defer { Task { @MainActor [weak self] in self?.endUpdate() } }
+            await displayNameTask?.value
+            do {
+                try await unsafeWriter.update(metadata: profileMetadata, conversationId: conversationId)
+            } catch {
+                Log.error("Error updating profile metadata: \(error.localizedDescription)")
+            }
+        }
+    }
+
     private func update(profileImage: UIImage, conversationId: String) {
         self.profileImage = profileImage
         ImageCache.shared.cacheImage(profileImage, for: profile.imageCacheIdentifier, imageFormat: .jpg)
@@ -117,6 +139,7 @@ class MyProfileViewModel {
 
     func update(using profile: Profile, profileImage: UIImage?, conversationId: String) {
         self.editingDisplayName = profile.name ?? ""
+        self.editingEmoji = profile.profileEmoji ?? ""
         self.profileImage = profileImage
         self.profile = profile.with(inboxId: self.profile.inboxId)
         // update image first so we don't see the 'monogram' flash in avatar
@@ -132,13 +155,27 @@ class MyProfileViewModel {
         var didChange = false
 
         let trimmedDisplayName = editingDisplayName.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedEmoji = editingEmoji.trimmingCharacters(in: .whitespacesAndNewlines)
         let latestProfile = try? myProfileRepository.fetch()
         if latestProfile == nil || latestProfile?.name != trimmedDisplayName {
             update(displayName: trimmedDisplayName, conversationId: conversationId)
             didChange = true
         }
 
-        // @jarodl check if the image was actually changed
+        let updatedMetadata: ProfileMetadata? = {
+            var metadata = latestProfile?.metadata ?? [:]
+            if trimmedEmoji.isEmpty {
+                metadata.removeValue(forKey: Constant.emojiMetadataKey)
+            } else {
+                metadata[Constant.emojiMetadataKey] = .string(trimmedEmoji)
+            }
+            return metadata.isEmpty ? nil : metadata
+        }()
+        if latestProfile?.profileEmoji != (trimmedEmoji.isEmpty ? nil : trimmedEmoji) {
+            update(profileMetadata: updatedMetadata, conversationId: conversationId)
+            didChange = true
+        }
+
         if let profileImage {
             update(profileImage: profileImage, conversationId: conversationId)
             didChange = true
@@ -158,6 +195,10 @@ class MyProfileViewModel {
         }
 
         return didChange
+    }
+
+    private enum Constant {
+        static let emojiMetadataKey: String = "emoji"
     }
 }
 

--- a/Convos/Shared Views/AvatarView.swift
+++ b/Convos/Shared Views/AvatarView.swift
@@ -5,6 +5,7 @@ struct AvatarView: View {
     let fallbackName: String
     let cacheableObject: any ImageCacheable
     let placeholderImage: UIImage?
+    let placeholderEmoji: String?
     let placeholderImageName: String?
     let agentVerification: AgentVerification
     @State private var cachedImage: UIImage?
@@ -13,12 +14,14 @@ struct AvatarView: View {
         fallbackName: String,
         cacheableObject: any ImageCacheable,
         placeholderImage: UIImage?,
+        placeholderEmoji: String? = nil,
         placeholderImageName: String?,
         agentVerification: AgentVerification = .unverified
     ) {
         self.fallbackName = fallbackName
         self.cacheableObject = cacheableObject
         self.placeholderImage = placeholderImage
+        self.placeholderEmoji = placeholderEmoji
         self.placeholderImageName = placeholderImageName
         self.agentVerification = agentVerification
         _cachedImage = State(initialValue: ImageCache.shared.image(for: cacheableObject))
@@ -31,6 +34,8 @@ struct AvatarView: View {
                     .resizable()
                     .scaledToFit()
                     .aspectRatio(contentMode: .fill)
+            } else if let placeholderEmoji, !placeholderEmoji.isEmpty {
+                EmojiAvatarView(emoji: placeholderEmoji)
             } else if let placeholderImageName {
                 Image(systemName: placeholderImageName)
                     .resizable()
@@ -62,6 +67,7 @@ struct ProfileAvatarView: View {
             fallbackName: profile.displayName,
             cacheableObject: profile,
             placeholderImage: profileImage,
+            placeholderEmoji: profile.profileEmoji,
             placeholderImageName: useSystemPlaceholder ? "person.crop.circle.fill" : nil,
             agentVerification: profile.isAgent ? agentVerification : .unverified
         )
@@ -101,7 +107,11 @@ struct ConversationAvatarView: View {
         case .customImage:
             MonogramView(name: conversation.computedDisplayName)
         case let .profile(profile, verification):
-            MonogramView(name: profile.displayName, agentVerification: verification)
+            if let emoji = profile.profileEmoji, !emoji.isEmpty {
+                EmojiAvatarView(emoji: emoji)
+            } else {
+                MonogramView(name: profile.displayName, agentVerification: verification)
+            }
         case .clustered(let profiles):
             ClusteredAvatarView(profiles: profiles)
         case .emoji(let emoji):
@@ -127,6 +137,8 @@ struct MessageAvatarView: View {
                 Image(uiImage: image)
                     .resizable()
                     .aspectRatio(contentMode: .fill)
+            } else if let emoji = profile.profileEmoji, !emoji.isEmpty {
+                EmojiAvatarView(emoji: emoji)
             } else {
                 MonogramView(name: profile.displayName, agentVerification: profile.isAgent ? agentVerification : .unverified)
             }

--- a/ConvosCore/Sources/ConvosCore/Mocks/MockMyProfileWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Mocks/MockMyProfileWriter.swift
@@ -1,9 +1,11 @@
+import ConvosProfiles
 import Foundation
 
 /// Mock implementation of MyProfileWriterProtocol for testing
 public final class MockMyProfileWriter: MyProfileWriterProtocol, @unchecked Sendable {
     public var updatedDisplayNames: [(name: String, conversationId: String)] = []
     public var updatedAvatars: [(image: ImageType?, conversationId: String)] = []
+    public var updatedMetadata: [(metadata: ProfileMetadata?, conversationId: String)] = []
 
     public init() {}
 
@@ -13,5 +15,9 @@ public final class MockMyProfileWriter: MyProfileWriterProtocol, @unchecked Send
 
     public func update(avatar: ImageType?, conversationId: String) async throws {
         updatedAvatars.append((image: avatar, conversationId: conversationId))
+    }
+
+    public func update(metadata: ProfileMetadata?, conversationId: String) async throws {
+        updatedMetadata.append((metadata: metadata, conversationId: conversationId))
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/Profile.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/Profile.swift
@@ -68,6 +68,13 @@ public struct Profile: Codable, Identifiable, Hashable, Sendable {
         return "Somebody"
     }
 
+    public var profileEmoji: String? {
+        metadata?[Constant.emojiMetadataKey]?.stringValue.flatMap { value in
+            let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimmed.isEmpty ? nil : trimmed
+        }
+    }
+
     public func verifyAgentAttestation(keyset: any AgentKeysetProviding) async -> AgentVerification {
         guard isAgent else {
             return .unverified
@@ -171,6 +178,10 @@ public struct Profile: Codable, Identifiable, Hashable, Sendable {
             avatar: "https://example.com/avatar.jpg"
         )
     }
+
+    private enum Constant {
+        static let emojiMetadataKey: String = "emoji"
+    }
 }
 
 // MARK: - Array Extensions
@@ -225,13 +236,13 @@ public extension Array where Element == Profile {
     }
 
     var hasAnyAvatar: Bool {
-        contains { $0.avatarURL != nil }
+        contains { $0.avatarURL != nil || $0.profileEmoji != nil }
     }
 
     func sortedForCluster() -> [Profile] {
         sorted { p1, p2 in
-            let p1HasAvatar = p1.avatarURL != nil
-            let p2HasAvatar = p2.avatarURL != nil
+            let p1HasAvatar = p1.avatarURL != nil || p1.profileEmoji != nil
+            let p2HasAvatar = p2.avatarURL != nil || p2.profileEmoji != nil
             if p1HasAvatar != p2HasAvatar { return p1HasAvatar }
 
             let p1HasName = p1.name != nil && !(p1.name ?? "").isEmpty

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/MyProfileWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/MyProfileWriter.swift
@@ -6,6 +6,7 @@ import GRDB
 public protocol MyProfileWriterProtocol {
     func update(displayName: String, conversationId: String) async throws
     func update(avatar: ImageType?, conversationId: String) async throws
+    func update(metadata: ProfileMetadata?, conversationId: String) async throws
 }
 
 enum MyProfileWriterError: Error {
@@ -56,6 +57,28 @@ class MyProfileWriter: MyProfileWriterProtocol {
             try await group.updateProfile(profile)
         } catch {
             Log.warning("Failed to write profile to appData (best-effort): \(error.localizedDescription)")
+        }
+        await sendProfileUpdate(profile: profile, group: group)
+    }
+
+    func update(metadata: ProfileMetadata?, conversationId: String) async throws {
+        let inboxReady = try await inboxStateManager.waitForInboxReadyResult()
+        guard let conversation = try await inboxReady.client.conversation(with: conversationId),
+              case .group(let group) = conversation else {
+            throw ConversationMetadataError.conversationNotFound(conversationId: conversationId)
+        }
+        let inboxId = inboxReady.client.inboxId
+        let profile = try await databaseWriter.write { db in
+            let member = DBMember(inboxId: inboxId)
+            try member.save(db)
+            let profile = (try DBMemberProfile.fetchOne(db, conversationId: conversationId, inboxId: inboxId) ?? .init(
+                conversationId: conversationId,
+                inboxId: inboxId,
+                name: nil,
+                avatar: nil
+            )).with(metadata: metadata?.isEmpty == true ? nil : metadata)
+            try profile.save(db)
+            return profile
         }
         await sendProfileUpdate(profile: profile, group: group)
     }

--- a/ConvosCore/Tests/ConvosCoreTests/DefaultConversationDisplayTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/DefaultConversationDisplayTests.swift
@@ -373,6 +373,34 @@ struct DefaultConversationDisplayTests {
         }
     }
 
+    @Test("avatarType clusters when another member has only an emoji avatar")
+    func avatarTypeClustersWhenOtherMemberHasEmojiAvatar() {
+        let members = [
+            ConversationMember.mock(isCurrentUser: true, name: "You"),
+            ConversationMember(
+                profile: Profile(
+                    inboxId: "other1",
+                    name: "Alice",
+                    avatar: nil,
+                    metadata: ["emoji": .string("🦊")]
+                ),
+                role: .member,
+                isCurrentUser: false
+            ),
+            ConversationMember(
+                profile: Profile(inboxId: "other2", name: "Bob", avatar: nil),
+                role: .member,
+                isCurrentUser: false
+            )
+        ]
+        let conversation = Conversation.mock(name: nil, members: members)
+        if case .clustered(let profiles) = conversation.avatarType {
+            #expect(profiles.contains { $0.profileEmoji == "🦊" })
+        } else {
+            #expect(Bool(false), "Expected clustered avatar type when a member has an emoji avatar")
+        }
+    }
+
     // MARK: - Member Name Limiting Tests
 
     @Test("Four named profiles shows three and 1 other")


### PR DESCRIPTION
## Summary
- add metadata-backed emoji avatar plumbing without shipping any new UI
- render emoji avatars when no profile photo is set
- support metadata-only profile updates so emoji can be written through the existing profile update path

## Details
The emoji is stored in `Profile.metadata["emoji"]` and uses the existing `ProfileUpdate.metadata` path. That metadata already flows into profile snapshots, so no schema or proto changes were needed.

Avatar rendering now prioritizes:
1. profile photo
2. emoji metadata
3. monogram

## Validation
- `xcodebuild build -project Convos.xcodeproj -scheme "Convos (Dev)"` succeeded
- joined a dev conversation via CLI
- set profile metadata with `--metadata emoji=🦊`
- sent a message and verified the emoji avatar rendered correctly in the app


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Allow assistants to set an emoji as their avatar
> - Adds `profileEmoji` computed property to `Profile` that reads an `"emoji"` key from metadata, used to display emoji avatars across `AvatarView`, `ConversationAvatarView`, and compact profile avatar views when no image is available.
> - Adds `update(metadata:conversationId:)` to `MyProfileWriter` to persist metadata changes to storage and broadcast them to the conversation.
> - Updates `MyProfileViewModel` to track `editingEmoji` state and persist emoji changes via the new metadata update path when editing ends.
> - Emoji avatars are treated equivalently to image avatars in `hasAnyAvatar` checks and cluster sorting.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2029361.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->