### PR TITLE
Fix convos-task for non-iTerm users and non-interactive gt output

### DIFF
--- a/.claude/scripts/convos-task
+++ b/.claude/scripts/convos-task
@@ -199,7 +199,7 @@ tell application "Terminal"
     else
         do script "$attach_cmd"
     end if
-    set custom title of front window to "$task_name"
+    set custom title of selected tab of front window to "$task_name"
 end tell
 EOF
     fi
@@ -304,10 +304,10 @@ cmd_new() {
     SIM_NAME=$(get_simulator_name "$TASK_NAME")
     echo -e "${BLUE}📱 Simulator: $SIM_NAME (creating in background)${NC}"
 
-    # Show stack info (pipe to cat to disable pager)
+    # Show stack info (--no-interactive disables gt's pager)
     cd "$WORKTREE_DIR"
     echo -e "\n${BLUE}Graphite stack:${NC}"
-    gt log short 2>/dev/null | cat || gt stack 2>/dev/null | cat || echo "Run 'gt stack' to see stack"
+    gt log short --no-interactive 2>/dev/null || gt stack --no-interactive 2>/dev/null || echo "Run 'gt stack' to see stack"
 
     # Create simulator in background with logging
     # The /setup command will verify/create simulator if this fails

--- a/.claude/scripts/convos-task
+++ b/.claude/scripts/convos-task
@@ -160,59 +160,40 @@ launch_claude_in_terminal() {
     # Create the tmux session on convos-tasks socket (for monitoring)
     create_task_session "$task_name" "$dir"
 
+    echo "Session created"
+
     # Attach to the session via Terminal/iTerm
     local attach_cmd="tmux -L convos-tasks attach -t $session_name"
 
     # Check if iTerm is available (installed)
     if [ -d "/Applications/iTerm.app" ]; then
-        osascript <<EOF
-tell application "iTerm"
-    if application "iTerm" is running then
-        activate
-        if (count of windows) > 0 then
-            tell current window
-                create tab with default profile
-                tell current session
-                    set name to "$task_name"
-                    write text "$attach_cmd"
-                end tell
-            end tell
-        else
-            create window with default profile
-            tell current window
-                tell current session
-                    set name to "$task_name"
-                    write text "$attach_cmd"
-                end tell
-            end tell
-        end if
-    else
-        activate
-        delay 0.5
-        tell current window
-            tell current session
-                set name to "$task_name"
-                write text "$attach_cmd"
-            end tell
-        end tell
-    end if
-end tell
-EOF
+        osascript \
+            -e 'tell application "iTerm"' \
+            -e '  activate' \
+            -e '  if (count of windows) is 0 then' \
+            -e '    create window with default profile' \
+            -e '  else' \
+            -e '    tell current window to create tab with default profile' \
+            -e '  end if' \
+            -e '  tell current session of current window' \
+            -e "    set name to \"$task_name\"" \
+            -e "    write text \"$attach_cmd\"" \
+            -e '  end tell' \
+            -e 'end tell'
     else
         # For Terminal.app
-        local title_cmd="printf '\\033]0;$task_name\\007'"
-        osascript <<EOF
-tell application "Terminal"
-    if (count of windows) > 0 then
-        tell application "System Events" to keystroke "t" using command down
-        delay 0.3
-        do script "$title_cmd; $attach_cmd" in front window
-    else
-        do script "$title_cmd; $attach_cmd"
-    end if
-    activate
-end tell
-EOF
+        osascript \
+            -e 'tell application "Terminal"' \
+            -e '  activate' \
+            -e '  if (count of windows) is 0 then' \
+            -e "    do script \"$attach_cmd\"" \
+            -e '  else' \
+            -e '    tell application "System Events" to keystroke "t" using command down' \
+            -e '    delay 0.3' \
+            -e "    do script \"$attach_cmd\" in front window" \
+            -e '  end if' \
+            -e "  set custom title of front window to \"$task_name\"" \
+            -e 'end tell'
     fi
 }
 
@@ -315,10 +296,10 @@ cmd_new() {
     SIM_NAME=$(get_simulator_name "$TASK_NAME")
     echo -e "${BLUE}📱 Simulator: $SIM_NAME (creating in background)${NC}"
 
-    # Show stack info
+    # Show stack info (pipe to cat to disable pager)
     cd "$WORKTREE_DIR"
     echo -e "\n${BLUE}Graphite stack:${NC}"
-    gt log short 2>/dev/null || gt stack 2>/dev/null || echo "Run 'gt stack' to see stack"
+    gt log short 2>/dev/null | cat || gt stack 2>/dev/null | cat || echo "Run 'gt stack' to see stack"
 
     # Create simulator in background with logging
     # The /setup command will verify/create simulator if this fails

--- a/.claude/scripts/convos-task
+++ b/.claude/scripts/convos-task
@@ -160,40 +160,48 @@ launch_claude_in_terminal() {
     # Create the tmux session on convos-tasks socket (for monitoring)
     create_task_session "$task_name" "$dir"
 
-    echo "Session created"
-
     # Attach to the session via Terminal/iTerm
     local attach_cmd="tmux -L convos-tasks attach -t $session_name"
 
     # Check if iTerm is available (installed)
     if [ -d "/Applications/iTerm.app" ]; then
-        osascript \
-            -e 'tell application "iTerm"' \
-            -e '  activate' \
-            -e '  if (count of windows) is 0 then' \
-            -e '    create window with default profile' \
-            -e '  else' \
-            -e '    tell current window to create tab with default profile' \
-            -e '  end if' \
-            -e '  tell current session of current window' \
-            -e "    set name to \"$task_name\"" \
-            -e "    write text \"$attach_cmd\"" \
-            -e '  end tell' \
-            -e 'end tell'
+        osascript <<EOF
+tell application "iTerm"
+    activate
+    if (count of windows) > 0 then
+        tell current window
+            create tab with default profile
+            tell current session
+                set name to "$task_name"
+                write text "$attach_cmd"
+            end tell
+        end tell
+    else
+        create window with default profile
+        tell current window
+            tell current session
+                set name to "$task_name"
+                write text "$attach_cmd"
+            end tell
+        end tell
+    end if
+end tell
+EOF
     else
         # For Terminal.app
-        osascript \
-            -e 'tell application "Terminal"' \
-            -e '  activate' \
-            -e '  if (count of windows) is 0 then' \
-            -e "    do script \"$attach_cmd\"" \
-            -e '  else' \
-            -e '    tell application "System Events" to keystroke "t" using command down' \
-            -e '    delay 0.3' \
-            -e "    do script \"$attach_cmd\" in front window" \
-            -e '  end if' \
-            -e "  set custom title of front window to \"$task_name\"" \
-            -e 'end tell'
+        osascript <<EOF
+tell application "Terminal"
+    activate
+    if (count of windows) > 0 then
+        tell application "System Events" to keystroke "t" using command down
+        delay 0.3
+        do script "$attach_cmd" in front window
+    else
+        do script "$attach_cmd"
+    end if
+    set custom title of front window to "$task_name"
+end tell
+EOF
     fi
 }
 


### PR DESCRIPTION
## Summary

Fixes two issues with `convos-task` that affect the `ct new` workflow:

- **Terminal.app fallback broken for non-iTerm users.** The Terminal.app AppleScript checked `count of windows` before calling `activate`, so Terminal might not be running when the query executes. Moved `activate` to the top and replaced the printf escape sequence title hack with AppleScript-native `set custom title`.
- **`gt log short` / `gt stack` hijacks the terminal.** The Graphite CLI renders through an interactive pager, blocking `ct new` from completing until the user presses `q`. Piped through `cat` to disable the pager.

Also simplifies the iTerm AppleScript by removing the `application "iTerm" is running` branching — just `activate` upfront and check window count, since `tell application` already launches the app.

## Test plan

- [ ] `ct new test-feature` on a machine without iTerm opens a Terminal.app window attached to the tmux session
- [ ] `ct new test-feature` on a machine with iTerm opens an iTerm tab attached to the tmux session
- [ ] The stack summary prints inline at the end of `ct new` and the command returns to the prompt without requiring `q` to exit a pager

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix convos-task terminal launching for non-iTerm users and non-interactive `gt` output
> - Fixes the iTerm branch in `launch_claude_in_terminal` to unconditionally activate iTerm, then open a tab in an existing window or create a new window, removing the stale running-state check and delay.
> - Fixes the Terminal.app branch to activate Terminal before running commands and sets the tab title via AppleScript instead of an ANSI escape sequence.
> - Appends `--no-interactive` to `gt log short` and `gt stack` calls in `cmd_new` so Graphite output never invokes a pager.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f3ce96a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->