### PR TITLE
Add regression test for assistant join status

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -139,6 +139,7 @@ excluded:
   - .build/
   - "**/.build"
   - .derivedData/
+  - .claude/worktrees/
   - ConvosCore/Tests
   - ConvosTests
   - ConvosTests/Helpers

--- a/ConvosCore/Tests/ConvosCoreTests/MessagesListProcessorTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/MessagesListProcessorTests.swift
@@ -859,6 +859,55 @@ struct MessagesListProcessorAssistantJoinTests {
         #expect(ajItems.count == 0)
     }
 
+    @Test("Assistant join request hidden and joined update remains visible")
+    func hiddenAfterAgentJoinedWhileUpdateStillShown() {
+        let now = Date()
+        let agentMember = ConversationMember(
+            profile: Profile(inboxId: "agent-1", conversationId: "test-conv", name: "Assistant", avatar: nil, isAgent: true),
+            role: .member,
+            isCurrentUser: false,
+            isAgent: true,
+            agentVerification: .verified(.convos)
+        )
+        let joinedUpdate = AnyMessage.message(Message(
+            id: "agent-joined",
+            sender: otherUser,
+            source: .incoming,
+            status: .published,
+            content: .update(ConversationUpdate(
+                creator: otherUser,
+                addedMembers: [agentMember],
+                removedMembers: [],
+                metadataChanges: []
+            )),
+            date: now.addingTimeInterval(5),
+            reactions: []
+        ), .existing)
+        let messages = [
+            makeAssistantJoinRequest(id: "aj-1", date: now),
+            joinedUpdate,
+        ]
+
+        let result = MessagesListProcessor.process(messages, currentOtherMemberCount: 1)
+
+        let assistantJoinStatuses = result.compactMap { item -> AssistantJoinStatus? in
+            if case .assistantJoinStatus(let status, _, _) = item {
+                return status
+            }
+            return nil
+        }
+        let updates = result.compactMap { item -> ConversationUpdate? in
+            if case .update(_, let update, _) = item {
+                return update
+            }
+            return nil
+        }
+
+        #expect(assistantJoinStatuses.isEmpty)
+        #expect(updates.count == 1)
+        #expect(updates.first?.addedVerifiedAssistant == true)
+    }
+
     @Test("Assistant join request stays visible if only an unverified agent joined after")
     func stayVisibleAfterUnverifiedAgentJoined() {
         // Regression coverage: a CLI joiner advertises itself as memberKind=agent


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add regression test for assistant join status hidden after agent joins
Adds `hiddenAfterAgentJoinedWhileUpdateStillShown` to [MessagesListProcessorAssistantJoinTests](https://github.com/xmtplabs/convos-ios/pull/757/files#diff-02e4f56ebdce0ca714f81c9e2a1d074ff74e2ae60e2747c9d74bf3bbf942a213) to cover a specific ordering: when a verified agent joins after an assistant join request, the join request status should be hidden while the 'joined' update remains visible with `addedVerifiedAssistant == true`.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0ae6e59.</sup>
<!-- Macroscope's review summary ends here -->

<!-- Macroscope's pull request summary ends here -->