### PR TITLE
Agents: don't downgrade verified agents on stale verification check

### DIFF
--- a/ConvosCore/Sources/ConvosCore/Inboxes/MessagingService+PushNotifications.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/MessagingService+PushNotifications.swift
@@ -728,11 +728,19 @@ extension MessagingService {
                     profile = profile.with(avatar: nil, salt: nil, nonce: nil, key: nil)
                 }
 
+                let priorMemberKind = profile.memberKind
                 profile = profile.with(memberKind: update.memberKind.dbMemberKind)
 
                 if profile.isAgent {
                     let verification = profile.hydrateProfile().verifyCachedAgentAttestation()
-                    profile = profile.with(memberKind: DBMemberKind.from(agentVerification: verification))
+                    if verification.isVerified {
+                        profile = profile.with(memberKind: DBMemberKind.from(agentVerification: verification))
+                    }
+                }
+
+                if let priorMemberKind, priorMemberKind.agentVerification.isVerified,
+                   !profile.agentVerification.isVerified {
+                    profile = profile.with(memberKind: priorMemberKind)
                 }
 
                 try profile.save(db)
@@ -790,11 +798,19 @@ extension MessagingService {
                         )
                     }
 
+                    let priorMemberKind = profile.memberKind
                     profile = profile.with(memberKind: memberProfile.memberKind.dbMemberKind)
 
                     if profile.isAgent {
                         let verification = profile.hydrateProfile().verifyCachedAgentAttestation()
-                        profile = profile.with(memberKind: DBMemberKind.from(agentVerification: verification))
+                        if verification.isVerified {
+                            profile = profile.with(memberKind: DBMemberKind.from(agentVerification: verification))
+                        }
+                    }
+
+                    if let priorMemberKind, priorMemberKind.agentVerification.isVerified,
+                       !profile.agentVerification.isVerified {
+                        profile = profile.with(memberKind: priorMemberKind)
                     }
 
                     try profile.save(db)

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationWriter.swift
@@ -776,6 +776,7 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
             profile = profile.with(metadata: metadata)
         }
 
+        let priorMemberKind = profile.memberKind
         if let memberKind {
             profile = profile.with(memberKind: memberKind)
 
@@ -786,6 +787,12 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
                 }
             }
         }
+
+        if let priorMemberKind, priorMemberKind.agentVerification.isVerified,
+           !profile.agentVerification.isVerified {
+            profile = profile.with(memberKind: priorMemberKind)
+        }
+
         try profile.save(db)
 
         if profile.agentVerification.isConvosAssistant,

--- a/ConvosCore/Sources/ConvosCore/Syncing/StreamProcessor.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/StreamProcessor.swift
@@ -393,6 +393,7 @@ actor StreamProcessor: StreamProcessorProtocol {
                     profile = profile.with(avatar: nil, salt: nil, nonce: nil, key: nil)
                 }
 
+                let priorMemberKind = profile.memberKind
                 profile = profile.with(memberKind: update.memberKind.dbMemberKind)
 
                 let profileMetadata = update.profileMetadata
@@ -400,7 +401,14 @@ actor StreamProcessor: StreamProcessorProtocol {
 
                 if profile.isAgent {
                     let verification = profile.hydrateProfile().verifyCachedAgentAttestation()
-                    profile = profile.with(memberKind: DBMemberKind.from(agentVerification: verification))
+                    if verification.isVerified {
+                        profile = profile.with(memberKind: DBMemberKind.from(agentVerification: verification))
+                    }
+                }
+
+                if let priorMemberKind, priorMemberKind.agentVerification.isVerified,
+                   !profile.agentVerification.isVerified {
+                    profile = profile.with(memberKind: priorMemberKind)
                 }
 
                 try profile.save(db)
@@ -457,6 +465,7 @@ actor StreamProcessor: StreamProcessorProtocol {
                         )
                     }
 
+                    let priorMemberKind = profile.memberKind
                     profile = profile.with(memberKind: memberProfile.memberKind.dbMemberKind)
 
                     let snapshotMetadata = memberProfile.profileMetadata
