### PR TITLE
Revert "Upgrade to XMTPiOS 4.10.0-dev.796011d (#706)"

### DIFF
--- a/Convos.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Convos.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "117a38cbe061d2bf5fd257d012ee24de3bdd440259ea9961a3cd34e0167f7c61",
+  "originHash" : "c40fcb5279ffcf05994801de5933e258d72c7e21e5c777ef54ffb951d4469a38",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -150,8 +150,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/xmtp/libxmtp.git",
       "state" : {
-        "branch" : "ios-4.10.0-dev.796011d",
-        "revision" : "a76287f985501d0bc63cfc038e37e304d41296a3"
+        "branch" : "ios-4.9.0-dev.88ddfad",
+        "revision" : "899650a4189207ca2df515bf46beb549da07ff46"
       }
     },
     {

--- a/ConvosCore/Package.resolved
+++ b/ConvosCore/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "b4427d76fbfe5ef793b402f1fc77bd6a1ca4ac5562dd00a277ce1aff21a1b1a3",
+  "originHash" : "579cd1d748e9b32204ec97c5a2a168f00af764e485cc3f70870e0129ee45605b",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -141,8 +141,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/xmtp/libxmtp.git",
       "state" : {
-        "branch" : "ios-4.10.0-dev.796011d",
-        "revision" : "a76287f985501d0bc63cfc038e37e304d41296a3"
+        "branch" : "ios-4.9.0-dev.88ddfad",
+        "revision" : "899650a4189207ca2df515bf46beb549da07ff46"
       }
     },
     {

--- a/ConvosCore/Package.swift
+++ b/ConvosCore/Package.swift
@@ -23,7 +23,7 @@ let package = Package(
         .package(url: "https://github.com/groue/GRDB.swift.git", exact: "7.5.0"),
         .package(
             url: "https://github.com/xmtp/libxmtp.git",
-            revision: "ios-4.10.0-dev.796011d"
+            revision: "ios-4.9.0-dev.88ddfad"
         ),
         .package(url: "https://github.com/tesseract-one/CSecp256k1.swift.git", from: "0.2.0"),
         .package(url: "https://github.com/firebase/firebase-ios-sdk", from: "12.1.0"),

--- a/ConvosCore/Sources/ConvosCore/Inboxes/InboxStateMachine.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/InboxStateMachine.swift
@@ -1117,10 +1117,8 @@ public actor InboxStateMachine: InboxStateManagerProtocol {
             dbEncryptionKey: keys.databaseKey,
             dbDirectory: environment.defaultDatabasesDirectory,
             deviceSyncEnabled: false,
-            dbPoolOptions: DbPoolOptions(
-                maxPoolSize: 10,
-                minPoolSize: 3
-            )
+            maxDbPoolSize: 10,
+            minDbPoolSize: 3
         )
     }
 

--- a/ConvosCore/Tests/ConvosCoreTests/SleepingInboxMessageCheckerIntegrationTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/SleepingInboxMessageCheckerIntegrationTests.swift
@@ -380,12 +380,7 @@ private class IntegrationTestFixtures {
                 TypingIndicatorCodec()
             ],
             dbEncryptionKey: keys.databaseKey,
-            dbDirectory: environment.defaultDatabasesDirectory,
-            deviceSyncEnabled: false,
-            dbPoolOptions: DbPoolOptions(
-                maxPoolSize: 10,
-                minPoolSize: 3
-            )
+            dbDirectory: environment.defaultDatabasesDirectory
         )
 
         let client = try await Client.create(account: keys.signingKey, options: clientOptions)

--- a/ConvosCore/Tests/ConvosCoreTests/TestHelpers.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/TestHelpers.swift
@@ -121,12 +121,7 @@ class TestFixtures {
                 TypingIndicatorCodec()
             ],
             dbEncryptionKey: keys.databaseKey,
-            dbDirectory: environment.defaultDatabasesDirectory,
-            deviceSyncEnabled: false,
-            dbPoolOptions: DbPoolOptions(
-                maxPoolSize: 10,
-                minPoolSize: 3
-            )
+            dbDirectory: environment.defaultDatabasesDirectory
         )
 
         let client = try await Client.create(account: keys.signingKey, options: clientOptions)

