### PR TITLE
Fix ConnectionManager lifecycle bugs (H1, H7, H8)

### DIFF
--- a/ConvosCore/Sources/ConvosCore/Connections/ConnectionManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Connections/ConnectionManager.swift
@@ -12,17 +12,20 @@ public final class ConnectionManager: ConnectionManagerProtocol, @unchecked Send
     private let oauthProvider: any OAuthSessionProvider
     private let databaseWriter: any DatabaseWriter
     private let callbackURLScheme: String
+    private let grantWriterProvider: @Sendable () -> (any ConnectionGrantWriterProtocol)?
 
     public init(
         apiClient: any ConvosAPIClientProtocol,
         oauthProvider: any OAuthSessionProvider,
         databaseWriter: any DatabaseWriter,
-        callbackURLScheme: String
+        callbackURLScheme: String,
+        grantWriterProvider: @escaping @Sendable () -> (any ConnectionGrantWriterProtocol)? = { nil }
     ) {
         self.apiClient = apiClient
         self.oauthProvider = oauthProvider
         self.databaseWriter = databaseWriter
         self.callbackURLScheme = callbackURLScheme
+        self.grantWriterProvider = grantWriterProvider
     }
 
     public func connect(serviceId canonicalServiceId: String) async throws -> Connection {
@@ -68,6 +71,46 @@ public final class ConnectionManager: ConnectionManagerProtocol, @unchecked Send
     public func disconnect(connectionId: String) async throws {
         try await apiClient.revokeConnection(connectionId: connectionId)
 
+        // Collect conversations that currently reference this connection so we
+        // can republish per-conversation metadata after the local rows are gone.
+        // Without this, the ProfileUpdate metadata previously published to XMTP
+        // groups still carries the revoked grants and the agent would keep
+        // using them.
+        let affectedConversationIds = try await databaseWriter.read { db in
+            try DBConnectionGrant
+                .filter(DBConnectionGrant.Columns.connectionId == connectionId)
+                .fetchAll(db)
+                .map { $0.conversationId }
+        }
+        let uniqueConversationIds = Array(Set(affectedConversationIds))
+
+        // revokeGrant deletes the row and republishes metadata for that
+        // conversation. We go through the public writer interface so the two
+        // paths stay in sync. A republish failure here is logged but doesn't
+        // block the subsequent DBConnection delete — the ON DELETE CASCADE
+        // guarantees any grant revokeGrant restored on failure still gets
+        // removed locally. The stale metadata on XMTP is the best we can do
+        // if the sync is down at wipe time.
+        if let grantWriter = grantWriterProvider() {
+            for conversationId in uniqueConversationIds {
+                do {
+                    try await grantWriter.revokeGrant(
+                        connectionId: connectionId,
+                        from: conversationId
+                    )
+                } catch {
+                    Log.warning("[CloudConnections] failed to republish grants after disconnect (connectionId=\(connectionId), conversationId=\(conversationId)): \(error.localizedDescription)")
+                }
+            }
+        } else if !uniqueConversationIds.isEmpty {
+            let conversationCount = uniqueConversationIds.count
+            Log.warning(
+                "[CloudConnections] disconnect had no grant writer injected; metadata for " +
+                "\(conversationCount) conversation(s) will remain stale until the next grant/revoke " +
+                "on the affected conversations"
+            )
+        }
+
         try await databaseWriter.write { db in
             _ = try DBConnection.deleteOne(db, key: connectionId)
         }
@@ -90,10 +133,25 @@ public final class ConnectionManager: ConnectionManagerProtocol, @unchecked Send
             )
         }
 
+        // Delta update rather than deleteAll-then-reinsert: DBConnectionGrant
+        // rows have ON DELETE CASCADE on DBConnection.id, so deleting every
+        // connection (even momentarily within the same transaction) wipes
+        // every grant on the device. Since refresh() fires every time the
+        // Connections settings screen appears, that path would destroy every
+        // grant on settings entry.
+        let serverIds = Set(connections.map { $0.id })
         try await databaseWriter.write { db in
-            try DBConnection.deleteAll(db)
+            let existingIds = Set(try DBConnection.fetchAll(db).map { $0.id })
+
             for connection in connections {
                 try DBConnection(from: connection).save(db)
+            }
+
+            let idsToDelete = existingIds.subtracting(serverIds)
+            if !idsToDelete.isEmpty {
+                try DBConnection
+                    .filter(idsToDelete.contains(DBConnection.Columns.id))
+                    .deleteAll(db)
             }
         }
 

