### PR TITLE
Video bubble fixes

### DIFF
--- a/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
@@ -366,7 +366,6 @@ private struct VideoTapAttachmentView: View {
                             )
                         }
                     }
-                    .offset(x: swipeOffset)
             }
         }
         .overlay(alignment: .topTrailing) {
@@ -376,7 +375,6 @@ private struct VideoTapAttachmentView: View {
                     isVideo: isVideo,
                     duration: resolvedDuration ?? attachment.duration
                 )
-                .offset(x: swipeOffset)
                 .allowsHitTesting(false)
             }
         }
@@ -394,7 +392,6 @@ private struct VideoTapAttachmentView: View {
                         )
                     }
                 }
-                .offset(x: swipeOffset)
                 .transition(.scale(scale: 0.85, anchor: .bottomLeading).combined(with: .opacity))
                 .animation(.spring(response: 0.34, dampingFraction: 0.72), value: reactionsPeekVisible)
             }


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add read receipts, stable conversation emoji, and video bubble reactions to messaging
- Introduces end-to-end read receipt support: `ReadReceiptWriter` sends and persists receipts via XMTP, `StreamProcessor` and `ConversationWriter` intercept receipt messages during sync, and `MessagesListProcessor` attaches reader avatars to the last outgoing group; users can toggle per-conversation and global sending preferences.
- Adds stable conversation emoji: groups seed a deterministic emoji via `XMTPiOS.Group.ensureConversationEmoji`, stored in `DBConversation.conversationEmoji` and propagated through invite payloads and custom metadata proto.
- Overhauls video/media bubbles in `MessagesGroupItemView` and `VideoTapAttachmentView`: reactions pill overlay, avatar tap, double-tap reaction, swipe corner radius, resolved duration, and generated thumbnails.
- Adds inline transcript UI to `VoiceMemoBubbleContent`: shows up to 3 lines with sheet expansion, a

<!-- Macroscope's review summary starts here -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized f1c7c3a. 64 files reviewed, 14 issues evaluated, 3 issues filtered, 3 comments posted</summary>

### 🗂️ Filtered Issues
<details>
<summary>Convos/Conversation Detail/ConversationViewModel+TypingIndicators.swift — 0 comments posted, 3 evaluated, 2 filtered</summary>

- [line 150](https://github.com/xmtplabs/convos-ios/blob/f1c7c3a15900786d12d878d430ab833fe9c70406/Convos/Conversation Detail/ConversationViewModel+TypingIndicators.swift#L150): When creating `updatedGroup` in `messagesWithSingleTyper`, the properties `adjacentToFullBleedAbove` and `adjacentToFullBleedBelow` from `lastGroup` are not copied to the new `MessagesGroup`. The diff shows these fields were added to `MessagesGroup.hash(into:)`, indicating they are meaningful properties. Losing these values when adding a typing indicator will cause the updated group to have default values instead of the original values, potentially causing incorrect UI rendering for message groups adjacent to full-bleed content. <b>[ Out of scope ]</b>
- [line 150](https://github.com/xmtplabs/convos-ios/blob/f1c7c3a15900786d12d878d430ab833fe9c70406/Convos/Conversation Detail/ConversationViewModel+TypingIndicators.swift#L150): In `messagesWithSingleTyper`, when creating `updatedGroup` to replace the last message group with a typing indicator, the `adjacentToFullBleedAbove` and `adjacentToFullBleedBelow` properties from `lastGroup` are not passed through. These properties were recently added to `MessagesGroup.hash(into:)` indicating they affect group identity, but they're lost here and will default to their initial values, potentially causing incorrect layout when the original group was adjacent to full-bleed content. <b>[ Cross-file consolidated ]</b>
</details>

<details>
<summary>ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationWriter.swift — 1 comment posted, 2 evaluated, 1 filtered</summary>

- [line 763](https://github.com/xmtplabs/convos-ios/blob/f1c7c3a15900786d12d878d430ab833fe9c70406/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationWriter.swift#L763): On line 763, `profile = profile.with(name: name)` unconditionally overwrites the existing profile's name with the `name` parameter, even when `name` is nil. When the caller passes `name: update.hasName ? update.name : nil`, a ProfileUpdate without a name field will clear any previously stored name for that member. This is inconsistent with how `encryptedImage` (line 765-769) and `metadata` (line 772-774) are conditionally applied only when non-nil/non-empty, and can cause data loss. The fix should be: `if let name = name { profile = profile.with(name: name) }` <b>[ Out of scope ]</b>
</details>


</details><!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->