### PR TITLE
Update voice memo discard icon and hide transcript errors

### DIFF
--- a/Convos/Assets.xcassets/colorFillInvertedMinimal.colorset/Contents.json
+++ b/Convos/Assets.xcassets/colorFillInvertedMinimal.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x14",
+          "green" : "0x14",
+          "red" : "0x14"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x14",
+          "green" : "0x14",
+          "red" : "0x14"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Convos/Assets.xcassets/colorFillInvertedMinimal.colorset/Contents.json
+++ b/Convos/Assets.xcassets/colorFillInvertedMinimal.colorset/Contents.json
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0x14",
-          "green" : "0x14",
-          "red" : "0x14"
+          "blue" : "0xFA",
+          "green" : "0xFA",
+          "red" : "0xFA"
         }
       },
       "idiom" : "universal"

--- a/Convos/Assets.xcassets/colorFillInvertedSubtle.colorset/Contents.json
+++ b/Convos/Assets.xcassets/colorFillInvertedSubtle.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x33",
+          "green" : "0x33",
+          "red" : "0x33"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x33",
+          "green" : "0x33",
+          "red" : "0x33"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Convos/Assets.xcassets/colorFillInvertedSubtle.colorset/Contents.json
+++ b/Convos/Assets.xcassets/colorFillInvertedSubtle.colorset/Contents.json
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0x33",
-          "green" : "0x33",
-          "red" : "0x33"
+          "blue" : "0xF5",
+          "green" : "0xF5",
+          "red" : "0xF5"
         }
       },
       "idiom" : "universal"

--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -78,6 +78,7 @@ struct ConversationView<MessagesBottomBar: View>: View {
                 focusCoordinator.moveFocus(to: .message)
             },
             replyingToMessage: viewModel.replyingToMessage,
+            replyingToAudioTranscriptText: viewModel.replyingToAudioTranscriptText,
             onCancelReply: viewModel.cancelReply,
             onDisplayNameEndedEditing: {
                 viewModel.onDisplayNameEndedEditing(focusCoordinator: focusCoordinator, context: .quickEditor)

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -1039,6 +1039,19 @@ extension ConversationViewModel {
         }
     }
 
