### PR TITLE
Add testnet environment

### DIFF
--- a/.claude/scripts/convos-task
+++ b/.claude/scripts/convos-task
@@ -199,7 +199,7 @@ tell application "Terminal"
     else
         do script "$attach_cmd"
     end if
-    set custom title of front window to "$task_name"
+    set custom title of selected tab of front window to "$task_name"
 end tell
 EOF
     fi
@@ -304,10 +304,10 @@ cmd_new() {
     SIM_NAME=$(get_simulator_name "$TASK_NAME")
     echo -e "${BLUE}📱 Simulator: $SIM_NAME (creating in background)${NC}"
 
-    # Show stack info (pipe to cat to disable pager)
+    # Show stack info (--no-interactive disables gt's pager)
     cd "$WORKTREE_DIR"
     echo -e "\n${BLUE}Graphite stack:${NC}"
-    gt log short 2>/dev/null | cat || gt stack 2>/dev/null | cat || echo "Run 'gt stack' to see stack"
+    gt log short --no-interactive 2>/dev/null || gt stack --no-interactive 2>/dev/null || echo "Run 'gt stack' to see stack"
 
     # Create simulator in background with logging
     # The /setup command will verify/create simulator if this fails

--- a/.claude/scripts/convos-task
+++ b/.claude/scripts/convos-task
@@ -160,59 +160,40 @@ launch_claude_in_terminal() {
     # Create the tmux session on convos-tasks socket (for monitoring)
     create_task_session "$task_name" "$dir"
 
+    echo "Session created"
+
     # Attach to the session via Terminal/iTerm
     local attach_cmd="tmux -L convos-tasks attach -t $session_name"
 
     # Check if iTerm is available (installed)
     if [ -d "/Applications/iTerm.app" ]; then
-        osascript <<EOF
-tell application "iTerm"
-    if application "iTerm" is running then
-        activate
-        if (count of windows) > 0 then
-            tell current window
-                create tab with default profile
-                tell current session
-                    set name to "$task_name"
-                    write text "$attach_cmd"
-                end tell
-            end tell
-        else
-            create window with default profile
-            tell current window
-                tell current session
-                    set name to "$task_name"
-                    write text "$attach_cmd"
-                end tell
-            end tell
-        end if
-    else
-        activate
-        delay 0.5
-        tell current window
-            tell current session
-                set name to "$task_name"
-                write text "$attach_cmd"
-            end tell
-        end tell
-    end if
-end tell
-EOF
+        osascript \
+            -e 'tell application "iTerm"' \
+            -e '  activate' \
+            -e '  if (count of windows) is 0 then' \
+            -e '    create window with default profile' \
+            -e '  else' \
+            -e '    tell current window to create tab with default profile' \
+            -e '  end if' \
+            -e '  tell current session of current window' \
+            -e "    set name to \"$task_name\"" \
+            -e "    write text \"$attach_cmd\"" \
+            -e '  end tell' \
+            -e 'end tell'
     else
         # For Terminal.app
-        local title_cmd="printf '\\033]0;$task_name\\007'"
-        osascript <<EOF
-tell application "Terminal"
-    if (count of windows) > 0 then
-        tell application "System Events" to keystroke "t" using command down
-        delay 0.3
-        do script "$title_cmd; $attach_cmd" in front window
-    else
-        do script "$title_cmd; $attach_cmd"
-    end if
-    activate
-end tell
-EOF
+        osascript \
+            -e 'tell application "Terminal"' \
+            -e '  activate' \
+            -e '  if (count of windows) is 0 then' \
+            -e "    do script \"$attach_cmd\"" \
+            -e '  else' \
+            -e '    tell application "System Events" to keystroke "t" using command down' \
+            -e '    delay 0.3' \
+            -e "    do script \"$attach_cmd\" in front window" \
+            -e '  end if' \
+            -e "  set custom title of front window to \"$task_name\"" \
+            -e 'end tell'
     fi
 }
 
@@ -315,10 +296,10 @@ cmd_new() {
     SIM_NAME=$(get_simulator_name "$TASK_NAME")
     echo -e "${BLUE}📱 Simulator: $SIM_NAME (creating in background)${NC}"
 
-    # Show stack info
+    # Show stack info (pipe to cat to disable pager)
     cd "$WORKTREE_DIR"
     echo -e "\n${BLUE}Graphite stack:${NC}"
-    gt log short 2>/dev/null || gt stack 2>/dev/null || echo "Run 'gt stack' to see stack"
+    gt log short 2>/dev/null | cat || gt stack 2>/dev/null | cat || echo "Run 'gt stack' to see stack"
 
     # Create simulator in background with logging
     # The /setup command will verify/create simulator if this fails

--- a/.claude/scripts/convos-task
+++ b/.claude/scripts/convos-task
@@ -160,40 +160,48 @@ launch_claude_in_terminal() {
     # Create the tmux session on convos-tasks socket (for monitoring)
     create_task_session "$task_name" "$dir"
 
-    echo "Session created"
-
     # Attach to the session via Terminal/iTerm
     local attach_cmd="tmux -L convos-tasks attach -t $session_name"
 
     # Check if iTerm is available (installed)
     if [ -d "/Applications/iTerm.app" ]; then
-        osascript \
-            -e 'tell application "iTerm"' \
-            -e '  activate' \
-            -e '  if (count of windows) is 0 then' \
-            -e '    create window with default profile' \
-            -e '  else' \
-            -e '    tell current window to create tab with default profile' \
-            -e '  end if' \
-            -e '  tell current session of current window' \
-            -e "    set name to \"$task_name\"" \
-            -e "    write text \"$attach_cmd\"" \
-            -e '  end tell' \
-            -e 'end tell'
+        osascript <<EOF
+tell application "iTerm"
+    activate
+    if (count of windows) > 0 then
+        tell current window
+            create tab with default profile
+            tell current session
+                set name to "$task_name"
+                write text "$attach_cmd"
+            end tell
+        end tell
+    else
+        create window with default profile
+        tell current window
+            tell current session
+                set name to "$task_name"
+                write text "$attach_cmd"
+            end tell
+        end tell
+    end if
+end tell
+EOF
     else
         # For Terminal.app
-        osascript \
-            -e 'tell application "Terminal"' \
-            -e '  activate' \
-            -e '  if (count of windows) is 0 then' \
-            -e "    do script \"$attach_cmd\"" \
-            -e '  else' \
-            -e '    tell application "System Events" to keystroke "t" using command down' \
-            -e '    delay 0.3' \
-            -e "    do script \"$attach_cmd\" in front window" \
-            -e '  end if' \
-            -e "  set custom title of front window to \"$task_name\"" \
-            -e 'end tell'
+        osascript <<EOF
+tell application "Terminal"
+    activate
+    if (count of windows) > 0 then
+        tell application "System Events" to keystroke "t" using command down
+        delay 0.3
+        do script "$attach_cmd" in front window
+    else
+        do script "$attach_cmd"
+    end if
+    set custom title of front window to "$task_name"
+end tell
+EOF
     fi
 }
 

--- a/.mcp.json
+++ b/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "XcodeBuildMCP": {
       "command": "npx",
-      "args": ["-y", "xcodebuildmcp@latest"],
+      "args": ["-y", "xcodebuildmcp@latest", "mcp"],
       "env": {
         "XCODE_PROJECT_PATH": "Convos.xcodeproj"
       }

--- a/Convos.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Convos.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "c40fcb5279ffcf05994801de5933e258d72c7e21e5c777ef54ffb951d4469a38",
+  "originHash" : "117a38cbe061d2bf5fd257d012ee24de3bdd440259ea9961a3cd34e0167f7c61",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -150,8 +150,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/xmtp/libxmtp.git",
       "state" : {
-        "branch" : "ios-4.9.0-dev.88ddfad",
-        "revision" : "899650a4189207ca2df515bf46beb549da07ff46"
+        "branch" : "ios-4.10.0-dev.796011d",
+        "revision" : "a76287f985501d0bc63cfc038e37e304d41296a3"
       }
     },
     {

--- a/ConvosCore/Package.resolved
+++ b/ConvosCore/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "579cd1d748e9b32204ec97c5a2a168f00af764e485cc3f70870e0129ee45605b",
+  "originHash" : "b4427d76fbfe5ef793b402f1fc77bd6a1ca4ac5562dd00a277ce1aff21a1b1a3",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -141,8 +141,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/xmtp/libxmtp.git",
       "state" : {
-        "branch" : "ios-4.9.0-dev.88ddfad",
-        "revision" : "899650a4189207ca2df515bf46beb549da07ff46"
+        "branch" : "ios-4.10.0-dev.796011d",
+        "revision" : "a76287f985501d0bc63cfc038e37e304d41296a3"
       }
     },
     {

--- a/ConvosCore/Package.swift
+++ b/ConvosCore/Package.swift
@@ -23,7 +23,7 @@ let package = Package(
         .package(url: "https://github.com/groue/GRDB.swift.git", exact: "7.5.0"),
         .package(
             url: "https://github.com/xmtp/libxmtp.git",
-            revision: "ios-4.9.0-dev.88ddfad"
+            revision: "ios-4.10.0-dev.796011d"
         ),
         .package(url: "https://github.com/tesseract-one/CSecp256k1.swift.git", from: "0.2.0"),
         .package(url: "https://github.com/firebase/firebase-ios-sdk", from: "12.1.0"),

--- a/ConvosCore/Sources/ConvosCore/Inboxes/InboxStateMachine.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/InboxStateMachine.swift
@@ -1117,8 +1117,10 @@ public actor InboxStateMachine: InboxStateManagerProtocol {
             dbEncryptionKey: keys.databaseKey,
             dbDirectory: environment.defaultDatabasesDirectory,
             deviceSyncEnabled: false,
-            maxDbPoolSize: 10,
-            minDbPoolSize: 3
+            dbPoolOptions: DbPoolOptions(
+                maxPoolSize: 10,
+                minPoolSize: 3
+            )
         )
     }
 

--- a/ConvosCore/Tests/ConvosCoreTests/Assets/AssetRenewalManagerTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/Assets/AssetRenewalManagerTests.swift
@@ -444,8 +444,10 @@ private extension AssetRenewalManagerTests {
             imageSalt: nil,
             imageNonce: nil,
             imageEncryptionKey: nil,
+            conversationEmoji: nil,
             imageLastRenewed: imageLastRenewed,
             isUnused: false,
+            hasHadVerifiedAssistant: false
         )
     }
 }
@@ -481,6 +483,11 @@ final class ConfigurableMockAPIClient: ConvosAPIClientProtocol, @unchecked Senda
         .init(success: true, joined: true)
     }
 
