### PR TITLE
Fix file preview regression

### DIFF
--- a/Convos/Conversation Detail/AssistantFilesLinksView.swift
+++ b/Convos/Conversation Detail/AssistantFilesLinksView.swift
@@ -161,7 +161,9 @@ struct AssistantFilesLinksView: View {
                         filename: file.filename
                     )
                     await MainActor.run {
-                        QuickLookSheetPresenter.present(fileURL: url)
+                        if let presenter = UIApplication.shared.topMostViewController() {
+                            FileAttachmentQuickLookCoordinator.shared.present(fileURL: url, from: presenter)
+                        }
                     }
                 } catch {
                     Log.error("Failed to open assistant file: \(error)")

--- a/Convos/Conversation Detail/FileAttachmentQuickLook.swift
+++ b/Convos/Conversation Detail/FileAttachmentQuickLook.swift
@@ -1,75 +1,53 @@
 import ConvosCore
 import QuickLook
-import SwiftUI
 import UIKit
 
-struct QuickLookPreviewSheet: UIViewControllerRepresentable {
-    let fileURL: URL
-    let onDismiss: () -> Void
+final class FileAttachmentQuickLookPresenter: NSObject, QLPreviewControllerDataSource, @preconcurrency QLPreviewControllerDelegate {
+    private let fileURL: URL
+    private weak var presenter: UIViewController?
 
-    func makeCoordinator() -> Coordinator {
-        Coordinator(fileURL: fileURL, onDismiss: onDismiss)
+    init(fileURL: URL, presenter: UIViewController) {
+        self.fileURL = fileURL
+        self.presenter = presenter
     }
 
-    func makeUIViewController(context: Context) -> QLPreviewController {
-        let controller = QLPreviewController()
-        controller.dataSource = context.coordinator
-        controller.delegate = context.coordinator
-        return controller
-    }
-
-    func updateUIViewController(_ uiViewController: QLPreviewController, context: Context) {
-        context.coordinator.fileURL = fileURL
-        uiViewController.reloadData()
-    }
-
-    final class Coordinator: NSObject, QLPreviewControllerDataSource, @preconcurrency QLPreviewControllerDelegate {
-        var fileURL: URL
-        let onDismiss: () -> Void
-
-        init(fileURL: URL, onDismiss: @escaping () -> Void) {
-            self.fileURL = fileURL
-            self.onDismiss = onDismiss
-        }
-
-        func numberOfPreviewItems(in controller: QLPreviewController) -> Int { 1 }
-
-        func previewController(_ controller: QLPreviewController, previewItemAt index: Int) -> any QLPreviewItem {
-            fileURL as NSURL
-        }
-
-        func previewControllerDidDismiss(_ controller: QLPreviewController) {
-            onDismiss()
-        }
-    }
-}
-
-private struct QuickLookSheetContainer: View {
-    let fileURL: URL
-    let onDismiss: () -> Void
-
-    @Environment(\.dismiss) private var dismiss: DismissAction
-
-    var body: some View {
-        QuickLookPreviewSheet(fileURL: fileURL) {
-            onDismiss()
-            dismiss()
-        }
-        .ignoresSafeArea()
-    }
-}
-
-enum QuickLookSheetPresenter {
     @MainActor
-    static func present(fileURL: URL, from presenter: UIViewController? = UIApplication.shared.topMostViewController()) {
-        guard let presenter else { return }
-        let host = UIHostingController(
-            rootView: QuickLookSheetContainer(fileURL: fileURL) {
-                try? FileManager.default.removeItem(at: fileURL.deletingLastPathComponent())
-            }
-        )
-        host.modalPresentationStyle = .pageSheet
-        presenter.present(host, animated: true)
+    func present() {
+        let previewController = QLPreviewController()
+        previewController.dataSource = self
+        previewController.delegate = self
+        presenter?.present(previewController, animated: true)
+    }
+
+    func numberOfPreviewItems(in controller: QLPreviewController) -> Int {
+        1
+    }
+
+    func previewController(_ controller: QLPreviewController, previewItemAt index: Int) -> any QLPreviewItem {
+        fileURL as NSURL
+    }
+
+    func previewControllerDidDismiss(_ controller: QLPreviewController) {
+        try? FileManager.default.removeItem(at: fileURL.deletingLastPathComponent())
+        FileAttachmentQuickLookCoordinator.shared.release(self)
+    }
+}
+
+@MainActor
+final class FileAttachmentQuickLookCoordinator {
+    static let shared: FileAttachmentQuickLookCoordinator = .init()
+
+    private var presenters: [ObjectIdentifier: FileAttachmentQuickLookPresenter] = [:]
+
+    func present(fileURL: URL, from presenter: UIViewController) {
+        let quickLookPresenter = FileAttachmentQuickLookPresenter(fileURL: fileURL, presenter: presenter)
+        let id = ObjectIdentifier(quickLookPresenter)
+        presenters[id] = quickLookPresenter
+        quickLookPresenter.present()
+    }
+
+    func release(_ presenter: FileAttachmentQuickLookPresenter) {
+        presenters.removeValue(forKey: ObjectIdentifier(presenter))
     }
 }
 

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/MessagesViewController.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/MessagesViewController.swift
@@ -882,12 +882,13 @@ extension MessagesViewController {
     private func openFileAttachment(_ attachment: HydratedAttachment) {
         Task {
             do {
-                let fileURL = try await FileAttachmentPreviewLoader.loadPreviewURL(
-                    key: attachment.key,
-                    filename: attachment.filename
-                )
+                let fileURL = try await loadFileForPreview(attachment)
                 await MainActor.run {
-                    QuickLookSheetPresenter.present(fileURL: fileURL, from: self)
+                    if attachment.isMarkdownFile {
+                        presentMarkdownPreview(fileURL: fileURL, filename: attachment.filename ?? "Markdown")
+                    } else {
+                        FileAttachmentQuickLookCoordinator.shared.present(fileURL: fileURL, from: self)
+                    }
                 }
             } catch {
                 Log.error("Failed to open file attachment: \(error)")


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Fix file preview regression by replacing SwiftUI-based Quick Look sheet with a direct `QLPreviewController` presenter
- Removes `QuickLookSheetPresenter` and its SwiftUI `UIViewControllerRepresentable` wrapper, replacing them with `FileAttachmentQuickLookCoordinator`, a `@MainActor` singleton that manages `QLPreviewController` presentation directly from the top-most `UIViewController`.
- `FileAttachmentQuickLookPresenter` (a new `NSObject`-based class) implements `QLPreviewControllerDataSource` and `QLPreviewControllerDelegate`, handling temp file cleanup on dismissal and notifying the coordinator to release its strong reference.
- Markdown file attachments opened from `MessagesViewController` now route to a dedicated Markdown preview instead of Quick Look.
- Behavioral Change: callers previously using `QuickLookSheetPresenter.present(fileURL:)` must switch to `FileAttachmentQuickLookCoordinator.shared.present(fileURL:from:)`.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7ed3441.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->