### PR TITLE
Fix MessageContextMenuOverlay type-check timeout

### DIFF
--- a/Convos/Conversation Detail/Messages/MessagesListView/MessageContextMenu/MessageContextMenuOverlay.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessageContextMenu/MessageContextMenuOverlay.swift
@@ -92,6 +92,24 @@ struct MessageContextMenuOverlay: View {
 
     @ViewBuilder
     private func overlayContent(message: AnyMessage) -> some View {
+        overlayGeometry(message: message)
+            .ignoresSafeArea()
+            .onAppear { handleAppear() }
+            .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillShowNotification)) { notification in
+                guard let frame = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect else { return }
+                withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) {
+                    keyboardHeight = frame.height
+                }
+            }
+            .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillHideNotification)) { _ in
+                withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) {
+                    keyboardHeight = 0
+                }
+            }
+    }
+
+    @ViewBuilder
+    private func overlayGeometry(message: AnyMessage) -> some View {
         GeometryReader { proxy in
             let overlayOrigin = proxy.frame(in: .global).origin
             let screenSize = proxy.size
@@ -102,17 +120,17 @@ struct MessageContextMenuOverlay: View {
                 width: state.bubbleFrame.width,
                 height: state.bubbleFrame.height
             )
-            let isPhoto = photoAttachment != nil
+            let isPhoto: Bool = photoAttachment != nil
             let endBubble = endBubbleRect(
                 source: localBubble,
                 screenSize: screenSize,
                 safeTop: safeTop,
                 isPhoto: isPhoto && !state.isReplyParent
             )
-            let activeBubble = appeared ? endBubble : localBubble
+            let activeBubble: CGRect = appeared ? endBubble : localBubble
             let keyboardTop: CGFloat = keyboardHeight > 0 ? screenSize.height - keyboardHeight : screenSize.height
-            let bubbleBottom = activeBubble.maxY + C.sectionSpacing
-            let keyboardOverlap = max(bubbleBottom - keyboardTop + C.sectionSpacing, 0)
+            let bubbleBottom: CGFloat = activeBubble.maxY + C.sectionSpacing
+            let keyboardOverlap: CGFloat = max(bubbleBottom - keyboardTop + C.sectionSpacing, 0)
             let keyboardAdjustment: CGFloat = showingEmojiPicker ? keyboardOverlap : 0
 
             ZStack(alignment: .topLeading) {
@@ -140,38 +158,6 @@ struct MessageContextMenuOverlay: View {
                     keyboardAdjustment: keyboardAdjustment
                 )
                 .zIndex(3)
-            }
-        }
-        .ignoresSafeArea()
-        .onAppear {
-            UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
-            emojiAppeared = Array(repeating: false, count: C.defaultReactions.count)
-            withAnimation(.spring(response: 0.28, dampingFraction: 0.78)) {
-                appeared = true
-            }
-            let totalDelay = C.emojiAppearanceDelayStep * Double(C.defaultReactions.count)
-            DispatchQueue.main.asyncAfter(deadline: .now() + totalDelay) {
-                withAnimation {
-                    showMoreAppeared = true
-                }
-            }
-            for index in C.defaultReactions.indices {
-                DispatchQueue.main.asyncAfter(deadline: .now() + C.emojiAppearanceDelayStep * Double(index)) {
-                    withAnimation {
-                        emojiAppeared[index] = true
-                    }
-                }
-            }
-        }
-        .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillShowNotification)) { notification in
-            guard let frame = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect else { return }
-            withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) {
-                keyboardHeight = frame.height
-            }
-        }
-        .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillHideNotification)) { _ in
-            withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) {
-                keyboardHeight = 0
             }
         }
     }
@@ -922,6 +908,31 @@ private struct ContextMenuRow: View {
             .padding(.horizontal, 28)
             .padding(.vertical, 11)
             .contentShape(Rectangle())
+        }
+    }
+}
+
+// MARK: - Appearance
+
+private extension MessageContextMenuOverlay {
+    func handleAppear() {
+        UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+        emojiAppeared = Array(repeating: false, count: C.defaultReactions.count)
+        withAnimation(.spring(response: 0.28, dampingFraction: 0.78)) {
+            appeared = true
+        }
+        let totalDelay = C.emojiAppearanceDelayStep * Double(C.defaultReactions.count)
+        DispatchQueue.main.asyncAfter(deadline: .now() + totalDelay) {
+            withAnimation {
+                showMoreAppeared = true
+            }
+        }
+        for index in C.defaultReactions.indices {
+            DispatchQueue.main.asyncAfter(deadline: .now() + C.emojiAppearanceDelayStep * Double(index)) {
+                withAnimation {
+                    emojiAppeared[index] = true
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- Split `overlayContent` into `overlayGeometry` (GeometryReader + layout) and `handleAppear` (animation setup)
- Added explicit type annotations on computed lets to help the type checker
- Verified locally at 100ms limit — zero errors

## Test plan
- [ ] Long-press a message, verify context menu appears with reactions and actions
- [ ] Verify CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix type-check timeout in `MessageContextMenuOverlay` by extracting layout helpers
> - Splits the monolithic `overlayContent` view builder into a new `overlayGeometry(message:)` helper to reduce Swift type-checker complexity and resolve a compilation timeout.
> - Moves `.ignoresSafeArea()`, `.onAppear`, and keyboard `onReceive` modifiers up to `overlayContent`, while `overlayGeometry` handles only the `GeometryReader` layout tree.
> - Extracts the `onAppear` logic into a new private `handleAppear()` method in [MessageContextMenuOverlay.swift](https://github.com/xmtplabs/convos-ios/pull/697/files#diff-3841c67fb70fc3069c2f14c71cff885be69b673383e92f30a46cbc89b69e6411).
> - Adds explicit type annotations to local variables inside `overlayGeometry` to further aid the type checker.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1560748.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->