### PR TITLE
Conversations list: persist delete via consent=.denied

### DIFF
--- a/Convos/Conversations List/ConversationsViewModel.swift
+++ b/Convos/Conversations List/ConversationsViewModel.swift
@@ -96,7 +96,7 @@ final class ConversationsViewModel {
     var presentingPinLimitInfo: Bool = false
 
     var conversations: [Conversation] = []
-    private var hiddenConversationIds: Set<String> = []
+    private(set) var hiddenConversationIds: Set<String> = []
     private var conversationsCount: Int = 0 {
         didSet {
             if conversationsCount > 1 {
@@ -304,7 +304,9 @@ final class ConversationsViewModel {
             do {
                 let writer = session.messagingService().conversationConsentWriter()
                 try await writer.delete(conversation: conversation)
+                self.hiddenConversationIds.remove(conversationId)
             } catch {
+                self.hiddenConversationIds.remove(conversationId)
                 Log.error("Failed to persist delete for \(conversationId): \(error.localizedDescription)")
             }
         }

--- a/Convos/Conversations List/ConversationsViewModel.swift
+++ b/Convos/Conversations List/ConversationsViewModel.swift
@@ -286,18 +286,27 @@ final class ConversationsViewModel {
     }
 
     func leave(conversation: Conversation) {
-        // Hide the row so the next conversationsPublisher emit doesn't re-add
-        // it (see sink at `conversationsRepository.conversationsPublisher`,
-        // which filters on hiddenConversationIds). A proper group-leave path
-        // via group.leaveGroup() is tracked as a follow-up to C11 — until
-        // then the user remains a group member on the protocol side, but the
-        // row stays hidden locally.
+        // Optimistic hide while the consent write lands. Once the DB row's
+        // consent flips to .denied, ConversationsRepository filters it out
+        // unconditionally, so the hiddenConversationIds fallback is only
+        // needed during the in-flight window.
         hiddenConversationIds.insert(conversation.id)
         if let index = conversations.firstIndex(of: conversation) {
             conversations.remove(at: index)
         }
         if selectedConversation == conversation {
             selectedConversation = nil
+        }
+
+        let conversationId = conversation.id
+        Task { [weak self] in
+            guard let self else { return }
+            do {
+                let writer = session.messagingService().conversationConsentWriter()
+                try await writer.delete(conversation: conversation)
+            } catch {
+                Log.error("Failed to persist delete for \(conversationId): \(error.localizedDescription)")
+            }
         }
     }
 

--- a/ConvosCore/Sources/ConvosCore/Mocks/MockConversationConsentWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Mocks/MockConversationConsentWriter.swift
@@ -5,6 +5,7 @@ public final class MockConversationConsentWriter: ConversationConsentWriterProto
     public var joinedConversations: [Conversation] = []
     public var deletedConversations: [Conversation] = []
     public var deleteAllCalled: Bool = false
+    public var deleteError: Error?
 
     public init() {}
 
@@ -13,6 +14,9 @@ public final class MockConversationConsentWriter: ConversationConsentWriterProto
     }
 
     public func delete(conversation: Conversation) async throws {
+        if let deleteError {
+            throw deleteError
+        }
         deletedConversations.append(conversation)
     }
 

--- a/ConvosCore/Tests/ConvosCoreTests/ConversationConsentWriterDeleteTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ConversationConsentWriterDeleteTests.swift
@@ -1,0 +1,111 @@
+@testable import ConvosCore
+import Foundation
+import GRDB
+import Testing
+
+/// Coverage for `ConversationConsentWriter.delete(conversation:)` — the path
+/// that powers the conversations-list "Delete" action. The writer must flip
+/// the local DB row's `consent` column to `.denied` so that the next
+/// `ConversationsRepository(for: [.allowed])` emit filters the row out and
+/// the delete survives an app restart.
+@Suite("ConversationConsentWriter delete persistence", .serialized)
+struct ConversationConsentWriterDeleteTests {
+    @Test("delete(conversation:) writes consent=.denied to the local DB row")
+    func deleteFlipsConsentToDenied() async throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        let conversationId = "conv-delete-1"
+        try seedAllowedConversation(in: dbManager.dbWriter, conversationId: conversationId)
+
+        let writer = ConversationConsentWriter(
+            sessionStateManager: MockSessionStateManager(),
+            databaseWriter: dbManager.dbWriter
+        )
+
+        try await writer.delete(conversation: .mock(id: conversationId))
+
+        let stored = try await dbManager.dbReader.read { db in
+            try DBConversation.fetchOne(db, id: conversationId)
+        }
+        #expect(stored?.consent == .denied)
+    }
+
+    @Test("delete(conversation:) no-ops cleanly when the DB row is missing")
+    func deleteWithMissingRowIsNoOp() async throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+
+        let writer = ConversationConsentWriter(
+            sessionStateManager: MockSessionStateManager(),
+            databaseWriter: dbManager.dbWriter
+        )
+
+        try await writer.delete(conversation: .mock(id: "conv-missing"))
+
+        let stored = try await dbManager.dbReader.read { db in
+            try DBConversation.fetchOne(db, id: "conv-missing")
+        }
+        #expect(stored == nil)
+    }
+
+    @Test("After delete, a fetch filtered on [.allowed] no longer returns the row")
+    func repositoryFilterExcludesDeniedRow() async throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        let conversationId = "conv-delete-2"
+        try seedAllowedConversation(in: dbManager.dbWriter, conversationId: conversationId)
+
+        let beforeDelete = try await dbManager.dbReader.read { db in
+            try DBConversation
+                .filter([Consent.allowed].contains(DBConversation.Columns.consent))
+                .filter(DBConversation.Columns.id == conversationId)
+                .fetchOne(db)
+        }
+        #expect(beforeDelete?.consent == .allowed)
+
+        let writer = ConversationConsentWriter(
+            sessionStateManager: MockSessionStateManager(),
+            databaseWriter: dbManager.dbWriter
+        )
+        try await writer.delete(conversation: .mock(id: conversationId))
+
+        let afterDelete = try await dbManager.dbReader.read { db in
+            try DBConversation
+                .filter([Consent.allowed].contains(DBConversation.Columns.consent))
+                .filter(DBConversation.Columns.id == conversationId)
+                .fetchOne(db)
+        }
+        #expect(afterDelete == nil)
+    }
+}
+
+// MARK: - Helpers
+
+private func seedAllowedConversation(
+    in writer: any DatabaseWriter,
+    conversationId: String
+) throws {
+    try writer.write { db in
+        try DBConversation(
+            id: conversationId,
+            clientConversationId: "client-\(conversationId)",
+            inviteTag: "invite-\(conversationId)",
+            creatorId: "inbox-1",
+            kind: .group,
+            consent: .allowed,
+            createdAt: Date(),
+            name: "Test",
+            description: nil,
+            imageURLString: nil,
+            publicImageURLString: nil,
+            includeInfoInPublicPreview: false,
+            expiresAt: nil,
+            debugInfo: .empty,
+            isLocked: false,
+            imageSalt: nil,
+            imageNonce: nil,
+            imageEncryptionKey: nil,
+            conversationEmoji: nil,
+            imageLastRenewed: nil,
+            isUnused: false,
+            hasHadVerifiedAssistant: false,
+        ).insert(db)
+    }
+}

