### PR TITLE
Log: emit build number + commit hash at app launch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 
 ### Secrets ###
 **/Secrets.swift
+**/BuildInfo.swift
 .env
 .env.local
 

--- a/Convos.xcodeproj/project.pbxproj
+++ b/Convos.xcodeproj/project.pbxproj
@@ -908,6 +908,7 @@
 			);
 			outputPaths = (
 				"$(TARGET_BUILD_DIR)/$(WRAPPER_NAME)/config.json",
+				"$(SRCROOT)/NotificationService/BuildInfo.swift",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/Convos/ConvosApp.swift
+++ b/Convos/ConvosApp.swift
@@ -34,6 +34,9 @@ struct ConvosApp: App {
             )
         }
         Log.info("App starting with environment: \(environment)")
+        let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "unknown"
+        let appBuild = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "unknown"
+        Log.info("Launch: version=\(appVersion) build=\(appBuild) commit=\(Secrets.GIT_COMMIT_SHA) environment=\(environment.name)")
         QAEvent.emit(.app, "launched", ["environment": environment.name])
 
         // Firebase must be configured before ConvosClient is created so AppCheck is ready when auth begins

--- a/NotificationService/NotificationService.swift
+++ b/NotificationService/NotificationService.swift
@@ -11,6 +11,9 @@ private let globalPushHandler: CachedPushNotificationHandler? = {
         let environment = try NotificationExtensionEnvironment.getEnvironment()
         ConvosLog.configure(environment: environment)
 
+        let nseVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "unknown"
+        let nseBuild = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "unknown"
+        Log.info("Launch: version=\(nseVersion) build=\(nseBuild) commit=\(BuildInfo.commitHash) environment=\(environment.name)")
         Log.info("Initializing global push handler for environment: \(environment.name)")
 
         if !environment.isProduction {

--- a/NotificationService/NotificationService.swift
+++ b/NotificationService/NotificationService.swift
@@ -11,9 +11,6 @@ private let globalPushHandler: CachedPushNotificationHandler? = {
         let environment = try NotificationExtensionEnvironment.getEnvironment()
         ConvosLog.configure(environment: environment)
 
-        let nseVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "unknown"
-        let nseBuild = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "unknown"
-        Log.info("Launch: version=\(nseVersion) build=\(nseBuild) commit=\(BuildInfo.commitHash) environment=\(environment.name)")
         Log.info("Initializing global push handler for environment: \(environment.name)")
 
         if !environment.isProduction {
@@ -26,6 +23,10 @@ private let globalPushHandler: CachedPushNotificationHandler? = {
                 processType: .notificationExtension
             )
         }
+
+        let nseVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "unknown"
+        let nseBuild = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "unknown"
+        Log.info("Launch: version=\(nseVersion) build=\(nseBuild) commit=\(BuildInfo.commitHash) environment=\(environment.name)")
 
         return try NotificationExtensionEnvironment.createPushNotificationHandler(
             platformProviders: .iOSExtension

--- a/Scripts/build-phases/copy-env-config-main-app.sh
+++ b/Scripts/build-phases/copy-env-config-main-app.sh
@@ -1,6 +1,27 @@
 #!/bin/bash
 set -e
 
+# Detect git commit SHA (CI env var takes priority, then git, then fallback)
+GIT_SHA="${GITHUB_SHA:-${BITRISE_GIT_COMMIT:-}}"
+if [ -z "$GIT_SHA" ]; then
+    GIT_SHA=$(cd "${SRCROOT}" && git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+else
+    GIT_SHA="${GIT_SHA:0:7}"
+fi
+
+# Generate BuildInfo.swift for the NotificationService extension
+if [ "$TARGET_NAME" = "NotificationService" ]; then
+    mkdir -p "${SRCROOT}/NotificationService"
+    cat > "${SRCROOT}/NotificationService/BuildInfo.swift" << EOF
+// swiftlint:disable all
+enum BuildInfo {
+    static let commitHash: String = "$GIT_SHA"
+}
+// swiftlint:enable all
+EOF
+    echo "🏁 Generated BuildInfo.swift for NotificationService (commit: $GIT_SHA)"
+fi
+
 # Part 1: Generate Secrets.swift for Local and Dev builds (App target only)
 if [ "$TARGET_NAME" = "Convos" ] && [ "$CONFIGURATION" = "Local" ]; then
     echo "🏠 Local build detected - generating secrets with auto-detected IP"
@@ -68,13 +89,15 @@ HEADER_EOF
         echo "🔍 Auto-detecting XMTP_CUSTOM_HOST"
         echo "    static let XMTP_CUSTOM_HOST = \"$LOCAL_IP\"" >> "$SECRETS_FILE"
     fi
-    
+
+    echo "    static let GIT_COMMIT_SHA = \"$GIT_SHA\"" >> "$SECRETS_FILE"
+
     # Add other secrets from .env if available
     if [ -f "${SRCROOT}/.env" ]; then
         echo "📋 Adding additional secrets from .env file..."
-        
+
         # Process .env file: skip comments, empty lines, and IP-related keys (since we handled them above), then format as Swift
-        sed -n '/^[^#]/p' "${SRCROOT}/.env" | grep '=' | grep -v '^CONVOS_API_BASE_URL' | grep -v '^XMTP_CUSTOM_HOST' | sed 's/^\\([^=]*\\)=\\(.*\\)$/    static let \\1 = "\\2"/' | sed 's/""\\(.*\\)""/"\\1"/' >> "$SECRETS_FILE"
+        sed -n '/^[^#]/p' "${SRCROOT}/.env" | grep '=' | grep -v '^CONVOS_API_BASE_URL' | grep -v '^XMTP_CUSTOM_HOST' | grep -v '^GIT_COMMIT_SHA' | sed 's/^\\([^=]*\\)=\\(.*\\)$/    static let \\1 = "\\2"/' | sed 's/""\\(.*\\)""/"\\1"/' >> "$SECRETS_FILE"
     fi
     
     # Close the enum
@@ -128,6 +151,7 @@ enum Secrets {
     static let GATEWAY_URL = ""
     static let SENTRY_DSN = ""
     static let FIREBASE_APP_CHECK_DEBUG_TOKEN = "$FIREBASE_TOKEN"
+    static let GIT_COMMIT_SHA = "$GIT_SHA"
 }
 
 // swiftlint:enable all

--- a/Scripts/build-phases/copy-env-config-main-app.sh
+++ b/Scripts/build-phases/copy-env-config-main-app.sh
@@ -1,13 +1,8 @@
 #!/bin/bash
 set -e
 
-# Detect git commit SHA (CI env var takes priority, then git, then fallback)
-GIT_SHA="${GITHUB_SHA:-${BITRISE_GIT_COMMIT:-}}"
-if [ -z "$GIT_SHA" ]; then
-    GIT_SHA=$(cd "${SRCROOT}" && git rev-parse --short HEAD 2>/dev/null || echo "unknown")
-else
-    GIT_SHA="${GIT_SHA:0:7}"
-fi
+source "${SRCROOT}/Scripts/secrets-utils.sh"
+GIT_SHA=$(get_git_commit_sha "${SRCROOT}")
 
 # Generate BuildInfo.swift for the NotificationService extension
 if [ "$TARGET_NAME" = "NotificationService" ]; then
@@ -15,7 +10,7 @@ if [ "$TARGET_NAME" = "NotificationService" ]; then
     cat > "${SRCROOT}/NotificationService/BuildInfo.swift" << EOF
 // swiftlint:disable all
 enum BuildInfo {
-    static let commitHash: String = "$GIT_SHA"
+    static let commitHash: String = "$(swift_escape "$GIT_SHA")"
 }
 // swiftlint:enable all
 EOF
@@ -90,7 +85,7 @@ HEADER_EOF
         echo "    static let XMTP_CUSTOM_HOST = \"$LOCAL_IP\"" >> "$SECRETS_FILE"
     fi
 
-    echo "    static let GIT_COMMIT_SHA = \"$GIT_SHA\"" >> "$SECRETS_FILE"
+    echo "    static let GIT_COMMIT_SHA: String = \"$(swift_escape "$GIT_SHA")\"" >> "$SECRETS_FILE"
 
     # Add other secrets from .env if available
     if [ -f "${SRCROOT}/.env" ]; then
@@ -151,12 +146,12 @@ enum Secrets {
     static let GATEWAY_URL = ""
     static let SENTRY_DSN = ""
     static let FIREBASE_APP_CHECK_DEBUG_TOKEN = "$FIREBASE_TOKEN"
-    static let GIT_COMMIT_SHA = "$GIT_SHA"
+    static let GIT_COMMIT_SHA: String = "$(swift_escape "$GIT_SHA")"
 }
 
 // swiftlint:enable all
 EOF
-    
+
     echo "🏁 Generated Secrets.swift for Dev"
 fi
 

--- a/Scripts/build-phases/copy-env-config-notification-service.sh
+++ b/Scripts/build-phases/copy-env-config-notification-service.sh
@@ -1,13 +1,8 @@
 #!/bin/bash
 set -e
 
-# Detect git commit SHA (CI env var takes priority, then git, then fallback)
-GIT_SHA="${GITHUB_SHA:-${BITRISE_GIT_COMMIT:-}}"
-if [ -z "$GIT_SHA" ]; then
-    GIT_SHA=$(cd "${SRCROOT}" && git rev-parse --short HEAD 2>/dev/null || echo "unknown")
-else
-    GIT_SHA="${GIT_SHA:0:7}"
-fi
+source "${SRCROOT}/Scripts/secrets-utils.sh"
+GIT_SHA=$(get_git_commit_sha "${SRCROOT}")
 
 # Part 1: Generate Secrets.swift for Local builds (auto-detect IP)
 if [ "$CONFIGURATION" = "Local" ]; then
@@ -47,7 +42,7 @@ enum Secrets {
     static let GATEWAY_URL = ""
     static let SENTRY_DSN = ""
     static let FIREBASE_APP_CHECK_DEBUG_TOKEN = "$FIREBASE_TOKEN"
-    static let GIT_COMMIT_SHA = "$GIT_SHA"
+    static let GIT_COMMIT_SHA: String = "$(swift_escape "$GIT_SHA")"
 }
 // swiftlint:enable all
 EOF
@@ -84,7 +79,7 @@ enum Secrets {
     static let GATEWAY_URL = ""
     static let SENTRY_DSN = ""
     static let FIREBASE_APP_CHECK_DEBUG_TOKEN = "$FIREBASE_TOKEN"
-    static let GIT_COMMIT_SHA = "$GIT_SHA"
+    static let GIT_COMMIT_SHA: String = "$(swift_escape "$GIT_SHA")"
 }
 // swiftlint:enable all
 EOF

--- a/Scripts/build-phases/copy-env-config-notification-service.sh
+++ b/Scripts/build-phases/copy-env-config-notification-service.sh
@@ -1,34 +1,42 @@
 #!/bin/bash
 set -e
 
+# Detect git commit SHA (CI env var takes priority, then git, then fallback)
+GIT_SHA="${GITHUB_SHA:-${BITRISE_GIT_COMMIT:-}}"
+if [ -z "$GIT_SHA" ]; then
+    GIT_SHA=$(cd "${SRCROOT}" && git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+else
+    GIT_SHA="${GIT_SHA:0:7}"
+fi
+
 # Part 1: Generate Secrets.swift for Local builds (auto-detect IP)
 if [ "$CONFIGURATION" = "Local" ]; then
     echo "🏠 Local build detected - generating secrets with auto-detected IP"
-    
+
     SECRETS_FILE="${SRCROOT}/Convos/Config/Secrets.swift"
-    
+
     LOCAL_IP=$(ifconfig | grep -E "inet [0-9]+" | grep -v "127\\." | grep -v "169\\.254\\." | grep -v "10\\." | grep -v "172\\.1[6-9]\\." | grep -v "172\\.2[0-9]\\." | grep -v "172\\.3[0-1]\\." | grep -v "192\\.168\\." | head -1 | awk '{print $2}')
     if [ -z "$LOCAL_IP" ]; then
         LOCAL_IP=$(ifconfig | grep -E "inet [0-9]+" | grep -v "127\\." | grep -v "169\\.254\\." | head -1 | awk '{print $2}')
     fi
-    
+
     if [ -z "$LOCAL_IP" ]; then
         echo "❌ Could not detect local IP address"
         exit 1
     fi
     echo "✅ Detected local IP"
     mkdir -p "${SRCROOT}/Convos/Config"
-    
+
     CONVOS_API_BASE_URL=""
     XMTP_CUSTOM_HOST=""
     FIREBASE_TOKEN=""
-    
+
     if [ -f "${SRCROOT}/.env" ]; then
         CONVOS_API_BASE_URL=$(grep -v '^#' "${SRCROOT}/.env" | grep '^CONVOS_API_BASE_URL=' | cut -d'=' -f2- | sed -e 's/^"//' -e 's/"$//' || true)
         XMTP_CUSTOM_HOST=$(grep -v '^#' "${SRCROOT}/.env" | grep '^XMTP_CUSTOM_HOST=' | cut -d'=' -f2- | sed -e 's/^"//' -e 's/"$//' || true)
         FIREBASE_TOKEN=$(grep -v '^#' "${SRCROOT}/.env" | grep '^FIREBASE_APP_CHECK_DEBUG_TOKEN=' | cut -d'=' -f2- | sed -e 's/^"//' -e 's/"$//' || true)
     fi
-    
+
     cat > "$SECRETS_FILE" << EOF
 import Foundation
 
@@ -39,6 +47,7 @@ enum Secrets {
     static let GATEWAY_URL = ""
     static let SENTRY_DSN = ""
     static let FIREBASE_APP_CHECK_DEBUG_TOKEN = "$FIREBASE_TOKEN"
+    static let GIT_COMMIT_SHA = "$GIT_SHA"
 }
 // swiftlint:enable all
 EOF
@@ -47,10 +56,10 @@ EOF
 # Part 2: Generate Secrets.swift for Dev builds (read Firebase token from .env)
 elif [ "$CONFIGURATION" = "Dev" ]; then
     echo "🔧 Dev build detected - generating secrets from .env"
-    
+
     SECRETS_FILE="${SRCROOT}/Convos/Config/Secrets.swift"
     mkdir -p "${SRCROOT}/Convos/Config"
-    
+
     FIREBASE_TOKEN=""
     CONVOS_API_BASE_URL=""
     if [ -f "${SRCROOT}/.env" ]; then
@@ -58,13 +67,13 @@ elif [ "$CONFIGURATION" = "Dev" ]; then
 
         CONVOS_API_BASE_URL=$(grep -v '^#' "${SRCROOT}/.env" | grep '^CONVOS_API_BASE_URL=' | cut -d'=' -f2- | sed -e 's/^"//' -e 's/"$//' || true)
     fi
-    
+
     if [ -n "$FIREBASE_TOKEN" ]; then
         echo "✅ Found Firebase debug token in .env"
     else
         echo "⚠️  No Firebase debug token in .env - you may need to register tokens manually"
     fi
-    
+
     cat > "$SECRETS_FILE" << EOF
 import Foundation
 
@@ -75,6 +84,7 @@ enum Secrets {
     static let GATEWAY_URL = ""
     static let SENTRY_DSN = ""
     static let FIREBASE_APP_CHECK_DEBUG_TOKEN = "$FIREBASE_TOKEN"
+    static let GIT_COMMIT_SHA = "$GIT_SHA"
 }
 // swiftlint:enable all
 EOF

--- a/Scripts/generate-secrets-local.sh
+++ b/Scripts/generate-secrets-local.sh
@@ -269,7 +269,7 @@ enum Secrets {
     static let GATEWAY_URL: String = "$(swift_escape "$FINAL_GATEWAY_URL")"
     static let SENTRY_DSN: String = "$(swift_escape "$ENV_SENTRY_DSN")"
     static let FIREBASE_APP_CHECK_DEBUG_TOKEN: String = "$(swift_escape "$ENV_FIREBASE_DEBUG_TOKEN")"
-    static let GIT_COMMIT_SHA: String = "$GIT_SHA"
+    static let GIT_COMMIT_SHA: String = "$(swift_escape "$GIT_SHA")"
 EOF
 
 # Check if .env file exists and add any additional secrets from it

--- a/Scripts/generate-secrets-local.sh
+++ b/Scripts/generate-secrets-local.sh
@@ -75,13 +75,7 @@ if [ "$1" = "--ensure-only" ]; then
     exit 0
 fi
 
-# Detect git commit SHA (CI env var takes priority, then git, then fallback)
-RAW_SHA="${GITHUB_SHA:-${BITRISE_GIT_COMMIT:-}}"
-if [ -z "$RAW_SHA" ]; then
-    GIT_SHA=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
-else
-    GIT_SHA="${RAW_SHA:0:7}"
-fi
+GIT_SHA=$(get_git_commit_sha)
 
 echo "🔍 Detecting configuration for Local development..."
 

--- a/Scripts/generate-secrets-local.sh
+++ b/Scripts/generate-secrets-local.sh
@@ -50,6 +50,7 @@ enum Secrets {
     static let GATEWAY_URL: String = ""
     static let SENTRY_DSN: String = ""
     static let FIREBASE_APP_CHECK_DEBUG_TOKEN: String = ""
+    static let GIT_COMMIT_SHA: String = ""
 }
 
 MINIMAL_EOF
@@ -72,6 +73,14 @@ if [ "$1" = "--ensure-only" ]; then
         echo "✅ Secrets.swift already exists for app clip"
     fi
     exit 0
+fi
+
+# Detect git commit SHA (CI env var takes priority, then git, then fallback)
+RAW_SHA="${GITHUB_SHA:-${BITRISE_GIT_COMMIT:-}}"
+if [ -z "$RAW_SHA" ]; then
+    GIT_SHA=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+else
+    GIT_SHA="${RAW_SHA:0:7}"
 fi
 
 echo "🔍 Detecting configuration for Local development..."
@@ -260,6 +269,7 @@ enum Secrets {
     static let GATEWAY_URL: String = "$(swift_escape "$FINAL_GATEWAY_URL")"
     static let SENTRY_DSN: String = "$(swift_escape "$ENV_SENTRY_DSN")"
     static let FIREBASE_APP_CHECK_DEBUG_TOKEN: String = "$(swift_escape "$ENV_FIREBASE_DEBUG_TOKEN")"
+    static let GIT_COMMIT_SHA: String = "$GIT_SHA"
 EOF
 
 # Check if .env file exists and add any additional secrets from it
@@ -278,6 +288,7 @@ if [ -f ".env" ]; then
         [[ "$key" == "GATEWAY_URL" ]] && continue
         [[ "$key" == "SENTRY_DSN" ]] && continue
         [[ "$key" == "FIREBASE_APP_CHECK_DEBUG_TOKEN" ]] && continue
+        [[ "$key" == "GIT_COMMIT_SHA" ]] && continue
 
         # Validate Swift identifier
         if ! is_valid_swift_identifier "$key"; then

--- a/Scripts/generate-secrets-secure.sh
+++ b/Scripts/generate-secrets-secure.sh
@@ -23,6 +23,14 @@ ESCAPED_API_URL=$(swift_escape "${CONVOS_API_BASE_URL:-}")
 ESCAPED_XMTP_HOST=$(swift_escape "${XMTP_CUSTOM_HOST:-}")
 ESCAPED_GATEWAY_URL=$(swift_escape "${GATEWAY_URL:-}")
 
+# Detect git commit SHA (CI env var takes priority, then git, then fallback)
+RAW_SHA="${GITHUB_SHA:-${BITRISE_GIT_COMMIT:-}}"
+if [ -z "$RAW_SHA" ]; then
+    GIT_SHA=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+else
+    GIT_SHA="${RAW_SHA:0:7}"
+fi
+
 # Handle Sentry DSN based on build configuration
 # BITRISE_BUILD_CONFIG is set by Bitrise CI (Dev, Release)
 # BUILD_CONFIGURATION is a fallback for other CI systems
@@ -66,6 +74,7 @@ enum Secrets {
     static let GATEWAY_URL: String = "$ESCAPED_GATEWAY_URL"
     static let SENTRY_DSN: String = "$ESCAPED_SENTRY_DSN"
     static let FIREBASE_APP_CHECK_DEBUG_TOKEN: String = ""
+    static let GIT_COMMIT_SHA: String = "$GIT_SHA"
 }
 EOF
 

--- a/Scripts/generate-secrets-secure.sh
+++ b/Scripts/generate-secrets-secure.sh
@@ -23,13 +23,8 @@ ESCAPED_API_URL=$(swift_escape "${CONVOS_API_BASE_URL:-}")
 ESCAPED_XMTP_HOST=$(swift_escape "${XMTP_CUSTOM_HOST:-}")
 ESCAPED_GATEWAY_URL=$(swift_escape "${GATEWAY_URL:-}")
 
-# Detect git commit SHA (CI env var takes priority, then git, then fallback)
-RAW_SHA="${GITHUB_SHA:-${BITRISE_GIT_COMMIT:-}}"
-if [ -z "$RAW_SHA" ]; then
-    GIT_SHA=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
-else
-    GIT_SHA="${RAW_SHA:0:7}"
-fi
+GIT_SHA=$(get_git_commit_sha)
+ESCAPED_GIT_SHA=$(swift_escape "$GIT_SHA")
 
 # Handle Sentry DSN based on build configuration
 # BITRISE_BUILD_CONFIG is set by Bitrise CI (Dev, Release)
@@ -74,7 +69,7 @@ enum Secrets {
     static let GATEWAY_URL: String = "$ESCAPED_GATEWAY_URL"
     static let SENTRY_DSN: String = "$ESCAPED_SENTRY_DSN"
     static let FIREBASE_APP_CHECK_DEBUG_TOKEN: String = ""
-    static let GIT_COMMIT_SHA: String = "$GIT_SHA"
+    static let GIT_COMMIT_SHA: String = "$ESCAPED_GIT_SHA"
 }
 EOF
 

--- a/Scripts/secrets-utils.sh
+++ b/Scripts/secrets-utils.sh
@@ -36,3 +36,22 @@ ensure_secrets_directories() {
     mkdir -p "Convos/Config"
     mkdir -p "ConvosAppClip/Config"
 }
+
+# Detect git commit SHA.
+# Optional first argument: repo directory to cd into (use for Xcode build phases
+# where the working directory is not the repo root). Omit for standalone scripts
+# that already run from the repo root.
+# Priority: $GITHUB_SHA -> $BITRISE_GIT_COMMIT -> git rev-parse -> "unknown"
+get_git_commit_sha() {
+    local repo_dir="${1:-}"
+    local raw_sha="${GITHUB_SHA:-${BITRISE_GIT_COMMIT:-}}"
+    if [ -z "$raw_sha" ]; then
+        if [ -n "$repo_dir" ]; then
+            (cd "$repo_dir" && git rev-parse --short HEAD 2>/dev/null) || echo "unknown"
+        else
+            git rev-parse --short HEAD 2>/dev/null || echo "unknown"
+        fi
+    else
+        echo "${raw_sha:0:7}"
+    fi
+}


### PR DESCRIPTION
## Summary

- On every launch, the main app and NSE each emit one `[info]` line identifying the running binary: version, build number, git commit SHA, and environment
- Example: `[info] [Convos] Launch: version=1.2.0 build=753 commit=c4c191e environment=dev`
- Motivating problem: `convos-app.log` persists across app upgrades, so log entries from different builds were interleaved with no way to tell which code produced what — this single line makes it permanently diagnosable

## How it works

**Main app (`ConvosApp.swift`):** reads version/build from `Bundle.main.infoDictionary`, reads the commit SHA from `Secrets.GIT_COMMIT_SHA` (the existing gitignored generated file).

**NotificationService (`NotificationService.swift`):** reads version/build from `Bundle.main.infoDictionary`, reads the commit SHA from a new gitignored `BuildInfo.swift` (same generation pattern as `Secrets.swift`).

**SHA injection follows the existing `Secrets.swift` pattern:**
- All build-phase scripts (`copy-env-config-*.sh`) now detect the SHA via `$GITHUB_SHA` → `$BITRISE_GIT_COMMIT` → `git rev-parse --short HEAD` → `"unknown"` and embed it in the generated file
- `generate-secrets-local.sh` and `generate-secrets-secure.sh` likewise inject the SHA
- `BuildInfo.swift` is generated for the NSE by its build phase (`copy-env-config-main-app.sh`) and listed as a build-phase output so Xcode tracks it as a generated source
- Both generated files are gitignored (`**/Secrets.swift`, `**/BuildInfo.swift`)

## Test plan

- [ ] Build `Convos (Dev)` scheme — should compile clean with no errors
- [ ] Check simulator log at launch — confirm line matching `Launch: version=X.Y.Z build=NNN commit=XXXXXXX environment=dev` appears immediately after `App starting with environment:`
- [ ] Trigger a push notification in dev — confirm NSE process emits the equivalent `Launch:` line with `[NotificationService]` namespace
- [ ] CI build: verify `$GITHUB_SHA` is picked up (check the generated `Secrets.swift` in build logs)

https://claude.ai/code/session_015WeFSxBcsHfu7fvxMRbrSx

---
_Generated by [Claude Code](https://claude.ai/code/session_015WeFSxBcsHfu7fvxMRbrSx)_

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Log build number and commit hash at app launch and notification service init
> - Adds a `get_git_commit_sha` helper to [secrets-utils.sh](https://github.com/xmtplabs/convos-ios/pull/743/files#diff-d9c4b5c221e5be2ead8b9ee0d2d0e9cb1ae57c0a604edb18c0d0110449a63206) that resolves the short SHA from CI env vars (`GITHUB_SHA`, `BITRISE_GIT_COMMIT`) or `git rev-parse --short HEAD`.
> - All secret-generation scripts now embed `GIT_COMMIT_SHA` in the generated `Secrets.swift`; the notification service uses a generated [BuildInfo.swift](https://github.com/xmtplabs/convos-ios/pull/743/files#diff-f2f9994220affc50307ec22c35932d3a90b9834795137bfd31b577c580d20050) instead.
> - [ConvosApp.swift](https://github.com/xmtplabs/convos-ios/pull/743/files#diff-de23c5a6e10cb84b89d91ed62b707b654c28566f38cc339af8b3cbbf6e003014) logs version, build number, commit, and environment on launch; [NotificationService.swift](https://github.com/xmtplabs/convos-ios/pull/743/files#diff-cd6c8fdb4518bf3bbc5ee11b88947aa53f113197875ddb7ca91ee8dd4eb0eed4) does the same on extension init.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4f617b4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->