### PR TITLE
Conversation: fix double-tap reactions in the new conversation view

### DIFF
--- a/Convos/Conversation Detail/Messages/MessagesListView/MessageContextMenu/MessageContextMenuState.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessageContextMenu/MessageContextMenuState.swift
@@ -9,7 +9,6 @@ class MessageContextMenuState: @unchecked Sendable {
     var bubbleStyle: MessageBubbleType = .normal
     var isReplyParent: Bool = false
     var sourceID: UUID?
-    var onReaction: ((String, String) -> Void)?
     var onToggleReaction: ((String, String) -> Void)?
 
     var currentSourceFrame: CGRect = .zero

--- a/Convos/Conversation Detail/Messages/MessagesView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesView.swift
@@ -193,7 +193,6 @@ struct MessagesView<BottomBarContent: View>: View {
             )
         }
         .onChange(of: conversation.id, initial: true) { _, _ in
-            contextMenuState.onReaction = onReaction
             contextMenuState.onToggleReaction = onToggleReaction
         }
     }

--- a/Convos/Conversation Detail/Messages/MessagesView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesView.swift
@@ -192,7 +192,7 @@ struct MessagesView<BottomBarContent: View>: View {
                 onPhotoHidden: onPhotoHidden
             )
         }
-        .onAppear {
+        .onChange(of: conversation.id, initial: true) { _, _ in
             contextMenuState.onReaction = onReaction
             contextMenuState.onToggleReaction = onToggleReaction
         }


### PR DESCRIPTION
## Summary

Double-tap reactions in the new conversation view were silently dropped — the gesture fired but the reaction never persisted to the database or sent to the network.

## Root cause

The new conversation view shows an initial placeholder `ConversationViewModel` backed by `MockMessagingService` (and therefore `MockReactionWriter`) while the real inbox is being acquired asynchronously. Once the real messaging service is ready, `NewConversationViewModel` swaps `conversationViewModel` for a real one.

`MessagesView` assigned the reaction closures onto `MessageContextMenuState` in `.onAppear`, which only fires once per view instance. The double-tap path in `MessageGestureModifier` reads `contextMenuState.onToggleReaction` — so after the VM swap, that state still held a closure bound to the placeholder's `MockReactionWriter`, which only records reactions in memory. Long-press context-menu reactions kept working because `MessageContextMenuOverlay` receives `onReaction` as a prop (fresh every render) rather than reading from the state.

## Fix

Switch the closure assignment from `.onAppear` to `.onChange(of: conversation.id, initial: true)`. The conversation id changes when the placeholder VM is swapped for the real one (different draft UUIDs) and again when the draft resolves to a real network id, so the state's closures are rebound to the current view model each time.

## Test plan

- [ ] Open the new conversation sheet, wait for it to load, send a message, and double-tap it — the heart reaction should appear and persist across relaunch.
- [ ] Same flow, but double-tap immediately after the conversation settles — confirm the reaction is sent to the network (visible to other participants).
- [ ] Open an existing conversation and confirm double-tap reactions still work (no regression on the non-draft path).
- [ ] Long-press a message and add a reaction from the context menu — confirm still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix double-tap reactions in the new conversation view
> Replace the `onAppear` block in [`MessagesView`](https://github.com/xmtplabs/convos-ios/pull/731/files#diff-ed03fcb26f82246b5e4b0ca3729f60a4c55ff6422fb9ac8e16bf1a7fc4ff37f1) with an `onChange` handler on `conversation.id` (with `initial: true`) to ensure `onToggleReaction` is set both on initial load and on conversation changes. Also removes the now-unused `onReaction` property from [`MessageContextMenuState`](https://github.com/xmtplabs/convos-ios/pull/731/files#diff-f943ad66dd73fe96b88c74f157f8756b0174788b17ff7993e2547e92dad4da0a).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3fc7243.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->