### PR TITLE
Fix local secret generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,9 +51,8 @@ secrets: ## Generate Secrets.swift (auto-detects CI environment)
 		echo "🔧 CI/CD environment detected, generating minimal secrets..."; \
 		./Scripts/generate-secrets-secure.sh; \
 	else \
-		echo "🏠 Local environment detected, generating minimal secrets..."; \
-		echo "💡 Tip: Use 'make secrets-local' for IP detection, or just build - the build phase handles it automatically"; \
-		./Scripts/generate-secrets-secure.sh; \
+		echo "🏠 Local environment detected, generating secrets with IP detection..."; \
+		./Scripts/generate-secrets-local.sh; \
 	fi
 
 .PHONY: secrets-local

--- a/Scripts/generate-secrets-local.sh
+++ b/Scripts/generate-secrets-local.sh
@@ -156,21 +156,21 @@ if [ -f ".env" ]; then
     # Check if keys exist in .env (even if empty)
     if grep -v '^#' ".env" | grep -q '^CONVOS_API_BASE_URL='; then
         ENV_HAS_BACKEND_URL=true
-        ENV_BACKEND_URL=$(grep -v '^#' ".env" | grep '^CONVOS_API_BASE_URL=' | tail -n1 | cut -d'=' -f2- | sed -e 's/^"//' -e 's/"$//' || true)
+        ENV_BACKEND_URL=$(grep -v '^#' ".env" | grep '^CONVOS_API_BASE_URL=' | tail -n1 | cut -d'=' -f2- | sed -e 's/^"//' -e 's/"$//' -e 's/[[:space:]]*#.*$//' || true)
     fi
     if grep -v '^#' ".env" | grep -q '^XMTP_CUSTOM_HOST='; then
         ENV_HAS_XMTP_HOST=true
-        ENV_XMTP_HOST=$(grep -v '^#' ".env" | grep '^XMTP_CUSTOM_HOST=' | tail -n1 | cut -d'=' -f2- | sed -e 's/^"//' -e 's/"$//' || true)
+        ENV_XMTP_HOST=$(grep -v '^#' ".env" | grep '^XMTP_CUSTOM_HOST=' | tail -n1 | cut -d'=' -f2- | sed -e 's/^"//' -e 's/"$//' -e 's/[[:space:]]*#.*$//' || true)
     fi
     if grep -v '^#' ".env" | grep -q '^GATEWAY_URL='; then
         ENV_HAS_GATEWAY_URL=true
-        ENV_GATEWAY_URL=$(grep -v '^#' ".env" | grep '^GATEWAY_URL=' | tail -n1 | cut -d'=' -f2- | sed -e 's/^"//' -e 's/"$//' || true)
+        ENV_GATEWAY_URL=$(grep -v '^#' ".env" | grep '^GATEWAY_URL=' | tail -n1 | cut -d'=' -f2- | sed -e 's/^"//' -e 's/"$//' -e 's/[[:space:]]*#.*$//' || true)
     fi
     if grep -v '^#' ".env" | grep -q '^SENTRY_DSN='; then
-        ENV_SENTRY_DSN=$(grep -v '^#' ".env" | grep '^SENTRY_DSN=' | tail -n1 | cut -d'=' -f2- | sed -e 's/^"//' -e 's/"$//' || true)
+        ENV_SENTRY_DSN=$(grep -v '^#' ".env" | grep '^SENTRY_DSN=' | tail -n1 | cut -d'=' -f2- | sed -e 's/^"//' -e 's/"$//' -e 's/[[:space:]]*#.*$//' || true)
     fi
     if grep -v '^#' ".env" | grep -q '^FIREBASE_APP_CHECK_DEBUG_TOKEN='; then
-        ENV_FIREBASE_DEBUG_TOKEN=$(grep -v '^#' ".env" | grep '^FIREBASE_APP_CHECK_DEBUG_TOKEN=' | tail -n1 | cut -d'=' -f2- | sed -e 's/^"//' -e 's/"$//' || true)
+        ENV_FIREBASE_DEBUG_TOKEN=$(grep -v '^#' ".env" | grep '^FIREBASE_APP_CHECK_DEBUG_TOKEN=' | tail -n1 | cut -d'=' -f2- | sed -e 's/^"//' -e 's/"$//' -e 's/[[:space:]]*#.*$//' || true)
     fi
 fi
 
@@ -285,8 +285,8 @@ if [ -f ".env" ]; then
             continue
         fi
 
-        # Remove any quotes from the value
-        value=$(echo "$value" | sed -e 's/^"//' -e 's/"$//')
+        # Remove any quotes from the value and strip inline comments
+        value=$(echo "$value" | sed -e 's/^"//' -e 's/"$//' -e 's/[[:space:]]*#.*$//')
 
         # Escape the value to prevent injection
         escaped_value=$(swift_escape "$value")


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Fix local secret generation to strip inline comments and use correct script
- Fixes `make secrets` outside CI to invoke [generate-secrets-local.sh](https://github.com/xmtplabs/convos-ios/pull/714/files#diff-717c215f48e874eafccee07cb09846cf1d98101625674260d2ae3232aaf11f23) instead of `generate-secrets-secure.sh`
- Strips trailing inline comments (e.g. `value # comment`) from `.env` values when parsing both named overrides and the generic secrets ingestion loop, so only the actual value is written to `Secrets.swift`

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized b3c25f5.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->