### PR TITLE
Fix encrypted profile image not updating after first set

### DIFF
--- a/ConvosCore/Sources/ConvosCore/Image Cache/ImageCache.swift
+++ b/ConvosCore/Sources/ConvosCore/Image Cache/ImageCache.swift
@@ -267,9 +267,13 @@ public final class ImageCache: ImageCacheProtocol, @unchecked Sendable {
             // The prefetcher will update the tracker when it caches the decrypted image
             let peek = await urlTracker.peek(url, for: identifier)
 
-            if peek.changed, let cachedImage = cache.object(forKey: identifier as NSString) {
-                // URL changed - return cached image (if any), prefetcher will handle decryption
-                return cachedImage
+            if peek.changed {
+                // URL changed — fetch and decrypt the new image inline
+                if let image = await fetchEncryptedImageInline(for: object, url: url, identifier: identifier) {
+                    return image
+                }
+                // Fetch failed — fall back to stale cached image rather than blank avatar
+                return cache.object(forKey: identifier as NSString)
             }
 
             // URL unchanged - normal cache lookup

--- a/ConvosCore/Sources/ConvosCore/Image Cache/ImageCache.swift
+++ b/ConvosCore/Sources/ConvosCore/Image Cache/ImageCache.swift
@@ -273,7 +273,7 @@ public final class ImageCache: ImageCacheProtocol, @unchecked Sendable {
                     return image
                 }
                 // Fetch failed — fall back to stale cached image rather than blank avatar
-                return cache.object(forKey: identifier as NSString)
+                return await loadImageFromCache(identifier: identifier, source: "loadImage (encrypted fallback)")
             }
 
             // URL unchanged - normal cache lookup

--- a/ConvosCore/Tests/ConvosCoreTests/ImageCacheTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ImageCacheTests.swift
@@ -725,6 +725,40 @@ struct EncryptedImageColdStartTests {
         // Cleanup
         cache2.removeImage(for: identifier)
     }
+
+    @Test("Encrypted image falls back to stale disk cache when inline fetch fails after URL change")
+    func encryptedImageFallsBackToStaleDiskCacheWhenInlineFetchFails() async throws {
+        let cache = ImageCache()
+        let identifier = "encrypted-fallback-\(UUID().uuidString)"
+        let staleURL = URL(string: "https://example.com/encrypted-avatar-v1.jpg")!
+        let newURL = URL(string: "https://example.com/encrypted-avatar-v2.jpg")!
+        let staleImage = createTestImage(color: .purple)
+
+        cache.cacheAfterUpload(staleImage, for: identifier, url: staleURL.absoluteString)
+        try await Task.sleep(nanoseconds: 500_000_000)
+
+        let cache2 = ImageCache()
+
+        struct EncryptedCacheable: ImageCacheable {
+            let imageCacheIdentifier: String
+            let imageCacheURL: URL?
+            let isEncryptedImage: Bool = true
+            let encryptionKey: Data? = nil
+            let encryptionSalt: Data? = nil
+            let encryptionNonce: Data? = nil
+        }
+
+        let encryptedCacheable = EncryptedCacheable(
+            imageCacheIdentifier: identifier,
+            imageCacheURL: newURL
+        )
+
+        let loadedImage = await cache2.loadImage(for: encryptedCacheable)
+
+        #expect(loadedImage != nil, "Should fall back to stale disk-cached image when inline fetch fails")
+
+        cache2.removeImage(for: identifier)
+    }
 }
 
 // MARK: - URL Tracking Behavior Tests


### PR DESCRIPTION
## Summary

- When an encrypted profile image URL changes (e.g. agent updates its avatar), the new image is now fetched and decrypted inline instead of returning the stale cached version

## Why

`loadImage()` had a code path for encrypted images where, if the URL changed but a cached image already existed, it returned the stale cached image immediately with a comment saying "prefetcher will handle decryption." But no prefetcher runs for streamed `ProfileUpdate` messages — only during full conversation sync. This meant the first profile image worked (no cached image → inline fetch) but every subsequent update was invisible to the user.

Traced from xmtplabs/convos-assistants#967 — the CLI correctly sends multiple `ProfileUpdate` messages with different encrypted image URLs, and the backend CDN gets updated, but the iOS app kept showing the first image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix encrypted profile image not updating after first URL change
> When an encrypted image URL changes, `ImageCache.loadImage(for:)` previously returned nothing if the image wasn't in memory. It now attempts to fetch and decrypt the new image inline, and falls back to the stale disk cache on failure rather than returning nil. A new test in [ImageCacheTests.swift](https://github.com/xmtplabs/convos-ios/pull/699/files#diff-46748de2913dea33414155df5d013713e957dacf1ada5c7e5c7cefb8baf3fb8a) validates the stale-cache fallback path.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 696dfd7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->