### PR TITLE
Setup: auto-generate .env with Firebase App Check token

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,105 +1,17 @@
 # Convos Local Development Environment Configuration
-# Copy this file to .env and customize for your local setup
-#
-# All values are optional - if not set, the app will auto-detect your local IP
-# and configure the development environment automatically.
+# Copy this file to .env and fill in your Firebase App Check debug token.
+# `Scripts/setup.sh` does this for you automatically.
 
-# ============================================================================
-# Backend API URL
-# ============================================================================
-# Controls which backend server the app connects to
-#
-# Options:
-#   - Leave commented/empty: Auto-detect local IP → http://{YOUR_IP}:4000/api
-#   - USE_CONFIG: Use config.local.json default → https://api.dev.convos.xyz/api/
-#   - Custom URL: Specify any backend URL
-#
-# Examples:
-#CONVOS_API_BASE_URL=                                # Auto-detect (default)
-#CONVOS_API_BASE_URL=USE_CONFIG                      # Use remote server (dev or prod depending on build scheme)
-#CONVOS_API_BASE_URL=http://localhost:4000/api       # Local backend on localhost
-#CONVOS_API_BASE_URL=http://192.168.1.100:4000/api   # Specific IP address
-#CONVOS_API_BASE_URL=https://api.dev.convos.xyz/api/ # Dev API
-
-# ============================================================================
-# XMTP Custom Host
-# ============================================================================
-# Controls which XMTP node the app connects to
-#
-# Options:
-#   - Leave commented/empty: Auto-detect local IP → {YOUR_IP}
-#   - USE_CONFIG: Use default XMTP network (no custom host)
-#   - Custom IP/hostname: Specify XMTP node address
-#
-# Examples:
-#XMTP_CUSTOM_HOST=                   # Auto-detect (default)
-#XMTP_CUSTOM_HOST=USE_CONFIG         # Use default XMTP network
-#XMTP_CUSTOM_HOST=localhost          # Local XMTP node
-#XMTP_CUSTOM_HOST=192.168.1.100      # Specific IP address
-
-# ============================================================================
-# Gateway URL (for d14n - decentralized network)
-# ============================================================================
-# Optional gateway URL for decentralized network mode
-#
-# Options:
-#   - Leave commented/empty: Direct XMTP connection (default)
-#   - USE_CONFIG: Direct connection (same as empty)
-#   - Custom URL: Use specified gateway
-#
-# Examples:
-#GATEWAY_URL=                        # Direct connection (default)
-#GATEWAY_URL=USE_CONFIG              # Direct connection (explicit)
-#GATEWAY_URL=http://localhost:5050   # Local gateway
-#GATEWAY_URL=http://192.168.1.100:5050 # Specific gateway address
-
-# ============================================================================
-# Sentry (Error Tracking)
-# ============================================================================
-# Optional Sentry DSN for error tracking and crash reporting
-#
-# Options:
-#   - Leave commented/empty: Sentry disabled (default for local development)
-#   - Custom DSN: Use specified Sentry project
-#
-# Examples:
-#SENTRY_DSN=                         # Sentry disabled (default)
-#SENTRY_DSN=https://abc123@o123.ingest.sentry.io/456 # Custom Sentry project
-#
-# Notes:
-#   - Only used for Convos (Dev) distribution builds
-#   - In CI, use SENTRY_DSN_DEV for dev builds and SENTRY_DSN_PROD for prod builds
-#   - Production builds explicitly set empty DSN to ensure Sentry is never shipped with prod
-
-# ============================================================================
 # Firebase App Check Debug Token
-# ============================================================================
-# A stable debug token for Firebase App Check, eliminating the need to register
-# a new token in Firebase Console every time the simulator changes.
 #
-# How to set up:
-#   1. Generate a UUID: uuidgen
-#   2. Go to Firebase Console → App Check → Manage debug tokens
-#   3. Add the generated UUID as a debug token
-#   4. Add to your .env file: FIREBASE_APP_CHECK_DEBUG_TOKEN=<your-uuid>
+# A stable UUID so Firebase App Check accepts requests from your simulator
+# without re-registering after every rebuild.
 #
-# Options:
-#   - Leave commented/empty: App generates a new token each simulator launch
-#   - Set UUID: Uses stable token (recommended for local development)
-#
-# Example:
-#FIREBASE_APP_CHECK_DEBUG_TOKEN=                                    # Dynamic (default)
-#FIREBASE_APP_CHECK_DEBUG_TOKEN=A1B2C3D4-E5F6-7890-ABCD-EF1234567890 # Stable token
-#
-# Notes:
-#   - Only used for non-production environments (Local, Dev)
-#   - Production builds explicitly ignore this token
-#   - The token must be registered in Firebase Console to work
-
-# ============================================================================
-# Notes
-# ============================================================================
-# - Auto-detection uses the first routable IPv4 address on your machine
-# - If IP detection fails, falls back to config.local.json defaults
-# - Changes take effect after next build (Xcode runs generate-secrets-local.sh)
-# - This file (.env.example) is tracked in git, but .env is ignored
+# Setup:
+#   1. Generate a UUID (setup.sh does this for you): uuidgen
+#   2. Register it at https://console.firebase.google.com/u/1/project/convos-otr/appcheck/apps
+#      → iOS app for your scheme (Dev: org.convos.ios-preview,
+#        Local: org.convos.ios-local, Prod: org.convos.ios)
+#      → overflow menu (⋮) → Manage debug tokens → Add debug token
+#   3. Only used for Local/Dev — production builds ignore it.
+FIREBASE_APP_CHECK_DEBUG_TOKEN=

