### PR TITLE
Add ConvosConnectionsXMTP: bridge ConvosConnections to XMTP content types

### DIFF
--- a/ConvosCore/Package.swift
+++ b/ConvosCore/Package.swift
@@ -18,6 +18,10 @@ let package = Package(
             name: "ConvosCoreiOS",
             targets: ["ConvosCoreiOS"]
         ),
+        .library(
+            name: "ConvosConnectionsXMTP",
+            targets: ["ConvosConnectionsXMTP"]
+        ),
     ],
     dependencies: [
         .package(url: "https://github.com/groue/GRDB.swift.git", exact: "7.5.0"),
@@ -32,6 +36,7 @@ let package = Package(
         .package(path: "../ConvosLogging"),
         .package(path: "../ConvosInvites"),
         .package(path: "../ConvosAppData"),
+        .package(path: "../ConvosConnections"),
     ],
     targets: [
         .target(
@@ -68,6 +73,19 @@ let package = Package(
                 .unsafeFlags(["-Onone"], .when(configuration: .debug)),
             ]
         ),
+        .target(
+            name: "ConvosConnectionsXMTP",
+            dependencies: [
+                .product(name: "XMTPiOS", package: "libxmtp"),
+                .product(name: "ConvosConnections", package: "ConvosConnections"),
+            ],
+            path: "Sources/ConvosConnectionsXMTP",
+            swiftSettings: [
+                .swiftLanguageMode(.v6),
+                .define("DEBUG", .when(configuration: .debug)),
+                .unsafeFlags(["-Onone"], .when(configuration: .debug)),
+            ]
+        ),
         .testTarget(
             name: "ConvosCoreTests",
             dependencies: [
@@ -75,6 +93,15 @@ let package = Package(
                 "ConvosAppData",
                 .target(name: "ConvosCoreiOS", condition: .when(platforms: [.iOS])),
             ]
+        ),
+        .testTarget(
+            name: "ConvosConnectionsXMTPTests",
+            dependencies: [
+                "ConvosConnectionsXMTP",
+                .product(name: "ConvosConnections", package: "ConvosConnections"),
+                .product(name: "XMTPiOS", package: "libxmtp"),
+            ],
+            path: "Tests/ConvosConnectionsXMTPTests"
         ),
     ]
 )

--- a/ConvosCore/Sources/ConvosConnectionsXMTP/Bootstrap/ConvosConnectionsXMTP.swift
+++ b/ConvosCore/Sources/ConvosConnectionsXMTP/Bootstrap/ConvosConnectionsXMTP.swift
@@ -1,0 +1,21 @@
+import Foundation
+@preconcurrency import XMTPiOS
+
+/// One-stop registration helper. Host code merges `ConvosConnectionsXMTP.codecs()` into
+/// its existing `ClientOptions(codecs: [...])` when constructing the XMTP client.
+///
+/// Exposed as a namespaced enum rather than free functions so call sites read clearly
+/// alongside existing Convos client construction code.
+public enum ConvosConnectionsXMTP {
+    /// The three ConvosConnections wire types.
+    ///
+    /// Returns fresh instances on every call because XMTPiOS's `ContentCodec` is a value
+    /// type with no shared state — cheap to construct, no reason to cache.
+    public static func codecs() -> [any ContentCodec] {
+        [
+            ConnectionPayloadCodec(),
+            ConnectionInvocationCodec(),
+            ConnectionInvocationResultCodec(),
+        ]
+    }
+}

--- a/ConvosCore/Sources/ConvosConnectionsXMTP/Codecs/ConnectionInvocationCodec.swift
+++ b/ConvosCore/Sources/ConvosConnectionsXMTP/Codecs/ConnectionInvocationCodec.swift
@@ -1,0 +1,57 @@
+import ConvosConnections
+import Foundation
+@preconcurrency import XMTPiOS
+
+/// Wire content type for `ConnectionInvocation` (agent → device write requests).
+public let ContentTypeConnectionInvocation = ContentTypeID(
+    authorityID: "convos.org",
+    typeID: "connection_invocation",
+    versionMajor: 1,
+    versionMinor: 0
+)
+
+public enum ConnectionInvocationCodecError: Error, LocalizedError {
+    case emptyContent
+    case invalidJSONFormat
+
+    public var errorDescription: String? {
+        switch self {
+        case .emptyContent: return "ConnectionInvocation content is empty"
+        case .invalidJSONFormat: return "Invalid JSON format for ConnectionInvocation"
+        }
+    }
+}
+
+public struct ConnectionInvocationCodec: ContentCodec {
+    public typealias T = ConnectionInvocation
+
+    public var contentType: ContentTypeID = ContentTypeConnectionInvocation
+
+    public init() {}
+
+    public func encode(content: ConnectionInvocation) throws -> EncodedContent {
+        var encoded = EncodedContent()
+        encoded.type = ContentTypeConnectionInvocation
+        encoded.content = try JSONEncoder().encode(content)
+        return encoded
+    }
+
+    public func decode(content: EncodedContent) throws -> ConnectionInvocation {
+        guard !content.content.isEmpty else {
+            throw ConnectionInvocationCodecError.emptyContent
+        }
+        do {
+            return try JSONDecoder().decode(ConnectionInvocation.self, from: content.content)
+        } catch {
+            throw ConnectionInvocationCodecError.invalidJSONFormat
+        }
+    }
+
+    public func fallback(content: ConnectionInvocation) throws -> String? {
+        "Connection invocation"
+    }
+
+    public func shouldPush(content: ConnectionInvocation) throws -> Bool {
+        false
+    }
+}

--- a/ConvosCore/Sources/ConvosConnectionsXMTP/Codecs/ConnectionInvocationResultCodec.swift
+++ b/ConvosCore/Sources/ConvosConnectionsXMTP/Codecs/ConnectionInvocationResultCodec.swift
@@ -1,0 +1,57 @@
+import ConvosConnections
+import Foundation
+@preconcurrency import XMTPiOS
+
+/// Wire content type for `ConnectionInvocationResult` (device → agent write outcomes).
+public let ContentTypeConnectionInvocationResult = ContentTypeID(
+    authorityID: "convos.org",
+    typeID: "connection_invocation_result",
+    versionMajor: 1,
+    versionMinor: 0
+)
+
+public enum ConnectionInvocationResultCodecError: Error, LocalizedError {
+    case emptyContent
+    case invalidJSONFormat
+
+    public var errorDescription: String? {
+        switch self {
+        case .emptyContent: return "ConnectionInvocationResult content is empty"
+        case .invalidJSONFormat: return "Invalid JSON format for ConnectionInvocationResult"
+        }
+    }
+}
+
+public struct ConnectionInvocationResultCodec: ContentCodec {
+    public typealias T = ConnectionInvocationResult
+
+    public var contentType: ContentTypeID = ContentTypeConnectionInvocationResult
+
+    public init() {}
+
+    public func encode(content: ConnectionInvocationResult) throws -> EncodedContent {
+        var encoded = EncodedContent()
+        encoded.type = ContentTypeConnectionInvocationResult
+        encoded.content = try JSONEncoder().encode(content)
+        return encoded
+    }
+
+    public func decode(content: EncodedContent) throws -> ConnectionInvocationResult {
+        guard !content.content.isEmpty else {
+            throw ConnectionInvocationResultCodecError.emptyContent
+        }
+        do {
+            return try JSONDecoder().decode(ConnectionInvocationResult.self, from: content.content)
+        } catch {
+            throw ConnectionInvocationResultCodecError.invalidJSONFormat
+        }
+    }
+
+    public func fallback(content: ConnectionInvocationResult) throws -> String? {
+        "Connection result"
+    }
+
+    public func shouldPush(content: ConnectionInvocationResult) throws -> Bool {
+        false
+    }
+}

--- a/ConvosCore/Sources/ConvosConnectionsXMTP/Codecs/ConnectionPayloadCodec.swift
+++ b/ConvosCore/Sources/ConvosConnectionsXMTP/Codecs/ConnectionPayloadCodec.swift
@@ -1,0 +1,57 @@
+import ConvosConnections
+import Foundation
+@preconcurrency import XMTPiOS
+
+/// Wire content type for `ConnectionPayload` (device → agent sensor events).
+public let ContentTypeConnectionPayload = ContentTypeID(
+    authorityID: "convos.org",
+    typeID: "connection_payload",
+    versionMajor: 1,
+    versionMinor: 0
+)
+
+public enum ConnectionPayloadCodecError: Error, LocalizedError {
+    case emptyContent
+    case invalidJSONFormat
+
+    public var errorDescription: String? {
+        switch self {
+        case .emptyContent: return "ConnectionPayload content is empty"
+        case .invalidJSONFormat: return "Invalid JSON format for ConnectionPayload"
+        }
+    }
+}
+
+public struct ConnectionPayloadCodec: ContentCodec {
+    public typealias T = ConnectionPayload
+
+    public var contentType: ContentTypeID = ContentTypeConnectionPayload
+
+    public init() {}
+
+    public func encode(content: ConnectionPayload) throws -> EncodedContent {
+        var encoded = EncodedContent()
+        encoded.type = ContentTypeConnectionPayload
+        encoded.content = try JSONEncoder().encode(content)
+        return encoded
+    }
+
+    public func decode(content: EncodedContent) throws -> ConnectionPayload {
+        guard !content.content.isEmpty else {
+            throw ConnectionPayloadCodecError.emptyContent
+        }
+        do {
+            return try JSONDecoder().decode(ConnectionPayload.self, from: content.content)
+        } catch {
+            throw ConnectionPayloadCodecError.invalidJSONFormat
+        }
+    }
+
+    public func fallback(content: ConnectionPayload) throws -> String? {
+        "Connection event"
+    }
+
+    public func shouldPush(content: ConnectionPayload) throws -> Bool {
+        false
+    }
+}

--- a/ConvosCore/Sources/ConvosConnectionsXMTP/Delivery/XMTPConnectionDelivery.swift
+++ b/ConvosCore/Sources/ConvosConnectionsXMTP/Delivery/XMTPConnectionDelivery.swift
@@ -1,0 +1,54 @@
+import ConvosConnections
+import Foundation
+@preconcurrency import XMTPiOS
+
+public enum XMTPConnectionDeliveryError: Error, LocalizedError, Equatable {
+    case conversationNotFound(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .conversationNotFound(let id): return "XMTP conversation not found for id '\(id)'."
+        }
+    }
+}
+
+/// XMTP-backed `ConnectionDelivering`.
+///
+/// Holds a closure that maps a conversation id to an `XMTPiOS.Conversation`. Convos
+/// supplies this with its GRDB-backed resolver so the adapter doesn't need to know about
+/// ConvosCore's conversation storage. Delivery is a two-step: look up → send with the
+/// right codec's contentType.
+///
+/// `XMTPiOS.Conversation` isn't Sendable, so we hold the closure rather than a conversation
+/// reference. Each delivery call resolves the conversation fresh.
+public final class XMTPConnectionDelivery: ConnectionDelivering, @unchecked Sendable {
+    public typealias ConversationLookup = @Sendable (String) async throws -> XMTPiOS.Conversation?
+
+    private let lookup: ConversationLookup
+
+    public init(conversationLookup: @escaping ConversationLookup) {
+        self.lookup = conversationLookup
+    }
+
+    public func deliver(_ payload: ConnectionPayload, to conversationId: String) async throws {
+        guard let conversation = try await lookup(conversationId) else {
+            throw XMTPConnectionDeliveryError.conversationNotFound(conversationId)
+        }
+        let codec = ConnectionPayloadCodec()
+        try await conversation.send(
+            content: payload,
+            options: .init(contentType: codec.contentType)
+        )
+    }
+
+    public func deliver(_ result: ConnectionInvocationResult, to conversationId: String) async throws {
+        guard let conversation = try await lookup(conversationId) else {
+            throw XMTPConnectionDeliveryError.conversationNotFound(conversationId)
+        }
+        let codec = ConnectionInvocationResultCodec()
+        try await conversation.send(
+            content: result,
+            options: .init(contentType: codec.contentType)
+        )
+    }
+}