--- a/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
@@ -426,6 +426,18 @@ public final class SessionManager: SessionManagerProtocol, @unchecked Sendable {
                 .filter(DBConversation.Columns.isUnused == true)
                 .deleteAll(db)
             try DBInbox.deleteAll(db)
+
+            // DBConnection has no FK to DBInbox or DBConversation, so the MLS
+            // cleanup path and the deletes above both miss it. Wipe it here so
+            // "Delete All Data" doesn't leave the next identity holding stale
+            // Composio entity/connection ids from the previous user. The FK
+            // cascade from DBConnection removes DBConnectionGrant as well.
+            //
+            // Server-side revoke is intentionally skipped: by the time this
+            // runs, identityStore.delete() has already nuked the JWT signer
+            // so apiClient.revokeConnection would fail auth, and the abandoned
+            // entity ids aren't reachable from any new identity anyway.
+            try DBConnection.deleteAll(db)
         }
     }
 
@@ -648,7 +660,10 @@ public final class SessionManager: SessionManagerProtocol, @unchecked Sendable {
             apiClient: apiClient,
             oauthProvider: oauthProvider,
             databaseWriter: databaseWriter,
-            callbackURLScheme: callbackURLScheme
+            callbackURLScheme: callbackURLScheme,
+            grantWriterProvider: { [weak self] in
+                self?.messagingService().connectionGrantWriter()
+            }
         )
     }
 