--- a/Scripts/setup.sh
+++ b/Scripts/setup.sh
@@ -146,40 +146,78 @@ echo "✅ All dependencies are properly installed"
 ################################################################################
 
 if [ ! "${CI}" = true ] || [ "${CLAUDE_SETUP}" = "1" ]; then
-    ENV_FILE="${DIRNAME}/../.env"
+    REPO_ROOT="$(cd "${DIRNAME}/.." && pwd)"
+    PARENT_DIR="$(dirname "${REPO_ROOT}")"
+    PARENT_ENV="${PARENT_DIR}/.env"
+    LOCAL_ENV="${REPO_ROOT}/.env"
     FIREBASE_CONSOLE_URL="https://console.firebase.google.com/u/1/project/convos-otr/appcheck/apps"
-    if [ ! -f "$ENV_FILE" ]; then
+
+    # Reads FIREBASE_APP_CHECK_DEBUG_TOKEN from a file, or empty string if missing/unset.
+    read_firebase_token() {
+        local file="$1"
+        [ -f "$file" ] || { echo ""; return; }
+        grep "^FIREBASE_APP_CHECK_DEBUG_TOKEN=" "$file" | tail -1 | cut -d'=' -f2-
+    }
+
+    # Matches the /firebase-token slash command's "new token" report.
+    print_firebase_report() {
+        local token="$1"
+        local pinned_path="$2"
+        local symlink_note="$3"
         echo ""
-        echo "⚠️  No .env file found at ${ENV_FILE}"
-        echo "   If this is a worktree, symlink the parent's .env:"
-        echo "     ln -s ../.env .env"
-        echo "   Otherwise, set a FIREBASE_APP_CHECK_DEBUG_TOKEN so Firebase App Check works:"
-        echo "     cp .env.example .env"
-        echo "     echo \"FIREBASE_APP_CHECK_DEBUG_TOKEN=\$(uuidgen)\" >> .env"
-        echo "   Then register the UUID at ${FIREBASE_CONSOLE_URL}"
-        echo "     → pick the iOS app for your scheme (Dev: org.convos.ios-preview,"
-        echo "       Local: org.convos.ios-local, Prod: org.convos.ios)"
-        echo "     → overflow menu (⋮) → Manage debug tokens → Add debug token"
-        echo "   Alternative: launch the app first, then run /firebase-token to grab the"
-        echo "   auto-generated token from simulator logs and register that instead."
-    elif ! grep -q "^FIREBASE_APP_CHECK_DEBUG_TOKEN=" "$ENV_FILE" || \
-         [ -z "$(grep "^FIREBASE_APP_CHECK_DEBUG_TOKEN=" "$ENV_FILE" | cut -d'=' -f2-)" ]; then
+        echo "🔥 Firebase App Check Debug Token"
         echo ""
-        echo "⚠️  FIREBASE_APP_CHECK_DEBUG_TOKEN is not set in .env"
-        echo "   Without it, you need to register a new debug token in Firebase each time"
-        echo "   the simulator changes."
+        echo "Token: ${token}"
         echo ""
-        echo "   Two ways to fix:"
-        echo "   (a) Generate and pin a stable UUID:"
-        echo "       echo \"FIREBASE_APP_CHECK_DEBUG_TOKEN=\$(uuidgen)\" >> .env"
-        echo "   (b) Launch the app, then run /firebase-token to extract the token the app"
-        echo "       generated, and paste that into .env."
+        echo "✓ Pinned in ${pinned_path}"
+        if [ -n "${symlink_note}" ]; then
+            echo "${symlink_note}"
+        fi
         echo ""
-        echo "   Register the token at ${FIREBASE_CONSOLE_URL}"
-        echo "     → iOS app for your scheme (Dev: org.convos.ios-preview,"
-        echo "       Local: org.convos.ios-local, Prod: org.convos.ios)"
-        echo "     → overflow menu (⋮) → Manage debug tokens → Add debug token"
+        echo "Register it in Firebase Console if you haven't already:"
+        echo "${FIREBASE_CONSOLE_URL}"
+        echo ""
+        echo "1. Click the link"
+        echo "2. Pick the iOS app for your scheme:"
+        echo "   - Dev:   org.convos.ios-preview"
+        echo "   - Local: org.convos.ios-local"
+        echo "   - Prod:  org.convos.ios"
+        echo "3. Overflow menu (⋮) → Manage debug tokens → Add debug token"
+        echo "4. Paste the UUID above"
+    }
+
+    LOCAL_TOKEN="$(read_firebase_token "${LOCAL_ENV}")"
+    PARENT_TOKEN="$(read_firebase_token "${PARENT_ENV}")"
+
+    if [ -n "${LOCAL_TOKEN}" ] || [ -n "${PARENT_TOKEN}" ]; then
+        if [ -L "${LOCAL_ENV}" ]; then
+            echo "✅ Firebase App Check debug token is configured (via ${LOCAL_ENV} → $(readlink "${LOCAL_ENV}"))"
+        elif [ -f "${LOCAL_ENV}" ] && [ -n "${LOCAL_TOKEN}" ]; then
+            echo "✅ Firebase App Check debug token is configured in ${LOCAL_ENV}"
+        else
+            echo "✅ Firebase App Check debug token is configured in ${PARENT_ENV}"
+        fi
     else