-    func redeemInviteCode(_ code: String) async throws {
+    func redeemInviteCode(_ code: String) async throws -> ConvosAPI.InviteCodeStatus {
+        .init(code: "MOCKCODE", name: nil, maxRedemptions: 5, redemptionCount: 0, remainingRedemptions: 5)
+    }
+
+    func fetchInviteCodeStatus(_ code: String) async throws -> ConvosAPI.InviteCodeStatus {
+        .init(code: "MOCKCODE", name: nil, maxRedemptions: 5, redemptionCount: 0, remainingRedemptions: 5)
     }
 }

--- a/ConvosCore/Tests/ConvosCoreTests/Assets/AssetRenewalURLCollectorTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/Assets/AssetRenewalURLCollectorTests.swift
@@ -242,8 +242,10 @@ private extension AssetRenewalURLCollectorTests {
             imageSalt: nil,
             imageNonce: nil,
             imageEncryptionKey: nil,
+            conversationEmoji: nil,
             imageLastRenewed: imageLastRenewed,
             isUnused: false,
+            hasHadVerifiedAssistant: false
         )
     }
 }

--- a/ConvosCore/Tests/ConvosCoreTests/ChronologicalSortIdTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ChronologicalSortIdTests.swift
@@ -417,8 +417,10 @@ struct ChronologicalSortIdTests {
             imageSalt: nil,
             imageNonce: nil,
             imageEncryptionKey: nil,
+            conversationEmoji: nil,
             imageLastRenewed: nil,
-            isUnused: false
+            isUnused: false,
+            hasHadVerifiedAssistant: false
         ).insert(db)
 
         try ConversationLocalState(

--- a/ConvosCore/Tests/ConvosCoreTests/DefaultConversationDisplayTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/DefaultConversationDisplayTests.swift
@@ -289,7 +289,8 @@ struct DefaultConversationDisplayTests {
             expiresAt: nil,
             debugInfo: .empty,
             isLocked: false,
-            assistantJoinStatus: nil
+            assistantJoinStatus: nil,
+            hasHadVerifiedAssistant: false
         )
         #expect(conversation.avatarType == .customImage)
     }