@@ -464,7 +473,14 @@ actor StreamProcessor: StreamProcessorProtocol {
 
                     if profile.isAgent {
                         let verification = profile.hydrateProfile().verifyCachedAgentAttestation()
-                        profile = profile.with(memberKind: DBMemberKind.from(agentVerification: verification))
+                        if verification.isVerified {
+                            profile = profile.with(memberKind: DBMemberKind.from(agentVerification: verification))
+                        }
+                    }
+
+                    if let priorMemberKind, priorMemberKind.agentVerification.isVerified,
+                       !profile.agentVerification.isVerified {
+                        profile = profile.with(memberKind: priorMemberKind)
                     }
 
                     try profile.save(db)

--- a/ConvosCore/Tests/ConvosCoreTests/Integration/AgentVerificationDowngradeTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/Integration/AgentVerificationDowngradeTests.swift
@@ -1,0 +1,202 @@
+@testable import ConvosCore
+import Foundation
+import GRDB
+import Testing
+@preconcurrency import XMTPiOS
+
+/// Verifies that profile-stream/snapshot writers do not flip a previously-verified
+/// agent back to `.agent` (unverified) when the cached attestation check
+/// transiently returns `.unverified` (stale `attestation_ts`, missing
+/// metadata, or a kid that the local keyset hasn't cached yet).
+///
+/// The NSE-side equivalents (`MessagingService+PushNotifications`) share the
+/// same fix but their `processProfileUpdateInNSE` / `processProfileSnapshotInNSE`
+/// entry points are private and don't have a lightweight test harness, so
+/// they're covered indirectly by the StreamProcessor cases below.
+@Suite("Agent Verification Downgrade Tests", .serialized)
+struct AgentVerificationDowngradeTests {
+    private enum TestError: Error {
+        case missingClients
+    }
+
+    /// Configures `AgentKeysetStore` so that `verifyCachedAgentAttestation`
+    /// resolves no kid and returns `.unverified`. Used to simulate the
+    /// keyset-cache-miss / missing-metadata cases.
+    private static func configureEmptyKeyset() {
+        AgentKeysetStore.instance.configure(MockAgentKeyset(keys: [:]))
+    }
+
+    private static func seedVerifiedAgent(
+        in databaseWriter: any DatabaseWriter,
+        conversationId: String,
+        inboxId: String,
+        name: String? = nil,
+        avatar: String? = nil
+    ) async throws {
+        try await databaseWriter.write { db in
+            try DBMember(inboxId: inboxId).save(db)
+            try DBMemberProfile(
+                conversationId: conversationId,
+                inboxId: inboxId,
+                name: name,
+                avatar: avatar,
+                memberKind: .verifiedConvos
+            ).save(db)
+        }
+    }
+
+    @Test("Stream ProfileUpdate without attestation does not downgrade verified agent")
+    func streamProfileUpdateMissingAttestationPreservesVerifiedConvos() async throws {
+        let fixtures = TestFixtures()
+        try await fixtures.createTestClients()
+
+        guard let clientA = fixtures.clientA as? Client,
+              let clientB = fixtures.clientB as? Client,
+              let clientIdB = fixtures.clientIdB else {
+            throw TestError.missingClients
+        }
+
+        Self.configureEmptyKeyset()
+
+        let inboxIdA = clientA.inboxID
+        let inboxIdB = clientB.inboxID
+
+        try await fixtures.databaseManager.dbWriter.write { db in
+            try DBInbox(inboxId: inboxIdB, clientId: clientIdB, createdAt: Date()).insert(db)
+        }
+
+        let group = try await clientA.conversations.newGroup(with: [inboxIdB], name: "Test Group")
+
+        try await clientB.conversations.sync()
+        let groupB = try #require(try clientB.conversations.listGroups().first { $0.id == group.id })
+        try await groupB.sync()
+        try await groupB.updateConsentState(state: .allowed)
+
+        let mockMessageWriter = MockIncomingMessageWriter()
+        let conversationWriter = ConversationWriter(
+            identityStore: fixtures.identityStore,
+            databaseWriter: fixtures.databaseManager.dbWriter,
+            messageWriter: mockMessageWriter
+        )
+        _ = try await conversationWriter.store(conversation: groupB, inboxId: inboxIdB)
+
+        try await Self.seedVerifiedAgent(
+            in: fixtures.databaseManager.dbWriter,
+            conversationId: group.id,
+            inboxId: inboxIdA,
+            name: "Verified Agent"
+        )
+
+        let preStateMemberKind = try await fixtures.databaseManager.dbReader.read { db in
+            try DBMemberProfile.fetchOne(db, conversationId: group.id, inboxId: inboxIdA)?.memberKind
+        }
+        #expect(preStateMemberKind == .verifiedConvos, "Pre-condition: profile starts as verified")
+
+        var update = ProfileUpdate(name: "Verified Agent")
+        update.memberKind = .agent
+        // Intentionally no attestation metadata.
+        let encoded = try ProfileUpdateCodec().encode(content: update)
+        _ = try await group.send(encodedContent: encoded)
+
+        try await groupB.sync()
+
+        let processor = StreamProcessor(
+            identityStore: fixtures.identityStore,
+            databaseWriter: fixtures.databaseManager.dbWriter,
+            databaseReader: fixtures.databaseManager.dbReader,
+            notificationCenter: MockUserNotificationCenter()
+        )
+        let params = SyncClientParams(client: clientB, apiClient: MockAPIClient())
+
+        let messages = try await groupB.messages(limit: 20, direction: .descending)
+        let updateMsg = try #require(messages.first {
+            (try? $0.encodedContent.type) == ContentTypeProfileUpdate
+        })
+        await processor.processMessage(updateMsg, params: params, activeConversationId: nil)
+
+        let postMemberKind = try await fixtures.databaseManager.dbReader.read { db in
+            try DBMemberProfile.fetchOne(db, conversationId: group.id, inboxId: inboxIdA)?.memberKind
+        }
+        #expect(postMemberKind == .verifiedConvos, "Verified agent must not downgrade after a missing-attestation update")
+
+        try? await fixtures.cleanup()
+    }
+
+    @Test("Stream ProfileSnapshot without attestation does not downgrade verified agent")
+    func streamProfileSnapshotMissingAttestationPreservesVerifiedConvos() async throws {
+        let fixtures = TestFixtures()
+        try await fixtures.createTestClients()
+
+        guard let clientA = fixtures.clientA as? Client,
+              let clientB = fixtures.clientB as? Client,
+              let clientIdB = fixtures.clientIdB else {
+            throw TestError.missingClients
+        }
+
+        Self.configureEmptyKeyset()
+
+        let inboxIdA = clientA.inboxID
+        let inboxIdB = clientB.inboxID
+
+        try await fixtures.databaseManager.dbWriter.write { db in
+            try DBInbox(inboxId: inboxIdB, clientId: clientIdB, createdAt: Date()).insert(db)
+        }
+
+        let group = try await clientA.conversations.newGroup(with: [inboxIdB], name: "Test Group")
+
+        try await clientB.conversations.sync()
+        let groupB = try #require(try clientB.conversations.listGroups().first { $0.id == group.id })
+        try await groupB.sync()
+        try await groupB.updateConsentState(state: .allowed)
+
+        let mockMessageWriter = MockIncomingMessageWriter()
+        let conversationWriter = ConversationWriter(
+            identityStore: fixtures.identityStore,
+            databaseWriter: fixtures.databaseManager.dbWriter,
+            messageWriter: mockMessageWriter
+        )
+        _ = try await conversationWriter.store(conversation: groupB, inboxId: inboxIdB)
+
+        try await Self.seedVerifiedAgent(
+            in: fixtures.databaseManager.dbWriter,
+            conversationId: group.id,
+            inboxId: inboxIdA
+        )
+
+        var memberProfile = MemberProfile()
+        if let inboxIdBytes = Data(hexString: inboxIdA), !inboxIdBytes.isEmpty {
+            memberProfile.inboxID = inboxIdBytes
+        }
+        memberProfile.name = "Snapshot Name"
+        memberProfile.memberKind = .agent
+        // Intentionally no attestation metadata.
+        var snapshot = ProfileSnapshot()
+        snapshot.profiles = [memberProfile]
+
+        let encoded = try ProfileSnapshotCodec().encode(content: snapshot)
+        _ = try await group.send(encodedContent: encoded)
+
+        try await groupB.sync()
+
+        let processor = StreamProcessor(
+            identityStore: fixtures.identityStore,
+            databaseWriter: fixtures.databaseManager.dbWriter,
+            databaseReader: fixtures.databaseManager.dbReader,
+            notificationCenter: MockUserNotificationCenter()
+        )
+        let params = SyncClientParams(client: clientB, apiClient: MockAPIClient())
+
+        let messages = try await groupB.messages(limit: 20, direction: .descending)
+        let snapshotMsg = try #require(messages.first {
+            (try? $0.encodedContent.type) == ContentTypeProfileSnapshot
+        })
+        await processor.processMessage(snapshotMsg, params: params, activeConversationId: nil)
+
+        let postMemberKind = try await fixtures.databaseManager.dbReader.read { db in
+            try DBMemberProfile.fetchOne(db, conversationId: group.id, inboxId: inboxIdA)?.memberKind
+        }
+        #expect(postMemberKind == .verifiedConvos, "Verified agent must not downgrade after a missing-attestation snapshot")
+
+        try? await fixtures.cleanup()
+    }
+}


