### PR TITLE
Avatars: lava background for verified assistants, threaded into read receipts

### DIFF
--- a/Convos/Conversation Detail/ConversationViewModel+TypingIndicators.swift
+++ b/Convos/Conversation Detail/ConversationViewModel+TypingIndicators.swift
@@ -155,7 +155,7 @@ extension ConversationViewModel {
                 isLastGroupSentByCurrentUser: lastGroup.isLastGroupSentByCurrentUser,
                 showsTypingIndicator: true,
                 allTypingMembers: [typer],
-                readByProfiles: lastGroup.readByProfiles,
+                readByMembers: lastGroup.readByMembers,
                 onlyVisibleToSender: lastGroup.onlyVisibleToSender,
                 isLastGroupBeforeOtherMembers: lastGroup.isLastGroupBeforeOtherMembers,
                 voiceMemoTranscripts: lastGroup.voiceMemoTranscripts

--- a/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/ReadReceiptAvatarsView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/ReadReceiptAvatarsView.swift
@@ -2,7 +2,7 @@ import ConvosCore
 import SwiftUI
 
 struct ReadReceiptAvatarsView: View {
-    let profiles: [Profile]
+    let members: [ConversationMember]
 
     @State private var contentWidth: CGFloat = 0
 
@@ -15,11 +15,11 @@ struct ReadReceiptAvatarsView: View {
 
     private var avatarStack: some View {
         HStack(spacing: DesignConstants.Spacing.stepX) {
-            ForEach(profiles, id: \.self) { profile in
-                ProfileAvatarView(
-                    profile: profile,
-                    profileImage: nil,
-                    useSystemPlaceholder: false
+            ForEach(members, id: \.self) { member in
+                MessageAvatarView(
+                    profile: member.profile,
+                    size: avatarSize,
+                    agentVerification: member.agentVerification
                 )
                 .frame(width: avatarSize, height: avatarSize)
             }
@@ -69,4 +69,20 @@ private struct AvatarContentWidthKey: PreferenceKey {
     static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
         value = max(value, nextValue())
     }
+}
+
+#Preview("Mixed read receipts") {
+    let regular = ConversationMember.mock(name: "Alice")
+    let verifiedAssistant = ConversationMember.mock(
+        name: "Convos Assistant",
+        isAgent: true,
+        agentVerification: .verified(.convos)
+    )
+    let userOAuthAgent = ConversationMember.mock(
+        name: "OAuth Agent",
+        isAgent: true,
+        agentVerification: .verified(.userOAuth)
+    )
+    return ReadReceiptAvatarsView(members: [regular, verifiedAssistant, userOAuthAgent])
+        .padding()
 }

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupView.swift
@@ -290,10 +290,10 @@ struct MessagesGroupView: View {
                         useSystemPlaceholder: false
                     )
                     .frame(width: 16, height: 16)
-                } else if !group.readByProfiles.isEmpty {
+                } else if !group.readByMembers.isEmpty {
                     Text("Read")
                         .font(.caption)
-                    ReadReceiptAvatarsView(profiles: group.readByProfiles)
+                    ReadReceiptAvatarsView(members: group.readByMembers)
                 } else {
                     Text("Sent")
                         .font(.caption)
@@ -312,9 +312,9 @@ struct MessagesGroupView: View {
             .accessibilityLabel(
                 group.onlyVisibleToSender
                     ? "Only visible to you"
-                    : (group.readByProfiles.isEmpty
+                    : (group.readByMembers.isEmpty
                         ? "Message sent"
-                        : "Message read by \(group.readByProfiles.count) \(group.readByProfiles.count == 1 ? "member" : "members")")
+                        : "Message read by \(group.readByMembers.count) \(group.readByMembers.count == 1 ? "member" : "members")")
             )
         }
     }

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessagesListRepository.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessagesListRepository.swift
@@ -125,7 +125,7 @@ final class MessagesListRepository: MessagesListRepositoryProtocol {
     private var lastReadReceipts: [ReadReceiptEntry] = []
     private var lastMemberProfiles: [String: MemberProfileInfo] = [:]
     private var lastOtherMemberCount: Int = 0
-    private var lastReadByProfiles: [Profile] = []
+    private var lastReadByMembers: [ConversationMember] = []
     var sendReadReceipts: Bool = true
 
     private func processMessages(_ messages: [AnyMessage], readReceipts: [ReadReceiptEntry] = [], memberProfiles: [String: MemberProfileInfo] = [:]) -> [MessagesListItemType] {
@@ -141,9 +141,9 @@ final class MessagesListRepository: MessagesListRepositoryProtocol {
             memberProfiles: memberProfiles,
             currentOtherMemberCount: currentOtherMemberCount,
             sendReadReceipts: sendReadReceipts,
-            previousReadByProfiles: lastReadByProfiles
+            previousReadByMembers: lastReadByMembers
         )
-        lastReadByProfiles = Self.extractReadByProfiles(from: items)
+        lastReadByMembers = Self.extractReadByMembers(from: items)
         scheduleAssistantJoinDismissIfNeeded(items)
         return items
     }
@@ -195,10 +195,10 @@ final class MessagesListRepository: MessagesListRepositoryProtocol {
         return result
     }
 
-    private static func extractReadByProfiles(from items: [MessagesListItemType]) -> [Profile] {
+    private static func extractReadByMembers(from items: [MessagesListItemType]) -> [ConversationMember] {
         for item in items.reversed() {
             if case .messages(let group) = item, group.isLastGroupSentByCurrentUser {
-                return group.readByProfiles
+                return group.readByMembers
             }
         }
         return []

--- a/Convos/Shared Views/AvatarView.swift
+++ b/Convos/Shared Views/AvatarView.swift
@@ -35,7 +35,7 @@ struct AvatarView: View {
                     .scaledToFit()
                     .aspectRatio(contentMode: .fill)
             } else if let placeholderEmoji, !placeholderEmoji.isEmpty {
-                EmojiAvatarView(emoji: placeholderEmoji)
+                EmojiAvatarView(emoji: placeholderEmoji, agentVerification: agentVerification)
             } else if let placeholderImageName {
                 Image(systemName: placeholderImageName)
                     .resizable()
@@ -108,7 +108,7 @@ struct ConversationAvatarView: View {
             MonogramView(name: conversation.computedDisplayName)
         case let .profile(profile, verification):
             if let emoji = profile.profileEmoji, !emoji.isEmpty {
-                EmojiAvatarView(emoji: emoji)
+                EmojiAvatarView(emoji: emoji, agentVerification: verification)
             } else if verification == .unverified {
                 EmojiAvatarView(emoji: conversation.defaultEmoji)
             } else {
@@ -140,7 +140,7 @@ struct MessageAvatarView: View {
                     .resizable()
                     .aspectRatio(contentMode: .fill)
             } else if let emoji = profile.profileEmoji, !emoji.isEmpty {
-                EmojiAvatarView(emoji: emoji)
+                EmojiAvatarView(emoji: emoji, agentVerification: profile.isAgent ? agentVerification : .unverified)
             } else {
                 MonogramView(name: profile.displayName, agentVerification: profile.isAgent ? agentVerification : .unverified)
             }

--- a/Convos/Shared Views/EmojiAvatarView.swift
+++ b/Convos/Shared Views/EmojiAvatarView.swift
@@ -1,7 +1,13 @@
+import ConvosCore
 import SwiftUI
 
 struct EmojiAvatarView: View {
     let emoji: String
+    var agentVerification: AgentVerification = .unverified
+
+    private var background: Color {
+        agentVerification.isVerified ? agentVerification.avatarBackgroundColor : .colorFillMinimal
+    }
 
     var body: some View {
         GeometryReader { geometry in
@@ -11,7 +17,7 @@ struct EmojiAvatarView: View {
             Text(emoji)
                 .font(.system(size: fontSize, weight: .semibold, design: .rounded))
                 .frame(width: side, height: side)
-                .background(.colorFillMinimal)
+                .background(background)
                 .clipShape(Circle())
         }
         .aspectRatio(1.0, contentMode: .fit)
@@ -28,6 +34,10 @@ struct EmojiAvatarView: View {
         EmojiAvatarView(emoji: "🌵")
             .frame(width: 56, height: 56)
         EmojiAvatarView(emoji: "😳")
+            .frame(width: 56, height: 56)
+        EmojiAvatarView(emoji: "🤖", agentVerification: .verified(.convos))
+            .frame(width: 56, height: 56)
+        EmojiAvatarView(emoji: "🛂", agentVerification: .verified(.userOAuth))
             .frame(width: 56, height: 56)
     }
     .padding()

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/MessagesGroup.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/MessagesGroup.swift
@@ -8,7 +8,7 @@ public struct MessagesGroup: Identifiable, Equatable, Sendable {
     public var isLastGroupSentByCurrentUser: Bool
     public let showsTypingIndicator: Bool
     public let allTypingMembers: [ConversationMember]
-    public let readByProfiles: [Profile]
+    public let readByMembers: [ConversationMember]
     public var onlyVisibleToSender: Bool = false
     public var isLastGroupBeforeOtherMembers: Bool = false
     public var adjacentToFullBleedAbove: Bool = false
@@ -42,7 +42,7 @@ public struct MessagesGroup: Identifiable, Equatable, Sendable {
         isLastGroupSentByCurrentUser: Bool,
         showsTypingIndicator: Bool = false,
         allTypingMembers: [ConversationMember] = [],
-        readByProfiles: [Profile] = [],
+        readByMembers: [ConversationMember] = [],
         onlyVisibleToSender: Bool = false,
         isLastGroupBeforeOtherMembers: Bool = false,
         voiceMemoTranscripts: [String: VoiceMemoTranscriptListItem] = [:]
@@ -54,7 +54,7 @@ public struct MessagesGroup: Identifiable, Equatable, Sendable {
         self.isLastGroupSentByCurrentUser = isLastGroupSentByCurrentUser
         self.showsTypingIndicator = showsTypingIndicator
         self.allTypingMembers = allTypingMembers
-        self.readByProfiles = readByProfiles
+        self.readByMembers = readByMembers
         self.onlyVisibleToSender = onlyVisibleToSender
         self.isLastGroupBeforeOtherMembers = isLastGroupBeforeOtherMembers
         self.voiceMemoTranscripts = voiceMemoTranscripts
@@ -68,7 +68,7 @@ public struct MessagesGroup: Identifiable, Equatable, Sendable {
         isLastGroupSentByCurrentUser: Bool,
         showsTypingIndicator: Bool = false,
         allTypingMembers: [ConversationMember] = [],
-        readByProfiles: [Profile] = [],
+        readByMembers: [ConversationMember] = [],
         onlyVisibleToSender: Bool = false,
         isLastGroupBeforeOtherMembers: Bool = false,
         voiceMemoTranscripts: [String: VoiceMemoTranscriptListItem] = [:]
@@ -80,7 +80,7 @@ public struct MessagesGroup: Identifiable, Equatable, Sendable {
         self.isLastGroupSentByCurrentUser = isLastGroupSentByCurrentUser
         self.showsTypingIndicator = showsTypingIndicator
         self.allTypingMembers = allTypingMembers
-        self.readByProfiles = readByProfiles
+        self.readByMembers = readByMembers
         self.onlyVisibleToSender = onlyVisibleToSender
         self.isLastGroupBeforeOtherMembers = isLastGroupBeforeOtherMembers
         self.voiceMemoTranscripts = voiceMemoTranscripts
@@ -94,7 +94,7 @@ public struct MessagesGroup: Identifiable, Equatable, Sendable {
         lhs.isLastGroupSentByCurrentUser == rhs.isLastGroupSentByCurrentUser &&
         lhs.showsTypingIndicator == rhs.showsTypingIndicator &&
         lhs.allTypingMembers == rhs.allTypingMembers &&
-        lhs.readByProfiles == rhs.readByProfiles &&
+        lhs.readByMembers == rhs.readByMembers &&
         lhs.onlyVisibleToSender == rhs.onlyVisibleToSender &&
         lhs.isLastGroupBeforeOtherMembers == rhs.isLastGroupBeforeOtherMembers &&
         lhs.adjacentToFullBleedAbove == rhs.adjacentToFullBleedAbove &&
@@ -112,7 +112,7 @@ extension MessagesGroup: Hashable {
         hasher.combine(isLastGroupSentByCurrentUser)
         hasher.combine(showsTypingIndicator)
         hasher.combine(allTypingMembers)
-        hasher.combine(readByProfiles)
+        hasher.combine(readByMembers)
         hasher.combine(onlyVisibleToSender)
         hasher.combine(isLastGroupBeforeOtherMembers)
         hasher.combine(adjacentToFullBleedAbove)

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/MessagesListProcessor.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/MessagesListProcessor.swift
@@ -10,7 +10,7 @@ public final class MessagesListProcessor: Sendable {
         memberProfiles: [String: MemberProfileInfo] = [:],
         currentOtherMemberCount: Int = 0,
         sendReadReceipts: Bool = true,
-        previousReadByProfiles: [Profile] = []
+        previousReadByMembers: [ConversationMember] = []
     ) -> [MessagesListItemType] {
         return processMessages(
             messages,
@@ -19,7 +19,7 @@ public final class MessagesListProcessor: Sendable {
             memberProfiles: memberProfiles,
             currentOtherMemberCount: currentOtherMemberCount,
             sendReadReceipts: sendReadReceipts,
-            previousReadByProfiles: previousReadByProfiles
+            previousReadByMembers: previousReadByMembers
         )
     }
 
@@ -31,7 +31,7 @@ public final class MessagesListProcessor: Sendable {
         memberProfiles: [String: MemberProfileInfo] = [:],
         currentOtherMemberCount: Int = 0,
         sendReadReceipts: Bool = true,
-        previousReadByProfiles: [Profile] = []
+        previousReadByMembers: [ConversationMember] = []
     ) -> [MessagesListItemType] {
         guard !messages.isEmpty else { return [] }
 
@@ -228,34 +228,42 @@ public final class MessagesListProcessor: Sendable {
                         .map(\.inboxId)
                 )
 
-                let resolveProfile: (String) -> Profile? = { inboxId in
+                let resolveMember: (String) -> ConversationMember? = { inboxId in
+                    if let member = messages.lazy
+                        .compactMap({ $0.sender.profile.inboxId == inboxId ? $0.sender : nil })
+                        .first {
+                        return member
+                    }
                     if let info = memberProfiles[inboxId] {
-                        return Profile(
+                        let profile = Profile(
                             inboxId: info.inboxId,
                             conversationId: info.conversationId,
                             name: info.name,
                             avatar: info.avatar
                         )
+                        return ConversationMember(
+                            profile: profile,
+                            role: .member,
+                            isCurrentUser: false
+                        )
                     }
-                    return messages.lazy
-                        .compactMap { $0.sender.profile.inboxId == inboxId ? $0.sender.profile : nil }
-                        .first
+                    return nil
                 }
 
                 if !currentReaderInboxIds.isEmpty {
-                    let keptInboxIds = previousReadByProfiles
-                        .map(\.inboxId)
+                    let keptInboxIds = previousReadByMembers
+                        .map(\.profile.inboxId)
                         .filter { currentReaderInboxIds.contains($0) }
-                    let kept = keptInboxIds.compactMap(resolveProfile)
-                    let keptIds = Set(kept.map(\.inboxId))
+                    let kept = keptInboxIds.compactMap(resolveMember)
+                    let keptIds = Set(kept.map(\.profile.inboxId))
                     let newInboxIds = currentReaderInboxIds.subtracting(keptIds)
                         .sorted { lhs, rhs in
                             let lhsNs = readReceipts.first { $0.inboxId == lhs }?.readAtNs ?? 0
                             let rhsNs = readReceipts.first { $0.inboxId == rhs }?.readAtNs ?? 0
                             return lhsNs != rhsNs ? lhsNs > rhsNs : lhs < rhs
                         }
-                    let newProfiles = newInboxIds.compactMap(resolveProfile)
-                    let profiles: [Profile] = kept + newProfiles
+                    let newMembers = newInboxIds.compactMap(resolveMember)
+                    let members: [ConversationMember] = kept + newMembers
                     group = MessagesGroup(
                         id: group.id,
                         sender: group.sender,
@@ -264,7 +272,7 @@ public final class MessagesListProcessor: Sendable {
                         isLastGroupSentByCurrentUser: true,
                         showsTypingIndicator: group.showsTypingIndicator,
                         allTypingMembers: group.allTypingMembers,
-                        readByProfiles: profiles,
+                        readByMembers: members,
                         onlyVisibleToSender: group.onlyVisibleToSender,
                         isLastGroupBeforeOtherMembers: group.isLastGroupBeforeOtherMembers,
                         voiceMemoTranscripts: group.voiceMemoTranscripts

--- a/ConvosCore/Tests/ConvosCoreTests/MessagesListProcessorTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/MessagesListProcessorTests.swift
@@ -973,3 +973,114 @@ struct MessagesListProcessorEdgeCaseTests {
         }
     }
 }
+
+// MARK: - Read Receipt Tests
+
+struct MessagesListProcessorReadReceiptTests {
+    @Test("Read-by member preserves agentVerification for verified Convos assistant")
+    func readByMemberPreservesVerification() {
+        let now = Date()
+        let assistant: ConversationMember = .mock(
+            isCurrentUser: false,
+            name: "Convos Assistant",
+            isAgent: true,
+            agentVerification: .verified(.convos)
+        )
+        let messages = [
+            makeMessage(id: "asst-1", sender: assistant, text: "Hi there", date: now),
+            makeMessage(id: "me-1", sender: currentUser, text: "Hi back", date: now.addingTimeInterval(10)),
+        ]
+        let readAtNs = Int64(now.addingTimeInterval(20).timeIntervalSince1970 * 1_000_000_000)
+        let receipts = [
+            ReadReceiptEntry(inboxId: assistant.profile.inboxId, readAtNs: readAtNs),
+        ]
+        let result = MessagesListProcessor.process(
+            messages,
+            readReceipts: receipts,
+            currentOtherMemberCount: 1
+        )
+        let g = groups(from: result)
+        let lastCurrentUserGroup = g.last { $0.isLastGroupSentByCurrentUser }
+        #expect(lastCurrentUserGroup != nil)
+        let readers = lastCurrentUserGroup?.readByMembers ?? []
+        #expect(readers.count == 1)
+        #expect(readers.first?.profile.inboxId == assistant.profile.inboxId)
+        #expect(readers.first?.agentVerification == .verified(.convos))
+    }
+
+    @Test("Read-by members carry mixed verification end-to-end")
+    func readByMembersMixedVerification() {
+        let now = Date()
+        let assistant: ConversationMember = .mock(
+            isCurrentUser: false,
+            name: "Convos Assistant",
+            isAgent: true,
+            agentVerification: .verified(.convos)
+        )
+        let oauthAgent: ConversationMember = .mock(
+            isCurrentUser: false,
+            name: "OAuth Agent",
+            isAgent: true,
+            agentVerification: .verified(.userOAuth)
+        )
+        let regular: ConversationMember = .mock(isCurrentUser: false, name: "Alice")
+        let messages = [
+            makeMessage(id: "asst-1", sender: assistant, text: "asst hi", date: now),
+            makeMessage(id: "oauth-1", sender: oauthAgent, text: "oauth hi", date: now.addingTimeInterval(1)),
+            makeMessage(id: "reg-1", sender: regular, text: "reg hi", date: now.addingTimeInterval(2)),
+            makeMessage(id: "me-1", sender: currentUser, text: "Hi all", date: now.addingTimeInterval(10)),
+        ]
+        let readAtNs = Int64(now.addingTimeInterval(20).timeIntervalSince1970 * 1_000_000_000)
+        let receipts = [
+            ReadReceiptEntry(inboxId: assistant.profile.inboxId, readAtNs: readAtNs),
+            ReadReceiptEntry(inboxId: oauthAgent.profile.inboxId, readAtNs: readAtNs + 1),
+            ReadReceiptEntry(inboxId: regular.profile.inboxId, readAtNs: readAtNs + 2),
+        ]
+        let result = MessagesListProcessor.process(
+            messages,
+            readReceipts: receipts,
+            currentOtherMemberCount: 3
+        )
+        let g = groups(from: result)
+        let lastCurrentUserGroup = g.last { $0.isLastGroupSentByCurrentUser }
+        let readers = lastCurrentUserGroup?.readByMembers ?? []
+        #expect(readers.count == 3)
+        let byInbox = Dictionary(uniqueKeysWithValues: readers.map { ($0.profile.inboxId, $0.agentVerification) })
+        #expect(byInbox[assistant.profile.inboxId] == .verified(.convos))
+        #expect(byInbox[oauthAgent.profile.inboxId] == .verified(.userOAuth))
+        #expect(byInbox[regular.profile.inboxId] == .unverified)
+    }
+
+    @Test("Read-by members fall back to memberProfiles cache as unverified")
+    func readByMembersFallbackToCache() {
+        let now = Date()
+        let conversationId = "conv-1"
+        let absentInboxId = "absent-reader"
+        let messages = [
+            makeMessage(id: "me-1", sender: currentUser, text: "Hello", date: now),
+        ]
+        let readAtNs = Int64(now.addingTimeInterval(5).timeIntervalSince1970 * 1_000_000_000)
+        let receipts = [
+            ReadReceiptEntry(inboxId: absentInboxId, readAtNs: readAtNs),
+        ]
+        let memberProfiles: [String: MemberProfileInfo] = [
+            absentInboxId: MemberProfileInfo(
+                inboxId: absentInboxId,
+                conversationId: conversationId,
+                name: "Absent Reader",
+                avatar: nil
+            ),
+        ]
+        let result = MessagesListProcessor.process(
+            messages,
+            readReceipts: receipts,
+            memberProfiles: memberProfiles,
+            currentOtherMemberCount: 1
+        )
+        let g = groups(from: result)
+        let readers = g.last { $0.isLastGroupSentByCurrentUser }?.readByMembers ?? []
+        #expect(readers.count == 1)
+        #expect(readers.first?.profile.inboxId == absentInboxId)
+        #expect(readers.first?.agentVerification == .unverified)
+    }
+}


### PR DESCRIPTION
## Summary

Two related avatar fixes for verified assistants.

### Bug 1: Verified assistant emoji avatars rendered on gray

A verified Convos assistant (`AgentVerification.verified(.convos)`) with a profile emoji set was showing the emoji on `.colorFillMinimal` (gray), even though every other verified-assistant avatar variant (monogram, system placeholder) used the orange `.colorLava` background.

`EmojiAvatarView` now takes an `agentVerification: AgentVerification = .unverified` and uses `agentVerification.avatarBackgroundColor` when verified. `.unverified` falls back to today's `.colorFillMinimal` so non-agent users see no change. Updated all `EmojiAvatarView(...)` call sites to thread the verification they already had access to (`AvatarView`, `MessageAvatarView`, `ConversationAvatarView`).

### Bug 2: Read receipts dropped agent verification on the floor

`ReadReceiptAvatarsView` invoked `ProfileAvatarView` without passing `agentVerification`, so verified assistants who read your message rendered with the gray default — visually inconsistent with their own message-bubble avatar above (which rendered correctly).

Threaded `ConversationMember` end-to-end:
- `MessagesGroup.readByProfiles: [Profile]` → `MessagesGroup.readByMembers: [ConversationMember]`
- `MessagesListProcessor` resolves `ConversationMember` instead of `Profile`, preserving `agentVerification`.
- `ReadReceiptAvatarsView` accepts members and passes verification into `ProfileAvatarView`.
- Updated callers in `MessagesListRepository`, `ConversationViewModel+TypingIndicators`, `MessagesGroupView`.

Result: a verified assistant's read-receipt avatar now matches their message-bubble avatar pixel for pixel.

## Test plan

- [ ] Verified Convos assistant with profile emoji → message-bubble avatar shows emoji on lava (unchanged); read-receipt avatar now also shows emoji on lava.
- [ ] Verified Convos assistant without profile emoji → read-receipt avatar shows monogram on lava.
- [ ] Unverified agent → both avatars stay gray (no regression).
- [ ] Regular user (non-agent) → emoji on `.colorFillMinimal` (no regression).

## Tests

- Updated `MessagesListProcessorTests` to assert `agentVerification` flows through the read-by member set end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add lava background for verified assistant avatars in read receipts
> - Replaces `Profile` with `ConversationMember` as the read receipt type throughout `MessagesGroup`, `MessagesListProcessor`, `MessagesListRepository`, and related views, so that agent verification state is available wherever read receipts are rendered.
> - `EmojiAvatarView` now accepts an `agentVerification` parameter and renders a lava background color when the agent is verified, falling back to the default `.colorFillMinimal` for unverified users.
> - `ReadReceiptAvatarsView` is updated to accept `[ConversationMember]` and renders each avatar via `MessageAvatarView`, propagating verification state to the avatar background.
> - `MessagesListProcessor` resolves readers as `ConversationMember` by matching on `inboxId` from the message list, falling back to constructing an unverified member from the profile cache.
> - Three new tests in `MessagesListProcessorReadReceiptTests` cover verified assistants, mixed verification states, and the unverified fallback path.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3b75ea8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->