### PR TITLE
Explode: drop leaveGroup, rely on removeMembers + denyConsent

### DIFF
--- a/ConvosCore/Sources/ConvosCore/Mocks/MockExplodeGroupOperations.swift
+++ b/ConvosCore/Sources/ConvosCore/Mocks/MockExplodeGroupOperations.swift
@@ -4,12 +4,12 @@ import os
 /// In-memory stub for `ExplodeGroupOperationsProtocol`. Records the
 /// sequence of MLS-level calls the explosion writer makes and lets the
 /// test inject failures on individual steps — enough to assert the
-/// remove-all-then-leave flow without standing up a real XMTP group.
+/// sendExplode → removeMembers → denyConsent flow without standing up a
+/// real XMTP group.
 final class MockExplodeGroupOperations: ExplodeGroupOperationsProtocol, @unchecked Sendable {
     enum Call: Equatable, Sendable {
         case currentInboxId
         case sendExplode(conversationId: String, expiresAt: Date)
-        case leaveGroup(conversationId: String)
         case denyConsent(conversationId: String)
     }
 
@@ -19,7 +19,6 @@ final class MockExplodeGroupOperations: ExplodeGroupOperationsProtocol, @uncheck
         var calls: [Call] = []
         var inboxId: String = "inbox-self"
         var sendExplodeError: (any Error)?
-        var leaveGroupError: (any Error)?
         var denyConsentError: (any Error)?
     }
 
@@ -31,10 +30,6 @@ final class MockExplodeGroupOperations: ExplodeGroupOperationsProtocol, @uncheck
 
     func failSendExplode(with error: any Error) {
         lock.withLock { $0.sendExplodeError = error }
-    }
-
-    func failLeaveGroup(with error: any Error) {
-        lock.withLock { $0.leaveGroupError = error }
     }
 
     func failDenyConsent(with error: any Error) {
@@ -52,14 +47,6 @@ final class MockExplodeGroupOperations: ExplodeGroupOperationsProtocol, @uncheck
         let error: (any Error)? = lock.withLock { state in
             state.calls.append(.sendExplode(conversationId: conversationId, expiresAt: expiresAt))
             return state.sendExplodeError
-        }
-        if let error { throw error }
-    }
-
-    func leaveGroup(conversationId: String) async throws {
-        let error: (any Error)? = lock.withLock { state in
-            state.calls.append(.leaveGroup(conversationId: conversationId))
-            return state.leaveGroupError
         }
         if let error { throw error }
     }

--- a/ConvosCore/Sources/ConvosCore/Storage/Workers/ExpiredConversationsWorker.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Workers/ExpiredConversationsWorker.swift
@@ -194,16 +194,14 @@ final class ExpiredConversationsWorker: ExpiredConversationsWorkerProtocol, @unc
         Log.info("Cleaning up expired conversation: \(conversation.conversationId), posting leftConversationNotification")
 
         // Scheduled-explode parity: when the timer fires on the creator's
-        // device, the MLS teardown (removeMembers + leaveGroup) has to
-        // actually run. Pre-fix, the worker only posted
-        // `.leftConversationNotification` — the creator stayed in the
-        // group on the network indefinitely until they manually exploded
-        // again from the UI. A scheduled explode was strictly weaker than
-        // an immediate one.
+        // device, the MLS teardown (`removeMembers` + `denyConsent`) has
+        // to actually run, otherwise the creator stays in the group on
+        // the network indefinitely until they manually explode again
+        // from the UI.
         //
         // We fetch the member list + creator inboxId, check whether the
         // current inbox is the creator, and if so invoke the writer. The