### PR DESCRIPTION
## Summary

Verified assistants flapped between **Assistant** (verified) and **Agent** (unverified) when profile updates / snapshots arrived via stream or push, then reverted back later (e.g. after app relaunch). The cached attestation check (`Profile.verifyCachedAgentAttestation()`) returns `.unverified` on transient miss, and several profile writers were unconditionally rewriting `memberKind` from the verifier's result, which silently downgraded a previously-verified agent.

## Failure modes that flip the cached check to `.unverified`

- `attestation_ts` older than the 24h `maxAge` in `AssistantAttestationVerifier`
- The agent's profile metadata is missing one of `attestation`, `attestation_ts`, `attestation_kid`
- The local `AgentKeyset` cache hasn't resolved the kid yet (e.g. before the keyset's prefetch completes)

## Fix

Mirrors and extends the existing guard in `ConversationWriter.applyProfileData`:

- Add the `if verification.isVerified` guard at every call site that re-runs the cached check, so we only ever upgrade `memberKind`, never overwrite it with `.unverified`'s mapping.
- Capture the prior `memberKind` before each profile mutation and, when the new state would lose verification, restore the prior verified `memberKind`. This handles the second part of the bug — the unconditional `profile.with(memberKind: update.memberKind.dbMemberKind)` line that immediately precedes the guarded check, which on its own collapses `.verifiedConvos` to `.agent`.

