### PR TITLE
fix(backup): heal stuck restores from broken legacy wipe (build 800)

### DIFF
--- a/ConvosCore/Sources/ConvosCore/Backup/RestoreManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Backup/RestoreManager.swift
@@ -102,7 +102,7 @@ public actor RestoreManager {
                       let sidecar = try? BackupSidecarMetadata.read(from: dir) else {
                     continue
                 }
-                guard sidecar.schemaGeneration == LegacyDataWipe.currentGeneration else {
+                guard LegacyDataWipe.isCompatibleGeneration(sidecar.schemaGeneration) else {
                     Log.info("RestoreManager: skipping bundle with incompatible schema " +
                         "(\(sidecar.schemaGeneration) vs \(LegacyDataWipe.currentGeneration))")
                     continue
@@ -438,7 +438,7 @@ public actor RestoreManager {
         }
 
         let currentGeneration = LegacyDataWipe.currentGeneration
-        guard metadata.schemaGeneration == currentGeneration else {
+        guard LegacyDataWipe.isCompatibleGeneration(metadata.schemaGeneration) else {
             QAEvent.emit(
                 .backup,
                 "schema_generation_mismatch",

--- a/ConvosCore/Sources/ConvosCore/Storage/LegacyDataWipe.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/LegacyDataWipe.swift
@@ -10,7 +10,35 @@ import Security
 /// re-wipe on next launch when the on-disk format changes incompatibly.
 public enum LegacyDataWipe {
     /// Current schema generation. Bump when a schema change requires a wipe.
-    public static let currentGeneration: String = "v1-single-inbox"
+    public static let currentGeneration: String = "single-inbox-v2"
+
+    /// Generation strings that are functionally equivalent to
+    /// `currentGeneration` and must not trigger a wipe. Bumping the
+    /// canonical name (e.g. for cosmetic alignment with the GRDB
+    /// migration identifier) would otherwise wipe every install whose
+    /// stored marker is one of these — and on the single-inbox file
+    /// layout the wipe deletes the active `xmtp-*.db3` files, which is
+    /// catastrophic. Add the previous canonical name here when renaming.
+    ///
+    /// `v1-single-inbox` covers two populations:
+    /// - users who shipped the (now reverted) v1-single-inbox build
+    /// - users whose marker got forwarded to v1-single-inbox by the
+    ///   broken wipe in build 800 (the wipe deleted xmtp-*.db3 but
+    ///   left convos-single-inbox.sqlite; their GRDB rows now refer
+    ///   to conversations that no longer exist in libxmtp's local
+    ///   store, and rerunning the wipe would not help)
+    private static let compatibleGenerations: Set<String> = [
+        currentGeneration,
+        "v1-single-inbox"
+    ]
+
+    /// Returns `true` when `value` may be treated as the current
+    /// generation. Used by `RestoreManager` so backups produced under
+    /// a compatible-but-stale generation remain restorable on the
+    /// fixed build.
+    public static func isCompatibleGeneration(_ value: String) -> Bool {
+        compatibleGenerations.contains(value)
+    }
 
     private static let schemaGenerationKey: String = "convos.schemaGeneration"
 
@@ -37,7 +65,12 @@ public enum LegacyDataWipe {
     ) {
         let stored = defaults.string(forKey: schemaGenerationKey)
 
-        if stored == currentGeneration {
+        if let stored, compatibleGenerations.contains(stored) {
+            // Bring the marker forward to the current canonical name so
+            // future launches short-circuit on the cheap equality check.
+            if stored != currentGeneration {
+                defaults.set(currentGeneration, forKey: schemaGenerationKey)
+            }
             return
         }
 
@@ -126,9 +159,11 @@ public enum LegacyDataWipe {
     /// every subsequent launch the marker short-circuits before the scan.
     private static func detectLegacyArtifacts(databasesDirectory: URL) -> Bool {
         let fileManager = FileManager.default
-        let grdbURL = databasesDirectory.appendingPathComponent("convos.sqlite")
-        if fileManager.fileExists(atPath: grdbURL.path) {
-            return true
+        for filename in legacyGRDBFilenames {
+            let url = databasesDirectory.appendingPathComponent(filename)
+            if fileManager.fileExists(atPath: url.path) {
+                return true
+            }
         }
 
         guard let entries = try? fileManager.contentsOfDirectory(
@@ -154,12 +189,7 @@ public enum LegacyDataWipe {
     private static func wipeDatabases(at directory: URL) {
         let fileManager = FileManager.default
 
-        let grdbFiles = [
-            "convos.sqlite",
-            "convos.sqlite-shm",
-            "convos.sqlite-wal"
-        ]
-        for filename in grdbFiles {
+        for filename in legacyGRDBFilenames {
             removeItem(at: directory.appendingPathComponent(filename), fileManager: fileManager)
         }
 
@@ -172,6 +202,20 @@ public enum LegacyDataWipe {
             }
         }
     }
+
+    /// GRDB databases the wipe must remove. Includes the new
+    /// single-inbox name (`convos-single-inbox.sqlite`) — the broken
+    /// build 800 wipe targeted only the obsolete `convos.sqlite`,
+    /// leaving the active GRDB intact while libxmtp's xmtp-*.db3 was
+    /// deleted, which is what stranded conversations.
+    private static let legacyGRDBFilenames: [String] = [
+        "convos.sqlite",
+        "convos.sqlite-shm",
+        "convos.sqlite-wal",
+        "convos-single-inbox.sqlite",
+        "convos-single-inbox.sqlite-shm",
+        "convos-single-inbox.sqlite-wal"
+    ]
 
     private static func removeItem(at url: URL, fileManager: FileManager) {
         guard fileManager.fileExists(atPath: url.path) else { return }

--- a/ConvosCore/Sources/ConvosCore/Syncing/OrphanedConversationReconciler.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/OrphanedConversationReconciler.swift
@@ -1,0 +1,118 @@
+import Foundation
+import GRDB
+@preconcurrency import XMTPiOS
+
+/// Reconciles GRDB conversation rows against libxmtp's local store after
+/// session start. If GRDB has rows that libxmtp does not, they are
+/// flipped to `isActive = false` so the UI surfaces "Awaiting
+/// reconnection" until the conversation comes back via #725's
+/// `InactiveConversationReactivator`.
+///
+/// Two known sources of drift this routine heals:
+///
+/// 1. Build 800's `LegacyDataWipe` deleted libxmtp's `xmtp-*.db3`
+///    files but missed `convos-single-inbox.sqlite`, leaving GRDB rows
+///    pointing at conversations the freshly-rebuilt libxmtp does not
+///    know about.
+/// 2. Pre-existing drift on healthy installs (observed in production
+///    logs from before the broken wipe shipped). The exact code path
+///    is still open — possible candidates include welcome packets
+///    dropped between NSE and main app, draft upgrades that wrote to
+///    GRDB before the libxmtp group was live, or invite-join races
+///    where the libxmtp commit silently failed. The QAEvent emitted
+///    here is the canary: a non-zero `flipped` count on a healthy
+///    user post-fix means the second bug is still firing.
+///
+/// Drafts (`id` prefix `draft-`) are excluded — by design they have
+/// no libxmtp counterpart until publish.
+///
+/// Not an actor because the only call site is single-threaded
+/// (SyncingManager runs `reconcile` once per session-ready transition)
+/// and `actor` isolation on `reconcile(client:)` collides with the
+/// non-Sendable `any ConversationsProvider` the call has to await on.
+public final class OrphanedConversationReconciler: @unchecked Sendable {
+    private let databaseReader: any DatabaseReader
+    private let stateWriter: any ConversationLocalStateWriterProtocol
+
+    public init(
+        databaseReader: any DatabaseReader,
+        stateWriter: any ConversationLocalStateWriterProtocol
+    ) {
+        self.databaseReader = databaseReader
+        self.stateWriter = stateWriter
+    }
+
+    /// Idempotent. Runs once after first `syncAllConversations` per
+    /// session-ready transition. Failures are logged; the caller does
+    /// not need to react.
+    public func reconcile(client: any XMTPClientProvider) async {
+        let xmtpConversationIds: Set<String>
+        do {
+            let conversations = try await client.conversationsProvider.list(
+                createdAfterNs: nil,
+                createdBeforeNs: nil,
+                lastActivityBeforeNs: nil,
+                lastActivityAfterNs: nil,
+                limit: nil,
+                consentStates: nil,
+                orderBy: .lastActivity
+            )
+            xmtpConversationIds = Set(conversations.map(\.id))
+        } catch {
+            Log.error("OrphanedConversationReconciler: failed to list libxmtp conversations: \(error)")
+            return
+        }
+        await reconcile(xmtpConversationIDs: xmtpConversationIds)
+    }
+
+    /// Test entry point — bypasses libxmtp listing because constructing
+    /// `XMTPiOS.Conversation` values in unit tests requires the Rust
+    /// runtime. Production goes through `reconcile(client:)`.
+    func reconcile(xmtpConversationIDs: Set<String>) async {
+        let grdbConversationIds: Set<String>
+        do {
+            grdbConversationIds = try await databaseReader.read { db in
+                let ids = try String.fetchAll(
+                    db,
+                    DBConversation
+                        .filter(!DBConversation.Columns.id.like("draft-%"))
+                        .select(DBConversation.Columns.id)
+                )
+                return Set(ids)
+            }
+        } catch {
+            Log.error("OrphanedConversationReconciler: failed to read GRDB conversation IDs: \(error)")
+            return
+        }
+
+        let orphans = grdbConversationIds.subtracting(xmtpConversationIDs)
+        guard !orphans.isEmpty else {
+            QAEvent.emit(.sync, "reconciliation_no_orphans", [
+                "grdb": String(grdbConversationIds.count),
+                "xmtp": String(xmtpConversationIDs.count),
+            ])
+            return
+        }
+
+        var flipped: Int = 0
+        for id in orphans {
+            do {
+                try await stateWriter.setActive(false, for: id)
+                flipped += 1
+            } catch {
+                Log.error("OrphanedConversationReconciler: failed to mark \(id) inactive: \(error)")
+            }
+        }
+
+        QAEvent.emit(.sync, "reconciliation_completed", [
+            "orphans": String(orphans.count),
+            "flipped": String(flipped),
+            "grdb": String(grdbConversationIds.count),
+            "xmtp": String(xmtpConversationIDs.count),
+        ])
+        Log.info(
+            "OrphanedConversationReconciler: flipped \(flipped)/\(orphans.count) orphans inactive "
+            + "(grdb=\(grdbConversationIds.count), xmtp=\(xmtpConversationIDs.count))"
+        )
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Syncing/SyncingManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/SyncingManager.swift
@@ -132,6 +132,7 @@ actor SyncingManager: SyncingManagerProtocol {
     // MARK: - Initialization
 
     private let databaseReader: any DatabaseReader
+    private let databaseWriter: any DatabaseWriter
 
     init(identityStore: any KeychainIdentityStoreProtocol,
          databaseWriter: any DatabaseWriter,
@@ -140,6 +141,7 @@ actor SyncingManager: SyncingManagerProtocol {
          notificationCenter: any UserNotificationCenterProtocol) {
         self.identityStore = identityStore
         self.databaseReader = databaseReader
+        self.databaseWriter = databaseWriter
         self.streamProcessor = StreamProcessor(
             identityStore: identityStore,
             databaseWriter: databaseWriter,
@@ -394,7 +396,22 @@ actor SyncingManager: SyncingManagerProtocol {
             // This handles cases where the joiner was added to a group while
             // the inbox was paused, stopped, or the stream had a timeout.
             await discoverNewConversations(params: params)
+
+            // Heal GRDB rows whose libxmtp counterpart is missing — see
+            // OrphanedConversationReconciler. Runs after discovery so newly
+            // delivered groups are present in GRDB before the diff. Foreground
+            // (paused → ready) transitions go through handleResume and skip
+            // this on purpose: the local store hasn't been replaced under us.
+            await reconcileOrphanedConversations(params: params)
         }
+    }
+
+    private func reconcileOrphanedConversations(params: SyncClientParams) async {
+        let reconciler = OrphanedConversationReconciler(
+            databaseReader: databaseReader,
+            stateWriter: ConversationLocalStateWriter(databaseWriter: databaseWriter)
+        )
+        await reconciler.reconcile(client: params.client)
     }
 
     /// Lists all XMTP groups and processes any that are missing from the local database.

--- a/ConvosCore/Tests/ConvosCoreTests/LegacyDataWipeTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/LegacyDataWipeTests.swift
@@ -44,6 +44,92 @@ struct LegacyDataWipeTests {
         #expect(FileManager.default.fileExists(atPath: grdb.path))
     }
 
+    @Test("Compatible legacy generation 'v1-single-inbox' is treated as current — no wipe, marker forwarded")
+    func compatibleGenerationIsNotWiped() throws {
+        let fixture = try TempFixture()
+        // Two populations land here:
+        //   1. Users who shipped the (now-reverted) v1-single-inbox build.
+        //   2. Users whose marker was forwarded to v1-single-inbox by the
+        //      broken build 800 wipe (which deleted xmtp-*.db3 but left
+        //      convos-single-inbox.sqlite intact).
+        // Neither should re-trigger a wipe — that would compound the damage.
+        fixture.defaults.set("v1-single-inbox", forKey: "convos.schemaGeneration")
+        let activeXmtp = fixture.databasesDirectory
+            .appendingPathComponent("xmtp-grpc.dev.xmtp.network-abc123.db3")
+        try Data("active-xmtp-db".utf8).write(to: activeXmtp)
+        let activeGRDB = fixture.databasesDirectory
+            .appendingPathComponent("convos-single-inbox.sqlite")
+        try Data("active-grdb".utf8).write(to: activeGRDB)
+
+        LegacyDataWipe.runIfNeeded(
+            defaults: fixture.defaults,
+            databasesDirectory: fixture.databasesDirectory,
+            legacyKeychainAccessGroup: legacyAccessGroup
+        )
+
+        #expect(FileManager.default.fileExists(atPath: activeXmtp.path))
+        #expect(FileManager.default.fileExists(atPath: activeGRDB.path))
+        #expect(
+            fixture.defaults.string(forKey: "convos.schemaGeneration")
+            == LegacyDataWipe.currentGeneration
+        )
+    }
+
+    @Test("isCompatibleGeneration recognises current and known-prior canonical names")
+    func isCompatibleGenerationMatchesAcceptedNames() {
+        #expect(LegacyDataWipe.isCompatibleGeneration(LegacyDataWipe.currentGeneration))
+        #expect(LegacyDataWipe.isCompatibleGeneration("v1-single-inbox"))
+        #expect(!LegacyDataWipe.isCompatibleGeneration("single-inbox-v0"))
+        #expect(!LegacyDataWipe.isCompatibleGeneration("totally-unknown"))
+    }
+
+    @Test("Wipe targets convos-single-inbox.sqlite GRDB sidecars too")
+    func wipeRemovesSingleInboxGRDB() throws {
+        let fixture = try TempFixture()
+        // Force a wipe path: stale generation, with the new GRDB filename
+        // present alongside the obsolete one. Build 800 only wiped the
+        // obsolete name, orphaning the active GRDB; this locks the fix.
+        fixture.defaults.set("single-inbox-v0", forKey: "convos.schemaGeneration")
+        let obsoleteGRDB = fixture.databasesDirectory.appendingPathComponent("convos.sqlite")
+        try Data("obsolete".utf8).write(to: obsoleteGRDB)
+        let singleInboxGRDB = fixture.databasesDirectory
+            .appendingPathComponent("convos-single-inbox.sqlite")
+        try Data("single-inbox".utf8).write(to: singleInboxGRDB)
+        let singleInboxWAL = fixture.databasesDirectory
+            .appendingPathComponent("convos-single-inbox.sqlite-wal")
+        try Data("wal".utf8).write(to: singleInboxWAL)
+
+        LegacyDataWipe.runIfNeeded(
+            defaults: fixture.defaults,
+            databasesDirectory: fixture.databasesDirectory,
+            legacyKeychainAccessGroup: legacyAccessGroup
+        )
+
+        #expect(!FileManager.default.fileExists(atPath: obsoleteGRDB.path))
+        #expect(!FileManager.default.fileExists(atPath: singleInboxGRDB.path))
+        #expect(!FileManager.default.fileExists(atPath: singleInboxWAL.path))
+        #expect(fixture.defaults.string(forKey: "convos.schemaGeneration") == LegacyDataWipe.currentGeneration)
+    }
+
+    @Test("Cold install with only convos-single-inbox.sqlite triggers wipe")
+    func singleInboxGRDBAloneTriggersWipe() throws {
+        let fixture = try TempFixture()
+        // No marker, but the new GRDB is present. detectLegacyArtifacts must
+        // see it so a stranded install doesn't silently keep the broken state.
+        let singleInboxGRDB = fixture.databasesDirectory
+            .appendingPathComponent("convos-single-inbox.sqlite")
+        try Data("orphan".utf8).write(to: singleInboxGRDB)
+
+        LegacyDataWipe.runIfNeeded(
+            defaults: fixture.defaults,
+            databasesDirectory: fixture.databasesDirectory,
+            legacyKeychainAccessGroup: legacyAccessGroup
+        )
+
+        #expect(!FileManager.default.fileExists(atPath: singleInboxGRDB.path))
+        #expect(fixture.defaults.string(forKey: "convos.schemaGeneration") == LegacyDataWipe.currentGeneration)
+    }
+
     @Test("Upgrade: legacy artifacts removed + marker set")
     func upgradeWipesAndMarksGeneration() throws {
         let fixture = try TempFixture()

--- a/ConvosCore/Tests/ConvosCoreTests/OrphanedConversationReconcilerTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/OrphanedConversationReconcilerTests.swift
@@ -1,0 +1,177 @@
+@testable import ConvosCore
+import Foundation
+import GRDB
+import Testing
+
+/// Coverage for the post-syncAllConversations reconciler that flips
+/// GRDB rows whose libxmtp counterpart is missing to `isActive=false`.
+@Suite("OrphanedConversationReconciler")
+struct OrphanedConversationReconcilerTests {
+    @Test("Orphans (in GRDB, missing from libxmtp) are flipped to inactive")
+    func orphansFlippedInactive() async throws {
+        let f = try Fixture()
+        try f.seedConversation(id: "stranded-1")
+        try f.seedConversation(id: "stranded-2")
+        try f.seedConversation(id: "live")
+
+        let reconciler = OrphanedConversationReconciler(
+            databaseReader: f.databaseManager.dbReader,
+            stateWriter: f.stateWriter
+        )
+        await reconciler.reconcile(xmtpConversationIDs: ["live"])
+
+        let stranded1 = try await f.isActive(id: "stranded-1")
+        let stranded2 = try await f.isActive(id: "stranded-2")
+        let live = try await f.isActive(id: "live")
+        #expect(stranded1 == false)
+        #expect(stranded2 == false)
+        #expect(live != false)
+    }
+
+    @Test("Healthy install (libxmtp knows every GRDB row) — nothing flipped")
+    func healthyInstallNoOp() async throws {
+        let f = try Fixture()
+        try f.seedConversation(id: "alpha")
+        try f.seedConversation(id: "beta")
+
+        let reconciler = OrphanedConversationReconciler(
+            databaseReader: f.databaseManager.dbReader,
+            stateWriter: f.stateWriter
+        )
+        await reconciler.reconcile(xmtpConversationIDs: ["alpha", "beta"])
+
+        let alpha = try await f.isActive(id: "alpha")
+        let beta = try await f.isActive(id: "beta")
+        #expect(alpha != false)
+        #expect(beta != false)
+    }
+
+    @Test("Empty libxmtp store (post-broken-wipe shape) — every GRDB row flipped")
+    func emptyXMTPFlipsAll() async throws {
+        let f = try Fixture()
+        try f.seedConversation(id: "a")
+        try f.seedConversation(id: "b")
+        try f.seedConversation(id: "c")
+
+        let reconciler = OrphanedConversationReconciler(
+            databaseReader: f.databaseManager.dbReader,
+            stateWriter: f.stateWriter
+        )
+        await reconciler.reconcile(xmtpConversationIDs: [])
+
+        for id in ["a", "b", "c"] {
+            let active = try await f.isActive(id: id)
+            #expect(active == false, "expected \(id) inactive")
+        }
+    }
+
+    @Test("Empty GRDB — no-op")
+    func emptyGRDBNoOp() async throws {
+        let f = try Fixture()
+
+        let reconciler = OrphanedConversationReconciler(
+            databaseReader: f.databaseManager.dbReader,
+            stateWriter: f.stateWriter
+        )
+        await reconciler.reconcile(xmtpConversationIDs: ["irrelevant"])
+
+        let count = try await f.databaseManager.dbReader.read { db in
+            try ConversationLocalState.fetchCount(db)
+        }
+        #expect(count == 0)
+    }
+
+    @Test("Idempotent — second pass with same inputs flips no additional rows")
+    func idempotent() async throws {
+        let f = try Fixture()
+        try f.seedConversation(id: "stuck")
+
+        let reconciler = OrphanedConversationReconciler(
+            databaseReader: f.databaseManager.dbReader,
+            stateWriter: f.stateWriter
+        )
+        await reconciler.reconcile(xmtpConversationIDs: [])
+        let firstPass = try await f.isActive(id: "stuck")
+        #expect(firstPass == false)
+
+        await reconciler.reconcile(xmtpConversationIDs: [])
+        let secondPass = try await f.isActive(id: "stuck")
+        #expect(secondPass == false)
+    }
+
+    @Test("Drafts (id prefix 'draft-') are excluded — no GRDB→xmtp counterpart by design")
+    func draftsExcluded() async throws {
+        let f = try Fixture()
+        let draftId = "draft-\(UUID().uuidString)"
+        try f.seedConversation(id: draftId)
+
+        let reconciler = OrphanedConversationReconciler(
+            databaseReader: f.databaseManager.dbReader,
+            stateWriter: f.stateWriter
+        )
+        // libxmtp obviously doesn't know the draft id. Reconciler must not
+        // touch the row — drafts are a local-only concept until publish.
+        await reconciler.reconcile(xmtpConversationIDs: [])
+
+        let state = try await f.databaseManager.dbReader.read { db in
+            try ConversationLocalState
+                .filter(ConversationLocalState.Columns.conversationId == draftId)
+                .fetchOne(db)
+        }
+        #expect(state == nil, "draft row should be untouched (no local state row written)")
+    }
+}
+
+// MARK: - Fixture
+
+private struct Fixture {
+    let databaseManager: MockDatabaseManager
+    let stateWriter: any ConversationLocalStateWriterProtocol
+
+    init() throws {
+        databaseManager = MockDatabaseManager.makeTestDatabase()
+        stateWriter = ConversationLocalStateWriter(databaseWriter: databaseManager.dbWriter)
+    }
+
+    func seedConversation(id: String) throws {
+        try databaseManager.dbWriter.write { db in
+            try DBMember(inboxId: "inbox-\(id)").save(db, onConflict: .ignore)
+            try DBConversation(
+                id: id,
+                clientConversationId: id,
+                inviteTag: "tag-\(id)",
+                creatorId: "inbox-\(id)",
+                kind: .group,
+                consent: .allowed,
+                createdAt: Date(),
+                name: nil,
+                description: nil,
+                imageURLString: nil,
+                publicImageURLString: nil,
+                includeInfoInPublicPreview: false,
+                expiresAt: nil,
+                debugInfo: .empty,
+                isLocked: false,
+                imageSalt: nil,
+                imageNonce: nil,
+                imageEncryptionKey: nil,
+                conversationEmoji: nil,
+                imageLastRenewed: nil,
+                isUnused: false,
+                hasHadVerifiedAssistant: false
+            ).insert(db)
+        }
+    }
+
+    /// Returns the row's `isActive` value, or `nil` if no `ConversationLocalState`
+    /// row exists yet (which is the same as "active" — `isActive` defaults to true
+    /// when hydrated against a missing row).
+    func isActive(id: String) async throws -> Bool? {
+        try await databaseManager.dbReader.read { db in
+            try ConversationLocalState
+                .filter(ConversationLocalState.Columns.conversationId == id)
+                .fetchOne(db)?
+                .isActive
+        }
+    }
+}

--- a/ConvosCore/Tests/ConvosCoreTests/RestoreManagerTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/RestoreManagerTests.swift
@@ -374,6 +374,45 @@ struct RestoreManagerTests {
         #expect(available?.bundleURL.lastPathComponent == "backup-latest.encrypted")
     }
 
+    @Test("findAvailableBackup accepts sidecars from compatible-but-prior schemaGeneration")
+    func testFindAvailableBackupAcceptsCompatibleSchemaGeneration() async throws {
+        let f = makeFixtures()
+        // Bundles produced in the broken-build window carry sidecar
+        // schemaGeneration="v1-single-inbox". Under the fixed build
+        // (currentGeneration="single-inbox-v2") they must remain
+        // restorable — otherwise the user's iCloud backup is silently
+        // hidden after they upgrade.
+        let backupsDir = f.environment.defaultDatabasesDirectoryURL
+            .appendingPathComponent("backups", isDirectory: true)
+            .appendingPathComponent("compat-device-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: backupsDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: backupsDir.deletingLastPathComponent()) }
+
+        let compatSidecar = BackupSidecarMetadata(
+            deviceId: "compat",
+            deviceName: "Compat Device",
+            osString: "ios",
+            conversationCount: 1,
+            schemaGeneration: "v1-single-inbox",
+            appVersion: "0.0.1"
+        )
+        try BackupSidecarMetadata.write(compatSidecar, to: backupsDir)
+        // Bundle file is required for the directory to surface as restorable.
+        let bundlePath = backupsDir.appendingPathComponent("backup-latest.encrypted")
+        try Data("placeholder-bundle".utf8).write(to: bundlePath)
+
+        let manager = RestoreManager(
+            identityStore: f.identityStore,
+            databaseManager: f.databaseManager,
+            archiveImporter: f.archiveImporter,
+            environment: f.environment,
+            restoreFlagSuiteName: f.suite
+        )
+        let found = await manager.findAvailableBackup()
+        #expect(found != nil)
+        #expect(found?.sidecar.schemaGeneration == "v1-single-inbox")
+    }
+
     @Test("findAvailableBackup rejects sidecars with stale schemaGeneration")
     func testFindAvailableBackupRejectsStale() async throws {
         let f = makeFixtures()


### PR DESCRIPTION
Build 800's `LegacyDataWipe` had two interacting bugs that stranded
users in "Conversation not found in XMTP local store":

1. `currentGeneration` was renamed `single-inbox-v2` → `v1-single-inbox`
   without a compatibility shim. Users whose marker was the prior name
   tripped the wipe at next launch.

2. The wipe deleted libxmtp's `xmtp-*.db3` files but only targeted the
   obsolete `convos.sqlite` GRDB filename — the active
   `convos-single-inbox.sqlite` was left intact. Result: GRDB rows
   pointing at conversations the freshly-rebuilt libxmtp does not
   know about. Marker then forwarded to `v1-single-inbox`, so the wipe
   never re-runs and the user is stuck.

Confirmed on a real device log:
    LegacyDataWipe: detected legacy data
    (storedGeneration=single-inbox-v2), wiping before migration
    Error building client, trying create...
    Failed to publish message: Conversation not found in XMTP local
    store: 6e2f9d1932adb2cdbe754f1785728dfa  (×N)

Fix surface:

- LegacyDataWipe: revert `currentGeneration` to `single-inbox-v2` so
  the cheap equality path matches the largest user population. Restore
  `compatibleGenerations` with `v1-single-inbox` to cover both the
  group that shipped that build and the group whose marker was
  forwarded by the broken wipe. Forward stale-but-compatible markers
  to current. Add `convos-single-inbox.sqlite{,-shm,-wal}` to the
  wipe's GRDB filename set so future legitimate wipes don't orphan
  the active GRDB. Expose `isCompatibleGeneration(_:)`.

- RestoreManager: replace exact-equality on `sidecar.schemaGeneration`
  and inner `metadata.schemaGeneration` with the compat helper so
  backups produced under `v1-single-inbox` remain restorable on the
  fixed build.

- OrphanedConversationReconciler (new): diff GRDB conversation IDs
  against `client.conversations.list()`; flip orphans to
  `isActive=false` via `ConversationLocalStateWriter.setActive`.
  Idempotent. Drafts (`draft-` prefix) excluded. Emits
  `[EVENT] sync.reconciliation_*` with grdb/xmtp/orphan counts —
  load-bearing telemetry: pre-wipe drift on different conversation
  IDs was already visible in production logs from healthy users, so
  this routine heals more than just the broken-wipe population.

- SyncingManager: run the reconciler once per session-ready
  transition, after `discoverNewConversations`. Foreground
  (paused→ready) transitions go through `handleResume` and skip on
  purpose — the local store hasn't been replaced under us.

Recovery path for the stuck cohort: marker `v1-single-inbox` →
forwarded to `single-inbox-v2`, no wipe. Reconciler runs, orphan
conversations flip to `isActive=false`, UI shows "Awaiting
reconnection" (#725 mechanism). Peers messaging triggers
`InactiveConversationReactivator.markReconnectionIfNeeded`,
conversations reactivate.

Tests:
- LegacyDataWipeTests: compat marker forwarded without wipe;
  `isCompatibleGeneration` matrix; `convos-single-inbox.sqlite` is
  swept by both detection and wipe.
- OrphanedConversationReconcilerTests: orphans → inactive, healthy
  no-op, empty libxmtp flips all, empty GRDB no-op, idempotent
  second pass, drafts excluded.
- RestoreManagerTests: sidecar `v1-single-inbox` accepted under
  `currentGeneration=single-inbox-v2`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/778"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix stuck restores by treating legacy schema generation "v1-single-inbox" as compatible with "single-inbox-v2"
> - Updates `LegacyDataWipe` to introduce a `compatibleGenerations` set and an `isCompatibleGeneration(_:)` helper, so installs with the prior `"v1-single-inbox"` marker are not wiped and have their marker migrated to `"single-inbox-v2"`.
> - Updates `RestoreManager` to use `isCompatibleGeneration` instead of strict equality when validating backup sidecar and bundle schema generations, unblocking restores that were stuck due to a generation string mismatch.
> - Adds `OrphanedConversationReconciler` to mark GRDB conversations inactive when they are absent from libxmpp after session start, wired into `SyncingManager.syncAllConversations`.
> - Expands legacy wipe detection and removal to include `convos-single-inbox.sqlite` and its `-shm`/`-wal` sidecars alongside the older `convos.sqlite` files.
> - Behavioral Change: installs with a compatible prior generation no longer trigger a data wipe; the stored marker is silently updated to the current generation name.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c322181.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->