### PR TITLE
Fix global notification on tests

### DIFF
--- a/ConvosCore/Sources/ConvosCore/Inboxes/AuthorizeInboxOperation.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/AuthorizeInboxOperation.swift
@@ -45,7 +45,8 @@ final class AuthorizeInboxOperation: AuthorizeInboxOperationProtocol, @unchecked
         overrideJWTToken: String? = nil,
         platformProviders: PlatformProviders,
         deviceRegistrationManager: (any DeviceRegistrationManagerProtocol)? = nil,
-        apiClient: (any ConvosAPIClientProtocol)? = nil
+        apiClient: (any ConvosAPIClientProtocol)? = nil,
+        xmtpClientFactory: XMTPClientFactory = .onDisk
     ) -> AuthorizeInboxOperation {
         let operation = AuthorizeInboxOperation(
             clientId: clientId,
@@ -58,7 +59,8 @@ final class AuthorizeInboxOperation: AuthorizeInboxOperationProtocol, @unchecked
             overrideJWTToken: overrideJWTToken,
             platformProviders: platformProviders,
             deviceRegistrationManager: deviceRegistrationManager,
-            apiClient: apiClient
+            apiClient: apiClient,
+            xmtpClientFactory: xmtpClientFactory
         )
         operation.authorize(inboxId: inboxId)
         return operation
@@ -72,7 +74,8 @@ final class AuthorizeInboxOperation: AuthorizeInboxOperationProtocol, @unchecked
         environment: AppEnvironment,
         platformProviders: PlatformProviders,
         deviceRegistrationManager: (any DeviceRegistrationManagerProtocol)? = nil,
-        apiClient: (any ConvosAPIClientProtocol)? = nil
+        apiClient: (any ConvosAPIClientProtocol)? = nil,
+        xmtpClientFactory: XMTPClientFactory = .onDisk
     ) -> AuthorizeInboxOperation {
         // Generate clientId before creating state machine
         let clientId = ClientId.generate().value
@@ -86,7 +89,8 @@ final class AuthorizeInboxOperation: AuthorizeInboxOperationProtocol, @unchecked
             startsStreamingServices: true,
             platformProviders: platformProviders,
             deviceRegistrationManager: deviceRegistrationManager,
-            apiClient: apiClient
+            apiClient: apiClient,
+            xmtpClientFactory: xmtpClientFactory
         )
         operation.register()
         return operation
@@ -103,7 +107,8 @@ final class AuthorizeInboxOperation: AuthorizeInboxOperationProtocol, @unchecked
         overrideJWTToken: String? = nil,
         platformProviders: PlatformProviders,
         deviceRegistrationManager: (any DeviceRegistrationManagerProtocol)?,
-        apiClient: (any ConvosAPIClientProtocol)?
+        apiClient: (any ConvosAPIClientProtocol)?,
+        xmtpClientFactory: XMTPClientFactory
     ) {
         let syncingManager = startsStreamingServices ? SyncingManager(
             identityStore: identityStore,
@@ -123,7 +128,8 @@ final class AuthorizeInboxOperation: AuthorizeInboxOperationProtocol, @unchecked
             overrideJWTToken: overrideJWTToken,
             environment: environment,
             appLifecycle: platformProviders.appLifecycle,
-            apiClient: apiClient
+            apiClient: apiClient,
+            xmtpClientFactory: xmtpClientFactory
         )
     }
 