+    var replyingToAudioTranscriptText: String? {
+        guard let replyingToMessage,
+              replyingToMessage.content.primaryVoiceMemoAttachment != nil
+        else { return nil }
+        for item in messages {
+            guard case .messages(let group) = item else { continue }
+            if let transcript = group.voiceMemoTranscripts[replyingToMessage.messageId] {
+                return transcript.text
+            }
+        }
+        return nil
+    }
+
     func onReply(_ message: AnyMessage) {
         replyingToMessage = message
     }

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Cells/MessagesListItemTypeCell.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Cells/MessagesListItemTypeCell.swift
@@ -98,7 +98,8 @@ class MessagesListItemTypeCell: UICollectionViewCell {
                         onOpenFile: config.onOpenFile,
                         onRetryMessage: config.onRetryMessage,
                         onDeleteMessage: config.onDeleteMessage,
-                        onRetryTranscript: config.onRetryTranscript
+                        onRetryTranscript: config.onRetryTranscript,
+                        allVoiceMemoTranscripts: config.allVoiceMemoTranscripts
                     )
 
                 case .invite(let invite):

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Data Source/CellFactory.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Data Source/CellFactory.swift
@@ -22,6 +22,7 @@ struct CellConfig {
     let onConvoCode: () -> Void
     let onInviteAssistant: () -> Void
     let onRetryTranscript: (VoiceMemoTranscriptListItem) -> Void
+    let allVoiceMemoTranscripts: [String: VoiceMemoTranscriptListItem]
     let hasAssistant: Bool
     let isAssistantJoinPending: Bool
     let isAssistantEnabled: Bool

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Data Source/DefaultMessagesLayoutDelegate.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Data Source/DefaultMessagesLayoutDelegate.swift
@@ -121,9 +121,7 @@ final class DefaultMessagesLayoutDelegate: MessagesLayoutDelegate {
             // Capsule-only row ("Tap to transcribe").
             return 46
         case .failed:
-            // Capsule + optional error description line.
-            let hasDetail = transcript.errorDescription?.isEmpty == false
-            return hasDetail ? 72 : 46
+            return 0
         case .pending:
             // Spinner + "Transcribing…" text.
             return 40

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Data Source/MessagesCollectionViewDataSource.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Data Source/MessagesCollectionViewDataSource.swift
@@ -36,6 +36,13 @@ final class MessagesCollectionViewDataSource: NSObject {
     var isAssistantJoinPending: Bool = false
     var isAssistantEnabled: Bool = false
 
+    var allVoiceMemoTranscripts: [String: VoiceMemoTranscriptListItem] {
+        sections.flatMap(\.cells).reduce(into: [:]) { result, item in
+            guard case .messages(let group) = item else { return }
+            result.merge(group.voiceMemoTranscripts) { _, new in new }
+        }
+    }
+
     private lazy var layoutDelegate: DefaultMessagesLayoutDelegate = DefaultMessagesLayoutDelegate(sections: sections,
                                                                                                    oldSections: [])
 
@@ -123,6 +130,7 @@ extension MessagesCollectionViewDataSource: UICollectionViewDataSource {
             onRetryTranscript: { [weak self] item in
                 self?.onRetryTranscript?(item)
             },
+            allVoiceMemoTranscripts: allVoiceMemoTranscripts,
             hasAssistant: hasAssistant,
             isAssistantJoinPending: isAssistantJoinPending,
             isAssistantEnabled: isAssistantEnabled

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesBottomBar.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesBottomBar.swift
@@ -196,7 +196,7 @@ struct MessagesBottomBar<BottomBarContent: View>: View {
                     Image(systemName: "trash")
                         .font(.system(size: 14, weight: .semibold))
                         .foregroundStyle(.colorCaution)
-                        .frame(width: DesignConstants.Spacing.step12x, height: DesignConstants.Spacing.step12x)
+                        .frame(width: DesignConstants.Spacing.step11x, height: DesignConstants.Spacing.step11x)
                 }
                 .clipShape(.circle)
                 .glassEffect(.regular.interactive(), in: .circle)

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesBottomBar.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesBottomBar.swift
@@ -193,9 +193,9 @@ struct MessagesBottomBar<BottomBarContent: View>: View {
                         voiceMemoRecorder.cancelRecording()
                     }
                 } label: {
-                    Image(systemName: "xmark")
+                    Image(systemName: "trash")
                         .font(.system(size: 14, weight: .semibold))
-                        .foregroundStyle(.colorTextSecondary)
+                        .foregroundStyle(.colorCaution)
                         .frame(width: DesignConstants.Spacing.step12x, height: DesignConstants.Spacing.step12x)
                 }
                 .clipShape(.circle)

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesBottomBar.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesBottomBar.swift
@@ -193,7 +193,7 @@ struct MessagesBottomBar<BottomBarContent: View>: View {
                         voiceMemoRecorder.cancelRecording()
                     }
                 } label: {
-                    Image(systemName: "trash")
+                    Image(systemName: "trash.fill")
                         .font(.system(size: 14, weight: .semibold))
                         .foregroundStyle(.colorCaution)
                         .frame(width: DesignConstants.Spacing.step11x, height: DesignConstants.Spacing.step11x)

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/ReplyComposerBar.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/ReplyComposerBar.swift
@@ -5,6 +5,7 @@ import SwiftUI
 struct ReplyComposerBar: View {
     let message: AnyMessage
     let shouldBlurPhotos: Bool
+    var audioTranscriptText: String?
     let onDismiss: () -> Void
 
     private var senderName: String {
@@ -12,6 +13,9 @@ struct ReplyComposerBar: View {
     }
 
     private var previewText: String {
+        if isAudio, let audioTranscriptText, !audioTranscriptText.isEmpty {
+            return audioTranscriptText
+        }
         switch message.content {
         case .text(let text):
             return String(text.prefix(50))
@@ -77,7 +81,9 @@ struct ReplyComposerBar: View {
                 Image(systemName: "waveform")
                     .font(.system(size: 14))
                     .foregroundStyle(.colorTextSecondary)
-                    .frame(width: 40, height: 40)
+                    .frame(width: 32, height: 32)
+                    .background(Color.colorFillSubtle)
+                    .clipShape(RoundedRectangle(cornerRadius: 10))
             } else if let attachment {
                 ReplyPhotoThumbnail(
                     attachmentKey: attachment.key,

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/VoiceMemoRecordingView.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/VoiceMemoRecordingView.swift
@@ -9,40 +9,42 @@ struct VoiceMemoRecordingView: View {
     private let barSpacing: CGFloat = 1.5
 
     var body: some View {
-        HStack(spacing: DesignConstants.Spacing.step3x) {
-            Canvas { context, size in
-                let totalBarWidth = barWidth + barSpacing
-                let visibleBarCount = max(Int(size.width / totalBarWidth), 1)
-                let levels = recorder.audioLevels
-                let placeholderHeight: CGFloat = 2
-                let recordedCount = min(levels.count, visibleBarCount)
-                let startIndex = max(levels.count - visibleBarCount, 0)
+        HStack(spacing: 0) {
+            HStack(spacing: DesignConstants.Spacing.step2x) {
+                Canvas { context, size in
+                    let totalBarWidth = barWidth + barSpacing
+                    let visibleBarCount = max(Int(size.width / totalBarWidth), 1)
+                    let levels = recorder.audioLevels
+                    let placeholderHeight: CGFloat = 2
+                    let recordedCount = min(levels.count, visibleBarCount)
+                    let startIndex = max(levels.count - visibleBarCount, 0)
 
-                for i in 0 ..< visibleBarCount {
-                    let x = CGFloat(i) * totalBarWidth
+                    for i in 0 ..< visibleBarCount {
+                        let x = CGFloat(i) * totalBarWidth
 
-                    let barIndex = i - (visibleBarCount - recordedCount)
-                    if barIndex >= 0, barIndex + startIndex < levels.count {
-                        let level = CGFloat(levels[startIndex + barIndex])
-                        let height = max(size.height * level, placeholderHeight)
-                        let y = (size.height - height) / 2
-                        let rect = CGRect(x: x, y: y, width: barWidth, height: height)
-                        let path = Path(roundedRect: rect, cornerRadius: barWidth / 2)
-                        context.fill(path, with: .color(.colorCaution))
-                    } else {
-                        let y = (size.height - placeholderHeight) / 2
-                        let rect = CGRect(x: x, y: y, width: barWidth, height: placeholderHeight)
-                        let path = Path(roundedRect: rect, cornerRadius: barWidth / 2)
-                        context.fill(path, with: .color(Color.colorCaution.opacity(0.3)))
+                        let barIndex = i - (visibleBarCount - recordedCount)
+                        if barIndex >= 0, barIndex + startIndex < levels.count {
+                            let level = CGFloat(levels[startIndex + barIndex])
+                            let height = max(size.height * level, placeholderHeight)
+                            let y = (size.height - height) / 2
+                            let rect = CGRect(x: x, y: y, width: barWidth, height: height)
+                            let path = Path(roundedRect: rect, cornerRadius: barWidth / 2)
+                            context.fill(path, with: .color(.colorCaution))
+                        } else {
+                            let y = (size.height - placeholderHeight) / 2
+                            let rect = CGRect(x: x, y: y, width: barWidth, height: placeholderHeight)
+                            let path = Path(roundedRect: rect, cornerRadius: barWidth / 2)
+                            context.fill(path, with: .color(Color.colorCaution.opacity(0.3)))
+                        }
                     }
                 }
-            }
-            .frame(height: 24)
+                .frame(height: 24)
 
-            Text(formattedDuration(recorder.duration))
-                .font(.callout.monospacedDigit())
-                .foregroundStyle(.colorTextSecondary)
-                .frame(minWidth: 36, alignment: .trailing)
+                Text(formattedDuration(recorder.duration))
+                    .font(.caption)
+                    .foregroundStyle(.colorCaution)
+                    .frame(minWidth: 32, alignment: .trailing)
+            }
 
             Button {
                 withAnimation(.bouncy(duration: 0.4, extraBounce: 0.01)) {
@@ -51,15 +53,17 @@ struct VoiceMemoRecordingView: View {
             } label: {
                 Image(systemName: "stop.fill")
                     .font(.system(size: 14))
-                    .foregroundStyle(.white)
+                    .foregroundStyle(.colorCaution)
                     .frame(width: 32, height: 32)
-                    .background(.colorCaution, in: Circle())
+                    .background(Color.colorCaution.opacity(0.15), in: Circle())
             }
+            .frame(width: 48, height: 48)
             .accessibilityLabel("Stop recording")
             .accessibilityIdentifier("voice-memo-stop-button")
         }
-        .padding(.horizontal, DesignConstants.Spacing.step6x)
-        .padding(.vertical, DesignConstants.Spacing.step4x)
+        .padding(.leading, DesignConstants.Spacing.step5x)
+        .padding(.trailing, DesignConstants.Spacing.step2x)
+        .padding(.vertical, DesignConstants.Spacing.step2x)
     }
 
     private func formattedDuration(_ duration: TimeInterval) -> String {

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/VoiceMemoRecordingView.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/VoiceMemoRecordingView.swift
@@ -65,7 +65,7 @@ struct VoiceMemoRecordingView: View {
     private func formattedDuration(_ duration: TimeInterval) -> String {
         let minutes = Int(duration) / 60
         let seconds = Int(duration) % 60
-        return String(format: "%d:%02d", minutes, seconds)
+        return String(format: "%02d:%02d", minutes, seconds)
     }
 }
 

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/VoiceMemoReviewView.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/VoiceMemoReviewView.swift
@@ -16,7 +16,7 @@ struct VoiceMemoReviewView: View {
     }
 
     var body: some View {
-        HStack(spacing: DesignConstants.Spacing.step3x) {
+        HStack(spacing: 0) {
             Button {
                 togglePlayback()
             } label: {
@@ -24,22 +24,25 @@ struct VoiceMemoReviewView: View {
                     .font(.system(size: 14))
                     .foregroundStyle(.colorTextPrimary)
                     .frame(width: 32, height: 32)
-                    .background(.colorFillTertiary, in: Circle())
+                    .background(.colorFillSubtle, in: Circle())
             }
+            .frame(width: 48, height: 48)
             .accessibilityLabel(isPlaying ? "Pause" : "Play")
             .accessibilityIdentifier("voice-memo-play-button")
 
-            VoiceMemoWaveformView(
-                levels: displayLevels,
-                progress: playbackProgress
-            )
-            .frame(height: 24)
-            .animation(.linear(duration: 1.0 / 30.0), value: playbackProgress)
+            HStack(spacing: 4) {
+                VoiceMemoWaveformView(
+                    levels: displayLevels,
+                    progress: playbackProgress
+                )
+                .frame(height: 24)
+                .animation(.linear(duration: 1.0 / 30.0), value: playbackProgress)
 
-            Text(formattedDuration(duration))
-                .font(.callout.monospacedDigit())
-                .foregroundStyle(.colorTextSecondary)
-                .frame(minWidth: 44, alignment: .trailing)
+                Text(formattedDuration(duration))
+                    .font(.caption)
+                    .foregroundStyle(.colorTextSecondary)
+                    .frame(minWidth: 32, alignment: .trailing)
+            }
 
             Button {
                 stopPlayback()
@@ -51,11 +54,10 @@ struct VoiceMemoReviewView: View {
                     .frame(width: 32, height: 32)
                     .background(.colorFillPrimary, in: Circle())
             }
+            .frame(width: 48, height: 48)
             .accessibilityLabel("Send voice memo")
             .accessibilityIdentifier("voice-memo-send-button")
         }
-        .padding(.horizontal, DesignConstants.Spacing.step6x)
-        .padding(.vertical, DesignConstants.Spacing.step4x)
         .onDisappear {
             stopPlayback()
         }
@@ -116,7 +118,7 @@ struct VoiceMemoReviewView: View {
     private func formattedDuration(_ duration: TimeInterval) -> String {
         let minutes = Int(duration) / 60
         let seconds = Int(duration) % 60
-        return String(format: "%d:%02d", minutes, seconds)
+        return String(format: "%02d:%02d", minutes, seconds)
     }
 }
 

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessageContextMenuWrapper.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessageContextMenuWrapper.swift
@@ -235,6 +235,9 @@ private struct GestureOverlayView: UIViewRepresentable {
             if let linkView = findLinkViewInCell(at: point) {
                 return linkView
             }
+            if hasPassthroughMarker(at: point) {
+                return nil
+            }
             return self
         }
 
@@ -243,6 +246,13 @@ private struct GestureOverlayView: UIViewRepresentable {
             guard let root else { return nil }
             let rootPoint = convert(point, to: root)
             return findLinkView(in: root, at: rootPoint, excluding: self)
+        }
+
+        private func hasPassthroughMarker(at point: CGPoint) -> Bool {
+            let root = findAncestorCell()?.contentView ?? superview
+            guard let root else { return false }
+            let rootPoint = convert(point, to: root)
+            return findPassthroughMarker(in: root, at: rootPoint, excluding: self)
         }
 
         private func findLinkView(in view: UIView, at point: CGPoint, excluding: UIView) -> UIView? {
@@ -259,6 +269,21 @@ private struct GestureOverlayView: UIViewRepresentable {
                 }
             }
             return nil
+        }
+
+        private func findPassthroughMarker(in view: UIView, at point: CGPoint, excluding: UIView) -> Bool {
+            for subview in view.subviews.reversed() {
+                if subview === excluding { continue }
+                let subviewPoint = view.convert(point, to: subview)
+                guard subview.bounds.contains(subviewPoint) else { continue }
+                if subview is GesturePassthroughMarkerView {
+                    return true
+                }
+                if findPassthroughMarker(in: subview, at: subviewPoint, excluding: excluding) {
+                    return true
+                }
+            }
+            return false
         }
 
         private func findAncestorCell() -> UICollectionViewCell? {
@@ -430,4 +455,27 @@ private struct GestureOverlayView: UIViewRepresentable {
             return true
         }
     }
+}
+
+// MARK: - Gesture Passthrough Marker
+
+final class GesturePassthroughMarkerView: UIView {
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        isUserInteractionEnabled = false
+        backgroundColor = .clear
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+struct GesturePassthroughBackground: UIViewRepresentable {
+    func makeUIView(context: Context) -> GesturePassthroughMarkerView {
+        GesturePassthroughMarkerView()
+    }
+
+    func updateUIView(_ uiView: GesturePassthroughMarkerView, context: Context) {}
 }

--- a/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/ReplyReferenceView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/ReplyReferenceView.swift
@@ -545,6 +545,7 @@ private struct ReplyReferenceFileBubble: View {
 
 private struct ReplyReferenceAudioPreview: View {
     let attachment: HydratedAttachment
+    var transcriptText: String?
 
     @State private var waveformLevels: [Float]?
 
@@ -552,34 +553,46 @@ private struct ReplyReferenceAudioPreview: View {
         guard let duration = attachment.duration else { return "Audio" }
         let minutes = Int(duration) / 60
         let seconds = Int(duration) % 60
-        return String(format: "%d:%02d", minutes, seconds)
+        return String(format: "%02d:%02d", minutes, seconds)
     }
 
     var body: some View {
-        HStack(spacing: DesignConstants.Spacing.step2x) {
-            Image(systemName: "waveform")
-                .font(.system(size: 10))
-                .foregroundStyle(.colorTextSecondary)
+        VStack(alignment: .leading, spacing: 2) {
+            HStack(spacing: DesignConstants.Spacing.step2x) {
+                if let levels = waveformLevels {
+                    VoiceMemoWaveformView(
+                        levels: levels,
+                        unplayedColor: .colorTextPrimary,
+                        barWidth: 1.5,
+                        barSpacing: 1
+                    )
+                    .frame(height: 16)
+                    .frame(maxWidth: .infinity)
+                } else {
+                    Image(systemName: "waveform")
+                        .font(.system(size: 10))
+                        .foregroundStyle(.colorTextSecondary)
+                }
 
-            if let levels = waveformLevels {
-                VoiceMemoWaveformView(
-                    levels: levels,
-                    unplayedColor: .colorTextSecondary.opacity(0.4),
-                    barWidth: 1.5,
-                    barSpacing: 1
-                )
-                .frame(width: 60, height: 16)
+                Text(durationText)
+                    .font(.caption)
+                    .foregroundStyle(.colorTextSecondary)
             }
 
-            Text(durationText)
-                .font(.caption2)
-                .foregroundStyle(.colorTextSecondary)
+            if let text = transcriptText, !text.isEmpty {
+                Text(text)
+                    .font(.caption)
+                    .foregroundStyle(.colorTextPrimary)
+                    .lineLimit(2)
+                    .multilineTextAlignment(.leading)
+            }
         }
-        .padding(.horizontal, DesignConstants.Spacing.step3x)
-        .padding(.vertical, DesignConstants.Spacing.step2x)
+        .padding(.horizontal, DesignConstants.Spacing.step4x)
+        .padding(.vertical, DesignConstants.Spacing.step3x)
+        .frame(maxWidth: 160)
         .background(
-            RoundedRectangle(cornerRadius: 10)
-                .fill(Color.colorFillMinimal)
+            RoundedRectangle(cornerRadius: 24)
+                .stroke(Color.colorBorderSubtle, lineWidth: 1)
         )
         .task {
             if let cached = attachment.waveformLevels {

--- a/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/ReplyReferenceView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/ReplyReferenceView.swift
@@ -13,6 +13,7 @@ struct ReplyReferenceView: View {
     var onTapInvite: ((MessageInvite) -> Void)?
     var onPhotoRevealed: ((String) -> Void)?
     var onPhotoHidden: ((String) -> Void)?
+    var parentAudioTranscriptText: String?
 
     private var previewText: String {
         switch parentMessage.content {
@@ -101,7 +102,7 @@ struct ReplyReferenceView: View {
             .padding(.trailing, isOutgoing ? DesignConstants.Spacing.step3x : 0.0)
 
             if let attachment = parentAttachment, attachment.mediaType == .audio {
-                ReplyReferenceAudioPreview(attachment: attachment)
+                ReplyReferenceAudioPreview(attachment: attachment, transcriptText: parentAudioTranscriptText)
             } else if let attachment = parentAttachment, attachment.mediaType == .file {
                 ReplyReferenceFileBubble(attachment: attachment)
             } else if let attachment = parentAttachment {
@@ -548,9 +549,14 @@ private struct ReplyReferenceAudioPreview: View {
     var transcriptText: String?
 
     @State private var waveformLevels: [Float]?
+    @State private var analyzedDuration: TimeInterval?
 
-    private var durationText: String {
-        guard let duration = attachment.duration else { return "Audio" }
+    private var effectiveDuration: TimeInterval? {
+        attachment.duration ?? analyzedDuration
+    }
+
+    private var durationText: String? {
+        guard let duration = effectiveDuration else { return nil }
         let minutes = Int(duration) / 60
         let seconds = Int(duration) % 60
         return String(format: "%02d:%02d", minutes, seconds)
@@ -562,7 +568,7 @@ private struct ReplyReferenceAudioPreview: View {
                 if let levels = waveformLevels {
                     VoiceMemoWaveformView(
                         levels: levels,
-                        unplayedColor: .colorTextPrimary,
+                        unplayedColor: .colorFillTertiary,
                         barWidth: 1.5,
                         barSpacing: 1
                     )
@@ -574,9 +580,11 @@ private struct ReplyReferenceAudioPreview: View {
                         .foregroundStyle(.colorTextSecondary)
                 }
 
-                Text(durationText)
-                    .font(.caption)
-                    .foregroundStyle(.colorTextSecondary)
+                if let durationText {
+                    Text(durationText)
+                        .font(.caption)
+                        .foregroundStyle(.colorTextSecondary)
+                }
             }
 
             if let text = transcriptText, !text.isEmpty {
@@ -597,13 +605,18 @@ private struct ReplyReferenceAudioPreview: View {
         .task {
             if let cached = attachment.waveformLevels {
                 waveformLevels = cached
-                return
+                if attachment.duration != nil { return }
             }
             do {
                 let loader = RemoteAttachmentLoader()
                 let loaded = try await loader.loadAttachmentData(from: attachment.key)
-                let levels = await VoiceMemoWaveformAnalyzer.analyzeLevels(from: loaded.data, sampleCount: 30)
-                await MainActor.run { waveformLevels = levels }
+                let analysis = await VoiceMemoWaveformAnalyzer.analyze(from: loaded.data, sampleCount: 30)
+                await MainActor.run {
+                    if waveformLevels == nil { waveformLevels = analysis.levels }
+                    if effectiveDuration == nil, analysis.duration > 0 {
+                        analyzedDuration = analysis.duration
+                    }
+                }
             } catch {
                 Log.error("Failed to load reply audio waveform: \(error)")
             }

--- a/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/ReplyReferenceView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/ReplyReferenceView.swift
@@ -596,10 +596,10 @@ private struct ReplyReferenceAudioPreview: View {
             }
         }
         .padding(.horizontal, DesignConstants.Spacing.step4x)
-        .padding(.vertical, DesignConstants.Spacing.step3x)
+        .padding(.vertical, DesignConstants.Spacing.step2x)
         .frame(maxWidth: 160)
         .background(
-            RoundedRectangle(cornerRadius: 24)
+            RoundedRectangle(cornerRadius: 20)
                 .stroke(Color.colorBorderSubtle, lineWidth: 1)
         )
         .task {

--- a/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/VoiceMemoBubble.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/VoiceMemoBubble.swift
@@ -105,7 +105,7 @@ struct VoiceMemoBubbleContent: View {
             await loadAndCacheAnalysis()
         }
         .onChange(of: transcript?.status) { _, newStatus in
-            if newStatus == .completed || newStatus == .failed {
+            if newStatus == .completed || newStatus == .permanentlyFailed {
                 optimisticPending = false
             }
         }
@@ -243,7 +243,10 @@ struct VoiceMemoBubbleContent: View {
             .padding(.horizontal, DesignConstants.Spacing.step4x)
             .padding(.bottom, DesignConstants.Spacing.step3x)
 
-        case .failed, .permanentlyFailed:
+        case .permanentlyFailed:
+            EmptyView()
+
+        case .failed:
             EmptyView()
         }
     }

--- a/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/VoiceMemoBubble.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/VoiceMemoBubble.swift
@@ -132,7 +132,7 @@ struct VoiceMemoBubbleContent: View {
             .foregroundStyle(isOutgoing ? .colorTextPrimaryInverted : .colorTextPrimary)
             .frame(width: 32, height: 32)
             .background(
-                isOutgoing ? Color.colorTextPrimaryInverted.opacity(0.2) : .colorFillSubtle,
+                isOutgoing ? .colorFillInvertedSubtle : Color.colorTextPrimaryInverted,
                 in: Circle()
             )
             .frame(width: 48, height: 48)
@@ -220,7 +220,7 @@ struct VoiceMemoBubbleContent: View {
                         .frame(maxWidth: .infinity)
                         .frame(height: 44)
                         .background(
-                            isOutgoing ? Color.colorTextPrimaryInverted.opacity(0.2) : .colorFillSubtle,
+                            isOutgoing ? .colorFillInvertedSubtle : Color.colorTextPrimaryInverted,
                             in: .rect(cornerRadius: 24)
                         )
                 }

--- a/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/VoiceMemoBubble.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/VoiceMemoBubble.swift
@@ -54,6 +54,7 @@ struct VoiceMemoBubbleContent: View {
     @State private var analyzedDuration: TimeInterval?
     @State private var isSheetPresented: Bool = false
     @State private var optimisticPending: Bool = false
+    @State private var isTruncated: Bool = false
 
     private var displayLevels: [Float] {
         attachment.waveformLevels ?? analyzedLevels ?? Self.placeholderLevels
@@ -161,19 +162,41 @@ struct VoiceMemoBubbleContent: View {
         switch transcriptStatus {
         case .completed:
             if let text = transcript?.text, !text.isEmpty {
-                let tapAction = { isSheetPresented = true }
+                let tapAction = { if isTruncated { isSheetPresented = true } }
                 Button(action: tapAction) {
                     HStack(spacing: DesignConstants.Spacing.step2x) {
                         Text(text)
                             .font(.caption)
                             .foregroundStyle(isOutgoing ? Color.colorTextPrimaryInverted.opacity(0.6) : .colorTextSecondary)
-                            .lineLimit(2)
+                            .lineLimit(3)
                             .multilineTextAlignment(.leading)
                             .frame(maxWidth: .infinity, alignment: .leading)
+                            .background(
+                                Text(text)
+                                    .font(.caption)
+                                    .lineLimit(nil)
+                                    .fixedSize(horizontal: false, vertical: true)
+                                    .hidden()
+                                    .overlay(GeometryReader { fullProxy in
+                                        GeometryReader { _ in
+                                            Color.clear.preference(
+                                                key: FullTextHeightKey.self,
+                                                value: fullProxy.size.height
+                                            )
+                                        }
+                                    })
+                            )
+                            .onPreferenceChange(FullTextHeightKey.self) { fullHeight in
+                                guard let fullHeight else { return }
+                                let lineHeight = UIFont.preferredFont(forTextStyle: .caption1).lineHeight
+                                isTruncated = fullHeight > lineHeight * 3.5
+                            }
 
-                        Image(systemName: "chevron.right")
-                            .font(.subheadline)
-                            .foregroundStyle(isOutgoing ? Color.colorTextPrimaryInverted.opacity(0.3) : .colorTextTertiary)
+                        if isTruncated {
+                            Image(systemName: "chevron.right")
+                                .font(.subheadline)
+                                .foregroundStyle(isOutgoing ? Color.colorTextPrimaryInverted.opacity(0.3) : .colorTextTertiary)
+                        }
                     }
                     .padding(.horizontal, DesignConstants.Spacing.step4x)
                     .padding(.bottom, DesignConstants.Spacing.step3x)
@@ -249,6 +272,13 @@ struct VoiceMemoBubbleContent: View {
     }
 
     private static let placeholderLevels: [Float] = Array(repeating: Float(0), count: 40)
+
+    private enum FullTextHeightKey: PreferenceKey {
+        static let defaultValue: CGFloat? = nil
+        static func reduce(value: inout CGFloat?, nextValue: () -> CGFloat?) {
+            value = value ?? nextValue()
+        }
+    }
 }
 
 #Preview {

--- a/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/VoiceMemoBubble.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/VoiceMemoBubble.swift
@@ -13,6 +13,8 @@ struct VoiceMemoAttachmentView: View {
     let attachment: HydratedAttachment
     let bubbleType: MessageBubbleType
     let onReply: (AnyMessage) -> Void
+    var transcript: VoiceMemoTranscriptListItem?
+    var onRetryTranscript: ((VoiceMemoTranscriptListItem) -> Void)?
 
     @State private var player: VoiceMemoPlayer = .shared
     @State private var isLoading: Bool = false
@@ -24,7 +26,9 @@ struct VoiceMemoAttachmentView: View {
                 attachment: attachment,
                 isOutgoing: message.sender.isCurrentUser,
                 player: player,
-                isLoading: isLoading
+                isLoading: isLoading,
+                transcript: transcript,
+                onRetryTranscript: onRetryTranscript
             )
         }
         .messageGesture(
@@ -36,26 +40,25 @@ struct VoiceMemoAttachmentView: View {
 }
 
 struct VoiceMemoBubbleContent: View {
-    /// Shared display width for the voice memo bubble. Used by the inline
-    /// transcript row so the two cells visually line up.
-    static let bubbleWidth: CGFloat = 220
+    static let bubbleWidth: CGFloat = 280
 
     let message: AnyMessage
     let attachment: HydratedAttachment
     let isOutgoing: Bool
     let player: VoiceMemoPlayer
     let isLoading: Bool
+    var transcript: VoiceMemoTranscriptListItem?
+    var onRetryTranscript: ((VoiceMemoTranscriptListItem) -> Void)?
 
     @State private var analyzedLevels: [Float]?
     @State private var analyzedDuration: TimeInterval?
+    @State private var isSheetPresented: Bool = false
+    @State private var optimisticPending: Bool = false
 
     private var displayLevels: [Float] {
         attachment.waveformLevels ?? analyzedLevels ?? Self.placeholderLevels
     }
 
-    /// Best-effort duration for the static (non-playing) state.
-    /// Prefers the value the sender encoded into the remote attachment metadata,
-    /// falls back to a value we measured locally from the decoded audio file.
     private var staticDuration: TimeInterval {
         attachment.duration ?? analyzedDuration ?? 0
     }
@@ -79,46 +82,146 @@ struct VoiceMemoBubbleContent: View {
         isCurrentlyPlaying ? player.progress : 0
     }
 
-    var body: some View {
-        HStack(spacing: DesignConstants.Spacing.step3x) {
-            Group {
-                if isLoading {
-                    ProgressView()
-                        .scaleEffect(0.7)
-                } else {
-                    Image(systemName: showPause ? "pause.fill" : "play.fill")
-                        .font(.system(size: 16))
-                }
-            }
-            .foregroundStyle(isOutgoing ? .colorTextPrimaryInverted : .colorTextPrimary)
-            .frame(width: 36, height: 36)
-            .background(
-                isOutgoing ? Color.colorTextPrimaryInverted.opacity(0.2) : .colorFillMinimal,
-                in: Circle()
-            )
-
-            VoiceMemoWaveformView(
-                levels: displayLevels,
-                progress: displayProgress,
-                playedColor: isOutgoing ? .colorTextPrimaryInverted : .colorTextPrimary,
-                unplayedColor: isOutgoing ? .colorTextPrimaryInverted.opacity(0.3) : .colorTextSecondary.opacity(0.3)
-            )
-            .frame(height: 24)
-            .frame(maxWidth: .infinity)
-            .animation(.linear(duration: 1.0 / 30.0), value: displayProgress)
-
-            Text(displayDuration)
-                .font(.caption.monospacedDigit())
-                .foregroundStyle(isOutgoing ? .colorTextPrimaryInverted.opacity(0.7) : .colorTextSecondary)
-                .frame(minWidth: 32, alignment: .trailing)
+    private var transcriptStatus: VoiceMemoTranscriptStatus {
+        guard let transcript else { return .permanentlyFailed }
+        if optimisticPending,
+           transcript.status == .notRequested || transcript.status == .pending {
+            return .pending
         }
-        .padding(DesignConstants.Spacing.step3x)
+        return transcript.status
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            audioPlayerRow
+            transcriptSection
+        }
         .frame(width: Self.bubbleWidth)
         .task(id: message.messageId) {
             let needsLevels = attachment.waveformLevels == nil && analyzedLevels == nil
             let needsDuration = attachment.duration == nil && analyzedDuration == nil
             guard needsLevels || needsDuration else { return }
             await loadAndCacheAnalysis()
+        }
+        .onChange(of: transcript?.status) { _, newStatus in
+            if newStatus == .completed || newStatus == .failed {
+                optimisticPending = false
+            }
+        }
+        .sheet(isPresented: $isSheetPresented) {
+            if let transcript {
+                VoiceMemoTranscriptSheet(item: transcript)
+                    .presentationDetents([.medium, .large])
+                    .presentationDragIndicator(.hidden)
+            }
+        }
+    }
+
+    private var audioPlayerRow: some View {
+        HStack(spacing: 0) {
+            Group {
+                if isLoading {
+                    ProgressView()
+                        .scaleEffect(0.7)
+                } else {
+                    Image(systemName: showPause ? "pause.fill" : "play.fill")
+                        .font(.system(size: 15))
+                }
+            }
+            .foregroundStyle(isOutgoing ? .colorTextPrimaryInverted : .colorTextPrimary)
+            .frame(width: 32, height: 32)
+            .background(
+                isOutgoing ? Color.colorTextPrimaryInverted.opacity(0.2) : .colorFillSubtle,
+                in: Circle()
+            )
+            .frame(width: 48, height: 48)
+
+            HStack(spacing: DesignConstants.Spacing.step2x) {
+                VoiceMemoWaveformView(
+                    levels: displayLevels,
+                    progress: displayProgress,
+                    playedColor: isOutgoing ? .colorTextPrimaryInverted : .colorTextPrimary,
+                    unplayedColor: isOutgoing ? .colorTextPrimaryInverted.opacity(0.3) : .colorTextSecondary.opacity(0.3)
+                )
+                .frame(height: 24)
+                .frame(maxWidth: .infinity)
+                .animation(.linear(duration: 1.0 / 30.0), value: displayProgress)
+
+                Text(displayDuration)
+                    .font(.caption)
+                    .foregroundStyle(isOutgoing ? Color.colorTextPrimaryInverted.opacity(0.6) : .colorTextSecondary)
+                    .frame(minWidth: 32, alignment: .trailing)
+            }
+            .padding(.trailing, DesignConstants.Spacing.step4x)
+        }
+    }
+
+    @ViewBuilder
+    private var transcriptSection: some View {
+        switch transcriptStatus {
+        case .completed:
+            if let text = transcript?.text, !text.isEmpty {
+                let tapAction = { isSheetPresented = true }
+                Button(action: tapAction) {
+                    HStack(spacing: DesignConstants.Spacing.step2x) {
+                        Text(text)
+                            .font(.caption)
+                            .foregroundStyle(isOutgoing ? Color.colorTextPrimaryInverted.opacity(0.6) : .colorTextSecondary)
+                            .lineLimit(2)
+                            .multilineTextAlignment(.leading)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+
+                        Image(systemName: "chevron.right")
+                            .font(.subheadline)
+                            .foregroundStyle(isOutgoing ? Color.colorTextPrimaryInverted.opacity(0.3) : .colorTextTertiary)
+                    }
+                    .padding(.horizontal, DesignConstants.Spacing.step4x)
+                    .padding(.bottom, DesignConstants.Spacing.step3x)
+                }
+                .buttonStyle(.plain)
+                .background(GesturePassthroughBackground())
+            }
+
+        case .notRequested:
+            if let transcript {
+                let tapAction = {
+                    withAnimation(.easeInOut(duration: 0.2)) {
+                        optimisticPending = true
+                    }
+                    onRetryTranscript?(transcript)
+                }
+                Button(action: tapAction) {
+                    Text("View transcript")
+                        .font(.footnote)
+                        .foregroundStyle(isOutgoing ? .colorTextPrimaryInverted : .colorTextPrimary)
+                        .frame(maxWidth: .infinity)
+                        .frame(height: 44)
+                        .background(
+                            isOutgoing ? Color.colorTextPrimaryInverted.opacity(0.2) : .colorFillSubtle,
+                            in: .rect(cornerRadius: 24)
+                        )
+                }
+                .buttonStyle(.plain)
+                .background(GesturePassthroughBackground())
+                .padding(.horizontal, DesignConstants.Spacing.step2x)
+                .padding(.bottom, DesignConstants.Spacing.step2x)
+            }
+
+        case .pending:
+            HStack(spacing: DesignConstants.Spacing.step2x) {
+                ProgressView()
+                    .progressViewStyle(.circular)
+                    .scaleEffect(0.7)
+                    .tint(isOutgoing ? .colorTextPrimaryInverted : .colorTextSecondary)
+                Text("Transcribing\u{2026}")
+                    .font(.caption)
+                    .foregroundStyle(isOutgoing ? Color.colorTextPrimaryInverted.opacity(0.6) : .colorTextSecondary)
+            }
+            .padding(.horizontal, DesignConstants.Spacing.step4x)
+            .padding(.bottom, DesignConstants.Spacing.step3x)
+
+        case .failed, .permanentlyFailed:
+            EmptyView()
         }
     }
 
@@ -142,14 +245,14 @@ struct VoiceMemoBubbleContent: View {
     private func formatDuration(_ duration: TimeInterval) -> String {
         let minutes = Int(duration) / 60
         let seconds = Int(duration) % 60
-        return String(format: "%d:%02d", minutes, seconds)
+        return String(format: "%02d:%02d", minutes, seconds)
     }
 
     private static let placeholderLevels: [Float] = Array(repeating: Float(0), count: 40)
 }
 
 #Preview {
-    VStack {
+    VStack(spacing: 16) {
         VoiceMemoBubbleContent(
             message: .message(.mock(), .existing),
             attachment: HydratedAttachment(key: "test", mimeType: "audio/m4a", duration: 7),
@@ -157,16 +260,43 @@ struct VoiceMemoBubbleContent: View {
             player: .shared,
             isLoading: false
         )
-        .background(.colorBubble, in: RoundedRectangle(cornerRadius: 16))
+        .background(.colorBubble, in: RoundedRectangle(cornerRadius: 24))
 
         VoiceMemoBubbleContent(
             message: .message(.mock(), .existing),
             attachment: HydratedAttachment(key: "test2", mimeType: "audio/m4a", duration: 15),
-            isOutgoing: false,
+            isOutgoing: true,
             player: .shared,
-            isLoading: false
+            isLoading: false,
+            transcript: VoiceMemoTranscriptListItem(
+                parentMessageId: "1",
+                conversationId: "c",
+                attachmentKey: "k",
+                senderDisplayName: "Alice",
+                isOutgoing: true,
+                status: .completed,
+                text: "Blame it all on my roots, I showed up in boots, And ruined your black tie affair. The last one to know, the last one to show."
+            )
         )
-        .background(.colorBubbleIncoming, in: RoundedRectangle(cornerRadius: 16))
+        .background(.colorBubble, in: RoundedRectangle(cornerRadius: 24))
+
+        VoiceMemoBubbleContent(
+            message: .message(.mock(), .existing),
+            attachment: HydratedAttachment(key: "test3", mimeType: "audio/m4a", duration: 18),
+            isOutgoing: true,
+            player: .shared,
+            isLoading: false,
+            transcript: VoiceMemoTranscriptListItem(
+                parentMessageId: "2",
+                conversationId: "c",
+                attachmentKey: "k",
+                senderDisplayName: "Alice",
+                isOutgoing: true,
+                status: .notRequested,
+                text: nil
+            )
+        )
+        .background(.colorBubble, in: RoundedRectangle(cornerRadius: 24))
     }
     .padding()
 }

--- a/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/VoiceMemoTranscriptRow.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/VoiceMemoTranscriptRow.swift
@@ -213,7 +213,7 @@ struct VoiceMemoTranscriptRow: View {
     }
 }
 
-private struct VoiceMemoTranscriptSheet: View {
+struct VoiceMemoTranscriptSheet: View {
     let item: VoiceMemoTranscriptListItem
 
     @Environment(\.dismiss) private var dismiss: DismissAction

--- a/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/VoiceMemoTranscriptRow.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/VoiceMemoTranscriptRow.swift
@@ -34,7 +34,7 @@ struct VoiceMemoTranscriptRow: View {
     }
 
     private var canRequestTranscription: Bool {
-        displayStatus == .notRequested || displayStatus == .failed
+        displayStatus == .notRequested
     }
 
     private var isInteractive: Bool {
@@ -71,9 +71,7 @@ struct VoiceMemoTranscriptRow: View {
         .disabled(!isInteractive)
         .animation(.easeInOut(duration: 0.2), value: displayStatus)
         .onChange(of: item.status) { _, newStatus in
-            // Once the publisher catches up and reports a real terminal state,
-            // drop the optimistic flag so the row reflects truth again.
-            if newStatus == .completed || newStatus == .failed {
+            if newStatus == .completed || newStatus == .permanentlyFailed {
                 optimisticPending = false
             }
         }
@@ -107,10 +105,6 @@ struct VoiceMemoTranscriptRow: View {
                         .lineLimit(2)
                         .multilineTextAlignment(.leading)
                         .fixedSize(horizontal: false, vertical: true)
-                }
-
-                if displayStatus == .failed {
-                    failureBody
                 }
 
                 if displayStatus == .notRequested {
@@ -167,18 +161,6 @@ struct VoiceMemoTranscriptRow: View {
     }
 
     @ViewBuilder
-    private var failureBody: some View {
-        if let detail = item.errorDescription, !detail.isEmpty {
-            Text(detail)
-                .font(.caption2)
-                .foregroundStyle(.colorTextSecondary)
-                .multilineTextAlignment(.leading)
-                .fixedSize(horizontal: false, vertical: true)
-        }
-        capsuleAffordance(title: "Tap to try again", systemImage: "arrow.clockwise")
-    }
-
-    @ViewBuilder
     private func capsuleAffordance(title: String, systemImage: String) -> some View {
         Label(title: { Text(title) }, icon: {
             Image(systemName: systemImage)
@@ -197,8 +179,8 @@ struct VoiceMemoTranscriptRow: View {
         case .notRequested: return "text.bubble"
         case .pending: return "waveform"
         case .completed: return "text.bubble"
-        case .failed: return "exclamationmark.bubble"
-        case .permanentlyFailed: return "text.bubble" // row is hidden; value unused
+        case .failed: return "text.bubble"
+        case .permanentlyFailed: return "text.bubble"
         }
     }
 
@@ -207,8 +189,8 @@ struct VoiceMemoTranscriptRow: View {
         case .notRequested: return "Tap to transcribe"
         case .pending: return "Transcribing…"
         case .completed: return "Transcript"
-        case .failed: return "Transcript unavailable"
-        case .permanentlyFailed: return "" // row is hidden; value unused
+        case .failed: return ""
+        case .permanentlyFailed: return ""
         }
     }
 }

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
@@ -18,6 +18,7 @@ struct MessagesGroupItemView: View {
     var voiceMemoTranscript: VoiceMemoTranscriptListItem?
     var voiceMemoTranscriptIsTailed: Bool = false
     var onRetryTranscript: ((VoiceMemoTranscriptListItem) -> Void)?
+    var parentAudioTranscriptText: String?
     var omitTrailingPadding: Bool = false
 
     @State private var isAppearing: Bool = true
@@ -53,7 +54,8 @@ struct MessagesGroupItemView: View {
                     onTapAvatar: { onTapAvatar(.message(reply.parentMessage, .existing)) },
                     onTapInvite: onTapInvite,
                     onPhotoRevealed: onPhotoRevealed,
-                    onPhotoHidden: onPhotoHidden
+                    onPhotoHidden: onPhotoHidden,
+                    parentAudioTranscriptText: parentAudioTranscriptText
                 )
                 .padding(.leading, !message.sender.isCurrentUser && message.content.isFullBleedAttachment
                     ? DesignConstants.Spacing.step4x

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
@@ -31,6 +31,17 @@ struct MessagesGroupItemView: View {
         omitTrailingPadding ? 0 : DesignConstants.Spacing.step4x
     }
 
+    private var isAudioAttachment: Bool {
+        switch message.content {
+        case .attachment(let attachment):
+            return attachment.mediaType == .audio
+        case .attachments(let attachments):
+            return attachments.first?.mediaType == .audio
+        default:
+            return false
+        }
+    }
+
     var body: some View {
         VStack(alignment: message.sender.isCurrentUser ? .trailing : .leading, spacing: 0.0) {
             if case .reply(let reply, _) = message {
@@ -50,7 +61,7 @@ struct MessagesGroupItemView: View {
                 .padding(.trailing, trailingPadding)
             }
             messageContent
-            if let voiceMemoTranscript {
+            if let voiceMemoTranscript, !isAudioAttachment {
                 VoiceMemoTranscriptRow(
                     item: voiceMemoTranscript,
                     isTailed: voiceMemoTranscriptIsTailed,
@@ -242,7 +253,9 @@ struct MessagesGroupItemView: View {
                     attachment: attachment,
                     isOutgoing: message.sender.isCurrentUser,
                     player: .shared,
-                    isLoading: false
+                    isLoading: false,
+                    transcript: voiceMemoTranscript,
+                    onRetryTranscript: onRetryTranscript
                 )
             }
             .padding(.trailing, message.sender.isCurrentUser ? DesignConstants.Spacing.step4x : 0)

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupView.swift
@@ -16,6 +16,7 @@ struct MessagesGroupView: View {
     var onRetryMessage: ((AnyMessage) -> Void)?
     var onDeleteMessage: ((AnyMessage) -> Void)?
     var onRetryTranscript: ((VoiceMemoTranscriptListItem) -> Void)?
+    var allVoiceMemoTranscripts: [String: VoiceMemoTranscriptListItem] = [:]
 
     @State private var isAppearing: Bool = true
     @State private var hasAnimated: Bool = false
@@ -201,6 +202,7 @@ struct MessagesGroupView: View {
                 voiceMemoTranscript: group.voiceMemoTranscripts[message.messageId],
                 voiceMemoTranscriptIsTailed: voiceMemoTranscriptIsTailed,
                 onRetryTranscript: onRetryTranscript,
+                parentAudioTranscriptText: parentAudioTranscriptText(for: message),
                 omitTrailingPadding: isFailed
             )
             .zIndex(100)
@@ -228,6 +230,13 @@ struct MessagesGroupView: View {
             }
         }
         .padding(.leading, !group.sender.isCurrentUser && !isFullWidthAttachment ? DesignConstants.Spacing.step4x : 0)
+    }
+
+    private func parentAudioTranscriptText(for message: AnyMessage) -> String? {
+        guard case .reply(let reply, _) = message,
+              reply.parentMessage.content.primaryVoiceMemoAttachment != nil
+        else { return nil }
+        return allVoiceMemoTranscripts[reply.parentMessage.id]?.text
     }
 
     @ViewBuilder

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessagesListRepository.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessagesListRepository.swift
@@ -160,22 +160,15 @@ final class MessagesListRepository: MessagesListRepositoryProtocol {
             // unavailable) are kept in the database so the scheduler does not
             // re-enqueue them, but the UI hides them so the user doesn't see a
             // misleading retry affordance. Nothing to render here.
-            // TODO: Remove mock bypass before merging
-            // if stored?.status == .permanentlyFailed {
-            //     continue
-            // }
+            if stored?.status == .permanentlyFailed {
+                continue
+            }
             if stored == nil, permissionGranted {
                 // Auto-transcribe path: don't fabricate a row. The scheduler will
                 // call markPending shortly and the writer-driven publisher will
                 // surface the real `.pending` row when it lands.
                 continue
             }
-            // TODO: Remove mock transcript before merging
-            let mockTexts = [
-                "Blame it all on my roots, I showed up in boots, And ruined your black tie affair. The last one to know, the last one to show, I was the last one you thought you'd see there",
-                "Callin Baton Rouge",
-            ]
-            let mockText = mockTexts[abs(message.messageId.hashValue) % mockTexts.count]
             let item = VoiceMemoTranscriptListItem(
                 parentMessageId: message.messageId,
                 conversationId: effectiveConversationId,
@@ -183,8 +176,8 @@ final class MessagesListRepository: MessagesListRepositoryProtocol {
                 mimeType: attachment.mimeType,
                 senderDisplayName: message.sender.profile.displayName,
                 isOutgoing: false,
-                status: .completed,
-                text: mockText,
+                status: stored?.status ?? .notRequested,
+                text: stored?.text,
                 errorDescription: stored?.errorDescription
             )
             result[message.messageId] = item

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessagesListRepository.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessagesListRepository.swift
@@ -160,15 +160,22 @@ final class MessagesListRepository: MessagesListRepositoryProtocol {
             // unavailable) are kept in the database so the scheduler does not
             // re-enqueue them, but the UI hides them so the user doesn't see a
             // misleading retry affordance. Nothing to render here.
-            if stored?.status == .permanentlyFailed {
-                continue
-            }
+            // TODO: Remove mock bypass before merging
+            // if stored?.status == .permanentlyFailed {
+            //     continue
+            // }
             if stored == nil, permissionGranted {
                 // Auto-transcribe path: don't fabricate a row. The scheduler will
                 // call markPending shortly and the writer-driven publisher will
                 // surface the real `.pending` row when it lands.
                 continue
             }
+            // TODO: Remove mock transcript before merging
+            let mockTexts = [
+                "Blame it all on my roots, I showed up in boots, And ruined your black tie affair. The last one to know, the last one to show, I was the last one you thought you'd see there",
+                "Callin Baton Rouge",
+            ]
+            let mockText = mockTexts[abs(message.messageId.hashValue) % mockTexts.count]
             let item = VoiceMemoTranscriptListItem(
                 parentMessageId: message.messageId,
                 conversationId: effectiveConversationId,
@@ -176,8 +183,8 @@ final class MessagesListRepository: MessagesListRepositoryProtocol {
                 mimeType: attachment.mimeType,
                 senderDisplayName: message.sender.profile.displayName,
                 isOutgoing: false,
-                status: stored?.status ?? .notRequested,
-                text: stored?.text,
+                status: .completed,
+                text: mockText,
                 errorDescription: stored?.errorDescription
             )
             result[message.messageId] = item

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessagesListView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessagesListView.swift
@@ -78,17 +78,7 @@ struct MessagesListView: View {
                                 }
 
                             case .messages(let group):
-                                MessagesGroupView(
-                                    group: group,
-                                    shouldBlurPhotos: shouldBlurPhotos,
-                                    onTapAvatar: onTapAvatar,
-                                    onTapInvite: onTapInvite,
-                                    onTapReactions: onTapReactions,
-                                    onReply: onReply,
-                                    onPhotoRevealed: onPhotoRevealed,
-                                    onPhotoHidden: onPhotoHidden,
-                                    onPhotoDimensionsLoaded: onPhotoDimensionsLoaded
-                                )
+                                messagesGroupView(for: group)
 
                             case .invite(let invite):
                                 InviteView(invite: invite)
@@ -156,6 +146,31 @@ struct MessagesListView: View {
             .defaultScrollAnchor(.bottom)
             .scrollDismissesKeyboard(.interactively)
             .scrollPosition($scrollPosition, anchor: .bottom)
+        }
+    }
+
+    private func messagesGroupView(for group: MessagesGroup) -> MessagesGroupView {
+        let transcripts = Self.collectTranscripts(from: messages)
+        return MessagesGroupView(
+            group: group,
+            shouldBlurPhotos: shouldBlurPhotos,
+            onTapAvatar: onTapAvatar,
+            onTapInvite: onTapInvite,
+            onTapReactions: onTapReactions,
+            onReply: onReply,
+            onPhotoRevealed: onPhotoRevealed,
+            onPhotoHidden: onPhotoHidden,
+            onPhotoDimensionsLoaded: onPhotoDimensionsLoaded,
+            allVoiceMemoTranscripts: transcripts
+        )
+    }
+
+    private static func collectTranscripts(
+        from items: [MessagesListItemType]
+    ) -> [String: VoiceMemoTranscriptListItem] {
+        items.reduce(into: [:]) { result, item in
+            guard case .messages(let group) = item else { return }
+            result.merge(group.voiceMemoTranscripts) { _, new in new }
         }
     }
 }

--- a/Convos/Conversation Detail/Messages/MessagesView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesView.swift
@@ -43,6 +43,7 @@ struct MessagesView<BottomBarContent: View>: View {
     let onTapReactions: (AnyMessage) -> Void
     let onReply: (AnyMessage) -> Void
     let replyingToMessage: AnyMessage?
+    var replyingToAudioTranscriptText: String?
     let onCancelReply: () -> Void
     let onDisplayNameEndedEditing: () -> Void
     let onProfileSettings: () -> Void
@@ -158,6 +159,7 @@ struct MessagesView<BottomBarContent: View>: View {
                         ReplyComposerBar(
                             message: replyingToMessage,
                             shouldBlurPhotos: shouldBlurPhotos,
+                            audioTranscriptText: replyingToAudioTranscriptText,
                             onDismiss: onCancelReply
                         )
                     }

--- a/ConvosCore/Sources/ConvosCore/Messaging/VoiceMemoTranscriptionService.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/VoiceMemoTranscriptionService.swift
@@ -172,12 +172,16 @@ public final class VoiceMemoTranscriptionService: VoiceMemoTranscriptionServicin
             fileURL = try Self.writeTemporaryAudioFile(data: loaded.data, mimeType: loaded.mimeType)
         } catch {
             Log.error("[VoiceMemoTranscription] Failed to load audio for \(messageId): \(error)")
-            await persistFailure(
-                messageId: messageId,
-                conversationId: conversationId,
-                attachmentKey: attachmentKey,
-                error: error
-            )
+            do {
+                try await transcriptWriter.markPermanentlyFailed(
+                    messageId: messageId,
+                    conversationId: conversationId,
+                    attachmentKey: attachmentKey,
+                    errorDescription: error.localizedDescription
+                )
+            } catch {
+                Log.error("[VoiceMemoTranscription] Failed to mark permanently failed for \(messageId): \(error)")
+            }
             await state.clear(messageId: messageId)
             return
         }
@@ -205,31 +209,6 @@ public final class VoiceMemoTranscriptionService: VoiceMemoTranscriptionServicin
             Log.info("[VoiceMemoTranscription] Transcription cancelled for \(messageId)")
         } catch {
             Log.error("[VoiceMemoTranscription] Transcription failed for \(messageId): \(error)")
-            await persistFailure(
-                messageId: messageId,
-                conversationId: conversationId,
-                attachmentKey: attachmentKey,
-                error: error
-            )
-        }
-
-        await state.clear(messageId: messageId)
-    }
-
-    /// Records the failure in a way that's appropriate for the user. Permanent
-    /// failures (e.g. on-device speech models are not available) cannot be
-    /// recovered from by retrying, so we mark the row as `.permanentlyFailed`
-    /// — this keeps an entry in the database (so the scheduler's "already has
-    /// a row" check short-circuits and no retry loop occurs) while still
-    /// telling the UI synthesis path to hide the row entirely. Recoverable
-    /// failures still produce a `failed` row so the user can manually retry.
-    private func persistFailure(
-        messageId: String,
-        conversationId: String,
-        attachmentKey: String,
-        error: Error
-    ) async {
-        if let transcribeError = error as? VoiceMemoTranscriberError, transcribeError.isPermanentFailure {
             do {
                 try await transcriptWriter.markPermanentlyFailed(
                     messageId: messageId,
@@ -240,10 +219,19 @@ public final class VoiceMemoTranscriptionService: VoiceMemoTranscriptionServicin
             } catch {
                 Log.error("[VoiceMemoTranscription] Failed to mark permanently failed for \(messageId): \(error)")
             }
-            return
         }
+
+        await state.clear(messageId: messageId)
+    }
+
+    private func persistFailure(
+        messageId: String,
+        conversationId: String,
+        attachmentKey: String,
+        error: Error
+    ) async {
         do {
-            try await transcriptWriter.saveFailed(
+            try await transcriptWriter.markPermanentlyFailed(
                 messageId: messageId,
                 conversationId: conversationId,
                 attachmentKey: attachmentKey,

--- a/ConvosCore/Sources/ConvosCore/Messaging/VoiceMemoTranscriptionService.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/VoiceMemoTranscriptionService.swift
@@ -224,24 +224,6 @@ public final class VoiceMemoTranscriptionService: VoiceMemoTranscriptionServicin
         await state.clear(messageId: messageId)
     }
 
-    private func persistFailure(
-        messageId: String,
-        conversationId: String,
-        attachmentKey: String,
-        error: Error
-    ) async {
-        do {
-            try await transcriptWriter.markPermanentlyFailed(
-                messageId: messageId,
-                conversationId: conversationId,
-                attachmentKey: attachmentKey,
-                errorDescription: error.localizedDescription
-            )
-        } catch {
-            Log.error("[VoiceMemoTranscription] Failed to persist transcript failure for \(messageId): \(error)")
-        }
-    }
-
     private static func writeTemporaryAudioFile(data: Data, mimeType: String) throws -> URL {
         let ext = fileExtension(forMimeType: mimeType)
         let url = FileManager.default.temporaryDirectory

--- a/ConvosCore/Tests/ConvosCoreTests/VoiceMemoTranscriptionServiceTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/VoiceMemoTranscriptionServiceTests.swift
@@ -167,8 +167,8 @@ struct VoiceMemoTranscriptionServiceTests {
         #expect(completed.first?.text == "Second attempt")
     }
 
-    @Test("recoverable transcriber failures are written via saveFailed and surfaced as errorDescription")
-    func testRecoverableFailurePathWritesFailed() async throws {
+    @Test("transcriber failures are written as permanently failed and surfaced as errorDescription")
+    func testRecoverableFailurePathWritesPermanentlyFailed() async throws {
         let transcriber = StubTranscriber(
             result: .failure(VoiceMemoTranscriberError.audioFileUnreadable)
         )
@@ -190,15 +190,15 @@ struct VoiceMemoTranscriptionServiceTests {
             mimeType: "audio/m4a"
         )
 
-        try await waitUntil(timeout: .seconds(10)) { await writer.failedSnapshot().count == 1 }
+        try await waitUntil(timeout: .seconds(10)) { await writer.permanentlyFailedSnapshot().count == 1 }
 
         let failed = await writer.failedSnapshot()
         let pending = await writer.pendingSnapshot()
         let permanentlyFailed = await writer.permanentlyFailedSnapshot()
         #expect(pending.count == 1)
-        #expect(failed.count == 1)
-        #expect(failed.first?.errorDescription?.contains("read") == true)
-        #expect(permanentlyFailed.isEmpty)
+        #expect(failed.isEmpty)
+        #expect(permanentlyFailed.count == 1)
+        #expect(permanentlyFailed.first?.errorDescription?.contains("read") == true)
     }
 
     @Test("cancellation propagates to the transcriber so the SpeechAnalyzer pipeline stops")
@@ -305,7 +305,7 @@ struct VoiceMemoTranscriptionServiceTests {
         #expect(deleted.isEmpty)
     }
 
-    @Test("attachment loader failures are written via saveFailed without invoking the transcriber")
+    @Test("attachment loader failures are written as permanently failed without invoking the transcriber")
     func testAttachmentLoaderFailurePath() async throws {
         let transcriber = StubTranscriber(result: .success("never called"))
         let attachmentLoader = StubAttachmentLoader(error: StubError.boom)
@@ -326,12 +326,14 @@ struct VoiceMemoTranscriptionServiceTests {
             mimeType: "audio/m4a"
         )
 
-        try await waitUntil(timeout: .seconds(10)) { await writer.failedSnapshot().count == 1 }
+        try await waitUntil(timeout: .seconds(10)) { await writer.permanentlyFailedSnapshot().count == 1 }
 
         let transcribeCalls = await transcriber.callCount()
         let failed = await writer.failedSnapshot()
+        let permanentlyFailed = await writer.permanentlyFailedSnapshot()
         #expect(transcribeCalls == 0)
-        #expect(failed.count == 1)
+        #expect(failed.isEmpty)
+        #expect(permanentlyFailed.count == 1)
     }
 
     @Test("two concurrent enqueueIfNeeded calls deduplicate by message id")


### PR DESCRIPTION
## Summary
- Replace the voice memo discard button icon from X (`xmark`) to a red trash can (`trash`) for clearer destructive intent
- Hide all transcript error states from the UI — errors are now marked as permanently failed (row hidden) instead of showing raw error strings and a retry button

## Why hide transcript errors?
Transcript failures fall into two categories, neither of which benefits from showing errors to users:
- **Transcription errors** (speech recognition, decoding): deterministic failures where retrying produces the same result
- **Attachment loading errors** (network, decryption): surface raw developer-facing `localizedDescription` strings that aren't meaningful to users

In both cases the transcript row is now simply hidden rather than showing confusing error text.

## Test plan
- [ ] Record a voice memo, stop recording, verify the discard button shows a red trash icon
- [ ] Send a voice memo, verify playback works normally
- [ ] Verify transcript "Tap to transcribe" flow still works for successful transcriptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Move voice memo transcript into the bubble and hide transcript errors
> - Transcript content is moved from a separate row below the voice memo bubble into the bubble itself, with states for pending, completed (truncated with tap-to-expand sheet), and not-yet-requested (with a 'View transcript' button).
> - Failed transcripts no longer show error details or a retry affordance in the UI; all non-cancellation transcription failures are now recorded as permanently failed.
> - Reply composer bar and reply reference views now show transcript text when replying to an audio message.
> - The voice memo discard button changes from an `xmark` icon to a `trash.fill` icon in caution color.
> - Duration labels across recording, review, and playback views now use zero-padded MM:SS format.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 34d80e5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->