### PR TITLE
Contacts MVP - PRD

### DIFF
--- a/docs/plans/contact-list-mocks/01-contacts-list.svg
+++ b/docs/plans/contact-list-mocks/01-contacts-list.svg
@@ -1,0 +1,92 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 693" width="320" height="693" role="img" aria-label="Contacts list">
+<title>Contacts list</title>
+
+  <rect x="1.5" y="1.5" width="317" height="690" rx="34" ry="34" fill="#000" stroke="#2a2a2a" stroke-width="3"/>
+  <rect x="122" y="6" width="76" height="18" rx="9" ry="9" fill="#000"/>
+
+
+  <text x="20" y="22" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="11" font-weight="400" fill="#fff" text-anchor="start">4:35</text>
+  <text x="270" y="22" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="9" font-weight="400" fill="#fff" text-anchor="start">SOS</text>
+  <rect x="288" y="14" width="14" height="9" rx="2" fill="none" stroke="#fff" stroke-width="0.8"/>
+  <rect x="290" y="16" width="6" height="5" fill="#fff"/>
+  <circle cx="284" cy="19" r="1" fill="#fff"/>
+  <path d="M 278 21 a 4 4 0 0 1 8 0" fill="none" stroke="#fff" stroke-width="0.8"/>
+
+<rect x="14" y="36" width="102" height="32" rx="16" fill="#1c1c1e"/>
+<circle cx="28" cy="52" r="6" fill="#fff"/>
+<text x="42" y="56" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="13" font-weight="400" fill="#fff" text-anchor="start">Contacts</text>
+<rect x="270" y="36" width="36" height="32" rx="16" fill="#1c1c1e"/>
+<text x="288" y="56" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="16" font-weight="400" fill="#fff" text-anchor="middle">≡</text>
+
+  <rect x="14" y="82" width="292" height="30" rx="15" fill="#1c1c1e"/>
+  <circle cx="32" cy="97" r="5" fill="none" stroke="#8e8e93" stroke-width="1.2"/>
+  <line x1="36" y1="101" x2="40" y2="105" stroke="#8e8e93" stroke-width="1.2"/>
+  <text x="48" y="101" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="12" font-weight="400" fill="#8e8e93" text-anchor="start">Search contacts</text>
+
+<text x="20" y="132" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="10.5" font-weight="400" fill="#8e8e93" text-anchor="start">14 contacts · auto-added from your convos</text>
+<text x="20" y="155" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="11" font-weight="400" fill="#8e8e93" text-anchor="start">C</text>
+
+    
+    
+  <circle cx="34" cy="178" r="17" fill="#5a3a2a"/>
+  <text x="34" y="182.33333333333334" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="13" font-weight="500" fill="#d1d1d6" text-anchor="middle">CD</text>
+
+    <text x="60" y="174" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="13" font-weight="500" fill="#fff" text-anchor="start">Cam Droid</text>
+    <text x="60" y="190" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="11" font-weight="400" fill="#8e8e93" text-anchor="start">2 shared convos · 1w</text>
+    
+  
+
+    
+    
+  <circle cx="34" cy="220" r="17" fill="#2c2c2e"/>
+  <text x="34" y="224.33333333333334" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="13" font-weight="500" fill="#d1d1d6" text-anchor="middle">CP</text>
+
+    <text x="60" y="216" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="13" font-weight="500" fill="#fff" text-anchor="start">Cam iPhone</text>
+    <text x="60" y="232" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="11" font-weight="400" fill="#8e8e93" text-anchor="start">3 shared convos</text>
+    
+  
+<text x="20" y="258" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="11" font-weight="400" fill="#8e8e93" text-anchor="start">G</text>
+
+    
+    
+  <circle cx="34" cy="281" r="17" fill="#2c2c2e"/>
+  <text x="34" y="285.3333333333333" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="13" font-weight="500" fill="#d1d1d6" text-anchor="middle">G</text>
+
+    <text x="60" y="277" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="13" font-weight="500" fill="#fff" text-anchor="start">Gerald</text>
+    <text x="60" y="293" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="11" font-weight="400" fill="#8e8e93" text-anchor="start">1 shared convo · 4d</text>
+    
+  
+<text x="20" y="319" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="11" font-weight="400" fill="#8e8e93" text-anchor="start">Q</text>
+
+    
+    
+  <circle cx="34" cy="342" r="17" fill="#5a3a2a"/>
+  <text x="34" y="346.3333333333333" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="13" font-weight="500" fill="#d1d1d6" text-anchor="middle">Q</text>
+
+    <text x="60" y="338" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="13" font-weight="500" fill="#fff" text-anchor="start">Quarter</text>
+    <text x="60" y="354" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="11" font-weight="400" fill="#8e8e93" text-anchor="start">added 7m ago via The Dev Convosation</text>
+    
+  
+<text x="20" y="380" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="11" font-weight="400" fill="#8e8e93" text-anchor="start">S</text>
+
+    
+    
+  <circle cx="34" cy="403" r="17" fill="#2c2c2e"/>
+  <text x="34" y="407.3333333333333" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="13" font-weight="500" fill="#d1d1d6" text-anchor="middle">S</text>
+
+    <text x="60" y="399" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="13" font-weight="500" fill="#fff" text-anchor="start">Saul</text>
+    <text x="60" y="415" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="11" font-weight="400" fill="#8e8e93" text-anchor="start">2 shared convos · 1w</text>
+    
+  
+<text x="20" y="441" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="11" font-weight="400" fill="#8e8e93" text-anchor="start">Y</text>
+
+    
+    
+  <circle cx="34" cy="464" r="17" fill="#2c2c2e"/>
+  <text x="34" y="468.3333333333333" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="13" font-weight="500" fill="#d1d1d6" text-anchor="middle">Y</text>
+
+    <text x="60" y="460" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="13" font-weight="500" fill="#fff" text-anchor="start">yewreeka</text>
+    <text x="60" y="476" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="11" font-weight="400" fill="#8e8e93" text-anchor="start">2 shared convos</text>
+    
+  
+</svg>

--- a/docs/plans/contact-list-mocks/02-contact-card.svg
+++ b/docs/plans/contact-list-mocks/02-contact-card.svg
@@ -1,0 +1,49 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 693" width="320" height="693" role="img" aria-label="Contact card">
+<title>Contact card</title>
+
+  <rect x="1.5" y="1.5" width="317" height="690" rx="34" ry="34" fill="#000" stroke="#2a2a2a" stroke-width="3"/>
+  <rect x="122" y="6" width="76" height="18" rx="9" ry="9" fill="#000"/>
+
+
+  <text x="20" y="22" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="11" font-weight="400" fill="#fff" text-anchor="start">4:35</text>
+  <text x="270" y="22" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="9" font-weight="400" fill="#fff" text-anchor="start">SOS</text>
+  <rect x="288" y="14" width="14" height="9" rx="2" fill="none" stroke="#fff" stroke-width="0.8"/>
+  <rect x="290" y="16" width="6" height="5" fill="#fff"/>
+  <circle cx="284" cy="19" r="1" fill="#fff"/>
+  <path d="M 278 21 a 4 4 0 0 1 8 0" fill="none" stroke="#fff" stroke-width="0.8"/>
+
+<rect x="14" y="36" width="32" height="32" rx="16" fill="#1c1c1e"/>
+<text x="30" y="57" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="13" font-weight="400" fill="#fff" text-anchor="middle">✕</text>
+<circle cx="160" cy="130" r="36" fill="#5a3a2a"/>
+<text x="160" y="138" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="26" font-weight="500" fill="#fff" text-anchor="middle">Q</text>
+<text x="160" y="190" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="20" font-weight="500" fill="#fff" text-anchor="middle">Quarter</text>
+<text x="160" y="210" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="11" font-weight="400" fill="#8e8e93" text-anchor="middle">"working on dev convosation"</text>
+<text x="160" y="226" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="10.5" font-weight="400" fill="#6e6e73" text-anchor="middle">added 7m ago · via The Dev Convosation</text>
+<rect x="20" y="250" width="280" height="36" rx="18" fill="#fff"/>
+<text x="160" y="273" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="13" font-weight="500" fill="#000" text-anchor="middle">Send a message</text>
+<text x="20" y="320" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="11" font-weight="400" fill="#8e8e93" text-anchor="start">Conversations you share (3)</text>
+<rect x="14" y="334" width="292" height="50" rx="14" fill="#1c1c1e"/>
+
+  <circle cx="36" cy="359" r="16" fill="#5a3a2a"/>
+  <text x="36" y="363.3333333333333" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="13" font-weight="500" fill="#d1d1d6" text-anchor="middle">Q</text>
+
+<text x="60" y="354" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="13" font-weight="500" fill="#fff" text-anchor="start">Direct</text>
+<text x="60" y="370" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="11" font-weight="400" fill="#8e8e93" text-anchor="start">5h · "sounds good"</text>
+<text x="298" y="363" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="16" font-weight="400" fill="#48484a" text-anchor="middle">›</text>
+<rect x="14" y="392" width="292" height="50" rx="14" fill="#1c1c1e"/>
+
+  <circle cx="36" cy="417" r="16" fill="#5a3a2a"/>
+  <text x="36" y="420.6666666666667" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="11" font-weight="500" fill="#d1d1d6" text-anchor="middle">DC</text>
+
+<text x="60" y="412" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="13" font-weight="500" fill="#fff" text-anchor="start">The Dev Convosation</text>
+<text x="60" y="428" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="11" font-weight="400" fill="#8e8e93" text-anchor="start">7m · 4 members</text>
+<text x="298" y="421" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="16" font-weight="400" fill="#48484a" text-anchor="middle">›</text>
+<rect x="14" y="450" width="292" height="50" rx="14" fill="#1c1c1e"/>
+
+  <circle cx="36" cy="475" r="16" fill="#2c2c2e"/>
+  <text x="36" y="479.3333333333333" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="13" font-weight="500" fill="#d1d1d6" text-anchor="middle">T</text>
+
+<text x="60" y="470" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="13" font-weight="500" fill="#fff" text-anchor="start">Team weekend updates!</text>
+<text x="60" y="486" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="11" font-weight="400" fill="#8e8e93" text-anchor="start">5h · 5 members</text>
+<text x="298" y="479" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="16" font-weight="400" fill="#48484a" text-anchor="middle">›</text>
+</svg>

--- a/docs/plans/contact-list-mocks/03-inbound-in-feed.svg
+++ b/docs/plans/contact-list-mocks/03-inbound-in-feed.svg
@@ -1,0 +1,96 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 693" width="320" height="693" role="img" aria-label="Inbound chats inline in main feed">
+<title>Inbound chats inline in main feed</title>
+
+  <rect x="1.5" y="1.5" width="317" height="690" rx="34" ry="34" fill="#000" stroke="#2a2a2a" stroke-width="3"/>
+  <rect x="122" y="6" width="76" height="18" rx="9" ry="9" fill="#000"/>
+
+
+  <text x="20" y="22" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="11" font-weight="400" fill="#fff" text-anchor="start">4:35</text>
+  <text x="270" y="22" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="9" font-weight="400" fill="#fff" text-anchor="start">SOS</text>
+  <rect x="288" y="14" width="14" height="9" rx="2" fill="none" stroke="#fff" stroke-width="0.8"/>
+  <rect x="290" y="16" width="6" height="5" fill="#fff"/>
+  <circle cx="284" cy="19" r="1" fill="#fff"/>
+  <path d="M 278 21 a 4 4 0 0 1 8 0" fill="none" stroke="#fff" stroke-width="0.8"/>
+
+
+  <rect x="14" y="36" width="92" height="32" rx="16" fill="#1c1c1e"/>
+  <circle cx="28" cy="52" r="6" fill="#fff"/>
+  <text x="42" y="56" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="13" font-weight="400" fill="#fff" text-anchor="start">Convos</text>
+  <rect x="270" y="36" width="36" height="32" rx="16" fill="#1c1c1e"/>
+  <text x="288" y="56" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="16" font-weight="400" fill="#fff" text-anchor="middle">≡</text>
+
+<rect x="8" y="86" width="304" height="56" rx="14" fill="#0e0c06"/>
+
+  <circle cx="34" cy="114" r="17" fill="#2d4a2a"/>
+  <ellipse cx="34" cy="113" rx="9.350000000000001" ry="11.899999999999999" fill="#5a8a4a"/>
+  <circle cx="36" cy="110" r="1.6" fill="#1a2a1a"/>
+  <path d="M 42.5 113 l 7.65 2 l -7.65 2 z" fill="#d8a838"/>
+
+<circle cx="60" cy="106" r="3" fill="#f0c060"/>
+<text x="70" y="109" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="13" font-weight="500" fill="#fff" text-anchor="start">New Convo</text>
+<rect x="140" y="99" width="84" height="14" rx="7" fill="#1f180a"/>
+<text x="182" y="109" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="9" font-weight="400" fill="#f0c060" text-anchor="middle">Saul added you</text>
+<text x="60" y="125" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="11" font-weight="400" fill="#8e8e93" text-anchor="start">5h · "hey, jumping you in here"</text>
+
+    
+    
+  <circle cx="34" cy="176" r="17" fill="#5a3a2a"/>
+  <text x="34" y="180.33333333333334" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="13" font-weight="500" fill="#d1d1d6" text-anchor="middle">CP</text>
+
+    <text x="60" y="172" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="13" font-weight="500" fill="#fff" text-anchor="start">Cam's phones</text>
+    <text x="60" y="188" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="11" font-weight="400" fill="#8e8e93" text-anchor="start">32s · "Done — I'm Meal Planne…</text>
+    
+  
+
+    
+    
+  <circle cx="34" cy="218" r="17" fill="#5a3a2a"/>
+  <text x="34" y="222.33333333333334" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="13" font-weight="500" fill="#d1d1d6" text-anchor="middle">DC</text>
+
+    <text x="60" y="214" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="13" font-weight="500" fill="#fff" text-anchor="start">The Dev Convosation</text>
+    <text x="60" y="230" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="11" font-weight="400" fill="#8e8e93" text-anchor="start">7m · "Quarter heart'd a message"</text>
+    <circle cx="296" cy="214" r="4" fill="#fff"/>
+  
+
+    
+    
+  <circle cx="34" cy="260" r="17" fill="#2d4a2a"/>
+  <ellipse cx="34" cy="259" rx="9.350000000000001" ry="11.899999999999999" fill="#5a8a4a"/>
+  <circle cx="36" cy="256" r="1.6" fill="#1a2a1a"/>
+  <path d="M 42.5 259 l 7.65 2 l -7.65 2 z" fill="#d8a838"/>
+
+    <text x="60" y="256" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="13" font-weight="500" fill="#fff" text-anchor="start">New Convo</text>
+    <text x="60" y="272" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="11" font-weight="400" fill="#8e8e93" text-anchor="start">5h</text>
+    
+  
+
+    
+    
+  <circle cx="34" cy="302" r="17" fill="#2c2c2e"/>
+  <text x="34" y="306.3333333333333" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="13" font-weight="500" fill="#d1d1d6" text-anchor="middle">T</text>
+
+    <text x="60" y="298" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="13" font-weight="500" fill="#fff" text-anchor="start">Team weekend updates!</text>
+    <text x="60" y="314" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="11" font-weight="400" fill="#8e8e93" text-anchor="start">5h · "You: Test"</text>
+    
+  
+
+    
+    
+  <circle cx="34" cy="344" r="17" fill="#2c2c2e"/>
+  <text x="34" y="348.3333333333333" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="13" font-weight="500" fill="#d1d1d6" text-anchor="middle">S</text>
+
+    <text x="60" y="340" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="13" font-weight="500" fill="#fff" text-anchor="start">Dev Convosation</text>
+    <text x="60" y="356" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="11" font-weight="400" fill="#8e8e93" text-anchor="start">3d · "Verifying"</text>
+    
+  
+
+    
+    
+  <circle cx="34" cy="386" r="17" fill="#2c2c2e"/>
+  <text x="34" y="390.3333333333333" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="13" font-weight="500" fill="#d1d1d6" text-anchor="middle">G</text>
+
+    <text x="60" y="382" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="13" font-weight="500" fill="#fff" text-anchor="start">Gerald</text>
+    <text x="60" y="398" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="11" font-weight="400" fill="#8e8e93" text-anchor="start">4d · "Email provisioning isn'…</text>
+    
+  
+</svg>

