### PR TITLE
Remove new-engineer onboarding friction

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,46 +22,41 @@ Learn more at [convos.org](https://convos.org).
 ### Prerequisites
 
 - macOS with Xcode 16+
-- Ruby 3.3.3
 - Homebrew
+- Docker (required for running the test suite via `./dev/up`)
 
 ### Quick Start
 
 ```bash
-# Run the setup script
-./Scripts/setup.sh
+# 1. Install dependencies and configure your environment
+./Scripts/setup.sh        # or: make setup
+
+# 2. Create your local .env from the template
+cp .env.example .env
+
+# 3. (Optional) Add a Firebase App Check debug token to .env
+#    See .env comments, or generate one at:
+#    https://console.firebase.google.com/project/convos-otr/appcheck
 ```
 
 The setup script will:
-- Install Git hooks for code quality checks
+- Configure the repo's Git hooks (`core.hooksPath` → `Scripts/hooks/`), which works for both regular clones and `git worktree`s
 - Configure Xcode defaults for consistent development
 - Install required dependencies:
-  - SwiftLint (code linting)
+  - SwiftLint (code linting, pinned version for compatibility)
   - SwiftFormat (code formatting)
   - swift-protobuf (Protocol Buffer support)
   - GitHub CLI (for release automation)
-  - Bundler and Ruby gems
 
 ### Manual Setup
 
-If you prefer to set up components individually:
+If you prefer to install dependencies individually, run:
 
 ```bash
-# Install SwiftLint
-brew install swiftlint
-
-# Install SwiftFormat
-brew install swiftformat
-
-# Install swift-protobuf
-brew install swift-protobuf
-
-# Install GitHub CLI (optional, for releases)
-brew install gh
-
-# Install Ruby dependencies
-bundle install
+brew install swiftformat swift-protobuf gh
 ```
+
+Then run `./Scripts/setup.sh` once to install the pinned SwiftLint version, configure git hooks, and apply Xcode defaults.
 
 ### Configuration
 
@@ -70,6 +65,18 @@ The setup script configures Xcode with:
 - 120-character page guide
 - Build operation duration display
 - Disabled plugin fingerprint validation for development
+
+For build environments (Local, Dev, Production), bundle IDs, and secrets handling, see [ENVIRONMENTS.md](ENVIRONMENTS.md).
+
+### Useful Make Targets
+
+```bash
+make setup           # Run Scripts/setup.sh
+make status          # Show version, secrets, git, and .env status
+make secrets-local   # Regenerate Convos/Config/Secrets.swift for Local builds
+make protobuf        # Regenerate Swift code from .proto files
+make clean           # Remove generated secrets and build artifacts
+```
 
 ## Project Structure
 
@@ -100,9 +107,22 @@ Open `Convos.xcodeproj` in Xcode and build normally. The project uses Swift Pack
 
 ### Testing
 
-Run tests in Xcode or via command line:
+Most ConvosCore tests require Docker to run a local XMTP node.
+
 ```bash
-xcodebuild test -project Convos.xcodeproj -scheme Convos
+# Full suite — starts Docker, runs tests, stops Docker
+./dev/test
+
+# Or manage Docker manually:
+./dev/up                                             # start local XMTP node
+swift test --package-path ConvosCore                 # run ConvosCore tests
+./dev/down                                           # stop when finished
+
+# iOS app tests via xcodebuild (use a scheme that includes the environment)
+xcodebuild test \
+  -project Convos.xcodeproj \
+  -scheme "Convos (Local)" \
+  -destination "platform=iOS Simulator,name=iPhone 17"
 ```
 
 ### Code Quality

--- a/Scripts/setup.sh
+++ b/Scripts/setup.sh
@@ -21,28 +21,14 @@ DIRNAME="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # setup developer environment
 
 if [ ! "${CI}" = true ]; then
-  # assumes you are in ./Scripts/ folder
-  git_dir="${DIRNAME}/../.git"
-  pre_commit_file="../../Scripts/hooks/pre-commit"
-  pre_push_file="../../Scripts/hooks/pre-push"
-  post_checkout_file="../../Scripts/hooks/post-checkout"
-  post_merge_file="../../Scripts/hooks/post-merge"
-
-  info "Installing Git hooks..."
-  cd "${git_dir}"
-  if [ ! -L hooks/pre-push ]; then
-      ln -sf "${pre_push_file}" hooks/pre-push
-  fi
-  if [ ! -L hooks/pre-commit ]; then
-      ln -sf "${pre_commit_file}" hooks/pre-commit
-  fi
-  if [ ! -L hooks/post-checkout ]; then
-      ln -sf "${post_checkout_file}" hooks/post-checkout
-  fi
-  if [ ! -L hooks/post-merge ]; then
-      ln -sf "${post_merge_file}" hooks/post-merge
-  fi
-  cd "${DIRNAME}"
+  info "Configuring Git hooks..."
+  # Use core.hooksPath so hooks work in both the main clone and any git worktree.
+  # This replaces the previous per-hook symlinks into .git/hooks, which were
+  # broken inside worktrees (where .git is a file, not a directory).
+  repo_root="$(cd "${DIRNAME}/.." && pwd)"
+  (cd "${repo_root}" && git config core.hooksPath Scripts/hooks)
+  # Ensure hook files are executable (they're tracked as +x, but be safe).
+  chmod +x "${repo_root}/Scripts/hooks/"*
 fi
 
 ################################################################################
@@ -73,14 +59,25 @@ if ! command -v brew &> /dev/null; then
     exit 1
 fi
 
-# Check and install SwiftLint (pinned to 0.62.2 for compatibility with project)
+# Check Xcode version (README requires 16+)
+if command -v xcodebuild &> /dev/null; then
+    xcode_major="$(xcodebuild -version 2>/dev/null | awk '/^Xcode/ {split($2, v, "."); print v[1]; exit}')"
+    if [ -n "${xcode_major}" ] && [ "${xcode_major}" -lt 16 ]; then
+        die "Xcode 16+ is required (detected Xcode ${xcode_major}). Update via the App Store or https://xcodereleases.com"
+    fi
+fi
+
+# Check and install SwiftLint (pinned for compatibility with the project's rules)
 SWIFTLINT_VERSION="0.62.2"
+SWIFTLINT_INSTALL_DIR="$(brew --prefix)/bin"  # user-writable, avoids sudo; in PATH on both Intel & Apple Silicon
 install_swiftlint() {
-    echo "Installing SwiftLint ${SWIFTLINT_VERSION}..."
-    local tmp_dir=$(mktemp -d)
+    echo "Installing SwiftLint ${SWIFTLINT_VERSION} to ${SWIFTLINT_INSTALL_DIR}..."
+    local tmp_dir
+    tmp_dir="$(mktemp -d)"
     curl -sL "https://github.com/realm/SwiftLint/releases/download/${SWIFTLINT_VERSION}/portable_swiftlint.zip" -o "${tmp_dir}/swiftlint.zip"
-    unzip -o "${tmp_dir}/swiftlint.zip" -d "${tmp_dir}"
-    sudo mv "${tmp_dir}/swiftlint" /usr/local/bin/swiftlint
+    unzip -o "${tmp_dir}/swiftlint.zip" -d "${tmp_dir}" >/dev/null
+    mv -f "${tmp_dir}/swiftlint" "${SWIFTLINT_INSTALL_DIR}/swiftlint"
+    chmod +x "${SWIFTLINT_INSTALL_DIR}/swiftlint"
     rm -rf "${tmp_dir}"
 }
 
@@ -153,8 +150,10 @@ if [ ! "${CI}" = true ]; then
     if [ ! -f "$ENV_FILE" ]; then
         echo ""
         echo "⚠️  No .env file found"
-        echo "   Create one to configure local development settings."
-        echo "   See: https://console.firebase.google.com/project/convos-otr/appcheck for debug tokens"
+        echo "   Copy the template to get started:"
+        echo "     cp .env.example .env"
+        echo "   Then (optionally) add a FIREBASE_APP_CHECK_DEBUG_TOKEN from:"
+        echo "     https://console.firebase.google.com/project/convos-otr/appcheck"
     elif ! grep -q "^FIREBASE_APP_CHECK_DEBUG_TOKEN=" "$ENV_FILE" || \
          [ -z "$(grep "^FIREBASE_APP_CHECK_DEBUG_TOKEN=" "$ENV_FILE" | cut -d'=' -f2-)" ]; then
         echo ""


### PR DESCRIPTION
## Summary

Walking through `README.md` + `Scripts/setup.sh` as a new engineer on a fresh machine turned up several papercuts. This PR fixes them.

### README.md
- Drop `Ruby 3.3.3` from prerequisites — no `Gemfile` exists in the repo, and `setup.sh` never ran `bundle install`.
- Add `Docker` to prerequisites — required by `./dev/test` and the XMTP local node, but it was only mentioned in `CLAUDE.md`.
- Expand **Quick Start** to include `cp .env.example .env` and the optional Firebase App Check debug token step.
- Fix the broken test example: the scheme `Convos` doesn't exist; use `Convos (Local)` with a `-destination`.
- Document the real test path for most devs: `./dev/test` (or `./dev/up` + `swift test --package-path ConvosCore` + `./dev/down`).
- Add **Useful Make Targets** (`make setup`/`status`/`secrets-local`/`protobuf`/`clean`) so folks can find them.
- Link to `ENVIRONMENTS.md` from the setup section.

### Scripts/setup.sh
- **Worktree-safe git hooks**: replace the per-hook symlinks into `.git/hooks/` with `git config core.hooksPath Scripts/hooks`. The old approach `cd`-ed into `${repo}/.git`, which is a **file** (not a directory) inside any `git worktree` — so it silently failed or pointed at the wrong place in `convos-task` worktrees.
- **No-sudo SwiftLint install**: install the pinned `portable_swiftlint` to `$(brew --prefix)/bin` instead of `sudo mv …  /usr/local/bin`. Avoids the mid-run password prompt, works on both Intel and Apple Silicon without PATH gymnastics.
- **Xcode version check**: `die` early if `xcodebuild -version` reports Xcode < 16, matching the README's stated minimum.
- **Better missing-`.env` hint**: the previous message said "create one" but didn't mention that `.env.example` is already a 4.8 KB template in the repo. Now it tells you to `cp .env.example .env`.

## Test plan
- [x] Run `./Scripts/setup.sh` on a fresh clone — completes cleanly, no sudo prompt
- [x] Verify `git config core.hooksPath` is set to `Scripts/hooks`
- [x] Make a commit → `pre-commit` hook fires (`🔍 Running pre-commit checks...`)
- [x] Push the branch → `pre-push` SwiftLint runs across all 510 Swift files with 0 violations
- [ ] Reviewer: try `./Scripts/setup.sh` from inside a `convos-task` worktree and confirm hooks fire there too
- [ ] Reviewer: sanity-check the updated `xcodebuild test` command runs locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reduce new-engineer onboarding friction by updating setup script and README
> - [setup.sh](https://github.com/xmtplabs/convos-ios/pull/720/files#diff-490f2d9bc338440322d4b7d5bcb8c209ee7633cdb9f4245ceb2cb78bc6486314) now configures Git hooks via `core.hooksPath` pointing to `Scripts/hooks` instead of per-hook symlinks in `.git/hooks`, and adds an Xcode 16+ version check that aborts setup if the requirement isn't met.
> - SwiftLint is installed into the Homebrew prefix bin directory without `sudo`, replacing the previous `/usr/local/bin` destination.
> - [README.md](https://github.com/xmtplabs/convos-ios/pull/720/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) expands the Quick Start with Docker prerequisites, a `make setup` option, `.env` setup from template, and a list of useful `make` targets; testing instructions now prefer `./dev/test` with a Docker-based XMTP node.
> - Behavioral Change: existing clones that previously relied on `.git/hooks` symlinks will need to re-run `setup.sh` to pick up the new `core.hooksPath` configuration.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9dc3dc5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->