--- a/ConvosCore/Tests/ConvosCoreTests/DeleteExpiredPendingInvitesTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/DeleteExpiredPendingInvitesTests.swift
@@ -50,8 +50,10 @@ struct DeleteExpiredPendingInvitesTests {
             imageSalt: nil,
             imageNonce: nil,
             imageEncryptionKey: nil,
+            conversationEmoji: nil,
             imageLastRenewed: nil,
             isUnused: false,
+            hasHadVerifiedAssistant: false
         )
     }
 

--- a/ConvosCore/Tests/ConvosCoreTests/ExpiredConversationsWorkerTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ExpiredConversationsWorkerTests.swift
@@ -215,8 +215,10 @@ private class ExpiredWorkerTestFixtures {
                 imageSalt: nil,
                 imageNonce: nil,
                 imageEncryptionKey: nil,
+                conversationEmoji: nil,
                 imageLastRenewed: nil,
                 isUnused: false,
+                hasHadVerifiedAssistant: false
             )
             try conversation.upsert(db)
         }

--- a/ConvosCore/Tests/ConvosCoreTests/InboxActivityRepositoryTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/InboxActivityRepositoryTests.swift
@@ -153,8 +153,10 @@ struct InboxActivityRepositoryTests {
             imageSalt: nil,
             imageNonce: nil,
             imageEncryptionKey: nil,
+            conversationEmoji: nil,
             imageLastRenewed: nil,
             isUnused: false,
+            hasHadVerifiedAssistant: false
         )
     }
 

--- a/ConvosCore/Tests/ConvosCoreTests/InboxLifecycleManagerTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/InboxLifecycleManagerTests.swift
@@ -1406,8 +1406,10 @@ struct InboxLifecycleManagerStaleExpiryTests {
             imageSalt: nil,
             imageNonce: nil,
             imageEncryptionKey: nil,
+            conversationEmoji: nil,
             imageLastRenewed: nil,
             isUnused: false,
+            hasHadVerifiedAssistant: false
         )
     }
 }

--- a/ConvosCore/Tests/ConvosCoreTests/IncomingMessageWriterExplodeTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/IncomingMessageWriterExplodeTests.swift
@@ -306,8 +306,10 @@ private class ExplodeTestFixtures {
                 imageSalt: nil,
                 imageNonce: nil,
                 imageEncryptionKey: nil,
+                conversationEmoji: nil,
                 imageLastRenewed: nil,
                 isUnused: false,
+                hasHadVerifiedAssistant: false
             )
             try conversation.insert(db)
 

--- a/ConvosCore/Tests/ConvosCoreTests/LockConversationTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/LockConversationTests.swift
@@ -192,8 +192,10 @@ struct LockConversationTests {
                 imageSalt: nil,
                 imageNonce: nil,
                 imageEncryptionKey: nil,
+                conversationEmoji: nil,
                 imageLastRenewed: nil,
                 isUnused: false,
+                hasHadVerifiedAssistant: false
             ).insert(db)
         }
 
@@ -287,8 +289,10 @@ struct LockConversationTests {
                 imageSalt: nil,
                 imageNonce: nil,
                 imageEncryptionKey: nil,
+                conversationEmoji: nil,
                 imageLastRenewed: nil,
                 isUnused: false,
+                hasHadVerifiedAssistant: false
             ).insert(db)
         }
 
@@ -459,8 +463,10 @@ struct LockConversationTests {
                 imageSalt: nil,
                 imageNonce: nil,
                 imageEncryptionKey: nil,
+                conversationEmoji: nil,
                 imageLastRenewed: nil,
                 isUnused: false,
+                hasHadVerifiedAssistant: false
             ).insert(db)
         }
 
@@ -585,8 +591,10 @@ struct LockConversationTests {
                 imageSalt: nil,
                 imageNonce: nil,
                 imageEncryptionKey: nil,
+                conversationEmoji: nil,
                 imageLastRenewed: nil,
                 isUnused: false,
+                hasHadVerifiedAssistant: false
             ).insert(db)
 
             // Create the member record with superAdmin role (this is what the UI reads)

--- a/ConvosCore/Tests/ConvosCoreTests/MessagesRepositoryBenchmarkTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/MessagesRepositoryBenchmarkTests.swift
@@ -62,8 +62,10 @@ struct MessagesRepositoryBenchmarkTests {
             imageSalt: nil,
             imageNonce: nil,
             imageEncryptionKey: nil,
+            conversationEmoji: nil,
             imageLastRenewed: nil,
             isUnused: false,
+            hasHadVerifiedAssistant: false
         ).insert(db)
 
         try ConversationLocalState(

--- a/ConvosCore/Tests/ConvosCoreTests/MessagesRepositoryTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/MessagesRepositoryTests.swift
@@ -420,8 +420,10 @@ struct MessagesRepositoryTests {
             imageSalt: nil,
             imageNonce: nil,
             imageEncryptionKey: nil,
+            conversationEmoji: nil,
             imageLastRenewed: nil,
             isUnused: false,
+            hasHadVerifiedAssistant: false
         ).insert(db)
 
         try ConversationLocalState(

--- a/ConvosCore/Tests/ConvosCoreTests/PendingInviteRepositoryTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/PendingInviteRepositoryTests.swift
@@ -195,8 +195,10 @@ struct PendingInviteRepositoryTests {
             imageSalt: nil,
             imageNonce: nil,
             imageEncryptionKey: nil,
+            conversationEmoji: nil,
             imageLastRenewed: nil,
             isUnused: false,
+            hasHadVerifiedAssistant: false
         )
     }
 }