--- a/ConvosCore/Sources/ConvosConnectionsXMTP/Listener/XMTPInvocationListener.swift
+++ b/ConvosCore/Sources/ConvosConnectionsXMTP/Listener/XMTPInvocationListener.swift
@@ -1,0 +1,70 @@
+import ConvosConnections
+import Foundation
+@preconcurrency import XMTPiOS
+
+/// Routes incoming XMTP messages carrying `ConnectionInvocation` content into the
+/// package's `ConnectionsManager`.
+///
+/// Deliberately not a subscriber — the host is expected to call `processIncoming` from
+/// its own decoded-message dispatch (e.g. from `SyncingManager`'s stream handler). This
+/// avoids spawning a parallel `conversations.streamAllMessages` subscription that would
+/// collide with the single-inbox refactor (PR 713).
+///
+/// Schema version skew is handled here, not in the manager: invocations with a schema
+/// version newer than the package knows about bypass the manager entirely and reply with
+/// a synthetic `executionFailed` result so the agent gets a structured no.
+public final class XMTPInvocationListener: @unchecked Sendable {
+    private let manager: ConnectionsManager
+    private let delivery: any ConnectionDelivering
+
+    /// The delivery parameter is typed as `ConnectionDelivering` rather than
+    /// `XMTPConnectionDelivery` specifically so tests can swap in a recording double.
+    /// Production callers pass their `XMTPConnectionDelivery` instance — usually the same
+    /// one they also hand to `ConnectionsManager`'s constructor.
+    public init(manager: ConnectionsManager, delivery: any ConnectionDelivering) {
+        self.manager = manager
+        self.delivery = delivery
+    }
+
+    /// Process a decoded XMTP message. No-ops for content types that aren't ours.
+    public func processIncoming(message: DecodedMessage, conversationId: String) async {
+        let encoded: EncodedContent
+        do {
+            encoded = try message.encodedContent
+        } catch {
+            return
+        }
+        guard encoded.type == ContentTypeConnectionInvocation else { return }
+
+        let invocation: ConnectionInvocation
+        do {
+            invocation = try ConnectionInvocationCodec().decode(content: encoded)
+        } catch {
+            // No invocationId available — can't reply. Host logging should pick this up.
+            return
+        }
+
+        await handle(invocation: invocation, conversationId: conversationId)
+    }
+
+    /// Visible for testing. Schema-version gate + manager routing, without the XMTP
+    /// decoding step. Exercised by the public `processIncoming` after decoding.
+    internal func handle(invocation: ConnectionInvocation, conversationId: String) async {
+        if invocation.schemaVersion > ConnectionInvocation.currentSchemaVersion {
+            let result = ConnectionInvocationResult(
+                invocationId: invocation.invocationId,
+                kind: invocation.kind,
+                actionName: invocation.action.name,
+                status: .executionFailed,
+                errorMessage: "unsupported schema version \(invocation.schemaVersion)"
+            )
+            try? await delivery.deliver(result, to: conversationId)
+            return
+        }
+
+        // Route through the manager's gating chain. The manager auto-delivers the result
+        // via whatever `ConnectionDelivering` it was constructed with — so long as the
+        // host passed `self.delivery` as that value, the agent gets its reply.
+        _ = await manager.handleInvocation(invocation, from: conversationId)
+    }
+}

