### PR TITLE
Fix ConvosCoreTests compile errors (stale mocks, missing DBConversation args)

### DIFF
--- a/ConvosCore/Tests/ConvosCoreTests/Assets/AssetRenewalManagerTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/Assets/AssetRenewalManagerTests.swift
@@ -444,8 +444,10 @@ private extension AssetRenewalManagerTests {
             imageSalt: nil,
             imageNonce: nil,
             imageEncryptionKey: nil,
+            conversationEmoji: nil,
             imageLastRenewed: imageLastRenewed,
             isUnused: false,
+            hasHadVerifiedAssistant: false,
         )
     }
 }
@@ -481,6 +483,11 @@ final class ConfigurableMockAPIClient: ConvosAPIClientProtocol, @unchecked Senda
         .init(success: true, joined: true)
     }
 
-    func redeemInviteCode(_ code: String) async throws {
+    func redeemInviteCode(_ code: String) async throws -> ConvosAPI.InviteCodeStatus {
+        .init(code: code, name: nil, maxRedemptions: 5, redemptionCount: 0, remainingRedemptions: 5)
+    }
+
+    func fetchInviteCodeStatus(_ code: String) async throws -> ConvosAPI.InviteCodeStatus {
+        .init(code: code, name: nil, maxRedemptions: 5, redemptionCount: 0, remainingRedemptions: 5)
     }
 }

--- a/ConvosCore/Tests/ConvosCoreTests/Assets/AssetRenewalURLCollectorTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/Assets/AssetRenewalURLCollectorTests.swift
@@ -242,8 +242,10 @@ private extension AssetRenewalURLCollectorTests {
             imageSalt: nil,
             imageNonce: nil,
             imageEncryptionKey: nil,
+            conversationEmoji: nil,
             imageLastRenewed: imageLastRenewed,
             isUnused: false,
+            hasHadVerifiedAssistant: false,
         )
     }
 }

--- a/ConvosCore/Tests/ConvosCoreTests/ChronologicalSortIdTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ChronologicalSortIdTests.swift
@@ -417,8 +417,10 @@ struct ChronologicalSortIdTests {
             imageSalt: nil,
             imageNonce: nil,
             imageEncryptionKey: nil,
+            conversationEmoji: nil,
             imageLastRenewed: nil,
-            isUnused: false
+            isUnused: false,
+            hasHadVerifiedAssistant: false
         ).insert(db)
 
         try ConversationLocalState(

--- a/ConvosCore/Tests/ConvosCoreTests/DefaultConversationDisplayTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/DefaultConversationDisplayTests.swift
@@ -289,7 +289,8 @@ struct DefaultConversationDisplayTests {
             expiresAt: nil,
             debugInfo: .empty,
             isLocked: false,
-            assistantJoinStatus: nil
+            assistantJoinStatus: nil,
+            hasHadVerifiedAssistant: false
         )
         #expect(conversation.avatarType == .customImage)
     }

--- a/ConvosCore/Tests/ConvosCoreTests/DeleteExpiredPendingInvitesTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/DeleteExpiredPendingInvitesTests.swift
@@ -50,8 +50,10 @@ struct DeleteExpiredPendingInvitesTests {
             imageSalt: nil,
             imageNonce: nil,
             imageEncryptionKey: nil,
+            conversationEmoji: nil,
             imageLastRenewed: nil,
             isUnused: false,
+            hasHadVerifiedAssistant: false,
         )
     }
 

--- a/ConvosCore/Tests/ConvosCoreTests/ExpiredConversationsWorkerTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ExpiredConversationsWorkerTests.swift
@@ -215,8 +215,10 @@ private class ExpiredWorkerTestFixtures {
                 imageSalt: nil,
                 imageNonce: nil,
                 imageEncryptionKey: nil,
+                conversationEmoji: nil,
                 imageLastRenewed: nil,
                 isUnused: false,
+                hasHadVerifiedAssistant: false,
             )
             try conversation.upsert(db)
         }

--- a/ConvosCore/Tests/ConvosCoreTests/InboxActivityRepositoryTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/InboxActivityRepositoryTests.swift
@@ -153,8 +153,10 @@ struct InboxActivityRepositoryTests {
             imageSalt: nil,
             imageNonce: nil,
             imageEncryptionKey: nil,
+            conversationEmoji: nil,
             imageLastRenewed: nil,
             isUnused: false,
+            hasHadVerifiedAssistant: false,
         )
     }
 

