### PR TITLE
Messages: thread reaction handler as a prop instead of a shared state slot

### DIFF
--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Cells/MessagesListItemTypeCell.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Cells/MessagesListItemTypeCell.swift
@@ -92,6 +92,7 @@ class MessagesListItemTypeCell: UICollectionViewCell {
                         onTapInvite: config.onTapInvite,
                         onTapReactions: config.onTapReactions,
                         onReaction: config.onReaction,
+                        onToggleReaction: config.onToggleReaction,
                         onReply: config.onReply,
                         onPhotoRevealed: config.onPhotoRevealed,
                         onPhotoHidden: config.onPhotoHidden,

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Data Source/CellFactory.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Data Source/CellFactory.swift
@@ -8,6 +8,7 @@ struct CellConfig {
     let onTapAvatar: (AnyMessage) -> Void
     let onTapReactions: (AnyMessage) -> Void
     let onReaction: (String, String) -> Void
+    let onToggleReaction: (String, String) -> Void
     let onReply: (AnyMessage) -> Void
     let contextMenuState: MessageContextMenuState
     let onPhotoRevealed: (String) -> Void

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Data Source/MessagesCollectionDataSource.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Data Source/MessagesCollectionDataSource.swift
@@ -9,6 +9,7 @@ protocol MessagesCollectionDataSource: UICollectionViewDataSource, MessagesLayou
     var onTapAvatar: ((ConversationMember) -> Void)? { get set }
     var onTapReactions: ((AnyMessage) -> Void)? { get set }
     var onReaction: ((String, String) -> Void)? { get set }
+    var onToggleReaction: ((String, String) -> Void)? { get set }
     var onReply: ((AnyMessage) -> Void)? { get set }
     var contextMenuState: MessageContextMenuState? { get set }
     var shouldBlurPhotos: Bool { get set }

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Data Source/MessagesCollectionViewDataSource.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Data Source/MessagesCollectionViewDataSource.swift
@@ -18,6 +18,7 @@ final class MessagesCollectionViewDataSource: NSObject {
     var onTapInvite: ((MessageInvite) -> Void)?
     var onTapReactions: ((AnyMessage) -> Void)?
     var onReaction: ((String, String) -> Void)?
+    var onToggleReaction: ((String, String) -> Void)?
     var onReply: ((AnyMessage) -> Void)?
     var contextMenuState: MessageContextMenuState?
     var onPhotoRevealed: ((String) -> Void)?
@@ -88,6 +89,9 @@ extension MessagesCollectionViewDataSource: UICollectionViewDataSource {
             },
             onReaction: { [weak self] emoji, messageId in
                 self?.onReaction?(emoji, messageId)
+            },
+            onToggleReaction: { [weak self] emoji, messageId in
+                self?.onToggleReaction?(emoji, messageId)
             },
             onReply: { [weak self] message in
                 self?.onReply?(message)

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/MessagesViewController.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/MessagesViewController.swift
@@ -174,6 +174,7 @@ final class MessagesViewController: UIViewController {
     var onTapAvatar: ((ConversationMember) -> Void)?
     var onLoadPreviousMessages: (() -> Void)?
     var onReaction: ((String, String) -> Void)?
+    var onToggleReaction: ((String, String) -> Void)?
     var onTapReactions: ((AnyMessage) -> Void)?
     var onReply: ((AnyMessage) -> Void)?
     var contextMenuState: MessageContextMenuState = .init() {
@@ -342,6 +343,10 @@ final class MessagesViewController: UIViewController {
         dataSource.onReaction = { [weak self] emoji, messageId in
             guard let self = self else { return }
             self.onReaction?(emoji, messageId)
+        }
+        dataSource.onToggleReaction = { [weak self] emoji, messageId in
+            guard let self = self else { return }
+            self.onToggleReaction?(emoji, messageId)
         }
         dataSource.onReply = { [weak self] message in
             guard let self = self else { return }

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesBottomBar.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesBottomBar.swift
@@ -364,6 +364,7 @@ struct MessagesBottomBar<BottomBarContent: View>: View {
             onLoadPreviousMessages: {},
             onTapInvite: { _ in },
             onReaction: { _, _ in },
+            onToggleReaction: { _, _ in },
             onTapReactions: { _ in },
             onReply: { _ in },
             contextMenuState: .init(),

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessageContextMenu/MessageContextMenuState.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessageContextMenu/MessageContextMenuState.swift
@@ -9,8 +9,6 @@ class MessageContextMenuState: @unchecked Sendable {
     var bubbleStyle: MessageBubbleType = .normal
     var isReplyParent: Bool = false
     var sourceID: UUID?
-    var onReaction: ((String, String) -> Void)?
-    var onToggleReaction: ((String, String) -> Void)?
 
     var currentSourceFrame: CGRect = .zero
 

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessageContextMenuWrapper.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessageContextMenuWrapper.swift
@@ -23,6 +23,7 @@ struct MessageGestureModifier: ViewModifier {
     let onSingleTap: (() -> Void)?
     let onDoubleTap: (() -> Void)?
     let onReply: (AnyMessage) -> Void
+    let onToggleReaction: (String, String) -> Void
     var externalSwipeOffset: Binding<CGFloat>?
 
     @State private var swipeOffset: CGFloat = 0
@@ -90,7 +91,7 @@ struct MessageGestureModifier: ViewModifier {
                                 onDoubleTap()
                             } else {
                                 UIImpactFeedbackGenerator(style: .light).impactOccurred()
-                                contextMenuState.onToggleReaction?(doubleTapEmoji, message.messageId)
+                                onToggleReaction(doubleTapEmoji, message.messageId)
                             }
                         },
                         onLongPress: {
@@ -120,7 +121,7 @@ struct MessageGestureModifier: ViewModifier {
                 }
             }
             .accessibilityAction(named: "React") {
-                contextMenuState.onToggleReaction?(doubleTapEmoji, message.messageId)
+                onToggleReaction(doubleTapEmoji, message.messageId)
             }
             .accessibilityAction(named: "Reply") {
                 onReply(message)
@@ -154,6 +155,7 @@ extension View {
         onSingleTap: (() -> Void)? = nil,
         onDoubleTap: (() -> Void)? = nil,
         onReply: @escaping (AnyMessage) -> Void,
+        onToggleReaction: @escaping (String, String) -> Void,
         swipeOffset: Binding<CGFloat>? = nil
     ) -> some View {
         modifier(MessageGestureModifier(
@@ -162,6 +164,7 @@ extension View {
             onSingleTap: onSingleTap,
             onDoubleTap: onDoubleTap,
             onReply: onReply,
+            onToggleReaction: onToggleReaction,
             externalSwipeOffset: swipeOffset
         ))
     }

--- a/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/VoiceMemoBubble.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/VoiceMemoBubble.swift
@@ -13,6 +13,7 @@ struct VoiceMemoAttachmentView: View {
     let attachment: HydratedAttachment
     let bubbleType: MessageBubbleType
     let onReply: (AnyMessage) -> Void
+    let onToggleReaction: (String, String) -> Void
     var transcript: VoiceMemoTranscriptListItem?
     var onRetryTranscript: ((VoiceMemoTranscriptListItem) -> Void)?
 
@@ -34,7 +35,8 @@ struct VoiceMemoAttachmentView: View {
         .messageGesture(
             message: message,
             bubbleStyle: bubbleType,
-            onReply: onReply
+            onReply: onReply,
+            onToggleReaction: onToggleReaction
         )
     }
 }

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
@@ -17,6 +17,7 @@ struct MessagesGroupItemView: View {
     var onOpenFile: ((HydratedAttachment) -> Void)?
     var onTapReactions: ((AnyMessage) -> Void)?
     var onReaction: ((String, String) -> Void)?
+    let onToggleReaction: (String, String) -> Void
     var voiceMemoTranscript: VoiceMemoTranscriptListItem?
     var voiceMemoTranscriptIsTailed: Bool = false
     var onRetryTranscript: ((VoiceMemoTranscriptListItem) -> Void)?
@@ -110,7 +111,8 @@ struct MessagesGroupItemView: View {
             .messageGesture(
                 message: message,
                 bubbleStyle: message.content.isEmoji ? .none : bubbleType,
-                onReply: onReply
+                onReply: onReply,
+                onToggleReaction: onToggleReaction
             )
             .id("bubble-\(message.messageId)")
             .scaleEffect(isAppearing ? 0.9 : 1.0)
@@ -138,7 +140,8 @@ struct MessagesGroupItemView: View {
             .messageGesture(
                 message: message,
                 bubbleStyle: .none,
-                onReply: onReply
+                onReply: onReply,
+                onToggleReaction: onToggleReaction
             )
             .id("emoji-bubble-\(message.messageId)")
             .opacity(isAppearing ? 0.0 : 1.0)
@@ -172,7 +175,8 @@ struct MessagesGroupItemView: View {
                 message: message,
                 bubbleStyle: bubbleType,
                 onSingleTap: { onTapInvite(invite) },
-                onReply: onReply
+                onReply: onReply,
+                onToggleReaction: onToggleReaction
             )
             .id("message-invite-\(message.messageId)")
             .scaleEffect(isAppearing ? 0.9 : 1.0)
@@ -207,7 +211,8 @@ struct MessagesGroupItemView: View {
                         UIApplication.shared.open(url)
                     }
                 },
-                onReply: onReply
+                onReply: onReply,
+                onToggleReaction: onToggleReaction
             )
             .id("link-preview-\(message.messageId)")
             .scaleEffect(isAppearing ? 0.9 : 1.0)
@@ -267,7 +272,8 @@ struct MessagesGroupItemView: View {
                 message: message,
                 bubbleStyle: bubbleType,
                 onSingleTap: playAction,
-                onReply: onReply
+                onReply: onReply,
+                onToggleReaction: onToggleReaction
             )
             .id(message.messageId)
         } else if attachment.mediaType == .file {
@@ -282,7 +288,8 @@ struct MessagesGroupItemView: View {
                 message: message,
                 bubbleStyle: bubbleType,
                 onSingleTap: fileTapAction,
-                onReply: onReply
+                onReply: onReply,
+                onToggleReaction: onToggleReaction
             )
             .id(message.messageId)
         } else {
@@ -297,6 +304,7 @@ struct MessagesGroupItemView: View {
                 onPhotoRevealed: onPhotoRevealed,
                 onPhotoDimensionsLoaded: onPhotoDimensionsLoaded,
                 onReply: onReply,
+                onToggleReaction: onToggleReaction,
                 onTapReactions: { onTapReactions?(message) },
                 onTapAvatar: { onTapAvatar(message) },
                 onDoubleTapReaction: { onReaction?("❤️", message.messageId) }
@@ -319,6 +327,7 @@ private struct MediaAttachmentView: View {
     let onPhotoRevealed: (String) -> Void
     let onPhotoDimensionsLoaded: (String, Int, Int) -> Void
     let onReply: (AnyMessage) -> Void
+    let onToggleReaction: (String, String) -> Void
     var onTapReactions: () -> Void = {}
     var onTapAvatar: () -> Void = {}
     var onDoubleTapReaction: (() -> Void)?
@@ -418,6 +427,7 @@ private struct MediaAttachmentView: View {
             onSingleTap: singleTapAction,
             onDoubleTap: doubleTapAction,
             onReply: onReply,
+            onToggleReaction: onToggleReaction,
             swipeOffset: $swipeOffset
         )
     }
@@ -1078,7 +1088,8 @@ private struct MediaTopGradient: View {
         onReply: { _ in },
         onPhotoRevealed: { _ in },
         onPhotoHidden: { _ in },
-        onPhotoDimensionsLoaded: { _, _, _ in }
+        onPhotoDimensionsLoaded: { _, _, _ in },
+        onToggleReaction: { _, _ in }
     )
     .padding()
 }
@@ -1097,7 +1108,8 @@ private struct MediaTopGradient: View {
         onReply: { _ in },
         onPhotoRevealed: { _ in },
         onPhotoHidden: { _ in },
-        onPhotoDimensionsLoaded: { _, _, _ in }
+        onPhotoDimensionsLoaded: { _, _, _ in },
+        onToggleReaction: { _, _ in }
     )
     .padding()
 }
@@ -1116,7 +1128,8 @@ private struct MediaTopGradient: View {
         onReply: { _ in },
         onPhotoRevealed: { _ in },
         onPhotoHidden: { _ in },
-        onPhotoDimensionsLoaded: { _, _, _ in }
+        onPhotoDimensionsLoaded: { _, _, _ in },
+        onToggleReaction: { _, _ in }
     )
     .padding()
 }
@@ -1135,7 +1148,8 @@ private struct MediaTopGradient: View {
         onReply: { _ in },
         onPhotoRevealed: { _ in },
         onPhotoHidden: { _ in },
-        onPhotoDimensionsLoaded: { _, _, _ in }
+        onPhotoDimensionsLoaded: { _, _, _ in },
+        onToggleReaction: { _, _ in }
     )
     .padding()
 }
@@ -1155,7 +1169,8 @@ private struct MediaTopGradient: View {
         onReply: { _ in },
         onPhotoRevealed: { _ in },
         onPhotoHidden: { _ in },
-        onPhotoDimensionsLoaded: { _, _, _ in }
+        onPhotoDimensionsLoaded: { _, _, _ in },
+        onToggleReaction: { _, _ in }
     )
     .padding()
 }
@@ -1175,7 +1190,8 @@ private struct MediaTopGradient: View {
         onReply: { _ in },
         onPhotoRevealed: { _ in },
         onPhotoHidden: { _ in },
-        onPhotoDimensionsLoaded: { _, _, _ in }
+        onPhotoDimensionsLoaded: { _, _, _ in },
+        onToggleReaction: { _, _ in }
     )
     .padding()
 }
@@ -1205,7 +1221,8 @@ private func recoverInlineAttachmentData(from path: String) async throws -> Data
         onReply: { _ in },
         onPhotoRevealed: { _ in },
         onPhotoHidden: { _ in },
-        onPhotoDimensionsLoaded: { _, _, _ in }
+        onPhotoDimensionsLoaded: { _, _, _ in },
+        onToggleReaction: { _, _ in }
     )
     .padding()
 }
@@ -1224,7 +1241,8 @@ private func recoverInlineAttachmentData(from path: String) async throws -> Data
         onReply: { _ in },
         onPhotoRevealed: { _ in },
         onPhotoHidden: { _ in },
-        onPhotoDimensionsLoaded: { _, _, _ in }
+        onPhotoDimensionsLoaded: { _, _, _ in },
+        onToggleReaction: { _, _ in }
     )
     .padding()
 }
@@ -1243,7 +1261,8 @@ private func recoverInlineAttachmentData(from path: String) async throws -> Data
         onReply: { _ in },
         onPhotoRevealed: { _ in },
         onPhotoHidden: { _ in },
-        onPhotoDimensionsLoaded: { _, _, _ in }
+        onPhotoDimensionsLoaded: { _, _, _ in },
+        onToggleReaction: { _, _ in }
     )
     .padding()
 }

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupView.swift
@@ -9,6 +9,7 @@ struct MessagesGroupView: View {
     let onTapInvite: (MessageInvite) -> Void
     let onTapReactions: (AnyMessage) -> Void
     let onReaction: (String, String) -> Void
+    let onToggleReaction: (String, String) -> Void
     let onReply: (AnyMessage) -> Void
     let onPhotoRevealed: (String) -> Void
     let onPhotoHidden: (String) -> Void
@@ -203,6 +204,7 @@ struct MessagesGroupView: View {
                 onOpenFile: onOpenFile,
                 onTapReactions: onTapReactions,
                 onReaction: onReaction,
+                onToggleReaction: onToggleReaction,
                 voiceMemoTranscript: group.voiceMemoTranscripts[message.messageId],
                 voiceMemoTranscriptIsTailed: voiceMemoTranscriptIsTailed,
                 onRetryTranscript: onRetryTranscript,
@@ -729,6 +731,7 @@ struct MessagesGroupView: View {
                     onTapInvite: { _ in },
                     onTapReactions: { _ in },
                     onReaction: { _, _ in },
+                    onToggleReaction: { _, _ in },
                     onReply: { _ in },
                     onPhotoRevealed: { _ in },
                     onPhotoHidden: { _ in },

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessagesListView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessagesListView.swift
@@ -11,6 +11,7 @@ struct MessagesListView: View {
     let onTapInvite: (MessageInvite) -> Void
     let onTapReactions: (AnyMessage) -> Void
     let onReaction: (String, String) -> Void
+    let onToggleReaction: (String, String) -> Void
     let onReply: (AnyMessage) -> Void
     let onPhotoRevealed: (String) -> Void
     let onPhotoHidden: (String) -> Void
@@ -153,6 +154,7 @@ struct MessagesListView: View {
             onTapInvite: onTapInvite,
             onTapReactions: onTapReactions,
             onReaction: onReaction,
+            onToggleReaction: onToggleReaction,
             onReply: onReply,
             onPhotoRevealed: onPhotoRevealed,
             onPhotoHidden: onPhotoHidden,

--- a/Convos/Conversation Detail/Messages/MessagesView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesView.swift
@@ -96,6 +96,7 @@ struct MessagesView<BottomBarContent: View>: View {
             onLoadPreviousMessages: onLoadPreviousMessages,
             onTapInvite: onTapInvite,
             onReaction: onReaction,
+            onToggleReaction: onToggleReaction,
             onTapReactions: onTapReactions,
             onReply: onReply,
             contextMenuState: contextMenuState,
@@ -191,10 +192,6 @@ struct MessagesView<BottomBarContent: View>: View {
                 onPhotoRevealed: onPhotoRevealed,
                 onPhotoHidden: onPhotoHidden
             )
-        }
-        .onAppear {
-            contextMenuState.onReaction = onReaction
-            contextMenuState.onToggleReaction = onToggleReaction
         }
     }
 }

--- a/Convos/Conversation Detail/Messages/MessagesViewRepresentable.swift
+++ b/Convos/Conversation Detail/Messages/MessagesViewRepresentable.swift
@@ -14,6 +14,7 @@ struct MessagesViewRepresentable: UIViewControllerRepresentable {
     let onLoadPreviousMessages: () -> Void
     let onTapInvite: (MessageInvite) -> Void
     let onReaction: (String, String) -> Void
+    let onToggleReaction: (String, String) -> Void
     let onTapReactions: (AnyMessage) -> Void
     let onReply: (AnyMessage) -> Void
     let contextMenuState: MessageContextMenuState
@@ -65,6 +66,7 @@ struct MessagesViewRepresentable: UIViewControllerRepresentable {
         messagesViewController.onLoadPreviousMessages = onLoadPreviousMessages
         messagesViewController.onTapInvite = onTapInvite
         messagesViewController.onReaction = onReaction
+        messagesViewController.onToggleReaction = onToggleReaction
         messagesViewController.onTapReactions = onTapReactions
         messagesViewController.onReply = onReply
         messagesViewController.shouldBlurPhotos = shouldBlurPhotos
@@ -135,6 +137,7 @@ struct MessagesViewRepresentable: UIViewControllerRepresentable {
         onLoadPreviousMessages: {},
         onTapInvite: { _ in },
         onReaction: { _, _ in },
+        onToggleReaction: { _, _ in },
         onTapReactions: { _ in },
         onReply: { _ in },
         contextMenuState: .init(),


### PR DESCRIPTION
## Summary

Thread the double-tap reaction handler (`onToggleReaction`) as a required prop on `MessageGestureModifier` — same plumbing shape as the existing `onReaction` — and remove the mutable-closure slots from `MessageContextMenuState`.

## Why

`MessageContextMenuState` was storing the double-tap handler as a `var onToggleReaction: ((String, String) -> Void)?` slot on a shared `@Observable` environment value, with `MessagesView` assigning the current ViewModel's handler once on `.onAppear`. That pattern is fragile: when a `ConversationViewModel` instance is swapped (as happens in the new-conversation flow when the placeholder VM is replaced with the real network-backed VM), the closure stays pinned to the dead VM.

PR #731 patched the specific stale-closure bug it caused by switching `.onAppear` to `.onChange(of: conversation.id)`. This PR removes the seam entirely so future contributors can't re-trigger the same class of bug by adding another gesture handler.

## What changed

- `MessageGestureModifier` / `.messageGesture(…)` extension now take a required `onToggleReaction: (String, String) -> Void` parameter and read it directly at the gesture callback and the accessibility "React" action.
- Added `onToggleReaction` alongside the existing `onReaction` prop at every layer of the plumbing chain:
  - `ConversationView` → `MessagesView` → `MessagesViewRepresentable` → `MessagesViewController` → `MessagesCollectionDataSource` / `MessagesCollectionViewDataSource` → `CellFactory` / `CellConfig` → `MessagesListItemTypeCell` → `MessagesGroupView` / `MessagesListView` → `MessagesGroupItemView` / `MediaAttachmentView` / `VoiceMemoAttachmentView`
- All 8 `.messageGesture(…)` call sites updated.
- `MessageContextMenuState` lost its `onReaction` and `onToggleReaction` closure slots.
- `MessagesView` lost the `.onAppear` / `.onChange` block that was keeping those slots in sync with the view model.
- Preview blocks in `MessagesGroupItemView`, `MessagesGroupView`, `MessagesViewRepresentable`, and `MessagesBottomBar` updated with the new `onToggleReaction: { _, _ in }` arg.

14 files, +64/−24 net.

## Test plan

- [ ] Double-tap a text bubble in a regular conversation → reaction toggles and persists
- [ ] Double-tap a text bubble in the new-conversation flow (before the network convo materializes) → reaction still routes to the real writer once the real VM swaps in
- [ ] Double-tap a link preview, an invite bubble, a file attachment, a voice memo — all still react
- [ ] Long-press → context menu react path still works
- [ ] Media (photo/video) double-tap still fires the ❤️ animation via the separate `onReaction` prop
- [ ] Accessibility "React" action on a message bubble fires the handler

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pass thread reaction handler as a prop instead of shared state in message views
> - Replaces the pattern of storing `onToggleReaction` in `MessageContextMenuState` with explicit prop-drilling through the view hierarchy.
> - Threads `onToggleReaction: (String, String) -> Void` from `MessagesView` down through `MessagesViewRepresentable`, `MessagesViewController`, `MessagesCollectionViewDataSource`, `MessagesGroupView`, and `MessagesGroupItemView` to each message bubble type.
> - Removes `onReaction`/`onToggleReaction` closures from `MessageContextMenuState`, and removes the `onAppear` block in `MessagesView` that previously assigned them.
> - Double-tap and accessibility 'React' gestures in `MessageGestureModifier` now call the injected closure directly instead of consulting shared state.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8a92644.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->