`AgentVerificationWriter.reverifyUnverifiedAgents` is intentionally untouched — it only runs at app launch and only on already-unverified agents, so it's correct as-is.

## Sites changed

- `StreamProcessor.processProfileUpdate`
- `StreamProcessor.processProfileSnapshot`
- `MessagingService+PushNotifications.processProfileUpdateInNSE`
- `MessagingService+PushNotifications.processProfileSnapshotInNSE`
- `ConversationWriter.applyProfileData` — surfaced by the audit pass. The streaming path always calls `conversationWriter.store` first, which kicks off `processProfileMessagesFromHistory` -> `applyProfileData` for the latest `ProfileUpdate`/`ProfileSnapshot` per sender. Without the preservation here, history processing collapses the verified state before the streaming path even runs. The literal `if verification.isVerified` guard inside `applyProfileData` is unchanged; the new logic is added around it.

## Test plan

- [x] `swift test --filter "AgentVerificationDowngradeTests" --package-path ConvosCore` — both new tests (StreamProcessor `ProfileUpdate` and `ProfileSnapshot` paths) pass.
- [x] Confirmed the new tests fail without the `applyProfileData` preservation, and pass with it (so the assertion actually exercises the bug).
- [x] `swift test --package-path ConvosCore` — full suite green (intermittent flakes unrelated to this change in `ScheduledExplosionManager` / `NetworkMonitor` / `SessionStateMachine`, all green in isolation).
- [x] `swiftlint --strict --quiet` clean.

The NSE-side equivalents share the same fix but their `processProfileUpdateInNSE` / `processProfileSnapshotInNSE` entry points are private and don't have a lightweight test harness; the test file documents that and they're covered by the inline structural change.