### PR TITLE
bump to latest libxmtp main/fix integration tests

### DIFF
--- a/.github/workflows/convoscore-tests.yml
+++ b/.github/workflows/convoscore-tests.yml
@@ -97,9 +97,9 @@ jobs:
       - name: Run integration tests
         env:
           XMTP_NODE_ADDRESS: ${{ needs.deploy-backend.outputs.xmtp_node_address }}
-        run: |
-          echo $XMTP_NODE_ADDRESS
-          ./ci/run-tests.sh --integration
+          CONVOS_TEST_XMTP_LOG_LEVEL: debug
+          CONVOS_TEST_XMTP_LOG_DIR: ${{ github.workspace }}/xmtp-test-logs
+        run: ./ci/run-tests.sh --integration
 
       - name: Upload test logs
         if: always()
@@ -108,6 +108,7 @@ jobs:
           name: integration-test-logs
           path: |
             ConvosCore/.build/debug/*.log
+            xmtp-test-logs/
           retention-days: 7
           if-no-files-found: ignore
 

--- a/Convos.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Convos.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -150,8 +150,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/xmtp/libxmtp.git",
       "state" : {
-        "branch" : "ios-4.9.0-dev.88ddfad",
-        "revision" : "899650a4189207ca2df515bf46beb549da07ff46"
+        "branch" : "ios-4.10.0-dev.d991b8a",
+        "revision" : "0b4dc376f139cd439319c2468cd51e5ce628bf2d"
       }
     },
     {

--- a/ConvosCore/Package.resolved
+++ b/ConvosCore/Package.resolved
@@ -141,8 +141,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/xmtp/libxmtp.git",
       "state" : {
-        "branch" : "ios-4.9.0-dev.88ddfad",
-        "revision" : "899650a4189207ca2df515bf46beb549da07ff46"
+        "branch" : "ios-4.10.0-dev.d991b8a",
+        "revision" : "0b4dc376f139cd439319c2468cd51e5ce628bf2d"
       }
     },
     {

--- a/ConvosCore/Package.swift
+++ b/ConvosCore/Package.swift
@@ -23,7 +23,7 @@ let package = Package(
         .package(url: "https://github.com/groue/GRDB.swift.git", exact: "7.5.0"),
         .package(
             url: "https://github.com/xmtp/libxmtp.git",
-            revision: "ios-4.9.0-dev.88ddfad"
+            revision: "ios-4.10.0-dev.d991b8a"
         ),
         .package(url: "https://github.com/tesseract-one/CSecp256k1.swift.git", from: "0.2.0"),
         .package(url: "https://github.com/firebase/firebase-ios-sdk", from: "12.1.0"),

--- a/ConvosCore/Sources/ConvosCore/Inboxes/SessionStateMachine.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/SessionStateMachine.swift
@@ -26,6 +26,40 @@ public struct InboxReadyResult: @unchecked Sendable {
 typealias AnySyncingManager = (any SyncingManagerProtocol)
 typealias AnyInviteJoinRequestsManager = (any InviteJoinRequestsManagerProtocol)
 
+/// Tests inject `.inMemory` so libxmtp's pool-management surface is inert; the
+/// `dropLocalDatabaseConnection` broadcast can't wedge an in-memory pool.
+struct XMTPClientFactory: Sendable {
+    typealias Create = @Sendable (SigningKey, ClientOptions) async throws -> any XMTPClientProvider
+    typealias Build = @Sendable (String, PublicIdentity, SigningKey, ClientOptions) async throws -> any XMTPClientProvider
+
+    let create: Create
+    let build: Build
+
+    static let production: XMTPClientFactory = XMTPClientFactory(
+        create: { signingKey, options in
+            try await Client.create(account: signingKey, options: options)
+        },
+        build: { inboxId, identity, _, options in
+            try await Client.build(publicIdentity: identity, options: options, inboxId: inboxId)
+        }
+    )
+
+    /// `build` reuses `createInMemory`: tests carry no on-disk history; inboxId
+    /// derives from signing key, preserving the `client.inboxId == identity.inboxId`
+    /// invariant in `authorize`.
+    static let inMemory: XMTPClientFactory = {
+        let createInMemory: Create = { signingKey, options in
+            try await Client.createInMemory(account: signingKey, options: options)
+        }
+        return XMTPClientFactory(
+            create: createInMemory,
+            build: { _, _, signingKey, options in
+                try await createInMemory(signingKey, options)
+            }
+        )
+    }()
+}
+
 // swiftlint:disable type_body_length
 
 /// Drives the XMTP inbox lifecycle: creating or loading a client,
@@ -70,6 +104,7 @@ public actor SessionStateMachine: SessionStateManagerProtocol {
     private let apiClient: any ConvosAPIClientProtocol
     private let networkMonitor: any NetworkMonitorProtocol
     private let appLifecycle: any AppLifecycleProviding
+    private let xmtpClientFactory: XMTPClientFactory
 
     private var currentTask: Task<Void, Never>?
     private var actionQueue: [Action] = []
@@ -223,7 +258,8 @@ public actor SessionStateMachine: SessionStateManagerProtocol {
         overrideJWTToken: String? = nil,
         environment: AppEnvironment,
         appLifecycle: any AppLifecycleProviding,
-        apiClient: (any ConvosAPIClientProtocol)? = nil
+        apiClient: (any ConvosAPIClientProtocol)? = nil,
+        xmtpClientFactory: XMTPClientFactory = .production
     ) {
         let initialState: State = .idle
         self.initialClientId = clientId
@@ -237,6 +273,7 @@ public actor SessionStateMachine: SessionStateManagerProtocol {
         self.overrideJWTToken = overrideJWTToken ?? environment.defaultOverrideJWTToken
         self.environment = environment
         self.appLifecycle = appLifecycle
+        self.xmtpClientFactory = xmtpClientFactory
 
         // Use provided API client or create a new one
         if let apiClient {
@@ -487,6 +524,7 @@ public actor SessionStateMachine: SessionStateManagerProtocol {
             client = try await buildXmtpClient(
                 inboxId: identity.inboxId,
                 identity: keys.signingKey.identity,
+                signingKey: keys.signingKey,
                 options: clientOptions
             )
         } catch {
@@ -953,20 +991,17 @@ public actor SessionStateMachine: SessionStateManagerProtocol {
     private func createXmtpClient(signingKey: SigningKey,
                                   options: ClientOptions) async throws -> any XMTPClientProvider {
         Log.info("Creating XMTP client...")
-        let client = try await Client.create(account: signingKey, options: options)
+        let client = try await xmtpClientFactory.create(signingKey, options)
         Log.info("XMTP Client created with app version: convos/\(Bundle.appVersion)")
         return client
     }
 
     private func buildXmtpClient(inboxId: String,
                                  identity: PublicIdentity,
+                                 signingKey: SigningKey,
                                  options: ClientOptions) async throws -> any XMTPClientProvider {
         Log.debug("Building XMTP client for \(inboxId)...")
-        let client = try await Client.build(
-            publicIdentity: identity,
-            options: options,
-            inboxId: inboxId
-        )
+        let client = try await xmtpClientFactory.build(inboxId, identity, signingKey, options)
         Log.debug("XMTP Client built.")
         return client
     }

--- a/ConvosCore/Sources/ConvosCore/Inboxes/SessionStateMachine.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/SessionStateMachine.swift
@@ -934,8 +934,7 @@ public actor SessionStateMachine: SessionStateManagerProtocol {
             dbEncryptionKey: keys.databaseKey,
             dbDirectory: environment.defaultDatabasesDirectory,
             deviceSyncEnabled: true,
-            maxDbPoolSize: 10,
-            minDbPoolSize: 3
+            dbPoolOptions: DbPoolOptions(maxPoolSize: 10, minPoolSize: 3)
         )
     }
 

--- a/ConvosCore/Tests/ConvosCoreTests/Integration/ProfileMessageIntegrationTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/Integration/ProfileMessageIntegrationTests.swift
@@ -19,7 +19,7 @@ struct ProfileMessageIntegrationTests {
             ],
             dbEncryptionKey: key
         )
-        return try await Client.create(
+        return try await Client.createInMemory(
             account: try PrivateKey.generate(),
             options: options
         )

--- a/ConvosCore/Tests/ConvosCoreTests/SessionStateMachineTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/SessionStateMachineTests.swift
@@ -40,7 +40,8 @@ struct SessionStateMachineTests {
             networkMonitor: networkMonitor,
             overrideJWTToken: "test-jwt-token",  // Skip backend auth for tests
             environment: .tests,
-            appLifecycle: testAppLifecycle
+            appLifecycle: testAppLifecycle,
+            xmtpClientFactory: .inMemory
         )
 
         // Start in idle state
@@ -99,7 +100,8 @@ struct SessionStateMachineTests {
             networkMonitor: networkMonitor,
             overrideJWTToken: "test-jwt-token",
             environment: .tests,
-            appLifecycle: testAppLifecycle
+            appLifecycle: testAppLifecycle,
+            xmtpClientFactory: .inMemory
         )
 
         await stateMachine.register()
@@ -162,7 +164,8 @@ struct SessionStateMachineTests {
             networkMonitor: networkMonitor,
             overrideJWTToken: "test-jwt-token",  // Skip backend auth for tests
             environment: .tests,
-            appLifecycle: testAppLifecycle
+            appLifecycle: testAppLifecycle,
+            xmtpClientFactory: .inMemory
         )
 
         // Authorize with the existing inbox
@@ -210,7 +213,8 @@ struct SessionStateMachineTests {
             syncingManager: nil,
             networkMonitor: networkMonitor,
             environment: .tests,
-            appLifecycle: testAppLifecycle
+            appLifecycle: testAppLifecycle,
+            xmtpClientFactory: .inMemory
         )
 
         // Try to authorize with wrong clientId. The state machine was
@@ -260,7 +264,8 @@ struct SessionStateMachineTests {
             networkMonitor: networkMonitor,
             overrideJWTToken: "test-jwt-token",  // Skip backend auth for tests
             environment: .tests,
-            appLifecycle: testAppLifecycle
+            appLifecycle: testAppLifecycle,
+            xmtpClientFactory: .inMemory
         )
 
         // Register and wait for ready
@@ -328,7 +333,8 @@ struct SessionStateMachineTests {
             networkMonitor: networkMonitor,
             overrideJWTToken: "test-jwt-token",  // Skip backend auth for tests
             environment: .tests,
-            appLifecycle: testAppLifecycle
+            appLifecycle: testAppLifecycle,
+            xmtpClientFactory: .inMemory
         )
 
         // Register and wait for ready
@@ -398,7 +404,8 @@ struct SessionStateMachineTests {
             networkMonitor: networkMonitor,
             overrideJWTToken: "test-jwt-token",  // Skip backend auth for tests
             environment: .tests,
-            appLifecycle: testAppLifecycle
+            appLifecycle: testAppLifecycle,
+            xmtpClientFactory: .inMemory
         )
 
         // Try to authorize with non-existent inboxId to trigger error
@@ -452,7 +459,8 @@ struct SessionStateMachineTests {
             syncingManager: nil,
             networkMonitor: networkMonitor,
             environment: .tests,
-            appLifecycle: testAppLifecycle
+            appLifecycle: testAppLifecycle,
+            xmtpClientFactory: .inMemory
         )
 
         actor StateCollector {
@@ -537,7 +545,8 @@ struct SessionStateMachineTests {
             networkMonitor: networkMonitor,
             overrideJWTToken: "test-jwt-token",  // Skip backend auth for tests
             environment: .tests,
-            appLifecycle: testAppLifecycle
+            appLifecycle: testAppLifecycle,
+            xmtpClientFactory: .inMemory
         )
 
         // Queue register and then stop
@@ -592,7 +601,8 @@ struct SessionStateMachineTests {
             networkMonitor: mockNetworkMonitor,
             overrideJWTToken: "test-jwt-token",
             environment: .tests,
-            appLifecycle: testAppLifecycle
+            appLifecycle: testAppLifecycle,
+            xmtpClientFactory: .inMemory
         )
 
         // Register and wait for ready
@@ -670,7 +680,8 @@ struct SessionStateMachineTests {
             networkMonitor: networkMonitor,
             overrideJWTToken: "test-jwt-token",
             environment: .tests,
-            appLifecycle: testAppLifecycle
+            appLifecycle: testAppLifecycle,
+            xmtpClientFactory: .inMemory
         )
 
         // Register and wait for ready
@@ -766,7 +777,8 @@ struct SessionStateMachineTests {
             networkMonitor: networkMonitor,
             overrideJWTToken: "test-jwt-token",
             environment: .tests,
-            appLifecycle: testAppLifecycle
+            appLifecycle: testAppLifecycle,
+            xmtpClientFactory: .inMemory
         )
 
         actor StateCollector {

--- a/ConvosCore/Tests/ConvosCoreTests/TestHelpers.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/TestHelpers.swift
@@ -90,6 +90,10 @@ class TestFixtures {
         let keys = try await identityStore.generateKeys()
         let clientId = ClientId.generate().value
 
+        // Tests use in-memory libxmtp clients to avoid file-backed pool
+        // contention between parallel test suites. createInMemory ignores
+        // dbDirectory/dbEncryptionKey but the ClientOptions initializer still
+        // requires dbEncryptionKey, so we pass the generated key for shape.
         let clientOptions = ClientOptions(
             api: .init(
                 env: .local,
@@ -110,11 +114,10 @@ class TestFixtures {
                 JoinRequestCodec(),
                 TypingIndicatorCodec()
             ],
-            dbEncryptionKey: keys.databaseKey,
-            dbDirectory: environment.defaultDatabasesDirectory
+            dbEncryptionKey: keys.databaseKey
         )
 
-        let client = try await Client.create(account: keys.signingKey, options: clientOptions)
+        let client = try await Client.createInMemory(account: keys.signingKey, options: clientOptions)
 
         // Save to mock identity store. In the single-inbox model there is only one
         // slot; multi-client fixtures overwrite each other and the tests that rely

--- a/ConvosCore/Tests/ConvosCoreTests/TestHelpers.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/TestHelpers.swift
@@ -5,13 +5,46 @@ import GRDB
 import Testing
 @preconcurrency import XMTPiOS
 
-// Set custom XMTP endpoint at module load time (before any async code)
-// This runs synchronously when the test module is loaded
-// @preconcurrency import suppresses strict concurrency warnings for XMTP static properties
 private let _configureXMTPEndpoint: Void = {
     if let endpoint = ProcessInfo.processInfo.environment["XMTP_NODE_ADDRESS"] {
         XMTPEnvironment.customLocalAddress = endpoint
     }
+}()
+
+// Rust tracing only flows to os_log on iOS — gated by env var so CI can
+// capture libxmtp output to disk for artifact upload.
+private let _configureXMTPLogging: Void = {
+    let env = ProcessInfo.processInfo.environment
+    guard let levelString = env["CONVOS_TEST_XMTP_LOG_LEVEL"], !levelString.isEmpty else {
+        return
+    }
+
+    let logLevel: Client.LogLevel
+    switch levelString.lowercased() {
+    case "error": logLevel = .error
+    case "warn", "warning": logLevel = .warn
+    case "info": logLevel = .info
+    case "debug": logLevel = .debug
+    default:
+        print("Unknown CONVOS_TEST_XMTP_LOG_LEVEL '\(levelString)', skipping libxmtp log activation")
+        return
+    }
+
+    let directoryURL: URL = if let custom = env["CONVOS_TEST_XMTP_LOG_DIR"], !custom.isEmpty {
+        URL(fileURLWithPath: custom, isDirectory: true)
+    } else {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("convos-test-xmtp-logs", isDirectory: true)
+    }
+
+    Client.activatePersistentLibXMTPLogWriter(
+        logLevel: logLevel,
+        rotationSchedule: .never,
+        maxFiles: 5,
+        customLogDirectory: directoryURL
+    )
+
+    print("libxmtp log writer activated at \(directoryURL.path) (level=\(levelString))")
 }()
 
 /// Waits until a condition becomes true, polling at a specified interval
@@ -82,7 +115,8 @@ class TestFixtures {
         PushNotificationRegistrar.resetForTesting()
         PushNotificationRegistrar.configure(MockPushNotificationRegistrarProvider())
 
-        // XMTP endpoint is configured at module load time via _configureXMTPEndpoint
+        _ = _configureXMTPEndpoint
+        _ = _configureXMTPLogging
     }
 
     /// Create a new XMTP client for testing

--- a/ConvosInvites/Package.resolved
+++ b/ConvosInvites/Package.resolved
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/xmtp/libxmtp.git",
       "state" : {
-        "branch" : "ios-4.9.0-dev.88ddfad",
-        "revision" : "899650a4189207ca2df515bf46beb549da07ff46"
+        "branch" : "ios-4.10.0-dev.d991b8a",
+        "revision" : "0b4dc376f139cd439319c2468cd51e5ce628bf2d"
       }
     },
     {

--- a/ConvosInvites/Package.swift
+++ b/ConvosInvites/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-log", from: "1.6.0"),
         .package(
             url: "https://github.com/xmtp/libxmtp.git",
-            revision: "ios-4.9.0-dev.88ddfad"
+            revision: "ios-4.10.0-dev.d991b8a"
         ),
         .package(path: "../ConvosAppData"),
     ],


### PR DESCRIPTION
this should contain the fix for "Pool Disconnected"

should fix #733 


~according to https://github.com/xmtplabs/convos-ios/pull/723 need to bump convos-cli to libxmtp v6~ done

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bump libxmtp to ios-4.10.0-dev and fix integration tests with in-memory clients
> - Updates the libxmtp dependency from `ios-4.9.0-dev.88ddfad` to `ios-4.10.0-dev.d991b8a` in both `ConvosCore` and `ConvosInvites` packages.
> - Switches test client creation in `TestFixtures`, `SessionStateMachineTests`, and `ProfileMessageIntegrationTests` from file-backed to in-memory XMTP clients, removing on-disk state from test runs.
> - Introduces `XMTPClientFactory` as an injectable factory struct on `SessionStateMachine`, with `.production` and `.inMemory` presets, so tests use in-memory clients without changing production behavior.
> - Adds libxmtp log capture to CI via `CONVOS_TEST_XMTP_LOG_LEVEL`/`CONVOS_TEST_XMTP_LOG_DIR` env vars and uploads the resulting `xmtp-test-logs/` directory as a CI artifact.
> - Updates `ClientOptions` construction in `SessionStateMachine.clientOptions` to use `dbPoolOptions: DbPoolOptions(maxPoolSize:minPoolSize)` to match the new libxmtp API.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2ca7023.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->