### PR TITLE
Fix ConversationInfoView type-check timeout in CI

### DIFF
--- a/Convos/Conversation Detail/ConversationInfoView.swift
+++ b/Convos/Conversation Detail/ConversationInfoView.swift
@@ -356,6 +356,40 @@ struct ConversationInfoView: View {
         infoContent
     }
 
+    private var vanishSection: some View {
+        Section {
+            HStack {
+                Text("Vanish")
+                    .foregroundStyle(.colorTextPrimary)
+                Spacer()
+                SoonLabel()
+            }
+        } footer: {
+            Text("Choose when this convo disappears from your device")
+                .foregroundStyle(.colorTextSecondary)
+        }
+        .disabled(true)
+    }
+
+    private var permissionsSection: some View {
+        Section {
+            NavigationLink {
+                EmptyView()
+            } label: {
+                HStack {
+                    Text("Permissions")
+                        .foregroundStyle(.colorTextPrimary)
+                    Spacer()
+                    SoonLabel()
+                }
+            }
+            .disabled(true)
+        } footer: {
+            Text("Choose who can manage the group")
+                .foregroundStyle(.colorTextSecondary)
+        }
+    }
+
     private var infoContent: some View {
         NavigationStack {
             List {
@@ -383,35 +417,9 @@ struct ConversationInfoView: View {
 
                 convoRulesSection
 
-                Section {
-                    HStack {
-                        Text("Vanish")
-                            .foregroundStyle(.colorTextPrimary)
-                        Spacer()
-                        SoonLabel()
-                    }
-                } footer: {
-                    Text("Choose when this convo disappears from your device")
-                        .foregroundStyle(.colorTextSecondary)
-                }
-                .disabled(true)
+                vanishSection
 
-                Section {
-                    NavigationLink {
-                        EmptyView()
-                    } label: {
-                        HStack {
-                            Text("Permissions")
-                                .foregroundStyle(.colorTextPrimary)
-                            Spacer()
-                            SoonLabel()
-                        }
-                    }
-                    .disabled(true)
-                } footer: {
-                    Text("Choose who can manage the group")
-                        .foregroundStyle(.colorTextSecondary)
-                }
+                permissionsSection
 
                 if !ConfigManager.shared.currentEnvironment.isProduction {
                     Section {


### PR DESCRIPTION
## Summary
- Extract `vanishSection` and `permissionsSection` from `infoContent` to stay under the 100ms type-check limit
- Verified locally with `-warn-long-expression-type-checking=100` — zero warnings

## Test plan
- [ ] Verify conversation info screen works
- [ ] Verify CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `ConversationInfoView` type-check timeout in CI by extracting view sections
> Extracts the inlined `vanish` and `permissions` sections in `ConversationInfoView` into private computed properties (`vanishSection` and `permissionsSection`). This reduces the complexity of the `infoContent` body, which resolves a Swift type-checker timeout in CI. No functional or UI changes are introduced.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 292b9fa.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->