### PR TITLE
Remove dead XMTPStaticOperations after single-inbox refactor

### DIFF
--- a/ConvosCore/Sources/ConvosCore/Inboxes/XMTPAPIOptionsBuilder.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/XMTPAPIOptionsBuilder.swift
@@ -3,8 +3,8 @@ import Foundation
 
 /// Builds XMTP API options for the given environment
 ///
-/// This extracts the API options construction from SessionStateMachine for reuse
-/// in static XMTP operations like `getNewestMessageMetadata`.
+/// This extracts the API options construction from SessionStateMachine so it
+/// can be reused anywhere XMTP API options are needed.
 public struct XMTPAPIOptionsBuilder {
     /// Builds ClientOptions.Api for the given environment
     ///

--- a/ConvosCore/Sources/ConvosCore/Messaging/XMTPClientProvider.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/XMTPClientProvider.swift
@@ -2,45 +2,6 @@ import ConvosInvites
 import Foundation
 @preconcurrency import XMTPiOS
 
-/// Protocol for static XMTP operations that don't require a client instance
-public protocol XMTPStaticOperations {
-    /// Fetches the newest message metadata for the given conversation IDs
-    ///
-    /// This is a static operation that can be performed without waking up the inbox's XMTP client.
-    /// - Parameters:
-    ///   - groupIds: Array of conversation/group IDs to fetch metadata for
-    ///   - api: XMTP API options for the request
-    /// - Returns: Dictionary mapping conversation ID to its newest message metadata
-    static func getNewestMessageMetadata(
-        groupIds: [String],
-        api: ClientOptions.Api
-    ) async throws -> [String: MessageMetadata]
-}
-
-extension Client: XMTPStaticOperations {}
-
-/// Sendable wrapper for XMTPStaticOperations metatypes.
-///
-/// Metatypes are inherently thread-safe since they only contain type metadata,
-/// not mutable instance state. This wrapper allows passing metatypes across
-/// actor boundaries without triggering false positive Sendable warnings.
-public struct SendableXMTPOperations: Sendable {
-    // Using @unchecked because metatypes are inherently thread-safe
-    // (they're just references to type metadata, not mutable instances)
-    private nonisolated(unsafe) let metatype: any XMTPStaticOperations.Type
-
-    public init(_ metatype: any XMTPStaticOperations.Type) {
-        self.metatype = metatype
-    }
-
-    public func getNewestMessageMetadata(
-        groupIds: [String],
-        api: ClientOptions.Api
-    ) async throws -> [String: MessageMetadata] {
-        try await metatype.getNewestMessageMetadata(groupIds: groupIds, api: api)
-    }
-}
-
 public protocol MessageSender {
     func sendExplode(expiresAt: Date) async throws
     func sendTypingIndicator(isTyping: Bool) async throws


### PR DESCRIPTION
## Summary

Investigation triggered by the iOS abstraction refactor identifying
`SleepingInboxMessageChecker` and its static-context dependency
`XMTPStaticOperations.getNewestMessageMetadata` as a DTU-incompatible
architectural seam (DTU's universe+actor model can't satisfy a static
metatype API).

It turns out `SleepingInboxMessageChecker.swift` was already deleted
in the single-inbox identity refactor (#713 / ADR 011) — every push
now implicitly wakes the only inbox, so the "should I wake before
doing work?" gate the checker provided no longer has a use case. ADR
003 explicitly calls out the entire wake/sleep subsystem as gone.

What was *not* deleted in #713 is the static-context API surface that
only existed to support the checker. This PR removes the orphans:

- `XMTPStaticOperations` protocol
- `extension Client: XMTPStaticOperations` conformance
- `SendableXMTPOperations` metatype Sendable wrapper

A grep across `ConvosCore/`, `Convos/`, and `NotificationService/`
turned up zero remaining references to these identifiers,
`getNewestMessageMetadata`, or `MessageMetadata` once these
declarations were removed. The only collateral was a stale doc comment
on `XMTPAPIOptionsBuilder` referencing `getNewestMessageMetadata` as
the motivating use case — also updated.

There were no `SleepingInboxMessageChecker[Integration]Tests` to
delete; #713 deleted those alongside the class.

## Test plan
- [x] `swift build --target ConvosCore` clean (10s, no warnings)
- [x] `bash ci/run-tests.sh --unit` — 160 tests in 12 suites pass
- [x] No grep hits in `ConvosCore/Sources`, `ConvosCore/Tests`, `Convos`, or `NotificationService` for `SleepingInbox*`, `XMTPStaticOperations`, `SendableXMTPOperations`, `getNewestMessageMetadata`, or `MessageMetadata` after removal

This is a single coherent commit so it's cleanly cherry-pickable onto
the iOS-refactor branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove dead `XMTPStaticOperations` protocol and related types after single-inbox refactor
> Deletes `XMTPStaticOperations`, its `Client` conformance extension, and the `SendableXMTPOperations` wrapper from [XMTPClientProvider.swift](https://github.com/xmtplabs/convos-ios/pull/758/files#diff-319627da6df510b09c2b33daf23ed1daf3897db8bf58aafff6904071ea610cc0) as part of the single-inbox refactor cleanup. These types are no longer referenced and their removal is a compile-time breaking change for any code that depended on them.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6561ec6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->