### PR TITLE
[WIP] DTUPilot: Convos iOS test using xmtp-dtu SDK

### DIFF
--- a/DTUPilot/Package.swift
+++ b/DTUPilot/Package.swift
@@ -1,0 +1,55 @@
+// swift-tools-version:5.9
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+// DTUPilot — the first Convos iOS pilot test that drives a local `dtu-server`
+// subprocess via the XMTPDTU Swift SDK. This package is intentionally
+// macOS-only: `DTUClient.spawn(...)` needs `Process`, which isn't available
+// in the iOS simulator. The value delivered is proving the SDK is consumable
+// from Convos's Swift ecosystem and can host the "conversation list sync +
+// newest-message preview" scenario end-to-end with zero XMTP backend and zero
+// Docker. See `DTUPilot/README.md` for the full run story.
+//
+// This package is intentionally isolated from the Convos app graph (no
+// `ConvosCore` dep, no Xcode project entry). That way it can't regress the
+// existing 59-unit-test baseline or pull XMTPiOS into builds that are
+// otherwise clean of it.
+let package = Package(
+    name: "DTUPilot",
+    platforms: [
+        // macOS-only: the pilot drives a subprocess and doesn't run on iOS.
+        // v12 matches what XMTPDTU publishes; bumping past that would serve
+        // no purpose here.
+        .macOS(.v12),
+    ],
+    products: [
+        // No library product — this package only exports a test target. Keep
+        // the graph tiny to minimize build friction for anyone running the
+        // pilot from a fresh checkout.
+    ],
+    dependencies: [
+        // Consume XMTPDTU as a local-path SwiftPM dependency. The sibling
+        // `xmtp-dtu` workspace lives next to `convos-ios-task-A`, so the
+        // relative path resolves reliably whether the caller runs `swift
+        // test` from the DTUPilot directory (default) or a parent.
+        //
+        // Deliberately NOT depending on `ConvosCore` for v0.1: ConvosCore
+        // targets iOS v26 / macOS v26 and pulls libxmtp + GRDB + Firebase +
+        // Sentry, which is incompatible with this package's macOS v12 floor
+        // and would turn the pilot into a 10+ minute fetch-and-build cycle.
+        // The Stage 3 follow-up refactors ConvosCore's `MessagingClient`
+        // injection seam so the pilot can target a clean protocol-surface
+        // instead.
+        .package(name: "XMTPDTU", path: "../../xmtp-dtu/clients/swift"),
+    ],
+    targets: [
+        .testTarget(
+            name: "DTUPilotTests",
+            dependencies: [
+                .product(name: "XMTPDTU", package: "XMTPDTU"),
+            ],
+            path: "Tests/DTUPilotTests"
+        ),
+    ]
+)

