### PR TITLE
Expired convos: delete row instead of soft-preserving shell

### DIFF
--- a/ConvosCore/Sources/ConvosCore/Storage/Workers/ExpiredConversationsWorker.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Workers/ExpiredConversationsWorker.swift
@@ -210,8 +210,6 @@ final class ExpiredConversationsWorker: ExpiredConversationsWorkerProtocol, @unc
             await executeExplodeIfCreator(conversation: conversation, context: context)
         }
 
-        await pruneExpiredSideConversationStorage(conversationId: conversation.conversationId)
-
         await MainActor.run {
             NotificationCenter.default.post(
                 name: .leftConversationNotification,
@@ -219,28 +217,23 @@ final class ExpiredConversationsWorker: ExpiredConversationsWorkerProtocol, @unc
                 userInfo: ["conversationId": conversation.conversationId]
             )
         }
+
+        await deleteExpiredConversationRow(conversationId: conversation.conversationId)
     }
 
-    /// Deletes the cached messages of an exploded side convo to free storage.
-    /// The `DBConversation` shell is intentionally left behind so the parent
-    /// convo's inline invite row can still render as "Exploded" via the
-    /// `DBInvite → DBConversation.expiresAt` join at fetch time.
-    private func pruneExpiredSideConversationStorage(conversationId: String) async {
+    /// Deletes the expired conversation's row so the worker stops re-processing it.
+    /// Foreign-key cascade removes every child table (messages, invites, members,
+    /// local state, photo prefs, attachments). The parent convo's inline invite
+    /// row still renders as "Exploded" because that check reads
+    /// `conversationExpiresAt` from the embedded `SignedInvite` payload on
+    /// `DBMessage.invite`, not from this row.
+    private func deleteExpiredConversationRow(conversationId: String) async {
         do {
-            let deletedCount = try await databaseWriter.write { db -> Int in
-                let isSideConvo = try DBInvite
-                    .filter(DBInvite.Columns.conversationId == conversationId)
-                    .fetchCount(db) > 0
-                guard isSideConvo else { return 0 }
-                return try DBMessage
-                    .filter(DBMessage.Columns.conversationId == conversationId)
-                    .deleteAll(db)
-            }
-            if deletedCount > 0 {
-                Log.info("Pruned \(deletedCount) message(s) from expired side convo \(conversationId)")
+            try await databaseWriter.write { db in
+                _ = try DBConversation.deleteOne(db, key: conversationId)
             }
         } catch {
-            Log.error("Failed to prune messages for expired side convo \(conversationId): \(error)")
+            Log.error("Failed to delete expired DBConversation row \(conversationId): \(error)")
         }
     }
 

--- a/ConvosCore/Tests/ConvosCoreTests/ExpiredConversationsWorkerTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ExpiredConversationsWorkerTests.swift
@@ -165,8 +165,8 @@ struct ExpiredConversationsWorkerTests {
         #expect(matched, "Should clean up conversation when conversationExpired notification received")
     }
 
-    @Test("Prunes cached messages from an exploded side convo but keeps the DBConversation shell")
-    func testPrunesSideConversationMessagesOnExpiration() async throws {
+    @Test("Deletes the DBConversation row of an exploded side convo, cascading its children")
+    func testDeletesSideConversationRowOnExpiration() async throws {
         let fixtures = ExpiredWorkerTestFixtures()
         let expiresAt = Date().addingTimeInterval(-60)
         try await fixtures.setupConversation(expiresAt: expiresAt)
@@ -187,21 +187,27 @@ struct ExpiredConversationsWorkerTests {
         }
 
         try await waitForCondition(timeout: 1.0) {
-            let count = try? fixtures.messageCount(for: conversationId)
-            return count == 0
+            let exists = (try? fixtures.conversationExists(id: conversationId)) ?? true
+            return exists == false
         }
 
-        let remainingMessages = try fixtures.messageCount(for: conversationId)
-        #expect(remainingMessages == 0, "Messages for the exploded side convo should be pruned")
-
         let stillHasConversation = try fixtures.conversationExists(id: conversationId)
-        #expect(stillHasConversation, "DBConversation shell should survive so parent invite rows still detect Exploded")
+        #expect(stillHasConversation == false, "DBConversation row should be deleted after cleanup")
+
+        let remainingMessages = try fixtures.messageCount(for: conversationId)
+        #expect(remainingMessages == 0, "Cascade should remove all messages")
+
+        let remainingInvites = try fixtures.inviteCount(for: conversationId)
+        #expect(remainingInvites == 0, "Cascade should remove the invite row")
+
+        let remainingMembers = try fixtures.memberCount(for: conversationId)
+        #expect(remainingMembers == 0, "Cascade should remove conversation members")
 
         withExtendedLifetime(worker) {}
     }
 
-    @Test("Does not prune messages from an exploded non-side conversation")
-    func testDoesNotPruneRegularConversationMessages() async throws {
+    @Test("Deletes the DBConversation row of an exploded regular conversation, cascading its children")
+    func testDeletesRegularConversationRowOnExpiration() async throws {
         let fixtures = ExpiredWorkerTestFixtures()
         let expiresAt = Date().addingTimeInterval(-60)
         try await fixtures.setupConversation(expiresAt: expiresAt)
@@ -220,11 +226,55 @@ struct ExpiredConversationsWorkerTests {
             }
         }
 
-        // Allow the pruning write a moment to run if it were going to.
-        try? await Task.sleep(for: .milliseconds(200))
+        try await waitForCondition(timeout: 1.0) {
+            let exists = (try? fixtures.conversationExists(id: conversationId)) ?? true
+            return exists == false
+        }
+
+        let stillHasConversation = try fixtures.conversationExists(id: conversationId)
+        #expect(stillHasConversation == false, "DBConversation row should be deleted after cleanup")
 
         let remainingMessages = try fixtures.messageCount(for: conversationId)
-        #expect(remainingMessages == 2, "Regular (non-side-convo) messages should not be pruned")
+        #expect(remainingMessages == 0, "Cascade should remove all messages")
+
+        withExtendedLifetime(worker) {}
+    }
+
+    @Test("Parent convo's inline invite still renders Exploded after the side convo row is deleted")
+    func testParentInviteRendersExplodedAfterSideConvoDeletion() async throws {
+        let fixtures = ExpiredWorkerTestFixtures()
+        let sideConvoExpiresAt = Date().addingTimeInterval(-60)
+        try await fixtures.setupConversation(expiresAt: sideConvoExpiresAt)
+        try await fixtures.markAsSideConversation()
+
+        let parentConversationId = "parent-of-\(fixtures.conversationId)"
+        try await fixtures.setupConversation(id: parentConversationId, expiresAt: nil)
+        let parentInviteMessageId = try await fixtures.seedInviteMessage(
+            inParentConversation: parentConversationId,
+            referencingSideConversationExpiresAt: sideConvoExpiresAt
+        )
+
+        let sideConvoId = fixtures.conversationId
+        let capture = NotificationCapture()
+        capture.startCapturing(.leftConversationNotification)
+        defer { capture.stopCapturing() }
+
+        let worker = fixtures.createWorker()
+
+        try await waitForCondition(timeout: 2.0) {
+            capture.notifications(named: .leftConversationNotification).contains {
+                ($0.userInfo?["conversationId"] as? String) == sideConvoId
+            }
+        }
+
+        try await waitForCondition(timeout: 1.0) {
+            let exists = (try? fixtures.conversationExists(id: sideConvoId)) ?? true
+            return exists == false
+        }
+
+        let parentInvite = try fixtures.loadInvitePayload(messageId: parentInviteMessageId)
+        #expect(parentInvite?.isConversationExpired == true,
+                "Parent invite should still report expired via embedded payload after side convo row is gone")
 
         withExtendedLifetime(worker) {}
     }
@@ -236,7 +286,6 @@ private class ExpiredWorkerTestFixtures {
     let sessionManager: MockInboxesService
     let conversationId: String = "expired-worker-test-\(UUID().uuidString)"
     let inboxId: String = "test-inbox-id"
-    let clientId: String = "test-client-id"
 
     init() {
         self.databaseManager = MockDatabaseManager.makeTestDatabase()
@@ -316,21 +365,83 @@ private class ExpiredWorkerTestFixtures {
         }
     }
 
+    func inviteCount(for conversationId: String) throws -> Int {
+        try databaseManager.dbReader.read { db in
+            try DBInvite
+                .filter(DBInvite.Columns.conversationId == conversationId)
+                .fetchCount(db)
+        }
+    }
+
+    func memberCount(for conversationId: String) throws -> Int {
+        try databaseManager.dbReader.read { db in
+            try DBConversationMember
+                .filter(DBConversationMember.Columns.conversationId == conversationId)
+                .fetchCount(db)
+        }
+    }
+
     func conversationExists(id: String) throws -> Bool {
         try databaseManager.dbReader.read { db in
             try DBConversation.fetchOne(db, key: id) != nil
         }
     }
 
+    func seedInviteMessage(
+        inParentConversation parentConversationId: String,
+        referencingSideConversationExpiresAt sideConvoExpiresAt: Date
+    ) async throws -> String {
+        let senderId = inboxId
+        let messageId = "invite-msg-\(parentConversationId)"
+        let invite = MessageInvite(
+            inviteSlug: "slug-parent-invite",
+            conversationName: "Test Side Convo",
+            conversationDescription: nil,
+            imageURL: nil,
+            emoji: nil,
+            expiresAt: nil,
+            conversationExpiresAt: sideConvoExpiresAt
+        )
+        try await databaseManager.dbWriter.write { db in
+            try DBMember(inboxId: senderId).save(db, onConflict: .ignore)
+            let now = Date()
+            try DBMessage(
+                id: messageId,
+                clientMessageId: messageId,
+                conversationId: parentConversationId,
+                senderId: senderId,
+                dateNs: Int64(now.timeIntervalSince1970 * 1_000_000_000),
+                date: now,
+                sortId: 0,
+                status: .published,
+                messageType: .original,
+                contentType: .text,
+                text: nil,
+                emoji: nil,
+                invite: invite,
+                linkPreview: nil,
+                sourceMessageId: nil,
+                attachmentUrls: [],
+                update: nil
+            ).insert(db)
+        }
+        return messageId
+    }
+
+    func loadInvitePayload(messageId: String) throws -> MessageInvite? {
+        try databaseManager.dbReader.read { db in
+            try DBMessage.fetchOne(db, key: messageId)?.invite
+        }
+    }
+
     func setupConversation(id: String? = nil, expiresAt: Date?) async throws {
         let convId = id ?? conversationId
         let inbxId = inboxId
-        let clId = clientId
         try await databaseManager.dbWriter.write { db in
             let conversation = DBConversation(
                 id: convId,
-                                clientConversationId: convId,
-                inviteTag: "test-invite-tag",
+                clientConversationId: convId,
+                inviteTag: "test-invite-tag-\(convId)",
                 creatorId: inbxId,
                 kind: .group,
                 consent: .allowed,


### PR DESCRIPTION
## Summary

`ExpiredConversationsWorker` was leaving `DBConversation` rows in place after explode teardown, so the worker matched them again on every `didBecomeActiveNotification` / cold launch. Each retry:

- Re-ran `removeMembers([])` on an already-empty group (wasted MLS commit).
- Called `leaveGroup` (fails in current code; PR #742 removes it).
- Raced with `SessionStateMachine.handleEnterBackground` / `dropLocalDatabaseConnection`, poisoning the shared SQLCipher pool.
- Collateral: unrelated active conversations started failing with `conversationNotFound` against the dead pool.

Production log evidence: `Cleaning up expired conversation: de7b26ae... leaveGroup failed` firing dozens of times over nine days for a single side convo. Root cause is the filter in `fetchExpiredConversations` (`expiresAt <= Date()`), which stays true forever.

This PR deletes the `DBConversation` row once the explode finishes. SQLite foreign-key cascade then removes every child table: `memberProfile`, `conversation_members`, `invite`, `conversationLocalState`, `message`, `photoPreferences`, `attachmentLocalState`, `pendingPhotoUpload` — all declared `onDelete: .cascade` in `SharedDatabaseMigrator`, with `config.foreignKeysEnabled = true` on the shared connection.

## Why the old "gravestone shell" rationale is stale

The prior comment claimed the row had to survive so the parent convo's inline invite could render as "Exploded" via a `DBInvite → DBConversation.expiresAt` join. That join was dropped in **PR #728's final commit** ("Side convos: derive expired state from the invite payload"). `MessageInvite.isConversationExpired` now reads `conversationExpiresAt` directly from the embedded `SignedInvite` payload in `DBMessage.invite`. A codebase grep confirms no repository joins against `DBConversation.expiresAt` for render purposes. Deleting the row does not break the parent's inline-invite Exploded UI.

## Implementation

- `cleanupExpiredConversation` now calls `deleteExpiredConversationRow` after the `.leftConversationNotification` post; the old `pruneExpiredSideConversationStorage` helper is removed entirely (cascade covers the same DBMessage rows plus everything else).
- Stale comment replaced with one that accurately describes the cascade + the invite-payload source of truth.

## Tests

- Rewrote the prune tests to assert the entire `DBConversation` row is deleted (for both side and regular convos) and that cascade removes messages/invites/members.
- Added "Parent convo's inline invite still renders Exploded after the side convo row is deleted" — seeds a parent convo with a `DBMessage` carrying a `MessageInvite` payload whose `conversationExpiresAt` is in the past, runs the worker against the side convo, and asserts the parent message still reports `isConversationExpired == true` after the side convo row is gone.
- All 585 tests in 69 suites pass locally against the final code.

## Out of scope

- PR #742 removes the still-failing `leaveGroup` call. This PR is independent of that branch and stops the retry loop that keeps the `leaveGroup` failure replaying.

## Test plan

- [x] `swiftlint --strict --quiet` clean
- [x] `./dev/up && swift test --package-path ConvosCore --filter ExpiredConversation` — 8/8 pass
- [x] `swift test --package-path ConvosCore` — 585/585 pass
- [x] Verified no other references to `pruneExpiredSideConversationStorage` or the "gravestone shell" rationale

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Delete expired conversation rows via FK cascade instead of soft-preserving the shell
> - `ExpiredConversationsWorker` now deletes the `DBConversation` row on expiration for both side and regular conversations, relying on FK cascade to remove all child records (messages, invites, members).
> - Previously, only side-conversation messages were pruned while the conversation shell was retained; now the row is fully removed unconditionally.
> - `.leftConversationNotification` is posted before the row deletion occurs.
> - The 'Exploded' rendering for parent inline invites is derived from the embedded `SignedInvite` payload on `DBMessage.invite` rather than the (now-deleted) conversation row.
> - Behavioral Change: expired conversations are no longer soft-preserved; any code relying on the conversation shell existing after expiry will find the row gone.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a9a5792.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->