--- a/ConvosTests/ConversationsViewModelDeleteTests.swift
+++ b/ConvosTests/ConversationsViewModelDeleteTests.swift
@@ -28,6 +28,63 @@ final class ConversationsViewModelDeleteTests: XCTestCase {
         XCTAssertEqual(consentWriter.deletedConversations.map(\.id), [conversation.id])
     }
 
+    func testLeaveSuccessRemovesFromHiddenConversationIds() async throws {
+        let conversation = Conversation.mock(id: "conv-success", name: "Success")
+        let consentWriter = MockConversationConsentWriter()
+        let messagingService = MockMessagingService(conversationConsentWriter: consentWriter)
+        let session = TestSessionManager(
+            base: MockInboxesService(),
+            messagingService: messagingService
+        )
+
+        let viewModel = ConversationsViewModel(session: session)
+        viewModel.conversations = [conversation]
+
+        viewModel.leave(conversation: conversation)
+
+        try await waitUntil(timeout: 1.0) {
+            !consentWriter.deletedConversations.isEmpty
+        }
+
+        try await waitUntilMainActor(timeout: 1.0) {
+            !viewModel.hiddenConversationIds.contains(conversation.id)
+        }
+
+        XCTAssertFalse(
+            viewModel.hiddenConversationIds.contains(conversation.id),
+            "Optimistic hide should be released once the consent write succeeds"
+        )
+    }
+
+    func testLeaveFailureRemovesFromHiddenConversationIds() async throws {
+        let conversation = Conversation.mock(id: "conv-fail", name: "Failure")
+        let consentWriter = MockConversationConsentWriter()
+        consentWriter.deleteError = TestError.deleteFailed
+        let messagingService = MockMessagingService(conversationConsentWriter: consentWriter)
+        let session = TestSessionManager(
+            base: MockInboxesService(),
+            messagingService: messagingService
+        )
+
+        let viewModel = ConversationsViewModel(session: session)
+        viewModel.conversations = [conversation]
+
+        viewModel.leave(conversation: conversation)
+
+        try await waitUntilMainActor(timeout: 1.0) {
+            !viewModel.hiddenConversationIds.contains(conversation.id)
+        }
+
+        XCTAssertFalse(
+            viewModel.hiddenConversationIds.contains(conversation.id),
+            "Optimistic hide should be released when the consent write fails so the row can reappear"
+        )
+        XCTAssertTrue(
+            consentWriter.deletedConversations.isEmpty,
+            "Writer should not have recorded a successful deletion when throwing"
+        )
+    }
+
     func testLeaveHidesRowBeforeWriterCompletes() async throws {
         let slowWriter = DelayedConsentWriter()
         let messagingService = MockMessagingService(conversationConsentWriter: slowWriter)
@@ -77,6 +134,25 @@ final class ConversationsViewModelDeleteTests: XCTestCase {
         }
         XCTFail("waitUntil timed out after \(timeout)s")
     }