--- a/ConvosCore/Sources/ConvosCore/Inboxes/SessionStateMachine.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/SessionStateMachine.swift
@@ -26,8 +26,10 @@ public struct InboxReadyResult: @unchecked Sendable {
 typealias AnySyncingManager = (any SyncingManagerProtocol)
 typealias AnyInviteJoinRequestsManager = (any InviteJoinRequestsManagerProtocol)
 
-/// Tests inject `.inMemory` so libxmtp's pool-management surface is inert; the
-/// `dropLocalDatabaseConnection` broadcast can't wedge an in-memory pool.
+/// `.onDisk` routes through libxmtp's persistent SQLCipher path (production
+/// behavior). `.inMemory` routes through `Client.createInMemory`, where
+/// `dropLocalDatabaseConnection` and friends are no-ops — so the lifecycle-
+/// notification broadcast can't wedge a parallel test's pool.
 struct XMTPClientFactory: Sendable {
     typealias Create = @Sendable (SigningKey, ClientOptions) async throws -> any XMTPClientProvider
     typealias Build = @Sendable (String, PublicIdentity, SigningKey, ClientOptions) async throws -> any XMTPClientProvider
@@ -35,7 +37,7 @@ struct XMTPClientFactory: Sendable {
     let create: Create
     let build: Build
 
-    static let production: XMTPClientFactory = XMTPClientFactory(
+    static let onDisk: XMTPClientFactory = XMTPClientFactory(
         create: { signingKey, options in
             try await Client.create(account: signingKey, options: options)
         },
@@ -259,7 +261,7 @@ public actor SessionStateMachine: SessionStateManagerProtocol {
         environment: AppEnvironment,
         appLifecycle: any AppLifecycleProviding,
         apiClient: (any ConvosAPIClientProtocol)? = nil,
-        xmtpClientFactory: XMTPClientFactory = .production
+        xmtpClientFactory: XMTPClientFactory = .onDisk
     ) {
         let initialState: State = .idle
         self.initialClientId = clientId

--- a/ConvosCore/Sources/ConvosCore/Messaging/MessagingService.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/MessagingService.swift
@@ -41,7 +41,8 @@ final class MessagingService: MessagingServiceProtocol, @unchecked Sendable {
         overrideJWTToken: String? = nil,
         platformProviders: PlatformProviders,
         deviceRegistrationManager: (any DeviceRegistrationManagerProtocol)? = nil,
-        apiClient: (any ConvosAPIClientProtocol)? = nil
+        apiClient: (any ConvosAPIClientProtocol)? = nil,
+        xmtpClientFactory: XMTPClientFactory = .onDisk
     ) -> MessagingService {
         let authorizationOperation = AuthorizeInboxOperation.authorize(
             inboxId: inboxId,
@@ -54,7 +55,8 @@ final class MessagingService: MessagingServiceProtocol, @unchecked Sendable {
             overrideJWTToken: overrideJWTToken,
             platformProviders: platformProviders,
             deviceRegistrationManager: deviceRegistrationManager,
-            apiClient: apiClient
+            apiClient: apiClient,
+            xmtpClientFactory: xmtpClientFactory
         )
         return MessagingService(
             authorizationOperation: authorizationOperation,

--- a/ConvosCore/Sources/ConvosCore/PlatformProviders.swift
+++ b/ConvosCore/Sources/ConvosCore/PlatformProviders.swift
@@ -65,7 +65,13 @@ public struct PlatformProviders: Sendable {
 
 // MARK: - Test/Mock Support
 
-/// Mock app lifecycle provider for testing
+/// Mock app lifecycle provider for testing.
+///
+/// Each instance defaults to a UUID-suffixed notification name so that
+/// `SessionStateMachine` instances observing on `NotificationCenter.default`
+/// only receive lifecycle events from their own provider. Sharing a fixed
+/// name across instances would let one test's background event wedge another
+/// test's libxmtp DB pool via `dropLocalDatabaseConnection`.
 public final class MockAppLifecycleProvider: AppLifecycleProviding, @unchecked Sendable {
     public let didEnterBackgroundNotification: Notification.Name
     public let willEnterForegroundNotification: Notification.Name
@@ -78,14 +84,18 @@ public final class MockAppLifecycleProvider: AppLifecycleProviding, @unchecked S
 
     public init(
         currentState: AppState = .active,
-        didEnterBackgroundNotification: Notification.Name = Notification.Name("MockDidEnterBackground"),
-        willEnterForegroundNotification: Notification.Name = Notification.Name("MockWillEnterForeground"),
-        didBecomeActiveNotification: Notification.Name = Notification.Name("MockDidBecomeActive")
+        didEnterBackgroundNotification: Notification.Name? = nil,
+        willEnterForegroundNotification: Notification.Name? = nil,
+        didBecomeActiveNotification: Notification.Name? = nil
     ) {
+        let suffix = UUID().uuidString
         self._currentState = currentState
         self.didEnterBackgroundNotification = didEnterBackgroundNotification
+            ?? Notification.Name("MockDidEnterBackground.\(suffix)")
         self.willEnterForegroundNotification = willEnterForegroundNotification
+            ?? Notification.Name("MockWillEnterForeground.\(suffix)")
         self.didBecomeActiveNotification = didBecomeActiveNotification
+            ?? Notification.Name("MockDidBecomeActive.\(suffix)")
     }
 
     public func setCurrentState(_ state: AppState) {

--- a/ConvosCore/Tests/ConvosCoreTests/SessionStateMachineTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/SessionStateMachineTests.swift
@@ -372,9 +372,12 @@ struct SessionStateMachineTests {
         let syncIsStarted = await mockSync.isStarted
         #expect(!syncIsStarted, "Syncing should be stopped")
 
-        // Verify identity was deleted
+        // Identity slot is deliberately preserved on local Reset — see
+        // SessionStateMachine.handleDelete: the synced keychain entry is the
+        // AES-GCM seal on every backup bundle, so deleting it would
+        // propagate via iCloud Keychain and orphan every existing backup.
         let identityAfterDelete = try await fixtures.identityStore.load()
-        #expect(identityAfterDelete == nil, "Identity should have been deleted")
+        #expect(identityAfterDelete != nil, "Identity should be preserved on local delete")
 
         // Verify database record was deleted
         let dbInboxes = try await fixtures.databaseManager.dbReader.read { db in
@@ -671,6 +674,14 @@ struct SessionStateMachineTests {
         let mockInvites = MockInvitesRepository()
         let networkMonitor = NetworkMonitor()
 
+        // Uses `.onDisk` because `dropLocalDatabaseConnection` and
+        // `reconnectLocalDatabase` early-return as no-ops on in-memory
+        // clients (libxmtp Client.swift:959, 964). Backgrounding is the
+        // exact production path this test is meant to exercise, so the
+        // on-disk SQLCipher pool is the right backing. A dedicated
+        // lifecycle provider isolates this test's notifications from
+        // the suite-shared `testAppLifecycle`.
+        let appLifecycle = MockAppLifecycleProvider()
         let stateMachine = SessionStateMachine(
             clientId: clientId,
             identityStore: fixtures.identityStore,
@@ -680,8 +691,8 @@ struct SessionStateMachineTests {
             networkMonitor: networkMonitor,
             overrideJWTToken: "test-jwt-token",
             environment: .tests,
-            appLifecycle: testAppLifecycle,
-            xmtpClientFactory: .inMemory
+            appLifecycle: appLifecycle,
+            xmtpClientFactory: .onDisk
         )
 
         // Register and wait for ready
@@ -711,7 +722,7 @@ struct SessionStateMachineTests {
         try await Task.sleep(for: .milliseconds(100))
 
         // Simulate app entering background
-        NotificationCenter.default.post(name: testAppLifecycle.didEnterBackgroundNotification, object: nil)
+        NotificationCenter.default.post(name: appLifecycle.didEnterBackgroundNotification, object: nil)
 
         // Wait for backgrounded state
         let backgroundedState = try await waitForState(stateMachine, timeout: 5) { state in
@@ -733,7 +744,7 @@ struct SessionStateMachineTests {
         Log.info("App backgrounded, sync paused. Simulating app returning to foreground...")
 
         // Simulate app entering foreground
-        NotificationCenter.default.post(name: testAppLifecycle.willEnterForegroundNotification, object: nil)
+        NotificationCenter.default.post(name: appLifecycle.willEnterForegroundNotification, object: nil)
 
         // Wait for ready state again
         let foregroundState = try await waitForState(stateMachine, timeout: 5) { state in
@@ -768,6 +779,13 @@ struct SessionStateMachineTests {
         let mockInvites = MockInvitesRepository()
         let networkMonitor = NetworkMonitor()
 
+        // Uses `.onDisk` so the backgrounded → ready transition
+        // actually drops and reconnects libxmtp's SQLCipher pool, the
+        // production path. In-memory clients no-op those calls (libxmtp
+        // Client.swift:959, 964) and would let regressions in the real
+        // pool teardown slip through. Dedicated lifecycle provider so
+        // this test's notifications stay isolated.
+        let appLifecycle = MockAppLifecycleProvider()
         let stateMachine = SessionStateMachine(
             clientId: clientId,
             identityStore: fixtures.identityStore,
@@ -777,8 +795,8 @@ struct SessionStateMachineTests {
             networkMonitor: networkMonitor,
             overrideJWTToken: "test-jwt-token",
             environment: .tests,
-            appLifecycle: testAppLifecycle,
-            xmtpClientFactory: .inMemory
+            appLifecycle: appLifecycle,
+            xmtpClientFactory: .onDisk
         )
 
         actor StateCollector {
@@ -842,7 +860,7 @@ struct SessionStateMachineTests {
         try await Task.sleep(for: .milliseconds(100))
 
         // Simulate background
-        NotificationCenter.default.post(name: testAppLifecycle.didEnterBackgroundNotification, object: nil)
+        NotificationCenter.default.post(name: appLifecycle.didEnterBackgroundNotification, object: nil)
 
         // Wait for backgrounded
         _ = try await waitForState(stateMachine, timeout: 5) { state in
@@ -851,7 +869,7 @@ struct SessionStateMachineTests {
         }
 
         // Simulate foreground
-        NotificationCenter.default.post(name: testAppLifecycle.willEnterForegroundNotification, object: nil)
+        NotificationCenter.default.post(name: appLifecycle.willEnterForegroundNotification, object: nil)
 
         // Wait for ready again
         _ = try await waitForState(stateMachine, timeout: 5) { state in

--- a/ConvosCore/Tests/ConvosCoreTests/TestHelpers.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/TestHelpers.swift
@@ -194,8 +194,11 @@ class TestFixtures {
     /// Builds a fresh MessagingService for tests that previously used
     /// `UnusedConversationCache.consumeOrCreateMessagingService` as a
     /// bootstrap. Registers a new XMTP identity for the fixture.
+    /// Uses `XMTPClientFactory.inMemory` so libxmtp's pool-management
+    /// surface is inert across parallel tests in the same process.
     func makeFreshMessagingService(
-        platformProviders: PlatformProviders = .mock
+        platformProviders: PlatformProviders = .mock,
+        xmtpClientFactory: XMTPClientFactory = .inMemory
     ) -> MessagingService {
         let authorizationOperation = AuthorizeInboxOperation.register(
             identityStore: identityStore,
@@ -204,7 +207,8 @@ class TestFixtures {
             environment: environment,
             platformProviders: platformProviders,
             deviceRegistrationManager: nil,
-            apiClient: nil
+            apiClient: nil,
+            xmtpClientFactory: xmtpClientFactory
         )
         return MessagingService(
             authorizationOperation: authorizationOperation,


### PR DESCRIPTION
Test using global notifications may drop the DB during migrations which would never finish running migrations


also adds XmtpClientFactory to more places to allow for in memory client instantiation

re-adds onDisk clients for tests which are testing dropLocalDatabase/backgrounding

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/779"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix global notification interference between test instances in `MockAppLifecycleProvider`
> - `MockAppLifecycleProvider` now generates unique `Notification.Name` values per instance (UUID-suffixed) when no names are provided, preventing lifecycle events from leaking between parallel tests.
> - `XMTPClientFactory.production` is renamed to `XMTPClientFactory.onDisk` in `SessionStateMachine` for clarity.
> - `xmtpClientFactory` is threaded through `AuthorizeInboxOperation`, `SessionStateMachine`, and `MessagingService` so tests can inject `.inMemory` to keep libxmtp pool management inert during parallel test runs.
> - Background/foreground tests in `SessionStateMachineTests` now use per-test `MockAppLifecycleProvider` instances and `.onDisk` to exercise SQLCipher pool drop/reconnect properly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4d3bb26.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->