### PR TITLE
Update composer attachment icon colors

### DIFF
--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesBottomBar.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesBottomBar.swift
@@ -231,7 +231,7 @@ struct MessagesBottomBar<BottomBarContent: View>: View {
                 } label: {
                     Image(systemName: "chevron.right")
                         .font(.system(size: 18.0, weight: .medium))
-                        .foregroundStyle(Color.colorTextSecondary)
+                        .foregroundStyle(Color.colorTextTertiary)
                         .frame(width: 32, height: 32)
                         .contentShape(.circle)
                 }

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesMediaInputView.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesMediaInputView.swift
@@ -13,7 +13,7 @@ struct MessagesMediaButtonsView: View {
             } label: {
                 Image(systemName: "photo.fill")
                     .font(.system(size: 18.0, weight: .medium))
-                    .foregroundStyle(Color.colorTextSecondary)
+                    .foregroundStyle(Color.colorTextPrimary)
                     .frame(width: Constant.buttonSize, height: Constant.buttonSize)
                     .contentShape(.circle)
             }
@@ -26,7 +26,7 @@ struct MessagesMediaButtonsView: View {
             } label: {
                 Image(systemName: "camera.fill")
                     .font(.system(size: 18.0, weight: .medium))
-                    .foregroundStyle(Color.colorTextSecondary)
+                    .foregroundStyle(Color.colorTextPrimary)
                     .frame(width: Constant.buttonSize, height: Constant.buttonSize)
                     .contentShape(.circle)
             }
@@ -39,7 +39,7 @@ struct MessagesMediaButtonsView: View {
             } label: {
                 Image(systemName: "waveform")
                     .font(.system(size: 18.0, weight: .medium))
-                    .foregroundStyle(Color.colorTextSecondary)
+                    .foregroundStyle(Color.colorTextPrimary)
                     .frame(width: Constant.buttonSize, height: Constant.buttonSize)
                     .contentShape(.circle)
             }
@@ -55,7 +55,7 @@ struct MessagesMediaButtonsView: View {
                     .resizable()
                     .scaledToFit()
                     .frame(height: 18)
-                    .foregroundStyle(Color.colorTextSecondary)
+                    .foregroundStyle(Color.colorTextPrimary)
                     .frame(width: Constant.buttonSize, height: Constant.buttonSize)
                     .contentShape(.circle)
             }


### PR DESCRIPTION
## Summary
- Change attachment button icons (photo, camera, waveform, convos) from `colorTextSecondary` to `colorTextPrimary` for stronger contrast
- Change the collapse chevron from `colorTextSecondary` to `colorTextTertiary` to de-emphasize it

## Test plan
- [ ] Open a conversation and verify the 4 attachment icons appear darker (primary color)
- [ ] Tap the text field to collapse attachments, verify the chevron appears lighter (tertiary color)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update attachment icon colors in composer media input view
> - Updates the four media action buttons (Photo library, Camera, Voice memo, Convos) in [`MessagesMediaInputView`](https://github.com/xmtplabs/convos-ios/pull/689/files#diff-2ef425132cd324e2bdecf8896c7f1faefde0b87061f46c59e109b152dd6f68ed) from secondary to primary text color.
> - Updates the collapse chevron button in [`MessagesBottomBar`](https://github.com/xmtplabs/convos-ios/pull/689/files#diff-b66861cd8ab11a6d499676511b14e2fba66afdb7467461c01255f35000b416a2) from secondary to tertiary text color when the input is focused.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 82a2647.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->