### PR TITLE
Install tmux in setup.sh; make pre-commit hook bash 3.2 compatible

### DIFF
--- a/Scripts/hooks/pre-commit
+++ b/Scripts/hooks/pre-commit
@@ -20,7 +20,10 @@ elif [ -d "/usr/local/bin" ]; then
 fi
 
 # Get staged Swift files (excluding deleted files and build directories)
-mapfile -t STAGED_SWIFT_FILES < <(
+STAGED_SWIFT_FILES=()
+while IFS= read -r line; do
+    [ -n "$line" ] && STAGED_SWIFT_FILES+=("$line")
+done < <(
     git diff --cached --name-only --diff-filter=d |
         grep '\.swift$' |
         grep -v -E '^\.derivedData/|^\.build/|/\.build/' || true

--- a/Scripts/setup.sh
+++ b/Scripts/setup.sh
@@ -110,6 +110,16 @@ if ! command -v protoc-gen-swift &> /dev/null; then
     fi
 fi
 
+# Check and install tmux (required by convos-task for parallel worktree sessions)
+if ! command -v tmux &> /dev/null; then
+    echo "Installing tmux..."
+    if ! brew install tmux; then
+        echo "❌ Failed to install tmux. Please try installing manually:"
+        echo "  brew install tmux"
+        exit 1
+    fi
+fi
+
 # Check and install GitHub CLI (skip installing in CI)
 if [ ! "${CI}" = true ]; then
     if ! command -v gh >/dev/null 2>&1; then


### PR DESCRIPTION
convos-task uses tmux for per-worktree sessions, but Scripts/setup.sh
wasn't installing it, so fresh setups failed with `tmux: command not
found`. Add a brew install step alongside the other dependencies.

While in here, the pre-commit hook used `mapfile` which requires bash
4+, but macOS ships bash 3.2 by default and the hook's shebang resolves
to /bin/bash. Replace it with a `while read` loop so the hook runs on
the stock system bash without requiring `brew install bash`.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Install tmux in setup.sh and make pre-commit hook compatible with bash 3.2
> - Adds a tmux installation check to [setup.sh](https://github.com/xmtplabs/convos-ios/pull/768/files#diff-490f2d9bc338440322d4b7d5bcb8c209ee7633cdb9f4245ceb2cb78bc6486314); if `tmux` is not found, it runs `brew install tmux` and exits with an error if the install fails.
> - Replaces `mapfile -t` in [pre-commit](https://github.com/xmtplabs/convos-ios/pull/768/files#diff-05ef8a5df0577442779af6a4ea9e431bab345d2620d166ee6ea004f38e6f2e4c) with a `while read` loop, making it compatible with bash 3.2 (the macOS default). Empty lines from the git/grep pipeline are skipped before appending to the array.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2858622.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->