--- a/ConvosCore/Tests/ConvosConnectionsXMTPTests/ConnectionCodecRoundTripTests.swift
+++ b/ConvosCore/Tests/ConvosConnectionsXMTPTests/ConnectionCodecRoundTripTests.swift
@@ -1,0 +1,87 @@
+import ConvosConnections
+@testable import ConvosConnectionsXMTP
+import Foundation
+import Testing
+@preconcurrency import XMTPiOS
+
+@Suite("Connection codec round-trip")
+struct ConnectionCodecRoundTripTests {
+    @Test("payload round-trips")
+    func payloadRoundTrips() throws {
+        let codec = ConnectionPayloadCodec()
+        let now = Date()
+        let payload = ConnectionPayload(
+            source: .calendar,
+            body: .calendar(CalendarPayload(
+                summary: "2 events today",
+                events: [],
+                rangeStart: now,
+                rangeEnd: now
+            ))
+        )
+        let encoded = try codec.encode(content: payload)
+        #expect(encoded.type == ContentTypeConnectionPayload)
+        let decoded = try codec.decode(content: encoded)
+        #expect(decoded.source == payload.source)
+        #expect(decoded.summary == payload.summary)
+    }
+
+    @Test("invocation round-trips")
+    func invocationRoundTrips() throws {
+        let codec = ConnectionInvocationCodec()
+        let invocation = ConnectionInvocation(
+            invocationId: "agent-1-001",
+            kind: .contacts,
+            action: ConnectionAction(
+                name: "create_contact",
+                arguments: [
+                    "givenName": .string("Jane"),
+                    "email": .string("jane@example.com"),
+                ]
+            )
+        )
+        let encoded = try codec.encode(content: invocation)
+        #expect(encoded.type == ContentTypeConnectionInvocation)
+        let decoded = try codec.decode(content: encoded)
+        #expect(decoded == invocation)
+    }
+
+    @Test("result round-trips")
+    func resultRoundTrips() throws {
+        let codec = ConnectionInvocationResultCodec()
+        let result = ConnectionInvocationResult(
+            invocationId: "agent-1-001",
+            kind: .contacts,
+            actionName: "create_contact",
+            status: .success,
+            result: ["contactId": .string("ABC123")]
+        )
+        let encoded = try codec.encode(content: result)
+        #expect(encoded.type == ContentTypeConnectionInvocationResult)
+        let decoded = try codec.decode(content: encoded)
+        #expect(decoded == result)
+    }
+
+    @Test("fallbacks are plain, no emoji")
+    func fallbacks() throws {
+        #expect(try ConnectionPayloadCodec().fallback(content: .init(source: .calendar, body: .calendar(.init(summary: "", events: [], rangeStart: Date(), rangeEnd: Date())))) == "Connection event")
+        #expect(try ConnectionInvocationCodec().fallback(content: .init(invocationId: "x", kind: .contacts, action: .init(name: "y", arguments: [:]))) == "Connection invocation")
+        #expect(try ConnectionInvocationResultCodec().fallback(content: .init(invocationId: "x", kind: .contacts, actionName: "y", status: .success)) == "Connection result")
+    }
+
+    @Test("all three codecs skip push")
+    func shouldPush() throws {
+        #expect(try ConnectionPayloadCodec().shouldPush(content: .init(source: .calendar, body: .calendar(.init(summary: "", events: [], rangeStart: Date(), rangeEnd: Date())))) == false)
+        #expect(try ConnectionInvocationCodec().shouldPush(content: .init(invocationId: "x", kind: .contacts, action: .init(name: "y", arguments: [:]))) == false)
+        #expect(try ConnectionInvocationResultCodec().shouldPush(content: .init(invocationId: "x", kind: .contacts, actionName: "y", status: .success)) == false)
+    }
+
+    @Test("empty content decode throws")
+    func emptyContent() {
+        var empty = EncodedContent()
+        empty.type = ContentTypeConnectionInvocation
+        #expect(throws: ConnectionInvocationCodecError.emptyContent) {
+            try ConnectionInvocationCodec().decode(content: empty)
+        }
+    }
+}

