### PR TITLE
Add assistant files and links view

### DIFF
--- a/Convos/Conversation Detail/AssistantFilesLinksView.swift
+++ b/Convos/Conversation Detail/AssistantFilesLinksView.swift
@@ -210,7 +210,7 @@ struct AssistantFilesLinksView: View {
 
                 Spacer()
 
-                Image(systemName: "arrow.up.right")
+                Image(systemName: "safari")
                     .foregroundStyle(.colorTextSecondary)
             }
             .padding(.horizontal, DesignConstants.Spacing.step4x)

--- a/Convos/Conversation Detail/AssistantFilesLinksView.swift
+++ b/Convos/Conversation Detail/AssistantFilesLinksView.swift
@@ -26,14 +26,14 @@ class AssistantFilesLinksViewModel {
     var filteredFiles: [AssistantFile] {
         guard !searchText.isEmpty else { return files }
         let query = searchText.lowercased()
-        return files.filter { ($0.displayName).lowercased().contains(query) }
+        return files.filter { $0.displayName.lowercased().contains(query) }
     }
 
     var filteredLinks: [AssistantLink] {
         guard !searchText.isEmpty else { return links }
         let query = searchText.lowercased()
         return links.filter {
-            ($0.displayTitle).lowercased().contains(query)
+            $0.displayTitle.lowercased().contains(query)
             || $0.url.lowercased().contains(query)
         }
     }
@@ -153,23 +153,22 @@ struct AssistantFilesLinksView: View {
     }
 
     private func fileRow(_ file: AssistantFile) -> some View {
-        Button {
+        let action = {
             Task {
                 do {
                     let url = try await FileAttachmentPreviewLoader.loadPreviewURL(
                         key: file.attachmentKey,
                         filename: file.filename
                     )
-                    await MainActor.run {
-                        guard let presenter = UIApplication.shared.topMostViewController() else { return }
-                        FileAttachmentQuickLookCoordinator.shared.present(fileURL: url, from: presenter)
-                    }
+                    guard let presenter = UIApplication.shared.topMostViewController() else { return }
+                    FileAttachmentQuickLookCoordinator.shared.present(fileURL: url, from: presenter)
                 } catch {
                     Log.error("Failed to open assistant file: \(error)")
                     viewModel.fileOpenError = "This file is no longer available on this device."
                 }
             }
-        } label: {
+        }
+        return Button(action: action) {
             HStack(spacing: DesignConstants.Spacing.step3x) {
                 fileThumbnail(file)
                     .frame(width: 56.0, height: 56.0)
@@ -232,11 +231,12 @@ struct AssistantFilesLinksView: View {
     }
 
     private func linkRow(_ link: AssistantLink) -> some View {
-        Button {
+        let action = {
             if let url = link.resolvedURL {
                 UIApplication.shared.open(url)
             }
-        } label: {
+        }
+        return Button(action: action) {
             HStack(spacing: DesignConstants.Spacing.step3x) {
                 linkThumbnail(link)
                     .frame(width: 56.0, height: 56.0)

--- a/Convos/Conversation Detail/AssistantFilesLinksView.swift
+++ b/Convos/Conversation Detail/AssistantFilesLinksView.swift
@@ -1,0 +1,254 @@
+import ConvosCore
+import SwiftUI
+
+enum AssistantFilesLinksTab: String, CaseIterable {
+    case files = "Files"
+    case links = "Links"
+}
+
+@MainActor
+@Observable
+class AssistantFilesLinksViewModel {
+    var selectedTab: AssistantFilesLinksTab = .files
+    var searchText: String = ""
+    var files: [AssistantFile] = []
+    var links: [AssistantLink] = []
+    var isLoading: Bool = true
+
+    private let repository: AssistantFilesLinksRepository
+
+    init(repository: AssistantFilesLinksRepository) {
+        self.repository = repository
+    }
+
+    var filteredFiles: [AssistantFile] {
+        guard !searchText.isEmpty else { return files }
+        let query = searchText.lowercased()
+        return files.filter { ($0.displayName).lowercased().contains(query) }
+    }
+
+    var filteredLinks: [AssistantLink] {
+        guard !searchText.isEmpty else { return links }
+        let query = searchText.lowercased()
+        return links.filter {
+            ($0.displayTitle).lowercased().contains(query)
+            || $0.url.lowercased().contains(query)
+        }
+    }
+
+    func load() async {
+        isLoading = true
+        do {
+            async let fetchedFiles = repository.fetchFiles()
+            async let fetchedLinks = repository.fetchLinks()
+            files = try await fetchedFiles
+            links = try await fetchedLinks
+        } catch {
+            Log.error("Failed to load assistant files and links: \(error.localizedDescription)")
+        }
+        isLoading = false
+    }
+}
+
+struct AssistantFilesLinksView: View {
+    @State private var viewModel: AssistantFilesLinksViewModel
+
+    init(repository: AssistantFilesLinksRepository) {
+        _viewModel = State(initialValue: AssistantFilesLinksViewModel(repository: repository))
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Picker("", selection: $viewModel.selectedTab) {
+                ForEach(AssistantFilesLinksTab.allCases, id: \.self) { tab in
+                    Text(tab.rawValue).tag(tab)
+                }
+            }
+            .pickerStyle(.segmented)
+            .padding(.horizontal, DesignConstants.Spacing.step4x)
+            .padding(.vertical, DesignConstants.Spacing.step2x)
+
+            HStack(spacing: DesignConstants.Spacing.step2x) {
+                Image(systemName: "magnifyingglass")
+                    .foregroundStyle(.colorTextSecondary)
+                TextField("Search", text: $viewModel.searchText)
+                    .textFieldStyle(.plain)
+                    .accessibilityIdentifier("files-links-search-field")
+            }
+            .padding(.horizontal, DesignConstants.Spacing.step3x)
+            .padding(.vertical, DesignConstants.Spacing.step2x)
+            .background(
+                RoundedRectangle(cornerRadius: DesignConstants.CornerRadius.regular)
+                    .fill(Color.colorFillMinimal)
+            )
+            .padding(.horizontal, DesignConstants.Spacing.step4x)
+
+            if viewModel.isLoading {
+                Spacer()
+                ProgressView()
+                Spacer()
+            } else {
+                switch viewModel.selectedTab {
+                case .files:
+                    filesTab
+                case .links:
+                    linksTab
+                }
+            }
+        }
+        .navigationTitle("Files & Links")
+        .navigationBarTitleDisplayMode(.inline)
+        .background(.colorBackgroundRaisedSecondary)
+        .task {
+            await viewModel.load()
+        }
+    }
+
+    @ViewBuilder
+    private var filesTab: some View {
+        if viewModel.filteredFiles.isEmpty {
+            emptyState(text: viewModel.searchText.isEmpty ? "No files yet" : "No files match your search")
+        } else {
+            ScrollView {
+                LazyVStack(spacing: 0) {
+                    ForEach(viewModel.filteredFiles) { file in
+                        fileRow(file)
+                        Divider()
+                            .padding(.leading, 80.0)
+                    }
+                }
+                .padding(.top, DesignConstants.Spacing.step2x)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var linksTab: some View {
+        if viewModel.filteredLinks.isEmpty {
+            emptyState(text: viewModel.searchText.isEmpty ? "No links yet" : "No links match your search")
+        } else {
+            ScrollView {
+                LazyVStack(spacing: 0) {
+                    ForEach(viewModel.filteredLinks) { link in
+                        linkRow(link)
+                        Divider()
+                            .padding(.leading, 80.0)
+                    }
+                }
+                .padding(.top, DesignConstants.Spacing.step2x)
+            }
+        }
+    }
+
+    private func fileRow(_ file: AssistantFile) -> some View {
+        HStack(spacing: DesignConstants.Spacing.step3x) {
+            fileThumbnail(file)
+                .frame(width: 56.0, height: 56.0)
+                .clipShape(RoundedRectangle(cornerRadius: DesignConstants.CornerRadius.small))
+
+            VStack(alignment: .leading, spacing: DesignConstants.Spacing.stepHalf) {
+                Text(file.displayName)
+                    .font(.body)
+                    .foregroundStyle(.colorTextPrimary)
+                    .lineLimit(1)
+
+                Text(file.formattedDate)
+                    .font(.caption)
+                    .foregroundStyle(.colorTextSecondary)
+            }
+
+            Spacer()
+
+            Image(systemName: "icloud.and.arrow.down")
+                .foregroundStyle(.colorTextSecondary)
+        }
+        .padding(.horizontal, DesignConstants.Spacing.step4x)
+        .padding(.vertical, DesignConstants.Spacing.step2x)
+        .contentShape(Rectangle())
+    }
+
+    @ViewBuilder
+    private func fileThumbnail(_ file: AssistantFile) -> some View {
+        if let base64 = file.thumbnailDataBase64,
+           let data = Data(base64Encoded: base64),
+           let uiImage = UIImage(data: data) {
+            Image(uiImage: uiImage)
+                .resizable()
+                .aspectRatio(contentMode: .fill)
+        } else {
+            RoundedRectangle(cornerRadius: DesignConstants.CornerRadius.small)
+                .fill(Color.colorFillMinimal)
+                .overlay {
+                    Image(systemName: "doc.fill")
+                        .foregroundStyle(.colorTextSecondary)
+                }
+        }
+    }
+
+    private func linkRow(_ link: AssistantLink) -> some View {
+        Button {
+            if let url = link.resolvedURL {
+                UIApplication.shared.open(url)
+            }
+        } label: {
+            HStack(spacing: DesignConstants.Spacing.step3x) {
+                linkThumbnail(link)
+                    .frame(width: 56.0, height: 56.0)
+                    .clipShape(RoundedRectangle(cornerRadius: DesignConstants.CornerRadius.small))
+
+                VStack(alignment: .leading, spacing: DesignConstants.Spacing.stepHalf) {
+                    Text(link.displayTitle)
+                        .font(.body)
+                        .foregroundStyle(.colorTextPrimary)
+                        .lineLimit(1)
+
+                    Text(link.displayHost)
+                        .font(.caption)
+                        .foregroundStyle(.colorTextSecondary)
+                        .lineLimit(1)
+                }
+
+                Spacer()
+
+                Image(systemName: "arrow.up.right")
+                    .foregroundStyle(.colorTextSecondary)
+            }
+            .padding(.horizontal, DesignConstants.Spacing.step4x)
+            .padding(.vertical, DesignConstants.Spacing.step2x)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+
+    @ViewBuilder
+    private func linkThumbnail(_ link: AssistantLink) -> some View {
+        if let imageURL = link.imageURL, let url = URL(string: imageURL) {
+            AsyncImage(url: url) { image in
+                image.resizable().aspectRatio(contentMode: .fill)
+            } placeholder: {
+                linkPlaceholder
+            }
+        } else {
+            linkPlaceholder
+        }
+    }
+
+    private var linkPlaceholder: some View {
+        RoundedRectangle(cornerRadius: DesignConstants.CornerRadius.small)
+            .fill(Color.colorFillMinimal)
+            .overlay {
+                Image(systemName: "link")
+                    .foregroundStyle(.colorTextSecondary)
+            }
+    }
+
+    private func emptyState(text: String) -> some View {
+        VStack {
+            Spacer()
+            Text(text)
+                .font(.body)
+                .foregroundStyle(.colorTextSecondary)
+            Spacer()
+        }
+    }
+}

--- a/Convos/Conversation Detail/AssistantFilesLinksView.swift
+++ b/Convos/Conversation Detail/AssistantFilesLinksView.swift
@@ -165,9 +165,12 @@ struct AssistantFilesLinksView: View {
                     }
                 } catch {
                     Log.error("Failed to open assistant file: \(error)")
-                    viewModel.fileOpenError = "This file is no longer available on this device."
+                    await MainActor.run {
+                        viewModel.fileOpenError = "This file is no longer available on this device."
+                    }
                 }
             }
+            return
         }
         return Button(action: action) {
             HStack(spacing: DesignConstants.Spacing.step3x) {

--- a/Convos/Conversation Detail/AssistantFilesLinksView.swift
+++ b/Convos/Conversation Detail/AssistantFilesLinksView.swift
@@ -1,5 +1,6 @@
 import ConvosCore
 import SwiftUI
+import UniformTypeIdentifiers
 
 enum AssistantFilesLinksTab: String, CaseIterable {
     case files = "Files"
@@ -14,6 +15,8 @@ class AssistantFilesLinksViewModel {
     var files: [AssistantFile] = []
     var links: [AssistantLink] = []
     var isLoading: Bool = true
+    var previewURL: URL?
+    var fileOpenError: String?
 
     private let repository: AssistantFilesLinksRepository
 
@@ -102,6 +105,25 @@ struct AssistantFilesLinksView: View {
         .task {
             await viewModel.load()
         }
+        .sheet(item: Binding(
+            get: { viewModel.previewURL.map(PreviewURL.init) },
+            set: { _ in }
+        )) { item in
+            QuickLookPreviewSheet(fileURL: item.url) {
+                try? FileManager.default.removeItem(at: item.url.deletingLastPathComponent())
+                viewModel.previewURL = nil
+            }
+        }
+        .alert("File Unavailable", isPresented: Binding(
+            get: { viewModel.fileOpenError != nil },
+            set: { if !$0 { viewModel.fileOpenError = nil } }
+        )) {
+            Button("OK", role: .cancel) {
+                viewModel.fileOpenError = nil
+            }
+        } message: {
+            Text(viewModel.fileOpenError ?? "This file is no longer available on this device.")
+        }
     }
 
     @ViewBuilder
@@ -141,30 +163,60 @@ struct AssistantFilesLinksView: View {
     }
 
     private func fileRow(_ file: AssistantFile) -> some View {
-        HStack(spacing: DesignConstants.Spacing.step3x) {
-            fileThumbnail(file)
-                .frame(width: 56.0, height: 56.0)
-                .clipShape(RoundedRectangle(cornerRadius: DesignConstants.CornerRadius.small))
+        Button {
+            Task {
+                do {
+                    viewModel.previewURL = try await FileAttachmentPreviewLoader.loadPreviewURL(
+                        key: file.attachmentKey,
+                        filename: file.filename
+                    )
+                } catch {
+                    Log.error("Failed to open assistant file: \(error)")
+                    viewModel.fileOpenError = "This file is no longer available on this device."
+                }
+            }
+        } label: {
+            HStack(spacing: DesignConstants.Spacing.step3x) {
+                fileThumbnail(file)
+                    .frame(width: 56.0, height: 56.0)
+                    .clipShape(RoundedRectangle(cornerRadius: DesignConstants.CornerRadius.small))
 
-            VStack(alignment: .leading, spacing: DesignConstants.Spacing.stepHalf) {
-                Text(file.displayName)
-                    .font(.body)
-                    .foregroundStyle(.colorTextPrimary)
-                    .lineLimit(1)
+                VStack(alignment: .leading, spacing: DesignConstants.Spacing.stepHalf) {
+                    Text(file.displayName)
+                        .font(.body)
+                        .foregroundStyle(.colorTextPrimary)
+                        .lineLimit(1)
 
-                Text(file.formattedDate)
-                    .font(.caption)
+                    Text(fileSubtitle(file))
+                        .font(.caption)
+                        .foregroundStyle(.colorTextSecondary)
+                        .lineLimit(1)
+                }
+
+                Spacer()
+
+                Image(systemName: "chevron.right")
+                    .font(.footnote.weight(.semibold))
                     .foregroundStyle(.colorTextSecondary)
             }
-
-            Spacer()
-
-            Image(systemName: "icloud.and.arrow.down")
-                .foregroundStyle(.colorTextSecondary)
+            .padding(.horizontal, DesignConstants.Spacing.step4x)
+            .padding(.vertical, DesignConstants.Spacing.step2x)
+            .contentShape(Rectangle())
         }
-        .padding(.horizontal, DesignConstants.Spacing.step4x)
-        .padding(.vertical, DesignConstants.Spacing.step2x)
-        .contentShape(Rectangle())
+        .buttonStyle(.plain)
+    }
+
+    private func fileSubtitle(_ file: AssistantFile) -> String {
+        var parts: [String] = []
+        if let mimeType = file.mimeType,
+           let utType = UTType(mimeType: mimeType),
+           let ext = utType.preferredFilenameExtension {
+            parts.append(ext.uppercased())
+        } else if let ext = (file.filename as NSString?)?.pathExtension, !ext.isEmpty {
+            parts.append(ext.uppercased())
+        }
+        parts.append(file.formattedDate)
+        return parts.joined(separator: " · ")
     }
 
     @ViewBuilder
@@ -251,4 +303,9 @@ struct AssistantFilesLinksView: View {
             Spacer()
         }
     }
+}
+
+private struct PreviewURL: Identifiable {
+    let url: URL
+    var id: String { url.path }
 }

--- a/Convos/Conversation Detail/AssistantFilesLinksView.swift
+++ b/Convos/Conversation Detail/AssistantFilesLinksView.swift
@@ -161,7 +161,8 @@ struct AssistantFilesLinksView: View {
                         filename: file.filename
                     )
                     await MainActor.run {
-                        QuickLookSheetPresenter.present(fileURL: url)
+                        guard let presenter = UIApplication.shared.topMostViewController() else { return }
+                        FileAttachmentQuickLookCoordinator.shared.present(fileURL: url, from: presenter)
                     }
                 } catch {
                     Log.error("Failed to open assistant file: \(error)")

--- a/Convos/Conversation Detail/AssistantFilesLinksView.swift
+++ b/Convos/Conversation Detail/AssistantFilesLinksView.swift
@@ -15,7 +15,6 @@ class AssistantFilesLinksViewModel {
     var files: [AssistantFile] = []
     var links: [AssistantLink] = []
     var isLoading: Bool = true
-    var previewURL: URL?
     var fileOpenError: String?
 
     private let repository: AssistantFilesLinksRepository
@@ -105,15 +104,6 @@ struct AssistantFilesLinksView: View {
         .task {
             await viewModel.load()
         }
-        .sheet(item: Binding(
-            get: { viewModel.previewURL.map(PreviewURL.init) },
-            set: { _ in }
-        )) { item in
-            QuickLookPreviewSheet(fileURL: item.url) {
-                try? FileManager.default.removeItem(at: item.url.deletingLastPathComponent())
-                viewModel.previewURL = nil
-            }
-        }
         .alert("File Unavailable", isPresented: Binding(
             get: { viewModel.fileOpenError != nil },
             set: { if !$0 { viewModel.fileOpenError = nil } }
@@ -166,10 +156,13 @@ struct AssistantFilesLinksView: View {
         Button {
             Task {
                 do {
-                    viewModel.previewURL = try await FileAttachmentPreviewLoader.loadPreviewURL(
+                    let url = try await FileAttachmentPreviewLoader.loadPreviewURL(
                         key: file.attachmentKey,
                         filename: file.filename
                     )
+                    await MainActor.run {
+                        FileAttachmentQuickLookPresenter.shared.present(fileURL: url)
+                    }
                 } catch {
                     Log.error("Failed to open assistant file: \(error)")
                     viewModel.fileOpenError = "This file is no longer available on this device."
@@ -303,9 +296,4 @@ struct AssistantFilesLinksView: View {
             Spacer()
         }
     }
-}
-
-private struct PreviewURL: Identifiable {
-    let url: URL
-    var id: String { url.path }
 }

--- a/Convos/Conversation Detail/AssistantFilesLinksView.swift
+++ b/Convos/Conversation Detail/AssistantFilesLinksView.swift
@@ -161,7 +161,7 @@ struct AssistantFilesLinksView: View {
                         filename: file.filename
                     )
                     await MainActor.run {
-                        FileAttachmentQuickLookPresenter.shared.present(fileURL: url)
+                        QuickLookSheetPresenter.present(fileURL: url)
                     }
                 } catch {
                     Log.error("Failed to open assistant file: \(error)")

--- a/Convos/Conversation Detail/AssistantFilesLinksView.swift
+++ b/Convos/Conversation Detail/AssistantFilesLinksView.swift
@@ -160,8 +160,9 @@ struct AssistantFilesLinksView: View {
                         key: file.attachmentKey,
                         filename: file.filename
                     )
-                    guard let presenter = UIApplication.shared.topMostViewController() else { return }
-                    FileAttachmentQuickLookCoordinator.shared.present(fileURL: url, from: presenter)
+                    await MainActor.run {
+                        QuickLookSheetPresenter.present(fileURL: url)
+                    }
                 } catch {
                     Log.error("Failed to open assistant file: \(error)")
                     viewModel.fileOpenError = "This file is no longer available on this device."

--- a/Convos/Conversation Detail/ConversationInfoView.swift
+++ b/Convos/Conversation Detail/ConversationInfoView.swift
@@ -94,6 +94,47 @@ struct ConversationInfoView: View {
     }
 
     @ViewBuilder
+    private var assistantSection: some View {
+        if viewModel.conversation.hasVerifiedAssistant {
+            Section {
+                filesAndLinksRow
+            }
+        }
+    }
+
+    private var convoCodeSection: some View {
+        Section {
+            convoCodeRow
+
+            lockRow
+        }
+    }
+
+    @ViewBuilder
+    private var filesAndLinksRow: some View {
+        NavigationLink {
+            AssistantFilesLinksView(
+                repository: viewModel.makeAssistantFilesLinksRepository()
+            )
+        } label: {
+            FeatureRowItem(
+                imageName: nil,
+                symbolName: "folder",
+                title: "Files & Links",
+                subtitle: "Managed by Assistants",
+                iconBackgroundColor: .colorFillMinimal,
+                iconForegroundColor: .colorTextPrimary
+            ) {
+                Image(systemName: "chevron.right")
+                    .font(.footnote.weight(.semibold))
+                    .foregroundStyle(.colorTextSecondary)
+            }
+        }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier("files-links-row")
+    }
+
+    @ViewBuilder
     private var convoCodeRow: some View {
         if viewModel.isLocked && !viewModel.isCurrentUserSuperAdmin {
             EmptyView()
@@ -397,11 +438,9 @@ struct ConversationInfoView: View {
 
                 membersSection
 
-                Section {
-                    convoCodeRow
+                assistantSection
 
-                    lockRow
-                }
+                convoCodeSection
 
                 if viewModel.canRemoveMembers {
                     Section {

--- a/Convos/Conversation Detail/ConversationInfoView.swift
+++ b/Convos/Conversation Detail/ConversationInfoView.swift
@@ -95,7 +95,7 @@ struct ConversationInfoView: View {
 
     @ViewBuilder
     private var assistantSection: some View {
-        if viewModel.conversation.hasVerifiedAssistant {
+        if viewModel.conversation.hasEverHadVerifiedAssistant {
             Section {
                 filesAndLinksRow
             }
@@ -125,9 +125,7 @@ struct ConversationInfoView: View {
                 iconBackgroundColor: .colorFillMinimal,
                 iconForegroundColor: .colorTextPrimary
             ) {
-                Image(systemName: "chevron.right")
-                    .font(.footnote.weight(.semibold))
-                    .foregroundStyle(.colorTextSecondary)
+                EmptyView()
             }
         }
         .buttonStyle(.plain)

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -1399,6 +1399,10 @@ extension ConversationViewModel {
         }
     }
 
+    func makeAssistantFilesLinksRepository() -> AssistantFilesLinksRepository {
+        session.assistantFilesLinksRepository(for: conversation.id)
+    }
+
     @MainActor
     func restoreInviteTagIfMissing(_ expectedTag: String) async throws {
         let trimmedTag = expectedTag.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Convos/Conversation Detail/FileAttachmentQuickLook.swift
+++ b/Convos/Conversation Detail/FileAttachmentQuickLook.swift
@@ -1,0 +1,97 @@
+import ConvosCore
+import QuickLook
+import SwiftUI
+
+struct QuickLookPreviewSheet: UIViewControllerRepresentable {
+    let fileURL: URL
+    let onDismiss: () -> Void
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(fileURL: fileURL, onDismiss: onDismiss)
+    }
+
+    func makeUIViewController(context: Context) -> QLPreviewController {
+        let controller = QLPreviewController()
+        controller.dataSource = context.coordinator
+        controller.delegate = context.coordinator
+        return controller
+    }
+
+    func updateUIViewController(_ uiViewController: QLPreviewController, context: Context) {
+        context.coordinator.fileURL = fileURL
+        uiViewController.reloadData()
+    }
+
+    final class Coordinator: NSObject, QLPreviewControllerDataSource, @preconcurrency QLPreviewControllerDelegate {
+        var fileURL: URL
+        let onDismiss: () -> Void
+
+        init(fileURL: URL, onDismiss: @escaping () -> Void) {
+            self.fileURL = fileURL
+            self.onDismiss = onDismiss
+        }
+
+        func numberOfPreviewItems(in controller: QLPreviewController) -> Int { 1 }
+
+        func previewController(_ controller: QLPreviewController, previewItemAt index: Int) -> any QLPreviewItem {
+            fileURL as NSURL
+        }
+
+        func previewControllerDidDismiss(_ controller: QLPreviewController) {
+            onDismiss()
+        }
+    }
+}
+
+enum FileAttachmentPreviewLoader {
+    static func loadPreviewURL(key: String, filename: String?) async throws -> URL {
+        let name = filename ?? "attachment"
+
+        if key.hasPrefix("file://") {
+            let path = String(key.dropFirst("file://".count))
+            let sourceURL = URL(fileURLWithPath: path)
+
+            if FileManager.default.fileExists(atPath: path) {
+                let tempURL = FileManager.default.temporaryDirectory
+                    .appendingPathComponent("preview_\(UUID().uuidString)")
+                    .appendingPathComponent(name)
+                try FileManager.default.createDirectory(
+                    at: tempURL.deletingLastPathComponent(),
+                    withIntermediateDirectories: true
+                )
+                try FileManager.default.copyItem(at: sourceURL, to: tempURL)
+                return tempURL
+            }
+
+            let fullFilename = sourceURL.lastPathComponent
+            if let underscoreIndex = fullFilename.firstIndex(of: "_") {
+                let messageId = String(fullFilename[..<underscoreIndex])
+                guard !messageId.isEmpty else { throw CocoaError(.fileReadNoSuchFile) }
+                let data = try await InlineAttachmentRecovery.shared.recoverData(messageId: messageId)
+                let tempURL = FileManager.default.temporaryDirectory
+                    .appendingPathComponent("preview_\(UUID().uuidString)")
+                    .appendingPathComponent(name)
+                try FileManager.default.createDirectory(
+                    at: tempURL.deletingLastPathComponent(),
+                    withIntermediateDirectories: true
+                )
+                try data.write(to: tempURL)
+                return tempURL
+            }
+
+            throw CocoaError(.fileReadNoSuchFile, userInfo: [NSFilePathErrorKey: path])
+        }
+
+        let loader = RemoteAttachmentLoader()
+        let loaded = try await loader.loadAttachmentData(from: key)
+        let tempURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("preview_\(UUID().uuidString)")
+            .appendingPathComponent(name)
+        try FileManager.default.createDirectory(
+            at: tempURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try loaded.data.write(to: tempURL)
+        return tempURL
+    }
+}

--- a/Convos/Conversation Detail/FileAttachmentQuickLook.swift
+++ b/Convos/Conversation Detail/FileAttachmentQuickLook.swift
@@ -1,6 +1,77 @@
 import ConvosCore
 import QuickLook
+import SwiftUI
 import UIKit
+
+struct QuickLookPreviewSheet: UIViewControllerRepresentable {
+    let fileURL: URL
+    let onDismiss: () -> Void
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(fileURL: fileURL, onDismiss: onDismiss)
+    }
+
+    func makeUIViewController(context: Context) -> QLPreviewController {
+        let controller = QLPreviewController()
+        controller.dataSource = context.coordinator
+        controller.delegate = context.coordinator
+        return controller
+    }
+
+    func updateUIViewController(_ uiViewController: QLPreviewController, context: Context) {
+        context.coordinator.fileURL = fileURL
+        uiViewController.reloadData()
+    }
+
+    final class Coordinator: NSObject, QLPreviewControllerDataSource, @preconcurrency QLPreviewControllerDelegate {
+        var fileURL: URL
+        let onDismiss: () -> Void
+
+        init(fileURL: URL, onDismiss: @escaping () -> Void) {
+            self.fileURL = fileURL
+            self.onDismiss = onDismiss
+        }
+
+        func numberOfPreviewItems(in controller: QLPreviewController) -> Int { 1 }
+
+        func previewController(_ controller: QLPreviewController, previewItemAt index: Int) -> any QLPreviewItem {
+            fileURL as NSURL
+        }
+
+        func previewControllerDidDismiss(_ controller: QLPreviewController) {
+            onDismiss()
+        }
+    }
+}
+
+private struct QuickLookSheetContainer: View {
+    let fileURL: URL
+    let onDismiss: () -> Void
+
+    @Environment(\.dismiss) private var dismiss: DismissAction
+
+    var body: some View {
+        QuickLookPreviewSheet(fileURL: fileURL) {
+            onDismiss()
+            dismiss()
+        }
+        .ignoresSafeArea()
+    }
+}
+
+enum QuickLookSheetPresenter {
+    @MainActor
+    static func present(fileURL: URL, from presenter: UIViewController? = UIApplication.shared.topMostViewController()) {
+        guard let presenter else { return }
+        let host = UIHostingController(
+            rootView: QuickLookSheetContainer(fileURL: fileURL) {
+                try? FileManager.default.removeItem(at: fileURL.deletingLastPathComponent())
+            }
+        )
+        host.modalPresentationStyle = .pageSheet
+        presenter.present(host, animated: true)
+    }
+}
 
 enum FileAttachmentPreviewLoader {
     static func loadPreviewURL(key: String, filename: String?) async throws -> URL {
@@ -52,54 +123,5 @@ enum FileAttachmentPreviewLoader {
         )
         try loaded.data.write(to: tempURL)
         return tempURL
-    }
-}
-
-final class FileAttachmentQuickLookPresenter: NSObject, QLPreviewControllerDataSource, @preconcurrency QLPreviewControllerDelegate {
-    private let fileURL: URL
-    private weak var presenter: UIViewController?
-
-    init(fileURL: URL, presenter: UIViewController) {
-        self.fileURL = fileURL
-        self.presenter = presenter
-    }
-
-    @MainActor
-    func present() {
-        let previewController = QLPreviewController()
-        previewController.dataSource = self
-        previewController.delegate = self
-        presenter?.present(previewController, animated: true)
-    }
-
-    func numberOfPreviewItems(in controller: QLPreviewController) -> Int {
-        1
-    }
-
-    func previewController(_ controller: QLPreviewController, previewItemAt index: Int) -> any QLPreviewItem {
-        fileURL as NSURL
-    }
-
-    func previewControllerDidDismiss(_ controller: QLPreviewController) {
-        try? FileManager.default.removeItem(at: fileURL.deletingLastPathComponent())
-        FileAttachmentQuickLookCoordinator.shared.release(self)
-    }
-}
-
-@MainActor
-final class FileAttachmentQuickLookCoordinator {
-    static let shared: FileAttachmentQuickLookCoordinator = .init()
-
-    private var presenters: [ObjectIdentifier: FileAttachmentQuickLookPresenter] = [:]
-
-    func present(fileURL: URL, from presenter: UIViewController) {
-        let quickLookPresenter = FileAttachmentQuickLookPresenter(fileURL: fileURL, presenter: presenter)
-        let id = ObjectIdentifier(quickLookPresenter)
-        presenters[id] = quickLookPresenter
-        quickLookPresenter.present()
-    }
-
-    func release(_ presenter: FileAttachmentQuickLookPresenter) {
-        presenters.removeValue(forKey: ObjectIdentifier(presenter))
     }
 }

--- a/Convos/Conversation Detail/FileAttachmentQuickLook.swift
+++ b/Convos/Conversation Detail/FileAttachmentQuickLook.swift
@@ -11,16 +11,20 @@ struct QuickLookPreviewSheet: UIViewControllerRepresentable {
         Coordinator(fileURL: fileURL, onDismiss: onDismiss)
     }
 
-    func makeUIViewController(context: Context) -> QLPreviewController {
+    func makeUIViewController(context: Context) -> UINavigationController {
         let controller = QLPreviewController()
         controller.dataSource = context.coordinator
         controller.delegate = context.coordinator
-        return controller
+        let navigationController = UINavigationController(rootViewController: controller)
+        navigationController.modalPresentationStyle = .pageSheet
+        return navigationController
     }
 
-    func updateUIViewController(_ uiViewController: QLPreviewController, context: Context) {
+    func updateUIViewController(_ uiViewController: UINavigationController, context: Context) {
         context.coordinator.fileURL = fileURL
-        uiViewController.reloadData()
+        if let controller = uiViewController.viewControllers.first as? QLPreviewController {
+            controller.reloadData()
+        }
     }
 
     final class Coordinator: NSObject, QLPreviewControllerDataSource, @preconcurrency QLPreviewControllerDelegate {

--- a/Convos/Conversation Detail/FileAttachmentQuickLook.swift
+++ b/Convos/Conversation Detail/FileAttachmentQuickLook.swift
@@ -1,47 +1,6 @@
 import ConvosCore
 import QuickLook
-import SwiftUI
-
-struct QuickLookPreviewSheet: UIViewControllerRepresentable {
-    let fileURL: URL
-    let onDismiss: () -> Void
-
-    func makeCoordinator() -> Coordinator {
-        Coordinator(fileURL: fileURL, onDismiss: onDismiss)
-    }
-
-    func makeUIViewController(context: Context) -> QLPreviewController {
-        let controller = QLPreviewController()
-        controller.dataSource = context.coordinator
-        controller.delegate = context.coordinator
-        return controller
-    }
-
-    func updateUIViewController(_ uiViewController: QLPreviewController, context: Context) {
-        context.coordinator.fileURL = fileURL
-        uiViewController.reloadData()
-    }
-
-    final class Coordinator: NSObject, QLPreviewControllerDataSource, @preconcurrency QLPreviewControllerDelegate {
-        var fileURL: URL
-        let onDismiss: () -> Void
-
-        init(fileURL: URL, onDismiss: @escaping () -> Void) {
-            self.fileURL = fileURL
-            self.onDismiss = onDismiss
-        }
-
-        func numberOfPreviewItems(in controller: QLPreviewController) -> Int { 1 }
-
-        func previewController(_ controller: QLPreviewController, previewItemAt index: Int) -> any QLPreviewItem {
-            fileURL as NSURL
-        }
-
-        func previewControllerDidDismiss(_ controller: QLPreviewController) {
-            onDismiss()
-        }
-    }
-}
+import UIKit
 
 enum FileAttachmentPreviewLoader {
     static func loadPreviewURL(key: String, filename: String?) async throws -> URL {
@@ -93,5 +52,35 @@ enum FileAttachmentPreviewLoader {
         )
         try loaded.data.write(to: tempURL)
         return tempURL
+    }
+}
+
+final class FileAttachmentQuickLookPresenter: NSObject, QLPreviewControllerDataSource, @preconcurrency QLPreviewControllerDelegate {
+    static let shared: FileAttachmentQuickLookPresenter = .init()
+
+    private var fileURL: URL?
+
+    func present(fileURL: URL) {
+        guard let presenter = UIApplication.shared.topMostViewController() else { return }
+        self.fileURL = fileURL
+        let previewController = QLPreviewController()
+        previewController.dataSource = self
+        previewController.delegate = self
+        presenter.present(previewController, animated: true)
+    }
+
+    func numberOfPreviewItems(in controller: QLPreviewController) -> Int {
+        fileURL != nil ? 1 : 0
+    }
+
+    func previewController(_ controller: QLPreviewController, previewItemAt index: Int) -> any QLPreviewItem {
+        (fileURL ?? URL(fileURLWithPath: "")) as NSURL
+    }
+
+    func previewControllerDidDismiss(_ controller: QLPreviewController) {
+        if let url = fileURL {
+            try? FileManager.default.removeItem(at: url.deletingLastPathComponent())
+        }
+        fileURL = nil
     }
 }

--- a/Convos/Conversation Detail/FileAttachmentQuickLook.swift
+++ b/Convos/Conversation Detail/FileAttachmentQuickLook.swift
@@ -1,81 +1,6 @@
 import ConvosCore
 import QuickLook
-import SwiftUI
 import UIKit
-
-struct QuickLookPreviewSheet: UIViewControllerRepresentable {
-    let fileURL: URL
-    let onDismiss: () -> Void
-
-    func makeCoordinator() -> Coordinator {
-        Coordinator(fileURL: fileURL, onDismiss: onDismiss)
-    }
-
-    func makeUIViewController(context: Context) -> UINavigationController {
-        let controller = QLPreviewController()
-        controller.dataSource = context.coordinator
-        controller.delegate = context.coordinator
-        let navigationController = UINavigationController(rootViewController: controller)
-        navigationController.modalPresentationStyle = .pageSheet
-        return navigationController
-    }
-
-    func updateUIViewController(_ uiViewController: UINavigationController, context: Context) {
-        context.coordinator.fileURL = fileURL
-        if let controller = uiViewController.viewControllers.first as? QLPreviewController {
-            controller.reloadData()
-        }
-    }
-
-    final class Coordinator: NSObject, QLPreviewControllerDataSource, @preconcurrency QLPreviewControllerDelegate {
-        var fileURL: URL
-        let onDismiss: () -> Void
-
-        init(fileURL: URL, onDismiss: @escaping () -> Void) {
-            self.fileURL = fileURL
-            self.onDismiss = onDismiss
-        }
-
-        func numberOfPreviewItems(in controller: QLPreviewController) -> Int { 1 }
-
-        func previewController(_ controller: QLPreviewController, previewItemAt index: Int) -> any QLPreviewItem {
-            fileURL as NSURL
-        }
-
-        func previewControllerDidDismiss(_ controller: QLPreviewController) {
-            onDismiss()
-        }
-    }
-}
-
-private struct QuickLookSheetContainer: View {
-    let fileURL: URL
-    let onDismiss: () -> Void
-
-    @Environment(\.dismiss) private var dismiss: DismissAction
-
-    var body: some View {
-        QuickLookPreviewSheet(fileURL: fileURL) {
-            onDismiss()
-            dismiss()
-        }
-        .ignoresSafeArea()
-    }
-}
-
-enum QuickLookSheetPresenter {
-    @MainActor
-    static func present(fileURL: URL, from presenter: UIViewController? = UIApplication.shared.topMostViewController()) {
-        guard let presenter else { return }
-        let host = UIHostingController(
-            rootView: QuickLookSheetContainer(fileURL: fileURL) {
-                try? FileManager.default.removeItem(at: fileURL.deletingLastPathComponent())
-            }
-        )
-        host.modalPresentationStyle = .pageSheet
-        presenter.present(host, animated: true)
-    }
-}
 
 enum FileAttachmentPreviewLoader {
     static func loadPreviewURL(key: String, filename: String?) async throws -> URL {
@@ -127,5 +52,54 @@ enum FileAttachmentPreviewLoader {
         )
         try loaded.data.write(to: tempURL)
         return tempURL
+    }
+}
+
+final class FileAttachmentQuickLookPresenter: NSObject, QLPreviewControllerDataSource, @preconcurrency QLPreviewControllerDelegate {
+    private let fileURL: URL
+    private weak var presenter: UIViewController?
+
+    init(fileURL: URL, presenter: UIViewController) {
+        self.fileURL = fileURL
+        self.presenter = presenter
+    }
+
+    @MainActor
+    func present() {
+        let previewController = QLPreviewController()
+        previewController.dataSource = self
+        previewController.delegate = self
+        presenter?.present(previewController, animated: true)
+    }
+
+    func numberOfPreviewItems(in controller: QLPreviewController) -> Int {
+        1
+    }
+
+    func previewController(_ controller: QLPreviewController, previewItemAt index: Int) -> any QLPreviewItem {
+        fileURL as NSURL
+    }
+
+    func previewControllerDidDismiss(_ controller: QLPreviewController) {
+        try? FileManager.default.removeItem(at: fileURL.deletingLastPathComponent())
+        FileAttachmentQuickLookCoordinator.shared.release(self)
+    }
+}
+
+@MainActor
+final class FileAttachmentQuickLookCoordinator {
+    static let shared: FileAttachmentQuickLookCoordinator = .init()
+
+    private var presenters: [ObjectIdentifier: FileAttachmentQuickLookPresenter] = [:]
+
+    func present(fileURL: URL, from presenter: UIViewController) {
+        let quickLookPresenter = FileAttachmentQuickLookPresenter(fileURL: fileURL, presenter: presenter)
+        let id = ObjectIdentifier(quickLookPresenter)
+        presenters[id] = quickLookPresenter
+        quickLookPresenter.present()
+    }
+
+    func release(_ presenter: FileAttachmentQuickLookPresenter) {
+        presenters.removeValue(forKey: ObjectIdentifier(presenter))
     }
 }

--- a/Convos/Conversation Detail/FileAttachmentQuickLook.swift
+++ b/Convos/Conversation Detail/FileAttachmentQuickLook.swift
@@ -1,6 +1,77 @@
 import ConvosCore
 import QuickLook
+import SwiftUI
 import UIKit
+
+struct QuickLookPreviewSheet: UIViewControllerRepresentable {
+    let fileURL: URL
+    let onDismiss: () -> Void
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(fileURL: fileURL, onDismiss: onDismiss)
+    }
+
+    func makeUIViewController(context: Context) -> QLPreviewController {
+        let controller = QLPreviewController()
+        controller.dataSource = context.coordinator
+        controller.delegate = context.coordinator
+        return controller
+    }
+
+    func updateUIViewController(_ uiViewController: QLPreviewController, context: Context) {
+        context.coordinator.fileURL = fileURL
+        uiViewController.reloadData()
+    }
+
+    final class Coordinator: NSObject, QLPreviewControllerDataSource, @preconcurrency QLPreviewControllerDelegate {
+        var fileURL: URL
+        let onDismiss: () -> Void
+
+        init(fileURL: URL, onDismiss: @escaping () -> Void) {
+            self.fileURL = fileURL
+            self.onDismiss = onDismiss
+        }
+
+        func numberOfPreviewItems(in controller: QLPreviewController) -> Int { 1 }
+
+        func previewController(_ controller: QLPreviewController, previewItemAt index: Int) -> any QLPreviewItem {
+            fileURL as NSURL
+        }
+
+        func previewControllerDidDismiss(_ controller: QLPreviewController) {
+            onDismiss()
+        }
+    }
+}
+
+private struct QuickLookSheetContainer: View {
+    let fileURL: URL
+    let onDismiss: () -> Void
+
+    @Environment(\.dismiss) private var dismiss: DismissAction
+
+    var body: some View {
+        QuickLookPreviewSheet(fileURL: fileURL) {
+            onDismiss()
+            dismiss()
+        }
+        .ignoresSafeArea()
+    }
+}
+
+enum QuickLookSheetPresenter {
+    @MainActor
+    static func present(fileURL: URL, from presenter: UIViewController? = UIApplication.shared.topMostViewController()) {
+        guard let presenter else { return }
+        let host = UIHostingController(
+            rootView: QuickLookSheetContainer(fileURL: fileURL) {
+                try? FileManager.default.removeItem(at: fileURL.deletingLastPathComponent())
+            }
+        )
+        host.modalPresentationStyle = .pageSheet
+        presenter.present(host, animated: true)
+    }
+}
 
 enum FileAttachmentPreviewLoader {
     static func loadPreviewURL(key: String, filename: String?) async throws -> URL {
@@ -52,35 +123,5 @@ enum FileAttachmentPreviewLoader {
         )
         try loaded.data.write(to: tempURL)
         return tempURL
-    }
-}
-
-final class FileAttachmentQuickLookPresenter: NSObject, QLPreviewControllerDataSource, @preconcurrency QLPreviewControllerDelegate {
-    static let shared: FileAttachmentQuickLookPresenter = .init()
-
-    private var fileURL: URL?
-
-    func present(fileURL: URL) {
-        guard let presenter = UIApplication.shared.topMostViewController() else { return }
-        self.fileURL = fileURL
-        let previewController = QLPreviewController()
-        previewController.dataSource = self
-        previewController.delegate = self
-        presenter.present(previewController, animated: true)
-    }
-
-    func numberOfPreviewItems(in controller: QLPreviewController) -> Int {
-        fileURL != nil ? 1 : 0
-    }
-
-    func previewController(_ controller: QLPreviewController, previewItemAt index: Int) -> any QLPreviewItem {
-        (fileURL ?? URL(fileURLWithPath: "")) as NSURL
-    }
-
-    func previewControllerDidDismiss(_ controller: QLPreviewController) {
-        if let url = fileURL {
-            try? FileManager.default.removeItem(at: url.deletingLastPathComponent())
-        }
-        fileURL = nil
     }
 }

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/MessagesViewController.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/MessagesViewController.swift
@@ -195,7 +195,7 @@ final class MessagesViewController: UIViewController {
     var onConvoCode: (() -> Void)?
     var onInviteAssistant: (() -> Void)?
     var onRetryTranscript: ((VoiceMemoTranscriptListItem) -> Void)?
-    private var filePreviewURL: URL?
+
     var hasAssistant: Bool = false {
         didSet { dataSource.hasAssistant = hasAssistant }
     }
@@ -878,20 +878,17 @@ extension MessagesViewController: KeyboardListenerDelegate {
 
 // MARK: - File Attachment QuickLook
 
-extension MessagesViewController: QLPreviewControllerDataSource {
+extension MessagesViewController {
     private func openFileAttachment(_ attachment: HydratedAttachment) {
         Task {
             do {
-                let fileURL = try await loadFileForPreview(attachment)
-                if attachment.isMarkdownFile {
-                    presentMarkdownPreview(fileURL: fileURL, filename: attachment.filename ?? "Markdown")
-                    return
+                let fileURL = try await FileAttachmentPreviewLoader.loadPreviewURL(
+                    key: attachment.key,
+                    filename: attachment.filename
+                )
+                await MainActor.run {
+                    QuickLookSheetPresenter.present(fileURL: fileURL, from: self)
                 }
-                let previewController = QLPreviewController()
-                filePreviewURL = fileURL
-                previewController.dataSource = self
-                previewController.delegate = self
-                present(previewController, animated: true)
             } catch {
                 Log.error("Failed to open file attachment: \(error)")
                 let alert = UIAlertController(
@@ -904,83 +901,6 @@ extension MessagesViewController: QLPreviewControllerDataSource {
                 present(alert, animated: true)
             }
         }
-    }
-
-    private func presentMarkdownPreview(fileURL: URL, filename: String) {
-        let preview = MarkdownAttachmentPreviewSheet(
-            fileURL: fileURL,
-            filename: filename
-        )
-        let controller = UIHostingController(rootView: preview)
-        controller.modalPresentationStyle = .pageSheet
-        controller.presentationController?.delegate = self
-        if let sheet = controller.sheetPresentationController {
-            sheet.detents = [.medium(), .large()]
-            sheet.prefersGrabberVisible = false
-        }
-        present(controller, animated: true)
-    }
-
-    private func loadFileForPreview(_ attachment: HydratedAttachment) async throws -> URL {
-        let filename = attachment.filename ?? "attachment"
-        let cache = FileAttachmentCache.shared
-
-        if let cached = await cache.cachedFileURL(for: attachment.key, filename: filename) {
-            return cached
-        }
-
-        if attachment.key.hasPrefix("file://") {
-            let path = String(attachment.key.dropFirst("file://".count))
-            let sourceURL = URL(fileURLWithPath: path)
-
-            if FileManager.default.fileExists(atPath: path) {
-                return try await cache.cacheFile(from: sourceURL, for: attachment.key, filename: filename)
-            }
-
-            let messageId = extractMessageId(from: sourceURL)
-            if let messageId {
-                let data = try await InlineAttachmentRecovery.shared.recoverData(messageId: messageId)
-                return try await cache.cacheFile(data: data, for: attachment.key, filename: filename)
-            }
-
-            throw CocoaError(.fileReadNoSuchFile, userInfo: [NSFilePathErrorKey: path])
-        }
-
-        let loader = RemoteAttachmentLoader()
-        let loaded = try await loader.loadAttachmentData(from: attachment.key)
-        return try await cache.cacheFile(data: loaded.data, for: attachment.key, filename: filename)
-    }
-
-    private func extractMessageId(from fileURL: URL) -> String? {
-        let filename = fileURL.lastPathComponent
-        guard let underscoreIndex = filename.firstIndex(of: "_") else { return nil }
-        let messageId = String(filename[filename.startIndex..<underscoreIndex])
-        guard !messageId.isEmpty else { return nil }
-        return messageId
-    }
-
-    func numberOfPreviewItems(in controller: QLPreviewController) -> Int {
-        filePreviewURL != nil ? 1 : 0
-    }
-
-    func previewController(_ controller: QLPreviewController, previewItemAt index: Int) -> any QLPreviewItem {
-        (filePreviewURL ?? URL(fileURLWithPath: "")) as NSURL
-    }
-}
-
-extension MessagesViewController: @preconcurrency QLPreviewControllerDelegate {
-    func previewControllerDidDismiss(_ controller: QLPreviewController) {
-        cleanupPresentedFilePreview()
-    }
-}
-
-extension MessagesViewController: UIAdaptivePresentationControllerDelegate {
-    func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
-        cleanupPresentedFilePreview()
-    }
-
-    private func cleanupPresentedFilePreview() {
-        filePreviewURL = nil
     }
 }
 

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/MessagesViewController.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/MessagesViewController.swift
@@ -882,13 +882,12 @@ extension MessagesViewController {
     private func openFileAttachment(_ attachment: HydratedAttachment) {
         Task {
             do {
-                let fileURL = try await loadFileForPreview(attachment)
-                if attachment.isMarkdownFile {
-                    presentMarkdownPreview(fileURL: fileURL, filename: attachment.filename ?? "Markdown")
-                    return
-                }
+                let fileURL = try await FileAttachmentPreviewLoader.loadPreviewURL(
+                    key: attachment.key,
+                    filename: attachment.filename
+                )
                 await MainActor.run {
-                    FileAttachmentQuickLookCoordinator.shared.present(fileURL: fileURL, from: self)
+                    QuickLookSheetPresenter.present(fileURL: fileURL, from: self)
                 }
             } catch {
                 Log.error("Failed to open file attachment: \(error)")

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/MessagesViewController.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/MessagesViewController.swift
@@ -882,10 +882,11 @@ extension MessagesViewController {
     private func openFileAttachment(_ attachment: HydratedAttachment) {
         Task {
             do {
-                let fileURL = try await FileAttachmentPreviewLoader.loadPreviewURL(
-                    key: attachment.key,
-                    filename: attachment.filename
-                )
+                let fileURL = try await loadFileForPreview(attachment)
+                if attachment.isMarkdownFile {
+                    presentMarkdownPreview(fileURL: fileURL, filename: attachment.filename ?? "Markdown")
+                    return
+                }
                 await MainActor.run {
                     FileAttachmentQuickLookCoordinator.shared.present(fileURL: fileURL, from: self)
                 }
@@ -900,6 +901,242 @@ extension MessagesViewController {
                 alert.addAction(okAction)
                 present(alert, animated: true)
             }
+        }
+    }
+
+    private func presentMarkdownPreview(fileURL: URL, filename: String) {
+        let preview = MarkdownAttachmentPreviewSheet(
+            fileURL: fileURL,
+            filename: filename
+        )
+        let controller = UIHostingController(rootView: preview)
+        controller.modalPresentationStyle = .pageSheet
+        if let sheet = controller.sheetPresentationController {
+            sheet.detents = [.medium(), .large()]
+            sheet.prefersGrabberVisible = false
+        }
+        present(controller, animated: true)
+    }
+
+    private func loadFileForPreview(_ attachment: HydratedAttachment) async throws -> URL {
+        let filename = attachment.filename ?? "attachment"
+        let cache = FileAttachmentCache.shared
+
+        if let cached = await cache.cachedFileURL(for: attachment.key, filename: filename) {
+            return cached
+        }
+
+        if attachment.key.hasPrefix("file://") {
+            let path = String(attachment.key.dropFirst("file://".count))
+            let sourceURL = URL(fileURLWithPath: path)
+
+            if FileManager.default.fileExists(atPath: path) {
+                return try await cache.cacheFile(from: sourceURL, for: attachment.key, filename: filename)
+            }
+
+            let messageId = extractMessageId(from: sourceURL)
+            if let messageId {
+                let data = try await InlineAttachmentRecovery.shared.recoverData(messageId: messageId)
+                return try await cache.cacheFile(data: data, for: attachment.key, filename: filename)
+            }
+
+            throw CocoaError(.fileReadNoSuchFile, userInfo: [NSFilePathErrorKey: path])
+        }
+
+        let loader = RemoteAttachmentLoader()
+        let loaded = try await loader.loadAttachmentData(from: attachment.key)
+        return try await cache.cacheFile(data: loaded.data, for: attachment.key, filename: filename)
+    }
+
+    private func extractMessageId(from fileURL: URL) -> String? {
+        let filename = fileURL.lastPathComponent
+        guard let underscoreIndex = filename.firstIndex(of: "_") else { return nil }
+        let messageId = String(filename[filename.startIndex..<underscoreIndex])
+        guard !messageId.isEmpty else { return nil }
+        return messageId
+    }
+}
+
+private struct MarkdownAttachmentPreviewSheet: View {
+    let fileURL: URL
+    let filename: String
+    @Environment(\.dismiss) private var dismiss: DismissAction
+
+    @State private var htmlString: String?
+    @State private var errorMessage: String?
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if let htmlString {
+                    MarkdownWebView(html: htmlString)
+                        .ignoresSafeArea(edges: .bottom)
+                } else if let errorMessage {
+                    ContentUnavailableView("Preview Unavailable", systemImage: "doc.text", description: Text(errorMessage))
+                } else {
+                    ProgressView()
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                }
+            }
+            .navigationTitle(filename)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    ShareLink(item: fileURL) {
+                        Image(systemName: "square.and.arrow.up")
+                    }
+                }
+                ToolbarItem(placement: .topBarTrailing) {
+                    let action = { dismiss() }
+                    Button("Done", action: action)
+                }
+            }
+        }
+        .task {
+            await loadMarkdown()
+        }
+    }
+
+    private func loadMarkdown() async {
+        guard let markedJS = Self.loadMarkedJS() else {
+            errorMessage = "Markdown renderer is unavailable."
+            return
+        }
+        do {
+            let url = fileURL
+            let markdown = try await Task.detached {
+                try String(contentsOf: url, encoding: .utf8)
+            }.value
+            let encodedMarkdown = Data(markdown.utf8).base64EncodedString()
+            htmlString = """
+            <!DOCTYPE html>
+            <html>
+            <head>
+            <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
+            <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; img-src data:;" />
+            <style>
+                :root { color-scheme: light dark; }
+                body {
+                    font: -apple-system-body;
+                    font-family: -apple-system, system-ui, sans-serif;
+                    padding: 16px;
+                    line-height: 1.6;
+                    word-wrap: break-word;
+                    overflow-wrap: break-word;
+                }
+                h1 { font-size: 1.6em; margin-top: 0; }
+                h2 { font-size: 1.4em; }
+                h3 { font-size: 1.2em; }
+                code {
+                    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+                    font-size: 0.9em;
+                    background: rgba(128, 128, 128, 0.15);
+                    padding: 2px 5px;
+                    border-radius: 4px;
+                }
+                pre {
+                    background: rgba(128, 128, 128, 0.1);
+                    padding: 12px;
+                    border-radius: 8px;
+                    overflow-x: auto;
+                }
+                pre code {
+                    background: none;
+                    padding: 0;
+                }
+                blockquote {
+                    border-left: 3px solid rgba(128, 128, 128, 0.4);
+                    margin-left: 0;
+                    padding-left: 16px;
+                    color: rgba(128, 128, 128, 0.8);
+                }
+                img { max-width: 100%; height: auto; }
+                table {
+                    border-collapse: collapse;
+                    width: 100%;
+                }
+                th, td {
+                    border: 1px solid rgba(128, 128, 128, 0.3);
+                    padding: 8px;
+                    text-align: left;
+                }
+                a { color: #007AFF; }
+                @media (prefers-color-scheme: dark) {
+                    a { color: #0A84FF; }
+                }
+            </style>
+            <script>\(markedJS)</script>
+            </head>
+            <body data-markdown="\(encodedMarkdown)">
+            <div id="content"></div>
+            <script>
+                var encoded = document.body.getAttribute('data-markdown');
+                var decoded = atob(encoded);
+                var text = new TextDecoder().decode(Uint8Array.from(decoded, function(c) { return c.charCodeAt(0); }));
+                var renderer = { html: function(token) { return ''; } };
+                marked.use({ renderer: renderer });
+                var html = marked.parse(text);
+                var div = document.createElement('div');
+                div.innerHTML = html;
+                div.querySelectorAll('script, iframe, object, embed, form, input, textarea, button, select').forEach(function(el) { el.remove(); });
+                div.querySelectorAll('*').forEach(function(el) {
+                    el.getAttributeNames().filter(function(n) { return n.startsWith('on'); }).forEach(function(n) { el.removeAttribute(n); });
+                });
+                div.querySelectorAll('a[href^="javascript:"]').forEach(function(el) { el.removeAttribute('href'); });
+                document.getElementById('content').innerHTML = div.innerHTML;
+            </script>
+            </body>
+            </html>
+            """
+        } catch {
+            errorMessage = "This markdown file could not be loaded."
+        }
+    }
+
+    private static func loadMarkedJS() -> String? {
+        guard let url = Bundle.main.url(forResource: "marked.min", withExtension: "js"),
+              let js = try? String(contentsOf: url, encoding: .utf8) else {
+            return nil
+        }
+        return js
+    }
+}
+
+private struct MarkdownWebView: UIViewRepresentable {
+    let html: String
+
+    func makeUIView(context: Context) -> WKWebView {
+        let config = WKWebViewConfiguration()
+        let webView = WKWebView(frame: .zero, configuration: config)
+        webView.isOpaque = false
+        webView.backgroundColor = .clear
+        webView.scrollView.backgroundColor = .clear
+        webView.navigationDelegate = context.coordinator
+        return webView
+    }
+
+    func updateUIView(_ webView: WKWebView, context: Context) {
+        guard context.coordinator.loadedHTML != html else { return }
+        context.coordinator.loadedHTML = html
+        webView.loadHTMLString(html, baseURL: nil)
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator()
+    }
+
+    final class Coordinator: NSObject, WKNavigationDelegate {
+        var loadedHTML: String?
+
+        func webView(
+            _ webView: WKWebView,
+            decidePolicyFor navigationAction: WKNavigationAction
+        ) async -> WKNavigationActionPolicy {
+            if navigationAction.navigationType == .linkActivated, let url = navigationAction.request.url {
+                await UIApplication.shared.open(url)
+                return .cancel
+            }
+            return .allow
         }
     }
 }

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/MessagesViewController.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/MessagesViewController.swift
@@ -887,7 +887,7 @@ extension MessagesViewController {
                     filename: attachment.filename
                 )
                 await MainActor.run {
-                    QuickLookSheetPresenter.present(fileURL: fileURL, from: self)
+                    FileAttachmentQuickLookCoordinator.shared.present(fileURL: fileURL, from: self)
                 }
             } catch {
                 Log.error("Failed to open file attachment: \(error)")

--- a/ConvosCore/Sources/ConvosCore/Crypto/AgentVerificationWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Crypto/AgentVerificationWriter.swift
@@ -21,6 +21,12 @@ public enum AgentVerificationWriter {
             try await dbWriter.write { db in
                 let updated = profile.with(memberKind: updatedKind)
                 try updated.save(db)
+
+                if updated.agentVerification.isConvosAssistant,
+                   let conversation = try DBConversation.fetchOne(db, id: updated.conversationId),
+                   !conversation.hasHadVerifiedAssistant {
+                    try conversation.with(hasHadVerifiedAssistant: true).save(db)
+                }
             }
             updatedCount += 1
         }

--- a/ConvosCore/Sources/ConvosCore/Inboxes/MessagingService+PushNotifications.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/MessagingService+PushNotifications.swift
@@ -730,7 +730,14 @@ extension MessagingService {
                 }
 
                 profile = profile.with(memberKind: update.memberKind.dbMemberKind)
+
+                if profile.isAgent {
+                    let verification = profile.hydrateProfile().verifyCachedAgentAttestation()
+                    profile = profile.with(memberKind: DBMemberKind.from(agentVerification: verification))
+                }
+
                 try profile.save(db)
+                try Self.markConversationHasVerifiedAssistantIfNeeded(profile: profile, conversationId: conversationId, db: db)
             }
             Log.debug("NSE: Processed ProfileUpdate from \(senderInboxId) in \(conversationId)")
         } catch {
@@ -785,13 +792,31 @@ extension MessagingService {
                     }
 
                     profile = profile.with(memberKind: memberProfile.memberKind.dbMemberKind)
+
+                    if profile.isAgent {
+                        let verification = profile.hydrateProfile().verifyCachedAgentAttestation()
+                        profile = profile.with(memberKind: DBMemberKind.from(agentVerification: verification))
+                    }
+
                     try profile.save(db)
+                    try Self.markConversationHasVerifiedAssistantIfNeeded(profile: profile, conversationId: conversationId, db: db)
                 }
             }
             Log.debug("NSE: Processed ProfileSnapshot with \(snapshot.profiles.count) profiles in \(conversationId)")
         } catch {
             Log.warning("NSE: Failed to process ProfileSnapshot: \(error.localizedDescription)")
         }
+    }
+
+    private static func markConversationHasVerifiedAssistantIfNeeded(
+        profile: DBMemberProfile,
+        conversationId: String,
+        db: Database
+    ) throws {
+        guard profile.agentVerification.isConvosAssistant,
+              let conversation = try DBConversation.fetchOne(db, id: conversationId),
+              !conversation.hasHadVerifiedAssistant else { return }
+        try conversation.with(hasHadVerifiedAssistant: true).save(db)
     }
 
     // MARK: - Conversation Storage

--- a/ConvosCore/Sources/ConvosCore/Inboxes/MockInboxesService.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/MockInboxesService.swift
@@ -134,8 +134,7 @@ public final class MockInboxesService: SessionManagerProtocol {
         MockAttachmentLocalStateWriter()
     }
 
-    // swiftlint:disable:next force_try
-    private static let mockDatabase: DatabaseQueue = try! DatabaseQueue()
+    private static let mockDatabase: DatabaseQueue = MockDatabaseManager.shared.dbPool
 
     public func assistantFilesLinksRepository(for conversationId: String) -> AssistantFilesLinksRepository {
         AssistantFilesLinksRepository(dbReader: Self.mockDatabase, conversationId: conversationId)

--- a/ConvosCore/Sources/ConvosCore/Inboxes/MockInboxesService.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/MockInboxesService.swift
@@ -1,5 +1,6 @@
 import Combine
 import Foundation
+import GRDB
 
 public final class MockInboxesService: SessionManagerProtocol {
     private let mockMessagingService: MockMessagingService = MockMessagingService()
@@ -131,6 +132,13 @@ public final class MockInboxesService: SessionManagerProtocol {
 
     public func attachmentLocalStateWriter() -> any AttachmentLocalStateWriterProtocol {
         MockAttachmentLocalStateWriter()
+    }
+
+    // swiftlint:disable:next force_try
+    private static let mockDatabase: DatabaseQueue = try! DatabaseQueue()
+
+    public func assistantFilesLinksRepository(for conversationId: String) -> AssistantFilesLinksRepository {
+        AssistantFilesLinksRepository(dbReader: Self.mockDatabase, conversationId: conversationId)
     }
 
     // MARK: - Lifecycle Management

--- a/ConvosCore/Sources/ConvosCore/Messaging/UnusedConversationCache.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/UnusedConversationCache.swift
@@ -1015,7 +1015,8 @@ extension UnusedConversationCache {
                 imageNonce: nil,
                 imageEncryptionKey: nil,
                 imageLastRenewed: nil,
-                isUnused: true
+                isUnused: true,
+                hasHadVerifiedAssistant: false
             )
             try dbConversation.save(db)
 
@@ -1075,6 +1076,7 @@ extension UnusedConversationCache {
                     imageEncryptionKey: nil,
                     imageLastRenewed: nil,
                     isUnused: true,
+                    hasHadVerifiedAssistant: false
                 )
                 try dbConversation.save(db)
             }

--- a/ConvosCore/Sources/ConvosCore/Mocks/ModelMocks.swift
+++ b/ConvosCore/Sources/ConvosCore/Mocks/ModelMocks.swift
@@ -54,7 +54,8 @@ public extension Conversation {
             expiresAt: nil,
             debugInfo: ConversationDebugInfo.empty,
             isLocked: false,
-            assistantJoinStatus: nil
+            assistantJoinStatus: nil,
+            hasHadVerifiedAssistant: mockMembers.contains(where: \.agentVerification.isConvosAssistant)
         )
     }
 
@@ -99,7 +100,8 @@ public extension Conversation {
             expiresAt: .distantFuture,
             debugInfo: .empty,
             isLocked: false,
-            assistantJoinStatus: nil
+            assistantJoinStatus: nil,
+            hasHadVerifiedAssistant: false
         )
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
@@ -367,6 +367,10 @@ public final class SessionManager: SessionManagerProtocol, @unchecked Sendable {
         AttachmentLocalStateWriter(databaseWriter: databaseWriter)
     }
 
+    public func assistantFilesLinksRepository(for conversationId: String) -> AssistantFilesLinksRepository {
+        AssistantFilesLinksRepository(dbReader: databaseReader, conversationId: conversationId)
+    }
+
     public func conversationsRepository(for consent: [Consent]) -> any ConversationsRepositoryProtocol {
         ConversationsRepository(dbReader: databaseReader, consent: consent)
     }

--- a/ConvosCore/Sources/ConvosCore/Sessions/SessionManagerProtocol.swift
+++ b/ConvosCore/Sources/ConvosCore/Sessions/SessionManagerProtocol.swift
@@ -45,6 +45,7 @@ public protocol SessionManagerProtocol: AnyObject, Sendable {
     func voiceMemoTranscriptionService() -> any VoiceMemoTranscriptionServicing
 
     func attachmentLocalStateWriter() -> any AttachmentLocalStateWriterProtocol
+    func assistantFilesLinksRepository(for conversationId: String) -> AssistantFilesLinksRepository
 
     func conversationsRepository(for consent: [Consent]) -> any ConversationsRepositoryProtocol
     func conversationsCountRepo(

--- a/ConvosCore/Sources/ConvosCore/Storage/Database Models/DBConversation.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Database Models/DBConversation.swift
@@ -50,6 +50,7 @@ struct DBConversation: Codable, FetchableRecord, PersistableRecord, Identifiable
         static let imageEncryptionKey: Column = Column(CodingKeys.imageEncryptionKey)
         static let imageLastRenewed: Column = Column(CodingKeys.imageLastRenewed)
         static let isUnused: Column = Column(CodingKeys.isUnused)
+        static let hasHadVerifiedAssistant: Column = Column(CodingKeys.hasHadVerifiedAssistant)
     }
 
     let id: String
@@ -74,6 +75,7 @@ struct DBConversation: Codable, FetchableRecord, PersistableRecord, Identifiable
     let imageEncryptionKey: Data?
     let imageLastRenewed: Date?
     let isUnused: Bool
+    let hasHadVerifiedAssistant: Bool
 
     static let creatorForeignKey: ForeignKey = ForeignKey(
         [Columns.creatorId, Columns.id],
@@ -257,7 +259,8 @@ extension DBConversation {
             imageNonce: imageNonce,
             imageEncryptionKey: imageEncryptionKey,
             imageLastRenewed: imageLastRenewed,
-            isUnused: isUnused
+            isUnused: isUnused,
+            hasHadVerifiedAssistant: hasHadVerifiedAssistant
         )
     }
 
@@ -284,7 +287,8 @@ extension DBConversation {
             imageNonce: imageNonce,
             imageEncryptionKey: imageEncryptionKey,
             imageLastRenewed: imageLastRenewed,
-            isUnused: isUnused
+            isUnused: isUnused,
+            hasHadVerifiedAssistant: hasHadVerifiedAssistant
         )
     }
 
@@ -311,7 +315,8 @@ extension DBConversation {
             imageNonce: imageNonce,
             imageEncryptionKey: imageEncryptionKey,
             imageLastRenewed: imageLastRenewed,
-            isUnused: isUnused
+            isUnused: isUnused,
+            hasHadVerifiedAssistant: hasHadVerifiedAssistant
         )
     }
 
@@ -338,7 +343,8 @@ extension DBConversation {
             imageNonce: imageNonce,
             imageEncryptionKey: imageEncryptionKey,
             imageLastRenewed: imageLastRenewed,
-            isUnused: isUnused
+            isUnused: isUnused,
+            hasHadVerifiedAssistant: hasHadVerifiedAssistant
         )
     }
 
@@ -365,7 +371,8 @@ extension DBConversation {
             imageNonce: imageNonce,
             imageEncryptionKey: imageEncryptionKey,
             imageLastRenewed: imageLastRenewed,
-            isUnused: isUnused
+            isUnused: isUnused,
+            hasHadVerifiedAssistant: hasHadVerifiedAssistant
         )
     }
 
@@ -394,7 +401,8 @@ extension DBConversation {
             imageNonce: imageNonce,
             imageEncryptionKey: imageEncryptionKey,
             imageLastRenewed: imageLastRenewed,
-            isUnused: isUnused
+            isUnused: isUnused,
+            hasHadVerifiedAssistant: hasHadVerifiedAssistant
         )
     }
 
@@ -421,7 +429,8 @@ extension DBConversation {
             imageNonce: imageNonce,
             imageEncryptionKey: imageEncryptionKey,
             imageLastRenewed: imageLastRenewed,
-            isUnused: isUnused
+            isUnused: isUnused,
+            hasHadVerifiedAssistant: hasHadVerifiedAssistant
         )
     }
 
@@ -448,7 +457,8 @@ extension DBConversation {
             imageNonce: imageNonce,
             imageEncryptionKey: imageEncryptionKey,
             imageLastRenewed: imageLastRenewed,
-            isUnused: isUnused
+            isUnused: isUnused,
+            hasHadVerifiedAssistant: hasHadVerifiedAssistant
         )
     }
 
@@ -475,7 +485,8 @@ extension DBConversation {
             imageNonce: imageNonce,
             imageEncryptionKey: imageEncryptionKey,
             imageLastRenewed: imageLastRenewed,
-            isUnused: isUnused
+            isUnused: isUnused,
+            hasHadVerifiedAssistant: hasHadVerifiedAssistant
         )
     }
 
@@ -502,7 +513,8 @@ extension DBConversation {
             imageNonce: imageNonce,
             imageEncryptionKey: imageEncryptionKey,
             imageLastRenewed: imageLastRenewed,
-            isUnused: isUnused
+            isUnused: isUnused,
+            hasHadVerifiedAssistant: hasHadVerifiedAssistant
         )
     }
 
@@ -529,7 +541,8 @@ extension DBConversation {
             imageNonce: imageNonce,
             imageEncryptionKey: imageEncryptionKey,
             imageLastRenewed: imageLastRenewed,
-            isUnused: isUnused
+            isUnused: isUnused,
+            hasHadVerifiedAssistant: hasHadVerifiedAssistant
         )
     }
 
@@ -556,7 +569,8 @@ extension DBConversation {
             imageNonce: imageNonce,
             imageEncryptionKey: imageEncryptionKey,
             imageLastRenewed: imageLastRenewed,
-            isUnused: isUnused
+            isUnused: isUnused,
+            hasHadVerifiedAssistant: hasHadVerifiedAssistant
         )
     }
 
@@ -583,7 +597,8 @@ extension DBConversation {
             imageNonce: imageNonce,
             imageEncryptionKey: imageEncryptionKey,
             imageLastRenewed: imageLastRenewed,
-            isUnused: isUnused
+            isUnused: isUnused,
+            hasHadVerifiedAssistant: hasHadVerifiedAssistant
         )
     }
 
@@ -610,7 +625,8 @@ extension DBConversation {
             imageNonce: imageNonce,
             imageEncryptionKey: imageEncryptionKey,
             imageLastRenewed: imageLastRenewed,
-            isUnused: isUnused
+            isUnused: isUnused,
+            hasHadVerifiedAssistant: hasHadVerifiedAssistant
         )
     }
 
@@ -637,7 +653,8 @@ extension DBConversation {
             imageNonce: imageNonce,
             imageEncryptionKey: imageEncryptionKey,
             imageLastRenewed: imageLastRenewed,
-            isUnused: isUnused
+            isUnused: isUnused,
+            hasHadVerifiedAssistant: hasHadVerifiedAssistant
         )
     }
 
@@ -664,7 +681,8 @@ extension DBConversation {
             imageNonce: imageNonce,
             imageEncryptionKey: imageEncryptionKey,
             imageLastRenewed: imageLastRenewed,
-            isUnused: isUnused
+            isUnused: isUnused,
+            hasHadVerifiedAssistant: hasHadVerifiedAssistant
         )
     }
 
@@ -691,7 +709,36 @@ extension DBConversation {
             imageNonce: imageNonce,
             imageEncryptionKey: imageEncryptionKey,
             imageLastRenewed: imageLastRenewed,
-            isUnused: isUnused
+            isUnused: isUnused,
+            hasHadVerifiedAssistant: hasHadVerifiedAssistant
+        )
+    }
+
+    func with(hasHadVerifiedAssistant: Bool) -> Self {
+        .init(
+            id: id,
+            inboxId: inboxId,
+            clientId: clientId,
+            clientConversationId: clientConversationId,
+            inviteTag: inviteTag,
+            creatorId: creatorId,
+            kind: kind,
+            consent: consent,
+            createdAt: createdAt,
+            name: name,
+            description: description,
+            imageURLString: imageURLString,
+            publicImageURLString: publicImageURLString,
+            includeInfoInPublicPreview: includeInfoInPublicPreview,
+            expiresAt: expiresAt,
+            debugInfo: debugInfo,
+            isLocked: isLocked,
+            imageSalt: imageSalt,
+            imageNonce: imageNonce,
+            imageEncryptionKey: imageEncryptionKey,
+            imageLastRenewed: imageLastRenewed,
+            isUnused: isUnused,
+            hasHadVerifiedAssistant: hasHadVerifiedAssistant
         )
     }
 

--- a/ConvosCore/Sources/ConvosCore/Storage/Hydration/DBConversationDetails+Conversation.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Hydration/DBConversationDetails+Conversation.swift
@@ -67,7 +67,8 @@ extension DBConversationDetails {
             expiresAt: conversation.expiresAt,
             debugInfo: conversation.debugInfo,
             isLocked: conversation.isLocked,
-            assistantJoinStatus: assistantJoinStatus
+            assistantJoinStatus: assistantJoinStatus,
+            hasHadVerifiedAssistant: conversation.hasHadVerifiedAssistant
         )
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/Conversation.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/Conversation.swift
@@ -32,6 +32,7 @@ public struct Conversation: Codable, Hashable, Identifiable, Sendable {
     public let debugInfo: ConversationDebugInfo
     public let isLocked: Bool
     public let assistantJoinStatus: AssistantJoinStatus?
+    public let hasHadVerifiedAssistant: Bool
 }
 
 public extension Conversation {
@@ -120,6 +121,10 @@ public extension Conversation {
 
     var hasVerifiedAssistant: Bool {
         members.contains(where: \.agentVerification.isConvosAssistant)
+    }
+
+    var hasEverHadVerifiedAssistant: Bool {
+        hasHadVerifiedAssistant
     }
 
     var hasVerifiedAgent: Bool {

--- a/ConvosCore/Sources/ConvosCore/Storage/Repositories/AssistantFilesLinksRepository.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Repositories/AssistantFilesLinksRepository.swift
@@ -1,0 +1,154 @@
+import Foundation
+import GRDB
+
+public struct AssistantFile: Sendable, Hashable, Identifiable {
+    public let id: String
+    public let filename: String?
+    public let mimeType: String?
+    public let date: Date
+    public let attachmentKey: String
+    public let thumbnailDataBase64: String?
+
+    public var displayName: String {
+        filename ?? "Untitled"
+    }
+
+    public var formattedDate: String {
+        date.formatted(.dateTime.month(.defaultDigits).day(.defaultDigits).year(.twoDigits))
+    }
+
+    public var mediaType: MediaType {
+        guard let mimeType else { return .file }
+        if mimeType.hasPrefix("image/") { return .image }
+        if mimeType.hasPrefix("video/") { return .video }
+        if mimeType.hasPrefix("audio/") { return .audio }
+        return .file
+    }
+}
+
+public struct AssistantLink: Sendable, Hashable, Identifiable {
+    public let id: String
+    public let url: String
+    public let title: String?
+    public let siteName: String?
+    public let imageURL: String?
+    public let date: Date
+
+    public var displayTitle: String {
+        title ?? displayHost
+    }
+
+    public var displayHost: String {
+        URL(string: url)?.host ?? url
+    }
+
+    public var formattedDate: String {
+        date.formatted(.dateTime.month(.defaultDigits).day(.defaultDigits).year(.twoDigits))
+    }
+
+    public var resolvedURL: URL? {
+        URL(string: url)
+    }
+}
+
+public final class AssistantFilesLinksRepository: Sendable {
+    private let dbReader: any DatabaseReader
+    private let conversationId: String
+
+    public init(dbReader: any DatabaseReader, conversationId: String) {
+        self.dbReader = dbReader
+        self.conversationId = conversationId
+    }
+
+    public func fetchFiles() async throws -> [AssistantFile] {
+        try await dbReader.read { [conversationId] db in
+            let rows = try Row.fetchAll(db, sql: """
+                SELECT m.id, m.date, m.attachmentUrls
+                FROM message m
+                INNER JOIN memberProfile mp
+                    ON mp.inboxId = m.senderId AND mp.conversationId = m.conversationId
+                WHERE m.conversationId = ?
+                    AND m.contentType = 'attachments'
+                    AND mp.memberKind IN ('agent', 'agent:convos', 'agent:user-oauth')
+                ORDER BY m.date DESC
+                """,
+                arguments: [conversationId]
+            )
+
+            return rows.compactMap { row -> AssistantFile? in
+                guard let id: String = row["id"],
+                      let date: Date = row["date"],
+                      let attachmentUrlsJson: String = row["attachmentUrls"],
+                      let keys = try? JSONDecoder().decode([String].self, from: Data(attachmentUrlsJson.utf8)),
+                      let firstKey = keys.first
+                else { return nil }
+
+                let stored = try? StoredRemoteAttachment.fromJSON(firstKey)
+                return AssistantFile(
+                    id: id,
+                    filename: stored?.filename,
+                    mimeType: stored?.mimeType,
+                    date: date,
+                    attachmentKey: firstKey,
+                    thumbnailDataBase64: stored?.thumbnailDataBase64
+                )
+            }
+        }
+    }
+
+    public func fetchLinks() async throws -> [AssistantLink] {
+        try await dbReader.read { [conversationId] db in
+            let rows = try Row.fetchAll(db, sql: """
+                SELECT m.id, m.date, m.linkPreview
+                FROM message m
+                INNER JOIN memberProfile mp
+                    ON mp.inboxId = m.senderId AND mp.conversationId = m.conversationId
+                WHERE m.conversationId = ?
+                    AND m.contentType = 'linkPreview'
+                    AND mp.memberKind IN ('agent', 'agent:convos', 'agent:user-oauth')
+                ORDER BY m.date DESC
+                """,
+                arguments: [conversationId]
+            )
+
+            return rows.compactMap { row -> AssistantLink? in
+                guard let id: String = row["id"],
+                      let date: Date = row["date"],
+                      let linkPreviewJson: String = row["linkPreview"],
+                      let data = linkPreviewJson.data(using: .utf8),
+                      let preview = try? JSONDecoder().decode(LinkPreview.self, from: data)
+                else { return nil }
+                return AssistantLink(
+                    id: id,
+                    url: preview.url,
+                    title: preview.title,
+                    siteName: preview.siteName,
+                    imageURL: preview.imageURL,
+                    date: date
+                )
+            }
+        }
+    }
+
+    public func hasContent() async -> Bool {
+        do {
+            return try await dbReader.read { [conversationId] db in
+                let count = try Int.fetchOne(db, sql: """
+                    SELECT COUNT(*)
+                    FROM message m
+                    INNER JOIN memberProfile mp
+                        ON mp.inboxId = m.senderId AND mp.conversationId = m.conversationId
+                    WHERE m.conversationId = ?
+                        AND m.contentType IN ('attachments', 'linkPreview')
+                        AND mp.memberKind IN ('agent', 'agent:convos', 'agent:user-oauth')
+                    LIMIT 1
+                    """,
+                    arguments: [conversationId]
+                )
+                return (count ?? 0) > 0
+            }
+        } catch {
+            return false
+        }
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Storage/Repositories/AssistantFilesLinksRepository.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Repositories/AssistantFilesLinksRepository.swift
@@ -1,5 +1,6 @@
 import Foundation
 import GRDB
+import UniformTypeIdentifiers
 
 public struct AssistantFile: Sendable, Hashable, Identifiable {
     public let id: String
@@ -83,14 +84,14 @@ public final class AssistantFilesLinksRepository: Sendable {
                       let firstKey = keys.first
                 else { return nil }
 
-                let stored = try? StoredRemoteAttachment.fromJSON(firstKey)
+                let parsed = Self.parseAttachmentKey(firstKey)
                 return AssistantFile(
                     id: id,
-                    filename: stored?.filename,
-                    mimeType: stored?.mimeType,
+                    filename: parsed.filename,
+                    mimeType: parsed.mimeType,
                     date: date,
                     attachmentKey: firstKey,
-                    thumbnailDataBase64: stored?.thumbnailDataBase64
+                    thumbnailDataBase64: parsed.thumbnailDataBase64
                 )
             }
         }
@@ -128,6 +129,41 @@ public final class AssistantFilesLinksRepository: Sendable {
                 )
             }
         }
+    }
+
+    private struct ParsedAttachment {
+        let filename: String?
+        let mimeType: String?
+        let thumbnailDataBase64: String?
+    }
+
+    private static func parseAttachmentKey(_ key: String) -> ParsedAttachment {
+        if let stored = try? StoredRemoteAttachment.fromJSON(key) {
+            return ParsedAttachment(
+                filename: stored.filename,
+                mimeType: stored.mimeType,
+                thumbnailDataBase64: stored.thumbnailDataBase64
+            )
+        }
+
+        if key.hasPrefix("file://") {
+            let url = URL(string: key) ?? URL(fileURLWithPath: String(key.dropFirst(7)))
+            let name = url.lastPathComponent
+            var filename: String
+            if let underscoreIndex = name.firstIndex(of: "_") {
+                filename = String(name[name.index(after: underscoreIndex)...])
+            } else {
+                filename = name
+            }
+            var mimeType: String?
+            let ext = (filename as NSString).pathExtension.lowercased()
+            if !ext.isEmpty, let utType = UTType(filenameExtension: ext) {
+                mimeType = utType.preferredMIMEType
+            }
+            return ParsedAttachment(filename: filename, mimeType: mimeType, thumbnailDataBase64: nil)
+        }
+
+        return ParsedAttachment(filename: nil, mimeType: nil, thumbnailDataBase64: nil)
     }
 
     public func hasContent() async -> Bool {

--- a/ConvosCore/Sources/ConvosCore/Storage/Repositories/AssistantFilesLinksRepository.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Repositories/AssistantFilesLinksRepository.swift
@@ -58,11 +58,15 @@ public final class AssistantFilesLinksRepository: Sendable {
             let rows = try Row.fetchAll(db, sql: """
                 SELECT m.id, m.date, m.attachmentUrls
                 FROM message m
-                INNER JOIN memberProfile mp
-                    ON mp.inboxId = m.senderId AND mp.conversationId = m.conversationId
                 WHERE m.conversationId = ?
                     AND m.contentType = 'attachments'
-                    AND mp.memberKind IN ('agent', 'agent:convos', 'agent:user-oauth')
+                    AND EXISTS (
+                        SELECT 1
+                        FROM memberProfile mp
+                        WHERE mp.conversationId = m.conversationId
+                            AND mp.inboxId = m.senderId
+                            AND mp.memberKind IN ('agent:convos', 'agent:user-oauth')
+                    )
                 ORDER BY m.date DESC
                 """,
                 arguments: [conversationId]
@@ -94,11 +98,15 @@ public final class AssistantFilesLinksRepository: Sendable {
             let rows = try Row.fetchAll(db, sql: """
                 SELECT m.id, m.date, m.linkPreview
                 FROM message m
-                INNER JOIN memberProfile mp
-                    ON mp.inboxId = m.senderId AND mp.conversationId = m.conversationId
                 WHERE m.conversationId = ?
                     AND m.contentType = 'linkPreview'
-                    AND mp.memberKind IN ('agent', 'agent:convos', 'agent:user-oauth')
+                    AND EXISTS (
+                        SELECT 1
+                        FROM memberProfile mp
+                        WHERE mp.conversationId = m.conversationId
+                            AND mp.inboxId = m.senderId
+                            AND mp.memberKind IN ('agent:convos', 'agent:user-oauth')
+                    )
                 ORDER BY m.date DESC
                 """,
                 arguments: [conversationId]
@@ -141,9 +149,10 @@ public final class AssistantFilesLinksRepository: Sendable {
         if key.hasPrefix("file://") {
             let url = URL(string: key) ?? URL(fileURLWithPath: String(key.dropFirst(7)))
             let name = url.lastPathComponent
-            var filename: String
+            let filename: String
             if let underscoreIndex = name.firstIndex(of: "_") {
-                filename = String(name[name.index(after: underscoreIndex)...])
+                let candidate = String(name[name.index(after: underscoreIndex)...])
+                filename = candidate.isEmpty ? name : candidate
             } else {
                 filename = name
             }

--- a/ConvosCore/Sources/ConvosCore/Storage/Repositories/AssistantFilesLinksRepository.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Repositories/AssistantFilesLinksRepository.swift
@@ -17,14 +17,6 @@ public struct AssistantFile: Sendable, Hashable, Identifiable {
     public var formattedDate: String {
         date.formatted(.dateTime.month(.defaultDigits).day(.defaultDigits).year(.twoDigits))
     }
-
-    public var mediaType: MediaType {
-        guard let mimeType else { return .file }
-        if mimeType.hasPrefix("image/") { return .image }
-        if mimeType.hasPrefix("video/") { return .video }
-        if mimeType.hasPrefix("audio/") { return .audio }
-        return .file
-    }
 }
 
 public struct AssistantLink: Sendable, Hashable, Identifiable {
@@ -164,27 +156,5 @@ public final class AssistantFilesLinksRepository: Sendable {
         }
 
         return ParsedAttachment(filename: nil, mimeType: nil, thumbnailDataBase64: nil)
-    }
-
-    public func hasContent() async -> Bool {
-        do {
-            return try await dbReader.read { [conversationId] db in
-                let count = try Int.fetchOne(db, sql: """
-                    SELECT COUNT(*)
-                    FROM message m
-                    INNER JOIN memberProfile mp
-                        ON mp.inboxId = m.senderId AND mp.conversationId = m.conversationId
-                    WHERE m.conversationId = ?
-                        AND m.contentType IN ('attachments', 'linkPreview')
-                        AND mp.memberKind IN ('agent', 'agent:convos', 'agent:user-oauth')
-                    LIMIT 1
-                    """,
-                    arguments: [conversationId]
-                )
-                return (count ?? 0) > 0
-            }
-        } catch {
-            return false
-        }
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Storage/Repositories/MessagesRepository.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Repositories/MessagesRepository.swift
@@ -768,7 +768,8 @@ private extension LightweightConversationDetails {
             expiresAt: conversation.expiresAt,
             debugInfo: conversation.debugInfo,
             isLocked: conversation.isLocked,
-            assistantJoinStatus: nil
+            assistantJoinStatus: nil,
+            hasHadVerifiedAssistant: conversation.hasHadVerifiedAssistant
         )
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Storage/SharedDatabaseMigrator.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/SharedDatabaseMigrator.swift
@@ -351,6 +351,12 @@ extension SharedDatabaseMigrator {
             }
         }
 
+        migrator.registerMigration("addHasHadVerifiedAssistantToConversation") { db in
+            try db.alter(table: "conversation") { t in
+                t.add(column: "hasHadVerifiedAssistant", .boolean).notNull().defaults(to: false)
+            }
+        }
+
         migrator.registerMigration("addAssetRenewalColumns") { db in
             try db.alter(table: "memberProfile") { t in
                 t.add(column: "avatarLastRenewed", .datetime)

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationWriter.swift
@@ -163,7 +163,8 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
                 imageNonce: nil,
                 imageEncryptionKey: nil,
                 imageLastRenewed: nil,
-                isUnused: false
+                isUnused: false,
+                hasHadVerifiedAssistant: false
             )
             try conversation.save(db)
             let memberProfile = DBMemberProfile(
@@ -303,6 +304,7 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
         let expiresAt: Date?
         let debugInfo: ConversationDebugInfo
         let isLocked: Bool
+        let hasHadVerifiedAssistant: Bool
     }
 
     private func extractConversationMetadata(from conversation: XMTPiOS.Group) async throws -> ConversationMetadata {
@@ -323,7 +325,8 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
             imageEncryptionKey: imageEncryptionKey,
             expiresAt: try conversation.expiresAt,
             debugInfo: debugInfo,
-            isLocked: isLocked
+            isLocked: isLocked,
+            hasHadVerifiedAssistant: false
         )
     }
 
@@ -364,7 +367,8 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
             imageNonce: metadata.imageNonce,
             imageEncryptionKey: metadata.imageEncryptionKey,
             imageLastRenewed: imageLastRenewed,
-            isUnused: false
+            isUnused: false,
+            hasHadVerifiedAssistant: metadata.hasHadVerifiedAssistant
         )
     }
 
@@ -470,6 +474,12 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
             preservedInviteTag = existingConversation.inviteTag
         } else {
             preservedInviteTag = nil
+        }
+
+        if let existingConversation {
+            conversationToSave = conversationToSave.with(
+                hasHadVerifiedAssistant: existingConversation.hasHadVerifiedAssistant || conversationToSave.hasHadVerifiedAssistant
+            )
         }
 
         let existingConversationByTag: DBConversation?
@@ -769,6 +779,12 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
             }
         }
         try profile.save(db)
+
+        if profile.agentVerification.isConvosAssistant,
+           let conversation = try DBConversation.fetchOne(db, id: conversationId),
+           !conversation.hasHadVerifiedAssistant {
+            try conversation.with(hasHadVerifiedAssistant: true).save(db)
+        }
     }
 
     private func getLastMessageTimestamp(for conversationId: String) async throws -> Int64? {

--- a/ConvosCore/Sources/ConvosCore/Syncing/InviteJoinRequestsManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/InviteJoinRequestsManager.swift
@@ -130,6 +130,12 @@ final class InviteJoinRequestsManager: InviteJoinRequestsManagerProtocol, Sendab
                     metadata: profileMetadata
                 )
                 try dbProfile.save(db)
+
+                if dbProfile.agentVerification.isConvosAssistant,
+                   let conversation = try DBConversation.fetchOne(db, id: result.conversationId),
+                   !conversation.hasHadVerifiedAssistant {
+                    try conversation.with(hasHadVerifiedAssistant: true).save(db)
+                }
             }
             Log.debug("Persisted join request profile for \(result.joinerInboxId) in \(result.conversationId)")
         } catch {

--- a/ConvosCore/Sources/ConvosCore/Syncing/StreamProcessor.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/StreamProcessor.swift
@@ -405,6 +405,7 @@ actor StreamProcessor: StreamProcessorProtocol {
                 }
 
                 try profile.save(db)
+                try Self.markConversationHasVerifiedAssistantIfNeeded(profile: profile, conversationId: conversationId, db: db)
             }
             Log.debug("Processed ProfileUpdate from \(senderInboxId) in \(conversationId)")
         } catch {
@@ -468,12 +469,24 @@ actor StreamProcessor: StreamProcessorProtocol {
                     }
 
                     try profile.save(db)
+                    try Self.markConversationHasVerifiedAssistantIfNeeded(profile: profile, conversationId: conversationId, db: db)
                 }
             }
             Log.debug("Processed ProfileSnapshot with \(snapshot.profiles.count) profiles in \(conversationId)")
         } catch {
             Log.error("Failed to process ProfileSnapshot: \(error.localizedDescription)")
         }
+    }
+
+    private static func markConversationHasVerifiedAssistantIfNeeded(
+        profile: DBMemberProfile,
+        conversationId: String,
+        db: Database
+    ) throws {
+        guard profile.agentVerification.isConvosAssistant,
+              let conversation = try DBConversation.fetchOne(db, id: conversationId),
+              !conversation.hasHadVerifiedAssistant else { return }
+        try conversation.with(hasHadVerifiedAssistant: true).save(db)
     }
 
     private func sendInitialProfileSnapshot(group: XMTPiOS.Group) async {

--- a/Scripts/hooks/pre-commit
+++ b/Scripts/hooks/pre-commit
@@ -20,25 +20,28 @@ elif [ -d "/usr/local/bin" ]; then
 fi
 
 # Get staged Swift files (excluding deleted files and build directories)
-STAGED_SWIFT_FILES=$(git diff --cached --name-only --diff-filter=d | grep '\.swift$' || true)
-STAGED_SWIFT_FILES=$(echo "$STAGED_SWIFT_FILES" | grep -v -E '^\.derivedData/|^\.build/|/\.build/' || true)
+mapfile -t STAGED_SWIFT_FILES < <(
+    git diff --cached --name-only --diff-filter=d |
+        grep '\.swift$' |
+        grep -v -E '^\.derivedData/|^\.build/|/\.build/' || true
+)
 
-if [ -z "$STAGED_SWIFT_FILES" ]; then
+if [ ${#STAGED_SWIFT_FILES[@]} -eq 0 ]; then
     echo -e "${GREEN}✓ No Swift files staged, skipping checks${NC}"
     exit 0
 fi
 
-echo "📝 Checking $(echo "$STAGED_SWIFT_FILES" | wc -l | tr -d ' ') Swift file(s)"
+echo "📝 Checking ${#STAGED_SWIFT_FILES[@]} Swift file(s)"
 
 # Check if SwiftFormat is available
 if command -v swiftformat &> /dev/null; then
     echo "🎨 Running SwiftFormat..."
-    while IFS= read -r file; do
+    for file in "${STAGED_SWIFT_FILES[@]}"; do
         if [ -f "$file" ]; then
             swiftformat "$file"
             git add "$file"
         fi
-    done <<< "$STAGED_SWIFT_FILES"
+    done
 else
     echo -e "${YELLOW}⚠ SwiftFormat not found, skipping formatting${NC}"
 fi
@@ -48,7 +51,7 @@ if command -v swiftlint &> /dev/null; then
     echo "🔎 Running SwiftLint..."
 
     LINT_ERRORS=0
-    while IFS= read -r file; do
+    for file in "${STAGED_SWIFT_FILES[@]}"; do
         if [ -f "$file" ]; then
             # Run SwiftLint with auto-fix
             swiftlint lint --fix "$file" 2>/dev/null || true
@@ -62,7 +65,7 @@ if command -v swiftlint &> /dev/null; then
                 echo -e "${RED}✗ Lint errors in: $file${NC}"
             fi
         fi
-    done <<< "$STAGED_SWIFT_FILES"
+    done
 
     if [ $LINT_ERRORS -gt 0 ]; then
         echo -e "${RED}✗ SwiftLint found errors that couldn't be auto-fixed${NC}"


### PR DESCRIPTION
## Summary
- add a Files & Links row to Conversation Info when a verified assistant is present
- add a Files & Links screen with tabs for assistant-shared files and links plus search
- reuse shared UIKit Quick Look presentation for file previews from both the messages list and the new assistant file list

## Details
- queries assistant-sent attachments and link previews from the conversation database
- parses both inline file:// attachment keys and remote attachment JSON for filenames and mime types
- file rows now open Quick Look instead of showing a download affordance
- link rows use the Safari icon

## Testing
- xcodebuild build -project Convos.xcodeproj -scheme "Convos (Dev)" -destination "platform=iOS Simulator,name=convos-jarod-assistant-files-links" -derivedDataPath .derivedData
- swiftlint on changed files

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add assistant files and links view to conversation info screen
> - Adds `AssistantFilesLinksView`, a new screen where users can browse, search, and open assistant-managed files (via Quick Look) and links (via system browser), accessible from the Conversation Info screen when the conversation has ever had a verified assistant.
> - Introduces `AssistantFilesLinksRepository` to fetch assistant files and links from the database by querying stored messages for a given conversation.
> - Tracks whether a conversation has ever had a verified assistant via a new `hasHadVerifiedAssistant` boolean column on the `conversation` table, set to `true` by `ConversationWriter`, `StreamProcessor`, `InviteJoinRequestsManager`, and the NSE messaging service when a verified Convos Assistant is detected.
> - Refactors file attachment preview in `MessagesViewController` to use a new `FileAttachmentPreviewLoader` + `QuickLookSheetPresenter`, replacing the previous in-controller `QLPreviewController` data source/delegate approach.
> - Risk: adds a new database migration (`addHasHadVerifiedAssistantToConversation`); existing conversations default to `false` and are only upgraded when agent verification runs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a9636f3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->