--- a/ConvosCore/Tests/ConvosCoreTests/ConnectionManagerTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ConnectionManagerTests.swift
@@ -1,0 +1,428 @@
+@testable import ConvosCore
+import Foundation
+import GRDB
+import Testing
+
+@Suite("ConnectionManager Tests", .serialized)
+struct ConnectionManagerTests {
+    // MARK: - H1: refreshConnections() delta update
+
+    @Test("refreshConnections preserves existing grants when server returns the same connection")
+    func refreshPreservesGrants() async throws {
+        let fixtures = try await makeTestFixtures()
+        let apiClient = StubAPIClient()
+        let grantWriter = RecordingGrantWriter()
+
+        let manager = makeManager(fixtures: fixtures, apiClient: apiClient, grantWriter: grantWriter)
+
+        let connectionId = "conn-1"
+        let conversationId = "convo-1"
+
+        try await fixtures.dbWriter.write { db in
+            try makeDBConversation(id: conversationId).insert(db)
+            try makeDBConnection(id: connectionId).insert(db)
+            try DBConnectionGrant(
+                connectionId: connectionId,
+                conversationId: conversationId,
+                serviceId: "google_calendar",
+                grantedAt: Date()
+            ).insert(db)
+        }
+
+        apiClient.stubbedConnections = [
+            makeConnectionResponse(connectionId: connectionId, serviceId: "google_calendar")
+        ]
+
+        _ = try await manager.refreshConnections()
+
+        let grantCount = try await fixtures.dbReader.read { db in
+            try DBConnectionGrant.fetchCount(db)
+        }
+        #expect(grantCount == 1, "Delta update must not cascade-delete grants for connections the server still returns")
+
+        let connectionCount = try await fixtures.dbReader.read { db in
+            try DBConnection.fetchCount(db)
+        }
+        #expect(connectionCount == 1)
+    }
+
+    @Test("refreshConnections removes local rows no longer returned by the server")
+    func refreshDeletesMissingConnections() async throws {
+        let fixtures = try await makeTestFixtures()
+        let apiClient = StubAPIClient()
+        let grantWriter = RecordingGrantWriter()
+
+        let manager = makeManager(fixtures: fixtures, apiClient: apiClient, grantWriter: grantWriter)
+
+        try await fixtures.dbWriter.write { db in
+            try makeDBConnection(id: "conn-stale").insert(db)
+            try makeDBConnection(id: "conn-keep").insert(db)
+        }
+
+        apiClient.stubbedConnections = [
+            makeConnectionResponse(connectionId: "conn-keep", serviceId: "google_calendar")
+        ]
+
+        _ = try await manager.refreshConnections()
+
+        let remaining = try await fixtures.dbReader.read { db in
+            try DBConnection.fetchAll(db).map(\.id).sorted()
+        }
+        #expect(remaining == ["conn-keep"], "Delta update must drop rows the server no longer returns")
+    }
+
+    @Test("refreshConnections upserts status changes without touching grants")
+    func refreshUpdatesStatus() async throws {
+        let fixtures = try await makeTestFixtures()
+        let apiClient = StubAPIClient()
+        let grantWriter = RecordingGrantWriter()
+
+        let manager = makeManager(fixtures: fixtures, apiClient: apiClient, grantWriter: grantWriter)
+
+        let connectionId = "conn-1"
+        let conversationId = "convo-1"
+
+        try await fixtures.dbWriter.write { db in
+            try makeDBConversation(id: conversationId).insert(db)
+            try makeDBConnection(id: connectionId, status: ConnectionStatus.active.rawValue).insert(db)
+            try DBConnectionGrant(
+                connectionId: connectionId,
+                conversationId: conversationId,
+                serviceId: "google_calendar",
+                grantedAt: Date()
+            ).insert(db)
+        }
+
+        apiClient.stubbedConnections = [
+            makeConnectionResponse(connectionId: connectionId, serviceId: "google_calendar", status: "EXPIRED")
+        ]
+
+        _ = try await manager.refreshConnections()
+
+        let storedStatus = try await fixtures.dbReader.read { db in
+            try DBConnection.fetchOne(db, key: connectionId)?.status
+        }
+        #expect(storedStatus == ConnectionStatus.expired.rawValue)
+
+        let grantCount = try await fixtures.dbReader.read { db in
+            try DBConnectionGrant.fetchCount(db)
+        }
+        #expect(grantCount == 1)
+    }
+
+    // MARK: - H7: disconnect() republishes metadata
+
+    @Test("disconnect republishes metadata for every conversation that referenced the connection")
+    func disconnectRepublishesMetadata() async throws {
+        let fixtures = try await makeTestFixtures()
+        let apiClient = StubAPIClient()
+        let grantWriter = RecordingGrantWriter()
+
+        let manager = makeManager(fixtures: fixtures, apiClient: apiClient, grantWriter: grantWriter)
+
+        let connectionId = "conn-1"
+
+        try await fixtures.dbWriter.write { db in
+            try makeDBConversation(id: "convo-a").insert(db)
+            try makeDBConversation(id: "convo-b").insert(db)
+            try makeDBConnection(id: connectionId).insert(db)
+            try makeDBConnection(id: "conn-other").insert(db)
+
+            try DBConnectionGrant(
+                connectionId: connectionId,
+                conversationId: "convo-a",
+                serviceId: "google_calendar",
+                grantedAt: Date()
+            ).insert(db)
+            try DBConnectionGrant(
+                connectionId: connectionId,
+                conversationId: "convo-b",
+                serviceId: "google_calendar",
+                grantedAt: Date()
+            ).insert(db)
+            // Unrelated grant for a different connection — must not trigger republish.
+            try DBConnectionGrant(
+                connectionId: "conn-other",
+                conversationId: "convo-a",
+                serviceId: "google_calendar",
+                grantedAt: Date()
+            ).insert(db)
+        }
+
+        try await manager.disconnect(connectionId: connectionId)
+
+        #expect(apiClient.revokedConnectionIds == [connectionId])
+
+        let revokedPairs = await grantWriter.revokedGrants()
+        let expected: Set<String> = ["convo-a", "convo-b"]
+        #expect(Set(revokedPairs.map(\.conversationId)) == expected)
+        #expect(revokedPairs.allSatisfy { $0.connectionId == connectionId })
+
+        let connectionRow = try await fixtures.dbReader.read { db in
+            try DBConnection.fetchOne(db, key: connectionId)
+        }
+        #expect(connectionRow == nil, "Local connection row must still be deleted after republish")
+    }
+
+    @Test("disconnect with no grants does not call the grant writer")
+    func disconnectWithNoGrantsSkipsRepublish() async throws {
+        let fixtures = try await makeTestFixtures()
+        let apiClient = StubAPIClient()
+        let grantWriter = RecordingGrantWriter()
+
+        let manager = makeManager(fixtures: fixtures, apiClient: apiClient, grantWriter: grantWriter)
+
+        try await fixtures.dbWriter.write { db in
+            try makeDBConnection(id: "conn-1").insert(db)
+        }
+
+        try await manager.disconnect(connectionId: "conn-1")
+
+        let revoked = await grantWriter.revokedGrants()
+        #expect(revoked.isEmpty)
+
+        let connectionRow = try await fixtures.dbReader.read { db in
+            try DBConnection.fetchOne(db, key: "conn-1")
+        }
+        #expect(connectionRow == nil)
+    }
+
+    @Test("disconnect still deletes the local row when the grant writer throws")
+    func disconnectTolerantOfGrantWriterFailure() async throws {
+        let fixtures = try await makeTestFixtures()
+        let apiClient = StubAPIClient()
+        let grantWriter = RecordingGrantWriter()
+        await grantWriter.setShouldThrow(true)
+
+        let manager = makeManager(fixtures: fixtures, apiClient: apiClient, grantWriter: grantWriter)
+
+        let connectionId = "conn-1"
+
+        try await fixtures.dbWriter.write { db in
+            try makeDBConversation(id: "convo-a").insert(db)
+            try makeDBConnection(id: connectionId).insert(db)
+            try DBConnectionGrant(
+                connectionId: connectionId,
+                conversationId: "convo-a",
+                serviceId: "google_calendar",
+                grantedAt: Date()
+            ).insert(db)
+        }
+
+        try await manager.disconnect(connectionId: connectionId)
+
+        let connectionRow = try await fixtures.dbReader.read { db in
+            try DBConnection.fetchOne(db, key: connectionId)
+        }
+        #expect(connectionRow == nil)
+    }
+}
+
+// MARK: - Helpers
+
+private extension ConnectionManagerTests {
+    struct TestFixtures {
+        let dbWriter: any DatabaseWriter
+        let dbReader: any DatabaseReader
+    }
+
+    func makeTestFixtures() async throws -> TestFixtures {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        return TestFixtures(dbWriter: dbManager.dbWriter, dbReader: dbManager.dbReader)
+    }
+
+    func makeManager(
+        fixtures: TestFixtures,
+        apiClient: any ConvosAPIClientProtocol,
+        grantWriter: RecordingGrantWriter
+    ) -> ConnectionManager {
+        ConnectionManager(
+            apiClient: apiClient,
+            oauthProvider: StubOAuthSessionProvider(),
+            databaseWriter: fixtures.dbWriter,
+            callbackURLScheme: "convos",
+            grantWriterProvider: { grantWriter }
+        )
+    }
+
+    func makeDBConversation(id: String) -> DBConversation {
+        DBConversation(
+            id: id,
+            clientConversationId: id,
+            inviteTag: "invite-\(id)",
+            creatorId: "inbox-1",
+            kind: .group,
+            consent: .allowed,
+            createdAt: Date(),
+            name: nil,
+            description: nil,
+            imageURLString: nil,
+            publicImageURLString: nil,
+            includeInfoInPublicPreview: false,
+            expiresAt: nil,
+            debugInfo: .empty,
+            isLocked: false,
+            imageSalt: nil,
+            imageNonce: nil,
+            imageEncryptionKey: nil,
+            conversationEmoji: nil,
+            imageLastRenewed: nil,
+            isUnused: false,
+            hasHadVerifiedAssistant: false,
+        )
+    }
+
+    func makeDBConnection(
+        id: String,
+        serviceId: String = "google_calendar",
+        status: String = ConnectionStatus.active.rawValue
+    ) -> DBConnection {
+        DBConnection(
+            id: id,
+            serviceId: serviceId,
+            serviceName: "Google Calendar",
+            provider: ConnectionProvider.composio.rawValue,
+            composioEntityId: "entity-\(id)",
+            composioConnectionId: "ca-\(id)",
+            status: status,
+            connectedAt: Date()
+        )
+    }
+
+    func makeConnectionResponse(
+        connectionId: String,
+        serviceId: String,
+        status: String = "ACTIVE"
+    ) -> ConnectionsAPI.ConnectionResponse {
+        ConnectionsAPI.ConnectionResponse(
+            connectionId: connectionId,
+            serviceId: serviceId,
+            serviceName: "Google Calendar",
+            composioEntityId: "entity-\(connectionId)",
+            composioConnectionId: "ca-\(connectionId)",
+            status: status
+        )
+    }
+}
+
+// MARK: - Doubles
+
+private final class StubAPIClient: ConvosAPIClientProtocol, @unchecked Sendable {
+    var stubbedConnections: [ConnectionsAPI.ConnectionResponse] = []
+    private(set) var revokedConnectionIds: [String] = []
+
+    func request(for path: String, method: String, queryParameters: [String: String]?) throws -> URLRequest {
+        guard let url = URL(string: "http://example.com") else {
+            throw StubError.invalidURL
+        }
+        return URLRequest(url: url)
+    }
+
+    func registerDevice(deviceId: String, pushToken: String?) async throws {}
+
+    func authenticate(appCheckToken: String, retryCount: Int) async throws -> String {
+        "stub-jwt"
+    }
+
+    func uploadAttachment(data: Data, filename: String, contentType: String, acl: String) async throws -> String {
+        "https://example.com/\(filename)"
+    }
+
+    func uploadAttachmentAndExecute(
+        data: Data,
+        filename: String,
+        afterUpload: @escaping (String) async throws -> Void
+    ) async throws -> String {
+        let url = "https://example.com/\(filename)"
+        try await afterUpload(url)
+        return url
+    }
+
+    func getPresignedUploadURL(filename: String, contentType: String) async throws -> (uploadURL: String, assetURL: String) {
+        (uploadURL: "https://example.com/upload/\(filename)", assetURL: "https://example.com/asset/\(filename)")
+    }
+
+    func subscribeToTopics(deviceId: String, clientId: String, topics: [String]) async throws {}
+    func unsubscribeFromTopics(clientId: String, topics: [String]) async throws {}
+    func unregisterInstallation(clientId: String) async throws {}
+
+    func renewAssetsBatch(assetKeys: [String]) async throws -> AssetRenewalResult {
+        AssetRenewalResult(renewed: assetKeys.count, failed: 0, expiredKeys: [])
+    }
+
+    func requestAgentJoin(slug: String, instructions: String, forceErrorCode: Int?) async throws -> ConvosAPI.AgentJoinResponse {
+        .init(success: true, joined: true)
+    }
+
+    func redeemInviteCode(_ code: String) async throws -> ConvosAPI.InviteCodeStatus {
+        .init(code: code, name: nil, maxRedemptions: 0, redemptionCount: 0, remainingRedemptions: 0)
+    }
+
+    func fetchInviteCodeStatus(_ code: String) async throws -> ConvosAPI.InviteCodeStatus {
+        .init(code: code, name: nil, maxRedemptions: 0, redemptionCount: 0, remainingRedemptions: 0)
+    }
+
+    func initiateConnection(serviceId: String, redirectUri: String) async throws -> ConnectionsAPI.InitiateResponse {
+        .init(connectionRequestId: "stub-request", redirectUrl: "https://example.com/oauth")
+    }
+
+    func completeConnection(connectionRequestId: String) async throws -> ConnectionsAPI.CompleteResponse {
+        .init(
+            connectionId: "stub-conn",
+            serviceId: "google_calendar",
+            serviceName: "Google Calendar",
+            composioEntityId: "entity",
+            composioConnectionId: "ca",
+            status: "ACTIVE"
+        )
+    }
+
+    func listConnections() async throws -> [ConnectionsAPI.ConnectionResponse] {
+        stubbedConnections
+    }
+
+    func revokeConnection(connectionId: String) async throws {
+        revokedConnectionIds.append(connectionId)
+    }
+
+    enum StubError: Error {
+        case invalidURL
+    }
+}
+
+private actor RecordingGrantWriter: ConnectionGrantWriterProtocol {
+    struct Call: Sendable, Equatable {
+        let connectionId: String
+        let conversationId: String
+    }
+
+    private var calls: [Call] = []
+    private var shouldThrow: Bool = false
+
+    func setShouldThrow(_ value: Bool) {
+        shouldThrow = value
+    }
+
+    func revokedGrants() -> [Call] {
+        calls
+    }
+
+    nonisolated func grantConnection(_ connectionId: String, to conversationId: String) async throws {}
+
+    func revokeGrant(connectionId: String, from conversationId: String) async throws {
+        calls.append(Call(connectionId: connectionId, conversationId: conversationId))
+        if shouldThrow {
+            throw StubError.republishFailed
+        }
+    }
+
+    enum StubError: Error {
+        case republishFailed
+    }
+}
+
+private struct StubOAuthSessionProvider: OAuthSessionProvider {
+    func authenticate(url: URL, callbackURLScheme: String) async throws -> URL {
+        url
+    }
+}


