### PR TITLE
Side convos: stop re-running quickname prompts after completion

### DIFF
--- a/Convos/Conversation Detail/ConversationOnboardingCoordinator.swift
+++ b/Convos/Conversation Detail/ConversationOnboardingCoordinator.swift
@@ -357,6 +357,16 @@ final class ConversationOnboardingCoordinator {
 
     /// Start or continue the quickname onboarding flow
     private func startQuicknameFlow(for clientId: String) async {
+        // Once the user finishes onboarding, the quickname prompts stop running
+        // in subsequent conversations. Notification nudges still run via the
+        // shared path below, but no setupQuickname or addQuickname state is
+        // surfaced per new conversation.
+        guard !hasCompletedOnboarding else {
+            QAEvent.emit(.onboarding, "quickname_skipped", ["reason": "already_completed"])
+            await transitionAfterQuickname()
+            return
+        }
+
         let hasSetQuicknameForConversation = hasSetQuickname(for: clientId)
         setHasSetQuickname(true, for: clientId)
 

--- a/ConvosTests/ConversationOnboardingCoordinatorTests.swift
+++ b/ConvosTests/ConversationOnboardingCoordinatorTests.swift
@@ -238,6 +238,37 @@ final class ConversationOnboardingCoordinatorTests: XCTestCase {
         XCTAssertFalse(UserDefaults.standard.bool(forKey: "hasSetQuicknameForConversation_\(testConversationId)"))
     }
 
+    // MARK: - Completed Onboarding Tests
+
+    func testStart_HasCompletedOnboarding_SkipsQuicknameForNewConversation() async {
+        mockNotificationCenter.authStatus = .authorized
+        UserDefaults.standard.set(true, forKey: "hasCompletedConversationOnboarding")
+        UserDefaults.standard.set(true, forKey: "hasShownQuicknameEditor")
+
+        let newConversationId = "side-convo-opened-for-first-time"
+        await coordinator.start(for: newConversationId)
+
+        XCTAssertEqual(coordinator.state, .idle)
+        // The guard returns before `setHasSetQuickname(true, for:)` would
+        // normally run, so a regression that drops the guard flips this flag.
+        XCTAssertFalse(
+            UserDefaults.standard.bool(forKey: "hasSetQuicknameForConversation_\(newConversationId)")
+        )
+        UserDefaults.standard.removeObject(forKey: "hasSetQuicknameForConversation_\(newConversationId)")
+    }
+
+    func testStart_HasCompletedOnboarding_NotificationsDenied_StillNudges() async {
+        mockNotificationCenter.authStatus = .denied
+        UserDefaults.standard.set(true, forKey: "hasCompletedConversationOnboarding")
+        UserDefaults.standard.set(true, forKey: "hasShownQuicknameEditor")
+
+        let newConversationId = "side-convo-opened-for-first-time"
+        await coordinator.start(for: newConversationId)
+
+        XCTAssertEqual(coordinator.state, .notificationsDenied)
+        UserDefaults.standard.removeObject(forKey: "hasSetQuicknameForConversation_\(newConversationId)")
+    }
+
     // MARK: - App Lifecycle Tests
 
     func testAppBecomesActive_CompletedState_NotificationsDenied_ShowsDeniedState() async {


### PR DESCRIPTION
## Summary

Fixes the bug where the conversation-onboarding flow (specifically the "Tap to chat as [Name]" `.addQuickname` prompt) was shown every time the user entered a new conversation — including side convos opened from the parent's messages list — even after they had finished onboarding.

## Root cause

`hasCompletedOnboarding` is set to `true` on `complete()` but was **never read** by any gate in the flow. The `.addQuickname` branch's sole decision was the per-conversation `hasSetQuickname(for:)` flag, which is `false` for every new conversation id. So every new conversation triggered the prompt.

## The fix

A single guard at the top of `startQuicknameFlow(for:)` that short-circuits to `transitionAfterQuickname` when the user has already finished onboarding. Notification nudges still run via the shared path, so denied-permission prompts continue to surface in new conversations.

This is deliberately narrower than the earlier rejected singleton approach — it addresses the root cause without introducing cross-VM state leakage.

## Test plan

- [ ] First-time user: enter first convo → setup flow shows (unchanged)
- [ ] Complete onboarding in first convo
- [ ] Open a new side convo from the parent's messages list → no quickname prompt, no setup flow, no "Tap to chat as Name"
- [ ] Open a second brand-new regular convo after onboarding → no quickname prompt either
- [ ] User with denied notifications opens a new convo after onboarding → `.notificationsDenied` nudge still surfaces (confirmed by new test)
- [ ] Existing test suite for `ConversationOnboardingCoordinatorTests` passes (2 new tests added)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Skip quickname prompt in side convos when onboarding is already completed
> In `ConversationOnboardingCoordinator.startQuicknameFlow`, adds an early guard that checks `hasCompletedOnboarding`. When true, it emits a `quickname_skipped` analytics event and calls `transitionAfterQuickname()` directly, bypassing the quickname UI and per-conversation flag. Two new tests cover this path: one for authorized notifications (expects `.idle` state) and one for denied notifications (expects `.notificationsDenied` state).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 087e446.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->