### PR TITLE
Add ConvosConnections package: 9 data sources, write capabilities, example app

### DIFF
--- a/ConvosConnections/Example/ConvosConnectionsExample.xcodeproj/project.pbxproj
+++ b/ConvosConnections/Example/ConvosConnectionsExample.xcodeproj/project.pbxproj
@@ -1,0 +1,382 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 77;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		CC10000000000000000000E3 /* ConvosConnections in Frameworks */ = {isa = PBXBuildFile; productRef = CC10000000000000000000E2 /* ConvosConnections */; };
+		CC10000000000000000000E5 /* ConvosConnectionsScreenTime in Frameworks */ = {isa = PBXBuildFile; productRef = CC10000000000000000000E4 /* ConvosConnectionsScreenTime */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		CC10000000000000000000B2 /* ConvosConnectionsExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ConvosConnectionsExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		CC10000000000000000000A4 /* ConvosConnectionsExample */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = ConvosConnectionsExample;
+			sourceTree = "<group>";
+		};
+/* End PBXFileSystemSynchronizedRootGroup section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		CC10000000000000000000B4 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CC10000000000000000000E3 /* ConvosConnections in Frameworks */,
+				CC10000000000000000000E5 /* ConvosConnectionsScreenTime in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		CC10000000000000000000A2 = {
+			isa = PBXGroup;
+			children = (
+				CC10000000000000000000A4 /* ConvosConnectionsExample */,
+				CC10000000000000000000A3 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		CC10000000000000000000A3 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				CC10000000000000000000B2 /* ConvosConnectionsExample.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		CC10000000000000000000B1 /* ConvosConnectionsExample */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CC10000000000000000000D3 /* Build configuration list for PBXNativeTarget "ConvosConnectionsExample" */;
+			buildPhases = (
+				CC10000000000000000000B3 /* Sources */,
+				CC10000000000000000000B4 /* Frameworks */,
+				CC10000000000000000000B5 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				CC10000000000000000000A4 /* ConvosConnectionsExample */,
+			);
+			name = ConvosConnectionsExample;
+			packageProductDependencies = (
+				CC10000000000000000000E2 /* ConvosConnections */,
+				CC10000000000000000000E4 /* ConvosConnectionsScreenTime */,
+			);
+			productName = ConvosConnectionsExample;
+			productReference = CC10000000000000000000B2 /* ConvosConnectionsExample.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		CC10000000000000000000A1 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1600;
+				LastUpgradeCheck = 1600;
+				TargetAttributes = {
+					CC10000000000000000000B1 = {
+						CreatedOnToolsVersion = 16.0;
+					};
+				};
+			};
+			buildConfigurationList = CC10000000000000000000C3 /* Build configuration list for PBXProject "ConvosConnectionsExample" */;
+			compatibilityVersion = "Xcode 16.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = CC10000000000000000000A2;
+			minimizedProjectReferenceProxies = 1;
+			packageReferences = (
+				CC10000000000000000000E1 /* XCLocalSwiftPackageReference ".." */,
+			);
+			productRefGroup = CC10000000000000000000A3 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				CC10000000000000000000B1 /* ConvosConnectionsExample */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		CC10000000000000000000B5 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		CC10000000000000000000B3 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		CC10000000000000000000C1 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		CC10000000000000000000C2 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+			};
+			name = Release;
+		};
+		CC10000000000000000000D1 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = ConvosConnectionsExample/ConvosConnectionsExample.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = FY4NZR34Z3;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSCalendarsFullAccessUsageDescription = "ConvosConnectionsExample reads your calendar events so the package can demonstrate delivering calendar payloads to mock conversations.";
+				INFOPLIST_KEY_NSCalendarsUsageDescription = "ConvosConnectionsExample reads your calendar events so the package can demonstrate delivering calendar payloads to mock conversations.";
+				INFOPLIST_KEY_NSContactsUsageDescription = "ConvosConnectionsExample reads your address book so the package can demonstrate delivering contacts payloads to mock conversations.";
+				INFOPLIST_KEY_NSHealthShareUsageDescription = "ConvosConnectionsExample reads your health data so the package can demonstrate delivering health payloads to mock conversations.";
+				INFOPLIST_KEY_NSHealthUpdateUsageDescription = "ConvosConnectionsExample writes sample health data (water, caffeine, mindful sessions) when the demo triggers agent write actions.";
+				INFOPLIST_KEY_NSHomeKitUsageDescription = "ConvosConnectionsExample reads your HomeKit home topology so the package can demonstrate delivering home summary payloads to mock conversations.";
+				INFOPLIST_KEY_NSLocationAlwaysAndWhenInUseUsageDescription = "ConvosConnectionsExample watches for significant location changes and visits so the package can demonstrate delivering location payloads to mock conversations in the background.";
+				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "ConvosConnectionsExample watches for significant location changes and visits so the package can demonstrate delivering location payloads to mock conversations.";
+				INFOPLIST_KEY_NSAppleMusicUsageDescription = "ConvosConnectionsExample reads your media library so the package can demonstrate delivering now-playing payloads to mock conversations.";
+				INFOPLIST_KEY_NSMotionUsageDescription = "ConvosConnectionsExample reads motion activity classifications (walking, running, driving) so the package can demonstrate delivering motion payloads to mock conversations.";
+				INFOPLIST_KEY_NSPhotoLibraryAddUsageDescription = "ConvosConnectionsExample saves agent-provided images to your photo library when the demo triggers write actions.";
+				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "ConvosConnectionsExample reads your photo library so the package can demonstrate delivering photo metadata payloads to mock conversations.";
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = UIInterfaceOrientationPortrait;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = org.convos.ConvosConnectionsExample;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 6.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		CC10000000000000000000D2 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = ConvosConnectionsExample/ConvosConnectionsExample.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = FY4NZR34Z3;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSCalendarsFullAccessUsageDescription = "ConvosConnectionsExample reads your calendar events so the package can demonstrate delivering calendar payloads to mock conversations.";
+				INFOPLIST_KEY_NSCalendarsUsageDescription = "ConvosConnectionsExample reads your calendar events so the package can demonstrate delivering calendar payloads to mock conversations.";
+				INFOPLIST_KEY_NSContactsUsageDescription = "ConvosConnectionsExample reads your address book so the package can demonstrate delivering contacts payloads to mock conversations.";
+				INFOPLIST_KEY_NSHealthShareUsageDescription = "ConvosConnectionsExample reads your health data so the package can demonstrate delivering health payloads to mock conversations.";
+				INFOPLIST_KEY_NSHealthUpdateUsageDescription = "ConvosConnectionsExample writes sample health data (water, caffeine, mindful sessions) when the demo triggers agent write actions.";
+				INFOPLIST_KEY_NSHomeKitUsageDescription = "ConvosConnectionsExample reads your HomeKit home topology so the package can demonstrate delivering home summary payloads to mock conversations.";
+				INFOPLIST_KEY_NSLocationAlwaysAndWhenInUseUsageDescription = "ConvosConnectionsExample watches for significant location changes and visits so the package can demonstrate delivering location payloads to mock conversations in the background.";
+				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "ConvosConnectionsExample watches for significant location changes and visits so the package can demonstrate delivering location payloads to mock conversations.";
+				INFOPLIST_KEY_NSAppleMusicUsageDescription = "ConvosConnectionsExample reads your media library so the package can demonstrate delivering now-playing payloads to mock conversations.";
+				INFOPLIST_KEY_NSMotionUsageDescription = "ConvosConnectionsExample reads motion activity classifications (walking, running, driving) so the package can demonstrate delivering motion payloads to mock conversations.";
+				INFOPLIST_KEY_NSPhotoLibraryAddUsageDescription = "ConvosConnectionsExample saves agent-provided images to your photo library when the demo triggers write actions.";
+				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "ConvosConnectionsExample reads your photo library so the package can demonstrate delivering photo metadata payloads to mock conversations.";
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = UIInterfaceOrientationPortrait;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = org.convos.ConvosConnectionsExample;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 6.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		CC10000000000000000000C3 /* Build configuration list for PBXProject "ConvosConnectionsExample" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				CC10000000000000000000C1 /* Debug */,
+				CC10000000000000000000C2 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		CC10000000000000000000D3 /* Build configuration list for PBXNativeTarget "ConvosConnectionsExample" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				CC10000000000000000000D1 /* Debug */,
+				CC10000000000000000000D2 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+
+/* Begin XCLocalSwiftPackageReference section */
+		CC10000000000000000000E1 /* XCLocalSwiftPackageReference ".." */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = ..;
+		};
+/* End XCLocalSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		CC10000000000000000000E2 /* ConvosConnections */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = ConvosConnections;
+		};
+		CC10000000000000000000E4 /* ConvosConnectionsScreenTime */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = ConvosConnectionsScreenTime;
+		};
+/* End XCSwiftPackageProductDependency section */
+	};
+	rootObject = CC10000000000000000000A1 /* Project object */;
+}

--- a/ConvosConnections/Example/ConvosConnectionsExample.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/ConvosConnections/Example/ConvosConnectionsExample.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/ConvosConnections/Example/ConvosConnectionsExample.xcodeproj/xcshareddata/xcschemes/ConvosConnectionsExample.xcscheme
+++ b/ConvosConnections/Example/ConvosConnectionsExample.xcodeproj/xcshareddata/xcschemes/ConvosConnectionsExample.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1600"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CC10000000000000000000B1"
+               BuildableName = "ConvosConnectionsExample.app"
+               BlueprintName = "ConvosConnectionsExample"
+               ReferencedContainer = "container:ConvosConnectionsExample.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "CC10000000000000000000B1"
+            BuildableName = "ConvosConnectionsExample.app"
+            BlueprintName = "ConvosConnectionsExample"
+            ReferencedContainer = "container:ConvosConnectionsExample.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "CC10000000000000000000B1"
+            BuildableName = "ConvosConnectionsExample.app"
+            BlueprintName = "ConvosConnectionsExample"
+            ReferencedContainer = "container:ConvosConnectionsExample.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/ConvosConnections/Example/ConvosConnectionsExample/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/ConvosConnections/Example/ConvosConnectionsExample/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ConvosConnections/Example/ConvosConnectionsExample/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/ConvosConnections/Example/ConvosConnectionsExample/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,35 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "tinted"
+        }
+      ],
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ConvosConnections/Example/ConvosConnectionsExample/Assets.xcassets/Contents.json
+++ b/ConvosConnections/Example/ConvosConnectionsExample/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ConvosConnections/Example/ConvosConnectionsExample/ConfirmationSheet.swift
+++ b/ConvosConnections/Example/ConvosConnectionsExample/ConfirmationSheet.swift
@@ -1,0 +1,104 @@
+import ConvosConnections
+import SwiftUI
+
+/// Presented whenever the manager's always-confirm gate asks the host to approve a write.
+///
+/// Shows the pre-computed human summary, the connection kind, the capability, and the full
+/// argument dictionary. Approve resumes with `.approved`; Deny and swipe-to-dismiss both
+/// resume with `.denied`.
+struct ConfirmationSheet: View {
+    let request: ConfirmationRequest
+    let handler: ExampleConfirmationHandler
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section {
+                    HStack(spacing: 10) {
+                        Image(systemName: request.kind.systemImageName)
+                            .font(.title2)
+                            .foregroundStyle(.white)
+                            .frame(width: 36, height: 36)
+                            .background(Color.accentColor)
+                            .clipShape(RoundedRectangle(cornerRadius: 8))
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("Agent wants to \(request.actionName)")
+                                .font(.headline)
+                            Text("\(request.kind.displayName) · \(request.capability.displayName)")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                    Text(request.humanSummary)
+                        .font(.callout)
+                }
+
+                Section("Arguments") {
+                    ForEach(Array(request.arguments.keys).sorted(), id: \.self) { key in
+                        HStack(alignment: .top) {
+                            Text(key)
+                                .font(.caption.monospaced())
+                                .foregroundStyle(.secondary)
+                            Spacer()
+                            Text(Self.render(request.arguments[key] ?? .null))
+                                .font(.caption.monospaced())
+                                .multilineTextAlignment(.trailing)
+                        }
+                    }
+                }
+
+                Section("Context") {
+                    LabeledContent("Invocation ID", value: request.invocationId)
+                        .font(.caption.monospaced())
+                    LabeledContent("Conversation ID", value: request.conversationId)
+                        .font(.caption.monospaced())
+                    LabeledContent("Requested", value: request.requestedAt.formatted(date: .omitted, time: .standard))
+                        .font(.caption)
+                }
+            }
+            .navigationTitle("Confirm write")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Deny", role: .destructive) {
+                        handler.resolve(.denied)
+                    }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Approve") {
+                        handler.resolve(.approved)
+                    }
+                    .fontWeight(.semibold)
+                }
+            }
+        }
+        .presentationDetents([.medium, .large])
+    }
+
+    private static func render(_ value: ArgumentValue) -> String {
+        switch value {
+        case .string(let v): return "\"\(v)\""
+        case .bool(let v): return String(v)
+        case .int(let v): return String(v)
+        case .double(let v): return String(v)
+        case .date(let v): return v.formatted()
+        case .iso8601DateTime(let v): return v
+        case .enumValue(let v): return ".\(v)"
+        case .array(let values):
+            let inner = values.map { render($0) }.joined(separator: ", ")
+            return "[\(inner)]"
+        case .null: return "null"
+        }
+    }
+}
+
+private extension ConnectionCapability {
+    var displayName: String {
+        switch self {
+        case .read: return "read"
+        case .writeCreate: return "write (create)"
+        case .writeUpdate: return "write (update)"
+        case .writeDelete: return "write (delete)"
+        }
+    }
+}

--- a/ConvosConnections/Example/ConvosConnectionsExample/ConnectionFeedView.swift
+++ b/ConvosConnections/Example/ConvosConnectionsExample/ConnectionFeedView.swift
@@ -1,0 +1,844 @@
+import ConvosConnections
+import SwiftUI
+import UIKit
+
+struct ConnectionFeedView: View {
+    let conversation: MockConversation
+    @Bindable var model: ExampleModel
+
+    var body: some View {
+        let messages = model.messagesByConversation[conversation.id] ?? []
+        let details = model.detailsByKind[conversation.kind] ?? []
+        let isEnabled = model.enabledConversationIds.contains(conversation.id)
+        let writeCapabilities = model.writeCapabilities(for: conversation.kind)
+        let relevantInvocations = model.invocationLog.filter { $0.conversationId == conversation.id }
+        ZStack(alignment: .bottom) {
+            ScrollViewReader { proxy in
+                ScrollView {
+                    LazyVStack(alignment: .leading, spacing: 12) {
+                        ConversationHeader(conversation: conversation, isEnabled: isEnabled)
+                        if !details.isEmpty {
+                            AuthorizationDetailsCard(kind: conversation.kind, details: details)
+                        }
+                        if !writeCapabilities.isEmpty {
+                            WriteCapabilitiesCard(
+                                conversation: conversation,
+                                capabilities: writeCapabilities,
+                                enabled: model.capabilityEnablement,
+                                alwaysConfirm: model.alwaysConfirmByConversation[conversation.id] ?? false,
+                                onToggleCapability: { capability, newValue in
+                                    Task { await model.toggleCapability(capability, enabled: newValue, conversation: conversation) }
+                                },
+                                onToggleAlwaysConfirm: { newValue in
+                                    Task { await model.toggleAlwaysConfirm(newValue, conversation: conversation) }
+                                }
+                            )
+                        }
+                        if !relevantInvocations.isEmpty {
+                            InvocationLogCard(entries: relevantInvocations)
+                        }
+                        if messages.isEmpty {
+                            EmptyFeedState(conversation: conversation, isEnabled: isEnabled)
+                                .padding(.top, 40)
+                        } else {
+                            ForEach(messages) { message in
+                                MessageBubble(message: message)
+                                    .id(message.id)
+                            }
+                        }
+                    }
+                    .padding()
+                    .padding(.bottom, 80)
+                }
+                .onChange(of: messages.count) {
+                    if let last = messages.last {
+                        withAnimation { proxy.scrollTo(last.id, anchor: .bottom) }
+                    }
+                }
+            }
+
+            controlsBar
+        }
+        .navigationTitle(conversation.name)
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    private var controlsBar: some View {
+        VStack(spacing: 8) {
+            if let error = model.lastError {
+                Text(error)
+                    .font(.caption)
+                    .foregroundStyle(.red)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal)
+            }
+            HStack(spacing: 8) {
+                Button {
+                    Task { await model.simulateSnapshot(for: conversation) }
+                } label: {
+                    Label("Read payload", systemImage: "arrow.down.circle.fill")
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.borderedProminent)
+
+                if conversation.kind == .calendar {
+                    Button {
+                        Task { await model.simulateAgentCreateEvent(for: conversation) }
+                    } label: {
+                        Label("Agent create", systemImage: "wand.and.stars")
+                            .frame(maxWidth: .infinity)
+                    }
+                    .buttonStyle(.bordered)
+                }
+
+                if conversation.kind == .contacts {
+                    Button {
+                        Task { await model.simulateAgentCreateContact(for: conversation) }
+                    } label: {
+                        Label("Agent create", systemImage: "wand.and.stars")
+                            .frame(maxWidth: .infinity)
+                    }
+                    .buttonStyle(.bordered)
+                }
+
+                if conversation.kind == .photos {
+                    Button {
+                        Task { await model.simulateAgentSaveImage(for: conversation) }
+                    } label: {
+                        Label("Agent save", systemImage: "wand.and.stars")
+                            .frame(maxWidth: .infinity)
+                    }
+                    .buttonStyle(.bordered)
+                }
+
+                if conversation.kind == .health {
+                    Button {
+                        Task { await model.simulateAgentLogWater(for: conversation) }
+                    } label: {
+                        Label("Log 8oz water", systemImage: "wand.and.stars")
+                            .frame(maxWidth: .infinity)
+                    }
+                    .buttonStyle(.bordered)
+                }
+
+                if conversation.kind == .music {
+                    Button {
+                        Task { await model.simulateAgentPauseMusic(for: conversation) }
+                    } label: {
+                        Label("Agent pause", systemImage: "wand.and.stars")
+                            .frame(maxWidth: .infinity)
+                    }
+                    .buttonStyle(.bordered)
+                }
+
+                Button {
+                    Task { await model.clearMessages(for: conversation) }
+                } label: {
+                    Image(systemName: "trash")
+                }
+                .buttonStyle(.bordered)
+            }
+            .padding(.horizontal)
+        }
+        .padding(.vertical, 10)
+        .background(.thinMaterial)
+    }
+}
+
+private struct ConversationHeader: View {
+    let conversation: MockConversation
+    let isEnabled: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(spacing: 8) {
+                Image(systemName: conversation.kind.systemImageName)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Text(conversation.kind.displayName)
+                    .font(.caption.weight(.medium))
+                    .foregroundStyle(.secondary)
+                Spacer()
+                Text(isEnabled ? "Enabled" : "Disabled")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(isEnabled ? .green : .secondary)
+            }
+            Text("Conversation id: \(conversation.id)")
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+        }
+        .padding(.bottom, 4)
+    }
+}
+
+private struct AuthorizationDetailsCard: View {
+    let kind: ConnectionKind
+    let details: [AuthorizationDetail]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Text("Permissions for \(kind.displayName)")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                Spacer()
+                Button {
+                    openAppSettings()
+                } label: {
+                    Label("Open in Settings", systemImage: "arrow.up.forward.app")
+                        .font(.caption)
+                }
+            }
+
+            ForEach(details) { detail in
+                HStack(alignment: .top, spacing: 8) {
+                    Image(systemName: systemImage(for: detail.status))
+                        .foregroundStyle(color(for: detail.status))
+                        .frame(width: 18)
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(detail.displayName)
+                            .font(.callout)
+                        Text(statusText(for: detail.status))
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                    }
+                    Spacer()
+                }
+            }
+
+            if let note = details.compactMap(\.note).first {
+                Text(note)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .padding(.top, 2)
+            }
+        }
+        .padding(14)
+        .background(Color.secondary.opacity(0.08))
+        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+    }
+
+    private func openAppSettings() {
+        if let url = URL(string: UIApplication.openSettingsURLString) {
+            UIApplication.shared.open(url)
+        }
+    }
+
+    private func systemImage(for status: ConnectionAuthorizationStatus) -> String {
+        switch status {
+        case .authorized: return "checkmark.circle.fill"
+        case .partial: return "exclamationmark.circle.fill"
+        case .denied: return "xmark.circle.fill"
+        case .unavailable: return "minus.circle.fill"
+        case .notDetermined: return "questionmark.circle"
+        }
+    }
+
+    private func color(for status: ConnectionAuthorizationStatus) -> Color {
+        switch status {
+        case .authorized: return .green
+        case .partial: return .orange
+        case .denied, .unavailable: return .red
+        case .notDetermined: return .secondary
+        }
+    }
+
+    private func statusText(for status: ConnectionAuthorizationStatus) -> String {
+        switch status {
+        case .notDetermined: return "Not yet requested"
+        case .authorized: return "Requested"
+        case .denied: return "Denied"
+        case .partial(let missing): return "Partial (\(missing.count) missing)"
+        case .unavailable: return "Unavailable"
+        }
+    }
+}
+
+private struct EmptyFeedState: View {
+    let conversation: MockConversation
+    let isEnabled: Bool
+
+    var body: some View {
+        VStack(spacing: 8) {
+            Image(systemName: conversation.kind.systemImageName)
+                .font(.system(size: 40))
+                .foregroundStyle(.secondary)
+            Text(isEnabled ? "No payloads yet." : "Connection is disabled for this conversation.")
+                .font(.headline)
+            Text(isEnabled
+                 ? "Tap \"Simulate payload\" to force a snapshot, or generate activity on the device to trigger real observation."
+                 : "Turn on the toggle for this conversation on the root screen to start receiving payloads here.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal)
+        }
+        .frame(maxWidth: .infinity)
+    }
+}
+
+private struct MessageBubble: View {
+    let message: MockMessageStore.Message
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 6) {
+                Image(systemName: message.payload.source.systemImageName)
+                    .font(.caption)
+                Text(message.payload.source.displayName)
+                    .font(.caption.weight(.semibold))
+                Spacer()
+                Text(message.receivedAt, style: .time)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+
+            Text(message.payload.summary)
+                .font(.callout)
+
+            bodyDetails
+        }
+        .padding(12)
+        .background(Color.accentColor.opacity(0.12))
+        .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+    }
+
+    @ViewBuilder
+    private var bodyDetails: some View {
+        switch message.payload.body {
+        case .health(let payload):
+            HealthBody(payload: payload)
+        case .calendar(let payload):
+            CalendarBody(payload: payload)
+        case .location(let payload):
+            LocationBody(payload: payload)
+        case .contacts(let payload):
+            ContactsBody(payload: payload)
+        case .photos(let payload):
+            PhotosBody(payload: payload)
+        case .music(let payload):
+            MusicBody(payload: payload)
+        case .motion(let payload):
+            MotionBody(payload: payload)
+        case .homeKit(let payload):
+            HomeBody(payload: payload)
+        case .screenTime(let payload):
+            ScreenTimeBody(payload: payload)
+        case .unknown(let rawType, _):
+            Text("Unknown body type: \(rawType)")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+}
+
+private struct WriteCapabilitiesCard: View {
+    let conversation: MockConversation
+    let capabilities: [ConnectionCapability]
+    let enabled: [ExampleModel.CapabilityKey: Bool]
+    let alwaysConfirm: Bool
+    let onToggleCapability: (ConnectionCapability, Bool) -> Void
+    let onToggleAlwaysConfirm: (Bool) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Write capabilities")
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+
+            Text("Separate from the read toggle on the previous screen. Each verb is a distinct user consent.")
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+
+            ForEach(capabilities, id: \.self) { capability in
+                Toggle(
+                    isOn: Binding(
+                        get: { enabled[ExampleModel.CapabilityKey(kind: conversation.kind, capability: capability, conversationId: conversation.id)] ?? false },
+                        set: { newValue in onToggleCapability(capability, newValue) }
+                    )
+                ) {
+                    HStack {
+                        Image(systemName: icon(for: capability))
+                            .font(.caption)
+                            .frame(width: 20)
+                        Text(capability.displayName)
+                            .font(.callout)
+                    }
+                }
+            }
+
+            Divider().padding(.vertical, 2)
+
+            Toggle(isOn: Binding(
+                get: { alwaysConfirm },
+                set: { newValue in onToggleAlwaysConfirm(newValue) }
+            )) {
+                HStack {
+                    Image(systemName: "exclamationmark.shield")
+                        .font(.caption)
+                        .frame(width: 20)
+                    VStack(alignment: .leading, spacing: 1) {
+                        Text("Always confirm writes")
+                            .font(.callout)
+                        Text("Off by default. When on, each write waits for your approval (or returns requiresConfirmation if the app is backgrounded).")
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+        }
+        .padding(14)
+        .background(Color.secondary.opacity(0.08))
+        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+    }
+
+    private func icon(for capability: ConnectionCapability) -> String {
+        switch capability {
+        case .read: return "eye"
+        case .writeCreate: return "plus.circle"
+        case .writeUpdate: return "pencil"
+        case .writeDelete: return "trash"
+        }
+    }
+}
+
+private struct InvocationLogCard: View {
+    let entries: [RecordedInvocation]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Text("Invocation log")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                Spacer()
+                Text("\(entries.count) entries")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+
+            ForEach(entries.reversed().prefix(5)) { entry in
+                VStack(alignment: .leading, spacing: 3) {
+                    HStack {
+                        Image(systemName: statusIcon(for: entry.result.status))
+                            .font(.caption)
+                            .foregroundStyle(statusColor(for: entry.result.status))
+                        Text(entry.invocation.action.name)
+                            .font(.caption.weight(.medium))
+                        Spacer()
+                        Text(entry.recordedAt, style: .time)
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                    }
+                    Text(statusLabel(for: entry.result.status))
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                    if let message = entry.result.errorMessage {
+                        Text(message)
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(2)
+                    }
+                }
+                .padding(8)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(Color.secondary.opacity(0.08))
+                .clipShape(RoundedRectangle(cornerRadius: 8))
+            }
+        }
+        .padding(14)
+        .background(Color.accentColor.opacity(0.08))
+        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+    }
+
+    private func statusIcon(for status: ConnectionInvocationResult.Status) -> String {
+        switch status {
+        case .success: return "checkmark.circle.fill"
+        case .capabilityNotEnabled, .capabilityRevoked: return "lock.fill"
+        case .requiresConfirmation: return "questionmark.circle.fill"
+        case .authorizationDenied: return "hand.raised.fill"
+        case .executionFailed: return "xmark.octagon.fill"
+        case .unknownAction: return "questionmark.square.fill"
+        }
+    }
+
+    private func statusColor(for status: ConnectionInvocationResult.Status) -> Color {
+        switch status {
+        case .success: return .green
+        case .capabilityNotEnabled, .capabilityRevoked, .requiresConfirmation: return .orange
+        case .authorizationDenied, .executionFailed, .unknownAction: return .red
+        }
+    }
+
+    private func statusLabel(for status: ConnectionInvocationResult.Status) -> String {
+        switch status {
+        case .success: return "Success"
+        case .capabilityNotEnabled: return "Capability not enabled"
+        case .capabilityRevoked: return "Capability revoked"
+        case .requiresConfirmation: return "Requires confirmation"
+        case .authorizationDenied: return "Authorization denied"
+        case .executionFailed: return "Execution failed"
+        case .unknownAction: return "Unknown action"
+        }
+    }
+}
+
+private struct ScreenTimeBody: View {
+    let payload: ScreenTimePayload
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(spacing: 6) {
+                Image(systemName: payload.authorized ? "checkmark.circle.fill" : "circle")
+                    .font(.caption)
+                    .foregroundStyle(payload.authorized ? .green : .secondary)
+                Text(payload.authorized ? "Authorized" : "Not authorized")
+                    .font(.caption.weight(.medium))
+            }
+            if payload.selectedApplicationCount + payload.selectedCategoryCount + payload.selectedWebDomainCount > 0 {
+                Text("Selection: \(payload.selectedApplicationCount) apps · \(payload.selectedCategoryCount) categories · \(payload.selectedWebDomainCount) web domains")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            } else {
+                Text("No app / category selection yet. A DeviceActivityMonitor extension is needed to surface usage hours.")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+}
+
+private struct HomeBody: View {
+    let payload: HomePayload
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            if payload.homes.isEmpty {
+                Text("No homes configured")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            } else {
+                ForEach(payload.homes) { home in
+                    HStack {
+                        Image(systemName: home.isPrimary ? "house.fill" : "house")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .frame(width: 18)
+                        Text(home.name)
+                            .font(.caption.weight(.medium))
+                        Spacer()
+                        Text("\(home.roomCount) rooms · \(home.accessoryCount) accessories")
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+        }
+    }
+}
+
+private struct MotionBody: View {
+    let payload: MotionPayload
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            if let activity = payload.activity {
+                HStack(spacing: 8) {
+                    Image(systemName: icon(for: activity.type))
+                        .font(.caption.weight(.medium))
+                    Text(activity.type.rawValue.capitalized)
+                        .font(.caption.weight(.medium))
+                }
+                Text("Confidence: \(activity.confidence.rawValue) · Since \(activity.startDate, style: .time)")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            } else {
+                Text("No activity classified yet.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    private func icon(for type: MotionActivityType) -> String {
+        switch type {
+        case .stationary: return "figure.stand"
+        case .walking: return "figure.walk"
+        case .running: return "figure.run"
+        case .automotive: return "car.fill"
+        case .cycling: return "figure.outdoor.cycle"
+        case .unknown: return "questionmark"
+        }
+    }
+}
+
+private struct MusicBody: View {
+    let payload: MusicPayload
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            if let nowPlaying = payload.nowPlaying {
+                Text(nowPlaying.title ?? "(untitled)")
+                    .font(.caption.weight(.semibold))
+                if let artist = nowPlaying.artist {
+                    Text(artist)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+                if let album = nowPlaying.album {
+                    Text("from \(album)")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+                Text("\(Self.format(nowPlaying.playbackTimeSeconds)) / \(Self.format(nowPlaying.durationSeconds))")
+                    .font(.caption2.monospacedDigit())
+                    .foregroundStyle(.secondary)
+            }
+            HStack(spacing: 6) {
+                Image(systemName: iconFor(state: payload.playbackState))
+                    .font(.caption2)
+                Text(payload.playbackState.rawValue)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    private func iconFor(state: MusicPlaybackState) -> String {
+        switch state {
+        case .playing: return "play.fill"
+        case .paused: return "pause.fill"
+        case .stopped: return "stop.fill"
+        case .interrupted: return "exclamationmark.triangle"
+        case .seekingForward: return "forward.fill"
+        case .seekingBackward: return "backward.fill"
+        case .unknown: return "questionmark"
+        }
+    }
+
+    private static func format(_ seconds: Double) -> String {
+        guard seconds.isFinite, seconds >= 0 else { return "0:00" }
+        let total = Int(seconds)
+        return String(format: "%d:%02d", total / 60, total % 60)
+    }
+}
+
+private struct PhotosBody: View {
+    let payload: PhotosPayload
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(spacing: 8) {
+                Badge(label: "photos", count: payload.photoCount)
+                Badge(label: "videos", count: payload.videoCount)
+                Badge(label: "screenshots", count: payload.screenshotCount)
+                Badge(label: "live", count: payload.livePhotoCount)
+            }
+            Text("Recent \(payload.recentAssets.count) of \(payload.totalAssetCount) total")
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+            ForEach(payload.recentAssets.prefix(4)) { asset in
+                HStack {
+                    Image(systemName: iconFor(type: asset.mediaType, subtype: asset.subtype))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .frame(width: 18)
+                    Text(asset.subtype == .none ? asset.mediaType.rawValue : asset.subtype.rawValue)
+                        .font(.caption.weight(.medium))
+                    Spacer()
+                    if let date = asset.creationDate {
+                        Text(date, style: .date)
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+        }
+    }
+
+    private func iconFor(type: PhotoMediaType, subtype: PhotoMediaSubtype) -> String {
+        switch subtype {
+        case .screenshot: return "camera.viewfinder"
+        case .livePhoto: return "livephoto"
+        case .panorama: return "pano"
+        case .hdr: return "square.2.layers.3d"
+        case .slomo, .timelapse: return "video"
+        default: break
+        }
+        switch type {
+        case .photo: return "photo"
+        case .video: return "video"
+        case .audio: return "waveform"
+        case .unknown: return "questionmark.square"
+        }
+    }
+}
+
+private struct Badge: View {
+    let label: String
+    let count: Int
+
+    var body: some View {
+        if count >= 1 {
+            Text("\(count) \(label)")
+                .font(.caption2)
+                .padding(.horizontal, 6)
+                .padding(.vertical, 2)
+                .background(Color.secondary.opacity(0.15))
+                .clipShape(Capsule())
+        }
+    }
+}
+
+private struct ContactsBody: View {
+    let payload: ContactsPayload
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text("\(payload.totalContactCount) total — showing first \(payload.previewContacts.count)")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            ForEach(payload.previewContacts.prefix(5)) { contact in
+                HStack {
+                    Text(contact.displayName)
+                        .font(.caption.weight(.medium))
+                    Spacer()
+                    if contact.hasEmail {
+                        Image(systemName: "envelope.fill")
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                    }
+                    if contact.hasPhone {
+                        Image(systemName: "phone.fill")
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+            if payload.previewContacts.count > 5 {
+                Text("…and \(payload.previewContacts.count - 5) more in preview")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+}
+
+private struct LocationBody: View {
+    let payload: LocationPayload
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            if payload.events.isEmpty {
+                Text("No events")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            } else {
+                ForEach(payload.events) { event in
+                    HStack {
+                        Image(systemName: icon(for: event.type))
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .frame(width: 18)
+                        VStack(alignment: .leading, spacing: 1) {
+                            Text(label(for: event.type))
+                                .font(.caption.weight(.medium))
+                            Text("\(formatCoord(event.latitude)), \(formatCoord(event.longitude)) ±\(Int(event.horizontalAccuracy))m")
+                                .font(.caption2.monospacedDigit())
+                                .foregroundStyle(.secondary)
+                        }
+                        Spacer()
+                        Text(event.eventDate, style: .time)
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+        }
+    }
+
+    private func icon(for type: LocationEventType) -> String {
+        switch type {
+        case .significantChange: return "arrow.triangle.turn.up.right.circle"
+        case .visitArrival: return "mappin.and.ellipse"
+        case .visitDeparture: return "figure.walk.departure"
+        }
+    }
+
+    private func label(for type: LocationEventType) -> String {
+        switch type {
+        case .significantChange: return "Significant change"
+        case .visitArrival: return "Arrival"
+        case .visitDeparture: return "Departure"
+        }
+    }
+
+    private func formatCoord(_ value: Double) -> String {
+        String(format: "%.4f", value)
+    }
+}
+
+private struct HealthBody: View {
+    let payload: HealthPayload
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            if payload.samples.isEmpty {
+                Text("No samples in window")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            } else {
+                ForEach(Array(payload.samples.prefix(5).enumerated()), id: \.offset) { _, sample in
+                    HStack {
+                        Text(sample.type.displayName)
+                            .font(.caption.weight(.medium))
+                        Spacer()
+                        Text("\(String(format: "%.1f", sample.value)) \(sample.unit)")
+                            .font(.caption.monospacedDigit())
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                if payload.samples.count > 5 {
+                    Text("…and \(payload.samples.count - 5) more")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+    }
+}
+
+private struct CalendarBody: View {
+    let payload: CalendarPayload
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            if payload.events.isEmpty {
+                Text("No events in window")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            } else {
+                ForEach(payload.events.prefix(4)) { event in
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(event.title ?? "(untitled)")
+                            .font(.caption.weight(.medium))
+                        Text(event.startDate, style: .date)
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                            + Text("  •  ")
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                            + Text(event.startDate, style: .time)
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                if payload.events.count > 4 {
+                    Text("…and \(payload.events.count - 4) more")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+    }
+}

--- a/ConvosConnections/Example/ConvosConnectionsExample/ConvosConnectionsExample.entitlements
+++ b/ConvosConnections/Example/ConvosConnectionsExample/ConvosConnectionsExample.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.healthkit</key>
+	<true/>
+	<key>com.apple.developer.healthkit.access</key>
+	<array/>
+</dict>
+</plist>

--- a/ConvosConnections/Example/ConvosConnectionsExample/ConvosConnectionsExampleApp.swift
+++ b/ConvosConnections/Example/ConvosConnectionsExample/ConvosConnectionsExampleApp.swift
@@ -1,0 +1,33 @@
+import ConvosConnections
+import SwiftUI
+
+@main
+struct ConvosConnectionsExampleApp: App {
+    @State private var model: ExampleModel = ExampleModel()
+
+    var body: some Scene {
+        WindowGroup {
+            NavigationStack {
+                RootConnectionsView(model: model)
+                    .navigationDestination(for: MockConversation.self) { conversation in
+                        ConnectionFeedView(conversation: conversation, model: model)
+                    }
+            }
+            .task { await model.refresh() }
+            .sheet(
+                isPresented: Binding(
+                    get: { model.confirmationHandler.pendingRequest != nil },
+                    set: { newValue in
+                        if !newValue, model.confirmationHandler.pendingRequest != nil {
+                            model.confirmationHandler.resolve(.denied)
+                        }
+                    }
+                )
+            ) {
+                if let request = model.confirmationHandler.pendingRequest {
+                    ConfirmationSheet(request: request, handler: model.confirmationHandler)
+                }
+            }
+        }
+    }
+}

--- a/ConvosConnections/Example/ConvosConnectionsExample/ExampleConfirmationHandler.swift
+++ b/ConvosConnections/Example/ConvosConnectionsExample/ExampleConfirmationHandler.swift
@@ -1,0 +1,45 @@
+import ConvosConnections
+import Foundation
+import Observation
+import UIKit
+
+/// Example implementation of `ConfirmationHandling`.
+///
+/// When the manager's always-confirm gate fires, it `await`s our `confirm(_:)`. We stash
+/// the request (plus its completion continuation) on the main actor, let SwiftUI observe
+/// `pendingRequest`, and wait for the user to tap Approve or Deny. `resolve(_:)` resumes
+/// the continuation, which causes the manager's 6-step routing chain to continue.
+///
+/// Returns `.cannotPresent` immediately when the app is not active — the manager surfaces
+/// that as `requiresConfirmation`, signalling the agent to retry when the user's back.
+@MainActor
+@Observable
+final class ExampleConfirmationHandler: ConfirmationHandling {
+    private(set) var pendingRequest: ConfirmationRequest?
+    private var continuation: CheckedContinuation<ConfirmationDecision, Never>?
+
+    nonisolated func confirm(_ request: ConfirmationRequest) async -> ConfirmationDecision {
+        await withCheckedContinuation { continuation in
+            Task { @MainActor in
+                guard UIApplication.shared.applicationState == .active else {
+                    continuation.resume(returning: .cannotPresent)
+                    return
+                }
+                // If a prior request is still pending (shouldn't happen in v1; manager calls
+                // confirm once per invocation), deny the old one so the new one takes over.
+                if let previous = self.continuation {
+                    previous.resume(returning: .denied)
+                }
+                self.continuation = continuation
+                self.pendingRequest = request
+            }
+        }
+    }
+
+    func resolve(_ decision: ConfirmationDecision) {
+        let active = continuation
+        continuation = nil
+        pendingRequest = nil
+        active?.resume(returning: decision)
+    }
+}

--- a/ConvosConnections/Example/ConvosConnectionsExample/ExampleModel.swift
+++ b/ConvosConnections/Example/ConvosConnectionsExample/ExampleModel.swift
@@ -1,0 +1,404 @@
+import ConvosConnections
+import ConvosConnectionsScreenTime
+import Foundation
+import Observation
+
+/// Drives the example app UI. Wraps a `ConnectionsManager` configured with the package's
+/// ship-worthy sources (Health, Calendar, Location, Contacts, Photos, Music, Motion,
+/// HomeKit, Screen Time) plus the `CalendarDataSink` for write capabilities.
+///
+/// Exposes two mock conversations per kind so the distinction between iOS authorization
+/// (global to the app) and per-conversation enablement (the package's core value) stays
+/// visible. For Calendar, also exposes per-capability write toggles and a simulated-agent
+/// "create event" button so contributors can see write-side round-trips.
+@MainActor
+@Observable
+final class ExampleModel {
+    let manager: ConnectionsManager
+    let messageStore: MockMessageStore
+    let confirmationHandler: ExampleConfirmationHandler
+
+    private(set) var kinds: [ConnectionKind] = []
+    private(set) var statuses: [ConnectionKind: ConnectionAuthorizationStatus] = [:]
+    private(set) var detailsByKind: [ConnectionKind: [AuthorizationDetail]] = [:]
+    private(set) var enabledConversationIds: Set<String> = []
+    private(set) var messagesByConversation: [String: [MockMessageStore.Message]] = [:]
+    /// Per-(kind, capability, conversationId) enablement flags.
+    private(set) var capabilityEnablement: [CapabilityKey: Bool] = [:]
+    /// Per-(kind, conversationId) always-confirm flags.
+    private(set) var alwaysConfirmByConversation: [String: Bool] = [:]
+    private(set) var invocationLog: [RecordedInvocation] = []
+    /// Write capabilities available per kind, derived from sink action schemas.
+    private(set) var writeCapabilitiesByKind: [ConnectionKind: [ConnectionCapability]] = [:]
+    private(set) var lastError: String?
+
+    struct CapabilityKey: Hashable, Sendable {
+        let kind: ConnectionKind
+        let capability: ConnectionCapability
+        let conversationId: String
+    }
+
+    init() {
+        let messageStore = MockMessageStore()
+        let enablementStore = UserDefaultsEnablementStore()
+        let confirmationHandler = ExampleConfirmationHandler()
+        let sources: [DataSource] = [
+            HealthDataSource(),
+            CalendarDataSource(),
+            LocationDataSource(),
+            ContactsDataSource(),
+            PhotosDataSource(),
+            MusicDataSource(),
+            MotionDataSource(),
+            HomeDataSource(),
+            ScreenTimeDataSource(),
+        ]
+        let sinks: [DataSink] = [
+            CalendarDataSink(),
+            ContactsDataSink(),
+            HomeKitDataSink(),
+            PhotosDataSink(),
+            HealthDataSink(),
+            ScreenTimeDataSink(),
+            MusicDataSink(),
+        ]
+        self.messageStore = messageStore
+        self.confirmationHandler = confirmationHandler
+        self.manager = ConnectionsManager(
+            sources: sources,
+            sinks: sinks,
+            store: enablementStore,
+            delivery: messageStore
+        )
+        Task { [manager = self.manager, handler = confirmationHandler] in
+            await manager.setConfirmationHandler(handler)
+        }
+    }
+
+    func conversations(for kind: ConnectionKind) -> [MockConversation] {
+        MockConversationCatalog.conversations(for: kind)
+    }
+
+    func writeCapabilities(for kind: ConnectionKind) -> [ConnectionCapability] {
+        writeCapabilitiesByKind[kind] ?? []
+    }
+
+    func toggle(conversation: MockConversation, enabled: Bool) async {
+        lastError = nil
+        let kind = conversation.kind
+        await manager.setEnabled(enabled, kind: kind, conversationId: conversation.id)
+
+        if enabled {
+            do {
+                let status = await manager.authorizationStatus(for: kind)
+                if status == .notDetermined {
+                    _ = try await manager.requestAuthorization(for: kind)
+                }
+                try await manager.startSource(kind: kind)
+            } catch {
+                lastError = error.localizedDescription
+            }
+        } else {
+            let remaining = await manager.enabledConversationIds(for: kind)
+            if remaining.isEmpty {
+                await manager.stopSource(kind: kind)
+            }
+        }
+        await refresh()
+    }
+
+    func toggleCapability(
+        _ capability: ConnectionCapability,
+        enabled: Bool,
+        conversation: MockConversation
+    ) async {
+        lastError = nil
+        await manager.setEnabled(enabled, kind: conversation.kind, capability: capability, conversationId: conversation.id)
+        await refresh()
+    }
+
+    func toggleAlwaysConfirm(_ enabled: Bool, conversation: MockConversation) async {
+        await manager.setAlwaysConfirmWrites(enabled, kind: conversation.kind, conversationId: conversation.id)
+        await refresh()
+    }
+
+    func requestAuthorization(for kind: ConnectionKind) async {
+        lastError = nil
+        do {
+            _ = try await manager.requestAuthorization(for: kind)
+        } catch {
+            lastError = error.localizedDescription
+        }
+        await refresh()
+    }
+
+    /// Simulate an agent creating a calendar event. The agent in the real app would emit a
+    /// `ConnectionInvocation` over XMTP; here we construct one inline and feed it to
+    /// `ConnectionsManager.handleInvocation`. The manager's gating and fan-out applies
+    /// identically to real XMTP-sourced invocations.
+    func simulateAgentCreateEvent(for conversation: MockConversation) async {
+        lastError = nil
+        guard conversation.kind == .calendar else {
+            lastError = "Agent simulation only implemented for Calendar."
+            return
+        }
+
+        let now = Date()
+        let startDate = Calendar.current.date(byAdding: .hour, value: 1, to: now) ?? now
+        let endDate = Calendar.current.date(byAdding: .hour, value: 2, to: now) ?? now
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        let startISO = formatter.string(from: startDate)
+        let endISO = formatter.string(from: endDate)
+
+        let invocation = ConnectionInvocation(
+            invocationId: "example-\(UUID().uuidString.prefix(8))",
+            kind: .calendar,
+            action: ConnectionAction(
+                name: "create_event",
+                arguments: [
+                    "title": .string("Agent-created event"),
+                    "startDate": .iso8601DateTime(startISO),
+                    "endDate": .iso8601DateTime(endISO),
+                    "timeZone": .string(TimeZone.current.identifier),
+                    "location": .string("Anywhere"),
+                    "notes": .string("Created by the example app via simulateAgentCreateEvent."),
+                ]
+            )
+        )
+        _ = await manager.handleInvocation(invocation, from: conversation.id)
+        await refresh()
+    }
+
+    /// Simulate an agent pausing music playback.
+    func simulateAgentPauseMusic(for conversation: MockConversation) async {
+        lastError = nil
+        guard conversation.kind == .music else {
+            lastError = "Agent simulation only implemented for Music here."
+            return
+        }
+        let invocation = ConnectionInvocation(
+            invocationId: "example-\(UUID().uuidString.prefix(8))",
+            kind: .music,
+            action: ConnectionAction(name: "pause", arguments: [:])
+        )
+        _ = await manager.handleInvocation(invocation, from: conversation.id)
+        await refresh()
+    }
+
+    /// Simulate an agent logging a glass of water to HealthKit.
+    func simulateAgentLogWater(for conversation: MockConversation) async {
+        lastError = nil
+        guard conversation.kind == .health else {
+            lastError = "Agent simulation only implemented for Health here."
+            return
+        }
+        let invocation = ConnectionInvocation(
+            invocationId: "example-\(UUID().uuidString.prefix(8))",
+            kind: .health,
+            action: ConnectionAction(
+                name: "log_water",
+                arguments: [
+                    "quantity": .double(8),
+                    "unit": .enumValue("oz"),
+                ]
+            )
+        )
+        _ = await manager.handleInvocation(invocation, from: conversation.id)
+        await refresh()
+    }
+
+    /// Simulate an agent saving a small red-pixel image to the photo library.
+    func simulateAgentSaveImage(for conversation: MockConversation) async {
+        lastError = nil
+        guard conversation.kind == .photos else {
+            lastError = "Agent simulation only implemented for Photos here."
+            return
+        }
+        // 10x10 solid red PNG, base64-encoded.
+        let base64 = "iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAH0lEQVR4nGP8z8DwnwEJMDGgASoJsDCgASoJsKAbAAAoIgMBl6Qn2wAAAABJRU5ErkJggg=="
+        let invocation = ConnectionInvocation(
+            invocationId: "example-\(UUID().uuidString.prefix(8))",
+            kind: .photos,
+            action: ConnectionAction(
+                name: "save_image",
+                arguments: [
+                    "imageData": .string(base64),
+                    "isFavorite": .bool(false),
+                ]
+            )
+        )
+        _ = await manager.handleInvocation(invocation, from: conversation.id)
+        await refresh()
+    }
+
+    /// Simulate an agent creating a contact. Uses the same gating pipeline.
+    func simulateAgentCreateContact(for conversation: MockConversation) async {
+        lastError = nil
+        guard conversation.kind == .contacts else {
+            lastError = "Agent simulation only implemented for Contacts here."
+            return
+        }
+        let stamp = Int(Date().timeIntervalSince1970) % 10000
+        let invocation = ConnectionInvocation(
+            invocationId: "example-\(UUID().uuidString.prefix(8))",
+            kind: .contacts,
+            action: ConnectionAction(
+                name: "create_contact",
+                arguments: [
+                    "givenName": .string("Convos"),
+                    "familyName": .string("Agent #\(stamp)"),
+                    "organization": .string("Convos Test"),
+                    "email": .string("agent+\(stamp)@convos.test"),
+                    "phone": .string("+15555550\(String(format: "%03d", stamp % 1000))"),
+                    "note": .string("Created by the example app via simulateAgentCreateContact."),
+                ]
+            )
+        )
+        _ = await manager.handleInvocation(invocation, from: conversation.id)
+        await refresh()
+    }
+
+    func simulateSnapshot(for conversation: MockConversation) async {
+        lastError = nil
+        do {
+            switch conversation.kind {
+            case .health:
+                if let source = await manager.source(for: .health) as? HealthDataSource {
+                    let payload = try await source.snapshotLast24Hours()
+                    try await messageStore.deliver(
+                        ConnectionPayload(source: .health, body: .health(payload)),
+                        to: conversation.id
+                    )
+                }
+            case .calendar:
+                if let source = await manager.source(for: .calendar) as? CalendarDataSource {
+                    let payload = try await source.snapshotCurrentWindow()
+                    try await messageStore.deliver(
+                        ConnectionPayload(source: .calendar, body: .calendar(payload)),
+                        to: conversation.id
+                    )
+                }
+            case .location:
+                let placeholder = LocationPayload(
+                    summary: "Simulated event (real Location events only fire on movement)",
+                    events: []
+                )
+                try await messageStore.deliver(
+                    ConnectionPayload(source: .location, body: .location(placeholder)),
+                    to: conversation.id
+                )
+            case .contacts:
+                if let source = await manager.source(for: .contacts) as? ContactsDataSource {
+                    let payload = try await source.snapshotCurrent()
+                    try await messageStore.deliver(
+                        ConnectionPayload(source: .contacts, body: .contacts(payload)),
+                        to: conversation.id
+                    )
+                }
+            case .photos:
+                if let source = await manager.source(for: .photos) as? PhotosDataSource {
+                    let payload = try await source.snapshotCurrent()
+                    try await messageStore.deliver(
+                        ConnectionPayload(source: .photos, body: .photos(payload)),
+                        to: conversation.id
+                    )
+                }
+            case .music:
+                if let source = await manager.source(for: .music) as? MusicDataSource {
+                    let payload = await source.snapshotCurrent()
+                    try await messageStore.deliver(
+                        ConnectionPayload(source: .music, body: .music(payload)),
+                        to: conversation.id
+                    )
+                }
+            case .motion:
+                if let source = await manager.source(for: .motion) as? MotionDataSource {
+                    let payload = try await source.snapshotCurrent()
+                    try await messageStore.deliver(
+                        ConnectionPayload(source: .motion, body: .motion(payload)),
+                        to: conversation.id
+                    )
+                }
+            case .homeKit:
+                if let source = await manager.source(for: .homeKit) as? HomeDataSource {
+                    let payload = await source.snapshotCurrent()
+                    try await messageStore.deliver(
+                        ConnectionPayload(source: .homeKit, body: .homeKit(payload)),
+                        to: conversation.id
+                    )
+                }
+            case .screenTime:
+                if let source = await manager.source(for: .screenTime) as? ScreenTimeDataSource {
+                    let payload = await source.snapshotCurrent()
+                    try await messageStore.deliver(
+                        ConnectionPayload(source: .screenTime, body: .screenTime(payload)),
+                        to: conversation.id
+                    )
+                }
+            }
+        } catch {
+            lastError = error.localizedDescription
+        }
+        await refresh()
+    }
+
+    func clearMessages(for conversation: MockConversation) async {
+        await messageStore.clearMessages(for: conversation.id)
+        await refresh()
+    }
+
+    func clearInvocationLog() async {
+        await manager.clearRecentInvocationLog()
+        await refresh()
+    }
+
+    func refresh() async {
+        let kinds = manager.availableKinds()
+        var statuses: [ConnectionKind: ConnectionAuthorizationStatus] = [:]
+        var details: [ConnectionKind: [AuthorizationDetail]] = [:]
+        var enabled: Set<String> = []
+        var messages: [String: [MockMessageStore.Message]] = [:]
+        var capabilityState: [CapabilityKey: Bool] = [:]
+        var alwaysConfirmState: [String: Bool] = [:]
+        var capabilitiesByKind: [ConnectionKind: [ConnectionCapability]] = [:]
+        for kind in kinds {
+            statuses[kind] = await manager.authorizationStatus(for: kind)
+            details[kind] = await manager.authorizationDetails(for: kind)
+            let schemas = await manager.actionSchemas(for: kind)
+            let capabilityOrder: [ConnectionCapability] = [.writeCreate, .writeUpdate, .writeDelete]
+            let writeCapabilities = capabilityOrder.filter { capability in
+                schemas.contains { $0.capability == capability }
+            }
+            capabilitiesByKind[kind] = writeCapabilities
+            let readEnabled = await manager.enabledConversationIds(for: kind)
+            for conversationId in readEnabled {
+                enabled.insert(conversationId)
+            }
+            for conversation in MockConversationCatalog.conversations(for: kind) {
+                messages[conversation.id] = await messageStore.messages(for: conversation.id)
+                for capability in writeCapabilities {
+                    let isOn = await manager.isEnabled(
+                        kind,
+                        capability: capability,
+                        conversationId: conversation.id
+                    )
+                    capabilityState[CapabilityKey(kind: kind, capability: capability, conversationId: conversation.id)] = isOn
+                }
+                if !writeCapabilities.isEmpty {
+                    let confirm = await manager.alwaysConfirmWrites(kind: kind, conversationId: conversation.id)
+                    alwaysConfirmState[conversation.id] = confirm
+                }
+            }
+        }
+        self.kinds = kinds
+        self.statuses = statuses
+        self.detailsByKind = details
+        self.enabledConversationIds = enabled
+        self.messagesByConversation = messages
+        self.capabilityEnablement = capabilityState
+        self.alwaysConfirmByConversation = alwaysConfirmState
+        self.writeCapabilitiesByKind = capabilitiesByKind
+        self.invocationLog = await manager.recentInvocationLog()
+    }
+}

--- a/ConvosConnections/Example/ConvosConnectionsExample/MockConversation.swift
+++ b/ConvosConnections/Example/ConvosConnectionsExample/MockConversation.swift
@@ -1,0 +1,60 @@
+import ConvosConnections
+import Foundation
+
+/// A stand-in for an XMTP conversation in the example app. Each mock conversation has a
+/// stable id (used as the delivery key) and a display name used in the UI.
+///
+/// The example ships two mock conversations per connection — this is the minimum needed
+/// to demonstrate the package's defining feature: iOS authorization is granted once, but
+/// enablement is per-conversation, so a user can allow Health in one conversation and not
+/// another without revoking iOS-level access.
+struct MockConversation: Identifiable, Hashable, Sendable {
+    let id: String
+    let name: String
+    let kind: ConnectionKind
+}
+
+enum MockConversationCatalog {
+    static let byKind: [ConnectionKind: [MockConversation]] = [
+        .health: [
+            MockConversation(id: "example:health:fitness", name: "Fitness coach", kind: .health),
+            MockConversation(id: "example:health:sleep", name: "Sleep coach", kind: .health),
+        ],
+        .calendar: [
+            MockConversation(id: "example:calendar:personal", name: "Personal planner", kind: .calendar),
+            MockConversation(id: "example:calendar:work", name: "Work schedule", kind: .calendar),
+        ],
+        .location: [
+            MockConversation(id: "example:location:journal", name: "Daily journal", kind: .location),
+            MockConversation(id: "example:location:commute", name: "Commute tracker", kind: .location),
+        ],
+        .contacts: [
+            MockConversation(id: "example:contacts:rolodex", name: "Relationship agent", kind: .contacts),
+            MockConversation(id: "example:contacts:onboarding", name: "New-contact welcomer", kind: .contacts),
+        ],
+        .photos: [
+            MockConversation(id: "example:photos:memories", name: "Memories curator", kind: .photos),
+            MockConversation(id: "example:photos:screenshots", name: "Screenshot triage", kind: .photos),
+        ],
+        .music: [
+            MockConversation(id: "example:music:dj", name: "Listening DJ", kind: .music),
+            MockConversation(id: "example:music:mood", name: "Mood tracker", kind: .music),
+        ],
+        .motion: [
+            MockConversation(id: "example:motion:coach", name: "Activity coach", kind: .motion),
+            MockConversation(id: "example:motion:commute", name: "Commute detector", kind: .motion),
+        ],
+        .homeKit: [
+            MockConversation(id: "example:home:keeper", name: "Home-state keeper", kind: .homeKit),
+            MockConversation(id: "example:home:planner", name: "Home-scene planner", kind: .homeKit),
+        ],
+        .screenTime: [
+            MockConversation(id: "example:screentime:focus", name: "Focus coach", kind: .screenTime),
+            MockConversation(id: "example:screentime:balance", name: "Balance tracker", kind: .screenTime),
+        ],
+    ]
+
+    static func conversations(for kind: ConnectionKind) -> [MockConversation] {
+        byKind[kind] ?? []
+    }
+}

--- a/ConvosConnections/Example/ConvosConnectionsExample/MockMessageStore.swift
+++ b/ConvosConnections/Example/ConvosConnectionsExample/MockMessageStore.swift
@@ -1,0 +1,32 @@
+import ConvosConnections
+import Foundation
+
+/// A `ConnectionDelivering` that records every delivered payload into an in-memory list,
+/// keyed by conversation id. Stands in for XMTP in the example app so the detail view has
+/// something concrete to render.
+///
+/// The actor is the message "database" for the example — treat it like a very small local
+/// equivalent of the XMTP message store. Messages have a stable id derived from the
+/// payload, so the same payload never appears twice.
+actor MockMessageStore: ConnectionDelivering {
+    struct Message: Identifiable, Sendable, Equatable {
+        let id: UUID
+        let payload: ConnectionPayload
+        let receivedAt: Date
+    }
+
+    private var messagesByConversation: [String: [Message]] = [:]
+
+    func deliver(_ payload: ConnectionPayload, to conversationId: String) async throws {
+        let message = Message(id: payload.id, payload: payload, receivedAt: Date())
+        messagesByConversation[conversationId, default: []].append(message)
+    }
+
+    func messages(for conversationId: String) -> [Message] {
+        messagesByConversation[conversationId] ?? []
+    }
+
+    func clearMessages(for conversationId: String) {
+        messagesByConversation[conversationId] = []
+    }
+}

--- a/ConvosConnections/Example/ConvosConnectionsExample/RootConnectionsView.swift
+++ b/ConvosConnections/Example/ConvosConnectionsExample/RootConnectionsView.swift
@@ -1,0 +1,184 @@
+import ConvosConnections
+import SwiftUI
+import UIKit
+
+struct RootConnectionsView: View {
+    @Bindable var model: ExampleModel
+
+    var body: some View {
+        List {
+            ForEach(model.kinds, id: \.self) { kind in
+                Section {
+                    AuthorizationRow(
+                        kind: kind,
+                        status: model.statuses[kind] ?? .notDetermined,
+                        onAttemptEnable: {
+                            Task { await model.requestAuthorization(for: kind) }
+                        },
+                        onAttemptDisable: {
+                            Self.openAppSettings()
+                            Task { await model.refresh() }
+                        }
+                    )
+
+                    ForEach(model.conversations(for: kind)) { conversation in
+                        ConversationRow(
+                            conversation: conversation,
+                            isEnabled: model.enabledConversationIds.contains(conversation.id),
+                            messageCount: model.messagesByConversation[conversation.id]?.count ?? 0,
+                            onToggle: { newValue in
+                                Task { await model.toggle(conversation: conversation, enabled: newValue) }
+                            }
+                        )
+                    }
+                }
+            }
+
+            Section {
+                Text(Self.explanation)
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            }
+
+            if let error = model.lastError {
+                Section("Last error") {
+                    Text(error)
+                        .font(.footnote)
+                        .foregroundStyle(.red)
+                }
+            }
+        }
+        .navigationTitle("ConvosConnections")
+        .refreshable { await model.refresh() }
+    }
+
+    private static func openAppSettings() {
+        if let url = URL(string: UIApplication.openSettingsURLString) {
+            UIApplication.shared.open(url)
+        }
+    }
+
+    private static let explanation: String = """
+        Authorization is one toggle per connection at the iOS level — granting Health covers \
+        every conversation. Enablement is the per-conversation toggle — turn Health on for \
+        "Fitness coach" without turning it on for "Sleep coach." That split is the package's \
+        main value.
+        """
+}
+
+private struct AuthorizationRow: View {
+    let kind: ConnectionKind
+    let status: ConnectionAuthorizationStatus
+    let onAttemptEnable: () -> Void
+    let onAttemptDisable: () -> Void
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Image(systemName: kind.systemImageName)
+                .font(.system(size: 16, weight: .semibold))
+                .foregroundStyle(.white)
+                .frame(width: 30, height: 30)
+                .background(Color.accentColor.opacity(0.8))
+                .clipShape(RoundedRectangle(cornerRadius: 8))
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(kind.displayName)
+                    .font(.body.weight(.semibold))
+                Text(statusText)
+                    .font(.caption)
+                    .foregroundStyle(statusColor)
+            }
+
+            Spacer()
+
+            Toggle(
+                "",
+                isOn: Binding(
+                    get: { Self.isAuthorized(status) },
+                    set: { newValue in
+                        if newValue {
+                            onAttemptEnable()
+                        } else {
+                            onAttemptDisable()
+                        }
+                    }
+                )
+            )
+            .labelsHidden()
+            .disabled(status == .unavailable)
+        }
+        .padding(.vertical, 2)
+    }
+
+    private var statusText: String {
+        switch status {
+        case .notDetermined: return "Not authorized — toggle to grant"
+        case .authorized: return "Authorized at iOS level"
+        case .denied: return "Denied in Settings"
+        case .partial(let missing): return "Partial (\(missing.count) missing)"
+        case .unavailable: return "Unavailable on this device"
+        }
+    }
+
+    private var statusColor: Color {
+        switch status {
+        case .authorized: return .green
+        case .partial: return .orange
+        case .denied, .unavailable: return .red
+        case .notDetermined: return .secondary
+        }
+    }
+
+    private static func isAuthorized(_ status: ConnectionAuthorizationStatus) -> Bool {
+        switch status {
+        case .authorized, .partial: return true
+        case .notDetermined, .denied, .unavailable: return false
+        }
+    }
+}
+
+private struct ConversationRow: View {
+    let conversation: MockConversation
+    let isEnabled: Bool
+    let messageCount: Int
+    let onToggle: (Bool) -> Void
+
+    var body: some View {
+        NavigationLink(value: conversation) {
+            HStack(spacing: 10) {
+                Image(systemName: "bubble.left.fill")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .frame(width: 20)
+
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(conversation.name)
+                        .font(.callout)
+                    Text(conversation.id)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+
+                Spacer()
+
+                if messageCount > 0 {
+                    Text("\(messageCount)")
+                        .font(.caption.weight(.medium))
+                        .padding(.horizontal, 7)
+                        .padding(.vertical, 2)
+                        .background(Color.secondary.opacity(0.15))
+                        .clipShape(Capsule())
+                }
+
+                Toggle(
+                    "",
+                    isOn: Binding(
+                        get: { isEnabled },
+                        set: { newValue in onToggle(newValue) }
+                    )
+                )
+                .labelsHidden()
+            }
+        }
+    }
+}

--- a/ConvosConnections/Example/ConvosConnectionsExample/UserDefaultsEnablementStore.swift
+++ b/ConvosConnections/Example/ConvosConnectionsExample/UserDefaultsEnablementStore.swift
@@ -1,0 +1,98 @@
+import ConvosConnections
+import Foundation
+
+/// `EnablementStore` backed by `UserDefaults`. Keeps per-(connection, capability, conversation)
+/// toggle state and the per-(connection, conversation) always-confirm flag across app
+/// relaunches so users don't have to re-toggle every session.
+///
+/// The example app uses this instead of `InMemoryEnablementStore` so toggle state survives
+/// backgrounding, relaunches, and reinstalls with the same bundle id.
+final class UserDefaultsEnablementStore: EnablementStore, @unchecked Sendable {
+    private struct PersistedShape: Codable {
+        var enablements: [Enablement]
+        var alwaysConfirm: [AlwaysConfirmEntry]
+    }
+
+    private struct AlwaysConfirmEntry: Codable, Hashable {
+        let kind: ConnectionKind
+        let conversationId: String
+    }
+
+    private let defaults: UserDefaults
+    private let key: String
+    private let lock: NSLock = NSLock()
+
+    init(defaults: UserDefaults = .standard, key: String = "ConvosConnectionsExample.enablements.v2") {
+        self.defaults = defaults
+        self.key = key
+    }
+
+    func isEnabled(kind: ConnectionKind, capability: ConnectionCapability, conversationId: String) async -> Bool {
+        read().enablements.contains(Enablement(kind: kind, capability: capability, conversationId: conversationId))
+    }
+
+    func setEnabled(_ enabled: Bool, kind: ConnectionKind, capability: ConnectionCapability, conversationId: String) async {
+        var shape = read()
+        var enablementSet = Set(shape.enablements)
+        let enablement = Enablement(kind: kind, capability: capability, conversationId: conversationId)
+        if enabled {
+            enablementSet.insert(enablement)
+        } else {
+            enablementSet.remove(enablement)
+        }
+        shape.enablements = enablementSet.sorted(by: { lhs, rhs in
+            if lhs.kind.rawValue != rhs.kind.rawValue { return lhs.kind.rawValue < rhs.kind.rawValue }
+            if lhs.capability.rawValue != rhs.capability.rawValue { return lhs.capability.rawValue < rhs.capability.rawValue }
+            return lhs.conversationId < rhs.conversationId
+        })
+        write(shape)
+    }
+
+    func conversationIds(enabledFor kind: ConnectionKind, capability: ConnectionCapability) async -> [String] {
+        read().enablements
+            .filter { $0.kind == kind && $0.capability == capability }
+            .map(\.conversationId)
+            .sorted()
+    }
+
+    func allEnablements() async -> [Enablement] {
+        read().enablements
+    }
+
+    func alwaysConfirmWrites(kind: ConnectionKind, conversationId: String) async -> Bool {
+        read().alwaysConfirm.contains(AlwaysConfirmEntry(kind: kind, conversationId: conversationId))
+    }
+
+    func setAlwaysConfirmWrites(_ alwaysConfirm: Bool, kind: ConnectionKind, conversationId: String) async {
+        var shape = read()
+        var alwaysConfirmSet = Set(shape.alwaysConfirm)
+        let entry = AlwaysConfirmEntry(kind: kind, conversationId: conversationId)
+        if alwaysConfirm {
+            alwaysConfirmSet.insert(entry)
+        } else {
+            alwaysConfirmSet.remove(entry)
+        }
+        shape.alwaysConfirm = alwaysConfirmSet.sorted(by: { lhs, rhs in
+            if lhs.kind.rawValue != rhs.kind.rawValue { return lhs.kind.rawValue < rhs.kind.rawValue }
+            return lhs.conversationId < rhs.conversationId
+        })
+        write(shape)
+    }
+
+    private func read() -> PersistedShape {
+        lock.lock()
+        defer { lock.unlock() }
+        guard let data = defaults.data(forKey: key),
+              let decoded = try? JSONDecoder().decode(PersistedShape.self, from: data) else {
+            return PersistedShape(enablements: [], alwaysConfirm: [])
+        }
+        return decoded
+    }
+
+    private func write(_ shape: PersistedShape) {
+        lock.lock()
+        defer { lock.unlock() }
+        guard let data = try? JSONEncoder().encode(shape) else { return }
+        defaults.set(data, forKey: key)
+    }
+}

--- a/ConvosConnections/Example/README.md
+++ b/ConvosConnections/Example/README.md
@@ -1,0 +1,69 @@
+# ConvosConnectionsExample
+
+A minimal iOS app that exercises the `ConvosConnections` package end-to-end. Useful for:
+
+- Testing new `DataSource` implementations on a real device or simulator before the rest of the Convos app is ready.
+- Demonstrating the "payload → conversation" delivery model without needing XMTP or a running Convos stack.
+- Hand-testing authorization flows for sensitive frameworks like HealthKit and EventKit.
+
+## Running it
+
+```bash
+open ConvosConnections/Example/ConvosConnectionsExample.xcodeproj
+```
+
+Select the `ConvosConnectionsExample` scheme, pick an iPhone simulator (iOS 26+), and run.
+
+The first launch will:
+1. Prompt for HealthKit when you toggle "Health" on.
+2. Prompt for Calendar when you toggle "Calendar" on.
+
+Decline either prompt to see denied-state behavior.
+
+## Building from the command line
+
+Xcode's Run button handles code signing automatically — just open the project and hit ⌘R. For CLI builds, you need to opt into ad-hoc simulator signing so the HealthKit entitlement sticks:
+
+```bash
+xcodebuild \
+    -project ConvosConnectionsExample.xcodeproj \
+    -scheme ConvosConnectionsExample \
+    -sdk iphonesimulator \
+    -destination 'id=<booted-simulator-udid>' \
+    CODE_SIGN_IDENTITY=- \
+    CODE_SIGN_STYLE=Manual \
+    CODE_SIGNING_REQUIRED=NO \
+    CODE_SIGNING_ALLOWED=YES \
+    build
+```
+
+Using `CODE_SIGNING_ALLOWED=NO` strips entitlements and HealthKit will refuse to authorize with "Missing com.apple.developer.healthkit entitlement."
+
+## How it works
+
+The app mirrors the real Convos flow but replaces XMTP with an in-memory store:
+
+- `ExampleModel` owns a `ConnectionsManager` configured with `HealthDataSource` and `CalendarDataSource`.
+- `MockMessageStore` stands in for XMTP. It implements `ConnectionDelivering` and keeps every payload in an in-memory dictionary keyed by mock conversation id.
+- Each connection is mapped to a single mock conversation id: `example:health`, `example:calendar`, etc.
+- Toggling a connection on enables that `(kind, conversationId)` pair in an `InMemoryEnablementStore` and starts the source (prompting for authorization if needed).
+- The feed view for a connection is a chat-style list of every payload delivered to that connection's mock conversation — structurally identical to how a real conversation would render these messages in Convos.
+
+## The "Simulate payload" button
+
+Observer queries (HealthKit) and `EKEventStoreChanged` (EventKit) only fire when new data actually arrives. In a fresh simulator that rarely happens, so the feed view exposes a "Simulate payload" button that calls the source's snapshot method (`snapshotLast24Hours()` / `snapshotCurrentWindow()`) and delivers the result directly. This lets you verify end-to-end delivery without seeding the simulator with real data.
+
+## Adding a new connection to the example
+
+1. Implement the `DataSource` inside `ConvosConnections` (see `HealthDataSource` / `CalendarDataSource` for the pattern).
+2. Add it to the `sources` array in `ExampleModel.init`.
+3. If the source has a snapshot method, add a `case` for it to `ExampleModel.simulateSnapshot(for:)`.
+4. If it has a new `ConnectionPayloadBody` case, add a matching body view to `ConnectionFeedView.MessageBubble.bodyDetails`.
+
+The app picks up new source types automatically via `manager.availableKinds()`.
+
+## Entitlements
+
+`ConvosConnectionsExample.entitlements` declares HealthKit. EventKit does not require an entitlement — only the `NSCalendarsFullAccessUsageDescription` string in the generated Info.plist.
+
+If you add a source that needs additional entitlements (Location background mode, HomeKit, etc.), extend `ConvosConnectionsExample.entitlements` and add the matching `INFOPLIST_KEY_*` build setting to both `Debug` and `Release` configurations in the pbxproj.

--- a/ConvosConnections/Package.swift
+++ b/ConvosConnections/Package.swift
@@ -1,0 +1,54 @@
+// swift-tools-version: 6.2
+
+import PackageDescription
+
+let package = Package(
+    name: "ConvosConnections",
+    platforms: [
+        .iOS(.v26),
+        .macOS(.v26),
+    ],
+    products: [
+        // Core library. All ship-worthy sources (Health, Calendar, Location, Contacts,
+        // Photos, Music, Motion, HomeKit) plus every payload type including
+        // `ScreenTimePayload`. Does NOT link FamilyControls.
+        .library(
+            name: "ConvosConnections",
+            targets: ["ConvosConnections"]
+        ),
+        // Optional add-on for the Screen Time / Family Controls data source.
+        //
+        // Pulled out into its own product because the `com.apple.developer.family-controls`
+        // entitlement requires Apple's explicit approval for App Store distribution (via a
+        // form on the developer portal). Apps that can't yet ship with that entitlement
+        // should depend on `ConvosConnections` alone. Once the entitlement is granted,
+        // add this product to the app's dependencies and register a `ScreenTimeDataSource`
+        // with your `ConnectionsManager`.
+        .library(
+            name: "ConvosConnectionsScreenTime",
+            targets: ["ConvosConnectionsScreenTime"]
+        ),
+    ],
+    targets: [
+        .target(
+            name: "ConvosConnections",
+            path: "Sources/ConvosConnections"
+        ),
+        .target(
+            name: "ConvosConnectionsScreenTime",
+            dependencies: ["ConvosConnections"],
+            path: "Sources/ConvosConnectionsScreenTime"
+        ),
+        .testTarget(
+            name: "ConvosConnectionsTests",
+            dependencies: ["ConvosConnections"],
+            path: "Tests/ConvosConnectionsTests"
+        ),
+        .testTarget(
+            name: "ConvosConnectionsScreenTimeTests",
+            dependencies: ["ConvosConnectionsScreenTime"],
+            path: "Tests/ConvosConnectionsScreenTimeTests"
+        ),
+    ],
+    swiftLanguageModes: [.v6]
+)

--- a/ConvosConnections/README.md
+++ b/ConvosConnections/README.md
@@ -1,0 +1,73 @@
+# ConvosConnections
+
+> **Library products**
+>
+> - `ConvosConnections` — the core package. All ship-worthy sources (Health, Calendar, Location, Contacts, Photos, Music, Motion, HomeKit) plus every payload type. Does **not** link Family Controls.
+> - `ConvosConnectionsScreenTime` — optional add-on that provides `ScreenTimeDataSource`. Pulled out because the `com.apple.developer.family-controls` entitlement requires Apple's explicit approval for App Store distribution. Depend on this product only when you're ready to ship with that entitlement.
+
+---
+
+
+A reusable Swift package that lets a Convos user enable native iOS data sources ("connections") and deliver the resulting payloads into conversations so that assistants (AI agents) can consume them.
+
+The package is deliberately **XMTP-agnostic**. It knows nothing about messaging, codecs, or encryption. It emits structured `ConnectionPayload` values through a `ConnectionDelivering` protocol that the host app implements.
+
+## Scope
+
+- Defines the `DataSource` protocol and ships concrete sources (initially `HealthDataSource`).
+- Handles per-source authorization flows and background observation.
+- Stores per-(connection, conversation) enablement state via an `EnablementStore` protocol — the host app provides the persistent implementation (GRDB in the Convos app).
+- Provides a SwiftUI `ConnectionsDebugView` for inspecting authorization status, toggling enablement, and viewing recent payloads.
+- Versions every payload body with a `schemaVersion` field so the wire format can evolve without breaking agents.
+
+## What it deliberately does not do
+
+- Send XMTP messages. The host app wraps payloads in a content type and sends them.
+- Register XMTP content codecs. That belongs in the single-inbox refactor's codec-registration path (PR 713, checkpoint C6).
+- Persist anything. All storage is pluggable; an `InMemoryEnablementStore` is provided for tests and the debug view.
+
+## Architecture
+
+```
+┌────────────────────────────────────────────────────────┐
+│ Host app (Convos)                                      │
+│                                                        │
+│  ┌──────────────────────────┐                          │
+│  │ XMTPConnectionDelivering │  ← registers codec,      │
+│  │ (implements Delivering)  │    wraps payload,        │
+│  └────────────┬─────────────┘    sends to conversation │
+│               │                                        │
+│  ┌────────────▼─────────────┐                          │
+│  │ GRDBEnablementStore      │  ← persists toggles      │
+│  └────────────┬─────────────┘                          │
+└───────────────┼────────────────────────────────────────┘
+                │
+┌───────────────▼────────────────────────────────────────┐
+│ ConvosConnections                                      │
+│                                                        │
+│  ConnectionsManager  ←── orchestrates                  │
+│         │                                              │
+│         ├── DataSource (protocol)                      │
+│         │     └── HealthDataSource (HealthKit)         │
+│         │                                              │
+│         ├── EnablementStore (protocol)                 │
+│         │                                              │
+│         └── ConnectionDelivering (protocol)            │
+│                                                        │
+│  ConnectionsDebugView  ←── SwiftUI inspector           │
+└────────────────────────────────────────────────────────┘
+```
+
+## Enablement granularity
+
+Enablement is keyed by `(ConnectionKind, conversationId)`. Per-assistant granularity was considered but deferred — everyone in an XMTP conversation receives every message, so a per-assistant toggle would not actually gate who sees the data. That dimension can be added later if rendering ever hides payloads from humans.
+
+## Adding a new data source
+
+1. Add a case to `ConnectionKind`.
+2. Add a payload body type (e.g. `CalendarPayload`) with its own `schemaVersion`.
+3. Add a case to `ConnectionPayloadBody`.
+4. Implement a `DataSource` conformance.
+5. Register it with the `ConnectionsManager` at launch.
+
+See `HealthDataSource` for a reference implementation.

--- a/ConvosConnections/Sources/ConvosConnections/Core/ActionSchema.swift
+++ b/ConvosConnections/Sources/ConvosConnections/Core/ActionSchema.swift
@@ -1,0 +1,254 @@
+import Foundation
+
+/// A uniformly-typed value carried by `ConnectionAction.arguments` and by the `success`
+/// branch of `ConnectionInvocationResult`.
+///
+/// Minimal-but-sufficient for the v1 action set while remaining round-trippable through
+/// JSON. Wire form is a tagged object: `{"type": "string", "value": "..."}`.
+public enum ArgumentValue: Sendable, Equatable {
+    case string(String)
+    case bool(Bool)
+    case int(Int)
+    case double(Double)
+    case date(Date)
+    case iso8601DateTime(String)
+    case enumValue(String)
+    case array([ArgumentValue])
+    case null
+}
+
+extension ArgumentValue: Codable {
+    private enum CodingKeys: String, CodingKey {
+        case type
+        case value
+    }
+
+    private enum Tag: String, Codable {
+        case string
+        case bool
+        case int
+        case double
+        case date
+        case iso8601 = "iso8601"
+        case enumValue = "enum"
+        case array
+        case null
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case .string(let value):
+            try container.encode(Tag.string, forKey: .type)
+            try container.encode(value, forKey: .value)
+        case .bool(let value):
+            try container.encode(Tag.bool, forKey: .type)
+            try container.encode(value, forKey: .value)
+        case .int(let value):
+            try container.encode(Tag.int, forKey: .type)
+            try container.encode(value, forKey: .value)
+        case .double(let value):
+            try container.encode(Tag.double, forKey: .type)
+            try container.encode(value, forKey: .value)
+        case .date(let value):
+            try container.encode(Tag.date, forKey: .type)
+            try container.encode(value, forKey: .value)
+        case .iso8601DateTime(let value):
+            try container.encode(Tag.iso8601, forKey: .type)
+            try container.encode(value, forKey: .value)
+        case .enumValue(let value):
+            try container.encode(Tag.enumValue, forKey: .type)
+            try container.encode(value, forKey: .value)
+        case .array(let values):
+            try container.encode(Tag.array, forKey: .type)
+            try container.encode(values, forKey: .value)
+        case .null:
+            try container.encode(Tag.null, forKey: .type)
+            try container.encodeNil(forKey: .value)
+        }
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let tag = try container.decode(Tag.self, forKey: .type)
+        switch tag {
+        case .string:
+            self = .string(try container.decode(String.self, forKey: .value))
+        case .bool:
+            self = .bool(try container.decode(Bool.self, forKey: .value))
+        case .int:
+            self = .int(try container.decode(Int.self, forKey: .value))
+        case .double:
+            self = .double(try container.decode(Double.self, forKey: .value))
+        case .date:
+            self = .date(try container.decode(Date.self, forKey: .value))
+        case .iso8601:
+            self = .iso8601DateTime(try container.decode(String.self, forKey: .value))
+        case .enumValue:
+            self = .enumValue(try container.decode(String.self, forKey: .value))
+        case .array:
+            self = .array(try container.decode([ArgumentValue].self, forKey: .value))
+        case .null:
+            self = .null
+        }
+    }
+}
+
+public extension ArgumentValue {
+    /// Convenience accessor. Returns `nil` if the value isn't `.string`.
+    var stringValue: String? {
+        if case .string(let value) = self { return value }
+        return nil
+    }
+
+    var boolValue: Bool? {
+        if case .bool(let value) = self { return value }
+        return nil
+    }
+
+    var intValue: Int? {
+        if case .int(let value) = self { return value }
+        return nil
+    }
+
+    var iso8601Value: String? {
+        if case .iso8601DateTime(let value) = self { return value }
+        return nil
+    }
+
+    var enumRawValue: String? {
+        if case .enumValue(let value) = self { return value }
+        return nil
+    }
+}
+
+/// One named parameter of an action schema.
+public struct ActionParameter: Sendable, Equatable, Codable {
+    public indirect enum ParameterType: Sendable, Equatable {
+        case string
+        case bool
+        case int
+        case double
+        case date
+        case iso8601DateTime
+        case enumValue(allowed: [String])
+        case arrayOf(ParameterType)
+    }
+
+    public let name: String
+    public let type: ParameterType
+    public let description: String
+    public let isRequired: Bool
+
+    public init(name: String, type: ParameterType, description: String, isRequired: Bool) {
+        self.name = name
+        self.type = type
+        self.description = description
+        self.isRequired = isRequired
+    }
+}
+
+extension ActionParameter.ParameterType: Codable {
+    private enum CodingKeys: String, CodingKey {
+        case kind
+        case allowed
+        case element
+    }
+
+    private enum Kind: String, Codable {
+        case string
+        case bool
+        case int
+        case double
+        case date
+        case iso8601DateTime = "iso8601"
+        case enumValue = "enum"
+        case arrayOf = "array"
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case .string:
+            try container.encode(Kind.string, forKey: .kind)
+        case .bool:
+            try container.encode(Kind.bool, forKey: .kind)
+        case .int:
+            try container.encode(Kind.int, forKey: .kind)
+        case .double:
+            try container.encode(Kind.double, forKey: .kind)
+        case .date:
+            try container.encode(Kind.date, forKey: .kind)
+        case .iso8601DateTime:
+            try container.encode(Kind.iso8601DateTime, forKey: .kind)
+        case .enumValue(let allowed):
+            try container.encode(Kind.enumValue, forKey: .kind)
+            try container.encode(allowed, forKey: .allowed)
+        case .arrayOf(let element):
+            try container.encode(Kind.arrayOf, forKey: .kind)
+            try container.encode(element, forKey: .element)
+        }
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let kind = try container.decode(Kind.self, forKey: .kind)
+        switch kind {
+        case .string: self = .string
+        case .bool: self = .bool
+        case .int: self = .int
+        case .double: self = .double
+        case .date: self = .date
+        case .iso8601DateTime: self = .iso8601DateTime
+        case .enumValue:
+            let allowed = try container.decode([String].self, forKey: .allowed)
+            self = .enumValue(allowed: allowed)
+        case .arrayOf:
+            let element = try container.decode(ActionParameter.ParameterType.self, forKey: .element)
+            self = .arrayOf(element)
+        }
+    }
+}
+
+/// Machine-readable schema for one action a `DataSink` can execute.
+///
+/// Agents fetch these via `DataSink.actionSchemas()` (in-process) or via
+/// `ConnectionsManager.actionSchemas(for:)` and use them to construct a valid
+/// `ConnectionInvocation`.
+public struct ActionSchema: Sendable, Equatable, Codable, Identifiable {
+    public var id: String { "\(kind.rawValue).\(actionName)" }
+
+    public let kind: ConnectionKind
+    public let actionName: String
+    public let capability: ConnectionCapability
+    public let summary: String
+    public let inputs: [ActionParameter]
+    public let outputs: [ActionParameter]
+
+    public init(
+        kind: ConnectionKind,
+        actionName: String,
+        capability: ConnectionCapability,
+        summary: String,
+        inputs: [ActionParameter],
+        outputs: [ActionParameter]
+    ) {
+        self.kind = kind
+        self.actionName = actionName
+        self.capability = capability
+        self.summary = summary
+        self.inputs = inputs
+        self.outputs = outputs
+    }
+}
+
+/// The agent-side view of an action invocation: which action, what arguments.
+public struct ConnectionAction: Sendable, Equatable, Codable {
+    public let name: String
+    public let arguments: [String: ArgumentValue]
+
+    public init(name: String, arguments: [String: ArgumentValue]) {
+        self.name = name
+        self.arguments = arguments
+    }
+}

--- a/ConvosConnections/Sources/ConvosConnections/Core/AuthorizationDetail.swift
+++ b/ConvosConnections/Sources/ConvosConnections/Core/AuthorizationDetail.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+/// Per-type authorization detail exposed by a data source.
+///
+/// Purpose: let the host app show the user *which specific permissions* were asked for and
+/// what the system returned, when that granularity matters. HealthKit is the driving case
+/// (many sample types, user granted them individually) but the shape works for any source
+/// that subdivides its permission scope.
+///
+/// ## Why not just use `ConnectionAuthorizationStatus` directly?
+///
+/// For some frameworks — notably HealthKit's read-only sample types — iOS deliberately
+/// does not disclose the per-type grant outcome to the app. In those cases `status` can
+/// only distinguish "we asked" from "we haven't asked yet." The `note` field carries a
+/// short user-facing explanation of that limitation so the UI can show the caveat without
+/// misleading the user into thinking the source has precise knowledge.
+public struct AuthorizationDetail: Sendable, Hashable, Identifiable {
+    /// Stable identifier for the sub-type. Source-specific (e.g. `"stepCount"`,
+    /// `"workout"`, `"event"`). Treated as opaque by the host app.
+    public let identifier: String
+
+    /// Short human-readable name for the UI row. Does not need to be localized by the
+    /// package — the host app can map identifiers to localized strings if needed.
+    public let displayName: String
+
+    /// The system's view of whether this sub-type is authorized. For read-only types where
+    /// the system hides the outcome, `.authorized` means "the user made a decision" rather
+    /// than "we have access" — pair it with `note` to convey that.
+    public let status: ConnectionAuthorizationStatus
+
+    /// Optional short note surfaced next to the row. Use it to explain imprecision or
+    /// caveats (e.g. "Actual read grant is hidden by iOS for privacy").
+    public let note: String?
+
+    public var id: String { identifier }
+
+    public init(
+        identifier: String,
+        displayName: String,
+        status: ConnectionAuthorizationStatus,
+        note: String? = nil
+    ) {
+        self.identifier = identifier
+        self.displayName = displayName
+        self.status = status
+        self.note = note
+    }
+}

--- a/ConvosConnections/Sources/ConvosConnections/Core/ConfirmationRequest.swift
+++ b/ConvosConnections/Sources/ConvosConnections/Core/ConfirmationRequest.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+/// What the host app needs in order to render a "agent wants to do X" confirmation sheet.
+///
+/// Deliberately stringly-typed: the package cannot know which rendering shape the host
+/// uses, so it offers the raw facts plus a `humanSummary` that sinks pre-compute.
+public struct ConfirmationRequest: Sendable, Identifiable {
+    public let id: UUID
+    public let invocationId: String
+    public let conversationId: String
+    public let kind: ConnectionKind
+    public let capability: ConnectionCapability
+    public let actionName: String
+    public let arguments: [String: ArgumentValue]
+    public let humanSummary: String
+    public let requestedAt: Date
+
+    public init(
+        id: UUID = UUID(),
+        invocationId: String,
+        conversationId: String,
+        kind: ConnectionKind,
+        capability: ConnectionCapability,
+        actionName: String,
+        arguments: [String: ArgumentValue],
+        humanSummary: String,
+        requestedAt: Date = Date()
+    ) {
+        self.id = id
+        self.invocationId = invocationId
+        self.conversationId = conversationId
+        self.kind = kind
+        self.capability = capability
+        self.actionName = actionName
+        self.arguments = arguments
+        self.humanSummary = humanSummary
+        self.requestedAt = requestedAt
+    }
+}
+
+/// The user's response to a `ConfirmationRequest`.
+public enum ConfirmationDecision: Sendable, Equatable {
+    /// User approved; sink should proceed.
+    case approved
+    /// User explicitly denied; manager returns `authorizationDenied`.
+    case denied
+    /// UI could not be presented (app backgrounded, no window, etc.); manager returns
+    /// `requiresConfirmation` so the agent knows to retry later.
+    case cannotPresent
+}
+
+/// Host-implemented bridge for user confirmation. The package calls `confirm(_:)` at most
+/// once per invocation; the host decides whether and how to present UI.
+public protocol ConfirmationHandling: Sendable {
+    func confirm(_ request: ConfirmationRequest) async -> ConfirmationDecision
+}

--- a/ConvosConnections/Sources/ConvosConnections/Core/ConnectionAuthorizationStatus.swift
+++ b/ConvosConnections/Sources/ConvosConnections/Core/ConnectionAuthorizationStatus.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+/// Unified authorization status across all data sources.
+///
+/// Individual sources (HealthKit, EventKit, CLLocationManager, etc.) each have their own
+/// native status types. Each `DataSource` maps its native status into this common shape.
+public enum ConnectionAuthorizationStatus: Sendable, Hashable {
+    /// User has not yet been prompted.
+    case notDetermined
+    /// User denied access, or the source is restricted by MDM / parental controls.
+    case denied
+    /// All requested data types are authorized.
+    case authorized
+    /// Some requested data types are authorized; others are denied or not determined.
+    /// `missing` lists the per-source identifiers the user has not granted.
+    case partial(missing: [String])
+    /// Source is unavailable on this device (e.g., HealthKit on a device without it).
+    case unavailable
+}
+
+public extension ConnectionAuthorizationStatus {
+    /// Whether the source can deliver any data in this state.
+    var canDeliverData: Bool {
+        switch self {
+        case .authorized, .partial:
+            return true
+        case .notDetermined, .denied, .unavailable:
+            return false
+        }
+    }
+}

--- a/ConvosConnections/Sources/ConvosConnections/Core/ConnectionCapability.swift
+++ b/ConvosConnections/Sources/ConvosConnections/Core/ConnectionCapability.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+/// A specific action dimension a connection can authorize, orthogonal to its `ConnectionKind`.
+///
+/// A user can grant `.read` without any write capability, or mix and match write capabilities.
+/// The raw value is the persisted discriminator; changing it is a breaking change to any
+/// durable `EnablementStore` backing.
+public enum ConnectionCapability: String, Codable, Sendable, CaseIterable, Hashable {
+    case read
+    case writeCreate = "write_create"
+    case writeUpdate = "write_update"
+    case writeDelete = "write_delete"
+}
+
+public extension ConnectionCapability {
+    /// True for every capability except `.read`.
+    var isWrite: Bool {
+        switch self {
+        case .read: return false
+        case .writeCreate, .writeUpdate, .writeDelete: return true
+        }
+    }
+
+    var displayName: String {
+        switch self {
+        case .read: return "Read"
+        case .writeCreate: return "Create"
+        case .writeUpdate: return "Update"
+        case .writeDelete: return "Delete"
+        }
+    }
+}

--- a/ConvosConnections/Sources/ConvosConnections/Core/ConnectionDelivering.swift
+++ b/ConvosConnections/Sources/ConvosConnections/Core/ConnectionDelivering.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+/// The contract the host app fulfills to route a payload or invocation result to a
+/// specific conversation.
+///
+/// In the Convos app this is implemented by wrapping the payload/result in a custom XMTP
+/// content type and sending it. Keeping the protocol here means the package has no XMTP
+/// dependency — swapping transports (or mocking in tests) is a one-file change.
+public protocol ConnectionDelivering: Sendable {
+    /// Deliver `payload` (a source-produced data payload) to `conversationId`.
+    func deliver(_ payload: ConnectionPayload, to conversationId: String) async throws
+
+    /// Deliver a write-capability invocation result back to the originating conversation.
+    ///
+    /// Default implementation throws `ConnectionDeliveringError.resultDeliveryUnimplemented`
+    /// so existing host adapters that predate the write-capability layer keep compiling.
+    /// When an invocation arrives and the host hasn't implemented this method, the manager
+    /// records the failure in its recent-invocations log but does not crash.
+    func deliver(_ result: ConnectionInvocationResult, to conversationId: String) async throws
+}
+
+/// Errors thrown by the default `ConnectionDelivering` extensions.
+public enum ConnectionDeliveringError: Error, Sendable, Equatable {
+    case resultDeliveryUnimplemented
+}
+
+public extension ConnectionDelivering {
+    func deliver(_ result: ConnectionInvocationResult, to conversationId: String) async throws {
+        throw ConnectionDeliveringError.resultDeliveryUnimplemented
+    }
+}
+
+/// Collects delivery outcomes without blocking observation. Useful in the debug view.
+public protocol ConnectionDeliveryObserver: Sendable {
+    func connectionDelivery(didSucceed payload: ConnectionPayload, conversationId: String) async
+    func connectionDelivery(didFail error: Error, payload: ConnectionPayload, conversationId: String) async
+
+    // Invocation delivery — default implementations provided so existing conformers compile.
+    func connectionInvocation(didDeliver result: ConnectionInvocationResult, conversationId: String) async
+    func connectionInvocation(didFailDelivery error: Error, result: ConnectionInvocationResult, conversationId: String) async
+}
+
+public extension ConnectionDeliveryObserver {
+    func connectionInvocation(didDeliver result: ConnectionInvocationResult, conversationId: String) async {}
+    func connectionInvocation(didFailDelivery error: Error, result: ConnectionInvocationResult, conversationId: String) async {}
+}

--- a/ConvosConnections/Sources/ConvosConnections/Core/ConnectionInvocation.swift
+++ b/ConvosConnections/Sources/ConvosConnections/Core/ConnectionInvocation.swift
@@ -1,0 +1,81 @@
+import Foundation
+
+/// Agent-to-device invocation envelope. Transport-agnostic; the host app wraps this in an
+/// XMTP content type at the messaging layer.
+public struct ConnectionInvocation: Sendable, Equatable, Codable, Identifiable {
+    public static let currentSchemaVersion: Int = 1
+
+    public let id: UUID
+    public let schemaVersion: Int
+    public let invocationId: String
+    public let kind: ConnectionKind
+    public let action: ConnectionAction
+    public let issuedAt: Date
+
+    public init(
+        id: UUID = UUID(),
+        schemaVersion: Int = Self.currentSchemaVersion,
+        invocationId: String,
+        kind: ConnectionKind,
+        action: ConnectionAction,
+        issuedAt: Date = Date()
+    ) {
+        self.id = id
+        self.schemaVersion = schemaVersion
+        self.invocationId = invocationId
+        self.kind = kind
+        self.action = action
+        self.issuedAt = issuedAt
+    }
+}
+
+/// Device-to-agent reply envelope. Always emitted, even on error. `invocationId` echoes
+/// the request so the agent can correlate.
+public struct ConnectionInvocationResult: Sendable, Equatable, Codable, Identifiable {
+    public static let currentSchemaVersion: Int = 1
+
+    public enum Status: String, Sendable, Codable, Equatable {
+        case success
+        case capabilityNotEnabled = "capability_not_enabled"
+        case capabilityRevoked = "capability_revoked"
+        case requiresConfirmation = "requires_confirmation"
+        case authorizationDenied = "authorization_denied"
+        case executionFailed = "execution_failed"
+        case unknownAction = "unknown_action"
+    }
+
+    public let id: UUID
+    public let schemaVersion: Int
+    public let invocationId: String
+    public let kind: ConnectionKind
+    public let actionName: String
+    public let status: Status
+    /// Populated only when `status == .success`. Keys match `ActionSchema.outputs`.
+    public let result: [String: ArgumentValue]
+    /// Human-readable failure description. Populated for non-success statuses where the
+    /// underlying framework surfaced a message.
+    public let errorMessage: String?
+    public let completedAt: Date
+
+    public init(
+        id: UUID = UUID(),
+        schemaVersion: Int = Self.currentSchemaVersion,
+        invocationId: String,
+        kind: ConnectionKind,
+        actionName: String,
+        status: Status,
+        result: [String: ArgumentValue] = [:],
+        errorMessage: String? = nil,
+        completedAt: Date = Date()
+    ) {
+        self.id = id
+        self.schemaVersion = schemaVersion
+        self.invocationId = invocationId
+        self.kind = kind
+        self.actionName = actionName
+        self.status = status
+        self.result = result
+        self.errorMessage = errorMessage
+        self.completedAt = completedAt
+    }
+}

--- a/ConvosConnections/Sources/ConvosConnections/Core/ConnectionKind.swift
+++ b/ConvosConnections/Sources/ConvosConnections/Core/ConnectionKind.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+/// Identifies a native iOS data source that Convos can pull data from.
+///
+/// A new case is added whenever a new `DataSource` implementation is written.
+/// The raw value is used as the discriminator in persisted enablement state and in
+/// the `ConnectionPayload` envelope — changing a raw value is a breaking change.
+public enum ConnectionKind: String, Codable, Sendable, CaseIterable, Hashable {
+    case health
+    case calendar
+    case contacts
+    case location
+    case photos
+    case music
+    case homeKit = "home_kit"
+    case screenTime = "screen_time"
+    case motion
+}
+
+public extension ConnectionKind {
+    var displayName: String {
+        switch self {
+        case .health: return "Health"
+        case .calendar: return "Calendar"
+        case .contacts: return "Contacts"
+        case .location: return "Location"
+        case .photos: return "Photos"
+        case .music: return "Music"
+        case .homeKit: return "Home"
+        case .screenTime: return "Screen Time"
+        case .motion: return "Motion & Activity"
+        }
+    }
+
+    var systemImageName: String {
+        switch self {
+        case .health: return "heart.fill"
+        case .calendar: return "calendar"
+        case .contacts: return "person.2.fill"
+        case .location: return "location.fill"
+        case .photos: return "photo.stack.fill"
+        case .music: return "music.note"
+        case .homeKit: return "house.fill"
+        case .screenTime: return "hourglass"
+        case .motion: return "figure.walk"
+        }
+    }
+}

--- a/ConvosConnections/Sources/ConvosConnections/Core/ConnectionsManager.swift
+++ b/ConvosConnections/Sources/ConvosConnections/Core/ConnectionsManager.swift
@@ -1,0 +1,457 @@
+import Foundation
+
+/// Orchestrates the lifecycle of data sources and sinks, consults the `EnablementStore` to
+/// decide which conversations each payload should go to, routes inbound invocations from
+/// agents to the right sink, and forwards payloads and invocation results to the host's
+/// `ConnectionDelivering` adapter.
+///
+/// The manager is an `actor` so internal state (started sources, recent-payload log,
+/// recent-invocation log) stays race-free across emit callbacks from sources and inbound
+/// invocations from multiple conversations.
+public actor ConnectionsManager {
+    private let sources: [ConnectionKind: DataSource]
+    private let sinks: [ConnectionKind: DataSink]
+    private let store: EnablementStore
+    private let delivery: ConnectionDelivering
+    private let deliveryObserver: ConnectionDeliveryObserver?
+    private var confirmationHandler: ConfirmationHandling?
+    private let recentPayloadLimit: Int
+    private let recentInvocationLimit: Int
+
+    private var started: Set<ConnectionKind> = []
+    private var recentPayloads: [RecordedPayload] = []
+    private var recentInvocations: [RecordedInvocation] = []
+
+    public init(
+        sources: [DataSource],
+        sinks: [DataSink] = [],
+        store: EnablementStore,
+        delivery: ConnectionDelivering,
+        deliveryObserver: ConnectionDeliveryObserver? = nil,
+        confirmationHandler: ConfirmationHandling? = nil,
+        recentPayloadLimit: Int = 100,
+        recentInvocationLimit: Int = 100
+    ) {
+        var sourcesByKind: [ConnectionKind: DataSource] = [:]
+        for source in sources {
+            sourcesByKind[source.kind] = source
+        }
+        var sinksByKind: [ConnectionKind: DataSink] = [:]
+        for sink in sinks {
+            sinksByKind[sink.kind] = sink
+        }
+        self.sources = sourcesByKind
+        self.sinks = sinksByKind
+        self.store = store
+        self.delivery = delivery
+        self.deliveryObserver = deliveryObserver
+        self.confirmationHandler = confirmationHandler
+        self.recentPayloadLimit = recentPayloadLimit
+        self.recentInvocationLimit = recentInvocationLimit
+    }
+
+    // MARK: - Available sources / sinks
+
+    public nonisolated func availableKinds() -> [ConnectionKind] {
+        Array(Set(sources.keys).union(sinks.keys)).sorted(by: { $0.rawValue < $1.rawValue })
+    }
+
+    public func source(for kind: ConnectionKind) -> DataSource? {
+        sources[kind]
+    }
+
+    public func sink(for kind: ConnectionKind) -> DataSink? {
+        sinks[kind]
+    }
+
+    public func actionSchemas(for kind: ConnectionKind) async -> [ActionSchema] {
+        guard let sink = sinks[kind] else { return [] }
+        return await sink.actionSchemas()
+    }
+
+    public func allActionSchemas() async -> [ActionSchema] {
+        var all: [ActionSchema] = []
+        for sink in sinks.values {
+            let schemas = await sink.actionSchemas()
+            all.append(contentsOf: schemas)
+        }
+        return all.sorted(by: { $0.id < $1.id })
+    }
+
+    // MARK: - Authorization
+
+    public func authorizationStatus(for kind: ConnectionKind) async -> ConnectionAuthorizationStatus {
+        if let source = sources[kind] {
+            return await source.authorizationStatus()
+        }
+        if let sink = sinks[kind] {
+            return await sink.authorizationStatus()
+        }
+        return .unavailable
+    }
+
+    @discardableResult
+    public func requestAuthorization(for kind: ConnectionKind) async throws -> ConnectionAuthorizationStatus {
+        if let source = sources[kind] {
+            return try await source.requestAuthorization()
+        }
+        if let sink = sinks[kind] {
+            return try await sink.requestAuthorization()
+        }
+        return .unavailable
+    }
+
+    public func authorizationDetails(for kind: ConnectionKind) async -> [AuthorizationDetail] {
+        if let source = sources[kind] {
+            return await source.authorizationDetails()
+        }
+        return []
+    }
+
+    // MARK: - Read enablement (capability = .read)
+
+    public func isEnabled(_ kind: ConnectionKind, conversationId: String) async -> Bool {
+        await store.isEnabled(kind: kind, capability: .read, conversationId: conversationId)
+    }
+
+    public func setEnabled(_ enabled: Bool, kind: ConnectionKind, conversationId: String) async {
+        await store.setEnabled(enabled, kind: kind, capability: .read, conversationId: conversationId)
+    }
+
+    public func enabledConversationIds(for kind: ConnectionKind) async -> [String] {
+        await store.conversationIds(enabledFor: kind, capability: .read)
+    }
+
+    public func allEnablements() async -> [Enablement] {
+        await store.allEnablements()
+    }
+
+    // MARK: - Per-capability enablement
+
+    public func isEnabled(_ kind: ConnectionKind, capability: ConnectionCapability, conversationId: String) async -> Bool {
+        await store.isEnabled(kind: kind, capability: capability, conversationId: conversationId)
+    }
+
+    public func setEnabled(_ enabled: Bool, kind: ConnectionKind, capability: ConnectionCapability, conversationId: String) async {
+        await store.setEnabled(enabled, kind: kind, capability: capability, conversationId: conversationId)
+    }
+
+    public func enabledConversationIds(for kind: ConnectionKind, capability: ConnectionCapability) async -> [String] {
+        await store.conversationIds(enabledFor: kind, capability: capability)
+    }
+
+    // MARK: - Always-confirm toggle
+
+    public func alwaysConfirmWrites(kind: ConnectionKind, conversationId: String) async -> Bool {
+        await store.alwaysConfirmWrites(kind: kind, conversationId: conversationId)
+    }
+
+    public func setAlwaysConfirmWrites(_ alwaysConfirm: Bool, kind: ConnectionKind, conversationId: String) async {
+        await store.setAlwaysConfirmWrites(alwaysConfirm, kind: kind, conversationId: conversationId)
+    }
+
+    // MARK: - Confirmation handler
+
+    public func setConfirmationHandler(_ handler: ConfirmationHandling?) {
+        confirmationHandler = handler
+    }
+
+    // MARK: - Source lifecycle
+
+    public func start() async throws {
+        let enablements = await store.allEnablements()
+        let kindsNeedingStart = Set(enablements.filter { $0.capability == .read }.map(\.kind))
+        for kind in kindsNeedingStart {
+            try await startSource(kind: kind)
+        }
+    }
+
+    public func startSource(kind: ConnectionKind) async throws {
+        guard !started.contains(kind) else { return }
+        guard let source = sources[kind] else { return }
+        try await source.start(emit: { [weak self] payload in
+            guard let self else { return }
+            Task { await self.handleEmittedPayload(payload) }
+        })
+        started.insert(kind)
+    }
+
+    public func stop() async {
+        for kind in started {
+            if let source = sources[kind] {
+                await source.stop()
+            }
+        }
+        started.removeAll()
+    }
+
+    public func stopSource(kind: ConnectionKind) async {
+        guard started.contains(kind) else { return }
+        if let source = sources[kind] {
+            await source.stop()
+        }
+        started.remove(kind)
+    }
+
+    // MARK: - Invocation routing
+
+    /// Main entry point for inbound agent invocations.
+    ///
+    /// Routing order:
+    /// 1. Sink lookup by `invocation.kind`. Missing → `unknownAction`.
+    /// 2. Action-schema lookup by `invocation.action.name`. Missing → `unknownAction`.
+    /// 3. Capability gate via `EnablementStore.isEnabled(kind, capability, conversationId)`.
+    ///    False → `capabilityNotEnabled`.
+    /// 4. Always-confirm gate: if `alwaysConfirmWrites` is true for the `(kind, conv)` pair,
+    ///    call the installed `ConfirmationHandling.confirm(request)`. Missing handler or
+    ///    `.cannotPresent` → `requiresConfirmation`. `.denied` → `authorizationDenied`.
+    /// 5. Re-check capability after confirmation (user may have revoked mid-prompt).
+    ///    False → `capabilityRevoked`.
+    /// 6. `sink.invoke(invocation)` — sink owns final status (success vs. executionFailed).
+    /// 7. Append to `recentInvocations` log.
+    /// 8. `delivery.deliver(result, to: conversationId)` — errors surface via
+    ///    `deliveryObserver.connectionInvocation(didFailDelivery:)` and are stored in the
+    ///    log entry's `resultDeliveryError`, but do not bubble up.
+    ///
+    /// Never throws: all failure modes surface through the returned/delivered result.
+    @discardableResult
+    public func handleInvocation(_ invocation: ConnectionInvocation, from conversationId: String) async -> ConnectionInvocationResult {
+        let result = await routeInvocation(invocation, from: conversationId)
+        var deliveryError: String?
+        do {
+            try await delivery.deliver(result, to: conversationId)
+            await deliveryObserver?.connectionInvocation(didDeliver: result, conversationId: conversationId)
+        } catch {
+            deliveryError = error.localizedDescription
+            await deliveryObserver?.connectionInvocation(didFailDelivery: error, result: result, conversationId: conversationId)
+        }
+        appendInvocationRecord(
+            RecordedInvocation(
+                invocation: invocation,
+                conversationId: conversationId,
+                result: result,
+                resultDeliveryError: deliveryError
+            )
+        )
+        return result
+    }
+
+    private func routeInvocation(_ invocation: ConnectionInvocation, from conversationId: String) async -> ConnectionInvocationResult {
+        guard let sink = sinks[invocation.kind] else {
+            return Self.makeResult(
+                for: invocation,
+                status: .unknownAction,
+                errorMessage: "No sink registered for \(invocation.kind.rawValue)."
+            )
+        }
+        let schemas = await sink.actionSchemas()
+        guard let schema = schemas.first(where: { $0.actionName == invocation.action.name }) else {
+            return Self.makeResult(
+                for: invocation,
+                status: .unknownAction,
+                errorMessage: "Action '\(invocation.action.name)' is not supported by the \(invocation.kind.rawValue) sink."
+            )
+        }
+        let capability = schema.capability
+        let enabledBefore = await store.isEnabled(kind: invocation.kind, capability: capability, conversationId: conversationId)
+        guard enabledBefore else {
+            return Self.makeResult(
+                for: invocation,
+                status: .capabilityNotEnabled,
+                errorMessage: "Capability \(capability.rawValue) is not enabled for this conversation."
+            )
+        }
+
+        if await store.alwaysConfirmWrites(kind: invocation.kind, conversationId: conversationId) {
+            let decision = await requestConfirmation(
+                invocation: invocation,
+                conversationId: conversationId,
+                capability: capability
+            )
+            switch decision {
+            case .approved:
+                break
+            case .denied:
+                return Self.makeResult(
+                    for: invocation,
+                    status: .authorizationDenied,
+                    errorMessage: "User denied the invocation."
+                )
+            case .cannotPresent:
+                return Self.makeResult(
+                    for: invocation,
+                    status: .requiresConfirmation,
+                    errorMessage: "Confirmation required but cannot be presented (app backgrounded or no handler installed)."
+                )
+            }
+
+            let enabledAfter = await store.isEnabled(kind: invocation.kind, capability: capability, conversationId: conversationId)
+            guard enabledAfter else {
+                return Self.makeResult(
+                    for: invocation,
+                    status: .capabilityRevoked,
+                    errorMessage: "Capability was revoked during confirmation."
+                )
+            }
+        }
+
+        return await sink.invoke(invocation)
+    }
+
+    private func requestConfirmation(
+        invocation: ConnectionInvocation,
+        conversationId: String,
+        capability: ConnectionCapability
+    ) async -> ConfirmationDecision {
+        guard let handler = confirmationHandler else { return .cannotPresent }
+        let request = ConfirmationRequest(
+            invocationId: invocation.invocationId,
+            conversationId: conversationId,
+            kind: invocation.kind,
+            capability: capability,
+            actionName: invocation.action.name,
+            arguments: invocation.action.arguments,
+            humanSummary: Self.humanSummary(for: invocation)
+        )
+        return await handler.confirm(request)
+    }
+
+    private static func humanSummary(for invocation: ConnectionInvocation) -> String {
+        let argsPreview = invocation.action.arguments
+            .sorted(by: { $0.key < $1.key })
+            .prefix(3)
+            .map { "\($0.key)=\(describe($0.value))" }
+            .joined(separator: ", ")
+        if argsPreview.isEmpty {
+            return "\(invocation.kind.displayName): \(invocation.action.name)"
+        }
+        return "\(invocation.kind.displayName): \(invocation.action.name) (\(argsPreview))"
+    }
+
+    private static func describe(_ value: ArgumentValue) -> String {
+        switch value {
+        case .string(let v): return "\"\(v)\""
+        case .bool(let v): return String(v)
+        case .int(let v): return String(v)
+        case .double(let v): return String(v)
+        case .date(let v): return String(describing: v)
+        case .iso8601DateTime(let v): return v
+        case .enumValue(let v): return v
+        case .array(let v): return "[\(v.count) items]"
+        case .null: return "null"
+        }
+    }
+
+    private static func makeResult(
+        for invocation: ConnectionInvocation,
+        status: ConnectionInvocationResult.Status,
+        errorMessage: String? = nil,
+        result: [String: ArgumentValue] = [:]
+    ) -> ConnectionInvocationResult {
+        ConnectionInvocationResult(
+            invocationId: invocation.invocationId,
+            kind: invocation.kind,
+            actionName: invocation.action.name,
+            status: status,
+            result: result,
+            errorMessage: errorMessage
+        )
+    }
+
+    // MARK: - Recent payload log
+
+    public func recentPayloadLog() -> [RecordedPayload] {
+        recentPayloads
+    }
+
+    public func clearRecentPayloadLog() {
+        recentPayloads.removeAll()
+    }
+
+    // MARK: - Recent invocation log
+
+    public func recentInvocationLog() -> [RecordedInvocation] {
+        recentInvocations
+    }
+
+    public func clearRecentInvocationLog() {
+        recentInvocations.removeAll()
+    }
+
+    // MARK: - Emit handling
+
+    private func handleEmittedPayload(_ payload: ConnectionPayload) async {
+        let conversationIds = await store.conversationIds(enabledFor: payload.source, capability: .read)
+        let record = RecordedPayload(
+            payload: payload,
+            fanOutConversationIds: conversationIds,
+            receivedAt: Date()
+        )
+        appendRecord(record)
+        for conversationId in conversationIds {
+            do {
+                try await delivery.deliver(payload, to: conversationId)
+                await deliveryObserver?.connectionDelivery(didSucceed: payload, conversationId: conversationId)
+            } catch {
+                await deliveryObserver?.connectionDelivery(didFail: error, payload: payload, conversationId: conversationId)
+            }
+        }
+    }
+
+    private func appendRecord(_ record: RecordedPayload) {
+        recentPayloads.append(record)
+        if recentPayloads.count > recentPayloadLimit {
+            let overflow = recentPayloads.count - recentPayloadLimit
+            recentPayloads.removeFirst(overflow)
+        }
+    }
+
+    private func appendInvocationRecord(_ record: RecordedInvocation) {
+        recentInvocations.append(record)
+        if recentInvocations.count > recentInvocationLimit {
+            let overflow = recentInvocations.count - recentInvocationLimit
+            recentInvocations.removeFirst(overflow)
+        }
+    }
+}
+
+/// A recent payload and the conversations it was fanned out to. Used by the debug view.
+public struct RecordedPayload: Sendable, Identifiable, Equatable {
+    public let payload: ConnectionPayload
+    public let fanOutConversationIds: [String]
+    public let receivedAt: Date
+
+    public var id: UUID { payload.id }
+
+    public init(payload: ConnectionPayload, fanOutConversationIds: [String], receivedAt: Date) {
+        self.payload = payload
+        self.fanOutConversationIds = fanOutConversationIds
+        self.receivedAt = receivedAt
+    }
+}
+
+/// A recent invocation, its result, and any delivery failure. Used by the debug view.
+public struct RecordedInvocation: Sendable, Identifiable, Equatable {
+    public let id: UUID
+    public let invocation: ConnectionInvocation
+    public let conversationId: String
+    public let result: ConnectionInvocationResult
+    public let resultDeliveryError: String?
+    public let recordedAt: Date
+
+    public init(
+        id: UUID = UUID(),
+        invocation: ConnectionInvocation,
+        conversationId: String,
+        result: ConnectionInvocationResult,
+        resultDeliveryError: String? = nil,
+        recordedAt: Date = Date()
+    ) {
+        self.id = id
+        self.invocation = invocation
+        self.conversationId = conversationId
+        self.result = result
+        self.resultDeliveryError = resultDeliveryError
+        self.recordedAt = recordedAt
+    }
+}

--- a/ConvosConnections/Sources/ConvosConnections/Core/DataSink.swift
+++ b/ConvosConnections/Sources/ConvosConnections/Core/DataSink.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+/// A destination that executes actions on the user's device in response to agent
+/// invocations. The write-side counterpart to `DataSource`.
+///
+/// A sink for a given `ConnectionKind` may coexist with a `DataSource` of the same kind;
+/// they represent opposite directions and do not share state through the protocols.
+/// Concrete implementations sometimes share an internal `StateBox` actor, but that's an
+/// implementation detail, not a protocol requirement.
+public protocol DataSink: Sendable {
+    /// The connection this sink writes to.
+    var kind: ConnectionKind { get }
+
+    /// Machine-readable schemas for every action this sink supports. Agents use these to
+    /// construct valid invocations.
+    func actionSchemas() async -> [ActionSchema]
+
+    /// Current authorization status. Uses the same vocabulary as `DataSource` so host UI
+    /// can render a single combined status indicator when a kind has both a source and a sink.
+    func authorizationStatus() async -> ConnectionAuthorizationStatus
+
+    /// Prompt for authorization if `notDetermined`. Separate from `DataSource.requestAuthorization`
+    /// because some frameworks (EventKit) distinguish read-only from read-write auth.
+    @discardableResult
+    func requestAuthorization() async throws -> ConnectionAuthorizationStatus
+
+    /// Execute an invocation. The sink is responsible for:
+    /// - Looking up the action by name
+    /// - Validating required arguments against its own schema
+    /// - Calling the underlying system API
+    /// - Returning a fully-formed `ConnectionInvocationResult`
+    ///
+    /// The sink must NOT check enablement or always-confirm policy — those are decided by
+    /// `ConnectionsManager` before `invoke(_:)` is called. This keeps sinks testable in
+    /// isolation and keeps policy in one place.
+    func invoke(_ invocation: ConnectionInvocation) async -> ConnectionInvocationResult
+
+    /// Optional hook for sinks that need long-lived resources.
+    func prepare() async throws
+
+    /// Optional teardown.
+    func teardown() async
+}
+
+public extension DataSink {
+    func prepare() async throws {}
+    func teardown() async {}
+}

--- a/ConvosConnections/Sources/ConvosConnections/Core/DataSource.swift
+++ b/ConvosConnections/Sources/ConvosConnections/Core/DataSource.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+/// Closure used by a `DataSource` to emit a payload to the manager.
+public typealias ConnectionPayloadEmitter = @Sendable (ConnectionPayload) -> Void
+
+/// A source of data that can be observed and surfaced to the user's conversations.
+///
+/// Implementations own the native-framework-specific details (HealthKit observer queries,
+/// EventKit change notifications, Core Location updates, etc.) and translate them into
+/// `ConnectionPayload` values via the `emit` closure supplied to `start(emit:)`.
+///
+/// Implementations should be safe to call from any isolation context. Conformers are
+/// typically `actor` types.
+public protocol DataSource: Sendable {
+    /// The connection this source represents. Stable across a single process's lifetime.
+    var kind: ConnectionKind { get }
+
+    /// Current authorization status. Should be cheap and non-blocking — cache internally
+    /// if the underlying API is slow.
+    func authorizationStatus() async -> ConnectionAuthorizationStatus
+
+    /// Prompt the user for authorization if `notDetermined`; otherwise return the current status.
+    /// Throws if the system call fails.
+    @discardableResult
+    func requestAuthorization() async throws -> ConnectionAuthorizationStatus
+
+    /// Per-type authorization breakdown.
+    ///
+    /// Sources that span multiple sub-types (HealthKit's many sample types, future Location
+    /// precision levels, etc.) return one entry per type. Sources with a single authorization
+    /// scope return an empty array — the top-level `authorizationStatus()` is the only
+    /// relevant signal in that case.
+    ///
+    /// Default implementation returns `[]`.
+    func authorizationDetails() async -> [AuthorizationDetail]
+
+    /// Begin observing the source. The source calls `emit` on its own isolation context
+    /// whenever a new payload is available. Calling `start` while already started is a no-op.
+    func start(emit: @escaping ConnectionPayloadEmitter) async throws
+
+    /// Stop observing. Safe to call when not started.
+    func stop() async
+}
+
+public extension DataSource {
+    func authorizationDetails() async -> [AuthorizationDetail] { [] }
+}

--- a/ConvosConnections/Sources/ConvosConnections/Core/EnablementStore.swift
+++ b/ConvosConnections/Sources/ConvosConnections/Core/EnablementStore.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+/// A single `(connection, capability, conversation)` enablement triple.
+///
+/// Per-assistant scoping is deliberately omitted; everyone in an XMTP conversation sees
+/// every message, so a per-assistant gate would give a false sense of control.
+public struct Enablement: Sendable, Hashable, Codable {
+    public let kind: ConnectionKind
+    public let capability: ConnectionCapability
+    public let conversationId: String
+
+    public init(kind: ConnectionKind, capability: ConnectionCapability, conversationId: String) {
+        self.kind = kind
+        self.capability = capability
+        self.conversationId = conversationId
+    }
+
+    /// Backward-compatible init: call sites that predate the capability model are
+    /// implicitly talking about `.read`.
+    public init(kind: ConnectionKind, conversationId: String) {
+        self.init(kind: kind, capability: .read, conversationId: conversationId)
+    }
+}
+
+/// Persists `(kind, capability, conversation)` enablement state plus a per-`(kind, conversation)`
+/// "always confirm writes" flag.
+///
+/// Backward compatibility: conforming types only need to implement the per-capability
+/// methods; the legacy three-argument methods get default-implementation shims that
+/// delegate to the `.read` capability so existing call sites continue to work.
+public protocol EnablementStore: Sendable {
+    // Per-capability API (required).
+    func isEnabled(kind: ConnectionKind, capability: ConnectionCapability, conversationId: String) async -> Bool
+    func setEnabled(_ enabled: Bool, kind: ConnectionKind, capability: ConnectionCapability, conversationId: String) async
+    func conversationIds(enabledFor kind: ConnectionKind, capability: ConnectionCapability) async -> [String]
+    func allEnablements() async -> [Enablement]
+
+    // Always-confirm flag, scoped per `(kind, conversationId)` — not per capability.
+    func alwaysConfirmWrites(kind: ConnectionKind, conversationId: String) async -> Bool
+    func setAlwaysConfirmWrites(_ alwaysConfirm: Bool, kind: ConnectionKind, conversationId: String) async
+}
+
+public extension EnablementStore {
+    // Backward-compatible read-only shims. Existing call sites keep compiling.
+    func isEnabled(kind: ConnectionKind, conversationId: String) async -> Bool {
+        await isEnabled(kind: kind, capability: .read, conversationId: conversationId)
+    }
+
+    func setEnabled(_ enabled: Bool, kind: ConnectionKind, conversationId: String) async {
+        await setEnabled(enabled, kind: kind, capability: .read, conversationId: conversationId)
+    }
+
+    func conversationIds(enabledFor kind: ConnectionKind) async -> [String] {
+        await conversationIds(enabledFor: kind, capability: .read)
+    }
+}

--- a/ConvosConnections/Sources/ConvosConnections/Core/UncheckedSendableBox.swift
+++ b/ConvosConnections/Sources/ConvosConnections/Core/UncheckedSendableBox.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+/// Wraps a non-`Sendable` value so it can be captured by a `@Sendable` closure.
+///
+/// Used sparingly at the boundary with Objective-C callback APIs (like HealthKit's
+/// `HKObserverQueryCompletionHandler`) where the framework guarantees thread safety
+/// the compiler cannot verify.
+struct UncheckedSendableBox<Value>: @unchecked Sendable {
+    let value: Value
+
+    init(_ value: Value) {
+        self.value = value
+    }
+}
+
+extension UncheckedSendableBox where Value == () -> Void {
+    func callAsFunction() {
+        value()
+    }
+}

--- a/ConvosConnections/Sources/ConvosConnections/DataSources/Calendar/CalendarActionSchemas.swift
+++ b/ConvosConnections/Sources/ConvosConnections/DataSources/Calendar/CalendarActionSchemas.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+/// Static `ActionSchema` values published by `CalendarDataSink`. Declared as an enum
+/// namespace so agents and the host app can reference them without constructing a sink.
+public enum CalendarActionSchemas {
+    public static let createEvent: ActionSchema = ActionSchema(
+        kind: .calendar,
+        actionName: "create_event",
+        capability: .writeCreate,
+        summary: "Create a new calendar event.",
+        inputs: [
+            ActionParameter(name: "title", type: .string, description: "Event title.", isRequired: true),
+            ActionParameter(name: "startDate", type: .iso8601DateTime, description: "RFC 3339 start. Must include offset.", isRequired: true),
+            ActionParameter(name: "endDate", type: .iso8601DateTime, description: "RFC 3339 end. Must include offset.", isRequired: true),
+            ActionParameter(name: "timeZone", type: .string, description: "IANA timezone identifier, e.g. America/Los_Angeles.", isRequired: true),
+            ActionParameter(name: "isAllDay", type: .bool, description: "Defaults to false.", isRequired: false),
+            ActionParameter(name: "location", type: .string, description: "Free-form location string.", isRequired: false),
+            ActionParameter(name: "notes", type: .string, description: "Event notes.", isRequired: false),
+            ActionParameter(name: "calendarId", type: .string, description: "Target calendar identifier. If omitted, uses the user's default calendar.", isRequired: false),
+            ActionParameter(name: "calendarTitle", type: .string, description: "Target calendar title. Collisions return executionFailed.", isRequired: false),
+        ],
+        outputs: [
+            ActionParameter(name: "eventId", type: .string, description: "Newly-created event identifier.", isRequired: true),
+            ActionParameter(name: "calendarId", type: .string, description: "Identifier of the calendar the event was written to.", isRequired: true),
+        ]
+    )
+
+    public static let updateEvent: ActionSchema = ActionSchema(
+        kind: .calendar,
+        actionName: "update_event",
+        capability: .writeUpdate,
+        summary: "Update an existing calendar event.",
+        inputs: [
+            ActionParameter(name: "eventId", type: .string, description: "Identifier of the event to update.", isRequired: true),
+            ActionParameter(name: "title", type: .string, description: "New title.", isRequired: false),
+            ActionParameter(name: "startDate", type: .iso8601DateTime, description: "New start, RFC 3339 with offset.", isRequired: false),
+            ActionParameter(name: "endDate", type: .iso8601DateTime, description: "New end, RFC 3339 with offset.", isRequired: false),
+            ActionParameter(name: "timeZone", type: .string, description: "IANA timezone. Required if startDate or endDate is supplied.", isRequired: false),
+            ActionParameter(name: "location", type: .string, description: "New location.", isRequired: false),
+            ActionParameter(name: "notes", type: .string, description: "New notes.", isRequired: false),
+            ActionParameter(name: "span", type: .enumValue(allowed: ["thisEvent", "futureEvents"]), description: "Recurring-event span. Defaults to futureEvents.", isRequired: false),
+        ],
+        outputs: [
+            ActionParameter(name: "eventId", type: .string, description: "Updated event identifier.", isRequired: true),
+        ]
+    )
+
+    public static let deleteEvent: ActionSchema = ActionSchema(
+        kind: .calendar,
+        actionName: "delete_event",
+        capability: .writeDelete,
+        summary: "Delete a calendar event.",
+        inputs: [
+            ActionParameter(name: "eventId", type: .string, description: "Identifier of the event to delete.", isRequired: true),
+            ActionParameter(name: "span", type: .enumValue(allowed: ["thisEvent", "futureEvents"]), description: "Recurring-event span. Defaults to futureEvents.", isRequired: false),
+        ],
+        outputs: []
+    )
+
+    public static let all: [ActionSchema] = [createEvent, updateEvent, deleteEvent]
+}

--- a/ConvosConnections/Sources/ConvosConnections/DataSources/Calendar/CalendarDataSink.swift
+++ b/ConvosConnections/Sources/ConvosConnections/DataSources/Calendar/CalendarDataSink.swift
@@ -1,0 +1,317 @@
+import Foundation
+#if canImport(EventKit)
+@preconcurrency import EventKit
+#endif
+
+/// Write-side counterpart to `CalendarDataSource`.
+///
+/// Supports three actions (see `CalendarActionSchemas`): `create_event`, `update_event`,
+/// `delete_event`. Enforces the PRD-mandated strict timezone rule — every datetime input
+/// must be paired with an explicit IANA `timeZone` identifier. Missing or ambiguous zones
+/// return `executionFailed` rather than silently falling back to the device zone.
+///
+/// Owns its own `EKEventStore`; does not share with `CalendarDataSource`. Keeping the
+/// stores separate means read-side observer tokens don't cross into write-side auth
+/// changes. The cost is an extra `EKEventStore` instance in memory, which is trivial.
+public final class CalendarDataSink: DataSink, @unchecked Sendable {
+    public let kind: ConnectionKind = .calendar
+
+    public init() {
+        #if canImport(EventKit)
+        self.state = StateBox()
+        #endif
+    }
+
+    public func actionSchemas() async -> [ActionSchema] {
+        CalendarActionSchemas.all
+    }
+
+    #if canImport(EventKit)
+    private let state: StateBox
+
+    public func authorizationStatus() async -> ConnectionAuthorizationStatus {
+        let status = EKEventStore.authorizationStatus(for: .event)
+        return CalendarDataSource.map(ekStatus: status)
+    }
+
+    @discardableResult
+    public func requestAuthorization() async throws -> ConnectionAuthorizationStatus {
+        let store = EKEventStore()
+        _ = try await store.requestFullAccessToEvents()
+        return await authorizationStatus()
+    }
+
+    public func invoke(_ invocation: ConnectionInvocation) async -> ConnectionInvocationResult {
+        await state.invoke(invocation)
+    }
+
+    private actor StateBox {
+        private let store: EKEventStore = EKEventStore()
+
+        private enum Resolution<Value> {
+            case success(Value)
+            case failure(String)
+        }
+
+        func invoke(_ invocation: ConnectionInvocation) async -> ConnectionInvocationResult {
+            let actionName = invocation.action.name
+            switch actionName {
+            case CalendarActionSchemas.createEvent.actionName:
+                return createEvent(invocation)
+            case CalendarActionSchemas.updateEvent.actionName:
+                return updateEvent(invocation)
+            case CalendarActionSchemas.deleteEvent.actionName:
+                return deleteEvent(invocation)
+            default:
+                return Self.makeResult(
+                    for: invocation,
+                    status: .unknownAction,
+                    errorMessage: "Calendar sink does not know action '\(actionName)'."
+                )
+            }
+        }
+
+        private func createEvent(_ invocation: ConnectionInvocation) -> ConnectionInvocationResult {
+            let args = invocation.action.arguments
+
+            guard EKEventStore.authorizationStatus(for: .event) == .fullAccess else {
+                return Self.makeResult(for: invocation, status: .authorizationDenied, errorMessage: "Calendar access is not granted.")
+            }
+
+            guard let title = args["title"]?.stringValue, !title.isEmpty else {
+                return Self.makeResult(for: invocation, status: .executionFailed, errorMessage: "Missing required argument 'title'.")
+            }
+            guard let startRaw = args["startDate"]?.iso8601Value else {
+                return Self.makeResult(for: invocation, status: .executionFailed, errorMessage: "Missing required argument 'startDate'.")
+            }
+            guard let endRaw = args["endDate"]?.iso8601Value else {
+                return Self.makeResult(for: invocation, status: .executionFailed, errorMessage: "Missing required argument 'endDate'.")
+            }
+            guard let zoneId = args["timeZone"]?.stringValue, let timeZone = TimeZone(identifier: zoneId) else {
+                return Self.makeResult(for: invocation, status: .executionFailed, errorMessage: "Missing or invalid IANA 'timeZone'.")
+            }
+            guard let startDate = Self.parseStrictISO8601(startRaw) else {
+                return Self.makeResult(for: invocation, status: .executionFailed, errorMessage: "Could not parse 'startDate' as RFC 3339 with offset.")
+            }
+            guard let endDate = Self.parseStrictISO8601(endRaw) else {
+                return Self.makeResult(for: invocation, status: .executionFailed, errorMessage: "Could not parse 'endDate' as RFC 3339 with offset.")
+            }
+
+            let calendarResult = resolveCalendar(
+                calendarId: args["calendarId"]?.stringValue,
+                calendarTitle: args["calendarTitle"]?.stringValue
+            )
+            let targetCalendar: EKCalendar
+            switch calendarResult {
+            case .success(let value):
+                targetCalendar = value
+            case .failure(let message):
+                return Self.makeResult(for: invocation, status: .executionFailed, errorMessage: message)
+            }
+
+            let event = EKEvent(eventStore: store)
+            event.title = title
+            event.startDate = startDate
+            event.endDate = endDate
+            event.timeZone = timeZone
+            event.isAllDay = args["isAllDay"]?.boolValue ?? false
+            event.location = args["location"]?.stringValue
+            event.notes = args["notes"]?.stringValue
+            event.calendar = targetCalendar
+
+            do {
+                try store.save(event, span: .thisEvent, commit: true)
+            } catch {
+                return Self.makeResult(for: invocation, status: .executionFailed, errorMessage: error.localizedDescription)
+            }
+
+            return Self.makeResult(
+                for: invocation,
+                status: .success,
+                result: [
+                    "eventId": .string(event.calendarItemIdentifier),
+                    "calendarId": .string(targetCalendar.calendarIdentifier),
+                ]
+            )
+        }
+
+        private func updateEvent(_ invocation: ConnectionInvocation) -> ConnectionInvocationResult {
+            let args = invocation.action.arguments
+
+            guard EKEventStore.authorizationStatus(for: .event) == .fullAccess else {
+                return Self.makeResult(for: invocation, status: .authorizationDenied, errorMessage: "Calendar access is not granted.")
+            }
+            guard let eventId = args["eventId"]?.stringValue else {
+                return Self.makeResult(for: invocation, status: .executionFailed, errorMessage: "Missing required argument 'eventId'.")
+            }
+            guard let event = store.event(withIdentifier: eventId) else {
+                return Self.makeResult(for: invocation, status: .executionFailed, errorMessage: "Event not found for id '\(eventId)'.")
+            }
+
+            let startRaw = args["startDate"]?.iso8601Value
+            let endRaw = args["endDate"]?.iso8601Value
+            let zoneId = args["timeZone"]?.stringValue
+
+            if startRaw != nil || endRaw != nil {
+                guard let zoneId, let timeZone = TimeZone(identifier: zoneId) else {
+                    return Self.makeResult(for: invocation, status: .executionFailed, errorMessage: "Missing or invalid IANA 'timeZone'. Required when updating start or end.")
+                }
+                event.timeZone = timeZone
+                if let startRaw {
+                    guard let parsed = Self.parseStrictISO8601(startRaw) else {
+                        return Self.makeResult(for: invocation, status: .executionFailed, errorMessage: "Could not parse 'startDate'.")
+                    }
+                    event.startDate = parsed
+                }
+                if let endRaw {
+                    guard let parsed = Self.parseStrictISO8601(endRaw) else {
+                        return Self.makeResult(for: invocation, status: .executionFailed, errorMessage: "Could not parse 'endDate'.")
+                    }
+                    event.endDate = parsed
+                }
+            }
+
+            if let newTitle = args["title"]?.stringValue {
+                event.title = newTitle
+            }
+            if let newLocation = args["location"]?.stringValue {
+                event.location = newLocation
+            }
+            if let newNotes = args["notes"]?.stringValue {
+                event.notes = newNotes
+            }
+
+            let spanResult = Self.resolveSpan(args["span"])
+            let span: EKSpan
+            switch spanResult {
+            case .success(let value):
+                span = value
+            case .failure(let message):
+                return Self.makeResult(for: invocation, status: .executionFailed, errorMessage: message)
+            }
+
+            do {
+                try store.save(event, span: span, commit: true)
+            } catch {
+                return Self.makeResult(for: invocation, status: .executionFailed, errorMessage: error.localizedDescription)
+            }
+
+            return Self.makeResult(
+                for: invocation,
+                status: .success,
+                result: ["eventId": .string(event.calendarItemIdentifier)]
+            )
+        }
+
+        private func deleteEvent(_ invocation: ConnectionInvocation) -> ConnectionInvocationResult {
+            let args = invocation.action.arguments
+
+            guard EKEventStore.authorizationStatus(for: .event) == .fullAccess else {
+                return Self.makeResult(for: invocation, status: .authorizationDenied, errorMessage: "Calendar access is not granted.")
+            }
+            guard let eventId = args["eventId"]?.stringValue else {
+                return Self.makeResult(for: invocation, status: .executionFailed, errorMessage: "Missing required argument 'eventId'.")
+            }
+            guard let event = store.event(withIdentifier: eventId) else {
+                return Self.makeResult(for: invocation, status: .executionFailed, errorMessage: "Event not found for id '\(eventId)'.")
+            }
+
+            let spanResult = Self.resolveSpan(args["span"])
+            let span: EKSpan
+            switch spanResult {
+            case .success(let value):
+                span = value
+            case .failure(let message):
+                return Self.makeResult(for: invocation, status: .executionFailed, errorMessage: message)
+            }
+
+            do {
+                try store.remove(event, span: span, commit: true)
+            } catch {
+                return Self.makeResult(for: invocation, status: .executionFailed, errorMessage: error.localizedDescription)
+            }
+
+            return Self.makeResult(for: invocation, status: .success)
+        }
+
+        private func resolveCalendar(calendarId: String?, calendarTitle: String?) -> Resolution<EKCalendar> {
+            if let calendarId {
+                if let calendar = store.calendar(withIdentifier: calendarId) {
+                    return .success(calendar)
+                }
+                return .failure("Calendar not found for id '\(calendarId)'.")
+            }
+            if let calendarTitle {
+                let matches = store.calendars(for: .event).filter { $0.title == calendarTitle }
+                if matches.count == 1, let calendar = matches.first {
+                    return .success(calendar)
+                }
+                if matches.isEmpty {
+                    return .failure("No calendar found with title '\(calendarTitle)'.")
+                }
+                return .failure("Multiple calendars named '\(calendarTitle)'; disambiguate by id.")
+            }
+            if let defaultCalendar = store.defaultCalendarForNewEvents {
+                return .success(defaultCalendar)
+            }
+            return .failure("No default calendar for new events is configured.")
+        }
+
+        private static func resolveSpan(_ argument: ArgumentValue?) -> Resolution<EKSpan> {
+            guard let argument else { return .success(.futureEvents) }
+            let raw: String? = {
+                if case .enumValue(let value) = argument { return value }
+                if case .string(let value) = argument { return value }
+                return nil
+            }()
+            switch raw {
+            case "thisEvent": return .success(.thisEvent)
+            case "futureEvents", .none: return .success(.futureEvents)
+            default:
+                return .failure("Unknown 'span' value. Allowed: thisEvent, futureEvents.")
+            }
+        }
+
+        private static func parseStrictISO8601(_ value: String) -> Date? {
+            let formatter = ISO8601DateFormatter()
+            formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+            if let date = formatter.date(from: value) {
+                return date
+            }
+            formatter.formatOptions = [.withInternetDateTime]
+            return formatter.date(from: value)
+        }
+
+        private static func makeResult(
+            for invocation: ConnectionInvocation,
+            status: ConnectionInvocationResult.Status,
+            errorMessage: String? = nil,
+            result: [String: ArgumentValue] = [:]
+        ) -> ConnectionInvocationResult {
+            ConnectionInvocationResult(
+                invocationId: invocation.invocationId,
+                kind: invocation.kind,
+                actionName: invocation.action.name,
+                status: status,
+                result: result,
+                errorMessage: errorMessage
+            )
+        }
+    }
+    #else
+    public func authorizationStatus() async -> ConnectionAuthorizationStatus { .unavailable }
+
+    @discardableResult
+    public func requestAuthorization() async throws -> ConnectionAuthorizationStatus { .unavailable }
+
+    public func invoke(_ invocation: ConnectionInvocation) async -> ConnectionInvocationResult {
+        ConnectionInvocationResult(
+            invocationId: invocation.invocationId,
+            kind: .calendar,
+            actionName: invocation.action.name,
+            status: .executionFailed,
+            errorMessage: "EventKit not available on this platform."
+        )
+    }
+    #endif
+}

--- a/ConvosConnections/Sources/ConvosConnections/DataSources/Calendar/CalendarDataSource.swift
+++ b/ConvosConnections/Sources/ConvosConnections/DataSources/Calendar/CalendarDataSource.swift
@@ -1,0 +1,196 @@
+import Foundation
+#if canImport(EventKit)
+@preconcurrency import EventKit
+#endif
+
+/// Bridges the user's calendars into `ConvosConnections`.
+///
+/// EventKit has no true background delivery, so this source relies on two wake-up paths:
+/// 1. The host app foregrounds → the source emits a fresh snapshot and subscribes to
+///    `EKEventStoreChanged`.
+/// 2. A `BGAppRefreshTask` calls `snapshotCurrentWindow()` to capture the latest events
+///    without going through the observer loop.
+///
+/// Each emission carries the full window of events (default: from 1 day ago to 14 days
+/// ahead). Sending the whole window rather than deltas keeps agent-side reasoning simple;
+/// volume is manageable because calendars change infrequently compared to Health.
+public final class CalendarDataSource: DataSource, @unchecked Sendable {
+    public let kind: ConnectionKind = .calendar
+    public let windowPast: TimeInterval
+    public let windowFuture: TimeInterval
+
+    public init(
+        windowPast: TimeInterval = 24 * 60 * 60,
+        windowFuture: TimeInterval = 14 * 24 * 60 * 60
+    ) {
+        self.windowPast = windowPast
+        self.windowFuture = windowFuture
+        #if canImport(EventKit)
+        self.state = StateBox()
+        #endif
+    }
+
+    #if canImport(EventKit)
+    private let state: StateBox
+
+    public func authorizationStatus() async -> ConnectionAuthorizationStatus {
+        let status = EKEventStore.authorizationStatus(for: .event)
+        return Self.map(ekStatus: status)
+    }
+
+    @discardableResult
+    public func requestAuthorization() async throws -> ConnectionAuthorizationStatus {
+        let store = EKEventStore()
+        _ = try await store.requestFullAccessToEvents()
+        return await authorizationStatus()
+    }
+
+    public func authorizationDetails() async -> [AuthorizationDetail] {
+        let status = await authorizationStatus()
+        return [
+            AuthorizationDetail(
+                identifier: "event",
+                displayName: "Calendar Events",
+                status: status,
+                note: nil
+            ),
+        ]
+    }
+
+    public func start(emit: @escaping ConnectionPayloadEmitter) async throws {
+        try await state.start(emit: emit, windowPast: windowPast, windowFuture: windowFuture)
+    }
+
+    public func stop() async {
+        await state.stop()
+    }
+
+    /// Produces a one-shot snapshot of the current window. Useful for the debug view and
+    /// for host-app `BGAppRefreshTask` handlers.
+    public func snapshotCurrentWindow() async throws -> CalendarPayload {
+        let store = EKEventStore()
+        let (start, end) = Self.currentWindow(past: windowPast, future: windowFuture)
+        let events = Self.fetchEvents(from: start, to: end, store: store)
+        return CalendarPayload(
+            summary: Self.summarize(events: events, from: start, to: end),
+            events: events,
+            rangeStart: start,
+            rangeEnd: end
+        )
+    }
+
+    static func map(ekStatus: EKAuthorizationStatus) -> ConnectionAuthorizationStatus {
+        switch ekStatus {
+        case .notDetermined:
+            return .notDetermined
+        case .restricted, .denied:
+            return .denied
+        case .fullAccess, .authorized:
+            return .authorized
+        case .writeOnly:
+            // We only read events; write-only auth is effectively not-yet-granted for us.
+            return .partial(missing: ["read-access"])
+        @unknown default:
+            return .notDetermined
+        }
+    }
+
+    static func currentWindow(past: TimeInterval, future: TimeInterval) -> (Date, Date) {
+        let now = Date()
+        return (now.addingTimeInterval(-past), now.addingTimeInterval(future))
+    }
+
+    static func fetchEvents(from start: Date, to end: Date, store: EKEventStore) -> [CalendarEvent] {
+        let calendars = store.calendars(for: .event)
+        let predicate = store.predicateForEvents(withStart: start, end: end, calendars: calendars)
+        let ekEvents = store.events(matching: predicate)
+        return ekEvents
+            .map(CalendarEventMapper.map(_:))
+            .sorted(by: { $0.startDate < $1.startDate })
+    }
+
+    static func summarize(events: [CalendarEvent], from start: Date, to end: Date) -> String {
+        guard !events.isEmpty else {
+            return "No events between \(Self.formatter.string(from: start)) and \(Self.formatter.string(from: end))."
+        }
+        let next = events.first(where: { $0.startDate >= Date() })
+        let count = events.count
+        if let next, let title = next.title {
+            return "\(count) events in window. Next: \(title) at \(Self.formatter.string(from: next.startDate))."
+        }
+        return "\(count) events in window."
+    }
+
+    private static let formatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .short
+        formatter.timeStyle = .short
+        return formatter
+    }()
+
+    /// Owns the `EKEventStore`, the `NotificationCenter` observer token, and the emitter.
+    private actor StateBox {
+        private var store: EKEventStore?
+        private var observerToken: NSObjectProtocol?
+        private var emitter: ConnectionPayloadEmitter?
+
+        func start(emit: @escaping ConnectionPayloadEmitter, windowPast: TimeInterval, windowFuture: TimeInterval) async throws {
+            if store != nil { return }
+            let store = EKEventStore()
+            self.store = store
+            self.emitter = emit
+
+            await emitSnapshot(store: store, windowPast: windowPast, windowFuture: windowFuture)
+
+            observerToken = NotificationCenter.default.addObserver(
+                forName: .EKEventStoreChanged,
+                object: store,
+                queue: nil
+            ) { [weak self] _ in
+                Task { [weak self] in
+                    await self?.handleChanged(windowPast: windowPast, windowFuture: windowFuture)
+                }
+            }
+        }
+
+        func stop() async {
+            if let observerToken {
+                NotificationCenter.default.removeObserver(observerToken)
+            }
+            observerToken = nil
+            store = nil
+            emitter = nil
+        }
+
+        private func handleChanged(windowPast: TimeInterval, windowFuture: TimeInterval) async {
+            guard let store else { return }
+            await emitSnapshot(store: store, windowPast: windowPast, windowFuture: windowFuture)
+        }
+
+        private func emitSnapshot(store: EKEventStore, windowPast: TimeInterval, windowFuture: TimeInterval) async {
+            let (start, end) = CalendarDataSource.currentWindow(past: windowPast, future: windowFuture)
+            let events = CalendarDataSource.fetchEvents(from: start, to: end, store: store)
+            let body = CalendarPayload(
+                summary: CalendarDataSource.summarize(events: events, from: start, to: end),
+                events: events,
+                rangeStart: start,
+                rangeEnd: end
+            )
+            emitter?(ConnectionPayload(source: .calendar, body: .calendar(body)))
+        }
+    }
+    #else
+    public func authorizationStatus() async -> ConnectionAuthorizationStatus { .unavailable }
+
+    @discardableResult
+    public func requestAuthorization() async throws -> ConnectionAuthorizationStatus { .unavailable }
+
+    public func start(emit: @escaping ConnectionPayloadEmitter) async throws {}
+
+    public func stop() async {}
+
+    public func snapshotCurrentWindow() async throws -> CalendarPayload {
+        CalendarPayload(summary: "EventKit not available.", events: [], rangeStart: Date(), rangeEnd: Date())
+    }
+    #endif
+}

--- a/ConvosConnections/Sources/ConvosConnections/DataSources/Calendar/CalendarEventMapper.swift
+++ b/ConvosConnections/Sources/ConvosConnections/DataSources/Calendar/CalendarEventMapper.swift
@@ -1,0 +1,38 @@
+import Foundation
+#if canImport(EventKit)
+@preconcurrency import EventKit
+#endif
+
+/// Translates `EKEvent` into the package's transport-friendly `CalendarEvent` value.
+///
+/// Kept separate from `CalendarDataSource` so the mapping is isolated for review and
+/// easier to unit-test on iOS. The package-level tests don't cover this directly because
+/// `EKEvent` can't be constructed without an `EKEventStore`.
+enum CalendarEventMapper {
+    #if canImport(EventKit)
+    static func map(_ event: EKEvent) -> CalendarEvent {
+        CalendarEvent(
+            id: event.calendarItemIdentifier,
+            title: event.title,
+            startDate: event.startDate ?? Date(),
+            endDate: event.endDate ?? event.startDate ?? Date(),
+            isAllDay: event.isAllDay,
+            location: event.location,
+            notes: event.notes,
+            calendarTitle: event.calendar?.title,
+            status: map(ekStatus: event.status),
+            isRecurring: event.hasRecurrenceRules
+        )
+    }
+
+    private static func map(ekStatus: EKEventStatus) -> CalendarEventStatus {
+        switch ekStatus {
+        case .confirmed: return .confirmed
+        case .tentative: return .tentative
+        case .canceled: return .canceled
+        case .none: return .none
+        @unknown default: return .none
+        }
+    }
+    #endif
+}

--- a/ConvosConnections/Sources/ConvosConnections/DataSources/Contacts/ContactsActionSchemas.swift
+++ b/ConvosConnections/Sources/ConvosConnections/DataSources/Contacts/ContactsActionSchemas.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+/// Static `ActionSchema` values published by `ContactsDataSink`.
+public enum ContactsActionSchemas {
+    public static let createContact: ActionSchema = ActionSchema(
+        kind: .contacts,
+        actionName: "create_contact",
+        capability: .writeCreate,
+        summary: "Create a new contact in the user's address book.",
+        inputs: [
+            ActionParameter(name: "givenName", type: .string, description: "Given (first) name.", isRequired: false),
+            ActionParameter(name: "familyName", type: .string, description: "Family (last) name.", isRequired: false),
+            ActionParameter(name: "organization", type: .string, description: "Organization name.", isRequired: false),
+            ActionParameter(name: "phone", type: .string, description: "Primary phone number (E.164 preferred).", isRequired: false),
+            ActionParameter(name: "email", type: .string, description: "Primary email address.", isRequired: false),
+            ActionParameter(name: "note", type: .string, description: "Free-form note attached to the contact.", isRequired: false),
+        ],
+        outputs: [
+            ActionParameter(name: "contactId", type: .string, description: "Newly-created contact identifier.", isRequired: true),
+        ]
+    )
+
+    public static let updateContact: ActionSchema = ActionSchema(
+        kind: .contacts,
+        actionName: "update_contact",
+        capability: .writeUpdate,
+        summary: "Update an existing contact.",
+        inputs: [
+            ActionParameter(name: "contactId", type: .string, description: "Identifier of the contact to update.", isRequired: true),
+            ActionParameter(name: "givenName", type: .string, description: "New given name.", isRequired: false),
+            ActionParameter(name: "familyName", type: .string, description: "New family name.", isRequired: false),
+            ActionParameter(name: "organization", type: .string, description: "New organization.", isRequired: false),
+            ActionParameter(name: "phone", type: .string, description: "Replace primary phone number.", isRequired: false),
+            ActionParameter(name: "email", type: .string, description: "Replace primary email address.", isRequired: false),
+            ActionParameter(name: "note", type: .string, description: "Replace note.", isRequired: false),
+        ],
+        outputs: [
+            ActionParameter(name: "contactId", type: .string, description: "Updated contact identifier.", isRequired: true),
+        ]
+    )
+
+    public static let deleteContact: ActionSchema = ActionSchema(
+        kind: .contacts,
+        actionName: "delete_contact",
+        capability: .writeDelete,
+        summary: "Delete a contact from the user's address book.",
+        inputs: [
+            ActionParameter(name: "contactId", type: .string, description: "Identifier of the contact to delete.", isRequired: true),
+        ],
+        outputs: []
+    )
+
+    public static let all: [ActionSchema] = [createContact, updateContact, deleteContact]
+}

--- a/ConvosConnections/Sources/ConvosConnections/DataSources/Contacts/ContactsDataSink.swift
+++ b/ConvosConnections/Sources/ConvosConnections/DataSources/Contacts/ContactsDataSink.swift
@@ -1,0 +1,225 @@
+import Foundation
+#if canImport(Contacts)
+@preconcurrency import Contacts
+#endif
+
+/// Write-side counterpart to `ContactsDataSource`.
+///
+/// Supports `create_contact`, `update_contact`, `delete_contact` via `CNSaveRequest` against
+/// a private `CNContactStore`. Phone and email are modelled as a single primary value per
+/// action; multi-value editing is intentionally out of scope for v1 — agents that need it
+/// can issue multiple `update_contact` calls or wait for a richer schema.
+public final class ContactsDataSink: DataSink, @unchecked Sendable {
+    public let kind: ConnectionKind = .contacts
+
+    public init() {
+        #if canImport(Contacts)
+        self.state = StateBox()
+        #endif
+    }
+
+    public func actionSchemas() async -> [ActionSchema] {
+        ContactsActionSchemas.all
+    }
+
+    #if canImport(Contacts)
+    private let state: StateBox
+
+    public func authorizationStatus() async -> ConnectionAuthorizationStatus {
+        ContactsDataSource.map(CNContactStore.authorizationStatus(for: .contacts))
+    }
+
+    @discardableResult
+    public func requestAuthorization() async throws -> ConnectionAuthorizationStatus {
+        let store = CNContactStore()
+        _ = try await store.requestAccess(for: .contacts)
+        return await authorizationStatus()
+    }
+
+    public func invoke(_ invocation: ConnectionInvocation) async -> ConnectionInvocationResult {
+        await state.invoke(invocation)
+    }
+
+    private actor StateBox {
+        private let store: CNContactStore = CNContactStore()
+
+        func invoke(_ invocation: ConnectionInvocation) async -> ConnectionInvocationResult {
+            switch invocation.action.name {
+            case ContactsActionSchemas.createContact.actionName:
+                return createContact(invocation)
+            case ContactsActionSchemas.updateContact.actionName:
+                return updateContact(invocation)
+            case ContactsActionSchemas.deleteContact.actionName:
+                return deleteContact(invocation)
+            default:
+                return Self.makeResult(
+                    for: invocation,
+                    status: .unknownAction,
+                    errorMessage: "Contacts sink does not know action '\(invocation.action.name)'."
+                )
+            }
+        }
+
+        private func createContact(_ invocation: ConnectionInvocation) -> ConnectionInvocationResult {
+            guard CNContactStore.authorizationStatus(for: .contacts) == .authorized else {
+                return Self.makeResult(for: invocation, status: .authorizationDenied, errorMessage: "Contacts access is not granted.")
+            }
+
+            let args = invocation.action.arguments
+            let contact = CNMutableContact()
+            if let value = args["givenName"]?.stringValue { contact.givenName = value }
+            if let value = args["familyName"]?.stringValue { contact.familyName = value }
+            if let value = args["organization"]?.stringValue { contact.organizationName = value }
+            if let value = args["phone"]?.stringValue, !value.isEmpty {
+                contact.phoneNumbers = [CNLabeledValue(label: CNLabelPhoneNumberMain, value: CNPhoneNumber(stringValue: value))]
+            }
+            if let value = args["email"]?.stringValue, !value.isEmpty {
+                contact.emailAddresses = [CNLabeledValue(label: CNLabelHome, value: value as NSString)]
+            }
+            if let value = args["note"]?.stringValue {
+                contact.note = value
+            }
+
+            guard !contact.givenName.isEmpty || !contact.familyName.isEmpty || !contact.organizationName.isEmpty else {
+                return Self.makeResult(for: invocation, status: .executionFailed, errorMessage: "At least one of givenName, familyName, or organization is required.")
+            }
+
+            let request = CNSaveRequest()
+            request.add(contact, toContainerWithIdentifier: nil)
+            do {
+                try store.execute(request)
+            } catch {
+                return Self.makeResult(for: invocation, status: .executionFailed, errorMessage: error.localizedDescription)
+            }
+            return Self.makeResult(
+                for: invocation,
+                status: .success,
+                result: ["contactId": .string(contact.identifier)]
+            )
+        }
+
+        private func updateContact(_ invocation: ConnectionInvocation) -> ConnectionInvocationResult {
+            guard CNContactStore.authorizationStatus(for: .contacts) == .authorized else {
+                return Self.makeResult(for: invocation, status: .authorizationDenied, errorMessage: "Contacts access is not granted.")
+            }
+            let args = invocation.action.arguments
+            guard let contactId = args["contactId"]?.stringValue else {
+                return Self.makeResult(for: invocation, status: .executionFailed, errorMessage: "Missing required argument 'contactId'.")
+            }
+
+            let keys: [CNKeyDescriptor] = [
+                CNContactIdentifierKey as CNKeyDescriptor,
+                CNContactGivenNameKey as CNKeyDescriptor,
+                CNContactFamilyNameKey as CNKeyDescriptor,
+                CNContactOrganizationNameKey as CNKeyDescriptor,
+                CNContactPhoneNumbersKey as CNKeyDescriptor,
+                CNContactEmailAddressesKey as CNKeyDescriptor,
+                CNContactNoteKey as CNKeyDescriptor,
+            ]
+
+            let mutable: CNMutableContact
+            do {
+                let fetched = try store.unifiedContact(withIdentifier: contactId, keysToFetch: keys)
+                guard let copy = fetched.mutableCopy() as? CNMutableContact else {
+                    return Self.makeResult(for: invocation, status: .executionFailed, errorMessage: "Could not load contact for editing.")
+                }
+                mutable = copy
+            } catch {
+                return Self.makeResult(for: invocation, status: .executionFailed, errorMessage: "Contact not found for id '\(contactId)'.")
+            }
+
+            if let value = args["givenName"]?.stringValue { mutable.givenName = value }
+            if let value = args["familyName"]?.stringValue { mutable.familyName = value }
+            if let value = args["organization"]?.stringValue { mutable.organizationName = value }
+            if let value = args["phone"]?.stringValue {
+                mutable.phoneNumbers = value.isEmpty
+                    ? []
+                    : [CNLabeledValue(label: CNLabelPhoneNumberMain, value: CNPhoneNumber(stringValue: value))]
+            }
+            if let value = args["email"]?.stringValue {
+                mutable.emailAddresses = value.isEmpty
+                    ? []
+                    : [CNLabeledValue(label: CNLabelHome, value: value as NSString)]
+            }
+            if let value = args["note"]?.stringValue {
+                mutable.note = value
+            }
+
+            let request = CNSaveRequest()
+            request.update(mutable)
+            do {
+                try store.execute(request)
+            } catch {
+                return Self.makeResult(for: invocation, status: .executionFailed, errorMessage: error.localizedDescription)
+            }
+            return Self.makeResult(
+                for: invocation,
+                status: .success,
+                result: ["contactId": .string(mutable.identifier)]
+            )
+        }
+
+        private func deleteContact(_ invocation: ConnectionInvocation) -> ConnectionInvocationResult {
+            guard CNContactStore.authorizationStatus(for: .contacts) == .authorized else {
+                return Self.makeResult(for: invocation, status: .authorizationDenied, errorMessage: "Contacts access is not granted.")
+            }
+            let args = invocation.action.arguments
+            guard let contactId = args["contactId"]?.stringValue else {
+                return Self.makeResult(for: invocation, status: .executionFailed, errorMessage: "Missing required argument 'contactId'.")
+            }
+
+            let keys: [CNKeyDescriptor] = [CNContactIdentifierKey as CNKeyDescriptor]
+            let mutable: CNMutableContact
+            do {
+                let fetched = try store.unifiedContact(withIdentifier: contactId, keysToFetch: keys)
+                guard let copy = fetched.mutableCopy() as? CNMutableContact else {
+                    return Self.makeResult(for: invocation, status: .executionFailed, errorMessage: "Could not load contact for deletion.")
+                }
+                mutable = copy
+            } catch {
+                return Self.makeResult(for: invocation, status: .executionFailed, errorMessage: "Contact not found for id '\(contactId)'.")
+            }
+
+            let request = CNSaveRequest()
+            request.delete(mutable)
+            do {
+                try store.execute(request)
+            } catch {
+                return Self.makeResult(for: invocation, status: .executionFailed, errorMessage: error.localizedDescription)
+            }
+            return Self.makeResult(for: invocation, status: .success)
+        }
+
+        private static func makeResult(
+            for invocation: ConnectionInvocation,
+            status: ConnectionInvocationResult.Status,
+            errorMessage: String? = nil,
+            result: [String: ArgumentValue] = [:]
+        ) -> ConnectionInvocationResult {
+            ConnectionInvocationResult(
+                invocationId: invocation.invocationId,
+                kind: invocation.kind,
+                actionName: invocation.action.name,
+                status: status,
+                result: result,
+                errorMessage: errorMessage
+            )
+        }
+    }
+    #else
+    public func authorizationStatus() async -> ConnectionAuthorizationStatus { .unavailable }
+
+    @discardableResult
+    public func requestAuthorization() async throws -> ConnectionAuthorizationStatus { .unavailable }
+
+    public func invoke(_ invocation: ConnectionInvocation) async -> ConnectionInvocationResult {
+        ConnectionInvocationResult(
+            invocationId: invocation.invocationId,
+            kind: .contacts,
+            actionName: invocation.action.name,
+            status: .executionFailed,
+            errorMessage: "Contacts not available on this platform."
+        )
+    }
+    #endif
+}

--- a/ConvosConnections/Sources/ConvosConnections/DataSources/Contacts/ContactsDataSource.swift
+++ b/ConvosConnections/Sources/ConvosConnections/DataSources/Contacts/ContactsDataSource.swift
@@ -1,0 +1,180 @@
+import Foundation
+#if canImport(Contacts)
+@preconcurrency import Contacts
+#endif
+
+/// Bridges the user's address book into `ConvosConnections` via the Contacts framework.
+///
+/// No background delivery — `CNContactStoreDidChange` only fires while the app is running.
+/// The host app's `BGAppRefreshTask` handler can call `snapshotCurrent()` to pick up deltas
+/// while the app is suspended.
+///
+/// Volume control: the emitted payload only carries total count and a bounded preview
+/// (`previewLimit`) of contacts sorted by most-recently-modified. Full address-book dumps
+/// would be both expensive to encode and rarely useful in a conversation.
+public final class ContactsDataSource: DataSource, @unchecked Sendable {
+    public let kind: ConnectionKind = .contacts
+    public let previewLimit: Int
+
+    public init(previewLimit: Int = 20) {
+        self.previewLimit = previewLimit
+        #if canImport(Contacts)
+        self.state = StateBox()
+        #endif
+    }
+
+    #if canImport(Contacts)
+    private let state: StateBox
+
+    public func authorizationStatus() async -> ConnectionAuthorizationStatus {
+        Self.map(CNContactStore.authorizationStatus(for: .contacts))
+    }
+
+    @discardableResult
+    public func requestAuthorization() async throws -> ConnectionAuthorizationStatus {
+        let store = CNContactStore()
+        _ = try await store.requestAccess(for: .contacts)
+        return await authorizationStatus()
+    }
+
+    public func authorizationDetails() async -> [AuthorizationDetail] {
+        let status = await authorizationStatus()
+        return [
+            AuthorizationDetail(
+                identifier: "contacts",
+                displayName: "Contacts",
+                status: status,
+                note: nil
+            ),
+        ]
+    }
+
+    public func start(emit: @escaping ConnectionPayloadEmitter) async throws {
+        try await state.start(emit: emit, previewLimit: previewLimit)
+    }
+
+    public func stop() async {
+        await state.stop()
+    }
+
+    /// One-shot snapshot. Useful for the debug view and `BGAppRefreshTask` callers.
+    public func snapshotCurrent() async throws -> ContactsPayload {
+        let store = CNContactStore()
+        return try Self.buildPayload(store: store, previewLimit: previewLimit)
+    }
+
+    static func map(_ status: CNAuthorizationStatus) -> ConnectionAuthorizationStatus {
+        switch status {
+        case .notDetermined: return .notDetermined
+        case .restricted, .denied: return .denied
+        case .authorized: return .authorized
+        case .limited: return .partial(missing: ["full-access"])
+        @unknown default: return .notDetermined
+        }
+    }
+
+    static func buildPayload(store: CNContactStore, previewLimit: Int) throws -> ContactsPayload {
+        let keys: [CNKeyDescriptor] = [
+            CNContactIdentifierKey as CNKeyDescriptor,
+            CNContactGivenNameKey as CNKeyDescriptor,
+            CNContactFamilyNameKey as CNKeyDescriptor,
+            CNContactOrganizationNameKey as CNKeyDescriptor,
+            CNContactEmailAddressesKey as CNKeyDescriptor,
+            CNContactPhoneNumbersKey as CNKeyDescriptor,
+        ]
+
+        var total = 0
+        var preview: [ContactSummary] = []
+        let request = CNContactFetchRequest(keysToFetch: keys)
+        request.sortOrder = .givenName
+        try store.enumerateContacts(with: request) { contact, stop in
+            total += 1
+            if preview.count < previewLimit {
+                preview.append(
+                    ContactSummary(
+                        id: contact.identifier,
+                        givenName: contact.givenName.isEmpty ? nil : contact.givenName,
+                        familyName: contact.familyName.isEmpty ? nil : contact.familyName,
+                        organization: contact.organizationName.isEmpty ? nil : contact.organizationName,
+                        hasEmail: !contact.emailAddresses.isEmpty,
+                        hasPhone: !contact.phoneNumbers.isEmpty
+                    )
+                )
+            } else if previewLimit <= 0 {
+                stop.pointee = true
+            }
+        }
+
+        let summary = "\(total) contact\(total == 1 ? "" : "s") in address book."
+        return ContactsPayload(
+            summary: summary,
+            totalContactCount: total,
+            previewContacts: preview
+        )
+    }
+
+    private actor StateBox {
+        private var store: CNContactStore?
+        private var observerToken: NSObjectProtocol?
+        private var emitter: ConnectionPayloadEmitter?
+        private var previewLimit: Int = 20
+
+        func start(emit: @escaping ConnectionPayloadEmitter, previewLimit: Int) async throws {
+            if store != nil { return }
+            let store = CNContactStore()
+            self.store = store
+            self.emitter = emit
+            self.previewLimit = previewLimit
+
+            emitCurrent(store: store)
+
+            observerToken = NotificationCenter.default.addObserver(
+                forName: .CNContactStoreDidChange,
+                object: nil,
+                queue: nil
+            ) { [weak self] _ in
+                Task { [weak self] in
+                    await self?.handleChanged()
+                }
+            }
+        }
+
+        func stop() async {
+            if let observerToken {
+                NotificationCenter.default.removeObserver(observerToken)
+            }
+            observerToken = nil
+            store = nil
+            emitter = nil
+        }
+
+        private func handleChanged() async {
+            guard let store else { return }
+            emitCurrent(store: store)
+        }
+
+        private func emitCurrent(store: CNContactStore) {
+            guard let emitter else { return }
+            do {
+                let payload = try ContactsDataSource.buildPayload(store: store, previewLimit: previewLimit)
+                emitter(ConnectionPayload(source: .contacts, body: .contacts(payload)))
+            } catch {
+                // enumeration can fail during permission transitions; silently skip.
+            }
+        }
+    }
+    #else
+    public func authorizationStatus() async -> ConnectionAuthorizationStatus { .unavailable }
+
+    @discardableResult
+    public func requestAuthorization() async throws -> ConnectionAuthorizationStatus { .unavailable }
+
+    public func start(emit: @escaping ConnectionPayloadEmitter) async throws {}
+
+    public func stop() async {}
+
+    public func snapshotCurrent() async throws -> ContactsPayload {
+        ContactsPayload(summary: "Contacts not available.", totalContactCount: 0, previewContacts: [])
+    }
+    #endif
+}

--- a/ConvosConnections/Sources/ConvosConnections/DataSources/Health/HealthActionSchemas.swift
+++ b/ConvosConnections/Sources/ConvosConnections/DataSources/Health/HealthActionSchemas.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+/// Static `ActionSchema` values published by `HealthDataSink`.
+///
+/// All three `log_*` actions are mapped to `.writeCreate` since they append a new sample.
+/// Updating or deleting existing samples is out of scope for v1.
+public enum HealthActionSchemas {
+    public static let logWater: ActionSchema = ActionSchema(
+        kind: .health,
+        actionName: "log_water",
+        capability: .writeCreate,
+        summary: "Log a water intake sample (dietary water).",
+        inputs: [
+            ActionParameter(name: "quantity", type: .double, description: "Volume value.", isRequired: true),
+            ActionParameter(name: "unit", type: .enumValue(allowed: ["oz", "mL", "L"]), description: "Volume unit.", isRequired: true),
+            ActionParameter(name: "date", type: .iso8601DateTime, description: "Sample time (RFC 3339 with offset). Defaults to now.", isRequired: false),
+        ],
+        outputs: [
+            ActionParameter(name: "sampleId", type: .string, description: "HealthKit sample UUID.", isRequired: true),
+        ]
+    )
+
+    public static let logCaffeine: ActionSchema = ActionSchema(
+        kind: .health,
+        actionName: "log_caffeine",
+        capability: .writeCreate,
+        summary: "Log a caffeine intake sample.",
+        inputs: [
+            ActionParameter(name: "milligrams", type: .double, description: "Caffeine dose in mg.", isRequired: true),
+            ActionParameter(name: "date", type: .iso8601DateTime, description: "Sample time. Defaults to now.", isRequired: false),
+        ],
+        outputs: [
+            ActionParameter(name: "sampleId", type: .string, description: "HealthKit sample UUID.", isRequired: true),
+        ]
+    )
+
+    public static let logMindfulMinutes: ActionSchema = ActionSchema(
+        kind: .health,
+        actionName: "log_mindful_minutes",
+        capability: .writeCreate,
+        summary: "Log a mindful session with a start and end time.",
+        inputs: [
+            ActionParameter(name: "startDate", type: .iso8601DateTime, description: "Session start (RFC 3339 with offset).", isRequired: true),
+            ActionParameter(name: "endDate", type: .iso8601DateTime, description: "Session end (RFC 3339 with offset).", isRequired: true),
+        ],
+        outputs: [
+            ActionParameter(name: "sampleId", type: .string, description: "HealthKit sample UUID.", isRequired: true),
+        ]
+    )
+
+    public static let all: [ActionSchema] = [logWater, logCaffeine, logMindfulMinutes]
+}

--- a/ConvosConnections/Sources/ConvosConnections/DataSources/Health/HealthDataSink.swift
+++ b/ConvosConnections/Sources/ConvosConnections/DataSources/Health/HealthDataSink.swift
@@ -1,0 +1,218 @@
+import Foundation
+#if canImport(HealthKit)
+@preconcurrency import HealthKit
+#endif
+
+/// Write-side counterpart to `HealthDataSource`.
+///
+/// Supports `log_water`, `log_caffeine`, `log_mindful_minutes`. Requires the
+/// `NSHealthUpdateUsageDescription` Info.plist key and a fresh `requestAuthorization`
+/// call listing the three share types. Authorization is handled separately from the read
+/// flow so writes don't implicitly request read access and vice versa.
+public final class HealthDataSink: DataSink, @unchecked Sendable {
+    public let kind: ConnectionKind = .health
+
+    public init() {
+        #if canImport(HealthKit)
+        self.store = HKHealthStore()
+        #else
+        // Keep the property out of the macOS stub build.
+        #endif
+    }
+
+    public func actionSchemas() async -> [ActionSchema] {
+        HealthActionSchemas.all
+    }
+
+    #if canImport(HealthKit)
+    private let store: HKHealthStore
+
+    public func authorizationStatus() async -> ConnectionAuthorizationStatus {
+        guard HKHealthStore.isHealthDataAvailable() else { return .unavailable }
+        let shareTypes = Self.writableSampleTypes()
+        guard !shareTypes.isEmpty else { return .unavailable }
+
+        let unauthorized = shareTypes.filter { store.authorizationStatus(for: $0) == .notDetermined }
+        let denied = shareTypes.filter { store.authorizationStatus(for: $0) == .sharingDenied }
+
+        if !unauthorized.isEmpty { return .notDetermined }
+        if denied.count == shareTypes.count { return .denied }
+        if !denied.isEmpty {
+            let missing = denied.compactMap { ($0 as? HKQuantityType)?.identifier ?? ($0 as? HKCategoryType)?.identifier }
+            return .partial(missing: missing)
+        }
+        return .authorized
+    }
+
+    @discardableResult
+    public func requestAuthorization() async throws -> ConnectionAuthorizationStatus {
+        let shareTypes = Self.writableSampleTypes()
+        guard !shareTypes.isEmpty else { return .unavailable }
+        try await store.requestAuthorization(toShare: shareTypes, read: [])
+        return await authorizationStatus()
+    }
+
+    public func invoke(_ invocation: ConnectionInvocation) async -> ConnectionInvocationResult {
+        switch invocation.action.name {
+        case HealthActionSchemas.logWater.actionName:
+            return await logWater(invocation)
+        case HealthActionSchemas.logCaffeine.actionName:
+            return await logCaffeine(invocation)
+        case HealthActionSchemas.logMindfulMinutes.actionName:
+            return await logMindfulMinutes(invocation)
+        default:
+            return Self.makeResult(
+                for: invocation,
+                status: .unknownAction,
+                errorMessage: "Health sink does not know action '\(invocation.action.name)'."
+            )
+        }
+    }
+
+    private func logWater(_ invocation: ConnectionInvocation) async -> ConnectionInvocationResult {
+        let args = invocation.action.arguments
+        guard let type = HKQuantityType.quantityType(forIdentifier: .dietaryWater) else {
+            return Self.makeResult(for: invocation, status: .executionFailed, errorMessage: "dietaryWater type unavailable on this platform.")
+        }
+        guard store.authorizationStatus(for: type) == .sharingAuthorized else {
+            return Self.makeResult(for: invocation, status: .authorizationDenied, errorMessage: "Water sharing is not granted.")
+        }
+        guard let quantityValue = args["quantity"]?.doubleArgumentValue else {
+            return Self.makeResult(for: invocation, status: .executionFailed, errorMessage: "Missing required argument 'quantity'.")
+        }
+        guard let unitArg = args["unit"]?.enumRawValue ?? args["unit"]?.stringValue,
+              let unit = Self.volumeUnit(from: unitArg) else {
+            return Self.makeResult(for: invocation, status: .executionFailed, errorMessage: "Missing or invalid 'unit'. Allowed: oz, mL, L.")
+        }
+
+        let date = Self.resolveDate(args["date"]) ?? Date()
+        let quantity = HKQuantity(unit: unit, doubleValue: quantityValue)
+        let sample = HKQuantitySample(type: type, quantity: quantity, start: date, end: date)
+
+        do {
+            try await store.save(sample)
+        } catch {
+            return Self.makeResult(for: invocation, status: .executionFailed, errorMessage: error.localizedDescription)
+        }
+        return Self.makeResult(for: invocation, status: .success, result: ["sampleId": .string(sample.uuid.uuidString)])
+    }
+
+    private func logCaffeine(_ invocation: ConnectionInvocation) async -> ConnectionInvocationResult {
+        let args = invocation.action.arguments
+        guard let type = HKQuantityType.quantityType(forIdentifier: .dietaryCaffeine) else {
+            return Self.makeResult(for: invocation, status: .executionFailed, errorMessage: "dietaryCaffeine type unavailable on this platform.")
+        }
+        guard store.authorizationStatus(for: type) == .sharingAuthorized else {
+            return Self.makeResult(for: invocation, status: .authorizationDenied, errorMessage: "Caffeine sharing is not granted.")
+        }
+        guard let milligrams = args["milligrams"]?.doubleArgumentValue else {
+            return Self.makeResult(for: invocation, status: .executionFailed, errorMessage: "Missing required argument 'milligrams'.")
+        }
+        let date = Self.resolveDate(args["date"]) ?? Date()
+        let quantity = HKQuantity(unit: .gramUnit(with: .milli), doubleValue: milligrams)
+        let sample = HKQuantitySample(type: type, quantity: quantity, start: date, end: date)
+
+        do {
+            try await store.save(sample)
+        } catch {
+            return Self.makeResult(for: invocation, status: .executionFailed, errorMessage: error.localizedDescription)
+        }
+        return Self.makeResult(for: invocation, status: .success, result: ["sampleId": .string(sample.uuid.uuidString)])
+    }
+
+    private func logMindfulMinutes(_ invocation: ConnectionInvocation) async -> ConnectionInvocationResult {
+        let args = invocation.action.arguments
+        guard let type = HKObjectType.categoryType(forIdentifier: .mindfulSession) else {
+            return Self.makeResult(for: invocation, status: .executionFailed, errorMessage: "mindfulSession type unavailable on this platform.")
+        }
+        guard store.authorizationStatus(for: type) == .sharingAuthorized else {
+            return Self.makeResult(for: invocation, status: .authorizationDenied, errorMessage: "Mindful session sharing is not granted.")
+        }
+        guard let start = Self.resolveDate(args["startDate"]),
+              let end = Self.resolveDate(args["endDate"]),
+              end > start else {
+            return Self.makeResult(for: invocation, status: .executionFailed, errorMessage: "Valid 'startDate' and 'endDate' (with end > start) are required.")
+        }
+        let sample = HKCategorySample(type: type, value: HKCategoryValue.notApplicable.rawValue, start: start, end: end)
+
+        do {
+            try await store.save(sample)
+        } catch {
+            return Self.makeResult(for: invocation, status: .executionFailed, errorMessage: error.localizedDescription)
+        }
+        return Self.makeResult(for: invocation, status: .success, result: ["sampleId": .string(sample.uuid.uuidString)])
+    }
+
+    private static func writableSampleTypes() -> Set<HKSampleType> {
+        var set: Set<HKSampleType> = []
+        if let type = HKQuantityType.quantityType(forIdentifier: .dietaryWater) { set.insert(type) }
+        if let type = HKQuantityType.quantityType(forIdentifier: .dietaryCaffeine) { set.insert(type) }
+        if let type = HKObjectType.categoryType(forIdentifier: .mindfulSession) { set.insert(type) }
+        return set
+    }
+
+    private static func volumeUnit(from raw: String) -> HKUnit? {
+        switch raw {
+        case "oz": return .fluidOunceUS()
+        case "mL": return .literUnit(with: .milli)
+        case "L": return .liter()
+        default: return nil
+        }
+    }
+
+    private static func resolveDate(_ argument: ArgumentValue?) -> Date? {
+        guard let argument else { return nil }
+        if case .iso8601DateTime(let raw) = argument {
+            let formatter = ISO8601DateFormatter()
+            formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+            if let date = formatter.date(from: raw) { return date }
+            formatter.formatOptions = [.withInternetDateTime]
+            return formatter.date(from: raw)
+        }
+        if case .date(let date) = argument { return date }
+        return nil
+    }
+
+    private static func makeResult(
+        for invocation: ConnectionInvocation,
+        status: ConnectionInvocationResult.Status,
+        errorMessage: String? = nil,
+        result: [String: ArgumentValue] = [:]
+    ) -> ConnectionInvocationResult {
+        ConnectionInvocationResult(
+            invocationId: invocation.invocationId,
+            kind: invocation.kind,
+            actionName: invocation.action.name,
+            status: status,
+            result: result,
+            errorMessage: errorMessage
+        )
+    }
+    #else
+    public func authorizationStatus() async -> ConnectionAuthorizationStatus { .unavailable }
+
+    @discardableResult
+    public func requestAuthorization() async throws -> ConnectionAuthorizationStatus { .unavailable }
+
+    public func invoke(_ invocation: ConnectionInvocation) async -> ConnectionInvocationResult {
+        ConnectionInvocationResult(
+            invocationId: invocation.invocationId,
+            kind: .health,
+            actionName: invocation.action.name,
+            status: .executionFailed,
+            errorMessage: "HealthKit not available on this platform."
+        )
+    }
+    #endif
+}
+
+private extension ArgumentValue {
+    /// Permissive accessor that accepts either `.double` or `.int` (coerced to Double).
+    var doubleArgumentValue: Double? {
+        switch self {
+        case .double(let value): return value
+        case .int(let value): return Double(value)
+        default: return nil
+        }
+    }
+}

--- a/ConvosConnections/Sources/ConvosConnections/DataSources/Health/HealthDataSource.swift
+++ b/ConvosConnections/Sources/ConvosConnections/DataSources/Health/HealthDataSource.swift
@@ -1,0 +1,316 @@
+import Foundation
+#if canImport(HealthKit)
+@preconcurrency import HealthKit
+#endif
+
+/// Bridges HealthKit into `ConvosConnections`.
+///
+/// Responsibilities:
+/// - Request read authorization for a curated set of health types.
+/// - Register observer queries with background delivery so the host app wakes when
+///   new samples arrive. The host app must have the `healthkit` background mode
+///   entitlement and the `NSHealthShareUsageDescription` key set in `Info.plist`.
+/// - On each observer wake-up, run anchored queries against the enabled types and
+///   aggregate the deltas into a single `HealthPayload`.
+///
+/// Volume control: raw heart-rate samples are intentionally **not** included. The source
+/// aggregates into digest-style values (daily totals, per-workout summaries, sleep
+/// duration) to keep per-payload size small and avoid flooding conversations.
+public final class HealthDataSource: DataSource, @unchecked Sendable {
+    public let kind: ConnectionKind = .health
+
+    #if canImport(HealthKit)
+    private let store: HKHealthStore
+    private let types: [HealthSampleType]
+    private let state: StateBox = StateBox()
+
+    public init(types: [HealthSampleType] = HealthSampleType.defaultSet) {
+        self.store = HKHealthStore()
+        self.types = types
+    }
+
+    public func authorizationStatus() async -> ConnectionAuthorizationStatus {
+        guard HKHealthStore.isHealthDataAvailable() else { return .unavailable }
+        let objectTypes = Set(types.compactMap { $0.hkSampleType })
+        guard !objectTypes.isEmpty else { return .unavailable }
+
+        // `statusForAuthorizationRequest` tells us whether we still need to prompt. For
+        // read-only types, iOS deliberately does not expose the per-type grant decision,
+        // so `authorizationStatus(for:)` would always report `.notDetermined` here — hence
+        // the request-status API is the only reliable "has the user answered yet" signal.
+        do {
+            let requestStatus = try await store.statusForAuthorizationRequest(toShare: [], read: objectTypes)
+            switch requestStatus {
+            case .shouldRequest:
+                return .notDetermined
+            case .unnecessary:
+                // The user has been asked. Actual read grants are hidden by iOS, but we can
+                // at least say "permission flow is complete." The source's `note` field on
+                // per-type details surfaces the caveat to the UI.
+                return .authorized
+            case .unknown:
+                return .notDetermined
+            @unknown default:
+                return .notDetermined
+            }
+        } catch {
+            return .notDetermined
+        }
+    }
+
+    public func authorizationDetails() async -> [AuthorizationDetail] {
+        guard HKHealthStore.isHealthDataAvailable() else { return [] }
+        var results: [AuthorizationDetail] = []
+        for type in types {
+            guard let hkType = type.hkSampleType else {
+                results.append(
+                    AuthorizationDetail(
+                        identifier: type.rawValue,
+                        displayName: type.displayName,
+                        status: .unavailable
+                    )
+                )
+                continue
+            }
+            let status = await perTypeStatus(for: hkType)
+            results.append(
+                AuthorizationDetail(
+                    identifier: type.rawValue,
+                    displayName: type.displayName,
+                    status: status,
+                    note: status == .authorized ? Self.readAccessNote : nil
+                )
+            )
+        }
+        return results
+    }
+
+    private func perTypeStatus(for type: HKObjectType) async -> ConnectionAuthorizationStatus {
+        do {
+            let requestStatus = try await store.statusForAuthorizationRequest(toShare: [], read: [type])
+            switch requestStatus {
+            case .shouldRequest: return .notDetermined
+            case .unnecessary: return .authorized
+            case .unknown: return .notDetermined
+            @unknown default: return .notDetermined
+            }
+        } catch {
+            return .notDetermined
+        }
+    }
+
+    private static let readAccessNote: String = "iOS hides the actual read grant for privacy. Check Settings › Privacy & Security › Health to see which types you allowed."
+
+    @discardableResult
+    public func requestAuthorization() async throws -> ConnectionAuthorizationStatus {
+        guard HKHealthStore.isHealthDataAvailable() else { return .unavailable }
+        let objectTypes = Set(types.compactMap { $0.hkSampleType })
+        guard !objectTypes.isEmpty else { return .unavailable }
+        try await store.requestAuthorization(toShare: [], read: objectTypes)
+        return await authorizationStatus()
+    }
+
+    public func start(emit: @escaping ConnectionPayloadEmitter) async throws {
+        guard HKHealthStore.isHealthDataAvailable() else { return }
+        await state.setEmitter(emit)
+        await state.startQueries(store: store, types: types)
+    }
+
+    public func stop() async {
+        await state.stop(store: store)
+    }
+
+    /// Runs a one-shot digest across the last 24 hours. Useful for the debug view.
+    public func snapshotLast24Hours() async throws -> HealthPayload {
+        let now = Date()
+        let start = now.addingTimeInterval(-24 * 60 * 60)
+        let samples = try await fetchSamples(from: start, to: now)
+        return HealthPayload(
+            summary: Self.summarize(samples: samples, from: start, to: now),
+            samples: samples,
+            rangeStart: start,
+            rangeEnd: now
+        )
+    }
+
+    private func fetchSamples(from start: Date, to end: Date) async throws -> [HealthSample] {
+        var all: [HealthSample] = []
+        for type in types {
+            guard let hkType = type.hkSampleType else { continue }
+            let predicate = HKQuery.predicateForSamples(withStart: start, end: end)
+            let fetched: [HealthSample] = try await withCheckedThrowingContinuation { continuation in
+                let query = HKSampleQuery(
+                    sampleType: hkType,
+                    predicate: predicate,
+                    limit: HKObjectQueryNoLimit,
+                    sortDescriptors: [NSSortDescriptor(key: HKSampleSortIdentifierStartDate, ascending: true)]
+                ) { _, samples, error in
+                    if let error {
+                        continuation.resume(throwing: error)
+                        return
+                    }
+                    let mapped = (samples ?? []).compactMap { HealthSampleMapper.map($0, as: type) }
+                    continuation.resume(returning: mapped)
+                }
+                store.execute(query)
+            }
+            all.append(contentsOf: fetched)
+        }
+        return all.sorted(by: { $0.startDate < $1.startDate })
+    }
+
+    private static func summarize(samples: [HealthSample], from start: Date, to end: Date) -> String {
+        guard !samples.isEmpty else {
+            return "No new health data between \(Self.format(start)) and \(Self.format(end))."
+        }
+        var byType: [HealthSampleType: [HealthSample]] = [:]
+        for sample in samples {
+            byType[sample.type, default: []].append(sample)
+        }
+        let parts = byType.keys.sorted(by: { $0.rawValue < $1.rawValue }).map { type -> String in
+            let entries = byType[type] ?? []
+            let total = entries.reduce(0.0) { $0 + $1.value }
+            let unit = entries.first?.unit ?? ""
+            return "\(type.rawValue): \(entries.count) samples, total \(Self.formatNumber(total)) \(unit)".trimmingCharacters(in: .whitespaces)
+        }
+        return parts.joined(separator: "; ")
+    }
+
+    private static let dateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .short
+        formatter.timeStyle = .short
+        return formatter
+    }()
+
+    private static func format(_ date: Date) -> String { dateFormatter.string(from: date) }
+
+    private static func formatNumber(_ value: Double) -> String {
+        String(format: "%.1f", value)
+    }
+
+    /// Actor that owns the per-instance mutable state (observer queries + emitter) so
+    /// the surrounding class can remain `@unchecked Sendable` without data races.
+    private actor StateBox {
+        private var emitter: ConnectionPayloadEmitter?
+        private var observerQueries: [HKObserverQuery] = []
+        private var lastFetch: Date = .distantPast
+
+        func setEmitter(_ emitter: @escaping ConnectionPayloadEmitter) {
+            self.emitter = emitter
+        }
+
+        func startQueries(store: HKHealthStore, types: [HealthSampleType]) async {
+            guard observerQueries.isEmpty else { return }
+            for type in types {
+                guard let hkType = type.hkSampleType else { continue }
+                let query = HKObserverQuery(sampleType: hkType, predicate: nil) { [weak self] _, completion, _ in
+                    let wrappedCompletion = UncheckedSendableBox(completion)
+                    Task { [weak self] in
+                        await self?.handleObserverFired(store: store, types: types)
+                        wrappedCompletion.value()
+                    }
+                }
+                store.execute(query)
+                observerQueries.append(query)
+                do {
+                    try await store.enableBackgroundDelivery(for: hkType, frequency: .hourly)
+                } catch {
+                    // Background delivery is best-effort; a failure here still leaves the
+                    // foreground observer query active.
+                }
+            }
+        }
+
+        func stop(store: HKHealthStore) async {
+            for query in observerQueries {
+                store.stop(query)
+            }
+            observerQueries.removeAll()
+            emitter = nil
+        }
+
+        private func handleObserverFired(store: HKHealthStore, types: [HealthSampleType]) async {
+            let now = Date()
+            let start = lastFetch == .distantPast ? now.addingTimeInterval(-24 * 60 * 60) : lastFetch
+            lastFetch = now
+            do {
+                let samples = try await Self.fetchSamples(store: store, types: types, from: start, to: now)
+                guard !samples.isEmpty else { return }
+                let body = HealthPayload(
+                    summary: HealthDataSource.summarize(samples: samples, from: start, to: now),
+                    samples: samples,
+                    rangeStart: start,
+                    rangeEnd: now
+                )
+                let payload = ConnectionPayload(source: .health, body: .health(body))
+                emitter?(payload)
+            } catch {
+                // Observer fires may race during low-memory conditions; silently skip on error.
+            }
+        }
+
+        private static func fetchSamples(store: HKHealthStore, types: [HealthSampleType], from start: Date, to end: Date) async throws -> [HealthSample] {
+            var all: [HealthSample] = []
+            for type in types {
+                guard let hkType = type.hkSampleType else { continue }
+                let predicate = HKQuery.predicateForSamples(withStart: start, end: end)
+                let fetched: [HealthSample] = try await withCheckedThrowingContinuation { continuation in
+                    let query = HKSampleQuery(
+                        sampleType: hkType,
+                        predicate: predicate,
+                        limit: HKObjectQueryNoLimit,
+                        sortDescriptors: [NSSortDescriptor(key: HKSampleSortIdentifierStartDate, ascending: true)]
+                    ) { _, samples, error in
+                        if let error {
+                            continuation.resume(throwing: error)
+                            return
+                        }
+                        let mapped = (samples ?? []).compactMap { HealthSampleMapper.map($0, as: type) }
+                        continuation.resume(returning: mapped)
+                    }
+                    store.execute(query)
+                }
+                all.append(contentsOf: fetched)
+            }
+            return all.sorted(by: { $0.startDate < $1.startDate })
+        }
+    }
+    #else
+    public init(types: [HealthSampleType] = HealthSampleType.defaultSet) {}
+
+    public func authorizationStatus() async -> ConnectionAuthorizationStatus { .unavailable }
+
+    @discardableResult
+    public func requestAuthorization() async throws -> ConnectionAuthorizationStatus { .unavailable }
+
+    public func start(emit: @escaping ConnectionPayloadEmitter) async throws {}
+
+    public func stop() async {}
+
+    public func snapshotLast24Hours() async throws -> HealthPayload {
+        HealthPayload(
+            summary: "HealthKit not available on this platform.",
+            samples: [],
+            rangeStart: Date(),
+            rangeEnd: Date()
+        )
+    }
+    #endif
+}
+
+public extension HealthSampleType {
+    /// The default set of types the source requests. Heart rate is deliberately omitted
+    /// to avoid high-volume streaming; HRV SDNN is used instead as a lower-frequency signal.
+    static var defaultSet: [HealthSampleType] {
+        [
+            .workout,
+            .sleepAnalysis,
+            .stepCount,
+            .heartRateVariabilitySDNN,
+            .mindfulSession,
+            .activeEnergyBurned,
+            .distanceWalkingRunning,
+        ]
+    }
+}

--- a/ConvosConnections/Sources/ConvosConnections/DataSources/Health/HealthSampleMapping.swift
+++ b/ConvosConnections/Sources/ConvosConnections/DataSources/Health/HealthSampleMapping.swift
@@ -1,0 +1,101 @@
+import Foundation
+#if canImport(HealthKit)
+@preconcurrency import HealthKit
+#endif
+
+/// Translates HealthKit sample types into `HealthSampleType` and back.
+///
+/// Split from `HealthDataSource` so the mapping logic is unit-testable on iOS and so the
+/// platform-conditional code stays localized.
+enum HealthSampleMapper {
+    #if canImport(HealthKit)
+    static func map(_ sample: HKSample, as type: HealthSampleType) -> HealthSample? {
+        switch type {
+        case .workout:
+            guard let workout = sample as? HKWorkout else { return nil }
+            return HealthSample(
+                type: .workout,
+                startDate: workout.startDate,
+                endDate: workout.endDate,
+                value: workout.duration,
+                unit: "seconds",
+                metadata: ["activityType": "\(workout.workoutActivityType.rawValue)"]
+            )
+        case .sleepAnalysis, .mindfulSession:
+            guard let category = sample as? HKCategorySample else { return nil }
+            return HealthSample(
+                type: type,
+                startDate: category.startDate,
+                endDate: category.endDate,
+                value: category.endDate.timeIntervalSince(category.startDate),
+                unit: "seconds",
+                metadata: ["value": "\(category.value)"]
+            )
+        case .stepCount, .heartRateVariabilitySDNN, .activeEnergyBurned, .distanceWalkingRunning:
+            guard let quantity = sample as? HKQuantitySample else { return nil }
+            guard let unit = type.preferredUnit else { return nil }
+            return HealthSample(
+                type: type,
+                startDate: quantity.startDate,
+                endDate: quantity.endDate,
+                value: quantity.quantity.doubleValue(for: unit),
+                unit: type.unitDisplayString,
+                metadata: nil
+            )
+        }
+    }
+    #endif
+}
+
+extension HealthSampleType {
+    #if canImport(HealthKit)
+    var hkSampleType: HKSampleType? {
+        switch self {
+        case .workout:
+            return HKObjectType.workoutType()
+        case .sleepAnalysis:
+            return HKObjectType.categoryType(forIdentifier: .sleepAnalysis)
+        case .stepCount:
+            return HKObjectType.quantityType(forIdentifier: .stepCount)
+        case .heartRateVariabilitySDNN:
+            return HKObjectType.quantityType(forIdentifier: .heartRateVariabilitySDNN)
+        case .mindfulSession:
+            return HKObjectType.categoryType(forIdentifier: .mindfulSession)
+        case .activeEnergyBurned:
+            return HKObjectType.quantityType(forIdentifier: .activeEnergyBurned)
+        case .distanceWalkingRunning:
+            return HKObjectType.quantityType(forIdentifier: .distanceWalkingRunning)
+        }
+    }
+
+    var preferredUnit: HKUnit? {
+        switch self {
+        case .stepCount:
+            return .count()
+        case .heartRateVariabilitySDNN:
+            return .secondUnit(with: .milli)
+        case .activeEnergyBurned:
+            return .kilocalorie()
+        case .distanceWalkingRunning:
+            return .meter()
+        case .workout, .sleepAnalysis, .mindfulSession:
+            return nil
+        }
+    }
+    #endif
+
+    var unitDisplayString: String {
+        switch self {
+        case .workout, .sleepAnalysis, .mindfulSession:
+            return "seconds"
+        case .stepCount:
+            return "count"
+        case .heartRateVariabilitySDNN:
+            return "ms"
+        case .activeEnergyBurned:
+            return "kcal"
+        case .distanceWalkingRunning:
+            return "m"
+        }
+    }
+}

--- a/ConvosConnections/Sources/ConvosConnections/DataSources/Home/HomeActionSchemas.swift
+++ b/ConvosConnections/Sources/ConvosConnections/DataSources/Home/HomeActionSchemas.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+/// Static `ActionSchema` values published by `HomeKitDataSink`.
+public enum HomeActionSchemas {
+    public static let runScene: ActionSchema = ActionSchema(
+        kind: .homeKit,
+        actionName: "run_scene",
+        capability: .writeCreate,
+        summary: "Execute a HomeKit scene (action set).",
+        inputs: [
+            ActionParameter(name: "homeId", type: .string, description: "Home identifier. If omitted, uses the primary home.", isRequired: false),
+            ActionParameter(name: "sceneId", type: .string, description: "Scene (HMActionSet) identifier. Takes precedence over sceneName.", isRequired: false),
+            ActionParameter(name: "sceneName", type: .string, description: "Scene name. Collisions return executionFailed.", isRequired: false),
+        ],
+        outputs: [
+            ActionParameter(name: "sceneId", type: .string, description: "Executed scene identifier.", isRequired: true),
+        ]
+    )
+
+    public static let setCharacteristicValue: ActionSchema = ActionSchema(
+        kind: .homeKit,
+        actionName: "set_characteristic_value",
+        capability: .writeUpdate,
+        summary: "Write a value to a specific accessory characteristic (e.g. turn a light on/off).",
+        inputs: [
+            ActionParameter(name: "homeId", type: .string, description: "Home identifier. If omitted, uses the primary home.", isRequired: false),
+            ActionParameter(name: "accessoryId", type: .string, description: "Accessory identifier.", isRequired: true),
+            ActionParameter(name: "characteristicType", type: .string, description: "HomeKit characteristic type UUID or short name ('power', 'brightness', 'targetTemperature').", isRequired: true),
+            ActionParameter(name: "value", type: .string, description: "Desired value. Coerced based on the characteristic's metadata format.", isRequired: true),
+        ],
+        outputs: [
+            ActionParameter(name: "accessoryId", type: .string, description: "Accessory identifier.", isRequired: true),
+            ActionParameter(name: "characteristicId", type: .string, description: "Resolved characteristic identifier.", isRequired: true),
+        ]
+    )
+
+    public static let all: [ActionSchema] = [runScene, setCharacteristicValue]
+}

--- a/ConvosConnections/Sources/ConvosConnections/DataSources/Home/HomeDataSource.swift
+++ b/ConvosConnections/Sources/ConvosConnections/DataSources/Home/HomeDataSource.swift
@@ -1,0 +1,197 @@
+import Foundation
+#if canImport(HomeKit) && os(iOS)
+@preconcurrency import HomeKit
+#endif
+
+/// Bridges the user's HomeKit topology into `ConvosConnections`.
+///
+/// Requires the `com.apple.developer.homekit` entitlement *and* the `NSHomeKitUsageDescription`
+/// key in `Info.plist`. Without the entitlement, `authorizationStatus()` returns `.denied`
+/// because HMHomeManager cannot be instantiated successfully.
+///
+/// Observation scope: home list changes. Accessory-level state changes (lock open, light
+/// on/off, temperature) are intentionally not surfaced — that granularity pushes the agent
+/// into command-and-control territory that a context-feeder shouldn't try to cover.
+public final class HomeDataSource: DataSource, @unchecked Sendable {
+    public let kind: ConnectionKind = .homeKit
+
+    public init() {
+        #if canImport(HomeKit) && os(iOS)
+        self.state = StateBox()
+        #endif
+    }
+
+    #if canImport(HomeKit) && os(iOS)
+    private let state: StateBox
+
+    public func authorizationStatus() async -> ConnectionAuthorizationStatus {
+        await state.authorizationStatus()
+    }
+
+    @discardableResult
+    public func requestAuthorization() async throws -> ConnectionAuthorizationStatus {
+        // HMHomeManager prompts implicitly on its first access. Trigger it by creating the
+        // manager and waiting for the "homes didUpdate" callback, which fires once
+        // authorization is resolved.
+        await state.primeAuthorization()
+        return await authorizationStatus()
+    }
+
+    public func authorizationDetails() async -> [AuthorizationDetail] {
+        let status = await authorizationStatus()
+        return [
+            AuthorizationDetail(
+                identifier: "home_kit",
+                displayName: "Home Data",
+                status: status,
+                note: "Requires the HomeKit entitlement in the app's provisioning profile. If the toggle won't turn on, the app isn't provisioned for HomeKit."
+            ),
+        ]
+    }
+
+    public func start(emit: @escaping ConnectionPayloadEmitter) async throws {
+        await state.start(emit: emit)
+    }
+
+    public func stop() async {
+        await state.stop()
+    }
+
+    public func snapshotCurrent() async -> HomePayload {
+        await state.snapshotCurrent()
+    }
+
+    static func map(_ status: HMHomeManagerAuthorizationStatus) -> ConnectionAuthorizationStatus {
+        if status.contains(.restricted) { return .denied }
+        if status.contains(.authorized) { return .authorized }
+        if status.contains(.determined) { return .denied }
+        return .notDetermined
+    }
+
+    static func buildPayload(homes: [HMHome]) -> HomePayload {
+        let summaries = homes.map { home in
+            HomeSummary(
+                id: home.uniqueIdentifier.uuidString,
+                name: home.name,
+                isPrimary: home.isPrimary,
+                roomCount: home.rooms.count,
+                accessoryCount: home.accessories.count
+            )
+        }
+        let accessoryTotal = summaries.reduce(0) { $0 + $1.accessoryCount }
+        let summaryText: String = {
+            if homes.isEmpty {
+                return "No HomeKit homes configured."
+            }
+            return "\(homes.count) home\(homes.count == 1 ? "" : "s"), \(accessoryTotal) accessor\(accessoryTotal == 1 ? "y" : "ies") total."
+        }()
+        return HomePayload(summary: summaryText, homes: summaries)
+    }
+
+    private actor StateBox {
+        private var manager: HMHomeManager?
+        private var delegate: Delegate?
+        private var emitter: ConnectionPayloadEmitter?
+        private var authorizationContinuation: CheckedContinuation<Void, Never>?
+        private var hasEmittedInitial: Bool = false
+
+        func authorizationStatus() -> ConnectionAuthorizationStatus {
+            let manager = manager ?? createManager()
+            return HomeDataSource.map(manager.authorizationStatus)
+        }
+
+        func primeAuthorization() async {
+            let manager = manager ?? createManager()
+            if HomeDataSource.map(manager.authorizationStatus) != .notDetermined {
+                return
+            }
+            await withCheckedContinuation { continuation in
+                authorizationContinuation = continuation
+            }
+        }
+
+        func start(emit: @escaping ConnectionPayloadEmitter) async {
+            self.emitter = emit
+            let manager = manager ?? createManager()
+            hasEmittedInitial = false
+            emitCurrent(homes: manager.homes)
+        }
+
+        func stop() async {
+            emitter = nil
+        }
+
+        func snapshotCurrent() -> HomePayload {
+            let manager = manager ?? createManager()
+            return HomeDataSource.buildPayload(homes: manager.homes)
+        }
+
+        fileprivate func onHomesDidUpdate(homes: [HMHome]) {
+            let continuation = authorizationContinuation
+            authorizationContinuation = nil
+            continuation?.resume()
+
+            emitCurrent(homes: homes)
+        }
+
+        fileprivate func onHomeListChange(homes: [HMHome]) {
+            emitCurrent(homes: homes)
+        }
+
+        private func emitCurrent(homes: [HMHome]) {
+            guard let emitter else { return }
+            let payload = HomeDataSource.buildPayload(homes: homes)
+            emitter(ConnectionPayload(source: .homeKit, body: .homeKit(payload)))
+            hasEmittedInitial = true
+        }
+
+        private func createManager() -> HMHomeManager {
+            let manager = HMHomeManager()
+            let delegate = Delegate(state: self)
+            manager.delegate = delegate
+            self.manager = manager
+            self.delegate = delegate
+            return manager
+        }
+    }
+
+    private final class Delegate: NSObject, HMHomeManagerDelegate, @unchecked Sendable {
+        weak var state: StateBox?
+
+        init(state: StateBox) {
+            self.state = state
+        }
+
+        func homeManagerDidUpdateHomes(_ manager: HMHomeManager) {
+            let ref = state
+            let box = UncheckedSendableBox(manager.homes)
+            Task { await ref?.onHomesDidUpdate(homes: box.value) }
+        }
+
+        func homeManager(_ manager: HMHomeManager, didAdd home: HMHome) {
+            let ref = state
+            let box = UncheckedSendableBox(manager.homes)
+            Task { await ref?.onHomeListChange(homes: box.value) }
+        }
+
+        func homeManager(_ manager: HMHomeManager, didRemove home: HMHome) {
+            let ref = state
+            let box = UncheckedSendableBox(manager.homes)
+            Task { await ref?.onHomeListChange(homes: box.value) }
+        }
+    }
+    #else
+    public func authorizationStatus() async -> ConnectionAuthorizationStatus { .unavailable }
+
+    @discardableResult
+    public func requestAuthorization() async throws -> ConnectionAuthorizationStatus { .unavailable }
+
+    public func start(emit: @escaping ConnectionPayloadEmitter) async throws {}
+
+    public func stop() async {}
+
+    public func snapshotCurrent() async -> HomePayload {
+        HomePayload(summary: "HomeKit not available.", homes: [])
+    }
+    #endif
+}

--- a/ConvosConnections/Sources/ConvosConnections/DataSources/Home/HomeKitDataSink.swift
+++ b/ConvosConnections/Sources/ConvosConnections/DataSources/Home/HomeKitDataSink.swift
@@ -1,0 +1,324 @@
+import Foundation
+#if canImport(HomeKit) && os(iOS)
+@preconcurrency import HomeKit
+#endif
+
+/// Write-side counterpart to `HomeDataSource`.
+///
+/// Two actions: `run_scene` (execute an action set) and `set_characteristic_value` (write a
+/// single characteristic — "turn on this light", "set thermostat"). The characteristic
+/// write coerces the supplied `value` argument to the characteristic's metadata format so
+/// the agent can pass a plain string/bool/int and we do the bridging.
+///
+/// Requires the `com.apple.developer.homekit` entitlement. Without it,
+/// `HMHomeManager.authorizationStatus` reports `.determined` without `.authorized` and all
+/// invocations return `authorizationDenied`.
+public final class HomeKitDataSink: DataSink, @unchecked Sendable {
+    public let kind: ConnectionKind = .homeKit
+
+    public init() {
+        #if canImport(HomeKit) && os(iOS)
+        self.state = StateBox()
+        #endif
+    }
+
+    public func actionSchemas() async -> [ActionSchema] {
+        HomeActionSchemas.all
+    }
+
+    #if canImport(HomeKit) && os(iOS)
+    private let state: StateBox
+
+    public func authorizationStatus() async -> ConnectionAuthorizationStatus {
+        await state.authorizationStatus()
+    }
+
+    @discardableResult
+    public func requestAuthorization() async throws -> ConnectionAuthorizationStatus {
+        await state.primeAuthorization()
+        return await authorizationStatus()
+    }
+
+    public func invoke(_ invocation: ConnectionInvocation) async -> ConnectionInvocationResult {
+        await state.invoke(invocation)
+    }
+
+    private actor StateBox {
+        private var manager: HMHomeManager?
+        private var delegate: Delegate?
+        private var authorizationContinuation: CheckedContinuation<Void, Never>?
+
+        func authorizationStatus() -> ConnectionAuthorizationStatus {
+            let manager = manager ?? createManager()
+            return HomeDataSource.map(manager.authorizationStatus)
+        }
+
+        func primeAuthorization() async {
+            let manager = manager ?? createManager()
+            if HomeDataSource.map(manager.authorizationStatus) != .notDetermined {
+                return
+            }
+            await withCheckedContinuation { continuation in
+                authorizationContinuation = continuation
+            }
+        }
+
+        fileprivate func onHomesDidUpdate() {
+            let continuation = authorizationContinuation
+            authorizationContinuation = nil
+            continuation?.resume()
+        }
+
+        func invoke(_ invocation: ConnectionInvocation) async -> ConnectionInvocationResult {
+            switch invocation.action.name {
+            case HomeActionSchemas.runScene.actionName:
+                return await runScene(invocation)
+            case HomeActionSchemas.setCharacteristicValue.actionName:
+                return await setCharacteristicValue(invocation)
+            default:
+                return Self.makeResult(
+                    for: invocation,
+                    status: .unknownAction,
+                    errorMessage: "HomeKit sink does not know action '\(invocation.action.name)'."
+                )
+            }
+        }
+
+        private func runScene(_ invocation: ConnectionInvocation) async -> ConnectionInvocationResult {
+            let manager = manager ?? createManager()
+            guard HomeDataSource.map(manager.authorizationStatus) == .authorized else {
+                return Self.makeResult(for: invocation, status: .authorizationDenied, errorMessage: "HomeKit access is not granted.")
+            }
+            let args = invocation.action.arguments
+            guard let home = resolveHome(manager: manager, homeId: args["homeId"]?.stringValue) else {
+                return Self.makeResult(for: invocation, status: .executionFailed, errorMessage: "No matching home found.")
+            }
+            let sceneResult = resolveScene(
+                in: home,
+                sceneId: args["sceneId"]?.stringValue,
+                sceneName: args["sceneName"]?.stringValue
+            )
+            guard case .success(let scene) = sceneResult else {
+                if case .failure(let message) = sceneResult {
+                    return Self.makeResult(for: invocation, status: .executionFailed, errorMessage: message)
+                }
+                return Self.makeResult(for: invocation, status: .executionFailed, errorMessage: "Scene not found.")
+            }
+
+            do {
+                try await home.executeActionSet(scene)
+            } catch {
+                return Self.makeResult(for: invocation, status: .executionFailed, errorMessage: error.localizedDescription)
+            }
+            return Self.makeResult(
+                for: invocation,
+                status: .success,
+                result: ["sceneId": .string(scene.uniqueIdentifier.uuidString)]
+            )
+        }
+
+        private func setCharacteristicValue(_ invocation: ConnectionInvocation) async -> ConnectionInvocationResult {
+            let manager = manager ?? createManager()
+            guard HomeDataSource.map(manager.authorizationStatus) == .authorized else {
+                return Self.makeResult(for: invocation, status: .authorizationDenied, errorMessage: "HomeKit access is not granted.")
+            }
+            let args = invocation.action.arguments
+            guard let home = resolveHome(manager: manager, homeId: args["homeId"]?.stringValue) else {
+                return Self.makeResult(for: invocation, status: .executionFailed, errorMessage: "No matching home found.")
+            }
+            guard let accessoryId = args["accessoryId"]?.stringValue else {
+                return Self.makeResult(for: invocation, status: .executionFailed, errorMessage: "Missing required argument 'accessoryId'.")
+            }
+            guard let accessory = home.accessories.first(where: { $0.uniqueIdentifier.uuidString == accessoryId }) else {
+                return Self.makeResult(for: invocation, status: .executionFailed, errorMessage: "Accessory not found for id '\(accessoryId)'.")
+            }
+            guard let characteristicType = args["characteristicType"]?.stringValue else {
+                return Self.makeResult(for: invocation, status: .executionFailed, errorMessage: "Missing required argument 'characteristicType'.")
+            }
+            guard let characteristic = Self.findCharacteristic(in: accessory, typeHint: characteristicType) else {
+                return Self.makeResult(for: invocation, status: .executionFailed, errorMessage: "Accessory has no characteristic matching '\(characteristicType)'.")
+            }
+            guard let rawValue = args["value"] else {
+                return Self.makeResult(for: invocation, status: .executionFailed, errorMessage: "Missing required argument 'value'.")
+            }
+            guard let coerced = Self.coerce(rawValue, for: characteristic) else {
+                return Self.makeResult(for: invocation, status: .executionFailed, errorMessage: "Could not coerce 'value' to characteristic format.")
+            }
+
+            do {
+                try await characteristic.writeValue(coerced)
+            } catch {
+                return Self.makeResult(for: invocation, status: .executionFailed, errorMessage: error.localizedDescription)
+            }
+
+            return Self.makeResult(
+                for: invocation,
+                status: .success,
+                result: [
+                    "accessoryId": .string(accessory.uniqueIdentifier.uuidString),
+                    "characteristicId": .string(characteristic.uniqueIdentifier.uuidString),
+                ]
+            )
+        }
+
+        private func resolveHome(manager: HMHomeManager, homeId: String?) -> HMHome? {
+            if let homeId {
+                return manager.homes.first { $0.uniqueIdentifier.uuidString == homeId }
+            }
+            return manager.primaryHome ?? manager.homes.first
+        }
+
+        private func resolveScene(in home: HMHome, sceneId: String?, sceneName: String?) -> Resolution<HMActionSet> {
+            if let sceneId {
+                if let match = home.actionSets.first(where: { $0.uniqueIdentifier.uuidString == sceneId }) {
+                    return .success(match)
+                }
+                return .failure("Scene not found for id '\(sceneId)'.")
+            }
+            if let sceneName {
+                let matches = home.actionSets.filter { $0.name == sceneName }
+                if matches.count == 1, let match = matches.first {
+                    return .success(match)
+                }
+                if matches.isEmpty {
+                    return .failure("No scene named '\(sceneName)'.")
+                }
+                return .failure("Multiple scenes named '\(sceneName)'; disambiguate by id.")
+            }
+            return .failure("Provide sceneId or sceneName.")
+        }
+
+        private enum Resolution<Value> {
+            case success(Value)
+            case failure(String)
+        }
+
+        private func createManager() -> HMHomeManager {
+            let manager = HMHomeManager()
+            let delegate = Delegate(state: self)
+            manager.delegate = delegate
+            self.manager = manager
+            self.delegate = delegate
+            return manager
+        }
+
+        private static func findCharacteristic(in accessory: HMAccessory, typeHint: String) -> HMCharacteristic? {
+            let lower = typeHint.lowercased()
+            let shortMap: [String: String] = [
+                "power": HMCharacteristicTypePowerState,
+                "on": HMCharacteristicTypePowerState,
+                "brightness": HMCharacteristicTypeBrightness,
+                "hue": HMCharacteristicTypeHue,
+                "saturation": HMCharacteristicTypeSaturation,
+                "targettemperature": HMCharacteristicTypeTargetTemperature,
+                "targetheatingcooling": HMCharacteristicTypeTargetHeatingCooling,
+                "lockstate": HMCharacteristicTypeTargetLockMechanismState,
+                "lock": HMCharacteristicTypeTargetLockMechanismState,
+            ]
+            let target = shortMap[lower] ?? typeHint
+            for service in accessory.services {
+                for characteristic in service.characteristics where characteristic.characteristicType == target {
+                    return characteristic
+                }
+            }
+            return nil
+        }
+
+        private static func coerce(_ argument: ArgumentValue, for characteristic: HMCharacteristic) -> Any? {
+            switch characteristic.metadata?.format ?? "" {
+            case HMCharacteristicMetadataFormatBool:
+                return coerceBool(argument)
+            case HMCharacteristicMetadataFormatInt,
+                HMCharacteristicMetadataFormatUInt8,
+                HMCharacteristicMetadataFormatUInt16,
+                HMCharacteristicMetadataFormatUInt32,
+                HMCharacteristicMetadataFormatUInt64:
+                return coerceInt(argument)
+            case HMCharacteristicMetadataFormatFloat:
+                return coerceDouble(argument)
+            case HMCharacteristicMetadataFormatString:
+                if case .string(let value) = argument { return value }
+                return nil
+            default:
+                return coerceAny(argument)
+            }
+        }
+
+        private static func coerceBool(_ argument: ArgumentValue) -> Any? {
+            if case .bool(let value) = argument { return NSNumber(value: value) }
+            if case .int(let value) = argument { return NSNumber(value: value != 0) }
+            if case .string(let value) = argument {
+                if ["true", "on", "1", "yes"].contains(value.lowercased()) { return NSNumber(value: true) }
+                if ["false", "off", "0", "no"].contains(value.lowercased()) { return NSNumber(value: false) }
+            }
+            return nil
+        }
+
+        private static func coerceInt(_ argument: ArgumentValue) -> Any? {
+            if case .int(let value) = argument { return NSNumber(value: value) }
+            if case .double(let value) = argument { return NSNumber(value: Int(value)) }
+            if case .string(let value) = argument, let parsed = Int(value) { return NSNumber(value: parsed) }
+            return nil
+        }
+
+        private static func coerceDouble(_ argument: ArgumentValue) -> Any? {
+            if case .double(let value) = argument { return NSNumber(value: value) }
+            if case .int(let value) = argument { return NSNumber(value: Double(value)) }
+            if case .string(let value) = argument, let parsed = Double(value) { return NSNumber(value: parsed) }
+            return nil
+        }
+
+        private static func coerceAny(_ argument: ArgumentValue) -> Any? {
+            if case .bool(let value) = argument { return NSNumber(value: value) }
+            if case .int(let value) = argument { return NSNumber(value: value) }
+            if case .double(let value) = argument { return NSNumber(value: value) }
+            if case .string(let value) = argument { return value }
+            return nil
+        }
+
+        private static func makeResult(
+            for invocation: ConnectionInvocation,
+            status: ConnectionInvocationResult.Status,
+            errorMessage: String? = nil,
+            result: [String: ArgumentValue] = [:]
+        ) -> ConnectionInvocationResult {
+            ConnectionInvocationResult(
+                invocationId: invocation.invocationId,
+                kind: invocation.kind,
+                actionName: invocation.action.name,
+                status: status,
+                result: result,
+                errorMessage: errorMessage
+            )
+        }
+    }
+
+    private final class Delegate: NSObject, HMHomeManagerDelegate, @unchecked Sendable {
+        weak var state: StateBox?
+
+        init(state: StateBox) {
+            self.state = state
+        }
+
+        func homeManagerDidUpdateHomes(_ manager: HMHomeManager) {
+            let ref = state
+            Task { await ref?.onHomesDidUpdate() }
+        }
+    }
+    #else
+    public func authorizationStatus() async -> ConnectionAuthorizationStatus { .unavailable }
+
+    @discardableResult
+    public func requestAuthorization() async throws -> ConnectionAuthorizationStatus { .unavailable }
+
+    public func invoke(_ invocation: ConnectionInvocation) async -> ConnectionInvocationResult {
+        ConnectionInvocationResult(
+            invocationId: invocation.invocationId,
+            kind: .homeKit,
+            actionName: invocation.action.name,
+            status: .executionFailed,
+            errorMessage: "HomeKit not available on this platform."
+        )
+    }
+    #endif
+}

--- a/ConvosConnections/Sources/ConvosConnections/DataSources/Location/LocationDataSource.swift
+++ b/ConvosConnections/Sources/ConvosConnections/DataSources/Location/LocationDataSource.swift
@@ -1,0 +1,236 @@
+import Foundation
+#if os(iOS)
+@preconcurrency import CoreLocation
+#endif
+
+/// Bridges Core Location into `ConvosConnections`.
+///
+/// Observation strategy (low-battery, wake-friendly):
+/// - **Significant location changes** — fire when the user moves ~500m+. iOS wakes the
+///   app from the background (or from terminated) to deliver these.
+/// - **Visits** — fire on arrival at and departure from places the user lingers at.
+///
+/// Deliberately does *not* use `startUpdatingLocation`, which drains battery and delivers
+/// far more samples than a conversation can usefully consume.
+///
+/// Authorization model follows Apple's recommended pattern: we request when-in-use first,
+/// then request always once when-in-use is granted. Only `authorizedAlways` enables real
+/// background wake — `authorizedWhenInUse` degrades to foreground-only observation.
+public final class LocationDataSource: DataSource, @unchecked Sendable {
+    public let kind: ConnectionKind = .location
+
+    #if os(iOS)
+    private let state: StateBox
+
+    public init() {
+        self.state = StateBox()
+    }
+
+    public func authorizationStatus() async -> ConnectionAuthorizationStatus {
+        await state.authorizationStatus()
+    }
+
+    @discardableResult
+    public func requestAuthorization() async throws -> ConnectionAuthorizationStatus {
+        await state.requestAuthorization()
+    }
+
+    public func authorizationDetails() async -> [AuthorizationDetail] {
+        let status = await authorizationStatus()
+        let note: String? = {
+            switch status {
+            case .partial:
+                return "Only \"While Using\" was granted. Background wake on significant-change and visits requires \"Always\" — upgrade in Settings."
+            case .authorized:
+                return nil
+            default:
+                return nil
+            }
+        }()
+        return [
+            AuthorizationDetail(
+                identifier: "location",
+                displayName: "Location Access",
+                status: status,
+                note: note
+            ),
+        ]
+    }
+
+    public func start(emit: @escaping ConnectionPayloadEmitter) async throws {
+        await state.start(emit: emit)
+    }
+
+    public func stop() async {
+        await state.stop()
+    }
+
+    // MARK: - Mapping
+
+    static func map(_ status: CLAuthorizationStatus) -> ConnectionAuthorizationStatus {
+        switch status {
+        case .notDetermined:
+            return .notDetermined
+        case .restricted, .denied:
+            return .denied
+        case .authorizedWhenInUse:
+            return .partial(missing: ["authorizedAlways"])
+        case .authorizedAlways:
+            return .authorized
+        @unknown default:
+            return .notDetermined
+        }
+    }
+
+    static func summarize(events: [LocationEvent]) -> String {
+        guard !events.isEmpty else { return "No new location events." }
+        let changeCount = events.filter { $0.type == .significantChange }.count
+        let arrivalCount = events.filter { $0.type == .visitArrival }.count
+        let departureCount = events.filter { $0.type == .visitDeparture }.count
+        var parts: [String] = []
+        if changeCount > 0 { parts.append("\(changeCount) significant change\(changeCount == 1 ? "" : "s")") }
+        if arrivalCount > 0 { parts.append("\(arrivalCount) arrival\(arrivalCount == 1 ? "" : "s")") }
+        if departureCount > 0 { parts.append("\(departureCount) departure\(departureCount == 1 ? "" : "s")") }
+        return parts.joined(separator: ", ")
+    }
+
+    /// Actor that owns the `CLLocationManager`, its delegate adapter, and the emitter.
+    /// Delegate callbacks arrive on the main thread and hop into the actor via `Task {}`.
+    private actor StateBox {
+        private var manager: CLLocationManager?
+        private var delegate: Delegate?
+        private var emitter: ConnectionPayloadEmitter?
+        private var authorizationContinuation: CheckedContinuation<Void, Never>?
+
+        func authorizationStatus() -> ConnectionAuthorizationStatus {
+            let manager = manager ?? createManager()
+            return LocationDataSource.map(manager.authorizationStatus)
+        }
+
+        func requestAuthorization() async -> ConnectionAuthorizationStatus {
+            let manager = manager ?? createManager()
+
+            if manager.authorizationStatus == .notDetermined {
+                await withCheckedContinuation { continuation in
+                    authorizationContinuation = continuation
+                    manager.requestWhenInUseAuthorization()
+                }
+            }
+            if manager.authorizationStatus == .authorizedWhenInUse {
+                await withCheckedContinuation { continuation in
+                    authorizationContinuation = continuation
+                    manager.requestAlwaysAuthorization()
+                }
+            }
+            return LocationDataSource.map(manager.authorizationStatus)
+        }
+
+        func start(emit: @escaping ConnectionPayloadEmitter) {
+            self.emitter = emit
+            let manager = manager ?? createManager()
+            manager.startMonitoringSignificantLocationChanges()
+            #if os(iOS)
+            manager.startMonitoringVisits()
+            #endif
+        }
+
+        func stop() {
+            manager?.stopMonitoringSignificantLocationChanges()
+            #if os(iOS)
+            manager?.stopMonitoringVisits()
+            #endif
+            emitter = nil
+        }
+
+        fileprivate func onLocationUpdate(_ locations: [CLLocation]) {
+            guard !locations.isEmpty else { return }
+            let events = locations.map { location in
+                LocationEvent(
+                    type: .significantChange,
+                    latitude: location.coordinate.latitude,
+                    longitude: location.coordinate.longitude,
+                    horizontalAccuracy: location.horizontalAccuracy,
+                    eventDate: location.timestamp
+                )
+            }
+            emit(events: events)
+        }
+
+        fileprivate func onVisit(_ visit: CLVisit) {
+            let isDeparture = visit.departureDate != Date.distantFuture
+            let event = LocationEvent(
+                type: isDeparture ? .visitDeparture : .visitArrival,
+                latitude: visit.coordinate.latitude,
+                longitude: visit.coordinate.longitude,
+                horizontalAccuracy: visit.horizontalAccuracy,
+                eventDate: isDeparture ? visit.departureDate : visit.arrivalDate,
+                arrivalDate: visit.arrivalDate,
+                departureDate: isDeparture ? visit.departureDate : nil
+            )
+            emit(events: [event])
+        }
+
+        fileprivate func onAuthorizationChange() {
+            let continuation = authorizationContinuation
+            authorizationContinuation = nil
+            continuation?.resume()
+        }
+
+        private func emit(events: [LocationEvent]) {
+            guard let emitter else { return }
+            let body = LocationPayload(
+                summary: LocationDataSource.summarize(events: events),
+                events: events
+            )
+            emitter(ConnectionPayload(source: .location, body: .location(body)))
+        }
+
+        private func createManager() -> CLLocationManager {
+            let manager = CLLocationManager()
+            let delegate = Delegate(state: self)
+            manager.delegate = delegate
+            self.manager = manager
+            self.delegate = delegate
+            return manager
+        }
+    }
+
+    /// Forwards `CLLocationManagerDelegate` callbacks into the actor. Held strongly by the
+    /// actor and referenced weakly here so it doesn't outlive the state.
+    private final class Delegate: NSObject, CLLocationManagerDelegate, @unchecked Sendable {
+        weak var state: StateBox?
+
+        init(state: StateBox) {
+            self.state = state
+        }
+
+        func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+            let ref = state
+            Task { await ref?.onLocationUpdate(locations) }
+        }
+
+        #if os(iOS)
+        func locationManager(_ manager: CLLocationManager, didVisit visit: CLVisit) {
+            let ref = state
+            Task { await ref?.onVisit(visit) }
+        }
+        #endif
+
+        func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
+            let ref = state
+            Task { await ref?.onAuthorizationChange() }
+        }
+    }
+    #else
+    public init() {}
+
+    public func authorizationStatus() async -> ConnectionAuthorizationStatus { .unavailable }
+
+    @discardableResult
+    public func requestAuthorization() async throws -> ConnectionAuthorizationStatus { .unavailable }
+
+    public func start(emit: @escaping ConnectionPayloadEmitter) async throws {}
+
+    public func stop() async {}
+    #endif
+}

--- a/ConvosConnections/Sources/ConvosConnections/DataSources/Motion/MotionDataSource.swift
+++ b/ConvosConnections/Sources/ConvosConnections/DataSources/Motion/MotionDataSource.swift
@@ -1,0 +1,186 @@
+import Foundation
+#if canImport(CoreMotion) && os(iOS)
+@preconcurrency import CoreMotion
+#endif
+
+/// Bridges the device's motion coprocessor classification into `ConvosConnections`.
+///
+/// Delivers high-level activity labels (stationary / walking / running / driving / cycling)
+/// rather than raw accelerometer samples — that's the right grain for a conversation
+/// payload. Each new activity classification emits one payload; steady-state stationary
+/// periods produce nothing.
+///
+/// CMMotionActivityManager wakes the app intermittently for delivery while authorized;
+/// it is *not* a true background-wake API like HealthKit observer queries.
+public final class MotionDataSource: DataSource, @unchecked Sendable {
+    public let kind: ConnectionKind = .motion
+
+    public init() {
+        #if canImport(CoreMotion) && os(iOS)
+        self.state = StateBox()
+        #endif
+    }
+
+    #if canImport(CoreMotion) && os(iOS)
+    private let state: StateBox
+
+    public func authorizationStatus() async -> ConnectionAuthorizationStatus {
+        guard CMMotionActivityManager.isActivityAvailable() else { return .unavailable }
+        return Self.map(CMMotionActivityManager.authorizationStatus())
+    }
+
+    @discardableResult
+    public func requestAuthorization() async throws -> ConnectionAuthorizationStatus {
+        // CoreMotion has no explicit request API — authorization is triggered implicitly
+        // by the first query. Run a trivial one-shot to surface the prompt.
+        guard CMMotionActivityManager.isActivityAvailable() else { return .unavailable }
+        try await state.primeAuthorization()
+        return await authorizationStatus()
+    }
+
+    public func authorizationDetails() async -> [AuthorizationDetail] {
+        let status = await authorizationStatus()
+        return [
+            AuthorizationDetail(
+                identifier: "motion",
+                displayName: "Motion & Fitness",
+                status: status,
+                note: nil
+            ),
+        ]
+    }
+
+    public func start(emit: @escaping ConnectionPayloadEmitter) async throws {
+        await state.start(emit: emit)
+    }
+
+    public func stop() async {
+        await state.stop()
+    }
+
+    public func snapshotCurrent() async throws -> MotionPayload {
+        try await state.snapshotCurrent()
+    }
+
+    static func map(_ status: CMAuthorizationStatus) -> ConnectionAuthorizationStatus {
+        switch status {
+        case .notDetermined: return .notDetermined
+        case .restricted, .denied: return .denied
+        case .authorized: return .authorized
+        @unknown default: return .notDetermined
+        }
+    }
+
+    static func map(activity: CMMotionActivity) -> MotionActivity {
+        let type: MotionActivityType = {
+            if activity.walking { return .walking }
+            if activity.running { return .running }
+            if activity.cycling { return .cycling }
+            if activity.automotive { return .automotive }
+            if activity.stationary { return .stationary }
+            return .unknown
+        }()
+        let confidence: MotionConfidence = {
+            switch activity.confidence {
+            case .low: return .low
+            case .medium: return .medium
+            case .high: return .high
+            @unknown default: return .low
+            }
+        }()
+        return MotionActivity(type: type, confidence: confidence, startDate: activity.startDate)
+    }
+
+    static func summary(for activity: MotionActivity?) -> String {
+        guard let activity else { return "No activity classified yet." }
+        return "\(activity.type.rawValue.capitalized) (confidence: \(activity.confidence.rawValue))"
+    }
+
+    private actor StateBox {
+        private let manager: CMMotionActivityManager = CMMotionActivityManager()
+        private let queue: OperationQueue = {
+            let queue = OperationQueue()
+            queue.qualityOfService = .utility
+            return queue
+        }()
+        private var emitter: ConnectionPayloadEmitter?
+        private var lastEmittedType: MotionActivityType?
+        private var started: Bool = false
+
+        func primeAuthorization() async throws {
+            _ = try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+                manager.queryActivityStarting(from: Date(timeIntervalSinceNow: -60), to: Date(), to: queue) { _, error in
+                    if let error {
+                        continuation.resume(throwing: error)
+                        return
+                    }
+                    continuation.resume()
+                }
+            }
+        }
+
+        func start(emit: @escaping ConnectionPayloadEmitter) async {
+            if started { return }
+            self.emitter = emit
+            started = true
+            manager.startActivityUpdates(to: queue) { [weak self] activity in
+                guard let activity else { return }
+                let ref = self
+                Task { await ref?.handleActivity(activity) }
+            }
+        }
+
+        func stop() async {
+            guard started else { return }
+            manager.stopActivityUpdates()
+            started = false
+            emitter = nil
+            lastEmittedType = nil
+        }
+
+        func snapshotCurrent() async throws -> MotionPayload {
+            let latest: MotionActivity? = try await withCheckedThrowingContinuation { continuation in
+                manager.queryActivityStarting(from: Date(timeIntervalSinceNow: -15 * 60), to: Date(), to: queue) { activities, error in
+                    if let error {
+                        continuation.resume(throwing: error)
+                        return
+                    }
+                    // Map to Sendable MotionActivity inside the handler so the continuation
+                    // only carries a Sendable value across isolation boundaries.
+                    let mapped = activities?.last.map(MotionDataSource.map(activity:))
+                    continuation.resume(returning: mapped)
+                }
+            }
+            return MotionPayload(
+                summary: MotionDataSource.summary(for: latest),
+                activity: latest
+            )
+        }
+
+        private func handleActivity(_ activity: CMMotionActivity) async {
+            let mapped = MotionDataSource.map(activity: activity)
+            if mapped.type == lastEmittedType { return }
+            lastEmittedType = mapped.type
+            guard let emitter else { return }
+            let payload = MotionPayload(
+                summary: MotionDataSource.summary(for: mapped),
+                activity: mapped
+            )
+            emitter(ConnectionPayload(source: .motion, body: .motion(payload)))
+        }
+    }
+    #else
+    public func authorizationStatus() async -> ConnectionAuthorizationStatus { .unavailable }
+
+    @discardableResult
+    public func requestAuthorization() async throws -> ConnectionAuthorizationStatus { .unavailable }
+
+    public func start(emit: @escaping ConnectionPayloadEmitter) async throws {}
+
+    public func stop() async {}
+
+    public func snapshotCurrent() async throws -> MotionPayload {
+        MotionPayload(summary: "Motion not available.", activity: nil)
+    }
+    #endif
+}

--- a/ConvosConnections/Sources/ConvosConnections/DataSources/Music/MusicActionSchemas.swift
+++ b/ConvosConnections/Sources/ConvosConnections/DataSources/Music/MusicActionSchemas.swift
@@ -1,0 +1,63 @@
+import Foundation
+
+/// Static `ActionSchema` values published by `MusicDataSink`.
+///
+/// All actions target `MPMusicPlayerController.systemMusicPlayer` — the same player
+/// observed by `MusicDataSource`. Third-party apps (Spotify, YouTube Music) are not
+/// reachable through this API.
+///
+/// `queue_store_items` requires `MPMediaLibraryAuthorizationStatus.authorized`, queues a
+/// set of Apple Music store product identifiers, and starts playback. For local library
+/// items, agents should use persistent-id queuing via a future expansion.
+public enum MusicActionSchemas {
+    public static let play: ActionSchema = ActionSchema(
+        kind: .music,
+        actionName: "play",
+        capability: .writeUpdate,
+        summary: "Resume playback on the system music player.",
+        inputs: [],
+        outputs: []
+    )
+
+    public static let pause: ActionSchema = ActionSchema(
+        kind: .music,
+        actionName: "pause",
+        capability: .writeUpdate,
+        summary: "Pause playback on the system music player.",
+        inputs: [],
+        outputs: []
+    )
+
+    public static let skipToNext: ActionSchema = ActionSchema(
+        kind: .music,
+        actionName: "skip_to_next",
+        capability: .writeUpdate,
+        summary: "Skip to the next track in the queue.",
+        inputs: [],
+        outputs: []
+    )
+
+    public static let skipToPrevious: ActionSchema = ActionSchema(
+        kind: .music,
+        actionName: "skip_to_previous",
+        capability: .writeUpdate,
+        summary: "Skip to the previous track in the queue.",
+        inputs: [],
+        outputs: []
+    )
+
+    public static let queueStoreItems: ActionSchema = ActionSchema(
+        kind: .music,
+        actionName: "queue_store_items",
+        capability: .writeCreate,
+        summary: "Queue one or more Apple Music store product IDs and begin playback.",
+        inputs: [
+            ActionParameter(name: "storeIds", type: .arrayOf(.string), description: "Apple Music store identifiers.", isRequired: true),
+        ],
+        outputs: [
+            ActionParameter(name: "queuedCount", type: .int, description: "Number of items queued.", isRequired: true),
+        ]
+    )
+
+    public static let all: [ActionSchema] = [play, pause, skipToNext, skipToPrevious, queueStoreItems]
+}

--- a/ConvosConnections/Sources/ConvosConnections/DataSources/Music/MusicDataSink.swift
+++ b/ConvosConnections/Sources/ConvosConnections/DataSources/Music/MusicDataSink.swift
@@ -1,0 +1,117 @@
+import Foundation
+#if canImport(MediaPlayer) && os(iOS)
+@preconcurrency import MediaPlayer
+#endif
+
+/// Write-side counterpart to `MusicDataSource`.
+///
+/// Drives `MPMusicPlayerController.systemMusicPlayer` directly. Transport controls don't
+/// require additional authorization — iOS allows any app to drive the shared player.
+/// Only `queue_store_items` needs `MPMediaLibrary.authorizationStatus()` to be authorized.
+public final class MusicDataSink: DataSink, @unchecked Sendable {
+    public let kind: ConnectionKind = .music
+
+    public init() {}
+
+    public func actionSchemas() async -> [ActionSchema] {
+        MusicActionSchemas.all
+    }
+
+    #if canImport(MediaPlayer) && os(iOS)
+    public func authorizationStatus() async -> ConnectionAuthorizationStatus {
+        MusicDataSource.map(MPMediaLibrary.authorizationStatus())
+    }
+
+    @discardableResult
+    public func requestAuthorization() async throws -> ConnectionAuthorizationStatus {
+        let status: MPMediaLibraryAuthorizationStatus = await withCheckedContinuation { continuation in
+            MPMediaLibrary.requestAuthorization { status in
+                continuation.resume(returning: status)
+            }
+        }
+        return MusicDataSource.map(status)
+    }
+
+    @MainActor
+    public func invoke(_ invocation: ConnectionInvocation) async -> ConnectionInvocationResult {
+        let player = MPMusicPlayerController.systemMusicPlayer
+        switch invocation.action.name {
+        case MusicActionSchemas.play.actionName:
+            player.play()
+            return Self.makeResult(for: invocation, status: .success)
+        case MusicActionSchemas.pause.actionName:
+            player.pause()
+            return Self.makeResult(for: invocation, status: .success)
+        case MusicActionSchemas.skipToNext.actionName:
+            player.skipToNextItem()
+            return Self.makeResult(for: invocation, status: .success)
+        case MusicActionSchemas.skipToPrevious.actionName:
+            player.skipToPreviousItem()
+            return Self.makeResult(for: invocation, status: .success)
+        case MusicActionSchemas.queueStoreItems.actionName:
+            return queueStoreItems(invocation, player: player)
+        default:
+            return Self.makeResult(
+                for: invocation,
+                status: .unknownAction,
+                errorMessage: "Music sink does not know action '\(invocation.action.name)'."
+            )
+        }
+    }
+
+    @MainActor
+    private func queueStoreItems(_ invocation: ConnectionInvocation, player: MPMusicPlayerController) -> ConnectionInvocationResult {
+        guard MPMediaLibrary.authorizationStatus() == .authorized else {
+            return Self.makeResult(for: invocation, status: .authorizationDenied, errorMessage: "Media library authorization is required for queuing store items.")
+        }
+        guard case .array(let values) = invocation.action.arguments["storeIds"] ?? .null else {
+            return Self.makeResult(for: invocation, status: .executionFailed, errorMessage: "Missing required argument 'storeIds' (expected an array of strings).")
+        }
+        let storeIds = values.compactMap(\.stringValue)
+        guard !storeIds.isEmpty else {
+            return Self.makeResult(for: invocation, status: .executionFailed, errorMessage: "'storeIds' must contain at least one identifier.")
+        }
+
+        let descriptor = MPMusicPlayerStoreQueueDescriptor(storeIDs: storeIds)
+        player.setQueue(with: descriptor)
+        player.play()
+
+        return Self.makeResult(
+            for: invocation,
+            status: .success,
+            result: ["queuedCount": .int(storeIds.count)]
+        )
+    }
+
+    private static func makeResult(
+        for invocation: ConnectionInvocation,
+        status: ConnectionInvocationResult.Status,
+        errorMessage: String? = nil,
+        result: [String: ArgumentValue] = [:]
+    ) -> ConnectionInvocationResult {
+        ConnectionInvocationResult(
+            invocationId: invocation.invocationId,
+            kind: invocation.kind,
+            actionName: invocation.action.name,
+            status: status,
+            result: result,
+            errorMessage: errorMessage
+        )
+    }
+    #else
+    public func authorizationStatus() async -> ConnectionAuthorizationStatus { .unavailable }
+
+    @discardableResult
+    public func requestAuthorization() async throws -> ConnectionAuthorizationStatus { .unavailable }
+
+    public func invoke(_ invocation: ConnectionInvocation) async -> ConnectionInvocationResult {
+        ConnectionInvocationResult(
+            invocationId: invocation.invocationId,
+            kind: .music,
+            actionName: invocation.action.name,
+            status: .executionFailed,
+            errorMessage: "MediaPlayer not available on this platform."
+        )
+    }
+    #endif
+}

--- a/ConvosConnections/Sources/ConvosConnections/DataSources/Music/MusicDataSource.swift
+++ b/ConvosConnections/Sources/ConvosConnections/DataSources/Music/MusicDataSource.swift
@@ -1,0 +1,177 @@
+import Foundation
+#if canImport(MediaPlayer) && os(iOS)
+@preconcurrency import MediaPlayer
+#endif
+
+/// Bridges the iOS system music player's now-playing state into `ConvosConnections`.
+///
+/// Observes `MPMusicPlayerController.systemMusicPlayer` — fires on track changes and
+/// playback state changes while the app is running. Does **not** surface third-party
+/// players (Spotify, YouTube Music) — those don't use `MPMusicPlayerController`.
+public final class MusicDataSource: DataSource, @unchecked Sendable {
+    public let kind: ConnectionKind = .music
+
+    public init() {
+        #if canImport(MediaPlayer) && os(iOS)
+        self.state = StateBox()
+        #endif
+    }
+
+    #if canImport(MediaPlayer) && os(iOS)
+    private let state: StateBox
+
+    public func authorizationStatus() async -> ConnectionAuthorizationStatus {
+        Self.map(MPMediaLibrary.authorizationStatus())
+    }
+
+    @discardableResult
+    public func requestAuthorization() async throws -> ConnectionAuthorizationStatus {
+        let status: MPMediaLibraryAuthorizationStatus = await withCheckedContinuation { continuation in
+            MPMediaLibrary.requestAuthorization { status in
+                continuation.resume(returning: status)
+            }
+        }
+        return Self.map(status)
+    }
+
+    public func authorizationDetails() async -> [AuthorizationDetail] {
+        let status = await authorizationStatus()
+        return [
+            AuthorizationDetail(
+                identifier: "music",
+                displayName: "Apple Music / Media Library",
+                status: status,
+                note: "Only reflects Apple Music / iTunes playback. Third-party players like Spotify aren't observable through this API."
+            ),
+        ]
+    }
+
+    public func start(emit: @escaping ConnectionPayloadEmitter) async throws {
+        await state.start(emit: emit)
+    }
+
+    public func stop() async {
+        await state.stop()
+    }
+
+    public func snapshotCurrent() async -> MusicPayload {
+        await state.snapshotCurrent()
+    }
+
+    static func map(_ status: MPMediaLibraryAuthorizationStatus) -> ConnectionAuthorizationStatus {
+        switch status {
+        case .notDetermined: return .notDetermined
+        case .restricted, .denied: return .denied
+        case .authorized: return .authorized
+        @unknown default: return .notDetermined
+        }
+    }
+
+    static func map(_ state: MPMusicPlaybackState) -> MusicPlaybackState {
+        switch state {
+        case .stopped: return .stopped
+        case .playing: return .playing
+        case .paused: return .paused
+        case .interrupted: return .interrupted
+        case .seekingForward: return .seekingForward
+        case .seekingBackward: return .seekingBackward
+        @unknown default: return .unknown
+        }
+    }
+
+    static func buildPayload(from player: MPMusicPlayerController) -> MusicPayload {
+        let state = map(player.playbackState)
+        if let item = player.nowPlayingItem {
+            let now = NowPlayingItem(
+                title: item.title,
+                artist: item.artist,
+                album: item.albumTitle,
+                genre: item.genre,
+                durationSeconds: item.playbackDuration,
+                playbackTimeSeconds: player.currentPlaybackTime.isFinite ? player.currentPlaybackTime : 0
+            )
+            let summary = [item.title, item.artist].compactMap { $0 }.joined(separator: " — ")
+            return MusicPayload(
+                summary: summary.isEmpty ? "Now playing (\(state.rawValue))" : summary,
+                nowPlaying: now,
+                playbackState: state
+            )
+        }
+        return MusicPayload(
+            summary: "Nothing playing",
+            nowPlaying: nil,
+            playbackState: state
+        )
+    }
+
+    private actor StateBox {
+        private var player: MPMusicPlayerController?
+        private var nowPlayingToken: NSObjectProtocol?
+        private var stateToken: NSObjectProtocol?
+        private var emitter: ConnectionPayloadEmitter?
+
+        func start(emit: @escaping ConnectionPayloadEmitter) async {
+            if player != nil { return }
+            self.emitter = emit
+            let player = MPMusicPlayerController.systemMusicPlayer
+            self.player = player
+            player.beginGeneratingPlaybackNotifications()
+
+            nowPlayingToken = NotificationCenter.default.addObserver(
+                forName: .MPMusicPlayerControllerNowPlayingItemDidChange,
+                object: player,
+                queue: nil
+            ) { [weak self] _ in
+                Task { [weak self] in await self?.emitCurrent() }
+            }
+            stateToken = NotificationCenter.default.addObserver(
+                forName: .MPMusicPlayerControllerPlaybackStateDidChange,
+                object: player,
+                queue: nil
+            ) { [weak self] _ in
+                Task { [weak self] in await self?.emitCurrent() }
+            }
+
+            emitCurrent()
+        }
+
+        func stop() async {
+            player?.endGeneratingPlaybackNotifications()
+            if let nowPlayingToken {
+                NotificationCenter.default.removeObserver(nowPlayingToken)
+            }
+            if let stateToken {
+                NotificationCenter.default.removeObserver(stateToken)
+            }
+            nowPlayingToken = nil
+            stateToken = nil
+            player = nil
+            emitter = nil
+        }
+
+        func snapshotCurrent() -> MusicPayload {
+            let player = player ?? MPMusicPlayerController.systemMusicPlayer
+            return MusicDataSource.buildPayload(from: player)
+        }
+
+        private func emitCurrent() {
+            guard let emitter, let player else { return }
+            let payload = MusicDataSource.buildPayload(from: player)
+            emitter(ConnectionPayload(source: .music, body: .music(payload)))
+        }
+    }
+    #else
+    public func authorizationStatus() async -> ConnectionAuthorizationStatus { .unavailable }
+
+    @discardableResult
+    public func requestAuthorization() async throws -> ConnectionAuthorizationStatus { .unavailable }
+
+    public func start(emit: @escaping ConnectionPayloadEmitter) async throws {}
+
+    public func stop() async {}
+
+    public func snapshotCurrent() async -> MusicPayload {
+        MusicPayload(summary: "Music not available.", nowPlaying: nil, playbackState: .stopped)
+    }
+    #endif
+}

--- a/ConvosConnections/Sources/ConvosConnections/DataSources/Photos/PhotosActionSchemas.swift
+++ b/ConvosConnections/Sources/ConvosConnections/DataSources/Photos/PhotosActionSchemas.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+/// Static `ActionSchema` values published by `PhotosDataSink`.
+public enum PhotosActionSchemas {
+    public static let saveImage: ActionSchema = ActionSchema(
+        kind: .photos,
+        actionName: "save_image",
+        capability: .writeCreate,
+        summary: "Save image data to the user's photo library.",
+        inputs: [
+            ActionParameter(name: "imageData", type: .string, description: "Base64-encoded image bytes (JPEG/PNG/HEIC).", isRequired: true),
+            ActionParameter(name: "isFavorite", type: .bool, description: "Mark the saved asset as a favorite.", isRequired: false),
+        ],
+        outputs: [
+            ActionParameter(name: "assetId", type: .string, description: "Local identifier of the newly-saved asset.", isRequired: true),
+        ]
+    )
+
+    public static let favoriteAsset: ActionSchema = ActionSchema(
+        kind: .photos,
+        actionName: "favorite_asset",
+        capability: .writeUpdate,
+        summary: "Toggle the favorite flag on a photo library asset.",
+        inputs: [
+            ActionParameter(name: "assetId", type: .string, description: "Local identifier of the asset.", isRequired: true),
+            ActionParameter(name: "isFavorite", type: .bool, description: "Desired favorite state.", isRequired: true),
+        ],
+        outputs: [
+            ActionParameter(name: "assetId", type: .string, description: "Updated asset identifier.", isRequired: true),
+        ]
+    )
+
+    public static let deleteAsset: ActionSchema = ActionSchema(
+        kind: .photos,
+        actionName: "delete_asset",
+        capability: .writeDelete,
+        summary: "Delete an asset from the user's photo library (user is prompted by iOS).",
+        inputs: [
+            ActionParameter(name: "assetId", type: .string, description: "Local identifier of the asset to delete.", isRequired: true),
+        ],
+        outputs: []
+    )
+
+    public static let all: [ActionSchema] = [saveImage, favoriteAsset, deleteAsset]
+}

--- a/ConvosConnections/Sources/ConvosConnections/DataSources/Photos/PhotosDataSink.swift
+++ b/ConvosConnections/Sources/ConvosConnections/DataSources/Photos/PhotosDataSink.swift
@@ -1,0 +1,163 @@
+import Foundation
+#if canImport(Photos)
+@preconcurrency import Photos
+#endif
+
+/// Write-side counterpart to `PhotosDataSource`.
+///
+/// Supports three actions: `save_image` (import Base64 image data), `favorite_asset` (flip
+/// the favorite flag), and `delete_asset` (iOS presents the confirmation sheet).
+///
+/// `save_image` accepts Base64-encoded bytes rather than raw binary because the arguments
+/// payload is a JSON-codable dictionary. Agents that want to send real images should
+/// Base64-encode them on their side.
+public final class PhotosDataSink: DataSink, @unchecked Sendable {
+    public let kind: ConnectionKind = .photos
+
+    public init() {}
+
+    public func actionSchemas() async -> [ActionSchema] {
+        PhotosActionSchemas.all
+    }
+
+    #if canImport(Photos)
+    public func authorizationStatus() async -> ConnectionAuthorizationStatus {
+        PhotosDataSource.map(PHPhotoLibrary.authorizationStatus(for: .readWrite))
+    }
+
+    @discardableResult
+    public func requestAuthorization() async throws -> ConnectionAuthorizationStatus {
+        let status = await PHPhotoLibrary.requestAuthorization(for: .readWrite)
+        return PhotosDataSource.map(status)
+    }
+
+    public func invoke(_ invocation: ConnectionInvocation) async -> ConnectionInvocationResult {
+        switch invocation.action.name {
+        case PhotosActionSchemas.saveImage.actionName:
+            return await saveImage(invocation)
+        case PhotosActionSchemas.favoriteAsset.actionName:
+            return await favoriteAsset(invocation)
+        case PhotosActionSchemas.deleteAsset.actionName:
+            return await deleteAsset(invocation)
+        default:
+            return Self.makeResult(
+                for: invocation,
+                status: .unknownAction,
+                errorMessage: "Photos sink does not know action '\(invocation.action.name)'."
+            )
+        }
+    }
+
+    private func saveImage(_ invocation: ConnectionInvocation) async -> ConnectionInvocationResult {
+        guard Self.canWrite() else {
+            return Self.makeResult(for: invocation, status: .authorizationDenied, errorMessage: "Photo library write access is not granted.")
+        }
+        let args = invocation.action.arguments
+        guard let base64 = args["imageData"]?.stringValue,
+              let data = Data(base64Encoded: base64, options: [.ignoreUnknownCharacters]) else {
+            return Self.makeResult(for: invocation, status: .executionFailed, errorMessage: "Missing or invalid 'imageData' (must be Base64).")
+        }
+        let isFavorite = args["isFavorite"]?.boolValue ?? false
+
+        var placeholderId: String?
+        do {
+            try await PHPhotoLibrary.shared().performChanges {
+                let request = PHAssetCreationRequest.forAsset()
+                request.addResource(with: .photo, data: data, options: nil)
+                request.isFavorite = isFavorite
+                placeholderId = request.placeholderForCreatedAsset?.localIdentifier
+            }
+        } catch {
+            return Self.makeResult(for: invocation, status: .executionFailed, errorMessage: error.localizedDescription)
+        }
+        guard let assetId = placeholderId else {
+            return Self.makeResult(for: invocation, status: .executionFailed, errorMessage: "Save succeeded but no asset identifier was produced.")
+        }
+        return Self.makeResult(for: invocation, status: .success, result: ["assetId": .string(assetId)])
+    }
+
+    private func favoriteAsset(_ invocation: ConnectionInvocation) async -> ConnectionInvocationResult {
+        guard Self.canWrite() else {
+            return Self.makeResult(for: invocation, status: .authorizationDenied, errorMessage: "Photo library write access is not granted.")
+        }
+        let args = invocation.action.arguments
+        guard let assetId = args["assetId"]?.stringValue else {
+            return Self.makeResult(for: invocation, status: .executionFailed, errorMessage: "Missing required argument 'assetId'.")
+        }
+        guard let isFavorite = args["isFavorite"]?.boolValue else {
+            return Self.makeResult(for: invocation, status: .executionFailed, errorMessage: "Missing required argument 'isFavorite'.")
+        }
+        let assets = PHAsset.fetchAssets(withLocalIdentifiers: [assetId], options: nil)
+        guard let asset = assets.firstObject else {
+            return Self.makeResult(for: invocation, status: .executionFailed, errorMessage: "Asset not found for id '\(assetId)'.")
+        }
+        do {
+            try await PHPhotoLibrary.shared().performChanges {
+                let request = PHAssetChangeRequest(for: asset)
+                request.isFavorite = isFavorite
+            }
+        } catch {
+            return Self.makeResult(for: invocation, status: .executionFailed, errorMessage: error.localizedDescription)
+        }
+        return Self.makeResult(for: invocation, status: .success, result: ["assetId": .string(assetId)])
+    }
+
+    private func deleteAsset(_ invocation: ConnectionInvocation) async -> ConnectionInvocationResult {
+        guard Self.canWrite() else {
+            return Self.makeResult(for: invocation, status: .authorizationDenied, errorMessage: "Photo library write access is not granted.")
+        }
+        let args = invocation.action.arguments
+        guard let assetId = args["assetId"]?.stringValue else {
+            return Self.makeResult(for: invocation, status: .executionFailed, errorMessage: "Missing required argument 'assetId'.")
+        }
+        let assets = PHAsset.fetchAssets(withLocalIdentifiers: [assetId], options: nil)
+        guard assets.firstObject != nil else {
+            return Self.makeResult(for: invocation, status: .executionFailed, errorMessage: "Asset not found for id '\(assetId)'.")
+        }
+        do {
+            try await PHPhotoLibrary.shared().performChanges {
+                PHAssetChangeRequest.deleteAssets(assets)
+            }
+        } catch {
+            return Self.makeResult(for: invocation, status: .executionFailed, errorMessage: error.localizedDescription)
+        }
+        return Self.makeResult(for: invocation, status: .success)
+    }
+
+    private static func canWrite() -> Bool {
+        let status = PHPhotoLibrary.authorizationStatus(for: .readWrite)
+        return status == .authorized || status == .limited
+    }
+
+    private static func makeResult(
+        for invocation: ConnectionInvocation,
+        status: ConnectionInvocationResult.Status,
+        errorMessage: String? = nil,
+        result: [String: ArgumentValue] = [:]
+    ) -> ConnectionInvocationResult {
+        ConnectionInvocationResult(
+            invocationId: invocation.invocationId,
+            kind: invocation.kind,
+            actionName: invocation.action.name,
+            status: status,
+            result: result,
+            errorMessage: errorMessage
+        )
+    }
+    #else
+    public func authorizationStatus() async -> ConnectionAuthorizationStatus { .unavailable }
+
+    @discardableResult
+    public func requestAuthorization() async throws -> ConnectionAuthorizationStatus { .unavailable }
+
+    public func invoke(_ invocation: ConnectionInvocation) async -> ConnectionInvocationResult {
+        ConnectionInvocationResult(
+            invocationId: invocation.invocationId,
+            kind: .photos,
+            actionName: invocation.action.name,
+            status: .executionFailed,
+            errorMessage: "Photos framework not available on this platform."
+        )
+    }
+    #endif
+}

--- a/ConvosConnections/Sources/ConvosConnections/DataSources/Photos/PhotosDataSource.swift
+++ b/ConvosConnections/Sources/ConvosConnections/DataSources/Photos/PhotosDataSource.swift
@@ -1,0 +1,224 @@
+import Foundation
+#if canImport(Photos)
+@preconcurrency import Photos
+#endif
+
+/// Bridges the user's photo library into `ConvosConnections` via PhotoKit.
+///
+/// Observes `PHPhotoLibraryChangeObserver` while the app is running; on each change it
+/// re-fetches a small metadata window and emits a summary payload. No background delivery.
+///
+/// Volume control: the library is never dumped wholesale — we emit total counts plus a
+/// bounded window of the most recent `recentLimit` assets with only metadata (never pixel
+/// data). Location is included when the asset carries it.
+public final class PhotosDataSource: DataSource, @unchecked Sendable {
+    public let kind: ConnectionKind = .photos
+    public let recentLimit: Int
+
+    public init(recentLimit: Int = 20) {
+        self.recentLimit = recentLimit
+        #if canImport(Photos)
+        self.state = StateBox()
+        #endif
+    }
+
+    #if canImport(Photos)
+    private let state: StateBox
+
+    public func authorizationStatus() async -> ConnectionAuthorizationStatus {
+        Self.map(PHPhotoLibrary.authorizationStatus(for: .readWrite))
+    }
+
+    @discardableResult
+    public func requestAuthorization() async throws -> ConnectionAuthorizationStatus {
+        let status = await PHPhotoLibrary.requestAuthorization(for: .readWrite)
+        return Self.map(status)
+    }
+
+    public func authorizationDetails() async -> [AuthorizationDetail] {
+        let status = await authorizationStatus()
+        let note: String? = {
+            if case .partial = status {
+                return "Limited library selected. Only user-picked assets are visible — change to All Photos in Settings to see the full library."
+            }
+            return nil
+        }()
+        return [
+            AuthorizationDetail(
+                identifier: "photo_library",
+                displayName: "Photo Library",
+                status: status,
+                note: note
+            ),
+        ]
+    }
+
+    public func start(emit: @escaping ConnectionPayloadEmitter) async throws {
+        await state.start(emit: emit, recentLimit: recentLimit)
+    }
+
+    public func stop() async {
+        await state.stop()
+    }
+
+    public func snapshotCurrent() async throws -> PhotosPayload {
+        Self.buildPayload(recentLimit: recentLimit)
+    }
+
+    static func map(_ status: PHAuthorizationStatus) -> ConnectionAuthorizationStatus {
+        switch status {
+        case .notDetermined: return .notDetermined
+        case .restricted, .denied: return .denied
+        case .authorized: return .authorized
+        case .limited: return .partial(missing: ["full-library"])
+        @unknown default: return .notDetermined
+        }
+    }
+
+    static func buildPayload(recentLimit: Int) -> PhotosPayload {
+        let options = PHFetchOptions()
+        options.sortDescriptors = [NSSortDescriptor(key: "creationDate", ascending: false)]
+
+        let allAssets = PHAsset.fetchAssets(with: options)
+        let total = allAssets.count
+        var photoCount = 0
+        var videoCount = 0
+        var screenshotCount = 0
+        var livePhotoCount = 0
+
+        allAssets.enumerateObjects { asset, _, _ in
+            switch asset.mediaType {
+            case .image: photoCount += 1
+            case .video: videoCount += 1
+            default: break
+            }
+            if asset.mediaSubtypes.contains(.photoScreenshot) { screenshotCount += 1 }
+            if asset.mediaSubtypes.contains(.photoLive) { livePhotoCount += 1 }
+        }
+
+        let recentOptions = PHFetchOptions()
+        recentOptions.sortDescriptors = [NSSortDescriptor(key: "creationDate", ascending: false)]
+        recentOptions.fetchLimit = recentLimit
+        let recentFetch = PHAsset.fetchAssets(with: recentOptions)
+
+        var recent: [PhotoAssetSummary] = []
+        recentFetch.enumerateObjects { asset, _, _ in
+            recent.append(
+                PhotoAssetSummary(
+                    id: asset.localIdentifier,
+                    mediaType: map(mediaType: asset.mediaType),
+                    subtype: map(subtypes: asset.mediaSubtypes),
+                    creationDate: asset.creationDate,
+                    isFavorite: asset.isFavorite,
+                    latitude: asset.location?.coordinate.latitude,
+                    longitude: asset.location?.coordinate.longitude
+                )
+            )
+        }
+
+        var summaryParts: [String] = ["\(total) asset\(total == 1 ? "" : "s")"]
+        if photoCount > 0 { summaryParts.append("\(photoCount) photo\(photoCount == 1 ? "" : "s")") }
+        if videoCount > 0 { summaryParts.append("\(videoCount) video\(videoCount == 1 ? "" : "s")") }
+
+        return PhotosPayload(
+            summary: summaryParts.joined(separator: ", "),
+            totalAssetCount: total,
+            photoCount: photoCount,
+            videoCount: videoCount,
+            screenshotCount: screenshotCount,
+            livePhotoCount: livePhotoCount,
+            recentAssets: recent
+        )
+    }
+
+    private static func map(mediaType: PHAssetMediaType) -> PhotoMediaType {
+        switch mediaType {
+        case .image: return .photo
+        case .video: return .video
+        case .audio: return .audio
+        case .unknown: return .unknown
+        @unknown default: return .unknown
+        }
+    }
+
+    private static func map(subtypes: PHAssetMediaSubtype) -> PhotoMediaSubtype {
+        if subtypes.contains(.photoScreenshot) { return .screenshot }
+        if subtypes.contains(.photoLive) { return .livePhoto }
+        if subtypes.contains(.photoPanorama) { return .panorama }
+        if subtypes.contains(.photoHDR) { return .hdr }
+        if subtypes.contains(.videoHighFrameRate) { return .slomo }
+        if subtypes.contains(.videoTimelapse) { return .timelapse }
+        return .none
+    }
+
+    private actor StateBox {
+        private var observer: ChangeObserver?
+        private var emitter: ConnectionPayloadEmitter?
+        private var recentLimit: Int = 20
+
+        func start(emit: @escaping ConnectionPayloadEmitter, recentLimit: Int) async {
+            if observer != nil { return }
+            self.emitter = emit
+            self.recentLimit = recentLimit
+
+            let observer = ChangeObserver(state: self)
+            PHPhotoLibrary.shared().register(observer)
+            self.observer = observer
+
+            emitCurrent()
+        }
+
+        func stop() async {
+            if let observer {
+                PHPhotoLibrary.shared().unregisterChangeObserver(observer)
+            }
+            observer = nil
+            emitter = nil
+        }
+
+        fileprivate func onLibraryChange() {
+            emitCurrent()
+        }
+
+        private func emitCurrent() {
+            guard let emitter else { return }
+            let payload = PhotosDataSource.buildPayload(recentLimit: recentLimit)
+            emitter(ConnectionPayload(source: .photos, body: .photos(payload)))
+        }
+    }
+
+    private final class ChangeObserver: NSObject, PHPhotoLibraryChangeObserver, @unchecked Sendable {
+        weak var state: StateBox?
+
+        init(state: StateBox) {
+            self.state = state
+        }
+
+        func photoLibraryDidChange(_ changeInstance: PHChange) {
+            let ref = state
+            Task { await ref?.onLibraryChange() }
+        }
+    }
+    #else
+    public func authorizationStatus() async -> ConnectionAuthorizationStatus { .unavailable }
+
+    @discardableResult
+    public func requestAuthorization() async throws -> ConnectionAuthorizationStatus { .unavailable }
+
+    public func start(emit: @escaping ConnectionPayloadEmitter) async throws {}
+
+    public func stop() async {}
+
+    public func snapshotCurrent() async throws -> PhotosPayload {
+        PhotosPayload(
+            summary: "Photos not available.",
+            totalAssetCount: 0,
+            photoCount: 0,
+            videoCount: 0,
+            screenshotCount: 0,
+            livePhotoCount: 0,
+            recentAssets: []
+        )
+    }
+    #endif
+}

--- a/ConvosConnections/Sources/ConvosConnections/Debug/ConnectionsDebugView.swift
+++ b/ConvosConnections/Sources/ConvosConnections/Debug/ConnectionsDebugView.swift
@@ -1,0 +1,212 @@
+import Foundation
+#if canImport(SwiftUI)
+import SwiftUI
+
+/// A SwiftUI inspector for the connections system. Shows every available source, its
+/// authorization status, the conversations it's enabled in, and a live log of emitted
+/// payloads with their fan-out targets.
+///
+/// Host apps surface this from a debug menu. The view owns no persistence of its own —
+/// it reads from and writes to the `ConnectionsManager` it is initialized with.
+public struct ConnectionsDebugView: View {
+    @State private var model: DebugModel
+
+    public init(manager: ConnectionsManager, sampleConversationIds: [String] = []) {
+        _model = State(initialValue: DebugModel(manager: manager, sampleConversationIds: sampleConversationIds))
+    }
+
+    public var body: some View {
+        List {
+            Section("Connections") {
+                ForEach(model.kinds, id: \.self) { kind in
+                    ConnectionRow(
+                        kind: kind,
+                        status: model.statuses[kind] ?? .notDetermined,
+                        enabledConversationIds: model.enabledByKind[kind] ?? [],
+                        sampleConversationIds: model.sampleConversationIds,
+                        onRequestAuth: { Task { await model.requestAuthorization(kind: kind) } },
+                        onToggleConversation: { conversationId, enabled in
+                            Task { await model.setEnabled(enabled, kind: kind, conversationId: conversationId) }
+                        }
+                    )
+                }
+            }
+
+            Section("Recent payloads (\(model.recentPayloads.count))") {
+                if model.recentPayloads.isEmpty {
+                    Text("No payloads delivered yet.")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                } else {
+                    ForEach(model.recentPayloads.reversed()) { record in
+                        RecentPayloadRow(record: record)
+                    }
+                }
+            }
+        }
+        .navigationTitle("Connections")
+        .task { await model.refresh() }
+        .refreshable { await model.refresh() }
+        .toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                Button("Refresh") {
+                    Task { await model.refresh() }
+                }
+            }
+        }
+    }
+}
+
+private struct ConnectionRow: View {
+    let kind: ConnectionKind
+    let status: ConnectionAuthorizationStatus
+    let enabledConversationIds: [String]
+    let sampleConversationIds: [String]
+    let onRequestAuth: () -> Void
+    let onToggleConversation: (String, Bool) -> Void
+
+    var body: some View {
+        DisclosureGroup {
+            VStack(alignment: .leading, spacing: 8) {
+                if case .notDetermined = status {
+                    Button("Request Authorization", action: onRequestAuth)
+                        .buttonStyle(.borderedProminent)
+                }
+                if sampleConversationIds.isEmpty {
+                    Text("Pass sample conversation ids to `ConnectionsDebugView(manager:sampleConversationIds:)` to toggle enablement here.")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                } else {
+                    ForEach(sampleConversationIds, id: \.self) { conversationId in
+                        Toggle(
+                            conversationId,
+                            isOn: Binding(
+                                get: { enabledConversationIds.contains(conversationId) },
+                                set: { newValue in onToggleConversation(conversationId, newValue) }
+                            )
+                        )
+                        .font(.callout)
+                    }
+                }
+            }
+            .padding(.vertical, 4)
+        } label: {
+            HStack {
+                Image(systemName: kind.systemImageName)
+                    .frame(width: 24)
+                VStack(alignment: .leading) {
+                    Text(kind.displayName)
+                        .font(.body)
+                    Text(statusDescription)
+                        .font(.footnote)
+                        .foregroundStyle(statusColor)
+                }
+                Spacer()
+                if !enabledConversationIds.isEmpty {
+                    Text("\(enabledConversationIds.count)")
+                        .font(.caption)
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(Color.accentColor.opacity(0.15))
+                        .clipShape(Capsule())
+                }
+            }
+        }
+    }
+
+    private var statusDescription: String {
+        switch status {
+        case .notDetermined: return "Not yet requested"
+        case .authorized: return "Authorized"
+        case .denied: return "Denied"
+        case .partial(let missing): return "Partial (\(missing.count) missing)"
+        case .unavailable: return "Unavailable on this device"
+        }
+    }
+
+    private var statusColor: Color {
+        switch status {
+        case .authorized: return .green
+        case .partial: return .orange
+        case .denied, .unavailable: return .red
+        case .notDetermined: return .secondary
+        }
+    }
+}
+
+private struct RecentPayloadRow: View {
+    let record: RecordedPayload
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Text(record.payload.source.displayName)
+                    .font(.caption.weight(.semibold))
+                Spacer()
+                Text(record.receivedAt, style: .time)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Text(record.payload.summary)
+                .font(.footnote)
+            if record.fanOutConversationIds.isEmpty {
+                Text("No conversations enabled — payload was recorded but not delivered.")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            } else {
+                Text("Delivered to: \(record.fanOutConversationIds.joined(separator: ", "))")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .padding(.vertical, 2)
+    }
+}
+
+@MainActor
+@Observable
+private final class DebugModel {
+    let manager: ConnectionsManager
+    let sampleConversationIds: [String]
+    private(set) var kinds: [ConnectionKind] = []
+    private(set) var statuses: [ConnectionKind: ConnectionAuthorizationStatus] = [:]
+    private(set) var enabledByKind: [ConnectionKind: [String]] = [:]
+    private(set) var recentPayloads: [RecordedPayload] = []
+
+    init(manager: ConnectionsManager, sampleConversationIds: [String]) {
+        self.manager = manager
+        self.sampleConversationIds = sampleConversationIds
+    }
+
+    func refresh() async {
+        let kinds = manager.availableKinds()
+        self.kinds = kinds
+        var statuses: [ConnectionKind: ConnectionAuthorizationStatus] = [:]
+        var enabled: [ConnectionKind: [String]] = [:]
+        for kind in kinds {
+            statuses[kind] = await manager.authorizationStatus(for: kind)
+            enabled[kind] = await manager.enabledConversationIds(for: kind)
+        }
+        self.statuses = statuses
+        self.enabledByKind = enabled
+        self.recentPayloads = await manager.recentPayloadLog()
+    }
+
+    func requestAuthorization(kind: ConnectionKind) async {
+        do {
+            _ = try await manager.requestAuthorization(for: kind)
+        } catch {
+            // surface in UI in a follow-up; for now just refresh
+        }
+        await refresh()
+    }
+
+    func setEnabled(_ enabled: Bool, kind: ConnectionKind, conversationId: String) async {
+        await manager.setEnabled(enabled, kind: kind, conversationId: conversationId)
+        if enabled {
+            try? await manager.startSource(kind: kind)
+        }
+        await refresh()
+    }
+}
+#endif

--- a/ConvosConnections/Sources/ConvosConnections/Delivery/ConsoleDelivering.swift
+++ b/ConvosConnections/Sources/ConvosConnections/Delivery/ConsoleDelivering.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+/// A no-op `ConnectionDelivering` that logs every attempt. Useful for the debug view
+/// and for local testing before the XMTP-backed delivery adapter exists.
+public actor ConsoleDelivering: ConnectionDelivering {
+    public private(set) var log: [LogEntry] = []
+    private let printToStdout: Bool
+
+    public init(printToStdout: Bool = true) {
+        self.printToStdout = printToStdout
+    }
+
+    public func deliver(_ payload: ConnectionPayload, to conversationId: String) async throws {
+        let entry = LogEntry(conversationId: conversationId, payload: payload, deliveredAt: Date())
+        log.append(entry)
+        if printToStdout {
+            print("[ConvosConnections] -> \(conversationId): \(payload.summary)")
+        }
+    }
+
+    public func snapshot() -> [LogEntry] {
+        log
+    }
+
+    public func clear() {
+        log.removeAll()
+    }
+
+    public struct LogEntry: Sendable, Identifiable, Equatable {
+        public let conversationId: String
+        public let payload: ConnectionPayload
+        public let deliveredAt: Date
+
+        public var id: UUID { payload.id }
+    }
+}

--- a/ConvosConnections/Sources/ConvosConnections/Payloads/CalendarPayload.swift
+++ b/ConvosConnections/Sources/ConvosConnections/Payloads/CalendarPayload.swift
@@ -1,0 +1,75 @@
+import Foundation
+
+/// A snapshot of calendar events over a rolling window. `CalendarDataSource` emits one of
+/// these on start and on every `EKEventStoreChanged` notification while the app is running.
+///
+/// EventKit has no true background delivery, so the host app relies on foreground /
+/// `BGAppRefreshTask` wake-ups to pick up changes. The payload carries the whole window,
+/// not a delta, so agents have a complete view of the user's upcoming schedule.
+public struct CalendarPayload: Codable, Sendable, Equatable {
+    public static let currentSchemaVersion: Int = 1
+
+    public let schemaVersion: Int
+    public let summary: String
+    public let events: [CalendarEvent]
+    public let rangeStart: Date
+    public let rangeEnd: Date
+
+    public init(
+        schemaVersion: Int = Self.currentSchemaVersion,
+        summary: String,
+        events: [CalendarEvent],
+        rangeStart: Date,
+        rangeEnd: Date
+    ) {
+        self.schemaVersion = schemaVersion
+        self.summary = summary
+        self.events = events
+        self.rangeStart = rangeStart
+        self.rangeEnd = rangeEnd
+    }
+}
+
+public struct CalendarEvent: Codable, Sendable, Equatable, Identifiable {
+    public let id: String
+    public let title: String?
+    public let startDate: Date
+    public let endDate: Date
+    public let isAllDay: Bool
+    public let location: String?
+    public let notes: String?
+    public let calendarTitle: String?
+    public let status: CalendarEventStatus
+    public let isRecurring: Bool
+
+    public init(
+        id: String,
+        title: String?,
+        startDate: Date,
+        endDate: Date,
+        isAllDay: Bool,
+        location: String?,
+        notes: String?,
+        calendarTitle: String?,
+        status: CalendarEventStatus,
+        isRecurring: Bool
+    ) {
+        self.id = id
+        self.title = title
+        self.startDate = startDate
+        self.endDate = endDate
+        self.isAllDay = isAllDay
+        self.location = location
+        self.notes = notes
+        self.calendarTitle = calendarTitle
+        self.status = status
+        self.isRecurring = isRecurring
+    }
+}
+
+public enum CalendarEventStatus: String, Codable, Sendable {
+    case confirmed
+    case tentative
+    case canceled
+    case none
+}

--- a/ConvosConnections/Sources/ConvosConnections/Payloads/ConnectionPayload.swift
+++ b/ConvosConnections/Sources/ConvosConnections/Payloads/ConnectionPayload.swift
@@ -1,0 +1,168 @@
+import Foundation
+
+/// The top-level envelope a `DataSource` emits and a `ConnectionDelivering` transports.
+///
+/// The envelope itself carries a `schemaVersion` so its shape can evolve. Each body type
+/// carries its own `schemaVersion` so individual data sources can iterate independently.
+///
+/// The serialized form is intentionally `Codable` (JSON) in this package. When the host
+/// app wraps the payload in an XMTP content codec it may re-encode to protobuf — the
+/// envelope is just a Swift value, and the wire format is the delivery adapter's concern.
+public struct ConnectionPayload: Codable, Sendable, Equatable, Identifiable {
+    public static let currentSchemaVersion: Int = 1
+
+    public let id: UUID
+    public let schemaVersion: Int
+    public let source: ConnectionKind
+    public let capturedAt: Date
+    public let body: ConnectionPayloadBody
+
+    public init(
+        id: UUID = UUID(),
+        schemaVersion: Int = Self.currentSchemaVersion,
+        source: ConnectionKind,
+        capturedAt: Date = Date(),
+        body: ConnectionPayloadBody
+    ) {
+        self.id = id
+        self.schemaVersion = schemaVersion
+        self.source = source
+        self.capturedAt = capturedAt
+        self.body = body
+    }
+}
+
+/// Source-specific payload body. New cases are added as new `DataSource`s are implemented.
+///
+/// `unknown` preserves forward compatibility when an older build of the app decodes a
+/// payload produced by a newer build — the raw bytes round-trip without loss.
+public enum ConnectionPayloadBody: Codable, Sendable, Equatable {
+    case health(HealthPayload)
+    case calendar(CalendarPayload)
+    case location(LocationPayload)
+    case contacts(ContactsPayload)
+    case photos(PhotosPayload)
+    case music(MusicPayload)
+    case motion(MotionPayload)
+    case homeKit(HomePayload)
+    case screenTime(ScreenTimePayload)
+    case unknown(rawType: String, data: Data)
+
+    private enum CodingKeys: String, CodingKey {
+        case type
+        case data
+    }
+
+    private enum BodyType: String, Codable {
+        case health
+        case calendar
+        case location
+        case contacts
+        case photos
+        case music
+        case motion
+        case homeKit = "home_kit"
+        case screenTime = "screen_time"
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case .health(let payload):
+            try container.encode(BodyType.health.rawValue, forKey: .type)
+            try container.encode(payload, forKey: .data)
+        case .calendar(let payload):
+            try container.encode(BodyType.calendar.rawValue, forKey: .type)
+            try container.encode(payload, forKey: .data)
+        case .location(let payload):
+            try container.encode(BodyType.location.rawValue, forKey: .type)
+            try container.encode(payload, forKey: .data)
+        case .contacts(let payload):
+            try container.encode(BodyType.contacts.rawValue, forKey: .type)
+            try container.encode(payload, forKey: .data)
+        case .photos(let payload):
+            try container.encode(BodyType.photos.rawValue, forKey: .type)
+            try container.encode(payload, forKey: .data)
+        case .music(let payload):
+            try container.encode(BodyType.music.rawValue, forKey: .type)
+            try container.encode(payload, forKey: .data)
+        case .motion(let payload):
+            try container.encode(BodyType.motion.rawValue, forKey: .type)
+            try container.encode(payload, forKey: .data)
+        case .homeKit(let payload):
+            try container.encode(BodyType.homeKit.rawValue, forKey: .type)
+            try container.encode(payload, forKey: .data)
+        case .screenTime(let payload):
+            try container.encode(BodyType.screenTime.rawValue, forKey: .type)
+            try container.encode(payload, forKey: .data)
+        case let .unknown(rawType, data):
+            try container.encode(rawType, forKey: .type)
+            try container.encode(data, forKey: .data)
+        }
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let type = try container.decode(String.self, forKey: .type)
+        switch BodyType(rawValue: type) {
+        case .health:
+            let payload = try container.decode(HealthPayload.self, forKey: .data)
+            self = .health(payload)
+        case .calendar:
+            let payload = try container.decode(CalendarPayload.self, forKey: .data)
+            self = .calendar(payload)
+        case .location:
+            let payload = try container.decode(LocationPayload.self, forKey: .data)
+            self = .location(payload)
+        case .contacts:
+            let payload = try container.decode(ContactsPayload.self, forKey: .data)
+            self = .contacts(payload)
+        case .photos:
+            let payload = try container.decode(PhotosPayload.self, forKey: .data)
+            self = .photos(payload)
+        case .music:
+            let payload = try container.decode(MusicPayload.self, forKey: .data)
+            self = .music(payload)
+        case .motion:
+            let payload = try container.decode(MotionPayload.self, forKey: .data)
+            self = .motion(payload)
+        case .homeKit:
+            let payload = try container.decode(HomePayload.self, forKey: .data)
+            self = .homeKit(payload)
+        case .screenTime:
+            let payload = try container.decode(ScreenTimePayload.self, forKey: .data)
+            self = .screenTime(payload)
+        case .none:
+            let data = try container.decode(Data.self, forKey: .data)
+            self = .unknown(rawType: type, data: data)
+        }
+    }
+}
+
+public extension ConnectionPayload {
+    /// A short human-readable summary used by the debug view and as a fallback render in chat.
+    var summary: String {
+        switch body {
+        case .health(let payload):
+            return payload.summary
+        case .calendar(let payload):
+            return payload.summary
+        case .location(let payload):
+            return payload.summary
+        case .contacts(let payload):
+            return payload.summary
+        case .photos(let payload):
+            return payload.summary
+        case .music(let payload):
+            return payload.summary
+        case .motion(let payload):
+            return payload.summary
+        case .homeKit(let payload):
+            return payload.summary
+        case .screenTime(let payload):
+            return payload.summary
+        case .unknown(let rawType, _):
+            return "Unknown payload (\(rawType))"
+        }
+    }
+}

--- a/ConvosConnections/Sources/ConvosConnections/Payloads/ContactsPayload.swift
+++ b/ConvosConnections/Sources/ConvosConnections/Payloads/ContactsPayload.swift
@@ -1,0 +1,65 @@
+import Foundation
+
+/// A summary snapshot of the user's contacts. Emitted by `ContactsDataSource` on start
+/// and on `CNContactStoreDidChange` notifications.
+///
+/// Volume control: address books can be huge (thousands of entries) and most entries are
+/// not useful for an agent most of the time. This payload therefore carries *counts* plus
+/// a bounded preview of names — never the full database. A richer pull API (lookup by id,
+/// search by name) can be layered on top later if agents actually need it.
+public struct ContactsPayload: Codable, Sendable, Equatable {
+    public static let currentSchemaVersion: Int = 1
+
+    public let schemaVersion: Int
+    public let summary: String
+    public let totalContactCount: Int
+    public let previewContacts: [ContactSummary]
+    public let capturedAt: Date
+
+    public init(
+        schemaVersion: Int = Self.currentSchemaVersion,
+        summary: String,
+        totalContactCount: Int,
+        previewContacts: [ContactSummary],
+        capturedAt: Date = Date()
+    ) {
+        self.schemaVersion = schemaVersion
+        self.summary = summary
+        self.totalContactCount = totalContactCount
+        self.previewContacts = previewContacts
+        self.capturedAt = capturedAt
+    }
+}
+
+public struct ContactSummary: Codable, Sendable, Equatable, Identifiable {
+    public let id: String
+    public let givenName: String?
+    public let familyName: String?
+    public let organization: String?
+    public let hasEmail: Bool
+    public let hasPhone: Bool
+
+    public init(
+        id: String,
+        givenName: String?,
+        familyName: String?,
+        organization: String?,
+        hasEmail: Bool,
+        hasPhone: Bool
+    ) {
+        self.id = id
+        self.givenName = givenName
+        self.familyName = familyName
+        self.organization = organization
+        self.hasEmail = hasEmail
+        self.hasPhone = hasPhone
+    }
+
+    public var displayName: String {
+        let parts = [givenName, familyName].compactMap { $0 }
+        if !parts.isEmpty {
+            return parts.joined(separator: " ")
+        }
+        return organization ?? "(unnamed)"
+    }
+}

--- a/ConvosConnections/Sources/ConvosConnections/Payloads/HealthPayload.swift
+++ b/ConvosConnections/Sources/ConvosConnections/Payloads/HealthPayload.swift
@@ -1,0 +1,77 @@
+import Foundation
+
+/// A batch of HealthKit samples aggregated into a single payload.
+///
+/// `HealthDataSource` produces one of these per observation wake-up. Volume control lives
+/// at the source — raw heart-rate streams are *not* sent; the source aggregates into
+/// digest-style values (daily totals, per-workout summaries, sleep duration, etc.).
+public struct HealthPayload: Codable, Sendable, Equatable {
+    public static let currentSchemaVersion: Int = 1
+
+    public let schemaVersion: Int
+    public let summary: String
+    public let samples: [HealthSample]
+    public let rangeStart: Date
+    public let rangeEnd: Date
+
+    public init(
+        schemaVersion: Int = Self.currentSchemaVersion,
+        summary: String,
+        samples: [HealthSample],
+        rangeStart: Date,
+        rangeEnd: Date
+    ) {
+        self.schemaVersion = schemaVersion
+        self.summary = summary
+        self.samples = samples
+        self.rangeStart = rangeStart
+        self.rangeEnd = rangeEnd
+    }
+}
+
+public struct HealthSample: Codable, Sendable, Equatable {
+    public let type: HealthSampleType
+    public let startDate: Date
+    public let endDate: Date
+    public let value: Double
+    public let unit: String
+    public let metadata: [String: String]?
+
+    public init(
+        type: HealthSampleType,
+        startDate: Date,
+        endDate: Date,
+        value: Double,
+        unit: String,
+        metadata: [String: String]? = nil
+    ) {
+        self.type = type
+        self.startDate = startDate
+        self.endDate = endDate
+        self.value = value
+        self.unit = unit
+        self.metadata = metadata
+    }
+}
+
+public enum HealthSampleType: String, Codable, Sendable, CaseIterable {
+    case workout
+    case sleepAnalysis = "sleep_analysis"
+    case stepCount = "step_count"
+    case heartRateVariabilitySDNN = "hrv_sdnn"
+    case mindfulSession = "mindful_session"
+    case activeEnergyBurned = "active_energy_burned"
+    case distanceWalkingRunning = "distance_walking_running"
+
+    public var displayName: String {
+        switch self {
+        case .workout: return "Workouts"
+        case .sleepAnalysis: return "Sleep"
+        case .stepCount: return "Steps"
+        case .heartRateVariabilitySDNN: return "Heart Rate Variability"
+        case .mindfulSession: return "Mindful Minutes"
+        case .activeEnergyBurned: return "Active Energy"
+        case .distanceWalkingRunning: return "Walking + Running Distance"
+        }
+    }
+}

--- a/ConvosConnections/Sources/ConvosConnections/Payloads/HomePayload.swift
+++ b/ConvosConnections/Sources/ConvosConnections/Payloads/HomePayload.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+/// Snapshot of the user's HomeKit topology — home names, room counts, accessory counts.
+/// `HomeDataSource` emits this on start and on HMHomeManager updates.
+///
+/// Intentionally coarse: the payload doesn't carry individual accessory state (lights on,
+/// lock open, etc.) because that would push the agent into a command-and-control role
+/// that's outside the scope of a context-feeder. If that shape is needed later, add a
+/// sibling `HomeAccessorySnapshot` payload.
+public struct HomePayload: Codable, Sendable, Equatable {
+    public static let currentSchemaVersion: Int = 1
+
+    public let schemaVersion: Int
+    public let summary: String
+    public let homes: [HomeSummary]
+    public let capturedAt: Date
+
+    public init(
+        schemaVersion: Int = Self.currentSchemaVersion,
+        summary: String,
+        homes: [HomeSummary],
+        capturedAt: Date = Date()
+    ) {
+        self.schemaVersion = schemaVersion
+        self.summary = summary
+        self.homes = homes
+        self.capturedAt = capturedAt
+    }
+}
+
+public struct HomeSummary: Codable, Sendable, Equatable, Identifiable {
+    public let id: String
+    public let name: String
+    public let isPrimary: Bool
+    public let roomCount: Int
+    public let accessoryCount: Int
+
+    public init(
+        id: String,
+        name: String,
+        isPrimary: Bool,
+        roomCount: Int,
+        accessoryCount: Int
+    ) {
+        self.id = id
+        self.name = name
+        self.isPrimary = isPrimary
+        self.roomCount = roomCount
+        self.accessoryCount = accessoryCount
+    }
+}

--- a/ConvosConnections/Sources/ConvosConnections/Payloads/LocationPayload.swift
+++ b/ConvosConnections/Sources/ConvosConnections/Payloads/LocationPayload.swift
@@ -1,0 +1,73 @@
+import Foundation
+
+/// Location events captured by `LocationDataSource` since the last emission.
+///
+/// Two classes of event are mixed into one payload:
+/// - **Significant location changes** — fire roughly when the user moves 500m+, wake the
+///   app from the background (or from a terminated state).
+/// - **Visits** — fire on arrival at and departure from places the user spends time at.
+///
+/// Both are low-frequency, low-battery signals intentionally — the source does *not* emit
+/// high-frequency raw location samples, because a human conversation can't usefully consume
+/// them and XMTP fan-out would be wasteful.
+public struct LocationPayload: Codable, Sendable, Equatable {
+    public static let currentSchemaVersion: Int = 1
+
+    public let schemaVersion: Int
+    public let summary: String
+    public let events: [LocationEvent]
+    public let capturedAt: Date
+
+    public init(
+        schemaVersion: Int = Self.currentSchemaVersion,
+        summary: String,
+        events: [LocationEvent],
+        capturedAt: Date = Date()
+    ) {
+        self.schemaVersion = schemaVersion
+        self.summary = summary
+        self.events = events
+        self.capturedAt = capturedAt
+    }
+}
+
+public struct LocationEvent: Codable, Sendable, Equatable, Identifiable {
+    public let id: UUID
+    public let type: LocationEventType
+    public let latitude: Double
+    public let longitude: Double
+    /// Radius (in meters) of uncertainty for the coordinate. Negative if invalid.
+    public let horizontalAccuracy: Double
+    /// The moment the event occurred (visit arrival, visit departure, or sample timestamp).
+    public let eventDate: Date
+    /// Only set for `.visitArrival` / `.visitDeparture`.
+    public let arrivalDate: Date?
+    /// Only set for `.visitDeparture`. `nil` for an active visit.
+    public let departureDate: Date?
+
+    public init(
+        id: UUID = UUID(),
+        type: LocationEventType,
+        latitude: Double,
+        longitude: Double,
+        horizontalAccuracy: Double,
+        eventDate: Date,
+        arrivalDate: Date? = nil,
+        departureDate: Date? = nil
+    ) {
+        self.id = id
+        self.type = type
+        self.latitude = latitude
+        self.longitude = longitude
+        self.horizontalAccuracy = horizontalAccuracy
+        self.eventDate = eventDate
+        self.arrivalDate = arrivalDate
+        self.departureDate = departureDate
+    }
+}
+
+public enum LocationEventType: String, Codable, Sendable {
+    case significantChange = "significant_change"
+    case visitArrival = "visit_arrival"
+    case visitDeparture = "visit_departure"
+}

--- a/ConvosConnections/Sources/ConvosConnections/Payloads/MotionPayload.swift
+++ b/ConvosConnections/Sources/ConvosConnections/Payloads/MotionPayload.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+/// Current motion activity as reported by the device's motion coprocessor — stationary,
+/// walking, running, driving, cycling. Emitted by `MotionDataSource` whenever the activity
+/// classification changes.
+public struct MotionPayload: Codable, Sendable, Equatable {
+    public static let currentSchemaVersion: Int = 1
+
+    public let schemaVersion: Int
+    public let summary: String
+    public let activity: MotionActivity?
+    public let capturedAt: Date
+
+    public init(
+        schemaVersion: Int = Self.currentSchemaVersion,
+        summary: String,
+        activity: MotionActivity?,
+        capturedAt: Date = Date()
+    ) {
+        self.schemaVersion = schemaVersion
+        self.summary = summary
+        self.activity = activity
+        self.capturedAt = capturedAt
+    }
+}
+
+public struct MotionActivity: Codable, Sendable, Equatable {
+    public let type: MotionActivityType
+    public let confidence: MotionConfidence
+    public let startDate: Date
+
+    public init(type: MotionActivityType, confidence: MotionConfidence, startDate: Date) {
+        self.type = type
+        self.confidence = confidence
+        self.startDate = startDate
+    }
+}
+
+public enum MotionActivityType: String, Codable, Sendable {
+    case stationary
+    case walking
+    case running
+    case automotive
+    case cycling
+    case unknown
+}
+
+public enum MotionConfidence: String, Codable, Sendable {
+    case low
+    case medium
+    case high
+}

--- a/ConvosConnections/Sources/ConvosConnections/Payloads/MusicPayload.swift
+++ b/ConvosConnections/Sources/ConvosConnections/Payloads/MusicPayload.swift
@@ -1,0 +1,65 @@
+import Foundation
+
+/// Now-playing snapshot captured by `MusicDataSource` on track changes and playback state
+/// changes in the iOS system music player.
+///
+/// Only reflects Apple Music / iTunes playback — third-party players (Spotify, YouTube
+/// Music, etc.) do not surface through `MPMusicPlayerController`.
+public struct MusicPayload: Codable, Sendable, Equatable {
+    public static let currentSchemaVersion: Int = 1
+
+    public let schemaVersion: Int
+    public let summary: String
+    public let nowPlaying: NowPlayingItem?
+    public let playbackState: MusicPlaybackState
+    public let capturedAt: Date
+
+    public init(
+        schemaVersion: Int = Self.currentSchemaVersion,
+        summary: String,
+        nowPlaying: NowPlayingItem?,
+        playbackState: MusicPlaybackState,
+        capturedAt: Date = Date()
+    ) {
+        self.schemaVersion = schemaVersion
+        self.summary = summary
+        self.nowPlaying = nowPlaying
+        self.playbackState = playbackState
+        self.capturedAt = capturedAt
+    }
+}
+
+public struct NowPlayingItem: Codable, Sendable, Equatable {
+    public let title: String?
+    public let artist: String?
+    public let album: String?
+    public let genre: String?
+    public let durationSeconds: Double
+    public let playbackTimeSeconds: Double
+
+    public init(
+        title: String?,
+        artist: String?,
+        album: String?,
+        genre: String?,
+        durationSeconds: Double,
+        playbackTimeSeconds: Double
+    ) {
+        self.title = title
+        self.artist = artist
+        self.album = album
+        self.genre = genre
+        self.durationSeconds = durationSeconds
+        self.playbackTimeSeconds = playbackTimeSeconds
+    }
+}
+
+public enum MusicPlaybackState: String, Codable, Sendable {
+    case stopped
+    case playing
+    case paused
+    case interrupted
+    case seekingForward = "seeking_forward"
+    case seekingBackward = "seeking_backward"
+    case unknown
+}

--- a/ConvosConnections/Sources/ConvosConnections/Payloads/PhotosPayload.swift
+++ b/ConvosConnections/Sources/ConvosConnections/Payloads/PhotosPayload.swift
@@ -1,0 +1,88 @@
+import Foundation
+
+/// A summary of the user's photo library, emitted when the library changes.
+///
+/// Volume control: photo libraries can contain hundreds of thousands of assets. This
+/// payload carries counts and a bounded list of recent asset metadata — never pixel data
+/// or the full library. Agents interested in specific assets can layer a pull API on top.
+public struct PhotosPayload: Codable, Sendable, Equatable {
+    public static let currentSchemaVersion: Int = 1
+
+    public let schemaVersion: Int
+    public let summary: String
+    public let totalAssetCount: Int
+    public let photoCount: Int
+    public let videoCount: Int
+    public let screenshotCount: Int
+    public let livePhotoCount: Int
+    public let recentAssets: [PhotoAssetSummary]
+    public let capturedAt: Date
+
+    public init(
+        schemaVersion: Int = Self.currentSchemaVersion,
+        summary: String,
+        totalAssetCount: Int,
+        photoCount: Int,
+        videoCount: Int,
+        screenshotCount: Int,
+        livePhotoCount: Int,
+        recentAssets: [PhotoAssetSummary],
+        capturedAt: Date = Date()
+    ) {
+        self.schemaVersion = schemaVersion
+        self.summary = summary
+        self.totalAssetCount = totalAssetCount
+        self.photoCount = photoCount
+        self.videoCount = videoCount
+        self.screenshotCount = screenshotCount
+        self.livePhotoCount = livePhotoCount
+        self.recentAssets = recentAssets
+        self.capturedAt = capturedAt
+    }
+}
+
+public struct PhotoAssetSummary: Codable, Sendable, Equatable, Identifiable {
+    public let id: String
+    public let mediaType: PhotoMediaType
+    public let subtype: PhotoMediaSubtype
+    public let creationDate: Date?
+    public let isFavorite: Bool
+    public let latitude: Double?
+    public let longitude: Double?
+
+    public init(
+        id: String,
+        mediaType: PhotoMediaType,
+        subtype: PhotoMediaSubtype,
+        creationDate: Date?,
+        isFavorite: Bool,
+        latitude: Double? = nil,
+        longitude: Double? = nil
+    ) {
+        self.id = id
+        self.mediaType = mediaType
+        self.subtype = subtype
+        self.creationDate = creationDate
+        self.isFavorite = isFavorite
+        self.latitude = latitude
+        self.longitude = longitude
+    }
+}
+
+public enum PhotoMediaType: String, Codable, Sendable {
+    case photo
+    case video
+    case audio
+    case unknown
+}
+
+public enum PhotoMediaSubtype: String, Codable, Sendable {
+    case none
+    case screenshot
+    case livePhoto = "live_photo"
+    case panorama
+    case hdr
+    case slomo
+    case timelapse
+    case portrait
+}

--- a/ConvosConnections/Sources/ConvosConnections/Payloads/ScreenTimePayload.swift
+++ b/ConvosConnections/Sources/ConvosConnections/Payloads/ScreenTimePayload.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+/// Surface state for the Screen Time / Family Controls connection.
+///
+/// Unlike other sources, this payload does **not** carry actual usage data — Apple isolates
+/// Screen Time data in a separate process and only exposes it through `DeviceActivityReport`
+/// views rendered in a host-app extension. Surfacing numeric usage (hours in apps,
+/// categories, etc.) to conversations would require a sibling `DeviceActivityMonitor`
+/// extension target, which is outside the package's scope.
+///
+/// What the payload *does* carry is the authorization state plus the user's
+/// `FamilyActivitySelection` — i.e. which apps / categories they've explicitly opted into
+/// sharing context about. That selection is what a future extension would monitor.
+public struct ScreenTimePayload: Codable, Sendable, Equatable {
+    public static let currentSchemaVersion: Int = 1
+
+    public let schemaVersion: Int
+    public let summary: String
+    public let authorized: Bool
+    public let selectedApplicationCount: Int
+    public let selectedCategoryCount: Int
+    public let selectedWebDomainCount: Int
+    public let capturedAt: Date
+
+    public init(
+        schemaVersion: Int = Self.currentSchemaVersion,
+        summary: String,
+        authorized: Bool,
+        selectedApplicationCount: Int = 0,
+        selectedCategoryCount: Int = 0,
+        selectedWebDomainCount: Int = 0,
+        capturedAt: Date = Date()
+    ) {
+        self.schemaVersion = schemaVersion
+        self.summary = summary
+        self.authorized = authorized
+        self.selectedApplicationCount = selectedApplicationCount
+        self.selectedCategoryCount = selectedCategoryCount
+        self.selectedWebDomainCount = selectedWebDomainCount
+        self.capturedAt = capturedAt
+    }
+}

--- a/ConvosConnections/Sources/ConvosConnections/Storage/InMemoryEnablementStore.swift
+++ b/ConvosConnections/Sources/ConvosConnections/Storage/InMemoryEnablementStore.swift
@@ -1,0 +1,85 @@
+import Foundation
+
+/// In-memory `EnablementStore` used by tests, previews, and the debug view.
+///
+/// The host app (Convos) supplies a persistent implementation backed by GRDB. This
+/// in-memory variant is intentionally simple: a `Set<Enablement>` for the triples plus a
+/// `[AlwaysConfirmKey: Bool]` for the always-confirm flag.
+public actor InMemoryEnablementStore: EnablementStore {
+    private var enablements: Set<Enablement>
+    private var alwaysConfirm: [AlwaysConfirmKey: Bool]
+
+    private struct AlwaysConfirmKey: Hashable, Sendable {
+        let kind: ConnectionKind
+        let conversationId: String
+    }
+
+    public struct AlwaysConfirmInitial: Sendable {
+        public let kind: ConnectionKind
+        public let conversationId: String
+        public let isOn: Bool
+
+        public init(kind: ConnectionKind, conversationId: String, isOn: Bool) {
+            self.kind = kind
+            self.conversationId = conversationId
+            self.isOn = isOn
+        }
+    }
+
+    public init(
+        initial: [Enablement] = [],
+        initialAlwaysConfirm: [AlwaysConfirmInitial] = []
+    ) {
+        self.enablements = Set(initial)
+        var dict: [AlwaysConfirmKey: Bool] = [:]
+        for entry in initialAlwaysConfirm where entry.isOn {
+            dict[AlwaysConfirmKey(kind: entry.kind, conversationId: entry.conversationId)] = true
+        }
+        self.alwaysConfirm = dict
+    }
+
+    public func isEnabled(kind: ConnectionKind, capability: ConnectionCapability, conversationId: String) async -> Bool {
+        enablements.contains(Enablement(kind: kind, capability: capability, conversationId: conversationId))
+    }
+
+    public func setEnabled(_ enabled: Bool, kind: ConnectionKind, capability: ConnectionCapability, conversationId: String) async {
+        let enablement = Enablement(kind: kind, capability: capability, conversationId: conversationId)
+        if enabled {
+            enablements.insert(enablement)
+        } else {
+            enablements.remove(enablement)
+        }
+    }
+
+    public func conversationIds(enabledFor kind: ConnectionKind, capability: ConnectionCapability) async -> [String] {
+        enablements
+            .filter { $0.kind == kind && $0.capability == capability }
+            .map(\.conversationId)
+            .sorted()
+    }
+
+    public func allEnablements() async -> [Enablement] {
+        enablements.sorted(by: { lhs, rhs in
+            if lhs.kind.rawValue != rhs.kind.rawValue {
+                return lhs.kind.rawValue < rhs.kind.rawValue
+            }
+            if lhs.capability.rawValue != rhs.capability.rawValue {
+                return lhs.capability.rawValue < rhs.capability.rawValue
+            }
+            return lhs.conversationId < rhs.conversationId
+        })
+    }
+
+    public func alwaysConfirmWrites(kind: ConnectionKind, conversationId: String) async -> Bool {
+        alwaysConfirm[AlwaysConfirmKey(kind: kind, conversationId: conversationId)] ?? false
+    }
+
+    public func setAlwaysConfirmWrites(_ alwaysConfirm: Bool, kind: ConnectionKind, conversationId: String) async {
+        let key = AlwaysConfirmKey(kind: kind, conversationId: conversationId)
+        if alwaysConfirm {
+            self.alwaysConfirm[key] = true
+        } else {
+            self.alwaysConfirm.removeValue(forKey: key)
+        }
+    }
+}

--- a/ConvosConnections/Sources/ConvosConnectionsScreenTime/ScreenTimeActionSchemas.swift
+++ b/ConvosConnections/Sources/ConvosConnectionsScreenTime/ScreenTimeActionSchemas.swift
@@ -1,0 +1,44 @@
+import ConvosConnections
+import Foundation
+
+/// Static `ActionSchema` values published by `ScreenTimeDataSink`.
+///
+/// Real-world Screen Time writes need a `FamilyActivitySelection` bundle that the *user*
+/// picks via Apple's `FamilyActivityPicker`. The agent can't enumerate apps on its own —
+/// iOS only exposes opaque tokens scoped to a single selection. So the action set here
+/// is split:
+///
+/// - `apply_selection` re-applies a previously-serialized selection bundle as a shield.
+/// - `clear_shields` removes all restrictions on the default `ManagedSettingsStore`.
+public enum ScreenTimeActionSchemas {
+    public static let applySelection: ActionSchema = ActionSchema(
+        kind: .screenTime,
+        actionName: "apply_selection",
+        capability: .writeUpdate,
+        summary: "Apply a previously-saved FamilyActivitySelection as a shield on the default store.",
+        inputs: [
+            ActionParameter(
+                name: "selectionData",
+                type: .string,
+                description: "Base64-encoded JSON of a FamilyActivitySelection, produced by a prior user picker interaction.",
+                isRequired: true
+            ),
+        ],
+        outputs: [
+            ActionParameter(name: "applicationCount", type: .int, description: "Number of applications in the applied selection.", isRequired: true),
+            ActionParameter(name: "categoryCount", type: .int, description: "Number of categories in the applied selection.", isRequired: true),
+            ActionParameter(name: "webDomainCount", type: .int, description: "Number of web domains in the applied selection.", isRequired: true),
+        ]
+    )
+
+    public static let clearShields: ActionSchema = ActionSchema(
+        kind: .screenTime,
+        actionName: "clear_shields",
+        capability: .writeDelete,
+        summary: "Remove all shields from the default ManagedSettingsStore.",
+        inputs: [],
+        outputs: []
+    )
+
+    public static let all: [ActionSchema] = [applySelection, clearShields]
+}

--- a/ConvosConnections/Sources/ConvosConnectionsScreenTime/ScreenTimeDataSink.swift
+++ b/ConvosConnections/Sources/ConvosConnectionsScreenTime/ScreenTimeDataSink.swift
@@ -1,0 +1,127 @@
+import ConvosConnections
+import Foundation
+#if canImport(FamilyControls) && os(iOS)
+@preconcurrency import FamilyControls
+@preconcurrency import ManagedSettings
+#endif
+
+/// Write-side counterpart to `ScreenTimeDataSource`.
+///
+/// Lives in the opt-in `ConvosConnectionsScreenTime` product because it depends on
+/// `com.apple.developer.family-controls`, which requires Apple distribution approval.
+///
+/// Two actions:
+/// - `apply_selection` — shield the set of apps/categories/web domains encoded in a
+///   previously-persisted `FamilyActivitySelection` JSON bundle (produced by a user
+///   `FamilyActivityPicker` interaction).
+/// - `clear_shields` — remove all restrictions from the default `ManagedSettingsStore`.
+public final class ScreenTimeDataSink: DataSink, @unchecked Sendable {
+    public let kind: ConnectionKind = .screenTime
+
+    public init() {}
+
+    public func actionSchemas() async -> [ActionSchema] {
+        ScreenTimeActionSchemas.all
+    }
+
+    #if canImport(FamilyControls) && os(iOS)
+    private let managedSettingsStore: ManagedSettingsStore = ManagedSettingsStore()
+
+    public func authorizationStatus() async -> ConnectionAuthorizationStatus {
+        ScreenTimeDataSource.map(AuthorizationCenter.shared.authorizationStatus)
+    }
+
+    @discardableResult
+    public func requestAuthorization() async throws -> ConnectionAuthorizationStatus {
+        try await AuthorizationCenter.shared.requestAuthorization(for: .individual)
+        return await authorizationStatus()
+    }
+
+    public func invoke(_ invocation: ConnectionInvocation) async -> ConnectionInvocationResult {
+        switch invocation.action.name {
+        case ScreenTimeActionSchemas.applySelection.actionName:
+            return applySelection(invocation)
+        case ScreenTimeActionSchemas.clearShields.actionName:
+            return clearShields(invocation)
+        default:
+            return Self.makeResult(
+                for: invocation,
+                status: .unknownAction,
+                errorMessage: "ScreenTime sink does not know action '\(invocation.action.name)'."
+            )
+        }
+    }
+
+    private func applySelection(_ invocation: ConnectionInvocation) -> ConnectionInvocationResult {
+        guard AuthorizationCenter.shared.authorizationStatus == .approved else {
+            return Self.makeResult(for: invocation, status: .authorizationDenied, errorMessage: "Screen Time (Family Controls) is not approved.")
+        }
+        guard let base64 = invocation.action.arguments["selectionData"]?.stringValue,
+              let data = Data(base64Encoded: base64, options: [.ignoreUnknownCharacters]) else {
+            return Self.makeResult(for: invocation, status: .executionFailed, errorMessage: "Missing or invalid 'selectionData' (must be Base64-encoded JSON).")
+        }
+
+        let selection: FamilyActivitySelection
+        do {
+            selection = try JSONDecoder().decode(FamilyActivitySelection.self, from: data)
+        } catch {
+            return Self.makeResult(for: invocation, status: .executionFailed, errorMessage: "Could not decode FamilyActivitySelection: \(error.localizedDescription).")
+        }
+
+        managedSettingsStore.shield.applications = selection.applicationTokens.isEmpty ? nil : selection.applicationTokens
+        managedSettingsStore.shield.applicationCategories = selection.categoryTokens.isEmpty ? nil : .specific(selection.categoryTokens)
+        managedSettingsStore.shield.webDomains = selection.webDomainTokens.isEmpty ? nil : selection.webDomainTokens
+
+        return Self.makeResult(
+            for: invocation,
+            status: .success,
+            result: [
+                "applicationCount": .int(selection.applicationTokens.count),
+                "categoryCount": .int(selection.categoryTokens.count),
+                "webDomainCount": .int(selection.webDomainTokens.count),
+            ]
+        )
+    }
+
+    private func clearShields(_ invocation: ConnectionInvocation) -> ConnectionInvocationResult {
+        guard AuthorizationCenter.shared.authorizationStatus == .approved else {
+            return Self.makeResult(for: invocation, status: .authorizationDenied, errorMessage: "Screen Time (Family Controls) is not approved.")
+        }
+        managedSettingsStore.shield.applications = nil
+        managedSettingsStore.shield.applicationCategories = nil
+        managedSettingsStore.shield.webDomains = nil
+        return Self.makeResult(for: invocation, status: .success)
+    }
+
+    private static func makeResult(
+        for invocation: ConnectionInvocation,
+        status: ConnectionInvocationResult.Status,
+        errorMessage: String? = nil,
+        result: [String: ArgumentValue] = [:]
+    ) -> ConnectionInvocationResult {
+        ConnectionInvocationResult(
+            invocationId: invocation.invocationId,
+            kind: invocation.kind,
+            actionName: invocation.action.name,
+            status: status,
+            result: result,
+            errorMessage: errorMessage
+        )
+    }
+    #else
+    public func authorizationStatus() async -> ConnectionAuthorizationStatus { .unavailable }
+
+    @discardableResult
+    public func requestAuthorization() async throws -> ConnectionAuthorizationStatus { .unavailable }
+
+    public func invoke(_ invocation: ConnectionInvocation) async -> ConnectionInvocationResult {
+        ConnectionInvocationResult(
+            invocationId: invocation.invocationId,
+            kind: .screenTime,
+            actionName: invocation.action.name,
+            status: .executionFailed,
+            errorMessage: "FamilyControls not available on this platform."
+        )
+    }
+    #endif
+}

--- a/ConvosConnections/Sources/ConvosConnectionsScreenTime/ScreenTimeDataSource.swift
+++ b/ConvosConnections/Sources/ConvosConnectionsScreenTime/ScreenTimeDataSource.swift
@@ -1,0 +1,118 @@
+import ConvosConnections
+import Foundation
+#if canImport(FamilyControls) && os(iOS)
+@preconcurrency import FamilyControls
+@preconcurrency import ManagedSettings
+#endif
+
+/// Bridges Family Controls / Screen Time authorization into `ConvosConnections`.
+///
+/// Requires the `com.apple.developer.family-controls` entitlement. Development builds can
+/// be signed with automatic provisioning; App Store distribution needs the special
+/// entitlement grant from Apple.
+///
+/// The source currently surfaces **authorization state only** — it does not emit usage
+/// hours, categories, or specific-app metrics. Those signals come from Apple's isolated
+/// Screen Time process, and surfacing them to the app requires a sibling
+/// `DeviceActivityMonitor` extension target. That's tracked as follow-up work.
+public final class ScreenTimeDataSource: DataSource, @unchecked Sendable {
+    public let kind: ConnectionKind = .screenTime
+
+    public init() {
+        #if canImport(FamilyControls) && os(iOS)
+        self.state = StateBox()
+        #endif
+    }
+
+    #if canImport(FamilyControls) && os(iOS)
+    private let state: StateBox
+
+    public func authorizationStatus() async -> ConnectionAuthorizationStatus {
+        Self.map(AuthorizationCenter.shared.authorizationStatus)
+    }
+
+    @discardableResult
+    public func requestAuthorization() async throws -> ConnectionAuthorizationStatus {
+        try await AuthorizationCenter.shared.requestAuthorization(for: .individual)
+        return await authorizationStatus()
+    }
+
+    public func authorizationDetails() async -> [AuthorizationDetail] {
+        let status = await authorizationStatus()
+        return [
+            AuthorizationDetail(
+                identifier: "family_controls",
+                displayName: "Screen Time",
+                status: status,
+                note: "Usage data (hours in apps, categories) is not exposed directly to the app — a DeviceActivityMonitor extension is required. This source surfaces authorization state only."
+            ),
+        ]
+    }
+
+    public func start(emit: @escaping ConnectionPayloadEmitter) async throws {
+        await state.start(emit: emit)
+    }
+
+    public func stop() async {
+        await state.stop()
+    }
+
+    public func snapshotCurrent() async -> ScreenTimePayload {
+        await state.snapshotCurrent()
+    }
+
+    static func map(_ status: AuthorizationStatus) -> ConnectionAuthorizationStatus {
+        switch status {
+        case .notDetermined: return .notDetermined
+        case .denied: return .denied
+        case .approved: return .authorized
+        @unknown default: return .notDetermined
+        }
+    }
+
+    static func buildPayload(authorized: Bool) -> ScreenTimePayload {
+        let summary = authorized
+            ? "Screen Time authorized. Usage data requires a DeviceActivityMonitor extension."
+            : "Screen Time not authorized."
+        return ScreenTimePayload(summary: summary, authorized: authorized)
+    }
+
+    private actor StateBox {
+        private var emitter: ConnectionPayloadEmitter?
+
+        func start(emit: @escaping ConnectionPayloadEmitter) async {
+            self.emitter = emit
+            emitCurrent()
+        }
+
+        func stop() async {
+            emitter = nil
+        }
+
+        func snapshotCurrent() -> ScreenTimePayload {
+            let status = AuthorizationCenter.shared.authorizationStatus
+            return ScreenTimeDataSource.buildPayload(authorized: status == .approved)
+        }
+
+        private func emitCurrent() {
+            guard let emitter else { return }
+            let status = AuthorizationCenter.shared.authorizationStatus
+            let payload = ScreenTimeDataSource.buildPayload(authorized: status == .approved)
+            emitter(ConnectionPayload(source: .screenTime, body: .screenTime(payload)))
+        }
+    }
+    #else
+    public func authorizationStatus() async -> ConnectionAuthorizationStatus { .unavailable }
+
+    @discardableResult
+    public func requestAuthorization() async throws -> ConnectionAuthorizationStatus { .unavailable }
+
+    public func start(emit: @escaping ConnectionPayloadEmitter) async throws {}
+
+    public func stop() async {}
+
+    public func snapshotCurrent() async -> ScreenTimePayload {
+        ScreenTimePayload(summary: "Screen Time not available.", authorized: false)
+    }
+    #endif
+}

--- a/ConvosConnections/Tests/ConvosConnectionsScreenTimeTests/ScreenTimeActionSchemasTests.swift
+++ b/ConvosConnections/Tests/ConvosConnectionsScreenTimeTests/ScreenTimeActionSchemasTests.swift
@@ -1,0 +1,32 @@
+import ConvosConnections
+@testable import ConvosConnectionsScreenTime
+import Testing
+
+@Suite("ScreenTime action schemas")
+struct ScreenTimeActionSchemasTests {
+    @Test("publishes two actions")
+    func publishesTwoActions() {
+        let schemas = ScreenTimeActionSchemas.all
+        #expect(schemas.count == 2)
+        #expect(Set(schemas.map(\.actionName)) == ["apply_selection", "clear_shields"])
+    }
+
+    @Test("capabilities")
+    func capabilities() {
+        #expect(ScreenTimeActionSchemas.applySelection.capability == .writeUpdate)
+        #expect(ScreenTimeActionSchemas.clearShields.capability == .writeDelete)
+    }
+
+    @Test("apply_selection requires selectionData")
+    func applyRequiresData() {
+        let required = ScreenTimeActionSchemas.applySelection.inputs.filter(\.isRequired).map(\.name)
+        #expect(required == ["selectionData"])
+    }
+
+    @Test("ScreenTimeDataSink publishes the same schemas")
+    func sinkPublishesSchemas() async {
+        let sink = ScreenTimeDataSink()
+        let schemas = await sink.actionSchemas()
+        #expect(schemas == ScreenTimeActionSchemas.all)
+    }
+}

--- a/ConvosConnections/Tests/ConvosConnectionsTests/ConnectionInvocationCodableTests.swift
+++ b/ConvosConnections/Tests/ConvosConnectionsTests/ConnectionInvocationCodableTests.swift
@@ -1,0 +1,104 @@
+@testable import ConvosConnections
+import Foundation
+import Testing
+
+@Suite("ConnectionInvocation coding")
+struct ConnectionInvocationCodableTests {
+    @Test("invocation round-trips through JSON")
+    func invocationRoundTrips() throws {
+        let invocation = ConnectionInvocation(
+            id: UUID(uuidString: "00000000-0000-0000-0000-0000000000AA") ?? UUID(),
+            invocationId: "agent-1-001",
+            kind: .calendar,
+            action: ConnectionAction(
+                name: "create_event",
+                arguments: [
+                    "title": .string("Team sync"),
+                    "startDate": .iso8601DateTime("2026-05-01T15:00:00-07:00"),
+                    "endDate": .iso8601DateTime("2026-05-01T16:00:00-07:00"),
+                    "timeZone": .string("America/Los_Angeles"),
+                    "isAllDay": .bool(false),
+                ]
+            ),
+            issuedAt: Date(timeIntervalSince1970: 1_700_000_000)
+        )
+
+        let data = try JSONEncoder().encode(invocation)
+        let decoded = try JSONDecoder().decode(ConnectionInvocation.self, from: data)
+        #expect(decoded == invocation)
+    }
+
+    @Test("result round-trips for every status case")
+    func resultRoundTripsAllStatuses() throws {
+        let statuses: [ConnectionInvocationResult.Status] = [
+            .success,
+            .capabilityNotEnabled,
+            .capabilityRevoked,
+            .requiresConfirmation,
+            .authorizationDenied,
+            .executionFailed,
+            .unknownAction,
+        ]
+        for status in statuses {
+            let result = ConnectionInvocationResult(
+                invocationId: "req-\(status.rawValue)",
+                kind: .calendar,
+                actionName: "create_event",
+                status: status,
+                result: status == .success ? ["eventId": .string("evt-abc"), "calendarId": .string("cal-1")] : [:],
+                errorMessage: status == .success ? nil : "test message"
+            )
+            let data = try JSONEncoder().encode(result)
+            let decoded = try JSONDecoder().decode(ConnectionInvocationResult.self, from: data)
+            #expect(decoded == result)
+        }
+    }
+
+    @Test("ArgumentValue round-trips all cases including nested array")
+    func argumentValueRoundTripsAllCases() throws {
+        let values: [ArgumentValue] = [
+            .string("hello"),
+            .bool(true),
+            .int(42),
+            .double(3.14),
+            .date(Date(timeIntervalSince1970: 1_700_000_000)),
+            .iso8601DateTime("2026-05-01T15:00:00Z"),
+            .enumValue("futureEvents"),
+            .array([.string("a"), .int(1), .null, .array([.bool(false)])]),
+            .null,
+        ]
+        for value in values {
+            let data = try JSONEncoder().encode(value)
+            let decoded = try JSONDecoder().decode(ArgumentValue.self, from: data)
+            #expect(decoded == value)
+        }
+    }
+
+    @Test("ActionSchema round-trips including recursive arrayOf parameter")
+    func actionSchemaRoundTrips() throws {
+        let schema = ActionSchema(
+            kind: .calendar,
+            actionName: "bulk_create",
+            capability: .writeCreate,
+            summary: "Create many events at once.",
+            inputs: [
+                ActionParameter(
+                    name: "events",
+                    type: .arrayOf(.string),
+                    description: "list",
+                    isRequired: true
+                ),
+                ActionParameter(
+                    name: "mode",
+                    type: .enumValue(allowed: ["fast", "careful"]),
+                    description: "mode",
+                    isRequired: false
+                ),
+            ],
+            outputs: []
+        )
+        let data = try JSONEncoder().encode(schema)
+        let decoded = try JSONDecoder().decode(ActionSchema.self, from: data)
+        #expect(decoded == schema)
+    }
+}

--- a/ConvosConnections/Tests/ConvosConnectionsTests/ConnectionKindTests.swift
+++ b/ConvosConnections/Tests/ConvosConnectionsTests/ConnectionKindTests.swift
@@ -1,0 +1,20 @@
+@testable import ConvosConnections
+import Testing
+
+@Suite("ConnectionKind")
+struct ConnectionKindTests {
+    @Test("raw values are stable")
+    func rawValuesAreStable() {
+        #expect(ConnectionKind.health.rawValue == "health")
+        #expect(ConnectionKind.homeKit.rawValue == "home_kit")
+        #expect(ConnectionKind.screenTime.rawValue == "screen_time")
+    }
+
+    @Test("every case has a display name and system image")
+    func everyCaseHasDisplayMetadata() {
+        for kind in ConnectionKind.allCases {
+            #expect(!kind.displayName.isEmpty)
+            #expect(!kind.systemImageName.isEmpty)
+        }
+    }
+}

--- a/ConvosConnections/Tests/ConvosConnectionsTests/ConnectionPayloadCodingTests.swift
+++ b/ConvosConnections/Tests/ConvosConnectionsTests/ConnectionPayloadCodingTests.swift
@@ -1,0 +1,306 @@
+@testable import ConvosConnections
+import Foundation
+import Testing
+
+@Suite("ConnectionPayload coding")
+struct ConnectionPayloadCodingTests {
+    @Test("health payload round-trips through JSON")
+    func healthPayloadRoundTrips() throws {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let payload = ConnectionPayload(
+            id: UUID(uuidString: "00000000-0000-0000-0000-000000000001") ?? UUID(),
+            source: .health,
+            capturedAt: now,
+            body: .health(
+                HealthPayload(
+                    summary: "3 workouts; 8h sleep",
+                    samples: [
+                        HealthSample(
+                            type: .workout,
+                            startDate: now.addingTimeInterval(-3600),
+                            endDate: now,
+                            value: 3600,
+                            unit: "seconds",
+                            metadata: ["activityType": "running"]
+                        )
+                    ],
+                    rangeStart: now.addingTimeInterval(-86_400),
+                    rangeEnd: now
+                )
+            )
+        )
+
+        let encoded = try JSONEncoder().encode(payload)
+        let decoded = try JSONDecoder().decode(ConnectionPayload.self, from: encoded)
+
+        #expect(decoded == payload)
+    }
+
+    @Test("calendar payload round-trips through JSON")
+    func calendarPayloadRoundTrips() throws {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let payload = ConnectionPayload(
+            source: .calendar,
+            capturedAt: now,
+            body: .calendar(
+                CalendarPayload(
+                    summary: "2 events",
+                    events: [
+                        CalendarEvent(
+                            id: "event-1",
+                            title: "Standup",
+                            startDate: now,
+                            endDate: now.addingTimeInterval(1800),
+                            isAllDay: false,
+                            location: "Zoom",
+                            notes: nil,
+                            calendarTitle: "Work",
+                            status: .confirmed,
+                            isRecurring: true
+                        ),
+                    ],
+                    rangeStart: now.addingTimeInterval(-86_400),
+                    rangeEnd: now.addingTimeInterval(14 * 86_400)
+                )
+            )
+        )
+
+        let encoded = try JSONEncoder().encode(payload)
+        let decoded = try JSONDecoder().decode(ConnectionPayload.self, from: encoded)
+
+        #expect(decoded == payload)
+    }
+
+    @Test("location payload round-trips through JSON")
+    func locationPayloadRoundTrips() throws {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let payload = ConnectionPayload(
+            source: .location,
+            capturedAt: now,
+            body: .location(
+                LocationPayload(
+                    summary: "1 arrival",
+                    events: [
+                        LocationEvent(
+                            id: UUID(uuidString: "00000000-0000-0000-0000-000000000abc") ?? UUID(),
+                            type: .visitArrival,
+                            latitude: 37.7749,
+                            longitude: -122.4194,
+                            horizontalAccuracy: 30.0,
+                            eventDate: now,
+                            arrivalDate: now,
+                            departureDate: nil
+                        ),
+                    ],
+                    capturedAt: now
+                )
+            )
+        )
+
+        let encoded = try JSONEncoder().encode(payload)
+        let decoded = try JSONDecoder().decode(ConnectionPayload.self, from: encoded)
+
+        #expect(decoded == payload)
+    }
+
+    @Test("contacts payload round-trips through JSON")
+    func contactsPayloadRoundTrips() throws {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let payload = ConnectionPayload(
+            source: .contacts,
+            capturedAt: now,
+            body: .contacts(
+                ContactsPayload(
+                    summary: "2 contacts",
+                    totalContactCount: 2,
+                    previewContacts: [
+                        ContactSummary(
+                            id: "c-1",
+                            givenName: "Ada",
+                            familyName: "Lovelace",
+                            organization: nil,
+                            hasEmail: true,
+                            hasPhone: false
+                        ),
+                        ContactSummary(
+                            id: "c-2",
+                            givenName: nil,
+                            familyName: nil,
+                            organization: "Acme",
+                            hasEmail: false,
+                            hasPhone: true
+                        ),
+                    ],
+                    capturedAt: now
+                )
+            )
+        )
+
+        let encoded = try JSONEncoder().encode(payload)
+        let decoded = try JSONDecoder().decode(ConnectionPayload.self, from: encoded)
+
+        #expect(decoded == payload)
+    }
+
+    @Test("photos payload round-trips through JSON")
+    func photosPayloadRoundTrips() throws {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let payload = ConnectionPayload(
+            source: .photos,
+            capturedAt: now,
+            body: .photos(
+                PhotosPayload(
+                    summary: "120 assets",
+                    totalAssetCount: 120,
+                    photoCount: 100,
+                    videoCount: 20,
+                    screenshotCount: 5,
+                    livePhotoCount: 3,
+                    recentAssets: [
+                        PhotoAssetSummary(
+                            id: "asset-1",
+                            mediaType: .photo,
+                            subtype: .livePhoto,
+                            creationDate: now,
+                            isFavorite: true,
+                            latitude: 37.7,
+                            longitude: -122.4
+                        ),
+                    ],
+                    capturedAt: now
+                )
+            )
+        )
+
+        let encoded = try JSONEncoder().encode(payload)
+        let decoded = try JSONDecoder().decode(ConnectionPayload.self, from: encoded)
+
+        #expect(decoded == payload)
+    }
+
+    @Test("music payload round-trips through JSON")
+    func musicPayloadRoundTrips() throws {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let payload = ConnectionPayload(
+            source: .music,
+            capturedAt: now,
+            body: .music(
+                MusicPayload(
+                    summary: "All Too Well — Taylor Swift",
+                    nowPlaying: NowPlayingItem(
+                        title: "All Too Well",
+                        artist: "Taylor Swift",
+                        album: "Red",
+                        genre: "Pop",
+                        durationSeconds: 325,
+                        playbackTimeSeconds: 42
+                    ),
+                    playbackState: .playing,
+                    capturedAt: now
+                )
+            )
+        )
+
+        let encoded = try JSONEncoder().encode(payload)
+        let decoded = try JSONDecoder().decode(ConnectionPayload.self, from: encoded)
+
+        #expect(decoded == payload)
+    }
+
+    @Test("motion payload round-trips through JSON")
+    func motionPayloadRoundTrips() throws {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let payload = ConnectionPayload(
+            source: .motion,
+            capturedAt: now,
+            body: .motion(
+                MotionPayload(
+                    summary: "Walking (confidence: high)",
+                    activity: MotionActivity(type: .walking, confidence: .high, startDate: now),
+                    capturedAt: now
+                )
+            )
+        )
+
+        let encoded = try JSONEncoder().encode(payload)
+        let decoded = try JSONDecoder().decode(ConnectionPayload.self, from: encoded)
+
+        #expect(decoded == payload)
+    }
+
+    @Test("home payload round-trips through JSON")
+    func homePayloadRoundTrips() throws {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let payload = ConnectionPayload(
+            source: .homeKit,
+            capturedAt: now,
+            body: .homeKit(
+                HomePayload(
+                    summary: "1 home, 5 accessories total.",
+                    homes: [
+                        HomeSummary(
+                            id: "home-1",
+                            name: "Main Street",
+                            isPrimary: true,
+                            roomCount: 4,
+                            accessoryCount: 5
+                        ),
+                    ],
+                    capturedAt: now
+                )
+            )
+        )
+
+        let encoded = try JSONEncoder().encode(payload)
+        let decoded = try JSONDecoder().decode(ConnectionPayload.self, from: encoded)
+
+        #expect(decoded == payload)
+    }
+
+    @Test("screen time payload round-trips through JSON")
+    func screenTimePayloadRoundTrips() throws {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let payload = ConnectionPayload(
+            source: .screenTime,
+            capturedAt: now,
+            body: .screenTime(
+                ScreenTimePayload(
+                    summary: "Screen Time authorized.",
+                    authorized: true,
+                    selectedApplicationCount: 3,
+                    selectedCategoryCount: 1,
+                    selectedWebDomainCount: 0,
+                    capturedAt: now
+                )
+            )
+        )
+
+        let encoded = try JSONEncoder().encode(payload)
+        let decoded = try JSONDecoder().decode(ConnectionPayload.self, from: encoded)
+
+        #expect(decoded == payload)
+    }
+
+    @Test("unknown body type decodes without throwing")
+    func unknownBodyTypeFallsBack() throws {
+        let envelope: [String: Any] = [
+            "id": "00000000-0000-0000-0000-000000000002",
+            "schemaVersion": 1,
+            "source": "health",
+            "capturedAt": 1_700_000_000.0,
+            "body": [
+                "type": "future_source_we_havent_shipped_yet",
+                "data": "AQID",
+            ],
+        ]
+        let jsonData = try JSONSerialization.data(withJSONObject: envelope)
+
+        let decoded = try JSONDecoder().decode(ConnectionPayload.self, from: jsonData)
+        switch decoded.body {
+        case .unknown(let rawType, _):
+            #expect(rawType == "future_source_we_havent_shipped_yet")
+        case .health, .calendar, .location, .contacts, .photos, .music, .motion, .homeKit, .screenTime:
+            Issue.record("Expected unknown body case")
+        }
+    }
+}

--- a/ConvosConnections/Tests/ConvosConnectionsTests/ConnectionsManagerInvocationTests.swift
+++ b/ConvosConnections/Tests/ConvosConnectionsTests/ConnectionsManagerInvocationTests.swift
@@ -1,0 +1,230 @@
+@testable import ConvosConnections
+import Foundation
+import Testing
+
+@Suite("ConnectionsManager invocation routing")
+struct ConnectionsManagerInvocationTests {
+    @Test("returns unknownAction when no sink is registered for the kind")
+    func unknownActionForMissingSink() async {
+        let manager = makeManager(sinks: [])
+        let result = await manager.handleInvocation(
+            makeCreateEventInvocation(),
+            from: "conv-1"
+        )
+        #expect(result.status == .unknownAction)
+    }
+
+    @Test("returns unknownAction when sink doesn't know the action")
+    func unknownActionForMissingActionName() async {
+        let sink = TestSink(kind: .calendar, schemas: [CalendarActionSchemas.createEvent])
+        let manager = makeManager(sinks: [sink])
+        let invocation = ConnectionInvocation(
+            invocationId: "x",
+            kind: .calendar,
+            action: ConnectionAction(name: "not_a_real_action", arguments: [:])
+        )
+        let result = await manager.handleInvocation(invocation, from: "conv-1")
+        #expect(result.status == .unknownAction)
+    }
+
+    @Test("returns capabilityNotEnabled when capability is off")
+    func capabilityNotEnabled() async {
+        let sink = TestSink(kind: .calendar, schemas: CalendarActionSchemas.all, response: .init(status: .success))
+        let manager = makeManager(sinks: [sink])
+        let result = await manager.handleInvocation(makeCreateEventInvocation(), from: "conv-1")
+        #expect(result.status == .capabilityNotEnabled)
+    }
+
+    @Test("calls sink.invoke and delivers result when capability is enabled")
+    func happyPathInvokesSinkAndDelivers() async {
+        let sink = TestSink(
+            kind: .calendar,
+            schemas: CalendarActionSchemas.all,
+            response: .init(status: .success, result: ["eventId": .string("evt-1")])
+        )
+        let delivery = RecordingDelivering()
+        let store = InMemoryEnablementStore()
+        await store.setEnabled(true, kind: .calendar, capability: .writeCreate, conversationId: "conv-1")
+        let manager = ConnectionsManager(sources: [], sinks: [sink], store: store, delivery: delivery)
+
+        let result = await manager.handleInvocation(makeCreateEventInvocation(), from: "conv-1")
+        #expect(result.status == .success)
+        #expect(result.result["eventId"] == .string("evt-1"))
+
+        let delivered = await delivery.invocationLog()
+        #expect(delivered.count == 1)
+        #expect(delivered.first?.conversationId == "conv-1")
+    }
+
+    @Test("returns requiresConfirmation when alwaysConfirm is on and no handler is installed")
+    func requiresConfirmationWhenNoHandler() async {
+        let sink = TestSink(kind: .calendar, schemas: CalendarActionSchemas.all, response: .init(status: .success))
+        let store = InMemoryEnablementStore()
+        await store.setEnabled(true, kind: .calendar, capability: .writeCreate, conversationId: "conv-1")
+        await store.setAlwaysConfirmWrites(true, kind: .calendar, conversationId: "conv-1")
+        let manager = ConnectionsManager(sources: [], sinks: [sink], store: store, delivery: RecordingDelivering())
+        let result = await manager.handleInvocation(makeCreateEventInvocation(), from: "conv-1")
+        #expect(result.status == .requiresConfirmation)
+    }
+
+    @Test("returns requiresConfirmation when handler responds cannotPresent")
+    func requiresConfirmationOnCannotPresent() async {
+        let sink = TestSink(kind: .calendar, schemas: CalendarActionSchemas.all, response: .init(status: .success))
+        let store = InMemoryEnablementStore()
+        await store.setEnabled(true, kind: .calendar, capability: .writeCreate, conversationId: "conv-1")
+        await store.setAlwaysConfirmWrites(true, kind: .calendar, conversationId: "conv-1")
+        let manager = ConnectionsManager(sources: [], sinks: [sink], store: store, delivery: RecordingDelivering())
+        await manager.setConfirmationHandler(TestConfirmationHandler(decision: .cannotPresent))
+        let result = await manager.handleInvocation(makeCreateEventInvocation(), from: "conv-1")
+        #expect(result.status == .requiresConfirmation)
+    }
+
+    @Test("returns authorizationDenied when handler responds denied")
+    func authorizationDeniedOnDenied() async {
+        let sink = TestSink(kind: .calendar, schemas: CalendarActionSchemas.all, response: .init(status: .success))
+        let store = InMemoryEnablementStore()
+        await store.setEnabled(true, kind: .calendar, capability: .writeCreate, conversationId: "conv-1")
+        await store.setAlwaysConfirmWrites(true, kind: .calendar, conversationId: "conv-1")
+        let manager = ConnectionsManager(sources: [], sinks: [sink], store: store, delivery: RecordingDelivering())
+        await manager.setConfirmationHandler(TestConfirmationHandler(decision: .denied))
+        let result = await manager.handleInvocation(makeCreateEventInvocation(), from: "conv-1")
+        #expect(result.status == .authorizationDenied)
+    }
+
+    @Test("proceeds to sink when handler approves")
+    func sinkInvokedOnApproved() async {
+        let sink = TestSink(
+            kind: .calendar,
+            schemas: CalendarActionSchemas.all,
+            response: .init(status: .success, result: ["eventId": .string("evt-x")])
+        )
+        let store = InMemoryEnablementStore()
+        await store.setEnabled(true, kind: .calendar, capability: .writeCreate, conversationId: "conv-1")
+        await store.setAlwaysConfirmWrites(true, kind: .calendar, conversationId: "conv-1")
+        let manager = ConnectionsManager(sources: [], sinks: [sink], store: store, delivery: RecordingDelivering())
+        await manager.setConfirmationHandler(TestConfirmationHandler(decision: .approved))
+        let result = await manager.handleInvocation(makeCreateEventInvocation(), from: "conv-1")
+        #expect(result.status == .success)
+    }
+
+    @Test("appends to recentInvocationLog")
+    func recordsInvocation() async {
+        let sink = TestSink(kind: .calendar, schemas: CalendarActionSchemas.all, response: .init(status: .success))
+        let store = InMemoryEnablementStore()
+        await store.setEnabled(true, kind: .calendar, capability: .writeCreate, conversationId: "conv-1")
+        let manager = ConnectionsManager(sources: [], sinks: [sink], store: store, delivery: RecordingDelivering())
+        _ = await manager.handleInvocation(makeCreateEventInvocation(), from: "conv-1")
+        let log = await manager.recentInvocationLog()
+        #expect(log.count == 1)
+        #expect(log.first?.result.status == .success)
+    }
+
+    @Test("records delivery failure when deliver(result:) is unimplemented")
+    func recordsDeliveryFailure() async {
+        let sink = TestSink(kind: .calendar, schemas: CalendarActionSchemas.all, response: .init(status: .success))
+        let store = InMemoryEnablementStore()
+        await store.setEnabled(true, kind: .calendar, capability: .writeCreate, conversationId: "conv-1")
+        let delivery = UnimplementedResultDelivering()
+        let manager = ConnectionsManager(sources: [], sinks: [sink], store: store, delivery: delivery)
+        let result = await manager.handleInvocation(makeCreateEventInvocation(), from: "conv-1")
+        #expect(result.status == .success) // sink still executes
+        let log = await manager.recentInvocationLog()
+        #expect(log.first?.resultDeliveryError != nil)
+    }
+
+    // MARK: - Helpers
+
+    private func makeManager(sinks: [DataSink]) -> ConnectionsManager {
+        ConnectionsManager(
+            sources: [],
+            sinks: sinks,
+            store: InMemoryEnablementStore(),
+            delivery: RecordingDelivering()
+        )
+    }
+
+    private func makeCreateEventInvocation() -> ConnectionInvocation {
+        ConnectionInvocation(
+            invocationId: "req-1",
+            kind: .calendar,
+            action: ConnectionAction(
+                name: "create_event",
+                arguments: ["title": .string("t")]
+            )
+        )
+    }
+}
+
+// MARK: - Test doubles
+
+private actor TestSink: DataSink {
+    struct Response: Sendable {
+        let status: ConnectionInvocationResult.Status
+        let result: [String: ArgumentValue]
+        let errorMessage: String?
+
+        init(
+            status: ConnectionInvocationResult.Status,
+            result: [String: ArgumentValue] = [:],
+            errorMessage: String? = nil
+        ) {
+            self.status = status
+            self.result = result
+            self.errorMessage = errorMessage
+        }
+    }
+
+    let kind: ConnectionKind
+    private let schemas: [ActionSchema]
+    private let response: Response
+
+    init(kind: ConnectionKind, schemas: [ActionSchema], response: Response = .init(status: .success)) {
+        self.kind = kind
+        self.schemas = schemas
+        self.response = response
+    }
+
+    func actionSchemas() async -> [ActionSchema] { schemas }
+
+    func authorizationStatus() async -> ConnectionAuthorizationStatus { .authorized }
+
+    func requestAuthorization() async throws -> ConnectionAuthorizationStatus { .authorized }
+
+    func invoke(_ invocation: ConnectionInvocation) async -> ConnectionInvocationResult {
+        ConnectionInvocationResult(
+            invocationId: invocation.invocationId,
+            kind: invocation.kind,
+            actionName: invocation.action.name,
+            status: response.status,
+            result: response.result,
+            errorMessage: response.errorMessage
+        )
+    }
+}
+
+private actor RecordingDelivering: ConnectionDelivering {
+    struct Entry: Sendable, Equatable {
+        let result: ConnectionInvocationResult
+        let conversationId: String
+    }
+
+    private var log: [Entry] = []
+
+    func deliver(_ payload: ConnectionPayload, to conversationId: String) async throws {}
+
+    func deliver(_ result: ConnectionInvocationResult, to conversationId: String) async throws {
+        log.append(Entry(result: result, conversationId: conversationId))
+    }
+
+    func invocationLog() -> [Entry] { log }
+}
+
+private struct UnimplementedResultDelivering: ConnectionDelivering {
+    func deliver(_ payload: ConnectionPayload, to conversationId: String) async throws {}
+    // No override for deliver(_:result:) — inherits the throwing default.
+}
+
+private struct TestConfirmationHandler: ConfirmationHandling {
+    let decision: ConfirmationDecision
+    func confirm(_ request: ConfirmationRequest) async -> ConfirmationDecision { decision }
+}

--- a/ConvosConnections/Tests/ConvosConnectionsTests/ConnectionsManagerTests.swift
+++ b/ConvosConnections/Tests/ConvosConnectionsTests/ConnectionsManagerTests.swift
@@ -1,0 +1,133 @@
+@testable import ConvosConnections
+import Foundation
+import Testing
+
+@Suite("ConnectionsManager")
+struct ConnectionsManagerTests {
+    @Test("emitted payload is fanned out to every enabled conversation")
+    func emitFansOut() async throws {
+        let source = TestDataSource(kind: .health)
+        let store = InMemoryEnablementStore()
+        let delivery = RecordingDelivering()
+
+        await store.setEnabled(true, kind: .health, conversationId: "conv-a")
+        await store.setEnabled(true, kind: .health, conversationId: "conv-b")
+
+        let manager = ConnectionsManager(sources: [source], store: store, delivery: delivery)
+        try await manager.startSource(kind: .health)
+
+        let payload = Self.makeHealthPayload()
+        await source.emit(payload)
+        try await Task.sleep(nanoseconds: 50_000_000) // let manager process
+
+        let log = await delivery.snapshot()
+        #expect(log.count == 2)
+        #expect(Set(log.map(\.conversationId)) == ["conv-a", "conv-b"])
+        #expect(log.allSatisfy { $0.payload == payload })
+    }
+
+    @Test("payload with no enabled conversations is recorded but not delivered")
+    func recordsWithoutDelivering() async throws {
+        let source = TestDataSource(kind: .health)
+        let store = InMemoryEnablementStore()
+        let delivery = RecordingDelivering()
+        let manager = ConnectionsManager(sources: [source], store: store, delivery: delivery)
+        try await manager.startSource(kind: .health)
+
+        let payload = Self.makeHealthPayload()
+        await source.emit(payload)
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        let log = await delivery.snapshot()
+        let recent = await manager.recentPayloadLog()
+        #expect(log.isEmpty)
+        #expect(recent.count == 1)
+        #expect(recent.first?.fanOutConversationIds.isEmpty == true)
+    }
+
+    @Test("toggling enablement is reflected through manager API")
+    func togglePropagates() async {
+        let source = TestDataSource(kind: .health)
+        let store = InMemoryEnablementStore()
+        let delivery = RecordingDelivering()
+        let manager = ConnectionsManager(sources: [source], store: store, delivery: delivery)
+
+        let before = await manager.isEnabled(.health, conversationId: "x")
+        #expect(before == false)
+
+        await manager.setEnabled(true, kind: .health, conversationId: "x")
+        let after = await manager.isEnabled(.health, conversationId: "x")
+        #expect(after == true)
+
+        let list = await manager.enabledConversationIds(for: .health)
+        #expect(list == ["x"])
+    }
+
+    @Test("unknown kind returns unavailable and does not throw on start")
+    func unknownKindIsUnavailable() async throws {
+        let store = InMemoryEnablementStore()
+        let delivery = RecordingDelivering()
+        let manager = ConnectionsManager(sources: [], store: store, delivery: delivery)
+
+        let status = await manager.authorizationStatus(for: .health)
+        #expect(status == .unavailable)
+
+        try await manager.startSource(kind: .health) // should be no-op
+    }
+
+    private static func makeHealthPayload() -> ConnectionPayload {
+        ConnectionPayload(
+            source: .health,
+            body: .health(
+                HealthPayload(
+                    summary: "test",
+                    samples: [],
+                    rangeStart: Date(),
+                    rangeEnd: Date()
+                )
+            )
+        )
+    }
+}
+
+/// Minimal `DataSource` that lets tests trigger emissions manually.
+private actor TestDataSource: DataSource {
+    let kind: ConnectionKind
+    private var emitter: ConnectionPayloadEmitter?
+
+    init(kind: ConnectionKind) {
+        self.kind = kind
+    }
+
+    func authorizationStatus() async -> ConnectionAuthorizationStatus { .authorized }
+
+    func requestAuthorization() async throws -> ConnectionAuthorizationStatus { .authorized }
+
+    func start(emit: @escaping ConnectionPayloadEmitter) async throws {
+        emitter = emit
+    }
+
+    func stop() async {
+        emitter = nil
+    }
+
+    func emit(_ payload: ConnectionPayload) {
+        emitter?(payload)
+    }
+}
+
+/// `ConnectionDelivering` that records every attempt.
+private actor RecordingDelivering: ConnectionDelivering {
+    struct Entry: Sendable, Equatable {
+        let payload: ConnectionPayload
+        let conversationId: String
+    }
+
+    private var log: [Entry] = []
+
+    func deliver(_ payload: ConnectionPayload, to conversationId: String) async throws {
+        log.append(Entry(payload: payload, conversationId: conversationId))
+    }
+
+    func snapshot() -> [Entry] { log }
+}

--- a/ConvosConnections/Tests/ConvosConnectionsTests/ContactsActionSchemasTests.swift
+++ b/ConvosConnections/Tests/ConvosConnectionsTests/ContactsActionSchemasTests.swift
@@ -1,0 +1,35 @@
+@testable import ConvosConnections
+import Testing
+
+@Suite("Contacts action schemas")
+struct ContactsActionSchemasTests {
+    @Test("publishes three actions")
+    func publishesThreeActions() {
+        let schemas = ContactsActionSchemas.all
+        #expect(schemas.count == 3)
+        let names = Set(schemas.map(\.actionName))
+        #expect(names == ["create_contact", "update_contact", "delete_contact"])
+    }
+
+    @Test("each action has the right capability")
+    func capabilities() {
+        #expect(ContactsActionSchemas.createContact.capability == .writeCreate)
+        #expect(ContactsActionSchemas.updateContact.capability == .writeUpdate)
+        #expect(ContactsActionSchemas.deleteContact.capability == .writeDelete)
+    }
+
+    @Test("update and delete require contactId")
+    func identifiersAreRequired() {
+        let updateRequired = ContactsActionSchemas.updateContact.inputs.first { $0.name == "contactId" }
+        let deleteRequired = ContactsActionSchemas.deleteContact.inputs.first { $0.name == "contactId" }
+        #expect(updateRequired?.isRequired == true)
+        #expect(deleteRequired?.isRequired == true)
+    }
+
+    @Test("ContactsDataSink publishes the same schemas")
+    func sinkPublishesSchemas() async {
+        let sink = ContactsDataSink()
+        let schemas = await sink.actionSchemas()
+        #expect(schemas == ContactsActionSchemas.all)
+    }
+}

--- a/ConvosConnections/Tests/ConvosConnectionsTests/HealthActionSchemasTests.swift
+++ b/ConvosConnections/Tests/ConvosConnectionsTests/HealthActionSchemasTests.swift
@@ -1,0 +1,30 @@
+@testable import ConvosConnections
+import Testing
+
+@Suite("Health action schemas")
+struct HealthActionSchemasTests {
+    @Test("publishes three actions")
+    func publishesThreeActions() {
+        let schemas = HealthActionSchemas.all
+        #expect(schemas.count == 3)
+        #expect(Set(schemas.map(\.actionName)) == ["log_water", "log_caffeine", "log_mindful_minutes"])
+    }
+
+    @Test("every action is writeCreate")
+    func capabilities() {
+        #expect(HealthActionSchemas.all.allSatisfy { $0.capability == .writeCreate })
+    }
+
+    @Test("log_water requires quantity + unit")
+    func waterRequirements() {
+        let required = HealthActionSchemas.logWater.inputs.filter(\.isRequired).map(\.name)
+        #expect(Set(required) == ["quantity", "unit"])
+    }
+
+    @Test("HealthDataSink publishes the same schemas")
+    func sinkPublishesSchemas() async {
+        let sink = HealthDataSink()
+        let schemas = await sink.actionSchemas()
+        #expect(schemas == HealthActionSchemas.all)
+    }
+}

--- a/ConvosConnections/Tests/ConvosConnectionsTests/HomeActionSchemasTests.swift
+++ b/ConvosConnections/Tests/ConvosConnectionsTests/HomeActionSchemasTests.swift
@@ -1,0 +1,33 @@
+@testable import ConvosConnections
+import Testing
+
+@Suite("HomeKit action schemas")
+struct HomeActionSchemasTests {
+    @Test("publishes two actions")
+    func publishesTwoActions() {
+        let schemas = HomeActionSchemas.all
+        #expect(schemas.count == 2)
+        let names = Set(schemas.map(\.actionName))
+        #expect(names == ["run_scene", "set_characteristic_value"])
+    }
+
+    @Test("capabilities are writeCreate and writeUpdate")
+    func capabilities() {
+        #expect(HomeActionSchemas.runScene.capability == .writeCreate)
+        #expect(HomeActionSchemas.setCharacteristicValue.capability == .writeUpdate)
+    }
+
+    @Test("set_characteristic requires accessoryId + characteristicType + value")
+    func requiredInputs() {
+        let inputs = HomeActionSchemas.setCharacteristicValue.inputs
+        let required = inputs.filter(\.isRequired).map(\.name)
+        #expect(Set(required) == ["accessoryId", "characteristicType", "value"])
+    }
+
+    @Test("HomeKitDataSink publishes the same schemas")
+    func sinkPublishesSchemas() async {
+        let sink = HomeKitDataSink()
+        let schemas = await sink.actionSchemas()
+        #expect(schemas == HomeActionSchemas.all)
+    }
+}

--- a/ConvosConnections/Tests/ConvosConnectionsTests/InMemoryEnablementStoreTests.swift
+++ b/ConvosConnections/Tests/ConvosConnectionsTests/InMemoryEnablementStoreTests.swift
@@ -1,0 +1,98 @@
+@testable import ConvosConnections
+import Foundation
+import Testing
+
+@Suite("InMemoryEnablementStore")
+struct InMemoryEnablementStoreTests {
+    @Test("toggling enablement persists across reads")
+    func togglePersists() async {
+        let store = InMemoryEnablementStore()
+        let isEnabledBefore = await store.isEnabled(kind: .health, conversationId: "conv-1")
+        #expect(isEnabledBefore == false)
+
+        await store.setEnabled(true, kind: .health, conversationId: "conv-1")
+        let isEnabledAfter = await store.isEnabled(kind: .health, conversationId: "conv-1")
+        #expect(isEnabledAfter == true)
+
+        await store.setEnabled(false, kind: .health, conversationId: "conv-1")
+        let isEnabledFinal = await store.isEnabled(kind: .health, conversationId: "conv-1")
+        #expect(isEnabledFinal == false)
+    }
+
+    @Test("conversationIds(enabledFor:) returns only matching kind")
+    func filterByKind() async {
+        let store = InMemoryEnablementStore()
+        await store.setEnabled(true, kind: .health, conversationId: "conv-a")
+        await store.setEnabled(true, kind: .health, conversationId: "conv-b")
+        await store.setEnabled(true, kind: .calendar, conversationId: "conv-c")
+
+        let healthConversations = await store.conversationIds(enabledFor: .health)
+        #expect(healthConversations == ["conv-a", "conv-b"])
+
+        let calendarConversations = await store.conversationIds(enabledFor: .calendar)
+        #expect(calendarConversations == ["conv-c"])
+
+        let photosConversations = await store.conversationIds(enabledFor: .photos)
+        #expect(photosConversations.isEmpty)
+    }
+
+    @Test("allEnablements returns a stable sort order")
+    func allEnablementsIsSorted() async {
+        let store = InMemoryEnablementStore()
+        await store.setEnabled(true, kind: .photos, conversationId: "z")
+        await store.setEnabled(true, kind: .health, conversationId: "b")
+        await store.setEnabled(true, kind: .health, conversationId: "a")
+
+        let all = await store.allEnablements()
+        #expect(all.map(\.conversationId) == ["a", "b", "z"])
+    }
+
+    @Test("per-capability enablement is independent")
+    func perCapabilityIndependence() async {
+        let store = InMemoryEnablementStore()
+        await store.setEnabled(true, kind: .calendar, capability: .writeCreate, conversationId: "c")
+        let readEnabled = await store.isEnabled(kind: .calendar, capability: .read, conversationId: "c")
+        let createEnabled = await store.isEnabled(kind: .calendar, capability: .writeCreate, conversationId: "c")
+        let deleteEnabled = await store.isEnabled(kind: .calendar, capability: .writeDelete, conversationId: "c")
+        #expect(readEnabled == false)
+        #expect(createEnabled == true)
+        #expect(deleteEnabled == false)
+    }
+
+    @Test("legacy read methods route to the .read capability")
+    func legacyReadShimsUseReadCapability() async {
+        let store = InMemoryEnablementStore()
+        await store.setEnabled(true, kind: .calendar, conversationId: "c")
+        let read = await store.isEnabled(kind: .calendar, capability: .read, conversationId: "c")
+        let writeCreate = await store.isEnabled(kind: .calendar, capability: .writeCreate, conversationId: "c")
+        #expect(read == true)
+        #expect(writeCreate == false)
+    }
+
+    @Test("alwaysConfirmWrites round-trips")
+    func alwaysConfirmRoundTrips() async {
+        let store = InMemoryEnablementStore()
+        var initial = await store.alwaysConfirmWrites(kind: .calendar, conversationId: "c")
+        #expect(initial == false)
+        await store.setAlwaysConfirmWrites(true, kind: .calendar, conversationId: "c")
+        var after = await store.alwaysConfirmWrites(kind: .calendar, conversationId: "c")
+        #expect(after == true)
+        await store.setAlwaysConfirmWrites(false, kind: .calendar, conversationId: "c")
+        after = await store.alwaysConfirmWrites(kind: .calendar, conversationId: "c")
+        #expect(after == false)
+        _ = initial
+    }
+
+    @Test("allEnablements includes every capability sorted deterministically")
+    func allEnablementsSortsEveryCapability() async {
+        let store = InMemoryEnablementStore()
+        await store.setEnabled(true, kind: .calendar, capability: .writeDelete, conversationId: "c")
+        await store.setEnabled(true, kind: .calendar, capability: .read, conversationId: "c")
+        await store.setEnabled(true, kind: .calendar, capability: .writeCreate, conversationId: "c")
+
+        let all = await store.allEnablements()
+        let capabilities = all.map(\.capability)
+        // Sorted by raw value: "read" < "write_create" < "write_delete"
+        #expect(capabilities == [.read, .writeCreate, .writeDelete])
+    }
+}

--- a/ConvosConnections/Tests/ConvosConnectionsTests/MusicActionSchemasTests.swift
+++ b/ConvosConnections/Tests/ConvosConnectionsTests/MusicActionSchemasTests.swift
@@ -1,0 +1,36 @@
+@testable import ConvosConnections
+import Testing
+
+@Suite("Music action schemas")
+struct MusicActionSchemasTests {
+    @Test("publishes five actions")
+    func publishesFiveActions() {
+        let schemas = MusicActionSchemas.all
+        #expect(schemas.count == 5)
+        #expect(Set(schemas.map(\.actionName)) == [
+            "play", "pause", "skip_to_next", "skip_to_previous", "queue_store_items",
+        ])
+    }
+
+    @Test("transport controls are writeUpdate")
+    func transportCapabilities() {
+        #expect(MusicActionSchemas.play.capability == .writeUpdate)
+        #expect(MusicActionSchemas.pause.capability == .writeUpdate)
+        #expect(MusicActionSchemas.skipToNext.capability == .writeUpdate)
+        #expect(MusicActionSchemas.skipToPrevious.capability == .writeUpdate)
+    }
+
+    @Test("queue_store_items is writeCreate and requires storeIds")
+    func queueRequirements() {
+        #expect(MusicActionSchemas.queueStoreItems.capability == .writeCreate)
+        let required = MusicActionSchemas.queueStoreItems.inputs.filter(\.isRequired).map(\.name)
+        #expect(required == ["storeIds"])
+    }
+
+    @Test("MusicDataSink publishes the same schemas")
+    func sinkPublishesSchemas() async {
+        let sink = MusicDataSink()
+        let schemas = await sink.actionSchemas()
+        #expect(schemas == MusicActionSchemas.all)
+    }
+}

--- a/ConvosConnections/Tests/ConvosConnectionsTests/PhotosActionSchemasTests.swift
+++ b/ConvosConnections/Tests/ConvosConnectionsTests/PhotosActionSchemasTests.swift
@@ -1,0 +1,32 @@
+@testable import ConvosConnections
+import Testing
+
+@Suite("Photos action schemas")
+struct PhotosActionSchemasTests {
+    @Test("publishes three actions")
+    func publishesThreeActions() {
+        let schemas = PhotosActionSchemas.all
+        #expect(schemas.count == 3)
+        #expect(Set(schemas.map(\.actionName)) == ["save_image", "favorite_asset", "delete_asset"])
+    }
+
+    @Test("capabilities")
+    func capabilities() {
+        #expect(PhotosActionSchemas.saveImage.capability == .writeCreate)
+        #expect(PhotosActionSchemas.favoriteAsset.capability == .writeUpdate)
+        #expect(PhotosActionSchemas.deleteAsset.capability == .writeDelete)
+    }
+
+    @Test("save_image requires imageData")
+    func saveImageRequiresImageData() {
+        let input = PhotosActionSchemas.saveImage.inputs.first { $0.name == "imageData" }
+        #expect(input?.isRequired == true)
+    }
+
+    @Test("PhotosDataSink publishes the same schemas")
+    func sinkPublishesSchemas() async {
+        let sink = PhotosDataSink()
+        let schemas = await sink.actionSchemas()
+        #expect(schemas == PhotosActionSchemas.all)
+    }
+}


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add ConvosConnections Swift package with 9 data sources, write sinks, and an example iOS app
- Introduces the `ConvosConnections` SPM package targeting iOS/macOS 26 with two library products: `ConvosConnections` (core) and `ConvosConnectionsScreenTime` (ScreenTime/FamilyControls add-on).
- Adds read-side `DataSource` implementations for Health, Calendar, Contacts, Location, Photos, Music, Motion, HomeKit, and ScreenTime — each handling authorization, start/stop emission of typed `ConnectionPayload` values, and per-type authorization details.
- Adds write-side `DataSink` implementations for the same domains, each publishing `ActionSchema` definitions and handling `ConnectionInvocation` requests (e.g. creating calendar events, logging HealthKit samples, saving photos, controlling music playback, applying Screen Time shields).
- Introduces `ConnectionsManager`, a central Swift actor that aggregates sources and sinks, routes invocations, gates execution on per-(kind, capability, conversation) enablement, and supports an async `ConfirmationHandling` protocol for user-approved writes.
- Includes an example iOS app ([ExampleModel.swift](https://github.com/xmtplabs/convos-ios/pull/717/files#diff-ae1015baaf4eb6cb9b1d56f6696fae79ee18d71368455928b185b8cdbc359c05)) wiring all sources/sinks together with a `UserDefaultsEnablementStore`, a SwiftUI feed view, and a confirmation sheet for write actions.
- Adds unit tests covering JSON round-trips, `ConnectionsManager` invocation routing, enablement store behavior, and per-sink action schema validation.

<!-- Macroscope's review summary starts here -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized cee816e. 52 files reviewed, 33 issues evaluated, 6 issues filtered, 7 comments posted</summary> (Automatic summaries will resume when PR exits draft mode or review begins).

### 🗂️ Filtered Issues
<details>
<summary>ConvosConnections/Sources/ConvosConnections/DataSources/Calendar/CalendarDataSink.swift — 1 comment posted, 5 evaluated, 1 filtered</summary>

- [line 67](https://github.com/xmtplabs/convos-ios/blob/4871a0d304f792840e46d05942d80fac17ea6964/ConvosConnections/Sources/ConvosConnections/DataSources/Calendar/CalendarDataSink.swift#L67): Authorization check uses `== .fullAccess` but on iOS 16 and earlier, the status is `.authorized` (not `.fullAccess`). If the app's deployment target includes iOS 16, users who granted calendar access will incorrectly receive "Calendar access is not granted" errors because `.authorized != .fullAccess`. The check should include both values, e.g., `[.fullAccess, .authorized].contains(status)`, matching the mapping logic in `CalendarDataSource.map(ekStatus:)`. <b>[ Out of scope (triage) ]</b>
</details>

<details>
<summary>ConvosConnections/Sources/ConvosConnections/DataSources/Calendar/CalendarDataSource.swift — 0 comments posted, 3 evaluated, 1 filtered</summary>

- [line 113](https://github.com/xmtplabs/convos-ios/blob/4871a0d304f792840e46d05942d80fac17ea6964/ConvosConnections/Sources/ConvosConnections/DataSources/Calendar/CalendarDataSource.swift#L113): `DateFormatter` is not thread-safe, but the static `formatter` property (lines 113-118) is accessed from `summarize()` which can be called concurrently. The public `snapshotCurrentWindow()` method on this non-actor class can be invoked from multiple threads simultaneously, each calling `Self.summarize()` which uses `Self.formatter.string(from:)` without synchronization. This can cause crashes or corrupted output. <b>[ Skipped comment generation ]</b>
</details>

<details>
<summary>ConvosConnections/Sources/ConvosConnections/DataSources/Contacts/ContactsDataSink.swift — 1 comment posted, 3 evaluated, 1 filtered</summary>

- [line 58](https://github.com/xmtplabs/convos-ios/blob/4871a0d304f792840e46d05942d80fac17ea6964/ConvosConnections/Sources/ConvosConnections/DataSources/Contacts/ContactsDataSink.swift#L58): Authorization checks in `createContact`, `updateContact`, and `deleteContact` only accept `CNAuthorizationStatus.authorized`, rejecting `.limited` status. On iOS 18+, limited Contacts access still allows apps to create new contacts and modify/delete contacts the app created. The current check causes valid `create_contact` invocations to fail with `.authorizationDenied` when the user has granted limited access, even though `CNSaveRequest` would succeed. The `ContactsDataSource.map` function already recognizes `.limited` as `.partial`, indicating the system acknowledges partial authorization, but the sink incorrectly blocks all operations. <b>[ Cross-file consolidated ]</b>
</details>

<details>
<summary>ConvosConnections/Sources/ConvosConnections/DataSources/Health/HealthDataSource.swift — 0 comments posted, 1 evaluated, 1 filtered</summary>

- [line 173](https://github.com/xmtplabs/convos-ios/blob/4871a0d304f792840e46d05942d80fac17ea6964/ConvosConnections/Sources/ConvosConnections/DataSources/Health/HealthDataSource.swift#L173): `DateFormatter` is not thread-safe, but the static `dateFormatter` property (lines 166-171) is accessed from multiple concurrent contexts without synchronization. The `format` helper is called from `summarize`, which runs inside the `StateBox` actor's `handleObserverFired` method. Multiple `HealthDataSource` instances can have their observer queries fire simultaneously on different threads, and `snapshotLast24Hours` can also be called concurrently from any context. All these call paths use the shared static `DateFormatter`, causing a data race. <b>[ Cross-file consolidated ]</b>
</details>

<details>
<summary>ConvosConnections/Sources/ConvosConnections/DataSources/Home/HomeDataSource.swift — 0 comments posted, 1 evaluated, 1 filtered</summary>

- [line 94](https://github.com/xmtplabs/convos-ios/blob/4871a0d304f792840e46d05942d80fac17ea6964/ConvosConnections/Sources/ConvosConnections/DataSources/Home/HomeDataSource.swift#L94): `primeAuthorization()` can hang indefinitely if `HMHomeManager` was created by a prior call (e.g., `authorizationStatus()` or `snapshotCurrent()`) and `homeManagerDidUpdateHomes(_:)` already fired. When the existing manager is reused via `manager ?? createManager()`, no new delegate callback will arrive to resume the continuation stored in `authorizationContinuation`. The `onHomesDidUpdate` method safely handles a nil continuation with `continuation?.resume()`, but this means if the callback fires before the continuation is set, the continuation is never resumed. Concrete path: `ExampleModel.refresh()` calls `authorizationStatus(for: .homeKit)` which creates the manager; later `homeManagerDidUpdateHomes` fires (with `authorizationContinuation` still nil); user then taps to enable HomeKit triggering `requestAuthorization()` → `primeAuthorization()`; status is still `.notDetermined` so we await forever. <b>[ Cross-file consolidated ]</b>
</details>

<details>
<summary>ConvosConnections/Sources/ConvosConnections/DataSources/Home/HomeKitDataSink.swift — 1 comment posted, 3 evaluated, 1 filtered</summary>

- [line 249](https://github.com/xmtplabs/convos-ios/blob/4871a0d304f792840e46d05942d80fac17ea6964/ConvosConnections/Sources/ConvosConnections/DataSources/Home/HomeKitDataSink.swift#L249): `Int(value)` will crash at runtime if `value` is `Double.infinity`, `Double.nan`, or exceeds the representable range of `Int`. Swift's `Int(_: Double)` initializer traps on such values rather than returning nil. If `ArgumentValue.double` originates from external/agent input, this can cause an unrecoverable crash. Consider using `Int(exactly:)` or adding bounds checking before conversion. <b>[ Out of scope ]</b>
</details>


</details><!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->