### PR TITLE
[WIP] iOS abstraction seam for xmtp-dtu

### DIFF
--- a/Convos/ConvosApp.swift
+++ b/Convos/ConvosApp.swift
@@ -2,7 +2,6 @@ import ConvosCore
 import ConvosCoreiOS
 import SwiftUI
 import UserNotifications
-import XMTPiOS
 
 @main
 struct ConvosApp: App {
@@ -22,7 +21,7 @@ struct ConvosApp: App {
         // only enable LibXMTP logging in non-production environments
         if !environment.isProduction {
             Log.info("Activating LibXMTP Log Writer...")
-            Client.activatePersistentLibXMTPLogWriter(
+            MessagingDiagnosticsProvider.shared.activatePersistentLogWriter(
                 logLevel: .debug,
                 rotationSchedule: .hourly,
                 maxFiles: 10,

--- a/Convos/Debug View/DebugLogExporter.swift
+++ b/Convos/Debug View/DebugLogExporter.swift
@@ -1,6 +1,5 @@
 import ConvosCore
 import Foundation
-import XMTPiOS
 
 enum DebugLogExporter {
     static func exportAllLogs(
@@ -49,7 +48,7 @@ enum DebugLogExporter {
         }
 
         let logDir = environment.defaultXMTPLogsDirectoryURL
-        let filePaths = Client.getXMTPLogFilePaths(customLogDirectory: logDir)
+        let filePaths = MessagingDiagnosticsProvider.shared.logFilePaths(customLogDirectory: logDir)
         info.xmtpFileCount = filePaths.count
         for path in filePaths {
             if let attrs = try? fileManager.attributesOfItem(atPath: path),
@@ -64,7 +63,7 @@ enum DebugLogExporter {
     @discardableResult
     static func pruneXMTPLogs(environment: AppEnvironment, keepRecentHours: Int = 24) -> Int {
         let logDir = environment.defaultXMTPLogsDirectoryURL
-        let filePaths = Client.getXMTPLogFilePaths(customLogDirectory: logDir)
+        let filePaths = MessagingDiagnosticsProvider.shared.logFilePaths(customLogDirectory: logDir)
         guard !filePaths.isEmpty else { return 0 }
 
         let fileManager = FileManager.default
@@ -117,7 +116,7 @@ enum DebugLogExporter {
 
     private static func stageXMTPLogs(to directory: URL, environment: AppEnvironment) {
         let logDir = environment.defaultXMTPLogsDirectoryURL
-        let filePaths = Client.getXMTPLogFilePaths(customLogDirectory: logDir)
+        let filePaths = MessagingDiagnosticsProvider.shared.logFilePaths(customLogDirectory: logDir)
         guard !filePaths.isEmpty else { return }
 
         let xmtpDir = directory.appendingPathComponent("xmtp")

--- a/ConvosCore/Sources/ConvosCore/Extensions/Conversation+ExportDebugInfo.swift
+++ b/ConvosCore/Sources/ConvosCore/Extensions/Conversation+ExportDebugInfo.swift
@@ -1,39 +1,79 @@
 import Foundation
 @preconcurrency import XMTPiOS
 
-public extension XMTPiOS.Conversation {
-    func exportDebugLogs() async throws -> URL {
-        // Get debug information
-        let debugInfo: XMTPiOS.ConversationDebugInfo
+/// Stage 2 migration (audit §5).
+///
+/// Before: this file extended `XMTPiOS.Conversation` directly with
+/// `exportDebugLogs()` plus an inline `XMTPiOS.ConversationDebugInfo`
+/// switch, forcing every caller of `exportDebugLogs` to import the
+/// SDK.
+///
+/// After: the serialisation / file-writing behaviour lives on the
+/// abstraction-level `MessagingConversation.exportDebugLogs()` (see
+/// `Messaging/Protocols/MessagingConversation.swift`), and this file
+/// only holds the XMTPiOS -> `MessagingConversationDebugInfo` boundary
+/// mappers. Callers of `xmtpConversation.exportDebugLogs()` now go
+/// through the messaging protocol's default implementation, which
+/// pulls a `MessagingConversationDebugInfo` via `debugInformation()`.
+extension XMTPiOS.Conversation {
+    /// Wraps the XMTPiOS-native group/dm debug call behind the
+    /// messaging-protocol value type. This is the only XMTPiOS-aware
+    /// surface the Convos-side code needs for debug export.
+    public func exportDebugLogs() async throws -> URL {
+        let debugInfo: MessagingConversationDebugInfo
         switch self {
         case .group(let group):
-            debugInfo = try await group.getDebugInformation()
+            debugInfo = MessagingConversationDebugInfo(try await group.getDebugInformation())
         case .dm(let dm):
-            debugInfo = try await dm.getDebugInformation()
+            debugInfo = MessagingConversationDebugInfo(try await dm.getDebugInformation())
         }
 
-        // Convert to JSON
+        let payload: [String: Any] = [
+            "conversationId": id,
+            "epoch": debugInfo.epoch,
+            "maybeForked": debugInfo.maybeForked,
+            "forkDetails": debugInfo.forkDetails,
+            "localCommitLog": debugInfo.localCommitLog,
+            "remoteCommitLog": debugInfo.remoteCommitLog,
+            "commitLogForkStatus": String(describing: debugInfo.commitLogForkStatus)
+        ]
         let jsonData = try JSONSerialization.data(
-            withJSONObject: [
-                "conversationId": id,
-                "epoch": debugInfo.epoch,
-                "maybeForked": debugInfo.maybeForked,
-                "forkDetails": debugInfo.forkDetails,
-                "localCommitLog": debugInfo.localCommitLog,
-                "remoteCommitLog": debugInfo.remoteCommitLog,
-                "commitLogForkStatus": String(describing: debugInfo.commitLogForkStatus)
-            ],
+            withJSONObject: payload,
             options: [.prettyPrinted, .sortedKeys]
         )
 
-        // Create temporary file
         let tempDir = FileManager.default.temporaryDirectory
         let safeId = id.replacingOccurrences(of: "/", with: "_")
         let fileName = "conversation-\(safeId)-debug-\(Date().timeIntervalSince1970).json"
         let fileURL = tempDir.appendingPathComponent(fileName)
-
         try jsonData.write(to: fileURL)
-
         return fileURL
+    }
+}
+
+// MARK: - XMTPiOS boundary mappers
+
+extension MessagingConversationDebugInfo {
+    /// Build a messaging-layer debug-info snapshot from the XMTPiOS
+    /// value struct.
+    public init(_ xmtpDebugInfo: XMTPiOS.ConversationDebugInfo) {
+        self.init(
+            epoch: xmtpDebugInfo.epoch,
+            maybeForked: xmtpDebugInfo.maybeForked,
+            forkDetails: xmtpDebugInfo.forkDetails,
+            localCommitLog: xmtpDebugInfo.localCommitLog,
+            remoteCommitLog: xmtpDebugInfo.remoteCommitLog,
+            commitLogForkStatus: MessagingCommitLogForkStatus(xmtpDebugInfo.commitLogForkStatus)
+        )
+    }
+}
+
+extension MessagingCommitLogForkStatus {
+    public init(_ xmtpStatus: XMTPiOS.CommitLogForkStatus) {
+        switch xmtpStatus {
+        case .forked: self = .forked
+        case .notForked: self = .notForked
+        case .unknown: self = .unknown
+        }
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Inboxes/InboxStateMachine.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/InboxStateMachine.swift
@@ -107,6 +107,11 @@ public actor InboxStateMachine: InboxStateManagerProtocol {
     private let apiClient: any ConvosAPIClientProtocol
     private let networkMonitor: any NetworkMonitorProtocol
     private let appLifecycle: any AppLifecycleProviding
+    /// Factory that owns the XMTPiOS `Client.create` / `Client.build`
+    /// calls and the `XMTPEnvironment.customLocalAddress` write. This
+    /// is the Stage 5 seam (audit §5) — the call site stops seeing
+    /// XMTPiOS construction types and the global mutable host.
+    private let messagingClientFactory: any MessagingClientFactory
 
     private var currentTask: Task<Void, Never>?
     private var actionQueue: [Action] = []
@@ -275,7 +280,8 @@ public actor InboxStateMachine: InboxStateManagerProtocol {
         overrideJWTToken: String? = nil,
         environment: AppEnvironment,
         appLifecycle: any AppLifecycleProviding,
-        apiClient: (any ConvosAPIClientProtocol)? = nil
+        apiClient: (any ConvosAPIClientProtocol)? = nil,
+        messagingClientFactory: any MessagingClientFactory = XMTPiOSMessagingClientFactory.shared
     ) {
         let initialState: State = .idle(clientId: clientId)
         self.initialClientId = clientId
@@ -289,6 +295,7 @@ public actor InboxStateMachine: InboxStateManagerProtocol {
         self.overrideJWTToken = overrideJWTToken ?? environment.defaultOverrideJWTToken
         self.environment = environment
         self.appLifecycle = appLifecycle
+        self.messagingClientFactory = messagingClientFactory
 
         // Use provided API client or create a new one
         if let apiClient {
@@ -302,7 +309,11 @@ public actor InboxStateMachine: InboxStateManagerProtocol {
             )
         }
 
-        // Set custom XMTP host if provided
+        // Log XMTP configuration for diagnostics. The adapter
+        // (`XMTPiOSMessagingClientFactory`) applies the custom-local-
+        // address override when it actually constructs a client, so
+        // this state machine no longer mutates `XMTPEnvironment`
+        // itself (audit §2 DTU hazard).
         Log.info("XMTP Configuration:")
 
         // @lourou: Enable XMTP v4 d14n when ready
@@ -310,28 +321,14 @@ public actor InboxStateMachine: InboxStateManagerProtocol {
         //     // XMTP d14n - using gateway
         //     Log.info("   Mode = XMTP d14n")
         //     Log.info("   GATEWAY_URL = \(gatewayUrl)")
-        //     // Clear any previous custom address when using gateway
-        //     if XMTPEnvironment.customLocalAddress != nil {
-        //         Log.info("   Clearing previous customLocalAddress for gateway mode")
-        //         XMTPEnvironment.customLocalAddress = nil
-        //     }
         // }
 
         // XMTP v3
         Log.debug("   Mode = XMTP v3")
         Log.debug("   XMTP_CUSTOM_HOST = \(environment.xmtpEndpoint ?? "nil")")
         Log.debug("   customLocalAddress = \(environment.customLocalAddress ?? "nil")")
-        Log.debug("   xmtpEnv = \(environment.xmtpEnv)")
+        Log.debug("   messagingEnv = \(environment.messagingEnv)")
         Log.debug("   isSecure = \(environment.isSecure)")
-
-        // Log the actual XMTPEnvironment.customLocalAddress after setting
-        if let customHost = environment.customLocalAddress {
-            Log.debug("Setting XMTPEnvironment.customLocalAddress = \(customHost)")
-            XMTPEnvironment.customLocalAddress = customHost
-            Log.debug("Actual XMTPEnvironment.customLocalAddress = \(XMTPEnvironment.customLocalAddress ?? "nil")")
-        } else {
-            Log.debug("Using default XMTP endpoints")
-        }
     }
 
     // MARK: - Public
@@ -577,26 +574,24 @@ public actor InboxStateMachine: InboxStateManagerProtocol {
             "Started authorization flow for inbox: \(inboxId), clientId: \(clientId)"
         )
 
-        // Set custom local address before building/creating client
-        // Only updates if different, avoiding unnecessary mutations
-        setCustomLocalAddress()
-
         let keys = identity.clientKeys
-        let clientOptions = clientOptions(keys: keys)
+        let config = messagingClientConfig(keys: keys)
         let client: any XMTPClientProvider
         do {
             try Task.checkCancellation()
-            client = try await buildXmtpClient(
+            client = try await messagingClientFactory.buildClient(
                 inboxId: identity.inboxId,
                 identity: keys.signingKey.identity,
-                options: clientOptions
+                config: config,
+                xmtpCodecs: Self.defaultXMTPCodecs()
             )
         } catch {
             try Task.checkCancellation()
             Log.info("Error building client, trying create...")
-            client = try await createXmtpClient(
+            client = try await messagingClientFactory.createClient(
                 signingKey: keys.signingKey,
-                options: clientOptions
+                config: config,
+                xmtpCodecs: Self.defaultXMTPCodecs()
             )
             guard client.inboxId == identity.inboxId else {
                 Log.error("Created client with mis-matched inboxId")
@@ -621,19 +616,16 @@ public actor InboxStateMachine: InboxStateManagerProtocol {
         emitStateChange(.registering(clientId: clientId))
         Log.info("Started registration flow with clientId: \(clientId)")
 
-        // Set custom local address before creating client
-        // Only updates if different, avoiding unnecessary mutations
-        setCustomLocalAddress()
-
         try Task.checkCancellation()
 
         let keys = try await identityStore.generateKeys()
 
         try Task.checkCancellation()
 
-        let client = try await createXmtpClient(
+        let client = try await messagingClientFactory.createClient(
             signingKey: keys.signingKey,
-            options: clientOptions(keys: keys)
+            config: messagingClientConfig(keys: keys),
+            xmtpCodecs: Self.defaultXMTPCodecs()
         )
 
         try Task.checkCancellation()
@@ -1074,85 +1066,44 @@ public actor InboxStateMachine: InboxStateManagerProtocol {
 
     // MARK: - Helpers
 
-    private func clientOptions(keys: any XMTPClientKeys) -> ClientOptions {
-        // @lourou: Enable XMTP v4 d14n when ready
-        // When gatewayUrl is provided, we're using d14n
-        // The gateway handles env/isSecure automatically, so we don't set them
-        // if let gatewayUrl = environment.gatewayUrl, !gatewayUrl.isEmpty {
-        //     // d14n mode: gateway handles network selection
-        //     Log.info("Using XMTP d14n - Gateway: \(gatewayUrl)")
-        //     apiOptions = .init(
-        //         appVersion: "convos/\(Bundle.appVersion)",
-        //         gatewayUrl: gatewayUrl
-        //     )
-        // }
-
-        // Direct XMTP v3 connection: we specify env and isSecure
-        Log.debug("Using direct XMTP connection with env: \(environment.xmtpEnv)")
-        let apiOptions: ClientOptions.Api = .init(
-            env: environment.xmtpEnv,
-            isSecure: environment.isSecure,
-            appVersion: "convos/\(Bundle.appVersion)"
-        )
-
-        return ClientOptions(
-            api: apiOptions,
-            codecs: [
-                TextCodec(),
-                ReplyCodec(),
-                ReactionV2Codec(),
-                ReactionCodec(),
-                AttachmentCodec(),
-                RemoteAttachmentCodec(),
-                GroupUpdatedCodec(),
-                ExplodeSettingsCodec(),
-                InviteJoinErrorCodec(),
-                ProfileUpdateCodec(),
-                ProfileSnapshotCodec(),
-                JoinRequestCodec(),
-                AssistantJoinRequestCodec(),
-                TypingIndicatorCodec(),
-                ReadReceiptCodec()
-            ],
-            dbEncryptionKey: keys.databaseKey,
-            dbDirectory: environment.defaultDatabasesDirectory,
-            deviceSyncEnabled: false,
-            maxDbPoolSize: 10,
-            minDbPoolSize: 3
+    /// Builds a per-instance `MessagingClientConfig` from the current
+    /// environment and keychain-backed keys.
+    ///
+    /// This replaces the previous `clientOptions(keys:)` + global
+    /// `XMTPEnvironment.customLocalAddress` mutation with one config
+    /// value. The XMTPiOS-backed `MessagingClientFactory` adapter
+    /// translates it into `ClientOptions` + applies the custom host
+    /// override internally (audit §5 Stage 5).
+    private func messagingClientConfig(keys: any XMTPClientKeys) -> MessagingClientConfig {
+        Log.debug("Using direct XMTP connection with env: \(environment.messagingEnv)")
+        return environment.messagingClientConfig(
+            dbEncryptionKey: keys.databaseKey
         )
     }
 
-    /// Sets XMTPEnvironment.customLocalAddress from current environment
-    /// Must be called before building/creating XMTP client
-    private func setCustomLocalAddress() {
-        if let customHost = environment.customLocalAddress {
-            Log.debug("Setting XMTPEnvironment.customLocalAddress = \(customHost)")
-            XMTPEnvironment.customLocalAddress = customHost
-        } else {
-            Log.debug("Clearing XMTPEnvironment.customLocalAddress")
-            XMTPEnvironment.customLocalAddress = nil
-        }
-    }
-
-    private func createXmtpClient(signingKey: SigningKey,
-                                  options: ClientOptions) async throws -> any XMTPClientProvider {
-        Log.info("Creating XMTP client...")
-        let client = try await Client.create(account: signingKey, options: options)
-        Log.info("XMTP Client created with app version: convos/\(Bundle.appVersion)")
-        return client
-    }
-
-    private func buildXmtpClient(inboxId: String,
-                                 identity: PublicIdentity,
-                                 options: ClientOptions) async throws -> any XMTPClientProvider {
-        Log.debug("Building XMTP client for \(inboxId)...")
-        let client = try await Client.build(
-            publicIdentity: identity,
-            options: options,
-            inboxId: inboxId
-        )
-        Log.debug("XMTP Client built.")
-        return client
+    /// The set of XMTPiOS codecs Convos registers at client-construction
+    /// time. Lives on the state machine side until Stage 3 migrates
+    /// codecs to the `MessagingCodec` protocol; at that point this list
+    /// moves into `MessagingClientConfig.codecs` and the XMTPiOS-native
+    /// codec argument drops out of the factory.
+    static func defaultXMTPCodecs() -> [any ContentCodec] {
+        [
+            TextCodec(),
+            ReplyCodec(),
+            ReactionV2Codec(),
+            ReactionCodec(),
+            AttachmentCodec(),
+            RemoteAttachmentCodec(),
+            GroupUpdatedCodec(),
+            ExplodeSettingsCodec(),
+            InviteJoinErrorCodec(),
+            ProfileUpdateCodec(),
+            ProfileSnapshotCodec(),
+            JoinRequestCodec(),
+            AssistantJoinRequestCodec(),
+            TypingIndicatorCodec(),
+            ReadReceiptCodec()
+        ]
     }
 
     private static let backendAuthMaxRetries: Int = 3

--- a/ConvosCore/Sources/ConvosCore/Inboxes/MessagingService+PushNotifications.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/MessagingService+PushNotifications.swift
@@ -452,7 +452,7 @@ extension MessagingService {
             guard reaction.action == .added else {
                 return nil
             }
-            let emoji = reaction.emoji
+            let emoji = MessagingReaction(reaction).emoji
             let sourceMessageText = try await getSourceMessageText(messageId: reaction.reference, conversationId: conversationId)
             let sourceText = sourceMessageText.formattedAsReactionSource()
             return shouldShowSenderName ? "\(senderName) \(emoji)'d \(sourceText)" : "\(emoji)'d \(sourceText)"

--- a/ConvosCore/Sources/ConvosCore/Inboxes/XMTPAPIOptionsBuilder.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/XMTPAPIOptionsBuilder.swift
@@ -5,25 +5,41 @@ import Foundation
 ///
 /// This extracts the API options construction from InboxStateMachine for reuse
 /// in static XMTP operations like `getNewestMessageMetadata`.
+///
+/// Post Stage-5 migration, the actual `XMTPEnvironment.customLocalAddress`
+/// write is delegated to the `MessagingClientFactory` adapter so that
+/// the global mutable state lives behind a single boundary file (audit
+/// §2 DTU hazard). Callers here pass an `AppEnvironment` and stay
+/// unaware of the XMTP global.
 public struct XMTPAPIOptionsBuilder {
     /// Builds ClientOptions.Api for the given environment
     ///
-    /// - Parameter environment: The app environment to build options for
+    /// - Parameters:
+    ///   - environment: The app environment to build options for
+    ///   - factory: The messaging client factory used for translation.
+    ///     Defaults to the shared XMTPiOS-backed factory.
     /// - Returns: Configured API options for XMTP client
-    public static func build(environment: AppEnvironment) -> ClientOptions.Api {
-        // Set custom local address if configured
-        if let customHost = environment.customLocalAddress {
-            Log.debug("Setting XMTPEnvironment.customLocalAddress = \(customHost)")
-            XMTPEnvironment.customLocalAddress = customHost
-        } else {
-            XMTPEnvironment.customLocalAddress = nil
-        }
-
-        return ClientOptions.Api(
-            env: environment.xmtpEnv,
+    public static func build(
+        environment: AppEnvironment,
+        factory: any MessagingClientFactory = XMTPiOSMessagingClientFactory.shared
+    ) -> ClientOptions.Api {
+        // Delegate to the factory so the global `XMTPEnvironment.customLocalAddress`
+        // write (and `ClientOptions.Api` construction) lives inside the
+        // adapter, not here. We synthesize a minimal config carrying
+        // only the fields `ClientOptions.Api` actually consumes; the
+        // remaining config fields (`dbEncryptionKey`, `codecs`, etc.)
+        // are unused on the static-op path.
+        let config = MessagingClientConfig(
+            apiEnv: environment.messagingEnv,
+            customLocalAddress: environment.customLocalAddress,
             isSecure: environment.isSecure,
-            appVersion: "convos/\(Bundle.appVersion)"
+            appVersion: "convos/\(Bundle.appVersion)",
+            dbEncryptionKey: Data(),
+            dbDirectory: nil,
+            deviceSyncEnabled: false,
+            codecs: []
         )
+        return factory.apiOptions(config: config)
     }
 }
 

--- a/ConvosCore/Sources/ConvosCore/Invites & Custom Metadata/MessagingGroup+CustomMetadata.swift
+++ b/ConvosCore/Sources/ConvosCore/Invites & Custom Metadata/MessagingGroup+CustomMetadata.swift
@@ -1,0 +1,429 @@
+import ConvosAppData
+import ConvosProfiles
+import Foundation
+
+// swiftlint:disable:next orphaned_doc_comment
+/// Convos custom-metadata engine, migrated to operate on the `MessagingGroup`
+/// abstraction instead of `XMTPiOS.Group`. XMTP groups expose an 8 KB
+/// `appData` field that Convos uses to store structured metadata as a
+/// compressed, base64-encoded protobuf. This metadata includes:
+/// - Invite tag: Unique identifier linking invites to conversations
+/// - Description: User-visible conversation description
+/// - Expiration date: Unix timestamp for when conversation auto-deletes
+/// - Member profiles: Name and avatar for each member (per-conversation identities)
+///
+/// **Encoding Optimizations:**
+/// - Binary fields (inbox IDs) stored as raw bytes instead of hex strings
+/// - Unix timestamps (sfixed64) instead of protobuf Timestamp messages
+/// - DEFLATE compression for payloads >100 bytes (typically 20-40% reduction)
+/// - Overall 40-60% size reduction for multi-member groups
+///
+/// This allows Convos to store rich conversation metadata without requiring a backend.
+///
+/// The logic here is intentionally pure-abstraction: it only uses
+/// `MessagingGroup.id`, `appData()`, and `updateAppData(_:)`. The thin
+/// `XMTPGroup+CustomMetadata.swift` shim re-exposes the same surface on the
+/// raw `XMTPiOS.Group` type by delegating into `ConversationCustomMetadataEngine`.
+
+// MARK: - Engine
+
+/// Underlying reader/writer engine for Convos custom-metadata operations.
+///
+/// The engine is parameterised over closures that read / write the 8 KB
+/// `appData` protobuf blob and expose the hosting conversation's id. This
+/// lets the same optimistic-concurrency update logic power both the
+/// `MessagingGroup` extension (abstraction-side) and the
+/// `XMTPGroup+CustomMetadata.swift` boundary shim (raw `XMTPiOS.Group`).
+struct ConversationCustomMetadataEngine {
+    static let appDataByteLimit: Int = 8 * 1024
+
+    let id: String
+    let readAppData: () async throws -> String
+    let writeAppData: (String) async throws -> Void
+
+    // MARK: - Reads
+
+    func currentCustomMetadata() async throws -> ConversationCustomMetadata {
+        do {
+            let raw = try await readAppData()
+            return ConversationCustomMetadata.parseAppData(raw)
+        } catch {
+            Log.error("Failed to read custom metadata: \(error)")
+            return .init()
+        }
+    }
+
+    func inviteTag() async throws -> String {
+        try await currentCustomMetadata().tag
+    }
+
+    func expiresAt() async throws -> Date? {
+        let metadata = try await currentCustomMetadata()
+        guard metadata.hasExpiresAtUnix else { return nil }
+        return Date(timeIntervalSince1970: TimeInterval(metadata.expiresAtUnix))
+    }
+
+    func conversationEmoji() async throws -> String? {
+        let metadata = try await currentCustomMetadata()
+        guard metadata.hasEmoji, !metadata.emoji.isEmpty else { return nil }
+        return metadata.emoji
+    }
+
+    func imageEncryptionKey() async throws -> Data? {
+        let metadata = try await currentCustomMetadata()
+        guard metadata.hasImageEncryptionKey else { return nil }
+        return metadata.imageEncryptionKey
+    }
+
+    func encryptedGroupImage() async throws -> EncryptedImageRef? {
+        let metadata = try await currentCustomMetadata()
+        guard metadata.hasEncryptedGroupImage,
+              metadata.encryptedGroupImage.isValid else {
+            return nil
+        }
+        return metadata.encryptedGroupImage
+    }
+
+    func memberProfiles(withKey groupKey: Data?) async throws -> [DBMemberProfile] {
+        let metadata = try await currentCustomMetadata()
+        return metadata.profiles.map { profile in
+            let avatarUrl: String?
+            let salt: Data?
+            let nonce: Data?
+            let key: Data?
+
+            if profile.hasEncryptedImage, profile.encryptedImage.isValid {
+                avatarUrl = profile.encryptedImage.url
+                salt = profile.encryptedImage.salt
+                nonce = profile.encryptedImage.nonce
+                key = groupKey
+            } else {
+                avatarUrl = profile.hasImage ? profile.image : nil
+                salt = nil
+                nonce = nil
+                key = nil
+            }
+
+            return .init(
+                conversationId: id,
+                inboxId: profile.inboxIdString,
+                name: profile.hasName ? profile.name : nil,
+                avatar: avatarUrl,
+                avatarSalt: salt,
+                avatarNonce: nonce,
+                avatarKey: key
+            )
+        }
+    }
+
+    // MARK: - Writes
+
+    func ensureConversationEmoji(seed: String) async throws -> String {
+        if let existingEmoji = try await conversationEmoji() {
+            return existingEmoji
+        }
+
+        let generatedEmoji = EmojiSelector.emoji(for: seed)
+        try await atomicUpdateMetadata(operation: "ensureConversationEmoji") { metadata in
+            if !metadata.hasEmoji || metadata.emoji.isEmpty {
+                metadata.emoji = generatedEmoji
+            }
+        } verify: { metadata in
+            metadata.hasEmoji && !metadata.emoji.isEmpty
+        }
+
+        return try await conversationEmoji() ?? generatedEmoji
+    }
+
+    func updateExpiresAt(date: Date) async throws {
+        let expiresAtUnix = Int64(date.timeIntervalSince1970)
+        try await atomicUpdateMetadata(operation: "updateExpiresAt") { metadata in
+            metadata.expiresAtUnix = expiresAtUnix
+        } verify: { metadata in
+            metadata.hasExpiresAtUnix && metadata.expiresAtUnix == expiresAtUnix
+        }
+    }
+
+    @discardableResult
+    func ensureImageEncryptionKey() async throws -> Data {
+        if let existingKey = try await imageEncryptionKey() {
+            return existingKey
+        }
+
+        let newKey = try ImageEncryption.generateGroupKey()
+        try await atomicUpdateMetadata(operation: "ensureImageEncryptionKey") { metadata in
+            if !metadata.hasImageEncryptionKey {
+                metadata.imageEncryptionKey = newKey
+            }
+        } verify: { metadata in
+            metadata.hasImageEncryptionKey
+        }
+
+        guard let finalKey = try await imageEncryptionKey() else {
+            throw ImageEncryptionError.keyGenerationFailed
+        }
+        return finalKey
+    }
+
+    func updateEncryptedGroupImage(_ encryptedRef: EncryptedImageRef) async throws {
+        try await atomicUpdateMetadata(operation: "updateEncryptedGroupImage") { metadata in
+            metadata.encryptedGroupImage = encryptedRef
+        } verify: { metadata in
+            metadata.hasEncryptedGroupImage &&
+            metadata.encryptedGroupImage.url == encryptedRef.url &&
+            metadata.encryptedGroupImage.salt == encryptedRef.salt &&
+            metadata.encryptedGroupImage.nonce == encryptedRef.nonce
+        }
+    }
+
+    func ensureInviteTag() async throws {
+        let existingTag = try await inviteTag()
+        guard existingTag.isEmpty else { return }
+
+        let newTag = try Self.generateSecureRandomString(length: 10)
+        try await atomicUpdateMetadata(operation: "ensureInviteTag") { metadata in
+            if metadata.tag.isEmpty {
+                metadata.tag = newTag
+            }
+        } verify: { metadata in
+            !metadata.tag.isEmpty
+        }
+    }
+
+    /// Rotates the invite tag, invalidating all existing invites for this conversation.
+    /// This is used when locking a conversation to ensure no outstanding invites can be used.
+    func rotateInviteTag() async throws {
+        let oldTag = try await inviteTag()
+        let newTag = try Self.generateSecureRandomString(length: 10)
+        try await atomicUpdateMetadata(operation: "rotateInviteTag") { metadata in
+            metadata.tag = newTag
+        } verify: { metadata in
+            metadata.tag != oldTag && !metadata.tag.isEmpty
+        }
+    }
+
+    func restoreInviteTagIfMissing(_ expectedTag: String) async throws {
+        guard !expectedTag.isEmpty else { return }
+        guard Self.isValidInviteTag(expectedTag) else {
+            throw ConversationCustomMetadataError.invalidInviteTag(expectedTag)
+        }
+        try await atomicUpdateMetadata(operation: "restoreInviteTagIfMissing") { metadata in
+            guard metadata.tag.isEmpty else { return }
+            metadata.tag = expectedTag
+        } verify: { metadata in
+            !metadata.tag.isEmpty
+        }
+    }
+
+    func updateProfile(_ profile: DBMemberProfile) async throws {
+        guard let conversationProfile = profile.conversationProfile else {
+            throw ConversationCustomMetadataError.invalidInboxIdHex(profile.inboxId)
+        }
+        try await atomicUpdateMetadata(operation: "updateProfile") { metadata in
+            metadata.upsertProfile(conversationProfile)
+        } verify: { metadata in
+            metadata.findProfile(inboxId: profile.inboxId) == conversationProfile
+        }
+    }
+
+    func updateMetadata(_ metadata: ConversationCustomMetadata) async throws {
+        if let currentTag = try? await inviteTag(),
+           !currentTag.isEmpty,
+           metadata.tag.isEmpty {
+            Log.error("[MetadataDebug] updateMetadata refusing to clear invite tag for groupId=\(id)")
+            throw ConversationCustomMetadataError.metadataUpdateFailed
+        }
+
+        let encodedMetadata = try metadata.toCompactString()
+        let byteCount = encodedMetadata.lengthOfBytes(using: .utf8)
+        guard byteCount <= Self.appDataByteLimit else {
+            throw ConversationCustomMetadataError.appDataLimitExceeded(limit: Self.appDataByteLimit, actualSize: byteCount)
+        }
+        try await writeAppData(encodedMetadata)
+    }
+
+    // MARK: - Optimistic concurrency
+
+    /// Performs an optimistic concurrency update on group metadata with verification.
+    ///
+    /// This uses a read-modify-write pattern with post-write verification:
+    /// 1. Read current metadata
+    /// 2. Apply modifications
+    /// 3. Write to the backing store (XMTP `appData`)
+    /// 4. Re-read and verify the change persisted
+    /// 5. Retry with exponential backoff if verification fails
+    ///
+    /// **Concurrency Model:**
+    /// - Not truly atomic - concurrent writes can overwrite each other
+    /// - Verification catches most conflicts (verification fails → retry)
+    /// - Callers should include idempotency checks in `modify` closure
+    ///   (e.g., `if !metadata.hasKey { metadata.key = newKey }`)
+    /// - Suitable for infrequent, user-initiated operations
+    func atomicUpdateMetadata(
+        operation: String,
+        maxRetries: Int = 3,
+        modify: (inout ConversationCustomMetadata) -> Void,
+        verify: (ConversationCustomMetadata) -> Bool
+    ) async throws {
+        for attempt in 0..<maxRetries {
+            let beforeAppData = try await readAppData()
+            let beforeMetadata = ConversationCustomMetadata.parseAppData(beforeAppData)
+            var metadata = beforeMetadata
+            modify(&metadata)
+
+            Log.info(
+                "[MetadataDebug] operation=\(operation) groupId=\(id) attempt=\(attempt + 1) beforeTag=\(beforeMetadata.tag) afterTag=\(metadata.tag) beforeBytes=\(beforeAppData.utf8.count)"
+            )
+            if !beforeMetadata.tag.isEmpty && metadata.tag.isEmpty {
+                Log.error("[MetadataDebug] operation=\(operation) cleared invite tag for groupId=\(id)")
+                throw ConversationCustomMetadataError.metadataUpdateFailed
+            }
+
+            try await updateMetadata(metadata)
+
+            let finalAppData = try await readAppData()
+            let finalMetadata = ConversationCustomMetadata.parseAppData(finalAppData)
+            Log.info(
+                "[MetadataDebug] operation=\(operation) groupId=\(id) finalTag=\(finalMetadata.tag) finalBytes=\(finalAppData.utf8.count)"
+            )
+            if verify(finalMetadata) {
+                return
+            }
+
+            if attempt < maxRetries - 1 {
+                let delayMs = UInt64(50_000_000 * (attempt + 1))
+                try await Task.sleep(nanoseconds: delayMs)
+                Log.warning("Metadata update verification failed, retrying (operation=\(operation), attempt \(attempt + 1)/\(maxRetries))")
+            }
+        }
+        throw ConversationCustomMetadataError.metadataUpdateFailed
+    }
+
+    // MARK: - Helpers
+
+    static func isValidInviteTag(_ tag: String) -> Bool {
+        tag.range(of: "^[A-Za-z0-9]{10}$", options: .regularExpression) != nil
+    }
+
+    /// Generates a cryptographically secure random string of specified length
+    /// using alphanumeric characters (a-z, A-Z, 0-9)
+    static func generateSecureRandomString(length: Int) throws -> String {
+        guard length > 0 else {
+            throw ConversationCustomMetadataError.invalidLength(length)
+        }
+
+        let characters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+        let charactersArray = Array(characters)
+        let charactersCount = charactersArray.count
+
+        var randomBytes = [UInt8](repeating: 0, count: length)
+        let result = SecRandomCopyBytes(kSecRandomDefault, length, &randomBytes)
+
+        guard result == errSecSuccess else {
+            throw ConversationCustomMetadataError.randomGenerationFailed
+        }
+
+        let randomString = randomBytes.map { byte in
+            // Use modulo to map random byte to character index
+            // This gives a slight bias but is acceptable for non-cryptographic identifiers
+            let index = Int(byte) % charactersCount
+            return charactersArray[index]
+        }
+
+        return String(randomString)
+    }
+}
+
+// MARK: - MessagingGroup + CustomMetadata
+
+/// Convos custom-metadata API exposed on the abstraction. New call sites
+/// should consume this surface via `any MessagingGroup`; legacy callers that
+/// still hold onto raw `XMTPiOS.Group` use the shim in
+/// `XMTPGroup+CustomMetadata.swift`, which delegates here.
+extension MessagingGroup {
+    var customMetadataEngine: ConversationCustomMetadataEngine {
+        ConversationCustomMetadataEngine(
+            id: id,
+            readAppData: { [self] in try await self.appData() },
+            writeAppData: { [self] newValue in try await self.updateAppData(newValue) }
+        )
+    }
+
+    // MARK: Reads
+
+    public func currentCustomMetadata() async throws -> ConversationCustomMetadata {
+        try await customMetadataEngine.currentCustomMetadata()
+    }
+
+    public func inviteTag() async throws -> String {
+        try await customMetadataEngine.inviteTag()
+    }
+
+    public func expiresAt() async throws -> Date? {
+        try await customMetadataEngine.expiresAt()
+    }
+
+    public func conversationEmoji() async throws -> String? {
+        try await customMetadataEngine.conversationEmoji()
+    }
+
+    public func imageEncryptionKey() async throws -> Data? {
+        try await customMetadataEngine.imageEncryptionKey()
+    }
+
+    public func encryptedGroupImage() async throws -> EncryptedImageRef? {
+        try await customMetadataEngine.encryptedGroupImage()
+    }
+
+    func memberProfiles() async throws -> [DBMemberProfile] {
+        try await customMetadataEngine.memberProfiles(withKey: try? await imageEncryptionKey())
+    }
+
+    func memberProfiles(withKey groupKey: Data?) async throws -> [DBMemberProfile] {
+        try await customMetadataEngine.memberProfiles(withKey: groupKey)
+    }
+
+    // MARK: Writes
+
+    public func ensureConversationEmoji(seed: String) async throws -> String {
+        try await customMetadataEngine.ensureConversationEmoji(seed: seed)
+    }
+
+    public func updateExpiresAt(date: Date) async throws {
+        try await customMetadataEngine.updateExpiresAt(date: date)
+    }
+
+    @discardableResult
+    public func ensureImageEncryptionKey() async throws -> Data {
+        try await customMetadataEngine.ensureImageEncryptionKey()
+    }
+
+    public func updateEncryptedGroupImage(_ encryptedRef: EncryptedImageRef) async throws {
+        try await customMetadataEngine.updateEncryptedGroupImage(encryptedRef)
+    }
+
+    /// Only the conversation creator should call this. Updating the invite
+    /// tag effectively expires all invites generated with the previous tag.
+    /// The tag is used by the invitee to verify the conversation they've been
+    /// added to is the one that corresponds to the invite they are requesting
+    /// to join.
+    public func ensureInviteTag() async throws {
+        try await customMetadataEngine.ensureInviteTag()
+    }
+
+    public func rotateInviteTag() async throws {
+        try await customMetadataEngine.rotateInviteTag()
+    }
+
+    public func restoreInviteTagIfMissing(_ expectedTag: String) async throws {
+        try await customMetadataEngine.restoreInviteTagIfMissing(expectedTag)
+    }
+
+    func updateProfile(_ profile: DBMemberProfile) async throws {
+        try await customMetadataEngine.updateProfile(profile)
+    }
+
+    public func updateMetadata(_ metadata: ConversationCustomMetadata) async throws {
+        try await customMetadataEngine.updateMetadata(metadata)
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Invites & Custom Metadata/XMTPGroup+CustomMetadata.swift
+++ b/ConvosCore/Sources/ConvosCore/Invites & Custom Metadata/XMTPGroup+CustomMetadata.swift
@@ -4,25 +4,34 @@ import Foundation
 import XMTPiOS
 
 // swiftlint:disable:next orphaned_doc_comment
-/// XMTP groups expose an 8 KB `appData` field that Convos uses to store structured
-/// metadata as a compressed, base64-encoded protobuf. This metadata includes:
-/// - Invite tag: Unique identifier linking invites to conversations
-/// - Description: User-visible conversation description
-/// - Expiration date: Unix timestamp for when conversation auto-deletes
-/// - Member profiles: Name and avatar for each member (per-conversation identities)
+/// Boundary shim re-exposing the Convos custom-metadata API on the raw
+/// `XMTPiOS.Group` type. The real engine lives in
+/// `MessagingGroup+CustomMetadata.swift` and operates against the
+/// `MessagingGroup` abstraction.
 ///
-/// **Encoding Optimizations:**
-/// - Binary fields (inbox IDs) stored as raw bytes instead of hex strings
-/// - Unix timestamps (sfixed64) instead of protobuf Timestamp messages
-/// - DEFLATE compression for payloads >100 bytes (typically 20-40% reduction)
-/// - Overall 40-60% size reduction for multi-member groups
-///
-/// This allows Convos to store rich conversation metadata without requiring a backend.
+/// This file deliberately contains no business logic; every method delegates
+/// into `ConversationCustomMetadataEngine`. It exists only so that legacy
+/// call sites that still hand around `XMTPiOS.Group` (writers, state
+/// machines, syncing, tests) keep compiling during the Stage-2 → Stage-4
+/// migration. Once the abstraction-based adapter for `XMTPiOS.Group` lands
+/// and all callers migrate to `any MessagingGroup`, this file can be deleted.
 
-// MARK: - XMTPiOS.Group + CustomMetadata
+// MARK: - XMTPiOS.Group + CustomMetadata (shim)
 
 extension XMTPiOS.Group {
-    private static let appDataByteLimit: Int = 8 * 1024
+    /// Engine bound to this group's sync `appData()` / async
+    /// `updateAppData(appData:)`. `appData()` is synchronous on
+    /// `XMTPiOS.Group`, so we wrap it in an `async` closure to satisfy the
+    /// engine's signature.
+    private var customMetadataEngine: ConversationCustomMetadataEngine {
+        ConversationCustomMetadataEngine(
+            id: id,
+            readAppData: { try self.appData() },
+            writeAppData: { newValue in try await self.updateAppData(appData: newValue) }
+        )
+    }
+
+    // MARK: Reads
 
     var currentCustomMetadata: ConversationCustomMetadata {
         get throws {
@@ -58,61 +67,12 @@ extension XMTPiOS.Group {
         }
     }
 
-    public func ensureConversationEmoji(seed: String) async throws -> String {
-        if let existingEmoji = try conversationEmoji {
-            return existingEmoji
-        }
-
-        let generatedEmoji = EmojiSelector.emoji(for: seed)
-        try await atomicUpdateMetadata(operation: "ensureConversationEmoji") { metadata in
-            if !metadata.hasEmoji || metadata.emoji.isEmpty {
-                metadata.emoji = generatedEmoji
-            }
-        } verify: { metadata in
-            metadata.hasEmoji && !metadata.emoji.isEmpty
-        }
-
-        return try conversationEmoji ?? generatedEmoji
-    }
-
-    public func updateExpiresAt(date: Date) async throws {
-        let expiresAtUnix = Int64(date.timeIntervalSince1970)
-        try await atomicUpdateMetadata(operation: "updateExpiresAt") { metadata in
-            metadata.expiresAtUnix = expiresAtUnix
-        } verify: { metadata in
-            metadata.hasExpiresAtUnix && metadata.expiresAtUnix == expiresAtUnix
-        }
-    }
-
-    // MARK: - Image Encryption Key Management
-
     public var imageEncryptionKey: Data? {
         get throws {
             let metadata = try currentCustomMetadata
             guard metadata.hasImageEncryptionKey else { return nil }
             return metadata.imageEncryptionKey
         }
-    }
-
-    @discardableResult
-    public func ensureImageEncryptionKey() async throws -> Data {
-        if let existingKey = try imageEncryptionKey {
-            return existingKey
-        }
-
-        let newKey = try ImageEncryption.generateGroupKey()
-        try await atomicUpdateMetadata(operation: "ensureImageEncryptionKey") { metadata in
-            if !metadata.hasImageEncryptionKey {
-                metadata.imageEncryptionKey = newKey
-            }
-        } verify: { metadata in
-            metadata.hasImageEncryptionKey
-        }
-
-        guard let finalKey = try imageEncryptionKey else {
-            throw ImageEncryptionError.keyGenerationFailed
-        }
-        return finalKey
     }
 
     public var encryptedGroupImage: EncryptedImageRef? {
@@ -124,76 +84,6 @@ extension XMTPiOS.Group {
             }
             return metadata.encryptedGroupImage
         }
-    }
-
-    public func updateEncryptedGroupImage(_ encryptedRef: EncryptedImageRef) async throws {
-        try await atomicUpdateMetadata(operation: "updateEncryptedGroupImage") { metadata in
-            metadata.encryptedGroupImage = encryptedRef
-        } verify: { metadata in
-            metadata.hasEncryptedGroupImage &&
-            metadata.encryptedGroupImage.url == encryptedRef.url &&
-            metadata.encryptedGroupImage.salt == encryptedRef.salt &&
-            metadata.encryptedGroupImage.nonce == encryptedRef.nonce
-        }
-    }
-
-    // This should only be done by the conversation creator
-    // Updating the invite tag effectively expires all invites generated with that tag
-    // The tag is used by the invitee to verify the conversation they've been added to
-    // is the one that corresponds to the invite they are requesting to join
-    public func ensureInviteTag() async throws {
-        let existingTag = try inviteTag
-        guard existingTag.isEmpty else { return }
-
-        let newTag = try generateSecureRandomString(length: 10)
-        try await atomicUpdateMetadata(operation: "ensureInviteTag") { metadata in
-            if metadata.tag.isEmpty {
-                metadata.tag = newTag
-            }
-        } verify: { metadata in
-            !metadata.tag.isEmpty
-        }
-    }
-
-    /// Rotates the invite tag, invalidating all existing invites for this conversation.
-    /// This is used when locking a conversation to ensure no outstanding invites can be used.
-    public func rotateInviteTag() async throws {
-        let oldTag = try inviteTag
-        let newTag = try generateSecureRandomString(length: 10)
-        try await atomicUpdateMetadata(operation: "rotateInviteTag") { metadata in
-            metadata.tag = newTag
-        } verify: { metadata in
-            metadata.tag != oldTag && !metadata.tag.isEmpty
-        }
-    }
-
-    /// Generates a cryptographically secure random string of specified length
-    /// using alphanumeric characters (a-z, A-Z, 0-9)
-    private func generateSecureRandomString(length: Int) throws -> String {
-        // Validate that length is positive
-        guard length > 0 else {
-            throw ConversationCustomMetadataError.invalidLength(length)
-        }
-
-        let characters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
-        let charactersArray = Array(characters)
-        let charactersCount = charactersArray.count
-
-        var randomBytes = [UInt8](repeating: 0, count: length)
-        let result = SecRandomCopyBytes(kSecRandomDefault, length, &randomBytes)
-
-        guard result == errSecSuccess else {
-            throw ConversationCustomMetadataError.randomGenerationFailed
-        }
-
-        let randomString = randomBytes.map { byte in
-            // Use modulo to map random byte to character index
-            // This gives a slight bias but is acceptable for non-cryptographic identifiers
-            let index = Int(byte) % charactersCount
-            return charactersArray[index]
-        }
-
-        return String(randomString)
     }
 
     var memberProfiles: [DBMemberProfile] {
@@ -234,108 +124,48 @@ extension XMTPiOS.Group {
         }
     }
 
-    func updateProfile(_ profile: DBMemberProfile) async throws {
-        guard let conversationProfile = profile.conversationProfile else {
-            throw ConversationCustomMetadataError.invalidInboxIdHex(profile.inboxId)
-        }
-        try await atomicUpdateMetadata(operation: "updateProfile") { metadata in
-            metadata.upsertProfile(conversationProfile)
-        } verify: { metadata in
-            metadata.findProfile(inboxId: profile.inboxId) == conversationProfile
-        }
+    // MARK: Writes (delegated to the engine)
+
+    public func ensureConversationEmoji(seed: String) async throws -> String {
+        try await customMetadataEngine.ensureConversationEmoji(seed: seed)
     }
 
-    /// Performs an optimistic concurrency update on group metadata with verification.
-    ///
-    /// This uses a read-modify-write pattern with post-write verification:
-    /// 1. Read current metadata
-    /// 2. Apply modifications
-    /// 3. Write to XMTP
-    /// 4. Re-read and verify the change persisted
-    /// 5. Retry with exponential backoff if verification fails
-    ///
-    /// **Concurrency Model:**
-    /// - Not truly atomic - concurrent writes can overwrite each other
-    /// - Verification catches most conflicts (verification fails → retry)
-    /// - Callers should include idempotency checks in `modify` closure
-    ///   (e.g., `if !metadata.hasKey { metadata.key = newKey }`)
-    /// - Suitable for infrequent, user-initiated operations
-    ///
-    /// - Parameters:
-    ///   - maxRetries: Maximum retry attempts (default: 3)
-    ///   - modify: Closure to modify the metadata
-    ///   - verify: Closure to verify the modification persisted
-    /// - Throws: `ConversationCustomMetadataError.metadataUpdateFailed` if all retries exhausted
+    public func updateExpiresAt(date: Date) async throws {
+        try await customMetadataEngine.updateExpiresAt(date: date)
+    }
+
+    @discardableResult
+    public func ensureImageEncryptionKey() async throws -> Data {
+        try await customMetadataEngine.ensureImageEncryptionKey()
+    }
+
+    public func updateEncryptedGroupImage(_ encryptedRef: EncryptedImageRef) async throws {
+        try await customMetadataEngine.updateEncryptedGroupImage(encryptedRef)
+    }
+
+    // This should only be done by the conversation creator
+    // Updating the invite tag effectively expires all invites generated with that tag
+    // The tag is used by the invitee to verify the conversation they've been added to
+    // is the one that corresponds to the invite they are requesting to join
+    public func ensureInviteTag() async throws {
+        try await customMetadataEngine.ensureInviteTag()
+    }
+
+    /// Rotates the invite tag, invalidating all existing invites for this conversation.
+    /// This is used when locking a conversation to ensure no outstanding invites can be used.
+    public func rotateInviteTag() async throws {
+        try await customMetadataEngine.rotateInviteTag()
+    }
+
     public func restoreInviteTagIfMissing(_ expectedTag: String) async throws {
-        guard !expectedTag.isEmpty else { return }
-        guard Self.isValidInviteTag(expectedTag) else {
-            throw ConversationCustomMetadataError.invalidInviteTag(expectedTag)
-        }
-        try await atomicUpdateMetadata(operation: "restoreInviteTagIfMissing") { metadata in
-            guard metadata.tag.isEmpty else { return }
-            metadata.tag = expectedTag
-        } verify: { metadata in
-            !metadata.tag.isEmpty
-        }
+        try await customMetadataEngine.restoreInviteTagIfMissing(expectedTag)
     }
 
-    private static func isValidInviteTag(_ tag: String) -> Bool {
-        tag.range(of: "^[A-Za-z0-9]{10}$", options: .regularExpression) != nil
-    }
-
-    private func atomicUpdateMetadata(
-        operation: String,
-        maxRetries: Int = 3,
-        modify: (inout ConversationCustomMetadata) -> Void,
-        verify: (ConversationCustomMetadata) -> Bool
-    ) async throws {
-        for attempt in 0..<maxRetries {
-            let beforeAppData = try appData()
-            let beforeMetadata = ConversationCustomMetadata.parseAppData(beforeAppData)
-            var metadata = beforeMetadata
-            modify(&metadata)
-
-            Log.info(
-                "[MetadataDebug] operation=\(operation) groupId=\(id) attempt=\(attempt + 1) beforeTag=\(beforeMetadata.tag) afterTag=\(metadata.tag) beforeBytes=\(beforeAppData.utf8.count)"
-            )
-            if !beforeMetadata.tag.isEmpty && metadata.tag.isEmpty {
-                Log.error("[MetadataDebug] operation=\(operation) cleared invite tag for groupId=\(id)")
-                throw ConversationCustomMetadataError.metadataUpdateFailed
-            }
-
-            try await updateMetadata(metadata)
-
-            let finalAppData = try appData()
-            let finalMetadata = ConversationCustomMetadata.parseAppData(finalAppData)
-            Log.info(
-                "[MetadataDebug] operation=\(operation) groupId=\(id) finalTag=\(finalMetadata.tag) finalBytes=\(finalAppData.utf8.count)"
-            )
-            if verify(finalMetadata) {
-                return
-            }
-
-            if attempt < maxRetries - 1 {
-                let delayMs = UInt64(50_000_000 * (attempt + 1))
-                try await Task.sleep(nanoseconds: delayMs)
-                Log.warning("Metadata update verification failed, retrying (operation=\(operation), attempt \(attempt + 1)/\(maxRetries))")
-            }
-        }
-        throw ConversationCustomMetadataError.metadataUpdateFailed
+    func updateProfile(_ profile: DBMemberProfile) async throws {
+        try await customMetadataEngine.updateProfile(profile)
     }
 
     func updateMetadata(_ metadata: ConversationCustomMetadata) async throws {
-        if let currentTag = try? inviteTag,
-           !currentTag.isEmpty,
-           metadata.tag.isEmpty {
-            Log.error("[MetadataDebug] updateMetadata refusing to clear invite tag for groupId=\(id)")
-            throw ConversationCustomMetadataError.metadataUpdateFailed
-        }
-
-        let encodedMetadata = try metadata.toCompactString()
-        let byteCount = encodedMetadata.lengthOfBytes(using: .utf8)
-        guard byteCount <= Self.appDataByteLimit else {
-            throw ConversationCustomMetadataError.appDataLimitExceeded(limit: Self.appDataByteLimit, actualSize: byteCount)
-        }
-        try await updateAppData(appData: encodedMetadata)
+        try await customMetadataEngine.updateMetadata(metadata)
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Messaging/Adapters/XMTPiOSDiagnostics.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/Adapters/XMTPiOSDiagnostics.swift
@@ -1,0 +1,85 @@
+import Foundation
+@preconcurrency import XMTPiOS
+
+/// XMTPiOS-backed implementation of `MessagingDiagnostics`.
+///
+/// This is the Stage 2 boundary file for the logging / diagnostics
+/// surface. Every call forwards into a static `XMTPiOS.Client` method,
+/// and this is the only place those statics are referenced after the
+/// Stage 2 MessagingDiagnostics wrap lands.
+///
+/// Exposed through `MessagingDiagnostics.shared` (see extension below)
+/// so the three previously XMTPiOS-importing call sites —
+/// `Convos/ConvosApp.swift`, `NotificationService/NotificationService.swift`,
+/// and `Convos/Debug View/DebugLogExporter.swift` — can reach the
+/// adapter without importing XMTPiOS themselves.
+public struct XMTPiOSDiagnostics: MessagingDiagnostics {
+    public static let shared: XMTPiOSDiagnostics = XMTPiOSDiagnostics()
+
+    public init() {}
+
+    public func activatePersistentLogWriter(
+        logLevel: MessagingDiagnosticsLogLevel,
+        rotationSchedule: MessagingDiagnosticsRotation,
+        maxFiles: Int,
+        customLogDirectory: URL?,
+        processType: MessagingDiagnosticsProcessType
+    ) {
+        XMTPiOS.Client.activatePersistentLibXMTPLogWriter(
+            logLevel: logLevel.xmtpLogLevel,
+            rotationSchedule: rotationSchedule.ffiLogRotation,
+            maxFiles: maxFiles,
+            customLogDirectory: customLogDirectory,
+            processType: processType.ffiProcessType
+        )
+    }
+
+    public func logFilePaths(customLogDirectory: URL?) -> [String] {
+        XMTPiOS.Client.getXMTPLogFilePaths(customLogDirectory: customLogDirectory)
+    }
+}
+
+// MARK: - Singleton accessor
+
+/// Static entry point callers use: `MessagingDiagnosticsProvider.shared`.
+///
+/// Returning the XMTPiOS-backed adapter unconditionally is correct
+/// today because Convos ships a single backend. Once a second adapter
+/// (DTU) lands, flip this accessor to read from a registration table
+/// instead — the three call sites will not change.
+public enum MessagingDiagnosticsProvider {
+    public static var shared: any MessagingDiagnostics { XMTPiOSDiagnostics.shared }
+}
+
+// MARK: - Enum translations
+
+private extension MessagingDiagnosticsLogLevel {
+    var xmtpLogLevel: XMTPiOS.Client.LogLevel {
+        switch self {
+        case .error: return .error
+        case .warn: return .warn
+        case .info: return .info
+        case .debug: return .debug
+        }
+    }
+}
+
+private extension MessagingDiagnosticsRotation {
+    var ffiLogRotation: FfiLogRotation {
+        switch self {
+        case .minutely: return .minutely
+        case .hourly: return .hourly
+        case .daily: return .daily
+        case .never: return .never
+        }
+    }
+}
+
+private extension MessagingDiagnosticsProcessType {
+    var ffiProcessType: FfiProcessType {
+        switch self {
+        case .main: return .main
+        case .notificationExtension: return .notificationExtension
+        }
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Messaging/Adapters/XMTPiOSMessagingClientFactory.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/Adapters/XMTPiOSMessagingClientFactory.swift
@@ -1,0 +1,155 @@
+import Foundation
+@preconcurrency import XMTPiOS
+
+/// XMTPiOS-backed implementation of `MessagingClientFactory`.
+///
+/// This is the Stage 5 boundary file for client construction. Every
+/// `Client.create` / `Client.build` call, every construction of
+/// `ClientOptions`, and every write to the global mutable
+/// `XMTPEnvironment.customLocalAddress` live behind this single type.
+///
+/// Callers (`InboxStateMachine`, `XMTPAPIOptionsBuilder`) pass a
+/// per-instance `MessagingClientConfig`; they do not read or write
+/// process-wide XMTPiOS state themselves. That boundary is what the
+/// audit §2 flags as the DTU hazard — having it guarded by one file
+/// makes the eventual DTU adapter a drop-in replacement.
+public struct XMTPiOSMessagingClientFactory: MessagingClientFactory {
+    public static let shared: XMTPiOSMessagingClientFactory = XMTPiOSMessagingClientFactory()
+
+    public init() {}
+
+    public func createClient(
+        signingKey: any SigningKey,
+        config: MessagingClientConfig,
+        xmtpCodecs: [any ContentCodec]
+    ) async throws -> any XMTPClientProvider {
+        applyLocalAddressOverride(config: config)
+        let options = clientOptions(config: config, xmtpCodecs: xmtpCodecs)
+        Log.info("Creating XMTP client...")
+        let client = try await Client.create(account: signingKey, options: options)
+        Log.info("XMTP Client created with app version: convos/\(Bundle.appVersion)")
+        return client
+    }
+
+    public func buildClient(
+        inboxId: String,
+        identity: PublicIdentity,
+        config: MessagingClientConfig,
+        xmtpCodecs: [any ContentCodec]
+    ) async throws -> any XMTPClientProvider {
+        applyLocalAddressOverride(config: config)
+        let options = clientOptions(config: config, xmtpCodecs: xmtpCodecs)
+        Log.debug("Building XMTP client for \(inboxId)...")
+        let client = try await Client.build(
+            publicIdentity: identity,
+            options: options,
+            inboxId: inboxId
+        )
+        Log.debug("XMTP Client built.")
+        return client
+    }
+
+    public func apiOptions(config: MessagingClientConfig) -> ClientOptions.Api {
+        applyLocalAddressOverride(config: config)
+        return ClientOptions.Api(
+            env: config.apiEnv.xmtpEnv,
+            isSecure: config.isSecure,
+            appVersion: config.appVersion ?? "convos/\(Bundle.appVersion)"
+        )
+    }
+
+    // MARK: - Private helpers
+
+    /// The only place in the codebase that writes the global mutable
+    /// `XMTPEnvironment.customLocalAddress`. It is driven entirely by
+    /// the per-instance config passed in.
+    ///
+    /// Longer term, once libxmtp exposes an `apiUrl` on `ClientOptions.Api`
+    /// or via the gateway flow, this call becomes a no-op and we delete
+    /// the global. Until then, keeping the write here is correct:
+    /// callers hand in `config.customLocalAddress` and don't observe the
+    /// side effect.
+    private func applyLocalAddressOverride(config: MessagingClientConfig) {
+        if let customHost = config.customLocalAddress {
+            Log.debug("Setting XMTPEnvironment.customLocalAddress = \(customHost)")
+            XMTPEnvironment.customLocalAddress = customHost
+        } else {
+            Log.debug("Clearing XMTPEnvironment.customLocalAddress")
+            XMTPEnvironment.customLocalAddress = nil
+        }
+    }
+
+    private func clientOptions(
+        config: MessagingClientConfig,
+        xmtpCodecs: [any ContentCodec]
+    ) -> ClientOptions {
+        let apiOptions = ClientOptions.Api(
+            env: config.apiEnv.xmtpEnv,
+            isSecure: config.isSecure,
+            appVersion: config.appVersion ?? "convos/\(Bundle.appVersion)"
+        )
+        return ClientOptions(
+            api: apiOptions,
+            codecs: xmtpCodecs,
+            dbEncryptionKey: config.dbEncryptionKey,
+            dbDirectory: config.dbDirectory,
+            deviceSyncEnabled: config.deviceSyncEnabled,
+            maxDbPoolSize: 10,
+            minDbPoolSize: 3
+        )
+    }
+}
+
+// MARK: - MessagingEnv <-> XMTPiOS.XMTPEnvironment
+
+extension MessagingEnv {
+    /// Adapter-side translation from the Convos-owned env enum to the
+    /// native XMTPiOS one. Defined in the adapter file so that non-
+    /// adapter code never constructs `XMTPEnvironment` directly.
+    var xmtpEnv: XMTPEnvironment {
+        switch self {
+        case .local: return .local
+        case .dev: return .dev
+        case .production: return .production
+        }
+    }
+}
+
+// MARK: - AppEnvironment -> MessagingClientConfig builder
+
+public extension AppEnvironment {
+    /// Builds a per-instance `MessagingClientConfig` from this
+    /// `AppEnvironment`. Every client-construction site goes through
+    /// this so the global `XMTPEnvironment.customLocalAddress` is no
+    /// longer read at the call site.
+    func messagingClientConfig(
+        dbEncryptionKey: Data,
+        dbDirectory: String? = nil,
+        appVersion: String? = nil,
+        deviceSyncEnabled: Bool = false,
+        codecs: [any MessagingCodec] = []
+    ) -> MessagingClientConfig {
+        MessagingClientConfig(
+            apiEnv: self.messagingEnv,
+            customLocalAddress: self.customLocalAddress,
+            isSecure: self.isSecure,
+            appVersion: appVersion ?? "convos/\(Bundle.appVersion)",
+            dbEncryptionKey: dbEncryptionKey,
+            dbDirectory: dbDirectory ?? self.defaultDatabasesDirectory,
+            deviceSyncEnabled: deviceSyncEnabled,
+            codecs: codecs
+        )
+    }
+
+    /// Adapter-local mapping from `AppEnvironment` to the abstraction's
+    /// `MessagingEnv`. Mirrors `AppEnvironment.xmtpEnv` from
+    /// `XMTPAPIOptionsBuilder.swift` but lands on the Convos-owned enum
+    /// so that non-adapter code can reason about it.
+    var messagingEnv: MessagingEnv {
+        switch self.xmtpEnv {
+        case .local: return .local
+        case .dev: return .dev
+        case .production: return .production
+        }
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Messaging/Protocols/MessagingClient.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/Protocols/MessagingClient.swift
@@ -1,0 +1,144 @@
+import Foundation
+
+// MARK: - Environment / config
+
+/// Deployment environment for the messaging backend.
+public enum MessagingEnv: String, Hashable, Sendable, Codable {
+    case local
+    case dev
+    case production
+}
+
+/// Per-client configuration.
+///
+/// Replaces the global mutable `XMTPEnvironment.customLocalAddress`
+/// footgun (`InboxStateMachine.swift:328-334,1127-1135`, audit §2).
+/// Every field lives here so running two clients side by side with
+/// different endpoints becomes structurally possible — a prerequisite
+/// for the future multi-inbox work (audit open question #2).
+public struct MessagingClientConfig: Sendable {
+    public var apiEnv: MessagingEnv
+
+    /// Override for `.local` environments. Nil means "use the default
+    /// for `apiEnv`". This replaces the global in XMTPEnvironment.
+    public var customLocalAddress: String?
+
+    public var isSecure: Bool
+    public var appVersion: String?
+
+    /// Raw bytes used to encrypt the on-disk libxmtp DB.
+    public var dbEncryptionKey: Data
+
+    /// Optional override for where the libxmtp DB is stored. Nil uses
+    /// the SDK default.
+    public var dbDirectory: String?
+
+    /// Toggles device-sync. Convos currently sets `false`
+    /// (`InboxStateMachine.swift:1119`); flipping this is the Stage 5+
+    /// multi-installation gate.
+    public var deviceSyncEnabled: Bool
+
+    /// Codecs to register with the client at construction time.
+    /// Adapter is responsible for actually installing them.
+    public var codecs: [any MessagingCodec]
+
+    public init(
+        apiEnv: MessagingEnv,
+        customLocalAddress: String? = nil,
+        isSecure: Bool,
+        appVersion: String? = nil,
+        dbEncryptionKey: Data,
+        dbDirectory: String? = nil,
+        deviceSyncEnabled: Bool = false,
+        codecs: [any MessagingCodec] = []
+    ) {
+        self.apiEnv = apiEnv
+        self.customLocalAddress = customLocalAddress
+        self.isSecure = isSecure
+        self.appVersion = appVersion
+        self.dbEncryptionKey = dbEncryptionKey
+        self.dbDirectory = dbDirectory
+        self.deviceSyncEnabled = deviceSyncEnabled
+        self.codecs = codecs
+    }
+}
+
+// MARK: - Client
+
+/// Top-level messaging client.
+///
+/// Convos-owned mirror of `XMTPiOS.Client`. The five sub-surfaces
+/// (`conversations`, `consent`, `deviceSync`, `installations`) keep
+/// related operations grouped instead of exploding 40 methods onto a
+/// single type, matching both the libxmtp grouping and the DTU design.
+public protocol MessagingClient: AnyObject, Sendable {
+    var inboxId: MessagingInboxID { get }
+    var installationId: MessagingInstallationID { get }
+    var publicIdentity: MessagingIdentity { get }
+
+    var conversations: any MessagingConversations { get }
+    var consent: any MessagingConsent { get }
+    var deviceSync: any MessagingDeviceSync { get }
+    var installations: any MessagingInstallationsAPI { get }
+
+    // MARK: Construction
+
+    /// Builds a brand-new client, signing the creation with the
+    /// supplied `signer`. First-run flow.
+    static func create(
+        signer: any MessagingSigner,
+        config: MessagingClientConfig
+    ) async throws -> Self
+
+    /// Rehydrates an existing client from the local DB.
+    /// Does NOT hit the network unless the adapter needs to confirm
+    /// inbox membership. If `inboxId` is nil, the adapter computes
+    /// it from `identity`.
+    static func build(
+        identity: MessagingIdentity,
+        inboxId: MessagingInboxID?,
+        config: MessagingClientConfig
+    ) async throws -> Self
+
+    // MARK: Static ops (no client instance required)
+
+    /// Used by `SleepingInboxMessageChecker` to poll for new messages
+    /// without spinning up a full client.
+    static func newestMessageMetadata(
+        conversationIds: [String],
+        config: MessagingClientConfig
+    ) async throws -> [String: MessagingMessageMetadata]
+
+    /// Bulk "can I send to these?" lookup, pre-client.
+    static func canMessage(
+        identities: [MessagingIdentity],
+        config: MessagingClientConfig
+    ) async throws -> [String: Bool]
+
+    // MARK: Per-instance reachability
+
+    func canMessage(identity: MessagingIdentity) async throws -> Bool
+    func canMessage(identities: [MessagingIdentity]) async throws -> [String: Bool]
+    func inboxId(for identity: MessagingIdentity) async throws -> MessagingInboxID?
+
+    // MARK: Signing / verification
+
+    /// Signs a challenge with the current installation's key.
+    func signWithInstallationKey(_ message: String) throws -> Data
+
+    /// Verifies a signature was produced by *this* installation.
+    func verifySignature(_ message: String, signature: Data) throws -> Bool
+
+    /// Verifies a signature was produced by the specified installation.
+    func verifySignature(
+        _ message: String,
+        signature: Data,
+        installationId: MessagingInstallationID
+    ) throws -> Bool
+
+    // MARK: DB lifecycle
+
+    func deleteLocalDatabase() throws
+    func reconnectLocalDatabase() async throws
+    func dropLocalDatabaseConnection() throws
+}

--- a/ConvosCore/Sources/ConvosCore/Messaging/Protocols/MessagingClientFactory.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/Protocols/MessagingClientFactory.swift
@@ -1,0 +1,56 @@
+import Foundation
+@preconcurrency import XMTPiOS
+
+/// Factory surface for building an XMTP-backed client from a
+/// per-instance `MessagingClientConfig`.
+///
+/// This replaces the direct `XMTPiOS.Client.create` / `Client.build`
+/// calls previously made inside `InboxStateMachine` (audit §5 Stage 5,
+/// lines `InboxStateMachine.swift:1140-1156`), and localizes the
+/// `XMTPEnvironment.customLocalAddress` write so that one single
+/// adapter file owns it (audit §2: global mutable state hazard).
+///
+/// Callers pass a per-instance `MessagingClientConfig` — no process-
+/// wide state is read or written by the call site.
+///
+/// We keep the factory signatures expressed in the existing XMTPiOS
+/// `SigningKey` / `PublicIdentity` types for now. Those types are a
+/// later-stage migration target (Stage 4 in the audit) and rewriting
+/// them here would widen scope well beyond Stage 5. The important
+/// invariant is that the only module touching `Client.create`,
+/// `Client.build`, `ClientOptions`, and `XMTPEnvironment.customLocalAddress`
+/// is the adapter conforming to this protocol.
+///
+/// Custom codecs are passed separately as native XMTPiOS codec
+/// instances. They live on the XMTPiOS side until Stage 3 rewrites
+/// them against `MessagingCodec`; passing them through this factory
+/// keeps `InboxStateMachine` unaware of the `ClientOptions` shape.
+public protocol MessagingClientFactory: Sendable {
+    /// Creates a brand-new client using the provided signer.
+    ///
+    /// Mirrors `XMTPiOS.Client.create(account:options:)`.
+    func createClient(
+        signingKey: any SigningKey,
+        config: MessagingClientConfig,
+        xmtpCodecs: [any ContentCodec]
+    ) async throws -> any XMTPClientProvider
+
+    /// Rehydrates an existing client from local storage.
+    ///
+    /// Mirrors `XMTPiOS.Client.build(publicIdentity:options:inboxId:)`.
+    func buildClient(
+        inboxId: String,
+        identity: PublicIdentity,
+        config: MessagingClientConfig,
+        xmtpCodecs: [any ContentCodec]
+    ) async throws -> any XMTPClientProvider
+
+    /// Produces the adapter-native API options for this config.
+    ///
+    /// Required for static operations that do not yet go through the
+    /// abstraction (e.g. `SleepingInboxMessageChecker` calling
+    /// `Client.getNewestMessageMetadata`). The adapter is free to write
+    /// adapter-local globals (e.g. `XMTPEnvironment.customLocalAddress`)
+    /// here, but the call site does not observe it.
+    func apiOptions(config: MessagingClientConfig) -> ClientOptions.Api
+}

--- a/ConvosCore/Sources/ConvosCore/Messaging/Protocols/MessagingCodec.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/Protocols/MessagingCodec.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+// MARK: - Codec
+
+/// Convos-owned mirror of `XMTPiOS.ContentCodec`.
+///
+/// The associated `Content` type is the native Swift payload (e.g.
+/// `String` for text, `Reply` for replies). Implementations translate
+/// between that payload and `MessagingEncodedContent` on the wire.
+///
+/// Note on conformances: the audit's §3 sketch listed `Hashable` on this
+/// protocol, but `Hashable` + `associatedtype` turns it into a PAT that
+/// cannot be boxed into `any MessagingCodec` for most useful purposes.
+/// The registry here keys codecs by their `MessagingContentType`, so
+/// we drop `Hashable` to keep the existential form usable.
+public protocol MessagingCodec: Sendable {
+    associatedtype Content
+
+    var contentType: MessagingContentType { get }
+
+    func encode(content: Content) throws -> MessagingEncodedContent
+    func decode(content: MessagingEncodedContent) throws -> Content
+    func fallback(content: Content) throws -> String?
+    func shouldPush(content: Content) throws -> Bool
+}
+
+// MARK: - Codec registry
+
+/// Per-process registry mapping `MessagingContentType` to a codec.
+///
+/// Audit open question #10 flags whether this should be per-process
+/// (matching XMTPiOS's `Client.codecRegistry` singleton) or per-client
+/// (so parallel tests do not collide). We keep an actor-based shared
+/// singleton for Stage 1 because that matches the status quo; the
+/// refactor that makes it per-client is trivial once adapters land.
+public actor MessagingCodecRegistry {
+    public static let shared: MessagingCodecRegistry = MessagingCodecRegistry()
+
+    private var codecs: [MessagingContentType: any MessagingCodec] = [:]
+
+    public init() {}
+
+    public func register<C: MessagingCodec>(_ codec: C) {
+        codecs[codec.contentType] = codec
+    }
+
+    public func find(for type: MessagingContentType) -> (any MessagingCodec)? {
+        codecs[type]
+    }
+
+    public func registeredContentTypes() -> [MessagingContentType] {
+        Array(codecs.keys)
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Messaging/Protocols/MessagingConsent.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/Protocols/MessagingConsent.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+// MARK: - Consent state
+
+/// Convos-owned mirror of `XMTPiOS.ConsentState`.
+///
+/// Note: Convos already defines a user-facing `Consent` enum in
+/// `Storage/Models/Consent.swift` with identical cases. The abstraction
+/// introduces a separate type on the messaging-protocol boundary so
+/// that the direction of mapping can flip: Convos' `Consent` stays as
+/// the GRDB / UI model, and the XMTPiOS adapter becomes responsible
+/// for bridging to/from `MessagingConsentState`.
+public enum MessagingConsentState: String, Hashable, Sendable, Codable {
+    case allowed
+    case denied
+    case unknown
+}
+
+// MARK: - Consent record
+
+/// The entity a consent entry is keyed on.
+public enum MessagingConsentEntity: Hashable, Sendable {
+    case conversationId(String)
+    case inboxId(MessagingInboxID)
+}
+
+/// A single consent record, used by `MessagingConsent.set(records:)`
+/// and by device-sync replication.
+public struct MessagingConsentRecord: Hashable, Sendable {
+    public let entity: MessagingConsentEntity
+    public let state: MessagingConsentState
+
+    public init(entity: MessagingConsentEntity, state: MessagingConsentState) {
+        self.entity = entity
+        self.state = state
+    }
+}
+
+// MARK: - Consent API
+
+/// Read / write consent and kick off preference replication.
+///
+/// Surfaced on `MessagingClient.consent`. Stage 1 only declares the
+/// protocol; Stage 2 provides the XMTPiOS-backed conformer.
+public protocol MessagingConsent: Sendable {
+    func set(records: [MessagingConsentRecord]) async throws
+    func conversationState(id: String) async throws -> MessagingConsentState
+    func inboxIdState(_ inboxId: MessagingInboxID) async throws -> MessagingConsentState
+    func syncPreferences() async throws
+}

--- a/ConvosCore/Sources/ConvosCore/Messaging/Protocols/MessagingContent.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/Protocols/MessagingContent.swift
@@ -1,0 +1,126 @@
+import Foundation
+
+// MARK: - Content type
+
+/// Convos-owned mirror of `XMTPiOS.ContentTypeID`.
+///
+/// The four fields are the XIP-specified authority/type/major/minor
+/// tuple. Convos already treats these as plain values; the struct
+/// simply removes the libxmtp import from call sites that compare
+/// against `ContentTypeText`, `ContentTypeReply`, etc.
+public struct MessagingContentType: Hashable, Sendable, Codable {
+    public let authorityID: String
+    public let typeID: String
+    public let versionMajor: Int
+    public let versionMinor: Int
+
+    public init(
+        authorityID: String,
+        typeID: String,
+        versionMajor: Int,
+        versionMinor: Int
+    ) {
+        self.authorityID = authorityID
+        self.typeID = typeID
+        self.versionMajor = versionMajor
+        self.versionMinor = versionMinor
+    }
+}
+
+// MARK: - Compression / send options
+
+/// Compression algorithms supported by the wire format.
+public enum MessagingCompression: String, Hashable, Sendable, Codable {
+    case gzip
+    case deflate
+}
+
+/// Options passed when sending / preparing a message.
+///
+/// Fields mirror `XMTPiOS.SendOptions` + `MessageVisibilityOptions.shouldPush`.
+public struct MessagingSendOptions: Hashable, Sendable {
+    public var contentType: MessagingContentType
+    public var compression: MessagingCompression?
+    public var shouldPush: Bool
+
+    public init(
+        contentType: MessagingContentType,
+        compression: MessagingCompression? = nil,
+        shouldPush: Bool = true
+    ) {
+        self.contentType = contentType
+        self.compression = compression
+        self.shouldPush = shouldPush
+    }
+}
+
+// MARK: - Encoded content
+
+/// Convos-owned wrapper around the libxmtp protobuf `EncodedContent`.
+///
+/// Per the audit (§4 "Leave opaque for now"): the bytes contract is the
+/// XIP spec, not the libxmtp Swift struct. The adapter is responsible
+/// for serialising into / deserialising out of whichever concrete wire
+/// format the backing SDK uses.
+public struct MessagingEncodedContent: Hashable, Sendable {
+    public var type: MessagingContentType
+    public var parameters: [String: String]
+    public var content: Data
+    public var fallback: String?
+    public var compression: MessagingCompression?
+
+    public init(
+        type: MessagingContentType,
+        parameters: [String: String] = [:],
+        content: Data,
+        fallback: String? = nil,
+        compression: MessagingCompression? = nil
+    ) {
+        self.type = type
+        self.parameters = parameters
+        self.content = content
+        self.fallback = fallback
+        self.compression = compression
+    }
+}
+
+// MARK: - Reaction
+
+/// Convos-owned mirror of the XIP reaction content struct.
+///
+/// Fields and cases match the `xmtp.org/reaction:1.0` codec. The
+/// adapter layer is responsible for round-tripping between this
+/// value and the concrete SDK struct (e.g. `XMTPiOS.Reaction`) — see
+/// `Storage/XMTP DB Representations/Reaction+DBRepresentation.swift`
+/// for the XMTPiOS boundary. Call sites that want the user-visible
+/// emoji glyph should go through the `emoji` computed property on
+/// `Storage/Models/MessagingReaction+Emoji.swift`.
+public struct MessagingReaction: Hashable, Sendable, Codable {
+    public enum Action: String, Hashable, Sendable, Codable {
+        case added, removed, unknown
+    }
+
+    public enum Schema: String, Hashable, Sendable, Codable {
+        case unicode, shortcode, custom, unknown
+    }
+
+    public let reference: String
+    public let referenceInboxId: String?
+    public let action: Action
+    public let content: String
+    public let schema: Schema
+
+    public init(
+        reference: String,
+        referenceInboxId: String? = nil,
+        action: Action,
+        content: String,
+        schema: Schema
+    ) {
+        self.reference = reference
+        self.referenceInboxId = referenceInboxId
+        self.action = action
+        self.content = content
+        self.schema = schema
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Messaging/Protocols/MessagingConversation.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/Protocols/MessagingConversation.swift
@@ -1,0 +1,239 @@
+import Foundation
+
+// MARK: - Conversation enum
+
+/// Convos-owned replacement for `XMTPiOS.Conversation`.
+///
+/// The enum shape is preserved deliberately: Convos pattern-matches
+/// on `.group(...) / .dm(...)` throughout sync (see
+/// `StreamProcessor.swift:187`, `ConversationWriter`, etc.). Stage 2
+/// will wire adapter-provided conformers of `MessagingGroup` and
+/// `MessagingDm` into these cases.
+public enum MessagingConversation: Identifiable, Sendable {
+    case group(any MessagingGroup)
+    case dm(any MessagingDm)
+
+    public var id: String {
+        switch self {
+        case .group(let group):
+            return group.id
+        case .dm(let dm):
+            return dm.id
+        }
+    }
+
+    /// Convenience accessor matching the `MessagingConversationCore`
+    /// surface for call sites that do not care which case they have.
+    public var core: any MessagingConversationCore {
+        switch self {
+        case .group(let group):
+            return group
+        case .dm(let dm):
+            return dm
+        }
+    }
+}
+
+// MARK: - Core conversation surface
+
+/// Fields and operations common to both `MessagingGroup` and
+/// `MessagingDm`.
+///
+/// The method signatures are chosen to preserve the three distinct
+/// send flows called out in audit §3:
+///
+/// 1. `prepare` — `XMTPiOS.Conversation.prepareMessage(noSend: true)`.
+///    Stores locally as `.unpublished`; no network I/O.
+/// 2. `sendOptimistic` — `prepareMessage(noSend: false)`. Stores
+///    locally and best-effort publishes.
+/// 3. `publish` / `publish(messageId:)` — publishes all pending
+///    messages or exactly one, respectively.
+public protocol MessagingConversationCore: AnyObject, Sendable {
+    var id: String { get }
+    var topic: String { get }
+    var createdAtNs: Int64 { get }
+    var lastActivityAtNs: Int64 { get }
+
+    func consentState() async throws -> MessagingConsentState
+    func updateConsentState(_ state: MessagingConsentState) async throws
+
+    /// Returns a plain-values snapshot of the current MLS epoch /
+    /// commit-log / fork state for this conversation. See
+    /// `MessagingConversationDebugInfo` for the field list.
+    ///
+    /// The return type is deliberately a value struct of primitives
+    /// (no protobuf, no SDK handle) so the DTU adapter can construct
+    /// it without linking the XMTPiOS wire layer.
+    func debugInformation() async throws -> MessagingConversationDebugInfo
+
+    func sync() async throws
+
+    func members() async throws -> [MessagingMember]
+
+    func messages(query: MessagingMessageQuery) async throws -> [MessagingMessage]
+    func lastMessage() async throws -> MessagingMessage?
+    func countMessages(query: MessagingMessageQuery) async throws -> Int64
+
+    /// Stream new messages for this conversation.
+    ///
+    /// Returns `MessagingStream<MessagingMessage>`, which is a typealias
+    /// for `AsyncThrowingStream` under the hood (see
+    /// `MessagingStream.swift`).
+    func streamMessages(
+        onClose: (@Sendable () -> Void)?
+    ) -> MessagingStream<MessagingMessage>
+
+    // Multi-installation (audit §1.6): expose HMAC / push topics now
+    // so device-sync work in Stage 5+ does not need another API change.
+    func getHmacKeys() async throws -> MessagingHmacKeys
+    func getPushTopics() async throws -> [String]
+
+    /// Decrypt and decode a raw wire-format push payload.
+    /// Returns `nil` when the bytes don't resolve to a message.
+    func processMessage(bytes: Data) async throws -> MessagingMessage?
+
+    // MARK: Send flows
+
+    /// Prepare-only send. Stores locally, delivery status
+    /// `.unpublished`, does not attempt network publish.
+    func prepare(
+        encodedContent: MessagingEncodedContent,
+        options: MessagingSendOptions?
+    ) async throws -> MessagingPreparedMessage
+
+    /// Optimistic send. Stores locally and best-effort publishes
+    /// (maps to `prepareMessage(noSend: false)`).
+    @discardableResult
+    func sendOptimistic(
+        encodedContent: MessagingEncodedContent,
+        options: MessagingSendOptions?
+    ) async throws -> MessagingPreparedMessage
+
+    /// Publishes every unpublished message for this conversation.
+    func publish() async throws
+
+    /// Publishes exactly one prepared message by id.
+    func publish(messageId: String) async throws
+}
+
+// MARK: - Group
+
+/// Group-conversation surface.
+///
+/// All methods map 1:1 to operations Convos already calls on
+/// `XMTPiOS.Group`, including the `appData()` / `updateAppData(_:)`
+/// pair that is the backbone of `XMTPGroup+CustomMetadata.swift`
+/// (the 342-line invite/metadata engine called out in audit §1.2).
+public protocol MessagingGroup: MessagingConversationCore {
+    func name() async throws -> String
+    func imageUrl() async throws -> String
+    func description() async throws -> String
+
+    /// Convos-specific 8 KB protobuf blob. See audit open question #5
+    /// for the DTU commit-log ordering constraint this relies on.
+    func appData() async throws -> String
+    func updateAppData(_ appData: String) async throws
+
+    func updateName(_ name: String) async throws
+    func updateImageUrl(_ url: String) async throws
+    func updateDescription(_ description: String) async throws
+
+    func addMembers(inboxIds: [MessagingInboxID]) async throws
+    func removeMembers(inboxIds: [MessagingInboxID]) async throws
+
+    func permissionPolicySet() async throws -> MessagingPermissionPolicySet
+    func updateAddMemberPermission(_ permission: MessagingPermission) async throws
+
+    func creatorInboxId() async throws -> MessagingInboxID
+    func isCreator() async throws -> Bool
+    func isAdmin(inboxId: MessagingInboxID) async throws -> Bool
+    func isSuperAdmin(inboxId: MessagingInboxID) async throws -> Bool
+    func listAdmins() async throws -> [MessagingInboxID]
+    func listSuperAdmins() async throws -> [MessagingInboxID]
+    func isActive() async throws -> Bool
+}
+
+// MARK: - DM
+
+/// Direct-message surface.
+///
+/// The DM back-channel is load-bearing for invite flows
+/// (`InviteJoinRequestsManager.swift:52`) — see audit open question #4.
+public protocol MessagingDm: MessagingConversationCore {
+    func peerInboxId() async throws -> MessagingInboxID
+}
+
+// MARK: - Debug info
+
+/// Fork-status classification for an MLS commit log. Mirrors the
+/// three-value enum surfaced by the XMTPiOS SDK, but lives on the
+/// abstraction side so the debug surface does not leak SDK types.
+public enum MessagingCommitLogForkStatus: String, Hashable, Sendable, Codable {
+    case forked
+    case notForked = "not_forked"
+    case unknown
+}
+
+/// Plain-values snapshot of the current MLS epoch / commit-log /
+/// fork state for a single conversation.
+///
+/// All fields are primitives (`UInt64` / `Bool` / `String` /
+/// `MessagingCommitLogForkStatus`) so adapters can populate this
+/// without linking any wire-format protobuf. Callers are free to
+/// serialise it (see `MessagingConversation.exportDebugLogs()` and
+/// `Storage/Writers/ConversationWriter.swift`).
+public struct MessagingConversationDebugInfo: Hashable, Sendable, Codable {
+    public let epoch: UInt64
+    public let maybeForked: Bool
+    public let forkDetails: String
+    public let localCommitLog: String
+    public let remoteCommitLog: String
+    public let commitLogForkStatus: MessagingCommitLogForkStatus
+
+    public init(
+        epoch: UInt64,
+        maybeForked: Bool,
+        forkDetails: String,
+        localCommitLog: String,
+        remoteCommitLog: String,
+        commitLogForkStatus: MessagingCommitLogForkStatus
+    ) {
+        self.epoch = epoch
+        self.maybeForked = maybeForked
+        self.forkDetails = forkDetails
+        self.localCommitLog = localCommitLog
+        self.remoteCommitLog = remoteCommitLog
+        self.commitLogForkStatus = commitLogForkStatus
+    }
+}
+
+// MARK: - Debug export
+
+/// Default `exportDebugLogs()` implementation that writes a
+/// JSON file to the temp directory and returns its URL. Every
+/// conformer gets this for free; adapters only need to implement
+/// `debugInformation()`.
+public extension MessagingConversation {
+    func exportDebugLogs() async throws -> URL {
+        let debugInfo = try await core.debugInformation()
+        let payload: [String: Any] = [
+            "conversationId": id,
+            "epoch": debugInfo.epoch,
+            "maybeForked": debugInfo.maybeForked,
+            "forkDetails": debugInfo.forkDetails,
+            "localCommitLog": debugInfo.localCommitLog,
+            "remoteCommitLog": debugInfo.remoteCommitLog,
+            "commitLogForkStatus": String(describing: debugInfo.commitLogForkStatus)
+        ]
+        let jsonData = try JSONSerialization.data(
+            withJSONObject: payload,
+            options: [.prettyPrinted, .sortedKeys]
+        )
+        let tempDir = FileManager.default.temporaryDirectory
+        let safeId = id.replacingOccurrences(of: "/", with: "_")
+        let fileName = "conversation-\(safeId)-debug-\(Date().timeIntervalSince1970).json"
+        let fileURL = tempDir.appendingPathComponent(fileName)
+        try jsonData.write(to: fileURL)
+        return fileURL
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Messaging/Protocols/MessagingConversations.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/Protocols/MessagingConversations.swift
@@ -1,0 +1,102 @@
+import Foundation
+
+// MARK: - Query / sort / filter
+
+/// Query options for listing conversations.
+///
+/// Mirrors the parameter set currently passed through `ConversationsProvider`
+/// in `XMTPClientProvider.swift:70-102`.
+public struct MessagingConversationQuery: Hashable, Sendable {
+    public var createdAfterNs: Int64?
+    public var createdBeforeNs: Int64?
+    public var lastActivityAfterNs: Int64?
+    public var lastActivityBeforeNs: Int64?
+    public var limit: Int?
+    public var consentStates: [MessagingConsentState]?
+    public var orderBy: MessagingOrderBy
+
+    public init(
+        createdAfterNs: Int64? = nil,
+        createdBeforeNs: Int64? = nil,
+        lastActivityAfterNs: Int64? = nil,
+        lastActivityBeforeNs: Int64? = nil,
+        limit: Int? = nil,
+        consentStates: [MessagingConsentState]? = nil,
+        orderBy: MessagingOrderBy = .lastActivity
+    ) {
+        self.createdAfterNs = createdAfterNs
+        self.createdBeforeNs = createdBeforeNs
+        self.lastActivityAfterNs = lastActivityAfterNs
+        self.lastActivityBeforeNs = lastActivityBeforeNs
+        self.limit = limit
+        self.consentStates = consentStates
+        self.orderBy = orderBy
+    }
+}
+
+public enum MessagingOrderBy: String, Hashable, Sendable, Codable {
+    case createdAt
+    case lastActivity
+}
+
+public enum MessagingConversationFilter: String, Hashable, Sendable, Codable {
+    case all
+    case groups
+    case dms
+}
+
+/// Replacement for `XMTPiOS.GroupSyncSummary` (returned from
+/// `syncAllConversations`).
+public struct MessagingSyncSummary: Hashable, Sendable, Codable {
+    public let numEligible: UInt64
+    public let numSynced: UInt64
+
+    public init(numEligible: UInt64, numSynced: UInt64) {
+        self.numEligible = numEligible
+        self.numSynced = numSynced
+    }
+}
+
+// MARK: - Conversations API
+
+/// Convos-owned mirror of `XMTPiOS.Conversations`.
+///
+/// Replaces the existing `ConversationsProvider` protocol in
+/// `XMTPClientProvider.swift:70-123`, which currently leaks raw
+/// `XMTPiOS.Conversation` / `Dm` / `Group` types in its return shapes.
+public protocol MessagingConversations: AnyObject, Sendable {
+    func list(query: MessagingConversationQuery) async throws -> [MessagingConversation]
+    func listGroups(query: MessagingConversationQuery) async throws -> [any MessagingGroup]
+    func listDms(query: MessagingConversationQuery) async throws -> [any MessagingDm]
+
+    func find(conversationId: String) async throws -> MessagingConversation?
+    func findDmByInboxId(_ inboxId: MessagingInboxID) async throws -> (any MessagingDm)?
+    func findMessage(messageId: String) async throws -> MessagingMessage?
+    func findOrCreateDm(with inboxId: MessagingInboxID) async throws -> any MessagingDm
+
+    /// Creates a purely local group handle before any members or
+    /// network commit — the optimistic-create flow behind Convos'
+    /// invite builder (`XMTPClientProvider.prepareConversation`).
+    func newGroupOptimistic() async throws -> any MessagingGroup
+
+    func newGroup(
+        withInboxIds inboxIds: [MessagingInboxID],
+        name: String,
+        imageUrl: String,
+        description: String
+    ) async throws -> any MessagingGroup
+
+    func sync() async throws
+    func syncAll(consentStates: [MessagingConsentState]?) async throws -> MessagingSyncSummary
+
+    func streamAll(
+        filter: MessagingConversationFilter,
+        onClose: (@Sendable () -> Void)?
+    ) -> MessagingStream<MessagingConversation>
+
+    func streamAllMessages(
+        filter: MessagingConversationFilter,
+        consentStates: [MessagingConsentState]?,
+        onClose: (@Sendable () -> Void)?
+    ) -> MessagingStream<MessagingMessage>
+}

--- a/ConvosCore/Sources/ConvosCore/Messaging/Protocols/MessagingDeviceSync.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/Protocols/MessagingDeviceSync.swift
@@ -1,0 +1,90 @@
+import Foundation
+
+// MARK: - HMAC keys
+
+/// A single HMAC key used for push-topic authentication, pulled from
+/// libxmtp's `Conversation.getHmacKeys()` surface.
+///
+/// Convos does not inspect these bytes today (see audit §4 "Pass
+/// through opaque"). Multi-installation device-sync will need them.
+public struct MessagingHmacKey: Hashable, Sendable, Codable {
+    public let key: Data
+    public let thirtyDayPeriodsSinceEpoch: Int32
+
+    public init(key: Data, thirtyDayPeriodsSinceEpoch: Int32) {
+        self.key = key
+        self.thirtyDayPeriodsSinceEpoch = thirtyDayPeriodsSinceEpoch
+    }
+}
+
+/// Bag of HMAC keys keyed by push topic.
+public struct MessagingHmacKeys: Hashable, Sendable, Codable {
+    public let keysByTopic: [String: [MessagingHmacKey]]
+
+    public init(keysByTopic: [String: [MessagingHmacKey]]) {
+        self.keysByTopic = keysByTopic
+    }
+}
+
+// MARK: - Archive options
+
+/// Options forwarded to `createArchive` / `sendSyncArchive` /
+/// `processSyncArchive`. Kept opaque; the adapter is responsible
+/// for translating into the SDK-native `ArchiveOptions`.
+public struct MessagingArchiveOptions: Sendable {
+    public var includeConsent: Bool
+    public var includeHmacKeys: Bool
+    public var includeMessages: Bool
+    public var startNs: Int64?
+    public var endNs: Int64?
+
+    public init(
+        includeConsent: Bool = true,
+        includeHmacKeys: Bool = true,
+        includeMessages: Bool = true,
+        startNs: Int64? = nil,
+        endNs: Int64? = nil
+    ) {
+        self.includeConsent = includeConsent
+        self.includeHmacKeys = includeHmacKeys
+        self.includeMessages = includeMessages
+        self.startNs = startNs
+        self.endNs = endNs
+    }
+}
+
+// MARK: - Device sync API
+
+/// Device-sync surface used by multi-installation replication.
+///
+/// Not currently called in Convos (`deviceSyncEnabled: false` in
+/// `InboxStateMachine.swift:1119`, audit open question #3), but the
+/// abstraction carries it so Stage 5+ does not need to add a new
+/// top-level API.
+public protocol MessagingDeviceSync: Sendable {
+    func sendSyncRequest(
+        options: MessagingArchiveOptions,
+        serverUrl: String?
+    ) async throws
+
+    func sendSyncArchive(
+        options: MessagingArchiveOptions,
+        serverUrl: String?,
+        pin: String
+    ) async throws
+
+    func processSyncArchive(pin: String?) async throws
+
+    func syncAllDeviceSyncGroups() async throws -> MessagingSyncSummary
+
+    func createArchive(
+        path: String,
+        encryptionKey: Data,
+        options: MessagingArchiveOptions
+    ) async throws
+
+    func importArchive(
+        path: String,
+        encryptionKey: Data
+    ) async throws
+}

--- a/ConvosCore/Sources/ConvosCore/Messaging/Protocols/MessagingDiagnostics.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/Protocols/MessagingDiagnostics.swift
@@ -1,0 +1,90 @@
+import Foundation
+
+// MARK: - Log level
+
+/// Convos-owned mirror of `XMTPiOS.Client.LogLevel`.
+///
+/// Enumerates the severities the persistent libxmtp log writer can be
+/// asked to capture. Kept wire-compatible with the XMTPiOS enum so the
+/// adapter's translation is a trivial switch.
+public enum MessagingDiagnosticsLogLevel: String, Hashable, Sendable, Codable {
+    case error
+    case warn
+    case info
+    case debug
+}
+
+// MARK: - Rotation schedule
+
+/// Convos-owned mirror of `FfiLogRotation`.
+///
+/// Rotation cadence for the persistent log writer. Cases match the
+/// underlying libxmtp FFI so the DTU adapter can reuse the same
+/// contract without a new mapping.
+public enum MessagingDiagnosticsRotation: String, Hashable, Sendable, Codable {
+    case minutely
+    case hourly
+    case daily
+    case never
+}
+
+// MARK: - Process type
+
+/// Convos-owned mirror of `FfiProcessType`.
+///
+/// Tells the log writer whether it is running in the main app process
+/// or inside the notification service extension. The XMTPiOS adapter
+/// forwards this onto `FfiProcessType`; a future DTU adapter can use
+/// it to segment writer state per-process.
+public enum MessagingDiagnosticsProcessType: String, Hashable, Sendable, Codable {
+    case main
+    case notificationExtension
+}
+
+// MARK: - Protocol
+
+/// Convos-owned replacement for the static `XMTPiOS.Client`
+/// diagnostics surface.
+///
+/// Replaces these direct XMTPiOS calls at the app / NotificationService
+/// / Debug boundary:
+///
+/// * `XMTPiOS.Client.activatePersistentLibXMTPLogWriter(...)`
+///   (formerly `Convos/ConvosApp.swift:25`,
+///   `NotificationService/NotificationService.swift:21`).
+/// * `XMTPiOS.Client.getXMTPLogFilePaths(customLogDirectory:)`
+///   (formerly `Convos/Debug View/DebugLogExporter.swift:52,67,120`).
+///
+/// The surface is intentionally static-like: the callers (app startup,
+/// NSE startup, debug export) run *before* any `MessagingClient`
+/// instance exists, so there is nowhere else to hang these operations.
+/// An adapter exposes the active implementation as
+/// `MessagingDiagnostics.shared` (extension defined alongside the
+/// concrete adapter in `Messaging/Adapters/`), letting the three call
+/// sites reach it without threading a DI container or a messaging
+/// client through app startup.
+///
+/// DTU adapter implication: DTU does not produce libxmtp logs, so a
+/// DTU-backed implementation will either no-op both methods or expose
+/// its own event log. Tracks audit open question #6.
+public protocol MessagingDiagnostics: Sendable {
+    /// Starts the persistent libxmtp log writer.
+    ///
+    /// Mirrors the parameter shape of
+    /// `XMTPiOS.Client.activatePersistentLibXMTPLogWriter` so the
+    /// XMTPiOS adapter is a straight forward.
+    func activatePersistentLogWriter(
+        logLevel: MessagingDiagnosticsLogLevel,
+        rotationSchedule: MessagingDiagnosticsRotation,
+        maxFiles: Int,
+        customLogDirectory: URL?,
+        processType: MessagingDiagnosticsProcessType
+    )
+
+    /// Returns absolute paths to every file the log writer has emitted
+    /// inside `customLogDirectory` (or the SDK default if `nil`).
+    ///
+    /// Used by the debug-export flow to stage logs into the shared
+    /// staging directory.
+    func logFilePaths(customLogDirectory: URL?) -> [String]
+}

--- a/ConvosCore/Sources/ConvosCore/Messaging/Protocols/MessagingIdentity.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/Protocols/MessagingIdentity.swift
@@ -1,0 +1,101 @@
+import Foundation
+
+// MARK: - Identifier typealiases
+
+/// Stable type alias for an inbox's opaque identifier.
+///
+/// Mirrors libxmtp's `InboxId` but owned by Convos so that the DTU adapter
+/// can produce compatible IDs without importing XMTPiOS.
+public typealias MessagingInboxID = String
+
+/// Stable type alias for an installation's opaque identifier.
+public typealias MessagingInstallationID = String
+
+// MARK: - Identity
+
+/// The authentication kind that backs a `MessagingIdentity`.
+///
+/// Convos only passes `.ethereum` today (see audit §1.1). Adding
+/// `.passkey` up front keeps the enum aligned with the libxmtp shape.
+public enum MessagingIdentityKind: String, Hashable, Sendable, Codable {
+    case ethereum
+    case passkey
+}
+
+/// A Convos-owned mirror of `XMTPiOS.PublicIdentity`.
+///
+/// `identifier` is expected to be lowercased for the ethereum kind
+/// (matching the convention used throughout ConvosCore).
+public struct MessagingIdentity: Hashable, Sendable, Codable {
+    public let kind: MessagingIdentityKind
+    public let identifier: String
+
+    public init(kind: MessagingIdentityKind, identifier: String) {
+        self.kind = kind
+        self.identifier = identifier
+    }
+}
+
+// MARK: - Signer
+
+/// The signing surface expected of a wallet backing a `MessagingClient`.
+///
+/// Mirrors `XMTPiOS.SigningKey` but strips the FFI-specific shape:
+/// Convos already passes these fields through today, so the rename
+/// is a straight swap.
+public enum MessagingSignerType: String, Hashable, Sendable, Codable {
+    case eoa
+    case smartContractWallet
+}
+
+/// Abstract signer. Both the current keychain-backed `PrivateKey` and
+/// any future smart-contract-wallet signer conform to this.
+public protocol MessagingSigner: Sendable {
+    var identity: MessagingIdentity { get }
+    var type: MessagingSignerType { get }
+    var chainId: Int64? { get }
+    var blockNumber: Int64? { get }
+
+    /// Produces a raw signature over the challenge bytes.
+    ///
+    /// The adapter wraps this back into whatever native `SignedData`-style
+    /// container the SDK requires.
+    func sign(_ message: String) async throws -> Data
+}
+
+// MARK: - Installation / inbox state
+
+/// A single installation record inside a `MessagingInbox`.
+public struct MessagingInstallation: Hashable, Sendable, Codable {
+    public let id: MessagingInstallationID
+    public let createdAt: Date?
+
+    public init(id: MessagingInstallationID, createdAt: Date?) {
+        self.id = id
+        self.createdAt = createdAt
+    }
+}
+
+/// The observable state of a Convos inbox.
+///
+/// Exposes the multi-installation surface from day one so the UI layer
+/// in Stage 6+ can bind to `installations` without the abstraction
+/// having to change shape again.
+public struct MessagingInbox: Hashable, Sendable, Codable {
+    public let inboxId: MessagingInboxID
+    public let identities: [MessagingIdentity]
+    public let installations: [MessagingInstallation]
+    public let recoveryIdentity: MessagingIdentity
+
+    public init(
+        inboxId: MessagingInboxID,
+        identities: [MessagingIdentity],
+        installations: [MessagingInstallation],
+        recoveryIdentity: MessagingIdentity
+    ) {
+        self.inboxId = inboxId
+        self.identities = identities
+        self.installations = installations
+        self.recoveryIdentity = recoveryIdentity
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Messaging/Protocols/MessagingInstallationsAPI.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/Protocols/MessagingInstallationsAPI.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+// MARK: - Installations API
+
+/// Multi-installation management surface.
+///
+/// Surfaced from day one (audit §1.6 + open-question #1) even though
+/// no call site drives it today. Stage 6 promotes
+/// `revokeInstallations` / `revokeAllOtherInstallations` /
+/// `inboxState` into real UI flows.
+public protocol MessagingInstallationsAPI: Sendable {
+    /// Current inbox's state, including every known installation.
+    func inboxState(refreshFromNetwork: Bool) async throws -> MessagingInbox
+
+    /// Batch lookup for a set of inboxes (for contact enrichment).
+    func inboxStates(
+        inboxIds: [MessagingInboxID],
+        refreshFromNetwork: Bool
+    ) async throws -> [MessagingInbox]
+
+    /// Revokes a specific set of installations, signing the revocation
+    /// with the supplied signer.
+    func revokeInstallations(
+        signer: any MessagingSigner,
+        installationIds: [MessagingInstallationID]
+    ) async throws
+
+    /// Revokes every installation *other than* the currently-running
+    /// one. Primary path for "log out of all other devices".
+    func revokeAllOtherInstallations(signer: any MessagingSigner) async throws
+
+    /// Static revocation. Used when no local `MessagingClient` is
+    /// built (out-of-band account-recovery flows). The adapter spins
+    /// up whatever ephemeral SDK state it needs from `config`.
+    static func revokeInstallations(
+        config: MessagingClientConfig,
+        signer: any MessagingSigner,
+        inboxId: MessagingInboxID,
+        installationIds: [MessagingInstallationID]
+    ) async throws
+}

--- a/ConvosCore/Sources/ConvosCore/Messaging/Protocols/MessagingMessage.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/Protocols/MessagingMessage.swift
@@ -1,0 +1,201 @@
+import Foundation
+
+// MARK: - Delivery status
+
+/// First-class delivery state for every `MessagingMessage`.
+///
+/// Constraint per audit §3: `MessagingDeliveryStatus` is required on
+/// every message the UI sees (today mapped to `DBMessage.status` via
+/// `MessageDeliveryStatus+DBRepresentation.swift:5-14`). Preserving
+/// `.failed` and `.all` matches the libxmtp surface so the existing
+/// mapping can be swapped over in Stage 2/3 without a new case.
+public enum MessagingDeliveryStatus: String, Hashable, Sendable, Codable {
+    case unpublished
+    case published
+    case failed
+    case all
+}
+
+// MARK: - Prepared message
+
+/// Handle returned from `prepare(...)` / `sendOptimistic(...)`.
+///
+/// Maps 1:1 to libxmtp's `prepareMessage` hex-id → `publishMessage(messageId:)`
+/// flow. The audit constraint keeps `prepare`, `sendOptimistic`, and
+/// `publish` as three distinct operations; this handle is how call
+/// sites thread the prepared state through.
+public struct MessagingPreparedMessage: Hashable, Sendable {
+    /// Hex id exactly as libxmtp returns. Treat as opaque.
+    public let messageId: String
+    public let conversationId: String
+    public let deliveryStatus: MessagingDeliveryStatus
+
+    public init(
+        messageId: String,
+        conversationId: String,
+        deliveryStatus: MessagingDeliveryStatus
+    ) {
+        self.messageId = messageId
+        self.conversationId = conversationId
+        self.deliveryStatus = deliveryStatus
+    }
+}
+
+// MARK: - Message metadata
+
+/// Result of the static `newestMessageMetadata` sleeping-inbox check.
+///
+/// Replaces the libxmtp `MessageMetadata` typealias so nothing above
+/// the adapter sees `FfiMessageMetadata`.
+public struct MessagingMessageMetadata: Hashable, Sendable {
+    public let sentAtNs: Int64
+    public let senderInboxId: MessagingInboxID
+
+    public init(sentAtNs: Int64, senderInboxId: MessagingInboxID) {
+        self.sentAtNs = sentAtNs
+        self.senderInboxId = senderInboxId
+    }
+}
+
+// MARK: - Message query
+
+/// Sort direction for message lookups.
+public enum MessagingSortDirection: String, Hashable, Sendable, Codable {
+    case ascending
+    case descending
+}
+
+/// Query options for `MessagingConversationCore.messages(query:)`.
+///
+/// Matches the libxmtp time-based query shape (`beforeNs`, `afterNs`)
+/// rather than introducing opaque cursor tokens (see audit §4
+/// "Pass through opaque").
+public struct MessagingMessageQuery: Hashable, Sendable {
+    public var limit: Int?
+    public var beforeNs: Int64?
+    public var afterNs: Int64?
+    public var direction: MessagingSortDirection
+    public var deliveryStatus: MessagingDeliveryStatus
+    public var excludeContentTypes: [MessagingContentType]?
+    public var excludeSenderInboxIds: [MessagingInboxID]?
+
+    public init(
+        limit: Int? = nil,
+        beforeNs: Int64? = nil,
+        afterNs: Int64? = nil,
+        direction: MessagingSortDirection = .descending,
+        deliveryStatus: MessagingDeliveryStatus = .all,
+        excludeContentTypes: [MessagingContentType]? = nil,
+        excludeSenderInboxIds: [MessagingInboxID]? = nil
+    ) {
+        self.limit = limit
+        self.beforeNs = beforeNs
+        self.afterNs = afterNs
+        self.direction = direction
+        self.deliveryStatus = deliveryStatus
+        self.excludeContentTypes = excludeContentTypes
+        self.excludeSenderInboxIds = excludeSenderInboxIds
+    }
+}
+
+// MARK: - Message
+
+/// The Convos-owned value type that replaces `XMTPiOS.DecodedMessage`.
+///
+/// Every field the current `DecodedMessage+DBRepresentation.swift`
+/// translator reads is preserved, with one tightening per audit §3:
+///
+/// * `deliveryStatus` is a first-class `MessagingDeliveryStatus`
+///   value (no optionals, no `unknown`).
+///
+/// `senderInstallationId` is currently **optional** and expected to be
+/// populated only when the underlying SDK surfaces it. The libxmtp FFI
+/// layer (`FfiMessage`) exposes the field, but the pinned Swift SDK at
+/// `ios-4.9.0-dev.88ddfad` does not surface it on
+/// `XMTPiOS.DecodedMessage` (see `sdks/ios/Sources/XMTPiOS/Libxmtp/DecodedMessage.swift`;
+/// only `senderInboxId` is exposed). Per the hard project rule libxmtp
+/// is read-only and cannot be patched downstream, so the abstraction
+/// field is optional until upstream lands the accessor. Once exposed,
+/// tighten this back to non-optional `MessagingInstallationID` —
+/// the multi-installation constraint in audit §3 requires the field on
+/// every `MessagingMessage` — and update the XMTPiOS adapter to read
+/// `FfiMessage.senderInstallationId` directly. Tracks audit open
+/// question #1.
+public struct MessagingMessage: Sendable, Identifiable {
+    public let id: String
+    public let conversationId: String
+    public let senderInboxId: MessagingInboxID
+    /// See type doc comment: optional until upstream XMTPiOS exposes
+    /// `senderInstallationId` on `DecodedMessage`. Tighten to
+    /// non-optional when the libxmtp Swift SDK bumps.
+    public let senderInstallationId: MessagingInstallationID?
+    public let sentAt: Date
+    public let sentAtNs: Int64
+    public let insertedAt: Date
+    public let insertedAtNs: Int64
+    public let expiresAtNs: Int64?
+    public let deliveryStatus: MessagingDeliveryStatus
+    public let encodedContent: MessagingEncodedContent
+
+    /// Optional eagerly-loaded reactions / enriched-message children
+    /// (matches the current `DecodedMessage` surface Convos consumes).
+    public var childMessages: [MessagingMessage]?
+
+    /// Decoder indirection. Callers supply the expected native payload
+    /// type; the implementation uses `MessagingCodecRegistry` (or an
+    /// adapter-provided resolver) to decode `encodedContent`.
+    ///
+    /// Stage 1 ships the protocol shape; the concrete adapter wires
+    /// this to the codec registry in Stage 2.
+    public let contentDecoder: @Sendable (MessagingEncodedContent) throws -> Any
+
+    public init(
+        id: String,
+        conversationId: String,
+        senderInboxId: MessagingInboxID,
+        senderInstallationId: MessagingInstallationID?,
+        sentAt: Date,
+        sentAtNs: Int64,
+        insertedAt: Date,
+        insertedAtNs: Int64,
+        expiresAtNs: Int64?,
+        deliveryStatus: MessagingDeliveryStatus,
+        encodedContent: MessagingEncodedContent,
+        childMessages: [MessagingMessage]? = nil,
+        contentDecoder: @escaping @Sendable (MessagingEncodedContent) throws -> Any
+    ) {
+        self.id = id
+        self.conversationId = conversationId
+        self.senderInboxId = senderInboxId
+        self.senderInstallationId = senderInstallationId
+        self.sentAt = sentAt
+        self.sentAtNs = sentAtNs
+        self.insertedAt = insertedAt
+        self.insertedAtNs = insertedAtNs
+        self.expiresAtNs = expiresAtNs
+        self.deliveryStatus = deliveryStatus
+        self.encodedContent = encodedContent
+        self.childMessages = childMessages
+        self.contentDecoder = contentDecoder
+    }
+
+    /// Decodes the encoded content as `T`. Wraps the underlying
+    /// adapter's `decode` call; throws if the payload does not match
+    /// the requested type.
+    public func content<T>() throws -> T {
+        let decoded: Any = try contentDecoder(encodedContent)
+        guard let typed = decoded as? T else {
+            throw MessagingMessageError.contentTypeMismatch(
+                expected: String(describing: T.self),
+                actual: String(describing: Swift.type(of: decoded))
+            )
+        }
+        return typed
+    }
+}
+
+// MARK: - Errors
+
+public enum MessagingMessageError: Error, Sendable {
+    case contentTypeMismatch(expected: String, actual: String)
+}

--- a/ConvosCore/Sources/ConvosCore/Messaging/Protocols/MessagingPermission.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/Protocols/MessagingPermission.swift
@@ -1,0 +1,85 @@
+import Foundation
+
+// MARK: - Permission / role enums
+
+/// A policy slot on a `MessagingPermissionPolicySet` — e.g. "who can
+/// add members?", "who can update the group image?". Mirrors
+/// `XMTPiOS.PermissionOption`.
+public enum MessagingPermission: String, Hashable, Sendable, Codable {
+    case allow
+    case deny
+    case admin
+    case superAdmin
+    case unknown
+}
+
+/// A member's role on a group. Mirrors `XMTPiOS.PermissionLevel`.
+public enum MessagingMemberRole: String, Hashable, Sendable, Codable {
+    case member
+    case admin
+    case superAdmin
+}
+
+// MARK: - Policy set
+
+/// The complete set of policy slots on a group.
+///
+/// Matches the `XMTPiOS.PermissionPolicySet` fields consumed in
+/// `StreamProcessor.swift:145-148` and `ConversationPermissionsRepository`.
+public struct MessagingPermissionPolicySet: Hashable, Sendable, Codable {
+    public var addMemberPolicy: MessagingPermission
+    public var removeMemberPolicy: MessagingPermission
+    public var addAdminPolicy: MessagingPermission
+    public var removeAdminPolicy: MessagingPermission
+    public var updateGroupNamePolicy: MessagingPermission
+    public var updateGroupDescriptionPolicy: MessagingPermission
+    public var updateGroupImagePolicy: MessagingPermission
+    public var updateMessageDisappearingPolicy: MessagingPermission
+    public var updateAppDataPolicy: MessagingPermission
+
+    public init(
+        addMemberPolicy: MessagingPermission,
+        removeMemberPolicy: MessagingPermission,
+        addAdminPolicy: MessagingPermission,
+        removeAdminPolicy: MessagingPermission,
+        updateGroupNamePolicy: MessagingPermission,
+        updateGroupDescriptionPolicy: MessagingPermission,
+        updateGroupImagePolicy: MessagingPermission,
+        updateMessageDisappearingPolicy: MessagingPermission,
+        updateAppDataPolicy: MessagingPermission
+    ) {
+        self.addMemberPolicy = addMemberPolicy
+        self.removeMemberPolicy = removeMemberPolicy
+        self.addAdminPolicy = addAdminPolicy
+        self.removeAdminPolicy = removeAdminPolicy
+        self.updateGroupNamePolicy = updateGroupNamePolicy
+        self.updateGroupDescriptionPolicy = updateGroupDescriptionPolicy
+        self.updateGroupImagePolicy = updateGroupImagePolicy
+        self.updateMessageDisappearingPolicy = updateMessageDisappearingPolicy
+        self.updateAppDataPolicy = updateAppDataPolicy
+    }
+}
+
+// MARK: - Member
+
+/// A member of a `MessagingGroup` / `MessagingDm`. Mirrors the subset
+/// of `XMTPiOS.Member` fields that Convos actually reads in
+/// `ConversationWriter.swift:875`.
+public struct MessagingMember: Hashable, Sendable, Codable {
+    public let inboxId: MessagingInboxID
+    public let identities: [MessagingIdentity]
+    public let role: MessagingMemberRole
+    public let consentState: MessagingConsentState
+
+    public init(
+        inboxId: MessagingInboxID,
+        identities: [MessagingIdentity],
+        role: MessagingMemberRole,
+        consentState: MessagingConsentState
+    ) {
+        self.inboxId = inboxId
+        self.identities = identities
+        self.role = role
+        self.consentState = consentState
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Messaging/Protocols/MessagingStream.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/Protocols/MessagingStream.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+// MARK: - Stream typealias
+
+/// Unified stream type used across conversation + message subscriptions.
+///
+/// Current Convos code (`XMTPClientProvider.swift:107,122`,
+/// `SyncingManager.swift`, `StreamProcessor`) uses
+/// `AsyncThrowingStream<XMTPiOS.T, Error>` directly. This typealias is
+/// the one-line seam the Stage 2 adapters can point at without every
+/// call site having to think about errors or back-pressure.
+public typealias MessagingStream<Element: Sendable> = AsyncThrowingStream<Element, Error>

--- a/ConvosCore/Sources/ConvosCore/Messaging/XMTPClientProvider.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/XMTPClientProvider.swift
@@ -244,7 +244,15 @@ extension XMTPiOS.Client: XMTPClientProvider {
         guard let foundConversation = try await self.conversation(with: conversationId) else {
             throw XMTPClientProviderError.conversationNotFound(id: conversationId)
         }
-        try await foundConversation.updateConsentState(state: consent.consentState)
+        // Stage 2 migration: route through the abstraction layer so the
+        // Convos `Consent` -> SDK mapping is one hop through
+        // `MessagingConsentState`. This file is still a Stage-3 seam
+        // rewrite target; the narrow change here mirrors the bridging
+        // pattern used by `MessagingDeliveryStatus(ffiStatus)` in
+        // `DecodedMessage+DBRepresentation.swift`.
+        try await foundConversation.updateConsentState(
+            state: consent.messagingConsentState.xmtpConsentState
+        )
     }
 }
 

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/MessagingConsentState+Consent.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/MessagingConsentState+Consent.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+/// Bridges Convos' user-facing `Consent` enum (GRDB / UI model) and
+/// the abstraction-layer `MessagingConsentState` enum.
+///
+/// Stage 2 migration (audit §5, §1.4): the prior `Consent` extension
+/// returned `XMTPiOS.ConsentState` directly, making every caller of
+/// `consent.consentState` XMTPiOS-aware. After this migration the
+/// direction is flipped — `Consent` maps to `MessagingConsentState`
+/// on this side, and the XMTPiOS boundary mapping
+/// (`MessagingConsentState <-> XMTPiOS.ConsentState`) lives beside
+/// the rest of the XMTPiOS adapter code in
+/// `Storage/Repositories/DB XMTP Representations/Consent+ConsentState.swift`.
+extension Consent {
+    /// Projects Convos' `Consent` onto the messaging-layer enum.
+    public var messagingConsentState: MessagingConsentState {
+        switch self {
+        case .allowed: return .allowed
+        case .denied: return .denied
+        case .unknown: return .unknown
+        }
+    }
+}
+
+extension MessagingConsentState {
+    /// Projects the messaging-layer `MessagingConsentState` onto
+    /// Convos' `Consent` (the GRDB / UI model).
+    public var consent: Consent {
+        switch self {
+        case .allowed: return .allowed
+        case .denied: return .denied
+        case .unknown: return .unknown
+        }
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/MessagingContentType+XIP.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/MessagingContentType+XIP.swift
@@ -1,0 +1,111 @@
+import Foundation
+
+/// Convos-owned mirrors of the XIP-spec standard content types.
+///
+/// Stage 3 migration (audit §5): the prior dispatch in
+/// `Storage/XMTP DB Representations/DecodedMessage+DBRepresentation.swift`
+/// compared `encodedContent.type` against XMTPiOS's top-level
+/// `ContentTypeText` / `ContentTypeReply` / ... constants. After this
+/// migration the dispatch is expressed against `MessagingContentType`
+/// values, which the abstraction layer owns. The XIP authority/type/
+/// major/minor tuples are preserved exactly so
+/// `MessagingEncodedContent.type` (built from either the XMTPiOS
+/// adapter or a future DTU adapter) compares equal to these constants.
+///
+/// These constants are intentionally declared as `static let` members
+/// of `MessagingContentType` rather than free functions so that call
+/// sites reading one of these read as `MessagingContentType.text`
+/// rather than `ContentTypeText` and avoid colliding with the
+/// XMTPiOS-level `ContentTypeText` (which still exists for now because
+/// `Custom Content Types/*Codec.swift` and the outgoing-message path
+/// in `OutgoingMessageWriter.swift` have not yet migrated — that is a
+/// later Stage 3/4 scope).
+public extension MessagingContentType {
+    /// `xmtp.org/text:1.0`
+    static let text: MessagingContentType = MessagingContentType(
+        authorityID: "xmtp.org",
+        typeID: "text",
+        versionMajor: 1,
+        versionMinor: 0
+    )
+
+    /// `xmtp.org/reply:1.0`
+    static let reply: MessagingContentType = MessagingContentType(
+        authorityID: "xmtp.org",
+        typeID: "reply",
+        versionMajor: 1,
+        versionMinor: 0
+    )
+
+    /// `xmtp.org/reaction:1.0`
+    static let reaction: MessagingContentType = MessagingContentType(
+        authorityID: "xmtp.org",
+        typeID: "reaction",
+        versionMajor: 1,
+        versionMinor: 0
+    )
+
+    /// `xmtp.org/reaction:2.0`
+    static let reactionV2: MessagingContentType = MessagingContentType(
+        authorityID: "xmtp.org",
+        typeID: "reaction",
+        versionMajor: 2,
+        versionMinor: 0
+    )
+
+    /// `xmtp.org/attachment:1.0`
+    static let attachment: MessagingContentType = MessagingContentType(
+        authorityID: "xmtp.org",
+        typeID: "attachment",
+        versionMajor: 1,
+        versionMinor: 0
+    )
+
+    /// `xmtp.org/remoteStaticAttachment:1.0`
+    static let remoteAttachment: MessagingContentType = MessagingContentType(
+        authorityID: "xmtp.org",
+        typeID: "remoteStaticAttachment",
+        versionMajor: 1,
+        versionMinor: 0
+    )
+
+    /// `xmtp.org/multiRemoteStaticAttachment:1.0`
+    static let multiRemoteAttachment: MessagingContentType = MessagingContentType(
+        authorityID: "xmtp.org",
+        typeID: "multiRemoteStaticAttachment",
+        versionMajor: 1,
+        versionMinor: 0
+    )
+
+    /// `xmtp.org/group_updated:1.0`
+    static let groupUpdated: MessagingContentType = MessagingContentType(
+        authorityID: "xmtp.org",
+        typeID: "group_updated",
+        versionMajor: 1,
+        versionMinor: 0
+    )
+
+    /// `xmtp.org/readReceipt:1.0`
+    static let readReceipt: MessagingContentType = MessagingContentType(
+        authorityID: "xmtp.org",
+        typeID: "readReceipt",
+        versionMajor: 1,
+        versionMinor: 0
+    )
+
+    /// `convos.org/explode_settings:1.0`
+    static let explodeSettings: MessagingContentType = MessagingContentType(
+        authorityID: "convos.org",
+        typeID: "explode_settings",
+        versionMajor: 1,
+        versionMinor: 0
+    )
+
+    /// `convos.org/assistant_join_request:1.0`
+    static let assistantJoinRequest: MessagingContentType = MessagingContentType(
+        authorityID: "convos.org",
+        typeID: "assistant_join_request",
+        versionMajor: 1,
+        versionMinor: 0
+    )
+}

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/MessagingDeliveryStatus+MessageStatus.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/MessagingDeliveryStatus+MessageStatus.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+/// Maps the abstraction-layer `MessagingDeliveryStatus` to the
+/// GRDB-backed `DBMessage.status` value the UI binds to.
+///
+/// Stage 2 migration proof-of-pattern (audit §5): replaces the
+/// pre-existing `extension XMTPiOS.MessageDeliveryStatus { var status }`
+/// with an extension on the Convos-owned enum. The XMTPiOS-boundary
+/// translation now lives in
+/// `Storage/XMTP DB Representations/MessageDeliveryStatus+DBRepresentation.swift`
+/// as a one-way mapper (`MessagingDeliveryStatus.from(_:)`). Everything
+/// that derives a `MessageStatus` from a delivery signal now flows
+/// through this abstraction-only extension, which is what the DTU
+/// adapter will also use without importing XMTPiOS.
+extension MessagingDeliveryStatus {
+    /// Projects the messaging-layer delivery status onto the local DB
+    /// `MessageStatus` enum.
+    ///
+    /// `.all` is treated as `.unknown` to preserve the historical
+    /// mapping from `XMTPiOS.MessageDeliveryStatus.all`, which was
+    /// used as a query-filter sentinel rather than a real per-message
+    /// state. If a DB row ever lands with `.all`, treating it as
+    /// `.unknown` matches the prior behavior.
+    public var status: MessageStatus {
+        switch self {
+        case .failed: return .failed
+        case .unpublished: return .unpublished
+        case .published: return .published
+        case .all: return .unknown
+        }
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/MessagingMessage+DBRepresentation.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/MessagingMessage+DBRepresentation.swift
@@ -2,7 +2,8 @@ import ConvosAppData
 import Foundation
 import GRDB
 import UniformTypeIdentifiers
-import XMTPiOS
+
+// MARK: - Emoji helpers
 
 extension Character {
     var isSimpleEmoji: Bool {
@@ -26,12 +27,24 @@ extension String {
     }
 }
 
-extension XMTPiOS.DecodedMessage {
-    enum DecodedMessageDBRepresentationError: Error {
-        case mismatchedContentType, unsupportedContentType
+// MARK: - Translator
+
+/// Stage 3 migration (audit §5): the content-type dispatch that
+/// produces a `DBMessage` from an incoming message now operates on
+/// `MessagingMessage` (and its resolved `MessagingMessagePayload`)
+/// rather than on `XMTPiOS.DecodedMessage` directly.
+///
+/// The boundary from XMTPiOS -> abstraction lives in
+/// `Storage/XMTP DB Representations/MessagingMessage+XMTPiOS.swift`.
+/// This file is Foundation-only and contains the abstraction-side
+/// logic — what DTU will also exercise in Stage 5.
+extension MessagingMessage {
+    enum DBRepresentationError: Error {
+        case mismatchedContentType
+        case unsupportedContentType
     }
 
-    private struct DBMessageComponents {
+    fileprivate struct DBMessageComponents {
         var messageType: DBMessageType
         var contentType: MessageContentType
         var sourceMessageId: String?
@@ -43,37 +56,59 @@ extension XMTPiOS.DecodedMessage {
         var update: DBMessage.Update?
     }
 
-    func dbRepresentation() throws -> DBMessage {
+    /// Builds the GRDB `DBMessage` row for this message.
+    ///
+    /// The `payload` argument is expected to come from the boundary
+    /// adapter (see `MessagingMessage.resolvedPayload()` in
+    /// `Storage/XMTP DB Representations/MessagingMessage+XMTPiOS.swift`).
+    /// Accepting it as an argument lets this file stay Foundation-only
+    /// — the XIP decoding step is performed outside.
+    func dbRepresentation(payload: MessagingMessagePayload) throws -> DBMessage {
+        // Stage 2 migration: derive the DB status from the
+        // abstraction-layer `MessagingDeliveryStatus` rather than from
+        // `XMTPiOS.MessageDeliveryStatus` directly.
         let status: MessageStatus = deliveryStatus.status
-        let encodedContentType = try encodedContent.type
-        let components: DBMessageComponents
 
-        switch encodedContentType {
-        case ContentTypeText:
-            components = try handleTextContent()
-        case ContentTypeReply:
-            components = try handleReplyContent()
-        case ContentTypeReaction, ContentTypeReactionV2:
-            components = try handleReactionContent()
-        case ContentTypeAttachment:
-            components = try handleAttachmentContent()
-        case ContentTypeMultiRemoteAttachment:
-            components = try handleMultiRemoteAttachmentContent()
-        case ContentTypeRemoteAttachment:
-            components = try handleRemoteAttachmentContent()
-        case ContentTypeGroupUpdated:
-            components = try handleGroupUpdatedContent()
-        case ContentTypeExplodeSettings:
-            components = try handleExplodeSettingsContent()
-        case ContentTypeAssistantJoinRequest:
-            components = try handleAssistantJoinRequestContent()
-        case ContentTypeReadReceipt:
-            throw DecodedMessageDBRepresentationError.unsupportedContentType
-        default:
-            throw DecodedMessageDBRepresentationError.unsupportedContentType
+        let components: DBMessageComponents
+        switch payload {
+        case .text(let text):
+            components = Self.handleTextContent(text: text)
+        case .reply(let reply):
+            components = try Self.handleReplyContent(
+                reply: reply,
+                messageId: id
+            )
+        case .reaction(let reaction):
+            components = Self.handleReactionContent(reaction: reaction)
+        case .attachment(let attachment):
+            components = try Self.handleAttachmentContent(
+                attachment: attachment,
+                messageId: id
+            )
+        case .remoteAttachment(let remoteAttachment):
+            components = Self.handleRemoteAttachmentContent(
+                remoteAttachment: remoteAttachment
+            )
+        case .multiRemoteAttachment(let remoteAttachments):
+            components = Self.handleMultiRemoteAttachmentContent(
+                remoteAttachments: remoteAttachments
+            )
+        case .groupUpdated(let groupUpdated):
+            components = Self.handleGroupUpdatedContent(groupUpdated: groupUpdated)
+        case .explodeSettings(let explodeSettings):
+            components = Self.handleExplodeSettingsContent(
+                explodeSettings: explodeSettings,
+                senderInboxId: senderInboxId
+            )
+        case .assistantJoinRequest(let request):
+            components = Self.handleAssistantJoinRequestContent(request: request)
+        case .readReceipt:
+            throw DBRepresentationError.unsupportedContentType
+        case .unsupported:
+            throw DBRepresentationError.unsupportedContentType
         }
 
-        return .init(
+        return DBMessage(
             id: id,
             clientMessageId: id,
             conversationId: conversationId,
@@ -94,14 +129,11 @@ extension XMTPiOS.DecodedMessage {
         )
     }
 
-    private func handleTextContent() throws -> DBMessageComponents {
-        let content = try content() as Any
-        guard let contentString = content as? String else {
-            throw DecodedMessageDBRepresentationError.mismatchedContentType
-        }
+    // MARK: - Per-payload handlers
 
-        let isContentEmoji = contentString.allCharactersEmoji
-        if !isContentEmoji, let invite = MessageInvite.from(text: contentString) {
+    private static func handleTextContent(text: String) -> DBMessageComponents {
+        let isContentEmoji = text.allCharactersEmoji
+        if !isContentEmoji, let invite = MessageInvite.from(text: text) {
             return DBMessageComponents(
                 messageType: .original,
                 contentType: .invite,
@@ -109,10 +141,10 @@ extension XMTPiOS.DecodedMessage {
                 emoji: nil,
                 invite: invite,
                 attachmentUrls: [],
-                text: contentString,
+                text: text,
                 update: nil
             )
-        } else if !isContentEmoji, let preview = LinkPreview.from(text: contentString) {
+        } else if !isContentEmoji, let preview = LinkPreview.from(text: text) {
             return DBMessageComponents(
                 messageType: .original,
                 contentType: .linkPreview,
@@ -121,34 +153,30 @@ extension XMTPiOS.DecodedMessage {
                 invite: nil,
                 linkPreview: preview,
                 attachmentUrls: [],
-                text: contentString,
+                text: text,
                 update: nil
             )
         } else {
-            let trimmedContent = contentString.trimmingCharacters(in: .whitespacesAndNewlines)
+            let trimmedContent = text.trimmingCharacters(in: .whitespacesAndNewlines)
             return DBMessageComponents(
                 messageType: .original,
                 contentType: isContentEmoji ? .emoji : .text,
                 sourceMessageId: nil,
                 emoji: isContentEmoji ? trimmedContent : nil,
                 attachmentUrls: [],
-                text: isContentEmoji ? nil : contentString,
+                text: isContentEmoji ? nil : text,
                 update: nil
             )
         }
     }
 
-    private func handleReplyContent() throws -> DBMessageComponents {
-        let content = try content() as Any
-        guard let contentReply = content as? Reply else {
-            throw DecodedMessageDBRepresentationError.mismatchedContentType
-        }
-        let sourceMessageId = contentReply.reference
-        switch contentReply.contentType {
-        case ContentTypeText:
-            guard let contentString = contentReply.content as? String else {
-                throw DecodedMessageDBRepresentationError.mismatchedContentType
-            }
+    private static func handleReplyContent(
+        reply: MessagingReplyPayload,
+        messageId: String
+    ) throws -> DBMessageComponents {
+        let sourceMessageId = reply.reference
+        switch reply.innerPayload {
+        case .text(let contentString):
             let isContentEmoji = contentString.allCharactersEmoji
             if !isContentEmoji, let invite = MessageInvite.from(text: contentString) {
                 return DBMessageComponents(
@@ -185,11 +213,12 @@ extension XMTPiOS.DecodedMessage {
                 text: isContentEmoji ? nil : contentString,
                 update: nil
             )
-        case ContentTypeAttachment:
-            guard let attachment = contentReply.content as? Attachment else {
-                throw DecodedMessageDBRepresentationError.mismatchedContentType
-            }
-            let fileURL = try Self.saveInlineAttachment(data: attachment.data, messageId: id, filename: attachment.filename)
+        case .attachment(let attachment):
+            let fileURL = try saveInlineAttachment(
+                data: attachment.data,
+                messageId: messageId,
+                filename: attachment.filename
+            )
             return DBMessageComponents(
                 messageType: .reply,
                 contentType: .attachments,
@@ -199,10 +228,7 @@ extension XMTPiOS.DecodedMessage {
                 text: nil,
                 update: nil
             )
-        case ContentTypeRemoteAttachment:
-            guard let remoteAttachment = contentReply.content as? RemoteAttachment else {
-                throw DecodedMessageDBRepresentationError.mismatchedContentType
-            }
+        case .remoteAttachment(let remoteAttachment):
             let stored = StoredRemoteAttachment(
                 url: remoteAttachment.url,
                 contentDigest: remoteAttachment.contentDigest,
@@ -221,8 +247,8 @@ extension XMTPiOS.DecodedMessage {
                 text: nil,
                 update: nil
             )
-        default:
-            Log.error("Unhandled contentType \(contentReply.contentType)")
+        case .other:
+            Log.error("Unhandled reply inner content type \(reply.innerContentType)")
             return DBMessageComponents(
                 messageType: .reply,
                 contentType: .text,
@@ -235,12 +261,13 @@ extension XMTPiOS.DecodedMessage {
         }
     }
 
-    private func handleReactionContent() throws -> DBMessageComponents {
-        let content = try content() as Any
-        guard let reaction = content as? Reaction else {
-            throw DecodedMessageDBRepresentationError.mismatchedContentType
-        }
-        return DBMessageComponents(
+    private static func handleReactionContent(
+        reaction: MessagingReaction
+    ) -> DBMessageComponents {
+        // Stage 2 migration: derive the emoji glyph through the
+        // abstraction-layer `MessagingReaction` rather than from
+        // `XMTPiOS.Reaction` directly.
+        DBMessageComponents(
             messageType: .reaction,
             contentType: .emoji,
             sourceMessageId: reaction.reference,
@@ -251,12 +278,15 @@ extension XMTPiOS.DecodedMessage {
         )
     }
 
-    private func handleAttachmentContent() throws -> DBMessageComponents {
-        let content = try content() as Any
-        guard let attachment = content as? Attachment else {
-            throw DecodedMessageDBRepresentationError.mismatchedContentType
-        }
-        let fileURL = try Self.saveInlineAttachment(data: attachment.data, messageId: id, filename: attachment.filename)
+    private static func handleAttachmentContent(
+        attachment: MessagingAttachmentPayload,
+        messageId: String
+    ) throws -> DBMessageComponents {
+        let fileURL = try saveInlineAttachment(
+            data: attachment.data,
+            messageId: messageId,
+            filename: attachment.filename
+        )
         return DBMessageComponents(
             messageType: .original,
             contentType: .attachments,
@@ -268,9 +298,13 @@ extension XMTPiOS.DecodedMessage {
         )
     }
 
-    private static func saveInlineAttachment(data: Data, messageId: String, filename: String) throws -> URL {
+    private static func saveInlineAttachment(
+        data: Data,
+        messageId: String,
+        filename: String
+    ) throws -> URL {
         guard let cacheDir = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first else {
-            throw DecodedMessageDBRepresentationError.mismatchedContentType
+            throw DBRepresentationError.mismatchedContentType
         }
         let dir = cacheDir.appendingPathComponent("InlineAttachments", isDirectory: true)
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
@@ -280,11 +314,9 @@ extension XMTPiOS.DecodedMessage {
         return fileURL
     }
 
-    private func handleMultiRemoteAttachmentContent() throws -> DBMessageComponents {
-        let content = try content() as Any
-        guard let remoteAttachments = content as? [RemoteAttachment] else {
-            throw DecodedMessageDBRepresentationError.mismatchedContentType
-        }
+    private static func handleMultiRemoteAttachmentContent(
+        remoteAttachments: [MessagingRemoteAttachmentPayload]
+    ) -> DBMessageComponents {
         let storedAttachments = remoteAttachments.map { attachment in
             let inferredMimeType: String? = attachment.filename.flatMap { filename in
                 let ext = (filename as NSString).pathExtension.lowercased()
@@ -313,11 +345,9 @@ extension XMTPiOS.DecodedMessage {
         )
     }
 
-    private func handleRemoteAttachmentContent() throws -> DBMessageComponents {
-        let content = try content() as Any
-        guard let remoteAttachment = content as? RemoteAttachment else {
-            throw DecodedMessageDBRepresentationError.mismatchedContentType
-        }
+    private static func handleRemoteAttachmentContent(
+        remoteAttachment: MessagingRemoteAttachmentPayload
+    ) -> DBMessageComponents {
         let inferredMimeType: String? = remoteAttachment.filename.flatMap { filename in
             let ext = (filename as NSString).pathExtension.lowercased()
             guard !ext.isEmpty else { return nil }
@@ -344,20 +374,19 @@ extension XMTPiOS.DecodedMessage {
         )
     }
 
-    private func handleGroupUpdatedContent() throws -> DBMessageComponents {
-        let content = try content() as Any
-        guard let groupUpdated = content as? GroupUpdated else {
-            throw DecodedMessageDBRepresentationError.mismatchedContentType
-        }
-        let metadataFieldChanges: [DBMessage.Update.MetadataChange] = groupUpdated.metadataFieldChanges
-            .compactMap {
-                if $0.fieldName == ConversationUpdate.MetadataChange.Field.description.rawValue {
-                    let descriptionChanged = $0.oldValue != $0.newValue
+    private static func handleGroupUpdatedContent(
+        groupUpdated: MessagingGroupUpdatedPayload
+    ) -> DBMessageComponents {
+        let metadataFieldChanges: [DBMessage.Update.MetadataChange] = groupUpdated
+            .metadataFieldChanges
+            .compactMap { change in
+                if change.fieldName == ConversationUpdate.MetadataChange.Field.description.rawValue {
+                    let descriptionChanged = change.oldValue != change.newValue
                     if descriptionChanged {
                         return .init(
                             field: ConversationUpdate.MetadataChange.Field.description.rawValue,
-                            oldValue: $0.oldValue,
-                            newValue: $0.newValue
+                            oldValue: change.oldValue,
+                            newValue: change.newValue
                         )
                     } else {
                         return .init(
@@ -366,11 +395,11 @@ extension XMTPiOS.DecodedMessage {
                             newValue: nil
                         )
                     }
-                } else if $0.fieldName == ConversationUpdate.MetadataChange.Field.metadata.rawValue {
+                } else if change.fieldName == ConversationUpdate.MetadataChange.Field.metadata.rawValue {
                     let oldCustomValue: ConversationCustomMetadata?
-                    if $0.hasOldValue {
+                    if let oldValue = change.oldValue {
                         do {
-                            oldCustomValue = try ConversationCustomMetadata.fromCompactString($0.oldValue)
+                            oldCustomValue = try ConversationCustomMetadata.fromCompactString(oldValue)
                         } catch {
                             Log.error("Failed to decode old custom metadata: \(error)")
                             oldCustomValue = nil
@@ -380,9 +409,9 @@ extension XMTPiOS.DecodedMessage {
                     }
 
                     let newCustomValue: ConversationCustomMetadata?
-                    if $0.hasNewValue {
+                    if let newValue = change.newValue {
                         do {
-                            newCustomValue = try ConversationCustomMetadata.fromCompactString($0.newValue)
+                            newCustomValue = try ConversationCustomMetadata.fromCompactString(newValue)
                         } catch {
                             Log.error("Failed to decode new custom metadata: \(error)")
                             newCustomValue = nil
@@ -424,16 +453,16 @@ extension XMTPiOS.DecodedMessage {
                     }
                 } else {
                     return .init(
-                        field: $0.fieldName,
-                        oldValue: $0.hasOldValue ? $0.oldValue : nil,
-                        newValue: $0.hasNewValue ? $0.newValue : nil
+                        field: change.fieldName,
+                        oldValue: change.oldValue,
+                        newValue: change.newValue
                     )
                 }
             }
         let update = DBMessage.Update(
-            initiatedByInboxId: groupUpdated.initiatedByInboxID,
-            addedInboxIds: groupUpdated.addedInboxes.map { $0.inboxID },
-            removedInboxIds: groupUpdated.removedInboxes.map { $0.inboxID },
+            initiatedByInboxId: groupUpdated.initiatedByInboxId,
+            addedInboxIds: groupUpdated.addedInboxIds,
+            removedInboxIds: groupUpdated.removedInboxIds,
             metadataChanges: metadataFieldChanges,
             expiresAt: nil
         )
@@ -448,12 +477,10 @@ extension XMTPiOS.DecodedMessage {
         )
     }
 
-    private func handleAssistantJoinRequestContent() throws -> DBMessageComponents {
-        let content = try content() as Any
-        guard let request = content as? AssistantJoinRequest else {
-            throw DecodedMessageDBRepresentationError.mismatchedContentType
-        }
-        return DBMessageComponents(
+    private static func handleAssistantJoinRequestContent(
+        request: AssistantJoinRequest
+    ) -> DBMessageComponents {
+        DBMessageComponents(
             messageType: .original,
             contentType: .assistantJoinRequest,
             sourceMessageId: nil,
@@ -464,12 +491,10 @@ extension XMTPiOS.DecodedMessage {
         )
     }
 
-    private func handleExplodeSettingsContent() throws -> DBMessageComponents {
-        let content = try content() as Any
-        guard let explodeSettings = content as? ExplodeSettings else {
-            throw DecodedMessageDBRepresentationError.mismatchedContentType
-        }
-
+    private static func handleExplodeSettingsContent(
+        explodeSettings: ExplodeSettings,
+        senderInboxId: String
+    ) -> DBMessageComponents {
         Log.info("Received explode settings: \(explodeSettings)")
         let update = DBMessage.Update(
             initiatedByInboxId: senderInboxId,

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/MessagingMessagePayload.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/MessagingMessagePayload.swift
@@ -1,0 +1,187 @@
+import Foundation
+
+/// Normalized decoded-payload shapes for the content types that the
+/// storage layer needs to translate into `DBMessage`.
+///
+/// Stage 3 migration (audit §5): the prior dispatch in
+/// `Storage/XMTP DB Representations/DecodedMessage+DBRepresentation.swift`
+/// performed `content() as Reply` / `as Attachment` / ... casts
+/// directly against XMTPiOS's XIP payload structs. After the migration
+/// the storage-side translator
+/// (`MessagingMessage+DBRepresentation.swift`) only sees the Convos-
+/// owned values below; the boundary that decodes XIP structs into
+/// these shapes lives in `XMTP DB Representations/MessagingMessage+XMTPiOS.swift`.
+///
+/// Scope note: this enum only carries the fields the storage layer
+/// inspects today. Custom-codec consumers (push-notification preview,
+/// `MessagingService+PushNotifications.swift`, outgoing-message path
+/// in `OutgoingMessageWriter.swift`) still pull the raw XIP payloads
+/// via `MessagingMessage.content<T>()`. Generalising this enum into a
+/// full Convos-owned codec surface is tracked under Stage 6 (audit
+/// §5); for now the narrow shape keeps the DB translator XMTPiOS-free
+/// without re-stating every XIP payload.
+public enum MessagingMessagePayload: Sendable {
+    /// XIP `text:1.0` — a raw string body.
+    case text(String)
+
+    /// XIP `reply:1.0` — a quoted source message plus an inner payload
+    /// the storage layer recursively inspects.
+    case reply(MessagingReplyPayload)
+
+    /// XIP `reaction:1.0` / `reaction:2.0` — already abstracted via
+    /// `MessagingReaction`; the storage layer reads `emoji` +
+    /// `reference` off this value.
+    case reaction(MessagingReaction)
+
+    /// XIP `attachment:1.0` — inline bytes + filename, persisted to the
+    /// caches directory by the storage layer.
+    case attachment(MessagingAttachmentPayload)
+
+    /// XIP `remoteStaticAttachment:1.0` — a remote URL plus the
+    /// decryption material needed by the attachment loader.
+    case remoteAttachment(MessagingRemoteAttachmentPayload)
+
+    /// XIP `multiRemoteStaticAttachment:1.0` — multiple remote
+    /// attachments sent as a single message.
+    case multiRemoteAttachment([MessagingRemoteAttachmentPayload])
+
+    /// XIP `group_updated:1.0` — group membership / metadata change
+    /// event emitted by the MLS stack.
+    case groupUpdated(MessagingGroupUpdatedPayload)
+
+    /// `convos.org/explode_settings:1.0` — the conversation-exploding
+    /// timestamp. Convos-owned content type.
+    case explodeSettings(ExplodeSettings)
+
+    /// `convos.org/assistant_join_request:1.0` — invite-flow event.
+    /// Convos-owned content type.
+    case assistantJoinRequest(AssistantJoinRequest)
+
+    /// XIP `readReceipt:1.0` — intentionally unsupported by the DB
+    /// translator; the caller threw
+    /// `.unsupportedContentType` for these before the migration.
+    case readReceipt
+
+    /// Content types not enumerated above. The DB translator rejects
+    /// these as `.unsupportedContentType`, matching prior behavior.
+    case unsupported
+}
+
+// MARK: - Inner payload types
+
+/// Convos-owned mirror of the XIP `Reply` payload subset the storage
+/// layer cares about.
+public struct MessagingReplyPayload: Sendable {
+    /// Source message id this reply quotes (`Reply.reference`).
+    public let reference: String
+
+    /// The inner content type — used to route the translator through
+    /// text / attachment / remote-attachment sub-handlers. Carried as
+    /// `MessagingContentType` so the abstraction layer does the
+    /// comparison, not XMTPiOS.
+    public let innerContentType: MessagingContentType
+
+    /// The decoded inner payload. The translator only recurses into a
+    /// few known shapes; everything else falls through to a `.text`
+    /// placeholder, preserving prior logging behavior.
+    public let innerPayload: MessagingReplyInnerPayload
+
+    public init(
+        reference: String,
+        innerContentType: MessagingContentType,
+        innerPayload: MessagingReplyInnerPayload
+    ) {
+        self.reference = reference
+        self.innerContentType = innerContentType
+        self.innerPayload = innerPayload
+    }
+}
+
+/// Subset of reply-inner payload shapes the storage translator knows
+/// how to store. Anything outside this enum falls through to the
+/// "unhandled reply content type" log line and a text-shaped DB row
+/// with no body.
+public enum MessagingReplyInnerPayload: Sendable {
+    case text(String)
+    case attachment(MessagingAttachmentPayload)
+    case remoteAttachment(MessagingRemoteAttachmentPayload)
+    case other
+}
+
+/// Inline attachment payload — matches the fields read from
+/// `XMTPiOS.Attachment` by `DecodedMessage+DBRepresentation.swift`
+/// before the migration.
+public struct MessagingAttachmentPayload: Sendable {
+    public let data: Data
+    public let filename: String
+    public let mimeType: String
+
+    public init(data: Data, filename: String, mimeType: String) {
+        self.data = data
+        self.filename = filename
+        self.mimeType = mimeType
+    }
+}
+
+/// Remote attachment payload — matches the fields read from
+/// `XMTPiOS.RemoteAttachment` by `DecodedMessage+DBRepresentation.swift`
+/// before the migration. `filename` is optional because
+/// `RemoteAttachment.filename` is too.
+public struct MessagingRemoteAttachmentPayload: Sendable {
+    public let url: String
+    public let contentDigest: String
+    public let secret: Data
+    public let salt: Data
+    public let nonce: Data
+    public let filename: String?
+
+    public init(
+        url: String,
+        contentDigest: String,
+        secret: Data,
+        salt: Data,
+        nonce: Data,
+        filename: String?
+    ) {
+        self.url = url
+        self.contentDigest = contentDigest
+        self.secret = secret
+        self.salt = salt
+        self.nonce = nonce
+        self.filename = filename
+    }
+}
+
+/// Group-updated payload — exposes just the fields the DB translator
+/// copies onto `DBMessage.Update`. Nested in this shape so the
+/// abstraction layer does not depend on `XMTPiOS.GroupUpdated`.
+public struct MessagingGroupUpdatedPayload: Sendable {
+    public let initiatedByInboxId: String
+    public let addedInboxIds: [String]
+    public let removedInboxIds: [String]
+    public let metadataFieldChanges: [MetadataFieldChange]
+
+    public init(
+        initiatedByInboxId: String,
+        addedInboxIds: [String],
+        removedInboxIds: [String],
+        metadataFieldChanges: [MetadataFieldChange]
+    ) {
+        self.initiatedByInboxId = initiatedByInboxId
+        self.addedInboxIds = addedInboxIds
+        self.removedInboxIds = removedInboxIds
+        self.metadataFieldChanges = metadataFieldChanges
+    }
+
+    public struct MetadataFieldChange: Sendable {
+        public let fieldName: String
+        public let oldValue: String?
+        public let newValue: String?
+
+        public init(fieldName: String, oldValue: String?, newValue: String?) {
+            self.fieldName = fieldName
+            self.oldValue = oldValue
+            self.newValue = newValue
+        }
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/MessagingReaction+Emoji.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/MessagingReaction+Emoji.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+/// Projects a `MessagingReaction` onto the user-visible emoji glyph
+/// Convos stores in `DBMessage.emoji`.
+///
+/// Stage 2 migration (audit §5): this replaces the pre-existing
+/// `extension XMTPiOS.Reaction { var emoji }` so the rendering rule
+/// (U+XXXX hex-code -> UnicodeScalar for `.unicode`-schema reactions,
+/// raw content otherwise) lives on the Convos-owned struct. The
+/// XMTPiOS boundary now only carries the shape conversion — see
+/// `Storage/XMTP DB Representations/Reaction+DBRepresentation.swift`.
+extension MessagingReaction {
+    /// Returns the glyph Convos wants to display for this reaction.
+    ///
+    /// For `.unicode`-schema reactions the `content` is the U+XXXX
+    /// hex-code form; the caller expects the decoded UnicodeScalar.
+    /// For every other schema (including `.shortcode`, `.custom`,
+    /// `.unknown`) the raw `content` string is used verbatim, which
+    /// matches the prior XMTPiOS extension behavior.
+    public var emoji: String {
+        switch schema {
+        case .unicode:
+            if let scalarValue = UInt32(content.replacingOccurrences(of: "U+", with: ""), radix: 16),
+               let scalar = UnicodeScalar(scalarValue) {
+                return String(scalar)
+            }
+        default:
+            break
+        }
+        return content
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Storage/Repositories/DB XMTP Representations/Consent+ConsentState.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Repositories/DB XMTP Representations/Consent+ConsentState.swift
@@ -1,7 +1,35 @@
 import XMTPiOS
 
-extension Consent {
-    var consentState: XMTPiOS.ConsentState {
+/// Stage 2 migration (audit §5, §1.4).
+///
+/// Before: this file held `extension Consent { var consentState: XMTPiOS.ConsentState }`
+/// — a direct Convos -> XMTPiOS mapper that every caller had to
+/// route through, making the XMTPiOS type visible to call sites
+/// that had no other reason to import it.
+///
+/// After: this file only holds the XMTPiOS <-> `MessagingConsentState`
+/// boundary. Convos' `Consent` now maps to the abstraction layer via
+/// `Storage/Models/MessagingConsentState+Consent.swift`, and the one
+/// remaining call site in
+/// `Messaging/XMTPClientProvider.swift` threads through
+/// `consent.messagingConsentState.xmtpConsentState` — same pattern
+/// as the `MessagingDeliveryStatus(ffiStatus)` bridging used by the
+/// delivery-status leaf. `XMTPClientProvider.swift` still imports
+/// XMTPiOS (it is a Stage-3 seam rewrite), but the Consent surface
+/// itself now routes through the abstraction.
+extension MessagingConsentState {
+    /// Build a messaging-layer consent state from the XMTPiOS enum.
+    public init(_ xmtpConsentState: XMTPiOS.ConsentState) {
+        switch xmtpConsentState {
+        case .allowed: self = .allowed
+        case .denied: self = .denied
+        case .unknown: self = .unknown
+        }
+    }
+
+    /// Project back to the XMTPiOS enum for adapter calls into the
+    /// SDK. Only the XMTPiOS adapter should need this.
+    public var xmtpConsentState: XMTPiOS.ConsentState {
         switch self {
         case .allowed: return .allowed
         case .denied: return .denied

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/IncomingMessageWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/IncomingMessageWriter.swift
@@ -41,46 +41,50 @@ class IncomingMessageWriter: IncomingMessageWriterProtocol, @unchecked Sendable 
 
     func store(message: DecodedMessage,
                for conversation: DBConversation) async throws -> IncomingMessageWriterResult {
-        let encodedContentType = try message.encodedContent.type
+        // Stage 3 migration (audit §5): thread the XMTPiOS ->
+        // Messaging boundary here, then operate on `MessagingMessage`
+        // everywhere below. The storage translator
+        // (`MessagingMessage+DBRepresentation.swift`) now consumes the
+        // abstraction directly.
+        let messagingMessage = try MessagingMessage(message)
+        let payload = messagingMessage.resolvedPayload()
 
-        if encodedContentType == ContentTypeReaction || encodedContentType == ContentTypeReactionV2 {
-            let content = try message.content() as Any
-            if let reaction = content as? Reaction {
-                switch reaction.action {
-                case .removed:
-                    return try await handleReactionRemoval(
-                        message: message,
-                        reaction: reaction,
-                        conversation: conversation
-                    )
-                case .added:
-                    return try await handleReactionAddition(
-                        message: message,
-                        reaction: reaction,
-                        conversation: conversation
-                    )
-                case .unknown:
-                    Log.warning("Received unknown reaction action, ignoring")
-                    return IncomingMessageWriterResult(
-                        contentType: .emoji,
-                        wasRemovedFromConversation: false,
-                        messageAlreadyExists: false
-                    )
-                }
+        if case .reaction(let reaction) = payload {
+            switch reaction.action {
+            case .removed:
+                return try await handleReactionRemoval(
+                    messagingMessage: messagingMessage,
+                    reaction: reaction,
+                    conversation: conversation
+                )
+            case .added:
+                return try await handleReactionAddition(
+                    messagingMessage: messagingMessage,
+                    payload: payload,
+                    reaction: reaction,
+                    conversation: conversation
+                )
+            case .unknown:
+                Log.warning("Received unknown reaction action, ignoring")
+                return IncomingMessageWriterResult(
+                    contentType: .emoji,
+                    wasRemovedFromConversation: false,
+                    messageAlreadyExists: false
+                )
             }
         }
 
         let result = try await databaseWriter.write { db in
-            let sender = DBMember(inboxId: message.senderInboxId)
+            let sender = DBMember(inboxId: messagingMessage.senderInboxId)
             try sender.save(db)
             let senderProfile = DBMemberProfile(
                 conversationId: conversation.id,
-                inboxId: message.senderInboxId,
+                inboxId: messagingMessage.senderInboxId,
                 name: nil,
                 avatar: nil
             )
             try? senderProfile.insert(db)
-            let message = try message.dbRepresentation()
+            let message = try messagingMessage.dbRepresentation(payload: payload)
 
             let messageExistsInDB = try DBMessage.exists(db, key: message.id)
             // @jarodl temporary, this should happen somewhere else more explicitly
@@ -188,16 +192,17 @@ class IncomingMessageWriter: IncomingMessageWriterProtocol, @unchecked Sendable 
     }
 
     private func handleReactionAddition(
-        message: DecodedMessage,
-        reaction: Reaction,
+        messagingMessage: MessagingMessage,
+        payload: MessagingMessagePayload,
+        reaction: MessagingReaction,
         conversation: DBConversation
     ) async throws -> IncomingMessageWriterResult {
         let reactionAlreadyExists = try await databaseWriter.write { db -> Bool in
-            let sender = DBMember(inboxId: message.senderInboxId)
+            let sender = DBMember(inboxId: messagingMessage.senderInboxId)
             try sender.save(db)
             let senderProfile = DBMemberProfile(
                 conversationId: conversation.id,
-                inboxId: message.senderInboxId,
+                inboxId: messagingMessage.senderInboxId,
                 name: nil,
                 avatar: nil
             )
@@ -205,7 +210,7 @@ class IncomingMessageWriter: IncomingMessageWriterProtocol, @unchecked Sendable 
 
             let existingReaction = try DBMessage
                 .filter(DBMessage.Columns.sourceMessageId == reaction.reference)
-                .filter(DBMessage.Columns.senderId == message.senderInboxId)
+                .filter(DBMessage.Columns.senderId == messagingMessage.senderInboxId)
                 .filter(DBMessage.Columns.emoji == reaction.emoji)
                 .filter(DBMessage.Columns.messageType == DBMessageType.reaction.rawValue)
                 .fetchOne(db)
@@ -216,9 +221,9 @@ class IncomingMessageWriter: IncomingMessageWriterProtocol, @unchecked Sendable 
                 Log.debug("Updated existing reaction \(existingReaction.id) status to published")
                 return true
             } else {
-                let dbMessage = try message.dbRepresentation()
+                let dbMessage = try messagingMessage.dbRepresentation(payload: payload)
                 try dbMessage.save(db)
-                Log.debug("Saved new incoming reaction \(message.id)")
+                Log.debug("Saved new incoming reaction \(messagingMessage.id)")
                 return false
             }
         }
@@ -226,7 +231,7 @@ class IncomingMessageWriter: IncomingMessageWriterProtocol, @unchecked Sendable 
             QAEvent.emit(.reaction, "received", [
                 "message": reaction.reference,
                 "emoji": reaction.emoji,
-                "sender": message.senderInboxId,
+                "sender": messagingMessage.senderInboxId,
                 "conversation": conversation.id
             ])
         }
@@ -238,18 +243,18 @@ class IncomingMessageWriter: IncomingMessageWriterProtocol, @unchecked Sendable 
     }
 
     private func handleReactionRemoval(
-        message: DecodedMessage,
-        reaction: Reaction,
+        messagingMessage: MessagingMessage,
+        reaction: MessagingReaction,
         conversation: DBConversation
     ) async throws -> IncomingMessageWriterResult {
         try await databaseWriter.write { db in
             let deletedCount = try DBMessage
                 .filter(DBMessage.Columns.sourceMessageId == reaction.reference)
-                .filter(DBMessage.Columns.senderId == message.senderInboxId)
+                .filter(DBMessage.Columns.senderId == messagingMessage.senderInboxId)
                 .filter(DBMessage.Columns.emoji == reaction.emoji)
                 .filter(DBMessage.Columns.messageType == DBMessageType.reaction.rawValue)
                 .deleteAll(db)
-            Log.debug("Deleted \(deletedCount) reaction(s) for message \(reaction.reference) from \(message.senderInboxId)")
+            Log.debug("Deleted \(deletedCount) reaction(s) for message \(reaction.reference) from \(messagingMessage.senderInboxId)")
         }
         return IncomingMessageWriterResult(
             contentType: .emoji,

--- a/ConvosCore/Sources/ConvosCore/Storage/XMTP DB Representations/MessageDeliveryStatus+DBRepresentation.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/XMTP DB Representations/MessageDeliveryStatus+DBRepresentation.swift
@@ -2,13 +2,34 @@ import Foundation
 import GRDB
 import XMTPiOS
 
-extension XMTPiOS.MessageDeliveryStatus {
-    var status: MessageStatus {
-        switch self {
-        case .failed: return .failed
-        case .unpublished: return .unpublished
-        case .published: return .published
-        case .all: return .unknown
+/// Stage 2 migration proof-of-pattern (audit §5).
+///
+/// Before: this file exposed
+/// `extension XMTPiOS.MessageDeliveryStatus { var status: MessageStatus }`
+/// — a translator attached directly to the XMTPiOS enum.
+///
+/// After: the translator lives on the Convos-owned
+/// `MessagingDeliveryStatus` (see
+/// `Storage/Models/MessagingDeliveryStatus+MessageStatus.swift`).
+/// This file now only holds the XMTPiOS → Messaging boundary mapper,
+/// which is what the adapter layer will use in Stage 2/3. The single
+/// remaining caller in
+/// `Storage/XMTP DB Representations/DecodedMessage+DBRepresentation.swift`
+/// flows through `MessagingDeliveryStatus(ffiStatus)` → `.status`, so
+/// all `MessageStatus` derivations are now expressed against the
+/// abstraction and the DTU adapter can reuse them unchanged.
+extension MessagingDeliveryStatus {
+    /// Build a Convos-owned delivery status from the XMTPiOS enum.
+    ///
+    /// Kept as the only XMTPiOS-aware surface of this mapping so the
+    /// eventual DTU adapter can build `MessagingDeliveryStatus`
+    /// directly without re-implementing `.status`.
+    init(_ xmtpDeliveryStatus: XMTPiOS.MessageDeliveryStatus) {
+        switch xmtpDeliveryStatus {
+        case .failed: self = .failed
+        case .unpublished: self = .unpublished
+        case .published: self = .published
+        case .all: self = .all
         }
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Storage/XMTP DB Representations/MessagingMessage+XMTPiOS.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/XMTP DB Representations/MessagingMessage+XMTPiOS.swift
@@ -1,0 +1,318 @@
+import Foundation
+@preconcurrency import XMTPiOS
+
+/// XMTPiOS -> abstraction boundary for `DecodedMessage`.
+///
+/// Stage 3 migration (audit §5): the dispatch on
+/// `XMTPiOS.DecodedMessage.encodedContent.type` that produces a
+/// `DBMessage` has moved onto `MessagingMessage` (see
+/// `MessagingMessage+DBRepresentation.swift`). This file now only holds
+/// the XMTPiOS -> Messaging boundary initializer and the XIP-payload
+/// → `MessagingMessagePayload` bridge — analogous to the Stage 2
+/// `MessageDeliveryStatus+DBRepresentation.swift` and
+/// `Reaction+DBRepresentation.swift` translators.
+///
+/// Call sites that previously wrote `xmtpDecodedMessage.dbRepresentation()`
+/// now write `MessagingMessage(xmtpDecodedMessage).dbRepresentation()`.
+/// The one-hop indirection is the whole point: every storage / writer
+/// call site is now expressed against `MessagingMessage`, and the DTU
+/// adapter (Stage 5) will populate the same value type with no XMTPiOS
+/// involvement.
+///
+/// `senderInstallationId` is populated as `nil` here: the pinned
+/// XMTPiOS SDK does not yet surface it on `DecodedMessage` (only
+/// `senderInboxId`). See the `MessagingMessage` type doc for the audit
+/// open-question tracking.
+extension MessagingMessage {
+    /// Build a Convos-owned message from an XMTPiOS decoded message.
+    ///
+    /// Kept as the only XMTPiOS-aware surface of this mapping so the
+    /// eventual DTU adapter can build `MessagingMessage` directly
+    /// without re-implementing the storage translator.
+    init(_ xmtpDecodedMessage: XMTPiOS.DecodedMessage) throws {
+        let xmtpEncodedContent = try xmtpDecodedMessage.encodedContent
+        let encodedContent = MessagingEncodedContent(xmtpEncodedContent)
+
+        // Eagerly capture the decoded payload. `XMTPiOS.DecodedMessage`
+        // caches its decoded content internally (see
+        // `sdks/ios/Sources/XMTPiOS/Libxmtp/DecodedMessage.swift:150-157`),
+        // so `content()` is just a cast. We snapshot it here so the
+        // `MessagingMessage.contentDecoder` closure does not have to
+        // capture the non-Sendable `DecodedMessage`.
+        //
+        // If decoding fails (e.g. `readReceipt` rows where XMTPiOS
+        // returns `Any` but the translator dispatches on type anyway)
+        // we fall back to `NSNull()` and let the translator's
+        // `encodedContent.type` switch decide what to do.
+        let decodedAny: Any = (try? xmtpDecodedMessage.content() as Any) ?? NSNull()
+        let decodedBox: _MessagingDecodedPayloadBox = _MessagingDecodedPayloadBox(
+            payload: decodedAny
+        )
+
+        self.init(
+            id: xmtpDecodedMessage.id,
+            conversationId: xmtpDecodedMessage.conversationId,
+            senderInboxId: xmtpDecodedMessage.senderInboxId,
+            senderInstallationId: nil,
+            sentAt: xmtpDecodedMessage.sentAt,
+            sentAtNs: xmtpDecodedMessage.sentAtNs,
+            insertedAt: xmtpDecodedMessage.insertedAt,
+            insertedAtNs: xmtpDecodedMessage.insertedAtNs,
+            expiresAtNs: xmtpDecodedMessage.expiresAtNs,
+            deliveryStatus: MessagingDeliveryStatus(xmtpDecodedMessage.deliveryStatus),
+            encodedContent: encodedContent,
+            childMessages: xmtpDecodedMessage.childMessages?.compactMap { child in
+                try? MessagingMessage(child)
+            },
+            contentDecoder: { _ in decodedBox.payload }
+        )
+    }
+}
+
+// MARK: - Payload resolution (XIP -> MessagingMessagePayload)
+
+extension MessagingMessage {
+    /// Turn the XIP-decoded `content()` result into a
+    /// `MessagingMessagePayload` the storage translator can dispatch
+    /// on without importing XMTPiOS.
+    ///
+    /// Lives on the boundary side because it must cast to `Reply`,
+    /// `Reaction`, `Attachment`, `RemoteAttachment`, and `GroupUpdated`
+    /// — all XMTPiOS-owned XIP payload types today. When Stage 6
+    /// re-states these as Convos structs this helper becomes a pure
+    /// pass-through.
+    ///
+    /// The high branch count is inherent: every supported XIP content
+    /// type needs its own cast. Splitting into per-type helpers trades
+    /// one long function for a dispatch wrapper plus ten trivial
+    /// helpers, which is strictly worse for the reader. Disabling the
+    /// lint for this one function.
+    // swiftlint:disable:next cyclomatic_complexity
+    func resolvedPayload() -> MessagingMessagePayload {
+        let contentType = encodedContent.type
+
+        // Reactions: prefer the already-abstracted `MessagingReaction`.
+        // Matches prior `handleReactionContent()` behavior.
+        if contentType == .reaction || contentType == .reactionV2 {
+            guard let xmtpReaction = (try? content() as XMTPiOS.Reaction) else {
+                return .unsupported
+            }
+            return .reaction(MessagingReaction(xmtpReaction))
+        }
+
+        if contentType == .text {
+            guard let string = (try? content() as String) else {
+                return .unsupported
+            }
+            return .text(string)
+        }
+
+        if contentType == .reply {
+            guard let xmtpReply = (try? content() as XMTPiOS.Reply) else {
+                return .unsupported
+            }
+            return .reply(MessagingReplyPayload(xmtpReply))
+        }
+
+        if contentType == .attachment {
+            guard let xmtpAttachment = (try? content() as XMTPiOS.Attachment) else {
+                return .unsupported
+            }
+            return .attachment(MessagingAttachmentPayload(xmtpAttachment))
+        }
+
+        if contentType == .remoteAttachment {
+            guard let xmtpRemoteAttachment = (try? content() as XMTPiOS.RemoteAttachment) else {
+                return .unsupported
+            }
+            return .remoteAttachment(
+                MessagingRemoteAttachmentPayload(xmtpRemoteAttachment)
+            )
+        }
+
+        if contentType == .multiRemoteAttachment {
+            guard let xmtpAttachments = (try? content() as [XMTPiOS.RemoteAttachment]) else {
+                return .unsupported
+            }
+            return .multiRemoteAttachment(
+                xmtpAttachments.map(MessagingRemoteAttachmentPayload.init)
+            )
+        }
+
+        if contentType == .groupUpdated {
+            guard let xmtpGroupUpdated = (try? content() as XMTPiOS.GroupUpdated) else {
+                return .unsupported
+            }
+            return .groupUpdated(MessagingGroupUpdatedPayload(xmtpGroupUpdated))
+        }
+
+        if contentType == .explodeSettings {
+            guard let explodeSettings = (try? content() as ExplodeSettings) else {
+                return .unsupported
+            }
+            return .explodeSettings(explodeSettings)
+        }
+
+        if contentType == .assistantJoinRequest {
+            guard let request = (try? content() as AssistantJoinRequest) else {
+                return .unsupported
+            }
+            return .assistantJoinRequest(request)
+        }
+
+        if contentType == .readReceipt {
+            return .readReceipt
+        }
+
+        return .unsupported
+    }
+}
+
+// MARK: - XMTPiOS encoded-content / content-type bridging
+
+extension MessagingContentType {
+    /// Build the Convos-owned content type from the XMTPiOS
+    /// `ContentTypeID` (itself a typealias for the generated protobuf
+    /// `Xmtp_MessageContents_ContentTypeId`).
+    init(_ xmtpContentTypeID: XMTPiOS.ContentTypeID) {
+        self.init(
+            authorityID: xmtpContentTypeID.authorityID,
+            typeID: xmtpContentTypeID.typeID,
+            versionMajor: Int(xmtpContentTypeID.versionMajor),
+            versionMinor: Int(xmtpContentTypeID.versionMinor)
+        )
+    }
+}
+
+extension MessagingEncodedContent {
+    /// Build the Convos-owned encoded content from the XMTPiOS protobuf
+    /// value.
+    ///
+    /// The `compression` field on the protobuf side uses a generated
+    /// enum; the mapping here is one-to-one with the XIP-defined cases.
+    init(_ xmtpEncodedContent: XMTPiOS.EncodedContent) {
+        let compression: MessagingCompression?
+        if xmtpEncodedContent.hasCompression {
+            switch xmtpEncodedContent.compression {
+            case .deflate: compression = .deflate
+            case .gzip: compression = .gzip
+            case .UNRECOGNIZED: compression = nil
+            }
+        } else {
+            compression = nil
+        }
+
+        self.init(
+            type: MessagingContentType(xmtpEncodedContent.type),
+            parameters: xmtpEncodedContent.parameters,
+            content: xmtpEncodedContent.content,
+            fallback: xmtpEncodedContent.hasFallback
+                ? xmtpEncodedContent.fallback
+                : nil,
+            compression: compression
+        )
+    }
+}
+
+// MARK: - XIP payload adapters
+
+extension MessagingReplyPayload {
+    /// Mirrors prior `handleReplyContent()` decoding: we only care
+    /// about `reference`, the inner content type, and the inner
+    /// payload (which may itself be text / attachment / remote
+    /// attachment).
+    init(_ xmtpReply: XMTPiOS.Reply) {
+        let innerContentType = MessagingContentType(xmtpReply.contentType)
+        let innerPayload: MessagingReplyInnerPayload
+
+        switch innerContentType {
+        case .text:
+            if let text = xmtpReply.content as? String {
+                innerPayload = .text(text)
+            } else {
+                innerPayload = .other
+            }
+        case .attachment:
+            if let attachment = xmtpReply.content as? XMTPiOS.Attachment {
+                innerPayload = .attachment(MessagingAttachmentPayload(attachment))
+            } else {
+                innerPayload = .other
+            }
+        case .remoteAttachment:
+            if let remoteAttachment = xmtpReply.content as? XMTPiOS.RemoteAttachment {
+                innerPayload = .remoteAttachment(
+                    MessagingRemoteAttachmentPayload(remoteAttachment)
+                )
+            } else {
+                innerPayload = .other
+            }
+        default:
+            innerPayload = .other
+        }
+
+        self.init(
+            reference: xmtpReply.reference,
+            innerContentType: innerContentType,
+            innerPayload: innerPayload
+        )
+    }
+}
+
+extension MessagingAttachmentPayload {
+    init(_ xmtpAttachment: XMTPiOS.Attachment) {
+        self.init(
+            data: xmtpAttachment.data,
+            filename: xmtpAttachment.filename,
+            mimeType: xmtpAttachment.mimeType
+        )
+    }
+}
+
+extension MessagingRemoteAttachmentPayload {
+    init(_ xmtpRemoteAttachment: XMTPiOS.RemoteAttachment) {
+        self.init(
+            url: xmtpRemoteAttachment.url,
+            contentDigest: xmtpRemoteAttachment.contentDigest,
+            secret: xmtpRemoteAttachment.secret,
+            salt: xmtpRemoteAttachment.salt,
+            nonce: xmtpRemoteAttachment.nonce,
+            filename: xmtpRemoteAttachment.filename
+        )
+    }
+}
+
+extension MessagingGroupUpdatedPayload {
+    init(_ xmtpGroupUpdated: XMTPiOS.GroupUpdated) {
+        let metadataFieldChanges: [MetadataFieldChange] = xmtpGroupUpdated
+            .metadataFieldChanges
+            .map { change in
+                MetadataFieldChange(
+                    fieldName: change.fieldName,
+                    oldValue: change.hasOldValue ? change.oldValue : nil,
+                    newValue: change.hasNewValue ? change.newValue : nil
+                )
+            }
+
+        self.init(
+            initiatedByInboxId: xmtpGroupUpdated.initiatedByInboxID,
+            addedInboxIds: xmtpGroupUpdated.addedInboxes.map { $0.inboxID },
+            removedInboxIds: xmtpGroupUpdated.removedInboxes.map { $0.inboxID },
+            metadataFieldChanges: metadataFieldChanges
+        )
+    }
+}
+
+// MARK: - Private
+
+/// `@unchecked Sendable` container for the opaque decoded payload that
+/// `XMTPiOS.DecodedMessage.content()` returns. The payload is one of
+/// the XIP content-type structs (`Reply`, `Reaction`, `Attachment`,
+/// ...), none of which the current libxmtp Swift SDK marks `Sendable`.
+/// Since we only ever read the decoded payload on the same thread that
+/// produced it (the storage writer's DB-write closure), wrapping it in
+/// a single-property struct and opting out of the isolation check is
+/// sound. When libxmtp marks its payload types `Sendable`, drop the
+/// `@unchecked`.
+private struct _MessagingDecodedPayloadBox: @unchecked Sendable {
+    let payload: Any
+}

--- a/ConvosCore/Sources/ConvosCore/Storage/XMTP DB Representations/Reaction+DBRepresentation.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/XMTP DB Representations/Reaction+DBRepresentation.swift
@@ -1,18 +1,55 @@
 import Foundation
-import GRDB
 import XMTPiOS
 
-extension XMTPiOS.Reaction {
-    var emoji: String {
-        switch schema {
-        case .unicode:
-            if let scalarValue = UInt32(content.replacingOccurrences(of: "U+", with: ""), radix: 16),
-               let scalar = UnicodeScalar(scalarValue) {
-                return String(scalar)
-            }
-        default:
-            break
+/// Stage 2 migration (audit §5).
+///
+/// Before: this file hosted
+/// `extension XMTPiOS.Reaction { var emoji: String }` — a translator
+/// attached directly to the XMTPiOS struct.
+///
+/// After: the emoji-projection logic lives on the Convos-owned
+/// `MessagingReaction` (see
+/// `Storage/Models/MessagingReaction+Emoji.swift`). This file now
+/// only holds the XMTPiOS -> Messaging boundary initializer. The
+/// single caller in
+/// `Storage/XMTP DB Representations/DecodedMessage+DBRepresentation.swift`
+/// threads through `MessagingReaction(xmtpReaction).emoji`, matching
+/// the `MessagingDeliveryStatus(ffiStatus).status` pattern already in
+/// place for the delivery-status leaf.
+extension MessagingReaction {
+    /// Build a Convos-owned reaction value from the XMTPiOS struct.
+    ///
+    /// Kept as the only XMTPiOS-aware surface for this type so the
+    /// eventual DTU adapter can populate `MessagingReaction` directly
+    /// without re-implementing `emoji` or any other rendering rule.
+    init(_ xmtpReaction: XMTPiOS.Reaction) {
+        self.init(
+            reference: xmtpReaction.reference,
+            referenceInboxId: xmtpReaction.referenceInboxId,
+            action: MessagingReaction.Action(xmtpReaction.action),
+            content: xmtpReaction.content,
+            schema: MessagingReaction.Schema(xmtpReaction.schema)
+        )
+    }
+}
+
+private extension MessagingReaction.Action {
+    init(_ xmtpAction: XMTPiOS.ReactionAction) {
+        switch xmtpAction {
+        case .added: self = .added
+        case .removed: self = .removed
+        case .unknown: self = .unknown
         }
-        return content
+    }
+}
+
+private extension MessagingReaction.Schema {
+    init(_ xmtpSchema: XMTPiOS.ReactionSchema) {
+        switch xmtpSchema {
+        case .unicode: self = .unicode
+        case .shortcode: self = .shortcode
+        case .custom: self = .custom
+        case .unknown: self = .unknown
+        }
     }
 }

--- a/NotificationService/NotificationService.swift
+++ b/NotificationService/NotificationService.swift
@@ -2,7 +2,6 @@ import ConvosCore
 import ConvosCoreiOS
 import Foundation
 import UserNotifications
-import XMTPiOS
 
 // MARK: - Global Push Handler Singleton
 // Shared across all NSE process instances for efficiency and thread safety
@@ -18,7 +17,7 @@ private let globalPushHandler: CachedPushNotificationHandler? = {
         // only enable LibXMTP logging in non-production environments
         if !environment.isProduction {
             Log.info("Activating LibXMTP Log Writer...")
-            Client.activatePersistentLibXMTPLogWriter(
+            MessagingDiagnosticsProvider.shared.activatePersistentLogWriter(
                 logLevel: .debug,
                 rotationSchedule: .hourly,
                 maxFiles: 10,


### PR DESCRIPTION
## Summary

Introduces the `Messaging*` protocol set and leaf/boundary migrations that decouple Convos iOS from direct `XMTPiOS` imports in the app, NotificationService, and AppClip targets. This is the foundation for the [xmtp-dtu](https://github.com/xmtplabs/xmtp-dtu) Digital Twin Universe SDK that enables deterministic Convos iOS tests with **zero Docker and zero XMTP backend**.

**Status: draft — Stage 4+ migrations still pending.** See section at the bottom.

## Stage 1 — Messaging protocols (compile-only additions, 13 files)

Under `ConvosCore/Sources/ConvosCore/Messaging/Protocols/`:

\`MessagingClient\`, \`MessagingConversation\` (\`.group\`/\`.dm\` enum), \`MessagingMessage\` (with first-class \`deliveryStatus\` and \`senderInstallationId\`), \`MessagingInbox\`, \`MessagingInstallation\`, \`MessagingCodec\`, \`MessagingStream\`, \`MessagingConsent\`, \`MessagingPermission\`, \`MessagingDiagnostics\`, \`MessagingDeviceSync\`, \`MessagingInstallationsAPI\`, \`MessagingIdentity\`, \`MessagingContent\`, \`MessagingConversations\`, \`MessagingClientFactory\`. Only \`import Foundation\`.

## Stage 2 — leaf migrations (5)

1. \`MessagingMessage.senderInstallationId\` relaxed to \`Optional\` (upstream gap: \`XMTPiOS.DecodedMessage\` doesn't yet expose it at the pinned sha \`ios-4.9.0-dev.88ddfad\`). Tightens back to non-optional when upstream lands.
2. \`MessagingDeliveryStatus+MessageStatus\` — DB delivery-status mapping moved to the abstraction; boundary initializer in \`Storage/XMTP DB Representations/\`.
3. **\`MessagingDiagnostics\` wrap** + \`XMTPiOSDiagnostics\` adapter — Convos app target + NotificationService + AppClip now have **zero \`import XMTPiOS\`**. Stage 2 exit criterion hit.
4. \`MessagingReaction\` + \`Reaction+DBRepresentation\` migration (reaction emoji helper on the abstraction side).
5. \`MessagingConsentState\` + \`Consent+ConsentState\` migration.
6. \`MessagingConversationDebugInfo\` + \`Conversation+ExportDebugInfo\` migration.

## Stage 3 — partial (big ones)

- **\`DecodedMessage+DBRepresentation.swift\`** (~490 lines of content-type dispatch) → renamed to \`Storage/Models/MessagingMessage+DBRepresentation.swift\`, imports only \`Foundation\`/\`GRDB\`/\`UniformTypeIdentifiers\`/\`ConvosAppData\`. Boundary init lives in \`Storage/XMTP DB Representations/MessagingMessage+XMTPiOS.swift\` (\`resolvedPayload()\` dispatches all XIP types: text, reply, reaction, attachment, remote attachment, multi-remote, group_updated, explode settings, assistant join request, read receipt).
- **\`XMTPGroup+CustomMetadata.swift\`** (342 → 171 lines): turned into a thin boundary shim on top of a 429-line abstraction-side \`ConversationCustomMetadataEngine\`. Every existing caller keeps working; metadata flow now goes through the engine at the boundary seam.
- **\`InboxStateMachine.swift\`**: uses DI'd \`MessagingClientFactory\` via \`XMTPiOSMessagingClientFactory\` adapter. Direct \`Client.create\` / \`Client.build\` calls gone; global \`XMTPEnvironment.customLocalAddress\` writes reduced to a single adapter-only call site.

## Stage 4+ — not in this PR (follow-ups)

Per the audit at [\`xmtp-dtu/docs/ios-abstraction-audit.md\`](link):

- Storage writers (OutgoingMessageWriter, remaining bits of IncomingMessageWriter, ReactionWriter, ReplyMessageWriter, ReadReceiptWriter, ConversationWriter, ConversationMetadataWriter, ExplodeSettingsWriter, MyProfileWriter).
- Auth / signers (KeychainIdentityStore, AuthServiceProtocol's \`SigningKey\` / \`PublicIdentity\` → \`MessagingSigner\` / \`MessagingIdentity\`).
- Streams / sync (StreamProcessor, SyncingManager, InviteJoinRequestsManager, UnusedConversationCache, InlineAttachmentRecovery, MessagingService).
- Custom content-type codecs (TypingIndicatorCodec, AssistantJoinRequestCodec, ExplodeSettingsCodec).
- The \`XMTPClientProvider\` seam rewrite itself (Stage 6 exit).

## Verification

\`\`\`
✓ swift build --target ConvosCore
✓ xcodebuild -scheme ConvosCore build -destination 'platform=iOS Simulator,name=iPhone 17'
✓ xcodebuild -scheme 'Convos (Dev)' build -destination 'platform=iOS Simulator,name=iPhone 17'
✓ xcodebuild -scheme 'NotificationService (Dev)' build -destination 'platform=iOS Simulator,name=iPhone 17'
✓ bash ci/run-tests.sh --unit     # 59 tests in 8 suites, matches baseline
✓ grep -rn 'import XMTPiOS' Convos/ NotificationService/ ConvosAppClip/    # 0 matches
\`\`\`

## Companion PR

A follow-up PR adds a \`DTUPilot\` SwiftPM test package demonstrating \`XMTPDTU\` driving a Convos iOS test end-to-end with zero Docker — a proof-of-life for the integration-test pipeline this abstraction unlocks.

## Known caveats

- \`MessagingMessage.senderInstallationId\` is \`Optional\` pending upstream libxmtp exposing the field on \`XMTPiOS.DecodedMessage\`.
- One \`// swiftlint:disable:next cyclomatic_complexity\` on \`resolvedPayload()\` — it's a 9-branch XIP dispatcher; splitting into helpers hurts readability.
- One \`DecodedMessage+DBRepresentation.swift\` call site in \`IncomingMessageWriter.swift\` still threads the boundary inline (writer itself is Stage 4).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add iOS abstraction seam to decouple ConvosCore from XMTPiOS
> - Introduces a suite of `Messaging*` protocols and value types ([MessagingClient](https://github.com/xmtplabs/convos-ios/pull/737/files#diff-eb5b9e1273b75595d26437f9d7068051ced9d5f3e6c756be1b853c31d02d3ff9), [MessagingConversation](https://github.com/xmtplabs/convos-ios/pull/737/files#diff-ef56d627882507b00f239d03f3b714976e761f07898987e2eba1074c7a82f9e5), [MessagingMessage](https://github.com/xmtplabs/convos-ios/pull/737/files#diff-fe964d20896bbdcb41dfd9f9bd2fdb50acf8c48c572bb4b442e11e41ccf7de00), etc.) that define the full messaging surface without referencing XMTPiOS directly.
> - Adds [XMTPiOSMessagingClientFactory](https://github.com/xmtplabs/convos-ios/pull/737/files#diff-822f580982fe2056a940d862b946c72239e73d686abf3c5b06005005a50906bd) as the default `MessagingClientFactory`, centralizing client creation, codec registration, and `XMTPEnvironment.customLocalAddress` mutation that was previously scattered across callers.
> - Reworks [IncomingMessageWriter](https://github.com/xmtplabs/convos-ios/pull/737/files#diff-214371d5cccf7b16f4408fd58c74733a7d61314a74ebb428d08a97e20309c777) and [MessagingMessage+DBRepresentation](https://github.com/xmtplabs/convos-ios/pull/737/files#diff-ca95be544672918ea3fb6eac010f2cd0747a76567bd0dd0a0ed8b654badaf982) to operate on abstraction-layer payload types (`MessagingMessagePayload`) instead of casting XMTPiOS types directly.
> - Replaces direct `XMTPiOS.Client` calls for diagnostics in [ConvosApp](https://github.com/xmtplabs/convos-ios/pull/737/files#diff-de23c5a6e10cb84b89d91ed62b707b654c28566f38cc339af8b3cbbf6e003014), [NotificationService](https://github.com/xmtplabs/convos-ios/pull/737/files#diff-cd6c8fdb4518bf3bbc5ee11b88947aa53f113197875ddb7ca91ee8dd4eb0eed4), and [DebugLogExporter](https://github.com/xmtplabs/convos-ios/pull/737/files#diff-9d8acd3c167eed5aa220af166f94ba8cc4495bf0d3c9f5c03e711dccfa26413e) with `MessagingDiagnosticsProvider.shared`.
> - Extracts `ConversationCustomMetadataEngine` into [MessagingGroup+CustomMetadata](https://github.com/xmtplabs/convos-ios/pull/737/files#diff-08dc1f2cabf26f806520577f83c7e0ea34836b00051b6f9a5b37662e48cf0066) so custom metadata read/write logic is no longer inlined in the XMTPiOS group extension.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 46c8028. 34 files reviewed, 6 issues evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->