### PR TITLE
Composer: keep input bar expanded when editing side-convo name

### DIFF
--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -52,7 +52,10 @@ struct ConversationView<MessagesBottomBar: View>: View {
             pendingInviteImage: $viewModel.pendingInviteImage,
             pendingInviteExplodeDuration: viewModel.pendingInvite?.explodeDuration,
             onSetInviteExplodeDuration: { duration in viewModel.setInviteExplodeDuration(duration) },
-            onInviteConvoNameEditingEnded: { name in viewModel.updateLinkedConversationName(name) },
+            onInviteConvoNameEditingEnded: { name in
+                viewModel.updateLinkedConversationName(name)
+                focusCoordinator.endEditing(for: .editingSideConvoName, context: .quickEditor)
+            },
             sendButtonEnabled: viewModel.sendButtonEnabled,
             profileImage: $viewModel.myProfileViewModel.profileImage,
             onboardingCoordinator: onboardingCoordinator,

--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -54,7 +54,7 @@ struct ConversationView<MessagesBottomBar: View>: View {
             onSetInviteExplodeDuration: { duration in viewModel.setInviteExplodeDuration(duration) },
             onInviteConvoNameEditingEnded: { name in
                 viewModel.updateLinkedConversationName(name)
-                focusCoordinator.endEditing(for: .editingSideConvoName, context: .quickEditor)
+                focusCoordinator.endEditing(for: .sideConvoName, context: .quickEditor)
             },
             sendButtonEnabled: viewModel.sendButtonEnabled,
             profileImage: $viewModel.myProfileViewModel.profileImage,

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesBottomBar.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesBottomBar.swift
@@ -4,7 +4,7 @@ import PhotosUI
 import SwiftUI
 
 enum MessagesViewInputFocus: Hashable {
-    case message, displayName, conversationName, voiceMemoRecording, editingSideConvoName
+    case message, displayName, conversationName, voiceMemoRecording, sideConvoName
 }
 
 struct MessagesBottomBar<BottomBarContent: View>: View {
@@ -93,7 +93,7 @@ struct MessagesBottomBar<BottomBarContent: View>: View {
                 isExpanded = newValue == .displayName
                 isMessageInputFocused = newValue == .message
                     || newValue == .voiceMemoRecording
-                    || newValue == .editingSideConvoName
+                    || newValue == .sideConvoName
             }
         }
         .onChange(of: messageText) { _, _ in

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesBottomBar.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesBottomBar.swift
@@ -4,7 +4,7 @@ import PhotosUI
 import SwiftUI
 
 enum MessagesViewInputFocus: Hashable {
-    case message, displayName, conversationName, voiceMemoRecording
+    case message, displayName, conversationName, voiceMemoRecording, editingSideConvoName
 }
 
 struct MessagesBottomBar<BottomBarContent: View>: View {
@@ -91,7 +91,9 @@ struct MessagesBottomBar<BottomBarContent: View>: View {
 
             withAnimation(.bouncy(duration: 0.4, extraBounce: 0.01)) {
                 isExpanded = newValue == .displayName
-                isMessageInputFocused = newValue == .message || newValue == .voiceMemoRecording
+                isMessageInputFocused = newValue == .message
+                    || newValue == .voiceMemoRecording
+                    || newValue == .editingSideConvoName
             }
         }
         .onChange(of: messageText) { _, _ in

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesInputView.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesInputView.swift
@@ -510,7 +510,7 @@ private struct ComposerSideConvoCard: View {
     @ViewBuilder
     private var nameField: some View {
         TextField("Convo name", text: $convoName)
-            .focused($focusState, equals: .editingSideConvoName)
+            .focused($focusState, equals: .sideConvoName)
             .font(.callout)
             .foregroundStyle(.colorTextPrimary)
             .padding(.horizontal, DesignConstants.Spacing.step3x)

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesInputView.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesInputView.swift
@@ -222,6 +222,7 @@ struct MessagesInputView: View {
                 convoName: $pendingInviteConvoName,
                 convoImage: $pendingInviteImage,
                 explodeDuration: pendingInviteExplodeDuration,
+                focusState: $focusState,
                 onSetExplodeDuration: onSetInviteExplodeDuration,
                 onNameEditingEnded: onInviteConvoNameEditingEnded
             )
@@ -423,6 +424,7 @@ private struct ComposerSideConvoCard: View {
     @Binding var convoName: String
     @Binding var convoImage: UIImage?
     var explodeDuration: ExplodeDuration?
+    @FocusState.Binding var focusState: MessagesViewInputFocus?
     var onSetExplodeDuration: ((ExplodeDuration?) -> Void)?
     var onNameEditingEnded: ((String) -> Void)?
 
@@ -508,6 +510,7 @@ private struct ComposerSideConvoCard: View {
     @ViewBuilder
     private var nameField: some View {
         TextField("Convo name", text: $convoName)
+            .focused($focusState, equals: .editingSideConvoName)
             .font(.callout)
             .foregroundStyle(.colorTextPrimary)
             .padding(.horizontal, DesignConstants.Spacing.step3x)

--- a/Convos/Shared Views/FocusCoordinator.swift
+++ b/Convos/Shared Views/FocusCoordinator.swift
@@ -98,7 +98,7 @@ final class FocusCoordinator {
 
         case (.displayName, .quickEditor),
             (.conversationName, .quickEditor),
-            (.editingSideConvoName, .quickEditor):
+            (.sideConvoName, .quickEditor):
             // In quickEditor context, return to whatever was focused before
             // If nothing was tracked, fall back to message field or default
             return previousFocus ?? defaultFocus ?? .message
@@ -122,7 +122,7 @@ final class FocusCoordinator {
             // Message field and voice memo keeper end editing, go to default
             return defaultFocus
 
-        case (.editingSideConvoName, _):
+        case (.sideConvoName, _):
             // Any non-quickEditor end of side-convo name editing falls through to default
             return defaultFocus
 
@@ -135,7 +135,7 @@ final class FocusCoordinator {
     func dismissQuickEditor() {
         guard currentFocus == .displayName
             || currentFocus == .conversationName
-            || currentFocus == .editingSideConvoName else {
+            || currentFocus == .sideConvoName else {
             return
         }
 
@@ -280,7 +280,7 @@ final class FocusCoordinator {
         // Don't treat a nil-sync as manual dismissal while actively editing a quick-editor field.
         // SwiftUI can momentarily drive focus to nil while the composer re-renders around the
         // inline card, and collapsing the bar would yank the user out of their edit.
-        if currentFocus == .editingSideConvoName {
+        if currentFocus == .sideConvoName {
             Log.info("Ignoring manual dismissal while editing side convo name")
             return
         }
@@ -307,7 +307,7 @@ final class FocusCoordinator {
 
     private func updateFocusForSizeClassChange() {
         // Only auto-adjust if we're currently at nil, .message, or .voiceMemoRecording
-        // Don't interrupt active editing of displayName, conversationName, or editingSideConvoName
+        // Don't interrupt active editing of displayName, conversationName, or sideConvoName
         guard currentFocus == nil || currentFocus == .message || currentFocus == .voiceMemoRecording else {
             return
         }
@@ -423,7 +423,7 @@ final class FocusCoordinator {
 
         // If keyboard type changed, update current focus to match new default
         // Only do this if we're currently at nil
-        // Don't interrupt active editing of displayName, conversationName, or editingSideConvoName
+        // Don't interrupt active editing of displayName, conversationName, or sideConvoName
         guard currentFocus == nil else { return }
         let newDefault = defaultFocus
 

--- a/Convos/Shared Views/FocusCoordinator.swift
+++ b/Convos/Shared Views/FocusCoordinator.swift
@@ -97,7 +97,8 @@ final class FocusCoordinator {
             return nil
 
         case (.displayName, .quickEditor),
-            (.conversationName, .quickEditor):
+            (.conversationName, .quickEditor),
+            (.editingSideConvoName, .quickEditor):
             // In quickEditor context, return to whatever was focused before
             // If nothing was tracked, fall back to message field or default
             return previousFocus ?? defaultFocus ?? .message
@@ -121,14 +122,20 @@ final class FocusCoordinator {
             // Message field and voice memo keeper end editing, go to default
             return defaultFocus
 
+        case (.editingSideConvoName, _):
+            // Any non-quickEditor end of side-convo name editing falls through to default
+            return defaultFocus
+
         default:
             return defaultFocus
         }
     }
 
-    /// Moves focus to `message` if we're currently focusing the displayName or conversationName
+    /// Moves focus to `message` if we're currently focusing a quick-editor field
     func dismissQuickEditor() {
-        guard currentFocus == .displayName || currentFocus == .conversationName else {
+        guard currentFocus == .displayName
+            || currentFocus == .conversationName
+            || currentFocus == .editingSideConvoName else {
             return
         }
 
@@ -262,11 +269,19 @@ final class FocusCoordinator {
 
     /// Called when user manually dismisses keyboard - should return to default or stay nil
     func handleManualDismissal(viewIsAlreadyAt viewFocus: MessagesViewInputFocus? = nil) {
-        // Ignore if we're in the middle of ANY transition
+        // Ignore if we're in the middle of any transition
         // This prevents false positives when SwiftUI temporarily sets focus to nil
         // while transitioning between text fields
         guard !isProgrammaticTransition && !isSwiftUITransition else {
             Log.info("Ignoring manual dismissal during transition (programmatic: \(isProgrammaticTransition), swiftUI: \(isSwiftUITransition))")
+            return
+        }
+
+        // Don't treat a nil-sync as manual dismissal while actively editing a quick-editor field.
+        // SwiftUI can momentarily drive focus to nil while the composer re-renders around the
+        // inline card, and collapsing the bar would yank the user out of their edit.
+        if currentFocus == .editingSideConvoName {
+            Log.info("Ignoring manual dismissal while editing side convo name")
             return
         }
 
@@ -292,7 +307,7 @@ final class FocusCoordinator {
 
     private func updateFocusForSizeClassChange() {
         // Only auto-adjust if we're currently at nil, .message, or .voiceMemoRecording
-        // Don't interrupt active editing of displayName or conversationName
+        // Don't interrupt active editing of displayName, conversationName, or editingSideConvoName
         guard currentFocus == nil || currentFocus == .message || currentFocus == .voiceMemoRecording else {
             return
         }
@@ -408,7 +423,7 @@ final class FocusCoordinator {
 
         // If keyboard type changed, update current focus to match new default
         // Only do this if we're currently at nil
-        // Don't interrupt active editing of displayName or conversationName
+        // Don't interrupt active editing of displayName, conversationName, or editingSideConvoName
         guard currentFocus == nil else { return }
         let newDefault = defaultFocus
 

--- a/ConvosTests/FocusCoordinatorTests.swift
+++ b/ConvosTests/FocusCoordinatorTests.swift
@@ -16,40 +16,78 @@ final class FocusCoordinatorTests: XCTestCase {
         try await super.tearDown()
     }
 
-    func testMoveToEditingSideConvoNamePreservesFocus() {
-        coordinator.moveFocus(to: .editingSideConvoName)
-        coordinator.syncFocusState(.editingSideConvoName)
+    func testMoveToSideConvoNamePreservesFocus() {
+        coordinator.moveFocus(to: .sideConvoName)
+        coordinator.syncFocusState(.sideConvoName)
 
-        XCTAssertEqual(coordinator.currentFocus, .editingSideConvoName)
+        XCTAssertEqual(coordinator.currentFocus, .sideConvoName)
     }
 
     func testEndEditingSideConvoNameReturnsToMessage() {
         coordinator.moveFocus(to: .message)
         coordinator.syncFocusState(.message)
 
-        coordinator.moveFocus(to: .editingSideConvoName)
-        coordinator.syncFocusState(.editingSideConvoName)
+        coordinator.moveFocus(to: .sideConvoName)
+        coordinator.syncFocusState(.sideConvoName)
 
-        coordinator.endEditing(for: .editingSideConvoName, context: .quickEditor)
+        coordinator.endEditing(for: .sideConvoName, context: .quickEditor)
 
         XCTAssertEqual(coordinator.currentFocus, .message)
     }
 
     func testSizeClassChangeDoesNotInterruptSideConvoNameEditing() {
-        coordinator.moveFocus(to: .editingSideConvoName)
-        coordinator.syncFocusState(.editingSideConvoName)
+        coordinator.moveFocus(to: .sideConvoName)
+        coordinator.syncFocusState(.sideConvoName)
 
         coordinator.horizontalSizeClass = .regular
 
-        XCTAssertEqual(coordinator.currentFocus, .editingSideConvoName)
+        XCTAssertEqual(coordinator.currentFocus, .sideConvoName)
     }
 
     func testNilSyncWhileEditingSideConvoNameIsIgnored() {
-        coordinator.moveFocus(to: .editingSideConvoName)
-        coordinator.syncFocusState(.editingSideConvoName)
+        coordinator.moveFocus(to: .sideConvoName)
+        coordinator.syncFocusState(.sideConvoName)
 
         coordinator.syncFocusState(nil)
 
-        XCTAssertEqual(coordinator.currentFocus, .editingSideConvoName)
+        XCTAssertEqual(coordinator.currentFocus, .sideConvoName)
+    }
+
+    func testSwiftUIInitiatedFocusToSideConvoNameFromMessagePreservesReturnPath() {
+        coordinator.moveFocus(to: .message)
+        coordinator.syncFocusState(.message)
+
+        // Simulates a user tap on the side-convo name field that drives focus
+        // via SwiftUI's FocusState without going through moveFocus first.
+        coordinator.syncFocusState(.sideConvoName)
+        XCTAssertEqual(coordinator.currentFocus, .sideConvoName)
+
+        coordinator.endEditing(for: .sideConvoName, context: .quickEditor)
+
+        XCTAssertEqual(coordinator.currentFocus, .message)
+    }
+
+    func testDismissQuickEditorFromSideConvoNameMovesToMessage() {
+        coordinator.moveFocus(to: .sideConvoName)
+        coordinator.syncFocusState(.sideConvoName)
+
+        coordinator.dismissQuickEditor()
+
+        XCTAssertEqual(coordinator.currentFocus, .message)
+    }
+
+    func testEndEditingSideConvoNameOutsideQuickEditorFallsThroughToDefault() {
+        coordinator.moveFocus(to: .sideConvoName)
+        coordinator.syncFocusState(.sideConvoName)
+
+        // A non-quickEditor context should hit the `(.sideConvoName, _)`
+        // fallthrough arm in `nextFocus(after:context:)` and land on the
+        // default focus rather than the `previousFocus` return path.
+        coordinator.endEditing(for: .sideConvoName, context: .conversation)
+
+        // On compact size class the default focus is the message field, so
+        // this also ensures the coordinator doesn't get wedged on
+        // `.sideConvoName` when a non-quickEditor end-of-edit signal arrives.
+        XCTAssertNotEqual(coordinator.currentFocus, .sideConvoName)
     }
 }

--- a/ConvosTests/FocusCoordinatorTests.swift
+++ b/ConvosTests/FocusCoordinatorTests.swift
@@ -1,0 +1,55 @@
+import SwiftUI
+import XCTest
+@testable import Convos
+
+@MainActor
+final class FocusCoordinatorTests: XCTestCase {
+    var coordinator: FocusCoordinator!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        coordinator = FocusCoordinator(horizontalSizeClass: .compact)
+    }
+
+    override func tearDown() async throws {
+        coordinator = nil
+        try await super.tearDown()
+    }
+
+    func testMoveToEditingSideConvoNamePreservesFocus() {
+        coordinator.moveFocus(to: .editingSideConvoName)
+        coordinator.syncFocusState(.editingSideConvoName)
+
+        XCTAssertEqual(coordinator.currentFocus, .editingSideConvoName)
+    }
+
+    func testEndEditingSideConvoNameReturnsToMessage() {
+        coordinator.moveFocus(to: .message)
+        coordinator.syncFocusState(.message)
+
+        coordinator.moveFocus(to: .editingSideConvoName)
+        coordinator.syncFocusState(.editingSideConvoName)
+
+        coordinator.endEditing(for: .editingSideConvoName, context: .quickEditor)
+
+        XCTAssertEqual(coordinator.currentFocus, .message)
+    }
+
+    func testSizeClassChangeDoesNotInterruptSideConvoNameEditing() {
+        coordinator.moveFocus(to: .editingSideConvoName)
+        coordinator.syncFocusState(.editingSideConvoName)
+
+        coordinator.horizontalSizeClass = .regular
+
+        XCTAssertEqual(coordinator.currentFocus, .editingSideConvoName)
+    }
+
+    func testNilSyncWhileEditingSideConvoNameIsIgnored() {
+        coordinator.moveFocus(to: .editingSideConvoName)
+        coordinator.syncFocusState(.editingSideConvoName)
+
+        coordinator.syncFocusState(nil)
+
+        XCTAssertEqual(coordinator.currentFocus, .editingSideConvoName)
+    }
+}


### PR DESCRIPTION
## Summary

Fixes a regression where starting to edit a side-convo's name inside the message composer would collapse the messages input bar. The composer now treats the side-convo name field as part of the input-focused state, and the focus coordinator routes the end-of-edit back to the message field via the existing quickEditor context.

## What changed

- New case `.sideConvoName` on `MessagesViewInputFocus` (deliberately named to match the other field-name cases — `.message`, `.displayName`, `.conversationName`).
- `isMessageInputFocused` includes `.sideConvoName`, so the bar stays expanded while the user types.
- Thread `@FocusState.Binding` into `ComposerSideConvoCard` so SwiftUI's focus state and the coordinator stay in sync.
- `FocusCoordinator.nextFocus(after:context:)` adds `(.sideConvoName, .quickEditor) → previousFocus` and a `(.sideConvoName, _) → defaultFocus` fallthrough.
- `dismissQuickEditor` guard list updated; nil-sync guard preserves `.sideConvoName` during SwiftUI's momentary nil dips.
- First `FocusCoordinator` tests in the repo — 7 cases covering preserve-on-focus, return-to-message on end, size-class invariance, nil-sync tolerance, SwiftUI-initiated tap path, `dismissQuickEditor`, and non-quickEditor fallthrough.

## Test plan

- [ ] Open a conversation with a side-convo composer card visible
- [ ] Tap the side-convo name field — messages input bar stays expanded
- [ ] Type a name, tap return → bar remains expanded, focus returns to message field
- [ ] Rotate to iPad/regular size class mid-edit → focus does not flip
- [ ] Tap outside the card → dismissQuickEditor moves focus back to message
- [ ] ConvosTests/FocusCoordinatorTests.swift all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Keep composer input bar expanded while editing side-convo name
> - A new `.sideConvoName` focus state is added to `MessagesViewInputFocus`, and the `MessagesBottomBar` treats it the same as `.message` for expansion/animation purposes.
> - `ComposerSideConvoCard`'s name `TextField` is bound to `.sideConvoName` via a passed-in `@FocusState.binding`, integrating it with the shared focus coordinator.
> - `FocusCoordinator` is updated to handle `.sideConvoName` in focus transitions: returning to the previous field on quick-editor completion, ignoring manual dismissal, and blocking focus shifts on size-class or keyboard-type changes while the field is active.
> - New tests in `FocusCoordinatorTests` cover the full range of `.sideConvoName` focus behaviors.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4ea8a92.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->