### PR TITLE
ConvoInfo debug: hidden messages list + assistant instance ID

### DIFF
--- a/Convos/Conversation Detail/ConversationInfoView.swift
+++ b/Convos/Conversation Detail/ConversationInfoView.swift
@@ -508,6 +508,25 @@ struct ConversationInfoView: View {
                 } label: {
                     Text("Metadata")
                 }
+                NavigationLink {
+                    HiddenMessagesView { try await viewModel.hiddenMessagesDebugInfo() }
+                } label: {
+                    Text("Hidden messages")
+                }
+                if let instanceId = viewModel.assistantInstanceId {
+                    HStack {
+                        Text("Assistant instance ID")
+                        Spacer()
+                        Text(instanceId)
+                            .font(.system(.caption, design: .monospaced))
+                            .foregroundStyle(.colorTextSecondary)
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                        ShareLink(item: instanceId) {
+                            Image(systemName: "square.and.arrow.up")
+                        }
+                    }
+                }
                 Button {
                     showingRestoreInviteTagAlert = true
                 } label: {

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -1532,6 +1532,22 @@ extension ConversationViewModel {
         }
     }
 
+    @MainActor
+    func hiddenMessagesDebugInfo() async throws -> [HiddenMessageDebugEntry] {
+        let messagingService = session.messagingService()
+        let inboxResult = try await messagingService.sessionStateManager.waitForInboxReadyResult()
+        return try await inboxResult.client.hiddenMessagesDebugInfo(conversationId: conversation.id)
+    }
+
+    var assistantInstanceId: String? {
+        guard let agent = conversation.members.first(where: \.isAgent),
+              case .string(let value) = agent.profile.metadata?["instanceId"],
+              !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return nil
+        }
+        return value
+    }
+
     func makeAssistantFilesLinksRepository() -> AssistantFilesLinksRepository {
         session.assistantFilesLinksRepository(for: conversation.id)
     }

