### PR TITLE
Fix media double tap reactions behavior

### DIFF
--- a/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
@@ -286,7 +286,7 @@ struct MessagesGroupItemView: View {
             )
             .id(message.messageId)
         } else {
-            VideoTapAttachmentView(
+            MediaAttachmentView(
                 attachment: attachment,
                 message: message,
                 isOutgoing: message.sender.isCurrentUser,
@@ -308,7 +308,7 @@ struct MessagesGroupItemView: View {
 
 // MARK: - Attachment Views
 
-private struct VideoTapAttachmentView: View {
+private struct MediaAttachmentView: View {
     let attachment: HydratedAttachment
     let message: AnyMessage
     let isOutgoing: Bool
@@ -416,7 +416,7 @@ private struct VideoTapAttachmentView: View {
             message: message,
             bubbleStyle: .normal,
             onSingleTap: singleTapAction,
-            onDoubleTap: handleDoubleTap,
+            onDoubleTap: doubleTapAction,
             onReply: onReply,
             swipeOffset: $swipeOffset
         )
@@ -436,10 +436,17 @@ private struct VideoTapAttachmentView: View {
         return nil
     }
 
+    private var doubleTapAction: (() -> Void)? {
+        guard isVideo else { return nil }
+        return handleDoubleTap
+    }
+
     private func handleDoubleTap() {
-        guard isVideo else { return }
         if isPlaying {
             playingDoubleTapAnimationTrigger += 1
+            if reactionsPeekVisible {
+                reactionsPeekVisible = false
+            }
             if currentUserHasHeartReaction == false {
                 pendingPlayingDoubleTapReaction = true
             }


### PR DESCRIPTION
## Summary
- restore photo double tap to use the default reaction path
- keep custom double tap handling only for videos
- replay the reactions pill animation when double tapping a playing video

## Testing
- xcodebuild build -project Convos.xcodeproj -scheme "Convos (Dev)" -destination "platform=iOS Simulator,name=convos-dev" -derivedDataPath .derivedData
- xcrun simctl install "convos-dev" .derivedData/Build/Products/Dev-iphonesimulator/Convos.app
- xcrun simctl launch "convos-dev" org.convos.ios-preview


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix double-tap reactions behavior for media attachments in `MediaAttachmentView`
> - Renames `VideoTapAttachmentView` to `MediaAttachmentView` and disables the double-tap gesture handler for non-video attachments.
> - For playing videos, a double-tap now hides any visible reactions peek before re-showing it, restarting the peek animation instead of stacking it.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 663e28b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->