--- a/docs/plans/contact-list-mocks/04-add-from-contacts-menu.svg
+++ b/docs/plans/contact-list-mocks/04-add-from-contacts-menu.svg
@@ -1,0 +1,80 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 693" width="320" height="693" role="img" aria-label="Add from Contacts in chat plus-menu">
+<title>Add from Contacts in chat plus-menu</title>
+
+  <rect x="1.5" y="1.5" width="317" height="690" rx="34" ry="34" fill="#000" stroke="#2a2a2a" stroke-width="3"/>
+  <rect x="122" y="6" width="76" height="18" rx="9" ry="9" fill="#000"/>
+
+
+  <text x="20" y="22" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="11" font-weight="400" fill="#fff" text-anchor="start">4:35</text>
+  <text x="270" y="22" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="9" font-weight="400" fill="#fff" text-anchor="start">SOS</text>
+  <rect x="288" y="14" width="14" height="9" rx="2" fill="none" stroke="#fff" stroke-width="0.8"/>
+  <rect x="290" y="16" width="6" height="5" fill="#fff"/>
+  <circle cx="284" cy="19" r="1" fill="#fff"/>
+  <path d="M 278 21 a 4 4 0 0 1 8 0" fill="none" stroke="#fff" stroke-width="0.8"/>
+
+
+  <rect x="14" y="36" width="32" height="32" rx="16" fill="#1c1c1e"/>
+  <text x="30" y="56" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="18" font-weight="400" fill="#fff" text-anchor="middle">‹</text>
+  <rect x="54" y="36" width="212" height="32" rx="16" fill="#1c1c1e"/>
+  <text x="160" y="56" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="12" font-weight="400" fill="#fff" text-anchor="middle">The Dev Convosation</text>
+  <rect x="274" y="36" width="32" height="32" rx="16" fill="#2c2c2e"/>
+  <text x="290" y="57" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="16" font-weight="400" fill="#fff" text-anchor="middle">+</text>
+
+<g opacity="0.35">
+
+  <circle cx="20" cy="100" r="10" fill="#5a3a2a"/>
+  <text x="20" y="103" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="9" font-weight="500" fill="#d1d1d6" text-anchor="middle">Q</text>
+
+<rect x="34" y="90" width="130" height="22" rx="11" fill="#1c1c1e"/>
+<text x="40" y="105" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="11" font-weight="400" fill="#fff" text-anchor="start">URL is live</text>
+<rect x="196" y="124" width="110" height="22" rx="11" fill="#fff"/>
+<text x="204" y="139" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="11" font-weight="400" fill="#000" text-anchor="start">Great, ship it</text>
+
+  <circle cx="20" cy="168" r="10" fill="#5a3a2a"/>
+  <text x="20" y="171" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="9" font-weight="500" fill="#d1d1d6" text-anchor="middle">Q</text>
+
+<rect x="34" y="158" width="145" height="22" rx="11" fill="#1c1c1e"/>
+<text x="40" y="173" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="11" font-weight="400" fill="#fff" text-anchor="start">Done — chef emoji set</text>
+<rect x="14" y="629" width="292" height="32" rx="16" fill="#1c1c1e"/>
+<text x="28" y="649" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="14" font-weight="400" fill="#6e6e73" text-anchor="start">›</text>
+
+  <circle cx="50" cy="645" r="10" fill="#5a3a2a"/>
+  <text x="50" y="649.3333333333334" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="13" font-weight="500" fill="#d1d1d6" text-anchor="middle"></text>
+
+<text x="72" y="649" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="11.5" font-weight="400" fill="#6e6e73" text-anchor="start">Chat as Cam iPhone</text>
+<text x="292" y="649" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="14" font-weight="400" fill="#6e6e73" text-anchor="middle">↑</text>
+</g>
+<rect x="86" y="80" width="220" height="178" rx="18" fill="#28282a"/>
+<g transform="translate(96, 92)">
+       <circle cx="14" cy="14" r="14" fill="transparent"/>
+       <path d="M 7 16 a 3 3 0 0 0 4 0 l 4 -4 a 3 3 0 0 0 -4 -4 l -1 1" fill="none" stroke="#fff" stroke-width="1.6" stroke-linecap="round"/>
+       <path d="M 13 12 a 3 3 0 0 0 -4 0 l -4 4 a 3 3 0 0 0 4 4 l 1 -1" fill="none" stroke="#fff" stroke-width="1.6" stroke-linecap="round"/>
+       <text x="36" y="13" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="13" font-weight="500" fill="#fff" text-anchor="start">Invite link</text>
+       <text x="36" y="27" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="10.5" font-weight="400" fill="#8e8e93" text-anchor="start">Copy to clipboard</text>
+     </g>
+<g transform="translate(96, 142)">
+       <rect x="2" y="2" width="11" height="11" fill="none" stroke="#fff" stroke-width="1.5"/>
+       <rect x="15" y="2" width="11" height="11" fill="none" stroke="#fff" stroke-width="1.5"/>
+       <rect x="2" y="15" width="11" height="11" fill="none" stroke="#fff" stroke-width="1.5"/>
+       <rect x="5" y="5" width="5" height="5" fill="#fff"/>
+       <rect x="18" y="5" width="5" height="5" fill="#fff"/>
+       <rect x="5" y="18" width="5" height="5" fill="#fff"/>
+       <rect x="16" y="16" width="3" height="3" fill="#fff"/>
+       <rect x="22" y="16" width="3" height="3" fill="#fff"/>
+       <rect x="16" y="22" width="3" height="3" fill="#fff"/>
+       <rect x="22" y="22" width="3" height="3" fill="#fff"/>
+       <text x="36" y="13" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="13" font-weight="500" fill="#fff" text-anchor="start">Convo code</text>
+       <text x="36" y="27" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="10.5" font-weight="400" fill="#8e8e93" text-anchor="start">Show, share or AirDrop it</text>
+     </g>
+<rect x="90" y="196" width="212" height="52" rx="12" fill="rgba(240,192,96,0.10)"/>
+<g transform="translate(96, 200)">
+       <circle cx="9" cy="9" r="4" fill="none" stroke="#fff" stroke-width="1.6"/>
+       <path d="M 2 22 c 0 -4 3 -7 7 -7 s 7 3 7 7" fill="none" stroke="#fff" stroke-width="1.6" stroke-linecap="round"/>
+       <circle cx="20" cy="6" r="2.4" fill="none" stroke="#fff" stroke-width="1.6"/>
+       <path d="M 17 16 c 4 0 7 1.5 7 4" fill="none" stroke="#fff" stroke-width="1.6" stroke-linecap="round"/>
+       <text x="36" y="14" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="13" font-weight="500" fill="#fff" text-anchor="start">Add from Contacts</text>
+       <text x="36" y="28" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="10.5" font-weight="400" fill="#8e8e93" text-anchor="start">Pick from your contact list</text>
+     </g>
+<rect x="270" y="210" width="30" height="14" rx="7" fill="#2a1f0a"/>
+<text x="285" y="220" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="9" font-weight="400" fill="#f0c060" text-anchor="middle">new</text>
+</svg>

--- a/docs/plans/contact-list-mocks/05-contacts-toolbar-icon.svg
+++ b/docs/plans/contact-list-mocks/05-contacts-toolbar-icon.svg
@@ -1,0 +1,100 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 693" width="320" height="693" role="img" aria-label="Contacts icon in conversations toolbar">
+<title>Contacts icon in conversations toolbar</title>
+
+  <rect x="1.5" y="1.5" width="317" height="690" rx="34" ry="34" fill="#000" stroke="#2a2a2a" stroke-width="3"/>
+  <rect x="122" y="6" width="76" height="18" rx="9" ry="9" fill="#000"/>
+
+
+  <text x="20" y="22" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="11" font-weight="400" fill="#fff" text-anchor="start">4:35</text>
+  <text x="270" y="22" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="9" font-weight="400" fill="#fff" text-anchor="start">SOS</text>
+  <rect x="288" y="14" width="14" height="9" rx="2" fill="none" stroke="#fff" stroke-width="0.8"/>
+  <rect x="290" y="16" width="6" height="5" fill="#fff"/>
+  <circle cx="284" cy="19" r="1" fill="#fff"/>
+  <path d="M 278 21 a 4 4 0 0 1 8 0" fill="none" stroke="#fff" stroke-width="0.8"/>
+
+
+  <rect x="14" y="36" width="92" height="32" rx="16" fill="#1c1c1e"/>
+  <circle cx="28" cy="52" r="6" fill="#fff"/>
+  <text x="42" y="56" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="13" font-weight="400" fill="#fff" text-anchor="start">Convos</text>
+  <rect x="270" y="36" width="36" height="32" rx="16" fill="#1c1c1e"/>
+  <text x="288" y="56" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="16" font-weight="400" fill="#fff" text-anchor="middle">≡</text>
+
+
+    
+    
+  <circle cx="34" cy="96" r="17" fill="#5a3a2a"/>
+  <text x="34" y="100.33333333333333" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="13" font-weight="500" fill="#d1d1d6" text-anchor="middle">CP</text>
+
+    <text x="60" y="92" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="13" font-weight="500" fill="#fff" text-anchor="start">Cam's phones</text>
+    <text x="60" y="108" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="11" font-weight="400" fill="#8e8e93" text-anchor="start">32s · "Done — I'm Meal Planne…</text>
+    
+  
+
+    
+    
+  <circle cx="34" cy="138" r="17" fill="#5a3a2a"/>
+  <text x="34" y="142.33333333333334" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="13" font-weight="500" fill="#d1d1d6" text-anchor="middle">DC</text>
+
+    <text x="60" y="134" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="13" font-weight="500" fill="#fff" text-anchor="start">The Dev Convosation</text>
+    <text x="60" y="150" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="11" font-weight="400" fill="#8e8e93" text-anchor="start">7m · "Quarter heart'd a message"</text>
+    <circle cx="296" cy="134" r="4" fill="#fff"/>
+  
+
+    
+    
+  <circle cx="34" cy="180" r="17" fill="#2d4a2a"/>
+  <ellipse cx="34" cy="179" rx="9.350000000000001" ry="11.899999999999999" fill="#5a8a4a"/>
+  <circle cx="36" cy="176" r="1.6" fill="#1a2a1a"/>
+  <path d="M 42.5 179 l 7.65 2 l -7.65 2 z" fill="#d8a838"/>
+
+    <text x="60" y="176" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="13" font-weight="500" fill="#fff" text-anchor="start">New Convo</text>
+    <text x="60" y="192" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="11" font-weight="400" fill="#8e8e93" text-anchor="start">5h</text>
+    
+  
+
+    
+    
+  <circle cx="34" cy="222" r="17" fill="#2c2c2e"/>
+  <text x="34" y="226.33333333333334" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="13" font-weight="500" fill="#d1d1d6" text-anchor="middle">T</text>
+
+    <text x="60" y="218" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="13" font-weight="500" fill="#fff" text-anchor="start">Team weekend updates!</text>
+    <text x="60" y="234" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="11" font-weight="400" fill="#8e8e93" text-anchor="start">5h · "You: Test"</text>
+    
+  
+
+    
+    
+  <circle cx="34" cy="264" r="17" fill="#2c2c2e"/>
+  <text x="34" y="268.3333333333333" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="13" font-weight="500" fill="#d1d1d6" text-anchor="middle">S</text>
+
+    <text x="60" y="260" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="13" font-weight="500" fill="#fff" text-anchor="start">Dev Convosation</text>
+    <text x="60" y="276" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="11" font-weight="400" fill="#8e8e93" text-anchor="start">3d · "Verifying"</text>
+    
+  
+
+    
+    
+  <circle cx="34" cy="306" r="17" fill="#2c2c2e"/>
+  <text x="34" y="310.3333333333333" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="13" font-weight="500" fill="#d1d1d6" text-anchor="middle">G</text>
+
+    <text x="60" y="302" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="13" font-weight="500" fill="#fff" text-anchor="start">Gerald</text>
+    <text x="60" y="318" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="11" font-weight="400" fill="#8e8e93" text-anchor="start">4d · "Email provisioning isn'…</text>
+    
+  
+<rect x="186" y="637" width="120" height="40" rx="20" fill="#1c1c1e"/>
+<g transform="translate(198, 645)">
+       <path d="M 2 6 V 2 H 6 M 22 6 V 2 H 18 M 2 18 V 22 H 6 M 22 18 V 22 H 18" fill="none" stroke="#fff" stroke-width="1.5" stroke-linecap="round"/>
+     </g>
+<g transform="translate(234, 645)">
+       <circle cx="3" cy="4" r="1.4" fill="#fff"/>
+       <circle cx="3" cy="12" r="1.4" fill="#fff"/>
+       <circle cx="3" cy="20" r="1.4" fill="#fff"/>
+       <line x1="8" y1="4" x2="20" y2="4" stroke="#fff" stroke-width="1.6" stroke-linecap="round"/>
+       <line x1="8" y1="12" x2="20" y2="12" stroke="#fff" stroke-width="1.6" stroke-linecap="round"/>
+       <line x1="8" y1="20" x2="20" y2="20" stroke="#fff" stroke-width="1.6" stroke-linecap="round"/>
+     </g>
+<g transform="translate(270, 645)">
+       <path d="M 2 18 H 22" fill="none" stroke="#fff" stroke-width="1.5" stroke-linecap="round"/>
+       <path d="M 16 2 l 4 4 l -12 12 H 4 v -4 z" fill="none" stroke="#fff" stroke-width="1.5" stroke-linejoin="round"/>
+     </g>
+</svg>

