### PR TITLE
Writers: rename missingClientProvider to conversationNotFound

### DIFF
--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/OutgoingMessageWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/OutgoingMessageWriter.swift
@@ -48,10 +48,21 @@ public protocol OutgoingMessageWriterProtocol: Sendable {
     func deleteFailedMessage(id: String) async throws
 }
 
-enum OutgoingMessageWriterError: Error {
-    case missingClientProvider
+enum OutgoingMessageWriterError: Error, CustomStringConvertible {
+    case conversationNotFound(conversationId: String)
     case eagerUploadNotFound
     case parentMessageNotFound
+
+    var description: String {
+        switch self {
+        case .conversationNotFound(let conversationId):
+            return "Conversation not found in XMTP local store: \(conversationId)"
+        case .eagerUploadNotFound:
+            return "Eager upload not found"
+        case .parentMessageNotFound:
+            return "Parent message not found"
+        }
+    }
 }
 
 // swiftlint:disable:next type_body_length
@@ -657,7 +668,7 @@ actor OutgoingMessageWriter: OutgoingMessageWriterProtocol {
         guard let sender = try await inboxReady.client.messageSender(for: conversationId) else {
             tracker.setStage(.failed, for: trackingKey)
             try? await markMessageFailed(clientMessageId: clientMessageId)
-            throw OutgoingMessageWriterError.missingClientProvider
+            throw OutgoingMessageWriterError.conversationNotFound(conversationId: conversationId)
         }
 
         do {
@@ -929,7 +940,7 @@ actor OutgoingMessageWriter: OutgoingMessageWriterProtocol {
 
         guard let sender = try await client.messageSender(for: conversationId) else {
             try? await markMessageFailed(clientMessageId: queued.clientMessageId)
-            throw OutgoingMessageWriterError.missingClientProvider
+            throw OutgoingMessageWriterError.conversationNotFound(conversationId: conversationId)
         }
 
         let xmtpMessageId: String
@@ -1406,7 +1417,7 @@ actor OutgoingMessageWriter: OutgoingMessageWriterProtocol {
 
         guard let sender = try await client.messageSender(for: conversationId) else {
             try? await markMessageFailed(messageId: messageId)
-            throw OutgoingMessageWriterError.missingClientProvider
+            throw OutgoingMessageWriterError.conversationNotFound(conversationId: conversationId)
         }
 
         do {

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/ReactionWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/ReactionWriter.swift
@@ -10,7 +10,6 @@ public protocol ReactionWriterProtocol: Sendable {
 }
 
 enum ReactionWriterError: Error {
-    case missingClientProvider
     case conversationNotFound(conversationId: String)
     case messageNotFound(messageId: String)
     case unknownReactionAction

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/ReadReceiptWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/ReadReceiptWriter.swift
@@ -12,7 +12,6 @@ public protocol ReadReceiptWriterProtocol: Sendable {
 }
 
 enum ReadReceiptWriterError: Error {
-    case missingClientProvider
     case conversationNotFound
 }
 


### PR DESCRIPTION
## Summary

`OutgoingMessageWriterError.missingClientProvider` was thrown when `client.messageSender(for: conversationId)` returned nil, i.e. when XMTPiOS's `conversations.findConversation(conversationId:)` couldn't find the conversation in libxmtp's local store. The client provider itself was fine — only the conversation lookup failed. The name led to real misdiagnosis during live log triage.

Rename to `conversationNotFound(conversationId:)` so the log line reads what it means:

```
Failed to publish message: Conversation not found in XMTP local store: a200b30c0ac8521461af545743c9e6d6
```

Also drops the dead `missingClientProvider` case from `ReactionWriterError` and `ReadReceiptWriterError` — both enums declared it but never threw it.

No behavior change; just clearer diagnostics.

## Test plan

- [x] ConvosCore full test suite: 584/584 passing.
- [x] `swiftlint --strict` clean.
- [ ] Spot-check in the simulator: trigger a send to a conversation libxmtp doesn't know about (e.g. race on post-explode) and verify the log line now reads "Conversation not found in XMTP local store: <id>".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Rename `OutgoingMessageWriterError.missingClientProvider` to `conversationNotFound` with conversation ID context
> - Replaces the `missingClientProvider` error case in `OutgoingMessageWriterError` with `conversationNotFound(conversationId: String)`, which includes the ID of the missing conversation.
> - Adds `CustomStringConvertible` conformance to `OutgoingMessageWriterError` with human-readable descriptions for all error cases.
> - Removes the unused `missingClientProvider` case from `ReactionWriterError` and `ReadReceiptWriterError`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 01f71dc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->