### PR TITLE
Fall back to LPMetadataProvider for link previews

### DIFF
--- a/ConvosCore/Sources/ConvosCore/Services/OpenGraphService.swift
+++ b/ConvosCore/Sources/ConvosCore/Services/OpenGraphService.swift
@@ -64,7 +64,12 @@ public actor OpenGraphService {
             }
 
             if let provider = RichLinkMetadata.provider {
-                return await provider.fetchMetadata(for: url)
+                Log.info("OpenGraph tags missing for \(urlString), falling back to LPMetadataProvider")
+                let result = await provider.fetchMetadata(for: url)
+                if result == nil {
+                    Log.warning("RichLink fallback also returned nil for \(urlString)")
+                }
+                return result
             }
 
             return nil
@@ -114,7 +119,7 @@ public actor OpenGraphService {
             }
             return result
         } catch {
-            Log.error("OpenGraph fetch error for \(urlString): \(error.localizedDescription)")
+            Log.error("OpenGraph fetch error for \(urlString): \(error)")
             return nil
         }
     }

--- a/ConvosCore/Sources/ConvosCore/Services/OpenGraphService.swift
+++ b/ConvosCore/Sources/ConvosCore/Services/OpenGraphService.swift
@@ -15,6 +15,20 @@ public actor OpenGraphService {
         public let siteName: String?
         public let imageWidth: Int?
         public let imageHeight: Int?
+
+        public init(
+            title: String?,
+            imageURL: String?,
+            siteName: String?,
+            imageWidth: Int?,
+            imageHeight: Int?
+        ) {
+            self.title = title
+            self.imageURL = imageURL
+            self.siteName = siteName
+            self.imageWidth = imageWidth
+            self.imageHeight = imageHeight
+        }
     }
 
     private struct CacheEntry {
@@ -44,41 +58,16 @@ public actor OpenGraphService {
         let task = Task<OpenGraphMetadata?, Never> {
             guard let url = URL(string: urlString) else { return nil }
 
-            do {
-                var request = URLRequest(url: url)
-                request.httpMethod = "GET"
-                request.timeoutInterval = 8
-                request.setValue(
-                    "facebookexternalhit/1.1 (compatible; Convos/1.0)",
-                    forHTTPHeaderField: "User-Agent"
-                )
-                request.setValue("text/html", forHTTPHeaderField: "Accept")
-
-                let (data, response) = try await Self.safeSession.data(for: request)
-
-                guard let httpResponse = response as? HTTPURLResponse,
-                      (200 ... 299).contains(httpResponse.statusCode) else {
-                    let code = (response as? HTTPURLResponse)?.statusCode ?? -1
-                    Log.error("OpenGraph fetch failed for \(urlString): HTTP \(code)")
-                    return nil
-                }
-
-                let htmlData = data.prefix(Self.maxHTMLBytes)
-                guard let html = String(data: htmlData, encoding: .utf8)
-                        ?? String(data: htmlData, encoding: .ascii) else {
-                    Log.error("OpenGraph decode failed for \(urlString): not UTF-8/ASCII")
-                    return nil
-                }
-
-                let result = parseOpenGraphTags(from: html)
-                if result == nil {
-                    Log.warning("OpenGraph no tags found for \(urlString) (\(data.count) bytes)")
-                }
-                return result
-            } catch {
-                Log.error("OpenGraph fetch error for \(urlString): \(error.localizedDescription)")
-                return nil
+            let ogResult = await fetchOpenGraphTags(for: url, urlString: urlString)
+            if let ogResult {
+                return ogResult
             }
+
+            if let provider = RichLinkMetadata.provider {
+                return await provider.fetchMetadata(for: url)
+            }
+
+            return nil
         }
 
         inFlightTasks[urlString] = task
@@ -90,6 +79,44 @@ public actor OpenGraphService {
         }
 
         return result
+    }
+
+    private func fetchOpenGraphTags(for url: URL, urlString: String) async -> OpenGraphMetadata? {
+        do {
+            var request = URLRequest(url: url)
+            request.httpMethod = "GET"
+            request.timeoutInterval = 8
+            request.setValue(
+                "facebookexternalhit/1.1 (compatible; Convos/1.0)",
+                forHTTPHeaderField: "User-Agent"
+            )
+            request.setValue("text/html", forHTTPHeaderField: "Accept")
+
+            let (data, response) = try await Self.safeSession.data(for: request)
+
+            guard let httpResponse = response as? HTTPURLResponse,
+                  (200 ... 299).contains(httpResponse.statusCode) else {
+                let code = (response as? HTTPURLResponse)?.statusCode ?? -1
+                Log.error("OpenGraph fetch failed for \(urlString): HTTP \(code)")
+                return nil
+            }
+
+            let htmlData = data.prefix(Self.maxHTMLBytes)
+            guard let html = String(data: htmlData, encoding: .utf8)
+                    ?? String(data: htmlData, encoding: .ascii) else {
+                Log.error("OpenGraph decode failed for \(urlString): not UTF-8/ASCII")
+                return nil
+            }
+
+            let result = parseOpenGraphTags(from: html)
+            if result == nil {
+                Log.warning("OpenGraph no tags found for \(urlString) (\(data.count) bytes)")
+            }
+            return result
+        } catch {
+            Log.error("OpenGraph fetch error for \(urlString): \(error.localizedDescription)")
+            return nil
+        }
     }
 
     private func insertCacheEntry(_ key: String, metadata: OpenGraphMetadata) {

--- a/ConvosCore/Sources/ConvosCore/Services/RichLinkMetadataProviding.swift
+++ b/ConvosCore/Sources/ConvosCore/Services/RichLinkMetadataProviding.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+public protocol RichLinkMetadataProviding: Sendable {
+    func fetchMetadata(for url: URL) async -> OpenGraphService.OpenGraphMetadata?
+}
+
+public enum RichLinkMetadata {
+    private static let lock: NSLock = .init()
+    nonisolated(unsafe) private static var _provider: (any RichLinkMetadataProviding)?
+
+    public static func configure(_ provider: any RichLinkMetadataProviding) {
+        lock.lock()
+        defer { lock.unlock() }
+        _provider = provider
+    }
+
+    public static var provider: (any RichLinkMetadataProviding)? {
+        lock.lock()
+        defer { lock.unlock() }
+        return _provider
+    }
+
+    public static func resetForTesting() {
+        lock.lock()
+        defer { lock.unlock() }
+        _provider = nil
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/LinkPreview+Detection.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/LinkPreview+Detection.swift
@@ -52,7 +52,7 @@ extension LinkPreview {
         return resolved
     }
 
-    static func isPrivateHost(_ url: URL) -> Bool {
+    public static func isPrivateHost(_ url: URL) -> Bool {
         guard let host = url.host?.lowercased() else { return true }
 
         if host == "localhost" || host.hasSuffix(".local") {

--- a/ConvosCore/Sources/ConvosCoreiOS/ConvosCoreiOS.swift
+++ b/ConvosCore/Sources/ConvosCoreiOS/ConvosCoreiOS.swift
@@ -48,6 +48,7 @@ extension PlatformProviders {
         DeviceInfo.configure(deviceInfo)
         PushNotificationRegistrar.configure(pushNotificationRegistrar)
         ImageCompression.configure(IOSImageCompression())
+        RichLinkMetadata.configure(IOSRichLinkMetadataProvider())
 
         return PlatformProviders(
             appLifecycle: appLifecycle,

--- a/ConvosCore/Sources/ConvosCoreiOS/IOSRichLinkMetadataProvider.swift
+++ b/ConvosCore/Sources/ConvosCoreiOS/IOSRichLinkMetadataProvider.swift
@@ -1,0 +1,96 @@
+#if canImport(UIKit)
+import ConvosCore
+import Foundation
+import LinkPresentation
+import UIKit
+import UniformTypeIdentifiers
+
+public final class IOSRichLinkMetadataProvider: RichLinkMetadataProviding, Sendable {
+    public init() {}
+
+    public func fetchMetadata(for url: URL) async -> OpenGraphService.OpenGraphMetadata? {
+        do {
+            let extracted = try await fetchLinkMetadata(for: url)
+
+            var imageURL: String?
+            if let imageProvider = extracted.imageProvider {
+                imageURL = try? await extractImageURL(from: imageProvider, originalURL: url)
+            }
+
+            guard extracted.title != nil || imageURL != nil else { return nil }
+
+            return OpenGraphService.OpenGraphMetadata(
+                title: extracted.title,
+                imageURL: imageURL,
+                siteName: url.host,
+                imageWidth: nil,
+                imageHeight: nil
+            )
+        } catch {
+            Log.error("RichLink fetch failed for \(url): \(error.localizedDescription)")
+            return nil
+        }
+    }
+
+    private struct ExtractedMetadata: @unchecked Sendable {
+        let title: String?
+        let imageProvider: NSItemProvider?
+    }
+
+    private func fetchLinkMetadata(for url: URL) async throws -> ExtractedMetadata {
+        try await withCheckedThrowingContinuation { continuation in
+            let provider = LPMetadataProvider()
+            provider.startFetchingMetadata(for: url) { metadata, error in
+                if let error {
+                    continuation.resume(throwing: error)
+                } else if let metadata {
+                    let extracted = ExtractedMetadata(
+                        title: metadata.title,
+                        imageProvider: metadata.imageProvider
+                    )
+                    continuation.resume(returning: extracted)
+                } else {
+                    continuation.resume(
+                        throwing: NSError(
+                            domain: "IOSRichLinkMetadataProvider",
+                            code: -1
+                        )
+                    )
+                }
+            }
+        }
+    }
+
+    private func extractImageURL(
+        from provider: NSItemProvider,
+        originalURL: URL
+    ) async throws -> String? {
+        let data: Data = try await withCheckedThrowingContinuation { continuation in
+            provider.loadDataRepresentation(
+                forTypeIdentifier: UTType.image.identifier
+            ) { data, error in
+                if let data {
+                    continuation.resume(returning: data)
+                } else {
+                    continuation.resume(
+                        throwing: error ?? NSError(
+                            domain: "IOSRichLinkMetadataProvider",
+                            code: -2
+                        )
+                    )
+                }
+            }
+        }
+
+        guard OpenGraphService.isValidImageData(data) else { return nil }
+        guard let image = UIImage(data: data),
+              OpenGraphService.isValidImageSize(width: image.size.width, height: image.size.height)
+        else { return nil }
+
+        let cacheKey = "richlink:\(originalURL.absoluteString)"
+        ImageCache.shared.cacheImage(image, for: cacheKey, storageTier: .cache)
+
+        return cacheKey
+    }
+}
+#endif

--- a/ConvosCore/Sources/ConvosCoreiOS/IOSRichLinkMetadataProvider.swift
+++ b/ConvosCore/Sources/ConvosCoreiOS/IOSRichLinkMetadataProvider.swift
@@ -9,6 +9,11 @@ public final class IOSRichLinkMetadataProvider: RichLinkMetadataProviding, Senda
     public init() {}
 
     public func fetchMetadata(for url: URL) async -> OpenGraphService.OpenGraphMetadata? {
+        guard !LinkPreview.isPrivateHost(url) else {
+            Log.warning("RichLink rejected private host: \(url)")
+            return nil
+        }
+
         do {
             let extracted = try await fetchLinkMetadata(for: url)
 
@@ -27,7 +32,7 @@ public final class IOSRichLinkMetadataProvider: RichLinkMetadataProviding, Senda
                 imageHeight: nil
             )
         } catch {
-            Log.error("RichLink fetch failed for \(url): \(error.localizedDescription)")
+            Log.error("RichLink fetch failed for \(url): \(error)")
             return nil
         }
     }
@@ -87,10 +92,10 @@ public final class IOSRichLinkMetadataProvider: RichLinkMetadataProviding, Senda
               OpenGraphService.isValidImageSize(width: image.size.width, height: image.size.height)
         else { return nil }
 
-        let cacheKey = "richlink:\(originalURL.absoluteString)"
-        ImageCache.shared.cacheImage(image, for: cacheKey, storageTier: .cache)
+        let imageURL = originalURL.absoluteString
+        ImageCache.shared.cacheImage(image, for: imageURL, storageTier: .cache)
 
-        return cacheKey
+        return imageURL
     }
 }
 #endif

--- a/ConvosCore/Tests/ConvosCoreTests/LinkPreviewTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/LinkPreviewTests.swift
@@ -383,3 +383,39 @@ struct ImageValidationTests {
         #expect(!OpenGraphService.isValidImageSize(width: 10000, height: 10000))
     }
 }
+
+@Suite("Rich Link Metadata Fallback")
+struct RichLinkMetadataFallbackTests {
+    @Test("Provider is nil by default")
+    func providerNilByDefault() {
+        RichLinkMetadata.resetForTesting()
+        #expect(RichLinkMetadata.provider == nil)
+    }
+
+    @Test("Provider can be configured")
+    func providerCanBeConfigured() {
+        RichLinkMetadata.resetForTesting()
+        let mock = MockRichLinkProvider(result: nil)
+        RichLinkMetadata.configure(mock)
+        #expect(RichLinkMetadata.provider != nil)
+        RichLinkMetadata.resetForTesting()
+    }
+
+    @Test("Provider can be reset for testing")
+    func providerResetForTesting() {
+        RichLinkMetadata.resetForTesting()
+        let mock = MockRichLinkProvider(result: nil)
+        RichLinkMetadata.configure(mock)
+        #expect(RichLinkMetadata.provider != nil)
+        RichLinkMetadata.resetForTesting()
+        #expect(RichLinkMetadata.provider == nil)
+    }
+}
+
+private struct MockRichLinkProvider: RichLinkMetadataProviding {
+    let result: OpenGraphService.OpenGraphMetadata?
+
+    func fetchMetadata(for url: URL) async -> OpenGraphService.OpenGraphMetadata? {
+        result
+    }
+}


### PR DESCRIPTION
## Summary
- x.com/twitter.com links now show rich link previews using Apple's `LPMetadataProvider` (same approach as iMessage)
- When the standard OpenGraph tag fetch returns nothing (as with x.com's JS-rendered pages), the system falls back to `LPMetadataProvider` which uses WebKit to render the page and extract metadata
- Follows the existing ConvosCore/ConvosCoreiOS bridge pattern: protocol in ConvosCore, iOS implementation using LinkPresentation framework, configured at app launch

## What changed
- **`OpenGraphService`**: Refactored fetch into `fetchOpenGraphTags` helper; added `RichLinkMetadata.provider` fallback when OG parsing returns nil
- **`RichLinkMetadataProviding`** (new): Protocol + singleton accessor in ConvosCore
- **`IOSRichLinkMetadataProvider`** (new): iOS implementation using `LPMetadataProvider`, extracts title + image, pre-caches images in `ImageCache`
- **`ConvosCoreiOS`**: Configures `RichLinkMetadata` alongside other platform providers

## Next steps
- [ ] New social media post card format for x.com, threads.net, bsky.app (design pending)

## Test plan
- [ ] Unit tests pass (`swift test --package-path ConvosCore`)
- [ ] Paste an x.com tweet URL in composer — verify preview shows title, image, and "x.com" subtitle
- [ ] Paste a normal URL (e.g. apple.com) — verify standard OG preview still works
- [ ] Verify link preview in message bubble after sending

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fall back to `LPMetadataProvider` for link previews when OpenGraph tags are missing
> - Adds a `RichLinkMetadataProviding` protocol and a global `RichLinkMetadata` registry so platform-specific providers can supply metadata for links that lack OpenGraph tags.
> - Implements `IOSRichLinkMetadataProvider` using `LPMetadataProvider` to fetch title and image, validate image data/size, cache via `ImageCache`, and reject private hosts.
> - `OpenGraphService` now falls back to the configured provider when OG tag parsing yields no result, returning metadata where it previously returned `nil`.
> - Makes `LinkPreview.isPrivateHost` public so the iOS provider can reuse it.
> - Behavioral Change: links without OG tags that previously returned `nil` may now return metadata on iOS.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 289c3b4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->