### PR TITLE
Validate deep-link grant requests before presenting sheet (H5)

### DIFF
--- a/Convos/App Settings/ConnectionGrantRequestSheet.swift
+++ b/Convos/App Settings/ConnectionGrantRequestSheet.swift
@@ -20,6 +20,7 @@ final class ConnectionGrantRequestSheetViewModel {
 
     let serviceId: String
     let conversationId: String
+    let conversation: Conversation?
 
     private let session: any SessionManagerProtocol
     private let connectionManager: any ConnectionManagerProtocol
@@ -29,10 +30,12 @@ final class ConnectionGrantRequestSheetViewModel {
     init(
         serviceId: String,
         conversationId: String,
+        conversation: Conversation?,
         session: any SessionManagerProtocol
     ) {
         self.serviceId = serviceId
         self.conversationId = conversationId
+        self.conversation = conversation
         self.session = session
 
         let oauthProvider: any OAuthSessionProvider = IOSOAuthSessionProvider()
@@ -57,6 +60,10 @@ final class ConnectionGrantRequestSheetViewModel {
 
     var displayName: String {
         ConnectionServiceCatalog.displayName(for: serviceId, fallback: connection?.serviceName)
+    }
+
+    var conversationDisplayName: String {
+        conversation?.displayName ?? "this conversation"
     }
 
     var hasConnection: Bool {
@@ -127,6 +134,8 @@ struct ConnectionGrantRequestSheet: View {
                     .foregroundStyle(.colorTextPrimary)
                     .multilineTextAlignment(.center)
 
+                conversationBadge
+
                 Text(bodyText)
                     .font(.body)
                     .foregroundStyle(.colorTextSecondary)
@@ -162,15 +171,35 @@ struct ConnectionGrantRequestSheet: View {
             )
     }
 
+    @ViewBuilder
+    private var conversationBadge: some View {
+        if let conversation = viewModel.conversation {
+            HStack(spacing: DesignConstants.Spacing.step2x) {
+                ConversationAvatarView(conversation: conversation, conversationImage: nil)
+                    .frame(width: 24, height: 24)
+                Text(conversation.displayName)
+                    .font(.subheadline.weight(.medium))
+                    .foregroundStyle(.colorTextPrimary)
+                    .lineLimit(1)
+            }
+            .padding(.horizontal, DesignConstants.Spacing.step3x)
+            .padding(.vertical, DesignConstants.Spacing.stepX)
+            .background(
+                Capsule().fill(Color.colorBackgroundRaisedSecondary)
+            )
+        }
+    }
+
     private var headline: String {
         viewModel.hasConnection ? "Share \(viewModel.displayName)?" : "Connect \(viewModel.displayName)?"
     }
 
     private var bodyText: String {
+        let target = viewModel.conversationDisplayName
         if viewModel.hasConnection {
-            return "The assistant will be able to use \(viewModel.displayName) in this conversation."
+            return "The assistant will be able to use \(viewModel.displayName) in \(target)."
         } else {
-            return "You haven't connected \(viewModel.displayName) yet. Connect it now to share with this conversation."
+            return "You haven't connected \(viewModel.displayName) yet. Connect it now to share with \(target)."
         }
     }
 

--- a/Convos/Conversations List/ConversationsViewModel.swift
+++ b/Convos/Conversations List/ConversationsViewModel.swift
@@ -251,9 +251,11 @@ final class ConversationsViewModel {
     }
 
     func makeGrantRequestSheetViewModel(for request: PendingGrantRequest) -> ConnectionGrantRequestSheetViewModel {
-        ConnectionGrantRequestSheetViewModel(
+        let conversation = conversations.first(where: { $0.id == request.conversationId })
+        return ConnectionGrantRequestSheetViewModel(
             serviceId: request.serviceId,
             conversationId: request.conversationId,
+            conversation: conversation,
             session: session
         )
     }
@@ -267,6 +269,10 @@ final class ConversationsViewModel {
         case .joinConversation(inviteCode: let inviteCode):
             join(from: inviteCode)
         case let .connectionGrant(serviceId: serviceId, conversationId: conversationId):
+            guard conversations.contains(where: { $0.id == conversationId }) else {
+                Log.warning("Dropping connection grant deep link for unknown conversationId")
+                return
+            }
             _selectedConversationId = conversationId
             pendingGrantRequest = PendingGrantRequest(
                 serviceId: serviceId,

--- a/Convos/DeepLinking/DeepLinkHandler.swift
+++ b/Convos/DeepLinking/DeepLinkHandler.swift
@@ -55,7 +55,30 @@ final class DeepLinkHandler {
             return nil
         }
 
+        guard ConnectionServiceCatalog.info(for: service) != nil else {
+            Log.warning("Connection grant deep link references unknown service; dropping")
+            return nil
+        }
+
+        guard isSafeConversationIdentifier(conversationId) else {
+            Log.warning("Connection grant deep link has unsafe conversationId; dropping")
+            return nil
+        }
+
         return .connectionGrant(serviceId: service, conversationId: conversationId)
+    }
+
+    private static let maxConversationIdLength: Int = 256
+
+    private static func isSafeConversationIdentifier(_ value: String) -> Bool {
+        guard !value.isEmpty, value.count <= maxConversationIdLength else {
+            return false
+        }
+        // Conversation IDs from XMTP are hex strings; restrict to a conservative
+        // alphanumeric + `-_` set so malformed or injection-style payloads are rejected
+        // before they ever reach the repository layer.
+        let allowed = CharacterSet(charactersIn: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_")
+        return value.unicodeScalars.allSatisfy { allowed.contains($0) }
     }
 
     private static func isValidHost(_ host: String?) -> Bool {

--- a/ConvosTests/DeepLinkHandlerTests.swift
+++ b/ConvosTests/DeepLinkHandlerTests.swift
@@ -1,3 +1,4 @@
+import ConvosCore
 import XCTest
 @testable import Convos
 
@@ -76,5 +77,100 @@ final class DeepLinkHandlerTests: XCTestCase {
     func testInvalidSchemeReturnsNil() throws {
         let url = try XCTUnwrap(URL(string: "http://example.com/connections/grant?service=x&conversationId=y"))
         XCTAssertNil(DeepLinkHandler.destination(for: url))
+    }
+
+    // MARK: - Service allow-list
+
+    func testUnknownServiceIsRejectedAtParseTime() throws {
+        let url = try XCTUnwrap(URL(string: "\(appUrlScheme)://connections/grant?service=evil_cloud&conversationId=abc123"))
+        XCTAssertNil(DeepLinkHandler.destination(for: url))
+    }
+
+    func testEmptyServiceIsRejectedAtParseTime() throws {
+        let url = try XCTUnwrap(URL(string: "\(appUrlScheme)://connections/grant?service=&conversationId=abc123"))
+        XCTAssertNil(DeepLinkHandler.destination(for: url))
+    }
+
+    func testKnownServiceIsAccepted() throws {
+        let url = try XCTUnwrap(URL(string: "\(appUrlScheme)://connections/grant?service=google_drive&conversationId=abc123"))
+        guard case let .connectionGrant(service, conversationId) = DeepLinkHandler.destination(for: url) else {
+            XCTFail("Expected .connectionGrant for known service")
+            return
+        }
+        XCTAssertEqual(service, "google_drive")
+        XCTAssertEqual(conversationId, "abc123")
+    }
+
+    // MARK: - Malicious conversationId
+
+    func testConversationIdWithQuotesIsRejected() throws {
+        let url = try XCTUnwrap(URL(string: "\(appUrlScheme)://connections/grant?service=google_calendar&conversationId=abc%27%20OR%201%3D1"))
+        XCTAssertNil(DeepLinkHandler.destination(for: url))
+    }
+
+    func testConversationIdWithPathTraversalIsRejected() throws {
+        let url = try XCTUnwrap(URL(string: "\(appUrlScheme)://connections/grant?service=google_calendar&conversationId=..%2Fetc%2Fpasswd"))
+        XCTAssertNil(DeepLinkHandler.destination(for: url))
+    }
+
+    func testConversationIdWithSpacesIsRejected() throws {
+        let url = try XCTUnwrap(URL(string: "\(appUrlScheme)://connections/grant?service=google_calendar&conversationId=abc%20123"))
+        XCTAssertNil(DeepLinkHandler.destination(for: url))
+    }
+
+    func testOverlyLongConversationIdIsRejected() throws {
+        let longId = String(repeating: "a", count: 600)
+        let url = try XCTUnwrap(URL(string: "\(appUrlScheme)://connections/grant?service=google_calendar&conversationId=\(longId)"))
+        XCTAssertNil(DeepLinkHandler.destination(for: url))
+    }
+
+    // MARK: - ConversationsViewModel.handleURL validation
+
+    @MainActor
+    func testHandleURLDropsUnknownConversationId() throws {
+        let knownConversation = Conversation.mock(id: "known-conv")
+        let viewModel = ConversationsViewModel.preview(conversations: [knownConversation])
+        let url = try XCTUnwrap(URL(string: "\(appUrlScheme)://connections/grant?service=google_calendar&conversationId=unknown-conv"))
+
+        viewModel.handleURL(url)
+
+        XCTAssertNil(viewModel.pendingGrantRequest, "Unknown conversationId should be dropped silently")
+        XCTAssertNil(viewModel.selectedConversationId, "Selection should not change for unknown conversationId")
+    }
+
+    @MainActor
+    func testHandleURLSetsPendingGrantForKnownConversation() throws {
+        let knownConversation = Conversation.mock(id: "known-conv")
+        let viewModel = ConversationsViewModel.preview(conversations: [knownConversation])
+        let url = try XCTUnwrap(URL(string: "\(appUrlScheme)://connections/grant?service=google_calendar&conversationId=known-conv"))
+
+        viewModel.handleURL(url)
+
+        XCTAssertNotNil(viewModel.pendingGrantRequest)
+        XCTAssertEqual(viewModel.pendingGrantRequest?.serviceId, "google_calendar")
+        XCTAssertEqual(viewModel.pendingGrantRequest?.conversationId, "known-conv")
+        XCTAssertEqual(viewModel.selectedConversationId, "known-conv")
+    }
+
+    @MainActor
+    func testHandleURLDropsUnknownServiceEvenForKnownConversation() throws {
+        let knownConversation = Conversation.mock(id: "known-conv")
+        let viewModel = ConversationsViewModel.preview(conversations: [knownConversation])
+        let url = try XCTUnwrap(URL(string: "\(appUrlScheme)://connections/grant?service=evil_cloud&conversationId=known-conv"))
+
+        viewModel.handleURL(url)
+
+        XCTAssertNil(viewModel.pendingGrantRequest, "Unknown service should be rejected at parse time")
+    }
+
+    @MainActor
+    func testHandleURLDropsMaliciousConversationId() throws {
+        let knownConversation = Conversation.mock(id: "known-conv")
+        let viewModel = ConversationsViewModel.preview(conversations: [knownConversation])
+        let url = try XCTUnwrap(URL(string: "\(appUrlScheme)://connections/grant?service=google_calendar&conversationId=abc%27%20OR%201%3D1"))
+
+        viewModel.handleURL(url)
+
+        XCTAssertNil(viewModel.pendingGrantRequest, "Malicious conversationId should be rejected")
     }
 }


### PR DESCRIPTION
## Summary

Fixes **H5** from the deep review of #719: the `convos://connections/grant` deep link performed no validation before presenting the grant sheet, allowing a crafted URL (phishing link, QR code) to trigger a legitimate-looking authorization prompt for any conversation id an attacker could guess.

## What changed

1. **Service allow-list in `DeepLinkHandler`.** Unknown service slugs are rejected at parse time against `ConnectionServiceCatalog`, preventing a hostile URL from producing a sheet titled "Share Your-Entire-Cloud?".

2. **Conversation-id shape check in `DeepLinkHandler`.** New `isSafeConversationIdentifier` guard (non-empty, length ≤ 256, only `[A-Za-z0-9_-]`) catches malformed/malicious inputs before they reach the VM.

3. **Presence check in `ConversationsViewModel.handleURL`.** Deep links whose `conversationId` is not present in the user's loaded conversations are silently dropped (logged as a warning). Stale or malicious links no longer produce a sheet or change selection.

4. **Conversation identity in the sheet.** `ConnectionGrantRequestSheet` now surfaces the conversation's name + avatar in a pill below the "Share X?" headline, and the body text mentions the conversation name ("…in Fam." vs "…in this conversation.") so users can visually confirm the target before authorizing.

## Test plan

- [x] 9 new tests in `ConvosTests/DeepLinkHandlerTests.swift`:
  - Allow-list: unknown/empty service rejected, known service accepted.
  - Malicious ids: quotes, path traversal, spaces, over-long → rejected.
  - VM-level: unknown conversationId silently dropped, known id sets pending grant, unknown service dropped even with a known conversationId.
- [x] `swiftlint lint --strict` on changed source files → 0 violations. Pre-commit hook also passed.
- [ ] Full `xcodebuild test` — **please run before merge**; I couldn't run it in the agent worktree (disk capacity). Per-file `swiftc -parse` was clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Validate deep-link grant requests before presenting connection grant sheet
> - Adds input validation in [`DeepLinkHandler.parseConnectionGrant`](https://github.com/xmtplabs/convos-ios/pull/750/files#diff-262e2f8dbcd00d6d932e4f36e4ac9d7bb8d3e2cc29e15ec625ec9d57ed612a8a): rejects unknown services via `ConnectionServiceCatalog` and malformed `conversationId` values via a new `isSafeConversationIdentifier` helper (max 256 chars, alphanumerics/`-`/`_` only).
> - Guards [`ConversationsViewModel.handleURL`](https://github.com/xmtplabs/convos-ios/pull/750/files#diff-e9ac0abeb6f4ab9d1335cf93b09f18a543936af17c742b0f60b5f57e26c07fce) so deep links referencing an unknown `conversationId` are silently dropped without mutating selection or pending grant state.
> - Passes the resolved `Conversation` into [`ConnectionGrantRequestSheetViewModel`](https://github.com/xmtplabs/convos-ios/pull/750/files#diff-0b271b9dc982dd99af46422ff6ec41a98e95ee9e38668663c31a67598ada90c3), which now displays the conversation's avatar and name in the grant sheet instead of a generic phrase.
> - Extends [`DeepLinkHandlerTests`](https://github.com/xmtplabs/convos-ios/pull/750/files#diff-841d0a19a05f3f8751bac545fcc20f8c4cb6561a614e053dc2cacac9943a2ccb) with cases covering service allow-list enforcement, malicious/malformed IDs, and `handleURL` behavior for unknown conversations.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 22fe20a.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->