--- a/ConvosCore/Tests/ConvosConnectionsXMTPTests/XMTPConnectionDeliveryTests.swift
+++ b/ConvosCore/Tests/ConvosConnectionsXMTPTests/XMTPConnectionDeliveryTests.swift
@@ -1,0 +1,50 @@
+import ConvosConnections
+@testable import ConvosConnectionsXMTP
+import Foundation
+import Testing
+
+@Suite("XMTP connection delivery")
+struct XMTPConnectionDeliveryTests {
+    @Test("payload delivery calls the conversation lookup")
+    func payloadCallsLookup() async throws {
+        let counter = LookupCounter()
+        let delivery = XMTPConnectionDelivery { conversationId in
+            await counter.record(conversationId)
+            return nil
+        }
+        let payload = ConnectionPayload(
+            source: .calendar,
+            body: .calendar(CalendarPayload(
+                summary: "",
+                events: [],
+                rangeStart: Date(),
+                rangeEnd: Date()
+            ))
+        )
+        await #expect(throws: XMTPConnectionDeliveryError.self) {
+            try await delivery.deliver(payload, to: "conv-x")
+        }
+        #expect(await counter.observedIds() == ["conv-x"])
+    }
+
+    @Test("result delivery throws conversationNotFound when lookup returns nil")
+    func resultThrowsOnMissing() async throws {
+        let delivery = XMTPConnectionDelivery { _ in nil }
+        let result = ConnectionInvocationResult(
+            invocationId: "x",
+            kind: .calendar,
+            actionName: "create_event",
+            status: .success
+        )
+        await #expect(throws: XMTPConnectionDeliveryError.self) {
+            try await delivery.deliver(result, to: "missing")
+        }
+    }
+}
+
+private actor LookupCounter {
+    private var ids: [String] = []
+
+    func record(_ id: String) { ids.append(id) }
+    func observedIds() -> [String] { ids }
+}