--- a/ConvosCore/Tests/ConvosCoreTests/PendingPhotoUploadTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/PendingPhotoUploadTests.swift
@@ -165,8 +165,10 @@ struct PendingPhotoUploadTests {
             imageSalt: nil,
             imageNonce: nil,
             imageEncryptionKey: nil,
+            conversationEmoji: nil,
             imageLastRenewed: nil,
             isUnused: false,
+            hasHadVerifiedAssistant: false
         )
     }
 }

--- a/ConvosCore/Tests/ConvosCoreTests/ScheduledExplosionManagerTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ScheduledExplosionManagerTests.swift
@@ -291,8 +291,10 @@ private class ScheduledExplosionTestFixtures {
                 imageSalt: nil,
                 imageNonce: nil,
                 imageEncryptionKey: nil,
+                conversationEmoji: nil,
                 imageLastRenewed: nil,
                 isUnused: false,
+                hasHadVerifiedAssistant: false
             )
             try conversation.insert(db)
         }

--- a/ConvosCore/Tests/ConvosCoreTests/SessionManagerTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/SessionManagerTests.swift
@@ -46,8 +46,10 @@ struct SessionManagerTests {
                 imageSalt: nil,
                 imageNonce: nil,
                 imageEncryptionKey: nil,
+                conversationEmoji: nil,
                 imageLastRenewed: nil,
                 isUnused: false,
+                hasHadVerifiedAssistant: false
             ).insert(db)
         }
 
@@ -119,8 +121,10 @@ struct SessionManagerTests {
                 imageSalt: nil,
                 imageNonce: nil,
                 imageEncryptionKey: nil,
+                conversationEmoji: nil,
                 imageLastRenewed: nil,
                 isUnused: false,
+                hasHadVerifiedAssistant: false
             ).insert(db)
         }
 
@@ -160,8 +164,10 @@ struct SessionManagerTests {
                 imageSalt: nil,
                 imageNonce: nil,
                 imageEncryptionKey: nil,
+                conversationEmoji: nil,
                 imageLastRenewed: nil,
                 isUnused: false,
+                hasHadVerifiedAssistant: false
             ).insert(db)
         }
 
@@ -209,8 +215,10 @@ struct SessionManagerTests {
                 imageSalt: nil,
                 imageNonce: nil,
                 imageEncryptionKey: nil,
+                conversationEmoji: nil,
                 imageLastRenewed: nil,
                 isUnused: false,
+                hasHadVerifiedAssistant: false
             ).insert(db)
 
             // Insert second inbox and conversation
@@ -236,8 +244,10 @@ struct SessionManagerTests {
                 imageSalt: nil,
                 imageNonce: nil,
                 imageEncryptionKey: nil,
+                conversationEmoji: nil,
                 imageLastRenewed: nil,
                 isUnused: false,
+                hasHadVerifiedAssistant: false
             ).insert(db)
         }
 
@@ -289,8 +299,10 @@ struct SessionManagerTests {
                 imageSalt: nil,
                 imageNonce: nil,
                 imageEncryptionKey: nil,
+                conversationEmoji: nil,
                 imageLastRenewed: nil,
                 isUnused: false,
+                hasHadVerifiedAssistant: false
             ).insert(db)
 
             // Insert second inbox and conversation
@@ -316,8 +328,10 @@ struct SessionManagerTests {
                 imageSalt: nil,
                 imageNonce: nil,
                 imageEncryptionKey: nil,
+                conversationEmoji: nil,
                 imageLastRenewed: nil,
                 isUnused: false,
+                hasHadVerifiedAssistant: false
             ).insert(db)
         }
 

--- a/ConvosCore/Tests/ConvosCoreTests/SleepingInboxMessageCheckerIntegrationTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/SleepingInboxMessageCheckerIntegrationTests.swift
@@ -380,7 +380,12 @@ private class IntegrationTestFixtures {
                 TypingIndicatorCodec()
             ],
             dbEncryptionKey: keys.databaseKey,
-            dbDirectory: environment.defaultDatabasesDirectory
+            dbDirectory: environment.defaultDatabasesDirectory,
+            deviceSyncEnabled: false,
+            dbPoolOptions: DbPoolOptions(
+                maxPoolSize: 10,
+                minPoolSize: 3
+            )
         )
 
         let client = try await Client.create(account: keys.signingKey, options: clientOptions)

--- a/ConvosCore/Tests/ConvosCoreTests/SyncingManagerTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/SyncingManagerTests.swift
@@ -362,7 +362,12 @@ final class TestableMockAPIClient: ConvosAPIClientProtocol, @unchecked Sendable 
         .init(success: true, joined: true)
     }
 
-    func redeemInviteCode(_ code: String) async throws {
+    func redeemInviteCode(_ code: String) async throws -> ConvosAPI.InviteCodeStatus {
+        .init(code: "MOCKCODE", name: nil, maxRedemptions: 5, redemptionCount: 0, remainingRedemptions: 5)
+    }
+
+    func fetchInviteCodeStatus(_ code: String) async throws -> ConvosAPI.InviteCodeStatus {
+        .init(code: "MOCKCODE", name: nil, maxRedemptions: 5, redemptionCount: 0, remainingRedemptions: 5)
     }
 }
 

--- a/ConvosCore/Tests/ConvosCoreTests/TestHelpers.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/TestHelpers.swift
@@ -121,7 +121,12 @@ class TestFixtures {
                 TypingIndicatorCodec()
             ],
             dbEncryptionKey: keys.databaseKey,
-            dbDirectory: environment.defaultDatabasesDirectory
+            dbDirectory: environment.defaultDatabasesDirectory,
+            deviceSyncEnabled: false,
+            dbPoolOptions: DbPoolOptions(
+                maxPoolSize: 10,
+                minPoolSize: 3
+            )
         )
 
         let client = try await Client.create(account: keys.signingKey, options: clientOptions)