--- a/DTUPilot/README.md
+++ b/DTUPilot/README.md
@@ -1,0 +1,106 @@
+# DTUPilot
+
+The first Convos iOS pilot test that consumes the **XMTPDTU** Swift SDK to
+drive a local `dtu-server` subprocess end-to-end — **zero XMTP backend,
+zero Docker**. It exercises the "conversation list sync + newest-message
+preview" scenario, which mirrors the most common binding on Convos's home
+screen: a user's installation pulls two groups (one they created, one they
+joined via sync) and renders each with its newest non-system message as a
+preview.
+
+## What this package does
+
+- Declares a SwiftPM-only, macOS-only test target that depends on
+  `XMTPDTU` (local-path sibling at `../../xmtp-dtu/clients/swift`).
+- Spawns `dtu-server` as a subprocess, creates a universe, bootstraps two
+  actors (`alice-phone`, `bob-phone`), drives a short scripted scenario,
+  and asserts the newest-message projection per conversation.
+- Auto-skips cleanly if the server binary can't be found, with a runnable
+  `cargo build` command in the skip message.
+
+## Why it's isolated from `ConvosCore`
+
+`ConvosCore` targets iOS v26 / macOS v26 and pulls libxmtp, GRDB,
+Firebase, and Sentry — a very different dependency surface than the
+zero-dep XMTPDTU SDK. Linking them in v0.1 would either bump `DTUPilot`'s
+platform floor past what `Process`-based tests need, or drag libxmtp into
+a test graph that's explicitly trying to demonstrate no-XMTP viability.
+The Stage 3 refactor introduces a `MessagingClient` injection seam in
+`ConvosCore`; once that lands, a follow-up pilot can assert the same
+scenario against a ConvosCore-hosted client backed by DTUClient instead
+of the real backend.
+
+## Running locally
+
+```sh
+# 1. Build the Rust server (one-time / after xmtp-dtu bumps).
+cd /Users/jarod/Code/xmtplabs/xmtp-dtu/server
+cargo build --release -p dtu-server
+
+# 2. Run the pilot.
+cd /Users/jarod/Code/xmtplabs/convos-ios-task-A/DTUPilot
+swift test
+```
+
+Expected output: one test (`testConversationListAndNewestMessagePreview`)
+passes. Runtime is a few seconds after SwiftPM finishes any
+incremental-build work.
+
+### Overriding the binary path
+
+```sh
+DTU_SERVER_BIN=/absolute/path/to/dtu-server swift test
+```
+
+The test's discovery chain is: `DTU_SERVER_BIN` env var first, then a
+workspace-relative `../../xmtp-dtu/server/target/release/dtu-server`
+resolved against the test source file (not CWD), so the test behaves the
+same when invoked from the package root or the enclosing workspace.
+
+## Running in CI
+
+The pilot is not yet wired into `ci/run-tests.sh` — that's the next PR.
+When CI is added, the recipe is:
+
+```yaml
+- name: Build dtu-server
+  working-directory: ${{ github.workspace }}/xmtp-dtu/server
+  run: cargo build --release -p dtu-server
+
+- name: Run DTU pilot
+  working-directory: ${{ github.workspace }}/convos-ios-task-A/DTUPilot
+  env:
+    DTU_SERVER_BIN: ${{ github.workspace }}/xmtp-dtu/server/target/release/dtu-server
+  run: swift test
+```
+
+CI should run this on macOS (GitHub-hosted `macos-latest` works). The
+pilot is macOS-only by design; see "Platform scope" below.
+
+## Platform scope — why macOS-only?
+
+`DTUClient.spawn(...)` uses `Process`, which isn't available on iOS. The
+pilot proves the SDK is usable from Convos's Swift ecosystem as a host-
+side driver for test scenarios; it's not yet exercised from the iOS
+simulator. iOS consumers would use `DTUClient.connect(url:)` against a
+server running on the host machine or a shared CI instance — that's the
+Stage 3 iOS refactor's job, not this pilot's.
+
+## Where to go next (Stage 3)
+
+1. **ConvosCore injection seam.** Introduce a `MessagingClient` protocol
+   in ConvosCore that today's XMTPiOS-backed implementation conforms to.
+   Add a `DTUClient`-backed conformance in a test module so existing
+   ConvosCore-level tests can run against `dtu-server` instead of the
+   real libxmtp.
+2. **iOS simulator pilot.** Run `dtu-server` on the host and point an
+   iOS-simulator XCTest at it via `DTUClient.connect(url:)`.
+3. **Wire contract parity tests.** Port the remaining XMTPDTU wire
+   scenarios (streams, consent, permissions, admins) into Convos-flavored
+   tests that assert end-to-end UI bindings.
+
+## Files
+
+- `Package.swift` — SwiftPM manifest, macOS v12, `XMTPDTU` via local path.
+- `Tests/DTUPilotTests/ConversationListPreviewPilotTests.swift` —
+  the single pilot test (one `XCTestCase`, one test method).

