### PR TITLE
Fix DM avatar priority over conversation emoji

### DIFF
--- a/ConvosCore/Sources/ConvosCore/Storage/Models/Conversation.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/Conversation.swift
@@ -86,12 +86,12 @@ public extension Conversation {
         if imageURL != nil {
             return .customImage
         }
-        if let conversationEmoji, !conversationEmoji.isEmpty {
-            return .emoji(conversationEmoji)
-        }
         let otherMembers = membersWithoutCurrent
         if otherMembers.count == 1, let member = otherMembers.first {
             return .profile(member.profile, member.agentVerification)
+        }
+        if let conversationEmoji, !conversationEmoji.isEmpty {
+            return .emoji(conversationEmoji)
         }
         let otherProfiles = otherMembers.map(\.profile)
         if otherProfiles.isEmpty || !otherProfiles.hasAnyAvatar {

--- a/ConvosCore/Tests/ConvosCoreTests/DefaultConversationDisplayTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/DefaultConversationDisplayTests.swift
@@ -294,6 +294,53 @@ struct DefaultConversationDisplayTests {
         #expect(conversation.avatarType == .customImage)
     }
 
+    @Test("avatarType returns profile for DM even when conversation emoji exists")
+    func avatarTypeProfileForDMWithConversationEmoji() {
+        let members = [
+            ConversationMember.mock(isCurrentUser: true, name: "You"),
+            ConversationMember.mock(isCurrentUser: false, name: "Alice")
+        ]
+        let conversation = Conversation(
+            id: "test",
+            clientConversationId: "client-test",
+            inboxId: "inbox",
+            clientId: "client",
+            creator: .mock(isCurrentUser: true),
+            createdAt: Date(),
+            consent: .allowed,
+            kind: .dm,
+            name: nil,
+            description: nil,
+            members: members,
+            otherMember: members.first(where: { !$0.isCurrentUser }),
+            messages: [],
+            isPinned: false,
+            isUnread: false,
+            isMuted: false,
+            pinnedOrder: nil,
+            lastMessage: nil,
+            imageURL: nil,
+            imageSalt: nil,
+            imageNonce: nil,
+            imageEncryptionKey: nil,
+            conversationEmoji: "🦊",
+            includeInfoInPublicPreview: false,
+            isDraft: false,
+            invite: nil,
+            expiresAt: nil,
+            debugInfo: .empty,
+            isLocked: false,
+            assistantJoinStatus: nil,
+            hasHadVerifiedAssistant: false
+        )
+
+        if case .profile(let profile, _) = conversation.avatarType {
+            #expect(profile.inboxId == "mock-inbox-id-other")
+        } else {
+            #expect(Bool(false), "Expected DM avatar to use other member profile before conversation emoji")
+        }
+    }
+
     @Test("avatarType returns emoji for fully anonymous group")
     func avatarTypeEmojiForAnonymous() {
         let members = [


### PR DESCRIPTION
## Summary\n- restore DM avatar priority so a 1:1 conversation shows the other member's profile/avatar before any conversation emoji\n- keep conversation emoji behavior for groups and fallback cases\n- add a regression test covering the DM + conversationEmoji case\n\n## Validation\n- swiftlint --strict\n- xcodebuild build -project Convos.xcodeproj -scheme "Convos (Dev)" -destination "platform=iOS Simulator,name=convos-jarod-stable-conversation-emoji-bugfixes" -derivedDataPath .derivedData\n

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `avatarType` to prioritize profile avatar over conversation emoji in DMs
> In [`Conversation.avatarType`](https://github.com/xmtplabs/convos-ios/pull/701/files#diff-0f2282bb29485aa591c36f01b7679dc5a8a33d489f6535e6c332d8f13da0b859), the profile avatar branch for one-on-one conversations now runs before the conversation emoji check. Previously, if a DM had a conversation emoji set, it would return the emoji instead of the other member's profile avatar.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1ede988.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->