### PR TITLE
Fix build-phase sandbox: declare secrets-utils.sh as an input

### DIFF
--- a/Convos.xcodeproj/project.pbxproj
+++ b/Convos.xcodeproj/project.pbxproj
@@ -877,6 +877,7 @@
 			);
 			inputPaths = (
 				"$(SRCROOT)/Scripts/build-phases/copy-env-config-app-clip.sh",
+				"$(SRCROOT)/Scripts/secrets-utils.sh",
 				"$(SRCROOT)/Convos/Config/$(CONFIG_FILE)",
 				"$(SRCROOT)/.env",
 			);
@@ -900,6 +901,7 @@
 			);
 			inputPaths = (
 				"$(SRCROOT)/Scripts/build-phases/copy-env-config-main-app.sh",
+				"$(SRCROOT)/Scripts/secrets-utils.sh",
 				"$(SRCROOT)/Convos/Config/$(CONFIG_FILE)",
 				"$(SRCROOT)/.env",
 			);
@@ -923,6 +925,7 @@
 			);
 			inputPaths = (
 				"$(SRCROOT)/Scripts/build-phases/copy-env-config-notification-service.sh",
+				"$(SRCROOT)/Scripts/secrets-utils.sh",
 				"$(SRCROOT)/Convos/Config/$(CONFIG_FILE)",
 				"$(SRCROOT)/.env",
 			);


### PR DESCRIPTION
## Summary

A fresh `Convos (Dev)` build fails with:

\`\`\`
copy-env-config-main-app.sh: line 4:
  .../Scripts/secrets-utils.sh: Operation not permitted
Command PhaseScriptExecution failed with a nonzero exit code
\`\`\`

The three `Copy Environment Config` build-phase scripts each `source "${SRCROOT}/Scripts/secrets-utils.sh"` (added in PR #743), but `secrets-utils.sh` was never added to the phases' declared `inputPaths`. With `ENABLE_USER_SCRIPT_SANDBOXING` on, Xcode runs each phase via `sandbox-exec` with a profile that only permits reads from declared inputs. The undeclared `source` is denied, the script exits nonzero, the build fails before any Swift compilation runs.

## The fix

Add `"$(SRCROOT)/Scripts/secrets-utils.sh"` to the `inputPaths` of all three `Copy Environment Config` phases in `Convos.xcodeproj/project.pbxproj`:

- `Convos` (main app)
- `NotificationService`
- `ConvosAppClip`

## Verified

\`\`\`
rm -rf .derivedData
xcodebuild build -scheme "Convos (Dev)" -destination "platform=iOS Simulator,id=..." -derivedDataPath .derivedData
# → ** BUILD SUCCEEDED ** [130.828 sec]
\`\`\`

Install and launch also work; simulator is running the new build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Declare `secrets-utils.sh` as a build-phase input in the Xcode project
> Adds `$(SRCROOT)/Scripts/secrets-utils.sh` to three input file lists in [project.pbxproj](https://github.com/xmtplabs/convos-ios/pull/753/files#diff-d58364582ce5ff189bf9f87c20898db7df50a681e6e9df35dca291d7b9373da7) so the build-phase sandbox recognises the script as a declared input. Without this, sandbox-enabled builds would fail when the script is read during a build phase.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 369b3f7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->