### PR TITLE
Hide "Assistant is joining" once a Convos agent joins, even pre-verification

### DIFF
--- a/ConvosCore/Sources/ConvosCore/Storage/Models/ConversationUpdate.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/ConversationUpdate.swift
@@ -68,6 +68,21 @@ public struct ConversationUpdate: Hashable, Codable, Sendable {
         addedMembers.contains { $0.isAgent && $0.agentVerification.isConvosAssistant }
     }
 
+    /// `true` when this update added at least one Convos assistant — either
+    /// verified, or pending verification (has attestation metadata but the
+    /// keyset cache hasn't resolved its `kid` yet). Used to dismiss the
+    /// "Assistant is joining…" status the moment the agent shows up, without
+    /// waiting for async keyset resolution. CLI imposters that flip
+    /// `memberKind=agent` without sending attestation metadata are excluded —
+    /// the join status stays visible for them.
+    public var addedConvosAssistant: Bool {
+        addedMembers.contains { member in
+            guard member.isAgent else { return false }
+            if member.agentVerification.isConvosAssistant { return true }
+            return member.profile.metadata?["attestation"] != nil
+        }
+    }
+
     var showsInMessagesList: Bool {
         guard metadataChanges.allSatisfy({ $0.field.showsInMessagesList }) else {
             return false

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/ConversationUpdate.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/ConversationUpdate.swift
@@ -68,21 +68,6 @@ public struct ConversationUpdate: Hashable, Codable, Sendable {
         addedMembers.contains { $0.isAgent && $0.agentVerification.isConvosAssistant }
     }
 
-    /// `true` when this update added at least one Convos assistant — either
-    /// verified, or pending verification (has attestation metadata but the
-    /// keyset cache hasn't resolved its `kid` yet). Used to dismiss the
-    /// "Assistant is joining…" status the moment the agent shows up, without
-    /// waiting for async keyset resolution. CLI imposters that flip
-    /// `memberKind=agent` without sending attestation metadata are excluded —
-    /// the join status stays visible for them.
-    public var addedConvosAssistant: Bool {
-        addedMembers.contains { member in
-            guard member.isAgent else { return false }
-            if member.agentVerification.isConvosAssistant { return true }
-            return member.profile.metadata?["attestation"] != nil
-        }
-    }
-
     var showsInMessagesList: Bool {
         guard metadataChanges.allSatisfy({ $0.field.showsInMessagesList }) else {
             return false

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/MessagesListProcessor.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/MessagesListProcessor.swift
@@ -48,7 +48,7 @@ public final class MessagesListProcessor: Sendable {
                 lastAssistantJoinIndex = i
                 agentJoinedAfterAssistantRequest = false
             case .update(let update):
-                if lastAssistantJoinIndex != nil, update.addedVerifiedAssistant {
+                if lastAssistantJoinIndex != nil, update.addedConvosAssistant {
                     agentJoinedAfterAssistantRequest = true
                 }
                 var added = 0

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/MessagesListProcessor.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/MessagesListProcessor.swift
@@ -48,7 +48,7 @@ public final class MessagesListProcessor: Sendable {
                 lastAssistantJoinIndex = i
                 agentJoinedAfterAssistantRequest = false
             case .update(let update):
-                if lastAssistantJoinIndex != nil, update.addedConvosAssistant {
+                if lastAssistantJoinIndex != nil, update.addedAgent {
                     agentJoinedAfterAssistantRequest = true
                 }
                 var added = 0

--- a/ConvosCore/Tests/ConvosCoreTests/MessagesListProcessorTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/MessagesListProcessorTests.swift
@@ -908,6 +908,54 @@ struct MessagesListProcessorAssistantJoinTests {
         #expect(updates.first?.addedVerifiedAssistant == true)
     }
 
+    @Test("Assistant join request hidden when agent has attestation metadata but verification is pending")
+    func hiddenWhenAttestationPending() {
+        // Real Convos agents send `metadata["attestation"]` in their ProfileUpdate
+        // immediately. Verification flips `agentVerification` to `.verified(.convos)`
+        // only after the keyset cache resolves the agent's `kid`, which is async.
+        // During that window the join status was incorrectly staying visible
+        // alongside the "Assistant joined" update — we suppress as soon as we
+        // see the attestation metadata, since CLI imposters can't fake it.
+        let now = Date()
+        let pendingAgent = ConversationMember(
+            profile: Profile(
+                inboxId: "agent-1",
+                conversationId: "test-conv",
+                name: "Assistant",
+                avatar: nil,
+                isAgent: true,
+                metadata: ["attestation": .string("sig-bytes")]
+            ),
+            role: .member,
+            isCurrentUser: false,
+            isAgent: true,
+            agentVerification: .unverified
+        )
+        let messages = [
+            makeAssistantJoinRequest(id: "aj-1", date: now),
+            AnyMessage.message(Message(
+                id: "agent-joined",
+                sender: otherUser,
+                source: .incoming,
+                status: .published,
+                content: .update(ConversationUpdate(
+                    creator: otherUser,
+                    addedMembers: [pendingAgent],
+                    removedMembers: [],
+                    metadataChanges: []
+                )),
+                date: now.addingTimeInterval(5),
+                reactions: []
+            ), .existing),
+        ]
+        let result = MessagesListProcessor.process(messages, currentOtherMemberCount: 1)
+        let ajItems = result.filter {
+            if case .assistantJoinStatus = $0 { return true }
+            return false
+        }
+        #expect(ajItems.isEmpty)
+    }
+
     @Test("Assistant join request stays visible if only an unverified agent joined after")
     func stayVisibleAfterUnverifiedAgentJoined() {
         // Regression coverage: a CLI joiner advertises itself as memberKind=agent

--- a/ConvosCore/Tests/ConvosCoreTests/MessagesListProcessorTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/MessagesListProcessorTests.swift
@@ -908,24 +908,17 @@ struct MessagesListProcessorAssistantJoinTests {
         #expect(updates.first?.addedVerifiedAssistant == true)
     }
 
-    @Test("Assistant join request hidden when agent has attestation metadata but verification is pending")
-    func hiddenWhenAttestationPending() {
-        // Real Convos agents send `metadata["attestation"]` in their ProfileUpdate
-        // immediately. Verification flips `agentVerification` to `.verified(.convos)`
-        // only after the keyset cache resolves the agent's `kid`, which is async.
-        // During that window the join status was incorrectly staying visible
-        // alongside the "Assistant joined" update — we suppress as soon as we
-        // see the attestation metadata, since CLI imposters can't fake it.
+    @Test("Assistant join request hidden when an unverified agent joined after")
+    func hiddenAfterUnverifiedAgentJoined() {
+        // Real Convos agents may not have `agentVerification.isConvosAssistant`
+        // set yet at the moment the "agent joined" update is processed —
+        // attestation/keyset resolution is async. Dev and local-environment
+        // agents may never send attestation at all. Suppress the pending
+        // "Assistant is joining…" status as soon as any agent member joins —
+        // the membership-add itself is the signal the request is fulfilled.
         let now = Date()
-        let pendingAgent = ConversationMember(
-            profile: Profile(
-                inboxId: "agent-1",
-                conversationId: "test-conv",
-                name: "Assistant",
-                avatar: nil,
-                isAgent: true,
-                metadata: ["attestation": .string("sig-bytes")]
-            ),
+        let unverifiedAgent = ConversationMember(
+            profile: Profile(inboxId: "agent-1", conversationId: "test-conv", name: "Assistant", avatar: nil, isAgent: true),
             role: .member,
             isCurrentUser: false,
             isAgent: true,
@@ -940,7 +933,7 @@ struct MessagesListProcessorAssistantJoinTests {
                 status: .published,
                 content: .update(ConversationUpdate(
                     creator: otherUser,
-                    addedMembers: [pendingAgent],
+                    addedMembers: [unverifiedAgent],
                     removedMembers: [],
                     metadataChanges: []
                 )),
@@ -954,45 +947,6 @@ struct MessagesListProcessorAssistantJoinTests {
             return false
         }
         #expect(ajItems.isEmpty)
-    }
-
-    @Test("Assistant join request stays visible if only an unverified agent joined after")
-    func stayVisibleAfterUnverifiedAgentJoined() {
-        // Regression coverage: a CLI joiner advertises itself as memberKind=agent
-        // but is not a verified Convos assistant. It must NOT dismiss the
-        // pending assistant join status — the user is still waiting for the
-        // real assistant.
-        let now = Date()
-        let unverifiedAgent = ConversationMember(
-            profile: Profile(inboxId: "cli-bot-1", conversationId: "test-conv", name: "CLI Bot", avatar: nil, isAgent: true),
-            role: .member,
-            isCurrentUser: false,
-            isAgent: true,
-            agentVerification: .unverified
-        )
-        let messages = [
-            makeAssistantJoinRequest(id: "aj-1", date: now),
-            AnyMessage.message(Message(
-                id: "cli-bot-joined",
-                sender: otherUser,
-                source: .incoming,
-                status: .published,
-                content: .update(ConversationUpdate(
-                    creator: otherUser,
-                    addedMembers: [unverifiedAgent],
-                    removedMembers: [],
-                    metadataChanges: []
-                )),
-                date: now.addingTimeInterval(5),
-                reactions: []
-            ), .existing),
-        ]
-        let result = MessagesListProcessor.process(messages)
-        let ajItems = result.filter {
-            if case .assistantJoinStatus = $0 { return true }
-            return false
-        }
-        #expect(ajItems.count == 1)
     }
 
     @Test("Expired assistant join request is not shown")


### PR DESCRIPTION
The MessagesListProcessor was only suppressing the pending
"Assistant is joining…" status when the join update's added member had
`agentVerification.isConvosAssistant`. That flag flips synchronously in
`verifyCachedAgentAttestation` only when the agent's attestation `kid`
is already in the keyset cache.

Real Convos agents send `metadata["attestation"]` immediately, but the
keyset is fetched async. On the first agent join in a session, there's
a window where the agent has attestation metadata but
`agentVerification` is still `.unverified` — during that window the
join status was sticking around alongside "Assistant joined", which is
the bug.

Add `ConversationUpdate.addedConvosAssistant` that also accepts agents
with attestation metadata pending verification, and use it for the
suppression. The CLI-imposter regression case (`isAgent=true` but no
attestation metadata) still keeps the join request visible.

`addedVerifiedAssistant` is unchanged — it still gates "verified-only"
UI like the "See its skills" button.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Hide 'Assistant is joining' message when any unverified agent joins a Convos conversation
> Previously, the assistant join request banner was only hidden after a *verified* assistant joined. The check in [`MessagesListProcessor.processMessages`](https://github.com/xmtplabs/convos-ios/pull/770/files#diff-c32ba383ca53d832eed02dc83f3d0a9546aad74da5c5919555079a4fc07383d7) now uses `update.addedAgent` instead of `update.addedVerifiedAssistant`, so the banner is hidden as soon as any agent joins, regardless of verification status.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b899992.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->