--- a/ConvosCore/Tests/ConvosConnectionsXMTPTests/XMTPInvocationListenerTests.swift
+++ b/ConvosCore/Tests/ConvosConnectionsXMTPTests/XMTPInvocationListenerTests.swift
@@ -1,0 +1,126 @@
+import ConvosConnections
+@testable import ConvosConnectionsXMTP
+import Foundation
+import Testing
+
+@Suite("XMTP invocation listener")
+struct XMTPInvocationListenerTests {
+    @Test("schema version mismatch delivers executionFailed and never touches the sink")
+    func schemaMismatch() async throws {
+        let recorder = DeliveryRecorder()
+        let sink = CountingSink()
+        let manager = ConnectionsManager(
+            sources: [],
+            sinks: [sink],
+            store: InMemoryEnablementStore(),
+            delivery: recorder
+        )
+        let listener = XMTPInvocationListener(manager: manager, delivery: recorder)
+
+        // Decode a future-version invocation from raw JSON so we bypass the default schemaVersion.
+        let futureJSON = """
+        {
+            "id": "00000000-0000-0000-0000-000000000001",
+            "schemaVersion": 999,
+            "invocationId": "future-001",
+            "kind": "contacts",
+            "action": { "name": "create_contact", "arguments": {} },
+            "issuedAt": 0
+        }
+        """.data(using: .utf8)!
+        let invocation = try JSONDecoder().decode(ConnectionInvocation.self, from: futureJSON)
+
+        await listener.handle(invocation: invocation, conversationId: "conv-1")
+
+        let results = await recorder.results()
+        #expect(results.count == 1)
+        #expect(results.first?.status == .executionFailed)
+        #expect(results.first?.errorMessage?.contains("999") == true)
+        #expect(await sink.invokeCount() == 0)
+    }
+
+    @Test("valid invocation routes through the manager")
+    func validInvocation() async throws {
+        let recorder = DeliveryRecorder()
+        let sink = CountingSink()
+        let store = InMemoryEnablementStore()
+        // Enable the capability so the manager's gate passes and the sink is hit.
+        await store.setEnabled(true, kind: .contacts, capability: .writeCreate, conversationId: "conv-1")
+
+        let manager = ConnectionsManager(
+            sources: [],
+            sinks: [sink],
+            store: store,
+            delivery: recorder
+        )
+        let listener = XMTPInvocationListener(manager: manager, delivery: recorder)
+
+        let invocation = ConnectionInvocation(
+            invocationId: "valid-001",
+            kind: .contacts,
+            action: ConnectionAction(name: "create_contact", arguments: [:])
+        )
+
+        await listener.handle(invocation: invocation, conversationId: "conv-1")
+
+        #expect(await sink.invokeCount() == 1)
+        let results = await recorder.results()
+        #expect(results.count == 1)
+        #expect(results.first?.status == .success)
+    }
+}
+
+// MARK: - Test doubles
+
+private actor DeliveryRecorder: ConnectionDelivering {
+    private var stored: [ConnectionInvocationResult] = []
+
+    func deliver(_ payload: ConnectionPayload, to conversationId: String) async throws {}
+
+    func deliver(_ result: ConnectionInvocationResult, to conversationId: String) async throws {
+        stored.append(result)
+    }
+
+    func results() -> [ConnectionInvocationResult] { stored }
+}
+
+private final class CountingSink: DataSink, @unchecked Sendable {
+    private let state: StateBox = StateBox()
+
+    private actor StateBox {
+        var count: Int = 0
+        func increment() { count += 1 }
+    }
+
+    var kind: ConnectionKind { .contacts }
+
+    func actionSchemas() async -> [ActionSchema] {
+        [
+            ActionSchema(
+                kind: .contacts,
+                actionName: "create_contact",
+                capability: .writeCreate,
+                summary: "test",
+                inputs: [],
+                outputs: []
+            ),
+        ]
+    }
+
+    func authorizationStatus() async -> ConnectionAuthorizationStatus { .authorized }
+
+    @discardableResult
+    func requestAuthorization() async throws -> ConnectionAuthorizationStatus { .authorized }
+
+    func invoke(_ invocation: ConnectionInvocation) async -> ConnectionInvocationResult {
+        await state.increment()
+        return ConnectionInvocationResult(
+            invocationId: invocation.invocationId,
+            kind: invocation.kind,
+            actionName: invocation.action.name,
+            status: .success
+        )
+    }
+
+    func invokeCount() async -> Int { await state.count }
+}


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add ConvosConnectionsXMTP to bridge ConvosConnections to XMTP content types
- Adds a new `ConvosConnectionsXMTP` library in [Package.swift](https://github.com/xmtplabs/convos-ios/pull/718/files#diff-a2bdca0eaceddfb5e4fbd6afdf3047a9c23f261d60140456b61baada4a24caa3) with three XMTP `ContentCodec` implementations: `ConnectionPayloadCodec`, `ConnectionInvocationCodec`, and `ConnectionInvocationResultCodec`, each using JSON encoding under the `convos.org/` content type namespace.
- Adds `XMTPConnectionDelivery` which resolves a conversation via an injected async lookup closure and sends `ConnectionPayload` or `ConnectionInvocationResult` with the correct codec; throws `conversationNotFound` if the lookup returns nil.
- Adds `XMTPInvocationListener` which filters incoming XMTP messages by the `connection_invocation` content type, gates on schema version, and either routes valid invocations to `ConnectionsManager` or replies with an `executionFailed` result for unsupported schema versions.
- Exposes `ConvosConnectionsXMTP.codecs()` as a convenience for registering all three codecs during XMTP client configuration.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized c779d10.</sup>
<!-- Macroscope's review summary ends here -->

<!-- Macroscope's pull request summary ends here -->