--- a/ConvosInvites/Package.resolved
+++ b/ConvosInvites/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "0af6d54eba20a113bed67cb33df8f1bbad656c172dabc1e5dd04912ff988c599",
+  "originHash" : "f2068d7274defba52ed0c02e1ec8bf59d2f7937b2a5e2aac7615f179fe4a0059",
   "pins" : [
     {
       "identity" : "connect-swift",
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/xmtp/libxmtp.git",
       "state" : {
-        "branch" : "ios-4.9.0-dev.6ecd439",
-        "revision" : "297e684d07e78f87da617be80565359c315ba6f0"
+        "branch" : "ios-4.10.0-dev.796011d",
+        "revision" : "a76287f985501d0bc63cfc038e37e304d41296a3"
       }
     },
     {

--- a/ConvosInvites/Package.swift
+++ b/ConvosInvites/Package.swift
@@ -25,7 +25,7 @@ let package = Package(
         .package(url: "https://github.com/tesseract-one/CSecp256k1.swift.git", from: "0.2.0"),
         .package(
             url: "https://github.com/xmtp/libxmtp.git",
-            revision: "ios-4.9.0-dev.88ddfad"
+            revision: "ios-4.10.0-dev.796011d"
         ),
         .package(path: "../ConvosAppData"),
     ],

--- a/ConvosProfiles/Package.resolved
+++ b/ConvosProfiles/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "138785d609d2af863597c6d4aee17739afbfe1f35b8eadee5ae714d7d14d24a1",
+  "originHash" : "07ba9825667936f8d2a56f6b7629adaf24a4a6553b362da83c9383b5bf1a83cd",
   "pins" : [
     {
       "identity" : "connect-swift",
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/xmtp/libxmtp.git",
       "state" : {
-        "branch" : "ios-4.9.0-dev.6ecd439",
-        "revision" : "297e684d07e78f87da617be80565359c315ba6f0"
+        "branch" : "ios-4.10.0-dev.796011d",
+        "revision" : "a76287f985501d0bc63cfc038e37e304d41296a3"
       }
     },
     {

--- a/ConvosProfiles/Package.swift
+++ b/ConvosProfiles/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
         .package(path: "../ConvosAppData"),
         .package(
             url: "https://github.com/xmtp/libxmtp.git",
-            revision: "ios-4.9.0-dev.88ddfad"
+            revision: "ios-4.10.0-dev.796011d"
         ),
     ],
     targets: [

--- a/Scripts/hooks/pre-commit
+++ b/Scripts/hooks/pre-commit
@@ -48,7 +48,7 @@ fi
 
 # Check if SwiftLint is available
 if command -v swiftlint &> /dev/null; then
-    echo "🔎 Running SwiftLint... $STAGED_SWIFT_FILES"
+    echo "🔎 Running SwiftLint..."
 
     LINT_ERRORS=0
     for file in "${STAGED_SWIFT_FILES[@]}"; do

--- a/Scripts/hooks/pre-commit
+++ b/Scripts/hooks/pre-commit
@@ -48,7 +48,7 @@ fi
 
 # Check if SwiftLint is available
 if command -v swiftlint &> /dev/null; then
-    echo "🔎 Running SwiftLint..."
+    echo "🔎 Running SwiftLint... $STAGED_SWIFT_FILES"
 
     LINT_ERRORS=0
     for file in "${STAGED_SWIFT_FILES[@]}"; do

--- a/docs/plans/add-testnet-environment.md
+++ b/docs/plans/add-testnet-environment.md
@@ -1,0 +1,310 @@
+# Feature: Testnet Environment
+
+> **Status**: Approved
+> **Author**: Nicholas Molnar
+> **Created**: 2026-04-15
+> **Updated**: 2026-04-15
+
+## Overview
+
+Add a fourth named build environment, "Testnet," that connects to the XMTP testnet network via a gateway (`payer.testnet-staging.xmtp.network`) and a separate Convos API backend. This environment is a separate dev environment. It has its own backend, bundle ID, and Apple identity, making it suitable for evaluating testnet infrastructure.
+
+## Problem Statement
+
+There is no way to connect to the `testnet-staging` backend network in Convos today. This makes it impossible to evaluate the d14n capabilies of the XMTP SDKs.
+
+## Goals
+
+- [ ] "Convos (Testnet)" scheme builds and runs in the simulator
+- [ ] App routes to the testnet Convos backend API (URL sourced from `.env` / `Secrets.swift`)
+- [ ] App connects to the XMTP dev network via gateway `payer.testnet-staging.xmtp.network`
+- [ ] Notification Service extension builds and works for Testnet
+- [ ] All existing Local, Dev, and Production environments continue to work without any behavior change
+- [ ] Documentation updated to reflect the new environment everywhere it is currently mentioned
+
+## Non-Goals
+
+- Creating a new Firebase project for Testnet (reuse Dev Firebase project initially)
+- Creating a dedicated App Clip scheme for Testnet (defer until there is a concrete need)
+- Changing how Secrets are generated for any existing environment
+- Adding a Testnet target to CI/CD pipelines (handled separately once the environment is stable)
+- Any UI or feature changes; this is purely infrastructure
+
+## User Stories
+
+### As a developer, I want to build "Convos (Testnet)" so that I can test against testnet infrastructure without touching Dev
+
+Acceptance criteria:
+- [ ] Selecting the "Convos (Testnet)" scheme in Xcode produces a runnable app
+- [ ] App display name is "Convos Testnet"
+- [ ] Bundle ID is `org.convos.ios-testnet`
+- [ ] App icon visually distinguishes the build from Dev and Production
+
+### As a developer, I want the testnet app to connect to the correct backend
+
+Acceptance criteria:
+- [ ] `CONVOS_API_BASE_URL` in `.env` is used as the API base URL when present
+- [ ] If `.env` has no value, the build fails with a clear error (no silent fallback to a wrong URL)
+- [ ] App logs confirm the correct API URL at launch
+
+### As a developer, I want push notifications to work for Testnet builds
+
+Acceptance criteria:
+- [ ] "NotificationService (Testnet)" scheme builds successfully
+- [ ] Notification extension reads the correct environment config from Keychain at runtime
+
+## Technical Design
+
+### Architecture
+
+The Testnet environment follows the identical layering used by Local, Dev, and Production:
+
+- `config.testnet.json` (config file, main app bundle) — declares environment identity and static values
+- `Testnet.xcconfig` (build settings) — bundle ID, display name, icon, URL scheme, associated domains
+- `Convos (Testnet).xcscheme` and `NotificationService (Testnet).xcscheme` — Xcode build entry points
+- `AppEnvironment.testnet` case (ConvosCore) — runtime environment enum
+- `ConfigManager` `"testnet"` switch arm (main app) — wires Secrets + config into `AppEnvironment`
+- Build phase scripts — Secrets.swift generation for the Testnet configuration
+- `GoogleService-Info.Testnet.plist` — Firebase configuration (copy of Dev initially)
+- `Info.Testnet.plist` — Info.plist variant
+
+### Component Breakdown
+
+#### config.testnet.json
+
+New file at `Convos/Config/config.testnet.json`. Mirrors `config.dev.json` with these differences:
+
+| Key | Value |
+|-----|-------|
+| `environment` | `"testnet"` |
+| `backendUrl` | empty string or omitted (Secrets is required) |
+| `xmtpNetwork` | `"dev"` |
+| `bundleId` | `"org.convos.ios-testnet"` |
+| `appGroupIdentifier` | `"group.org.convos.ios-testnet"` |
+| `relyingPartyIdentifier` | [NEEDS DECISION] `"testnet.convos.org"` or same as Dev |
+| `associatedDomains` | [NEEDS DECISION] — see Open Questions |
+| `appUrlScheme` | `"convos-testnet"` |
+| `gatewayUrl` | `"payer.testnet-staging.xmtp.network"` |
+
+Placing `gatewayUrl` in the config JSON is the cleanest approach: it follows the existing pattern, is visible in version control, and avoids hardcoding a fallback inside `ConfigManager`.
+
+#### Testnet.xcconfig
+
+New file at `Convos/Config/Testnet.xcconfig`. Based on `Dev.xcconfig`:
+
+```
+CONFIG_FILE = config.testnet.json
+DEVELOPMENT_TEAM = FY4NZR34Z3
+SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG
+OTHER_SWIFT_FLAGS = $(inherited) -Onone
+
+MAIN_BUNDLE_ID = org.convos.ios-testnet
+PRODUCT_BUNDLE_IDENTIFIER = $(MAIN_BUNDLE_ID)
+CONVOS_BUNDLE_ID = $(MAIN_BUNDLE_ID)
+CONVOS_TESTS_BUNDLE_ID = $(MAIN_BUNDLE_ID).tests
+CONVOS_APP_CLIP_BUNDLE_ID = $(MAIN_BUNDLE_ID).Clip
+NOTIFICATION_SERVICE_BUNDLE_ID = $(MAIN_BUNDLE_ID).ConvosNSE
+
+APP_GROUP_IDENTIFIER = group.$(MAIN_BUNDLE_ID)
+ASSOCIATED_DOMAIN = [NEEDS DECISION]
+WEB_CREDENTIALS_DOMAIN = [NEEDS DECISION]
+SECONDARY_ASSOCIATED_DOMAIN = [NEEDS DECISION]
+URL_SCHEME = convos-testnet
+KEYCHAIN_GROUP_IDENTIFIER = $(MAIN_BUNDLE_ID)
+APP_DISPLAY_NAME = Convos Testnet
+APNS_ENVIRONMENT = production
+
+ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon-Dev  (reuse Dev initially; swap to AppIcon-Testnet once asset is created)
+
+SWIFT_OPTIMIZATION_LEVEL = -Onone
+ENABLE_TESTABILITY = YES
+DEBUG_INFORMATION_FORMAT = dwarf
+```
+
+#### Xcode Project Build Configurations
+
+The `.xcodeproj/project.pbxproj` must gain a "Testnet" build configuration for every target that currently has Local / Dev / Prod configurations. This is the most structurally complex part of the change because it must be done through Xcode's UI (or careful manual pbxproj editing) to avoid corrupting the project file.
+
+Targets that need a "Testnet" configuration:
+- Convos (main app)
+- ConvosTests
+- NotificationService
+- ConvosAppClip (even without a Testnet scheme, the target config must exist to avoid build system errors)
+- Any other targets present in the project
+
+Each new configuration should be based on the "Dev" configuration in Xcode's "Duplicate" flow, then have its xcconfig file set to `Testnet.xcconfig`.
+
+#### AppEnvironment (ConvosCore)
+
+File: `ConvosCore/Sources/ConvosCore/AppEnvironment.swift`
+
+Add `case testnet(config: ConvosConfiguration)` to the `AppEnvironment` enum and update every switch statement:
+
+- `name` → return `"testnet"`
+- `firebaseConfigURL` → return `"GoogleService-Info.Testnet"` resource
+- `apiBaseURL` → delegate to `config.apiBaseURL` (same pattern as dev)
+- `appGroupIdentifier` → delegate to `config.appGroupIdentifier`
+- `relyingPartyIdentifier` → delegate to `config.relyingPartyIdentifier`
+- `xmtpEndpoint` → delegate to `config.xmtpEndpoint`
+- `xmtpNetwork` → delegate to `config.xmtpNetwork`
+- `gatewayUrl` → delegate to `config.gatewayUrl`
+- `isProduction` → `false`
+- `isTestingEnvironment` → `false`
+
+Also update `EnvironmentType`:
+```swift
+public enum EnvironmentType {
+    case local, dev, testnet, production, tests
+}
+```
+
+And `configured(_:type:)` to handle `.testnet`.
+
+#### AppEnvironment+Shared.swift
+
+`SharedAppConfiguration.toAppEnvironment()` currently falls through to `.production` for unknown environment strings. Add an explicit `"testnet"` case:
+```swift
+case "testnet":
+    return .testnet(config: config)
+```
+
+#### ConfigManager
+
+File: `Convos/Config/ConfigManager.swift`
+
+Add a `case "testnet":` arm in `createEnvironment()`. The testnet case:
+
+1. Requires `CONVOS_API_BASE_URL` from Secrets (same as Dev — no hardcoded fallback URL acceptable)
+2. Passes `gatewayUrl` from config JSON (already populated in `config.testnet.json`)
+3. Does not pass `xmtpEndpoint` from Secrets unless `XMTP_CUSTOM_HOST` is set (same behavior as Dev)
+4. Returns `.testnet(config: config)`
+
+Also extend the `xmtpNetwork` validator to accept `"testnet"` if that string ever appears; currently it only accepts `"local"`, `"dev"`, `"production"`, and `"prod"`. Since `config.testnet.json` sets `xmtpNetwork` to `"dev"`, this validator change may not be strictly required, but it is defensive hygiene.
+
+#### Build Phase Scripts
+
+All three scripts in `Scripts/build-phases/` handle Local and Dev with explicit branches; all other configurations fall through to the config-copy step only. Testnet needs its own branch to generate a `Secrets.swift` with the correct shape.
+
+Pattern for each script: add an `elif [ "$CONFIGURATION" = "Testnet" ]` block that:
+
+1. Reads `CONVOS_API_BASE_URL` from `.env` (same as Dev)
+2. Reads `FIREBASE_APP_CHECK_DEBUG_TOKEN` from `.env` (same as Dev)
+3. Writes `GATEWAY_URL = ""` (the gateway URL comes from config.json, not Secrets, for testnet)
+4. Writes `XMTP_CUSTOM_HOST = ""` (not overridable for testnet)
+5. Writes `SENTRY_DSN = ""` (unless a testnet-specific DSN is configured — deferred)
+
+For `copy-env-config-main-app.sh`, the branch guard is `[ "$TARGET_NAME" = "Convos" ] && [ "$CONFIGURATION" = "Testnet" ]`, matching the existing Dev pattern.
+
+#### Firebase Configuration
+
+Create `Convos/Config/GoogleService-Info.Testnet.plist` as a copy of `GoogleService-Info.Dev.plist` initially. A dedicated Firebase project or app registration can be created later if testnet analytics need to be separated from Dev. There is no App Clip for Testnet in this phase, so no `ConvosAppClip/Config/GoogleService-Info.Testnet.plist` is needed.
+
+#### Info.plist Variant
+
+Create `Convos/Config/Info.Testnet.plist` as a copy of `Convos/Config/Info.Dev.plist`. The bundle display name will be controlled by `APP_DISPLAY_NAME` from the xcconfig, so no content changes are needed beyond using it as the per-configuration Info.plist for the Testnet build configuration.
+
+#### App Icon
+
+Add `AppIcon-Testnet` to the asset catalog, or reuse `AppIcon-Dev` by pointing `ASSETCATALOG_COMPILER_APPICON_NAME` at it. A distinct icon is preferable for clarity on-device but is not a blocker for the initial implementation.
+
+#### Xcode Schemes
+
+Create two new schemes in `Convos.xcodeproj/xcshareddata/xcschemes/`:
+
+`Convos (Testnet).xcscheme` — copy of `Convos (Dev).xcscheme` with all `buildConfiguration = "Dev"` replaced by `buildConfiguration = "Testnet"`. The test plan reference (`Convos (Dev).xctestplan`) should be updated to a `Convos (Testnet).xctestplan` or simply omitted until one is created.
+
+`NotificationService (Testnet).xcscheme` — copy of `NotificationService (Dev).xcscheme` with `buildConfiguration = "Dev"` replaced by `buildConfiguration = "Testnet"` in the LaunchAction.
+
+### Data Model
+
+No new database tables or model changes. The existing `ConvosConfiguration` struct and `SharedAppConfiguration` Codable type already carry all required fields (`gatewayUrl`, `xmtpNetwork`, etc.).
+
+### API Changes
+
+No API contract changes. The testnet environment points at a different base URL but uses the identical API surface as Dev.
+
+### UI/UX
+
+No UI changes. The only visible difference to a user is the app display name ("Convos Testnet") and app icon.
+
+## Implementation Plan
+
+### Phase 1: Core infrastructure (no Xcode project editing yet)
+
+- [ ] Create `Convos/Config/config.testnet.json`
+- [ ] Create `Convos/Config/Testnet.xcconfig`
+- [ ] Create `Convos/Config/GoogleService-Info.Testnet.plist` (copy of Dev)
+- [ ] Create `Convos/Config/Info.Testnet.plist` (copy of Dev)
+- [ ] Add `AppIcon-Testnet` to asset catalog (or confirm Dev reuse)
+- [ ] Add `case testnet(config: ConvosConfiguration)` to `AppEnvironment` and update all switch statements
+- [ ] Add `case testnet` to `EnvironmentType` and `configured(_:type:)`
+- [ ] Update `AppEnvironment+Shared.swift` `toAppEnvironment()` with explicit `"testnet"` case
+- [ ] Add `"testnet"` arm to `ConfigManager.createEnvironment()`
+- [ ] Extend `xmtpNetwork` validator to allow `"testnet"` network string
+- [ ] Add Testnet branch to `copy-env-config-main-app.sh`
+- [ ] Add Testnet branch to `copy-env-config-notification-service.sh`
+- [ ] Add Testnet branch to `copy-env-config-app-clip.sh`
+
+### Phase 2: Xcode project wiring
+
+Done manually, not via Claude
+
+- [ ] Open Xcode, duplicate the "Dev" build configuration for every target and name it "Testnet"
+- [ ] Assign `Testnet.xcconfig` as the xcconfig for the Testnet configuration on each target
+- [ ] Create `Convos (Testnet).xcscheme`
+- [ ] Create `NotificationService (Testnet).xcscheme`
+- [ ] Verify build succeeds for "Convos (Testnet)" scheme
+
+### Phase 3: Apple Developer Portal
+
+- [x] Register App ID `org.convos.ios-testnet` in the Developer Portal
+- [x] Register App Group `group.org.convos.ios-testnet`
+- [x] Register Notification Service extension App ID `org.convos.ios-testnet.ConvosNSE`
+- [x] Create provisioning profiles for Testnet (development and distribution)
+- [x] Configure associated domains for `testnet.convos.org` once the domain is decided
+- [x] Update entitlements if associated domains differ from what xcconfig variables provide
+
+### Phase 4: Validation and documentation
+
+- [ ] Run "Convos (Testnet)" in a simulator and confirm: correct display name, bundle ID, API URL logged, gateway URL logged
+- [ ] Run "NotificationService (Testnet)" scheme and confirm it builds without errors
+- [ ] Confirm all existing schemes (Local, Dev, Prod) still build and behave correctly
+- [ ] Update `CLAUDE.md` environment list and build command examples
+- [ ] Update `.claude/commands/build.md` with testnet scheme
+- [ ] Update `.claude/commands/setup.md` if it references specific environments
+- [ ] Update `.claude/DESIGNER.md` if it references environments
+
+## Testing Strategy
+
+- Manual testing: build Testnet scheme in simulator, verify API URL and gateway URL in launch logs
+- Manual testing: send a test message and confirm it routes through the XMTP dev network
+- Manual testing: build each existing scheme (Local, Dev, Prod) and confirm no regressions
+- No new unit tests required — the `AppEnvironment` switch changes follow the existing exhaustive pattern and the compiler will flag any missing cases
+
+## Risks & Mitigations
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| pbxproj corruption when manually adding build configurations | High | Make the change through Xcode UI, not direct file editing; commit the pbxproj change as its own isolated commit so it can be reverted cleanly |
+| Missing `CONVOS_API_BASE_URL` in `.env` causes build-time failure | Medium | The `resolveAndValidateURL` helper already produces a clear `fatalError` message; document the required `.env` key in the testnet setup instructions |
+| Associated domains for Testnet are not yet provisioned | Medium | The app will install and run without them; passkeys and universal links won't work until the domain is registered, but messaging functionality is unaffected |
+| Reusing Dev Firebase project conflates testnet and dev analytics | Low | Acceptable for initial rollout; create a dedicated Firebase app registration later if needed |
+| Notification extension Keychain sharing breaks without the registered App Group | Medium | Register the App Group in Phase 3 before testing push notifications on device; simulator does not require it |
+
+## Open Questions
+
+- [ ] Should Testnet have a completely separate Firebase project/app, or is sharing the Dev Firebase project acceptable long-term?
+- [ ] Does the App Clip need a Testnet variant at any point in the near future?
+
+## References
+
+- `ConvosCore/Sources/ConvosCore/AppEnvironment.swift` — enum to extend
+- `ConvosCore/Sources/ConvosCore/AppEnvironment+Shared.swift` — Keychain round-trip to update
+- `Convos/Config/ConfigManager.swift` — environment creation logic
+- `Convos/Config/Dev.xcconfig` — template for Testnet.xcconfig
+- `Convos/Config/config.dev.json` — template for config.testnet.json
+- `Scripts/build-phases/copy-env-config-main-app.sh` — Secrets generation to extend
+- `Scripts/build-phases/copy-env-config-notification-service.sh` — Secrets generation to extend
+- `Scripts/build-phases/copy-env-config-app-clip.sh` — Secrets generation to extend
+- `Convos.xcodeproj/xcshareddata/xcschemes/Convos (Dev).xcscheme` — template for Convos (Testnet) scheme
+- `Convos.xcodeproj/xcshareddata/xcschemes/NotificationService (Dev).xcscheme` — template for NotificationService (Testnet) scheme


### PR DESCRIPTION
## Summary

- PRD and planning document for adding a "Testnet" environment to the Convos iOS app
- Defines the architecture, implementation plan, and open questions for connecting to the XMTP dev network via a d14n gateway

## What's in this PR

This is the **plan PR** — it contains only the PRD at `docs/plans/add-testnet-environment.md`. The implementation is in the stacked PR above.

See the [implementation PR (#710)](https://github.com/xmtplabs/convos-ios/pull/710) for the code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add testnet environment support with new `DBConversation` fields and updated XMTP client options
> - Bumps the XMTP SDK dependency from `ios-4.9.0-dev.88ddfad` to `ios-4.10.0-dev.796011d` across [ConvosCore/Package.swift](https://github.com/xmtplabs/convos-ios/pull/709/files#diff-a2bdca0eaceddfb5e4fbd6afdf3047a9c23f261d60140456b61baada4a24caa3), [ConvosInvites/Package.swift](https://github.com/xmtplabs/convos-ios/pull/709/files#diff-d4750024712f96fb2f92c7de6b61dc8dee585572e6f28f155e99eaf0fbf171e7), and [ConvosProfiles/Package.swift](https://github.com/xmtplabs/convos-ios/pull/709/files#diff-dffdebfa73b61aa396e5d5d379ef0e7829ff2870ecd692601391f7ae8ebfe6d7).
> - Replaces separate `maxDbPoolSize`/`minDbPoolSize` parameters with a `DbPoolOptions` struct (`maxPoolSize: 10`, `minPoolSize: 3`) in `InboxStateMachine` and test helpers to match the new SDK API.
> - Adds `conversationEmoji: nil` and `hasHadVerifiedAssistant: false` fields to `DBConversation` initializers across all test fixtures to satisfy new required fields.
> - Updates invite code API mocks to return `ConvosAPI.InviteCodeStatus` and adds a `fetchInviteCodeStatus` method to test mocks.
> - Adds a design doc at [docs/plans/add-testnet-environment.md](https://github.com/xmtplabs/convos-ios/pull/709/files#diff-550313f5345d890ba43e90bfb4a373470840a3324939fb3e6b7146af1a436562) outlining the testnet environment plan.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1521008.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->