### PR TITLE
Invites: split conversationExpired into not-found / consent-not-allowed

### DIFF
--- a/Convos/Conversation Creation/NewConversationViewModel.swift
+++ b/Convos/Conversation Creation/NewConversationViewModel.swift
@@ -551,7 +551,13 @@ class NewConversationViewModel: Identifiable {
         let inviteCode = extractInviteCode(from: conversationState)
 
         guard error.errorType == .genericFailure, let inviteCode else {
-            let title = error.errorType == .conversationExpired ? "Convo no longer exists" : "Couldn't join"
+            let title: String
+            switch error.errorType {
+            case .conversationExpired, .conversationNotFound, .consentNotAllowed:
+                title = "Convo no longer exists"
+            case .genericFailure:
+                title = "Couldn't join"
+            }
             displayError = IdentifiableError(title: title, description: error.userFacingMessage, retryAction: nil)
             return
         }

--- a/ConvosInvites/Package.resolved
+++ b/ConvosInvites/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "0af6d54eba20a113bed67cb33df8f1bbad656c172dabc1e5dd04912ff988c599",
+  "originHash" : "0298dfbdae8964e217a56969da7bc0fc1eda09de9135baf2edf547a9cebd5a32",
   "pins" : [
     {
       "identity" : "connect-swift",
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/xmtp/libxmtp.git",
       "state" : {
-        "branch" : "ios-4.9.0-dev.6ecd439",
-        "revision" : "297e684d07e78f87da617be80565359c315ba6f0"
+        "branch" : "ios-4.9.0-dev.88ddfad",
+        "revision" : "899650a4189207ca2df515bf46beb549da07ff46"
       }
     },
     {
@@ -53,6 +53,15 @@
       "state" : {
         "revision" : "7b847a3b7008b2dc2f47ca3110d8c782fb2e5c7e",
         "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swift-log",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-log",
+      "state" : {
+        "revision" : "5073617dac96330a486245e4c0179cb0a6fd2256",
+        "version" : "1.12.0"
       }
     },
     {

--- a/ConvosInvites/Package.swift
+++ b/ConvosInvites/Package.swift
@@ -23,6 +23,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.28.0"),
         .package(url: "https://github.com/tesseract-one/CSecp256k1.swift.git", from: "0.2.0"),
+        .package(url: "https://github.com/apple/swift-log", from: "1.6.0"),
         .package(
             url: "https://github.com/xmtp/libxmtp.git",
             revision: "ios-4.9.0-dev.88ddfad"
@@ -46,6 +47,7 @@ let package = Package(
                 "ConvosInvitesCore",
                 "ConvosAppData",
                 .product(name: "XMTPiOS", package: "libxmtp"),
+                .product(name: "Logging", package: "swift-log"),
             ],
             path: "Sources/ConvosInvites"
         ),

--- a/ConvosInvites/Sources/ConvosInvites/InviteCoordinator.swift
+++ b/ConvosInvites/Sources/ConvosInvites/InviteCoordinator.swift
@@ -292,10 +292,18 @@ public final class InviteCoordinator: @unchecked Sendable {
             return nil
         }
 
-        guard let conversation = try? await client.findConversation(conversationId: conversationId),
-              (try? conversation.consentState()) == .allowed else {
-            await sendJoinError(.conversationExpired, for: request, client: client)
+        guard let conversation = try? await client.findConversation(conversationId: conversationId) else {
+            Log.warning("Rejecting join for \(conversationId) (inviteTag: \(request.signedInvite.invitePayload.tag)): conversation not found in local store")
+            await sendJoinError(.conversationNotFound, for: request, client: client)
             delegate?.coordinator(self, didRejectJoinRequest: request, error: .conversationNotFound(conversationId))
+            return nil
+        }
+
+        let consent = (try? conversation.consentState()) ?? .unknown
+        guard consent == .allowed else {
+            Log.warning("Rejecting join for \(conversationId) (inviteTag: \(request.signedInvite.invitePayload.tag)): consent=\(consent)")
+            await sendJoinError(.consentNotAllowed, for: request, client: client)
+            delegate?.coordinator(self, didRejectJoinRequest: request, error: .consentNotAllowed(conversationId, consent))
             return nil
         }
 

--- a/ConvosInvites/Sources/ConvosInvites/InviteCoordinator.swift
+++ b/ConvosInvites/Sources/ConvosInvites/InviteCoordinator.swift
@@ -301,7 +301,7 @@ public final class InviteCoordinator: @unchecked Sendable {
 
         let consent = (try? conversation.consentState()) ?? .unknown
         guard consent == .allowed else {
-            Log.warning("Rejecting join for \(conversationId) (inviteTag: \(request.signedInvite.invitePayload.tag)): consent=\(consent)")
+            Log.warning("Rejecting join for \(conversationId) (inviteTag: \(request.signedInvite.invitePayload.tag)): consent state '\(consent)' is not .allowed")
             await sendJoinError(.consentNotAllowed, for: request, client: client)
             delegate?.coordinator(self, didRejectJoinRequest: request, error: .consentNotAllowed(conversationId, consent))
             return nil

--- a/ConvosInvites/Sources/ConvosInvites/Logger.swift
+++ b/ConvosInvites/Sources/ConvosInvites/Logger.swift
@@ -6,9 +6,7 @@ import Logging
 ///
 /// Internal so it does not collide with `ConvosCore.Log` for downstream consumers.
 enum Log {
-    private static var logger: Logging.Logger {
-        Logging.Logger(label: "convos")
-    }
+    private static let logger: Logging.Logger = Logging.Logger(label: "convos")
 
     static func debug(_ message: String, file: String = #file, function: String = #function, line: Int = #line) {
         logger.debug("[ConvosInvites] \(message)", source: makeSource(file: file, function: function, line: line))

--- a/ConvosInvites/Sources/ConvosInvites/Logger.swift
+++ b/ConvosInvites/Sources/ConvosInvites/Logger.swift
@@ -1,0 +1,33 @@
+import Foundation
+import Logging
+
+/// ConvosInvites logging wrapper - uses "ConvosInvites" namespace and the
+/// swift-log `LoggingSystem` configured by the host app.
+///
+/// Internal so it does not collide with `ConvosCore.Log` for downstream consumers.
+enum Log {
+    private static var logger: Logging.Logger {
+        Logging.Logger(label: "convos")
+    }
+
+    static func debug(_ message: String, file: String = #file, function: String = #function, line: Int = #line) {
+        logger.debug("[ConvosInvites] \(message)", source: makeSource(file: file, function: function, line: line))
+    }
+
+    static func info(_ message: String, file: String = #file, function: String = #function, line: Int = #line) {
+        logger.info("[ConvosInvites] \(message)", source: makeSource(file: file, function: function, line: line))
+    }
+
+    static func warning(_ message: String, file: String = #file, function: String = #function, line: Int = #line) {
+        logger.warning("[ConvosInvites] \(message)", source: makeSource(file: file, function: function, line: line))
+    }
+
+    static func error(_ message: String, file: String = #file, function: String = #function, line: Int = #line) {
+        logger.error("[ConvosInvites] \(message)", source: makeSource(file: file, function: function, line: line))
+    }
+
+    private static func makeSource(file: String, function: String, line: Int) -> String {
+        let fileName = (file as NSString).lastPathComponent
+        return "\(fileName):\(line) \(function)"
+    }
+}

--- a/ConvosInvites/Sources/ConvosInvites/Models.swift
+++ b/ConvosInvites/Sources/ConvosInvites/Models.swift
@@ -145,11 +145,14 @@ public enum JoinRequestError: Error, Sendable {
     /// The invite has expired
     case expired
 
-    /// The conversation has expired
+    /// The signed invite's `conversationExpiresAt` has passed
     case conversationExpired
 
-    /// The conversation was not found
+    /// `findConversation` returned nil — libxmtp doesn't have the group locally
     case conversationNotFound(String)
+
+    /// The conversation exists locally but its consent state is not `.allowed`
+    case consentNotAllowed(String, ConsentState)
 
     /// The message is not a valid join request format
     case invalidFormat
@@ -164,20 +167,33 @@ public enum JoinRequestError: Error, Sendable {
     case addMemberFailed
 }
 
-/// Error types sent back to joiners when their request fails
+/// Error types sent back to joiners when their request fails.
+///
+/// Wire-format compatibility: any unrecognized rawValue (from a newer client we
+/// don't know about) decodes to `.conversationExpired` so older clients keep
+/// the existing "this conversation is no longer available" UX.
 public enum InviteJoinErrorType: Equatable, Sendable {
+    /// The signed invite's `conversationExpiresAt` has passed
     case conversationExpired
+
+    /// `findConversation` returned nil — libxmtp doesn't have the group locally
+    case conversationNotFound
+
+    /// The conversation exists locally but its consent state is not `.allowed`
+    case consentNotAllowed
+
     case genericFailure
-    case unknown(String)
 
     public var rawValue: String {
         switch self {
         case .conversationExpired:
             return "conversation_expired"
+        case .conversationNotFound:
+            return "conversation_not_found"
+        case .consentNotAllowed:
+            return "consent_not_allowed"
         case .genericFailure:
             return "generic_failure"
-        case .unknown(let value):
-            return value
         }
     }
 
@@ -185,10 +201,14 @@ public enum InviteJoinErrorType: Equatable, Sendable {
         switch rawValue {
         case "conversation_expired":
             self = .conversationExpired
+        case "conversation_not_found":
+            self = .conversationNotFound
+        case "consent_not_allowed":
+            self = .consentNotAllowed
         case "generic_failure":
             self = .genericFailure
         default:
-            self = .unknown(rawValue)
+            self = .conversationExpired
         }
     }
 }
@@ -220,9 +240,9 @@ public struct InviteJoinError: Codable, Equatable, Sendable {
 
     public var userFacingMessage: String {
         switch errorType {
-        case .conversationExpired:
+        case .conversationExpired, .conversationNotFound, .consentNotAllowed:
             return "This conversation is no longer available"
-        case .genericFailure, .unknown:
+        case .genericFailure:
             return "Failed to join conversation"
         }
     }

--- a/ConvosInvites/Tests/ConvosInvitesTests/ContentTypes/InviteJoinErrorCodecTests.swift
+++ b/ConvosInvites/Tests/ConvosInvitesTests/ContentTypes/InviteJoinErrorCodecTests.swift
@@ -59,23 +59,38 @@ struct InviteJoinErrorCodecTests {
         #expect(decodedError.inviteTag == "invite-abc")
     }
 
-    @Test("Encode and decode unknown error type")
-    func encodeDecodeUnknownErrorType() throws {
+    @Test("Encode and decode conversationNotFound error")
+    func encodeDecodeConversationNotFound() throws {
         let originalError = InviteJoinError(
-            errorType: .unknown("future_error"),
-            inviteTag: "test-tag",
+            errorType: .conversationNotFound,
+            inviteTag: "tag-not-found",
             timestamp: Date()
         )
 
         let encodedContent = try codec.encode(content: originalError)
         let decodedError: InviteJoinError = try codec.decode(content: encodedContent)
 
-        #expect(decodedError.errorType == .unknown("future_error"))
-        #expect(decodedError.inviteTag == "test-tag")
+        #expect(decodedError.errorType == .conversationNotFound)
+        #expect(decodedError.inviteTag == "tag-not-found")
     }
 
-    @Test("Forward compatibility with unknown error types")
-    func forwardCompatibilityUnknownTypes() throws {
+    @Test("Encode and decode consentNotAllowed error")
+    func encodeDecodeConsentNotAllowed() throws {
+        let originalError = InviteJoinError(
+            errorType: .consentNotAllowed,
+            inviteTag: "tag-consent",
+            timestamp: Date()
+        )
+
+        let encodedContent = try codec.encode(content: originalError)
+        let decodedError: InviteJoinError = try codec.decode(content: encodedContent)
+
+        #expect(decodedError.errorType == .consentNotAllowed)
+        #expect(decodedError.inviteTag == "tag-consent")
+    }
+
+    @Test("Backward compatibility: unknown rawValue decodes to conversationExpired")
+    func backwardCompatUnknownDecodesToConversationExpired() throws {
         let encoder = JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
 
@@ -98,8 +113,36 @@ struct InviteJoinErrorCodecTests {
 
         let decodedError: InviteJoinError = try codec.decode(content: encodedContent)
 
-        #expect(decodedError.errorType == .unknown("new_error_type_from_future"))
+        #expect(decodedError.errorType == .conversationExpired)
         #expect(decodedError.inviteTag == "future-tag")
+        #expect(decodedError.userFacingMessage == "This conversation is no longer available")
+    }
+
+    @Test("Backward compatibility: numeric-string rawValue decodes to conversationExpired")
+    func backwardCompatNumericRawValueDecodesToConversationExpired() throws {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+
+        struct FutureError: Codable {
+            let errorType: String
+            let inviteTag: String
+            let timestamp: Date
+        }
+
+        let futureError = FutureError(
+            errorType: "99",
+            inviteTag: "tag-99",
+            timestamp: Date()
+        )
+
+        let jsonData = try encoder.encode(futureError)
+        var encodedContent = EncodedContent()
+        encodedContent.type = ContentTypeInviteJoinError
+        encodedContent.content = jsonData
+
+        let decodedError: InviteJoinError = try codec.decode(content: encodedContent)
+
+        #expect(decodedError.errorType == .conversationExpired)
     }
 
     @Test("Fallback content for conversationExpired")
@@ -126,16 +169,28 @@ struct InviteJoinErrorCodecTests {
         #expect(fallback == "Failed to join conversation")
     }
 
-    @Test("Fallback content for unknown error")
-    func fallbackUnknown() throws {
+    @Test("Fallback content for conversationNotFound")
+    func fallbackConversationNotFound() throws {
         let error = InviteJoinError(
-            errorType: .unknown("custom_error"),
+            errorType: .conversationNotFound,
             inviteTag: "test-tag",
             timestamp: Date()
         )
 
         let fallback = try codec.fallback(content: error)
-        #expect(fallback == "Failed to join conversation")
+        #expect(fallback == "This conversation is no longer available")
+    }
+
+    @Test("Fallback content for consentNotAllowed")
+    func fallbackConsentNotAllowed() throws {
+        let error = InviteJoinError(
+            errorType: .consentNotAllowed,
+            inviteTag: "test-tag",
+            timestamp: Date()
+        )
+
+        let fallback = try codec.fallback(content: error)
+        #expect(fallback == "This conversation is no longer available")
     }
 
     @Test("User facing message for conversationExpired")
@@ -160,15 +215,26 @@ struct InviteJoinErrorCodecTests {
         #expect(error.userFacingMessage == "Failed to join conversation")
     }
 
-    @Test("User facing message for unknown error")
-    func userFacingMessageUnknown() {
+    @Test("User facing message for conversationNotFound")
+    func userFacingMessageConversationNotFound() {
         let error = InviteJoinError(
-            errorType: .unknown("future_error"),
+            errorType: .conversationNotFound,
             inviteTag: "test-tag",
             timestamp: Date()
         )
 
-        #expect(error.userFacingMessage == "Failed to join conversation")
+        #expect(error.userFacingMessage == "This conversation is no longer available")
+    }
+
+    @Test("User facing message for consentNotAllowed")
+    func userFacingMessageConsentNotAllowed() {
+        let error = InviteJoinError(
+            errorType: .consentNotAllowed,
+            inviteTag: "test-tag",
+            timestamp: Date()
+        )
+
+        #expect(error.userFacingMessage == "This conversation is no longer available")
     }
 
     @Test("Invite tags with special characters")
@@ -269,17 +335,35 @@ struct InviteJoinErrorCodecTests {
     @Test("InviteJoinErrorType Equatable conformance")
     func errorTypeEquatable() {
         #expect(InviteJoinErrorType.conversationExpired == .conversationExpired)
+        #expect(InviteJoinErrorType.conversationNotFound == .conversationNotFound)
+        #expect(InviteJoinErrorType.consentNotAllowed == .consentNotAllowed)
         #expect(InviteJoinErrorType.genericFailure == .genericFailure)
-        #expect(InviteJoinErrorType.unknown("test") == .unknown("test"))
-        #expect(InviteJoinErrorType.unknown("test1") != .unknown("test2"))
         #expect(InviteJoinErrorType.conversationExpired != .genericFailure)
+        #expect(InviteJoinErrorType.conversationNotFound != .conversationExpired)
+        #expect(InviteJoinErrorType.consentNotAllowed != .conversationNotFound)
     }
 
     @Test("InviteJoinErrorType rawValue")
     func errorTypeRawValue() {
         #expect(InviteJoinErrorType.conversationExpired.rawValue == "conversation_expired")
+        #expect(InviteJoinErrorType.conversationNotFound.rawValue == "conversation_not_found")
+        #expect(InviteJoinErrorType.consentNotAllowed.rawValue == "consent_not_allowed")
         #expect(InviteJoinErrorType.genericFailure.rawValue == "generic_failure")
-        #expect(InviteJoinErrorType.unknown("custom").rawValue == "custom")
+    }
+
+    @Test("InviteJoinErrorType init from known rawValues")
+    func errorTypeInitFromKnownRawValues() {
+        #expect(InviteJoinErrorType(rawValue: "conversation_expired") == .conversationExpired)
+        #expect(InviteJoinErrorType(rawValue: "conversation_not_found") == .conversationNotFound)
+        #expect(InviteJoinErrorType(rawValue: "consent_not_allowed") == .consentNotAllowed)
+        #expect(InviteJoinErrorType(rawValue: "generic_failure") == .genericFailure)
+    }
+
+    @Test("InviteJoinErrorType init from unknown rawValue falls back to conversationExpired")
+    func errorTypeInitFallback() {
+        #expect(InviteJoinErrorType(rawValue: "totally_new_thing") == .conversationExpired)
+        #expect(InviteJoinErrorType(rawValue: "") == .conversationExpired)
+        #expect(InviteJoinErrorType(rawValue: "99") == .conversationExpired)
     }
 
     @Test("Decode malformed JSON throws error")

--- a/ConvosInvites/Tests/ConvosInvitesTests/JoinRequestProcessingTests.swift
+++ b/ConvosInvites/Tests/ConvosInvitesTests/JoinRequestProcessingTests.swift
@@ -2,6 +2,7 @@
 @testable import ConvosInvitesCore
 import Foundation
 import Testing
+import XMTPiOS
 
 /// Tests for the join request validation logic used by InviteCoordinator.
 ///
@@ -313,13 +314,14 @@ struct JoinRequestProcessingTests {
             .expired,
             .conversationExpired,
             .conversationNotFound("conv-123"),
+            .consentNotAllowed("conv-123", .denied),
             .invalidFormat,
             .creatorMismatch,
             .revoked,
             .addMemberFailed,
         ]
 
-        #expect(errors.count == 8)
+        #expect(errors.count == 9)
     }
 
     // MARK: - InviteJoinError Feedback
@@ -354,6 +356,48 @@ struct JoinRequestProcessingTests {
         )
 
         #expect(error.userFacingMessage == "Failed to join conversation")
+    }
+
+    @Test("InviteJoinError conversationNotFound round-trips through JSON")
+    func conversationNotFoundRoundTrip() throws {
+        let error = InviteJoinError(
+            errorType: .conversationNotFound,
+            inviteTag: "tag-nf",
+            timestamp: Date(timeIntervalSince1970: 1_000_000)
+        )
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(error)
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(InviteJoinError.self, from: data)
+
+        #expect(decoded.errorType == .conversationNotFound)
+        #expect(decoded.inviteTag == "tag-nf")
+        #expect(decoded.userFacingMessage == "This conversation is no longer available")
+    }
+
+    @Test("InviteJoinError consentNotAllowed round-trips through JSON")
+    func consentNotAllowedRoundTrip() throws {
+        let error = InviteJoinError(
+            errorType: .consentNotAllowed,
+            inviteTag: "tag-cn",
+            timestamp: Date(timeIntervalSince1970: 1_000_000)
+        )
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(error)
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(InviteJoinError.self, from: data)
+
+        #expect(decoded.errorType == .consentNotAllowed)
+        #expect(decoded.inviteTag == "tag-cn")
+        #expect(decoded.userFacingMessage == "This conversation is no longer available")
     }
 
     // MARK: - Date Extension


### PR DESCRIPTION
## Summary

A real user just hit a misleading "conversation_expired" rejection that was actually a consent-not-allowed scenario on an otherwise healthy conversation, and we couldn't tell from the log which of the three lumped failure modes (`conversationExpiresAt` past, `findConversation` returned nil, or consent != `.allowed`) had fired. This PR splits the join-request rejection branch into three explicit error buckets so triage doesn't waste time on the wrong hypothesis.

- **Three new error mode buckets**, mapped on encode (`conversation_expired`, `conversation_not_found`, `consent_not_allowed`) and decoded with backward-compat fallback — any unrecognized rawValue decodes to `.conversationExpired` so older clients keep the existing "this conversation is no longer available" UX.
- **New `Log.warning` lines** surface the exact failure + invite tag for every rejection (`Rejecting join for <conversationId> (inviteTag: <tag>): conversation not found in local store` / `... consent=denied`). ConvosInvites picks up `swift-log` directly so the package-local `Log` facade routes through the host app's bootstrapped logging system; the facade is `internal` to avoid colliding with `ConvosCore.Log`.
- **Joiner-side display copy is unchanged** — the new `InviteJoinErrorType` cases map to the same `userFacingMessage` as `conversationExpired`, and `NewConversationViewModel` treats them identically ("Convo no longer exists"). A follow-up can localize the new cases.

## Files

- `ConvosInvites/Sources/ConvosInvites/Models.swift` — added `JoinRequestError.consentNotAllowed(String, ConsentState)`, added `InviteJoinErrorType.conversationNotFound` / `.consentNotAllowed`, replaced `unknown(String)` with a `conversationExpired` fallback in `init(rawValue:)`.
- `ConvosInvites/Sources/ConvosInvites/InviteCoordinator.swift` — split lines 295–299 into two distinct guards with `Log.warning` and the right wire/delegate error per branch.
- `ConvosInvites/Sources/ConvosInvites/Logger.swift` — new internal `Log` facade for the package.
- `ConvosInvites/Package.swift` / `Package.resolved` — added `swift-log` dependency.
- `Convos/Conversation Creation/NewConversationViewModel.swift` — title selection treats all three "no longer available" buckets the same.
- Tests updated and added in `InviteJoinErrorCodecTests.swift` and `JoinRequestProcessingTests.swift`: round-trips per case, backward-compat decode of unknown / numeric tags falls back to `conversationExpired`.

## Test plan

- [x] `swift test --package-path ConvosInvites` — all 168 tests pass
- [x] `swiftlint --strict --quiet` clean on all changed files
- [x] `swiftformat --lint` clean on all changed files
- [x] `swift build --package-path ConvosCore` succeeds
- [ ] `swift test --package-path ConvosCore` — Docker daemon was unresponsive in this environment; ConvosCore swift package builds clean and these changes don't touch any ConvosCore code paths exercised by ConvosCore's integration tests
- [ ] `xcodebuild build -scheme "Convos (Dev)"` — verified locally the same build command fails on `dev` HEAD with a flaky `-warn-long-expression-type-checking 100` warning-as-error in `DeepLinkHandler.swift` / `DebugView.swift`, unrelated to this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Split `conversationExpired` invite join error into `conversationNotFound` and `consentNotAllowed`
> - Adds two new `InviteJoinErrorType` cases (`conversationNotFound`, `consentNotAllowed`) and a `JoinRequestError.consentNotAllowed` case in [Models.swift](https://github.com/xmtplabs/convos-ios/pull/763/files#diff-edfe12d0f4ee4a6fdfa84ec008693ae9e7ec4a1339902f40d421c5ad9fa6d939); unknown wire values fall back to `conversationExpired` for backward compatibility.
> - Updates `InviteCoordinator.processJoinRequest` in [InviteCoordinator.swift](https://github.com/xmtplabs/convos-ios/pull/763/files#diff-87d55c5ffa790402965a59c8132ef0a34a6485257304dd2f6de696c14cf22917) to send distinct errors and delegate callbacks depending on whether the conversation is missing or consent is not allowed.
> - Maps both new error types to "Convo no longer exists" in `NewConversationViewModel.handleJoinFailedState` and to "This conversation is no longer available" in `InviteJoinError.userFacingMessage`.
> - Adds a swift-log-backed `Log` utility in [Logger.swift](https://github.com/xmtplabs/convos-ios/pull/763/files#diff-5b745dc65ea9a2a97f54da435fb36969fb674f88d1d86fed2c87aedc1e7d4445) used to emit warning logs with file/function/line context on join rejections.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ba7c763.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->