### PR DESCRIPTION
## Summary

Fixes 3 HIGH severity lifecycle bugs surfaced in the deep review of #719. All in `ConnectionManager` + the delete-all-data path in `SessionManager`.

### H1 — `refreshConnections()` was silently wiping every local grant
`DBConnectionGrant.connectionId` has `ON DELETE CASCADE` on `DBConnection(id)`. The old code did `DBConnection.deleteAll(db)` then re-inserted — cascade-deleted every grant row, then reinserted the connections with the same ids but the grants were gone. `ConnectionsListView.task { viewModel.refresh() }` fires on every appearance, so opening the settings once destroyed every grant on device.

- `refreshConnections()` now does a **delta update**: fetches existing row ids, upserts present rows, deletes only those the server no longer returns.

### H7 — `disconnect()` left stale grants published in every affected conversation
The local DB delete cascaded grants, but the ProfileUpdate metadata previously published to XMTP groups still carried those grant entries. Agent kept using revoked tokens.

- `disconnect(connectionId:)` now collects distinct `conversationId`s for the connection's grants *before* the delete, then calls `grantWriter.revokeGrant(connectionId:from:)` per conversation (which republishes ProfileUpdate metadata with the grant removed).
- Wired in via a new `grantWriterProvider` injection point on `ConnectionManager.init`. `SessionManager.connectionManager(...)` passes a `[weak self]` closure that resolves to `messagingService().connectionGrantWriter()` lazily, avoiding circular deps.
- Republish failures are logged and don't block the final `DBConnection.deleteOne` — cascade still cleans up local state.

