### PR TITLE
Fix stale mock string in DefaultConversationDisplay test

### DIFF
--- a/ConvosCore/Tests/ConvosCoreTests/DefaultConversationDisplayTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/DefaultConversationDisplayTests.swift
@@ -297,9 +297,10 @@ struct DefaultConversationDisplayTests {
 
     @Test("avatarType returns profile for DM even when conversation emoji exists")
     func avatarTypeProfileForDMWithConversationEmoji() {
+        let otherMemberValue = ConversationMember.mock(isCurrentUser: false, name: "Alice")
         let members = [
             ConversationMember.mock(isCurrentUser: true, name: "You"),
-            ConversationMember.mock(isCurrentUser: false, name: "Alice")
+            otherMemberValue
         ]
         let conversation = Conversation(
             id: "test",
@@ -336,7 +337,7 @@ struct DefaultConversationDisplayTests {
         )
 
         if case .profile(let profile, _) = conversation.avatarType {
-            #expect(profile.inboxId == "mock-inbox-id-other")
+            #expect(profile.inboxId == otherMemberValue.profile.inboxId)
         } else {
             #expect(Bool(false), "Expected DM avatar to use other member profile before conversation emoji")
         }


### PR DESCRIPTION
## Summary
- Fixes `avatarTypeProfileForDMWithConversationEmoji` in `DefaultConversationDisplayTests.swift`, which has been failing every run since PR #701 landed and was historically treated as a flake.
- The test hard-coded `"mock-inbox-id-other"`, but `ConversationMember.mock(isCurrentUser: false)` has always produced `"other-user-\(UUID)"`. Assertion never matched the real mock output.
- Fix: capture the `ConversationMember` fixture into a local `let` and assert against its actual inboxId, not a hard-coded string.

## Context
Surfaced while resolving conflicts for #706 (XMTPiOS 4.10 upgrade). Splitting this out so #706 stays scoped to the XMTPiOS upgrade and its CI run isn't red for an unrelated, pre-existing bug.

## Test plan
- [x] `swift test --package-path ConvosCore --filter DefaultConversationDisplayTests` passes locally
- [x] Full `swift test --package-path ConvosCore` run: 590/590 green with this fix applied

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix stale hardcoded string in `avatarTypeProfileForDMWithConversationEmoji` test
> The test in [DefaultConversationDisplayTests.swift](https://github.com/xmtplabs/convos-ios/pull/722/files#diff-6c3a35457df9f60046f38ed010b5e3c17e576c733fb9acb743380367dcd9207d) was asserting against a hardcoded `inboxId` string instead of the actual mock member's value. The assertion now compares against `otherMemberValue.profile.inboxId`, so the test stays correct if the mock data changes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d0185f8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->