### PR TITLE
drop isSecure

### DIFF
--- a/.github/workflows/convoscore-tests.yml
+++ b/.github/workflows/convoscore-tests.yml
@@ -50,7 +50,6 @@ jobs:
     timeout-minutes: 10
     outputs:
       xmtp_node_address: ${{ steps.deploy.outputs.xmtp_node_address }}
-      xmtp_is_secure: ${{ steps.deploy.outputs.xmtp_is_secure }}
       app_name: ${{ steps.deploy.outputs.app_name }}
 
     steps:
@@ -67,7 +66,6 @@ jobs:
         run: |
           APP_NAME="convos-ios-test-${{ github.run_id }}-${{ github.run_attempt }}"
           ./ci/fly/deploy "$APP_NAME"
-
 
   integration-tests:
     name: Integration Tests
@@ -99,8 +97,9 @@ jobs:
       - name: Run integration tests
         env:
           XMTP_NODE_ADDRESS: ${{ needs.deploy-backend.outputs.xmtp_node_address }}
-          XMTP_IS_SECURE: ${{ needs.deploy-backend.outputs.xmtp_is_secure }}
-        run: ./ci/run-tests.sh --integration
+        run: |
+          echo $XMTP_NODE_ADDRESS
+          ./ci/run-tests.sh --integration
 
       - name: Upload test logs
         if: always()

--- a/ConvosCore/Sources/ConvosCore/Inboxes/SessionStateMachine.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/SessionStateMachine.swift
@@ -270,7 +270,6 @@ public actor SessionStateMachine: SessionStateManagerProtocol {
         Log.debug("   XMTP_CUSTOM_HOST = \(environment.xmtpEndpoint ?? "nil")")
         Log.debug("   customLocalAddress = \(environment.customLocalAddress ?? "nil")")
         Log.debug("   xmtpEnv = \(environment.xmtpEnv)")
-        Log.debug("   isSecure = \(environment.isSecure)")
 
         // Log the actual XMTPEnvironment.customLocalAddress after setting
         if let customHost = environment.customLocalAddress {
@@ -883,7 +882,7 @@ public actor SessionStateMachine: SessionStateManagerProtocol {
     private func clientOptions(keys: any XMTPClientKeys) -> ClientOptions {
         // @lourou: Enable XMTP v4 d14n when ready
         // When gatewayUrl is provided, we're using d14n
-        // The gateway handles env/isSecure automatically, so we don't set them
+        // The gateway handles env automatically, so we don't set it
         // if let gatewayUrl = environment.gatewayUrl, !gatewayUrl.isEmpty {
         //     // d14n mode: gateway handles network selection
         //     Log.info("Using XMTP d14n - Gateway: \(gatewayUrl)")
@@ -893,11 +892,12 @@ public actor SessionStateMachine: SessionStateManagerProtocol {
         //     )
         // }
 
-        // Direct XMTP v3 connection: we specify env and isSecure
+        // Direct XMTP v3 connection: we specify env. TLS is conveyed via the
+        // http:// or https:// scheme on customLocalAddress when overriding the
+        // default endpoint.
         Log.debug("Using direct XMTP connection with env: \(environment.xmtpEnv)")
         let apiOptions: ClientOptions.Api = .init(
             env: environment.xmtpEnv,
-            isSecure: environment.isSecure,
             appVersion: "convos/\(Bundle.appVersion)"
         )
 

--- a/ConvosCore/Sources/ConvosCore/Inboxes/XMTPAPIOptionsBuilder.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/XMTPAPIOptionsBuilder.swift
@@ -21,7 +21,6 @@ public struct XMTPAPIOptionsBuilder {
 
         return ClientOptions.Api(
             env: environment.xmtpEnv,
-            isSecure: environment.isSecure,
             appVersion: "convos/\(Bundle.appVersion)"
         )
     }
@@ -55,19 +54,5 @@ public extension AppEnvironment {
             return nil
         }
         return endpoint
-    }
-
-    /// Whether to use secure (TLS) connection
-    var isSecure: Bool {
-        switch self {
-        case .local, .tests:
-            // Support environment variable for CI
-            guard let envSecure = ProcessInfo.processInfo.environment["XMTP_IS_SECURE"] else {
-                return false
-            }
-            return envSecure.lowercased() == "true" || envSecure == "1"
-        default:
-            return true
-        }
     }
 }

--- a/ConvosCore/Tests/ConvosCoreTests/Integration/ProfileMessageIntegrationTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/Integration/ProfileMessageIntegrationTests.swift
@@ -11,7 +11,7 @@ struct ProfileMessageIntegrationTests {
         _ = SecRandomCopyBytes(kSecRandomDefault, 32, &keyBytes)
         let key = Data(keyBytes)
         let options = ClientOptions(
-            api: .init(env: .local, isSecure: false, appVersion: "convos-tests/1.0.0"),
+            api: .init(env: .local, appVersion: "convos-tests/1.0.0"),
             codecs: [
                 TextCodec(),
                 ProfileUpdateCodec(),

--- a/ConvosCore/Tests/ConvosCoreTests/TestHelpers.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/TestHelpers.swift
@@ -90,18 +90,9 @@ class TestFixtures {
         let keys = try await identityStore.generateKeys()
         let clientId = ClientId.generate().value
 
-        // Check environment variables for CI configuration
-        let isSecure: Bool
-        if let envSecure = ProcessInfo.processInfo.environment["XMTP_IS_SECURE"] {
-            isSecure = envSecure.lowercased() == "true" || envSecure == "1"
-        } else {
-            isSecure = false
-        }
-
         let clientOptions = ClientOptions(
             api: .init(
                 env: .local,
-                isSecure: isSecure,
                 appVersion: "convos-tests/1.0.0"
             ),
             codecs: [

--- a/ci/run-tests.sh
+++ b/ci/run-tests.sh
@@ -37,7 +37,6 @@ case "$TEST_TYPE" in
         echo ""
         echo "Environment:"
         echo "  XMTP_NODE_ADDRESS=${XMTP_NODE_ADDRESS:-not set}"
-        echo "  XMTP_IS_SECURE=${XMTP_IS_SECURE:-not set}"
         echo ""
 
         if [[ -z "${XMTP_NODE_ADDRESS:-}" ]]; then


### PR DESCRIPTION
isSecure is deprecated in this version of libxtmp, and TLS is switched on/off based on `http` vs `https`


some integration tests were failing with TLS issues, isSecure tls switch was moved to libxmtp to mke this distinction clearer and more failure resistant so should improve reliability

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove `isSecure` flag from XMTP client configuration
> Drops the `isSecure` parameter from all `ClientOptions.Api` construction sites across production code, test helpers, and CI. TLS is now implied by the endpoint URL scheme rather than set explicitly. Removes the `AppEnvironment.isSecure` computed property and the `XMTP_IS_SECURE` environment variable from CI workflows and test helpers.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f8a0aae.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->