+
+    private func waitUntilMainActor(
+        timeout: TimeInterval,
+        interval: TimeInterval = 0.02,
+        condition: @MainActor () -> Bool
+    ) async throws {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if condition() {
+                return
+            }
+            try await Task.sleep(nanoseconds: UInt64(interval * 1_000_000_000))
+        }
+        XCTFail("waitUntilMainActor timed out after \(timeout)s")
+    }
+}
+
+private enum TestError: Error {
+    case deleteFailed
 }
 
 private actor DelayedConsentWriterState {

--- a/ConvosTests/ConversationsViewModelDeleteTests.swift
+++ b/ConvosTests/ConversationsViewModelDeleteTests.swift
@@ -1,0 +1,262 @@
+import ConvosCore
+import XCTest
+@testable import Convos
+
+@MainActor
+final class ConversationsViewModelDeleteTests: XCTestCase {
+    func testLeaveRoutesThroughConsentWriter() async throws {
+        let conversation = Conversation.mock(id: "conv-to-delete", name: "Test")
+        let consentWriter = MockConversationConsentWriter()
+        let messagingService = MockMessagingService(conversationConsentWriter: consentWriter)
+        let session = TestSessionManager(
+            base: MockInboxesService(),
+            messagingService: messagingService
+        )
+
+        let viewModel = ConversationsViewModel(session: session)
+        viewModel.conversations = [conversation]
+
+        viewModel.leave(conversation: conversation)
+
+        XCTAssertFalse(viewModel.conversations.contains(conversation),
+                       "Row should be hidden optimistically before the writer finishes")
+
+        try await waitUntil(timeout: 1.0) {
+            !consentWriter.deletedConversations.isEmpty
+        }
+
+        XCTAssertEqual(consentWriter.deletedConversations.map(\.id), [conversation.id])
+    }
+
+    func testLeaveHidesRowBeforeWriterCompletes() async throws {
+        let slowWriter = DelayedConsentWriter()
+        let messagingService = MockMessagingService(conversationConsentWriter: slowWriter)
+        let session = TestSessionManager(
+            base: MockInboxesService(),
+            messagingService: messagingService
+        )
+
+        let conversation = Conversation.mock(id: "conv-delayed", name: "Delayed")
+        let viewModel = ConversationsViewModel(session: session)
+        viewModel.conversations = [conversation]
+
+        viewModel.leave(conversation: conversation)
+
+        XCTAssertTrue(
+            viewModel.conversations.isEmpty,
+            "Optimistic hide must happen before the writer resolves"
+        )
+        let beforeResume = await slowWriter.deletedConversations
+        XCTAssertTrue(
+            beforeResume.isEmpty,
+            "Writer should not have been observed completing yet"
+        )
+
+        await slowWriter.resume()
+
+        try await waitUntil(timeout: 1.0) {
+            await !slowWriter.deletedConversations.isEmpty
+        }
+        let afterResume = await slowWriter.deletedConversations
+        XCTAssertEqual(afterResume.map(\.id), [conversation.id])
+    }
+
+    // MARK: - Helpers
+
+    private func waitUntil(
+        timeout: TimeInterval,
+        interval: TimeInterval = 0.02,
+        condition: @Sendable () async -> Bool
+    ) async throws {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if await condition() {
+                return
+            }
+            try await Task.sleep(nanoseconds: UInt64(interval * 1_000_000_000))
+        }
+        XCTFail("waitUntil timed out after \(timeout)s")
+    }
+}
+
+private actor DelayedConsentWriterState {
+    private var _deletedConversations: [Conversation] = []
+    private var gate: CheckedContinuation<Void, Never>?
+    private var released: Bool = false
+
+    var deletedConversations: [Conversation] {
+        _deletedConversations
+    }
+
+    func waitForGate() async {
+        if released { return }
+        await withCheckedContinuation { continuation in
+            gate = continuation
+        }
+    }
+
+    func recordDeletion(_ conversation: Conversation) {
+        _deletedConversations.append(conversation)
+    }
+
+    func release() {
+        released = true
+        let pending = gate
+        gate = nil
+        pending?.resume()
+    }
+}
+
+private final class DelayedConsentWriter: ConversationConsentWriterProtocol, @unchecked Sendable {
+    private let state: DelayedConsentWriterState = DelayedConsentWriterState()
+
+    var deletedConversations: [Conversation] {
+        get async { await state.deletedConversations }
+    }
+
+    func join(conversation: Conversation) async throws {}
+
+    func delete(conversation: Conversation) async throws {
+        await state.waitForGate()
+        await state.recordDeletion(conversation)
+    }
+
+    func deleteAll() async throws {}
+
+    func resume() async {
+        await state.release()
+    }
+}
+
+private final class TestSessionManager: SessionManagerProtocol, @unchecked Sendable {
+    private let base: MockInboxesService
+    private let customMessagingService: any MessagingServiceProtocol
+
+    init(
+        base: MockInboxesService,
+        messagingService: any MessagingServiceProtocol
+    ) {
+        self.base = base
+        self.customMessagingService = messagingService
+    }
+
+    func prepareNewConversation() async -> (service: AnyMessagingService, conversationId: String?) {
+        (service: customMessagingService, conversationId: nil)
+    }
+
+    func deleteAllInboxes() async throws {
+        try await base.deleteAllInboxes()
+    }
+
+    func deleteAllInboxesWithProgress() -> AsyncThrowingStream<InboxDeletionProgress, Error> {
+        base.deleteAllInboxesWithProgress()
+    }
+
+    func messagingService() -> AnyMessagingService {
+        customMessagingService
+    }
+
+    func messagingServiceSync() -> AnyMessagingService {
+        customMessagingService
+    }
+
+    func inviteRepository(for conversationId: String) -> any InviteRepositoryProtocol {
+        base.inviteRepository(for: conversationId)
+    }
+
+    func conversationRepository(for conversationId: String) -> any ConversationRepositoryProtocol {
+        base.conversationRepository(for: conversationId)
+    }
+
+    func messagesRepository(for conversationId: String) -> any MessagesRepositoryProtocol {
+        base.messagesRepository(for: conversationId)
+    }
+
+    func photoPreferencesRepository(for conversationId: String) -> any PhotoPreferencesRepositoryProtocol {
+        base.photoPreferencesRepository(for: conversationId)
+    }
+
+    func photoPreferencesWriter() -> any PhotoPreferencesWriterProtocol {
+        base.photoPreferencesWriter()
+    }
+
+    func attachmentLocalStateWriter() -> any AttachmentLocalStateWriterProtocol {
+        base.attachmentLocalStateWriter()
+    }
+
+    func conversationsRepository(for consent: [Consent]) -> any ConversationsRepositoryProtocol {
+        base.conversationsRepository(for: consent)
+    }
+
+    func conversationsCountRepo(for consent: [Consent], kinds: [ConversationKind]) -> any ConversationsCountRepositoryProtocol {
+        base.conversationsCountRepo(for: consent, kinds: kinds)
+    }
+
+    func pinnedConversationsCountRepo() -> any PinnedConversationsCountRepositoryProtocol {
+        base.pinnedConversationsCountRepo()
+    }
+
+    func notifyChangesInDatabase() {
+        base.notifyChangesInDatabase()
+    }
+
+    func shouldDisplayNotification(for conversationId: String) async -> Bool {
+        await base.shouldDisplayNotification(for: conversationId)
+    }
+
+    func setIsOnConversationsList(_ isOn: Bool) {
+        base.setIsOnConversationsList(isOn)
+    }
+
+    func wakeInboxForNotification(conversationId: String) {
+        base.wakeInboxForNotification(conversationId: conversationId)
+    }
+
+    func inboxId(for conversationId: String) async -> String? {
+        await base.inboxId(for: conversationId)
+    }
+
+    func requestAgentJoin(slug: String, instructions: String, forceErrorCode: Int? = nil) async throws -> ConvosAPI.AgentJoinResponse {
+        try await base.requestAgentJoin(slug: slug, instructions: instructions, forceErrorCode: forceErrorCode)
+    }
+
+    func redeemInviteCode(_ code: String) async throws -> ConvosAPI.InviteCodeStatus {
+        try await base.redeemInviteCode(code)
+    }
+
+    func fetchInviteCodeStatus(_ code: String) async throws -> ConvosAPI.InviteCodeStatus {
+        try await base.fetchInviteCodeStatus(code)
+    }
+
+    func voiceMemoTranscriptRepository() -> any VoiceMemoTranscriptRepositoryProtocol {
+        base.voiceMemoTranscriptRepository()
+    }
+
+    func voiceMemoTranscriptWriter() -> any VoiceMemoTranscriptWriterProtocol {
+        base.voiceMemoTranscriptWriter()
+    }
+
+    func voiceMemoTranscriptionService() -> any VoiceMemoTranscriptionServicing {
+        base.voiceMemoTranscriptionService()
+    }
+
+    func assistantFilesLinksRepository(for conversationId: String) -> AssistantFilesLinksRepository {
+        base.assistantFilesLinksRepository(for: conversationId)
+    }
+
+    func pendingInviteDetails() throws -> [PendingInviteDetail] {
+        try base.pendingInviteDetails()
+    }
+
+    func deleteExpiredPendingInvites() async throws -> Int {
+        try await base.deleteExpiredPendingInvites()
+    }
+
+    func isAccountOrphaned() throws -> Bool {
+        try base.isAccountOrphaned()
+    }
+
+    func makeAssetRenewalManager() async -> AssetRenewalManager {
+        await base.makeAssetRenewalManager()
+    }
+}


