### PR TITLE
Fix XcodeBuildMCP config for v2.x CLI change

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "XcodeBuildMCP": {
       "command": "npx",
-      "args": ["-y", "xcodebuildmcp@latest"],
+      "args": ["-y", "xcodebuildmcp@latest", "mcp"],
       "env": {
         "XCODE_PROJECT_PATH": "Convos.xcodeproj"
       }


### PR DESCRIPTION
## Summary

- Fix the XcodeBuildMCP MCP server configuration for the v2.x CLI change that requires an explicit `mcp` subcommand

## What changed

The `xcodebuildmcp` CLI v2.x changed its invocation to require the `mcp` subcommand. Updated `.mcp.json` to pass `"mcp"` as an additional argument so the MCP server starts correctly.

```diff
- "args": ["-y", "xcodebuildmcp@latest"],
+ "args": ["-y", "xcodebuildmcp@latest", "mcp"],
```

## Test plan

- [x] Verify XcodeBuildMCP MCP tools work in Claude Code (e.g., `list_sims`, `build_sim`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix XcodeBuildMCP config to pass `mcp` subcommand for v2.x CLI
> Adds `"mcp"` as a positional argument in [.mcp.json](https://github.com/xmtplabs/convos-ios/pull/708/files#diff-d5d3368a61f8d02e085f7a4cb666ee471cf5383690a04b64c839c6ae2080ceb9) to match the updated CLI interface in XcodeBuildMCP v2.x, which requires an explicit subcommand.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1a2de45.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->