--- a/docs/plans/contact-list-mocks/06-contacts-picker.svg
+++ b/docs/plans/contact-list-mocks/06-contacts-picker.svg
@@ -1,0 +1,91 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 693" width="320" height="693" role="img" aria-label="Contacts picker invoked from chat plus-menu">
+<title>Contacts picker invoked from chat plus-menu</title>
+
+  <rect x="1.5" y="1.5" width="317" height="690" rx="34" ry="34" fill="#000" stroke="#2a2a2a" stroke-width="3"/>
+  <rect x="122" y="6" width="76" height="18" rx="9" ry="9" fill="#000"/>
+
+
+  <text x="20" y="22" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="11" font-weight="400" fill="#fff" text-anchor="start">4:35</text>
+  <text x="270" y="22" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="9" font-weight="400" fill="#fff" text-anchor="start">SOS</text>
+  <rect x="288" y="14" width="14" height="9" rx="2" fill="none" stroke="#fff" stroke-width="0.8"/>
+  <rect x="290" y="16" width="6" height="5" fill="#fff"/>
+  <circle cx="284" cy="19" r="1" fill="#fff"/>
+  <path d="M 278 21 a 4 4 0 0 1 8 0" fill="none" stroke="#fff" stroke-width="0.8"/>
+
+<rect x="14" y="36" width="32" height="32" rx="16" fill="#1c1c1e"/>
+<text x="30" y="56" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="18" font-weight="400" fill="#fff" text-anchor="middle">‹</text>
+<rect x="54" y="36" width="212" height="32" rx="16" fill="#1c1c1e"/>
+<circle cx="70" cy="52" r="9" fill="#5a3a2a"/>
+<text x="70" y="55" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="9" font-weight="500" fill="#d1d1d6" text-anchor="middle">DC</text>
+<text x="166" y="56" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="11.5" font-weight="400" fill="#fff" text-anchor="middle">Add to The Dev Convosation</text>
+<rect x="274" y="36" width="32" height="32" rx="16" fill="#1c1c1e"/>
+<text x="290" y="56" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="12" font-weight="400" fill="#fff" text-anchor="middle">✕</text>
+<text x="20" y="88" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="11" font-weight="400" fill="#8e8e93" text-anchor="start">2 selected · tap to add or remove</text>
+
+  <rect x="14" y="100" width="292" height="30" rx="15" fill="#1c1c1e"/>
+  <circle cx="32" cy="115" r="5" fill="none" stroke="#8e8e93" stroke-width="1.2"/>
+  <line x1="36" y1="119" x2="40" y2="123" stroke="#8e8e93" stroke-width="1.2"/>
+  <text x="48" y="119" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="12" font-weight="400" fill="#8e8e93" text-anchor="start">Search contacts</text>
+
+<text x="20" y="152" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="11" font-weight="400" fill="#8e8e93" text-anchor="start">C</text>
+<g>
+    
+  <circle cx="34" cy="174" r="17" fill="#5a3a2a"/>
+  <text x="34" y="178.33333333333334" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="13" font-weight="500" fill="#d1d1d6" text-anchor="middle">CD</text>
+
+    <text x="60" y="170" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="13" font-weight="500" fill="#fff" text-anchor="start">Cam Droid</text>
+    <text x="60" y="186" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="11" font-weight="400" fill="#8e8e93" text-anchor="start">2 shared convos</text>
+    <circle cx="296" cy="174" r="9" fill="#fff"/><path d="M 292 175 l 3 3 l 6 -6" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  </g>
+<g>
+    
+  <circle cx="34" cy="214" r="17" fill="#2c2c2e"/>
+  <text x="34" y="218.33333333333334" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="13" font-weight="500" fill="#d1d1d6" text-anchor="middle">CP</text>
+
+    <text x="60" y="210" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="13" font-weight="500" fill="#fff" text-anchor="start">Cam iPhone</text>
+    <text x="60" y="226" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="11" font-weight="400" fill="#8e8e93" text-anchor="start">3 shared convos</text>
+    <circle cx="296" cy="214" r="9" fill="none" stroke="#48484a" stroke-width="1.5"/>
+  </g>
+<text x="20" y="250" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="11" font-weight="400" fill="#8e8e93" text-anchor="start">G</text>
+<g>
+    
+  <circle cx="34" cy="272" r="17" fill="#2c2c2e"/>
+  <text x="34" y="276.3333333333333" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="13" font-weight="500" fill="#d1d1d6" text-anchor="middle">G</text>
+
+    <text x="60" y="268" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="13" font-weight="500" fill="#fff" text-anchor="start">Gerald</text>
+    <text x="60" y="284" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="11" font-weight="400" fill="#8e8e93" text-anchor="start">1 shared convo · 4d</text>
+    <circle cx="296" cy="272" r="9" fill="#fff"/><path d="M 292 273 l 3 3 l 6 -6" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  </g>
+<text x="20" y="308" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="11" font-weight="400" fill="#8e8e93" text-anchor="start">M</text>
+<g opacity="0.45">
+    
+  <circle cx="34" cy="330" r="17" fill="#2c2c2e"/>
+  <text x="34" y="334.3333333333333" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="13" font-weight="500" fill="#d1d1d6" text-anchor="middle">M</text>
+
+    <text x="60" y="326" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="13" font-weight="500" fill="#fff" text-anchor="start">Maya</text>
+    <text x="60" y="342" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="11" font-weight="400" fill="#8e8e93" text-anchor="start">joined 2d ago</text>
+    <rect x="254" y="322" width="52" height="16" rx="8" fill="#1c1c1e"/><text x="280" y="333" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="9" font-weight="400" fill="#8e8e93" text-anchor="middle">in chat</text>
+  </g>
+<text x="20" y="366" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="11" font-weight="400" fill="#8e8e93" text-anchor="start">Q</text>
+<g opacity="0.45">
+    
+  <circle cx="34" cy="388" r="17" fill="#5a3a2a"/>
+  <text x="34" y="392.3333333333333" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="13" font-weight="500" fill="#d1d1d6" text-anchor="middle">Q</text>
+
+    <text x="60" y="384" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="13" font-weight="500" fill="#fff" text-anchor="start">Quarter</text>
+    <text x="60" y="400" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="11" font-weight="400" fill="#8e8e93" text-anchor="start">admin</text>
+    <rect x="254" y="380" width="52" height="16" rx="8" fill="#1c1c1e"/><text x="280" y="391" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="9" font-weight="400" fill="#8e8e93" text-anchor="middle">in chat</text>
+  </g>
+<text x="20" y="424" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="11" font-weight="400" fill="#8e8e93" text-anchor="start">Y</text>
+<g>
+    
+  <circle cx="34" cy="446" r="17" fill="#2c2c2e"/>
+  <text x="34" y="450.3333333333333" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="13" font-weight="500" fill="#d1d1d6" text-anchor="middle">Y</text>
+
+    <text x="60" y="442" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="13" font-weight="500" fill="#fff" text-anchor="start">yewreeka</text>
+    <text x="60" y="458" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="11" font-weight="400" fill="#8e8e93" text-anchor="start">2 shared convos</text>
+    <circle cx="296" cy="446" r="9" fill="none" stroke="#48484a" stroke-width="1.5"/>
+  </g>
+<rect x="20" y="613" width="280" height="40" rx="20" fill="#fff"/>
+<text x="160" y="638" font-family='-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif' font-size="13" font-weight="500" fill="#000" text-anchor="middle">Add 2 to convo</text>
+</svg>

