### PR TITLE
Reactions drawer: self-size to content again

### DIFF
--- a/Convos/Conversation Detail/Messages/Messages View Controller/Reactions/ReactionsDrawerView.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/Reactions/ReactionsDrawerView.swift
@@ -42,11 +42,10 @@ struct ReactionsDrawerView: View {
             .scrollBounceBehavior(.basedOnSize)
             .scrollIndicatorsFlash(onAppear: true)
             .scrollContentBackground(.hidden)
-            .frame(minHeight: 120, idealHeight: 400, maxHeight: 600)
+            .frame(maxHeight: 600)
         }
         .padding([.leading, .top, .trailing], DesignConstants.Spacing.step10x)
         .padding(.bottom, DesignConstants.Spacing.step3x)
-        .frame(minHeight: 160)
     }
 }
 


### PR DESCRIPTION
The drawer was hard-coded to `idealHeight: 400` on its ScrollView,
which `selfSizingSheet` locks onto regardless of the row count — so
1 reaction and 15 reactions both rendered at ~400pt, defeating the
sheet's measurement.

Drop the `minHeight`/`idealHeight` from the ScrollView and the outer
`minHeight: 160`, leaving only `maxHeight: 600` so a tray with many
reactions still caps. The intrinsic height of the
`VStack(ReactionRowView…)` now drives the sheet height, and the
title + first row stay tall enough on their own that no min is
needed.

The 400pt ideal was introduced in #662 (78ca53bf) to fix an empty
drawer caused by a `GeometryReader` returning zero height to
`selfSizingSheet`. That root cause is gone now — the ScrollView
itself is fine without explicit sizing inside the sheet.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove minimum height constraints from `ReactionsDrawerView` to self-size to content
> Removes the `minHeight: 160` from the root `VStack` and the `minHeight`/`idealHeight` constraints from the `ScrollView` in [ReactionsDrawerView.swift](https://github.com/xmtplabs/convos-ios/pull/772/files#diff-88381b66065b4ece75e23e2a886812e1256a994b3f015fb285a7bf767cc96ef0). The drawer now sizes to its content, capped at 600pt tall.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9f60748.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->