### PR TITLE
CLAUDE.md: rules to prevent type-check timeout build failures

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -284,6 +284,60 @@ Logger.error("Error message")
 - Minimize view body complexity
 - Extract complex views into separate components
 
+## Build Performance: Type-Check Time
+
+The project builds with `-warn-long-expression-type-checking 100` and `-warn-long-function-bodies 100`, with `SWIFT_TREAT_WARNINGS_AS_ERRORS=YES`. **Any expression or function body the type-checker spends more than 100ms on becomes a hard build failure.** Do not raise the thresholds. Write expressions the solver can resolve quickly.
+
+The two patterns that consume nearly all of these errors:
+1. Several ternaries stacked across many SwiftUI modifier arguments in one chain.
+2. Big `@ViewBuilder` `switch` statements where each case has its own modifier chain with conditional values.
+
+### Rules
+
+- **Annotate the type on any non-trivial `let`.** If the RHS uses ternaries, optionals, generics, or arithmetic across types, write the type. Type inference is what gives the solver too many candidates.
+- **Never stack ternaries inside SwiftUI modifier arguments.** Hoist each conditional to a typed `let` above the modifier chain.
+
+  ```swift
+  // ❌ — three ternaries × N chained modifiers blows up the solver
+  content
+      .scaleEffect(isPressed ? 1.03 : 1.0, anchor: isCurrentUser ? .trailing : .leading)
+      .opacity(isSourceBubble ? 0 : 1)
+      .offset(x: swipeOffset > 0 ? min(swipeOffset, maxOffset) : 0)
+
+  // ✅ — typed lets above, plain modifier chain below
+  let scale: CGFloat = isPressed ? 1.03 : 1.0
+  let anchor: UnitPoint = isCurrentUser ? .trailing : .leading
+  let bubbleOpacity: Double = isSourceBubble ? 0 : 1
+  let xOffset: CGFloat = swipeOffset > 0 ? min(swipeOffset, maxOffset) : 0
+  content
+      .scaleEffect(scale, anchor: anchor)
+      .opacity(bubbleOpacity)
+      .offset(x: xOffset)
+  ```
+
+- **No nested ternaries.** One ternary per expression. Two-deep is the cap; three-deep → use `switch` or extract a helper.
+- **Cap SwiftUI `body` / `body(content:)` at ~50 lines or ~10 modifiers.** Beyond that, extract subviews or `@ViewBuilder` computed properties.
+- **For `@ViewBuilder switch` statements:** if any case has more than 3 chained modifiers or a conditional argument, extract that case to its own `@ViewBuilder` helper.
+- **No `+` for string concatenation across optionals or non-`String` types.** Always use interpolation: `"\(a)\(b ?? "")"`.
+- **One numeric type per expression.** Don't mix `Int`, `Double`, `CGFloat` in a single `let` — cast at the boundary.
+- **Annotate parameter and return types in non-trivial `.map` / `.reduce` / `.sorted` closures.**
+
+  ```swift
+  array.map { (item: Item) -> Value in … }
+  ```
+
+- **Build arrays and dicts with `var` + `append`, not conditional `+` chains.**
+
+### When you hit a type-check timeout
+
+Fix the expression. Do not bump the threshold and do not `// swiftlint:disable` past it.
+
+1. Find the line in the error message — it points at the exact offender.
+2. Hoist the most complex sub-expression(s) to typed `let` bindings above.
+3. Replace nested ternaries with `switch` or `if/else`.
+4. Extract subviews or `@ViewBuilder` helpers from oversized SwiftUI bodies.
+5. Rebuild.
+
 ## Build & Release
 
 ### Build Commands


### PR DESCRIPTION
## Summary

Build flags `-warn-long-expression-type-checking 100` + `-warn-long-function-bodies 100` plus `SWIFT_TREAT_WARNINGS_AS_ERRORS=YES` turn any expression the solver chews on for >100ms into a hard build failure. AI coding agents repeatedly trip these (we hit two just on the recent assistant-join fix) and burn turns rewriting around them.

Adds a `Build Performance: Type-Check Time` section to `CLAUDE.md` spelling out the two patterns responsible for nearly every failure we see and the concrete rules that avoid them.

## Test plan

- [x] Docs-only change; no code or tests affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add type-check timeout prevention rules to CLAUDE.md
> Documents Swift type-checker thresholds (`-warn-long-expression-type-checking 100`, `-warn-long-function-bodies 100` with warnings-as-errors) and coding rules to avoid build failures in [CLAUDE.md](https://github.com/xmtplabs/convos-ios/pull/773/files#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7).
>
> - Covers common offenders: stacked ternaries in SwiftUI modifier chains and large `@ViewBuilder` switches
> - Provides before/after code examples contrasting ternary-heavy chains with hoisted, explicitly-typed `let` bindings
> - Adds rules on annotation, ternary depth, SwiftUI body size caps, `ViewBuilder` case extraction, and array/dict construction
> - Includes a remediation checklist for diagnosing and fixing type-check timeouts when they occur
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dd54851.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->