--- a/docs/plans/contact-list-prd.md
+++ b/docs/plans/contact-list-prd.md
@@ -1,0 +1,840 @@
+# PRD: Contact List (Contacts MVP)
+
+> **Status**: Draft (post-review revisions)
+> **Author**: Cameron Voell
+> **Created**: 2026-04-28
+> **Updated**: 2026-04-30
+> **Companion 1-pager**: [contact-list.md](./contact-list.md) — wireframes and strategic framing
+> **Architecture review**: TODO — `swift-architect` agent
+
+## Overview
+
+Convos already has a contact list — it's smeared across every conversation. This feature names it: a local, GRDB-backed address book of every user the local user has shared a conversation with (and taken some explicit action with), keyed by `inboxId` under the single-inbox identity model ([ADR-011](../adr/011-single-inbox-identity-model.md)). Contacts are auto-populated when the local user takes an explicit action in a shared conversation, surfaced as a browseable list, navigable to a contact card, and reusable as a picker when starting new chats or adding members to existing ones.
+
+The contact list also drives **inbound conversation filtering**: a new conversation arriving from an `inboxId` that is in the local user's contact list lands directly in the main feed; one from an `inboxId` that is not in the contact list is ignored (and dropped after a reasonable time window). This is the mechanism Convos uses to gate "who is allowed to message me directly," replacing today's external invite only paradigm.
+
+**Two-step delivery.** This work ships in two discrete milestones:
+
+1. **Step 1 — Populate and view the contact list.** Auto-add contacts on first explicit action in a shared group; add new group members on join; expose the contact list from the Convos top-left menu (linked under "My info"); for conversations outside the existing invite flow - apply inbound conversation filtering so only contacts can land new conversations in the main feed.
+2. **Step 2 — Messaging and adding from contacts.** Add a contact picker UI for starting new conversations with one or more contacts; add members to existing groups from the picker; add a contact card with a "Send a message" CTA. The list of conversations shared with a contact, surfaced on the contact card, is a stretch item that may slip to a follow-up.
+
+The implementation leans heavily on existing primitives — `DBConversationMember` already has the right shape and index, the member-profile system from [ADR-005](../adr/005-member-profile-system.md) already produces profile data, and `ConversationsRepository` already publishes reactive feed updates. The new surface area is a contacts table, a sync coordinator, an inbound-filter check, and a small set of UI screens.
+
+## Problem Statement
+
+Today, a user who wants to start a new conversation with someone they already know on Convos has to generate a new invite link and forward it to that user in an existing group chat or external channel. Furthermore, there is no "people I know" surface that collapses cross-group acquaintance into a single searchable list. Equivalently, a user who wants to add a known person to an existing group chat has no way to do so without either re-inviting them externally or finding a shared group and pulling them through that. The data exists locally — every conversation has a member roster — but it isn't named or surfaced, or directly actionable.
+
+Separately, the inbound conversation surface today is **invite-flow-gated, not permissive**. The current gate at `StreamProcessor.shouldProcessConversation` (`ConvosCore/Sources/ConvosCore/Syncing/StreamProcessor.swift`, lines 713-739) lets a new conversation through only if (a) XMTP `consent == .allowed`, (b) the local user is the conversation creator, or (c) `consent == .unknown` and the local user has an outgoing join request for it via `InviteJoinRequestsManager`. Anything else is **silently dropped — never persisted**. In practice this means: the only conversations that land in the local DB today are ones the user created or joined via the Convos invite flow. A 1:1 DM sent directly to the local user's `inboxId` from someone the user has never invite-flow'd with is dropped on the floor (and DMs are not persisted as their own conversation rows in any case — they are used today purely as the transport for invite join-request payloads in `StreamProcessor.processMessage`, lines 184-311).
+
+The contacts feature both **opens this up** and **adds a new gate**. We want known contacts to be able to message the local user directly without needing a fresh invite handshake every time. We do not want to roll back to a fully permissive default. The new filter is: a contact can land, a stranger cannot, regardless of whether an invite handshake happened.
+
+Naming "contacts" as a first-class concept solves both problems at once. It unlocks profile-first navigation (tap a person, message them directly), removes redundant work from common flows (DM-from-group, add-known-person-to-chat), and serves as the gating set for inbound conversations — anyone in the contact list can message the local user directly; everyone else is held or rejected. It also creates a foundation that later features (cross-device backups, mentions, message forwarding) can build against.
+
+## Goals
+
+### Step 1 — Populate and view
+
+Step 1 is purely additive: build the contact list, keep it accurate, and let the user browse it. No behavior changes for existing users — no filtering, no blocking, nothing that affects what lands in the main feed.
+
+- [ ] **Local contact list.** A GRDB-backed table of contacts, keyed by `inboxId`, populated by explicit action in shared conversations, queryable in an alphabetical list.
+- [ ] **Auto-add on first explicit action in a group.** When the local user joins a new group via invite, the other members are added to the contact list **as soon as the local user sends their first message in that group** — not on join. This treats sending a message as the explicit "I want to be in this conversation" signal.
+- [ ] **Auto-add new members of existing groups.** When the local user is already in a group and a new member joins, that new member is added to the contact list immediately.
+- [ ] **One-time backfill on first launch post-feature.** Every existing conversation on the device that the local user has clearly acted in (i.e., sent at least one message) is scanned once, its members upserted into the contacts table, and the conversation marked synced; never re-scanned.
+- [ ] **Contact list entry from the Convos menu.** The contact list is reachable from the Convos top-left menu (the same menu that surfaces "My info", "Assistants", "Customize", etc.), placed under the "My info" row. There is **no** new toolbar icon on the conversations list.
+
+### Step 2 — Messaging, filtering, and blocking
+
+Step 2 is where the contact list starts gating behavior. It introduces messaging from contacts, the contact-gated inbound filter, and blocking. By landing all behavior changes together in one step, we avoid shipping a silent filter without giving users the messaging-from-contacts affordance that motivates it.
+
+- [ ] **Contact card.** Tap a contact to see their profile (name, avatar, bio) and a "Send a message" CTA that lets the local user start a new conversation with that contact.
+- [ ] **Contact picker for new conversations.** From the contact card "Send a message" CTA, or from a top-level "new conversation" affordance, the local user picks one or more contacts to start a new conversation with. The picker uses the design with a "To: <bubbles>" header that fills with selected names, a Favorites section, an alphabetical-only main list, and a side-letter index (matching the attached UI mock).
+- [ ] **Messaging from a contact card.** "Send a message" on a contact card opens the picker pre-populated with that contact selected; the local user can confirm to start a 1:1 or add additional contacts before sending.
+- [ ] **"Add from Contacts" in chat plus-menu.** Reuses the picker UI scoped to a destination chat — members already in are inline-disabled with an "in chat" badge — and adds the chosen contacts via the existing `addMembers` flow.
+- [ ] **Inbound conversation filtering — opens up the invite-flow gate while adding a contacts gate.** Today, the only inbound conversations that survive `StreamProcessor.shouldProcessConversation` are those that came through the Convos invite flow (or that the local user created). With this feature, a new inbound conversation is also accepted if the sender's `inboxId` is in the local user's contact list at delivery time. If the sender is not a contact and the conversation also did not come through an invite, it is held in a quarantine area and dropped after a configurable window (target: 7 days). If the sender is a blocked contact, the conversation is rejected outright. The invite-flow path (today's behavior) continues to work unchanged.
+- [ ] **Main feed unchanged.** No new "added you" badge on the home conversation list — same icons for unread messages, same row layout. The filtering is invisible in the happy path.
+- [ ] **Block.** A user can block a contact. Blocking causes any future inbound conversation invitations from that user to be ignored (does not delete existing conversations; per-conversation removal is a separate affordance).
+- [ ] **No regressions.** All existing conversation, profile, and invite flows continue to work unchanged. Auto-add never blocks or slows the message-send path; the new filter never breaks the existing invite-flow path.
+- [ ] **Shared-conversations list on contact card** *(stretch).* The contact card surfaces every active conversation the local user shares with the contact, sorted by recency. This is the lowest-priority Step 2 item and may slip to a Step 2.5 follow-up.
+
+## Non-Goals
+
+- **No discovery / global directory.** A user can only contact someone they've already shared a conversation with and acted in. No "people you may know."
+- **No cross-device sync.** Contacts live in local GRDB only for MVP. A future integration with the backups system is anticipated; the schema should be forward-compatible but the durability layer is explicitly out of scope.
+- **No server-side contact graph.** No backend storage of contacts, no server queries, no recommendations.
+- **No "added you" badge on the main feed.** Per review feedback, the main conversation list keeps its current visual treatment. Inbound filtering happens before a conversation reaches the main feed; there is nothing to badge once it's there.
+- **No new toolbar icon on the conversations list.** The contact list is reached only from the Convos top-left menu.
+- **No multi-inbox support.** Contacts assume the single-inbox model from ADR-011. If Convos ever returns to multi-inbox, contacts as designed will not be forward-compatible without rework.
+- **No manual contact-add UI.** Contacts are populated only by acting in shared conversations. There is no "add a contact by inboxId / address" flow.
+- **No per-contact muting, pinning, or notification settings.** Out of scope for MVP.
+- **No recency-sort or recency-filter on the picker.** V1 is alphabetical only. Recency-aware sort is a follow-up.
+- **No mid-group blocking.** "Block" affects future inbound conversation invitations from that user; it does not silence their messages within an existing shared group. That tradeoff (block-in-group) is explicitly TBD and tracked as an open question.
+
+## User Stories
+
+### Step 1 stories
+
+#### As a user joining a Convos group via invite link, I want the other participants added as contacts when I start engaging with the group, so that I can later message them directly without re-discovering them — but I don't want to add strangers as contacts merely by being invited into a group with them.
+
+Acceptance criteria:
+
+- [ ] After accepting an invite to a group of N members, my contacts list does **not** change until I send my first message in the group.
+- [ ] The instant I send my first message in the group, the other N − 1 members are added to my contact list within 2 seconds.
+- [ ] The new contacts have their display name and avatar resolved from the most recently received member-profile data on the device; no contact appears with placeholder data if any profile was available.
+- [ ] If I leave the group later, the contacts remain — they're tied to having shared a conversation I acted in, not to current membership.
+
+#### As a user already in a group, I want anyone newly added to the group to become a contact automatically, so that the contact list stays current.
+
+Acceptance criteria:
+
+- [ ] When a new member joins a group I am already a member of and have already acted in, that member is added to my contact list within 2 seconds of the local member-add event being processed.
+- [ ] The contact's source-group attribution (`addedViaConversationId`) is set to that group.
+
+#### As a user, I want to see my contact list from the top-left menu, so that I can browse the people I've talked to without leaving the home screen.
+
+Acceptance criteria:
+
+- [ ] Tapping the "Convos" capsule in the top-left of the home screen opens the existing menu; a "Contacts" entry appears under "My info".
+- [ ] Tapping "Contacts" opens a list view of all contacts, alphabetical by display name.
+- [ ] The list does not need search in V1 (alphabetical-only is acceptable); search is optional polish.
+- [ ] Tapping a contact opens the contact card. For Step 1, the contact card is a placeholder with the contact's profile and a back button — no "Send a message" CTA, no block / unblock.
+
+### Step 2 stories
+
+#### As a user, I want to start a new conversation with one or more existing contacts.
+
+Acceptance criteria:
+
+- [ ] From a top-level "new conversation" affordance, the picker opens with no contacts pre-selected.
+- [ ] The picker has a "To" header bubble that fills with each selected contact's name as I tap them (matching the attached UI mock).
+- [ ] A Favorites section appears at the top above the alphabetical list.
+- [ ] The main list is alphabetical-only (no recency sort) with a side-letter index.
+- [ ] After selecting at least one contact, the CTA to send the first message becomes enabled.
+- [ ] The new conversation is created with the selected participants. Recipients only receive the message if they have not blocked the local user *and* have already acted in some shared group with the local user (i.e., the local user is in their contact list too); the UI does not need to expose this caveat in V1 but the behavior should be documented for support.
+
+#### As a user viewing a contact card, I want a one-tap path to message that contact.
+
+Acceptance criteria:
+
+- [ ] The contact card shows the contact's profile and a "Send a message" CTA.
+- [ ] Tapping the CTA opens the picker with that contact pre-selected; I can confirm immediately or add other contacts before sending.
+
+#### As a user adding a known contact to an existing group chat, I want to pick from my contacts without manually inviting them.
+
+Acceptance criteria:
+
+- [ ] In the chat plus-menu, "Add from Contacts" appears as a row alongside Invite link and Convo code.
+- [ ] Tapping it opens the picker scoped to the destination chat: people already in the chat are shown inline alphabetically, dimmed, with an "in chat" badge instead of a checkbox.
+- [ ] Multi-select with the same "To" header bubble; the bottom CTA reads "Add N to convo" and is disabled when N = 0.
+- [ ] Selected contacts are added to the chat via the existing `addMembers` flow; they receive a profile snapshot per the existing profile-system contract.
+
+#### As a user, I want to receive direct messages only from people I have already chosen to interact with, so that strangers cannot land messages in my main feed.
+
+Acceptance criteria:
+
+- [ ] An inbound conversation (welcome) from an `inboxId` that is in my contact list is delivered to the main feed within the same time budget as today, even if no Convos invite handshake occurred.
+- [ ] An inbound conversation from an `inboxId` that is not in my contact list and that did not come through the Convos invite flow is held (persisted but not surfaced in the main feed) and dropped after 7 days.
+- [ ] If a held conversation's sender becomes a contact within the 7-day window (because we share a group and I act in it), the held conversation is promoted to the main feed.
+- [ ] An inbound conversation that did come through the Convos invite flow continues to land as it does today, regardless of contact status. (Regression guarantee.)
+- [ ] No UI is shown for the held / quarantined conversations in V1.
+
+#### As a user, I want to block someone, so that they cannot start new conversations with me even if we share a group.
+
+Acceptance criteria:
+
+- [ ] From the contact card, I can mark a contact as blocked.
+- [ ] Once blocked, any inbound conversation (welcome) from that user is rejected and never delivered to my main feed, even if the user remains in my contact list.
+- [ ] Blocking does not delete existing shared conversations (per-conversation removal is a separate affordance).
+- [ ] Blocking does not silence messages within an existing shared group conversation (TBD, tracked in open questions).
+
+#### As a user viewing a contact card, I want to see every conversation I share with that person *(stretch — may slip to follow-up)*.
+
+Acceptance criteria:
+
+- [ ] The contact card lists every active conversation (DM and group) the local user and the contact are both currently members of, sorted by most recent activity.
+- [ ] Each conversation entry shows the conversation's name, last-message timestamp, and last-message preview (matching the main-feed treatment).
+- [ ] Tapping a conversation entry opens that conversation.
+
+## UI / UX
+
+Wireframes are in `contact-list-mocks/`; the picker design is updated to match the new mock attached to the post-review feedback (see "picker" entry below). The MVP surfaces, mapped to the two delivery steps:
+
+| # | Step | Screen | View / VM | Entry point |
+|---|---|---|---|---|
+| 1 | Step 1 | Convos menu — "Contacts" entry | Existing menu (one new row under "My info") | Tap "Convos" capsule on home; menu opens |
+| 2 | Step 1 | Contacts list (browse, alphabetical) | `ContactsView` / `ContactsViewModel` | "Contacts" entry in Convos menu |
+| 3 | Step 1 / Step 2 | Contact card | `ContactCardView` / `ContactCardViewModel` | Tap row in screen 2. Step 1: profile-only placeholder. Step 2: adds "Send a message" CTA and (stretch) shared-conversations list. |
+| 4 | Step 2 | Contact picker (new conversation, multi-select) | `ContactsPickerView` / `ContactsPickerViewModel` | Top-level "new conversation" affordance; "Send a message" CTA on contact card; "Add from Contacts" row in chat plus-menu (scoped mode) |
+| 5 | Step 2 | "Add from Contacts" in chat plus-menu | Existing chat plus-menu (one new row) | + button in chat header |
+
+**Picker design (screen 4)** — matches the attached mock:
+
+- A pill-shaped "To" header at the top that fills with each selected contact's name as a small bubble; a hamburger / disclosure button on the right edge of the pill.
+- A "Favorites" section below the header (forward-compatible: V1 may render this section empty if no favorites concept exists yet, or seed it from a simple "most-recently-messaged contacts" heuristic — defer to designer pass).
+- An alphabetical main list with section headers ("ABC", letter sections), each row showing avatar, name, and a sub-label (e.g., "DM" for 1:1, group name for group-derived attribution).
+- A right-edge alphabetical index strip (★ A B C … Z #) for fast scrolling.
+- Selected rows show a filled checkmark on the right; unselected rows show no indicator.
+- In **scoped (add-to-chat) mode**, members already in the destination chat are inline-disabled with an "in chat" badge instead of a checkbox.
+
+**Browse list (screen 2)** — simpler than the picker:
+
+- Same alphabetical sectioning + side-letter index.
+- No "To" header pill; no Favorites section in V1 (a single alphabetical list is fine — Favorites can come later when we add per-contact metadata).
+- Tapping a row opens the contact card (screen 3).
+
+**Component reuse:** screens 2 and 4 share `ContactRow`, alphabetical sectioning, and the side-letter index. Implement as one `ContactRow` view + one `ContactsList` container that takes a mode (`.browse`, `.pickerForNewConversation`, `.pickerScopedToConversation(conversationId)`); the mode parameterizes the header (none / "To" pill), Favorites visibility, tap behavior, "in chat" disable rules, and bottom CTA.
+
+**Inbound filtering is invisible (Step 2).** When the contact-gated filter ships in Step 2, the main conversations feed continues to render exactly as today — no badge, no banner, no requests tray. Held / quarantined inbound conversations are persisted but hidden from the feed query. Step 1 does not change main-feed behavior at all.
+
+**Open visual questions** (deferred to designer pass):
+
+- What populates the Favorites section in V1 (empty / heuristic / explicit favoriting affordance).
+- Empty state for a contact with zero remaining shared conversations on the contact card.
+- Whether to surface a "blocked" indicator on the contact list row, or only inside the contact card.
+- Whether the picker should section off "already in this chat" members at large group sizes (the inline-disabled treatment is fine for groups up to ~10; beyond that we may want to revisit).
+- Final placement of "Block" affordance on the contact card.
+
+## Technical Design
+
+### Architecture
+
+The feature lives almost entirely in `ConvosCore`, with thin SwiftUI views in the main app. No new MCP-style protocols needed; no new platform dependencies. ConvosCore must continue to compile on macOS — no `UIKit` imports.
+
+**New components — Step 1:**
+
+- `DBContact` (GRDB record) — the contacts table. Stores a denormalized "global default profile" (most-recent-wins). Step 1 ships *without* the `blockedAt` column; Step 2 adds it via a separate migration.
+- `DBConversationContactsSync` (GRDB record) — per-conversation marker tracking whether the contact-sync coordinator has run for that conversation.
+- `ContactsRepository` / `ContactsRepositoryProtocol` — reactive read API; publisher for the alphabetical list and `isContact(inboxId:)` lookup. (`isBlocked(inboxId:)` is added in Step 2.)
+- `ContactsWriter` / `ContactsWriterProtocol` — write API; idempotent upsert and profile-snapshot writes. (Block / unblock writers added in Step 2.)
+- `ContactSyncCoordinator` — single entry point for "ensure all non-self members of this conversation are contacts." Wraps `ContactsWriter`; idempotent.
+- `ContactsProfileSyncWriter` — listens for member-profile / profile-snapshot events and updates `DBContact` profile fields per most-recent-wins.
+- `ContactsBackfillService` — one-time job that scans every conversation the local user has acted in on first launch post-feature; idempotent (uses `DBConversationContactsSync`).
+- `ContactsView` (browse) and a placeholder `ContactCardView` (profile + back, no actions).
+- `ContactsViewModel`, `ContactCardViewModel` — `@Observable` view models per current convention.
+
+**New components — Step 2:**
+
+- `addContactBlockedAt` migration — adds the `blockedAt` column to `contact`.
+- `addConversationQuarantineFields` migration — adds `quarantinedAt`, `quarantineReleasedAt` to `conversation`.
+- `InboundConversationFilter` — extends the existing `StreamProcessor.shouldProcessConversation` gate with contact-list and block-list checks; returns `.deliver | .quarantine | .reject`.
+- `QuarantineSweeper` — periodic / launch-time job that drops quarantined conversations whose hold window has expired, and promotes any whose senders have since become contacts.
+- `ContactsPickerView` and the full `ContactCardView` (with "Send a message" CTA and block / unblock affordance).
+- `ContactsPickerViewModel`.
+
+**Hook surfaces:**
+
+- **First-message-sent in a conversation** (Step 1, primary auto-add trigger) — at the point where the local user's outbound message is persisted, if it's the first outbound message the local user has sent in that conversation, run the contact-sync coordinator on that conversation. Implementation hook: in the message-send path inside `MessagesWriter` (or equivalent), check whether the conversation already has a `conversation_contacts_sync` row before / after the message persists; if not, enqueue the sync. Replaces the old hook sites in `StreamProcessor.processConversation` and `InviteJoinRequestsManager.processJoinRequest`.
+- **`ConversationMetadataWriter.addMembers()`** (Step 1, secondary trigger) — after `DBConversationMember` rows are persisted for an existing group the local user has already acted in, run the coordinator with `force: true` to pick up new members.
+- **Inbound conversation arrival** (Step 2, filter site) — `StreamProcessor.shouldProcessConversation` is the existing chokepoint at `ConvosCore/Sources/ConvosCore/Syncing/StreamProcessor.swift` lines 713-739, called from `processConversation` (lines 140-145) before any DB persistence. The new `InboundConversationFilter` plugs in *here* in Step 2, extending the existing consent + invite-flow logic with a contact-list and block-list check. See the dedicated section below. Step 1 does **not** touch this site.
+
+The coordinator does not block its caller — it is `async` but fire-and-forget from the hook sites (errors logged to `Logger.error`, no UI surface for failure).
+
+### Data Model
+
+#### `DBContact`
+
+The contacts table. Keyed by the contact's `inboxId`. Stores a denormalized "global default profile" (display name, avatar, bio) updated on a most-recent-wins basis whenever we observe a member-profile event for that inbox. Per the post-review feedback: *"Contact = inbox, profile = whatever we heard about most recently for that inbox ID."*
+
+The full struct (post-Step 2):
+
+```swift
+struct DBContact: FetchableRecord, PersistableRecord, Codable {
+    static let databaseTableName = "contact"
+
+    let inboxId: String                 // Primary key — see ADR-011
+    let addedAt: Date                   // When the contact was first auto-added
+    let addedViaConversationId: String? // The conversation that triggered the original auto-add (informational)
+
+    // Most-recent-wins profile snapshot
+    var displayName: String?
+    var avatarURL: String?
+    var bio: String?
+    var profileUpdatedAt: Date?         // Timestamp of the source event we last accepted
+
+    // Blocking — added in Step 2
+    var blockedAt: Date?                // Non-nil ⇒ blocked
+
+    enum Columns: String, ColumnExpression {
+        case inboxId, addedAt, addedViaConversationId
+        case displayName, avatarURL, bio, profileUpdatedAt
+        case blockedAt
+    }
+}
+```
+
+Migrations are split between Step 1 (base table + profile snapshot) and Step 2 (`blockedAt`):
+
+```swift
+// Step 1 — Phase 1.1
+migrator.registerMigration("createContactTable") { db in
+    try db.create(table: "contact") { t in
+        t.column("inboxId", .text).notNull().primaryKey()
+        t.column("addedAt", .datetime).notNull()
+        t.column("addedViaConversationId", .text)
+            .references("conversation", onDelete: .setNull)
+        t.column("displayName", .text)
+        t.column("avatarURL", .text)
+        t.column("bio", .text)
+        t.column("profileUpdatedAt", .datetime)
+    }
+    try db.create(index: "idx_contact_displayName", on: "contact", columns: ["displayName"])
+}
+
+// Step 2 — Phase 2.1
+migrator.registerMigration("addContactBlockedAt") { db in
+    try db.alter(table: "contact") { t in
+        t.add(column: "blockedAt", .datetime)
+    }
+}
+```
+
+In Step 1, the `DBContact` struct should omit the `blockedAt` field; it is added together with the alter-table migration in Step 2. Tests against the Step 1 build should not reference blocking.
+
+The contacts table does not foreign-key the `member` row directly — a contact survives the local user leaving every shared conversation. `addedViaConversationId` uses `onDelete: .setNull` so deleting the source group does not cascade-delete the contact.
+
+#### `DBConversationContactsSync`
+
+Tracks whether the contact-sync coordinator has run for a given conversation. Same shape as before:
+
+```swift
+struct DBConversationContactsSync: FetchableRecord, PersistableRecord, Codable {
+    static let databaseTableName = "conversation_contacts_sync"
+
+    let conversationId: String
+    let contactsSyncedAt: Date
+
+    enum Columns: String, ColumnExpression {
+        case conversationId, contactsSyncedAt
+    }
+}
+```
+
+Migration is unchanged from the original draft.
+
+#### Inbound conversation quarantine *(Step 2)*
+
+Inbound conversations whose sender is not a contact at delivery time are persisted but hidden from the main feed. This is a Step 2 concern — Step 1 does not change inbound-conversation persistence behavior. Two implementation options:
+
+- **Option A (preferred):** Add nullable `quarantinedAt: Date` and `quarantineReleasedAt: Date` columns to the existing `conversation` table. The main-feed query filters out rows where `quarantinedAt IS NOT NULL AND quarantineReleasedAt IS NULL`. Simple, no new table.
+- **Option B:** A separate `quarantined_conversation` table keyed on `conversationId`. Cleaner separation, but requires another join.
+
+We start with Option A. The quarantine TTL is configured as a `Constant` (default 7 days). The `QuarantineSweeper` runs at launch and on a 1-hour timer while the app is foregrounded:
+
+1. For each row with `quarantinedAt IS NOT NULL AND quarantineReleasedAt IS NULL`:
+   - If the sender is now in `contact` and not blocked → write `quarantineReleasedAt = now` (promotes to feed).
+   - Else if `now - quarantinedAt > QuarantineConstant.ttl` → delete the conversation row (and its messages) and record a debug-only log.
+2. No UI surfacing for quarantined conversations in V1.
+
+Migration:
+
+```swift
+migrator.registerMigration("addConversationQuarantineFields") { db in
+    try db.alter(table: "conversation") { t in
+        t.add(column: "quarantinedAt", .datetime)
+        t.add(column: "quarantineReleasedAt", .datetime)
+    }
+}
+```
+
+#### Indexes
+
+Existing `conversation_members` already has `(inboxId, conversationId)` index — used by the contact card (Step 2) for shared-conversations lookup. The new `idx_contact_displayName` index supports the alphabetical list-paint path.
+
+### Profile Resolution (most-recent-wins)
+
+The post-review feedback resolved the per-conversation-profile ambiguity: *"Contact = inbox, profile = whatever we heard about most recently for that inbox ID."*
+
+We replace the original at-query-time heuristic with a denormalized profile snapshot on `DBContact`, updated on a most-recent-wins basis:
+
+- A `ContactsProfileSyncWriter` listens for events that yield new profile data for a known `inboxId`:
+  - `DBMemberProfile` writes (existing per-conversation profile delivery).
+  - Profile snapshots received via the existing profile-snapshot codec on conversation join.
+  - Profile updates received in-band (e.g., `ProfileUpdate` codec messages).
+- For each event, the writer compares the source event's timestamp against `DBContact.profileUpdatedAt`. If the event is newer, it overwrites `displayName`, `avatarURL`, `bio`, and `profileUpdatedAt` on the contact row. If older, the event is dropped from the contact-update path (the `member_profile` table still stores it for in-conversation rendering).
+- "Newer" is decided by the source event's authoring timestamp. If the source has no timestamp, fall back to local receive time.
+
+This keeps `DBContact` thin, eliminates the at-query-time heuristic, and makes the contact list render on a single primary-key-indexed read with no joins. The contact card (Step 2) and picker render the contact's `DBContact` snapshot; in-conversation rendering continues to use `DBMemberProfile` per ADR-005.
+
+**Tradeoff acknowledged.** The contact list may show a stale name briefly if a member updates their profile and we have not yet processed the corresponding event. Acceptable for V1; the eventual consistency window is the same as today's profile update propagation.
+
+### Auto-Add Coordinator
+
+`ContactSyncCoordinator` is the single entry point for all auto-add work. It encapsulates the "for this conversation, ensure all non-self members are contacts" operation idempotently.
+
+```swift
+public protocol ContactSyncCoordinatorProtocol: Sendable {
+    /// Idempotent. Safe to call repeatedly. Skips if the conversation is already synced unless `force: true`.
+    func syncContacts(for conversationId: String, force: Bool) async throws
+}
+
+final class ContactSyncCoordinator: ContactSyncCoordinatorProtocol, @unchecked Sendable {
+    private let databaseWriter: DatabaseWriter
+    private let contactsWriter: ContactsWriterProtocol
+    private let selfInboxIdProvider: () -> String?
+
+    public func syncContacts(for conversationId: String, force: Bool = false) async throws {
+        // In a single GRDB transaction:
+        // - If !force and `conversation_contacts_sync` already has a row, return.
+        // - Read all `conversation_members` rows for conversationId, excluding self.
+        // - For each non-self inboxId, contactsWriter.upsertContact(inboxId:addedVia:profileSnapshot:)
+        //   passing the most recent member-profile data we currently have.
+        // - Save `conversation_contacts_sync(conversationId, now)`.
+    }
+}
+```
+
+**Idempotency.** Upserts into `contact` use `INSERT OR IGNORE` for the identity columns (`inboxId`, `addedAt`, `addedViaConversationId`) so that re-runs do not clobber the original `addedAt` / `addedViaConversationId`. Profile fields are updated separately by the `ContactsProfileSyncWriter` per most-recent-wins.
+
+**Concurrency.** GRDB's `DatabaseWriter` serializes writes, so concurrent calls for the same conversation linearize and the second short-circuits on the sync-marker check.
+
+**Self-skip.** The local user's own inboxId comes from `DBInbox` (singleton per ADR-011) or the in-memory XMTP client; injected into the coordinator as a closure.
+
+### Hook Integration (Step 1)
+
+Two hook sites in Step 1, both calling `coordinator.syncContacts(for:)` fire-and-forget:
+
+```swift
+// 1. First outbound message persisted in a conversation
+//    (in MessagesWriter.persistOutgoing, or equivalent — confirm during implementation)
+//    Trigger: BEFORE returning success to the caller, check if `conversation_contacts_sync`
+//    has a row for conversationId. If not, enqueue:
+Task.detached { try? await contactSyncCoordinator.syncContacts(for: conversationId, force: false) }
+
+// 2. New members added to an existing group
+//    (in ConversationMetadataWriter.addMembers, after DBConversationMember writes)
+Task.detached { try? await contactSyncCoordinator.syncContacts(for: conversationId, force: true) }
+```
+
+The first hook replaces the old `StreamProcessor.processConversation` and `InviteJoinRequestsManager.processJoinRequest` hooks. We no longer auto-add on conversation-arrival; the local user must take an explicit action (send a message). This matches the review-feedback requirement: *"all other members of the group are added to your Contact List as soon as you send a message in the group."*
+
+The second hook is unchanged in spirit but now should only run for conversations the local user has already acted in — i.e., conversations that already have a `conversation_contacts_sync` row. The coordinator can short-circuit `force: true` calls for conversations that have not been synced before (the local user has not acted in them yet, so we do not pull their members into our contacts).
+
+Errors are caught locally and logged; auto-add is a best-effort enrichment.
+
+### Inbound Conversation Filter (Step 2)
+
+#### Today's gate (what we're extending)
+
+`StreamProcessor.shouldProcessConversation` (`ConvosCore/Sources/ConvosCore/Syncing/StreamProcessor.swift`, lines 713-739) is the single chokepoint for accepting an inbound group conversation. Quoting the existing logic:
+
+```swift
+var consentState = try conversation.consentState()
+guard consentState != .allowed else { return true }
+guard try await conversation.creatorInboxId() != params.client.inboxId else { return true }
+
+if consentState == .unknown {
+    let hasOutgoingJoinRequest = try await joinRequestsManager.hasOutgoingJoinRequest(
+        for: conversation, client: params.client
+    )
+    if hasOutgoingJoinRequest {
+        try await conversation.updateConsentState(state: .allowed)
+        consentState = try conversation.consentState()
+    }
+}
+return consentState == .allowed
+```
+
+In English: a conversation passes if XMTP says `consent == .allowed`, or the local user is the creator, or `consent == .unknown` and the local user already sent an invite-side outgoing join request for it (in which case consent is bumped to `.allowed`). Anything else returns `false`, and `processConversation` drops it without persisting (lines 140-145). DM messages take a separate path in `processMessage` (lines 184-311) — DMs are *not* persisted as conversation rows; they exist purely as transport for invite join-request payloads handed to `InviteJoinRequestsManager.processJoinRequestOutcome`.
+
+The practical effect today is that the only inbound group conversations the user ever sees are ones gated by the Convos invite system. A direct 1:1 DM from someone the user has never invite-flow'd with does not appear in the local DB at all.
+
+#### New gate (Step 2 — Phase 2.6 of this work)
+
+We extend `shouldProcessConversation` to add a contact-list path that elevates `.unknown` → `.allowed`, plus a block check that rejects outright, plus a quarantine path for everything else. The invite-flow branch is unchanged.
+
+```swift
+// Pseudocode for the extended decision; the actual structure should preserve the existing guards.
+var consentState = try conversation.consentState()
+if consentState == .allowed { return .deliver }
+if try await conversation.creatorInboxId() == params.client.inboxId { return .deliver }
+
+let creatorInboxId = try await conversation.creatorInboxId()
+
+// Hard reject: blocked contacts always lose, no matter the path.
+if contactsRepository.isBlocked(inboxId: creatorInboxId) {
+    return .reject  // do not persist (matches today's drop-on-floor behavior)
+}
+
+if consentState == .unknown {
+    // Existing path: invite-flow handshake.
+    if try await joinRequestsManager.hasOutgoingJoinRequest(for: conversation, client: params.client) {
+        try await conversation.updateConsentState(state: .allowed)
+        return .deliver
+    }
+    // New path: known contact.
+    if contactsRepository.isContact(inboxId: creatorInboxId) {
+        try await conversation.updateConsentState(state: .allowed)
+        return .deliver
+    }
+    // New path: stranger — persist hidden, sweep later.
+    return .quarantine
+}
+
+// consentState == .denied — drop on floor, as today.
+return .reject
+```
+
+Notes:
+
+- The "sender" of an inbound conversation is its creator — `creatorInboxId()` on the XMTP conversation, the same value `shouldProcessConversation` already reads on line 722. There is exactly one creator per conversation.
+- The contact-list and block-list checks are indexed point reads on `DBContact` (lookup by primary-key `inboxId`); negligible overhead relative to the existing async XMTP calls.
+- `InboundConversationFilter` is the Swift type that owns the new logic; `shouldProcessConversation` becomes a thin wrapper over `InboundConversationFilter.decide(for: conversation, client:)` to keep the file small and the decision testable in isolation.
+- Once delivered or rejected, the decision is final. We do not re-evaluate when the sender is later unblocked or removed-from-contacts; that is handled by future inbound conversations.
+- Quarantined conversations *are* persisted (so we can promote them later if the sender becomes a contact during the hold window), but excluded from the main-feed `ConversationsRepository` query and from any unread-count, badge, or notification surface.
+
+#### DMs (the deferred part)
+
+Today DMs are not persistable conversations — `StreamProcessor.processMessage` consumes them as invite-payload transport and discards the rest. For Step 1, we treat DMs the same as today (no behavioral change there); only group conversations flow through the new filter. This is fine for Step 1's goal of contact-driven inbound filtering on group conversations.
+
+For Step 2 ("Send a message" from a contact card creating a new conversation with a single recipient), we have two options and need to pick one before Phase 2.2:
+
+1. **Use a group conversation under the hood** — the contact picker creates a group with the local user + the chosen contact(s) regardless of count. This works with today's persistence model and the new contact-gated filter; the only loss is that "1:1 DM" doesn't exist as a distinct concept on the wire. Most likely the simpler path.
+2. **Persist DMs as first-class conversations** — extend `processMessage` (or add a sibling) to write a `conversation` row for inbound DMs, gated by the same `InboundConversationFilter`. Cleaner conceptually, larger blast radius. Likely a follow-up after Step 2 ships.
+
+This is tracked as an open question; the recommendation is option 1 for V1.
+
+### Blocking *(Step 2)*
+
+A user can block a contact. Blocking is a per-contact flag stored on `DBContact.blockedAt` (added by the Step 2 migration):
+
+```swift
+public protocol ContactsWriterProtocol: Sendable {
+    func block(inboxId: String) async throws        // sets blockedAt = now
+    func unblock(inboxId: String) async throws      // sets blockedAt = nil
+    // ... other write methods
+}
+```
+
+Effects:
+
+- Future inbound conversations from this `inboxId` are rejected by `InboundConversationFilter` (never persisted, never surfaced).
+- Blocked contacts are still listed in the contacts list (so the user can find them to unblock); the contact card surfaces the blocked state with an unblock affordance.
+- Existing shared conversations are not touched — the blocked party can still post in groups the local user is in. Mid-group muting is out of scope for V1 (open question).
+- Blocking does not delete the contact. The user can independently remove a contact (open question — not shipped V1) once we add that affordance.
+
+Blocking is local-only. The blocked party is not notified.
+
+### Backfill Service (Step 1)
+
+`ContactsBackfillService` runs on first launch after this feature ships. Crucially, it backfills only conversations the local user has already acted in — not every conversation on the device. This matches the new auto-add semantics.
+
+```swift
+public protocol ContactsBackfillServiceProtocol: Sendable {
+    func backfillIfNeeded() async throws
+}
+```
+
+Implementation:
+
+1. Query: every `conversation.id` that (a) does not have a `conversation_contacts_sync` row, and (b) has at least one outbound message from the local user in `messages`.
+2. For each such conversationId, call `coordinator.syncContacts(for:)`.
+3. Per-conversation transactions make partial progress durable; an interrupted backfill resumes on next launch.
+
+Conversations the local user is in but has not posted in are intentionally skipped. They will be picked up the moment the local user sends their first message there, via the auto-add hook.
+
+Triggered after `SessionManager` is ready, on a background priority Task; UI is not blocked.
+
+### Picker Logic (Step 2)
+
+`ContactsPickerView` takes a mode parameter:
+
+```swift
+enum ContactsPickerMode {
+    case newConversation
+    case addToConversation(conversationId: String)
+}
+```
+
+In `.newConversation` mode, the query is a simple list of all non-blocked contacts ordered by `displayName`. In `.addToConversation` mode, the query LEFT-JOINs `conversation_members` to mark members already in the destination chat:
+
+```sql
+SELECT contact.*,
+       (conversation_members.inboxId IS NOT NULL) AS isAlreadyInChat
+FROM contact
+LEFT JOIN conversation_members
+       ON conversation_members.inboxId = contact.inboxId
+      AND conversation_members.conversationId = ?destinationChatId
+WHERE contact.blockedAt IS NULL
+ORDER BY contact.displayName COLLATE NOCASE ASC
+```
+
+Rows where `isAlreadyInChat = 1` render disabled with the "in chat" badge. Selectable rows are tap-to-toggle; their names appear in the "To" header pill at the top.
+
+CTAs:
+
+- `.newConversation` → on confirm, create a new conversation with the selected `inboxId`s via the existing conversation-create flow, then send the first message.
+- `.addToConversation` → on confirm, call `ConversationMetadataWriter.addMembers(...)` with the selected ids.
+
+### View Model State Management
+
+Per CLAUDE.md, new view models use `@Observable`:
+
+```swift
+@Observable
+final class ContactsViewModel {
+    var contacts: [ContactRow] = []
+    var isLoading: Bool = false
+
+    private let contactsRepository: ContactsRepositoryProtocol
+    private var subscription: AnyCancellable?
+
+    init(contactsRepository: ContactsRepositoryProtocol) {
+        self.contactsRepository = contactsRepository
+        subscription = contactsRepository.contactsPublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] in self?.contacts = $0 }
+    }
+}
+```
+
+`ContactRow` is a presentation struct that bundles the resolved profile snapshot from `DBContact` plus the blocked flag.
+
+## Implementation Plan
+
+Stacked PRs via Graphite, one logical chunk per PR. Two discrete delivery steps.
+
+### Phase 0: Plan PR (already in flight)
+
+- [x] Wireframes in `contact-list-mocks/`.
+- [x] 1-pager.
+- [ ] This PRD.
+
+---
+
+### Step 1 — Populate and view
+
+The goal of Step 1 is to build the contact list, keep it accurate, and let the user browse it. No filtering, no blocking, no messaging-from-contacts. Step 1 is purely additive: existing users see no change in behavior beyond a new "Contacts" entry in the Convos menu.
+
+#### Phase 1.1: Data layer
+
+- [ ] `DBContact` record + migration `createContactTable` (with profile-snapshot columns; **no** `blockedAt` yet — that's added in Step 2's data-layer phase).
+- [ ] `DBConversationContactsSync` record + migration.
+- [ ] `ContactsRepository` with alphabetical-list publisher, `isContact(inboxId:)`. *(`isBlocked(inboxId:)` is added in Step 2.)*
+- [ ] `ContactsWriter` with idempotent upsert and profile-snapshot most-recent-wins update.
+- [ ] Unit tests for repository queries (alphabetical sort, `isContact`) and writer idempotency, profile-snapshot recency.
+
+Ship-readiness: ConvosCore tests pass; data layer fully tested with mocked profile data; no UI yet.
+
+#### Phase 1.2: Auto-add coordinator + hooks
+
+- [ ] `ContactSyncCoordinator` with the read-members → upsert-contacts → write-sync-marker transaction.
+- [ ] Self-skip wiring via `DBInbox`.
+- [ ] Wire **first-outbound-message** hook in the message-send path.
+- [ ] Wire **member-added-to-existing-group** hook in `ConversationMetadataWriter.addMembers` — guarded so it only runs for conversations already synced (i.e., the local user has already acted there).
+- [ ] `ContactsProfileSyncWriter` listening for `member_profile` writes / profile-snapshot / `ProfileUpdate` events; updates `DBContact` profile fields per most-recent-wins.
+- [ ] Integration tests: simulate sending first message in a fresh group → assert contacts populate; simulate a member-add to an already-acted-in group → new contact appears; simulate joining a group and not posting → assert no contacts added.
+
+Ship-readiness: Auto-add works end-to-end on Local environment; existing tests still pass.
+
+#### Phase 1.3: Backfill service
+
+- [ ] `ContactsBackfillService.backfillIfNeeded()` — backfills only conversations the local user has acted in.
+- [ ] App-launch wiring after `SessionManager` is ready.
+- [ ] Test: device fixture with N existing conversations, M of which have outbound messages from the local user, run backfill; assert M conversations marked synced and contacts populated for those only.
+
+Ship-readiness: Backfill completes within 30 seconds for a synthetic 200-conversation device; doesn't block launch UI.
+
+#### Phase 1.4: Browse UI
+
+- [ ] "Contacts" entry under "My info" in the existing Convos top-left menu.
+- [ ] `ContactsView` with alphabetical sectioning + side-letter index. No search in V1.
+- [ ] Placeholder `ContactCardView` (profile + back; no "Send a message" CTA, no block / unblock — both are added in Step 2).
+- [ ] SwiftUI Previews with `.mock` data.
+- [ ] Manual testing against the wireframes.
+
+Ship-readiness: User can open the menu, tap "Contacts", browse the list, tap a contact, see their profile.
+
+**End of Step 1.** Ship a stacked PR or merge train including phases 1.1 – 1.4. Existing inbound conversation behavior is unchanged at this point.
+
+---
+
+### Step 2 — Messaging, filtering, and blocking
+
+Step 2 is where the contact list starts gating behavior. It introduces messaging from contacts (picker UI, "Send a message", "Add from Contacts"), the contact-gated inbound filter (extending `StreamProcessor.shouldProcessConversation`), the quarantine sweeper, and blocking. The phases are sequenced so the data and filter layers land before the UX that depends on them, and the messaging UX before the filter is wired (so we can validate the messaging end-to-end with today's invite-flow path before the filter changes happen).
+
+#### Phase 2.1: Step 2 data layer additions
+
+- [ ] `addContactBlockedAt` migration — adds `blockedAt: DATETIME NULL` column on `contact`.
+- [ ] `addConversationQuarantineFields` migration — adds `quarantinedAt`, `quarantineReleasedAt` columns on `conversation`.
+- [ ] Extend `ContactsRepository` with `isBlocked(inboxId:)`.
+- [ ] Extend `ContactsWriter` with `block(inboxId:)` / `unblock(inboxId:)`.
+- [ ] Unit tests for blocking transitions and the new query helper.
+
+Ship-readiness: data layer ready for the filter and the contact-card block affordance; no behavior changes yet.
+
+#### Phase 2.2: Picker UI shell
+
+- [ ] `ContactsPickerView` matching the attached mock — "To" pill header, Favorites section (V1 may render empty), alphabetical main list, side-letter index, multi-select check indicators.
+- [ ] `ContactsPickerViewModel` parameterized by `ContactsPickerMode` (`.newConversation` vs `.addToConversation`).
+- [ ] SwiftUI Previews with `.mock` data for both modes.
+
+Ship-readiness: picker renders and supports multi-select; no integration with conversation creation or member-add yet.
+
+#### Phase 2.3: New conversation flow
+
+- [ ] Top-level "new conversation" entry point (compose button or equivalent — confirm during implementation).
+- [ ] On picker confirm in `.newConversation` mode, create a new conversation with the selected `inboxId`s and route the user into it.
+- [ ] Manual testing: pick 1 contact, confirm DM creation; pick 3 contacts, confirm group creation.
+
+Ship-readiness: new conversation creation from contacts works end-to-end against today's invite-flow filter (before the filter is extended).
+
+#### Phase 2.4: Send message from contact card + block UX
+
+- [ ] `ContactCardView` upgraded with "Send a message" CTA.
+- [ ] CTA opens `ContactsPickerView` in `.newConversation` mode with that contact pre-selected.
+- [ ] Block / unblock affordance on the contact card; confirms before applying.
+- [ ] Manual testing: tap a contact → tap "Send a message" → picker opens with that contact selected and CTA enabled. Block a contact → confirm `blockedAt` is set; unblock → confirm cleared.
+
+Ship-readiness: contact-card-to-message flow works end-to-end; block / unblock is wired even though the inbound-filter consequence isn't observable until Phase 2.6.
+
+#### Phase 2.5: Add-to-chat from chat plus-menu
+
+- [ ] New "Add from Contacts" row in the chat plus-menu (alongside Invite link and Convo code).
+- [ ] Tapping opens `ContactsPickerView` in `.addToConversation(conversationId:)` mode.
+- [ ] CTA invokes `ConversationMetadataWriter.addMembers(...)` with the selected ids.
+- [ ] Manual testing: open a group, tap +, tap "Add from Contacts", select 2 contacts, confirm; verify members appear in the group.
+
+Ship-readiness: add-to-chat flow works end-to-end.
+
+#### Phase 2.6: Inbound filter + quarantine sweeper
+
+- [ ] Refactor `StreamProcessor.shouldProcessConversation` (lines 713-739) to delegate to a new `InboundConversationFilter.decide(for:client:)` returning `.deliver | .quarantine | .reject`. Preserve the existing consent / creator-self / outgoing-join-request branches verbatim.
+- [ ] Add the contact-list path: `consent == .unknown` and `contactsRepository.isContact(creatorInboxId)` and not blocked → bump consent to `.allowed` and deliver.
+- [ ] Add the block path: `contactsRepository.isBlocked(creatorInboxId)` → reject outright (drop on floor, matches today's behavior for non-allowed conversations).
+- [ ] Add the quarantine path: `consent == .unknown`, no outgoing join request, sender not a contact, not blocked → persist with `quarantinedAt = now`, hidden from main feed.
+- [ ] Update `processConversation` (lines 140-145) to honor the three-way return — `.quarantine` persists with the new flag set, `.reject` matches today's drop, `.deliver` matches today's pass.
+- [ ] `QuarantineSweeper` that runs on launch and every hour while foregrounded; promotes quarantined conversations whose senders are now contacts; deletes those past TTL (default 7 days, configurable via `QuarantineConstant`).
+- [ ] Update `ConversationsRepository` main-feed query to exclude `quarantinedAt IS NOT NULL AND quarantineReleasedAt IS NULL`.
+- [ ] Integration tests: existing invite-flow path still delivers (regression); inbound from a contact (no invite handshake) → delivered with consent bumped to `.allowed`; inbound from a stranger → quarantined; stranger becomes a contact → promoted; quarantined past TTL → deleted; inbound from a blocked contact → rejected; conversation creator-is-self → delivered as today.
+
+Ship-readiness: filter and sweeper both work; today's invite-flow happy path is unchanged; contacts can now land conversations directly; blocking has observable effect.
+
+#### Phase 2.7 *(stretch)*: Shared-conversations list on contact card
+
+- [ ] Query for "every conversation both inboxes are members of, sorted by recent activity."
+- [ ] Render below the "Send a message" CTA on the contact card.
+- [ ] Tapping a row opens that conversation.
+
+Ship-readiness: shared-conversations list renders correctly.
+
+**End of Step 2.** Stacked PR or merge train including phases 2.1 – 2.6 (and 2.7 if it makes the cut).
+
+---
+
+### Phase 3: Polish + UAQ resolution
+
+- [ ] Resolve open questions (block-in-group behavior, contact removal, quarantine TTL tuning, Favorites section seeding) — small follow-up commits.
+- [ ] Designer pass on the wireframes → real Figma + visual updates.
+- [ ] QA test plan in `qa/tests/` for every new flow.
+
+## Testing Strategy
+
+**Unit tests** (`ConvosCoreTests`, no Docker needed):
+
+- `ContactsRepository` query correctness — alphabetical sort, `isContact`, `isBlocked`.
+- `ContactsWriter` idempotency — repeated upserts do not clobber `addedAt` / `addedViaConversationId`.
+- `ContactsProfileSyncWriter` most-recent-wins — older event dropped, newer event applied; missing timestamp falls back to receive time.
+- `ContactSyncCoordinator` self-skip, sync-marker short-circuit, force-rerun.
+- `ContactsBackfillService` resumability — kill mid-run, restart, assert correct final state.
+- `InboundConversationFilter` decision-table tests for contact / stranger / blocked sender.
+- `QuarantineSweeper` — promotes when sender becomes contact; deletes when past TTL.
+
+**Integration tests** (require Docker via `./dev/up`):
+
+- Send first message in a fresh group → other members appear as contacts.
+- New member added to an already-acted-in group → that member appears as contact.
+- Join a group and never post → no contacts added.
+- Inbound from a contact → main feed.
+- Inbound from a stranger → quarantined; not in main feed query.
+- Stranger becomes contact during quarantine window → conversation promoted to main feed.
+- Stranger never becomes contact → quarantined conversation deleted past TTL.
+- Block then receive new inbound from blocked party → rejected outright.
+- Profile recency: receive an old profile event after a newer one → contact's profile snapshot does not regress.
+
+**UI tests** (separate target):
+
+- Contacts list renders for a fixture session with mock GRDB data.
+- Picker (new conversation mode) renders alphabetically with "To" pill filling on selection.
+- Picker (add-to-conversation mode) disables already-in-chat members.
+- Convos top-left menu shows "Contacts" entry under "My info".
+
+**Manual / QA test plan** (`qa/tests/<NN>-contacts-list.md`):
+
+- Onboarding flow: new install, accept invite, send a message, observe contact list populates.
+- Existing-user flow: install update, observe backfill completes for conversations the user has acted in.
+- Quarantine edge: new install, receive an inbound from a stranger, observe nothing in main feed; share a group with that stranger and act in it, observe the held conversation appear.
+- Blocking edge: block a contact, have them try to start a new DM, observe the DM never lands.
+- Edge: leave every group with a contact; observe the contact remains in the list with their last-known profile snapshot.
+- Edge: very large group (100+ members), local user posts → all members backfilled; picker scroll performance.
+
+**Architecture review:** Hand the data-model + filter design to `swift-architect` for a final review before Step 1 Phase 1.1 lands.
+
+## Performance / Scale
+
+**Backfill on a high-conversation device.** Backfill scope is now narrower than the original draft — only conversations the local user has *acted in* are backfilled. Users in many lurk-only groups will see far fewer contact-rows than before. For a worst-case acted-in conversation count of ~100 with ~20 members each, that is ~2,000 contact upserts in a few seconds. The per-conversation transaction model means we never hold a single huge write open.
+
+**Steady-state queries.** The contacts list is a single primary-key-ordered scan of `contact` filtered by `blockedAt IS NULL` and ordered by `displayName`. The `idx_contact_displayName` index keeps this O(log N) for the first paint regardless of contact volume. Budget: ≤100ms for first paint with 1,000 contacts on iPhone 13.
+
+**Inbound filter overhead.** Each inbound conversation arrival adds two indexed point reads (`isContact`, `isBlocked`) before delivery. Negligible.
+
+**Quarantine sweeper.** Runs once at launch and once per hour. Each run scans rows where `quarantinedAt IS NOT NULL AND quarantineReleasedAt IS NULL` — typically a small set. No concerns.
+
+**Picker list rendering.** SwiftUI `LazyVStack` virtualizes the list. The `conversation_members` join for the "in chat" filter is keyed on the destination conversation, which has the existing index. No concerns at expected scales.
+
+## Privacy & Security
+
+**Local-only.** Contacts never leave the device. No server storage, no analytics events with contact data.
+
+**Action-gated auto-add.** The new policy ("contact only after you act in a shared conversation") is meaningfully more conservative than the original draft. A user who is invited into a group but never engages does not pull strangers into their contact list, and so does not implicitly authorize those strangers to message them directly via the inbound filter.
+
+**Inbound filtering is a different shape, not a strict tightening.** Today the gate is invite-flow-only: strangers cannot land *unless* they came through an invite handshake. The new gate keeps the invite-flow path verbatim and adds a contact-list path. Net effect: known contacts can now message the local user directly without a fresh invite handshake (this is *opening up*); strangers without an invite handshake or contact relationship still cannot land in the main feed (this is *unchanged*); strangers' conversations are now persisted-but-hidden for 7 days instead of dropped on the floor, which is a small storage-tradeoff we accept to enable the "just met in a group, then DM'd me" promotion path.
+
+**Blocking is local-only.** Blocked parties are not notified. They can still see the local user as a member of any shared group (existing groups continue to work, modulo the open question on mid-group blocking).
+
+**The other party doesn't know they've been added.** Same as before — auto-add is purely local. There is no "X added you as a contact" event sent over the network.
+
+**iCloud keychain account compromise** (the documented risk in ADR-011) is unchanged — the contacts and the block list are derivable from local data; a compromise does not expose anything that wasn't already accessible.
+
+## Risks & Mitigations
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Backfill is slow on a high-conversation device, blocking launch UX | Low | Backfill scope is now narrower (only conversations the local user has acted in). Run on background priority Task; per-conversation transactions make partial progress durable. If a real device shows >5s perceptible delay, surface a one-time "setting up your contacts" indicator. |
+| Profile snapshot on `DBContact` goes stale relative to `DBMemberProfile` | Low | `ContactsProfileSyncWriter` listens for member-profile writes and updates the snapshot most-recent-wins. Worst case is brief eventual-consistency; documented in user stories. |
+| `addedViaConversationId` references a deleted conversation | Low | FK uses `onDelete: .setNull`. The "added via" subtitle falls back gracefully when the source convo is gone. |
+| Auto-add fires from a large stranger group merely because the user posted "hi" | Medium | The action-gated trigger is intentional — sending a message is the explicit signal. If users complain about getting hundreds of contacts from one large room, follow-up: add a "skip auto-add for groups with > N members" setting. |
+| Hook ordering bugs — auto-add fires before `DBConversationMember` writes are committed, sees no members | High | Both hook sites are wired *after* their respective `DBConversationMember` writes commit. The coordinator's read happens in a separate transaction, after the writer's transaction is committed. Integration tests cover this. |
+| Quarantine sweeper drops a held conversation that the user would have wanted | Medium | TTL is configurable and starts at 7 days, which is long enough for most "we just met in a group, then they DM'd me" flows. The sweeper promotes conversations whose senders become contacts during the window. If user feedback shows lost conversations, raise the TTL or add a UI surface for the held set. |
+| Block does not silence in-group messages from the blocked party | Medium | This is an explicit V1 limitation. Tracked in open questions. If user demand is high, a follow-up adds either per-message hide or per-conversation mute-of-sender. |
+| User sends a DM to a contact who has never acted in any shared group with them, so the recipient quietly never receives it | Medium | The local sender's UX shows the message as "sent" because it is — at the protocol level. The recipient's `InboundConversationFilter` decides not to surface it because the sender is not in their contacts. This asymmetry is by design but can confuse users. Mitigation: documentation in support; consider a future "delivery" indicator. |
+| Multi-inbox reversion (theoretical) | Low | Documented as a non-goal. Schema is keyed on inboxId; if Convos ever has multiple inboxes per user, the contacts feature needs explicit rework. Acceptable long-tail concern. |
+
+## Open Questions
+
+- [ ] **Block-in-group behavior.** Does blocking a contact silence their messages within an existing shared group, or only reject future inbound conversation invitations from them? V1 ships with the latter (block affects only inbound welcomes). Block-in-group is a follow-up.
+- [ ] **Manual contact removal.** Can a user delete a contact (separate from blocking)? If yes, what happens when they next appear in a shared group action? *(Recommendation: ship without manual removal; revisit after user feedback. Blocking covers the most common "I don't want this person to message me" intent already.)*
+- [ ] **Self-contact.** Does the local user appear as their own contact (for "note to self")? *(Recommendation: no for V1. The coordinator filters self via `DBInbox`.)*
+- [ ] **Quarantine TTL.** Default 7 days. Validate with product / privacy review before Phase 2.6 ships.
+- [ ] **Quarantine UX.** No surface for held conversations in V1. Should there be a "message requests" tray for power users who want to see what was filtered out? Tracked as a follow-up — not in V1.
+- [ ] **Empty state on contact card.** What is shown when a contact has zero shared conversations remaining (Step 2.5)? *(Recommendation: empty state with avatar / name and a "Start a conversation" CTA.)*
+- [ ] **Favorites section in the picker.** What seeds Favorites in V1? Empty / heuristic / explicit favoriting affordance. Defer to designer pass.
+- [ ] **Sort policy.** V1 is alphabetical only (per review feedback). Recency-aware sort is a follow-up.
+- [ ] **Naming.** "Contacts" — confirmed via review feedback. Wording for the menu entry under "My info" still TBD ("Contacts" vs. "My contacts" vs. "People"). Designer call.
+- [ ] **Privacy framing review.** Action-gated auto-add and contact-gated inbound filter together change the messaging-permission model meaningfully. Walk through with privacy / legal before launch.
+- [ ] **Recipient-side disclosure for new DMs.** When the local user starts a new DM with a contact whose contact list does *not* include the local user, the message is silently quarantined on the recipient side. Should the sender's UI hint at this possibility? Tracked as a follow-up — not in V1.
+- [ ] **DM persistence model for "Send a message" (Step 2).** Today, 1:1 DMs are not persisted as `conversation` rows — `StreamProcessor.processMessage` (lines 184-311) consumes them as transport for invite-payload routing. Step 2's "Send a message" CTA needs a destination conversation type. Two options: (1) create a group-of-two under the hood so the new contact-gated filter applies as-is on the inbound side, or (2) extend the persistence model to accept DMs as first-class conversations gated by `InboundConversationFilter`. *(Recommendation: option 1 for V1 to avoid expanding scope; option 2 in a follow-up.)*
+
+## References
+
+- [1-pager (companion document, with wireframes)](./contact-list.md)
+- [Wireframes](./contact-list-mocks/)
+- [ADR-005: Member Profile System](../adr/005-member-profile-system.md) — per-conversation profile data we synthesize from.
+- [ADR-011: Single Inbox Identity Model](../adr/011-single-inbox-identity-model.md) — the identity model that lets us key on inboxId.
+- [docs/identity-system-overview.md](../identity-system-overview.md) — broader identity context.
+- [docs/plans/show-pending-invites-home-view.md](./show-pending-invites-home-view.md) — related but distinct surface for pending invites.
+- [docs/plans/invite-system-single-inbox.md](./invite-system-single-inbox.md) — invite-accept flow.
+- `ConvosCore/Sources/ConvosCore/Storage/SharedDatabaseMigrator.swift` — migration registration site.
+- `ConvosCore/Sources/ConvosCore/Storage/Repositories/ConversationsRepository.swift` — main-feed read path; updated to exclude quarantined rows.
+- `ConvosCore/Sources/ConvosCore/Syncing/StreamProcessor.swift` — inbound-conversation arrival site. `shouldProcessConversation` lines 713-739 is the existing consent + outgoing-join-request gate that the new `InboundConversationFilter` extends; `processConversation` lines 140-145 calls it; `processMessage` lines 184-311 handles DM-as-invite-transport.
+- `ConvosCore/Sources/ConvosCore/Syncing/InviteJoinRequestsManager.swift` — `hasOutgoingJoinRequest(for:client:)` lines 149-154 (the existing invite-flow elevator); `processJoinRequestOutcome(message:client:)` lines 106-115 (DM-borne invite payload validator).
+- `ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationMetadataWriter.swift` — `addMembers` hook site for member-added trigger.
+- `ConvosCore/Sources/ConvosCore/Storage/Writers/MessagesWriter.swift` (or equivalent) — first-outbound-message hook site for the primary auto-add trigger; confirm exact file during implementation.

--- a/docs/plans/contact-list.md
+++ b/docs/plans/contact-list.md
@@ -1,0 +1,117 @@
+# 1-Pager: Contact List (Contacts MVP)
+
+> **Status**: Draft
+> **Author**: Cameron Voell
+> **Created**: 2026-04-27
+> **Updated**: 2026-04-28 (six wireframes added)
+
+## 1. Tweet Headline
+
+👉 "Convos now has a contact list — everyone you've ever talked to, in one place, ready to start a new chat."
+
+## 2. Show, Don't Tell
+
+Wireframes for the six MVP surfaces. Built as standalone SVGs so they live in-repo and render in any markdown viewer.
+
+| | |
+|:---:|:---:|
+| <img src="contact-list-mocks/01-contacts-list.svg" width="260" alt="Contacts list"/><br/>**1. Contacts list** — alphabetical, search, "via" subtitle hints at auto-add. Browse-mode entry point: tap a row to open the contact card | <img src="contact-list-mocks/02-contact-card.svg" width="260" alt="Contact card"/><br/>**2. Contact card** — profile + every shared conversation. Single-recipient flow: card → "Send a message" → 1:1 chat |
+| <img src="contact-list-mocks/03-inbound-in-feed.svg" width="260" alt="Inbound chats in main feed"/><br/>**3. Inbound chats in main feed** — subtle "added you" badge, no separate tray | <img src="contact-list-mocks/04-add-from-contacts-menu.svg" width="260" alt="Add from Contacts in chat plus-menu"/><br/>**4. "Add from Contacts"** — new row in the chat plus-menu, alongside Invite link and Convo code |
+| <img src="contact-list-mocks/05-contacts-toolbar-icon.svg" width="260" alt="Contacts icon in conversations toolbar"/><br/>**5. Contacts icon in conversations toolbar** — third icon between scan and compose, opens screen 1. Open question whether 3 icons is too many | <img src="contact-list-mocks/06-contacts-picker.svg" width="260" alt="Contacts picker"/><br/>**6. Contacts picker** — invoked from screen 4. Same row component as screen 1 in pick-mode. Members already in the destination chat sit inline alphabetically, dimmed, with an "in chat" badge so the user can see why they're not selectable |
+
+These are wireframes, not final visuals — they fix the surfaces and copy but leave room for a real designer pass before ship. Two design notes worth calling out from the sketching pass:
+
+- **Browse vs. picker is one component, two modes.** Screens 1 and 6 share a row format, search bar, and alphabetical sectioning by design — the picker should read as "your contacts, with toggles" rather than as a different surface. The differences are: tap behavior (open card vs. toggle check), header (just a title vs. a destination chat pill), and bottom CTA. The browse mode (1) is the only path to the contact card; the picker (6) is invoked solely from the chat plus-menu row in screen 4.
+- **No standalone "new conversation" picker.** Compose creates an empty convo with an auto-generated name; participants are added afterward via the chat plus-menu, which routes through the picker (6). Single-recipient DMs flow through the contact card's "Send a message" CTA on screen 2. This keeps the picker tightly scoped to one job ("add people to this chat from your contacts") and removes a redundant entry point.
+
+Open visual questions still on the table: sort/search behavior on screen 1 (alphabetical vs. recency toggle), empty state for a contact with zero remaining shared conversations on screen 2, whether the "added you" badge on screen 3 wants accept/ignore inline actions or relies on opening the convo to engage, whether 3 icons in the conversations toolbar (screen 5) feels crowded vs. moving the contacts entry point elsewhere, and whether the picker should section off "already in this chat" members at large group sizes (the inline-disabled treatment is fine for groups up to ~10; beyond that we may want to revisit).
+
+- 🍿 Loom demo link — N/A
+- 🎨 Figma file link — N/A
+
+## 3. How It Works
+
+The five MVP features:
+
+1. **Contact list** — a local "address book" of every user you've had a conversation with. Backed by a new GRDB table; a contact is keyed by `inboxId` (the other party's inbox identifier under the single-inbox identity model from ADR-011).
+2. **Contact card** — a per-contact detail screen that surfaces the user's profile (name, avatar, bio via the existing member-profile system in ADR-005) and the list of conversations you currently share with them. Send Message starts a new group with just you and that member if you do not have one already. If you have one already, I'm thinking we send you to the existing 1 on 1 Group, maybe with a temporary bubble that says (start a new chat instead?).
+3. **Auto-add on conversation join or new member add** — when the local user joins a conversation (1:1, group, or invite-accept flow), every other participant is added as a contact if not already present. If a new user joins a conversation, they are auto-added as a new contact as well. This is MVP behavior, still thinking how we can add more user choice here. 
+4. **Add a known contact to an existing chat + inbound chats surfacing** — inside an existing conversation, surface a "+ Add contact" affordance backed by the contact list. Inbound conversations the local user has been added to (by others) appear in the main conversations feed for MVP — no separate requests tray.
+5. **Start a new conversation with a contact** — For MVP, the two places you can do this are from the send message button on a contact screen, or from the plus button on a new conversation. 
+
+Auto-add scope:
+
+- **Past conversations on first migration**: a one-time backfill scans every existing conversation on the device and populates the contacts table. 
+- **New conversations going forward**: auto-add fires on the conversation-join hook (same plumbing the migration uses, just called per-event).
+- **New Member added to a group**: on group refresh we should passively calculate the group membership state and check to see if it has updated since we last synced contacts. 
+
+## 4. Who Cares
+
+- **New user onboarding from invite link**: Maya joins a Convos group via invite, gets auto-added as a contact for everyone in that group, and now has a starter set of people she can DM directly without re-discovering them.
+- **Power user with many overlapping groups**: Jarod is in 30 group chats with overlapping memberships. He wants to DM someone he met in one of them but can't remember which group — the contact list collapses everyone into a single searchable surface.
+- **Cross-conversation context**: Cameron taps a contact card and immediately sees every conversation he shares with that person — useful for "where did I last talk to this person about X?" without having to scroll the whole inbox.
+- **Reaching out from outside an existing chat**: Alice wants to message Bob but they don't have a 1:1 yet — only a shared group. "Start new conversation with contact" turns Bob into a directly-addressable person, not just a group member.
+
+## 5. What It Isn't
+
+- **This is not a discovery / global directory.** You can only contact someone you've already shared a conversation with.
+- **This does not solve cross-device sync.** Contacts live in local GRDB only for MVP. A future integration with a backups system (for users who lose a device) is anticipated but explicitly out of scope.
+- **This is not a server-side contact graph.** No backend storage, no server-side queries, no "people you may know" recommendations.
+- **This is not a permissions / blocking system.** Blocked users — see UAQ — are not implemented in Convos today, and the contact list is not the right place to add them. We will add a hook to filter blocked users *if and when* a blocking concept is introduced.
+- **This is not a separate "message requests" inbox.** Inbound chats appear inline in the main conversations feed for MVP.
+- **This is not multi-inbox aware.** Contacts assume the single-inbox identity model from ADR-011.
+
+## 6. FAQ + UAQ
+
+### FAQ (known questions)
+
+1. **Q**: How is a contact identified?
+   **A**: By the other party's `inboxId` under the single-inbox identity model ([ADR-011](../adr/011-single-inbox-identity-model.md)). The contact row stores the `inboxId`; profile data (display name, avatar, bio) is resolved through the existing member-profile system ([ADR-005](../adr/005-member-profile-system.md)), not duplicated in the contacts table.
+
+2. **Q**: What happens when I'm in a 1,000-person group chat?
+   **A**: For MVP, every participant is auto-added. We've flagged "make auto-add configurable for large stranger groups" as an explicit follow-up TODO so we can ship MVP without being blocked on the policy debate.
+
+3. **Q**: Why local-only? Won't users be sad if they switch phones and lose contacts?
+   **A**: Yes, eventually. Per the answer in the brief, MVP scope is local GRDB only, and integration with a future backups system is anticipated. We'd rather ship contacts now and layer on durable storage when the backup system is ready, than block on it.
+
+4. **Q**: How do we avoid re-scanning conversations every launch?
+   **A**: A `contacts_synced_at` (or equivalent) marker per conversation, stored in GRDB. Scan once, mark synced, skip on subsequent launches.
+
+5. **Q**: Where does the inbound-chats UI live?
+   **A**: In the main conversations feed for MVP. We are *not* building a separate requests/pending tray (cf. `docs/plans/show-pending-invites-home-view.md` which is a related but distinct surface).
+
+### UAQ (unanswered questions)
+
+- [ ] **Blocked users** — Convos does not currently implement a user-blocking concept (verified: no `BlockedUser`, `isBlocked`, or `BlockList` types in the codebase). What should happen in MVP? Two reasonable defaults: (a) ship without any block awareness and add the filter later when blocking lands, or (b) add an `isBlocked: Bool` column to contacts now as future-proofing. Recommend (a) for simplicity unless we know blocking is coming soon.
+- [ ] **Removing a contact** — can the user manually delete a contact from the list? If so, do they re-appear on next conversation activity, or is there a "hidden" / "soft-delete" state?
+- [ ] **Self-contact** — does the local user appear as a contact (e.g. for a "note to self" flow)? Default answer: no.
+- [ ] **Contact card → conversation list** — what's shown when a contact has *no* conversations remaining (e.g. you left every group you shared)? Empty state with a "Start a conversation" CTA?
+- [ ] **Sort + search** — alphabetical with search, or recency-based? Likely both with a toggle, but needs a designer call.
+- [ ] **Naming for the auto-add semantics** — is this called "Contacts," "Address Book," or something more Convos-flavored? Settle this before strings ship.
+- [ ] **Migration performance** — for users with many large groups, the first-launch backfill could be expensive. Background task, batched, or streamed during normal app use?
+- [ ] **Privacy framing** — does auto-adding everyone in every group chat create a privacy expectation issue (the other party doesn't know they've been "added")? Since this is purely local, probably fine, but worth a quick legal/privacy check.
+
+## 7. Counterintuitive Angle
+
+👉 "Convos already has a contact list — it's just smeared across every conversation. Naming it unlocks the social features (DMs from groups, profile-first navigation, future backups, future blocking) that everyone is going to want next."
+
+## 8. Call to Action
+
+- [x] ✅ Build
+- [ ] 🧪 Test
+- [ ] 🚫 Drop
+- [ ] 💬 Debate
+
+**Next steps if approved:**
+
+- Hand the wireframes in [`contact-list-mocks/`](./contact-list-mocks/) to a designer for a polish pass and a Figma source — the SVGs fix the five surfaces and the copy, but the visual treatment (typography, spacing, the "added you" badge styling, toolbar icon) deserves a designer's eye before ship.
+- Resolve the open UAQs above, especially the blocked-users default and contact-removal semantics.
+- Graduate this 1-pager to a full PRD at `docs/plans/contact-list.md` (in place) using `docs/TEMPLATE_PRD.md`.
+- Bring in the `swift-architect` agent to design the GRDB schema, the auto-add hook integration with the conversation-join flow, and the migration strategy.
+- Likely needs a new ADR for the storage model and its forward-compatibility with the future backups system.
+
+## References
+
+- [ADR-005: Member Profile System](../adr/005-member-profile-system.md) — profile resolution we'll lean on for contact display.
+- [ADR-011: Single Inbox Identity Model](../adr/011-single-inbox-identity-model.md) — the identity assumption that lets us key contacts on `inboxId`.
+- [docs/plans/show-pending-invites-home-view.md](./show-pending-invites-home-view.md) — related but distinct surface for pending invites; we are *not* building that for inbound chats in MVP.


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add Contacts MVP product requirements document and wireframes
Adds a PRD and 1-pager for the Contacts MVP feature, covering the full product and technical design. Key documents added:
- [contact-list-prd.md](https://github.com/xmtplabs/convos-ios/pull/775/files#diff-710b666262494315244bbb656d083a0ab77fc4dcf8a6096a0e3bab5952d183aa): Full PRD with data model, migrations, auto-add coordinator, profile resolution, inbound filtering, blocking, backfill logic, and a phased implementation plan
- [contact-list.md](https://github.com/xmtplabs/convos-ios/pull/775/files#diff-4dacd91dbb5240248d0703fdc221e0391bcf49cb772eb9d2b5292c748b34b317): 1-pager summarizing the feature, user stories, non-goals, and FAQ
- Six SVG wireframes in [docs/plans/contact-list-mocks/](https://github.com/xmtplabs/convos-ios/pull/775/files#diff-18c3c1ff805be3547329e405928f23a0f0613de956134c4196cf0f772bd1dd8c) covering the contacts list, contact card, in-feed inbound chats, plus-menu, toolbar icon, and contacts picker

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized a2d89e8.</sup>
<!-- Macroscope's review summary ends here -->
<!-- Macroscope's pull request summary ends here -->