-        echo "✅ Firebase App Check debug token is configured"
+        # Nothing set anywhere — generate, pin in parent, symlink local.
+        NEW_TOKEN="$(uuidgen)"
+        if [ -f "${PARENT_ENV}" ] && grep -q "^FIREBASE_APP_CHECK_DEBUG_TOKEN=" "${PARENT_ENV}"; then
+            sed -i.bak "s|^FIREBASE_APP_CHECK_DEBUG_TOKEN=.*|FIREBASE_APP_CHECK_DEBUG_TOKEN=${NEW_TOKEN}|" "${PARENT_ENV}"
+            rm -f "${PARENT_ENV}.bak"
+        else
+            echo "FIREBASE_APP_CHECK_DEBUG_TOKEN=${NEW_TOKEN}" >> "${PARENT_ENV}"
+        fi
+
+        SYMLINK_NOTE=""
+        if [ ! -e "${LOCAL_ENV}" ] && [ ! -L "${LOCAL_ENV}" ]; then
+            ln -s ../.env "${LOCAL_ENV}"
+            SYMLINK_NOTE="✓ Linked .env → ../.env at ${LOCAL_ENV}"
+        elif [ -L "${LOCAL_ENV}" ]; then
+            link_target="$(readlink "${LOCAL_ENV}")"
+            SYMLINK_NOTE="✓ .env → ${link_target} symlink already in place at ${LOCAL_ENV}"
+        elif [ -f "${LOCAL_ENV}" ]; then
+            SYMLINK_NOTE=$'⚠️  '"${LOCAL_ENV}"$' is a regular file, not a symlink.\n   To share one token across worktrees:\n     cat .env >> ../.env && rm .env && ln -s ../.env .env'
+        fi
+
+        print_firebase_report "${NEW_TOKEN}" "${PARENT_ENV}" "${SYMLINK_NOTE}"
     fi
 fi


### PR DESCRIPTION
## Summary
- `Scripts/setup.sh`: instead of printing a warning when `.env` is missing, generate a UUID, pin it in the shared parent `.env`, symlink the local `.env`, and print the same `🔥 Firebase App Check Debug Token` registration report that `/firebase-token` uses. Idempotent on re-run — an already-configured token (local, parent, or via symlink) just prints a ✅ line.
- `.env.example`: trimmed from ~105 lines of commented-out defaults down to the Firebase token block. Everything else auto-detects.

## Test plan
- [x] Re-run on the current repo (already has a local `.env` with a token) → prints `✅ Firebase App Check debug token is configured in ...` and changes nothing
- [x] Run in a clean sandbox with no `.env` anywhere → generates a UUID, writes `../.env`, symlinks `convos-ios/.env → ../.env`, and prints the registration report
- [x] Re-run in the same sandbox → shows `✅ ... configured (via ... → ../.env)` and does not regenerate
- [ ] Verify a fresh clone produces a working App Check token after registering the printed UUID

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Auto-generate Firebase App Check debug token during setup
> - [setup.sh](https://github.com/xmtplabs/convos-ios/pull/740/files#diff-490f2d9bc338440322d4b7d5bcb8c209ee7633cdb9f4245ceb2cb78bc6486314) now auto-generates a UUID `FIREBASE_APP_CHECK_DEBUG_TOKEN` when none is found, writing it into the parent `../.env` and symlinking `./.env` to `../.env` for worktree setups.
> - Adds `read_firebase_token` and `print_firebase_report` helpers to detect existing tokens across local and parent `.env` files and print registration instructions with app bundle IDs.
> - [.env.example](https://github.com/xmtplabs/convos-ios/pull/740/files#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8c) is rewritten to document only the Firebase App Check token setup flow.
> - Behavioral Change: setup no longer just warns about a missing token — it now provisions one automatically and manages the `.env` symlink.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1df8add.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->