### PR TITLE
Reveal Mode: default to off for new installs

### DIFF
--- a/Convos/App Settings/GlobalConvoDefaults.swift
+++ b/Convos/App Settings/GlobalConvoDefaults.swift
@@ -8,8 +8,8 @@ final class GlobalConvoDefaults: @unchecked Sendable {
     var autoRevealPhotos: Bool {
         get {
             access(keyPath: \.autoRevealPhotos)
-            // Default false means photos are not auto-revealed (blur incoming pics is on).
-            return UserDefaults.standard.object(forKey: Constant.autoRevealPhotosKey) as? Bool ?? false
+            // Default true means photos are auto-revealed (Reveal Mode toggle is off).
+            return UserDefaults.standard.object(forKey: Constant.autoRevealPhotosKey) as? Bool ?? true
         }
         set {
             withMutation(keyPath: \.autoRevealPhotos) {

--- a/ConvosTests/GlobalConvoDefaultsTests.swift
+++ b/ConvosTests/GlobalConvoDefaultsTests.swift
@@ -14,7 +14,7 @@ final class GlobalConvoDefaultsTests: XCTestCase {
     }
 
     func testDefaultValuesWhenUnset() {
-        XCTAssertFalse(GlobalConvoDefaults.shared.autoRevealPhotos)
+        XCTAssertTrue(GlobalConvoDefaults.shared.autoRevealPhotos)
         XCTAssertFalse(GlobalConvoDefaults.shared.includeInfoWithInvites)
     }
 
@@ -32,7 +32,7 @@ final class GlobalConvoDefaultsTests: XCTestCase {
 
         GlobalConvoDefaults.shared.reset()
 
-        XCTAssertFalse(GlobalConvoDefaults.shared.autoRevealPhotos)
+        XCTAssertTrue(GlobalConvoDefaults.shared.autoRevealPhotos)
         XCTAssertFalse(GlobalConvoDefaults.shared.includeInfoWithInvites)
     }
 }


### PR DESCRIPTION
## Summary
- Flip the global `autoRevealPhotos` UserDefaults fallback from `false` to `true` so the "Reveal mode" toggle (which is bound to `!autoRevealPhotos`) appears **off** on fresh installs — new conversations auto-reveal photos by default, matching the desired product behavior.
- Update the two default-value assertions in `GlobalConvoDefaultsTests` to match.
- Users who previously toggled the setting keep their stored preference (the `??` only applies when the key is absent).

## Test plan
- [ ] Fresh install: Settings → Customize shows "Reveal mode" **off**; start a new conversation and confirm incoming photos appear un-blurred.
- [ ] Toggle "Reveal mode" on, start another new conversation, confirm incoming photos are blurred.
- [ ] Existing users who had set the toggle still see their saved preference after updating.
- [ ] `GlobalConvoDefaultsTests` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Default `autoRevealPhotos` to on for new installs
> Changes the unset fallback value of `GlobalConvoDefaults.autoRevealPhotos` from `false` to `true` in [GlobalConvoDefaults.swift](https://github.com/xmtplabs/convos-ios/pull/744/files#diff-9b7426f539f4440e427de136137f59672b486a31c091ec181cb2696784327bf1), so new installs have Reveal Mode enabled by default. Updates corresponding tests in [GlobalConvoDefaultsTests.swift](https://github.com/xmtplabs/convos-ios/pull/744/files#diff-4e798f3ee4f55451936203411e30587b1e7bce3ce9d022cc54a68919543dd8f2) to expect `true` for both the default and post-reset states. Risk: existing users who have never set this preference will now see Reveal Mode turned on.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e86c6c2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->