### PR TITLE
Fix type-check timeouts in MessageContextMenuOverlay and ConversationInfoView

### DIFF
--- a/Convos/Conversation Detail/ConversationInfoView.swift
+++ b/Convos/Conversation Detail/ConversationInfoView.swift
@@ -353,6 +353,10 @@ struct ConversationInfoView: View {
     }
 
     var body: some View {
+        infoContent
+    }
+
+    private var infoContent: some View {
         NavigationStack {
             List {
                 headerSection

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessageContextMenu/MessageContextMenuOverlay.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessageContextMenu/MessageContextMenuOverlay.swift
@@ -86,87 +86,92 @@ struct MessageContextMenuOverlay: View {
 
     var body: some View {
         if let message = state.presentedMessage {
-            GeometryReader { proxy in
-                let overlayOrigin = proxy.frame(in: .global).origin
-                let screenSize = proxy.size
-                let safeTop = max(proxy.safeAreaInsets.top, windowSafeTop)
-                let localBubble = CGRect(
-                    x: state.bubbleFrame.origin.x - overlayOrigin.x,
-                    y: state.bubbleFrame.origin.y - overlayOrigin.y,
-                    width: state.bubbleFrame.width,
-                    height: state.bubbleFrame.height
+            overlayContent(message: message)
+        }
+    }
+
+    @ViewBuilder
+    private func overlayContent(message: AnyMessage) -> some View {
+        GeometryReader { proxy in
+            let overlayOrigin = proxy.frame(in: .global).origin
+            let screenSize = proxy.size
+            let safeTop = max(proxy.safeAreaInsets.top, windowSafeTop)
+            let localBubble = CGRect(
+                x: state.bubbleFrame.origin.x - overlayOrigin.x,
+                y: state.bubbleFrame.origin.y - overlayOrigin.y,
+                width: state.bubbleFrame.width,
+                height: state.bubbleFrame.height
+            )
+            let isPhoto = photoAttachment != nil
+            let endBubble = endBubbleRect(
+                source: localBubble,
+                screenSize: screenSize,
+                safeTop: safeTop,
+                isPhoto: isPhoto && !state.isReplyParent
+            )
+            let activeBubble = appeared ? endBubble : localBubble
+            let keyboardTop: CGFloat = keyboardHeight > 0 ? screenSize.height - keyboardHeight : screenSize.height
+            let bubbleBottom = activeBubble.maxY + C.sectionSpacing
+            let keyboardOverlap = max(bubbleBottom - keyboardTop + C.sectionSpacing, 0)
+            let keyboardAdjustment: CGFloat = showingEmojiPicker ? keyboardOverlap : 0
+
+            ZStack(alignment: .topLeading) {
+                backgroundDimming
+
+                reactionsBar(
+                    messageId: message.messageId,
+                    bubbleRect: activeBubble,
+                    sourceBubble: localBubble,
+                    keyboardAdjustment: keyboardAdjustment,
+                    minBarY: safeTop
                 )
-                let isPhoto = photoAttachment != nil
-                let endBubble = endBubbleRect(
-                    source: localBubble,
-                    screenSize: screenSize,
-                    safeTop: safeTop,
-                    isPhoto: isPhoto && !state.isReplyParent
+                .zIndex(1)
+
+                actionMenu(
+                    message: message,
+                    bubbleRect: activeBubble
                 )
-                let activeBubble = appeared ? endBubble : localBubble
-                let keyboardTop = keyboardHeight > 0 ? screenSize.height - keyboardHeight : screenSize.height
-                let bubbleBottom = activeBubble.maxY + C.sectionSpacing
-                let keyboardOverlap = max(bubbleBottom - keyboardTop + C.sectionSpacing, 0)
-                let keyboardAdjustment = showingEmojiPicker ? keyboardOverlap : 0
+                .zIndex(2)
 
-                ZStack(alignment: .topLeading) {
-                    backgroundDimming
-
-                    reactionsBar(
-                        messageId: message.messageId,
-                        bubbleRect: activeBubble,
-                        sourceBubble: localBubble,
-                        keyboardAdjustment: keyboardAdjustment,
-                        minBarY: safeTop
-                    )
-                    .zIndex(1)
-
-                    actionMenu(
-                        message: message,
-                        bubbleRect: activeBubble
-                    )
-                    .zIndex(2)
-
-                    bubblePreview(
-                        message: message,
-                        sourceBubble: localBubble,
-                        endBubble: endBubble,
-                        keyboardAdjustment: keyboardAdjustment
-                    )
-                    .zIndex(3)
+                bubblePreview(
+                    message: message,
+                    sourceBubble: localBubble,
+                    endBubble: endBubble,
+                    keyboardAdjustment: keyboardAdjustment
+                )
+                .zIndex(3)
+            }
+        }
+        .ignoresSafeArea()
+        .onAppear {
+            UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+            emojiAppeared = Array(repeating: false, count: C.defaultReactions.count)
+            withAnimation(.spring(response: 0.28, dampingFraction: 0.78)) {
+                appeared = true
+            }
+            let totalDelay = C.emojiAppearanceDelayStep * Double(C.defaultReactions.count)
+            DispatchQueue.main.asyncAfter(deadline: .now() + totalDelay) {
+                withAnimation {
+                    showMoreAppeared = true
                 }
             }
-            .ignoresSafeArea()
-            .onAppear {
-                UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
-                emojiAppeared = Array(repeating: false, count: C.defaultReactions.count)
-                withAnimation(.spring(response: 0.28, dampingFraction: 0.78)) {
-                    appeared = true
-                }
-                let totalDelay = C.emojiAppearanceDelayStep * Double(C.defaultReactions.count)
-                DispatchQueue.main.asyncAfter(deadline: .now() + totalDelay) {
+            for index in C.defaultReactions.indices {
+                DispatchQueue.main.asyncAfter(deadline: .now() + C.emojiAppearanceDelayStep * Double(index)) {
                     withAnimation {
-                        showMoreAppeared = true
-                    }
-                }
-                for index in C.defaultReactions.indices {
-                    DispatchQueue.main.asyncAfter(deadline: .now() + C.emojiAppearanceDelayStep * Double(index)) {
-                        withAnimation {
-                            emojiAppeared[index] = true
-                        }
+                        emojiAppeared[index] = true
                     }
                 }
             }
-            .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillShowNotification)) { notification in
-                guard let frame = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect else { return }
-                withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) {
-                    keyboardHeight = frame.height
-                }
+        }
+        .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillShowNotification)) { notification in
+            guard let frame = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect else { return }
+            withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) {
+                keyboardHeight = frame.height
             }
-            .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillHideNotification)) { _ in
-                withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) {
-                    keyboardHeight = 0
-                }
+        }
+        .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillHideNotification)) { _ in
+            withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) {
+                keyboardHeight = 0
             }
         }
     }


### PR DESCRIPTION
## Summary
- Extract complex `body` getter into `overlayContent(message:)` method to fix CI type-check timeout (107ms > 100ms limit)

## Test plan
- [ ] Verify context menu still works (long-press on message, reactions bar, action menu)
- [ ] Verify CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix type-check timeout in `MessageContextMenuOverlay` by extracting overlay logic
> - Extracts the `GeometryReader`/`ZStack` overlay logic from `body` into a new `@ViewBuilder` method `overlayContent(message:)` in [MessageContextMenuOverlay.swift](https://github.com/xmtplabs/convos-ios/pull/695/files#diff-3841c67fb70fc3069c2f14c71cff885be69b673383e92f30a46cbc89b69e6411) to resolve a Swift type-checker timeout.
> - Similarly extracts the `NavigationStack`/`List` content from `body` into a computed `infoContent` property in [ConversationInfoView.swift](https://github.com/xmtplabs/convos-ios/pull/695/files#diff-30ae741e90f8fd3b2d28bd543f330b1bb685d691d37fd1e95edcc8bd87159a2a) for the same reason.
> - Both changes are structural refactors with no change to view hierarchy or runtime behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d1c4380.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->