### PR TITLE
Harden markdown preview follow-ups

### DIFF
--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/MessagesViewController.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/MessagesViewController.swift
@@ -1109,7 +1109,21 @@ private struct MarkdownAttachmentPreviewSheet: View {
                 div.querySelectorAll('*').forEach(function(el) {
                     el.getAttributeNames().filter(function(n) { return n.startsWith('on'); }).forEach(function(n) { el.removeAttribute(n); });
                 });
-                div.querySelectorAll('a[href^="javascript:"]').forEach(function(el) { el.removeAttribute('href'); });
+                div.querySelectorAll('a').forEach(function(el) {
+                    var href = el.getAttribute('href');
+                    if (!href) {
+                        return;
+                    }
+                    try {
+                        var parsed = new URL(href, 'https://example.invalid');
+                        var scheme = parsed.protocol.toLowerCase();
+                        if (scheme !== 'http:' && scheme !== 'https:' && scheme !== 'mailto:') {
+                            el.removeAttribute('href');
+                        }
+                    } catch (e) {
+                        el.removeAttribute('href');
+                    }
+                });
                 document.getElementById('content').innerHTML = div.innerHTML;
             </script>
             </body>
@@ -1159,11 +1173,18 @@ private struct MarkdownWebView: UIViewRepresentable {
             _ webView: WKWebView,
             decidePolicyFor navigationAction: WKNavigationAction
         ) async -> WKNavigationActionPolicy {
-            if navigationAction.navigationType == .linkActivated, let url = navigationAction.request.url {
-                await UIApplication.shared.open(url)
+            guard navigationAction.navigationType == .linkActivated,
+                  let url = navigationAction.request.url else {
+                return .allow
+            }
+
+            guard let scheme = url.scheme?.lowercased(),
+                  ["http", "https", "mailto"].contains(scheme) else {
                 return .cancel
             }
-            return .allow
+
+            await UIApplication.shared.open(url)
+            return .cancel
         }
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/HydratedAttachment.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/HydratedAttachment.swift
@@ -60,7 +60,8 @@ public struct HydratedAttachment: Hashable, Codable, Sendable {
             return true
         }
         guard let mimeType else { return false }
-        return mimeType == "text/markdown" || mimeType == "text/x-markdown"
+        let normalizedMimeType = mimeType.lowercased()
+        return normalizedMimeType == "text/markdown" || normalizedMimeType == "text/x-markdown"
     }
 
     public var mediaType: MediaType {

--- a/ConvosCore/Tests/ConvosCoreTests/HydratedAttachmentTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/HydratedAttachmentTests.swift
@@ -33,6 +33,14 @@ struct HydratedAttachmentIsMarkdownFileTests {
         #expect(attachment.isMarkdownFile)
     }
 
+    @Test("detects markdown mime types case-insensitively")
+    func markdownMimeCaseInsensitive() {
+        let markdown = HydratedAttachment(key: "test", mimeType: "Text/Markdown", filename: "file")
+        let xMarkdown = HydratedAttachment(key: "test", mimeType: "TEXT/X-MARKDOWN", filename: "file")
+        #expect(markdown.isMarkdownFile)
+        #expect(xMarkdown.isMarkdownFile)
+    }
+
     @Test("returns false for non-markdown files")
     func nonMarkdown() {
         let pdf = HydratedAttachment(key: "test", filename: "document.pdf")


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Harden markdown preview link handling and MIME type detection
- Strips hrefs from anchor tags in the markdown preview HTML unless the scheme is `http`, `https`, or `mailto`; malformed or missing hrefs are also removed
- Blocks navigation to non-http/https/mailto URLs in `MarkdownWebView`'s `WKNavigationDelegate`, preventing other schemes from being opened externally
- Normalizes `mimeType` to lowercase in `HydratedAttachment.isMarkdownFile` so markdown attachments are detected regardless of MIME type casing (e.g. `Text/Markdown`)

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 22dc936.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->