### PR TITLE
automate libxmtp release updates with renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "labels": ["dependencies"],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Match the libxmtp tag in Package.swift `revision:` pins. Both -dev and -nightly tags are recognized as currentValue so manual dev pins aren't dropped; the versioningTemplate constrains *update candidates* to nightly only.",
+      "managerFilePatterns": ["/Package\\.swift$/"],
+      "matchStrings": [
+        "url:\\s*\"https://github\\.com/xmtp/libxmtp\\.git\"[\\s\\S]*?revision:\\s*\"(?<currentValue>ios-[^\"]+)\""
+      ],
+      "datasourceTemplate": "git-tags",
+      "depNameTemplate": "https://github.com/xmtp/libxmtp",
+      "versioningTemplate": "regex:^ios-(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-nightly\\.(?<build>\\d{8}\\.[a-f0-9]+)$"
+    },
+    {
+      "customType": "regex",
+      "description": "Match Package.resolved's libxmtp entry. SPM stores the tag under `branch` and the resolved commit SHA under `revision`; both must be updated together, captured here as currentValue + currentDigest.",
+      "managerFilePatterns": ["/Package\\.resolved$/"],
+      "matchStrings": [
+        "\"identity\"\\s*:\\s*\"libxmtp\"[\\s\\S]*?\"branch\"\\s*:\\s*\"(?<currentValue>ios-[^\"]+)\"[\\s\\S]*?\"revision\"\\s*:\\s*\"(?<currentDigest>[a-f0-9]{40})\""
+      ],
+      "datasourceTemplate": "git-tags",
+      "depNameTemplate": "https://github.com/xmtp/libxmtp",
+      "versioningTemplate": "regex:^ios-(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-nightly\\.(?<build>\\d{8}\\.[a-f0-9]+)$"
+    }
+  ],
+  "packageRules": [
+    {
+      "matchPackageNames": ["https://github.com/xmtp/libxmtp"],
+      "groupName": "libxmtp",
+      "branchName": "renovate/libxmtp",
+      "prConcurrentLimit": 1,
+      "rebaseWhen": "behind-base-branch",
+      "schedule": ["after 7am and before 9am every weekday"],
+      "timezone": "UTC",
+      "commitMessageTopic": "libxmtp",
+      "commitMessageExtra": "to {{newValue}}",
+      "prTitle": "chore(deps): update libxmtp to {{newValue}}"
+    }
+  ]
+}


### PR DESCRIPTION
I added [nightly libxmtp releases](https://github.com/xmtp/libxmtp/pull/3573) so every day at 6UTC a libxmtp release will be out if there were new changes in main. this adds a renovate configuration to automatically open a PR and update libxmtp refs with the new version once the release lands.


blocked on adding renovate to this repo

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Automate libxmtp release updates with Renovate
> Adds [renovate.json](https://github.com/xmtplabs/convos-ios/pull/776/files#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57) with two custom regex managers that track `libxmtp` tags in `Package.swift` and `Package.resolved`, constrained to nightly-versioned tags.
>
> - Updates are grouped under a single `renovate/libxmtp` branch with a PR concurrency limit of 1
> - PRs are scheduled weekdays between 7–9am UTC and rebased automatically when behind base
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2ac22e5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->