### PR TITLE
Fix ConnectionGrantWriter rollback correctness (H2, H3, H4)

### DIFF
--- a/ConvosCore/Sources/ConvosCore/Connections/ConnectionGrantWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Connections/ConnectionGrantWriter.swift
@@ -1,4 +1,3 @@
-import ConvosProfiles
 import Foundation
 import GRDB
 @preconcurrency import XMTPiOS
@@ -44,28 +43,23 @@ final class ConnectionGrantWriter: ConnectionGrantWriterProtocol, @unchecked Sen
             grantedAt: Date()
         )
 
+        // Publish before persisting. If the publish fails we never commit the grant
+        // locally, so there is no way for a partially-completed operation to leave a
+        // local grant that was never announced to the group.
+        let targetGrants = try await projectedGrants(
+            for: conversationId,
+            addingOrReplacing: grant,
+            removing: nil
+        )
+        try await syncGrantsToMetadata(for: conversationId, desiredGrants: targetGrants)
+
         try await databaseWriter.write { db in
             try grant.save(db)
-        }
-
-        do {
-            try await syncGrantsToMetadata(for: conversationId)
-        } catch {
-            Log.warning("[CloudConnections] metadata write failed, rolling back DB grant (connectionId=\(connectionId), conversationId=\(conversationId)): \(error.localizedDescription)")
-            try? await databaseWriter.write { db in
-                try DBConnectionGrant
-                    .filter(
-                        DBConnectionGrant.Columns.connectionId == connectionId
-                            && DBConnectionGrant.Columns.conversationId == conversationId
-                    )
-                    .deleteAll(db)
-            }
-            throw error
         }
     }
 
     func revokeGrant(connectionId: String, from conversationId: String) async throws {
-        let removedGrant = try await databaseReader.read { db in
+        let existing = try await databaseReader.read { db in
             try DBConnectionGrant
                 .filter(
                     DBConnectionGrant.Columns.connectionId == connectionId
@@ -73,6 +67,20 @@ final class ConnectionGrantWriter: ConnectionGrantWriterProtocol, @unchecked Sen
                 )
                 .fetchOne(db)
         }
+        guard existing != nil else {
+            // Nothing to revoke, no-op.
+            return
+        }
+
+        // Publish the reduced grant set first; only delete locally after the agent sees
+        // the removal. If publish fails we leave the row intact so the UI/agent stay
+        // consistent.
+        let targetGrants = try await projectedGrants(
+            for: conversationId,
+            addingOrReplacing: nil,
+            removing: (connectionId: connectionId, conversationId: conversationId)
+        )
+        try await syncGrantsToMetadata(for: conversationId, desiredGrants: targetGrants)
 
         try await databaseWriter.write { db in
             try DBConnectionGrant
@@ -82,34 +90,42 @@ final class ConnectionGrantWriter: ConnectionGrantWriterProtocol, @unchecked Sen
                 )
                 .deleteAll(db)
         }
-
-        do {
-            try await syncGrantsToMetadata(for: conversationId)
-        } catch {
-            Log.warning("[CloudConnections] metadata write failed, restoring DB grant (connectionId=\(connectionId), conversationId=\(conversationId)): \(error.localizedDescription)")
-            if let removedGrant {
-                try? await databaseWriter.write { db in
-                    try removedGrant.save(db)
-                }
-            }
-            throw error
-        }
     }
 