### PR DESCRIPTION
## Summary

Tapping Delete in the conversations list context menu previously only inserted the id into an in-memory `hiddenConversationIds` set and removed the row from the in-memory `conversations` array. Nothing was written to the DB, so on restart `conversationsPublisher` reloaded the row unfiltered and the "deleted" conversation reappeared.

## The fix

`ConversationsViewModel.leave(conversation:)` now routes through the existing `ConversationConsentWriter.delete`, which:

1. Calls `client.update(consent: .denied, for: conversationId)` on the XMTP side.
2. Writes `consent = .denied` to the `DBConversation` row locally.

`ConversationsRepository.composeAllConversations(consent:)` at `:65` already filters `consent.contains(DBConversation.Columns.consent)`. Every home-list caller passes `[.allowed]`, so the `.denied` row is filtered out consistently in memory **and** across app restarts.

The in-memory `hiddenConversationIds` hide is retained as an optimistic update so the UI removes the row instantly while the async DB write is in flight.

## Not in scope

- **No `group.leaveGroup()` call.** The user remains a member of the MLS group. Peers will still see them as a group member. This matches XMTP's `.denied` consent semantics: "I don't want to see this" without leaving the protocol-level group. A true leave-group flow is distinct and runs into libxmtp's 1→0 invariant (see PR #742 for context).
- **No block on incoming messages.** Messages sent to the group still arrive via sync; they're just hidden by the consent filter. An `.denied` convo can be un-denied via `ConversationConsentWriter.join(conversation:)` if needed.

