### PR TITLE
Republish metadata for orphaned grants in ConnectionManager.refreshConnections

### DIFF
--- a/ConvosCore/Sources/ConvosCore/Connections/ConnectionManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Connections/ConnectionManager.swift
@@ -141,6 +141,43 @@ public final class ConnectionManager: ConnectionManagerProtocol, @unchecked Send
         // historical "connected on" date to now. Only brand-new rows get
         // `Date()` as their creation timestamp.
         let serverIds = Set(responses.map { $0.connectionId })
+
+        // Before deleting orphaned connections, republish ProfileUpdate
+        // metadata for every conversation that referenced them — same
+        // rationale as disconnect(). Without this, the FK cascade deletes
+        // local DBConnectionGrant rows but the XMTP group metadata still
+        // carries the revoked grants and the assistant keeps using them.
+        let orphanedGrants = try await databaseWriter.read { db in
+            let existingIds = Set(try DBConnection.fetchAll(db).map { $0.id })
+            let toDelete = existingIds.subtracting(serverIds)
+            guard !toDelete.isEmpty else { return [DBConnectionGrant]() }
+            return try DBConnectionGrant
+                .filter(toDelete.contains(DBConnectionGrant.Columns.connectionId))
+                .fetchAll(db)
+        }
+
+        if !orphanedGrants.isEmpty {
+            if let grantWriter = grantWriterProvider() {
+                for grant in orphanedGrants {
+                    do {
+                        try await grantWriter.revokeGrant(
+                            connectionId: grant.connectionId,
+                            from: grant.conversationId
+                        )
+                    } catch {
+                        Log.warning(
+                            "[CloudConnections] failed to republish grants during refresh (connectionId=\(grant.connectionId), conversationId=\(grant.conversationId)): \(error.localizedDescription)"
+                        )
+                    }
+                }
+            } else {
+                Log.warning(
+                    "[CloudConnections] refresh had \(orphanedGrants.count) orphaned grant(s) but no grant writer was " +
+                    "injected; metadata for the affected conversation(s) will remain stale until the next grant/revoke"
+                )
+            }
+        }
+
         let connections: [Connection] = try await databaseWriter.write { [self] db in
             let existingById = try Dictionary(
                 uniqueKeysWithValues: DBConnection.fetchAll(db).map { ($0.id, $0) }


### PR DESCRIPTION
## Summary

Macroscope review finding on the merged PR #719: `ConnectionManager.refreshConnections()` deletes connections that exist locally but are missing from the server response, and the FK cascade on `connectionGrant.connectionId` removes the local grant rows. **But the XMTP group metadata** — the per-conversation `ProfileUpdate` carrying the grant set — **still references those revoked connections**, so the assistant in those conversations keeps trying to use them.

This is the same bug pattern fixed in `disconnect()`: without an explicit `ProfileUpdate` republish, peer clients never learn the grants are gone.

## Fix

Mirror the `disconnect()` flow:
1. Before the cascade-delete, fetch the soon-to-be-orphaned `(connectionId, conversationId)` pairs.
2. Call `grantWriter.revokeGrant(connectionId:from:)` for each — this publishes a `ProfileUpdate` with the reduced grant set and removes the local row.
3. The subsequent cascade-delete inside the write block then has nothing left to cascade for those connections, but still removes the `DBConnection` rows themselves.

Republish failures are logged but don't block the local delete (same trade-off as `disconnect`). Missing `grantWriter` (e.g. before session bootstrap) is logged with a count so it's observable in support traces.

## Test plan

- [x] Pre-commit (SwiftFormat + SwiftLint) clean
- [ ] CI: `ConvosCore` unit tests, especially the existing `ConnectionManagerTests` — should still pass since the public surface is unchanged
- [ ] Manual: connect a service in conversation A, then revoke it server-side (e.g. via Composio dashboard), then open the Connections settings screen on iOS — the assistant in conversation A should stop trying to use the revoked connection on the next message

## Related

- Original PR: #719 (Cloud Connections v0.1)
- Same fix pattern: `ConnectionManager.disconnect()` (lines 71-126)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Revoke grants for orphaned connections in `ConnectionManager.refreshConnections`
> - During connection refresh, detects locally stored connections that are no longer present on the server (orphaned connections) before deleting them.
> - For each orphaned connection, fetches associated `DBConnectionGrant` rows and calls `revokeGrant(connectionId:from:)` on each prior to the deletion write transaction.
> - Logs a warning per grant if revocation fails, or a single warning if no grant writer is available.
> - Behavioral Change: grant revocation now occurs automatically as part of connection cleanup in [ConnectionManager.swift](https://github.com/xmtplabs/convos-ios/pull/762/files#diff-b3bb7b4c7f24eb47d26de7b77deb73014f2e13de68abe49d889ae2324792f6bc), where previously orphaned grants were left unhandled.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cb9f2fc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->