### PR TITLE
Authenticate ConnectionGrantRequest sender (H6, M6, M7)

### DIFF
--- a/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/ConnectionGrantRequestCardView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/ConnectionGrantRequestCardView.swift
@@ -4,6 +4,7 @@ import SwiftUI
 struct ConnectionGrantRequestCardView: View {
     let request: ConnectionGrantRequest
     let conversationId: String
+    let sender: ConversationMember
 
     @Environment(\.openURL) private var openURL: OpenURLAction
 
@@ -15,7 +16,21 @@ struct ConnectionGrantRequestCardView: View {
         ConnectionServiceCatalog.displayName(for: request.service, fallback: request.service)
     }
 
+    private var isTrustedSender: Bool {
+        sender.isVerifiedAssistant && request.requestedByInboxId == sender.profile.inboxId
+    }
+
     var body: some View {
+        VStack(alignment: .leading, spacing: DesignConstants.Spacing.stepX) {
+            card
+            Text("Sent by \(sender.displayName)")
+                .font(.caption2)
+                .foregroundStyle(.colorTextSecondary)
+                .padding(.horizontal, DesignConstants.Spacing.step4x)
+        }
+    }
+
+    private var card: some View {
         VStack(alignment: .leading, spacing: DesignConstants.Spacing.step2x) {
             HStack(spacing: DesignConstants.Spacing.step2x) {
                 icon
@@ -33,19 +48,26 @@ struct ConnectionGrantRequestCardView: View {
                 Spacer(minLength: 0)
             }
 
-            let action = { openGrantLink() }
-            Button(action: action) {
-                Text("Open Settings")
-                    .font(.callout.weight(.semibold))
-                    .foregroundStyle(.white)
-                    .frame(maxWidth: .infinity)
-                    .padding(.vertical, DesignConstants.Spacing.step3x)
-                    .background(
-                        RoundedRectangle(cornerRadius: DesignConstants.CornerRadius.regular)
-                            .fill(Color.colorFillPrimary)
-                    )
+            if isTrustedSender {
+                let action = { openGrantLink() }
+                Button(action: action) {
+                    Text("Open Settings")
+                        .font(.callout.weight(.semibold))
+                        .foregroundStyle(.white)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, DesignConstants.Spacing.step3x)
+                        .background(
+                            RoundedRectangle(cornerRadius: DesignConstants.CornerRadius.regular)
+                                .fill(Color.colorFillPrimary)
+                        )
+                }
+                .buttonStyle(.plain)
+            } else {
+                Text("This request was not sent by a verified assistant.")
+                    .font(.footnote)
+                    .foregroundStyle(.colorTextSecondary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
             }
-            .buttonStyle(.plain)
         }
         .padding(DesignConstants.Spacing.step3x)
         .background(

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
@@ -246,7 +246,8 @@ struct MessagesGroupItemView: View {
         case .connectionGrantRequest(let request):
             ConnectionGrantRequestCardView(
                 request: request,
-                conversationId: conversationId
+                conversationId: conversationId,
+                sender: message.sender
             )
             .messageGesture(
                 message: message,

--- a/ConvosCore/Sources/ConvosCore/Custom Content Types/ConnectionGrantRequestCodec.swift
+++ b/ConvosCore/Sources/ConvosCore/Custom Content Types/ConnectionGrantRequestCodec.swift
@@ -2,6 +2,14 @@ import Foundation
 @preconcurrency import XMTPiOS
 
 public struct ConnectionGrantRequest: Codable, Sendable, Hashable {
+    /// Highest protocol version this client understands. Payloads with a larger
+    /// version must be rejected so that we don't render untrusted future fields.
+    public static let supportedVersion: Int = 1
+
+    /// Cap on the `reason` field. Anything longer is truncated on decode so a
+    /// hostile sender can't bloat the local DB or the card UI.
+    public static let maxReasonLength: Int = 500
+
     public let version: Int
     public let service: String
     public let requestedByInboxId: String
@@ -9,7 +17,7 @@ public struct ConnectionGrantRequest: Codable, Sendable, Hashable {
     public let reason: String
 
     public init(
-        version: Int = 1,
+        version: Int = ConnectionGrantRequest.supportedVersion,
         service: String,
         requestedByInboxId: String,
         targetInboxId: String,
@@ -19,7 +27,26 @@ public struct ConnectionGrantRequest: Codable, Sendable, Hashable {
         self.service = service
         self.requestedByInboxId = requestedByInboxId
         self.targetInboxId = targetInboxId
-        self.reason = reason
+        self.reason = Self.truncatedReason(reason)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case version, service, requestedByInboxId, targetInboxId, reason
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.version = try container.decode(Int.self, forKey: .version)
+        self.service = try container.decode(String.self, forKey: .service)
+        self.requestedByInboxId = try container.decode(String.self, forKey: .requestedByInboxId)
+        self.targetInboxId = try container.decode(String.self, forKey: .targetInboxId)
+        let rawReason = try container.decode(String.self, forKey: .reason)
+        self.reason = Self.truncatedReason(rawReason)
+    }
+
+    private static func truncatedReason(_ reason: String) -> String {
+        guard reason.count > maxReasonLength else { return reason }
+        return String(reason.prefix(maxReasonLength))
     }
 }
 
@@ -33,6 +60,7 @@ public let ContentTypeConnectionGrantRequest = ContentTypeID(
 public enum ConnectionGrantRequestCodecError: Error, LocalizedError {
     case emptyContent
     case invalidJSONFormat
+    case unsupportedVersion(Int)
 
     public var errorDescription: String? {
         switch self {
@@ -40,6 +68,8 @@ public enum ConnectionGrantRequestCodecError: Error, LocalizedError {
             "ConnectionGrantRequest content is empty"
         case .invalidJSONFormat:
             "Invalid JSON format for ConnectionGrantRequest"
+        case .unsupportedVersion(let version):
+            "Unsupported ConnectionGrantRequest version \(version)"
         }
     }
 }
@@ -62,11 +92,16 @@ public struct ConnectionGrantRequestCodec: ContentCodec {
         guard !content.content.isEmpty else {
             throw ConnectionGrantRequestCodecError.emptyContent
         }
+        let decoded: ConnectionGrantRequest
         do {
-            return try JSONDecoder().decode(ConnectionGrantRequest.self, from: content.content)
+            decoded = try JSONDecoder().decode(ConnectionGrantRequest.self, from: content.content)
         } catch {
             throw ConnectionGrantRequestCodecError.invalidJSONFormat
         }
+        guard decoded.version <= ConnectionGrantRequest.supportedVersion else {
+            throw ConnectionGrantRequestCodecError.unsupportedVersion(decoded.version)
+        }
+        return decoded
     }
 
     public func fallback(content: ConnectionGrantRequest) throws -> String? {

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/IncomingMessageWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/IncomingMessageWriter.swift
@@ -39,6 +39,7 @@ class IncomingMessageWriter: IncomingMessageWriterProtocol, @unchecked Sendable 
         self.databaseWriter = databaseWriter
     }
 
+    // swiftlint:disable:next function_body_length cyclomatic_complexity
     func store(message: DecodedMessage,
                for conversation: DBConversation) async throws -> IncomingMessageWriterResult {
         let encodedContentType = try message.encodedContent.type
@@ -70,16 +71,22 @@ class IncomingMessageWriter: IncomingMessageWriterProtocol, @unchecked Sendable 
             }
         }
 
-        let result = try await databaseWriter.write { db in
-            let sender = DBMember(inboxId: message.senderInboxId)
-            try sender.save(db)
-            let senderProfile = DBMemberProfile(
+        let result = try await databaseWriter.write { db -> IncomingMessageWriterResult? in
+            let senderVerified = try Self.bootstrapSenderProfile(
+                db: db,
                 conversationId: conversation.id,
-                inboxId: message.senderInboxId,
-                name: nil,
-                avatar: nil
+                senderInboxId: message.senderInboxId
             )
-            try? senderProfile.insert(db)
+
+            // Defense against unverified or spoofed ConnectionGrantRequest senders:
+            // only persist grant requests whose sender is a verified Convos assistant
+            // in this conversation. Anything else gets dropped silently with a warning
+            // so the UI never has a chance to render the deep-link card.
+            if encodedContentType == ContentTypeConnectionGrantRequest, !senderVerified {
+                Log.warning("Dropping ConnectionGrantRequest from unverified sender \(message.senderInboxId) in \(conversation.id)")
+                return nil
+            }
+
             let message = try message.dbRepresentation()
 
             let messageExistsInDB = try DBMessage.exists(db, key: message.id)
@@ -171,6 +178,17 @@ class IncomingMessageWriter: IncomingMessageWriterProtocol, @unchecked Sendable 
                 contentType: message.contentType,
                 wasRemovedFromConversation: wasRemovedFromConversation,
                 messageAlreadyExists: messageExistsInDB
+            )
+        }
+
+        // Dropped messages (e.g. unverified-sender ConnectionGrantRequests) return
+        // nil from the write block so the rest of the ingest pipeline treats them
+        // as a no-op rather than a new message.
+        guard let result else {
+            return IncomingMessageWriterResult(
+                contentType: .connectionGrantRequest,
+                wasRemovedFromConversation: false,
+                messageAlreadyExists: true
             )
         }
 
@@ -275,6 +293,34 @@ class IncomingMessageWriter: IncomingMessageWriterProtocol, @unchecked Sendable 
         }
 
         return explodeSettings
+    }
+
+    /// Ensures the sender has a row in `DBMember` and a `DBMemberProfile` for the
+    /// conversation. Returns true when the existing profile is already marked as a
+    /// verified Convos assistant — used to gate persisting sensitive content types
+    /// whose rendering assumes the sender is trusted.
+    static func bootstrapSenderProfile(
+        db: Database,
+        conversationId: String,
+        senderInboxId: String
+    ) throws -> Bool {
+        let sender = DBMember(inboxId: senderInboxId)
+        try sender.save(db)
+        let existingProfile = try DBMemberProfile.fetchOne(
+            db,
+            conversationId: conversationId,
+            inboxId: senderInboxId
+        )
+        if existingProfile == nil {
+            let newProfile = DBMemberProfile(
+                conversationId: conversationId,
+                inboxId: senderInboxId,
+                name: nil,
+                avatar: nil
+            )
+            try? newProfile.insert(db)
+        }
+        return existingProfile?.agentVerification.isConvosAssistant ?? false
     }
 
     /// Computes a sortId that places the message in chronological order within the conversation.

--- a/ConvosCore/Sources/ConvosCore/Storage/XMTP DB Representations/DecodedMessage+DBRepresentation.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/XMTP DB Representations/DecodedMessage+DBRepresentation.swift
@@ -28,7 +28,7 @@ extension String {
 
 extension XMTPiOS.DecodedMessage {
     enum DecodedMessageDBRepresentationError: Error {
-        case mismatchedContentType, unsupportedContentType
+        case mismatchedContentType, unsupportedContentType, untrustedSender
     }
 
     private struct DBMessageComponents {
@@ -471,6 +471,11 @@ extension XMTPiOS.DecodedMessage {
         guard let request = content as? ConnectionGrantRequest else {
             throw DecodedMessageDBRepresentationError.mismatchedContentType
         }
+        try Self.validateConnectionGrantRequest(
+            request,
+            senderInboxId: senderInboxId,
+            messageId: id
+        )
         let json = try JSONEncoder().encode(request)
         let text = String(data: json, encoding: .utf8)
         return DBMessageComponents(
@@ -482,6 +487,24 @@ extension XMTPiOS.DecodedMessage {
             text: text,
             update: nil
         )
+    }
+
+    /// Validates a `ConnectionGrantRequest` against its actual sender. Throws
+    /// `untrustedSender` when the payload's `requestedByInboxId` does not match
+    /// the XMTP-attested sender — a hostile member could otherwise attribute
+    /// the request to the assistant and trick the user into running a grant
+    /// flow for services the real assistant never asked for.
+    static func validateConnectionGrantRequest(
+        _ request: ConnectionGrantRequest,
+        senderInboxId: String,
+        messageId: String
+    ) throws {
+        guard request.requestedByInboxId == senderInboxId else {
+            Log.warning(
+                "Dropping ConnectionGrantRequest \(messageId): sender \(senderInboxId) does not match requestedByInboxId \(request.requestedByInboxId)"
+            )
+            throw DecodedMessageDBRepresentationError.untrustedSender
+        }
     }
 
     private func handleExplodeSettingsContent() throws -> DBMessageComponents {

--- a/ConvosCore/Tests/ConvosCoreTests/ConnectionGrantRequestCodecTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ConnectionGrantRequestCodecTests.swift
@@ -1,6 +1,7 @@
 @testable import ConvosCore
 import Foundation
 import Testing
+import XMTPiOS
 
 @Suite("ConnectionGrantRequestCodec Tests")
 struct ConnectionGrantRequestCodecTests {
@@ -61,5 +62,105 @@ struct ConnectionGrantRequestCodecTests {
         #expect(throws: ConnectionGrantRequestCodecError.self) {
             _ = try codec.decode(content: bogus)
         }
+    }
+
+    @Test("Decoding a payload with a future version is rejected")
+    func futureVersionRejected() throws {
+        let futurePayload = """
+        {
+          "version": 2,
+          "service": "google_calendar",
+          "requestedByInboxId": "agent_inbox",
+          "targetInboxId": "user_inbox",
+          "reason": "future schema"
+        }
+        """
+        var encoded = try codec.encode(content: sampleRequest)
+        encoded.content = Data(futurePayload.utf8)
+
+        #expect(throws: ConnectionGrantRequestCodecError.self) {
+            _ = try codec.decode(content: encoded)
+        }
+
+        do {
+            _ = try codec.decode(content: encoded)
+            Issue.record("Expected unsupportedVersion error")
+        } catch ConnectionGrantRequestCodecError.unsupportedVersion(let version) {
+            #expect(version == 2)
+        } catch {
+            Issue.record("Expected unsupportedVersion, got \(error)")
+        }
+    }
+
+    @Test("Reason longer than the cap is truncated on decode")
+    func reasonTruncatedOnDecode() throws {
+        let oversizedReason = String(repeating: "A", count: ConnectionGrantRequest.maxReasonLength + 250)
+        let paddedRequest = ConnectionGrantRequest(
+            service: "google_calendar",
+            requestedByInboxId: "agent_inbox",
+            targetInboxId: "user_inbox",
+            reason: oversizedReason
+        )
+
+        // The public initializer also truncates — confirm that first so callers
+        // building payloads locally can't bloat the DB either.
+        #expect(paddedRequest.reason.count == ConnectionGrantRequest.maxReasonLength)
+
+        // Craft a raw payload with the oversized reason and make sure decode still caps it.
+        struct RawPayload: Encodable {
+            let version: Int
+            let service: String
+            let requestedByInboxId: String
+            let targetInboxId: String
+            let reason: String
+        }
+        let rawData = try JSONEncoder().encode(RawPayload(
+            version: ConnectionGrantRequest.supportedVersion,
+            service: "google_calendar",
+            requestedByInboxId: "agent_inbox",
+            targetInboxId: "user_inbox",
+            reason: oversizedReason
+        ))
+
+        var encoded = try codec.encode(content: sampleRequest)
+        encoded.content = rawData
+        let decoded = try codec.decode(content: encoded)
+
+        #expect(decoded.reason.count == ConnectionGrantRequest.maxReasonLength)
+        #expect(decoded.reason == String(repeating: "A", count: ConnectionGrantRequest.maxReasonLength))
+    }
+
+    @Test("validateConnectionGrantRequest rejects spoofed requestedByInboxId")
+    func validateRejectsSpoofedSender() throws {
+        let spoofed = ConnectionGrantRequest(
+            service: "google_calendar",
+            requestedByInboxId: "trusted_assistant_inbox",
+            targetInboxId: "user_inbox",
+            reason: "hostile reason"
+        )
+
+        #expect(throws: XMTPiOS.DecodedMessage.DecodedMessageDBRepresentationError.self) {
+            try XMTPiOS.DecodedMessage.validateConnectionGrantRequest(
+                spoofed,
+                senderInboxId: "hostile_member_inbox",
+                messageId: "msg-1"
+            )
+        }
+    }
+
+    @Test("validateConnectionGrantRequest passes when sender matches requestedByInboxId")
+    func validateAcceptsMatchingSender() throws {
+        let legitimate = ConnectionGrantRequest(
+            service: "google_calendar",
+            requestedByInboxId: "assistant_inbox",
+            targetInboxId: "user_inbox",
+            reason: "I can check your schedule."
+        )
+
+        try XMTPiOS.DecodedMessage.validateConnectionGrantRequest(
+            legitimate,
+            senderInboxId: "assistant_inbox",
+            messageId: "msg-2"
+        )
     }
 }


### PR DESCRIPTION
## Summary

Fixes **H6** from the deep review of #719: any group member could send a `ConnectionGrantRequest` message and it would render as a trusted-looking card with an "Open Settings" deep-link button. No check that the sender was a verified assistant; `requestedByInboxId` was not compared against `senderInboxId`. Straightforward social-engineering vector.

Also picks up **M6** (codec version guard) and **M7** (reason-length cap) as closely-related hardening.

## What changed

### H6 — sender authentication, defense in depth

**At decode/validate time** (`DecodedMessage+DBRepresentation.swift`):
- New `DecodedMessage.validateConnectionGrantRequest(_:senderInboxId:messageId:)` throws `.untrustedSender` when `request.requestedByInboxId != senderInboxId`.
- `handleConnectionGrantRequestContent` now runs that validator first; untrusted-sender messages are not persisted.

**At ingest time** (`IncomingMessageWriter.swift`):
- Extracted `bootstrapSenderProfile(db:conversationId:senderInboxId:)` that returns whether the existing `DBMemberProfile.memberKind` is `.verifiedConvos`.
- Messages with content type `ConnectionGrantRequest` from senders who are not verified Convos assistants are dropped with a warning and never reach the UI.

**At render time** (`ConnectionGrantRequestCardView.swift`):
- Card now takes `sender: ConversationMember`.
- `isTrustedSender` requires both `sender.isVerifiedAssistant` and `request.requestedByInboxId == sender.profile.inboxId`.
- Untrusted-sender renders a neutered informational card (no "Open Settings" deep-link button), with text: "This request was not sent by a verified assistant."
- Card always shows "Sent by <sender displayName>" underneath so the user can see who sent it even in the happy path.

### M6 — codec version guard
`ConnectionGrantRequest` now has `supportedVersion = 1`. Decode throws `.unsupportedVersion(Int)` on any payload whose `version > 1`. Prevents silent acceptance of future-schema payloads whose semantics haven't been vetted.

### M7 — reason field length cap
`maxReasonLength = 500`. Oversized `reason` is truncated on both decode and public init to prevent DB bloat / UI jank from hostile senders.

## Test plan

- [x] 4 new tests in `ConvosCore/Tests/ConvosCoreTests/ConnectionGrantRequestCodecTests.swift`: future-version rejection, oversized-reason truncation (both init + decode paths), spoofed-sender validation rejection, matching-sender happy path.
- [x] `swiftlint lint --strict` on all changed files → 0 violations. Pre-commit hook also passed.
- [ ] **Full test suite did not run** in the agent worktree — the `connections` branch has a pre-existing stale `import ConvosProfiles` in `ConnectionGrantWriter.swift` (removed as a module in commit `c4c191ea`), which breaks the test build. PR #749 removes that stale import; once #749 lands on `connections`, a rebase here should unblock CI. Please confirm tests run green before merge.

## Merge order note

This PR depends on **#749 landing first** to resolve the `ConvosProfiles` import issue. Does not otherwise depend on the other stack PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Authenticate ConnectionGrantRequest sender to block spoofed and unverified grant requests
> - Validates that `requestedByInboxId` in the payload matches the attested `senderInboxId` in [`DecodedMessage+DBRepresentation.swift`](https://github.com/xmtplabs/convos-ios/pull/751/files#diff-506364f62b39595ed5e23f0dcfed112f9c4cf3e1f1fd7b263dbe1e386dbf2934); mismatches throw `untrustedSender` and are rejected before storage.
> - Drops incoming `ConnectionGrantRequest` messages in [`IncomingMessageWriter`](https://github.com/xmtplabs/convos-ios/pull/751/files#diff-214371d5cccf7b16f4408fd58c74733a7d61314a74ebb428d08a97e20309c777) if the sender is not a verified Convos assistant, treating them as no-ops with no side effects.
> - Updates [`ConnectionGrantRequestCardView`](https://github.com/xmtplabs/convos-ios/pull/751/files#diff-f369dcd3c3e3e64216e9a35b435543fde963cd48ad1fb7dfa71c6e8d9216c5af) to show sender attribution and gate the "Open Settings" button on sender verification; unverified senders see an informational notice instead.
> - Adds version gating in [`ConnectionGrantRequestCodec`](https://github.com/xmtplabs/convos-ios/pull/751/files#diff-7fa79f86de4b742f3fd395748dd958d5fdd7caa760215f226c75b5aeebce1c61): payloads with a version above `supportedVersion` (1) are rejected, and `reason` is truncated to 500 characters on init and decode.
> - Risk: `ConnectionGrantRequest` messages from any non-verified sender are silently dropped with no notification to the user.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 72e39a7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->