### PR TITLE
Speed up first conversation creation on fresh install

### DIFF
--- a/ConvosCore/Sources/ConvosCore/Messaging/UnusedConversationCache.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/UnusedConversationCache.swift
@@ -701,12 +701,6 @@ extension UnusedConversationCache {
         databaseReader: any DatabaseReader,
         environment: AppEnvironment
     ) async -> MessagingService {
-        scheduleBackgroundCreation(
-            databaseWriter: databaseWriter,
-            databaseReader: databaseReader,
-            environment: environment
-        )
-
         let authorizationOperation = AuthorizeInboxOperation.register(
             identityStore: identityStore,
             databaseReader: databaseReader,
@@ -717,7 +711,7 @@ extension UnusedConversationCache {
             apiClient: apiClient
         )
 
-        return MessagingService(
+        let service = MessagingService(
             authorizationOperation: authorizationOperation,
             databaseWriter: databaseWriter,
             databaseReader: databaseReader,
@@ -725,6 +719,40 @@ extension UnusedConversationCache {
             environment: environment,
             backgroundUploadManager: UnavailableBackgroundUploadManager()
         )
+
+        scheduleDeferredBackgroundCreation(
+            after: service,
+            databaseWriter: databaseWriter,
+            databaseReader: databaseReader,
+            environment: environment
+        )
+
+        return service
+    }
+
+    func scheduleDeferredBackgroundCreation(
+        after service: MessagingService,
+        databaseWriter: any DatabaseWriter,
+        databaseReader: any DatabaseReader,
+        environment: AppEnvironment
+    ) {
+        backgroundCreationTask?.cancel()
+        backgroundCreationTask = Task(priority: .background) { [weak self, weak databaseWriter, weak databaseReader, weak service] in
+            guard let service else { return }
+            do {
+                _ = try await service.inboxStateManager.waitForInboxReadyResult()
+            } catch {
+                return
+            }
+            guard let self,
+                  let databaseWriter,
+                  let databaseReader else { return }
+            await createNewUnusedConversation(
+                databaseWriter: databaseWriter,
+                databaseReader: databaseReader,
+                environment: environment
+            )
+        }
     }
 
     func scheduleBackgroundCreation(

--- a/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
@@ -106,7 +106,7 @@ public final class SessionManager: SessionManagerProtocol, @unchecked Sendable {
             await self.sleepingInboxChecker.startPeriodicChecks()
 
             guard !Task.isCancelled else { return }
-            self.unusedInboxPrepTask = Task(priority: .background) { [weak self] in
+            self.unusedInboxPrepTask = Task(priority: .utility) { [weak self] in
                 guard let self, !Task.isCancelled else { return }
                 await self.lifecycleManager.prepareUnusedConversationIfNeeded()
             }


### PR DESCRIPTION
## Problem

On a fresh app install, creating the first conversation takes **~17 seconds**. The user taps compose and sees a disabled text field for a very long time with no feedback.

## Root Cause

Two issues compound:

1. **Competing XMTP client creation**: When no cached inbox exists (fresh install), `createFreshMessagingService` immediately starts creating a background cached inbox alongside the user's real inbox. Both `Client.create()` calls (~7-8s each) compete for CPU and network, roughly doubling the total time.

2. **Pre-warm too low priority**: The `prepareUnusedConversationIfNeeded` task runs at `.background` priority on app launch, meaning it makes little progress before the user taps compose (typically 2-5 seconds after launch).

## Fix

**Phase 1 — Defer background cache replenishment**: `createFreshMessagingService` no longer starts background creation immediately. Instead, `scheduleDeferredBackgroundCreation` waits for the user's service inbox to be fully ready before creating the next cached inbox. This eliminates contention during the critical path.

**Phase 2 — Raise pre-warm priority**: Changed the unused inbox preparation task from `.background` to `.utility` priority. This allows the cache to be populated during the few seconds the user spends on the onboarding screen.

## Results

| Metric | Before | After | Improvement |
|--------|--------|-------|-------------|
| `NewConversation.ready` | **16,955ms** | **654ms** | **26x faster** |
| Origin | `created` (cold) | `existing` (cached) | Pre-warm hit |
| Text field enabled | ~17s+ | 0.2s | Instant |

When the pre-warm completes before the user taps compose (typical case with ~5s on onboarding screen), first conversation creation is sub-second. When the user taps immediately, the pre-warm is usually in-progress and can be awaited rather than starting from scratch.

## Changes

- `UnusedConversationCache.swift`: New `scheduleDeferredBackgroundCreation` method that waits for the user's service to be ready before starting background cache creation
- `SessionManager.swift`: Raised `unusedInboxPrepTask` priority from `.background` to `.utility`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Defer unused conversation pre-creation until inbox is ready on fresh install
> - In `UnusedConversationCache`, background conversation creation is now deferred until `inboxStateManager.waitForInboxReadyResult()` succeeds, instead of being scheduled immediately on `MessagingService` construction.
> - A new `scheduleDeferredBackgroundCreation` helper manages this: it cancels any existing background task, then waits for inbox readiness before calling `createNewUnusedConversation`.
> - In `SessionManager`, the unused inbox prep task priority is raised from `.background` to `.utility` so it runs sooner during session setup.
> - Behavioral Change: if the inbox readiness check fails, no unused conversation is created at that point — previously creation would be attempted regardless of inbox state.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 59dc585.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->