--- a/ConvosInvites/Package.resolved
+++ b/ConvosInvites/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "f2068d7274defba52ed0c02e1ec8bf59d2f7937b2a5e2aac7615f179fe4a0059",
+  "originHash" : "0af6d54eba20a113bed67cb33df8f1bbad656c172dabc1e5dd04912ff988c599",
   "pins" : [
     {
       "identity" : "connect-swift",
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/xmtp/libxmtp.git",
       "state" : {
-        "branch" : "ios-4.10.0-dev.796011d",
-        "revision" : "a76287f985501d0bc63cfc038e37e304d41296a3"
+        "branch" : "ios-4.9.0-dev.6ecd439",
+        "revision" : "297e684d07e78f87da617be80565359c315ba6f0"
       }
     },
     {

--- a/ConvosInvites/Package.swift
+++ b/ConvosInvites/Package.swift
@@ -25,7 +25,7 @@ let package = Package(
         .package(url: "https://github.com/tesseract-one/CSecp256k1.swift.git", from: "0.2.0"),
         .package(
             url: "https://github.com/xmtp/libxmtp.git",
-            revision: "ios-4.10.0-dev.796011d"
+            revision: "ios-4.9.0-dev.88ddfad"
         ),
         .package(path: "../ConvosAppData"),
     ],

--- a/ConvosProfiles/Package.resolved
+++ b/ConvosProfiles/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "07ba9825667936f8d2a56f6b7629adaf24a4a6553b362da83c9383b5bf1a83cd",
+  "originHash" : "138785d609d2af863597c6d4aee17739afbfe1f35b8eadee5ae714d7d14d24a1",
   "pins" : [
     {
       "identity" : "connect-swift",
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/xmtp/libxmtp.git",
       "state" : {
-        "branch" : "ios-4.10.0-dev.796011d",
-        "revision" : "a76287f985501d0bc63cfc038e37e304d41296a3"
+        "branch" : "ios-4.9.0-dev.6ecd439",
+        "revision" : "297e684d07e78f87da617be80565359c315ba6f0"
       }
     },
     {

--- a/ConvosProfiles/Package.swift
+++ b/ConvosProfiles/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
         .package(path: "../ConvosAppData"),
         .package(
             url: "https://github.com/xmtp/libxmtp.git",
-            revision: "ios-4.10.0-dev.796011d"
+            revision: "ios-4.9.0-dev.88ddfad"
         ),
     ],
     targets: [


### PR DESCRIPTION
Reverts #706.

## Why
The XMTPiOS 4.10 upgrade bumps bundled libxmtp from **1.9.1 → 1.10.0**. The `convos` CLI (used for internal QA and likely still in the field) bundles libxmtp 1.9.1 via `@xmtp/node-sdk@5.3.0`. Cross-version JoinRequest DMs are silently dropped — the app sends the request (logs confirm `[EVENT] invite.join_request_sent`) but the CLI's libxmtp 1.9.1 runtime doesn't surface it, so join flows hang indefinitely on "Verifying".

Reproduced during QA on dev right after #706 merged:

- App (dev tip): libxmtp 1.10.0
- CLI (`convos` 0.1.0, `@xmtp/node-bindings@1.9.1`): libxmtp 1.9.1
- Result: `process-join-requests --watch` sees no DMs arrive; app spins forever on the discovery-sync loop.

This isn't only a QA-tooling problem — any real client pair straddling the 1.9 ↔ 1.10 boundary during rollout likely hits the same silent drop, with no user-facing error path.

## What's restored
After this revert, `Package.resolved` pins XMTPiOS back to `ios-4.9.0-dev.88ddfad` (libxmtp 1.9.0), matching what the CLI and older app builds speak.

## Before re-landing
- Bump the `convos` CLI's `@xmtp/node-sdk` to `6.0.0` (bundles libxmtp 1.10.0), publish, and confirm internal QA works.
- Confirm with the XMTP team whether 1.9 ↔ 1.10 wire compat was intended for group DMs / JoinRequest content type, or if this is a known breaking change the app needs to gate on.

## Test plan
- [x] `swift test --package-path ConvosCore`: **590/590 passed** locally on the revert
- [x] `xcodebuild build -scheme "Convos (Dev)"`: **BUILD SUCCEEDED**

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Revert XMTPiOS dependency from 4.10.0-dev to 4.9.0-dev
> Reverts the XMTPiOS SDK pin across all packages from `ios-4.10.0-dev.796011d` back to `ios-4.9.0-dev.88ddfad`. Also reverts related `ClientOptions` API changes in `InboxStateMachine` and test helpers that were introduced alongside the upgrade, including removal of `dbPoolOptions` and `deviceSyncEnabled` arguments.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4860b48.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->