### PR TITLE
Quickname: gate onboarding on stable conversation id

### DIFF
--- a/Convos/Conversation Detail/ConversationOnboardingCoordinator.swift
+++ b/Convos/Conversation Detail/ConversationOnboardingCoordinator.swift
@@ -357,16 +357,6 @@ final class ConversationOnboardingCoordinator {
 
     /// Start or continue the quickname onboarding flow
     private func startQuicknameFlow(for clientId: String) async {
-        // Once the user finishes onboarding, the quickname prompts stop running
-        // in subsequent conversations. Notification nudges still run via the
-        // shared path below, but no setupQuickname or addQuickname state is
-        // surfaced per new conversation.
-        guard !hasCompletedOnboarding else {
-            QAEvent.emit(.onboarding, "quickname_skipped", ["reason": "already_completed"])
-            await transitionAfterQuickname()
-            return
-        }
-
         let hasSetQuicknameForConversation = hasSetQuickname(for: clientId)
         setHasSetQuickname(true, for: clientId)
 

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -139,6 +139,7 @@ class ConversationViewModel { // swiftlint:disable:this type_body_length
                 // Keep the draft include-info override until remote metadata changes propagate.
                 // Clearing it here can briefly show stale false values during async sync.
                 applyPendingDraftEdits()
+                startOnboarding()
             }
 
             if oldValue.isPendingInvite, !conversation.isPendingInvite {
@@ -761,10 +762,12 @@ class ConversationViewModel { // swiftlint:disable:this type_body_length
     // MARK: - Public
 
     func startOnboarding() {
+        // Draft ids are ephemeral placeholders (e.g. "draft-<UUID>"). Running the
+        // coordinator against them would write hasSetQuicknameForConversation_<uuid>
+        // flags that are never read again — the real id arrives later via the
+        // conversation publisher and triggers startOnboarding from didSet.
+        guard !conversation.isDraft else { return }
         Task { @MainActor in
-            // Scoping the coordinator by conversation.id (not the singleton clientId)
-            // preserves per-conversation quickname-prompt tracking now that clientId
-            // is identical across every conversation.
             await onboardingCoordinator.start(
                 for: conversation.id,
                 isConversationCreator: conversation.creator.isCurrentUser

--- a/ConvosTests/ConversationOnboardingCoordinatorTests.swift
+++ b/ConvosTests/ConversationOnboardingCoordinatorTests.swift
@@ -240,33 +240,46 @@ final class ConversationOnboardingCoordinatorTests: XCTestCase {
 
     // MARK: - Completed Onboarding Tests
 
-    func testStart_HasCompletedOnboarding_SkipsQuicknameForNewConversation() async {
+    func testStart_HasCompletedOnboarding_NewConversation_SurfacesQuicknameState() async {
         mockNotificationCenter.authStatus = .authorized
         UserDefaults.standard.set(true, forKey: "hasCompletedConversationOnboarding")
         UserDefaults.standard.set(true, forKey: "hasShownQuicknameEditor")
 
-        let newConversationId = "side-convo-opened-for-first-time"
+        let newConversationId = "new-convo-after-onboarding"
         await coordinator.start(for: newConversationId)
 
-        XCTAssertEqual(coordinator.state, .idle)
-        // The guard returns before `setHasSetQuickname(true, for:)` would
-        // normally run, so a regression that drops the guard flips this flag.
-        XCTAssertFalse(
-            UserDefaults.standard.bool(forKey: "hasSetQuicknameForConversation_\(newConversationId)")
+        switch coordinator.state {
+        case .setupQuickname, .addQuickname:
+            XCTAssertTrue(true, "New convo after onboarding should surface a quickname state")
+        default:
+            XCTFail("Expected a quickname state, got \(coordinator.state)")
+        }
+
+        XCTAssertTrue(
+            UserDefaults.standard.bool(forKey: "hasSetQuicknameForConversation_\(newConversationId)"),
+            "Entry into startQuicknameFlow should mark the per-conversation flag"
         )
         UserDefaults.standard.removeObject(forKey: "hasSetQuicknameForConversation_\(newConversationId)")
     }
 
-    func testStart_HasCompletedOnboarding_NotificationsDenied_StillNudges() async {
-        mockNotificationCenter.authStatus = .denied
+    func testStart_HasCompletedOnboarding_ReopensSameConversation_Skips() async {
+        mockNotificationCenter.authStatus = .authorized
         UserDefaults.standard.set(true, forKey: "hasCompletedConversationOnboarding")
         UserDefaults.standard.set(true, forKey: "hasShownQuicknameEditor")
 
-        let newConversationId = "side-convo-opened-for-first-time"
-        await coordinator.start(for: newConversationId)
+        let conversationId = "convo-seen-before"
+        UserDefaults.standard.set(true, forKey: "hasSetQuicknameForConversation_\(conversationId)")
 
-        XCTAssertEqual(coordinator.state, .notificationsDenied)
-        UserDefaults.standard.removeObject(forKey: "hasSetQuicknameForConversation_\(newConversationId)")
+        await coordinator.start(for: conversationId)
+
+        switch coordinator.state {
+        case .setupQuickname, .addQuickname:
+            XCTFail("Re-opening a convo with the per-conversation flag set must not re-prompt")
+        default:
+            break
+        }
+
+        UserDefaults.standard.removeObject(forKey: "hasSetQuicknameForConversation_\(conversationId)")
     }
 
     // MARK: - App Lifecycle Tests

--- a/ConvosTests/ConversationViewModelGlobalDefaultsTests.swift
+++ b/ConvosTests/ConversationViewModelGlobalDefaultsTests.swift
@@ -228,8 +228,28 @@ private final class TestSessionManager: SessionManagerProtocol, @unchecked Senda
         try await base.requestAgentJoin(slug: slug, instructions: instructions, forceErrorCode: forceErrorCode)
     }
 
-    func redeemInviteCode(_ code: String) async throws {
+    func redeemInviteCode(_ code: String) async throws -> ConvosAPI.InviteCodeStatus {
         try await base.redeemInviteCode(code)
+    }
+
+    func fetchInviteCodeStatus(_ code: String) async throws -> ConvosAPI.InviteCodeStatus {
+        try await base.fetchInviteCodeStatus(code)
+    }
+
+    func voiceMemoTranscriptRepository() -> any VoiceMemoTranscriptRepositoryProtocol {
+        base.voiceMemoTranscriptRepository()
+    }
+
+    func voiceMemoTranscriptWriter() -> any VoiceMemoTranscriptWriterProtocol {
+        base.voiceMemoTranscriptWriter()
+    }
+
+    func voiceMemoTranscriptionService() -> any VoiceMemoTranscriptionServicing {
+        base.voiceMemoTranscriptionService()
+    }
+
+    func assistantFilesLinksRepository(for conversationId: String) -> AssistantFilesLinksRepository {
+        base.assistantFilesLinksRepository(for: conversationId)
     }
 
     func pendingInviteDetails() throws -> [PendingInviteDetail] {

--- a/ConvosTests/InviteURLDetectorTests.swift
+++ b/ConvosTests/InviteURLDetectorTests.swift
@@ -1,3 +1,4 @@
+import ConvosCore
 import XCTest
 @testable import Convos
 


### PR DESCRIPTION
## Summary

PR #729's blanket `!hasCompletedOnboarding` guard in `ConversationOnboardingCoordinator.startQuicknameFlow` over-suppressed the "Tap to chat as [Name]" pill for every conversation after onboarding completion — including user-created new convos and invite-accept flows where the prompt is still useful.

## Root cause of the original bug #729 was targeting

Tapping the inline invite card from a parent conversation's message list (`ConversationViewModel.onTapInvite`) instantiates a `NewConversationViewModel(.joinInvite)`, which in turn creates a placeholder `ConversationViewModel` with `conversation.id = "draft-<UUID>"` via `createPlaceholderConversationViewModel()`. The per-conversation `hasSetQuicknameForConversation_<id>` flag was therefore written against an ephemeral UUID that changes every tap, so re-taps of the same side convo always read `false` and re-prompted.

## Fix

- Remove the blanket `hasCompletedOnboarding` guard — the per-conversation flag is the sole gate again, as originally intended.
- Gate `ConversationViewModel.startOnboarding()` with `guard !conversation.isDraft` so the coordinator never receives draft-UUID ids.
- Call `startOnboarding()` from `conversation.didSet` on the draft→non-draft transition so the real conversation id drives onboarding once the publisher resolves the joined/created group.

After the fix, every entry point (home-screen tap, user-created new convo, invite-accept, inline-invite side convo) prompts once per conversation via the per-conversation flag, and re-opens skip.

## Tests

- Replaced the two PR #729 tests that locked in the over-broad skip:
  - `testStart_HasCompletedOnboarding_NewConversation_SurfacesQuicknameState` — asserts new convos post-onboarding land in `.setupQuickname` or `.addQuickname`.
  - `testStart_HasCompletedOnboarding_ReopensSameConversation_Skips` — asserts re-opens with the per-conversation flag set skip the prompt.
- All 10 coordinator tests pass locally.
- QA run on `convos-dev` simulator emitted `onboarding.add_quickname` for three separate join flows (confirming the pill renders correctly), paired with `onboarding.quickname_skipped reason=already_set` on re-entry (confirming the per-conversation flag path).

## Infra (bundled)

`ConvosTests` test target couldn't build locally on `dev` — included two pre-existing fixes so future local runs work:
- `TestSessionManager` was missing six `SessionManagerProtocol` methods.
- `InviteURLDetectorTests` was missing `import ConvosCore`.

## Test plan

- [ ] Complete onboarding in first convo.
- [ ] Open a new regular convo → "Tap to chat as [Name]" pill appears.
- [ ] Open an invite via deep link → pill appears.
- [ ] Tap an inline invite card inside a parent convo → pill appears.
- [ ] Tap the pill → applies the quickname to the message.
- [ ] Re-tap the same inline invite card → no pill re-appears.
- [ ] Re-enter any previously-joined convo → no pill re-appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Gate quickname onboarding on stable (non-draft) conversation ID
> - `startOnboarding()` in [ConversationViewModel.swift](https://github.com/xmtplabs/convos-ios/pull/739/files#diff-d056b0b131534648b6d13cddafd053be956f5d23d035ad2538db85a8cc370d8d) now returns early when the conversation is a draft, deferring onboarding until a stable ID is available.
> - A `didSet` observer triggers `startOnboarding()` when a conversation transitions from draft to non-draft, so onboarding runs immediately after the stable ID is assigned.
> - `startQuicknameFlow` in [ConversationOnboardingCoordinator.swift](https://github.com/xmtplabs/convos-ios/pull/739/files#diff-cfdcd58edc9cdb689c4014d4562251b351c87c7f4a586d344060839e97af7f6f) removes the early-exit for previously completed global onboarding, so the per-conversation quickname flag is checked and set for each new conversation.
> - Behavioral Change: quickname prompts can now surface for new conversations even after global onboarding is complete, as long as the per-conversation flag has not been set.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8784d09.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->