### PR TITLE
Quickname: flip per-conversation flag on apply, not on entry

### DIFF
--- a/Convos/Conversation Detail/ConversationOnboardingCoordinator.swift
+++ b/Convos/Conversation Detail/ConversationOnboardingCoordinator.swift
@@ -136,8 +136,8 @@ final class ConversationOnboardingCoordinator {
     var isWaitingForInviteAcceptance: Bool = false
 
     private var shouldShowQuicknameAfterNotifications: Bool = false
-    private var pendingClientId: String?
-    private var currentClientId: String?
+    private var pendingConversationId: String?
+    private var currentConversationId: String?
     private var isConversationCreator: Bool = false
 
     // MARK: - Persistence
@@ -173,12 +173,12 @@ final class ConversationOnboardingCoordinator {
         set { UserDefaults.standard.set(newValue, forKey: Self.hasCompletedOnboardingKey) }
     }
 
-    private func hasSetQuickname(for clientId: String) -> Bool {
-        UserDefaults.standard.bool(forKey: Self.hasSetQuicknamePrefix + clientId)
+    private func hasSetQuickname(for conversationId: String) -> Bool {
+        UserDefaults.standard.bool(forKey: Self.hasSetQuicknamePrefix + conversationId)
     }
 
-    private func setHasSetQuickname(_ value: Bool, for clientId: String) {
-        UserDefaults.standard.set(value, forKey: Self.hasSetQuicknamePrefix + clientId)
+    private func setHasSetQuickname(_ value: Bool, for conversationId: String) {
+        UserDefaults.standard.set(value, forKey: Self.hasSetQuicknamePrefix + conversationId)
     }
 
     private var hasSeenAddAsQuickname: Bool {
@@ -266,10 +266,10 @@ final class ConversationOnboardingCoordinator {
             case .savedAsQuicknameSuccess:
                 await transitionAfterQuickname()
             case .notificationsEnabled:
-                if shouldShowQuicknameAfterNotifications, let clientId = pendingClientId {
-                    await startQuicknameFlow(for: clientId)
+                if shouldShowQuicknameAfterNotifications, let conversationId = pendingConversationId {
+                    await startQuicknameFlow(for: conversationId)
                     shouldShowQuicknameAfterNotifications = false
-                    pendingClientId = nil
+                    pendingConversationId = nil
                 } else {
                     await complete()
                 }
@@ -309,27 +309,27 @@ final class ConversationOnboardingCoordinator {
 
     // MARK: - State Transitions
 
-    func start(for clientId: String, isConversationCreator: Bool = false) async {
+    func start(for conversationId: String, isConversationCreator: Bool = false) async {
         guard case .idle = state else {
             return
         }
 
-        self.currentClientId = clientId
+        self.currentConversationId = conversationId
         self.isConversationCreator = isConversationCreator
 
         state = .started
 
         if isWaitingForInviteAcceptance {
-            await startNotificationFlow(for: clientId)
+            await startNotificationFlow(for: conversationId)
         } else {
-            await startQuicknameFlow(for: clientId)
+            await startQuicknameFlow(for: conversationId)
         }
     }
 
     /// Start the notification flow (used when coming from invite acceptance)
-    private func startNotificationFlow(for clientId: String) async {
+    private func startNotificationFlow(for conversationId: String) async {
         shouldShowQuicknameAfterNotifications = true
-        pendingClientId = clientId
+        pendingConversationId = conversationId
 
         let authStatus = await notificationCenter.authorizationStatus()
 
@@ -342,23 +342,22 @@ final class ConversationOnboardingCoordinator {
             handleStateChange()
         case .authorized, .provisional, .ephemeral:
             if !isWaitingForInviteAcceptance {
-                await startQuicknameFlow(for: clientId)
+                await startQuicknameFlow(for: conversationId)
             }
             shouldShowQuicknameAfterNotifications = false
-            pendingClientId = nil
+            pendingConversationId = nil
         @unknown default:
             if !isWaitingForInviteAcceptance {
-                await startQuicknameFlow(for: clientId)
+                await startQuicknameFlow(for: conversationId)
             }
             shouldShowQuicknameAfterNotifications = false
-            pendingClientId = nil
+            pendingConversationId = nil
         }
     }
 
     /// Start or continue the quickname onboarding flow
-    private func startQuicknameFlow(for clientId: String) async {
-        let hasSetQuicknameForConversation = hasSetQuickname(for: clientId)
-        setHasSetQuickname(true, for: clientId)
+    private func startQuicknameFlow(for conversationId: String) async {
+        let hasSetQuicknameForConversation = hasSetQuickname(for: conversationId)
 
         let quicknameSettings = quicknameViewModel.quicknameSettings
 
@@ -384,7 +383,7 @@ final class ConversationOnboardingCoordinator {
     }
 
     /// Call this when the invite has been accepted
-    func inviteWasAccepted(for clientId: String) async {
+    func inviteWasAccepted(for conversationId: String) async {
         guard isWaitingForInviteAcceptance else {
             return
         }
@@ -392,7 +391,7 @@ final class ConversationOnboardingCoordinator {
 
         switch state {
         case .idle, .started:
-            await startNotificationFlow(for: clientId)
+            await startNotificationFlow(for: conversationId)
         default:
             break
         }
@@ -423,6 +422,9 @@ final class ConversationOnboardingCoordinator {
     func didSelectQuickname() async {
         QAEvent.emit(.onboarding, "quickname_applied")
         shouldAnimateAvatarForQuicknameSetup = false
+        if let conversationId = currentConversationId {
+            setHasSetQuickname(true, for: conversationId)
+        }
         await transitionAfterQuickname()
     }
 
@@ -467,10 +469,10 @@ final class ConversationOnboardingCoordinator {
             // Check if we need to show quickname flow next (from invite acceptance)
             if shouldShowQuicknameAfterNotifications,
                !isWaitingForInviteAcceptance,
-               let clientId = pendingClientId {
-                await startQuicknameFlow(for: clientId)
+               let conversationId = pendingConversationId {
+                await startQuicknameFlow(for: conversationId)
                 shouldShowQuicknameAfterNotifications = false
-                pendingClientId = nil
+                pendingConversationId = nil
             }
         } else {
             // Check if it was denied or just not determined

--- a/ConvosTests/ConversationOnboardingCoordinatorTests.swift
+++ b/ConvosTests/ConversationOnboardingCoordinatorTests.swift
@@ -255,11 +255,49 @@ final class ConversationOnboardingCoordinatorTests: XCTestCase {
             XCTFail("Expected a quickname state, got \(coordinator.state)")
         }
 
-        XCTAssertTrue(
+        XCTAssertFalse(
             UserDefaults.standard.bool(forKey: "hasSetQuicknameForConversation_\(newConversationId)"),
-            "Entry into startQuicknameFlow should mark the per-conversation flag"
+            "Entry into startQuicknameFlow must not mark the per-conversation flag — only didSelectQuickname does"
         )
         UserDefaults.standard.removeObject(forKey: "hasSetQuicknameForConversation_\(newConversationId)")
+    }
+
+    func testDidSelectQuickname_SetsPerConversationFlag() async {
+        mockNotificationCenter.authStatus = .authorized
+        UserDefaults.standard.set(true, forKey: "hasCompletedConversationOnboarding")
+        UserDefaults.standard.set(true, forKey: "hasShownQuicknameEditor")
+
+        let conversationId = "convo-applying-quickname"
+        await coordinator.start(for: conversationId)
+        XCTAssertFalse(
+            UserDefaults.standard.bool(forKey: "hasSetQuicknameForConversation_\(conversationId)"),
+            "Pre-condition: flag should not yet be set after start()"
+        )
+
+        await coordinator.didSelectQuickname()
+
+        XCTAssertTrue(
+            UserDefaults.standard.bool(forKey: "hasSetQuicknameForConversation_\(conversationId)"),
+            "didSelectQuickname (user applied the quickname) must set the per-conversation flag"
+        )
+        UserDefaults.standard.removeObject(forKey: "hasSetQuicknameForConversation_\(conversationId)")
+    }
+
+    func testSkipAddQuickname_DoesNotSetPerConversationFlag() async {
+        mockNotificationCenter.authStatus = .authorized
+        UserDefaults.standard.set(true, forKey: "hasCompletedConversationOnboarding")
+        UserDefaults.standard.set(true, forKey: "hasShownQuicknameEditor")
+
+        let conversationId = "convo-skipping-quickname"
+        await coordinator.start(for: conversationId)
+
+        coordinator.skipAddQuickname()
+
+        XCTAssertFalse(
+            UserDefaults.standard.bool(forKey: "hasSetQuicknameForConversation_\(conversationId)"),
+            "Skipping must not set the flag — re-opening should re-prompt the user to apply their quickname"
+        )
+        UserDefaults.standard.removeObject(forKey: "hasSetQuicknameForConversation_\(conversationId)")
     }
 
     func testStart_HasCompletedOnboarding_ReopensSameConversation_Skips() async {

--- a/ConvosTests/ConversationsViewModelDeleteTests.swift
+++ b/ConvosTests/ConversationsViewModelDeleteTests.swift
@@ -335,4 +335,12 @@ private final class TestSessionManager: SessionManagerProtocol, @unchecked Senda
     func makeAssetRenewalManager() async -> AssetRenewalManager {
         await base.makeAssetRenewalManager()
     }
+
+    func connectionManager(callbackURLScheme: String) -> any ConnectionManagerProtocol {
+        base.connectionManager(callbackURLScheme: callbackURLScheme)
+    }
+
+    func connectionRepository() -> any ConnectionRepositoryProtocol {
+        base.connectionRepository()
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #759 — quickname display name failing to reach peers after the single-inbox refactor.

The per-conversation `hasSetQuicknameForConversation_<id>` flag was being written to UserDefaults at the *top* of `startQuicknameFlow`, before the user had even seen the AddQuicknameView prompt. Pre-#713 this didn't matter — `ProfileUpdate` was auto-broadcast when the inbox was created on join. Post-#713 the only broadcast path is the user explicitly tapping the prompt, which calls `onUseQuickname()` → `MyProfileWriter.update(displayName:conversationId:)`. Setting the flag on entry meant: dismiss once → no broadcast, no re-prompt, peer Convos clients see the user as their inbox ID forever.

## Fix

- Move `setHasSetQuickname(true, for: conversationId)` from `startQuicknameFlow` into `didSelectQuickname` — the same call site that fires the broadcast.
- Skip / auto-dismiss → flag stays unset, next conversation open re-prompts.
- Apply → flag set, broadcast fires, no re-prompt.
- Rename `clientId` → `conversationId` throughout the coordinator. The storage key prefix is already `hasSetQuicknameForConversation_`, callers all pass `conversation.id`, and after the single-inbox refactor there's one client per install — the parameter name was always misleading and is now plainly wrong.

## Tests

- Flipped `testStart_HasCompletedOnboarding_NewConversation_SurfacesQuicknameState` — it previously codified the bug ("Entry into startQuicknameFlow should mark the per-conversation flag"). Now asserts the opposite.
- New `testDidSelectQuickname_SetsPerConversationFlag` — covers the apply path.
- New `testSkipAddQuickname_DoesNotSetPerConversationFlag` — covers the skip path.
- All 24 coordinator tests pass on simulator.

## Bundled

`TestSessionManager` in `ConversationsViewModelDeleteTests` was missing `connectionManager` / `connectionRepository`, added in PR #719 (Cloud Connections). Added them so the test target builds.

## Test plan

- [ ] Two devices with different Quicknames join a group with a Convos agent.
- [ ] Tap "Tap to chat as [Name]" on each device.
- [ ] Send messages — agent should attribute them to the display names, not inbox IDs.
- [ ] Re-open the same conversation — no re-prompt.
- [ ] Open a fresh conversation and dismiss the prompt by swiping.
- [ ] Re-open it — prompt re-appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix quickname per-conversation flag to persist on apply, not on flow entry
> - The per-conversation quickname flag was previously set when entering `startQuicknameFlow(for:)`, meaning it would be marked even if the user never completed the flow.
> - Now, the flag is only persisted in `didSelectQuickname()` when the user actually selects and applies a quickname.
> - A test is added to confirm `didSelectQuickname()` sets the flag, and another confirms `skipAddQuickname()` does not.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 4209543. 1 file reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->