### H8 — Delete-all-data left orphaned `DBConnection` rows with live Composio tokens
`wipeResidualInboxRows` only touched `DBConversation` / `DBInbox`. `DBConnection` rows persisted across account deletion, leaking the previous identity's Composio entity/connection ids into a new inbox.

- `wipeResidualInboxRows` now runs `try DBConnection.deleteAll(db)`. Cascade removes grants.
- Server-side revoke intentionally skipped at this point (identity store already gone, JWT signer dead). Comment explains why.

## Test plan

- [x] 6 new tests in `ConvosCore/Tests/ConvosCoreTests/ConnectionManagerTests.swift`:
  - H1: existing grants survive refresh when server still returns the connection; status changes upsert in place; rows missing from server response are deleted.
  - H7: disconnect republishes for every distinct conversation that had a grant for the revoked connection (and only those — no spurious calls); no-op when no grants exist; local row still removed when grant writer throws.
- [x] `swift test --filter ConnectionManagerTests --package-path ConvosCore` → 6/6 pass. Existing `ConnectionGrantWriterTests` 8/8 also pass.
- [x] `swiftlint --strict` on changed files → 0 violations. Pre-commit hook passed.
- [ ] Full `swift test --package-path ConvosCore` — please run before merge.

## Merge context

This is the last of 4 stacked PRs addressing the HIGH-severity findings from the deep review. The previous three (#749, #750, #751) are already merged into `connections`. No dependencies between this PR and the already-merged ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix ConnectionManager lifecycle bugs in refresh and disconnect flows
> - `refreshConnections` now performs a delta update instead of delete-all-and-reinsert, removing only connections absent from the server response to prevent unnecessary cascade deletion of `DBConnectionGrant` rows.
> - `disconnect` now queries `DBConnectionGrant` for affected conversations and calls `revokeGrant(connectionId:from:)` on each before deleting the local connection row, republishing per-conversation metadata on disconnect.
> - `SessionManager` wires a `grantWriterProvider` closure into `ConnectionManager` and adds `DBConnection.deleteAll` to the local data wipe path so cascading grants are cleaned up without server-side revocation.
> - New tests in [ConnectionManagerTests.swift](https://github.com/xmtplabs/convos-ios/pull/752/files#diff-71c8d9b853aa878f7228e15a4e8fd5a8aa9418036c0912ce73f4ab722ea3b830) cover delta update semantics, grant revocation on disconnect, and failure tolerance.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 55c1624.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->