-        // writer's own `runBoundedMLSOp` helper absorbs any MLS flakes
+        // writer's own `runBoundedOp` helper absorbs any MLS flakes
         // without rethrowing, so this is fire-and-observe — failures log
         // and the notification still posts below.
         if let context = conversation.ownershipContext {

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationExplosionWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationExplosionWriter.swift
@@ -8,14 +8,12 @@ public protocol ConversationExplosionWriterProtocol: Sendable {
 
 /// The MLS-level operations the explosion writer needs to reach through to
 /// the XMTP SDK. Factored out so tests can assert the call sequence
-/// (`sendExplode` → remove members → `leaveGroup` → fallback
-/// `updateConsentState`) without standing up a real MLS group. Production
-/// implementation is `XMTPExplodeGroupOperations`; `MockExplodeGroupOperations`
-/// backs the unit tests.
+/// (`sendExplode` → remove members → `denyConsent`) without standing up a
+/// real MLS group. Production implementation is `XMTPExplodeGroupOperations`;
+/// `MockExplodeGroupOperations` backs the unit tests.
 protocol ExplodeGroupOperationsProtocol: Sendable {
     func currentInboxId() async throws -> String
     func sendExplode(conversationId: String, expiresAt: Date) async throws
-    func leaveGroup(conversationId: String) async throws
     func denyConsent(conversationId: String) async throws
 }
 
@@ -45,11 +43,6 @@ struct XMTPExplodeGroupOperations: ExplodeGroupOperationsProtocol {
         let (xmtpConversation, _) = try await findGroupConversation(conversationId: conversationId)
         nonisolated(unsafe) let unsafeConversation = xmtpConversation
         try await unsafeConversation.sendExplode(expiresAt: expiresAt)
-    }
-
-    func leaveGroup(conversationId: String) async throws {
-        let (_, group) = try await findGroupConversation(conversationId: conversationId)
-        try await group.leaveGroup()
     }
 
     func denyConsent(conversationId: String) async throws {
@@ -92,21 +85,22 @@ final class ConversationExplosionWriter: ConversationExplosionWriterProtocol, @u
 
         // Filter the creator's own inboxId out of the member list. The
         // ViewModel passes `conversation.members.map { $0.profile.inboxId }`
-        // which includes the current user. MLS rejects self-removal via
-        // `removeMembers` — the creator must leave via `leaveGroup()` at the end.
-        // Without this filter the remove step throws and the explode degrades to
-        // "the codec message went out but nothing else happened."
+        // which includes the current user, and MLS rejects self-removal via
+        // `removeMembers`. Without this filter the remove step throws and the
+        // explode degrades to "the codec message went out but nothing else
+        // happened."
         let currentInboxId = try await operations.currentInboxId()
         let otherMemberInboxIds = memberInboxIds.filter { $0 != currentInboxId }
 
         // Every leg below runs through `runBoundedOp`: bounded timeout,
-        // logged failure, non-fatal. The MLS teardown (removeMembers +
-        // leaveGroup) is the source of truth for "group ends"; the codec
-        // `ExplodeSettings` send is a best-effort hint so receivers can hide the
-        // conversation ahead of the MLS commit arriving. Any single leg failing
-        // must not abort the remaining legs — partial-destruction leaves the
-        // group half-gone on the network, which is strictly worse than a
-        // best-effort full sweep where some pieces may still retry later.
+        // logged failure, non-fatal. `removeMembers` is the source of truth
+        // for "group ends" from the other participants' perspective; the
+        // codec `ExplodeSettings` send is a best-effort hint so receivers
+        // can hide the conversation ahead of the MLS commit arriving. Any
+        // single leg failing must not abort the remaining legs — partial-
+        // destruction leaves the group half-gone on the network, which is
+        // strictly worse than a best-effort full sweep where some pieces
+        // may still retry later.
         await runBoundedOp("ExplodeSettings send", logSuccess: true) { [operations] in
             try await operations.sendExplode(conversationId: conversationId, expiresAt: expiresAt)
         }
@@ -127,21 +121,15 @@ final class ConversationExplosionWriter: ConversationExplosionWriterProtocol, @u
             try await metadataWriter.removeMembers(otherMemberInboxIds, from: conversationId)
         }
 
-        // The creator leaves the group via an explicit self-remove; the
-        // XMTP SDK sends the MLS commit that takes us out. `denyConsent` is
-        // a belt-and-suspenders fallback for when `leaveGroup()` gets
-        // interrupted — we're out of the group on success so there's
-        // nothing left to sync, but denying consent still blocks the
-        // conversation from re-syncing if the leave commit never landed.
-        let left = await runBoundedOp("leaveGroup", logSuccess: true) { [operations] in
-            try await operations.leaveGroup(conversationId: conversationId)
-        }
-        if left {
-            Log.info("Creator left exploded group: \(conversationId)")
-        } else {
-            await runBoundedOp("denyConsent fallback", logSuccess: true) { [operations] in
-                try await operations.denyConsent(conversationId: conversationId)
-            }
+        // Deny consent so the exploded conversation doesn't re-sync
+        // locally. `removeMembers` upstream is the real teardown signal to
+        // other participants; consent just prevents the local client from
+        // pulling the conversation back in. libxmtp rejects an explicit
+        // `leaveGroup()` here because the creator is the sole remaining
+        // member after `removeMembers`, and a 1 → 0 MLS commit has nobody
+        // left to validate it.
+        await runBoundedOp("denyConsent", logSuccess: true) { [operations] in
+            try await operations.denyConsent(conversationId: conversationId)
         }
     }
 
@@ -171,27 +159,21 @@ final class ConversationExplosionWriter: ConversationExplosionWriterProtocol, @u
     /// Bounded best-effort wrapper for a single leg of the explode sweep. Any
     /// thrown error or timeout is logged and swallowed so the remaining legs
     /// still run — partial destruction is strictly worse than a best-effort
-    /// full sweep. Returns `true` on success, `false` on throw or timeout;
-    /// callers that branch on the result (e.g. `leaveGroup` → `denyConsent`
-    /// fallback) read it. `logSuccess` toggles a success log line, set to
-    /// true on the network-visible MLS legs so telemetry can confirm they
-    /// completed.
-    @discardableResult
+    /// full sweep. `logSuccess` toggles a success log line, set to true on
+    /// the network-visible MLS legs so telemetry can confirm they completed.
     private func runBoundedOp(
         _ name: String,
         timeout: TimeInterval = 20,
         logSuccess: Bool = false,
         _ body: @escaping @Sendable () async throws -> Void
-    ) async -> Bool {
+    ) async {
         do {
             try await withTimeout(seconds: timeout, operation: body)
             if logSuccess {
                 Log.info("\(name) succeeded")
             }
-            return true
         } catch {
             Log.error("\(name) failed: \(error.localizedDescription)")
-            return false
         }
     }
 }

--- a/ConvosCore/Tests/ConvosCoreTests/ConversationExplosionWriterTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ConversationExplosionWriterTests.swift
@@ -2,21 +2,20 @@
 import Foundation
 import Testing
 
-/// Sender-side coverage for the single-inbox explode flow (ADR 004 C9
-/// amendment): broadcast `ExplodeSettings`, update local `expiresAt`,
-/// remove every *other* member from the MLS group, then `leaveGroup`.
-/// `denyConsent` is the fallback when the leave call itself throws.
-/// These tests pin the call sequence and the self-filter invariant;
-/// integration coverage of the receiver side lives in
-/// `IncomingMessageWriterExplodeTests`.
-@Suite("ConversationExplosionWriter — remove-and-leave flow", .serialized)
-struct ExplodeRemoveAndLeaveTests {
+/// Sender-side coverage for the single-inbox explode flow: broadcast
+/// `ExplodeSettings`, update local `expiresAt`, remove every *other*
+/// member from the MLS group, deny consent so the creator's client
+/// doesn't re-sync the conversation. These tests pin the call sequence
+/// and the self-filter invariant; integration coverage of the receiver
+/// side lives in `IncomingMessageWriterExplodeTests`.
+@Suite("ConversationExplosionWriter — remove-and-deny flow", .serialized)
+struct ConversationExplosionWriterTests {
     private let conversationId = "conv-explode-1"
     private let selfInboxId = "inbox-self"
     private let otherA = "inbox-A"
     private let otherB = "inbox-B"
 
-    @Test("Happy path: sendExplode → updateExpiresAt → removeMembers → leaveGroup, no denyConsent")
+    @Test("Happy path: sendExplode → updateExpiresAt → removeMembers → denyConsent")
     func happyPathCallOrder() async throws {
         let fixtures = Fixtures()
 
@@ -36,7 +35,7 @@ struct ExplodeRemoveAndLeaveTests {
             Issue.record("Expected sendExplode at index 1, got \(fixtures.operations.calls[1])")
         }
 
-        #expect(fixtures.operations.calls[2] == .leaveGroup(conversationId: conversationId))
+        #expect(fixtures.operations.calls[2] == .denyConsent(conversationId: conversationId))
 
         #expect(fixtures.metadataWriter.updatedExpiresAt.count == 1)
         #expect(fixtures.metadataWriter.updatedExpiresAt.first?.conversationId == conversationId)
@@ -61,25 +60,9 @@ struct ExplodeRemoveAndLeaveTests {
         #expect(Set(removed) == Set([otherA, otherB]))
     }
 
-    @Test("leaveGroup failure falls back to denyConsent; writer still succeeds")
-    func leaveFailureFallsBackToDenyConsent() async throws {
+    @Test("denyConsent failure is swallowed, not rethrown")
+    func denyConsentFailureIsSwallowed() async throws {
         let fixtures = Fixtures()
-        fixtures.operations.failLeaveGroup(with: StubError.leaveFailed)
-
-        try await fixtures.writer.explodeConversation(
-            conversationId: conversationId,
-            memberInboxIds: [selfInboxId, otherA]
-        )
-
-        // currentInboxId → sendExplode → leaveGroup (throws) → denyConsent
-        #expect(fixtures.operations.calls.count == 4)
-        #expect(fixtures.operations.calls.last == .denyConsent(conversationId: conversationId))
-    }
-
-    @Test("Both leaveGroup and denyConsent failing is swallowed, not rethrown")
-    func bothLeavePathsFailingIsSwallowed() async throws {
-        let fixtures = Fixtures()
-        fixtures.operations.failLeaveGroup(with: StubError.leaveFailed)
         fixtures.operations.failDenyConsent(with: StubError.consentFailed)
 
         try await fixtures.writer.explodeConversation(
@@ -90,14 +73,15 @@ struct ExplodeRemoveAndLeaveTests {
         #expect(fixtures.operations.calls.last == .denyConsent(conversationId: conversationId))
     }
 
-    @Test("sendExplode failure is logged but does not abort MLS teardown")
+    @Test("sendExplode failure is logged but does not abort the remaining legs")
     func sendExplodeFailureDoesNotAbortFlow() async throws {
-        // MLS teardown (removeMembers + leaveGroup) is the source of truth
-        // for "group ends"; the ExplodeSettings codec message is a best-effort
-        // hint so receivers can hide the conversation ahead of the MLS commit
-        // arriving. If sendExplode flakes, the remaining legs must still run —
-        // partial-destruction (message went out but group still has all
-        // members) is strictly worse than a full best-effort sweep.
+        // `removeMembers` is the source of truth for "group ends" from the
+        // other participants' perspective; the ExplodeSettings codec
+        // message is a best-effort hint so receivers can hide the
+        // conversation ahead of the MLS commit arriving. If sendExplode
+        // flakes, the remaining legs must still run — partial destruction
+        // (message went out but group still has all members) is strictly
+        // worse than a full best-effort sweep.
         let fixtures = Fixtures()
         fixtures.operations.failSendExplode(with: StubError.sendFailed)
 
@@ -106,16 +90,14 @@ struct ExplodeRemoveAndLeaveTests {
             memberInboxIds: [selfInboxId, otherA]
         )
 
-        // currentInboxId → sendExplode (fails) → leaveGroup still fires.
         #expect(fixtures.operations.calls.count == 3)
-        #expect(fixtures.operations.calls.last == .leaveGroup(conversationId: conversationId))
-        // Local expiresAt + removeMembers both land despite the send failure.
+        #expect(fixtures.operations.calls.last == .denyConsent(conversationId: conversationId))
         #expect(fixtures.metadataWriter.updatedExpiresAt.count == 1)
         #expect(fixtures.metadataWriter.removedMembers.count == 1)
     }
 
-    @Test("metadataWriter.removeMembers failure does not prevent leaveGroup")
-    func removeMembersFailureStillLeaves() async throws {
+    @Test("metadataWriter.removeMembers failure does not prevent denyConsent")
+    func removeMembersFailureStillDeniesConsent() async throws {
         let fixtures = Fixtures()
         fixtures.metadataWriter.removeMembersError = StubError.removeFailed
 
@@ -124,22 +106,19 @@ struct ExplodeRemoveAndLeaveTests {
             memberInboxIds: [selfInboxId, otherA]
         )
 
-        #expect(fixtures.operations.calls.last == .leaveGroup(conversationId: conversationId))
+        #expect(fixtures.operations.calls.last == .denyConsent(conversationId: conversationId))
     }
 
     @Test("currentInboxId throw aborts before any MLS call — session not ready")
     func currentInboxIdThrowAbortsEarly() async throws {
         // If the session never reports ready (keychain load failure, XMTP
         // bootstrap stuck), the writer should propagate and land nothing.
-        // Pre-refactor this path was never asserted — adding it pins the
-        // contract that explode requires a ready session at entry.
         let fixtures = Fixtures()
         final class ThrowingOperations: ExplodeGroupOperationsProtocol, @unchecked Sendable {
             func currentInboxId() async throws -> String {
                 throw NSError(domain: "test", code: -1, userInfo: [NSLocalizedDescriptionKey: "session not ready"])
             }
             func sendExplode(conversationId: String, expiresAt: Date) async throws {}
-            func leaveGroup(conversationId: String) async throws {}
             func denyConsent(conversationId: String) async throws {}
         }
         let throwing = ThrowingOperations()
@@ -158,21 +137,18 @@ struct ExplodeRemoveAndLeaveTests {
             // Expected
         }
 
-        // Writer aborted before any MLS call or metadata write.
         #expect(fixtures.metadataWriter.updatedExpiresAt.isEmpty)
         #expect(fixtures.metadataWriter.removedMembers.isEmpty)
     }
 
-    @Test("All three MLS calls fail — writer completes without throwing; denyConsent runs as leave fallback")
+    @Test("Both MLS calls fail — writer completes without throwing")
     func allMLSOperationsFailingDoesNotThrow() async throws {
-        // The category-collapse fix: no single leg's failure aborts the
-        // other legs. Even if sendExplode, leaveGroup, and denyConsent
-        // all fail, the writer still completes and metadataWriter still
-        // gets its calls — a best-effort sweep is strictly better than
-        // partial destruction.
+        // No single leg's failure aborts the other legs. Even if
+        // sendExplode and denyConsent both fail, the writer still
+        // completes and metadataWriter still gets its calls — a
+        // best-effort sweep is strictly better than partial destruction.
         let fixtures = Fixtures()
         fixtures.operations.failSendExplode(with: StubError.sendFailed)
-        fixtures.operations.failLeaveGroup(with: StubError.leaveFailed)
         fixtures.operations.failDenyConsent(with: StubError.consentFailed)
 
         try await fixtures.writer.explodeConversation(
@@ -180,18 +156,15 @@ struct ExplodeRemoveAndLeaveTests {
             memberInboxIds: [selfInboxId, otherA]
         )
 
-        // sendExplode, leaveGroup, denyConsent all recorded even though
-        // each threw; metadata writes still landed.
         let calls = fixtures.operations.calls
         #expect(calls.contains { if case .sendExplode = $0 { return true } else { return false } })
-        #expect(calls.contains(.leaveGroup(conversationId: conversationId)))
         #expect(calls.contains(.denyConsent(conversationId: conversationId)))
         #expect(fixtures.metadataWriter.updatedExpiresAt.count == 1)
         #expect(fixtures.metadataWriter.removedMembers.count == 1)
     }
 
-    @Test("scheduleExplosion sends the message and records expiresAt; never touches leaveGroup")
-    func scheduleExplosionDoesNotLeaveGroup() async throws {
+    @Test("scheduleExplosion sends the message and records expiresAt; never touches denyConsent")
+    func scheduleExplosionDoesNotDenyConsent() async throws {
         let fixtures = Fixtures()
         let expiresAt = Date().addingTimeInterval(3600)
 
@@ -208,11 +181,11 @@ struct ExplodeRemoveAndLeaveTests {
         }
         #expect(hasSend)
 
-        let hasLeave = fixtures.operations.calls.contains { call in
-            if case .leaveGroup = call { return true }
+        let hasDeny = fixtures.operations.calls.contains { call in
+            if case .denyConsent = call { return true }
             return false
         }
-        #expect(!hasLeave)
+        #expect(!hasDeny)
 
         #expect(fixtures.metadataWriter.updatedExpiresAt.first?.expiresAt == expiresAt)
     }
@@ -240,7 +213,6 @@ struct ExplodeRemoveAndLeaveTests {
 
     private enum StubError: Error {
         case sendFailed
-        case leaveFailed
         case consentFailed
         case removeFailed
     }


### PR DESCRIPTION
## Summary

Remove the `group.leaveGroup()` call from `ConversationExplosionWriter.explodeConversation`. libxmtp always rejects it for single-member groups, so every explode sweep was producing an error.

Observed in the wild: 43 failures in a single user's 48-hour log, one per explode:

```
leaveGroup failed: XMTPiOS.FfiError.Error(message: "[GroupError::LeaveCantProcessed] Group error: cannot leave a group that has only one member")
```

## Why it fails

`leaveGroup()` maps to the MLS `removeSelf` commit. After the explode sweep's `removeMembers(otherInboxIds)` step succeeds, the creator is the sole remaining member — a 1→0 transition has nobody left to validate the commit, and libxmtp refuses it. This is a hard invariant, not a timing issue.

The `leaveGroup` call was introduced by the single-inbox identity refactor (PR #713, `c4c191e`) on the theory that the creator must actively leave. Pre-refactor the flow was `sendExplode → updateExpiresAt → removeMembers → updateConsentState(.denied)` and worked.

## What the fix restores

- **Writer**: drop the `leaveGroup` leg + its `denyConsent` fallback. The flow is now `sendExplode → updateExpiresAt → removeMembers → denyConsent` — pre-refactor shape. `removeMembers` is the authoritative teardown signal to other participants; `denyConsent` prevents the creator's client from re-syncing the conversation locally.
- **Protocol + mock**: drop `leaveGroup` from `ExplodeGroupOperationsProtocol` and `MockExplodeGroupOperations` (only the explode flow used it).
- **Tests**: rewrite against the new 3-call sequence and rename the suite to `ConversationExplosionWriterTests`.
- **Worker comment**: `ExpiredConversationsWorker` still referenced "removeMembers + leaveGroup"; updated to "removeMembers + denyConsent" to match.

`UnusedConversationCache`'s `leaveGroup` call on its 2-member rollback path is untouched — it doesn't hit the 1→0 invariant.

## Test plan
- [x] `swift test --package-path ConvosCore --filter ConversationExplosionWriter` — 8/8 passing
- [x] `swift test --package-path ConvosCore` — full suite, 583/583 passing
- [x] `swiftlint --strict --quiet` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Drop `leaveGroup` from explode teardown and always call `denyConsent` after `removeMembers`
> - Removes `leaveGroup` from `ExplodeGroupOperationsProtocol`, `XMTPExplodeGroupOperations`, and the mock, so the protocol no longer exposes a self-leave operation.
> - `ConversationExplosionWriter.explodeConversation` now unconditionally calls `denyConsent` after `removeMembers`, replacing the previous logic that tried `leaveGroup` first and fell back to `denyConsent` on failure.
> - `runBoundedOp` is simplified to return `Void` instead of `Bool`, removing the boolean branch from callers.
> - Tests are updated to reflect the new flow: `denyConsent` failures are swallowed, `sendExplode` failures do not abort subsequent steps, and `scheduleExplosion` does not call `denyConsent`.
> - Behavioral Change: the MLS self-leave is skipped entirely; consent denial is now the sole mechanism to prevent local re-sync after group explosion.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 686b055.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->