### PR TITLE
Notifications: suppress in-app banner for active convo + conversations list

### DIFF
--- a/Convos/Conversations List/ConversationsView.swift
+++ b/Convos/Conversations List/ConversationsView.swift
@@ -216,6 +216,10 @@ struct ConversationsView: View {
                 if viewModel.selectedConversationViewModel != nil {
                     preferredColumn = .detail
                 }
+                viewModel.onAppear()
+            }
+            .onDisappear {
+                viewModel.onDisappear()
             }
             .onChange(of: viewModel.selectedConversationViewModel == nil) { _, isNil in
                 preferredColumn = isNil ? .sidebar : .detail

--- a/Convos/Conversations List/ConversationsViewModel.swift
+++ b/Convos/Conversations List/ConversationsViewModel.swift
@@ -75,6 +75,8 @@ final class ConversationsViewModel {
                 userInfo: userInfo
             )
         }
+
+        updateListVisibility()
     }
 
     var newConversationViewModel: NewConversationViewModel? {
@@ -87,6 +89,7 @@ final class ConversationsViewModel {
                     userInfo: [:]
                 )
             }
+            updateListVisibility()
         }
     }
     var presentingExplodeInfo: Bool = false
@@ -219,6 +222,26 @@ final class ConversationsViewModel {
         guard horizontalSizeClass != sizeClass else { return }
         horizontalSizeClass = sizeClass
         focusCoordinator.horizontalSizeClass = sizeClass
+    }
+
+    func onAppear() {
+        isVisible = true
+        updateListVisibility()
+    }
+
+    func onDisappear() {
+        isVisible = false
+        updateListVisibility()
+    }
+
+    @ObservationIgnored
+    private var isVisible: Bool = false
+
+    private func updateListVisibility() {
+        let isFocusedOnList = isVisible
+            && selectedConversationViewModel == nil
+            && newConversationViewModel == nil
+        session.setIsOnConversationsList(isFocusedOnList)
     }
 
     deinit {

--- a/ConvosCore/Sources/ConvosCore/Inboxes/MockInboxesService.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/MockInboxesService.swift
@@ -129,6 +129,8 @@ public final class MockInboxesService: SessionManagerProtocol {
         true
     }
 
+    public func setIsOnConversationsList(_ isOn: Bool) {}
+
     public func wakeInboxForNotification(conversationId: String) {}
 
     // MARK: - Helpers

--- a/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
@@ -177,7 +177,7 @@ public final class SessionManager: SessionManagerProtocol, @unchecked Sendable {
         activeConversationObserver = NotificationCenter.default.addObserver(
             forName: .activeConversationChanged,
             object: nil,
-            queue: nil
+            queue: .main
         ) { [weak self] notification in
             let conversationId = notification.userInfo?["conversationId"] as? String
             self?.updateActiveConversation(conversationId)

--- a/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
@@ -27,6 +27,19 @@ public final class SessionManager: SessionManagerProtocol, @unchecked Sendable {
 
     private var foregroundObserverTask: Task<Void, Never>?
     private var assetRenewalTask: Task<Void, Never>?
+    private var activeConversationObserver: NSObjectProtocol?
+
+    /// Tracks the user's current screen context. Used by
+    /// `shouldDisplayNotification(for:)` to suppress in-app banners when they
+    /// would be redundant — either because the user is already viewing the
+    /// target conversation, or because they're on the list where the new-
+    /// message indicator already surfaces the update.
+    private let screenStateLock: OSAllocatedUnfairLock<ScreenState> = .init(initialState: ScreenState())
+
+    private struct ScreenState {
+        var activeConversationId: String?
+        var isOnConversationsList: Bool = false
+    }
 
     private let databaseWriter: any DatabaseWriter
     private let databaseReader: any DatabaseReader
@@ -142,6 +155,9 @@ public final class SessionManager: SessionManagerProtocol, @unchecked Sendable {
         initializationTask?.cancel()
         foregroundObserverTask?.cancel()
         assetRenewalTask?.cancel()
+        if let activeConversationObserver {
+            NotificationCenter.default.removeObserver(activeConversationObserver)
+        }
     }
 
     // MARK: - Private Methods
@@ -156,6 +172,21 @@ public final class SessionManager: SessionManagerProtocol, @unchecked Sendable {
                 guard let self else { return }
                 self.notificationChangeReporter.notifyChangesInDatabase()
             }
+        }
+
+        activeConversationObserver = NotificationCenter.default.addObserver(
+            forName: .activeConversationChanged,
+            object: nil,
+            queue: nil
+        ) { [weak self] notification in
+            let conversationId = notification.userInfo?["conversationId"] as? String
+            self?.updateActiveConversation(conversationId)
+        }
+    }
+
+    private func updateActiveConversation(_ conversationId: String?) {
+        screenStateLock.withLock { state in
+            state.activeConversationId = (conversationId?.isEmpty == false) ? conversationId : nil
         }
     }
 
@@ -505,12 +536,16 @@ public final class SessionManager: SessionManagerProtocol, @unchecked Sendable {
     // MARK: Notifications
 
     public func shouldDisplayNotification(for conversationId: String) async -> Bool {
-        // Always returns true today. The hook exists so the NSE has a
-        // well-defined place to suppress notifications when the target
-        // conversation is already on-screen; until that signal is plumbed
-        // through, erring on the side of over-notification is safer than
-        // silently swallowing a legitimate notification.
-        true
+        let state = screenStateLock.withLock { $0 }
+        if state.isOnConversationsList { return false }
+        if state.activeConversationId == conversationId { return false }
+        return true
+    }
+
+    public func setIsOnConversationsList(_ isOn: Bool) {
+        screenStateLock.withLock { state in
+            state.isOnConversationsList = isOn
+        }
     }
 
     public func notifyChangesInDatabase() {

--- a/ConvosCore/Sources/ConvosCore/Sessions/SessionManagerProtocol.swift
+++ b/ConvosCore/Sources/ConvosCore/Sessions/SessionManagerProtocol.swift
@@ -58,6 +58,12 @@ public protocol SessionManagerProtocol: AnyObject, Sendable {
     func notifyChangesInDatabase()
     func shouldDisplayNotification(for conversationId: String) async -> Bool
 
+    /// Tells the session manager whether the conversations list is currently
+    /// on-screen. Used to suppress in-app notification banners — the list
+    /// already surfaces the new-message indicator, so a banner would be
+    /// redundant.
+    func setIsOnConversationsList(_ isOn: Bool)
+
     /// Ensures the messaging service is ready before processing a notification
     /// for the given conversation. Safe to call from the NSE.
     func wakeInboxForNotification(conversationId: String)

--- a/ConvosCore/Tests/ConvosCoreTests/SessionManagerNotificationSuppressionTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/SessionManagerNotificationSuppressionTests.swift
@@ -1,0 +1,107 @@
+@testable import ConvosCore
+import Foundation
+import Testing
+
+/// Coverage for `SessionManager.shouldDisplayNotification(for:)` — the hook
+/// `ConvosAppDelegate` consults before presenting an in-app banner. The
+/// manager suppresses banners in two cases:
+///
+/// - The user is already viewing the target conversation (active conversation
+///   id matches, fed via `.activeConversationChanged`).
+/// - The user is on the conversations list, where the new-message indicator
+///   already surfaces the update (fed via `setIsOnConversationsList`).
+@Suite("SessionManager notification banner suppression")
+struct SessionManagerNotificationSuppressionTests {
+    @Test("Displays banner when user is on an unrelated screen")
+    func displaysWhenIdle() async throws {
+        let session = makeSession()
+
+        let shouldDisplay = await session.shouldDisplayNotification(for: "conv-1")
+
+        #expect(shouldDisplay == true)
+    }
+
+    @Test("Suppresses banner for the currently-active conversation")
+    func suppressesActiveConversation() async throws {
+        let session = makeSession()
+
+        post(activeConversationId: "conv-1")
+
+        let sameConversation = await session.shouldDisplayNotification(for: "conv-1")
+        let otherConversation = await session.shouldDisplayNotification(for: "conv-2")
+
+        #expect(sameConversation == false)
+        #expect(otherConversation == true)
+    }
+
+    @Test("Resumes banners after active conversation clears")
+    func resumesAfterActiveConversationClears() async throws {
+        let session = makeSession()
+
+        post(activeConversationId: "conv-1")
+        post(activeConversationId: nil)
+
+        let shouldDisplay = await session.shouldDisplayNotification(for: "conv-1")
+
+        #expect(shouldDisplay == true)
+    }
+
+    @Test("Suppresses banners for any conversation while on the list")
+    func suppressesOnConversationsList() async throws {
+        let session = makeSession()
+
+        session.setIsOnConversationsList(true)
+
+        let first = await session.shouldDisplayNotification(for: "conv-1")
+        let second = await session.shouldDisplayNotification(for: "conv-2")
+
+        #expect(first == false)
+        #expect(second == false)
+    }
+
+    @Test("Resumes banners after leaving the list")
+    func resumesAfterLeavingList() async throws {
+        let session = makeSession()
+
+        session.setIsOnConversationsList(true)
+        session.setIsOnConversationsList(false)
+
+        let shouldDisplay = await session.shouldDisplayNotification(for: "conv-1")
+
+        #expect(shouldDisplay == true)
+    }
+
+    @Test("List visibility suppresses banners even with no active conversation")
+    func listVisibilityOverridesNoActive() async throws {
+        let session = makeSession()
+
+        post(activeConversationId: nil)
+        session.setIsOnConversationsList(true)
+
+        let shouldDisplay = await session.shouldDisplayNotification(for: "conv-1")
+
+        #expect(shouldDisplay == false)
+    }
+
+    // MARK: - Helpers
+
+    private func post(activeConversationId: String?) {
+        let userInfo: [AnyHashable: Any] = activeConversationId.map { ["conversationId": $0] } ?? [:]
+        NotificationCenter.default.post(
+            name: .activeConversationChanged,
+            object: nil,
+            userInfo: userInfo
+        )
+    }
+
+    private func makeSession() -> SessionManager {
+        let databaseManager = MockDatabaseManager.makeTestDatabase()
+        return SessionManager(
+            databaseWriter: databaseManager.dbWriter,
+            databaseReader: databaseManager.dbReader,
+            environment: .tests,
+            identityStore: MockKeychainIdentityStore(),
+            platformProviders: .mock
+        )
+    }
+}

--- a/ConvosCore/Tests/ConvosCoreTests/SessionManagerNotificationSuppressionTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/SessionManagerNotificationSuppressionTests.swift
@@ -10,7 +10,7 @@ import Testing
 ///   id matches, fed via `.activeConversationChanged`).
 /// - The user is on the conversations list, where the new-message indicator
 ///   already surfaces the update (fed via `setIsOnConversationsList`).
-@Suite("SessionManager notification banner suppression")
+@Suite("SessionManager notification banner suppression", .serialized)
 struct SessionManagerNotificationSuppressionTests {
     @Test("Displays banner when user is on an unrelated screen")
     func displaysWhenIdle() async throws {

--- a/ConvosTests/ConversationViewModelGlobalDefaultsTests.swift
+++ b/ConvosTests/ConversationViewModelGlobalDefaultsTests.swift
@@ -212,6 +212,10 @@ private final class TestSessionManager: SessionManagerProtocol, @unchecked Senda
         await base.shouldDisplayNotification(for: conversationId)
     }
 
+    func setIsOnConversationsList(_ isOn: Bool) {
+        base.setIsOnConversationsList(isOn)
+    }
+
     func wakeInboxForNotification(conversationId: String) {
         base.wakeInboxForNotification(conversationId: conversationId)
     }


### PR DESCRIPTION
## Summary

Stop showing the in-app notification banner when the user is already looking at the relevant UI — either the conversation the notification belongs to, or the conversations list where the new-message indicator already surfaces it.

## What changed

- `SessionManager` now holds a lock-protected `ScreenState { activeConversationId, isOnConversationsList }` that is read by `shouldDisplayNotification(for:)`.
- `activeConversationId` is fed by a `.activeConversationChanged` observer; `isOnConversationsList` is fed by a new `setIsOnConversationsList(_:)` method on `SessionManagerProtocol`.
- `ConversationsViewModel` toggles the list flag via `onAppear`/`onDisappear`, only when the list is the focus (no selected/new-conversation VM active).
- Added `SessionManagerNotificationSuppressionTests` (Swift Testing, `.serialized`) — 6 cases covering idle, active convo match/miss, list visibility, and mutual exclusion.

## Test plan

- [ ] Foreground app, open convo A, send a push to convo A → no banner
- [ ] Foreground app, open convo A, push arrives for convo B → banner shows
- [ ] Foreground app, on conversations list, push arrives for any convo → no banner
- [ ] Foreground app, on conversation B but a NewConversationViewModel overlay is present → list flag stays false (banner can still show for unrelated convo)
- [ ] Background app, push arrives → standard OS notification path (unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Suppress in-app notification banners for the active conversation and conversations list
> - `SessionManager.shouldDisplayNotification` now returns `false` when the user is on the conversations list or when the target conversation is already active.
> - `ConversationsViewModel` tracks view visibility via `onAppear`/`onDisappear` and calls `session.setIsOnConversationsList(_:)` to update the session manager whenever selection state or list focus changes.
> - `SessionManager` observes `.activeConversationChanged` notifications to track the active conversation ID under a lock alongside list visibility state.
> - A new test suite in [SessionManagerNotificationSuppressionTests.swift](https://github.com/xmtplabs/convos-ios/pull/727/files#diff-ecd5f7dd6a4104cd92ea02143072ba959f6a920df365aa8c006144c39b344af7) covers suppression behavior across idle, active, and list-focused states.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8c56cfe.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->