--- a/Convos/Conversation Detail/HiddenMessagesView.swift
+++ b/Convos/Conversation Detail/HiddenMessagesView.swift
@@ -1,0 +1,141 @@
+import ConvosCore
+import SwiftUI
+
+struct HiddenMessagesView: View {
+    private let load: () async throws -> [HiddenMessageDebugEntry]
+
+    @State private var entries: [HiddenMessageDebugEntry] = []
+    @State private var isLoading: Bool = true
+    @State private var errorText: String?
+
+    init(load: @escaping () async throws -> [HiddenMessageDebugEntry]) {
+        self.load = load
+    }
+
+    var body: some View {
+        Group {
+            if isLoading {
+                VStack(spacing: 12.0) {
+                    ProgressView()
+                    Text("Loading hidden messages…")
+                        .font(.footnote)
+                        .foregroundStyle(.colorTextSecondary)
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else if let errorText {
+                ScrollView {
+                    Text(errorText)
+                        .font(.system(.footnote, design: .monospaced))
+                        .foregroundStyle(.colorTextSecondary)
+                        .padding()
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+            } else if entries.isEmpty {
+                VStack(spacing: 8.0) {
+                    Text("No hidden messages")
+                        .font(.body)
+                    Text("XMTP returned no messages with hidden content types for this conversation.")
+                        .font(.footnote)
+                        .foregroundStyle(.colorTextSecondary)
+                        .multilineTextAlignment(.center)
+                }
+                .padding()
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else {
+                List {
+                    Section {
+                        ForEach(entries) { entry in
+                            HiddenMessageRow(entry: entry)
+                        }
+                    } header: {
+                        Text("\(entries.count) hidden \(entries.count == 1 ? "message" : "messages")")
+                            .font(.footnote.weight(.medium))
+                            .foregroundStyle(.colorTextSecondary)
+                    }
+                }
+                .listStyle(.insetGrouped)
+            }
+        }
+        .navigationTitle("Hidden messages")
+        .navigationBarTitleDisplayMode(.inline)
+        .task {
+            await refresh()
+        }
+        .refreshable {
+            await refresh()
+        }
+    }
+
+    private func refresh() async {
+        isLoading = true
+        errorText = nil
+        do {
+            let fetched = try await load()
+            entries = fetched.sorted { $0.date > $1.date }
+        } catch {
+            errorText = "Failed to load: \(error.localizedDescription)"
+        }
+        isLoading = false
+    }
+}
+
+private struct HiddenMessageRow: View {
+    let entry: HiddenMessageDebugEntry
+
+    private static let dateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .short
+        formatter.timeStyle = .medium
+        return formatter
+    }()
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4.0) {
+            HStack {
+                Text(entry.reason.rawValue)
+                    .font(.subheadline.weight(.semibold))
+                Spacer()
+                Text(Self.dateFormatter.string(from: entry.date))
+                    .font(.caption)
+                    .foregroundStyle(.colorTextSecondary)
+            }
+            Text(entry.contentTypeDescription)
+                .font(.system(.caption, design: .monospaced))
+                .foregroundStyle(.colorTextSecondary)
+            Text(entry.summary)
+                .font(.system(.footnote, design: .monospaced))
+                .foregroundStyle(.colorTextPrimary)
+            Text("from \(entry.senderInboxId)")
+                .font(.system(.caption2, design: .monospaced))
+                .foregroundStyle(.colorTextSecondary)
+                .lineLimit(1)
+                .truncationMode(.middle)
+        }
+        .padding(.vertical, 4.0)
+    }
+}
+
+#Preview {
+    NavigationStack {
+        HiddenMessagesView(load: {
+            [
+                HiddenMessageDebugEntry(
+                    id: "1",
+                    date: Date(),
+                    senderInboxId: "0xabc123def456789abc123def456789abc123def4",
+                    contentTypeDescription: "convos.org/profile_update:1.0",
+                    summary: "name=\"Alice\", avatar, kind=agent",
+                    reason: .profileUpdate
+                ),
+                HiddenMessageDebugEntry(
+                    id: "2",
+                    date: Date().addingTimeInterval(-3600),
+                    senderInboxId: "0xdef456789abc123def456789abc123def456789a",
+                    contentTypeDescription: "convos.org/typing_indicator:1.0",
+                    summary: "isTyping=true",
+                    reason: .typingIndicator
+                ),
+            ]
+        })
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Messaging/XMTPClientProvider+HiddenMessagesDebug.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/XMTPClientProvider+HiddenMessagesDebug.swift
@@ -1,0 +1,148 @@
+import Foundation
+@preconcurrency import XMTPiOS
+
+public struct HiddenMessageDebugEntry: Sendable, Identifiable, Hashable {
+    public enum Reason: String, Sendable, Hashable {
+        case profileUpdate = "Profile update"
+        case profileSnapshot = "Profile snapshot"
+        case typingIndicator = "Typing indicator"
+        case readReceipt = "Read receipt"
+        case reaction = "Reaction"
+        case unknown = "Unknown"
+    }
+
+    public let id: String
+    public let date: Date
+    public let senderInboxId: String
+    public let contentTypeDescription: String
+    public let summary: String
+    public let reason: Reason
+
+    public init(
+        id: String,
+        date: Date,
+        senderInboxId: String,
+        contentTypeDescription: String,
+        summary: String,
+        reason: Reason
+    ) {
+        self.id = id
+        self.date = date
+        self.senderInboxId = senderInboxId
+        self.contentTypeDescription = contentTypeDescription
+        self.summary = summary
+        self.reason = reason
+    }
+}
+
+public extension XMTPClientProvider {
+    func hiddenMessagesDebugInfo(
+        conversationId: String,
+        limit: Int = 500
+    ) async throws -> [HiddenMessageDebugEntry] {
+        guard let xmtpConversation = try await conversation(with: conversationId) else {
+            throw XMTPClientProviderError.conversationNotFound(id: conversationId)
+        }
+
+        let messages: [DecodedMessage]
+        switch xmtpConversation {
+        case .group(let group):
+            messages = try await group.messages(limit: limit)
+        case .dm(let dm):
+            messages = try await dm.messages(limit: limit)
+        }
+
+        return messages.compactMap(HiddenMessageDebugEntry.init(decodedMessage:))
+    }
+}
+
+private extension HiddenMessageDebugEntry {
+    init?(decodedMessage message: DecodedMessage) {
+        guard let encodedContent = try? message.encodedContent else { return nil }
+        let contentType = encodedContent.type
+
+        let reason: Reason
+        let summary: String
+
+        if contentType == ContentTypeProfileUpdate {
+            reason = .profileUpdate
+            summary = Self.profileUpdateSummary(content: encodedContent)
+        } else if contentType == ContentTypeProfileSnapshot {
+            reason = .profileSnapshot
+            summary = Self.profileSnapshotSummary(content: encodedContent)
+        } else if contentType.authorityID == ContentTypeTypingIndicator.authorityID,
+                  contentType.typeID == ContentTypeTypingIndicator.typeID {
+            reason = .typingIndicator
+            summary = Self.typingIndicatorSummary(content: encodedContent)
+        } else if contentType.authorityID == ContentTypeReadReceipt.authorityID,
+                  contentType.typeID == ContentTypeReadReceipt.typeID {
+            reason = .readReceipt
+            summary = "Read receipt"
+        } else if contentType == ContentTypeReaction || contentType == ContentTypeReactionV2 {
+            reason = .reaction
+            summary = Self.reactionSummary(message: message)
+        } else if Self.visibleContentTypes.contains(where: {
+            $0.authorityID == contentType.authorityID && $0.typeID == contentType.typeID
+        }) {
+            return nil
+        } else {
+            reason = .unknown
+            summary = "byte length: \(encodedContent.content.count)"
+        }
+
+        self.id = message.id
+        self.date = message.sentAt
+        self.senderInboxId = message.senderInboxId
+        self.contentTypeDescription = "\(contentType.authorityID)/\(contentType.typeID):" +
+            "\(contentType.versionMajor).\(contentType.versionMinor)"
+        self.summary = summary
+        self.reason = reason
+    }
+
+    static let visibleContentTypes: [ContentTypeID] = [
+        ContentTypeText,
+        ContentTypeReply,
+        ContentTypeAttachment,
+        ContentTypeMultiRemoteAttachment,
+        ContentTypeRemoteAttachment,
+        ContentTypeGroupUpdated,
+        ContentTypeExplodeSettings,
+        ContentTypeAssistantJoinRequest,
+        ContentTypeConnectionGrantRequest,
+    ]
+
+    static func profileUpdateSummary(content: EncodedContent) -> String {
+        guard let update = try? ProfileUpdateCodec().decode(content: content) else {
+            return "<decode failed>"
+        }
+        var parts: [String] = []
+        if update.hasName { parts.append("name=\"\(update.name)\"") }
+        if update.hasEncryptedImage { parts.append("avatar") }
+        if !update.profileMetadata.isEmpty { parts.append("metadata") }
+        parts.append("kind=\(update.memberKind)")
+        return parts.joined(separator: ", ")
+    }
+
+    static func profileSnapshotSummary(content: EncodedContent) -> String {
+        guard let snapshot = try? ProfileSnapshotCodec().decode(content: content) else {
+            return "<decode failed>"
+        }
+        return "profiles=\(snapshot.profiles.count)"
+    }
+
+    static func typingIndicatorSummary(content: EncodedContent) -> String {
+        guard let indicator = try? TypingIndicatorCodec().decode(content: content) else {
+            return "<decode failed>"
+        }
+        return "isTyping=\(indicator.isTyping)"
+    }
+
+    static func reactionSummary(message: DecodedMessage) -> String {
+        let reaction: Reaction? = try? message.content()
+        guard let reaction else {
+            return "<decode failed>"
+        }
+        let referencePrefix = reaction.reference.prefix(8)
+        return "\(reaction.action) \(reaction.content) → \(referencePrefix)"
+    }
+}


### PR DESCRIPTION
Add two rows to the debug section of `ConversationInfoView`:

1. **Hidden messages** — pushes `HiddenMessagesView`, which calls a new
   `XMTPClientProvider.hiddenMessagesDebugInfo(conversationId:)` extension
   that pulls messages directly from XMTP (group or DM) and surfaces every
   message whose content type we don't render in the messages list:
   profile updates, profile snapshots, typing indicators, read receipts,
   reactions, and unknown content types. Each row shows the reason, the
   raw `authority/type:major.minor` content type ID, a short decoded
   summary, and the sender inbox ID. Pull-to-refresh re-fetches.

2. **Assistant instance ID** — when the conversation has a verified
   assistant member, reads `metadata["instanceId"]` from the agent's
   `ProfileUpdate` profile and shows it monospaced with a `ShareLink`
   share button. The row only renders when the value is present and
   non-empty.

Both rows are gated behind `!ConfigManager.shared.currentEnvironment
.isProduction`, like the rest of the debug section.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add hidden messages list and assistant instance ID to conversation debug info
> - Adds a `HiddenMessagesView` screen (via `NavigationLink`) to the assistant debug section in [`ConversationInfoView`](https://github.com/xmtplabs/convos-ios/pull/769/files#diff-30ae741e90f8fd3b2d28bd543f330b1bb685d691d37fd1e95edcc8bd87159a2a), showing hidden-content-type messages with pull-to-refresh and error handling.
> - Adds an assistant instance ID row in the same section, with monospaced/truncated display and a `ShareLink` when the ID is available.
> - Implements `hiddenMessagesDebugInfo()` in [`ConversationViewModel`](https://github.com/xmtplabs/convos-ios/pull/769/files#diff-d056b0b131534648b6d13cddafd053be956f5d23d035ad2538db85a8cc370d8d) to fetch hidden messages via the XMTP inbox client, and `assistantInstanceId` to extract the instance ID from the first agent member's profile metadata.
> - Introduces [`XMTPClientProvider+HiddenMessagesDebug.swift`](https://github.com/xmtplabs/convos-ios/pull/769/files#diff-c89e5294684d784697368455a8cf13a039e8f84995fb73b6d937f8053b63e186) with `HiddenMessageDebugEntry` (including a `Reason` enum) and a method that fetches recent messages (up to 500), filters out visible content types, and maps the rest to debug entries with summaries.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 319914f.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->