--- a/DTUPilot/Tests/DTUPilotTests/ConversationListPreviewPilotTests.swift
+++ b/DTUPilot/Tests/DTUPilotTests/ConversationListPreviewPilotTests.swift
@@ -1,0 +1,283 @@
+import XCTest
+import XMTPDTU
+
+/// The first end-to-end Convos iOS pilot test that uses the XMTPDTU Swift
+/// SDK to drive a local `dtu-server` subprocess — zero XMTP backend, zero
+/// Docker. The scenario mirrors the most common UI surface on the Convos
+/// home screen: bob joins two groups (one he created, one alice created)
+/// and expects his conversation list to surface both, with the newest
+/// user-authored message for each as the preview text.
+///
+/// Why this scenario:
+///  - Exercises cross-actor sync (bob must pick up alice's welcome + posts).
+///  - Exercises `list_conversations` + `newest_message_metadata` together,
+///    which is exactly what a home-screen cell binding does.
+///  - Keeps membership churn minimal so any failure here is a real wire/
+///    SDK regression, not a test-scenario defect.
+///
+/// This test runs on macOS only — `DTUClient.spawn(...)` needs `Process`,
+/// which iOS lacks. That's fine for v0.1: the goal is proving the SDK's
+/// usability from Convos's Swift ecosystem before Stage 3 adds the
+/// `MessagingClient` injection seam that lets the iOS app consume XMTPDTU
+/// against a remote server.
+final class ConversationListPreviewPilotTests: XCTestCase {
+    private var client: DTUClient?
+    private var universe: DTUUniverse?
+
+    override func tearDown() async throws {
+        // Order matters: destroy the universe first so the server doesn't
+        // log a dangling-tenant warning on shutdown, then terminate the
+        // subprocess. Both calls are idempotent.
+        if let universe {
+            await universe.destroy()
+        }
+        if let client {
+            await client.terminate()
+        }
+        universe = nil
+        client = nil
+        try await super.tearDown()
+    }
+
+    func testConversationListAndNewestMessagePreview() async throws {
+        #if !os(macOS)
+        throw XCTSkip("DTUClient.spawn requires macOS; the pilot is a host-only test.")
+        #else
+        // MARK: Binary discovery
+        //
+        // 1. DTU_SERVER_BIN env var (CI override).
+        // 2. Explicit workspace-relative fallback so `swift test` Just Works
+        //    when the server is prebuilt at the conventional location. We
+        //    resolve it against THIS source file's path rather than CWD —
+        //    when `swift test` runs the working directory is the package
+        //    root (DTUPilot), not the caller's shell pwd, and relative
+        //    paths get confusing for folks reading the test code.
+        let binary = try resolveBinary()
+
+        // MARK: Spawn + health check
+        let client: DTUClient
+        do {
+            client = try await DTUClient.spawn(binaryPath: binary)
+        } catch {
+            throw XCTSkip(
+                """
+                Could not spawn dtu-server at \(binary.path).
+                Rebuild: `cd \(Self.xmtpDtuServerDir.path) && cargo build --release -p dtu-server`.
+                Underlying: \(error)
+                """
+            )
+        }
+        self.client = client
+
+        let health = try await client.health()
+        XCTAssertEqual(health.status, "ok", "dtu-server health check should return ok")
+        XCTAssertEqual(health.service, "dtu-server")
+
+        // MARK: Universe bootstrap
+        //
+        // Deterministic `seedTimeNs` so downstream timestamp assertions (if
+        // a future PR adds them) are stable. `id` is also fixed, purely for
+        // log-grep friendliness across CI runs.
+        let universe = try await client.createUniverse(
+            id: "u_pilot_list_preview",
+            seedTimeNs: 1_700_000_000_000_000_000
+        )
+        self.universe = universe
+
+        // Actors: alice and bob each get a user, an inbox, and one
+        // installation. The alias scheme (<user>-main for inboxes,
+        // <user>-phone for installations) matches the convention used by
+        // the DTU integration tests upstream.
+        try await universe.createUser(id: "alice")
+        try await universe.createInbox(inboxId: "alice-main", userId: "alice")
+        try await universe.createInstallation(installationId: "alice-phone", inboxId: "alice-main")
+
+        try await universe.createUser(id: "bob")
+        try await universe.createInbox(inboxId: "bob-main", userId: "bob")
+        try await universe.createInstallation(installationId: "bob-phone", inboxId: "bob-main")
+
+        // MARK: Scenario — g1 (alice's group) with two sends
+        let g1 = try await universe.createGroup(
+            alias: "g1",
+            members: ["alice-main", "bob-main"],
+            actor: "alice-phone"
+        )
+        XCTAssertEqual(g1.conversation, "g1")
+        XCTAssertEqual(g1.memberCount, 2, "g1 should count alice + bob")
+
+        _ = try await universe.send(
+            conversation: "g1",
+            text: "first g1 msg",
+            actor: "alice-phone"
+        )
+        _ = try await universe.send(
+            conversation: "g1",
+            text: "second g1 msg",
+            actor: "alice-phone"
+        )
+
+        // MARK: Scenario — g2 (bob's group) with one send
+        let g2 = try await universe.createGroup(
+            alias: "g2",
+            members: ["alice-main", "bob-main"],
+            actor: "bob-phone"
+        )
+        XCTAssertEqual(g2.conversation, "g2")
+        XCTAssertEqual(g2.memberCount, 2, "g2 should count alice + bob")
+
+        _ = try await universe.send(
+            conversation: "g2",
+            text: "hello from bob in g2",
+            actor: "bob-phone"
+        )
+
+        // MARK: Bob syncs to pull alice's g1 welcome + messages
+        //
+        // This is the critical step for the conversation-list scenario —
+        // without the sync, bob's installation wouldn't know about g1 even
+        // though he's a member. The returned count should include both
+        // groups (the one he created + the one he joined via sync).
+        let syncResult = try await universe.sync(actor: "bob-phone")
+        XCTAssertGreaterThanOrEqual(
+            syncResult.syncedConversations, 2,
+            "bob should observe at least g1 + g2 after sync"
+        )
+
+        // MARK: Assert: conversation list
+        //
+        // Both groups should be present and active for bob. We compare as a
+        // set because the wire contract doesn't nail down list ordering
+        // (libxmtp's own `list_conversations` sorts by last-message time,
+        // which is fine but not what we're asserting here — that's a job
+        // for the newest-message projection below).
+        let conversations = try await universe.listConversations(actor: "bob-phone")
+        let aliases = Set(conversations.map(\.alias))
+        XCTAssertEqual(aliases, Set(["g1", "g2"]), "bob should see both groups")
+        for entry in conversations {
+            XCTAssertTrue(entry.isActive, "bob should be active in \(entry.alias)")
+        }
+
+        // MARK: Assert: newest-message previews
+        //
+        // This is the payoff — the home-screen cell binding. For g1 the
+        // second send must win (sequence ordering); for g2 the single send
+        // is trivially the newest. Both entries must be application
+        // messages (system/membership_change messages are filtered server-
+        // side per the wire contract, matching libxmtp's
+        // `ConversationListItem::last_message`).
+        let newest = try await universe.newestMessageMetadata(
+            conversations: ["g1", "g2"],
+            actor: "bob-phone"
+        )
+        XCTAssertEqual(newest.count, 2, "expected both groups in newest-message map")
+
+        guard case .message(let g1Newest) = newest["g1"] else {
+            XCTFail("g1 should have a newest message; got \(String(describing: newest["g1"]))")
+            return
+        }
+        XCTAssertEqual(g1Newest.kind, .application, "g1 newest should be application, not system")
+        assertText(g1Newest.content, equals: "second g1 msg", in: "g1")
+
+        guard case .message(let g2Newest) = newest["g2"] else {
+            XCTFail("g2 should have a newest message; got \(String(describing: newest["g2"]))")
+            return
+        }
+        XCTAssertEqual(g2Newest.kind, .application, "g2 newest should be application, not system")
+        assertText(g2Newest.content, equals: "hello from bob in g2", in: "g2")
+
+        // Redundant-but-intentional: explicit cleanup here so an assertion
+        // failure above still leaves tearDown to pick up the slack, while
+        // happy-path runs get deterministic teardown timing.
+        await universe.destroy()
+        self.universe = nil
+        await client.terminate()
+        self.client = nil
+        #endif
+    }
+
+    // MARK: - Helpers
+
+    /// Resolve the `dtu-server` binary with a CI-friendly discovery chain:
+    /// `DTU_SERVER_BIN` override first, workspace-relative release build
+    /// second. On miss, emit an `XCTSkip` with a runnable `cargo build`
+    /// command so local users can recover without hunting through docs.
+    private func resolveBinary() throws -> URL {
+        let fm = FileManager.default
+        if let envPath = ProcessInfo.processInfo.environment["DTU_SERVER_BIN"], !envPath.isEmpty {
+            let url = URL(fileURLWithPath: envPath)
+            guard fm.isExecutableFile(atPath: url.path) else {
+                throw XCTSkip(
+                    "DTU_SERVER_BIN=\(envPath) is not executable. "
+                    + "Build with `cargo build --release -p dtu-server` under "
+                    + Self.xmtpDtuServerDir.path
+                )
+            }
+            return url
+        }
+        let fallback = Self.defaultBinaryURL
+        guard fm.isExecutableFile(atPath: fallback.path) else {
+            throw XCTSkip(
+                """
+                dtu-server binary not found at \(fallback.path).
+                Build it with:
+                    cd \(Self.xmtpDtuServerDir.path) && cargo build --release -p dtu-server
+                Or set DTU_SERVER_BIN to an absolute path.
+                """
+            )
+        }
+        return fallback
+    }
+
+    /// Workspace-relative path anchored against THIS source file rather than
+    /// CWD — that way `swift test` behaves the same whether invoked from
+    /// the package root or the enclosing workspace.
+    private static var xmtpDtuServerDir: URL {
+        // This file: .../xmtplabs/convos-ios-task-A/DTUPilot/Tests/DTUPilotTests/ConversationListPreviewPilotTests.swift
+        // Server:    .../xmtplabs/xmtp-dtu/server/
+        let thisFile = URL(fileURLWithPath: #filePath)
+        // Walk up five levels from the file to the shared workspace parent
+        // (xmtplabs/), then descend into the xmtp-dtu sibling.
+        let workspaceParent = thisFile
+            .deletingLastPathComponent() // DTUPilotTests/
+            .deletingLastPathComponent() // Tests/
+            .deletingLastPathComponent() // DTUPilot/
+            .deletingLastPathComponent() // convos-ios-task-A/
+            .deletingLastPathComponent() // xmtplabs/
+        return workspaceParent
+            .appendingPathComponent("xmtp-dtu")
+            .appendingPathComponent("server")
+    }
+
+    private static var defaultBinaryURL: URL {
+        xmtpDtuServerDir
+            .appendingPathComponent("target")
+            .appendingPathComponent("release")
+            .appendingPathComponent("dtu-server")
+    }
+
+    /// XCTAssert-style helper that unwraps a `NormalizedMessage.Content`'s
+    /// text case and compares it. Keeps the call site in the test body
+    /// reading like prose, and gives a more useful failure message than a
+    /// bare `if case` / `XCTFail` pair.
+    private func assertText(
+        _ content: NormalizedMessage.Content,
+        equals expected: String,
+        in alias: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        switch content {
+        case .text(let text):
+            XCTAssertEqual(
+                text, expected,
+                "newest preview text mismatch for \(alias)",
+                file: file, line: line
+            )
+        case .binary:
+            XCTFail(
+                "expected text content on newest message in \(alias); got binary",
+                file: file, line: line
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Proof-of-life for the xmtp-dtu Digital Twin Universe SDK. New SwiftPM test package at \`DTUPilot/\` that spawns \`dtu-server\` as a subprocess and drives a full two-actor messaging scenario through \`XMTPDTU\` in **36 ms**, with **zero Docker** and **zero XMTP backend**.

**Status: draft** — independent of the abstraction-seam PR (#737). Both off \`dev\`.

## Pilot scenario

Alice and Bob each create a group, alice sends 2 messages in g1, bob creates g2, bob sends 1 message in g2, bob syncs, bob calls \`listConversations\` + \`newestMessageMetadata\`. Assertions:

- Bob's conversation list has both \`g1\` and \`g2\`.
- \`g1\`'s newest message preview is alice's latest text.
- \`g2\`'s newest message preview is bob's own text.

Fails the test loudly on structural drift (no \`XCTSkip\` for parity mismatches — DTO contract drift is surfaced, not swallowed).

## Why isolated from ConvosCore

ConvosCore's \`Package.swift\` targets iOS v26 / macOS v26; DTUPilot needs macOS v12 for \`Process\` subprocess spawning. Depending on ConvosCore would also drag libxmtp, GRDB, Firebase, Sentry, and the sibling ConvosLogging/Invites/AppData/Profiles local packages into the test graph, defeating the "zero external services" thesis.

When Stage 4+ iOS migrations land (see #737 for Stage 1-3 partial), a \`MessagingClient\` adapter wrapping \`XMTPDTU.DTUClient\` will let real ConvosCore integration tests use this same SDK.

## xmtp-dtu SDK location

Currently local-path referenced at \`/Users/jarod/Code/xmtplabs/xmtp-dtu/clients/swift\`. For CI we'll need one of:
- git submodule
- SwiftPM git dep on a tagged xmtp-dtu release
- The binary (\`dtu-server\`) built + \`DTU_SERVER_BIN\` env var

That wiring is a separate PR. This one just proves the shape works locally.

## Verification

\`\`\`
✓ cd DTUPilot && swift build                              # 0.46s cold, 0.09s warm
✓ cd DTUPilot && swift test                               # 1 test, 0 failures, 36ms runtime
✓ cd .. && bash ci/run-tests.sh --unit                    # 59 tests, 8 suites, baseline preserved
✓ xcodebuild -scheme ConvosCore build …                  # BUILD SUCCEEDED (unaffected)
✓ grep 'import XMTPiOS' Convos/ NotificationService/ …   # 0 matches (Stage 2 baseline preserved)
\`\`\`

## What's in the package

- \`DTUPilot/Package.swift\` — 55 lines. \`.macOS(.v12)\`, \`XMTPDTU\` via local-path sibling.
- \`DTUPilot/Tests/DTUPilotTests/ConversationListPreviewPilotTests.swift\` — 284 lines.
- \`DTUPilot/README.md\` — 106 lines, run story + CI recipe + Stage 3 pointer.

## Companion PR

#737 introduces the \`Messaging*\` abstraction that Stage 4+ will build on top of. DTUPilot lives alongside it in \`dev\` without depending on the migration — reviewable independently.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add DTUPilot end-to-end iOS conversation tests using the xmtp-dtu SDK
> - Adds a new macOS-only SwiftPM package `DTUPilot` with a single test target that depends on the local `XMTPDTU` package at `../../xmtp-dtu/clients/swift`.
> - Introduces [`ConversationListPreviewPilotTests`](https://github.com/xmtplabs/convos-ios/pull/738/files#diff-594b932b902869f73ddbcab1edb289c8a3605adf3044f0736c1405fcab42ba95), an end-to-end XCTest that spawns a local `dtu-server` binary, creates a deterministic universe with two users (alice and bob), sends messages across two groups, and asserts conversation listing and newest-message preview correctness.
> - The test resolves the server binary via an environment variable override or a workspace-relative fallback path, and skips cleanly with an explanatory message if the binary is missing or the platform is not macOS.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7a973ad.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->