-    private func syncGrantsToMetadata(for conversationId: String) async throws {
-        let inboxReady = try await sessionStateManager.waitForInboxReadyResult()
-        let senderId = inboxReady.client.inboxId
-
-        guard let conversation = try await inboxReady.client.conversation(with: conversationId),
-              case .group(let group) = conversation else {
-            throw ConnectionGrantError.conversationNotFound(conversationId)
-        }
-
-        let grants = try await databaseReader.read { db in
+    private func projectedGrants(
+        for conversationId: String,
+        addingOrReplacing addition: DBConnectionGrant?,
+        removing removal: (connectionId: String, conversationId: String)?
+    ) async throws -> [DBConnectionGrant] {
+        let existing = try await databaseReader.read { db in
             try DBConnectionGrant
                 .filter(DBConnectionGrant.Columns.conversationId == conversationId)
                 .fetchAll(db)
         }
+
+        var projected = existing
+        if let removal {
+            projected.removeAll {
+                $0.connectionId == removal.connectionId
+                    && $0.conversationId == removal.conversationId
+            }
+        }
+        if let addition {
+            projected.removeAll {
+                $0.connectionId == addition.connectionId
+                    && $0.conversationId == addition.conversationId
+            }
+            projected.append(addition)
+        }
+        return projected
+    }
+
+    private func syncGrantsToMetadata(
+        for conversationId: String,
+        desiredGrants: [DBConnectionGrant]
+    ) async throws {
+        let inboxReady = try await sessionStateManager.waitForInboxReadyResult()
+        let senderId = inboxReady.client.inboxId
 
         let connections = try await databaseReader.read { db in
             try DBConnection
@@ -119,7 +135,7 @@ final class ConnectionGrantWriter: ConnectionGrantWriterProtocol, @unchecked Sen
         let connectionsById = Dictionary(uniqueKeysWithValues: connections.map { ($0.id, $0) })
 
         let iso8601 = ISO8601DateFormatter()
-        let entries: [ConnectionGrantEntry] = grants.compactMap { grant in
+        let entries: [ConnectionGrantEntry] = desiredGrants.compactMap { grant in
             guard let conn = connectionsById[grant.connectionId] else { return nil }
             // Guard against DB rows written before canonical-naming landed: if the
             // stored serviceId is a Composio toolkit slug, translate back to canonical.
@@ -146,9 +162,10 @@ final class ConnectionGrantWriter: ConnectionGrantWriterProtocol, @unchecked Sen
         }
 
         // Primary: send a ProfileUpdate message with metadata["connections"]. This is
-        // the CLI's (and therefore the agent's) current read path — throws on failure
-        // so the caller rolls the DB grant back. We run this BEFORE the best-effort
-        // appData write so a ProfileUpdate failure can't leave a stale grant in appData.
+        // the CLI's (and therefore the agent's) current read path. We use the throwing
+        // variant so a send failure propagates to the caller, which then declines to
+        // persist the local grant change. We run this before the best-effort appData
+        // write so a ProfileUpdate failure can't leave a stale grant in appData.
         try await sendProfileUpdateWithConnections(
             conversationId: conversationId,
             senderId: senderId,
@@ -156,8 +173,14 @@ final class ConnectionGrantWriter: ConnectionGrantWriterProtocol, @unchecked Sen
         )
 
         // Best-effort: stash on the sender's ConversationProfile in appData (field 5).
-        // Forward-compat hedge for any CLI reader that looks at appData — failures are logged only.
+        // Forward-compat hedge for any CLI reader that looks at appData — failures are logged only,
+        // including failure to locate the group (appData isn't on the critical path).
         do {
+            guard let conversation = try await inboxReady.client.conversation(with: conversationId),
+                  case .group(let group) = conversation else {
+                Log.warning("[CloudConnections] appData write skipped (best-effort), conversation not found: \(conversationId)")
+                return
+            }
             if let grantsJson {
                 try await group.updateSenderConnections(grantsJson, senderInboxId: senderId)
             } else {
@@ -187,7 +210,7 @@ final class ConnectionGrantWriter: ConnectionGrantWriterProtocol, @unchecked Sen
             merged.removeValue(forKey: Constant.connectionsKey)
         }
 
-        try await myProfileWriter.update(
+        try await myProfileWriter.updateAndPublish(
             metadata: merged.isEmpty ? nil : merged,
             conversationId: conversationId
         )

--- a/ConvosCore/Sources/ConvosCore/Mocks/MockMyProfileWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Mocks/MockMyProfileWriter.swift
@@ -5,6 +5,8 @@ public final class MockMyProfileWriter: MyProfileWriterProtocol, @unchecked Send
     public var updatedDisplayNames: [(name: String, conversationId: String)] = []
     public var updatedAvatars: [(image: ImageType?, conversationId: String)] = []
     public var updatedMetadata: [(metadata: ProfileMetadata?, conversationId: String)] = []
+    public var publishedMetadata: [(metadata: ProfileMetadata?, conversationId: String)] = []
+    public var publishError: (any Error)?
 
     public init() {}
 
@@ -18,5 +20,12 @@ public final class MockMyProfileWriter: MyProfileWriterProtocol, @unchecked Send
 
     public func update(metadata: ProfileMetadata?, conversationId: String) async throws {
         updatedMetadata.append((metadata: metadata, conversationId: conversationId))
+    }
+
+    public func updateAndPublish(metadata: ProfileMetadata?, conversationId: String) async throws {
+        publishedMetadata.append((metadata: metadata, conversationId: conversationId))
+        if let publishError {
+            throw publishError
+        }
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/MyProfileWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/MyProfileWriter.swift
@@ -6,10 +6,15 @@ public protocol MyProfileWriterProtocol {
     func update(displayName: String, conversationId: String) async throws
     func update(avatar: ImageType?, conversationId: String) async throws
     func update(metadata: ProfileMetadata?, conversationId: String) async throws
+    /// Like `update(metadata:conversationId:)` but propagates ProfileUpdate publish failures.
+    /// Use this when the caller needs to know whether the ProfileUpdate reached the network
+    /// (e.g. to roll back a dependent local write).
+    func updateAndPublish(metadata: ProfileMetadata?, conversationId: String) async throws
 }
 
 enum MyProfileWriterError: Error {
     case imageCompressionFailed
+    case profileUpdatePublishFailed(underlying: any Error)
 }
 
 class MyProfileWriter: MyProfileWriterProtocol {
@@ -61,6 +66,14 @@ class MyProfileWriter: MyProfileWriterProtocol {
     }
 
     func update(metadata: ProfileMetadata?, conversationId: String) async throws {
+        do {
+            try await updateAndPublish(metadata: metadata, conversationId: conversationId)
+        } catch MyProfileWriterError.profileUpdatePublishFailed(let underlying) {
+            Log.warning("Failed to send ProfileUpdate message: \(underlying.localizedDescription)")
+        }
+    }
+
+    func updateAndPublish(metadata: ProfileMetadata?, conversationId: String) async throws {
         let inboxReady = try await sessionStateManager.waitForInboxReadyResult()
         guard let conversation = try await inboxReady.client.conversation(with: conversationId),
               case .group(let group) = conversation else {
@@ -79,7 +92,7 @@ class MyProfileWriter: MyProfileWriterProtocol {
             try profile.save(db)
             return profile
         }
-        await sendProfileUpdate(profile: profile, group: group)
+        try await sendProfileUpdateThrowing(profile: profile, group: group)
     }
 
     func update(avatar: ImageType?, conversationId: String) async throws {
@@ -169,6 +182,16 @@ class MyProfileWriter: MyProfileWriterProtocol {
     }
 
     private func sendProfileUpdate(profile: DBMemberProfile, group: XMTPiOS.Group) async {
+        do {
+            try await sendProfileUpdateThrowing(profile: profile, group: group)
+        } catch MyProfileWriterError.profileUpdatePublishFailed(let underlying) {
+            Log.warning("Failed to send ProfileUpdate message: \(underlying.localizedDescription)")
+        } catch {
+            Log.warning("Failed to send ProfileUpdate message: \(error.localizedDescription)")
+        }
+    }
+
+    private func sendProfileUpdateThrowing(profile: DBMemberProfile, group: XMTPiOS.Group) async throws {
         var update = ProfileUpdate()
         if let name = profile.name {
             update.name = name
@@ -183,13 +206,19 @@ class MyProfileWriter: MyProfileWriterProtocol {
             update.metadata = metadata.asProtoMap
         }
 
+        let codec = ProfileUpdateCodec()
+        let encoded: EncodedContent
         do {
-            let codec = ProfileUpdateCodec()
-            let encoded = try codec.encode(content: update)
+            encoded = try codec.encode(content: update)
+        } catch {
+            throw MyProfileWriterError.profileUpdatePublishFailed(underlying: error)
+        }
+
+        do {
             _ = try await group.send(encodedContent: encoded)
             Log.debug("Sent ProfileUpdate message for \(profile.inboxId) in \(profile.conversationId)")
         } catch {
-            Log.warning("Failed to send ProfileUpdate message: \(error.localizedDescription)")
+            throw MyProfileWriterError.profileUpdatePublishFailed(underlying: error)
         }
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/MyProfileWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/MyProfileWriter.swift
@@ -93,6 +93,11 @@ class MyProfileWriter: MyProfileWriterProtocol {
             return profile
         }
         try await sendProfileUpdateThrowing(profile: profile, group: group)
+        do {
+            try await group.updateProfile(profile)
+        } catch {
+            Log.warning("Failed to write profile to appData (best-effort): \(error.localizedDescription)")
+        }
     }
 
     func update(avatar: ImageType?, conversationId: String) async throws {

--- a/ConvosCore/Tests/ConvosCoreTests/Assets/AssetRenewalManagerTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/Assets/AssetRenewalManagerTests.swift
@@ -488,4 +488,16 @@ final class ConfigurableMockAPIClient: ConvosAPIClientProtocol, @unchecked Senda
     func fetchInviteCodeStatus(_ code: String) async throws -> ConvosAPI.InviteCodeStatus {
         .init(code: code, name: nil, maxRedemptions: 5, redemptionCount: 0, remainingRedemptions: 5)
     }
+
+    func initiateConnection(serviceId: String, redirectUri: String) async throws -> ConnectionsAPI.InitiateResponse {
+        .init(connectionRequestId: "", redirectUrl: "")
+    }
+
+    func completeConnection(connectionRequestId: String) async throws -> ConnectionsAPI.CompleteResponse {
+        .init(connectionId: "", serviceId: "", serviceName: "", composioEntityId: "", composioConnectionId: "", status: "")
+    }
+
+    func listConnections() async throws -> [ConnectionsAPI.ConnectionResponse] { [] }
+
+    func revokeConnection(connectionId: String) async throws {}
 }

--- a/ConvosCore/Tests/ConvosCoreTests/ConnectionGrantWriterTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ConnectionGrantWriterTests.swift
@@ -1,0 +1,308 @@
+@testable import ConvosCore
+import Foundation
+import GRDB
+import Testing
+
+/// Tests for ConnectionGrantWriter
+///
+/// Covers the atomicity/rollback correctness of grant and revoke flows:
+/// - grant succeeds → DB row present, metadata was published
+/// - metadata publish fails → no DB row committed, error propagates
+/// - revoke succeeds → DB row removed, metadata was published with reduced set
+/// - revoke publish fails → DB row remains, error propagates
+@Suite("ConnectionGrantWriter Tests")
+struct ConnectionGrantWriterTests {
+    // MARK: - Fixtures
+
+    private struct Fixture {
+        let databaseManager: MockDatabaseManager
+        let sessionStateManager: MockSessionStateManager
+        let profileWriter: MockMyProfileWriter
+        let writer: ConnectionGrantWriter
+
+        init(inboxId: String = "mock-inbox-id") {
+            let databaseManager = MockDatabaseManager.makeTestDatabase()
+            let profileWriter = MockMyProfileWriter()
+            let mockClient = MockXMTPClientProvider(inboxId: inboxId)
+            let sessionStateManager = MockSessionStateManager(mockClient: mockClient)
+            self.databaseManager = databaseManager
+            self.sessionStateManager = sessionStateManager
+            self.profileWriter = profileWriter
+            self.writer = ConnectionGrantWriter(
+                sessionStateManager: sessionStateManager,
+                databaseWriter: databaseManager.dbWriter,
+                databaseReader: databaseManager.dbReader,
+                myProfileWriter: profileWriter
+            )
+        }
+
+        func seedConnection(
+            id: String = "conn_google_cal",
+            serviceId: String = "google_calendar",
+            status: ConnectionStatus = .active
+        ) throws -> DBConnection {
+            let connection = DBConnection(
+                id: id,
+                serviceId: serviceId,
+                serviceName: "Google Calendar",
+                provider: ConnectionProvider.composio.rawValue,
+                composioEntityId: "entity_abc",
+                composioConnectionId: "ca_abc",
+                status: status.rawValue,
+                connectedAt: Date()
+            )
+            try databaseManager.dbWriter.write { db in
+                try connection.save(db)
+            }
+            return connection
+        }
+
+        func seedConversation(id: String) throws {
+            let conversation = DBConversation(
+                id: id,
+                clientConversationId: id,
+                inviteTag: "invite-\(id)",
+                creatorId: "test-inbox",
+                kind: .group,
+                consent: .allowed,
+                createdAt: Date(),
+                name: nil,
+                description: nil,
+                imageURLString: nil,
+                publicImageURLString: nil,
+                includeInfoInPublicPreview: false,
+                expiresAt: nil,
+                debugInfo: .empty,
+                isLocked: false,
+                imageSalt: nil,
+                imageNonce: nil,
+                imageEncryptionKey: nil,
+                conversationEmoji: nil,
+                imageLastRenewed: nil,
+                isUnused: false,
+                hasHadVerifiedAssistant: false,
+            )
+            try databaseManager.dbWriter.write { db in
+                try conversation.save(db)
+            }
+        }
+
+        func seedGrant(
+            connectionId: String,
+            conversationId: String,
+            serviceId: String
+        ) throws {
+            let grant = DBConnectionGrant(
+                connectionId: connectionId,
+                conversationId: conversationId,
+                serviceId: serviceId,
+                grantedAt: Date()
+            )
+            try databaseManager.dbWriter.write { db in
+                try grant.save(db)
+            }
+        }
+
+        func storedGrants(for conversationId: String) throws -> [DBConnectionGrant] {
+            try databaseManager.dbReader.read { db in
+                try DBConnectionGrant
+                    .filter(DBConnectionGrant.Columns.conversationId == conversationId)
+                    .fetchAll(db)
+            }
+        }
+
+        func cleanup() {
+            try? databaseManager.erase()
+        }
+    }
+
+    // MARK: - Grant flow
+
+    @Test("Grant: publish succeeds then DB row is persisted and metadata carries the new grant")
+    func grantPersistsAfterSuccessfulPublish() async throws {
+        let fixture = Fixture()
+        defer { fixture.cleanup() }
+
+        let connection = try fixture.seedConnection()
+        let conversationId = "conv_1"
+        try fixture.seedConversation(id: conversationId)
+
+        try await fixture.writer.grantConnection(connection.id, to: conversationId)
+
+        let stored = try fixture.storedGrants(for: conversationId)
+        #expect(stored.count == 1)
+        #expect(stored.first?.connectionId == connection.id)
+        #expect(stored.first?.serviceId == connection.serviceId)
+
+        #expect(fixture.profileWriter.publishedMetadata.count == 1)
+        let published = try #require(fixture.profileWriter.publishedMetadata.first)
+        #expect(published.conversationId == conversationId)
+        let metadata = try #require(published.metadata)
+        guard case .string(let grantsJson) = try #require(metadata["connections"]) else {
+            Issue.record("connections entry was not a string")
+            return
+        }
+        let payload = try ConnectionsMetadataPayload.fromJsonString(grantsJson)
+        #expect(payload.grants.count == 1)
+        #expect(payload.grants.first?.composioConnectionId == connection.composioConnectionId)
+        #expect(payload.grants.first?.service == connection.serviceId)
+    }
+
+    @Test("Grant: publish failure leaves no DB row and propagates the error")
+    func grantRollsBackWhenPublishFails() async throws {
+        let fixture = Fixture()
+        defer { fixture.cleanup() }
+
+        let connection = try fixture.seedConnection()
+        let conversationId = "conv_2"
+        try fixture.seedConversation(id: conversationId)
+
+        struct PublishFailure: Error, Equatable {}
+        fixture.profileWriter.publishError = PublishFailure()
+
+        var caughtExpectedError: Bool = false
+        do {
+            try await fixture.writer.grantConnection(connection.id, to: conversationId)
+            Issue.record("Expected grantConnection to throw")
+        } catch is PublishFailure {
+            caughtExpectedError = true
+        } catch {
+            Issue.record("Expected PublishFailure but got \(error)")
+        }
+        #expect(caughtExpectedError)
+
+        let stored = try fixture.storedGrants(for: conversationId)
+        #expect(stored.isEmpty, "no grant row should be committed after a publish failure")
+    }
+
+    @Test("Grant: connection not found throws without touching DB or publishing")
+    func grantThrowsWhenConnectionMissing() async throws {
+        let fixture = Fixture()
+        defer { fixture.cleanup() }
+
+        await #expect(throws: ConnectionGrantError.self) {
+            try await fixture.writer.grantConnection("missing", to: "conv_x")
+        }
+        #expect(fixture.profileWriter.publishedMetadata.isEmpty)
+        let stored = try fixture.storedGrants(for: "conv_x")
+        #expect(stored.isEmpty)
+    }
+
+    @Test("Grant: rejects inactive connections without publishing")
+    func grantRejectsInactiveConnection() async throws {
+        let fixture = Fixture()
+        defer { fixture.cleanup() }
+
+        let connection = try fixture.seedConnection(id: "conn_inactive", status: .revoked)
+
+        await #expect(throws: ConnectionGrantError.self) {
+            try await fixture.writer.grantConnection(connection.id, to: "conv_x")
+        }
+        #expect(fixture.profileWriter.publishedMetadata.isEmpty)
+    }
+
+    // MARK: - Revoke flow
+
+    @Test("Revoke: publish succeeds then DB row is removed and metadata is cleared")
+    func revokeRemovesGrantAfterSuccessfulPublish() async throws {
+        let fixture = Fixture()
+        defer { fixture.cleanup() }
+
+        let connection = try fixture.seedConnection()
+        let conversationId = "conv_rev"
+        try fixture.seedConversation(id: conversationId)
+        try fixture.seedGrant(
+            connectionId: connection.id,
+            conversationId: conversationId,
+            serviceId: connection.serviceId
+        )
+
+        try await fixture.writer.revokeGrant(connectionId: connection.id, from: conversationId)
+
+        let stored = try fixture.storedGrants(for: conversationId)
+        #expect(stored.isEmpty)
+
+        // The published metadata should have cleared the connections entry.
+        #expect(fixture.profileWriter.publishedMetadata.count == 1)
+        let published = try #require(fixture.profileWriter.publishedMetadata.first)
+        #expect(published.conversationId == conversationId)
+        // With no remaining grants the writer passes nil metadata (empty map collapses).
+        #expect(published.metadata == nil)
+    }
+
+    @Test("Revoke: publish failure leaves the DB row intact and propagates the error")
+    func revokeRollsBackWhenPublishFails() async throws {
+        let fixture = Fixture()
+        defer { fixture.cleanup() }
+
+        let connection = try fixture.seedConnection()
+        let conversationId = "conv_rev_fail"
+        try fixture.seedConversation(id: conversationId)
+        try fixture.seedGrant(
+            connectionId: connection.id,
+            conversationId: conversationId,
+            serviceId: connection.serviceId
+        )
+
+        struct PublishFailure: Error, Equatable {}
+        fixture.profileWriter.publishError = PublishFailure()
+
+        var caughtExpectedError: Bool = false
+        do {
+            try await fixture.writer.revokeGrant(connectionId: connection.id, from: conversationId)
+            Issue.record("Expected revokeGrant to throw")
+        } catch is PublishFailure {
+            caughtExpectedError = true
+        } catch {
+            Issue.record("Expected PublishFailure but got \(error)")
+        }
+        #expect(caughtExpectedError)
+
+        let stored = try fixture.storedGrants(for: conversationId)
+        #expect(stored.count == 1, "grant row should remain when publish fails")
+        #expect(stored.first?.connectionId == connection.id)
+    }
+
+    @Test("Revoke: no-op when grant does not exist")
+    func revokeNoOpWhenGrantMissing() async throws {
+        let fixture = Fixture()
+        defer { fixture.cleanup() }
+
+        try await fixture.writer.revokeGrant(connectionId: "nope", from: "conv_nope")
+
+        #expect(fixture.profileWriter.publishedMetadata.isEmpty)
+        let stored = try fixture.storedGrants(for: "conv_nope")
+        #expect(stored.isEmpty)
+    }
+
+    // MARK: - Multi-grant projection
+
+    @Test("Grant: publishes the union of existing and new grants")
+    func grantPublishesUnion() async throws {
+        let fixture = Fixture()
+        defer { fixture.cleanup() }
+
+        let first = try fixture.seedConnection(id: "conn_a", serviceId: "google_calendar")
+        let second = try fixture.seedConnection(id: "conn_b", serviceId: "google_drive")
+        let conversationId = "conv_multi"
+        try fixture.seedConversation(id: conversationId)
+
+        try await fixture.writer.grantConnection(first.id, to: conversationId)
+        try await fixture.writer.grantConnection(second.id, to: conversationId)
+
+        let stored = try fixture.storedGrants(for: conversationId)
+        #expect(stored.count == 2)
+
+        #expect(fixture.profileWriter.publishedMetadata.count == 2)
+        let lastPublish = try #require(fixture.profileWriter.publishedMetadata.last)
+        let metadata = try #require(lastPublish.metadata)
+        guard case .string(let grantsJson) = try #require(metadata["connections"]) else {
+            Issue.record("connections entry was not a string")
+            return
+        }
+        let payload = try ConnectionsMetadataPayload.fromJsonString(grantsJson)
+        #expect(payload.grants.count == 2)
+        let serviceIds = Set(payload.grants.map(\.service))
+        #expect(serviceIds == ["google_calendar", "google_drive"])
+    }
+}

--- a/ConvosCore/Tests/ConvosCoreTests/SyncingManagerTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/SyncingManagerTests.swift
@@ -369,6 +369,18 @@ final class TestableMockAPIClient: ConvosAPIClientProtocol, @unchecked Sendable 
     func fetchInviteCodeStatus(_ code: String) async throws -> ConvosAPI.InviteCodeStatus {
         .init(code: code, name: nil, maxRedemptions: 5, redemptionCount: 0, remainingRedemptions: 5)
     }
+
+    func initiateConnection(serviceId: String, redirectUri: String) async throws -> ConnectionsAPI.InitiateResponse {
+        .init(connectionRequestId: "", redirectUrl: "")
+    }
+
+    func completeConnection(connectionRequestId: String) async throws -> ConnectionsAPI.CompleteResponse {
+        .init(connectionId: "", serviceId: "", serviceName: "", composioEntityId: "", composioConnectionId: "", status: "")
+    }
+
+    func listConnections() async throws -> [ConnectionsAPI.ConnectionResponse] { [] }
+
+    func revokeConnection(connectionId: String) async throws {}
 }
 
 /// Comprehensive tests for SyncingManager state machine


### PR DESCRIPTION
## Summary

Fixes 3 HIGH severity issues surfaced in the deep review of #719. Scopes itself to `ConnectionGrantWriter` + `MyProfileWriter` + mocks + tests.

### H2 — Rollback was a mirage
`myProfileWriter.update(metadata:)` called into `sendProfileUpdate(profile:group:)` which caught every `group.send(encodedContent:)` error as `Log.warning`. The writer never saw real XMTP send failures — so a grant that silently failed to publish stayed in the local DB with the UI showing it as on, while the agent never saw it.

- Added `MyProfileWriter.updateAndPublish(metadata:conversationId:)` that throws a new `MyProfileWriterError.profileUpdatePublishFailed(underlying:)` on either encode or `group.send` failure.
- Preserved the existing non-throwing `update(metadata:)` (delegates to the throwing variant, swallows publish errors for its existing log-and-continue callers).
- `ConnectionGrantWriter` now routes through the throwing variant, so send failures actually surface.

### H3 — Rollback used `try?`
Rollback writes were `try?`-swallowed, so a rollback failure would permanently desync DB and metadata.

- Eliminated the rollback path entirely (see H4). No more `try?` to fix.

### H4 — No atomicity between DB write and publish
If the app died between the `DBConnectionGrant.save` and the XMTP publish, the DB kept the grant and nothing reconciled on relaunch.

- Switched to **publish-first-then-persist**: compute the post-change grants list, publish the `ProfileUpdate`, then write/delete the `DBConnectionGrant` row only on success. A partially-completed operation can no longer leave a committed local grant that was never announced.
- Chose this over adding a `publishedAt` column because the diff is strictly smaller (no migration, no launch-time reconciler) and the UX trade-off (losing optimism briefly) is acceptable for a per-conversation grant flow.

## Test plan

- [x] 8 new unit tests in `ConvosCore/Tests/ConvosCoreTests/ConnectionGrantWriterTests.swift` covering: grant/revoke success + publish failure paths, missing-connection, inactive-connection, union-of-grants on publish, no-op revoke.
- [x] `swift test --filter ConnectionGrantWriterTests --package-path ConvosCore` → 8/8 pass in 0.05s.
- [x] `swiftlint lint --strict` on all changed files → 0 violations.
- [ ] Full `swift test --package-path ConvosCore` — **please run before merge**; I couldn't run Docker-backed integration tests in the agent worktree.

## Notes

- Also dropped a stale `import ConvosProfiles` (module was folded into `ConvosCore` in commit `c4c191ea`) — was blocking test target compilation.
- Added stub methods for the new Cloud Connections API to `ConfigurableMockAPIClient` and `TestableMockAPIClient` for the same reason.
- Made the best-effort appData write tolerate a missing group lookup (it was already documented as best-effort; now it actually behaves that way).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `ConnectionGrantWriter` rollback correctness by publishing metadata before persisting DB changes
> - `grantConnection` now publishes the `ProfileUpdate` via `updateAndPublish` before saving the `DBConnectionGrant` row; if publish fails, the grant is never persisted and the error propagates.
> - `revokeGrant` now publishes the reduced grant set before deleting the local DB row; revoking a non-existent grant is a no-op.
> - Adds `MyProfileWriter.updateAndPublish(metadata:conversationId:)` as a new throwing path that surfaces publish failures, while the existing non-throwing `update` method preserves its behavior by swallowing publish errors.
> - Adds `projectedGrants(with:)` helper to compute the target grant set before any DB write, used by both grant and revoke flows.
> - Risk: callers of `grantConnection` and `revokeGrant` now receive errors on publish failure where they previously would not.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9233123.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->