## Tests

- `ConvosCore/Tests/ConvosCoreTests/ConversationConsentWriterDeleteTests.swift` — direct tests of the writer's delete path (new).
- `ConvosTests/ConversationsViewModelDeleteTests.swift` — covers the ViewModel's optimistic hide + async DB write (new).

## Related

- PR #742 — drops `leaveGroup` from the explode flow (independent).
- PR #746 — deletes expired convo rows instead of keeping a gravestone (independent).
- This PR is the third piece of "local convo lifecycle" cleanup; each is scoped to one entry point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Persist conversation deletion via `ConversationConsentWriter.delete` with optimistic hide in `ConversationsViewModel`
> - `leave(conversation:)` now optimistically hides the conversation immediately, then calls `ConversationConsentWriter.delete` asynchronously to persist the deletion with `consent=.denied`.
> - The optimistic hidden flag is cleared after the async call completes, whether it succeeds or fails, and errors are logged with the conversation ID.
> - Adds tests for the new delete flow in [`ConversationsViewModelDeleteTests`](https://github.com/xmtplabs/convos-ios/pull/747/files#diff-7971f76dbf8b3c53bc8e132b37480e21a47e3262f471ea7015d2cee2e06b2325) and DB-level consent behavior in [`ConversationConsentWriterDeleteTests`](https://github.com/xmtplabs/convos-ios/pull/747/files#diff-14e4dbd0a54ad4ccfaa5539c4bfb8ddc139299ee999e3759366882609ae0ffbd).
> - `MockConversationConsentWriter` gains a configurable `deleteError` to simulate failures in tests.
> - Behavioral Change: previously, leaving a conversation was local-only; it now makes an async persistence call that may fail silently (with logging).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0850f39.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->