--- a/ConvosCore/Tests/ConvosCoreTests/InboxLifecycleManagerTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/InboxLifecycleManagerTests.swift
@@ -1406,8 +1406,10 @@ struct InboxLifecycleManagerStaleExpiryTests {
             imageSalt: nil,
             imageNonce: nil,
             imageEncryptionKey: nil,
+            conversationEmoji: nil,
             imageLastRenewed: nil,
             isUnused: false,
+            hasHadVerifiedAssistant: false,
         )
     }
 }

--- a/ConvosCore/Tests/ConvosCoreTests/IncomingMessageWriterExplodeTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/IncomingMessageWriterExplodeTests.swift
@@ -306,8 +306,10 @@ private class ExplodeTestFixtures {
                 imageSalt: nil,
                 imageNonce: nil,
                 imageEncryptionKey: nil,
+                conversationEmoji: nil,
                 imageLastRenewed: nil,
                 isUnused: false,
+                hasHadVerifiedAssistant: false,
             )
             try conversation.insert(db)
 

--- a/ConvosCore/Tests/ConvosCoreTests/LockConversationTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/LockConversationTests.swift
@@ -192,8 +192,10 @@ struct LockConversationTests {
                 imageSalt: nil,
                 imageNonce: nil,
                 imageEncryptionKey: nil,
+                conversationEmoji: nil,
                 imageLastRenewed: nil,
                 isUnused: false,
+                hasHadVerifiedAssistant: false,
             ).insert(db)
         }
 
@@ -287,8 +289,10 @@ struct LockConversationTests {
                 imageSalt: nil,
                 imageNonce: nil,
                 imageEncryptionKey: nil,
+                conversationEmoji: nil,
                 imageLastRenewed: nil,
                 isUnused: false,
+                hasHadVerifiedAssistant: false,
             ).insert(db)
         }
 
@@ -459,8 +463,10 @@ struct LockConversationTests {
                 imageSalt: nil,
                 imageNonce: nil,
                 imageEncryptionKey: nil,
+                conversationEmoji: nil,
                 imageLastRenewed: nil,
                 isUnused: false,
+                hasHadVerifiedAssistant: false,
             ).insert(db)
         }
 
@@ -585,8 +591,10 @@ struct LockConversationTests {
                 imageSalt: nil,
                 imageNonce: nil,
                 imageEncryptionKey: nil,
+                conversationEmoji: nil,
                 imageLastRenewed: nil,
                 isUnused: false,
+                hasHadVerifiedAssistant: false,
             ).insert(db)
 
             // Create the member record with superAdmin role (this is what the UI reads)

--- a/ConvosCore/Tests/ConvosCoreTests/MessagesRepositoryBenchmarkTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/MessagesRepositoryBenchmarkTests.swift
@@ -62,8 +62,10 @@ struct MessagesRepositoryBenchmarkTests {
             imageSalt: nil,
             imageNonce: nil,
             imageEncryptionKey: nil,
+            conversationEmoji: nil,
             imageLastRenewed: nil,
             isUnused: false,
+            hasHadVerifiedAssistant: false,
         ).insert(db)
 
         try ConversationLocalState(

--- a/ConvosCore/Tests/ConvosCoreTests/MessagesRepositoryTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/MessagesRepositoryTests.swift
@@ -420,8 +420,10 @@ struct MessagesRepositoryTests {
             imageSalt: nil,
             imageNonce: nil,
             imageEncryptionKey: nil,
+            conversationEmoji: nil,
             imageLastRenewed: nil,
             isUnused: false,
+            hasHadVerifiedAssistant: false,
         ).insert(db)
 
         try ConversationLocalState(

--- a/ConvosCore/Tests/ConvosCoreTests/PendingInviteRepositoryTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/PendingInviteRepositoryTests.swift
@@ -195,8 +195,10 @@ struct PendingInviteRepositoryTests {
             imageSalt: nil,
             imageNonce: nil,
             imageEncryptionKey: nil,
+            conversationEmoji: nil,
             imageLastRenewed: nil,
             isUnused: false,
+            hasHadVerifiedAssistant: false,
         )
     }
 }

--- a/ConvosCore/Tests/ConvosCoreTests/PendingPhotoUploadTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/PendingPhotoUploadTests.swift
@@ -165,8 +165,10 @@ struct PendingPhotoUploadTests {
             imageSalt: nil,
             imageNonce: nil,
             imageEncryptionKey: nil,
+            conversationEmoji: nil,
             imageLastRenewed: nil,
             isUnused: false,
+            hasHadVerifiedAssistant: false,
         )
     }
 }

--- a/ConvosCore/Tests/ConvosCoreTests/ScheduledExplosionManagerTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ScheduledExplosionManagerTests.swift
@@ -291,8 +291,10 @@ private class ScheduledExplosionTestFixtures {
                 imageSalt: nil,
                 imageNonce: nil,
                 imageEncryptionKey: nil,
+                conversationEmoji: nil,
                 imageLastRenewed: nil,
                 isUnused: false,
+                hasHadVerifiedAssistant: false,
             )
             try conversation.insert(db)
         }

