### PR TITLE
feat(backup): bundle format, crypto, metadata

### DIFF
--- a/Convos/Conversations List/ConversationsView.swift
+++ b/Convos/Conversations List/ConversationsView.swift
@@ -124,14 +124,27 @@ struct ConversationsView: View {
 
     @ViewBuilder
     private var sidebarContent: some View {
-        if viewModel.unpinnedConversations.isEmpty && viewModel.pinnedConversations.isEmpty && viewModel.activeFilter == .all && horizontalSizeClass == .compact {
-            emptyConversationsViewScrollable
-        } else if viewModel.isFilteredResultEmpty && viewModel.pinnedConversations.isEmpty && horizontalSizeClass == .compact {
-            ScrollView {
-                filteredEmptyStateView
+        VStack(spacing: 0) {
+            if viewModel.isDeviceReplaced {
+                StaleDeviceBanner(
+                    onResetDevice: { viewModel.resetDevice() },
+                    onLearnMore: {
+                        if let url = URL(string: "https://learn.convos.org/") {
+                            UIApplication.shared.open(url)
+                        }
+                    }
+                )
+                .padding(.top, 8)
             }
-        } else {
-            conversationsCollectionView
+            if viewModel.unpinnedConversations.isEmpty && viewModel.pinnedConversations.isEmpty && viewModel.activeFilter == .all && horizontalSizeClass == .compact {
+                emptyConversationsViewScrollable
+            } else if viewModel.isFilteredResultEmpty && viewModel.pinnedConversations.isEmpty && horizontalSizeClass == .compact {
+                ScrollView {
+                    filteredEmptyStateView
+                }
+            } else {
+                conversationsCollectionView
+            }
         }
     }
 

--- a/Convos/Conversations List/ConversationsViewModel.swift
+++ b/Convos/Conversations List/ConversationsViewModel.swift
@@ -13,6 +13,38 @@ final class ConversationsViewModel {
 
     private(set) var focusCoordinator: FocusCoordinator
 
+    // MARK: - Device Replaced
+
+    private func observeSessionState() {
+        let messagingService = session.messagingService()
+        let manager = messagingService.sessionStateManager
+        sessionStateHandle = manager.observeState { [weak self] state in
+            let replaced: Bool
+            if case let .error(error) = state, error is DeviceReplacedError {
+                replaced = true
+            } else {
+                replaced = false
+            }
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                if self.isDeviceReplaced != replaced {
+                    self.isDeviceReplaced = replaced
+                }
+            }
+        }
+    }
+
+    func resetDevice() {
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            do {
+                try await self.session.deleteAllInboxes()
+            } catch {
+                Log.error("resetDevice: deleteAllInboxes failed: \(error)")
+            }
+        }
+    }
+
     // MARK: - Selection State
 
     @ObservationIgnored
@@ -180,6 +212,16 @@ final class ConversationsViewModel {
     private var cancellables: Set<AnyCancellable> = .init()
     @ObservationIgnored
     private var leftConversationObserver: Any?
+    @ObservationIgnored
+    private var sessionStateHandle: StateObserverHandle?
+
+    /// True when `SessionStateMachine` has transitioned to
+    /// `.error(DeviceReplacedError)` — the sole XMTP installation
+    /// for this inbox was revoked, almost always because the user
+    /// restored on another device. Drives the `StaleDeviceBanner`
+    /// at the top of the conversations list; the banner's "Reset
+    /// device" action runs `session.deleteAllInboxes()`.
+    var isDeviceReplaced: Bool = false
 
     private var horizontalSizeClass: UserInterfaceSizeClass?
 
@@ -279,6 +321,7 @@ final class ConversationsViewModel {
     }
 
     private func observe() {
+        observeSessionState()
         leftConversationObserver = NotificationCenter.default
             .addObserver(forName: .leftConversationNotification, object: nil, queue: .main) { [weak self] notification in
                 guard let conversationId = notification.userInfo?["conversationId"] as? String else {

--- a/Convos/Conversations List/StaleDeviceBanner.swift
+++ b/Convos/Conversations List/StaleDeviceBanner.swift
@@ -1,0 +1,69 @@
+import ConvosCore
+import SwiftUI
+
+/// Top-of-list banner shown when `SessionStateMachine` surfaces a
+/// `DeviceReplacedError` — i.e., the sole XMTP installation for
+/// this inbox has been revoked, almost always because the user
+/// restored on another device.
+///
+/// Single variant: Rev 4 collapsed the old `partialStale` /
+/// `fullStale` distinction into a binary. "Reset device" is the
+/// only path out; `Learn more` links to the convos learn site.
+struct StaleDeviceBanner: View {
+    let onResetDevice: () -> Void
+    let onLearnMore: () -> Void
+
+    var body: some View {
+        let resetAction = onResetDevice
+        let learnMoreAction = onLearnMore
+        VStack(spacing: 10) {
+            HStack(spacing: 8) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .foregroundStyle(.colorLava)
+                    .font(.callout)
+                Text("This device has been replaced")
+                    .font(.callout)
+                    .fontWeight(.semibold)
+                    .foregroundStyle(.colorTextPrimary)
+                    .multilineTextAlignment(.center)
+            }
+            Text("Your account has been restored on another device. Resetting will clear local data on this device and restart setup.")
+                .font(.system(size: 13))
+                .foregroundStyle(.colorTextSecondary)
+                .multilineTextAlignment(.center)
+                .fixedSize(horizontal: false, vertical: true)
+
+            HStack(spacing: 8) {
+                Button(action: learnMoreAction) {
+                    Text("Learn more")
+                        .font(.system(size: 14, weight: .medium))
+                }
+                .buttonStyle(.bordered)
+
+                Button(role: .destructive, action: resetAction) {
+                    Text("Reset device")
+                        .font(.system(size: 14, weight: .medium))
+                }
+                .buttonStyle(.bordered)
+                .tint(.colorLava)
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .padding(16)
+        .background(Color.colorFillMinimal, in: RoundedRectangle(cornerRadius: 16))
+        .padding(.horizontal, 16)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(
+            "This device has been replaced. Your account has been restored on another device. Resetting will clear local data on this device and restart setup. Learn more or reset device."
+        )
+        .accessibilityIdentifier("stale-device-banner")
+    }
+}
+
+#Preview {
+    StaleDeviceBanner(
+        onResetDevice: {},
+        onLearnMore: {}
+    )
+    .padding()
+}

--- a/ConvosCore/Sources/ConvosCore/AppEnvironment.swift
+++ b/ConvosCore/Sources/ConvosCore/AppEnvironment.swift
@@ -109,6 +109,22 @@ public enum AppEnvironment: Sendable {
         }
     }
 
+    /// iCloud container identifier for the backup bundle. Derived from
+    /// the app-group identifier so it tracks per-environment naming
+    /// (dev / prod / local) without a second source of truth. The
+    /// entitlement must declare this container for the ubiquity URL
+    /// lookup to succeed; in tests the value is a valid-looking
+    /// placeholder that will resolve to `nil` at runtime (no account).
+    public var iCloudContainerIdentifier: String {
+        switch self {
+        case .local(config: let config), .dev(config: let config), .production(config: let config):
+            let bundleId = config.appGroupIdentifier.replacingOccurrences(of: "group.", with: "")
+            return "iCloud.\(bundleId)"
+        case .tests:
+            return "iCloud.org.convos.ios-local"
+        }
+    }
+
     public var keychainAccessGroup: String {
         // Use the app group identifier with team prefix for keychain sharing
         // This matches $(AppIdentifierPrefix)$(APP_GROUP_IDENTIFIER) in entitlements

--- a/ConvosCore/Sources/ConvosCore/Backup/BackupBundle.swift
+++ b/ConvosCore/Sources/ConvosCore/Backup/BackupBundle.swift
@@ -1,0 +1,236 @@
+import Foundation
+
+/// Tar format + pack/unpack for the iCloud backup bundle.
+///
+/// Format:
+///
+///     [4-byte magic "CVBD"]
+///     [1-byte format version]
+///     [entries...]
+///
+/// Each entry:
+///
+///     [4-byte path length BE][path UTF8][8-byte file length BE][file data]
+///
+/// The magic + version header lets future bundle-format bumps
+/// discriminate cleanly rather than decoding past-incompatible data.
+/// The entry format is a straight port of the old single-file-at-a-time
+/// layout; hardened against path-traversal on unpack via both a
+/// standardized-path check and a symlink-resolved re-check after
+/// `createDirectory`.
+public enum BackupBundle {
+    enum BundleError: Error, LocalizedError {
+        case directoryCreationFailed(String)
+        case packagingFailed(String)
+        case unpackingFailed(String)
+        case missingComponent(String)
+        case invalidMagic(expected: String, got: String)
+        case unsupportedVersion(got: UInt8, supported: UInt8)
+
+        var errorDescription: String? {
+            switch self {
+            case let .directoryCreationFailed(reason):
+                return "Failed to create backup directory: \(reason)"
+            case let .packagingFailed(reason):
+                return "Failed to package backup bundle: \(reason)"
+            case let .unpackingFailed(reason):
+                return "Failed to unpack backup bundle: \(reason)"
+            case let .missingComponent(name):
+                return "Missing backup component: \(name)"
+            case let .invalidMagic(expected, got):
+                return "Not a Convos backup bundle (expected magic \(expected), got \(got))"
+            case let .unsupportedVersion(got, supported):
+                return "Backup bundle format v\(got) is not supported (this build supports v\(supported))"
+            }
+        }
+    }
+
+    /// ASCII "CVBD" — Convos Backup Data.
+    static let magic: [UInt8] = [0x43, 0x56, 0x42, 0x44]
+
+    /// Current on-disk format version. Bump when a backwards-incompatible
+    /// structural change lands (e.g. media blobs, compressed entries).
+    static let currentFormatVersion: UInt8 = 1
+
+    public enum Component {
+        public static let database: String = "convos-single-inbox.sqlite"
+        public static let xmtpArchive: String = "xmtp-archive.bin"
+        public static let metadata: String = "metadata.json"
+    }
+
+    // MARK: - Staging
+
+    public static func createStagingDirectory() throws -> URL {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("convos-backup-\(UUID().uuidString)", isDirectory: true)
+        do {
+            try FileManager.default.createDirectory(
+                at: tempDir,
+                withIntermediateDirectories: true
+            )
+        } catch {
+            throw BundleError.directoryCreationFailed(error.localizedDescription)
+        }
+        return tempDir
+    }
+
+    public static func cleanup(directory: URL) {
+        try? FileManager.default.removeItem(at: directory)
+    }
+
+    public static func databasePath(in directory: URL) -> URL {
+        directory.appendingPathComponent(Component.database)
+    }
+
+    public static func xmtpArchivePath(in directory: URL) -> URL {
+        directory.appendingPathComponent(Component.xmtpArchive)
+    }
+
+    // MARK: - Pack / unpack
+
+    public static func pack(directory: URL, encryptionKey: Data) throws -> Data {
+        let tarData = try tarDirectory(directory)
+        return try BackupBundleCrypto.encrypt(data: tarData, key: encryptionKey)
+    }
+
+    public static func unpack(data: Data, encryptionKey: Data, to directory: URL) throws {
+        let tarData = try BackupBundleCrypto.decrypt(data: data, key: encryptionKey)
+        try untarData(tarData, to: directory)
+    }
+
+    // MARK: - Tar (internal)
+
+    static func tarDirectory(_ directory: URL) throws -> Data {
+        var archive = Data()
+        archive.append(contentsOf: magic)
+        archive.append(currentFormatVersion)
+
+        let fileManager = FileManager.default
+        let resolvedDirPath = resolvedPath(directory)
+        let resolvedDirURL = URL(fileURLWithPath: resolvedDirPath, isDirectory: true)
+        guard let enumerator = fileManager.enumerator(
+            at: resolvedDirURL,
+            includingPropertiesForKeys: [.isRegularFileKey],
+            options: [.skipsHiddenFiles]
+        ) else {
+            throw BundleError.packagingFailed("failed to enumerate directory")
+        }
+
+        for case let fileURL as URL in enumerator {
+            let resourceValues = try fileURL.resourceValues(forKeys: [.isRegularFileKey])
+            guard resourceValues.isRegularFile == true else { continue }
+
+            let resolvedFilePath = resolvedPath(fileURL)
+            guard resolvedFilePath.hasPrefix(resolvedDirPath + "/") else {
+                throw BundleError.packagingFailed("file outside backup directory: \(fileURL.path)")
+            }
+            let relativePath = String(resolvedFilePath.dropFirst(resolvedDirPath.count + 1))
+            let pathData = Data(relativePath.utf8)
+            let fileData = try Data(contentsOf: fileURL)
+
+            var pathLength = UInt32(pathData.count).bigEndian
+            var fileLength = UInt64(fileData.count).bigEndian
+            archive.append(Data(bytes: &pathLength, count: 4))
+            archive.append(pathData)
+            archive.append(Data(bytes: &fileLength, count: 8))
+            archive.append(fileData)
+        }
+
+        return archive
+    }
+
+    static func untarData(_ data: Data, to directory: URL) throws {
+        let fileManager = FileManager.default
+        let resolvedDirPath = resolvedPath(directory)
+        var offset = 0
+
+        try validateHeader(data, offset: &offset)
+
+        while offset < data.count {
+            guard offset + 4 <= data.count else {
+                throw BundleError.unpackingFailed("truncated path length")
+            }
+            let pathLength = Int(data
+                .subdata(in: offset ..< offset + 4)
+                .withUnsafeBytes { $0.load(as: UInt32.self).bigEndian })
+            offset += 4
+
+            guard offset + pathLength <= data.count else {
+                throw BundleError.unpackingFailed("truncated path data")
+            }
+            guard let relativePath = String(
+                data: data.subdata(in: offset ..< offset + pathLength),
+                encoding: .utf8
+            ) else {
+                throw BundleError.unpackingFailed("invalid path encoding")
+            }
+            offset += pathLength
+
+            guard offset + 8 <= data.count else {
+                throw BundleError.unpackingFailed("truncated file length")
+            }
+            let fileLengthU64 = data.subdata(in: offset ..< offset + 8)
+                .withUnsafeBytes { $0.load(as: UInt64.self).bigEndian }
+            guard fileLengthU64 <= UInt64(Int.max) else {
+                throw BundleError.unpackingFailed("file length exceeds maximum: \(fileLengthU64)")
+            }
+            let fileLength = Int(fileLengthU64)
+            offset += 8
+
+            guard offset + fileLength <= data.count else {
+                throw BundleError.unpackingFailed("truncated file data")
+            }
+            let fileData = data.subdata(in: offset ..< offset + fileLength)
+            offset += fileLength
+
+            let resolvedFileURL = URL(fileURLWithPath: resolvedDirPath)
+                .appendingPathComponent(relativePath)
+
+            // First-pass containment check on the standardized path.
+            let standardizedPath = resolvedFileURL.standardizedFileURL.path
+            guard standardizedPath.hasPrefix(resolvedDirPath + "/") else {
+                throw BundleError.unpackingFailed("path traversal attempt: \(relativePath)")
+            }
+
+            // Create the parent directory, then re-validate using the
+            // symlink-resolved path of the parent. `fileData.write(to:)`
+            // follows symlinks when writing, so a pre-existing symlink
+            // under the staging dir could escape the first-pass check.
+            // Re-resolving the parent after createDirectory catches that.
+            let parentDir = resolvedFileURL.deletingLastPathComponent()
+            try fileManager.createDirectory(at: parentDir, withIntermediateDirectories: true)
+
+            let resolvedParentPath = parentDir.standardizedFileURL.resolvingSymlinksInPath().path
+            guard resolvedParentPath == resolvedDirPath
+                || resolvedParentPath.hasPrefix(resolvedDirPath + "/") else {
+                throw BundleError.unpackingFailed("path traversal via symlink: \(relativePath)")
+            }
+
+            try fileData.write(to: resolvedFileURL)
+        }
+    }
+
+    private static func validateHeader(_ data: Data, offset: inout Int) throws {
+        guard data.count >= magic.count + 1 else {
+            throw BundleError.unpackingFailed("bundle too short to contain header")
+        }
+        let magicBytes = Array(data[offset ..< offset + magic.count])
+        guard magicBytes == magic else {
+            let expected = String(bytes: magic, encoding: .ascii) ?? "CVBD"
+            let got = String(bytes: magicBytes, encoding: .ascii) ?? "<invalid>"
+            throw BundleError.invalidMagic(expected: expected, got: got)
+        }
+        offset += magic.count
+
+        let version = data[offset]
+        guard version == currentFormatVersion else {
+            throw BundleError.unsupportedVersion(got: version, supported: currentFormatVersion)
+        }
+        offset += 1
+    }
+
+    private static func resolvedPath(_ url: URL) -> String {
+        let path = url.standardizedFileURL.resolvingSymlinksInPath().path
+        return path.hasSuffix("/") ? String(path.dropLast()) : path
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Backup/BackupBundle.swift
+++ b/ConvosCore/Sources/ConvosCore/Backup/BackupBundle.swift
@@ -53,7 +53,10 @@ public enum BackupBundle {
     static let currentFormatVersion: UInt8 = 1
 
     public enum Component {
-        public static let database: String = "convos-single-inbox.sqlite"
+        /// Must match `DatabaseManager.databaseFilename` — the live DB
+        /// file is handed to the bundle unchanged, then read back
+        /// under the same name by `RestoreManager.replaceDatabase`.
+        public static let database: String = DatabaseManager.databaseFilename
         public static let xmtpArchive: String = "xmtp-archive.bin"
         public static let metadata: String = "metadata.json"
     }
@@ -154,6 +157,15 @@ public enum BackupBundle {
                 .subdata(in: offset ..< offset + 4)
                 .withUnsafeBytes { $0.load(as: UInt32.self).bigEndian })
             offset += 4
+
+            // A zero-length path would decode to the empty string and
+            // resolve via `appendingPathComponent("")` to the staging
+            // directory URL itself — the containment check would reject
+            // it for not having the trailing-slash prefix, but costs
+            // nothing to bail early with a clearer error.
+            guard pathLength > 0 else {
+                throw BundleError.unpackingFailed("empty entry path")
+            }
 
             guard offset + pathLength <= data.count else {
                 throw BundleError.unpackingFailed("truncated path data")

--- a/ConvosCore/Sources/ConvosCore/Backup/BackupBundleCrypto.swift
+++ b/ConvosCore/Sources/ConvosCore/Backup/BackupBundleCrypto.swift
@@ -1,0 +1,80 @@
+import CryptoKit
+import Foundation
+
+/// AES-256-GCM seal/open for the outer backup bundle.
+///
+/// The outer seal is keyed directly on the identity's 32-byte
+/// `databaseKey` — the same key XMTPiOS uses as the SQLCipher key for
+/// the local XMTP DB, so compromising the bundle key already implied
+/// compromising the XMTP DB. HKDF adds no meaningful isolation under
+/// that threat model (see `docs/plans/icloud-backup-single-inbox.md`
+/// §"No HKDF on the bundle key"). The inner XMTP archive uses its
+/// own per-bundle `archiveKey`; see §"Two keys, two roles" for why
+/// the two keys are kept distinct.
+package enum BackupBundleCrypto {
+    static let expectedKeyLength: Int = 32
+
+    enum CryptoError: Error, LocalizedError {
+        case encryptionFailed(String)
+        case decryptionFailed(String)
+        case invalidKeyLength(expected: Int, got: Int)
+
+        var errorDescription: String? {
+            switch self {
+            case let .encryptionFailed(reason):
+                return "Backup encryption failed: \(reason)"
+            case let .decryptionFailed(reason):
+                return "Backup decryption failed: \(reason)"
+            case let .invalidKeyLength(expected, got):
+                return "Bundle encryption key must be \(expected) bytes (got \(got))"
+            }
+        }
+    }
+
+    static func encrypt(data: Data, key: Data) throws -> Data {
+        let symmetricKey = try makeSymmetricKey(from: key)
+        let sealedBox: AES.GCM.SealedBox
+        do {
+            sealedBox = try AES.GCM.seal(data, using: symmetricKey)
+        } catch {
+            throw CryptoError.encryptionFailed("\(error)")
+        }
+        guard let combined = sealedBox.combined else {
+            throw CryptoError.encryptionFailed("failed to produce combined representation")
+        }
+        return combined
+    }
+
+    static func decrypt(data: Data, key: Data) throws -> Data {
+        let symmetricKey = try makeSymmetricKey(from: key)
+        do {
+            let sealedBox = try AES.GCM.SealedBox(combined: data)
+            return try AES.GCM.open(sealedBox, using: symmetricKey)
+        } catch {
+            throw CryptoError.decryptionFailed("\(error)")
+        }
+    }
+
+    /// 32 bytes of CSPRNG, suitable as the inner `archiveKey` handed to
+    /// `XMTPiOS.Client.createArchive`. Fresh per bundle (never reused).
+    static func generateArchiveKey() throws -> Data {
+        var key = Data(count: expectedKeyLength)
+        let status = key.withUnsafeMutableBytes { bytes -> OSStatus in
+            guard let baseAddress = bytes.baseAddress else {
+                return errSecUnknownFormat
+            }
+            return SecRandomCopyBytes(kSecRandomDefault, expectedKeyLength, baseAddress)
+        }
+        guard status == errSecSuccess else {
+            throw CryptoError.encryptionFailed("SecRandomCopyBytes returned \(status)")
+        }
+        return key
+    }
+
+    private static func makeSymmetricKey(from key: Data) throws -> SymmetricKey {
+        guard key.count == expectedKeyLength else {
+            throw CryptoError.invalidKeyLength(expected: expectedKeyLength, got: key.count)
+        }
+        return SymmetricKey(data: key)
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Backup/BackupBundleMetadata.swift
+++ b/ConvosCore/Sources/ConvosCore/Backup/BackupBundleMetadata.swift
@@ -119,8 +119,15 @@ public struct BackupBundleMetadata: Codable, Sendable, Equatable {
     }
 
     /// Read the sidecar-shaped metadata. Works on either the sidecar
-    /// file next to the bundle or the inside-tar file (decoder ignores
-    /// the extra `archiveKey` key).
+    /// file next to the bundle or the inside-tar file.
+    ///
+    /// Load-bearing detail: the `Sidecar` decoder relies on
+    /// `JSONDecoder`'s default "ignore unknown keys" behavior to
+    /// accept full-form input (where `archiveKey` is also present).
+    /// Do not switch this decoder to a strict mode without adding an
+    /// explicit "project to sidecar" step — callers that hand a
+    /// full-form file to this function expect success, not a decode
+    /// error on the extra key.
     public static func readSidecar(from directory: URL) throws -> Sidecar {
         let data = try Data(contentsOf: directory.appendingPathComponent(Constant.filename))
         return try jsonDecoder().decode(Sidecar.self, from: data)

--- a/ConvosCore/Sources/ConvosCore/Backup/BackupBundleMetadata.swift
+++ b/ConvosCore/Sources/ConvosCore/Backup/BackupBundleMetadata.swift
@@ -1,0 +1,151 @@
+import Foundation
+
+/// Metadata that accompanies a backup bundle.
+///
+/// Two serialized forms, written to two different locations:
+/// - **Internal** (`writeFull(to:)`): written inside the encrypted tar,
+///   includes `archiveKey` so `RestoreManager` can decrypt the inner
+///   `xmtp-archive.bin`. Read after the outer seal is opened.
+/// - **Sidecar** (`writeSidecar(to:)`): written next to
+///   `backup-latest.encrypted`, unencrypted, omits every secret.
+///   Powers `RestoreManager.findAvailableBackup` discovery without
+///   requiring the bundle key.
+///
+/// The only secret carried here is `archiveKey`. Everything else is
+/// safe to expose in the sidecar.
+public struct BackupBundleMetadata: Codable, Sendable, Equatable {
+    public let version: Int
+    public let createdAt: Date
+    public let deviceId: String
+    public let deviceName: String
+    public let osString: String
+    public let conversationCount: Int
+    public let schemaGeneration: String
+    public let appVersion: String
+    /// 32-byte XMTP archive key. Fresh CSPRNG per bundle. Required to
+    /// decrypt `xmtp-archive.bin`. Never written to the sidecar.
+    public let archiveKey: Data
+
+    public init(
+        version: Int = Self.currentVersion,
+        createdAt: Date = Date(),
+        deviceId: String,
+        deviceName: String,
+        osString: String,
+        conversationCount: Int,
+        schemaGeneration: String,
+        appVersion: String,
+        archiveKey: Data
+    ) {
+        self.version = version
+        self.createdAt = createdAt
+        self.deviceId = deviceId
+        self.deviceName = deviceName
+        self.osString = osString
+        self.conversationCount = conversationCount
+        self.schemaGeneration = schemaGeneration
+        self.appVersion = appVersion
+        self.archiveKey = archiveKey
+    }
+
+    public static let currentVersion: Int = 1
+
+    /// Secret-free projection. This is what the sidecar file contains.
+    public var sidecar: Sidecar {
+        Sidecar(
+            version: version,
+            createdAt: createdAt,
+            deviceId: deviceId,
+            deviceName: deviceName,
+            osString: osString,
+            conversationCount: conversationCount,
+            schemaGeneration: schemaGeneration,
+            appVersion: appVersion
+        )
+    }
+
+    public struct Sidecar: Codable, Sendable, Equatable {
+        public let version: Int
+        public let createdAt: Date
+        public let deviceId: String
+        public let deviceName: String
+        public let osString: String
+        public let conversationCount: Int
+        public let schemaGeneration: String
+        public let appVersion: String
+
+        public init(
+            version: Int,
+            createdAt: Date,
+            deviceId: String,
+            deviceName: String,
+            osString: String,
+            conversationCount: Int,
+            schemaGeneration: String,
+            appVersion: String
+        ) {
+            self.version = version
+            self.createdAt = createdAt
+            self.deviceId = deviceId
+            self.deviceName = deviceName
+            self.osString = osString
+            self.conversationCount = conversationCount
+            self.schemaGeneration = schemaGeneration
+            self.appVersion = appVersion
+        }
+    }
+
+    // MARK: - I/O
+
+    /// Write the full metadata (including `archiveKey`) into a tar
+    /// staging directory as `metadata.json`.
+    public static func writeFull(_ metadata: BackupBundleMetadata, to directory: URL) throws {
+        let data = try jsonEncoder().encode(metadata)
+        try data.write(to: directory.appendingPathComponent(Constant.filename))
+    }
+
+    /// Write the secret-free sidecar to a backup directory (next to
+    /// `backup-latest.encrypted`) as `metadata.json`.
+    public static func writeSidecar(_ sidecar: Sidecar, to directory: URL) throws {
+        let data = try jsonEncoder().encode(sidecar)
+        try data.write(to: directory.appendingPathComponent(Constant.filename))
+    }
+
+    /// Read the full metadata from an unpacked tar staging directory.
+    /// Fails if `archiveKey` is missing.
+    public static func readFull(from directory: URL) throws -> BackupBundleMetadata {
+        let data = try Data(contentsOf: directory.appendingPathComponent(Constant.filename))
+        return try jsonDecoder().decode(BackupBundleMetadata.self, from: data)
+    }
+
+    /// Read the sidecar-shaped metadata. Works on either the sidecar
+    /// file next to the bundle or the inside-tar file (decoder ignores
+    /// the extra `archiveKey` key).
+    public static func readSidecar(from directory: URL) throws -> Sidecar {
+        let data = try Data(contentsOf: directory.appendingPathComponent(Constant.filename))
+        return try jsonDecoder().decode(Sidecar.self, from: data)
+    }
+
+    public static func exists(in directory: URL) -> Bool {
+        FileManager.default.fileExists(
+            atPath: directory.appendingPathComponent(Constant.filename).path
+        )
+    }
+
+    private static func jsonEncoder() -> JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        return encoder
+    }
+
+    private static func jsonDecoder() -> JSONDecoder {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }
+
+    private enum Constant {
+        static let filename: String = "metadata.json"
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Backup/BackupManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Backup/BackupManager.swift
@@ -1,0 +1,239 @@
+import Foundation
+import GRDB
+
+/// Errors surfaced by `BackupManager.createBackup`.
+public enum BackupError: Error, LocalizedError {
+    case noIdentity
+    case restoreInProgress
+    case clientUnavailable(any Error)
+    case archiveFailed(any Error)
+    case writeFailed(any Error)
+
+    public var errorDescription: String? {
+        switch self {
+        case .noIdentity:
+            return "No identity in the keychain — nothing to back up yet"
+        case .restoreInProgress:
+            return "A restore is in progress; skipping this backup"
+        case let .clientUnavailable(inner):
+            return "Live XMTP client unavailable for archive creation: \(inner)"
+        case let .archiveFailed(inner):
+            return "XMTP archive creation failed: \(inner)"
+        case let .writeFailed(inner):
+            return "Writing bundle to disk failed: \(inner)"
+        }
+    }
+}
+
+/// Orchestrates creation of a single iCloud backup bundle.
+///
+/// The flow, per
+/// `docs/plans/icloud-backup-single-inbox.md` §"Backup flow":
+///
+/// 1. Skip early if `RestoreInProgressFlag` is set — a concurrent
+///    backup would race the restore on shared files.
+/// 2. Read the identity via `identityStore.loadSync`; skip if `nil`
+///    (first launch, no inbox yet — nothing to back up).
+/// 3. Snapshot the live GRDB pool into a staging file via
+///    `DatabasePool.backup(to:)`. This is a consistent point-in-time
+///    copy even while the main app continues to write.
+/// 4. Generate a fresh 32-byte `archiveKey`, hand it to
+///    `client.createArchive` to produce an XMTP archive of
+///    `{conversations, messages}`.
+/// 5. Write the full metadata (includes `archiveKey`) into the
+///    staging directory.
+/// 6. Tar + AES-GCM-seal with `identity.keys.databaseKey`.
+/// 7. Atomic write to iCloud (with local fallback). Sidecar
+///    metadata (no `archiveKey`) is written next to the sealed
+///    bundle so `findAvailableBackup` can discover without the
+///    outer-seal key.
+///
+/// Non-actor deliberately — `createBackup` is inherently serialized
+/// by its one caller (`BackupScheduler` fires sequentially, UI
+/// "Back up now" is user-driven). Concurrency protection is at the
+/// call site, not inside the manager.
+public final class BackupManager: @unchecked Sendable {
+    public typealias ClientProvider = @Sendable () async throws -> any XMTPClientProvider
+
+    private let databaseManager: any DatabaseManagerProtocol
+    private let identityStore: any KeychainIdentityStoreProtocol
+    private let clientProvider: ClientProvider
+    private let environment: AppEnvironment
+    private let bundleFilename: String
+    private let now: @Sendable () -> Date
+
+    public init(
+        databaseManager: any DatabaseManagerProtocol,
+        identityStore: any KeychainIdentityStoreProtocol,
+        clientProvider: @escaping ClientProvider,
+        environment: AppEnvironment,
+        now: @escaping @Sendable () -> Date = Date.init
+    ) {
+        self.databaseManager = databaseManager
+        self.identityStore = identityStore
+        self.clientProvider = clientProvider
+        self.environment = environment
+        self.bundleFilename = Constant.bundleFilename
+        self.now = now
+    }
+
+    /// Full create flow. Returns the URL of the sealed bundle on
+    /// success (iCloud or local fallback). Throws on skip conditions
+    /// and on any failure past the point of a fresh staging dir.
+    @discardableResult
+    public func createBackup() async throws -> URL {
+        if RestoreInProgressFlag.isSet(environment: environment) {
+            Log.info("createBackup: restore in progress, skipping")
+            throw BackupError.restoreInProgress
+        }
+
+        let identity: KeychainIdentity
+        do {
+            guard let loaded = try identityStore.loadSync() else {
+                Log.info("createBackup: no identity present, skipping")
+                throw BackupError.noIdentity
+            }
+            identity = loaded
+        } catch let error as BackupError {
+            throw error
+        } catch {
+            Log.warning("createBackup: keychain loadSync failed (\(error)); skipping")
+            throw BackupError.noIdentity
+        }
+
+        let staging = try BackupBundle.createStagingDirectory()
+        defer { BackupBundle.cleanup(directory: staging) }
+
+        try snapshotDatabase(to: staging)
+        let archiveKey = try BackupBundleCrypto.generateArchiveKey()
+        try await createXMTPArchive(at: staging, archiveKey: archiveKey)
+
+        let metadata = try buildMetadata(archiveKey: archiveKey)
+        try BackupBundleMetadata.writeFull(metadata, to: staging)
+
+        let sealed: Data
+        do {
+            sealed = try BackupBundle.pack(
+                directory: staging,
+                encryptionKey: identity.keys.databaseKey
+            )
+        } catch {
+            throw BackupError.writeFailed(error)
+        }
+
+        return try writeBundle(sealed: sealed, sidecar: metadata.sidecar)
+    }
+
+    // MARK: - Step helpers
+
+    private func snapshotDatabase(to staging: URL) throws {
+        let destination = BackupBundle.databasePath(in: staging)
+        let destinationQueue: DatabaseQueue
+        do {
+            destinationQueue = try DatabaseQueue(path: destination.path)
+        } catch {
+            throw BackupError.writeFailed(error)
+        }
+        do {
+            try databaseManager.dbReader.backup(to: destinationQueue)
+        } catch {
+            throw BackupError.writeFailed(error)
+        }
+    }
+
+    private func createXMTPArchive(at staging: URL, archiveKey: Data) async throws {
+        let archivePath = BackupBundle.xmtpArchivePath(in: staging).path
+
+        let client: any XMTPClientProvider
+        do {
+            client = try await clientProvider()
+        } catch {
+            throw BackupError.clientUnavailable(error)
+        }
+
+        do {
+            try await client.createArchive(
+                path: archivePath,
+                encryptionKey: archiveKey
+            )
+        } catch {
+            throw BackupError.archiveFailed(error)
+        }
+    }
+
+    private func buildMetadata(archiveKey: Data) throws -> BackupBundleMetadata {
+        let conversationCount = (try? databaseManager.dbReader.read { db in
+            try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM conversation WHERE isUnused = 0") ?? 0
+        }) ?? 0
+
+        return BackupBundleMetadata(
+            createdAt: now(),
+            deviceId: DeviceInfo.deviceIdentifier,
+            deviceName: DeviceInfo.deviceName,
+            osString: DeviceInfo.osString,
+            conversationCount: conversationCount,
+            schemaGeneration: LegacyDataWipe.currentGeneration,
+            appVersion: Bundle.appVersion,
+            archiveKey: archiveKey
+        )
+    }
+
+    private func writeBundle(
+        sealed: Data,
+        sidecar: BackupBundleMetadata.Sidecar
+    ) throws -> URL {
+        let outputDir: URL
+        do {
+            outputDir = try resolveBackupDirectory()
+        } catch {
+            throw BackupError.writeFailed(error)
+        }
+
+        let bundlePath = outputDir.appendingPathComponent(bundleFilename)
+        let tempPath = outputDir.appendingPathComponent(bundleFilename + ".tmp")
+
+        do {
+            try sealed.write(to: tempPath, options: [.atomic])
+            let fm = FileManager.default
+            if fm.fileExists(atPath: bundlePath.path) {
+                _ = try fm.replaceItemAt(bundlePath, withItemAt: tempPath)
+            } else {
+                try fm.moveItem(at: tempPath, to: bundlePath)
+            }
+            // Sidecar written *after* the bundle — `findAvailableBackup`
+            // validates both exist before offering a restore, so a
+            // reader that sees the new sidecar sees the new bundle too.
+            try BackupBundleMetadata.writeSidecar(sidecar, to: outputDir)
+        } catch {
+            throw BackupError.writeFailed(error)
+        }
+
+        Log.info("createBackup: wrote bundle to \(bundlePath.path)")
+        return bundlePath
+    }
+
+    private func resolveBackupDirectory() throws -> URL {
+        let deviceId = DeviceInfo.deviceIdentifier
+        let fm = FileManager.default
+
+        if let iCloudURL = fm.url(forUbiquityContainerIdentifier: environment.iCloudContainerIdentifier) {
+            let dir = iCloudURL
+                .appendingPathComponent("Documents", isDirectory: true)
+                .appendingPathComponent("backups", isDirectory: true)
+                .appendingPathComponent(deviceId, isDirectory: true)
+            try fm.createDirectory(at: dir, withIntermediateDirectories: true)
+            return dir
+        }
+
+        Log.warning("createBackup: iCloud container unavailable, writing locally")
+        let localDir = environment.defaultDatabasesDirectoryURL
+            .appendingPathComponent("backups", isDirectory: true)
+            .appendingPathComponent(deviceId, isDirectory: true)
+        try fm.createDirectory(at: localDir, withIntermediateDirectories: true)
+        return localDir
+    }
+
+    private enum Constant {
+        static let bundleFilename: String = "backup-latest.encrypted"
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Backup/RestoreInProgressFlag.swift
+++ b/ConvosCore/Sources/ConvosCore/Backup/RestoreInProgressFlag.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+/// Process-crossing signal that an iCloud restore is actively rewriting
+/// the shared GRDB database and the XMTP local DB files.
+///
+/// Lives in the app-group `UserDefaults` so the main app and the
+/// NotificationService Extension can both read it. Set by
+/// `SessionManager.pauseForRestore()` and cleared by
+/// `resumeAfterRestore()`.
+///
+/// Consumers:
+/// - `DatabaseManager.replaceDatabase` wraps the swap in an
+///   `NSFileCoordinator` write barrier; this flag is the fast
+///   pre-check for readers that want to bail **before** opening
+///   coordinated handles.
+/// - The NSE early-exits with an empty content delivery when the
+///   flag is set — push loss within a narrow user-initiated window
+///   is an acceptable trade for not risking a torn read.
+/// - `BackupScheduler` skips + reschedules while the flag is set.
+public enum RestoreInProgressFlag {
+    private static let suiteName: String = "convos.restore-in-progress"
+    private static let key: String = "convos.restore-in-progress.flag"
+
+    /// The in-process-only flag — guarded separately by
+    /// `SessionManager` inside its `cachedMessagingService` lock.
+    /// See `docs/plans/icloud-backup-single-inbox.md`
+    /// §"Throwaway XMTP client for archive import" for why the
+    /// app-group flag alone doesn't close the in-process race.
+    public static func isSet(environment: AppEnvironment) -> Bool {
+        defaults(environment: environment)?.bool(forKey: key) ?? false
+    }
+
+    public static func set(_ value: Bool, environment: AppEnvironment) {
+        guard let defaults = defaults(environment: environment) else {
+            Log.warning("RestoreInProgressFlag: app-group defaults unavailable; flag not written")
+            return
+        }
+        defaults.set(value, forKey: key)
+    }
+
+    private static func defaults(environment: AppEnvironment) -> UserDefaults? {
+        UserDefaults(suiteName: environment.appGroupIdentifier)
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Backup/RestoreInProgressFlag.swift
+++ b/ConvosCore/Sources/ConvosCore/Backup/RestoreInProgressFlag.swift
@@ -18,27 +18,61 @@ import Foundation
 ///   is an acceptable trade for not risking a torn read.
 /// - `BackupScheduler` skips + reschedules while the flag is set.
 public enum RestoreInProgressFlag {
-    private static let suiteName: String = "convos.restore-in-progress"
     private static let key: String = "convos.restore-in-progress.flag"
+
+    public enum FlagError: Error, LocalizedError {
+        case appGroupUnavailable(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case let .appGroupUnavailable(groupId):
+                return "App-group UserDefaults (\(groupId)) unavailable; cannot signal restore-in-progress to the NSE"
+            }
+        }
+    }
 
     /// The in-process-only flag — guarded separately by
     /// `SessionManager` inside its `cachedMessagingService` lock.
     /// See `docs/plans/icloud-backup-single-inbox.md`
     /// §"Throwaway XMTP client for archive import" for why the
     /// app-group flag alone doesn't close the in-process race.
+    ///
+    /// Read path is lenient: "container unavailable" degrades to
+    /// `false`, which matches the pre-flag NSE behavior of
+    /// attempting delivery. This is safe because the coordinator +
+    /// in-process gate close the same race even if this flag
+    /// silently fails to read.
     public static func isSet(environment: AppEnvironment) -> Bool {
         defaults(environment: environment)?.bool(forKey: key) ?? false
     }
 
-    public static func set(_ value: Bool, environment: AppEnvironment) {
+    /// Strict: throws if the app-group container is unavailable.
+    /// `SessionManager.pauseForRestore` must abort the restore on
+    /// throw rather than proceeding into destructive ops with an
+    /// un-signaled NSE.
+    public static func set(_ value: Bool, environment: AppEnvironment) throws {
         guard let defaults = defaults(environment: environment) else {
-            Log.warning("RestoreInProgressFlag: app-group defaults unavailable; flag not written")
-            return
+            throw FlagError.appGroupUnavailable(environment.appGroupIdentifier)
         }
         defaults.set(value, forKey: key)
     }
 
     private static func defaults(environment: AppEnvironment) -> UserDefaults? {
         UserDefaults(suiteName: environment.appGroupIdentifier)
+    }
+}
+
+/// Error surfaced by `SessionManager.loadOrCreateService()` while a
+/// restore is actively in-process. Observers see
+/// `SessionStateMachine.State.error(RestoreInProgressError)` and can
+/// render a "Restoring…" banner instead of attempting recovery.
+///
+/// Not a `TerminalSessionError` — the state clears by design when
+/// `SessionManager.resumeAfterRestore()` nilpotently cleans up.
+public struct RestoreInProgressError: Error, LocalizedError {
+    public init() {}
+
+    public var errorDescription: String? {
+        "Restore in progress"
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Backup/RestoreManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Backup/RestoreManager.swift
@@ -1,0 +1,465 @@
+import Foundation
+import GRDB
+@preconcurrency import XMTPiOS
+
+/// High-level progress signal for `RestoreManager.restoreFromBackup`.
+/// Surfaced to the UI so the user sees where the restore is at.
+public enum RestoreState: Sendable, Equatable {
+    case idle
+    case decrypting
+    case validating
+    case preparingSession
+    case replacingDatabase
+    case importingArchive
+    case revokingStaleInstallations
+    case completed
+    case failed(String)
+    /// Non-fatal: GRDB restore committed but XMTP archive import
+    /// failed. Retry path surfaces in Settings as "Retry history
+    /// import"; see CP3e for the persistence half.
+    case archiveImportFailed(String)
+
+    public static func == (lhs: RestoreState, rhs: RestoreState) -> Bool {
+        switch (lhs, rhs) {
+        case (.idle, .idle), (.decrypting, .decrypting),
+             (.validating, .validating), (.preparingSession, .preparingSession),
+             (.replacingDatabase, .replacingDatabase),
+             (.importingArchive, .importingArchive),
+             (.revokingStaleInstallations, .revokingStaleInstallations),
+             (.completed, .completed):
+            return true
+        case let (.failed(l), .failed(r)):
+            return l == r
+        case let (.archiveImportFailed(l), .archiveImportFailed(r)):
+            return l == r
+        default:
+            return false
+        }
+    }
+}
+
+/// Errors surfaced by `RestoreManager.restoreFromBackup`.
+public enum RestoreError: Error, LocalizedError {
+    case bundleUnreadable(any Error)
+    case decryptionFailed(any Error)
+    case validationFailed(String)
+    case identityNotAvailable
+    case identityTimeout
+    case schemaGenerationMismatch(bundleGeneration: String, currentGeneration: String)
+    case sessionPauseFailed(any Error)
+    case replaceFailed(any Error)
+
+    public var errorDescription: String? {
+        switch self {
+        case let .bundleUnreadable(error):
+            return "Couldn't read the backup bundle: \(error.localizedDescription)"
+        case let .decryptionFailed(error):
+            return "Bundle decryption failed: \(error.localizedDescription)"
+        case let .validationFailed(reason):
+            return "Bundle is missing required contents: \(reason)"
+        case .identityNotAvailable:
+            return "No identity present in keychain — iCloud Keychain may still be syncing"
+        case .identityTimeout:
+            return "Timed out waiting for iCloud Keychain to provide the identity. Try again shortly."
+        case let .schemaGenerationMismatch(bundle, current):
+            return "This backup was made on an older version of Convos and can't be restored (bundle generation \(bundle), device generation \(current)). Try a newer backup, or start fresh."
+        case let .sessionPauseFailed(error):
+            return "Couldn't pause the current session for restore: \(error.localizedDescription)"
+        case let .replaceFailed(error):
+            return "Database replacement failed: \(error.localizedDescription)"
+        }
+    }
+}
+
+/// Orchestrates the read-side of the iCloud backup flow. Companion to
+/// `BackupManager`.
+///
+/// The full flow, per
+/// `docs/plans/icloud-backup-single-inbox.md` §"Restore flow":
+/// 1. findAvailableBackup (sidecar read, schemaGeneration check)
+/// 2. User confirms
+/// 3. `awaitIdentityWithTimeout` — iCloud Keychain may lag
+/// 4. Read + decrypt + untar → staging
+/// 5. Validate staging contents
+/// 6. `SessionManager.pauseForRestore()`
+/// 7. Stage aside XMTP files + snapshot identity (rollback anchors)
+/// 8. `DatabaseManager.replaceDatabase`
+/// 9. Throwaway Client.build → importArchive → dropLocalDatabaseConnection
+/// 10. Commit boundary — past here, errors are non-fatal
+/// 11. markAllConversationsInactive
+/// 12. `XMTPInstallationRevoker.revokeOtherInstallations` (non-fatal)
+/// 13. `SessionManager.resumeAfterRestore()`
+///
+/// Rollback path (pre-commit): restore XMTP file stash, restore
+/// keychain snapshot, resumeAfterRestore. Post-commit failures are
+/// surfaced but do not roll back — GRDB + keychain are already in
+/// the restored state.
+public actor RestoreManager {
+    public typealias ThrowawayClientBuilder = @Sendable (
+        _ identity: KeychainIdentity,
+        _ environment: AppEnvironment
+    ) async throws -> any XMTPClientProvider
+
+    // MARK: - Dependencies
+
+    private let databaseManager: any DatabaseManagerProtocol
+    private let identityStore: any KeychainIdentityStoreProtocol
+    private let sessionManager: SessionManager
+    private let environment: AppEnvironment
+    private let clientBuilder: ThrowawayClientBuilder
+    private let currentSchemaGeneration: String
+    private let identityPollInterval: Duration
+    private let identityTimeout: Duration
+
+    public private(set) var state: RestoreState = .idle
+
+    public init(
+        databaseManager: any DatabaseManagerProtocol,
+        identityStore: any KeychainIdentityStoreProtocol,
+        sessionManager: SessionManager,
+        environment: AppEnvironment,
+        clientBuilder: @escaping ThrowawayClientBuilder = RestoreManager.productionClientBuilder,
+        currentSchemaGeneration: String,
+        identityPollInterval: Duration = .milliseconds(500),
+        identityTimeout: Duration = .seconds(30)
+    ) {
+        self.databaseManager = databaseManager
+        self.identityStore = identityStore
+        self.sessionManager = sessionManager
+        self.environment = environment
+        self.clientBuilder = clientBuilder
+        self.currentSchemaGeneration = currentSchemaGeneration
+        self.identityPollInterval = identityPollInterval
+        self.identityTimeout = identityTimeout
+    }
+
+    // MARK: - Discovery
+
+    /// Look for an available backup bundle near the current device's
+    /// iCloud container or local fallback. Reads the **sidecar** only
+    /// — no decryption — so discovery works before the identity has
+    /// arrived via iCloud Keychain.
+    public nonisolated static func findAvailableBackup(
+        environment: AppEnvironment
+    ) -> (url: URL, sidecar: BackupBundleMetadata.Sidecar)? {
+        let fm = FileManager.default
+        let deviceId = DeviceInfo.deviceIdentifier
+
+        let candidates: [URL] = [
+            fm.url(forUbiquityContainerIdentifier: environment.iCloudContainerIdentifier)?
+                .appendingPathComponent("Documents", isDirectory: true)
+                .appendingPathComponent("backups", isDirectory: true)
+                .appendingPathComponent(deviceId, isDirectory: true),
+            environment.defaultDatabasesDirectoryURL
+                .appendingPathComponent("backups", isDirectory: true)
+                .appendingPathComponent(deviceId, isDirectory: true),
+        ].compactMap { $0 }
+
+        for dir in candidates {
+            guard BackupBundleMetadata.exists(in: dir) else { continue }
+            guard let sidecar = try? BackupBundleMetadata.readSidecar(from: dir) else { continue }
+
+            let bundle = dir.appendingPathComponent("backup-latest.encrypted")
+            guard fm.fileExists(atPath: bundle.path) else { continue }
+
+            // schemaGeneration-mismatch rejection belongs to the restore
+            // path (so we can surface a specific error); discovery
+            // returns the sidecar so the UI can format the
+            // mismatch message.
+            return (bundle, sidecar)
+        }
+        return nil
+    }
+
+    // MARK: - Main flow
+
+    public func restoreFromBackup(bundleURL: URL) async throws {
+        state = .decrypting
+
+        let bundleData = try readBundle(at: bundleURL)
+        let staging = try BackupBundle.createStagingDirectory()
+        var cleanStaging = true
+        defer {
+            if cleanStaging {
+                BackupBundle.cleanup(directory: staging)
+            }
+        }
+
+        let identity = try await awaitIdentity()
+
+        do {
+            try BackupBundle.unpack(
+                data: bundleData,
+                encryptionKey: identity.keys.databaseKey,
+                to: staging
+            )
+        } catch {
+            throw RestoreError.decryptionFailed(error)
+        }
+
+        state = .validating
+        let fullMetadata = try readAndValidateMetadata(stagingDir: staging)
+
+        state = .preparingSession
+        do {
+            try await sessionManager.pauseForRestore()
+        } catch {
+            throw RestoreError.sessionPauseFailed(error)
+        }
+
+        var committed = false
+
+        // Stash existing XMTP files before the swap so a rollback can
+        // restore them. Keychain doesn't need separate snapshotting
+        // here — the identity itself is unchanged across a restore,
+        // only GRDB + xmtp-*.db3 get replaced.
+        let xmtpStashDir: URL?
+        do {
+            xmtpStashDir = try stageXMTPFiles()
+        } catch {
+            await sessionManager.resumeAfterRestore()
+            throw RestoreError.replaceFailed(error)
+        }
+
+        do {
+            try await performRestore(
+                identity: identity,
+                stagingDir: staging,
+                fullMetadata: fullMetadata
+            )
+            committed = true
+        } catch {
+            // Pre-commit failure: restore the stash, then rethrow.
+            if let stash = xmtpStashDir {
+                restoreXMTPStash(from: stash)
+            }
+            await sessionManager.resumeAfterRestore()
+            state = .failed(error.localizedDescription)
+            throw error
+        }
+
+        // Post-commit, stash is stale — throw it away.
+        if let stash = xmtpStashDir {
+            try? FileManager.default.removeItem(at: stash)
+        }
+
+        // Resume regardless of whether post-commit steps had issues.
+        // Those are surfaced via `state` (archiveImportFailed,
+        // revokeStale failure logs), not via throws.
+        await sessionManager.resumeAfterRestore()
+
+        if committed {
+            if case .archiveImportFailed = state {
+                // Leave the state as-is; completed doesn't apply.
+            } else {
+                state = .completed
+            }
+        }
+
+        // cleanStaging stays true — the defer cleans up the staging dir.
+        _ = cleanStaging
+    }
+
+    // MARK: - Step helpers
+
+    private func readBundle(at url: URL) throws -> Data {
+        do {
+            return try Data(contentsOf: url)
+        } catch {
+            throw RestoreError.bundleUnreadable(error)
+        }
+    }
+
+    private func awaitIdentity() async throws -> KeychainIdentity {
+        let deadline = ContinuousClock.now.advanced(by: identityTimeout)
+        while ContinuousClock.now < deadline {
+            if let identity = try? identityStore.loadSync() {
+                return identity
+            }
+            try await Task.sleep(for: identityPollInterval)
+        }
+        // One final attempt after deadline so a just-synced identity
+        // isn't missed by a hair.
+        if let identity = try? identityStore.loadSync() {
+            return identity
+        }
+        throw RestoreError.identityTimeout
+    }
+
+    private func readAndValidateMetadata(stagingDir: URL) throws -> BackupBundleMetadata {
+        let metadata: BackupBundleMetadata
+        do {
+            metadata = try BackupBundleMetadata.readFull(from: stagingDir)
+        } catch {
+            throw RestoreError.validationFailed("metadata.json unreadable: \(error.localizedDescription)")
+        }
+
+        guard metadata.schemaGeneration == currentSchemaGeneration else {
+            QAEvent.emit(
+                .conversation,
+                "schema_generation_mismatch",
+                [
+                    "bundle": metadata.schemaGeneration,
+                    "current": currentSchemaGeneration,
+                ]
+            )
+            throw RestoreError.schemaGenerationMismatch(
+                bundleGeneration: metadata.schemaGeneration,
+                currentGeneration: currentSchemaGeneration
+            )
+        }
+
+        let dbPath = BackupBundle.databasePath(in: stagingDir)
+        guard FileManager.default.fileExists(atPath: dbPath.path) else {
+            throw RestoreError.validationFailed("GRDB snapshot missing from bundle")
+        }
+
+        let archivePath = BackupBundle.xmtpArchivePath(in: stagingDir)
+        guard FileManager.default.fileExists(atPath: archivePath.path) else {
+            throw RestoreError.validationFailed("XMTP archive missing from bundle")
+        }
+
+        guard metadata.archiveKey.count == BackupBundleCrypto.expectedKeyLength else {
+            throw RestoreError.validationFailed("archiveKey missing or wrong length")
+        }
+
+        return metadata
+    }
+
+    private func performRestore(
+        identity: KeychainIdentity,
+        stagingDir: URL,
+        fullMetadata: BackupBundleMetadata
+    ) async throws {
+        state = .replacingDatabase
+        let dbPath = BackupBundle.databasePath(in: stagingDir)
+        do {
+            try databaseManager.replaceDatabase(with: dbPath)
+        } catch {
+            throw RestoreError.replaceFailed(error)
+        }
+
+        state = .importingArchive
+        var archiveImportError: (any Error)?
+        do {
+            try await importXMTPArchive(
+                identity: identity,
+                archivePath: BackupBundle.xmtpArchivePath(in: stagingDir).path,
+                archiveKey: fullMetadata.archiveKey
+            )
+        } catch {
+            // Non-fatal: GRDB is already restored, so the user ends
+            // up with the conversation list but missing history.
+            // CP3e will persist the archive bytes for retry.
+            Log.warning("Archive import failed (non-fatal): \(error)")
+            archiveImportError = error
+        }
+
+        do {
+            let writer = ConversationLocalStateWriter(databaseWriter: databaseManager.dbWriter)
+            try await writer.markAllConversationsInactive()
+        } catch {
+            Log.warning("markAllConversationsInactive failed (non-fatal): \(error)")
+        }
+
+        if archiveImportError == nil {
+            state = .revokingStaleInstallations
+        }
+        await revokeStaleInstallations(identity: identity)
+
+        // Re-pin the archive-import state as the final post-commit
+        // signal so `completed` vs `archiveImportFailed` is stable
+        // by the time the caller observes it.
+        if let archiveImportError {
+            state = .archiveImportFailed(archiveImportError.localizedDescription)
+        }
+    }
+
+    private func importXMTPArchive(
+        identity: KeychainIdentity,
+        archivePath: String,
+        archiveKey: Data
+    ) async throws {
+        let client = try await clientBuilder(identity, environment)
+        defer { try? client.dropLocalDatabaseConnection() }
+        try await client.importArchive(path: archivePath, encryptionKey: archiveKey)
+    }
+
+    private func revokeStaleInstallations(identity: KeychainIdentity) async {
+        do {
+            let client = try await clientBuilder(identity, environment)
+            defer { try? client.dropLocalDatabaseConnection() }
+            _ = try await XMTPInstallationRevoker.revokeOtherInstallations(
+                client: client,
+                signingKey: identity.keys.signingKey,
+                keepInstallationId: client.installationId
+            )
+        } catch {
+            Log.warning("revokeStaleInstallations failed (non-fatal): \(error)")
+        }
+    }
+
+    // MARK: - Stash helpers
+
+    private func stageXMTPFiles() throws -> URL? {
+        let fm = FileManager.default
+        let stashDir = fm.temporaryDirectory
+            .appendingPathComponent("xmtp-restore-stash-\(UUID().uuidString)")
+        try fm.createDirectory(at: stashDir, withIntermediateDirectories: true)
+
+        let source = environment.defaultDatabasesDirectoryURL
+        guard let files = try? fm.contentsOfDirectory(
+            at: source,
+            includingPropertiesForKeys: nil,
+            options: [.skipsHiddenFiles]
+        ) else {
+            return stashDir
+        }
+
+        for file in files where file.lastPathComponent.hasPrefix("xmtp-") &&
+            !file.lastPathComponent.hasPrefix("xmtp-restore-stash-") {
+            let destination = stashDir.appendingPathComponent(file.lastPathComponent)
+            try? fm.moveItem(at: file, to: destination)
+        }
+        return stashDir
+    }
+
+    private func restoreXMTPStash(from stashDir: URL) {
+        let fm = FileManager.default
+        let dest = environment.defaultDatabasesDirectoryURL
+        guard let files = try? fm.contentsOfDirectory(
+            at: stashDir,
+            includingPropertiesForKeys: nil
+        ) else {
+            try? fm.removeItem(at: stashDir)
+            return
+        }
+        for file in files {
+            let target = dest.appendingPathComponent(file.lastPathComponent)
+            try? fm.removeItem(at: target)
+            try? fm.moveItem(at: file, to: target)
+        }
+        try? fm.removeItem(at: stashDir)
+    }
+
+    // MARK: - Production client builder
+
+    /// Default throwaway-client factory for production. Builds an
+    /// `XMTPiOS.Client` against the (now-empty) XMTP DB directory on
+    /// the restored identity. The caller `defer`s
+    /// `dropLocalDatabaseConnection` so the pool releases before
+    /// `resumeAfterRestore` rebuilds the real session client.
+    public static let productionClientBuilder: ThrowawayClientBuilder = { identity, environment in
+        let api = XMTPAPIOptionsBuilder.build(environment: environment)
+        let options = ClientOptions(
+            api: api,
+            dbEncryptionKey: identity.keys.databaseKey,
+            dbDirectory: environment.defaultDatabasesDirectory
+        )
+        return try await Client.build(
+            publicIdentity: identity.keys.signingKey.identity,
+            options: options,
+            inboxId: identity.inboxId
+        )
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Backup/XMTPInstallationRevoker.swift
+++ b/ConvosCore/Sources/ConvosCore/Backup/XMTPInstallationRevoker.swift
@@ -1,0 +1,73 @@
+import Foundation
+@preconcurrency import XMTPiOS
+
+/// Revokes every MLS installation on the user's inbox **except** the
+/// one we want to keep — used at the tail of a restore to evict the
+/// stale installation from the device whose backup we just unpacked.
+///
+/// Lives at the end of the restore flow: by the time this runs, the
+/// throwaway `XMTPiOS.Client` already exists locally, its freshly-
+/// minted installation is registered on the network, and we want to
+/// revoke all the others so the old device's installation flips to
+/// `stale` on its next foreground cycle.
+///
+/// Takes `any XMTPClientProvider` rather than a raw `XMTPiOS.Client`
+/// so tests can inject a mock without spinning up a real XMTP client.
+/// All network-talking calls go through the protocol's
+/// `inboxState(refreshFromNetwork:)` + `revokeInstallations(signingKey:installationIds:)`.
+///
+/// The call is non-fatal: a revocation failure logs and returns; the
+/// restore itself still counts as successful because the local GRDB +
+/// XMTP archive are already committed.
+public enum XMTPInstallationRevoker {
+    public enum RevocationError: Error, LocalizedError {
+        case noActiveInstallations
+
+        public var errorDescription: String? {
+            switch self {
+            case .noActiveInstallations:
+                return "Inbox state refresh returned zero installations — expected at least the local one"
+            }
+        }
+    }
+
+    /// Revoke every installation on this inbox except `keepInstallationId`.
+    ///
+    /// - Parameters:
+    ///   - client: Live XMTP client for the inbox being revoked from.
+    ///     Typically the throwaway `Client.build` `RestoreManager` just
+    ///     finished calling `importArchive` on.
+    ///   - signingKey: The identity's signing key. Needed to authorize
+    ///     the revocation commits on the network.
+    ///   - keepInstallationId: The id to preserve — almost always
+    ///     `client.installationId` of the caller.
+    /// - Returns: The number of installations that were revoked.
+    @discardableResult
+    public static func revokeOtherInstallations(
+        client: any XMTPClientProvider,
+        signingKey: any SigningKey,
+        keepInstallationId: String
+    ) async throws -> Int {
+        Log.info("revokeOtherInstallations: fetching current inbox state")
+        let state = try await client.inboxState(refreshFromNetwork: true)
+        let allIds = state.installations.map(\.id)
+
+        guard !allIds.isEmpty else {
+            throw RevocationError.noActiveInstallations
+        }
+
+        let toRevoke = allIds.filter { $0 != keepInstallationId }
+        Log.info("revokeOtherInstallations: \(allIds.count) active, revoking \(toRevoke.count), keeping \(keepInstallationId)")
+
+        guard !toRevoke.isEmpty else {
+            return 0
+        }
+
+        try await client.revokeInstallations(
+            signingKey: signingKey,
+            installationIds: toRevoke
+        )
+        Log.info("revokeOtherInstallations: revoked \(toRevoke.count) installation(s)")
+        return toRevoke.count
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Device/DeviceInfoProviding.swift
+++ b/ConvosCore/Sources/ConvosCore/Device/DeviceInfoProviding.swift
@@ -20,6 +20,13 @@ public protocol DeviceInfoProviding: Sendable {
 
     /// Returns the current OS string (e.g., "ios", "macos").
     var osString: String { get }
+
+    /// Human-readable device name for display in backup-discovery UI
+    /// (e.g., "Jarod's iPhone"). On iOS this is `UIDevice.current.name`,
+    /// which may be set to the user's custom name. Not guaranteed to
+    /// be unique or stable across renames — use `deviceIdentifier`
+    /// for anything that needs either property.
+    var deviceName: String { get }
 }
 
 // MARK: - Shared Instance Access
@@ -76,6 +83,11 @@ public enum DeviceInfo {
     /// Convenience accessor for `DeviceInfo.shared.osString`
     public static var osString: String {
         shared.osString
+    }
+
+    /// Convenience accessor for `DeviceInfo.shared.deviceName`.
+    public static var deviceName: String {
+        shared.deviceName
     }
 
     /// Resets the configuration state. Only for use in tests.

--- a/ConvosCore/Sources/ConvosCore/Inboxes/SessionStateMachine.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/SessionStateMachine.swift
@@ -596,6 +596,28 @@ public actor SessionStateMachine: SessionStateManagerProtocol {
     }
 
     private func handleAuthorized(result: InboxReadyResult) async throws {
+        // Stale-installation check. If the network says our
+        // installation has been revoked (likely because the user
+        // restored on another device), transition to
+        // `.error(DeviceReplacedError())` — a TerminalSessionError
+        // that handleRetryFromError won't retry, so the banner +
+        // reset-device flow is the only path out.
+        do {
+            let state = try await result.client.inboxState(refreshFromNetwork: true)
+            let active = state.installations.map(\.id)
+            if !active.contains(result.client.installationId) {
+                Log.warning("handleAuthorized: local installation \(result.client.installationId) not in active set \(active); treating as device-replaced")
+                throw DeviceReplacedError()
+            }
+        } catch is DeviceReplacedError {
+            throw DeviceReplacedError()
+        } catch {
+            // Network failure on the stale check shouldn't block
+            // session startup — log and proceed as if active. The
+            // next foreground cycle will retry the probe.
+            Log.warning("handleAuthorized: stale-installation probe failed (\(error)); proceeding as active")
+        }
+
         await syncingManager?.start(with: result.client, apiClient: result.apiClient)
         foregroundRetryCount = 0
         emitStateChange(.ready(result))
@@ -736,6 +758,17 @@ public actor SessionStateMachine: SessionStateManagerProtocol {
 
     private func handleRetryFromError() async throws {
         try Task.checkCancellation()
+
+        // Terminal errors (e.g. DeviceReplacedError) must not retry —
+        // the observer-side reset flow is the only recovery path.
+        // Retrying re-runs handleAuthorize against the same revoked
+        // identity, burning counters and masking the banner if a
+        // retry happens to land in `.ready` by coincidence.
+        if case let .error(currentError) = currentState,
+           currentError is TerminalSessionError {
+            Log.info("Not retrying terminal session error: \(currentError)")
+            return
+        }
 
         guard foregroundRetryCount < Self.maxForegroundRetries else {
             Log.warning("Max foreground retries (\(Self.maxForegroundRetries)) reached, not retrying")

--- a/ConvosCore/Sources/ConvosCore/Inboxes/TerminalSessionError.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/TerminalSessionError.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+/// Marker for session errors that **cannot** be recovered by
+/// retrying `SessionStateMachine`'s authorize path.
+///
+/// Retryable errors (network hiccup, keychain-daemon stall, XMTP
+/// node blip) are the common case — foreground retry pulls the
+/// session back to `.ready`. Terminal errors surface the same
+/// `SessionStateMachine.State.error` case, but retries silently
+/// burn counters and — worse — can flip the state to `.ready` by
+/// happenstance (e.g. iCloud Keychain refreshed between retries),
+/// masking the UI affordance that was the only real path out.
+///
+/// `SessionStateMachine.handleRetryFromError` short-circuits when
+/// the current error conforms. Observer-side code (banners, reset
+/// flows) is the only path out of a terminal state.
+///
+/// See `docs/plans/icloud-backup-single-inbox.md` §"Terminal errors:
+/// `handleRetryFromError` must not retry them".
+public protocol TerminalSessionError: Error {}
+
+/// The device's sole XMTP installation has been revoked — either
+/// the user restored on another device (Apple ID sync scenario),
+/// or an admin action elsewhere. Recovery is a full local reset,
+/// not a retry.
+public struct DeviceReplacedError: TerminalSessionError, Equatable {
+    public init() {}
+}

--- a/ConvosCore/Sources/ConvosCore/Messaging/XMTPClientProvider.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/XMTPClientProvider.swift
@@ -143,6 +143,27 @@ public protocol XMTPClientProvider: AnyObject {
     func revokeInstallations(
         signingKey: SigningKey, installationIds: [String]
     ) async throws
+
+    /// Fetch this inbox's current MLS state. Used by the revoker to
+    /// enumerate live installations before deciding which to revoke.
+    /// `refreshFromNetwork: true` forces a fresh read; with `false`
+    /// the SDK returns its cached view which may be stale.
+    func inboxState(refreshFromNetwork: Bool) async throws -> XMTPiOS.InboxState
+
+    /// Write an encrypted XMTP archive of this client's conversations
+    /// and messages to `path`. Key must be 32 bytes. The archive is
+    /// AES-256-GCM-encrypted by the SDK; we carry the same key inside
+    /// the backup bundle's full-form metadata so `importArchive` can
+    /// read it back.
+    func createArchive(path: String, encryptionKey: Data) async throws
+
+    /// Read an encrypted XMTP archive at `path` and apply it to this
+    /// client's local MLS state. Caller must have constructed the
+    /// client against an empty XMTP DB file — importing onto a
+    /// populated DB has undefined behavior per the SDK's archive
+    /// contract.
+    func importArchive(path: String, encryptionKey: Data) async throws
+
     func deleteLocalDatabase() throws
     func reconnectLocalDatabase() async throws
     func dropLocalDatabaseConnection() throws
@@ -187,6 +208,15 @@ extension XMTPiOS.Client: XMTPClientProvider {
 
     public var inboxId: String {
         inboxID
+    }
+
+    // Forwarding wrappers for the backup/restore archive APIs.
+    // XMTPiOS.Client's `createArchive(path:encryptionKey:opts:)` takes
+    // an `opts: ArchiveOptions = .init()` third arg; the protocol
+    // requirement takes only path + encryptionKey, so an explicit
+    // pass-through is needed for the witness to resolve.
+    public func createArchive(path: String, encryptionKey: Data) async throws {
+        try await self.createArchive(path: path, encryptionKey: encryptionKey, opts: ArchiveOptions())
     }
 
     public func canMessage(identity: String) async throws -> Bool {

--- a/ConvosCore/Sources/ConvosCore/Mocks/MockXMTPClientProvider.swift
+++ b/ConvosCore/Sources/ConvosCore/Mocks/MockXMTPClientProvider.swift
@@ -67,6 +67,44 @@ public final class MockXMTPClientProvider: XMTPClientProvider, @unchecked Sendab
 
     public func revokeInstallations(signingKey: any SigningKey, installationIds: [String]) async throws {
         // No-op for mock
+        revokeCalls.append((signingKey, installationIds))
+    }
+
+    public var revokeCalls: [(signingKey: any SigningKey, installationIds: [String])] = []
+    public var stubInboxState: XMTPiOS.InboxState?
+    public var inboxStateError: (any Error)?
+
+    public func inboxState(refreshFromNetwork: Bool) async throws -> XMTPiOS.InboxState {
+        if let error = inboxStateError {
+            throw error
+        }
+        guard let state = stubInboxState else {
+            fatalError("MockXMTPClientProvider.inboxState called without stubInboxState set")
+        }
+        return state
+    }
+
+    public var createArchiveCalls: [(path: String, encryptionKey: Data)] = []
+    public var createArchiveError: (any Error)?
+
+    public func createArchive(path: String, encryptionKey: Data) async throws {
+        createArchiveCalls.append((path, encryptionKey))
+        if let error = createArchiveError {
+            throw error
+        }
+        // Produce a placeholder file at the path so callers that stat
+        // the result see it exists.
+        try? Data("mock-archive".utf8).write(to: URL(fileURLWithPath: path))
+    }
+
+    public var importArchiveCalls: [(path: String, encryptionKey: Data)] = []
+    public var importArchiveError: (any Error)?
+
+    public func importArchive(path: String, encryptionKey: Data) async throws {
+        importArchiveCalls.append((path, encryptionKey))
+        if let error = importArchiveError {
+            throw error
+        }
     }
 
     public func deleteLocalDatabase() throws {

--- a/ConvosCore/Sources/ConvosCore/PlatformProviders.swift
+++ b/ConvosCore/Sources/ConvosCore/PlatformProviders.swift
@@ -94,17 +94,20 @@ public final class MockDeviceInfoProvider: DeviceInfoProviding, Sendable {
     public let fallbackIdentifier: String
     public let deviceIdentifier: String
     public let osString: String
+    public let deviceName: String
 
     public init(
         identifierForVendor: String? = "mock-vendor-id",
         fallbackIdentifier: String = "mock-fallback-id",
         deviceIdentifier: String = "mock-device-id",
-        osString: String = "mock"
+        osString: String = "mock",
+        deviceName: String = "Mock Device"
     ) {
         self.identifierForVendor = identifierForVendor
         self.fallbackIdentifier = fallbackIdentifier
         self.deviceIdentifier = deviceIdentifier
         self.osString = osString
+        self.deviceName = deviceName
     }
 }
 

--- a/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
@@ -451,20 +451,33 @@ public final class SessionManager: SessionManagerProtocol, @unchecked Sendable {
             return slot
         }
 
-        await unusedConversationCache.cancel()
+        // Defensive: `cancel()` and `stop()` are non-throwing today,
+        // but if either grows a throw site in the future the caller
+        // would see a half-paused session (flag set, cache not
+        // cleared) with no cleanup. The `Task.checkCancellation()`
+        // below also lets a cancelled restore unwind cleanly — the
+        // catch re-runs `resumeAfterRestore` so the flags come off
+        // before we rethrow.
+        do {
+            try Task.checkCancellation()
+            await unusedConversationCache.cancel()
 
-        if let existing {
-            Log.info("pauseForRestore: stopping cached messaging service")
-            await existing.stop()
+            if let existing {
+                Log.info("pauseForRestore: stopping cached messaging service")
+                await existing.stop()
+            }
+
+            // Clear the slot only after `stop()` so a concurrent
+            // `loadOrCreateService()` sees the being-stopped service
+            // (while also observing `isRestoringInProcess` and falling
+            // through to the placeholder path). The slot will be
+            // repopulated with a `RestoreInProgressError` placeholder on
+            // the next call.
+            cachedMessagingService.withLock { $0 = nil }
+        } catch {
+            await resumeAfterRestore()
+            throw error
         }
-
-        // Clear the slot only after `stop()` so a concurrent
-        // `loadOrCreateService()` sees the being-stopped service
-        // (while also observing `isRestoringInProcess` and falling
-        // through to the placeholder path). The slot will be
-        // repopulated with a `RestoreInProgressError` placeholder on
-        // the next call.
-        cachedMessagingService.withLock { $0 = nil }
 
         Log.info("pauseForRestore: session paused")
     }
@@ -486,11 +499,11 @@ public final class SessionManager: SessionManagerProtocol, @unchecked Sendable {
             Log.error("resumeAfterRestore: failed to clear app-group flag (\(error)); NSE will see stale 'restoring' until app-group becomes available")
         }
 
-        // Trigger a rebuild. `loadOrCreateService()` is no longer
-        // short-circuited by `isRestoringInProcess`, so this restarts
-        // the state machine against the restored identity + DB.
-        _ = loadOrCreateService()
-
+        // Lazy rebuild — next `messagingService()` caller builds the
+        // real service against the restored identity + DB. Mirrors
+        // `tearDownInbox`'s pattern (nil the slot, don't prewarm);
+        // eagerly rebuilding here would swallow keychain-unreadable
+        // errors into a silently-errored cached service.
         Log.info("resumeAfterRestore: session resumed")
     }
 

--- a/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
@@ -47,6 +47,17 @@ public final class SessionManager: SessionManagerProtocol, @unchecked Sendable {
     /// concurrent callers can never spawn two `AuthorizeInboxOperation`s.
     private let cachedMessagingService: OSAllocatedUnfairLock<MessagingService?> = .init(initialState: nil)
 
+    /// In-process counterpart to `RestoreInProgressFlag` (which covers
+    /// the NSE via app-group UserDefaults). Set inside the same lock
+    /// block as `cachedMessagingService` so a concurrent push
+    /// delivery in the main-app process can't race a second XMTP
+    /// client against `RestoreManager`'s throwaway client while a
+    /// restore is rewriting the shared SQLCipher DB. `loadOrCreateService`
+    /// short-circuits to a `RestoreInProgressError` placeholder while
+    /// set. See `docs/plans/icloud-backup-single-inbox.md` §"Throwaway
+    /// XMTP client for archive import".
+    private var isRestoringInProcess: Bool = false
+
     /// Wall-clock of the last `identityStore.loadSync()` failure, lock-
     /// protected via the same lock as `cachedMessagingService` (both live
     /// inside the same `withLock` block). Used together with
@@ -198,6 +209,32 @@ public final class SessionManager: SessionManagerProtocol, @unchecked Sendable {
     ///   fix collapses the pre-refactor thrash where every call rebuilt).
     private func loadOrCreateService() -> MessagingService {
         cachedMessagingService.withLock { cached in
+            // Restore short-circuit. Building a real service now would
+            // open a second SQLCipher pool against the same xmtp-*.db3
+            // that `RestoreManager`'s throwaway client holds open.
+            // Return (or build-and-cache) a frozen placeholder whose
+            // state is `.error(RestoreInProgressError)`. Observers
+            // render that as "Restoring…"; next access after
+            // `resumeAfterRestore` clears both the flag and the slot,
+            // and the real service builds on the following call.
+            if isRestoringInProcess {
+                if let existing = cached,
+                   case let .error(error) = existing.sessionStateManager.currentState,
+                   error is RestoreInProgressError {
+                    return existing
+                }
+                let placeholder = MessagingService(
+                    identityReadFailure: RestoreInProgressError(),
+                    databaseWriter: databaseWriter,
+                    databaseReader: databaseReader,
+                    identityStore: identityStore,
+                    environment: environment,
+                    backgroundUploadManager: platformProviders.backgroundUploadManager
+                )
+                cached = placeholder
+                return placeholder
+            }
+
             let previousWasErrored: Bool
             if let existing = cached {
                 if case .error = existing.sessionStateManager.currentState {
@@ -382,6 +419,79 @@ public final class SessionManager: SessionManagerProtocol, @unchecked Sendable {
         try await wipeResidualInboxRows()
 
         cachedMessagingService.withLock { $0 = nil }
+    }
+
+    // MARK: - Restore Lifecycle (package-internal, for RestoreManager)
+
+    /// Signal that a restore is about to rewrite the shared GRDB and
+    /// the XMTP local DB. Callable only from `RestoreManager`.
+    ///
+    /// Four things happen atomically from the perspective of anyone
+    /// reading the cached service:
+    /// 1. `RestoreInProgressFlag` (app-group UserDefaults) is set so
+    ///    the NSE bails on incoming pushes.
+    /// 2. `isRestoringInProcess` flips to `true` inside the cache
+    ///    lock, so the main-app process short-circuits
+    ///    `loadOrCreateService()` to a frozen `RestoreInProgressError`
+    ///    placeholder for the duration.
+    /// 3. The cached `MessagingService` (if any) is stopped — NOT
+    ///    deleted; identity + DBInbox rows are preserved.
+    /// 4. The in-flight `UnusedConversationCache` prewarm is
+    ///    cancelled and awaited.
+    ///
+    /// Throws if the app-group flag can't be written. `RestoreManager`
+    /// must abort the restore before any destructive op on throw — a
+    /// silent "flag not set" would let the NSE proceed into a torn
+    /// read of the DB being rewritten page-by-page.
+    func pauseForRestore() async throws {
+        try RestoreInProgressFlag.set(true, environment: environment)
+
+        let existing = cachedMessagingService.withLock { slot -> MessagingService? in
+            isRestoringInProcess = true
+            return slot
+        }
+
+        await unusedConversationCache.cancel()
+
+        if let existing {
+            Log.info("pauseForRestore: stopping cached messaging service")
+            await existing.stop()
+        }
+
+        // Clear the slot only after `stop()` so a concurrent
+        // `loadOrCreateService()` sees the being-stopped service
+        // (while also observing `isRestoringInProcess` and falling
+        // through to the placeholder path). The slot will be
+        // repopulated with a `RestoreInProgressError` placeholder on
+        // the next call.
+        cachedMessagingService.withLock { $0 = nil }
+
+        Log.info("pauseForRestore: session paused")
+    }
+
+    /// Counterpart to `pauseForRestore`. Clears the flags and lets
+    /// the next `loadOrCreateService()` build the real service
+    /// against the restored DB. Never throws — `pauseForRestore`
+    /// already committed, and the flag-clear path must complete
+    /// even on partial failure.
+    func resumeAfterRestore() async {
+        cachedMessagingService.withLock { slot in
+            isRestoringInProcess = false
+            slot = nil
+        }
+
+        do {
+            try RestoreInProgressFlag.set(false, environment: environment)
+        } catch {
+            Log.error("resumeAfterRestore: failed to clear app-group flag (\(error)); NSE will see stale 'restoring' until app-group becomes available")
+        }
+
+        // Trigger a rebuild. `loadOrCreateService()` is no longer
+        // short-circuited by `isRestoringInProcess`, so this restarts
+        // the state machine against the restored identity + DB.
+        _ = loadOrCreateService()
+
+        Log.info("resumeAfterRestore: session resumed")
     }
 
     private func wipeResidualInboxRows() async throws {

--- a/ConvosCore/Sources/ConvosCore/Storage/DatabaseManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/DatabaseManager.swift
@@ -45,6 +45,12 @@ public enum DatabaseManagerError: Error, LocalizedError {
 /// Configures connection pooling, busy timeouts, and persistent WAL mode for
 /// read-only processes.
 public final class DatabaseManager: DatabaseManagerProtocol, @unchecked Sendable {
+    /// Canonical filename for the single-inbox GRDB database. Shared
+    /// between the pool setup here and the bundle format (see
+    /// `BackupBundle.Component.database`) so the two sites can't
+    /// drift apart.
+    public static let databaseFilename: String = "convos-single-inbox.sqlite"
+
     let environment: AppEnvironment
 
     public let dbPool: DatabasePool
@@ -156,7 +162,7 @@ public final class DatabaseManager: DatabaseManagerProtocol, @unchecked Sendable
         let fileManager = FileManager.default
         // Shared App Group container so the main app and NSE share the same DB.
         let groupDirURL = environment.defaultDatabasesDirectoryURL
-        let dbURL = groupDirURL.appendingPathComponent("convos-single-inbox.sqlite")
+        let dbURL = groupDirURL.appendingPathComponent(databaseFilename)
 
         // Ensure the App Group directory exists
         try fileManager.createDirectory(at: groupDirURL, withIntermediateDirectories: true)

--- a/ConvosCore/Sources/ConvosCore/Storage/DatabaseManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/DatabaseManager.swift
@@ -2,9 +2,39 @@ import Foundation
 import GRDB
 import SQLite3
 
-public protocol DatabaseManagerProtocol {
+public protocol DatabaseManagerProtocol: Sendable {
     var dbWriter: DatabaseWriter { get }
     var dbReader: DatabaseReader { get }
+
+    /// Replace the live database contents with a GRDB file at `backupPath`.
+    ///
+    /// Pool-to-pool copy through GRDB's `backup(to:)`; the existing
+    /// `DatabasePool` instance is preserved so long-lived readers/
+    /// writers held elsewhere in the app remain valid across the swap.
+    /// A rollback snapshot is captured before the copy begins — any
+    /// failure past the first write triggers a restore of the
+    /// pre-restore state. Double-fault (replace fails AND rollback
+    /// fails) throws `DatabaseManagerError.rollbackFailed`, which the
+    /// UI must treat as fatal.
+    ///
+    /// Runs under an `NSFileCoordinator` write barrier so a coordinated
+    /// reader in another process (the NSE) waits for completion rather
+    /// than opening the file mid-write.
+    func replaceDatabase(with backupPath: URL) throws
+}
+
+public enum DatabaseManagerError: Error, LocalizedError {
+    case backupFileMissing(URL)
+    case rollbackFailed(original: any Error, rollback: any Error)
+
+    public var errorDescription: String? {
+        switch self {
+        case let .backupFileMissing(url):
+            return "Backup database file not found at \(url.path)"
+        case let .rollbackFailed(original, rollback):
+            return "Database replacement failed (\(original)) and rollback also failed (\(rollback)). Reinstall required."
+        }
+    }
 }
 
 /// Manages the SQLite database for Convos
@@ -14,10 +44,11 @@ public protocol DatabaseManagerProtocol {
 /// is stored in the shared App Group container to enable multi-process access.
 /// Configures connection pooling, busy timeouts, and persistent WAL mode for
 /// read-only processes.
-public final class DatabaseManager: DatabaseManagerProtocol {
+public final class DatabaseManager: DatabaseManagerProtocol, @unchecked Sendable {
     let environment: AppEnvironment
 
     public let dbPool: DatabasePool
+    private let dbURL: URL
 
     public var dbWriter: DatabaseWriter {
         dbPool as DatabaseWriter
@@ -34,13 +65,94 @@ public final class DatabaseManager: DatabaseManagerProtocol {
         // removed so the migration below runs against a clean directory.
         LegacyDataWipe.runIfNeeded(environment: environment)
         do {
-            dbPool = try Self.makeDatabasePool(environment: environment)
+            let (pool, url) = try Self.makeDatabasePool(environment: environment)
+            dbPool = pool
+            dbURL = url
         } catch {
             fatalError("Failed to initialize database: \(error)")
         }
     }
 
-    private static func makeDatabasePool(environment: AppEnvironment) throws -> DatabasePool {
+    public func replaceDatabase(with backupPath: URL) throws {
+        guard FileManager.default.fileExists(atPath: backupPath.path) else {
+            throw DatabaseManagerError.backupFileMissing(backupPath)
+        }
+
+        // Capture a pre-restore snapshot before touching the live pool.
+        // If the incoming copy fails partway through, we replay this.
+        Log.info("replaceDatabase: capturing rollback snapshot")
+        let rollbackQueue = try DatabaseQueue()
+        try dbPool.backup(to: rollbackQueue)
+
+        // Checkpoint the WAL into the main DB file before handing off
+        // to the coordinator — leaves the on-disk file a consistent
+        // self-contained snapshot so any process that coordinates a
+        // read after the barrier sees the new contents, not a mixture
+        // of new pages + stale WAL tail.
+        do {
+            try dbPool.writeWithoutTransaction { db in
+                try db.checkpoint(.truncate)
+            }
+        } catch {
+            Log.warning("replaceDatabase: WAL checkpoint failed: \(error); continuing")
+        }
+
+        let coordinator = NSFileCoordinator(filePresenter: nil)
+        var coordinationError: NSError?
+        var innerError: (any Error)?
+
+        coordinator.coordinate(
+            writingItemAt: dbURL,
+            options: [.forReplacing],
+            error: &coordinationError
+        ) { _ in
+            do {
+                try performReplace(backupPath: backupPath, rollbackQueue: rollbackQueue)
+            } catch {
+                innerError = error
+            }
+        }
+
+        if let coordinationError {
+            throw coordinationError
+        }
+        if let innerError {
+            throw innerError
+        }
+    }
+
+    private func performReplace(
+        backupPath: URL,
+        rollbackQueue: DatabaseQueue
+    ) throws {
+        let backupQueue = try DatabaseQueue(path: backupPath.path)
+
+        do {
+            Log.info("replaceDatabase: copying backup pages into live pool")
+            try backupQueue.backup(to: dbPool)
+            Log.info("replaceDatabase: running migrations against restored schema")
+            try SharedDatabaseMigrator.shared.migrate(database: dbPool)
+            Log.info("replaceDatabase: success")
+        // swiftlint:disable:next untyped_error_in_catch
+        } catch let copyError {
+            Log.warning("replaceDatabase failed (\(copyError)), rolling back")
+            do {
+                try rollbackQueue.backup(to: dbPool)
+                try SharedDatabaseMigrator.shared.migrate(database: dbPool)
+                Log.info("replaceDatabase: rollback succeeded")
+            // swiftlint:disable:next untyped_error_in_catch
+            } catch let rollbackError {
+                Log.error("replaceDatabase: rollback failed — DB in indeterminate state")
+                throw DatabaseManagerError.rollbackFailed(
+                    original: copyError,
+                    rollback: rollbackError
+                )
+            }
+            throw copyError
+        }
+    }
+
+    private static func makeDatabasePool(environment: AppEnvironment) throws -> (DatabasePool, URL) {
         let fileManager = FileManager.default
         // Shared App Group container so the main app and NSE share the same DB.
         let groupDirURL = environment.defaultDatabasesDirectoryURL
@@ -83,6 +195,6 @@ public final class DatabaseManager: DatabaseManagerProtocol {
         let dbPool = try DatabasePool(path: dbURL.path, configuration: config)
         let migrator = SharedDatabaseMigrator.shared
         try migrator.migrate(database: dbPool)
-        return dbPool
+        return (dbPool, dbURL)
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Storage/MockDatabaseManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/MockDatabaseManager.swift
@@ -20,6 +20,38 @@ final class MockDatabaseManager: DatabaseManagerProtocol, @unchecked Sendable {
         try SharedDatabaseMigrator.shared.migrate(database: dbPool)
     }
 
+    /// Mirror of `DatabaseManager.replaceDatabase` for test fixtures.
+    /// Skips `NSFileCoordinator` (single-process) and the WAL checkpoint
+    /// (in-memory queues don't use WAL), but preserves the same
+    /// rollback-snapshot + migration semantics so tests exercise the
+    /// contract rather than the transport.
+    func replaceDatabase(with backupPath: URL) throws {
+        guard FileManager.default.fileExists(atPath: backupPath.path) else {
+            throw DatabaseManagerError.backupFileMissing(backupPath)
+        }
+        let rollbackQueue = try DatabaseQueue()
+        try dbPool.backup(to: rollbackQueue)
+
+        let backupQueue = try DatabaseQueue(path: backupPath.path)
+        do {
+            try backupQueue.backup(to: dbPool)
+            try SharedDatabaseMigrator.shared.migrate(database: dbPool)
+        // swiftlint:disable:next untyped_error_in_catch
+        } catch let copyError {
+            do {
+                try rollbackQueue.backup(to: dbPool)
+                try SharedDatabaseMigrator.shared.migrate(database: dbPool)
+            // swiftlint:disable:next untyped_error_in_catch
+            } catch let rollbackError {
+                throw DatabaseManagerError.rollbackFailed(
+                    original: copyError,
+                    rollback: rollbackError
+                )
+            }
+            throw copyError
+        }
+    }
+
     private init(migrate: Bool = true) {
         do {
             dbPool = try DatabaseQueue(named: "MockDatabase")

--- a/ConvosCore/Sources/ConvosCoreiOS/IOSDeviceInfo.swift
+++ b/ConvosCore/Sources/ConvosCoreiOS/IOSDeviceInfo.swift
@@ -10,9 +10,11 @@ import UIKit
 @MainActor
 public final class IOSDeviceInfo: DeviceInfoProviding, @unchecked Sendable {
     private let _identifierForVendor: String?
+    private let _deviceName: String
 
     public init() {
         _identifierForVendor = UIDevice.current.identifierForVendor?.uuidString
+        _deviceName = UIDevice.current.name
     }
 
     /// Returns the device's identifier for vendor (IDFV).
@@ -49,6 +51,14 @@ public final class IOSDeviceInfo: DeviceInfoProviding, @unchecked Sendable {
         #else
         return "ios"
         #endif
+    }
+
+    /// Human-readable device name (`UIDevice.current.name` on iOS).
+    /// Captured at init time to avoid re-reading a main-actor-isolated
+    /// property from a non-main context; a post-init rename won't
+    /// propagate until the app restarts.
+    public nonisolated var deviceName: String {
+        _deviceName
     }
 }
 #endif

--- a/ConvosCore/Tests/ConvosCoreTests/BackupBundleTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/BackupBundleTests.swift
@@ -1,0 +1,234 @@
+@testable import ConvosCore
+import Foundation
+import Testing
+
+/// `BackupBundle` — tar pack/unpack + crypto + metadata round-trip.
+///
+/// Covers the three-part contract the bundle layer owns:
+/// 1. Pack/unpack is a clean round-trip for arbitrary staging layouts.
+/// 2. Header (magic + version) rejects non-bundle / future-format blobs.
+/// 3. Path-traversal (including symlink escape) cannot escape the
+///    staging directory during unpack.
+@Suite("BackupBundle")
+struct BackupBundleTests {
+    // MARK: - Round-trip
+
+    @Test("pack then unpack restores all entries byte-for-byte")
+    func testRoundTrip() throws {
+        let source = try makeTempDir()
+        defer { BackupBundle.cleanup(directory: source) }
+
+        let contents: [(String, Data)] = [
+            ("convos-single-inbox.sqlite", Data(repeating: 0x01, count: 4_096)),
+            ("xmtp-archive.bin", Data(repeating: 0x02, count: 8_192)),
+            ("metadata.json", Data("{\"version\":1}".utf8)),
+        ]
+        for (name, data) in contents {
+            try data.write(to: source.appendingPathComponent(name))
+        }
+
+        let key = try BackupBundleCrypto.generateArchiveKey()
+        let sealed = try BackupBundle.pack(directory: source, encryptionKey: key)
+
+        let destination = try makeTempDir()
+        defer { BackupBundle.cleanup(directory: destination) }
+        try BackupBundle.unpack(data: sealed, encryptionKey: key, to: destination)
+
+        for (name, original) in contents {
+            let restored = try Data(contentsOf: destination.appendingPathComponent(name))
+            #expect(restored == original, "\(name) did not round-trip")
+        }
+    }
+
+    @Test("unpack rejects blobs without the CVBD magic header")
+    func testRejectsMissingMagic() throws {
+        let stagingForPack = try makeTempDir()
+        defer { BackupBundle.cleanup(directory: stagingForPack) }
+        try Data("payload".utf8).write(to: stagingForPack.appendingPathComponent("file.txt"))
+
+        let key = try BackupBundleCrypto.generateArchiveKey()
+        let sealed = try BackupBundle.pack(directory: stagingForPack, encryptionKey: key)
+
+        // Strip the outer seal so we can inspect the decrypted tar,
+        // then corrupt the magic and re-seal.
+        var tar = try BackupBundleCrypto.decrypt(data: sealed, key: key)
+        tar[0] = 0x00
+        tar[1] = 0x00
+        tar[2] = 0x00
+        tar[3] = 0x00
+        let corrupted = try BackupBundleCrypto.encrypt(data: tar, key: key)
+
+        let destination = try makeTempDir()
+        defer { BackupBundle.cleanup(directory: destination) }
+        #expect(throws: BackupBundle.BundleError.self) {
+            try BackupBundle.unpack(data: corrupted, encryptionKey: key, to: destination)
+        }
+    }
+
+    @Test("unpack rejects unsupported format versions")
+    func testRejectsFutureVersion() throws {
+        let stagingForPack = try makeTempDir()
+        defer { BackupBundle.cleanup(directory: stagingForPack) }
+        try Data("payload".utf8).write(to: stagingForPack.appendingPathComponent("file.txt"))
+
+        let key = try BackupBundleCrypto.generateArchiveKey()
+        let sealed = try BackupBundle.pack(directory: stagingForPack, encryptionKey: key)
+
+        var tar = try BackupBundleCrypto.decrypt(data: sealed, key: key)
+        // Position 4 is the 1-byte version field, right after the 4-byte magic.
+        tar[4] = 0xFF
+        let corrupted = try BackupBundleCrypto.encrypt(data: tar, key: key)
+
+        let destination = try makeTempDir()
+        defer { BackupBundle.cleanup(directory: destination) }
+        #expect(throws: BackupBundle.BundleError.self) {
+            try BackupBundle.unpack(data: corrupted, encryptionKey: key, to: destination)
+        }
+    }
+
+    // MARK: - Path traversal
+
+    @Test("unpack refuses entries whose relative path escapes the staging dir")
+    func testRejectsPathTraversal() throws {
+        let key = try BackupBundleCrypto.generateArchiveKey()
+        // Hand-craft a tar with the correct header but a "../escape" entry.
+        var tar = Data()
+        tar.append(contentsOf: BackupBundle.magic)
+        tar.append(BackupBundle.currentFormatVersion)
+
+        let relativePath = "../escape.bin"
+        let fileData = Data("escape-me".utf8)
+        var pathLength = UInt32(relativePath.utf8.count).bigEndian
+        var fileLength = UInt64(fileData.count).bigEndian
+        tar.append(Data(bytes: &pathLength, count: 4))
+        tar.append(Data(relativePath.utf8))
+        tar.append(Data(bytes: &fileLength, count: 8))
+        tar.append(fileData)
+
+        let sealed = try BackupBundleCrypto.encrypt(data: tar, key: key)
+        let destination = try makeTempDir()
+        defer { BackupBundle.cleanup(directory: destination) }
+
+        #expect(throws: BackupBundle.BundleError.self) {
+            try BackupBundle.unpack(data: sealed, encryptionKey: key, to: destination)
+        }
+
+        // And the traversal target must not exist on disk afterwards.
+        let escapeTarget = destination.deletingLastPathComponent().appendingPathComponent("escape.bin")
+        #expect(!FileManager.default.fileExists(atPath: escapeTarget.path))
+    }
+
+    // MARK: - Crypto
+
+    @Test("crypto rejects keys of the wrong length")
+    func testCryptoRejectsWrongKeyLength() {
+        let payload = Data("hi".utf8)
+        let badKey = Data(repeating: 0x00, count: 16)
+        #expect(throws: BackupBundleCrypto.CryptoError.self) {
+            _ = try BackupBundleCrypto.encrypt(data: payload, key: badKey)
+        }
+        #expect(throws: BackupBundleCrypto.CryptoError.self) {
+            _ = try BackupBundleCrypto.decrypt(data: payload, key: badKey)
+        }
+    }
+
+    @Test("generated archive keys are 32 bytes and random")
+    func testGeneratedArchiveKey() throws {
+        let a = try BackupBundleCrypto.generateArchiveKey()
+        let b = try BackupBundleCrypto.generateArchiveKey()
+        #expect(a.count == 32)
+        #expect(b.count == 32)
+        #expect(a != b, "two consecutive generateArchiveKey() calls must not collide")
+    }
+
+    // MARK: - Metadata
+
+    @Test("full metadata round-trips through writeFull / readFull")
+    func testFullMetadataRoundTrip() throws {
+        let dir = try makeTempDir()
+        defer { BackupBundle.cleanup(directory: dir) }
+        let key = try BackupBundleCrypto.generateArchiveKey()
+        let original = BackupBundleMetadata(
+            version: 1,
+            createdAt: Date(timeIntervalSince1970: 1_700_000_000),
+            deviceId: "device-id",
+            deviceName: "Test iPhone",
+            osString: "ios",
+            conversationCount: 7,
+            schemaGeneration: "single-inbox-v2",
+            appVersion: "3.14.0",
+            archiveKey: key
+        )
+        try BackupBundleMetadata.writeFull(original, to: dir)
+        let loaded = try BackupBundleMetadata.readFull(from: dir)
+        #expect(loaded == original)
+        #expect(loaded.archiveKey == key)
+    }
+
+    @Test("sidecar omits archiveKey and readSidecar succeeds on both files")
+    func testSidecarOmitsArchiveKey() throws {
+        let sidecarDir = try makeTempDir()
+        let tarDir = try makeTempDir()
+        defer {
+            BackupBundle.cleanup(directory: sidecarDir)
+            BackupBundle.cleanup(directory: tarDir)
+        }
+        let key = try BackupBundleCrypto.generateArchiveKey()
+        // ISO8601 encoding loses sub-second precision; pin a whole-second
+        // date so the round-trip equality check is deterministic.
+        let full = BackupBundleMetadata(
+            createdAt: Date(timeIntervalSince1970: 1_700_000_000),
+            deviceId: "device-id",
+            deviceName: "Test iPhone",
+            osString: "ios",
+            conversationCount: 3,
+            schemaGeneration: "single-inbox-v2",
+            appVersion: "3.14.0",
+            archiveKey: key
+        )
+        try BackupBundleMetadata.writeFull(full, to: tarDir)
+        try BackupBundleMetadata.writeSidecar(full.sidecar, to: sidecarDir)
+
+        let sidecarBytes = try Data(contentsOf: sidecarDir.appendingPathComponent("metadata.json"))
+        let sidecarJSON = try #require(String(data: sidecarBytes, encoding: .utf8))
+        #expect(!sidecarJSON.contains("archiveKey"), "sidecar must not contain archiveKey")
+
+        // Sidecar reads cleanly.
+        let sidecarFromSidecarFile = try BackupBundleMetadata.readSidecar(from: sidecarDir)
+        #expect(sidecarFromSidecarFile == full.sidecar)
+
+        // Sidecar reads cleanly from the full file too (extra key is ignored).
+        let sidecarFromFullFile = try BackupBundleMetadata.readSidecar(from: tarDir)
+        #expect(sidecarFromFullFile == full.sidecar)
+    }
+
+    @Test("readFull fails when archiveKey is missing")
+    func testReadFullFailsWithoutArchiveKey() throws {
+        let dir = try makeTempDir()
+        defer { BackupBundle.cleanup(directory: dir) }
+        let sidecar = BackupBundleMetadata.Sidecar(
+            version: 1,
+            createdAt: Date(),
+            deviceId: "id",
+            deviceName: "name",
+            osString: "ios",
+            conversationCount: 0,
+            schemaGeneration: "single-inbox-v2",
+            appVersion: "3.14.0"
+        )
+        try BackupBundleMetadata.writeSidecar(sidecar, to: dir)
+
+        #expect(throws: DecodingError.self) {
+            _ = try BackupBundleMetadata.readFull(from: dir)
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func makeTempDir() throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("backup-bundle-test-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+}

--- a/ConvosCore/Tests/ConvosCoreTests/BackupManagerTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/BackupManagerTests.swift
@@ -1,0 +1,190 @@
+@testable import ConvosCore
+import Foundation
+import GRDB
+import Testing
+
+/// `BackupManager.createBackup()` end-to-end contract.
+///
+/// Verifies:
+/// - Happy path: GRDB + XMTP archive + metadata land in a sealed
+///   bundle the outer key decrypts.
+/// - Sidecar metadata sits next to the sealed bundle and omits
+///   `archiveKey` (discovery without the bundle key works; secrets
+///   stay inside the seal).
+/// - Skip conditions: restore-in-progress flag + missing identity
+///   throw the expected `BackupError` cases *before* any file I/O.
+/// - Local fallback kicks in when no iCloud container is available
+///   (the default in tests).
+@Suite("BackupManager.createBackup", .serialized)
+struct BackupManagerTests {
+    @Test("happy path produces a sealed bundle and a secret-free sidecar")
+    func testHappyPath() async throws {
+        clearRestoreFlag()
+        let env = AppEnvironment.tests
+        let fixtures = TestFixtures()
+        let (identity, _) = try await seedIdentity(in: fixtures, inboxId: "test-inbox")
+
+        let mockClient = MockXMTPClientProvider()
+        let manager = BackupManager(
+            databaseManager: fixtures.databaseManager,
+            identityStore: fixtures.identityStore,
+            clientProvider: { mockClient },
+            environment: env,
+            now: { Date(timeIntervalSince1970: 1_700_000_000) }
+        )
+
+        let bundleURL = try await manager.createBackup()
+        defer { cleanupBackupDirectory(at: bundleURL.deletingLastPathComponent()) }
+
+        // File exists.
+        #expect(FileManager.default.fileExists(atPath: bundleURL.path))
+        #expect(bundleURL.lastPathComponent == "backup-latest.encrypted")
+
+        // Sealed bundle decrypts + unpacks with the identity's databaseKey.
+        let sealed = try Data(contentsOf: bundleURL)
+        let stagingOut = try makeTempDir()
+        defer { BackupBundle.cleanup(directory: stagingOut) }
+        try BackupBundle.unpack(
+            data: sealed,
+            encryptionKey: identity.keys.databaseKey,
+            to: stagingOut
+        )
+
+        // GRDB snapshot, XMTP archive, metadata.json all present.
+        let dbPath = BackupBundle.databasePath(in: stagingOut)
+        let xmtpPath = BackupBundle.xmtpArchivePath(in: stagingOut)
+        #expect(FileManager.default.fileExists(atPath: dbPath.path))
+        #expect(FileManager.default.fileExists(atPath: xmtpPath.path))
+        #expect(BackupBundleMetadata.exists(in: stagingOut))
+
+        // Full metadata carries archiveKey; XMTP createArchive was
+        // called exactly once with that same key.
+        let fullMetadata = try BackupBundleMetadata.readFull(from: stagingOut)
+        #expect(fullMetadata.archiveKey.count == 32)
+        #expect(mockClient.createArchiveCalls.count == 1)
+        #expect(mockClient.createArchiveCalls.first?.encryptionKey == fullMetadata.archiveKey)
+
+        // Sidecar sits next to the bundle and omits archiveKey.
+        let sidecarDir = bundleURL.deletingLastPathComponent()
+        let sidecar = try BackupBundleMetadata.readSidecar(from: sidecarDir)
+        #expect(sidecar == fullMetadata.sidecar)
+        let sidecarBytes = try Data(
+            contentsOf: sidecarDir.appendingPathComponent("metadata.json")
+        )
+        let sidecarJSON = try #require(String(data: sidecarBytes, encoding: .utf8))
+        #expect(!sidecarJSON.contains("archiveKey"))
+
+        try? await fixtures.cleanup()
+    }
+
+    @Test("skips with .restoreInProgress when the flag is set")
+    func testSkipsWhenRestoreInProgress() async throws {
+        clearRestoreFlag()
+        let env = AppEnvironment.tests
+        let fixtures = TestFixtures()
+        _ = try await seedIdentity(in: fixtures, inboxId: "test-inbox-restore")
+
+        try RestoreInProgressFlag.set(true, environment: env)
+        defer { try? RestoreInProgressFlag.set(false, environment: env) }
+
+        let mockClient = MockXMTPClientProvider()
+        let manager = BackupManager(
+            databaseManager: fixtures.databaseManager,
+            identityStore: fixtures.identityStore,
+            clientProvider: { mockClient },
+            environment: env
+        )
+
+        await #expect(throws: BackupError.self) {
+            _ = try await manager.createBackup()
+        }
+        // Client must not have been touched.
+        #expect(mockClient.createArchiveCalls.isEmpty)
+        try? await fixtures.cleanup()
+    }
+
+    @Test("skips with .noIdentity when the keychain is empty")
+    func testSkipsWithoutIdentity() async throws {
+        clearRestoreFlag()
+        let env = AppEnvironment.tests
+        let fixtures = TestFixtures()
+        // Deliberately do NOT call seedIdentity — keychain stays empty.
+
+        let mockClient = MockXMTPClientProvider()
+        let manager = BackupManager(
+            databaseManager: fixtures.databaseManager,
+            identityStore: fixtures.identityStore,
+            clientProvider: { mockClient },
+            environment: env
+        )
+
+        await #expect(throws: BackupError.self) {
+            _ = try await manager.createBackup()
+        }
+        #expect(mockClient.createArchiveCalls.isEmpty)
+        try? await fixtures.cleanup()
+    }
+
+    @Test("archive failure surfaces as .archiveFailed and cleans up staging")
+    func testArchiveFailureSurfaces() async throws {
+        clearRestoreFlag()
+        let env = AppEnvironment.tests
+        let fixtures = TestFixtures()
+        _ = try await seedIdentity(in: fixtures, inboxId: "test-inbox-archive-fail")
+
+        let mockClient = MockXMTPClientProvider()
+        mockClient.createArchiveError = ArchiveStubError.simulated
+
+        let manager = BackupManager(
+            databaseManager: fixtures.databaseManager,
+            identityStore: fixtures.identityStore,
+            clientProvider: { mockClient },
+            environment: env
+        )
+
+        await #expect(throws: BackupError.self) {
+            _ = try await manager.createBackup()
+        }
+        try? await fixtures.cleanup()
+    }
+
+    // MARK: - Helpers
+
+    private enum ArchiveStubError: Error {
+        case simulated
+    }
+
+    /// Seed a keychain identity on the fixtures' MockKeychainIdentityStore
+    /// and return it. Used by tests that expect createBackup to find an
+    /// identity when it calls `loadSync`.
+    private func seedIdentity(
+        in fixtures: TestFixtures,
+        inboxId: String
+    ) async throws -> (KeychainIdentity, KeychainIdentityKeys) {
+        let keys = try await fixtures.identityStore.generateKeys()
+        let clientId = UUID().uuidString
+        let identity = try await fixtures.identityStore.save(
+            inboxId: inboxId,
+            clientId: clientId,
+            keys: keys
+        )
+        return (identity, keys)
+    }
+
+    private func makeTempDir() throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("backup-manager-test-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    /// Remove the per-device backup directory so tests don't accumulate
+    /// files on disk across runs.
+    private func cleanupBackupDirectory(at url: URL) {
+        try? FileManager.default.removeItem(at: url)
+    }
+
+    private func clearRestoreFlag() {
+        try? RestoreInProgressFlag.set(false, environment: .tests)
+    }
+}

--- a/ConvosCore/Tests/ConvosCoreTests/DatabaseManagerReplaceTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/DatabaseManagerReplaceTests.swift
@@ -1,0 +1,143 @@
+@testable import ConvosCore
+import Foundation
+import GRDB
+import Testing
+
+/// `DatabaseManager.replaceDatabase` (exercised via `MockDatabaseManager`).
+///
+/// The mock implementation mirrors the real one's pool-to-pool +
+/// rollback-snapshot + migration-after-swap contract — tests verify
+/// the *contract*, not the file-system transport. File-system / NSE
+/// coordination are tested manually on device.
+@Suite("DatabaseManager.replaceDatabase")
+struct DatabaseManagerReplaceTests {
+    @Test("successful replace copies rows from backup file into the live pool")
+    func testSuccessfulReplace() async throws {
+        let fixtures = TestFixtures()
+        defer { try? fixtures.databaseManager.dbPool.erase() }
+
+        // Seed the live DB with one conversation, then create a separate
+        // backup file with a different conversation. After replace, the
+        // live DB should reflect the backup's contents.
+        try await fixtures.databaseManager.dbWriter.write { db in
+            try seedConversation(id: "pre-restore", in: db)
+        }
+
+        let backupPath = try makeBackupFile(seedConversationId: "post-restore")
+        defer { try? FileManager.default.removeItem(at: backupPath) }
+
+        try fixtures.databaseManager.replaceDatabase(with: backupPath)
+
+        let ids = try await fixtures.databaseManager.dbReader.read { db in
+            try String.fetchAll(db, sql: "SELECT id FROM conversation ORDER BY id")
+        }
+        #expect(ids == ["post-restore"])
+
+        try? await fixtures.cleanup()
+    }
+
+    @Test("missing backup file throws backupFileMissing before touching the live pool")
+    func testMissingBackupFile() async throws {
+        let fixtures = TestFixtures()
+        defer { try? fixtures.databaseManager.dbPool.erase() }
+
+        try await fixtures.databaseManager.dbWriter.write { db in
+            try seedConversation(id: "pre-restore", in: db)
+        }
+
+        let missing = FileManager.default.temporaryDirectory
+            .appendingPathComponent("nonexistent-\(UUID().uuidString).sqlite")
+
+        #expect(throws: DatabaseManagerError.self) {
+            try fixtures.databaseManager.replaceDatabase(with: missing)
+        }
+
+        // Live DB untouched.
+        let ids = try await fixtures.databaseManager.dbReader.read { db in
+            try String.fetchAll(db, sql: "SELECT id FROM conversation")
+        }
+        #expect(ids == ["pre-restore"])
+
+        try? await fixtures.cleanup()
+    }
+
+    @Test("corrupt backup rolls back — live pool returns to pre-restore state")
+    func testRollbackOnCorruptBackup() async throws {
+        let fixtures = TestFixtures()
+        defer { try? fixtures.databaseManager.dbPool.erase() }
+
+        try await fixtures.databaseManager.dbWriter.write { db in
+            try seedConversation(id: "pre-restore", in: db)
+        }
+
+        // Write a non-SQLite file masquerading as a .sqlite backup.
+        let corrupt = FileManager.default.temporaryDirectory
+            .appendingPathComponent("corrupt-\(UUID().uuidString).sqlite")
+        try Data("not a sqlite database".utf8).write(to: corrupt)
+        defer { try? FileManager.default.removeItem(at: corrupt) }
+
+        // Expect *some* throw — could be the DatabaseQueue init, the
+        // backup call, or the migrate pass. Either way, rollback runs
+        // and the live DB ends up with the original row.
+        do {
+            try fixtures.databaseManager.replaceDatabase(with: corrupt)
+            Issue.record("expected replaceDatabase to throw on corrupt file")
+        } catch {
+            // Expected — continue to state assertion.
+        }
+
+        let ids = try await fixtures.databaseManager.dbReader.read { db in
+            try String.fetchAll(db, sql: "SELECT id FROM conversation")
+        }
+        #expect(ids == ["pre-restore"], "rollback must leave the live DB at pre-restore state")
+
+        try? await fixtures.cleanup()
+    }
+
+    // MARK: - Helpers
+
+    /// Seed a single `DBConversation` row. Mirrors the helper in
+    /// `InactiveConversationReactivatorTests` but kept local here so
+    /// the two files don't couple.
+    private func seedConversation(id: String, in db: Database) throws {
+        let creatorInboxId = "inbox-\(id)"
+        try DBMember(inboxId: creatorInboxId).save(db, onConflict: .ignore)
+        try DBConversation(
+            id: id,
+            clientConversationId: id,
+            inviteTag: "tag-\(id)",
+            creatorId: creatorInboxId,
+            kind: .group,
+            consent: .allowed,
+            createdAt: Date(),
+            name: nil,
+            description: nil,
+            imageURLString: nil,
+            publicImageURLString: nil,
+            includeInfoInPublicPreview: false,
+            expiresAt: nil,
+            debugInfo: .empty,
+            isLocked: false,
+            imageSalt: nil,
+            imageNonce: nil,
+            imageEncryptionKey: nil,
+            conversationEmoji: nil,
+            imageLastRenewed: nil,
+            isUnused: false,
+            hasHadVerifiedAssistant: false
+        ).insert(db)
+    }
+
+    /// Produce an on-disk, migrated GRDB file seeded with one conversation.
+    /// The result is a valid `.sqlite` at a unique temp path; caller owns cleanup.
+    private func makeBackupFile(seedConversationId: String) throws -> URL {
+        let path = FileManager.default.temporaryDirectory
+            .appendingPathComponent("backup-\(UUID().uuidString).sqlite")
+        let queue = try DatabaseQueue(path: path.path)
+        try SharedDatabaseMigrator.shared.migrate(database: queue)
+        try queue.write { db in
+            try seedConversation(id: seedConversationId, in: db)
+        }
+        return path
+    }
+}

--- a/ConvosCore/Tests/ConvosCoreTests/RestoreManagerTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/RestoreManagerTests.swift
@@ -1,0 +1,263 @@
+@testable import ConvosCore
+import Foundation
+import GRDB
+import os
+import Testing
+
+/// End-to-end contract for `RestoreManager.restoreFromBackup` and
+/// its static `findAvailableBackup` discovery.
+///
+/// Uses `BackupManager` to produce a real sealed bundle, then hands
+/// the bundle to `RestoreManager` with a throwaway-client factory
+/// that returns `MockXMTPClientProvider` — no Docker required. The
+/// XMTP-archive import is recorded on the mock; tests verify the
+/// protocol calls happened + final state transitions.
+@Suite("RestoreManager.restoreFromBackup", .serialized)
+struct RestoreManagerTests {
+    @Test("happy path: bundle decrypts, archive imported, state = completed")
+    func testHappyPath() async throws {
+        clearRestoreFlag()
+        let ctx = try await TestContext.make()
+        defer { ctx.cleanup() }
+
+        let bundleURL = try await ctx.makeBundle()
+        try await ctx.restoreManager.restoreFromBackup(bundleURL: bundleURL)
+
+        let state = await ctx.restoreManager.state
+        #expect(state == .completed)
+        #expect(ctx.restoreMockClient.importArchiveCalls.count == 1)
+        // Revocation path constructs a *second* throwaway client after
+        // import, so builder was called twice total. (Once for import,
+        // once for `inboxState + revokeInstallations`.)
+        #expect(ctx.clientBuilderCallCount.withLock { $0 } == 2)
+    }
+
+    @Test("findAvailableBackup returns the sidecar created by BackupManager")
+    func testDiscovery() async throws {
+        clearRestoreFlag()
+        let ctx = try await TestContext.make()
+        defer { ctx.cleanup() }
+
+        let bundleURL = try await ctx.makeBundle()
+        let found = RestoreManager.findAvailableBackup(environment: .tests)
+        #expect(found != nil)
+        #expect(found?.url == bundleURL)
+        #expect(found?.sidecar.conversationCount == 0)
+        #expect(found?.sidecar.schemaGeneration == LegacyDataWipe.currentGeneration)
+    }
+
+    @Test("schema-generation mismatch surfaces the specific error")
+    func testSchemaGenerationMismatch() async throws {
+        clearRestoreFlag()
+        let ctx = try await TestContext.make()
+        defer { ctx.cleanup() }
+
+        let bundleURL = try await ctx.makeBundle()
+        // Build a restore manager whose "current" generation is
+        // deliberately different from the one the bundle carries.
+        let mismatchManager = RestoreManager(
+            databaseManager: ctx.databaseManager,
+            identityStore: ctx.identityStore,
+            sessionManager: ctx.sessionManager,
+            environment: .tests,
+            clientBuilder: ctx.clientBuilder,
+            currentSchemaGeneration: "single-inbox-v999"
+        )
+
+        await #expect(throws: RestoreError.self) {
+            try await mismatchManager.restoreFromBackup(bundleURL: bundleURL)
+        }
+    }
+
+    @Test("missing identity surfaces identityTimeout quickly")
+    func testIdentityTimeout() async throws {
+        clearRestoreFlag()
+        let ctx = try await TestContext.make()
+        defer { ctx.cleanup() }
+        let bundleURL = try await ctx.makeBundle()
+
+        // Wipe the identity so awaitIdentityWithTimeout can't find one.
+        try await ctx.identityStore.delete()
+
+        // Short timeout so the test doesn't sit in a poll loop.
+        let timeoutManager = RestoreManager(
+            databaseManager: ctx.databaseManager,
+            identityStore: ctx.identityStore,
+            sessionManager: ctx.sessionManager,
+            environment: .tests,
+            clientBuilder: ctx.clientBuilder,
+            currentSchemaGeneration: LegacyDataWipe.currentGeneration,
+            identityPollInterval: .milliseconds(5),
+            identityTimeout: .milliseconds(20)
+        )
+
+        await #expect(throws: RestoreError.self) {
+            try await timeoutManager.restoreFromBackup(bundleURL: bundleURL)
+        }
+    }
+
+    @Test("archive import failure is non-fatal; state = archiveImportFailed")
+    func testArchiveImportFailureIsNonFatal() async throws {
+        clearRestoreFlag()
+        let ctx = try await TestContext.make()
+        defer { ctx.cleanup() }
+
+        ctx.restoreMockClient.importArchiveError = StubArchiveError.simulated
+        let bundleURL = try await ctx.makeBundle()
+
+        try await ctx.restoreManager.restoreFromBackup(bundleURL: bundleURL)
+
+        let state = await ctx.restoreManager.state
+        if case .archiveImportFailed = state {
+            // expected
+        } else {
+            Issue.record("expected .archiveImportFailed, got \(state)")
+        }
+    }
+
+    // MARK: - Helpers
+
+    private enum StubArchiveError: Error {
+        case simulated
+    }
+
+    private enum StubInboxStateError: Error {
+        case notMockable
+    }
+
+    private func clearRestoreFlag() {
+        try? RestoreInProgressFlag.set(false, environment: .tests)
+    }
+
+    /// Test harness: seeds identity, builds a SessionManager +
+    /// BackupManager + RestoreManager wired with mock XMTP clients.
+    final class TestContext {
+        let fixtures: TestFixtures
+        let sessionManager: SessionManager
+        let databaseManager: MockDatabaseManager
+        let identityStore: MockKeychainIdentityStore
+        /// The mock client handed out by the backup-side factory
+        /// (one per `createBackup` call). Not inspected after the
+        /// bundle is created.
+        let backupMockClient: MockXMTPClientProvider
+        /// The mock client handed out by the restore-side
+        /// `clientBuilder`. Shared across the import + revocation
+        /// calls — `importArchiveCalls` / `revokeCalls` are
+        /// observable on this instance.
+        let restoreMockClient: MockXMTPClientProvider
+        let clientBuilderCallCount: OSAllocatedUnfairLock<Int>
+        let clientBuilder: RestoreManager.ThrowawayClientBuilder
+        let backupManager: BackupManager
+        let restoreManager: RestoreManager
+        let backupDirectory: URL
+
+        static func make() async throws -> TestContext {
+            let fixtures = TestFixtures()
+            let identityStore = fixtures.identityStore
+            let keys = try await identityStore.generateKeys()
+            let identity = try await identityStore.save(
+                inboxId: "restore-test-inbox",
+                clientId: UUID().uuidString,
+                keys: keys
+            )
+
+            let databaseManager = fixtures.databaseManager
+            let sessionManager = SessionManager(
+                databaseWriter: databaseManager.dbWriter,
+                databaseReader: databaseManager.dbReader,
+                environment: .tests,
+                identityStore: identityStore,
+                platformProviders: .mock
+            )
+
+            let backupMockClient = MockXMTPClientProvider()
+            let backupManager = BackupManager(
+                databaseManager: databaseManager,
+                identityStore: identityStore,
+                clientProvider: { backupMockClient },
+                environment: .tests
+            )
+
+            // Make the revoker's `inboxState` call throw — the mock
+            // can't construct an `XMTPiOS.InboxState` (no public init).
+            // The revoker swallows this as a non-fatal warning, which
+            // matches the production contract: revocation failures
+            // never block the restore itself.
+            let restoreMockClient = MockXMTPClientProvider()
+            restoreMockClient.inboxStateError = StubInboxStateError.notMockable
+            let counter: OSAllocatedUnfairLock<Int> = .init(initialState: 0)
+            let clientBuilder: RestoreManager.ThrowawayClientBuilder = { _, _ in
+                counter.withLock { $0 += 1 }
+                return restoreMockClient
+            }
+            let restoreManager = RestoreManager(
+                databaseManager: databaseManager,
+                identityStore: identityStore,
+                sessionManager: sessionManager,
+                environment: .tests,
+                clientBuilder: clientBuilder,
+                currentSchemaGeneration: LegacyDataWipe.currentGeneration,
+                identityPollInterval: .milliseconds(5),
+                identityTimeout: .milliseconds(200)
+            )
+
+            let deviceId = DeviceInfo.deviceIdentifier
+            let backupDir = AppEnvironment.tests.defaultDatabasesDirectoryURL
+                .appendingPathComponent("backups", isDirectory: true)
+                .appendingPathComponent(deviceId, isDirectory: true)
+
+            _ = identity  // silence unused-let
+            return TestContext(
+                fixtures: fixtures,
+                sessionManager: sessionManager,
+                databaseManager: databaseManager,
+                identityStore: identityStore,
+                backupMockClient: backupMockClient,
+                restoreMockClient: restoreMockClient,
+                clientBuilderCallCount: counter,
+                clientBuilder: clientBuilder,
+                backupManager: backupManager,
+                restoreManager: restoreManager,
+                backupDirectory: backupDir
+            )
+        }
+
+        private init(
+            fixtures: TestFixtures,
+            sessionManager: SessionManager,
+            databaseManager: MockDatabaseManager,
+            identityStore: MockKeychainIdentityStore,
+            backupMockClient: MockXMTPClientProvider,
+            restoreMockClient: MockXMTPClientProvider,
+            clientBuilderCallCount: OSAllocatedUnfairLock<Int>,
+            clientBuilder: @escaping RestoreManager.ThrowawayClientBuilder,
+            backupManager: BackupManager,
+            restoreManager: RestoreManager,
+            backupDirectory: URL
+        ) {
+            self.fixtures = fixtures
+            self.sessionManager = sessionManager
+            self.databaseManager = databaseManager
+            self.identityStore = identityStore
+            self.backupMockClient = backupMockClient
+            self.restoreMockClient = restoreMockClient
+            self.clientBuilderCallCount = clientBuilderCallCount
+            self.clientBuilder = clientBuilder
+            self.backupManager = backupManager
+            self.restoreManager = restoreManager
+            self.backupDirectory = backupDirectory
+        }
+
+        func makeBundle() async throws -> URL {
+            try await backupManager.createBackup()
+        }
+
+        func cleanup() {
+            try? FileManager.default.removeItem(at: backupDirectory)
+            // Drop the DB pool synchronously; fixtures.cleanup also
+            // resets mock singletons but we don't need that in the
+            // serialized suite.
+            try? databaseManager.dbPool.erase()
+        }
+    }
+}

--- a/ConvosCore/Tests/ConvosCoreTests/SessionManagerRestoreTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/SessionManagerRestoreTests.swift
@@ -1,0 +1,107 @@
+@testable import ConvosCore
+import Foundation
+import Testing
+
+/// Contract for `SessionManager.pauseForRestore()` / `resumeAfterRestore()`
+/// — the seam `RestoreManager` will drive in CP3c.
+///
+/// Covers the invariants laid out in the plan's
+/// §"Throwaway XMTP client for archive import":
+/// 1. The app-group flag is strict on set (NSE would otherwise open
+///    the DB mid-swap).
+/// 2. While paused, `messagingService()` returns a frozen placeholder
+///    whose state is `.error(RestoreInProgressError)`. Repeated calls
+///    return the same cached instance — no rebuild thrash.
+/// 3. `resumeAfterRestore` clears both flags and allows the next
+///    `messagingService()` call to build a real service.
+/// Serialized: all tests share the app-group `UserDefaults` suite
+/// that `RestoreInProgressFlag` lives in, so parallel execution
+/// would race on flag reads/writes between tests that pause and
+/// tests that resume.
+@Suite("SessionManager restore lifecycle", .serialized)
+struct SessionManagerRestoreTests {
+    @Test("pauseForRestore sets the app-group flag; resume clears it")
+    func testFlagLifecycle() async throws {
+        let session = makeSession()
+        // Baseline: flag is not set before any restore.
+        clearFlag()
+        #expect(!RestoreInProgressFlag.isSet(environment: .tests))
+
+        try await session.pauseForRestore()
+        #expect(RestoreInProgressFlag.isSet(environment: .tests))
+
+        await session.resumeAfterRestore()
+        #expect(!RestoreInProgressFlag.isSet(environment: .tests))
+    }
+
+    @Test("messagingService() returns a RestoreInProgressError placeholder while paused")
+    func testPlaceholderDuringPause() async throws {
+        let session = makeSession()
+        clearFlag()
+
+        try await session.pauseForRestore()
+        let service = session.messagingService()
+        let state = service.sessionStateManager.currentState
+        guard case let .error(error) = state else {
+            Issue.record("expected .error state, got \(state)")
+            return
+        }
+        #expect(error is RestoreInProgressError)
+
+        await session.resumeAfterRestore()
+    }
+
+    @Test("placeholder is cached — repeated calls return the same instance")
+    func testPlaceholderCached() async throws {
+        let session = makeSession()
+        clearFlag()
+
+        try await session.pauseForRestore()
+        let first = session.messagingService()
+        let second = session.messagingService()
+        #expect(ObjectIdentifier(first) == ObjectIdentifier(second))
+
+        await session.resumeAfterRestore()
+    }
+
+    @Test("resumeAfterRestore evicts placeholder so next call can build a real service")
+    func testResumeEvictsPlaceholder() async throws {
+        let session = makeSession()
+        clearFlag()
+
+        try await session.pauseForRestore()
+        let placeholder = session.messagingService()
+
+        await session.resumeAfterRestore()
+        // After resume, next messagingService() call must rebuild — it
+        // will hit the normal auth path and either authorize the
+        // restored identity or register. Either way, the new service
+        // is a *different* object from the placeholder.
+        let rebuilt = session.messagingService()
+        #expect(ObjectIdentifier(rebuilt) != ObjectIdentifier(placeholder),
+                "post-resume rebuild must return a fresh service, not the paused placeholder")
+    }
+
+    // MARK: - Helpers
+
+    private func makeSession() -> SessionManager {
+        let databaseManager = MockDatabaseManager.makeTestDatabase()
+        return SessionManager(
+            databaseWriter: databaseManager.dbWriter,
+            databaseReader: databaseManager.dbReader,
+            environment: .tests,
+            identityStore: MockKeychainIdentityStore(),
+            platformProviders: .mock
+        )
+    }
+
+    /// Clear the app-group flag before each test so no prior run's
+    /// state leaks into the current one. Safe to call even if the
+    /// suite doesn't yet exist.
+    private func clearFlag() {
+        // `set(false, ...)` is the public way to clear; an unset flag
+        // and an explicit-false flag read as the same `false`, so this
+        // just normalizes both cases.
+        try? RestoreInProgressFlag.set(false, environment: .tests)
+    }
+}

--- a/ConvosCore/Tests/ConvosCoreTests/SyncingManagerTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/SyncingManagerTests.swift
@@ -82,6 +82,16 @@ class TestableMockClient: XMTPClientProvider, @unchecked Sendable {
     func revokeInstallations(signingKey: any SigningKey, installationIds: [String]) async throws {
     }
 
+    func inboxState(refreshFromNetwork: Bool) async throws -> XMTPiOS.InboxState {
+        fatalError("TestableMockClient.inboxState unused by tests in this suite")
+    }
+
+    func createArchive(path: String, encryptionKey: Data) async throws {
+    }
+
+    func importArchive(path: String, encryptionKey: Data) async throws {
+    }
+
     func deleteLocalDatabase() throws {
     }
 

--- a/ConvosCore/Tests/ConvosCoreTests/TerminalSessionErrorTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/TerminalSessionErrorTests.swift
@@ -1,0 +1,33 @@
+@testable import ConvosCore
+import Foundation
+import Testing
+
+/// Marker protocol contract for session errors that must not retry.
+///
+/// The short-circuit logic lives in
+/// `SessionStateMachine.handleRetryFromError` and is exercised by
+/// the XMTP-backed integration tests when a real revoked
+/// installation is simulated. This suite pins the type-level
+/// shape so a future rename or accidentally-broken conformance
+/// surfaces as a focused failure rather than an opaque
+/// integration-test flake.
+@Suite("TerminalSessionError contract")
+struct TerminalSessionErrorTests {
+    @Test("DeviceReplacedError conforms to TerminalSessionError")
+    func testDeviceReplacedConforms() {
+        let error: any Error = DeviceReplacedError()
+        #expect(error is TerminalSessionError)
+    }
+
+    @Test("DeviceReplacedError is Equatable")
+    func testDeviceReplacedEquatable() {
+        #expect(DeviceReplacedError() == DeviceReplacedError())
+    }
+
+    @Test("generic Error does not conform to TerminalSessionError")
+    func testGenericErrorDoesNotConform() {
+        struct NonTerminal: Error {}
+        let error: any Error = NonTerminal()
+        #expect(!(error is TerminalSessionError))
+    }
+}

--- a/NotificationService/NotificationService.swift
+++ b/NotificationService/NotificationService.swift
@@ -61,6 +61,18 @@ final class NotificationService: UNNotificationServiceExtension, @unchecked Send
 
         Log.info("[PID: \(processId)] [Instance: \(instanceId)] [Request: \(requestId)] Starting notification processing")
 
+        // Bail immediately if the main app is mid-restore. Opening the
+        // shared GRDB during `DatabaseManager.replaceDatabase` risks a
+        // torn read against the database currently being rewritten
+        // page-by-page. Push loss within that narrow user-initiated
+        // window is an acceptable trade for data integrity.
+        if let env = try? NotificationExtensionEnvironment.getEnvironment(),
+           RestoreInProgressFlag.isSet(environment: env) {
+            Log.info("Restore in progress — suppressing notification")
+            deliverNotification(UNMutableNotificationContent())
+            return
+        }
+
         guard let pushHandler = globalPushHandler else {
             Log.error("No global push handler available - suppressing notification")
             deliverNotification(UNMutableNotificationContent())

--- a/docs/adr/012-icloud-backup-single-inbox.md
+++ b/docs/adr/012-icloud-backup-single-inbox.md
@@ -1,0 +1,328 @@
+# ADR 012: iCloud Backup — Single-Inbox Architecture
+
+> **Status**: Accepted (2026-04-23).
+> **Supersedes**: the vault-centric backup design in
+> [docs/plans/icloud-backup.md](../plans/icloud-backup.md),
+> [docs/plans/stale-device-detection.md](../plans/stale-device-detection.md),
+> [docs/plans/icloud-backup-inactive-conversation-mode.md](../plans/icloud-backup-inactive-conversation-mode.md),
+> [docs/plans/vault-re-creation-on-restore.md](../plans/vault-re-creation-on-restore.md),
+> [docs/plans/backup-restore-followups.md](../plans/backup-restore-followups.md)
+> (marked Superseded by this ADR).
+> **Implementation plan**: [docs/plans/icloud-backup-single-inbox.md](../plans/icloud-backup-single-inbox.md) (Rev 4).
+> **Depends on**: [ADR 011 — Single-Inbox Identity Model](./011-single-inbox-identity-model.md).
+
+## Context
+
+The vault-centric backup stack on `louis/icloud-backup` was designed
+under the per-conversation-inbox model (superseded by ADR 011): N
+keychain identities, N XMTP databases, a vault group that broadcast
+conversation keys to paired devices, and an `ICloudIdentityStore`
+dual-write that kept the vault key in sync across iCloud Keychain.
+With ADR 011's collapse to a single XMTP inbox per user, that
+machinery is obsolete:
+
+- **One identity**, already synchronizable by default
+  (`KeychainIdentityStore` v3: `kSecAttrSynchronizable = true` +
+  `kSecAttrAccessibleAfterFirstUnlock`). Identity flows across
+  same-Apple-ID devices without any bundle.
+- **Group memberships + message history** are replayed by XMTP
+  Device Sync (`deviceSyncEnabled: true`) — **only when a
+  pre-existing installation is online** to upload the archive to the
+  history server. In the device-loss / single-device-reinstall
+  cases (the entire reason backup exists), there is no such
+  installation.
+- **Local GRDB state** (conversation local flags, pending invites,
+  unread cursors, pinned/muted, profile snapshots, invite-tag
+  ledger, asset-renewal bookkeeping) is neither identity-material
+  nor XMTP-managed — only the app's backup can preserve it.
+
+The plan doc walks the rev 1→4 evolution; this ADR captures what
+landed.
+
+## Decision
+
+Convos backs up a **single encrypted bundle** per device to iCloud
+Drive. The bundle carries exactly what Device Sync and iCloud
+Keychain don't: a GRDB snapshot, a single-inbox XMTP archive, and
+metadata. Restore is destructive and user-initiated; progress is
+surfaced via a typed `RestoreState` enum.
+
+### 1. Bundle format
+
+```
+iCloud Drive / Convos / Documents / backups / <deviceId> /
+    metadata.json             (sidecar, unencrypted, discovery-only)
+    backup-latest.encrypted   (AES-256-GCM with identity.databaseKey)
+        └─ tar (CVBD magic + 1-byte version):
+             convos-single-inbox.sqlite   (GRDB snapshot)
+             xmtp-archive.bin             (single-inbox XMTP archive)
+             metadata.json                (full form; carries archiveKey)
+```
+
+- **Outer seal key**: `identity.databaseKey` (32 bytes). Raw — no
+  HKDF. Under the ADR 011 threat model, XMTPiOS already uses the
+  same `databaseKey` as the SQLCipher key, so HKDF buys no
+  isolation that isn't already conceded.
+- **Inner `archiveKey`**: fresh 32 bytes of CSPRNG per bundle,
+  used only to decrypt `xmtp-archive.bin`, stored inside the
+  GRDB-sidecar metadata tar entry. Ephemeral: a leaked historical
+  bundle's archive key does not compromise any other bundle.
+- **Sidecar**: unencrypted `metadata.json` next to the sealed
+  bundle. Carries `deviceName`, `deviceId`, `createdAt`,
+  `conversationCount`, `schemaGeneration`, `appVersion`, and
+  bundle format `version`. Never carries `archiveKey` or any
+  secret. Drives `findAvailableBackup` discovery without requiring
+  the outer-seal key.
+
+The tar format uses a 4-byte ASCII magic (`"CVBD"`) + 1-byte format
+version at the head so future bundle-format bumps discriminate
+cleanly rather than decoding past-incompatible data.
+
+### 2. Create flow
+
+`BackupManager.createBackup()`:
+
+1. Early-exit if `RestoreInProgressFlag` is set (app-group
+   UserDefaults).
+2. Load identity via `loadSync()`; skip if `nil` (no inbox yet).
+3. Snapshot GRDB via `dbReader.backup(to:)` into a staging dir.
+4. Generate a fresh `archiveKey`; call
+   `client.createArchive(path:encryptionKey:)` via the
+   `XMTPClientProvider` protocol.
+5. Write full `metadata.json` (with `archiveKey`) into the
+   staging dir.
+6. Tar the staging dir with the magic+version header.
+7. `AES.GCM.seal` with `identity.databaseKey` → sealed bytes.
+8. Atomic write (`replaceItemAt`) to
+   `iCloud/Convos/Documents/backups/<deviceId>/backup-latest.encrypted`;
+   fall back to local shared container if the iCloud container is
+   unavailable.
+9. Write the sidecar `metadata.json` (secret-free) **after** the
+   sealed bundle. `findAvailableBackup` readers never see a sidecar
+   pointing at a not-yet-landed bundle.
+
+### 3. Restore flow
+
+`RestoreManager.restoreFromBackup(bundleURL:)`:
+
+1. Read bundle bytes.
+2. `awaitIdentityWithTimeout` — bounded `loadSync()` poll (default
+   30s, 500ms interval). iCloud Keychain may lag on fresh install;
+   entering the `.register` branch with the restore bundle in hand
+   would mint a forked identity that can never decrypt the bundle.
+3. Decrypt + untar to a staging dir.
+4. Validate: metadata present, `schemaGeneration` matches
+   `LegacyDataWipe.currentGeneration` (mismatch throws a distinct
+   `RestoreError.schemaGenerationMismatch` + emits telemetry),
+   GRDB + XMTP archive present, `archiveKey` length correct.
+5. `SessionManager.pauseForRestore()` — sets
+   `RestoreInProgressFlag` (app-group) **and** an in-process
+   `isRestoringInProcess` flag; stops the cached
+   `MessagingService`; cancels the `UnusedConversationCache`
+   prewarm. Cancellation-safe: any throw triggers
+   `resumeAfterRestore` + rethrow.
+6. Stage existing `xmtp-*.db3` files aside (rollback anchor).
+7. `DatabaseManager.replaceDatabase(with:)` — pool-to-pool GRDB
+   `backup(to:)`, WAL checkpoint before the swap,
+   `NSFileCoordinator.coordinate(writingItemAt:)` barrier,
+   rollback snapshot. Double-fault surfaces as
+   `DatabaseManagerError.rollbackFailed`; UI treats as fatal.
+8. Build a throwaway `XMTPiOS.Client` against the
+   now-empty `xmtp-*.db3` directory and call `importArchive`.
+   `defer { try? dropLocalDatabaseConnection() }` ensures the
+   SQLCipher pool releases before the real session rebuilds.
+   Non-fatal on throw: state transitions to
+   `.archiveImportFailed`; GRDB restore is already committed, so
+   degrading to conversation-list-only beats aborting.
+9. **Commit point.** Discard the XMTP stash. Post-commit errors
+   do not roll back.
+10. `ConversationLocalStateWriter.markAllConversationsInactive()`
+    — restored conversations land in the `InactiveConversationBanner`
+    state until peers re-admit this installation. Reactivation is
+    handled by `InactiveConversationReactivator` (PR #725).
+11. `XMTPInstallationRevoker.revokeOtherInstallations` — one
+    network call using the restored identity's signing key,
+    keeping the newly-registered installation. Non-fatal.
+12. `SessionManager.resumeAfterRestore()` — clears both flags;
+    next `messagingService()` call rebuilds the session against
+    the restored DB.
+
+### 4. NSE coordination
+
+The shared GRDB (`convos-single-inbox.sqlite`) and `xmtp-*.db3`
+files are visible to the NotificationService Extension via the
+app-group container. During the 1–2s restore window, the NSE must
+not open coordinated handles on either.
+
+Two-layer protection:
+
+- **Process-crossing flag**: `RestoreInProgressFlag` in app-group
+  `UserDefaults`. `SessionManager.pauseForRestore` sets it;
+  `resumeAfterRestore` clears it. `NotificationService.didReceive`
+  early-exits with empty content when set. Strict on set (throws
+  if the app-group container is unavailable); lenient on read.
+- **`NSFileCoordinator` write barrier**: `replaceDatabase` runs
+  the swap under
+  `coordinate(writingItemAt: .forReplacing)` against the DB URL.
+  Any coordinated reader waits for the barrier.
+
+### 5. Device-replaced detection
+
+On successful authorization (`authenticatingBackend → ready`) and
+on foreground retry, `SessionStateMachine.handleAuthorized`
+probes `client.inboxState(refreshFromNetwork: true)`. If the
+local installation ID is not in the active set, it throws
+`DeviceReplacedError`, which conforms to a new
+`TerminalSessionError` marker protocol.
+
+`handleRetryFromError` short-circuits on `TerminalSessionError`
+conformance — without this, a foreground retry could coincide with
+a background keychain refresh and silently flip the session to
+`.ready`, masking the reset-device banner that was the only path
+out. Observer-side code (the `StaleDeviceBanner`) watches
+`SessionStateObserver` and renders when the current state matches
+`.error(DeviceReplacedError)`.
+
+### 6. What the bundle does **not** contain
+
+- Media assets. Remote attachments have their own 30-day URLs; a
+  future bundle version (the 1-byte tar header bumps cleanly) may
+  include them.
+- Keychain identity material. iCloud Keychain handles that.
+- MLS group memberships or message history in non-archive form.
+  The single-inbox XMTP archive is the one and only copy.
+- Retained XMTP server credentials. Archive is authoritative for
+  its own point-in-time; divergence reconciles via MLS sync.
+
+## Consequences
+
+### Positive
+
+- **One bundle, one key family**: outer seal keyed on the
+  identity's `databaseKey`, inner archive keyed on a fresh
+  ephemeral. Straightforward cryptographic story; the sidecar
+  metadata is the only unencrypted file.
+- **Device Sync + archive are complementary**, not competing.
+  Multi-device-still-active restores use Device Sync; device-loss /
+  single-device-reinstall uses the archive. Imported conversations
+  are MLS-inactive until peers re-admit, reconciled by
+  `InactiveConversationReactivator`.
+- **One rollback path**: pre-commit throws unwind the XMTP file
+  stash + session state. Post-commit errors surface via state
+  (`archiveImportFailed`, revocation log), not thrown. User
+  consented to destructive op; degrading beats aborting.
+- **Terminal errors are explicit.** `TerminalSessionError` marker
+  prevents the state machine from retrying a revoked installation
+  into an incorrect `.ready` by coincidence.
+
+### Negative
+
+- **No media in v1.** Remote-attachment URLs may expire between
+  backup and restore; user sees placeholder thumbnails for older
+  messages.
+- **Cross-Apple-ID users cannot restore.** Identity only crosses
+  same-Apple-ID devices via iCloud Keychain. An Android user
+  signing into iOS for the first time has no identity to decrypt
+  the bundle with. Acceptable under the current consumer-app
+  threat model.
+- **`schemaGeneration` mismatch is a hard refusal.** Users with
+  stale bundles (uninstalled after an older schema, reinstalling
+  on a newer build) see a specific error and must start fresh. The
+  next scheduled daily backup refreshes the sidecar for future
+  cross-device restores.
+
+### Mitigations
+
+- **`archiveImportFailed` is retryable** (persistence + retry UI
+  deferred to CP3e / follow-up PR): archive bytes stay on disk,
+  Settings surfaces a "Retry history import" affordance, GRDB
+  restore stands on its own in the meantime.
+- **iCloud Keychain sync lag**: `awaitIdentityWithTimeout` gates
+  the restore entry point on `loadSync()` success before touching
+  any destructive op. Fresh-install restore prompt (deferred to
+  follow-up PR) also re-checks on `sceneDidBecomeActive` so a
+  late-syncing identity unblocks the Restore button without a
+  manual retry.
+- **NSE + `BackupScheduler` both honor `RestoreInProgressFlag`**.
+  Scheduled backups mid-restore reschedule silently; NSE drops
+  deliveries in-window.
+
+## Security model
+
+| Threat | Treatment |
+| --- | --- |
+| Attacker reads sealed bundle without identity | Blocked — AES-256-GCM with 32-byte `databaseKey` |
+| Attacker reads sealed bundle with cached archive key from another bundle | Blocked — per-bundle ephemeral `archiveKey` |
+| Attacker reads sidecar `metadata.json` | Only learns `deviceName`, `deviceId`, `createdAt`, `conversationCount`, `schemaGeneration`, `appVersion`, and bundle version. No secrets. |
+| NSE reads DB mid-restore | Blocked — `RestoreInProgressFlag` + `NSFileCoordinator` barrier |
+| Restored device spawns a second XMTP client against the same SQLCipher pool | Blocked — in-process `isRestoringInProcess` flag short-circuits `loadOrCreateService` during restore |
+| Foreground retry masks device-replaced state | Blocked — `TerminalSessionError` marker + `handleRetryFromError` short-circuit |
+| Stale bundle restored after schema bump silently corrupts DB | Blocked — `schemaGeneration` check in `findAvailableBackup` rejects cross-generation bundles |
+
+## Related Files
+
+### Code
+
+- `ConvosCore/Sources/ConvosCore/Backup/BackupBundle.swift` — tar
+  format, pack/unpack, path-traversal hardening.
+- `ConvosCore/Sources/ConvosCore/Backup/BackupBundleCrypto.swift`
+  — AES-256-GCM + archive-key generation.
+- `ConvosCore/Sources/ConvosCore/Backup/BackupBundleMetadata.swift`
+  — full vs sidecar projection.
+- `ConvosCore/Sources/ConvosCore/Backup/BackupManager.swift` — create flow.
+- `ConvosCore/Sources/ConvosCore/Backup/RestoreManager.swift` —
+  restore flow + rollback harness + static `findAvailableBackup`.
+- `ConvosCore/Sources/ConvosCore/Backup/RestoreInProgressFlag.swift`
+  — app-group coordination flag + `RestoreInProgressError`
+  placeholder for the `SessionManager` cache slot.
+- `ConvosCore/Sources/ConvosCore/Backup/XMTPInstallationRevoker.swift`
+  — one-call revocation via the `XMTPClientProvider` protocol.
+- `ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift`
+  — `pauseForRestore` / `resumeAfterRestore` with in-process flag
+  gating `loadOrCreateService`.
+- `ConvosCore/Sources/ConvosCore/Storage/DatabaseManager.swift`
+  — `replaceDatabase(with:)` + `DatabaseManagerError.rollbackFailed`.
+- `ConvosCore/Sources/ConvosCore/Inboxes/TerminalSessionError.swift`
+  — marker protocol + `DeviceReplacedError`.
+- `ConvosCore/Sources/ConvosCore/Inboxes/SessionStateMachine.swift`
+  — stale-installation probe in `handleAuthorized` +
+  `handleRetryFromError` short-circuit.
+- `Convos/Conversations List/StaleDeviceBanner.swift` — "This device
+  has been replaced" banner; wired into `ConversationsView` via
+  `ConversationsViewModel.isDeviceReplaced`.
+
+### Tests
+
+- `BackupBundleTests` — tar round-trip, magic-byte rejection,
+  path-traversal refusal, crypto key-length, sidecar omits
+  `archiveKey`, metadata round-trip.
+- `DatabaseManagerReplaceTests` — successful replace, missing file,
+  corrupt backup rollback.
+- `SessionManagerRestoreTests` — flag lifecycle, placeholder during
+  pause, placeholder caching, eviction on resume.
+- `BackupManagerTests` — happy path (sealed bundle decrypts,
+  sidecar omits archiveKey), skip-on-restore, skip-on-no-identity,
+  archive-failure surfaces.
+- `RestoreManagerTests` — happy path, discovery, schema-generation
+  mismatch, identity timeout, archive-import non-fatal.
+- `TerminalSessionErrorTests` — marker-protocol conformance
+  contract.
+
+### Deferred to follow-up PRs
+
+- `BackupRestoreSettingsView` + `BackupRestoreViewModel`
+  (user-facing "Back up now" / "Restore" screen + retry-history
+  affordance).
+- `BackupDebugView` (debug-build diagnostics).
+- `BackupScheduler` (main-app target, `BGProcessingTask`
+  daily scheduling, `INFOPLIST_KEY_BGTaskSchedulerPermittedIdentifiers`
+  xcconfig).
+- Fresh-install restore-prompt card on the empty conversations
+  view.
+- Persisted archive bytes at `<sharedContainer>/pending-archive-import.bin`
+  + "Retry history import" UX for the `archiveImportFailed`
+  state.
+
+All of the above depend on the machinery this ADR describes being
+in place; none of them affect the on-disk bundle format or the
+threat model, so they can land incrementally.


### PR DESCRIPTION
feat(backup): bundle format, crypto, metadata

First checkpoint of PR 3 (iCloud backup port). Self-contained: no
callers yet, just the leaf pieces restore and backup will build on.

- BackupBundle: tar pack/unpack with "CVBD" magic + 1-byte version
  header at the head of the tar. Future bundle-format bumps can
  discriminate cleanly without having to decode past-incompatible
  data. Path-traversal hardening (standardized-path check + symlink-
  resolved re-check after createDirectory) ported from the old
  louis/icloud-backup branch unchanged.
- BackupBundleCrypto: AES-256-GCM seal/open keyed directly on the
  identity's databaseKey. No HKDF. Also generates per-bundle 32-byte
  archiveKeys for the inner XMTP archive — fresh CSPRNG, never
  reused across bundles.
- BackupBundleMetadata: full vs sidecar projections. Full form lives
  inside the encrypted tar and carries the inner archiveKey; sidecar
  form sits unencrypted next to backup-latest.encrypted for discovery
  and strictly omits every secret. One Codable type with a secret-free
  nested Sidecar struct reachable via a computed property.

Tests: 9 cases
- Round-trip: pack → unpack restores all entries byte-for-byte.
- Header: rejects missing CVBD magic; rejects unsupported format
  versions (forged 0xFF in the version byte).
- Path traversal: hand-crafted tar with "../escape.bin" entry is
  refused and no file lands outside the staging dir.
- Crypto: rejects non-32-byte keys on both encrypt and decrypt;
  consecutive generateArchiveKey() calls don't collide.
- Metadata: full round-trip preserves archiveKey; sidecar omits
  archiveKey (verified by searching the serialized JSON); readSidecar
  works on both sidecar and full files; readFull fails when
  archiveKey is missing (legacy decoder path).

Plan: docs/plans/icloud-backup-single-inbox.md §"Bundle format + crypto"
and §"Two keys, two roles — don't collapse them".

feat(backup): DatabaseManager.replaceDatabase + NSE restore gate

Second checkpoint of PR 3. Adds the destructive-swap primitive
RestoreManager will drive on top, plus the app-group flag that
keeps the NotificationService Extension out of the way while the
DB is being rewritten page-by-page.

DatabaseManager
- replaceDatabase(with backupPath: URL) on DatabaseManagerProtocol.
  Pool-to-pool copy via GRDB's backup(to:) so the DatabasePool
  instance itself isn't swapped — any long-lived reader/writer
  elsewhere stays valid across the restore.
- Captures a pre-restore snapshot first; if the copy throws, we
  replay the snapshot back into the live pool and re-migrate.
  Double-fault (copy throws AND rollback throws) surfaces as
  DatabaseManagerError.rollbackFailed, which the UI must treat
  as fatal.
- WAL checkpoint (TRUNCATE) before the swap so the on-disk file
  is a consistent self-contained snapshot; any coordinated
  reader after the barrier sees the new contents, not a mixture
  of new pages + stale WAL tail.
- Entire operation runs under NSFileCoordinator.coordinate(
  writingItemAt:,options: .forReplacing) against the DB URL —
  the NSE, if it happened to be the only reader not honoring the
  flag, would block at the coordinator barrier instead of
  tearing a read.

RestoreInProgressFlag
- New helper at ConvosCore/Backup/RestoreInProgressFlag.swift.
- Lives in app-group UserDefaults under suite
  "convos.restore-in-progress" + key
  "convos.restore-in-progress.flag".
- Set/cleared by the yet-to-land SessionManager pauseForRestore /
  resumeAfterRestore (Checkpoint 3). Checked by the NSE at entry.
- Plan §"NSE coordination during DB swap" — app-group flag is
  belt, NSFileCoordinator is suspenders; either alone is
  insufficient.

NotificationService
- didReceive early-exits with an empty content delivery when the
  flag is set. Push loss within a narrow user-initiated restore
  window is an acceptable trade for not risking a torn read on
  the shared GRDB.

MockDatabaseManager
- Mirrors the real replaceDatabase contract (rollback snapshot +
  migrate) for test fixtures. Skips NSFileCoordinator (single-
  process) and the WAL checkpoint (in-memory queues don't WAL).

Tests (3 cases, DatabaseManagerReplaceTests)
- Successful replace: live pool reflects backup's rows after
  replaceDatabase.
- Missing backup file: throws DatabaseManagerError.backupFileMissing
  before touching the live pool.
- Corrupt backup: rolls back; live pool returns to the pre-restore
  state (verified by row contents, not just the throw).

Plan: docs/plans/icloud-backup-single-inbox.md §"DatabaseManager.
replaceDatabase + NSE coordination" and §"Throwaway XMTP client
for archive import" (the in-process flag arrives in Checkpoint 3
as SessionManager's isRestoringInProcess).

fix(backup): tighten CP1/CP2 loose ends before CP3

Small correctness + clarity fixes surfaced by architect review of
the bundle-format and replaceDatabase checkpoints. No behavior
change on the happy path; closes a minor edge case, makes the
restore-flag failure mode strict, and consolidates a file-path
constant so the CP3 backup writer and DatabaseManager can't drift.

- BackupBundle.untarData: guard pathLength > 0. An empty path would
  decode to the empty string and resolve via appendingPathComponent("")
  to the staging directory URL itself. The containment check already
  catches that (prefix match fails), but an explicit early bail gives
  a clearer error and keeps the intent visible.
- BackupBundleMetadata.readSidecar: add a code comment pinning
  "JSONDecoder's default ignore-unknown-keys behavior is load-bearing"
  so a future switch to a strict decoder doesn't silently break
  reading full-form files.
- RestoreInProgressFlag.set is now strict (throws on missing
  app-group container) while read stays lenient (degrades to false).
  Asymmetric on purpose: the NSE reading a stale false value
  degrades to current behavior, whereas a silent set failure would
  let pauseForRestore proceed into destructive ops with an
  un-signaled NSE. SessionManager.pauseForRestore (CP3) must abort
  on throw.
- DatabaseManager.databaseFilename exposed as a public static
  constant; BackupBundle.Component.database now references it.
  Single source of truth for "convos-single-inbox.sqlite". CP3's
  BackupManager will pick up the same constant.

One architect finding dismissed: SharedDatabaseMigrator's
eraseDatabaseOnSchemaChange is already #if DEBUG-gated (lines
19-21), contrary to the agent's reading. Rollback path is safe
in release builds as designed.

Tests: 12/12 pass across BackupBundleTests (now 9 cases) and
DatabaseManagerReplaceTests (3 cases). No new cases needed — the
edge case guard in untarData is a belt-and-suspenders on top of
the existing path-traversal test.

feat(backup): SessionManager pause/resume for restore lifecycle

CP3a of PR 3 — the coordination seam `RestoreManager` will drive.
No callers yet inside the repo; the next commit (CP3b) adds the
archive wrappers + revoker, and CP3c/d wire the actual managers.

SessionManager
- New `isRestoringInProcess: Bool` flag, lock-guarded via the same
  `cachedMessagingService` OSAllocatedUnfairLock as the cache slot
  itself. Strict pairing matters: a concurrent `loadOrCreateService()`
  must see either both (restoring + cleared slot) or neither
  (not-restoring + live cache).
- `loadOrCreateService()` short-circuits when the flag is set:
  returns a frozen `MessagingService(identityReadFailure:
  RestoreInProgressError())` placeholder. Cached under the lock so
  repeated `messagingService()` calls during pause don't thrash.
  The error-state observer sees `.error(RestoreInProgressError)`
  and can render "Restoring…" without attempting recovery.
- Package-internal `pauseForRestore()` / `resumeAfterRestore()`:
  - Pause: sets `RestoreInProgressFlag` (app-group) strict-throws,
    flips the in-process flag inside the lock, calls
    `unusedConversationCache.cancel()`, stops (not deletes) the
    existing cached service, clears the slot. On throw from the
    flag-set step, RestoreManager must abort before any destructive
    op — the NSE coordination contract depends on both flags.
  - Resume: clears the in-process flag + slot atomically, clears
    the app-group flag (log-on-failure since we're already
    committed past the destructive point), triggers
    `loadOrCreateService()` to rebuild against the restored DB.

RestoreInProgressError
- Surfaces via `SessionStateMachine.State.error(RestoreInProgressError)`.
- Not a `TerminalSessionError`: this state clears when resume
  completes.

Tests (4 cases, SessionManagerRestoreTests, .serialized):
- pauseForRestore sets the app-group flag; resume clears it.
- messagingService() during pause returns a RestoreInProgressError
  placeholder.
- Placeholder is cached — repeated calls return same instance.
- Resume evicts placeholder; next call builds a fresh service.

Suite is `.serialized` because all tests share the app-group
UserDefaults suite that RestoreInProgressFlag lives in — parallel
execution would race on flag reads/writes.

Plan: docs/plans/icloud-backup-single-inbox.md §"Throwaway XMTP
client for archive import" + §"Restore integration with
SessionManager directly".

feat(backup): XMTP archive protocol surface + installation revoker

CP3b of PR 3. Extends the XMTPClientProvider seam with the archive
and inbox-state methods that BackupManager/RestoreManager will
drive in CP3c/d, plus the installation revoker that runs at the
tail of a restore. Also lands the two architect-review fixes to
CP3a's SessionManager pause/resume.

XMTPClientProvider additions (protocol + Client extension + mocks)
- createArchive(path:encryptionKey:) — forwards to XMTPiOS.Client
  with default ArchiveOptions. Explicit pass-through required
  because the SDK's method takes a third `opts` arg with default;
  Swift's protocol witness doesn't auto-bridge that shape.
- importArchive(path:encryptionKey:) — signature matches the SDK
  exactly, default witness resolves.
- inboxState(refreshFromNetwork:) — needed by the revoker to
  enumerate live installations. refreshFromNetwork: true forces a
  fresh read; the cached view is often stale post-importArchive.

Mock + TestableMockClient conformances updated. MockXMTPClientProvider
grows call-recording for createArchive / importArchive /
revokeInstallations so tests can assert the protocol calls happened
without spinning up a real XMTP client. stubInboxState + inboxStateError
let tests drive the inboxState branch.

XMTPInstallationRevoker (new)
- Static util taking any XMTPClientProvider. Fetches inbox state
  (refreshFromNetwork: true), filters out keepInstallationId,
  revokes the rest. Returns the revoked count. Throws
  .noActiveInstallations if the network refresh yields zero
  installations (expected-impossible post-import, but guard
  catches SDK weirdness before we hand an empty list to
  revokeInstallations).
- Protocol-seam design per architect call: keeps the revoker
  mockable without a real Client. No mock test in this commit —
  XMTPiOS.InboxState has no public initializer outside the SDK,
  so the revoker is exercised via RestoreManager's integration
  path in CP3d.

SessionManager architect fixes to CP3a
- pauseForRestore: post-flag work wrapped in do/catch with
  Task.checkCancellation() at the top so the catch is reachable.
  Any throw (cancellation today, future cancel/stop throws) now
  runs resumeAfterRestore() and rethrows — no more half-paused
  sessions on partial failure.
- resumeAfterRestore: dropped the eager loadOrCreateService()
  call. Lazy rebuild matches tearDownInbox's pattern (nil the
  slot, let the next caller rebuild). Previously, a
  keychain-unreadable-post-restore error would silently cache a
  FailedIdentityLoadOperation-backed service and return void,
  hiding the causal link for RestoreManager.

Deferred: per-test appGroupIdentifier suffix to replace the
.serialized scope in SessionManagerRestoreTests. Fine for now;
revisit at CP3c when more suites touch RestoreInProgressFlag.

Dismissed from architect review: "eraseDatabaseOnSchemaChange
unconditional" — verified still #if DEBUG-gated at
SharedDatabaseMigrator.swift:19-21.

Tests: 16/16 pass across touched suites
(SessionManagerRestoreTests 4, BackupBundleTests 9,
DatabaseManagerReplaceTests 3). SwiftLint clean on all files.

Plan: docs/plans/icloud-backup-single-inbox.md §"Throwaway XMTP
client for archive import" — the three invariants' enforcement
lands in RestoreManager (CP3d); the protocol-level primitives
ship here.

feat(backup): BackupManager — sealed-bundle create flow

CP3c of PR 3. Lands the backup-side manager that BackupScheduler
(CP5) and the "Back up now" button will drive. Read-path matches
the plan's §"Backup flow".

BackupManager (new)
- Non-actor final class. createBackup() is inherently serialized
  by its one caller (scheduler fires sequentially, UI is user-
  driven); concurrency protection lives at the call site.
- Flow: skip-if-restore-in-progress → loadSync identity (skip if
  nil) → GRDB snapshot via dbReader.backup(to:) → fresh 32-byte
  archiveKey → client.createArchive via the CP3b protocol seam →
  buildMetadata (conversationCount, schemaGeneration, appVersion,
  archiveKey inner) → writeFull into the staging tar → pack + seal
  with identity.keys.databaseKey → atomic write to iCloud Documents
  /backups/<deviceId>/backup-latest.encrypted, fallback to local.
- Sidecar written *after* the sealed bundle so findAvailableBackup
  readers can't see a sidecar pointing at a not-yet-landed bundle.
  The sidecar omits archiveKey (secret stays inside the seal).
- BackupError surface: .noIdentity, .restoreInProgress,
  .clientUnavailable, .archiveFailed, .writeFailed — each rooted at
  the specific failure domain so callers can branch on the semantic,
  not parse localized strings.
- Staging dir cleanup via `defer { BackupBundle.cleanup(...) }` so
  cancelled/failed backups never leak bytes.
- `now:` closure in the init is a test seam — BackupManagerTests
  pin the createdAt deterministically without freezing wall-clock.

Prerequisite additions
- AppEnvironment.iCloudContainerIdentifier — derived from the
  app-group identifier (same pattern the old louis/icloud-backup
  branch used); Rev 4 plan §"Per-device backup path" assumes this
  accessor exists.
- DeviceInfoProviding.deviceName — new protocol requirement + iOS
  impl (captures UIDevice.current.name at init) + MockDeviceInfoProvider
  default. Backed by the user-facing requirement in the plan's
  fresh-install restore card: "A backup from [deviceName] is
  available". deviceIdentifier is stable-but-opaque; deviceName is
  display-facing.

Tests (4 cases, BackupManagerTests, .serialized)
- Happy path: createBackup returns a URL, file exists, sealed bundle
  unpacks with the identity's databaseKey, full metadata inside the
  tar carries archiveKey, MockXMTPClientProvider.createArchive was
  called once with that exact archiveKey, sidecar next to the bundle
  omits archiveKey (verified via JSON substring search).
- skips with .restoreInProgress — MockXMTPClientProvider never gets
  called (assertion on createArchiveCalls.isEmpty).
- skips with .noIdentity — same isEmpty assertion.
- archive failure surfaces as BackupError.

Design notes
- clientProvider is a `@Sendable () async throws -> any XMTPClientProvider`
  closure in the init. Callers that have a live SessionManager bind
  `{ try await session.messagingService().waitForInboxReadyResult().client }`.
  Tests bind a trivial `{ mockClient }`. No production adapter
  protocol, no production mock — one seam.
- conversationCount query filters `isUnused = 0` so unused-cache
  prewarm rows don't inflate the sidecar count shown in the restore
  prompt.
- The sidecar-after-bundle write ordering is half of the
  "pair-atomic write" concern the architect raised in the CP1/CP2
  review; the other half (findAvailableBackup cross-check) lands
  with RestoreManager in CP3d.

Plan: docs/plans/icloud-backup-single-inbox.md §"Backup flow (new)".

feat(backup): RestoreManager — decrypt, swap DB, import archive, revoke

CP3d of PR 3 — the restore side. Companion to BackupManager (CP3c).
The full flow from the plan's §"Restore flow" in a single actor,
with the throwaway-XMTP-client contract (three invariants from
plan §"Throwaway XMTP client for archive import") enforced
in-process.

RestoreManager (new)
- Actor. restoreFromBackup(bundleURL:) is the one entry point.
  Public findAvailableBackup(environment:) static for discovery
  that doesn't need the bundle key (sidecar read only).
- Wired dependencies: DatabaseManagerProtocol (replaceDatabase),
  KeychainIdentityStoreProtocol (loadSync polling),
  SessionManager (pauseForRestore / resumeAfterRestore), and a
  ThrowawayClientBuilder closure that hands out an
  XMTPClientProvider on demand. The production default builder
  calls XMTPiOS.Client.build against the restored DB directory;
  tests inject a closure that returns MockXMTPClientProvider.

The flow executes the Rev 4 plan literally:
  1. Read + decrypt bundle (seal key = identity.databaseKey).
  2. awaitIdentity — bounded loadSync poll (default 30s, 500ms
     poll) so iCloud Keychain lag doesn't cause
     `loadOrCreateService` to `.register` a forked identity.
  3. Validate metadata.schemaGeneration against currentGeneration;
     mismatch throws .schemaGenerationMismatch (distinct from
     decryption / validation errors so the UI can render the
     user-facing "made on an older version" copy + emits a
     QAEvent telemetry hit for future diagnostics).
  4. Validate GRDB snapshot + xmtp-archive.bin + archiveKey
     present before any destructive op.
  5. SessionManager.pauseForRestore() — sets both app-group
     and in-process flags, stops the cached service, clears
     the slot. Throws wrap in .sessionPauseFailed.
  6. Stage xmtp-*.db3 files aside in a temp dir (rollback
     anchor).
  7. DatabaseManager.replaceDatabase (WAL-checkpoint +
     NSFileCoordinator write barrier, from CP2).
  8. Build throwaway XMTP client via clientBuilder →
     importArchive → dropLocalDatabaseConnection in defer.
     Any throw here is CAUGHT and recorded as
     .archiveImportFailed — GRDB restore is already
     committed, so degrading to conversation-list-only is
     strictly better than aborting.
  9. markAllConversationsInactive on the restored GRDB.
  10. revokeStaleInstallations — builds a second throwaway
     client, calls XMTPInstallationRevoker. Non-fatal
     (revocation can fail without blocking the restore).
  11. SessionManager.resumeAfterRestore() — clears flags,
     next messagingService() call lazy-rebuilds the session
     against the restored identity + DB.

Rollback harness
- Pre-commit: any throw before the DB swap + any throw from the
  swap itself rolls back the XMTP file stash, resumes the
  session, rethrows, sets state = .failed. Mirrors the discipline
  on the old louis/icloud-backup branch.
- Post-commit: GRDB + XMTP state are already in the restored
  shape; further failures surface via state (.archiveImportFailed)
  but DO NOT attempt to undo. The plan §"Rollback harness" is
  explicit: no half-imported state gets unwound, the user hit
  "Restore" and consented.

State preservation
- If archive import fails, the subsequent revocation pass doesn't
  overwrite the .archiveImportFailed state — captured in a local
  var, re-pinned at the end so the caller sees the final signal.

Prerequisite tweaks
- AppEnvironment.iCloudContainerIdentifier (added in CP3c).
- DeviceInfoProviding.deviceName (added in CP3c).
- RestoreManager.init drops the default-arg for
  currentSchemaGeneration — LegacyDataWipe.currentGeneration is
  internal, and default-args can't reference internal symbols
  from a public initializer. Callers pass the generation
  explicitly; CP5's settings wiring will hand it in.

Tests (5 cases, RestoreManagerTests, .serialized)
- Happy path: create bundle via BackupManager, restoreFromBackup
  completes with state == .completed, importArchive recorded
  once on the mock, throwaway clientBuilder called twice (import +
  revocation).
- Discovery: findAvailableBackup returns the sidecar matching
  the one BackupManager wrote; conversationCount and
  schemaGeneration propagate.
- schemaGeneration mismatch: a RestoreManager built with a
  deliberately-different generation throws RestoreError.
- Identity timeout: short-timeout RestoreManager with empty
  keychain throws .identityTimeout within ~20ms.
- Archive import failure is non-fatal: mock's importArchive
  throws, restore still completes, state ends in
  .archiveImportFailed.

Deferred to CP3e
- Persisted archive bytes at <sharedContainer>/pending-archive-import.bin
  + "Retry history import" affordance in Settings. The state
  machine already emits .archiveImportFailed; CP3e just wires
  the persistence + UI surface.

Plan: docs/plans/icloud-backup-single-inbox.md §"Restore flow (new)",
§"Throwaway XMTP client for archive import", and the
`archiveImportFailed is retryable, not terminal` subsection.

feat(backup): TerminalSessionError + DeviceReplacedError + stale-check

CP4 of PR 3. Session-machine machinery that surfaces "this device
has been replaced" as a terminal error so the UI reset-flow (CP5)
has a state to observe. No UI in this commit — the banner +
conversations-list wiring lands alongside the rest of the
observer-side work in CP5 to keep CP4 pure-ConvosCore.

TerminalSessionError (new)
- Marker protocol. Empty protocol requirement — presence of the
  conformance is the contract.
- DeviceReplacedError: TerminalSessionError, Equatable. The only
  conformer today; future terminal conditions (hypothetical
  BackupRestoreCorruptedError, etc.) opt in via a one-line
  conformance.

SessionStateMachine changes
- handleRetryFromError short-circuits when
  `currentState == .error(e)` and `e is TerminalSessionError`.
  Prevents the retry-counter burn + "retry-by-coincidence lands
  in `.ready`" edge case the architect flagged in the Rev 4
  plan. Without this short-circuit, a background iCloud
  Keychain refresh between foreground attempts could silently
  flip the session to `.ready` on a revoked installation,
  masking the reset banner.
- handleAuthorized gains a stale-installation probe right
  before `emitStateChange(.ready(result))`:
    try await client.inboxState(refreshFromNetwork: true)
    if !state.installations.map(\.id).contains(client.installationId) {
        throw DeviceReplacedError()
    }
  Network failures during the probe log and proceed — the
  next foreground cycle retries. A successful probe that
  confirms revocation throws DeviceReplacedError, which the
  state machine catches and transitions to `.error(…)`.

Why handleAuthorized (and not elsewhere)
- Only authoritative place to catch the revocation:
  authenticatingBackend → ready is the first moment we have a
  live client that can read inboxState. Foreground-retry flows
  through the same helper via handleStop + handleAuthorize, so
  a single probe site covers both entry points per the plan's
  §"Stale-device as a session state, not a sidecar".

Tests (3 cases, TerminalSessionErrorTests)
- DeviceReplacedError conforms to TerminalSessionError.
- DeviceReplacedError is Equatable (default struct conformance).
- A non-conforming error type does NOT match `is
  TerminalSessionError`.
- The handleRetryFromError short-circuit + handleAuthorized
  probe require a live XMTP client and are exercised via the
  Docker-backed integration tests (not re-tested here — the
  marker-protocol contract pinned by this suite is the unit
  of coverage CP4 owns).

Plan: docs/plans/icloud-backup-single-inbox.md
§"Terminal errors: handleRetryFromError must not retry them"
and §"Stale-device as a session state, not a sidecar".

feat(backup): StaleDeviceBanner + ConversationsView wiring

CP5a of PR 3. UI observer-side half of CP4 — surfaces the
TerminalSessionError state to the user when the sole XMTP
installation for this inbox has been revoked.

StaleDeviceBanner (new)
- Single-variant pill: "This device has been replaced" with a
  destructive "Reset device" action and a bordered "Learn more"
  link. Rev 4 collapsed the old partialStale / fullStale
  variants into this one.
- Pure SwiftUI view, no VM of its own — takes two closures and
  lets the caller wire them.
- Accessibility: combined children, explicit label + identifier.

ConversationsViewModel wiring
- Subscribes to SessionStateMachine via
  `session.messagingService().sessionStateManager.observeState(_:)`
  — the same ClosureStateObserver + StateObserverHandle pattern
  the rest of the app uses.
- Flips isDeviceReplaced on every state change; the setter short-
  circuits no-op transitions so SwiftUI doesn't churn.
- `resetDevice()` action wraps `session.deleteAllInboxes()` in a
  MainActor Task + logs on failure.

ConversationsView
- sidebarContent now wraps its existing layout in a VStack; when
  isDeviceReplaced is true, StaleDeviceBanner renders above the
  list (or the empty state). Uses the same learn.convos.org URL
  as the InactiveConversationBanner from PR #725 so the two
  banners share an external resource.

No new tests in this commit — the banner itself is a pure view,
the VM wiring is a standard observer bridge, and the state
transitions it reacts to are already covered by
TerminalSessionErrorTests (CP4) + the Docker-backed integration
tests that exercise real revocation flows.

Plan: docs/plans/icloud-backup-single-inbox.md
§"Stale-device as a session state, not a sidecar" — banner's
"Reset device" action = session.deleteAllInboxes() per the plan.

docs(adr): ADR 012 — iCloud Backup (single-inbox architecture)

Captures what landed across CPs 1–5a of PR 3. Canonical
reference for reviewers who don't want to read the 8-commit
diff or the (now-mostly-historical) rev 4 plan doc. Supersedes
the vault-era plan documents authored on louis/icloud-backup.

Covers:
- Bundle format (CVBD magic + version header, tar, outer AES-GCM
  on identity.databaseKey, inner per-bundle archiveKey, sidecar
  vs full metadata projection).
- Create flow (BackupManager: skip guards → GRDB snapshot →
  client.createArchive → metadata → pack → seal → atomic iCloud
  write → sidecar after bundle).
- Restore flow (RestoreManager: discovery → awaitIdentity →
  decrypt + untar → validate → pauseForRestore → XMTP stash →
  replaceDatabase → throwaway Client.importArchive → commit →
  markAllConversationsInactive → revoke → resumeAfterRestore;
  rollback harness for pre-commit failures).
- NSE coordination (RestoreInProgressFlag + NSFileCoordinator
  write barrier).
- Device-replaced detection (TerminalSessionError marker +
  handleAuthorized probe + handleRetryFromError short-circuit +
  StaleDeviceBanner observer).
- Security model table and the list of things the bundle
  deliberately doesn't carry (media, keychain material,
  non-archive MLS history).
- Explicit pointer to CP5 follow-ups that are out of scope for
  this PR: BackupRestoreSettingsView + VM, BackupDebugView,
  BackupScheduler + xcconfig, fresh-install restore prompt,
  archiveImportFailed retry UX.

No source code changes in this commit — pure documentation.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add iCloud backup and restore with AES-256-GCM bundle format, metadata, and device-replaced detection
> - Adds `BackupManager` to create encrypted iCloud backup bundles: snapshots the GRDB database, generates an XMTP archive, writes signed metadata, packs everything into a custom tar-like format, and encrypts with AES-256-GCM using the identity's database key.
> - Adds `RestoreManager` to discover and restore bundles: decrypts and validates the bundle, replaces the live database (with rollback), imports the XMTP archive, revokes stale installations, and exposes typed `RestoreState` progress transitions.
> - Introduces `BackupBundleCrypto` (AES-GCM, 32-byte CSPRNG keys), `BackupBundle` (custom tar with path-traversal hardening), and `BackupBundleMetadata` (full + secret-free sidecar for discovery without decryption).
> - Adds `TerminalSessionError` protocol and `DeviceReplacedError`; `SessionStateMachine` now probes active installations on authorization and enters a terminal error state if the local installation has been revoked, surfacing a `StaleDeviceBanner` in the conversations list.
> - `SessionManager` gains `pauseForRestore`/`resumeAfterRestore` and returns a `RestoreInProgressError` placeholder service while a restore is active; the notification service extension suppresses pushes during restore.
> - Risk: `replaceDatabase(with:)` performs an in-place swap of the live `DatabasePool` contents under `NSFileCoordinator`; double-fault (copy failure + rollback failure) throws `DatabaseManagerError.rollbackFailed` and leaves the database in an indeterminate state.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 98f55bd. 23 files reviewed, 10 issues evaluated, 2 issues filtered, 5 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> <details>
> <summary>Convos/Conversations List/ConversationsViewModel.swift — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 37](https://github.com/xmtplabs/convos-ios/blob/98f55bd1166df51f159f8ee42dc9a42753286c15/Convos/Conversations List/ConversationsViewModel.swift#L37): After `session.deleteAllInboxes()` completes successfully, the `isDeviceReplaced` flag remains stale because `sessionStateHandle` (created in `observeSessionState()`) is observing the old, now-deleted `MessagingService`. Any subsequent calls to `session.messagingService()` return a newly-created service whose state manager is not being observed. The banner will continue to show "This device has been replaced" even though the reset completed successfully, leaving the user with no indication the operation worked and no clear path forward. <b>[ Out of scope ]</b>
> </details>
>
> <details>
> <summary>ConvosCore/Sources/ConvosCore/Backup/RestoreManager.swift — 2 comments posted, 5 evaluated, 1 filtered</summary>
>
> - [line 128](https://github.com/xmtplabs/convos-ios/blob/98f55bd1166df51f159f8ee42dc9a42753286c15/ConvosCore/Sources/ConvosCore/Backup/RestoreManager.swift#L128): `findAvailableBackup` searches for backups in directories keyed by `DeviceInfo.deviceIdentifier` — the **current** device's ID. In a cross-device restore scenario (restoring Device B from Device A's backup), the backup lives in `.../backups/<DeviceA-id>/...` but this function looks in `.../backups/<DeviceB-id>/...`. The function will always return `nil` for backups created on a different device, silently failing to discover them. <b>[ Out of scope ]</b>
> </details>
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->