### PR TITLE
SwiftLint: flag multiple ternaries in one modifier call

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -135,6 +135,16 @@ custom_rules:
     message: "Log an error using Sentry or something else rather than using assertions in non-test code"
     severity: warning
 
+  multiple_ternaries_in_modifier_arg:
+    regex: '(?m)^\s+\.[a-z][a-zA-Z0-9_]*\([^()]*?\s\?\s[^()]*?\s:\s[^()]*?\s\?\s[^()]*?\s:\s[^()]*?\)'
+    name: "Multiple ternaries inside one modifier call"
+    message: "Hoist these conditional values to typed `let`s above the modifier chain. Stacking ternaries inside a single chained .modifier(...) call is a top cause of Swift type-check timeouts. See CLAUDE.md → Build Performance: Type-Check Time."
+    severity: warning
+    excluded_match_kinds:
+      - string
+      - comment
+      - doccomment
+
 excluded:
   - .build/
   - "**/.build"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -284,6 +284,60 @@ Logger.error("Error message")
 - Minimize view body complexity
 - Extract complex views into separate components
 
+## Build Performance: Type-Check Time
+
+The project builds with `-warn-long-expression-type-checking 100` and `-warn-long-function-bodies 100`, with `SWIFT_TREAT_WARNINGS_AS_ERRORS=YES`. **Any expression or function body the type-checker spends more than 100ms on becomes a hard build failure.** Do not raise the thresholds. Write expressions the solver can resolve quickly.
+
+The two patterns that consume nearly all of these errors:
+1. Several ternaries stacked across many SwiftUI modifier arguments in one chain.
+2. Big `@ViewBuilder` `switch` statements where each case has its own modifier chain with conditional values.
+
+### Rules
+
+- **Annotate the type on any non-trivial `let`.** If the RHS uses ternaries, optionals, generics, or arithmetic across types, write the type. Type inference is what gives the solver too many candidates.
+- **Never stack ternaries inside SwiftUI modifier arguments.** Hoist each conditional to a typed `let` above the modifier chain.
+
+  ```swift
+  // ❌ — three ternaries × N chained modifiers blows up the solver
+  content
+      .scaleEffect(isPressed ? 1.03 : 1.0, anchor: isCurrentUser ? .trailing : .leading)
+      .opacity(isSourceBubble ? 0 : 1)
+      .offset(x: swipeOffset > 0 ? min(swipeOffset, maxOffset) : 0)
+
+  // ✅ — typed lets above, plain modifier chain below
+  let scale: CGFloat = isPressed ? 1.03 : 1.0
+  let anchor: UnitPoint = isCurrentUser ? .trailing : .leading
+  let bubbleOpacity: Double = isSourceBubble ? 0 : 1
+  let xOffset: CGFloat = swipeOffset > 0 ? min(swipeOffset, maxOffset) : 0
+  content
+      .scaleEffect(scale, anchor: anchor)
+      .opacity(bubbleOpacity)
+      .offset(x: xOffset)
+  ```
+
+- **No nested ternaries.** One ternary per expression. Two-deep is the cap; three-deep → use `switch` or extract a helper.
+- **Cap SwiftUI `body` / `body(content:)` at ~50 lines or ~10 modifiers.** Beyond that, extract subviews or `@ViewBuilder` computed properties.
+- **For `@ViewBuilder switch` statements:** if any case has more than 3 chained modifiers or a conditional argument, extract that case to its own `@ViewBuilder` helper.
+- **No `+` for string concatenation across optionals or non-`String` types.** Always use interpolation: `"\(a)\(b ?? "")"`.
+- **One numeric type per expression.** Don't mix `Int`, `Double`, `CGFloat` in a single `let` — cast at the boundary.
+- **Annotate parameter and return types in non-trivial `.map` / `.reduce` / `.sorted` closures.**
+
+  ```swift
+  array.map { (item: Item) -> Value in … }
+  ```
+
+- **Build arrays and dicts with `var` + `append`, not conditional `+` chains.**
+
+### When you hit a type-check timeout
+
+Fix the expression. Do not bump the threshold and do not `// swiftlint:disable` past it.
+
+1. Find the line in the error message — it points at the exact offender.
+2. Hoist the most complex sub-expression(s) to typed `let` bindings above.
+3. Replace nested ternaries with `switch` or `if/else`.
+4. Extract subviews or `@ViewBuilder` helpers from oversized SwiftUI bodies.
+5. Rebuild.
+
 ## Build & Release
 
 ### Build Commands

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessageContextMenuWrapper.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessageContextMenuWrapper.swift
@@ -42,22 +42,15 @@ struct MessageGestureModifier: ViewModifier {
     }
 
     func body(content: Content) -> some View {
-        content
+        let pressedScale: CGFloat = isPressed && hasAppeared ? 1.03 : 1.0
+        let pressedAnchor: UnitPoint = message.sender.isCurrentUser ? .trailing : .leading
+        let bubbleOpacity: Double = isSourceBubble ? 0 : 1
+        return content
             .environment(\.messagePressed, isPressed)
-            .scaleEffect(
-                isPressed && hasAppeared ? 1.03 : 1.0,
-                anchor: message.sender.isCurrentUser ? .trailing : .leading
-            )
-            .opacity(isSourceBubble ? 0 : 1)
+            .scaleEffect(pressedScale, anchor: pressedAnchor)
+            .opacity(bubbleOpacity)
             .onAppear { hasAppeared = true }
-            .background {
-                if isSourceBubble {
-                    GeometryReader { geo in
-                        Color.clear
-                            .preference(key: SourceFrameKey.self, value: geo.frame(in: .global))
-                    }
-                }
-            }
+            .background { sourceFramePreferenceBackground }
             .onPreferenceChange(SourceFrameKey.self) { frame in
                 if isSourceBubble, let frame {
                     contextMenuState.currentSourceFrame = frame
@@ -68,64 +61,80 @@ struct MessageGestureModifier: ViewModifier {
             }
             .animation(.easeInOut(duration: 0.25), value: isPressed)
             .offset(x: swipeOffset)
-            .background(alignment: .leading) {
-                if swipeOffset > 0 {
-                    let progress = min(swipeOffset / Constant.swipeThreshold, 1.0)
-                    Image(systemName: "arrowshape.turn.up.left.fill")
-                        .foregroundStyle(.tertiary)
-                        .scaleEffect(0.4 + progress * 0.6)
-                        .opacity(Double(progress))
-                        .padding(.leading, DesignConstants.Spacing.step2x)
-                        .accessibilityHidden(true)
-                }
-            }
-            .overlay {
-                GeometryReader { geometry in
-                    GestureOverlayView(
-                        contextMenuState: contextMenuState,
-                        hasSingleTap: onSingleTap != nil,
-                        excludedFrames: interactiveExclusionFrames,
-                        onSingleTap: { onSingleTap?() },
-                        onDoubleTap: {
-                            if let onDoubleTap {
-                                onDoubleTap()
-                            } else {
-                                UIImpactFeedbackGenerator(style: .light).impactOccurred()
-                                onToggleReaction(doubleTapEmoji, message.messageId)
-                            }
-                        },
-                        onLongPress: {
-                            UIImpactFeedbackGenerator(style: .medium).impactOccurred()
-                            let frame = geometry.frame(in: .global)
-                            contextMenuState.present(
-                                message: message,
-                                bubbleFrame: frame,
-                                bubbleStyle: bubbleStyle
-                            )
-                        },
-                        onSwipeOffsetChanged: { offset in
-                            swipeOffset = offset
-                            externalSwipeOffset?.wrappedValue = offset
-                        },
-                        onSwipeEnded: { triggered in
-                            withAnimation(.spring(response: 0.25, dampingFraction: 0.8)) {
-                                swipeOffset = 0
-                                externalSwipeOffset?.wrappedValue = 0
-                            }
-                            if triggered { onReply(message) }
-                        },
-                        onPressChanged: { pressed in
-                            isPressed = pressed
-                        }
-                    )
-                }
-            }
+            .background(alignment: .leading) { swipeReplyIndicator }
+            .overlay { gestureOverlay }
             .accessibilityAction(named: "React") {
                 onToggleReaction(doubleTapEmoji, message.messageId)
             }
             .accessibilityAction(named: "Reply") {
                 onReply(message)
             }
+    }
+
+    @ViewBuilder
+    private var sourceFramePreferenceBackground: some View {
+        if isSourceBubble {
+            GeometryReader { geo in
+                Color.clear
+                    .preference(key: SourceFrameKey.self, value: geo.frame(in: .global))
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var swipeReplyIndicator: some View {
+        if swipeOffset > 0 {
+            let progress = min(swipeOffset / Constant.swipeThreshold, 1.0)
+            let indicatorScale: CGFloat = 0.4 + progress * 0.6
+            Image(systemName: "arrowshape.turn.up.left.fill")
+                .foregroundStyle(.tertiary)
+                .scaleEffect(indicatorScale)
+                .opacity(Double(progress))
+                .padding(.leading, DesignConstants.Spacing.step2x)
+                .accessibilityHidden(true)
+        }
+    }
+
+    private var gestureOverlay: some View {
+        GeometryReader { geometry in
+            GestureOverlayView(
+                contextMenuState: contextMenuState,
+                hasSingleTap: onSingleTap != nil,
+                excludedFrames: interactiveExclusionFrames,
+                onSingleTap: { onSingleTap?() },
+                onDoubleTap: {
+                    if let onDoubleTap {
+                        onDoubleTap()
+                    } else {
+                        UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                        onToggleReaction(doubleTapEmoji, message.messageId)
+                    }
+                },
+                onLongPress: {
+                    UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+                    let frame = geometry.frame(in: .global)
+                    contextMenuState.present(
+                        message: message,
+                        bubbleFrame: frame,
+                        bubbleStyle: bubbleStyle
+                    )
+                },
+                onSwipeOffsetChanged: { offset in
+                    swipeOffset = offset
+                    externalSwipeOffset?.wrappedValue = offset
+                },
+                onSwipeEnded: { triggered in
+                    withAnimation(.spring(response: 0.25, dampingFraction: 0.8)) {
+                        swipeOffset = 0
+                        externalSwipeOffset?.wrappedValue = 0
+                    }
+                    if triggered { onReply(message) }
+                },
+                onPressChanged: { pressed in
+                    isPressed = pressed
+                }
+            )
+        }
     }
 
     private enum Constant {

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
@@ -103,65 +103,10 @@ struct MessagesGroupItemView: View {
     private var messageContent: some View {
         switch message.content {
         case .text(let text):
-            MessageBubble(
-                style: message.content.isEmoji ? .none : bubbleType,
-                message: text,
-                isOutgoing: message.sender.isCurrentUser,
-                profile: message.sender.profile
-            )
-            .messageGesture(
-                message: message,
-                bubbleStyle: message.content.isEmoji ? .none : bubbleType,
-                onReply: onReply,
-                onToggleReaction: onToggleReaction
-            )
-            .id("bubble-\(message.messageId)")
-            .scaleEffect(isAppearing ? 0.9 : 1.0)
-            .rotationEffect(
-                .radians(
-                    isAppearing
-                    ? (message.source == .incoming ? -0.05 : 0.05)
-                    : 0
-                )
-            )
-            .offset(
-                x: isAppearing
-                ? (message.source == .incoming ? -20 : 20)
-                : 0,
-                y: isAppearing ? 40 : 0
-            )
-            .padding(.trailing, trailingPadding)
+            textBubble(text: text)
 
         case .emoji(let text):
-            EmojiBubble(
-                emoji: text,
-                isOutgoing: message.sender.isCurrentUser,
-                profile: message.sender.profile
-            )
-            .messageGesture(
-                message: message,
-                bubbleStyle: .none,
-                onReply: onReply,
-                onToggleReaction: onToggleReaction
-            )
-            .id("emoji-bubble-\(message.messageId)")
-            .opacity(isAppearing ? 0.0 : 1.0)
-            .blur(radius: isAppearing ? 10.0 : 0.0)
-            .scaleEffect(isAppearing ? 0.0 : 1.0)
-            .rotationEffect(
-                .radians(
-                    isAppearing
-                    ? (message.source == .incoming ? -0.10 : 0.10)
-                    : 0
-                )
-            )
-            .offset(
-                x: isAppearing
-                ? (message.source == .incoming ? -200 : 200)
-                : 0,
-                y: isAppearing ? 40 : 0
-            )
-            .padding(.trailing, trailingPadding)
+            emojiBubble(text: text)
 
         case .invite(let invite):
             MessageInviteContainerView(
@@ -265,6 +210,78 @@ struct MessagesGroupItemView: View {
                 EmptyView()
             }
         }
+    }
+
+    private var bubbleAppearingRotation: Double {
+        guard isAppearing else { return 0 }
+        return message.source == .incoming ? -0.05 : 0.05
+    }
+
+    private var bubbleAppearingOffsetX: CGFloat {
+        guard isAppearing else { return 0 }
+        return message.source == .incoming ? -20 : 20
+    }
+
+    private var bubbleAppearingOffsetY: CGFloat {
+        isAppearing ? 40 : 0
+    }
+
+    private var emojiAppearingRotation: Double {
+        guard isAppearing else { return 0 }
+        return message.source == .incoming ? -0.10 : 0.10
+    }
+
+    private var emojiAppearingOffsetX: CGFloat {
+        guard isAppearing else { return 0 }
+        return message.source == .incoming ? -200 : 200
+    }
+
+    @ViewBuilder
+    private func textBubble(text: String) -> some View {
+        let bubbleStyle: MessageBubbleType = message.content.isEmoji ? .none : bubbleType
+        let scale: CGFloat = isAppearing ? 0.9 : 1.0
+        MessageBubble(
+            style: bubbleStyle,
+            message: text,
+            isOutgoing: message.sender.isCurrentUser,
+            profile: message.sender.profile
+        )
+        .messageGesture(
+            message: message,
+            bubbleStyle: bubbleStyle,
+            onReply: onReply,
+            onToggleReaction: onToggleReaction
+        )
+        .id("bubble-\(message.messageId)")
+        .scaleEffect(scale)
+        .rotationEffect(.radians(bubbleAppearingRotation))
+        .offset(x: bubbleAppearingOffsetX, y: bubbleAppearingOffsetY)
+        .padding(.trailing, trailingPadding)
+    }
+
+    @ViewBuilder
+    private func emojiBubble(text: String) -> some View {
+        let opacity: Double = isAppearing ? 0.0 : 1.0
+        let blur: CGFloat = isAppearing ? 10.0 : 0.0
+        let scale: CGFloat = isAppearing ? 0.0 : 1.0
+        EmojiBubble(
+            emoji: text,
+            isOutgoing: message.sender.isCurrentUser,
+            profile: message.sender.profile
+        )
+        .messageGesture(
+            message: message,
+            bubbleStyle: .none,
+            onReply: onReply,
+            onToggleReaction: onToggleReaction
+        )
+        .id("emoji-bubble-\(message.messageId)")
+        .opacity(opacity)
+        .blur(radius: blur)
+        .scaleEffect(scale)
+        .rotationEffect(.radians(emojiAppearingRotation))
+        .offset(x: emojiAppearingOffsetX, y: bubbleAppearingOffsetY)
+        .padding(.trailing, trailingPadding)
     }
 
     @ViewBuilder


### PR DESCRIPTION
## Summary

Adds a SwiftLint custom rule that catches the dominant cause of `expression took N ms to type-check` build failures in this codebase: multiple inline ternaries inside a single chained `.modifier(...)` call.

The regex requires an indented chained call (`(?m)^\s+\.method(...)` form) so it skips enum case constructors and regular function calls — verified against the whole repo, zero false positives after the two fixes in this PR.

Single-ternary modifier args (e.g. `.opacity(isPressed ? 0.6 : 1.0)`) are intentionally not flagged — they don't blow up the solver on their own. Earlier I tried a broader version of the rule and it produced 209 hits, almost all benign.

Companion to #773 which adds the `Build Performance: Type-Check Time` section to `CLAUDE.md`.

## What's in this PR

- `.swiftlint.yml`: new `multiple_ternaries_in_modifier_arg` rule (warning).
- `MessageContextMenuWrapper.body(content:)`: hoist the two ternaries on the `.scaleEffect(...)` call to typed `let`s and extract three helper views so the body type-checks reliably.
- `MessagesGroupItemView.messageContent`: extract the `.text` and `.emoji` cases (each had a long chain of modifiers with nested ternaries) into `textBubble(text:)` / `emojiBubble(text:)` helpers and hoist the appearing-transform values to dedicated computed properties.

## Test plan

- [x] Custom rule verified on a fixture with bad/good cases — fires only on multi-ternary chained modifier calls; correctly excludes string literals, optional chaining, nil-coalescing, and single ternaries.
- [x] `swiftlint lint` reports 0 violations of the new rule across the repo.
- [x] `swiftlint --strict` passes on the touched Swift files.

## Known flakes

The codebase has several other type-check expressions sitting at the 100ms boundary (e.g. `MessageContextMenuOverlay.reactionsBarContent`, `AppSettingsView.body`, `ConnectionGrantRequestCardView.card`) that flare on some builds and pass on others. Those are unrelated to this rule and exist on `dev` today — addressing them is follow-up work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Flag multiple ternary operators in a single SwiftUI modifier call with SwiftLint
> - Adds a custom SwiftLint rule `multiple_ternaries_in_modifier_arg` in [.swiftlint.yml](.swiftlint.yml) that emits a warning when multiple ternaries appear in one modifier argument, excluding strings and comments.
> - Refactors [MessageContextMenuWrapper.swift](https://github.com/xmtplabs/convos-ios/pull/774/files#diff-56c11050397716624973b3debe7a9f3701baf1e15d9d091cabc6e9ed0acaf076) and [MessagesGroupItemView.swift](https://github.com/xmtplabs/convos-ios/pull/774/files#diff-34b33cae925fe553d357af97d04319b8de2de329c1903afe72c915e36aa98774) to comply: inline ternaries are replaced with typed local constants and extracted `@ViewBuilder` helpers.
> - Documents compiler type-check thresholds (100ms) and guidance on avoiding nested ternaries in [CLAUDE.md](https://github.com/xmtplabs/convos-ios/pull/774/files#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ad79bcf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->