--- a/ConvosCore/Tests/ConvosCoreTests/SessionManagerTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/SessionManagerTests.swift
@@ -46,8 +46,10 @@ struct SessionManagerTests {
                 imageSalt: nil,
                 imageNonce: nil,
                 imageEncryptionKey: nil,
+                conversationEmoji: nil,
                 imageLastRenewed: nil,
                 isUnused: false,
+                hasHadVerifiedAssistant: false,
             ).insert(db)
         }
 
@@ -119,8 +121,10 @@ struct SessionManagerTests {
                 imageSalt: nil,
                 imageNonce: nil,
                 imageEncryptionKey: nil,
+                conversationEmoji: nil,
                 imageLastRenewed: nil,
                 isUnused: false,
+                hasHadVerifiedAssistant: false,
             ).insert(db)
         }
 
@@ -160,8 +164,10 @@ struct SessionManagerTests {
                 imageSalt: nil,
                 imageNonce: nil,
                 imageEncryptionKey: nil,
+                conversationEmoji: nil,
                 imageLastRenewed: nil,
                 isUnused: false,
+                hasHadVerifiedAssistant: false,
             ).insert(db)
         }
 
@@ -209,8 +215,10 @@ struct SessionManagerTests {
                 imageSalt: nil,
                 imageNonce: nil,
                 imageEncryptionKey: nil,
+                conversationEmoji: nil,
                 imageLastRenewed: nil,
                 isUnused: false,
+                hasHadVerifiedAssistant: false,
             ).insert(db)
 
             // Insert second inbox and conversation
@@ -236,8 +244,10 @@ struct SessionManagerTests {
                 imageSalt: nil,
                 imageNonce: nil,
                 imageEncryptionKey: nil,
+                conversationEmoji: nil,
                 imageLastRenewed: nil,
                 isUnused: false,
+                hasHadVerifiedAssistant: false,
             ).insert(db)
         }
 
@@ -289,8 +299,10 @@ struct SessionManagerTests {
                 imageSalt: nil,
                 imageNonce: nil,
                 imageEncryptionKey: nil,
+                conversationEmoji: nil,
                 imageLastRenewed: nil,
                 isUnused: false,
+                hasHadVerifiedAssistant: false,
             ).insert(db)
 
             // Insert second inbox and conversation
@@ -316,8 +328,10 @@ struct SessionManagerTests {
                 imageSalt: nil,
                 imageNonce: nil,
                 imageEncryptionKey: nil,
+                conversationEmoji: nil,
                 imageLastRenewed: nil,
                 isUnused: false,
+                hasHadVerifiedAssistant: false,
             ).insert(db)
         }
 

--- a/ConvosCore/Tests/ConvosCoreTests/SyncingManagerTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/SyncingManagerTests.swift
@@ -362,7 +362,12 @@ final class TestableMockAPIClient: ConvosAPIClientProtocol, @unchecked Sendable 
         .init(success: true, joined: true)
     }
 
-    func redeemInviteCode(_ code: String) async throws {
+    func redeemInviteCode(_ code: String) async throws -> ConvosAPI.InviteCodeStatus {
+        .init(code: code, name: nil, maxRedemptions: 5, redemptionCount: 0, remainingRedemptions: 5)
+    }
+
+    func fetchInviteCodeStatus(_ code: String) async throws -> ConvosAPI.InviteCodeStatus {
+        .init(code: code, name: nil, maxRedemptions: 5, redemptionCount: 0, remainingRedemptions: 5)
     }
 }
 


### PR DESCRIPTION
- Update TestableMockAPIClient and ConfigurableMockAPIClient to match the
  updated ConvosAPIClientProtocol signatures: redeemInviteCode now returns
  InviteCodeStatus, and fetchInviteCodeStatus has been added.
- Add the new conversationEmoji and hasHadVerifiedAssistant arguments to
  all DBConversation initializers in test files.
- Add hasHadVerifiedAssistant to the Conversation initializer in
  DefaultConversationDisplayTests.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix ConvosCoreTests compile errors from stale mocks and missing DBConversation args
> - Adds `conversationEmoji: nil` and `hasHadVerifiedAssistant: false` to `DBConversation` initializers across all test fixtures to match updated model requirements.
> - Updates `redeemInviteCode` in `ConfigurableMockAPIClient` and `TestableMockAPIClient` to return `ConvosAPI.InviteCodeStatus` instead of `Void`, and adds `fetchInviteCodeStatus` to both mocks.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6698270.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->