### PR TITLE
Fix invite DM push subscriptions

### DIFF
--- a/Convos/Conversation Detail/ConversationInfoEditView.swift
+++ b/Convos/Conversation Detail/ConversationInfoEditView.swift
@@ -104,5 +104,6 @@ struct ConversationInfoEditView: View {
 
 #Preview {
     @Previewable @State var focusCoordinator: FocusCoordinator = FocusCoordinator(horizontalSizeClass: nil)
-    ConversationInfoEditView(viewModel: .mock, focusCoordinator: focusCoordinator)
+    let mockViewModel: ConversationViewModel = .mock
+    ConversationInfoEditView(viewModel: mockViewModel, focusCoordinator: focusCoordinator)
 }

--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -280,132 +280,140 @@ struct ConversationView<MessagesBottomBar: View>: View {
         }
     }
 
-    var body: some View {
+    private var messagesViewWithLifecycle: some View {
         messagesView
-        .onChange(of: viewModel.selectedAttachmentImage) { oldValue, newValue in
-            if let image = newValue {
-                viewModel.onPhotoSelected(image)
-            } else if oldValue != nil {
-                viewModel.onPhotoRemoved()
+            .onChange(of: viewModel.selectedAttachmentImage) { oldValue, newValue in
+                if let image = newValue {
+                    viewModel.onPhotoSelected(image)
+                } else if oldValue != nil {
+                    viewModel.onPhotoRemoved()
+                }
             }
-        }
-        .onChange(of: viewModel.messageText) { _, _ in
-            viewModel.checkForInviteURL()
-            viewModel.checkForPastedLink()
-        }
-        .animation(.easeOut, value: viewModel.explodeState)
-        .dynamicTypeSize(...DynamicTypeSize.xxxLarge)
-        .onAppear { viewModel.onConversationAppeared() }
-        .onDisappear { viewModel.onConversationDisappeared() }
-        .selfSizingSheet(isPresented: $viewModel.presentingConversationForked) {
-            ConversationForkedInfoView {
-                viewModel.leaveConvo()
+            .onChange(of: viewModel.messageText) { _, _ in
+                viewModel.checkForInviteURL()
+                viewModel.checkForPastedLink()
             }
-        }
-        .sheet(isPresented: $viewModel.presentingProfileSettings) {
-            MyInfoView(
-                profile: .constant(viewModel.myProfileViewModel.profile),
-                profileImage: $viewModel.myProfileViewModel.profileImage,
-                editingDisplayName: $viewModel.myProfileViewModel.editingDisplayName,
-                quicknameViewModel: quicknameViewModel,
-                showsCancelButton: true,
-                showsProfile: true,
-                showsUseQuicknameButton: true,
-                canEditQuickname: false
-            ) { quicknameSettings in
-                viewModel.onUseQuickname(quicknameSettings.profile, quicknameSettings.profileImage)
+            .animation(.easeOut, value: viewModel.explodeState)
+            .dynamicTypeSize(...DynamicTypeSize.xxxLarge)
+            .onAppear { viewModel.onConversationAppeared() }
+            .onDisappear { viewModel.onConversationDisappeared() }
+            .alert(
+                "Awaiting reconnection",
+                isPresented: $showingReconnectionAlert
+            ) {
+                Button("Got it", role: .cancel) {}
+            } message: {
+                Text("You can see and send new messages, reactions and more after another member sends a message.")
             }
+            .toolbar { topBarTrailingItem }
             .onDisappear {
-                viewModel.onProfileSettingsDismissed(focusCoordinator: focusCoordinator)
+                VoiceMemoPlayer.shared.stop()
+                viewModel.voiceMemoRecorder.cancelRecording()
             }
-        }
-        .alert(
-            "Awaiting reconnection",
-            isPresented: $showingReconnectionAlert
-        ) {
-            Button("Got it", role: .cancel) {}
-        } message: {
-            Text("You can see and send new messages, reactions and more after another member sends a message.")
-        }
-        .toolbar { topBarTrailingItem }
-        .sheet(item: $viewModel.presentingNewConversationForInvite) { viewModel in
-            NewConversationView(
-                viewModel: viewModel,
-                quicknameViewModel: quicknameViewModel
-            )
-            .background(.colorBackgroundSurfaceless)
-        }
-        .selfSizingSheet(isPresented: $viewModel.presentingExplodedInviteInfo) {
-            ExplodeInfoView()
-        }
-        .selfSizingSheet(isPresented: $viewModel.presentingAssistantConfirmation) {
-            AssistantsInfoView(
-                isConfirmation: true,
-                onConfirm: { viewModel.requestAssistantJoin() }
-            )
-            .padding(.top, 20)
-        }
-        .selfSizingSheet(isPresented: $showingProcessingPowerInfo) {
-            AssistantProcessingPowerInfoView()
+    }
+
+    private var conversationSheets: some View {
+        messagesViewWithLifecycle
+            .selfSizingSheet(isPresented: $viewModel.presentingConversationForked) {
+                ConversationForkedInfoView {
+                    viewModel.leaveConvo()
+                }
+            }
+            .sheet(isPresented: $viewModel.presentingProfileSettings) {
+                MyInfoView(
+                    profile: .constant(viewModel.myProfileViewModel.profile),
+                    profileImage: $viewModel.myProfileViewModel.profileImage,
+                    editingDisplayName: $viewModel.myProfileViewModel.editingDisplayName,
+                    quicknameViewModel: quicknameViewModel,
+                    showsCancelButton: true,
+                    showsProfile: true,
+                    showsUseQuicknameButton: true,
+                    canEditQuickname: false
+                ) { quicknameSettings in
+                    viewModel.onUseQuickname(quicknameSettings.profile, quicknameSettings.profileImage)
+                }
+                .onDisappear {
+                    viewModel.onProfileSettingsDismissed(focusCoordinator: focusCoordinator)
+                }
+            }
+            .sheet(item: $viewModel.presentingNewConversationForInvite) { viewModel in
+                NewConversationView(
+                    viewModel: viewModel,
+                    quicknameViewModel: quicknameViewModel
+                )
+                .background(.colorBackgroundSurfaceless)
+            }
+            .selfSizingSheet(isPresented: $viewModel.presentingExplodedInviteInfo) {
+                ExplodeInfoView()
+            }
+            .selfSizingSheet(isPresented: $viewModel.presentingAssistantConfirmation) {
+                AssistantsInfoView(
+                    isConfirmation: true,
+                    onConfirm: { viewModel.requestAssistantJoin() }
+                )
                 .padding(.top, 20)
-        }
-        .selfSizingSheet(isPresented: $showingAssistantsInfo) {
-            AssistantsInfoView()
-                .padding(.top, 20)
-        }
-        .sheet(item: $viewModel.presentingProfileForMember) { member in
-            NavigationStack {
-                ConversationMemberView(viewModel: viewModel, member: member)
-                    .toolbar {
-                        ToolbarItem(placement: .cancellationAction) {
-                            Button(role: .cancel) {
-                                viewModel.presentingProfileForMember = nil
+            }
+            .selfSizingSheet(isPresented: $showingProcessingPowerInfo) {
+                AssistantProcessingPowerInfoView()
+                    .padding(.top, 20)
+            }
+            .selfSizingSheet(isPresented: $showingAssistantsInfo) {
+                AssistantsInfoView()
+                    .padding(.top, 20)
+            }
+    }
+
+    var body: some View {
+        conversationSheets
+            .sheet(item: $viewModel.presentingProfileForMember) { member in
+                NavigationStack {
+                    ConversationMemberView(viewModel: viewModel, member: member)
+                        .toolbar {
+                            ToolbarItem(placement: .cancellationAction) {
+                                Button(role: .cancel) {
+                                    viewModel.presentingProfileForMember = nil
+                                }
                             }
                         }
+                }
+            }
+            .selfSizingSheet(item: $viewModel.presentingReactionsForMessage) { message in
+                ReactionsDrawerView(message: message) { reaction in
+                    viewModel.removeReaction(reaction, from: message)
+                }
+            }
+            .selfSizingSheet(isPresented: $showingLockedInfo) {
+                LockedConvoInfoView(
+                    isCurrentUserSuperAdmin: viewModel.isCurrentUserSuperAdmin,
+                    isLocked: viewModel.isLocked,
+                    onLock: {
+                        viewModel.toggleLock()
+                        showingLockedInfo = false
+                    },
+                    onDismiss: {
+                        showingLockedInfo = false
                     }
+                )
             }
-        }
-        .selfSizingSheet(item: $viewModel.presentingReactionsForMessage) { message in
-            ReactionsDrawerView(message: message) { reaction in
-                viewModel.removeReaction(reaction, from: message)
+            .selfSizingSheet(isPresented: $showingFullInfo) {
+                FullConvoInfoView(onDismiss: {
+                    showingFullInfo = false
+                })
             }
-        }
-        .selfSizingSheet(isPresented: $showingLockedInfo) {
-            LockedConvoInfoView(
-                isCurrentUserSuperAdmin: viewModel.isCurrentUserSuperAdmin,
-                isLocked: viewModel.isLocked,
-                onLock: {
-                    viewModel.toggleLock()
-                    showingLockedInfo = false
-                },
-                onDismiss: {
-                    showingLockedInfo = false
+            .selfSizingSheet(
+                isPresented: $viewModel.presentingRevealMediaInfoSheet,
+                onDismiss: { viewModel.showRevealSettingsToast() },
+                content: {
+                    RevealMediaInfoSheet()
                 }
             )
-        }
-        .selfSizingSheet(isPresented: $showingFullInfo) {
-            FullConvoInfoView(onDismiss: {
-                showingFullInfo = false
-            })
-        }
-        .selfSizingSheet(
-            isPresented: $viewModel.presentingRevealMediaInfoSheet,
-            onDismiss: { viewModel.showRevealSettingsToast() },
-            content: {
-                RevealMediaInfoSheet()
-            }
-        )
-        .selfSizingSheet(
-            isPresented: $viewModel.presentingPhotosInfoSheet,
-            onDismiss: { focusCoordinator.moveFocus(to: .message) },
-            content: {
-                PhotosInfoSheet()
-            }
-        )
-        .onDisappear {
-            VoiceMemoPlayer.shared.stop()
-            viewModel.voiceMemoRecorder.cancelRecording()
-        }
+            .selfSizingSheet(
+                isPresented: $viewModel.presentingPhotosInfoSheet,
+                onDismiss: { focusCoordinator.moveFocus(to: .message) },
+                content: {
+                    PhotosInfoSheet()
+                }
+            )
     }
 }
 

--- a/Convos/Conversation Detail/Messages/Messages View Controller/Reactions/MessageReactionsView.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/Reactions/MessageReactionsView.swift
@@ -22,63 +22,67 @@ struct MessageReactionsView: View {
         }
     }
 
-    var body: some View {
-        Group {
-            GeometryReader { reader in
-                let contentHeight = max(reader.size.height - (Constant.padding * 2.0), 0.0)
-                ZStack(alignment: .leading) {
-                    reactionsScrollView(reader: reader, contentHeight: contentHeight)
-                    HStack(spacing: 0.0) {
-                        Spacer()
-                        selectedEmojiView(reader: reader)
-                        expandCollapseButton(contentHeight: contentHeight)
-                    }
-                }
-                .padding(0.0)
-                .animation(
-                    .spring(response: Constant.springResponse,
-                            dampingFraction: Constant.springDampingFractionPlus),
-                    value: viewModel.viewState
-                )
-            }
-            .frame(width: containerWidth, height: Constant.height)
-            .background(.colorBackgroundSurfaceless)
-            .clipShape(Capsule())
-            .shadow(
-                color: Color.black.opacity(0.15),
-                radius: 10.0,
-                x: 0, y: 0
-            )
-            .scaleEffect(viewModel.viewState.isMinimized ? 0.0 : 1.0)
-            .opacity(viewModel.viewState.isMinimized ? 0.0 : 1.0)
-            .animation(.spring(response: 0.6, dampingFraction: 0.8), value: viewModel.viewState)
-            .onChange(of: viewModel.viewState) { lhs, _ in
-                if lhs == .minimized {
-                    if emojiAppeared.count != viewModel.reactions.count {
-                        emojiAppeared = Array(repeating: false, count: viewModel.reactions.count)
-                    }
-                    let totalDelay = (Constant.emojiAppearanceDelay +
-                                      (Constant.emojiAppearanceDelayStep * Double(viewModel.reactions.count)))
-                    DispatchQueue.main.asyncAfter(deadline: .now() + totalDelay) {
-                        withAnimation {
-                            showMoreAppeared = true
-                        }
-                    }
-                }
+    private var reactionsCapsule: some View {
+        GeometryReader { reader in
+            reactionsCapsuleContents(reader: reader)
+        }
+        .frame(width: containerWidth, height: Constant.height)
+        .background(.colorBackgroundSurfaceless)
+        .clipShape(Capsule())
+        .shadow(color: Color.black.opacity(0.15), radius: 10.0, x: 0, y: 0)
+        .scaleEffect(viewModel.viewState.isMinimized ? 0.0 : 1.0)
+        .opacity(viewModel.viewState.isMinimized ? 0.0 : 1.0)
+        .animation(.spring(response: 0.6, dampingFraction: 0.8), value: viewModel.viewState)
+        .onChange(of: viewModel.viewState) { lhs, _ in
+            handleViewStateChange(from: lhs)
+        }
+    }
+
+    private func reactionsCapsuleContents(reader: GeometryProxy) -> some View {
+        let contentHeight = max(reader.size.height - (Constant.padding * 2.0), 0.0)
+        return ZStack(alignment: .leading) {
+            reactionsScrollView(reader: reader, contentHeight: contentHeight)
+            HStack(spacing: 0.0) {
+                Spacer()
+                selectedEmojiView(reader: reader)
+                expandCollapseButton(contentHeight: contentHeight)
             }
         }
-        .frame(maxWidth: .infinity, alignment: viewModel.alignment)
-        .background(.clear)
-        .emojiPicker(
-            isPresented: $viewModel.showingEmojiPicker,
-            onPick: { emoji in
-                customEmoji = emoji
-                viewModel.add(reaction: .init(emoji: emoji, isSelected: true))
-            },
-            onDelete: {
-                customEmoji = nil
-            }
+        .padding(0.0)
+        .animation(
+            .spring(response: Constant.springResponse, dampingFraction: Constant.springDampingFractionPlus),
+            value: viewModel.viewState
         )
+    }
+
+    private func handleViewStateChange(from previous: MessageReactionMenuViewModel.ViewState) {
+        guard previous == .minimized else { return }
+        if emojiAppeared.count != viewModel.reactions.count {
+            emojiAppeared = Array(repeating: false, count: viewModel.reactions.count)
+        }
+        let totalDelay = Constant.emojiAppearanceDelay
+            + (Constant.emojiAppearanceDelayStep * Double(viewModel.reactions.count))
+        DispatchQueue.main.asyncAfter(deadline: .now() + totalDelay) {
+            withAnimation {
+                showMoreAppeared = true
+            }
+        }
+    }
+
+    var body: some View {
+        reactionsCapsule
+            .frame(maxWidth: .infinity, alignment: viewModel.alignment)
+            .background(.clear)
+            .emojiPicker(
+                isPresented: $viewModel.showingEmojiPicker,
+                onPick: { emoji in
+                    customEmoji = emoji
+                    viewModel.add(reaction: .init(emoji: emoji, isSelected: true))
+                },
+                onDelete: {
+                    customEmoji = nil
+                }
+            )
     }
 
     // MARK: - Subviews

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Cells/MessageInviteContainerView.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Cells/MessageInviteContainerView.swift
@@ -117,33 +117,36 @@ struct MessageInviteView: View {
         return "invite-preview-subtitle"
     }
 
+    @ViewBuilder
+    private var avatarOverlay: some View {
+        if isExpired {
+            Image(systemName: "burst")
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(height: 76.0)
+                .foregroundStyle(.colorTextSecondary)
+        } else if let image = cachedImage {
+            Image(uiImage: image)
+                .resizable()
+                .aspectRatio(contentMode: .fill)
+        } else if let emoji = invite.emoji, !emoji.isEmpty {
+            Text(emoji)
+                .font(.system(size: 160))
+        } else {
+            Image("convosOrangeIcon")
+                .resizable()
+                .tint(.colorTextPrimaryInverted)
+                .foregroundStyle(.colorTextPrimaryInverted)
+                .aspectRatio(contentMode: .fit)
+                .frame(height: 76.0)
+        }
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 0.0) {
             Color.colorFillMinimal
                 .aspectRatio(1, contentMode: .fit)
-                .overlay {
-                    if isExpired {
-                        Image(systemName: "burst")
-                            .resizable()
-                            .aspectRatio(contentMode: .fit)
-                            .frame(height: 76.0)
-                            .foregroundStyle(.colorTextSecondary)
-                    } else if let image = cachedImage {
-                        Image(uiImage: image)
-                            .resizable()
-                            .aspectRatio(contentMode: .fill)
-                    } else if let emoji = invite.emoji, !emoji.isEmpty {
-                        Text(emoji)
-                            .font(.system(size: 160))
-                    } else {
-                        Image("convosOrangeIcon")
-                            .resizable()
-                            .tint(.colorTextPrimaryInverted)
-                            .foregroundStyle(.colorTextPrimaryInverted)
-                            .aspectRatio(contentMode: .fit)
-                            .frame(height: 76.0)
-                    }
-                }
+                .overlay { avatarOverlay }
                 .clipped()
                 .opacity(isExpired ? 0.6 : 1.0)
                 .accessibilityLabel(invite.imageURL != nil ? "Invite image preview" : (invite.emoji.map { "Invite emoji \($0)" } ?? "Invite placeholder"))

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessageContextMenuWrapper.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessageContextMenuWrapper.swift
@@ -41,6 +41,71 @@ struct MessageGestureModifier: ViewModifier {
         return uniqueEmoji.count == 1 ? uniqueEmoji.first ?? "❤️" : "❤️"
     }
 
+    @ViewBuilder
+    private func sourceFrameBackground() -> some View {
+        if isSourceBubble {
+            GeometryReader { geo in
+                Color.clear
+                    .preference(key: SourceFrameKey.self, value: geo.frame(in: .global))
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func swipeReplyIndicator() -> some View {
+        if swipeOffset > 0 {
+            let progress = min(swipeOffset / Constant.swipeThreshold, 1.0)
+            Image(systemName: "arrowshape.turn.up.left.fill")
+                .foregroundStyle(.tertiary)
+                .scaleEffect(0.4 + progress * 0.6)
+                .opacity(Double(progress))
+                .padding(.leading, DesignConstants.Spacing.step2x)
+                .accessibilityHidden(true)
+        }
+    }
+
+    private func gestureOverlay() -> some View {
+        GeometryReader { geometry in
+            GestureOverlayView(
+                contextMenuState: contextMenuState,
+                hasSingleTap: onSingleTap != nil,
+                excludedFrames: interactiveExclusionFrames,
+                onSingleTap: { onSingleTap?() },
+                onDoubleTap: {
+                    if let onDoubleTap {
+                        onDoubleTap()
+                    } else {
+                        UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                        onToggleReaction(doubleTapEmoji, message.messageId)
+                    }
+                },
+                onLongPress: {
+                    UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+                    let frame = geometry.frame(in: .global)
+                    contextMenuState.present(
+                        message: message,
+                        bubbleFrame: frame,
+                        bubbleStyle: bubbleStyle
+                    )
+                },
+                onSwipeOffsetChanged: { offset in
+                    swipeOffset = offset
+                    externalSwipeOffset?.wrappedValue = offset
+                },
+                onSwipeEnded: { triggered in
+                    withAnimation(.spring(response: 0.25, dampingFraction: 0.8)) {
+                        swipeOffset = 0
+                        externalSwipeOffset?.wrappedValue = 0
+                    }
+                    if triggered { onReply(message) }
+                },
+                onPressChanged: { pressed in
+                    isPressed = pressed
+                }
+            )
+        }
+    }
+
     func body(content: Content) -> some View {
         content
             .environment(\.messagePressed, isPressed)
@@ -50,14 +115,7 @@ struct MessageGestureModifier: ViewModifier {
             )
             .opacity(isSourceBubble ? 0 : 1)
             .onAppear { hasAppeared = true }
-            .background {
-                if isSourceBubble {
-                    GeometryReader { geo in
-                        Color.clear
-                            .preference(key: SourceFrameKey.self, value: geo.frame(in: .global))
-                    }
-                }
-            }
+            .background { sourceFrameBackground() }
             .onPreferenceChange(SourceFrameKey.self) { frame in
                 if isSourceBubble, let frame {
                     contextMenuState.currentSourceFrame = frame
@@ -68,58 +126,8 @@ struct MessageGestureModifier: ViewModifier {
             }
             .animation(.easeInOut(duration: 0.25), value: isPressed)
             .offset(x: swipeOffset)
-            .background(alignment: .leading) {
-                if swipeOffset > 0 {
-                    let progress = min(swipeOffset / Constant.swipeThreshold, 1.0)
-                    Image(systemName: "arrowshape.turn.up.left.fill")
-                        .foregroundStyle(.tertiary)
-                        .scaleEffect(0.4 + progress * 0.6)
-                        .opacity(Double(progress))
-                        .padding(.leading, DesignConstants.Spacing.step2x)
-                        .accessibilityHidden(true)
-                }
-            }
-            .overlay {
-                GeometryReader { geometry in
-                    GestureOverlayView(
-                        contextMenuState: contextMenuState,
-                        hasSingleTap: onSingleTap != nil,
-                        excludedFrames: interactiveExclusionFrames,
-                        onSingleTap: { onSingleTap?() },
-                        onDoubleTap: {
-                            if let onDoubleTap {
-                                onDoubleTap()
-                            } else {
-                                UIImpactFeedbackGenerator(style: .light).impactOccurred()
-                                onToggleReaction(doubleTapEmoji, message.messageId)
-                            }
-                        },
-                        onLongPress: {
-                            UIImpactFeedbackGenerator(style: .medium).impactOccurred()
-                            let frame = geometry.frame(in: .global)
-                            contextMenuState.present(
-                                message: message,
-                                bubbleFrame: frame,
-                                bubbleStyle: bubbleStyle
-                            )
-                        },
-                        onSwipeOffsetChanged: { offset in
-                            swipeOffset = offset
-                            externalSwipeOffset?.wrappedValue = offset
-                        },
-                        onSwipeEnded: { triggered in
-                            withAnimation(.spring(response: 0.25, dampingFraction: 0.8)) {
-                                swipeOffset = 0
-                                externalSwipeOffset?.wrappedValue = 0
-                            }
-                            if triggered { onReply(message) }
-                        },
-                        onPressChanged: { pressed in
-                            isPressed = pressed
-                        }
-                    )
-                }
-            }
+            .background(alignment: .leading) { swipeReplyIndicator() }
+            .overlay { gestureOverlay() }
             .accessibilityAction(named: "React") {
                 onToggleReaction(doubleTapEmoji, message.messageId)
             }

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
@@ -103,167 +103,167 @@ struct MessagesGroupItemView: View {
     private var messageContent: some View {
         switch message.content {
         case .text(let text):
-            MessageBubble(
-                style: message.content.isEmoji ? .none : bubbleType,
-                message: text,
-                isOutgoing: message.sender.isCurrentUser,
-                profile: message.sender.profile
-            )
-            .messageGesture(
-                message: message,
-                bubbleStyle: message.content.isEmoji ? .none : bubbleType,
-                onReply: onReply,
-                onToggleReaction: onToggleReaction
-            )
-            .id("bubble-\(message.messageId)")
-            .scaleEffect(isAppearing ? 0.9 : 1.0)
-            .rotationEffect(
-                .radians(
-                    isAppearing
-                    ? (message.source == .incoming ? -0.05 : 0.05)
-                    : 0
-                )
-            )
-            .offset(
-                x: isAppearing
-                ? (message.source == .incoming ? -20 : 20)
-                : 0,
-                y: isAppearing ? 40 : 0
-            )
-            .padding(.trailing, trailingPadding)
-
+            textBubble(text: text)
         case .emoji(let text):
-            EmojiBubble(
-                emoji: text,
-                isOutgoing: message.sender.isCurrentUser,
-                profile: message.sender.profile
-            )
-            .messageGesture(
-                message: message,
-                bubbleStyle: .none,
-                onReply: onReply,
-                onToggleReaction: onToggleReaction
-            )
-            .id("emoji-bubble-\(message.messageId)")
-            .opacity(isAppearing ? 0.0 : 1.0)
-            .blur(radius: isAppearing ? 10.0 : 0.0)
-            .scaleEffect(isAppearing ? 0.0 : 1.0)
-            .rotationEffect(
-                .radians(
-                    isAppearing
-                    ? (message.source == .incoming ? -0.10 : 0.10)
-                    : 0
-                )
-            )
-            .offset(
-                x: isAppearing
-                ? (message.source == .incoming ? -200 : 200)
-                : 0,
-                y: isAppearing ? 40 : 0
-            )
-            .padding(.trailing, trailingPadding)
-
+            emojiBubble(text: text)
         case .invite(let invite):
-            MessageInviteContainerView(
-                invite: invite,
-                style: bubbleType,
-                isOutgoing: message.source == .outgoing,
-                profile: message.sender.profile,
-                onTapInvite: onTapInvite,
-                onTapAvatar: { onTapAvatar(message) }
-            )
-            .messageGesture(
-                message: message,
-                bubbleStyle: bubbleType,
-                onSingleTap: { onTapInvite(invite) },
-                onReply: onReply,
-                onToggleReaction: onToggleReaction
-            )
-            .id("message-invite-\(message.messageId)")
-            .scaleEffect(isAppearing ? 0.9 : 1.0)
-            .rotationEffect(
-                .radians(
-                    isAppearing
-                    ? (message.source == .incoming ? -0.05 : 0.05)
-                    : 0
-                )
-            )
-            .offset(
-                x: isAppearing
-                ? (message.source == .incoming ? -20 : 20)
-                : 0,
-                y: isAppearing ? 40 : 0
-            )
-            .padding(.trailing, trailingPadding)
-
+            inviteBubble(invite: invite)
         case .linkPreview(let preview):
-            LinkPreviewBubbleView(
-                preview: preview,
-                style: bubbleType,
-                isOutgoing: message.source == .outgoing,
-                profile: message.sender.profile,
-                messageId: message.messageId
-            )
-            .messageGesture(
-                message: message,
-                bubbleStyle: bubbleType,
-                onSingleTap: {
-                    if let url = preview.resolvedURL {
-                        UIApplication.shared.open(url)
-                    }
-                },
-                onReply: onReply,
-                onToggleReaction: onToggleReaction
-            )
-            .id("link-preview-\(message.messageId)")
-            .scaleEffect(isAppearing ? 0.9 : 1.0)
-            .rotationEffect(
-                .radians(
-                    isAppearing
-                    ? (message.source == .incoming ? -0.05 : 0.05)
-                    : 0
-                )
-            )
-            .offset(
-                x: isAppearing
-                ? (message.source == .incoming ? -20 : 20)
-                : 0,
-                y: isAppearing ? 40 : 0
-            )
-            .padding(.trailing, trailingPadding)
-
+            linkPreviewBubble(preview: preview)
         case .attachment(let attachment):
             attachmentView(for: attachment)
-
         case .attachments(let attachments):
             if let attachment = attachments.first {
                 attachmentView(for: attachment)
             }
-
         case .update, .assistantJoinRequest:
             EmptyView()
-
         case .connectionGrantRequest(let request):
-            // Cloud Connections is feature-flagged. With the flag off, an
-            // authorized assistant can still send a grant-request payload —
-            // we receive and decode it but render nothing so the unsupported
-            // feature isn't surfaced to the user.
-            if FeatureFlags.shared.isCloudConnectionsEnabled {
-                ConnectionGrantRequestCardView(
-                    request: request,
-                    conversationId: conversationId,
-                    sender: message.sender
-                )
-                .messageGesture(
-                    message: message,
-                    bubbleStyle: bubbleType,
-                    onReply: onReply,
-                    onToggleReaction: onToggleReaction
-                )
-                .padding(.trailing, trailingPadding)
-            } else {
-                EmptyView()
+            connectionGrantBubble(request: request)
+        }
+    }
+
+    private var standardRotation: Angle {
+        guard isAppearing else { return .radians(0) }
+        return .radians(message.source == .incoming ? -0.05 : 0.05)
+    }
+
+    private var emojiRotation: Angle {
+        guard isAppearing else { return .radians(0) }
+        return .radians(message.source == .incoming ? -0.10 : 0.10)
+    }
+
+    private var standardOffset: CGSize {
+        guard isAppearing else { return .zero }
+        let x: CGFloat = message.source == .incoming ? -20 : 20
+        return CGSize(width: x, height: 40)
+    }
+
+    private var emojiOffset: CGSize {
+        guard isAppearing else { return .zero }
+        let x: CGFloat = message.source == .incoming ? -200 : 200
+        return CGSize(width: x, height: 40)
+    }
+
+    @ViewBuilder
+    private func textBubble(text: String) -> some View {
+        let style: MessageBubbleType = message.content.isEmoji ? .none : bubbleType
+        MessageBubble(
+            style: style,
+            message: text,
+            isOutgoing: message.sender.isCurrentUser,
+            profile: message.sender.profile
+        )
+        .messageGesture(
+            message: message,
+            bubbleStyle: style,
+            onReply: onReply,
+            onToggleReaction: onToggleReaction
+        )
+        .id("bubble-\(message.messageId)")
+        .scaleEffect(isAppearing ? 0.9 : 1.0)
+        .rotationEffect(standardRotation)
+        .offset(standardOffset)
+        .padding(.trailing, trailingPadding)
+    }
+
+    @ViewBuilder
+    private func emojiBubble(text: String) -> some View {
+        EmojiBubble(
+            emoji: text,
+            isOutgoing: message.sender.isCurrentUser,
+            profile: message.sender.profile
+        )
+        .messageGesture(
+            message: message,
+            bubbleStyle: .none,
+            onReply: onReply,
+            onToggleReaction: onToggleReaction
+        )
+        .id("emoji-bubble-\(message.messageId)")
+        .opacity(isAppearing ? 0.0 : 1.0)
+        .blur(radius: isAppearing ? 10.0 : 0.0)
+        .scaleEffect(isAppearing ? 0.0 : 1.0)
+        .rotationEffect(emojiRotation)
+        .offset(emojiOffset)
+        .padding(.trailing, trailingPadding)
+    }
+
+    @ViewBuilder
+    private func inviteBubble(invite: MessageInvite) -> some View {
+        let inviteTap = { onTapInvite(invite) }
+        let avatarTap = { onTapAvatar(message) }
+        MessageInviteContainerView(
+            invite: invite,
+            style: bubbleType,
+            isOutgoing: message.source == .outgoing,
+            profile: message.sender.profile,
+            onTapInvite: onTapInvite,
+            onTapAvatar: avatarTap
+        )
+        .messageGesture(
+            message: message,
+            bubbleStyle: bubbleType,
+            onSingleTap: inviteTap,
+            onReply: onReply,
+            onToggleReaction: onToggleReaction
+        )
+        .id("message-invite-\(message.messageId)")
+        .scaleEffect(isAppearing ? 0.9 : 1.0)
+        .rotationEffect(standardRotation)
+        .offset(standardOffset)
+        .padding(.trailing, trailingPadding)
+    }
+
+    @ViewBuilder
+    private func linkPreviewBubble(preview: LinkPreview) -> some View {
+        let openLink: () -> Void = {
+            if let url = preview.resolvedURL {
+                UIApplication.shared.open(url)
             }
+        }
+        LinkPreviewBubbleView(
+            preview: preview,
+            style: bubbleType,
+            isOutgoing: message.source == .outgoing,
+            profile: message.sender.profile,
+            messageId: message.messageId
+        )
+        .messageGesture(
+            message: message,
+            bubbleStyle: bubbleType,
+            onSingleTap: openLink,
+            onReply: onReply,
+            onToggleReaction: onToggleReaction
+        )
+        .id("link-preview-\(message.messageId)")
+        .scaleEffect(isAppearing ? 0.9 : 1.0)
+        .rotationEffect(standardRotation)
+        .offset(standardOffset)
+        .padding(.trailing, trailingPadding)
+    }
+
+    @ViewBuilder
+    private func connectionGrantBubble(request: ConnectionGrantRequest) -> some View {
+        // Cloud Connections is feature-flagged. With the flag off, an
+        // authorized assistant can still send a grant-request payload —
+        // we receive and decode it but render nothing so the unsupported
+        // feature isn't surfaced to the user.
+        if FeatureFlags.shared.isCloudConnectionsEnabled {
+            ConnectionGrantRequestCardView(
+                request: request,
+                conversationId: conversationId,
+                sender: message.sender
+            )
+            .messageGesture(
+                message: message,
+                bubbleStyle: bubbleType,
+                onReply: onReply,
+                onToggleReaction: onToggleReaction
+            )
+            .padding(.trailing, trailingPadding)
+        } else {
+            EmptyView()
         }
     }
 

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessagesListView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessagesListView.swift
@@ -33,116 +33,135 @@ struct MessagesListView: View {
 
     var body: some View {
         ScrollViewReader { _ in
-            ScrollView {
-                LazyVStack(spacing: 0.0) {
-                    if conversation.creator.isCurrentUser && !conversation.isLocked && !conversation.isFull {
-                        VStack(spacing: DesignConstants.Spacing.step4x) {
-                            InviteView(invite: invite)
-                            NewConvoIdentityView(
-                                onCopyLink: onCopyInviteLink,
-                                onConvoCode: onConvoCode,
-                                onInviteAssistant: onInviteAssistant,
-                                hasAssistant: hasAssistant,
-                                isAssistantJoinPending: isAssistantJoinPending,
-                                isAssistantEnabled: isAssistantEnabled
-                            )
-                        }
-                        .id("invite")
-                    } else {
-                        VStack(spacing: DesignConstants.Spacing.step4x) {
-                            ConversationInfoPreview(conversation: conversation)
-                        }
-                        .id("conversation-info")
-                    }
+            scrollContent
+        }
+    }
 
-                    ForEach(messages.enumerated(), id: \.element.id) { index, item in
-                        Group {
-                            switch item {
-                            case .date(let dateGroup):
-                                TextTitleContentView(title: dateGroup.value, profile: nil)
-                                    .padding(.vertical, DesignConstants.Spacing.step2x)
+    private var scrollContent: some View {
+        ScrollView {
+            LazyVStack(spacing: 0.0) {
+                listHeader
+                messagesList
+            }
+        }
+        .scrollEdgeEffectHidden(for: [.bottom])
+        .animation(.spring(duration: 0.5, bounce: 0.2), value: messages)
+        .contentMargins(.horizontal, DesignConstants.Spacing.step4x, for: .scrollContent)
+        .defaultScrollAnchor(.bottom)
+        .scrollDismissesKeyboard(.interactively)
+        .scrollPosition($scrollPosition, anchor: .bottom)
+    }
 
-                            case .update(_, let update, _):
-                                VStack(spacing: 0) {
-                                    TextTitleContentView(
-                                        title: update.summary,
-                                        profile: update.profile,
-                                        agentVerification: update.profileMember?.agentVerification ?? .unverified,
-                                        onTap: update.profileMember.map { member in
-                                            { onTapUpdateMember(member) }
-                                        }
-                                    )
-                                        .padding(.vertical, DesignConstants.Spacing.stepX)
-                                    if update.addedVerifiedAssistant {
-                                        AssistantJoinedInfoView()
-                                    }
-                                }
+    @ViewBuilder
+    private var listHeader: some View {
+        if conversation.creator.isCurrentUser && !conversation.isLocked && !conversation.isFull {
+            VStack(spacing: DesignConstants.Spacing.step4x) {
+                InviteView(invite: invite)
+                NewConvoIdentityView(
+                    onCopyLink: onCopyInviteLink,
+                    onConvoCode: onConvoCode,
+                    onInviteAssistant: onInviteAssistant,
+                    hasAssistant: hasAssistant,
+                    isAssistantJoinPending: isAssistantJoinPending,
+                    isAssistantEnabled: isAssistantEnabled
+                )
+            }
+            .id("invite")
+        } else {
+            VStack(spacing: DesignConstants.Spacing.step4x) {
+                ConversationInfoPreview(conversation: conversation)
+            }
+            .id("conversation-info")
+        }
+    }
 
-                            case .messages(let group):
-                                messagesGroupView(for: group)
-
-                            case .invite(let invite):
-                                InviteView(invite: invite)
-                                    .padding(.vertical, DesignConstants.Spacing.step2x)
-
-                            case .conversationInfo(let conversation):
-                                ConversationInfoPreview(conversation: conversation)
-                                    .padding(.vertical, DesignConstants.Spacing.step2x)
-
-                            case .agentOutOfCredits(let profile):
-                                TextTitleContentView(
-                                    title: "\(profile.displayName) is out of processing power",
-                                    profile: profile,
-                                    onTap: onAgentOutOfCredits
-                                )
-                                .padding(.vertical, DesignConstants.Spacing.step2x)
-
-                            case let .assistantJoinStatus(status, requesterName, _):
-                                AssistantJoinStatusView(
-                                    status: status,
-                                    requesterName: requesterName,
-                                    onRetry: onRetryAssistantJoin
-                                )
-                                .padding(.vertical, DesignConstants.Spacing.step2x)
-
-                            case let .assistantPresentInfo(agent, inviterName):
-                                let isVerified = agent.agentVerification.isVerified
-                                let label = isVerified ? "Assistant" : "Agent"
-                                let title = inviterName.map { "\(label) is present · Invited by \($0)" } ?? "\(label) is present"
-                                VStack(spacing: 0) {
-                                    TextTitleContentView(
-                                        title: title,
-                                        profile: agent.profile,
-                                        agentVerification: agent.agentVerification
-                                    )
-                                        .padding(.vertical, DesignConstants.Spacing.step4x)
-                                        .padding(.horizontal, DesignConstants.Spacing.step4x)
-                                    if isVerified {
-                                        AssistantJoinedInfoView()
-                                            .padding(.horizontal, DesignConstants.Spacing.step4x)
-                                    }
-                                }
-
-                            case .typingIndicator:
-                                EmptyView()
-                            }
-                        }
-                        .onScrollVisibilityChange(threshold: 0.1) { isVisible in
-                            guard lastItemIndex == nil else { return }
-
-                            if isVisible && index == messages.count - 1 {
-                                lastItemIndex = index
-                            }
-                        }
-                    }
+    private var messagesList: some View {
+        ForEach(messages.enumerated(), id: \.element.id) { index, item in
+            Group {
+                listItemView(for: item)
+            }
+            .onScrollVisibilityChange(threshold: 0.1) { isVisible in
+                guard lastItemIndex == nil else { return }
+                if isVisible && index == messages.count - 1 {
+                    lastItemIndex = index
                 }
             }
-            .scrollEdgeEffectHidden(for: [.bottom])
-            .animation(.spring(duration: 0.5, bounce: 0.2), value: messages)
-            .contentMargins(.horizontal, DesignConstants.Spacing.step4x, for: .scrollContent)
-            .defaultScrollAnchor(.bottom)
-            .scrollDismissesKeyboard(.interactively)
-            .scrollPosition($scrollPosition, anchor: .bottom)
+        }
+    }
+
+    @ViewBuilder
+    private func listItemView(for item: MessagesListItemType) -> some View {
+        switch item {
+        case .date(let dateGroup):
+            TextTitleContentView(title: dateGroup.value, profile: nil)
+                .padding(.vertical, DesignConstants.Spacing.step2x)
+        case .update(_, let update, _):
+            updateRow(update: update)
+        case .messages(let group):
+            messagesGroupView(for: group)
+        case .invite(let invite):
+            InviteView(invite: invite)
+                .padding(.vertical, DesignConstants.Spacing.step2x)
+        case .conversationInfo(let conversation):
+            ConversationInfoPreview(conversation: conversation)
+                .padding(.vertical, DesignConstants.Spacing.step2x)
+        case .agentOutOfCredits(let profile):
+            TextTitleContentView(
+                title: "\(profile.displayName) is out of processing power",
+                profile: profile,
+                onTap: onAgentOutOfCredits
+            )
+            .padding(.vertical, DesignConstants.Spacing.step2x)
+        case let .assistantJoinStatus(status, requesterName, _):
+            AssistantJoinStatusView(
+                status: status,
+                requesterName: requesterName,
+                onRetry: onRetryAssistantJoin
+            )
+            .padding(.vertical, DesignConstants.Spacing.step2x)
+        case let .assistantPresentInfo(agent, inviterName):
+            assistantPresentRow(agent: agent, inviterName: inviterName)
+        case .typingIndicator:
+            EmptyView()
+        }
+    }
+
+    @ViewBuilder
+    private func updateRow(update: ConversationUpdate) -> some View {
+        let memberTap: (() -> Void)? = update.profileMember.map { member in
+            { onTapUpdateMember(member) }
+        }
+        VStack(spacing: 0) {
+            TextTitleContentView(
+                title: update.summary,
+                profile: update.profile,
+                agentVerification: update.profileMember?.agentVerification ?? .unverified,
+                onTap: memberTap
+            )
+                .padding(.vertical, DesignConstants.Spacing.stepX)
+            if update.addedVerifiedAssistant {
+                AssistantJoinedInfoView()
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func assistantPresentRow(agent: ConversationMember, inviterName: String?) -> some View {
+        let isVerified = agent.agentVerification.isVerified
+        let label = isVerified ? "Assistant" : "Agent"
+        let title = inviterName.map { "\(label) is present · Invited by \($0)" } ?? "\(label) is present"
+        VStack(spacing: 0) {
+            TextTitleContentView(
+                title: title,
+                profile: agent.profile,
+                agentVerification: agent.agentVerification
+            )
+                .padding(.vertical, DesignConstants.Spacing.step4x)
+                .padding(.horizontal, DesignConstants.Spacing.step4x)
+            if isVerified {
+                AssistantJoinedInfoView()
+                    .padding(.horizontal, DesignConstants.Spacing.step4x)
+            }
         }
     }
 

--- a/Convos/Conversations List/ExplodeConvoSheet.swift
+++ b/Convos/Conversations List/ExplodeConvoSheet.swift
@@ -134,7 +134,21 @@ struct ExplodeConvoSheet: View {
     private var scheduleMenuContent: some View {
         let items = scheduleMenuItems
         let rowHeight: CGFloat = DesignConstants.Spacing.step11x
-        return VStack(alignment: .leading, spacing: 0) {
+        return scheduleMenuList(items: items, rowHeight: rowHeight)
+            .background(alignment: .topLeading) {
+                scheduleMenuHighlight(rowHeight: rowHeight)
+            }
+            .animation(.smooth(duration: 0.15), value: highlightedMenuIndex)
+            .contentShape(Rectangle())
+            .sensoryFeedback(.selection, trigger: highlightedMenuIndex) { _, newValue in
+                newValue != nil
+            }
+            .coordinateSpace(name: "scheduleMenu")
+            .gesture(scheduleMenuGesture(items: items, rowHeight: rowHeight))
+    }
+
+    private func scheduleMenuList(items: [(label: String, showsChevron: Bool)], rowHeight: CGFloat) -> some View {
+        VStack(alignment: .leading, spacing: 0) {
             ForEach(Array(items.enumerated()), id: \.offset) { _, item in
                 HStack {
                     Text(item.label)
@@ -150,38 +164,38 @@ struct ExplodeConvoSheet: View {
                 .frame(height: rowHeight)
             }
         }
-        .background(alignment: .topLeading) {
-            if highlightedMenuIndex != nil {
-                RoundedRectangle(cornerRadius: DesignConstants.CornerRadius.regular)
-                    .fill(Color.primary.opacity(0.06))
-                    .frame(height: rowHeight)
-                    .frame(maxWidth: .infinity)
-                    .offset(y: CGFloat(highlightedMenuIndex ?? 0) * rowHeight)
-                    .transition(.opacity.animation(.easeOut(duration: 0.08)))
+    }
+
+    @ViewBuilder
+    private func scheduleMenuHighlight(rowHeight: CGFloat) -> some View {
+        if highlightedMenuIndex != nil {
+            RoundedRectangle(cornerRadius: DesignConstants.CornerRadius.regular)
+                .fill(Color.primary.opacity(0.06))
+                .frame(height: rowHeight)
+                .frame(maxWidth: .infinity)
+                .offset(y: CGFloat(highlightedMenuIndex ?? 0) * rowHeight)
+                .transition(.opacity.animation(.easeOut(duration: 0.08)))
+        }
+    }
+
+    private func scheduleMenuGesture(
+        items: [(label: String, showsChevron: Bool)],
+        rowHeight: CGFloat
+    ) -> some Gesture {
+        DragGesture(minimumDistance: 0, coordinateSpace: .named("scheduleMenu"))
+            .onChanged { value in
+                let index = Int(value.location.y / rowHeight)
+                let newIndex = (index >= 0 && index < items.count) ? index : nil
+                if newIndex != highlightedMenuIndex {
+                    highlightedMenuIndex = newIndex
+                }
             }
-        }
-        .animation(.smooth(duration: 0.15), value: highlightedMenuIndex)
-        .contentShape(Rectangle())
-        .sensoryFeedback(.selection, trigger: highlightedMenuIndex) { _, newValue in
-            newValue != nil
-        }
-        .coordinateSpace(name: "scheduleMenu")
-        .gesture(
-            DragGesture(minimumDistance: 0, coordinateSpace: .named("scheduleMenu"))
-                .onChanged { value in
-                    let index = Int(value.location.y / rowHeight)
-                    let newIndex = (index >= 0 && index < items.count) ? index : nil
-                    if newIndex != highlightedMenuIndex {
-                        highlightedMenuIndex = newIndex
-                    }
+            .onEnded { _ in
+                if let index = highlightedMenuIndex {
+                    performScheduleMenuAction(at: index)
                 }
-                .onEnded { _ in
-                    if let index = highlightedMenuIndex {
-                        performScheduleMenuAction(at: index)
-                    }
-                    highlightedMenuIndex = nil
-                }
-        )
+                highlightedMenuIndex = nil
+            }
     }
 
     private func performScheduleMenuAction(at index: Int) {

--- a/Convos/Debug View/DebugView.swift
+++ b/Convos/Debug View/DebugView.swift
@@ -71,187 +71,211 @@ struct DebugViewSection: View {
         }
     }
 
+    @ViewBuilder
+    private var pushNotificationsSection: some View {
+        Section(header: Text("Push Notifications")) {
+            HStack {
+                Text("Auth Status")
+                Spacer()
+                Text(statusText(notificationAuthStatus))
+                    .foregroundStyle(.colorTextSecondary)
+            }
+            HStack {
+                Text("Authorized")
+                Spacer()
+                Text(notificationAuthGranted ? "Yes" : "No")
+                    .foregroundStyle(.colorTextSecondary)
+            }
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Device Token")
+                HStack(spacing: 8) {
+                    ScrollView(.horizontal, showsIndicators: true) {
+                        Text(lastDeviceToken)
+                            .font(.system(.footnote, design: .monospaced))
+                            .foregroundStyle(.colorTextSecondary)
+                            .textSelection(.enabled)
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                    }
+                    Button {
+                        UIPasteboard.general.string = lastDeviceToken
+                    } label: {
+                        Image(systemName: "doc.on.doc")
+                    }
+                    .buttonStyle(.borderless)
+                    .disabled(lastDeviceToken.isEmpty)
+                }
+            }
+            HStack {
+                Text("APNS Environment")
+                Spacer()
+                Text(ConfigManager.shared.currentEnvironment.apnsEnvironment.rawValue)
+                    .foregroundStyle(.colorTextSecondary)
+            }
+            HStack {
+                Button("Request Now") {
+                    Task { await requestNotificationsNow() }
+                }
+                .disabled(notificationAuthGranted)
+                .opacity(notificationAuthGranted ? 0.5 : 1.0)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var debugInfoSection: some View {
+        Section("Debug") {
+            HStack {
+                Text("Bundle ID")
+                Spacer()
+                Text(Bundle.main.bundleIdentifier ?? "Unknown")
+                    .foregroundStyle(.colorTextSecondary)
+            }
+            HStack {
+                Text("Version")
+                Spacer()
+                Text(Bundle.appVersion)
+                    .foregroundStyle(.colorTextSecondary)
+            }
+            HStack {
+                Text("Environment")
+                Spacer()
+                Text(ConfigManager.shared.currentEnvironment.name.capitalized)
+                    .foregroundStyle(.colorTextSecondary)
+            }
+            HStack {
+                Text("Log storage")
+                Spacer()
+                if let info = logStorageInfo {
+                    Text(info.formattedTotalSize)
+                        .foregroundStyle(.colorTextSecondary)
+                } else {
+                    ProgressView()
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var sentryTestingSection: some View {
+        Section("Sentry Testing") {
+            Button {
+                testSentryMessage()
+            } label: {
+                Text("Send Test Message")
+                    .foregroundStyle(.colorTextPrimary)
+            }
+            Button {
+                testSentryError()
+            } label: {
+                Text("Send Test Error")
+                    .foregroundStyle(.colorTextPrimary)
+            }
+            Button {
+                testSentryException()
+            } label: {
+                Text("Send Test Exception")
+                    .foregroundStyle(.colorTextPrimary)
+            }
+            Button {
+                testSentryWithBreadcrumbs()
+            } label: {
+                Text("Send Event with Breadcrumbs")
+                    .foregroundStyle(.colorTextPrimary)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var pendingInvitesSection: some View {
+        Section("Pending Invites") {
+            NavigationLink {
+                PendingInviteDebugView(session: session)
+            } label: {
+                Text("View Pending Invites")
+                    .foregroundStyle(.colorTextPrimary)
+            }
+            NavigationLink {
+                OrphanedInboxDebugView(session: session)
+            } label: {
+                Text("View Orphaned Inboxes")
+                    .foregroundStyle(.colorTextPrimary)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var assetRenewalSection: some View {
+        Section("Asset Renewal") {
+            NavigationLink {
+                DebugAssetRenewalView(session: session)
+            } label: {
+                Text("View Renewable Assets")
+                    .foregroundStyle(.colorTextPrimary)
+            }
+            Button {
+                Task { await renewAssetsNow() }
+            } label: {
+                HStack {
+                    Text("Renew Assets Now")
+                        .foregroundStyle(.colorTextPrimary)
+                    Spacer()
+                    if isRenewingAssets { ProgressView() }
+                }
+            }
+            .disabled(isRenewingAssets)
+        }
+    }
+
+    @ViewBuilder
+    private var sheetsSection: some View {
+        Section("Sheets") {
+            Button {
+                presentingPhotosInfoSheet = true
+            } label: {
+                Text("Show Photos Info Sheet")
+                    .foregroundStyle(.colorTextPrimary)
+            }
+        }
+        .selfSizingSheet(isPresented: $presentingPhotosInfoSheet) {
+            PhotosInfoSheet()
+        }
+    }
+
+    @ViewBuilder
+    private var resetActionsSection: some View {
+        Section {
+            Button {
+                Task { await registerDeviceAgain() }
+            } label: {
+                Text("Register Device Again")
+                    .foregroundStyle(.colorTextPrimary)
+            }
+            Button {
+                resetOnboarding()
+            } label: {
+                Text("Reset Onboarding")
+                    .foregroundStyle(.colorTextPrimary)
+            }
+            Button {
+                resetAllSettings()
+            } label: {
+                Text("Reset All Settings")
+                    .foregroundStyle(.colorTextPrimary)
+            }
+        }
+    }
+
     var body: some View {
         Group {
             featuresSection
-
-            Section(header: Text("Push Notifications")) {
-                HStack {
-                    Text("Auth Status")
-                    Spacer()
-                    Text(statusText(notificationAuthStatus))
-                        .foregroundStyle(.colorTextSecondary)
-                }
-                HStack {
-                    Text("Authorized")
-                    Spacer()
-                    Text(notificationAuthGranted ? "Yes" : "No")
-                        .foregroundStyle(.colorTextSecondary)
-                }
-                VStack(alignment: .leading, spacing: 6) {
-                    Text("Device Token")
-                    HStack(spacing: 8) {
-                        ScrollView(.horizontal, showsIndicators: true) {
-                            Text(lastDeviceToken)
-                                .font(.system(.footnote, design: .monospaced))
-                                .foregroundStyle(.colorTextSecondary)
-                                .textSelection(.enabled)
-                                .lineLimit(1)
-                                .truncationMode(.middle)
-                        }
-                        Button {
-                            UIPasteboard.general.string = lastDeviceToken
-                        } label: {
-                            Image(systemName: "doc.on.doc")
-                        }
-                        .buttonStyle(.borderless)
-                        .disabled(lastDeviceToken.isEmpty)
-                    }
-                }
-                HStack {
-                    Text("APNS Environment")
-                    Spacer()
-                    Text(ConfigManager.shared.currentEnvironment.apnsEnvironment.rawValue)
-                        .foregroundStyle(.colorTextSecondary)
-                }
-                HStack {
-                    Button("Request Now") {
-                        Task { await requestNotificationsNow() }
-                    }
-                    .disabled(notificationAuthGranted)
-                    .opacity(notificationAuthGranted ? 0.5 : 1.0)
-                }
-            }
-
-            Section("Debug") {
-                HStack {
-                    Text("Bundle ID")
-                    Spacer()
-                    Text(Bundle.main.bundleIdentifier ?? "Unknown")
-                        .foregroundStyle(.colorTextSecondary)
-                }
-
-                HStack {
-                    Text("Version")
-                    Spacer()
-                    Text(Bundle.appVersion)
-                        .foregroundStyle(.colorTextSecondary)
-                }
-
-                HStack {
-                    Text("Environment")
-                    Spacer()
-                    Text(ConfigManager.shared.currentEnvironment.name.capitalized)
-                        .foregroundStyle(.colorTextSecondary)
-                }
-
-                HStack {
-                    Text("Log storage")
-                    Spacer()
-                    if let info = logStorageInfo {
-                        Text(info.formattedTotalSize)
-                            .foregroundStyle(.colorTextSecondary)
-                    } else {
-                        ProgressView()
-                    }
-                }
-            }
-
-            Section("Sentry Testing") {
-                Button {
-                    testSentryMessage()
-                } label: {
-                    Text("Send Test Message")
-                        .foregroundStyle(.colorTextPrimary)
-                }
-                Button {
-                    testSentryError()
-                } label: {
-                    Text("Send Test Error")
-                        .foregroundStyle(.colorTextPrimary)
-                }
-                Button {
-                    testSentryException()
-                } label: {
-                    Text("Send Test Exception")
-                        .foregroundStyle(.colorTextPrimary)
-                }
-                Button {
-                    testSentryWithBreadcrumbs()
-                } label: {
-                    Text("Send Event with Breadcrumbs")
-                        .foregroundStyle(.colorTextPrimary)
-                }
-            }
-
-            Section("Pending Invites") {
-                NavigationLink {
-                    PendingInviteDebugView(session: session)
-                } label: {
-                    Text("View Pending Invites")
-                        .foregroundStyle(.colorTextPrimary)
-                }
-                NavigationLink {
-                    OrphanedInboxDebugView(session: session)
-                } label: {
-                    Text("View Orphaned Inboxes")
-                        .foregroundStyle(.colorTextPrimary)
-                }
-            }
-
-            Section("Asset Renewal") {
-                NavigationLink {
-                    DebugAssetRenewalView(session: session)
-                } label: {
-                    Text("View Renewable Assets")
-                        .foregroundStyle(.colorTextPrimary)
-                }
-
-                Button {
-                    Task { await renewAssetsNow() }
-                } label: {
-                    HStack {
-                        Text("Renew Assets Now")
-                            .foregroundStyle(.colorTextPrimary)
-                        Spacer()
-                        if isRenewingAssets { ProgressView() }
-                    }
-                }
-                .disabled(isRenewingAssets)
-            }
-
-            Section("Sheets") {
-                Button {
-                    presentingPhotosInfoSheet = true
-                } label: {
-                    Text("Show Photos Info Sheet")
-                        .foregroundStyle(.colorTextPrimary)
-                }
-            }
-            .selfSizingSheet(isPresented: $presentingPhotosInfoSheet) {
-                PhotosInfoSheet()
-            }
-
-            Section {
-                Button {
-                    Task { await registerDeviceAgain() }
-                } label: {
-                    Text("Register Device Again")
-                        .foregroundStyle(.colorTextPrimary)
-                }
-                Button {
-                    resetOnboarding()
-                } label: {
-                    Text("Reset Onboarding")
-                        .foregroundStyle(.colorTextPrimary)
-                }
-                Button {
-                    resetAllSettings()
-                } label: {
-                    Text("Reset All Settings")
-                        .foregroundStyle(.colorTextPrimary)
-                }
-            }
+            pushNotificationsSection
+            debugInfoSection
+            sentryTestingSection
+            pendingInvitesSection
+            assetRenewalSection
+            sheetsSection
+            resetActionsSection
         }
         .task {
             await refreshNotificationStatus()

--- a/Convos/DeepLinking/DeepLinkHandler.swift
+++ b/Convos/DeepLinking/DeepLinkHandler.swift
@@ -63,23 +63,22 @@ final class DeepLinkHandler {
     }
 
     /// Split out so `parseConnectionGrant`'s body stays under the
-    /// project's 100ms warn-long-function-bodies budget — the chained
-    /// boolean expressions otherwise tip the type-checker over.
+    /// project's 100ms warn-long-function-bodies budget — chaining the
+    /// optional `String?` comparisons with `&&` otherwise tips the
+    /// type-checker over.
     private static func isConnectionGrantURL(_ url: URL) -> Bool {
         let pathComponents = url.pathComponents.filter { $0 != "/" }
 
-        let isCustomScheme = url.scheme == ConfigManager.shared.appUrlScheme
-            && url.host == "connections"
-            && pathComponents.first == "grant"
-        if isCustomScheme {
+        if url.scheme == ConfigManager.shared.appUrlScheme,
+           url.host == "connections",
+           pathComponents.first == "grant" {
             return true
         }
 
-        let isUniversalLink = url.scheme == "https"
-            && pathComponents.count >= 2
-            && pathComponents[0] == "connections"
-            && pathComponents[1] == "grant"
-        return isUniversalLink
+        guard url.scheme == "https", pathComponents.count >= 2 else {
+            return false
+        }
+        return pathComponents[0] == "connections" && pathComponents[1] == "grant"
     }
 
     private static func connectionGrantParams(from url: URL) -> (service: String, conversationId: String)? {

--- a/Convos/Shared Views/ShatteringText.swift
+++ b/Convos/Shared Views/ShatteringText.swift
@@ -28,37 +28,47 @@ struct ShatteringText: View {
 
     var body: some View {
         ZStack {
-            // Regular text when not exploded
             Text(text)
                 .opacity(isExploded ? 0 : 1)
                 .animation(.easeOut(duration: 0.1), value: isExploded)
 
-            // Shattered letters
-            HStack(spacing: 0) {
-                ForEach(Array(text.enumerated()), id: \.offset) { index, character in
-                    let delay = Double(index) * config.letterStaggerDelay
-                    let springAnimation = Animation
-                        .spring(response: config.letterAnimationResponse, dampingFraction: config.letterAnimationDamping)
-                        .delay(delay)
-                    // Use easeOut for opacity to prevent bounce-back visibility
-                    let opacityAnimation = Animation
-                        .easeOut(duration: config.letterAnimationResponse * 0.6)
-                        .delay(delay)
-
-                    Text(String(character))
-                        .offset(isExploded && index < letterOffsets.count ? letterOffsets[index] : .zero)
-                        .rotationEffect(.degrees(isExploded && index < letterRotations.count ? letterRotations[index] : 0))
-                        .scaleEffect(isExploded && index < letterScales.count ? letterScales[index] : 1)
-                        .blur(radius: isExploded ? config.letterBlurRadius : 0)
-                        .animation(isExploded ? springAnimation : .none, value: isExploded)
-                        .opacity(isExploded ? 0.0 : 1.0)
-                        .animation(isExploded ? opacityAnimation : .none, value: isExploded)
-                }
-            }
-            .opacity(isExploded ? 1.0 : 0.0)
-            .animation(.none, value: isExploded)
+            shatteredLetters
         }
         .task(id: text) { generateRandomValues() }
+    }
+
+    private var shatteredLetters: some View {
+        HStack(spacing: 0) {
+            ForEach(Array(text.enumerated()), id: \.offset) { index, character in
+                shatteredLetter(index: index, character: character)
+            }
+        }
+        .opacity(isExploded ? 1.0 : 0.0)
+        .animation(.none, value: isExploded)
+    }
+
+    private func shatteredLetter(index: Int, character: Character) -> some View {
+        let delay = Double(index) * config.letterStaggerDelay
+        let springAnimation = Animation
+            .spring(response: config.letterAnimationResponse, dampingFraction: config.letterAnimationDamping)
+            .delay(delay)
+        // easeOut for opacity to prevent bounce-back visibility
+        let opacityAnimation = Animation
+            .easeOut(duration: config.letterAnimationResponse * 0.6)
+            .delay(delay)
+
+        let offset: CGSize = (isExploded && index < letterOffsets.count) ? letterOffsets[index] : .zero
+        let rotation: Double = (isExploded && index < letterRotations.count) ? letterRotations[index] : 0
+        let scale: Double = (isExploded && index < letterScales.count) ? letterScales[index] : 1
+
+        return Text(String(character))
+            .offset(offset)
+            .rotationEffect(.degrees(rotation))
+            .scaleEffect(scale)
+            .blur(radius: isExploded ? config.letterBlurRadius : 0)
+            .animation(isExploded ? springAnimation : .none, value: isExploded)
+            .opacity(isExploded ? 0.0 : 1.0)
+            .animation(isExploded ? opacityAnimation : .none, value: isExploded)
     }
 
     private func generateRandomValues() {

--- a/ConvosCore/Sources/ConvosCore/Inboxes/MessagingService+PushNotifications.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/MessagingService+PushNotifications.swift
@@ -73,6 +73,7 @@ extension MessagingService {
             return try await handleWelcomeMessage(
                 contentTopic: contentTopic,
                 client: client,
+                apiClient: apiClient,
                 userInfo: payload.userInfo
             )
         }
@@ -91,7 +92,8 @@ extension MessagingService {
             contentTopic: contentTopic,
             currentInboxId: currentInboxId,
             userInfo: payload.userInfo,
-            client: client
+            client: client,
+            apiClient: apiClient
         )
     }
 
@@ -106,6 +108,7 @@ extension MessagingService {
     private func handleWelcomeMessage(
         contentTopic: String,
         client: any XMTPClientProvider,
+        apiClient: any ConvosAPIClientProtocol,
         userInfo: [AnyHashable: Any]
     ) async throws -> DecodedNotificationContent? {
         Log.debug("Syncing conversations after receiving welcome message")
@@ -131,8 +134,12 @@ extension MessagingService {
         _ = try await client.conversationsProvider.syncAllConversations(consentStates: [.unknown])
 
         // Case 1: Process join requests (others accepting our invites)
-        let joinRequestResults = await joinRequestsManager.processJoinRequests(since: lastProcessed, client: client)
-        if let result = joinRequestResults.first {
+        let joinRequestOutcomes = await joinRequestsManager.processJoinRequestOutcomes(since: lastProcessed, client: client)
+        for outcome in joinRequestOutcomes {
+            await handleJoinRequestOutcomeForPush(outcome, client: client, apiClient: apiClient, context: "welcome")
+        }
+
+        if let result = joinRequestOutcomes.compactMap(\.result).first {
             setLastWelcomeProcessed(processTime, for: client.inboxId)
 
             let displayName = (try? await getComputedDisplayName(
@@ -190,6 +197,43 @@ extension MessagingService {
         return .droppedMessage
     }
 
+    private func handleJoinRequestOutcomeForPush(
+        _ outcome: InviteJoinRequestOutcome,
+        client: any XMTPClientProvider,
+        apiClient: any ConvosAPIClientProtocol,
+        context: String
+    ) async {
+        guard let dmConversationId = outcome.dmConversationId else { return }
+
+        let params = SyncClientParams(client: client, apiClient: apiClient)
+        let topicManager = PushTopicSubscriptionManager(
+            identityStore: identityStore,
+            deviceInfoProvider: deviceInfoProvider
+        )
+
+        if outcome.shouldKeepDMSubscribed {
+            await topicManager.subscribeToInviteDMTopic(
+                conversationId: dmConversationId,
+                params: params,
+                context: "NSE \(context)"
+            )
+        } else if case .malicious = outcome {
+            await topicManager.unsubscribeFromInviteDMTopic(
+                conversationId: dmConversationId,
+                params: params,
+                context: "NSE \(context)"
+            )
+        }
+
+        if let result = outcome.result {
+            await topicManager.subscribeToGroupAndWelcome(
+                conversationId: result.conversationId,
+                params: params,
+                context: "NSE \(context) accepted join"
+            )
+        }
+    }
+
     private func getExistingGroupIds(client: any XMTPClientProvider) async throws -> Set<String> {
         let groups = try client.conversationsProvider.listGroups(
             createdAfterNs: nil,
@@ -240,7 +284,8 @@ extension MessagingService {
         contentTopic: String,
         currentInboxId: String,
         userInfo: [AnyHashable: Any],
-        client: any XMTPClientProvider
+        client: any XMTPClientProvider,
+        apiClient: any ConvosAPIClientProtocol
     ) async throws -> DecodedNotificationContent? {
         // Extract conversation ID from topic path
         guard let conversationId = contentTopic.conversationIdFromXMTPGroupTopic else {
@@ -282,7 +327,10 @@ extension MessagingService {
                 databaseWriter: databaseWriter
             )
 
-            if let result = await joinRequestsManager.processJoinRequest(message: decodedMessage, client: client) {
+            let outcome = await joinRequestsManager.processJoinRequestOutcome(message: decodedMessage, client: client)
+            await handleJoinRequestOutcomeForPush(outcome, client: client, apiClient: apiClient, context: "encrypted DM")
+
+            if let result = outcome.result {
                 let displayName = (try? await getComputedDisplayName(
                     conversationId: result.conversationId,
                     currentInboxId: currentInboxId

--- a/ConvosCore/Sources/ConvosCore/Inboxes/MessagingService+PushNotifications.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/MessagingService+PushNotifications.swift
@@ -135,9 +135,12 @@ extension MessagingService {
 
         // Case 1: Process join requests (others accepting our invites)
         let joinRequestOutcomes = await joinRequestsManager.processJoinRequestOutcomes(since: lastProcessed, client: client)
-        for outcome in joinRequestOutcomes {
-            await handleJoinRequestOutcomeForPush(outcome, client: client, apiClient: apiClient, context: "welcome")
-        }
+        await handleJoinRequestOutcomesForPush(
+            joinRequestOutcomes,
+            client: client,
+            apiClient: apiClient,
+            context: "welcome"
+        )
 
         if let result = joinRequestOutcomes.compactMap(\.result).first {
             setLastWelcomeProcessed(processTime, for: client.inboxId)
@@ -203,35 +206,37 @@ extension MessagingService {
         apiClient: any ConvosAPIClientProtocol,
         context: String
     ) async {
-        guard let dmConversationId = outcome.dmConversationId else { return }
+        await handleJoinRequestOutcomesForPush([outcome], client: client, apiClient: apiClient, context: context)
+    }
 
+    private func handleJoinRequestOutcomesForPush(
+        _ outcomes: [InviteJoinRequestOutcome],
+        client: any XMTPClientProvider,
+        apiClient: any ConvosAPIClientProtocol,
+        context: String
+    ) async {
+        guard !outcomes.isEmpty else { return }
+        var dmsToSub: [String] = []
+        var dmsToUnsub: [String] = []
+        var acceptedGroups: [String] = []
+        for outcome in outcomes {
+            if let dmId = outcome.dmConversationId {
+                if outcome.shouldKeepDMSubscribed {
+                    dmsToSub.append(dmId)
+                } else if case .malicious = outcome {
+                    dmsToUnsub.append(dmId)
+                }
+            }
+            if let result = outcome.result {
+                acceptedGroups.append(result.conversationId)
+            }
+        }
+        guard !dmsToSub.isEmpty || !dmsToUnsub.isEmpty || !acceptedGroups.isEmpty else { return }
         let params = SyncClientParams(client: client, apiClient: apiClient)
-        let topicManager = PushTopicSubscriptionManager(
-            identityStore: identityStore,
-            deviceInfoProvider: deviceInfoProvider
-        )
-
-        if outcome.shouldKeepDMSubscribed {
-            await topicManager.subscribeToInviteDMTopic(
-                conversationId: dmConversationId,
-                params: params,
-                context: "NSE \(context)"
-            )
-        } else if case .malicious = outcome {
-            await topicManager.unsubscribeFromInviteDMTopic(
-                conversationId: dmConversationId,
-                params: params,
-                context: "NSE \(context)"
-            )
-        }
-
-        if let result = outcome.result {
-            await topicManager.subscribeToGroupAndWelcome(
-                conversationId: result.conversationId,
-                params: params,
-                context: "NSE \(context) accepted join"
-            )
-        }
+        let mgr = PushTopicSubscriptionManager(identityStore: identityStore, deviceInfoProvider: deviceInfoProvider)
+        await mgr.subscribeToInviteDMTopics(conversationIds: dmsToSub, params: params, context: "NSE \(context)")
+        await mgr.unsubscribeFromInviteDMTopics(conversationIds: dmsToUnsub, params: params, context: "NSE \(context)")
+        await mgr.subscribeToGroupsAndWelcome(conversationIds: acceptedGroups, params: params, context: "NSE \(context) accepted join")
     }
 
     private func getExistingGroupIds(client: any XMTPClientProvider) async throws -> Set<String> {

--- a/ConvosCore/Sources/ConvosCore/Messaging/MessagingService.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/MessagingService.swift
@@ -25,6 +25,7 @@ final class MessagingService: MessagingServiceProtocol, @unchecked Sendable {
     internal let identityStore: any KeychainIdentityStoreProtocol
     internal let databaseReader: any DatabaseReader
     internal let databaseWriter: any DatabaseWriter
+    internal let deviceInfoProvider: any DeviceInfoProviding
     private let environment: AppEnvironment
     private let backgroundUploadManager: any BackgroundUploadManagerProtocol
     private var cancellables: Set<AnyCancellable> = []
@@ -62,6 +63,7 @@ final class MessagingService: MessagingServiceProtocol, @unchecked Sendable {
             databaseReader: databaseReader,
             identityStore: identityStore,
             environment: environment,
+            deviceInfoProvider: platformProviders.deviceInfo,
             backgroundUploadManager: platformProviders.backgroundUploadManager
         )
     }
@@ -71,6 +73,7 @@ final class MessagingService: MessagingServiceProtocol, @unchecked Sendable {
                   databaseReader: any DatabaseReader,
                   identityStore: any KeychainIdentityStoreProtocol,
                   environment: AppEnvironment,
+                  deviceInfoProvider: any DeviceInfoProviding,
                   backgroundUploadManager: any BackgroundUploadManagerProtocol) {
         self.identityStore = identityStore
         self.authorizationOperation = authorizationOperation
@@ -78,6 +81,7 @@ final class MessagingService: MessagingServiceProtocol, @unchecked Sendable {
         self.clientId = authorizationOperation.stateMachine.initialClientId
         self.databaseReader = databaseReader
         self.databaseWriter = databaseWriter
+        self.deviceInfoProvider = deviceInfoProvider
         self.environment = environment
         self.backgroundUploadManager = backgroundUploadManager
     }
@@ -93,6 +97,7 @@ final class MessagingService: MessagingServiceProtocol, @unchecked Sendable {
                   databaseReader: any DatabaseReader,
                   identityStore: any KeychainIdentityStoreProtocol,
                   environment: AppEnvironment,
+                  deviceInfoProvider: any DeviceInfoProviding,
                   backgroundUploadManager: any BackgroundUploadManagerProtocol) {
         let operation = FailedIdentityLoadOperation(error: error)
         self.identityStore = identityStore
@@ -101,6 +106,7 @@ final class MessagingService: MessagingServiceProtocol, @unchecked Sendable {
         self.clientId = ""
         self.databaseReader = databaseReader
         self.databaseWriter = databaseWriter
+        self.deviceInfoProvider = deviceInfoProvider
         self.environment = environment
         self.backgroundUploadManager = backgroundUploadManager
     }

--- a/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
@@ -272,6 +272,7 @@ public final class SessionManager: SessionManagerProtocol, @unchecked Sendable {
                     databaseReader: databaseReader,
                     identityStore: identityStore,
                     environment: environment,
+                    deviceInfoProvider: platformProviders.deviceInfo,
                     backgroundUploadManager: platformProviders.backgroundUploadManager
                 )
                 cached = placeholder
@@ -326,6 +327,7 @@ public final class SessionManager: SessionManagerProtocol, @unchecked Sendable {
                     databaseReader: databaseReader,
                     identityStore: identityStore,
                     environment: environment,
+                    deviceInfoProvider: platformProviders.deviceInfo,
                     backgroundUploadManager: platformProviders.backgroundUploadManager
                 )
                 cached = errored
@@ -357,6 +359,7 @@ public final class SessionManager: SessionManagerProtocol, @unchecked Sendable {
                     databaseReader: databaseReader,
                     identityStore: identityStore,
                     environment: environment,
+                    deviceInfoProvider: platformProviders.deviceInfo,
                     backgroundUploadManager: platformProviders.backgroundUploadManager
                 )
                 cached = placeholder
@@ -405,6 +408,7 @@ public final class SessionManager: SessionManagerProtocol, @unchecked Sendable {
             databaseReader: databaseReader,
             identityStore: identityStore,
             environment: environment,
+            deviceInfoProvider: platformProviders.deviceInfo,
             backgroundUploadManager: platformProviders.backgroundUploadManager
         )
     }

--- a/ConvosCore/Sources/ConvosCore/Syncing/InviteJoinRequestsManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/InviteJoinRequestsManager.swift
@@ -203,7 +203,7 @@ final class InviteJoinRequestsManager: InviteJoinRequestsManagerProtocol, Sendab
         client: AnyClientProvider
     ) async -> InviteJoinRequestOutcome {
         switch outcome {
-        case .accepted(let result, dmConversationId: let dmConversationId):
+        case let .accepted(result, dmConversationId: dmConversationId):
             logAccepted(result)
             await persistJoinerProfile(result)
             await sendProfileSnapshotAfterJoin(conversationId: result.conversationId, client: client)
@@ -217,14 +217,14 @@ final class InviteJoinRequestsManager: InviteJoinRequestsManagerProtocol, Sendab
                 ),
                 dmConversationId: dmConversationId
             )
-        case .benignFailure(let dmConversationId, let senderInboxId, let error):
+        case let .benignFailure(dmConversationId, senderInboxId, error):
             Log.info("Join request failed without blocking DM \(dmConversationId): \(error)")
             return .benignFailure(
                 dmConversationId: dmConversationId,
                 senderInboxId: senderInboxId,
                 error: error
             )
-        case .malicious(let dmConversationId, let senderInboxId, let error):
+        case let .malicious(dmConversationId, senderInboxId, error):
             Log.warning("Join request marked malicious for DM \(dmConversationId), sender \(senderInboxId): \(error)")
             return .malicious(
                 dmConversationId: dmConversationId,

--- a/ConvosCore/Sources/ConvosCore/Syncing/InviteJoinRequestsManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/InviteJoinRequestsManager.swift
@@ -13,6 +13,11 @@ public struct JoinRequestResult: Sendable {
 
 /// Core-local projection of `JoinRequestDMOutcome` after applying ConvosCore
 /// side effects, including profile persistence and post-join profile snapshots.
+///
+/// Mirrors the upstream cases. See `JoinRequestDMOutcome` for the full
+/// per-case rationale, including why `benignFailure` keeps the DM
+/// subscribed (transient/local errors should not block legitimate retries
+/// from the same joiner).
 enum InviteJoinRequestOutcome: Sendable {
     case accepted(JoinRequestResult, dmConversationId: String)
     case benignFailure(dmConversationId: String, senderInboxId: String?, error: JoinRequestError)

--- a/ConvosCore/Sources/ConvosCore/Syncing/InviteJoinRequestsManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/InviteJoinRequestsManager.swift
@@ -11,6 +11,8 @@ public struct JoinRequestResult: Sendable {
     public let metadata: [String: String]?
 }
 
+/// Core-local projection of `JoinRequestDMOutcome` after applying ConvosCore
+/// side effects, including profile persistence and post-join profile snapshots.
 enum InviteJoinRequestOutcome: Sendable {
     case accepted(JoinRequestResult, dmConversationId: String)
     case benignFailure(dmConversationId: String, senderInboxId: String?, error: JoinRequestError)

--- a/ConvosCore/Sources/ConvosCore/Syncing/InviteJoinRequestsManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/InviteJoinRequestsManager.swift
@@ -11,15 +11,57 @@ public struct JoinRequestResult: Sendable {
     public let metadata: [String: String]?
 }
 
+enum InviteJoinRequestOutcome: Sendable {
+    case accepted(JoinRequestResult, dmConversationId: String)
+    case benignFailure(dmConversationId: String, senderInboxId: String?, error: JoinRequestError)
+    case malicious(dmConversationId: String, senderInboxId: String, error: JoinRequestError)
+    case noJoinRequest
+
+    var result: JoinRequestResult? {
+        guard case .accepted(let result, dmConversationId: _) = self else { return nil }
+        return result
+    }
+
+    var dmConversationId: String? {
+        switch self {
+        case .accepted(_, dmConversationId: let dmConversationId):
+            return dmConversationId
+        case .benignFailure(let dmConversationId, _, _):
+            return dmConversationId
+        case .malicious(let dmConversationId, _, _):
+            return dmConversationId
+        case .noJoinRequest:
+            return nil
+        }
+    }
+
+    var shouldKeepDMSubscribed: Bool {
+        switch self {
+        case .accepted, .benignFailure:
+            return true
+        case .malicious, .noJoinRequest:
+            return false
+        }
+    }
+}
+
 protocol InviteJoinRequestsManagerProtocol: Sendable {
     func processJoinRequest(
         message: XMTPiOS.DecodedMessage,
         client: AnyClientProvider
     ) async -> JoinRequestResult?
+    func processJoinRequestOutcome(
+        message: XMTPiOS.DecodedMessage,
+        client: AnyClientProvider
+    ) async -> InviteJoinRequestOutcome
     func processJoinRequests(
         since: Date?,
         client: AnyClientProvider
     ) async -> [JoinRequestResult]
+    func processJoinRequestOutcomes(
+        since: Date?,
+        client: AnyClientProvider
+    ) async -> [InviteJoinRequestOutcome]
     func hasOutgoingJoinRequest(
         for conversation: XMTPiOS.Group,
         client: AnyClientProvider
@@ -50,38 +92,42 @@ final class InviteJoinRequestsManager: InviteJoinRequestsManagerProtocol, Sendab
         message: XMTPiOS.DecodedMessage,
         client: AnyClientProvider
     ) async -> JoinRequestResult? {
-        guard let result = await coordinator.processMessage(message, client: InviteClientProviderAdapter(client)) else {
-            return nil
-        }
-        logAccepted(result)
-        await persistJoinerProfile(result)
-        await sendProfileSnapshotAfterJoin(conversationId: result.conversationId, client: client)
-        return JoinRequestResult(
-            conversationId: result.conversationId,
-            conversationName: result.conversationName,
-            joinerInboxId: result.joinerInboxId,
-            profile: result.profile,
-            metadata: result.metadata
+        let outcome = await processJoinRequestOutcome(message: message, client: client)
+        return outcome.result
+    }
+
+    func processJoinRequestOutcome(
+        message: XMTPiOS.DecodedMessage,
+        client: AnyClientProvider
+    ) async -> InviteJoinRequestOutcome {
+        let outcome = await coordinator.processMessageOutcome(
+            message,
+            client: InviteClientProviderAdapter(client)
         )
+        return await mapOutcome(outcome, client: client)
     }
 
     func processJoinRequests(
         since: Date?,
         client: AnyClientProvider
     ) async -> [JoinRequestResult] {
-        var results: [JoinRequestResult] = []
-        for joinResult in await coordinator.processJoinRequests(since: since, client: InviteClientProviderAdapter(client)) {
-            logAccepted(joinResult)
-            await persistJoinerProfile(joinResult)
-            results.append(JoinRequestResult(
-                conversationId: joinResult.conversationId,
-                conversationName: joinResult.conversationName,
-                joinerInboxId: joinResult.joinerInboxId,
-                profile: joinResult.profile,
-                metadata: joinResult.metadata
-            ))
+        let outcomes = await processJoinRequestOutcomes(since: since, client: client)
+        return outcomes.compactMap(\.result)
+    }
+
+    func processJoinRequestOutcomes(
+        since: Date?,
+        client: AnyClientProvider
+    ) async -> [InviteJoinRequestOutcome] {
+        let outcomes = await coordinator.processJoinRequestOutcomes(
+            since: since,
+            client: InviteClientProviderAdapter(client)
+        )
+        var mapped: [InviteJoinRequestOutcome] = []
+        for outcome in outcomes {
+            mapped.append(await mapOutcome(outcome, client: client))
         }
-        return results
+        return mapped
     }
 
     func hasOutgoingJoinRequest(
@@ -142,6 +188,44 @@ final class InviteJoinRequestsManager: InviteJoinRequestsManagerProtocol, Sendab
             Log.debug("Persisted join request profile for \(result.joinerInboxId) in \(result.conversationId)")
         } catch {
             Log.warning("Failed to persist join request profile: \(error.localizedDescription)")
+        }
+    }
+
+    private func mapOutcome(
+        _ outcome: JoinRequestDMOutcome,
+        client: AnyClientProvider
+    ) async -> InviteJoinRequestOutcome {
+        switch outcome {
+        case .accepted(let result, dmConversationId: let dmConversationId):
+            logAccepted(result)
+            await persistJoinerProfile(result)
+            await sendProfileSnapshotAfterJoin(conversationId: result.conversationId, client: client)
+            return .accepted(
+                JoinRequestResult(
+                    conversationId: result.conversationId,
+                    conversationName: result.conversationName,
+                    joinerInboxId: result.joinerInboxId,
+                    profile: result.profile,
+                    metadata: result.metadata
+                ),
+                dmConversationId: dmConversationId
+            )
+        case .benignFailure(let dmConversationId, let senderInboxId, let error):
+            Log.info("Join request failed without blocking DM \(dmConversationId): \(error)")
+            return .benignFailure(
+                dmConversationId: dmConversationId,
+                senderInboxId: senderInboxId,
+                error: error
+            )
+        case .malicious(let dmConversationId, let senderInboxId, let error):
+            Log.warning("Join request marked malicious for DM \(dmConversationId), sender \(senderInboxId): \(error)")
+            return .malicious(
+                dmConversationId: dmConversationId,
+                senderInboxId: senderInboxId,
+                error: error
+            )
+        case .noJoinRequest:
+            return .noJoinRequest
         }
     }
 

--- a/ConvosCore/Sources/ConvosCore/Syncing/InviteJoinRequestsManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/InviteJoinRequestsManager.swift
@@ -122,6 +122,15 @@ final class InviteJoinRequestsManager: InviteJoinRequestsManagerProtocol, Sendab
         return outcomes.compactMap(\.result)
     }
 
+    /// Eventual-consistency note: between the moment the coordinator
+    /// snapshots the DM list and the moment the caller subscribes /
+    /// unsubscribes from push topics for those outcomes, a new join
+    /// request can land in another DM. That request is missed by the
+    /// current pass, so the device may briefly hold a stale push
+    /// subscription set. The next reconcile (after sync, resume, or
+    /// `requestDiscovery` — see `SyncingManager`) heals it. We accept
+    /// the lag because serializing the whole pipeline would require an
+    /// app-wide lock around DM message delivery for marginal benefit.
     func processJoinRequestOutcomes(
         since: Date?,
         client: AnyClientProvider

--- a/ConvosCore/Sources/ConvosCore/Syncing/PushTopicSubscriptionManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/PushTopicSubscriptionManager.swift
@@ -163,8 +163,14 @@ actor PushTopicSubscriptionManager: PushTopicSubscriptionManaging {
         context: String
     ) async {
         guard !conversationIds.isEmpty else { return }
+        let allowed = await filterAllowedInviteDMs(
+            conversationIds: conversationIds,
+            params: params,
+            context: context
+        )
+        guard !allowed.isEmpty else { return }
         await subscribe(
-            to: conversationIds.map(inviteDMSubscription(conversationId:)),
+            to: allowed.map(inviteDMSubscription(conversationId:)),
             params: params,
             context: context
         )
@@ -265,6 +271,12 @@ actor PushTopicSubscriptionManager: PushTopicSubscriptionManaging {
             Log.debug("Subscribed push topic values \(context): \(subscriptions.map(\.topic).joined(separator: ", "))")
         } catch {
             Log.warning("Failed subscribing to push topics \(context): \(error)")
+            QAEvent.emit(.sync, "push_topic_subscribe_failed", [
+                "context": context,
+                "topic_count": String(subscriptions.count),
+                "kinds": kindSummary(subscriptions),
+                "error": String(describing: error),
+            ])
         }
     }
 
@@ -285,7 +297,63 @@ actor PushTopicSubscriptionManager: PushTopicSubscriptionManaging {
             Log.info("Unsubscribed from push topics \(context): \(topics.joined(separator: ", "))")
         } catch {
             Log.warning("Failed unsubscribing from push topics \(context): \(error)")
+            QAEvent.emit(.sync, "push_topic_unsubscribe_failed", [
+                "context": context,
+                "topic_count": String(topics.count),
+                "error": String(describing: error),
+            ])
         }
+    }
+
+    /// Drops invite DMs whose current consent is `.denied`. The user has
+    /// explicitly opted out of that DM, so re-subscribing on a benign
+    /// processing failure (or any retry path) would re-arm pushes the
+    /// user actively rejected. Conversations we can't resolve (mock
+    /// clients, transient lookup failures) fall through unchanged so we
+    /// preserve the previous best-effort behaviour for tests and
+    /// degraded states.
+    private func filterAllowedInviteDMs(
+        conversationIds: [String],
+        params: SyncClientParams,
+        context: String
+    ) async -> [String] {
+        var allowed: [String] = []
+        var dropped: [String] = []
+        for id in conversationIds {
+            let conversation: XMTPiOS.Conversation?
+            do {
+                conversation = try await params.client.conversationsProvider.findConversation(conversationId: id)
+            } catch {
+                Log.warning("Failed loading DM \(id) consent for push subscribe \(context): \(error)")
+                allowed.append(id)
+                continue
+            }
+            guard let conversation else {
+                allowed.append(id)
+                continue
+            }
+            let consent: ConsentState
+            do {
+                consent = try conversation.consentState()
+            } catch {
+                Log.warning("Failed reading DM \(id) consent for push subscribe \(context): \(error)")
+                allowed.append(id)
+                continue
+            }
+            if consent == .denied {
+                dropped.append(id)
+            } else {
+                allowed.append(id)
+            }
+        }
+        if !dropped.isEmpty {
+            QAEvent.emit(.sync, "push_topic_subscribe_skipped_denied", [
+                "context": context,
+                "count": String(dropped.count),
+            ])
+            Log.info("Skipping push subscribe for denied DMs \(context): \(dropped.joined(separator: ", "))")
+        }
+        return allowed
     }
 
     private func identity(matching params: SyncClientParams) async -> KeychainIdentity? {
@@ -335,6 +403,17 @@ actor PushTopicSubscriptionManager: PushTopicSubscriptionManaging {
         subscriptions
             .map { "\($0.kind.rawValue):\($0.sourceId)" }
             .joined(separator: ", ")
+    }
+
+    private func kindSummary(_ subscriptions: [TopicSubscription]) -> String {
+        var counts: [String: Int] = [:]
+        for subscription in subscriptions {
+            counts[subscription.kind.rawValue, default: 0] += 1
+        }
+        return counts
+            .sorted { $0.key < $1.key }
+            .map { "\($0.key)=\($0.value)" }
+            .joined(separator: ",")
     }
 
     private func welcomeSubscription(params: SyncClientParams) -> TopicSubscription {

--- a/ConvosCore/Sources/ConvosCore/Syncing/PushTopicSubscriptionManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/PushTopicSubscriptionManager.swift
@@ -1,25 +1,41 @@
 import Foundation
 @preconcurrency import XMTPiOS
 
+/// Owns the per-installation push-topic subscription state with the Convos backend.
+///
+/// Subscriptions are keyed by APNS topic string; each call resolves the
+/// caller's keychain identity and device id, then issues a single
+/// subscribe/unsubscribe to `apiClient`. Failures are logged but never
+/// propagated — callers treat push subscriptions as best-effort so a
+/// transient API failure does not block message processing or join flows.
 protocol PushTopicSubscriptionManaging: Actor {
+    /// Subscribes to the group's message topic and the inbox-wide welcome
+    /// topic. Use after a group is created or joined.
     func subscribeToGroupAndWelcome(
         conversationId: String,
         params: SyncClientParams,
         context: String
     ) async
 
+    /// Subscribes to a DM that is hosting an invite join-request flow so
+    /// the creator receives the joiner's signed slug as a push.
     func subscribeToInviteDMTopic(
         conversationId: String,
         params: SyncClientParams,
         context: String
     ) async
 
+    /// Unsubscribes from an invite DM. Used when a join request is rejected
+    /// for malicious reasons so the spammer can no longer wake the device.
     func unsubscribeFromInviteDMTopic(
         conversationId: String,
         params: SyncClientParams,
         context: String
     ) async
 
+    /// Re-derives and resends the full topic set (welcome + groups +
+    /// invite DMs) so server state matches the local conversation list.
+    /// Called on resume / cold start to recover from missed deltas.
     func reconcilePushTopics(
         params: SyncClientParams,
         context: String
@@ -111,14 +127,22 @@ actor PushTopicSubscriptionManager: PushTopicSubscriptionManaging {
         params: SyncClientParams,
         context: String
     ) async {
-        await subscribe(
-            to: [
-                groupSubscription(conversationId: conversationId),
-                welcomeSubscription(params: params)
-            ],
+        await subscribeToGroupsAndWelcome(
+            conversationIds: [conversationId],
             params: params,
             context: context
         )
+    }
+
+    func subscribeToGroupsAndWelcome(
+        conversationIds: [String],
+        params: SyncClientParams,
+        context: String
+    ) async {
+        guard !conversationIds.isEmpty else { return }
+        var subscriptions: [TopicSubscription] = conversationIds.map(groupSubscription(conversationId:))
+        subscriptions.append(welcomeSubscription(params: params))
+        await subscribe(to: subscriptions, params: params, context: context)
     }
 
     func subscribeToInviteDMTopic(
@@ -126,8 +150,21 @@ actor PushTopicSubscriptionManager: PushTopicSubscriptionManaging {
         params: SyncClientParams,
         context: String
     ) async {
+        await subscribeToInviteDMTopics(
+            conversationIds: [conversationId],
+            params: params,
+            context: context
+        )
+    }
+
+    func subscribeToInviteDMTopics(
+        conversationIds: [String],
+        params: SyncClientParams,
+        context: String
+    ) async {
+        guard !conversationIds.isEmpty else { return }
         await subscribe(
-            to: [inviteDMSubscription(conversationId: conversationId)],
+            to: conversationIds.map(inviteDMSubscription(conversationId:)),
             params: params,
             context: context
         )
@@ -138,8 +175,21 @@ actor PushTopicSubscriptionManager: PushTopicSubscriptionManaging {
         params: SyncClientParams,
         context: String
     ) async {
+        await unsubscribeFromInviteDMTopics(
+            conversationIds: [conversationId],
+            params: params,
+            context: context
+        )
+    }
+
+    func unsubscribeFromInviteDMTopics(
+        conversationIds: [String],
+        params: SyncClientParams,
+        context: String
+    ) async {
+        guard !conversationIds.isEmpty else { return }
         await unsubscribe(
-            topics: [conversationId.xmtpGroupTopicFormat],
+            topics: conversationIds.map(\.xmtpGroupTopicFormat),
             params: params,
             context: context
         )
@@ -226,17 +276,25 @@ actor PushTopicSubscriptionManager: PushTopicSubscriptionManaging {
     }
 
     private func identity(matching params: SyncClientParams) async -> KeychainIdentity? {
+        let loaded: KeychainIdentity?
         do {
-            guard let identity = try await identityStore.load(),
-                  identity.inboxId == params.client.inboxId else {
-                Log.warning("Identity not found, skipping push topic subscription for inbox \(params.client.inboxId)")
-                return nil
-            }
-            return identity
+            loaded = try await identityStore.load()
         } catch {
             Log.warning("Failed loading identity, skipping push topic subscription: \(error)")
             return nil
         }
+        guard let identity = loaded else {
+            Log.warning("Identity not found in keychain, skipping push topic subscription")
+            return nil
+        }
+        guard identity.inboxId == params.client.inboxId else {
+            Log.warning(
+                "Identity inbox mismatch, skipping push topic subscription "
+                + "(stored=\(identity.inboxId), requested=\(params.client.inboxId))"
+            )
+            return nil
+        }
+        return identity
     }
 
     private func deviceIdentifier(context: String) async -> String? {

--- a/ConvosCore/Sources/ConvosCore/Syncing/PushTopicSubscriptionManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/PushTopicSubscriptionManager.swift
@@ -200,6 +200,7 @@ actor PushTopicSubscriptionManager: PushTopicSubscriptionManaging {
         context: String
     ) async {
         var subscriptions: [TopicSubscription] = [welcomeSubscription(params: params)]
+        var degradedSources: [String] = []
 
         do {
             let groupIds = try conversationLister.listGroupConversationIds(
@@ -210,6 +211,7 @@ actor PushTopicSubscriptionManager: PushTopicSubscriptionManaging {
             subscriptions.append(contentsOf: groupIds.map(groupSubscription(conversationId:)))
         } catch {
             Log.warning("Failed listing groups for push topic reconciliation \(context): \(error)")
+            degradedSources.append("groups")
         }
 
         do {
@@ -221,6 +223,17 @@ actor PushTopicSubscriptionManager: PushTopicSubscriptionManaging {
             subscriptions.append(contentsOf: dmIds.map(inviteDMSubscription(conversationId:)))
         } catch {
             Log.warning("Failed listing DMs for push topic reconciliation \(context): \(error)")
+            degradedSources.append("dms")
+        }
+
+        // Surface partial reconciles as a structured event so dashboards
+        // can spot the case where the device is on a stale topic set
+        // (only welcome was re-subscribed). The happy path stays silent.
+        if !degradedSources.isEmpty {
+            QAEvent.emit(.sync, "push_topic_reconcile_degraded", [
+                "context": context,
+                "missing": degradedSources.joined(separator: ","),
+            ])
         }
 
         await subscribe(to: subscriptions, params: params, context: context)

--- a/ConvosCore/Sources/ConvosCore/Syncing/PushTopicSubscriptionManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/PushTopicSubscriptionManager.swift
@@ -1,0 +1,246 @@
+import Foundation
+@preconcurrency import XMTPiOS
+
+protocol PushTopicSubscriptionManaging: Actor {
+    func subscribeToGroupAndWelcome(
+        conversationId: String,
+        params: SyncClientParams,
+        context: String
+    ) async
+
+    func subscribeToInviteDMTopic(
+        conversationId: String,
+        params: SyncClientParams,
+        context: String
+    ) async
+
+    func unsubscribeFromInviteDMTopic(
+        conversationId: String,
+        params: SyncClientParams,
+        context: String
+    ) async
+
+    func reconcilePushTopics(
+        params: SyncClientParams,
+        context: String
+    ) async
+}
+
+actor PushTopicSubscriptionManager: PushTopicSubscriptionManaging {
+    private enum TopicKind: String, Sendable {
+        case welcome
+        case group
+        case inviteDM
+    }
+
+    private struct TopicSubscription: Sendable {
+        let kind: TopicKind
+        let topic: String
+        let sourceId: String
+    }
+
+    private let identityStore: any KeychainIdentityStoreProtocol
+    private let deviceRegistrationManager: (any DeviceRegistrationManagerProtocol)?
+    private let deviceInfoProvider: (any DeviceInfoProviding)?
+
+    init(
+        identityStore: any KeychainIdentityStoreProtocol,
+        deviceRegistrationManager: (any DeviceRegistrationManagerProtocol)? = nil,
+        deviceInfoProvider: (any DeviceInfoProviding)? = nil
+    ) {
+        self.identityStore = identityStore
+        self.deviceRegistrationManager = deviceRegistrationManager
+        self.deviceInfoProvider = deviceInfoProvider
+    }
+
+    func subscribeToGroupAndWelcome(
+        conversationId: String,
+        params: SyncClientParams,
+        context: String
+    ) async {
+        await subscribe(
+            to: [
+                groupSubscription(conversationId: conversationId),
+                welcomeSubscription(params: params)
+            ],
+            params: params,
+            context: context
+        )
+    }
+
+    func subscribeToInviteDMTopic(
+        conversationId: String,
+        params: SyncClientParams,
+        context: String
+    ) async {
+        await subscribe(
+            to: [inviteDMSubscription(conversationId: conversationId)],
+            params: params,
+            context: context
+        )
+    }
+
+    func unsubscribeFromInviteDMTopic(
+        conversationId: String,
+        params: SyncClientParams,
+        context: String
+    ) async {
+        await unsubscribe(
+            topics: [conversationId.xmtpGroupTopicFormat],
+            params: params,
+            context: context
+        )
+    }
+
+    func reconcilePushTopics(
+        params: SyncClientParams,
+        context: String
+    ) async {
+        var subscriptions: [TopicSubscription] = [welcomeSubscription(params: params)]
+
+        do {
+            let groups = try params.client.conversationsProvider.listGroups(
+                createdAfterNs: nil,
+                createdBeforeNs: nil,
+                lastActivityAfterNs: nil,
+                lastActivityBeforeNs: nil,
+                limit: nil,
+                consentStates: params.consentStates,
+                orderBy: .lastActivity
+            )
+            subscriptions.append(contentsOf: groups.map { groupSubscription(conversationId: $0.id) })
+        } catch {
+            Log.warning("Failed listing groups for push topic reconciliation \(context): \(error)")
+        }
+
+        do {
+            let dms = try params.client.conversationsProvider.listDms(
+                createdAfterNs: nil,
+                createdBeforeNs: nil,
+                lastActivityBeforeNs: nil,
+                lastActivityAfterNs: nil,
+                limit: nil,
+                consentStates: [.unknown, .allowed],
+                orderBy: .lastActivity
+            )
+            subscriptions.append(contentsOf: dms.map { inviteDMSubscription(conversationId: $0.id) })
+        } catch {
+            Log.warning("Failed listing DMs for push topic reconciliation \(context): \(error)")
+        }
+
+        await subscribe(to: subscriptions, params: params, context: context)
+    }
+
+    // MARK: - Private
+
+    private func subscribe(
+        to subscriptions: [TopicSubscription],
+        params: SyncClientParams,
+        context: String
+    ) async {
+        let subscriptions = dedupe(subscriptions)
+        guard !subscriptions.isEmpty else { return }
+        guard let identity = await identity(matching: params) else { return }
+        guard let deviceId = await deviceIdentifier(context: context) else { return }
+
+        if let deviceRegistrationManager {
+            await deviceRegistrationManager.registerDeviceIfNeeded()
+        }
+
+        do {
+            try await params.apiClient.subscribeToTopics(
+                deviceId: deviceId,
+                clientId: identity.clientId,
+                topics: subscriptions.map(\.topic)
+            )
+            Log.info("Subscribed to push topics \(context): \(topicSummary(subscriptions))")
+            Log.debug("Subscribed push topic values \(context): \(subscriptions.map(\.topic).joined(separator: ", "))")
+        } catch {
+            Log.warning("Failed subscribing to push topics \(context): \(error)")
+        }
+    }
+
+    private func unsubscribe(
+        topics: [String],
+        params: SyncClientParams,
+        context: String
+    ) async {
+        let topics = Array(Set(topics)).sorted()
+        guard !topics.isEmpty else { return }
+        guard let identity = await identity(matching: params) else { return }
+
+        do {
+            try await params.apiClient.unsubscribeFromTopics(
+                clientId: identity.clientId,
+                topics: topics
+            )
+            Log.info("Unsubscribed from push topics \(context): \(topics.joined(separator: ", "))")
+        } catch {
+            Log.warning("Failed unsubscribing from push topics \(context): \(error)")
+        }
+    }
+
+    private func identity(matching params: SyncClientParams) async -> KeychainIdentity? {
+        do {
+            guard let identity = try await identityStore.load(),
+                  identity.inboxId == params.client.inboxId else {
+                Log.warning("Identity not found, skipping push topic subscription for inbox \(params.client.inboxId)")
+                return nil
+            }
+            return identity
+        } catch {
+            Log.warning("Failed loading identity, skipping push topic subscription: \(error)")
+            return nil
+        }
+    }
+
+    private func deviceIdentifier(context: String) async -> String? {
+        if let deviceInfoProvider {
+            return deviceInfoProvider.deviceIdentifier
+        }
+        guard deviceRegistrationManager != nil else {
+            Log.warning("DeviceRegistrationManager not available, skipping push topic subscription \(context)")
+            return nil
+        }
+        return DeviceInfo.deviceIdentifier
+    }
+
+    private func dedupe(_ subscriptions: [TopicSubscription]) -> [TopicSubscription] {
+        var seen: Set<String> = []
+        var result: [TopicSubscription] = []
+        for subscription in subscriptions where seen.insert(subscription.topic).inserted {
+            result.append(subscription)
+        }
+        return result
+    }
+
+    private func topicSummary(_ subscriptions: [TopicSubscription]) -> String {
+        subscriptions
+            .map { "\($0.kind.rawValue):\($0.sourceId)" }
+            .joined(separator: ", ")
+    }
+
+    private func welcomeSubscription(params: SyncClientParams) -> TopicSubscription {
+        TopicSubscription(
+            kind: .welcome,
+            topic: params.client.installationId.xmtpWelcomeTopicFormat,
+            sourceId: params.client.installationId
+        )
+    }
+
+    private func groupSubscription(conversationId: String) -> TopicSubscription {
+        TopicSubscription(
+            kind: .group,
+            topic: conversationId.xmtpGroupTopicFormat,
+            sourceId: conversationId
+        )
+    }
+
+    private func inviteDMSubscription(conversationId: String) -> TopicSubscription {
+        TopicSubscription(
+            kind: .inviteDM,
+            topic: conversationId.xmtpGroupTopicFormat,
+            sourceId: conversationId
+        )
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Syncing/PushTopicSubscriptionManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/PushTopicSubscriptionManager.swift
@@ -26,6 +26,56 @@ protocol PushTopicSubscriptionManaging: Actor {
     ) async
 }
 
+protocol PushTopicConversationListing: Sendable {
+    func listGroupConversationIds(
+        params: SyncClientParams,
+        consentStates: [ConsentState]?,
+        orderBy: ConversationsOrderBy
+    ) throws -> [String]
+
+    func listInviteDMConversationIds(
+        params: SyncClientParams,
+        consentStates: [ConsentState]?,
+        orderBy: ConversationsOrderBy
+    ) throws -> [String]
+}
+
+struct XMTPPushTopicConversationLister: PushTopicConversationListing {
+    func listGroupConversationIds(
+        params: SyncClientParams,
+        consentStates: [ConsentState]?,
+        orderBy: ConversationsOrderBy
+    ) throws -> [String] {
+        try params.client.conversationsProvider.listGroups(
+            createdAfterNs: nil,
+            createdBeforeNs: nil,
+            lastActivityAfterNs: nil,
+            lastActivityBeforeNs: nil,
+            limit: nil,
+            consentStates: consentStates,
+            orderBy: orderBy
+        )
+        .map(\.id)
+    }
+
+    func listInviteDMConversationIds(
+        params: SyncClientParams,
+        consentStates: [ConsentState]?,
+        orderBy: ConversationsOrderBy
+    ) throws -> [String] {
+        try params.client.conversationsProvider.listDms(
+            createdAfterNs: nil,
+            createdBeforeNs: nil,
+            lastActivityBeforeNs: nil,
+            lastActivityAfterNs: nil,
+            limit: nil,
+            consentStates: consentStates,
+            orderBy: orderBy
+        )
+        .map(\.id)
+    }
+}
+
 actor PushTopicSubscriptionManager: PushTopicSubscriptionManaging {
     private enum TopicKind: String, Sendable {
         case welcome
@@ -42,15 +92,18 @@ actor PushTopicSubscriptionManager: PushTopicSubscriptionManaging {
     private let identityStore: any KeychainIdentityStoreProtocol
     private let deviceRegistrationManager: (any DeviceRegistrationManagerProtocol)?
     private let deviceInfoProvider: (any DeviceInfoProviding)?
+    private let conversationLister: any PushTopicConversationListing
 
     init(
         identityStore: any KeychainIdentityStoreProtocol,
         deviceRegistrationManager: (any DeviceRegistrationManagerProtocol)? = nil,
-        deviceInfoProvider: (any DeviceInfoProviding)? = nil
+        deviceInfoProvider: (any DeviceInfoProviding)? = nil,
+        conversationLister: any PushTopicConversationListing = XMTPPushTopicConversationLister()
     ) {
         self.identityStore = identityStore
         self.deviceRegistrationManager = deviceRegistrationManager
         self.deviceInfoProvider = deviceInfoProvider
+        self.conversationLister = conversationLister
     }
 
     func subscribeToGroupAndWelcome(
@@ -99,31 +152,23 @@ actor PushTopicSubscriptionManager: PushTopicSubscriptionManaging {
         var subscriptions: [TopicSubscription] = [welcomeSubscription(params: params)]
 
         do {
-            let groups = try params.client.conversationsProvider.listGroups(
-                createdAfterNs: nil,
-                createdBeforeNs: nil,
-                lastActivityAfterNs: nil,
-                lastActivityBeforeNs: nil,
-                limit: nil,
+            let groupIds = try conversationLister.listGroupConversationIds(
+                params: params,
                 consentStates: params.consentStates,
                 orderBy: .lastActivity
             )
-            subscriptions.append(contentsOf: groups.map { groupSubscription(conversationId: $0.id) })
+            subscriptions.append(contentsOf: groupIds.map(groupSubscription(conversationId:)))
         } catch {
             Log.warning("Failed listing groups for push topic reconciliation \(context): \(error)")
         }
 
         do {
-            let dms = try params.client.conversationsProvider.listDms(
-                createdAfterNs: nil,
-                createdBeforeNs: nil,
-                lastActivityBeforeNs: nil,
-                lastActivityAfterNs: nil,
-                limit: nil,
+            let dmIds = try conversationLister.listInviteDMConversationIds(
+                params: params,
                 consentStates: [.unknown, .allowed],
                 orderBy: .lastActivity
             )
-            subscriptions.append(contentsOf: dms.map { inviteDMSubscription(conversationId: $0.id) })
+            subscriptions.append(contentsOf: dmIds.map(inviteDMSubscription(conversationId:)))
         } catch {
             Log.warning("Failed listing DMs for push topic reconciliation \(context): \(error)")
         }
@@ -206,6 +251,7 @@ actor PushTopicSubscriptionManager: PushTopicSubscriptionManaging {
     }
 
     private func dedupe(_ subscriptions: [TopicSubscription]) -> [TopicSubscription] {
+        // APNS subscription state is keyed by topic; source kind is only used for logging.
         var seen: Set<String> = []
         var result: [TopicSubscription] = []
         for subscription in subscriptions where seen.insert(subscription.topic).inserted {

--- a/ConvosCore/Sources/ConvosCore/Syncing/StreamProcessor.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/StreamProcessor.swift
@@ -25,6 +25,8 @@ protocol StreamProcessorProtocol: Actor {
         activeConversationId: String?
     ) async
 
+    func reconcilePushSubscriptions(params: SyncClientParams, context: String) async
+
     func setInviteJoinErrorHandler(_ handler: (any InviteJoinErrorHandler)?)
     func setTypingIndicatorHandler(_ handler: @escaping @Sendable (String, String, Bool) -> Void)
 }
@@ -66,7 +68,7 @@ actor StreamProcessor: StreamProcessorProtocol {
     private let messageWriter: any IncomingMessageWriterProtocol
     private let localStateWriter: any ConversationLocalStateWriterProtocol
     private let joinRequestsManager: any InviteJoinRequestsManagerProtocol
-    private let deviceRegistrationManager: (any DeviceRegistrationManagerProtocol)?
+    private let pushTopicSubscriptionManager: any PushTopicSubscriptionManaging
     private let databaseWriter: any DatabaseWriter
     private let databaseReader: any DatabaseReader
     private let notificationCenter: any UserNotificationCenterProtocol
@@ -87,7 +89,10 @@ actor StreamProcessor: StreamProcessorProtocol {
         self.identityStore = identityStore
         self.databaseWriter = databaseWriter
         self.databaseReader = databaseReader
-        self.deviceRegistrationManager = deviceRegistrationManager
+        self.pushTopicSubscriptionManager = PushTopicSubscriptionManager(
+            identityStore: identityStore,
+            deviceRegistrationManager: deviceRegistrationManager
+        )
         self.notificationCenter = notificationCenter
         self.inviteJoinErrorHandler = nil
         let messageWriter = IncomingMessageWriter(databaseWriter: databaseWriter)
@@ -169,7 +174,7 @@ actor StreamProcessor: StreamProcessorProtocol {
         }
 
         // Subscribe to push notifications
-        await subscribeToConversationTopics(
+        await pushTopicSubscriptionManager.subscribeToGroupAndWelcome(
             conversationId: conversation.id,
             params: params,
             context: "on stream"
@@ -197,10 +202,11 @@ actor StreamProcessor: StreamProcessorProtocol {
                     return
                 }
 
-                _ = await joinRequestsManager.processJoinRequest(
+                let outcome = await joinRequestsManager.processJoinRequestOutcome(
                     message: message,
                     client: params.client
                 )
+                await handleJoinRequestOutcome(outcome, params: params, context: "message stream")
                 Log.debug("Processed potential join request: \(message.id)")
             case .group(let conversation):
                 do {
@@ -734,39 +740,29 @@ actor StreamProcessor: StreamProcessorProtocol {
 
     // MARK: - Push Notifications
 
-    private func subscribeToConversationTopics(
-        conversationId: String,
+    func reconcilePushSubscriptions(params: SyncClientParams, context: String) async {
+        await pushTopicSubscriptionManager.reconcilePushTopics(params: params, context: context)
+    }
+
+    private func handleJoinRequestOutcome(
+        _ outcome: InviteJoinRequestOutcome,
         params: SyncClientParams,
         context: String
     ) async {
-        // Ensure device is registered before subscribing to topics
-        // This is a defensive check - the device should already be registered on app launch,
-        // but we want to ensure it's registered before we attempt topic subscription
-        guard let deviceManager = deviceRegistrationManager else {
-            Log.warning("DeviceRegistrationManager not available, skipping topic subscription")
-            return
-        }
+        guard let dmConversationId = outcome.dmConversationId else { return }
 
-        let conversationTopic = conversationId.xmtpGroupTopicFormat
-        let welcomeTopic = params.client.installationId.xmtpWelcomeTopicFormat
-
-        guard let identity = try? await identityStore.load(), identity.inboxId == params.client.inboxId else {
-            Log.warning("Identity not found, skipping push notification subscription")
-            return
-        }
-
-        await deviceManager.registerDeviceIfNeeded()
-
-        do {
-            let deviceId = DeviceInfo.deviceIdentifier
-            try await params.apiClient.subscribeToTopics(
-                deviceId: deviceId,
-                clientId: identity.clientId,
-                topics: [conversationTopic, welcomeTopic]
+        if outcome.shouldKeepDMSubscribed {
+            await pushTopicSubscriptionManager.subscribeToInviteDMTopic(
+                conversationId: dmConversationId,
+                params: params,
+                context: context
             )
-            Log.debug("Subscribed to push topics \(context): \(conversationTopic), \(welcomeTopic)")
-        } catch {
-            Log.warning("Failed subscribing to topics \(context): \(error)")
+        } else if case .malicious = outcome {
+            await pushTopicSubscriptionManager.unsubscribeFromInviteDMTopic(
+                conversationId: dmConversationId,
+                params: params,
+                context: context
+            )
         }
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Syncing/SyncingManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/SyncingManager.swift
@@ -394,6 +394,10 @@ actor SyncingManager: SyncingManagerProtocol {
             // This handles cases where the joiner was added to a group while
             // the inbox was paused, stopped, or the stream had a timeout.
             await discoverNewConversations(params: params)
+            await streamProcessor.reconcilePushSubscriptions(
+                params: params,
+                context: "after initial sync"
+            )
         }
     }
 
@@ -599,6 +603,10 @@ actor SyncingManager: SyncingManagerProtocol {
         Log.info("Sync resumed")
 
         await discoverNewConversations(params: params)
+        await streamProcessor.reconcilePushSubscriptions(
+            params: params,
+            context: "after resume"
+        )
     }
 
     func requestDiscovery() async {
@@ -612,6 +620,10 @@ actor SyncingManager: SyncingManagerProtocol {
             let syncElapsed = String(format: "%.0f", (CFAbsoluteTimeGetCurrent() - syncStart) * 1000)
             Log.info("[PERF] sync.requestDiscovery: \(syncElapsed)ms")
             await discoverNewConversations(params: params)
+            await streamProcessor.reconcilePushSubscriptions(
+                params: params,
+                context: "after requested discovery"
+            )
         } catch {
             Log.error("requestDiscovery failed: \(error)")
         }

--- a/ConvosCore/Tests/ConvosCoreTests/Integration/InviteCoordinatorIntegrationTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/Integration/InviteCoordinatorIntegrationTests.swift
@@ -1,5 +1,5 @@
-@testable import ConvosInvites
-@testable import ConvosInvitesCore
+@testable import ConvosCore
+import ConvosInvites
 import Foundation
 import Testing
 @preconcurrency import XMTPiOS

--- a/ConvosCore/Tests/ConvosCoreTests/Integration/PushTopicSubscriptionDeniedDMTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/Integration/PushTopicSubscriptionDeniedDMTests.swift
@@ -1,0 +1,200 @@
+@testable import ConvosCore
+import Foundation
+import os.lock
+import Testing
+@preconcurrency import XMTPiOS
+
+/// Integration tests for `PushTopicSubscriptionManager`'s denied-DM filter,
+/// run against a local XMTP node (`./dev/up`). The filter cannot be exercised
+/// in pure unit tests because `XMTPiOS.Conversation.consentState()` requires
+/// real MLS state.
+@Suite("Push Topic Subscription Denied DM Tests", .serialized)
+struct PushTopicSubscriptionDeniedDMTests {
+    private func createClient() async throws -> Client {
+        var keyBytes = [UInt8](repeating: 0, count: 32)
+        _ = SecRandomCopyBytes(kSecRandomDefault, 32, &keyBytes)
+        let dbKey = Data(keyBytes)
+        let options = ClientOptions(
+            api: .init(env: .local, appVersion: "convos-tests/1.0.0"),
+            codecs: [TextCodec()],
+            dbEncryptionKey: dbKey
+        )
+        return try await Client.createInMemory(
+            account: try PrivateKey.generate(),
+            options: options
+        )
+    }
+
+    @Test("Skips subscribing to a DM the user has manually denied")
+    func skipsDeniedDmOnSubscribe() async throws {
+        let creatorClient = try await createClient()
+        let joinerClient = try await createClient()
+        defer {
+            try? creatorClient.deleteLocalDatabase()
+            try? joinerClient.deleteLocalDatabase()
+        }
+
+        let dm = try await joinerClient.conversations.findOrCreateDm(
+            with: creatorClient.inboxId
+        )
+        try await dm.send(encodedContent: TextCodec().encode(content: "ping"))
+
+        _ = try await creatorClient.conversations.syncAllConversations(consentStates: nil)
+
+        let creatorDms = try creatorClient.conversations.listDms(
+            createdAfterNs: nil,
+            createdBeforeNs: nil,
+            lastActivityBeforeNs: nil,
+            lastActivityAfterNs: nil,
+            limit: nil,
+            consentStates: nil,
+            orderBy: .lastActivity
+        )
+        let creatorDm = try #require(creatorDms.first { $0.id == dm.id })
+        try await creatorDm.updateConsentState(state: .denied)
+
+        let identityStore = MockKeychainIdentityStore()
+        let keys = try await identityStore.generateKeys()
+        _ = try await identityStore.save(
+            inboxId: creatorClient.inboxId,
+            clientId: "client-1",
+            keys: keys
+        )
+        let apiClient = ThrowawayPushAPIClient()
+        let manager = PushTopicSubscriptionManager(
+            identityStore: identityStore,
+            deviceInfoProvider: MockDeviceInfoProvider(deviceIdentifier: "device-1")
+        )
+
+        await manager.subscribeToInviteDMTopics(
+            conversationIds: [dm.id],
+            params: SyncClientParams(client: creatorClient, apiClient: apiClient),
+            context: "denied-dm-test"
+        )
+
+        #expect(apiClient.subscribeCalls.isEmpty, "Manager must not call subscribeToTopics for a denied DM")
+    }
+
+    @Test("Subscribes a DM that has not been denied")
+    func subscribesAllowedDmOnSubscribe() async throws {
+        let creatorClient = try await createClient()
+        let joinerClient = try await createClient()
+        defer {
+            try? creatorClient.deleteLocalDatabase()
+            try? joinerClient.deleteLocalDatabase()
+        }
+
+        let dm = try await joinerClient.conversations.findOrCreateDm(
+            with: creatorClient.inboxId
+        )
+        try await dm.send(encodedContent: TextCodec().encode(content: "ping"))
+
+        _ = try await creatorClient.conversations.syncAllConversations(consentStates: nil)
+
+        let creatorDms = try creatorClient.conversations.listDms(
+            createdAfterNs: nil,
+            createdBeforeNs: nil,
+            lastActivityBeforeNs: nil,
+            lastActivityAfterNs: nil,
+            limit: nil,
+            consentStates: nil,
+            orderBy: .lastActivity
+        )
+        let creatorDm = try #require(creatorDms.first { $0.id == dm.id })
+        try await creatorDm.updateConsentState(state: .allowed)
+
+        let identityStore = MockKeychainIdentityStore()
+        let keys = try await identityStore.generateKeys()
+        _ = try await identityStore.save(
+            inboxId: creatorClient.inboxId,
+            clientId: "client-1",
+            keys: keys
+        )
+        let apiClient = ThrowawayPushAPIClient()
+        let manager = PushTopicSubscriptionManager(
+            identityStore: identityStore,
+            deviceInfoProvider: MockDeviceInfoProvider(deviceIdentifier: "device-1")
+        )
+
+        await manager.subscribeToInviteDMTopics(
+            conversationIds: [dm.id],
+            params: SyncClientParams(client: creatorClient, apiClient: apiClient),
+            context: "allowed-dm-test"
+        )
+
+        #expect(apiClient.subscribeCalls.count == 1)
+        #expect(apiClient.subscribeCalls.first?.topics == [dm.id.xmtpGroupTopicFormat])
+    }
+}
+
+private final class ThrowawayPushAPIClient: ConvosAPIClientProtocol, @unchecked Sendable {
+    struct SubscribeCall: Equatable {
+        let deviceId: String
+        let clientId: String
+        let topics: [String]
+    }
+
+    private let lock = OSAllocatedUnfairLock(initialState: [SubscribeCall]())
+
+    var subscribeCalls: [SubscribeCall] {
+        lock.withLock { $0 }
+    }
+
+    func request(for path: String, method: String, queryParameters: [String: String]?) throws -> URLRequest {
+        URLRequest(url: URL(string: "https://example.com")!)
+    }
+
+    func registerDevice(deviceId: String, pushToken: String?) async throws {}
+
+    func authenticate(appCheckToken: String, retryCount: Int) async throws -> String { "token" }
+
+    func uploadAttachment(data: Data, filename: String, contentType: String, acl: String) async throws -> String { "" }
+
+    func uploadAttachmentAndExecute(
+        data: Data,
+        filename: String,
+        afterUpload: @escaping (String) async throws -> Void
+    ) async throws -> String { "" }
+
+    func subscribeToTopics(deviceId: String, clientId: String, topics: [String]) async throws {
+        lock.withLock {
+            $0.append(SubscribeCall(deviceId: deviceId, clientId: clientId, topics: topics))
+        }
+    }
+
+    func unsubscribeFromTopics(clientId: String, topics: [String]) async throws {}
+
+    func unregisterInstallation(clientId: String) async throws {}
+
+    func renewAssetsBatch(assetKeys: [String]) async throws -> AssetRenewalResult {
+        AssetRenewalResult(renewed: assetKeys.count, failed: 0, expiredKeys: [])
+    }
+
+    func getPresignedUploadURL(filename: String, contentType: String) async throws -> (uploadURL: String, assetURL: String) {
+        ("https://example.com/upload/\(filename)", "https://example.com/assets/\(filename)")
+    }
+
+    func requestAgentJoin(slug: String, instructions: String, forceErrorCode: Int?) async throws -> ConvosAPI.AgentJoinResponse {
+        .init(success: true, joined: true)
+    }
+
+    func redeemInviteCode(_ code: String) async throws -> ConvosAPI.InviteCodeStatus {
+        .init(code: code, name: nil, maxRedemptions: 5, redemptionCount: 0, remainingRedemptions: 5)
+    }
+
+    func fetchInviteCodeStatus(_ code: String) async throws -> ConvosAPI.InviteCodeStatus {
+        .init(code: code, name: nil, maxRedemptions: 5, redemptionCount: 0, remainingRedemptions: 5)
+    }
+
+    func initiateConnection(serviceId: String, redirectUri: String) async throws -> ConnectionsAPI.InitiateResponse {
+        .init(connectionRequestId: "", redirectUrl: "")
+    }
+
+    func completeConnection(connectionRequestId: String) async throws -> ConnectionsAPI.CompleteResponse {
+        .init(connectionId: "", serviceId: "", serviceName: "", composioEntityId: "", composioConnectionId: "", status: "")
+    }
+
+    func listConnections() async throws -> [ConnectionsAPI.ConnectionResponse] { [] }
+
+    func revokeConnection(connectionId: String) async throws {}
+}

--- a/ConvosCore/Tests/ConvosCoreTests/KeychainSyncConfigTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/KeychainSyncConfigTests.swift
@@ -17,7 +17,11 @@ import Testing
 struct KeychainSyncConfigTests {
     @Test("Service name is stable across launches")
     func serviceNameIsStable() {
-        #expect(KeychainIdentityStore.defaultService == "org.convos.ios.KeychainIdentityStore.v3")
+        // The default identity slot moved from v3 → v4-local during the
+        // single-inbox refactor; v3 is preserved as `legacySyncedIdentityService`
+        // for `KeychainLayoutMigrator` to read during the one-shot migration.
+        #expect(KeychainIdentityStore.defaultService == "org.convos.ios.KeychainIdentityStore.v4-local")
+        #expect(KeychainIdentityStore.legacySyncedIdentityService == "org.convos.ios.KeychainIdentityStore.v3")
     }
 
     @Test("Identity account key is a fixed, non-empty string")

--- a/ConvosCore/Tests/ConvosCoreTests/PushTopicSubscriptionManagerTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/PushTopicSubscriptionManagerTests.swift
@@ -2,9 +2,40 @@
 import Foundation
 import os.lock
 import Testing
+@preconcurrency import XMTPiOS
 
 @Suite("Push Topic Subscription Manager Tests")
 struct PushTopicSubscriptionManagerTests {
+    @Test("Subscribes group and welcome topics")
+    func subscribesGroupAndWelcomeTopics() async throws {
+        let identityStore = MockKeychainIdentityStore()
+        let keys = try await identityStore.generateKeys()
+        _ = try await identityStore.save(inboxId: "test-inbox-id", clientId: "client-1", keys: keys)
+
+        let client = TestableMockClient()
+        client.inboxId = "test-inbox-id"
+        let apiClient = RecordingPushAPIClient()
+        let manager = PushTopicSubscriptionManager(
+            identityStore: identityStore,
+            deviceInfoProvider: MockDeviceInfoProvider(deviceIdentifier: "device-1")
+        )
+
+        await manager.subscribeToGroupAndWelcome(
+            conversationId: "group-1",
+            params: SyncClientParams(client: client, apiClient: apiClient),
+            context: "test"
+        )
+
+        let calls = apiClient.subscribeCalls
+        #expect(calls.count == 1)
+        #expect(calls.first?.deviceId == "device-1")
+        #expect(calls.first?.clientId == "client-1")
+        #expect(calls.first?.topics == [
+            "group-1".xmtpGroupTopicFormat,
+            "test-installation-id".xmtpWelcomeTopicFormat,
+        ])
+    }
+
     @Test("Subscribes invite DM topic with extension device identifier")
     func subscribesInviteDMTopic() async throws {
         let identityStore = MockKeychainIdentityStore()
@@ -79,6 +110,86 @@ struct PushTopicSubscriptionManagerTests {
         )
 
         #expect(apiClient.subscribeCalls.isEmpty)
+    }
+
+    @Test("Reconciles welcome, group, and invite DM topics with deduplication")
+    func reconcilesPushTopics() async throws {
+        let identityStore = MockKeychainIdentityStore()
+        let keys = try await identityStore.generateKeys()
+        _ = try await identityStore.save(inboxId: "test-inbox-id", clientId: "client-1", keys: keys)
+
+        let client = TestableMockClient()
+        client.inboxId = "test-inbox-id"
+        let apiClient = RecordingPushAPIClient()
+        let conversationLister = RecordingPushConversationLister(
+            groupIds: ["group-1", "shared-conversation"],
+            dmIds: ["dm-1", "shared-conversation"]
+        )
+        let manager = PushTopicSubscriptionManager(
+            identityStore: identityStore,
+            deviceInfoProvider: MockDeviceInfoProvider(deviceIdentifier: "device-1"),
+            conversationLister: conversationLister
+        )
+
+        await manager.reconcilePushTopics(
+            params: SyncClientParams(
+                client: client,
+                apiClient: apiClient,
+                consentStates: [.allowed]
+            ),
+            context: "test"
+        )
+
+        let groupCalls = conversationLister.groupCalls
+        let dmCalls = conversationLister.dmCalls
+        #expect(groupCalls.count == 1)
+        #expect(groupCalls.first?.consentStateRawValues == ["allowed"])
+        #expect(groupCalls.first?.usesLastActivityOrder == true)
+        #expect(dmCalls.count == 1)
+        #expect(dmCalls.first?.consentStateRawValues == ["unknown", "allowed"])
+        #expect(dmCalls.first?.usesLastActivityOrder == true)
+
+        let calls = apiClient.subscribeCalls
+        #expect(calls.count == 1)
+        #expect(calls.first?.topics == [
+            "test-installation-id".xmtpWelcomeTopicFormat,
+            "group-1".xmtpGroupTopicFormat,
+            "shared-conversation".xmtpGroupTopicFormat,
+            "dm-1".xmtpGroupTopicFormat,
+        ])
+    }
+
+    @Test("Reconcile still subscribes available topics when one listing fails")
+    func reconcileSubscribesAvailableTopicsWhenListingFails() async throws {
+        let identityStore = MockKeychainIdentityStore()
+        let keys = try await identityStore.generateKeys()
+        _ = try await identityStore.save(inboxId: "test-inbox-id", clientId: "client-1", keys: keys)
+
+        let client = TestableMockClient()
+        client.inboxId = "test-inbox-id"
+        let apiClient = RecordingPushAPIClient()
+        let conversationLister = RecordingPushConversationLister(
+            groupIds: [],
+            dmIds: ["dm-1"],
+            groupShouldFail: true
+        )
+        let manager = PushTopicSubscriptionManager(
+            identityStore: identityStore,
+            deviceInfoProvider: MockDeviceInfoProvider(deviceIdentifier: "device-1"),
+            conversationLister: conversationLister
+        )
+
+        await manager.reconcilePushTopics(
+            params: SyncClientParams(client: client, apiClient: apiClient),
+            context: "test"
+        )
+
+        let calls = apiClient.subscribeCalls
+        #expect(calls.count == 1)
+        #expect(calls.first?.topics == [
+            "test-installation-id".xmtpWelcomeTopicFormat,
+            "dm-1".xmtpGroupTopicFormat,
+        ])
     }
 }
 
@@ -180,5 +291,92 @@ private final class RecordingPushAPIClient: ConvosAPIClientProtocol, @unchecked 
     }
 
     func revokeConnection(connectionId: String) async throws {
+    }
+}
+
+private enum PushTopicListError: Error {
+    case failed
+}
+
+private final class RecordingPushConversationLister: PushTopicConversationListing, @unchecked Sendable {
+    struct ListCall: Sendable {
+        let consentStateRawValues: [String]?
+        let usesLastActivityOrder: Bool
+    }
+
+    private struct State: Sendable {
+        var groupIds: [String]
+        var dmIds: [String]
+        var groupShouldFail: Bool
+        var dmShouldFail: Bool
+        var groupCalls: [ListCall] = []
+        var dmCalls: [ListCall] = []
+    }
+
+    private let state: OSAllocatedUnfairLock<State>
+
+    init(
+        groupIds: [String],
+        dmIds: [String],
+        groupShouldFail: Bool = false,
+        dmShouldFail: Bool = false
+    ) {
+        state = OSAllocatedUnfairLock(
+            initialState: State(
+                groupIds: groupIds,
+                dmIds: dmIds,
+                groupShouldFail: groupShouldFail,
+                dmShouldFail: dmShouldFail
+            )
+        )
+    }
+
+    var groupCalls: [ListCall] {
+        state.withLock { $0.groupCalls }
+    }
+
+    var dmCalls: [ListCall] {
+        state.withLock { $0.dmCalls }
+    }
+
+    func listGroupConversationIds(
+        params _: SyncClientParams,
+        consentStates: [ConsentState]?,
+        orderBy: ConversationsOrderBy
+    ) throws -> [String] {
+        let call = ListCall(
+            consentStateRawValues: consentStates?.map(\.rawValue),
+            usesLastActivityOrder: usesLastActivityOrder(orderBy)
+        )
+        return try state.withLock {
+            $0.groupCalls.append(call)
+            if $0.groupShouldFail {
+                throw PushTopicListError.failed
+            }
+            return $0.groupIds
+        }
+    }
+
+    func listInviteDMConversationIds(
+        params _: SyncClientParams,
+        consentStates: [ConsentState]?,
+        orderBy: ConversationsOrderBy
+    ) throws -> [String] {
+        let call = ListCall(
+            consentStateRawValues: consentStates?.map(\.rawValue),
+            usesLastActivityOrder: usesLastActivityOrder(orderBy)
+        )
+        return try state.withLock {
+            $0.dmCalls.append(call)
+            if $0.dmShouldFail {
+                throw PushTopicListError.failed
+            }
+            return $0.dmIds
+        }
+    }
+
+    private func usesLastActivityOrder(_ orderBy: ConversationsOrderBy) -> Bool {
+        guard case .lastActivity = orderBy else { return false }
+        return true
     }
 }

--- a/ConvosCore/Tests/ConvosCoreTests/PushTopicSubscriptionManagerTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/PushTopicSubscriptionManagerTests.swift
@@ -159,6 +159,32 @@ struct PushTopicSubscriptionManagerTests {
         ])
     }
 
+    @Test("Subscribe failure is swallowed so callers don't surface it")
+    func subscribeFailureIsSwallowed() async throws {
+        let identityStore = MockKeychainIdentityStore()
+        let keys = try await identityStore.generateKeys()
+        _ = try await identityStore.save(inboxId: "test-inbox-id", clientId: "client-1", keys: keys)
+
+        let client = TestableMockClient()
+        client.inboxId = "test-inbox-id"
+        let apiClient = ThrowingPushAPIClient()
+        let manager = PushTopicSubscriptionManager(
+            identityStore: identityStore,
+            deviceInfoProvider: MockDeviceInfoProvider(deviceIdentifier: "device-1")
+        )
+
+        // Caller must not propagate; this would fail compilation if the manager
+        // started rethrowing. The QAEvent emission for the failure is exercised
+        // by integration tests where ConvosLog is wired up.
+        await manager.subscribeToGroupAndWelcome(
+            conversationId: "group-1",
+            params: SyncClientParams(client: client, apiClient: apiClient),
+            context: "test"
+        )
+
+        #expect(apiClient.subscribeCallCount == 1)
+    }
+
     @Test("Reconcile still subscribes available topics when one listing fails")
     func reconcileSubscribesAvailableTopicsWhenListingFails() async throws {
         let identityStore = MockKeychainIdentityStore()
@@ -296,6 +322,76 @@ private final class RecordingPushAPIClient: ConvosAPIClientProtocol, @unchecked 
 
 private enum PushTopicListError: Error {
     case failed
+}
+
+private enum ThrowingPushAPIClientError: Error {
+    case subscribeFailure
+    case unsubscribeFailure
+}
+
+private final class ThrowingPushAPIClient: ConvosAPIClientProtocol, @unchecked Sendable {
+    private let counter = OSAllocatedUnfairLock(initialState: 0)
+
+    var subscribeCallCount: Int { counter.withLock { $0 } }
+
+    func request(for path: String, method: String, queryParameters: [String: String]?) throws -> URLRequest {
+        URLRequest(url: URL(string: "https://example.com")!)
+    }
+
+    func registerDevice(deviceId: String, pushToken: String?) async throws {}
+
+    func authenticate(appCheckToken: String, retryCount: Int) async throws -> String { "token" }
+
+    func uploadAttachment(data: Data, filename: String, contentType: String, acl: String) async throws -> String { "" }
+
+    func uploadAttachmentAndExecute(
+        data: Data,
+        filename: String,
+        afterUpload: @escaping (String) async throws -> Void
+    ) async throws -> String { "" }
+
+    func subscribeToTopics(deviceId: String, clientId: String, topics: [String]) async throws {
+        counter.withLock { $0 += 1 }
+        throw ThrowingPushAPIClientError.subscribeFailure
+    }
+
+    func unsubscribeFromTopics(clientId: String, topics: [String]) async throws {
+        throw ThrowingPushAPIClientError.unsubscribeFailure
+    }
+
+    func unregisterInstallation(clientId: String) async throws {}
+
+    func renewAssetsBatch(assetKeys: [String]) async throws -> AssetRenewalResult {
+        AssetRenewalResult(renewed: assetKeys.count, failed: 0, expiredKeys: [])
+    }
+
+    func getPresignedUploadURL(filename: String, contentType: String) async throws -> (uploadURL: String, assetURL: String) {
+        ("https://example.com/upload/\(filename)", "https://example.com/assets/\(filename)")
+    }
+
+    func requestAgentJoin(slug: String, instructions: String, forceErrorCode: Int?) async throws -> ConvosAPI.AgentJoinResponse {
+        .init(success: true, joined: true)
+    }
+
+    func redeemInviteCode(_ code: String) async throws -> ConvosAPI.InviteCodeStatus {
+        .init(code: code, name: nil, maxRedemptions: 5, redemptionCount: 0, remainingRedemptions: 5)
+    }
+
+    func fetchInviteCodeStatus(_ code: String) async throws -> ConvosAPI.InviteCodeStatus {
+        .init(code: code, name: nil, maxRedemptions: 5, redemptionCount: 0, remainingRedemptions: 5)
+    }
+
+    func initiateConnection(serviceId: String, redirectUri: String) async throws -> ConnectionsAPI.InitiateResponse {
+        .init(connectionRequestId: "", redirectUrl: "")
+    }
+
+    func completeConnection(connectionRequestId: String) async throws -> ConnectionsAPI.CompleteResponse {
+        .init(connectionId: "", serviceId: "", serviceName: "", composioEntityId: "", composioConnectionId: "", status: "")
+    }
+
+    func listConnections() async throws -> [ConnectionsAPI.ConnectionResponse] { [] }
+
+    func revokeConnection(connectionId: String) async throws {}
 }
 
 private final class RecordingPushConversationLister: PushTopicConversationListing, @unchecked Sendable {

--- a/ConvosCore/Tests/ConvosCoreTests/PushTopicSubscriptionManagerTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/PushTopicSubscriptionManagerTests.swift
@@ -1,0 +1,184 @@
+@testable import ConvosCore
+import Foundation
+import os.lock
+import Testing
+
+@Suite("Push Topic Subscription Manager Tests")
+struct PushTopicSubscriptionManagerTests {
+    @Test("Subscribes invite DM topic with extension device identifier")
+    func subscribesInviteDMTopic() async throws {
+        let identityStore = MockKeychainIdentityStore()
+        let keys = try await identityStore.generateKeys()
+        _ = try await identityStore.save(inboxId: "test-inbox-id", clientId: "client-1", keys: keys)
+
+        let client = TestableMockClient()
+        client.inboxId = "test-inbox-id"
+        let apiClient = RecordingPushAPIClient()
+        let manager = PushTopicSubscriptionManager(
+            identityStore: identityStore,
+            deviceInfoProvider: MockDeviceInfoProvider(deviceIdentifier: "device-1")
+        )
+
+        await manager.subscribeToInviteDMTopic(
+            conversationId: "dm-1",
+            params: SyncClientParams(client: client, apiClient: apiClient),
+            context: "test"
+        )
+
+        let calls = apiClient.subscribeCalls
+        #expect(calls.count == 1)
+        #expect(calls.first?.deviceId == "device-1")
+        #expect(calls.first?.clientId == "client-1")
+        #expect(calls.first?.topics == ["dm-1".xmtpGroupTopicFormat])
+    }
+
+    @Test("Unsubscribes malicious invite DM topic")
+    func unsubscribesInviteDMTopic() async throws {
+        let identityStore = MockKeychainIdentityStore()
+        let keys = try await identityStore.generateKeys()
+        _ = try await identityStore.save(inboxId: "test-inbox-id", clientId: "client-1", keys: keys)
+
+        let client = TestableMockClient()
+        client.inboxId = "test-inbox-id"
+        let apiClient = RecordingPushAPIClient()
+        let manager = PushTopicSubscriptionManager(
+            identityStore: identityStore,
+            deviceInfoProvider: MockDeviceInfoProvider(deviceIdentifier: "device-1")
+        )
+
+        await manager.unsubscribeFromInviteDMTopic(
+            conversationId: "dm-1",
+            params: SyncClientParams(client: client, apiClient: apiClient),
+            context: "test"
+        )
+
+        let calls = apiClient.unsubscribeCalls
+        #expect(calls.count == 1)
+        #expect(calls.first?.clientId == "client-1")
+        #expect(calls.first?.topics == ["dm-1".xmtpGroupTopicFormat])
+    }
+
+    @Test("Skips subscription when stored identity does not match client")
+    func skipsSubscriptionForIdentityMismatch() async throws {
+        let identityStore = MockKeychainIdentityStore()
+        let keys = try await identityStore.generateKeys()
+        _ = try await identityStore.save(inboxId: "other-inbox-id", clientId: "client-1", keys: keys)
+
+        let client = TestableMockClient()
+        client.inboxId = "test-inbox-id"
+        let apiClient = RecordingPushAPIClient()
+        let manager = PushTopicSubscriptionManager(
+            identityStore: identityStore,
+            deviceInfoProvider: MockDeviceInfoProvider(deviceIdentifier: "device-1")
+        )
+
+        await manager.subscribeToInviteDMTopic(
+            conversationId: "dm-1",
+            params: SyncClientParams(client: client, apiClient: apiClient),
+            context: "test"
+        )
+
+        #expect(apiClient.subscribeCalls.isEmpty)
+    }
+}
+
+private final class RecordingPushAPIClient: ConvosAPIClientProtocol, @unchecked Sendable {
+    struct SubscribeCall: Equatable {
+        let deviceId: String
+        let clientId: String
+        let topics: [String]
+    }
+
+    struct UnsubscribeCall: Equatable {
+        let clientId: String
+        let topics: [String]
+    }
+
+    private struct State {
+        var subscribeCalls: [SubscribeCall] = []
+        var unsubscribeCalls: [UnsubscribeCall] = []
+    }
+
+    private let state = OSAllocatedUnfairLock(initialState: State())
+
+    var subscribeCalls: [SubscribeCall] {
+        state.withLock { $0.subscribeCalls }
+    }
+
+    var unsubscribeCalls: [UnsubscribeCall] {
+        state.withLock { $0.unsubscribeCalls }
+    }
+
+    func request(for path: String, method: String, queryParameters: [String: String]?) throws -> URLRequest {
+        URLRequest(url: URL(string: "https://example.com")!)
+    }
+
+    func registerDevice(deviceId: String, pushToken: String?) async throws {
+    }
+
+    func authenticate(appCheckToken: String, retryCount: Int) async throws -> String {
+        "token"
+    }
+
+    func uploadAttachment(data: Data, filename: String, contentType: String, acl: String) async throws -> String {
+        ""
+    }
+
+    func uploadAttachmentAndExecute(
+        data: Data,
+        filename: String,
+        afterUpload: @escaping (String) async throws -> Void
+    ) async throws -> String {
+        ""
+    }
+
+    func subscribeToTopics(deviceId: String, clientId: String, topics: [String]) async throws {
+        state.withLock {
+            $0.subscribeCalls.append(SubscribeCall(deviceId: deviceId, clientId: clientId, topics: topics))
+        }
+    }
+
+    func unsubscribeFromTopics(clientId: String, topics: [String]) async throws {
+        state.withLock {
+            $0.unsubscribeCalls.append(UnsubscribeCall(clientId: clientId, topics: topics))
+        }
+    }
+
+    func unregisterInstallation(clientId: String) async throws {
+    }
+
+    func renewAssetsBatch(assetKeys: [String]) async throws -> AssetRenewalResult {
+        AssetRenewalResult(renewed: assetKeys.count, failed: 0, expiredKeys: [])
+    }
+
+    func getPresignedUploadURL(filename: String, contentType: String) async throws -> (uploadURL: String, assetURL: String) {
+        ("https://example.com/upload/\(filename)", "https://example.com/assets/\(filename)")
+    }
+
+    func requestAgentJoin(slug: String, instructions: String, forceErrorCode: Int?) async throws -> ConvosAPI.AgentJoinResponse {
+        .init(success: true, joined: true)
+    }
+
+    func redeemInviteCode(_ code: String) async throws -> ConvosAPI.InviteCodeStatus {
+        .init(code: code, name: nil, maxRedemptions: 5, redemptionCount: 0, remainingRedemptions: 5)
+    }
+
+    func fetchInviteCodeStatus(_ code: String) async throws -> ConvosAPI.InviteCodeStatus {
+        .init(code: code, name: nil, maxRedemptions: 5, redemptionCount: 0, remainingRedemptions: 5)
+    }
+
+    func initiateConnection(serviceId: String, redirectUri: String) async throws -> ConnectionsAPI.InitiateResponse {
+        .init(connectionRequestId: "", redirectUrl: "")
+    }
+
+    func completeConnection(connectionRequestId: String) async throws -> ConnectionsAPI.CompleteResponse {
+        .init(connectionId: "", serviceId: "", serviceName: "", composioEntityId: "", composioConnectionId: "", status: "")
+    }
+
+    func listConnections() async throws -> [ConnectionsAPI.ConnectionResponse] {
+        []
+    }
+
+    func revokeConnection(connectionId: String) async throws {
+    }
+}

--- a/ConvosCore/Tests/ConvosCoreTests/RestoreManagerTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/RestoreManagerTests.swift
@@ -4,7 +4,12 @@ import GRDB
 import Security
 import Testing
 
-@Suite("RestoreManager Tests")
+// `.serialized` is required: `findAvailableBackup` scans
+// `AppEnvironment.tests.defaultDatabasesDirectoryURL`, which resolves to the
+// process-wide `FileManager.temporaryDirectory`. Tests that write sidecars
+// into `<temp>/backups/<deviceId>/` share that directory across the suite,
+// so parallel execution lets one test surface another's fixture.
+@Suite("RestoreManager Tests", .serialized)
 struct RestoreManagerTests {
     // MARK: - Fixtures
 

--- a/ConvosCore/Tests/ConvosCoreTests/SyncingManagerPushReconciliationTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/SyncingManagerPushReconciliationTests.swift
@@ -1,0 +1,255 @@
+@testable import ConvosCore
+import Foundation
+import os.lock
+import Testing
+import XMTPiOS
+
+/// Verifies that `SyncingManager` re-runs push topic reconciliation at every
+/// point that's expected to: after the initial sync, after resume, and after
+/// `requestDiscovery`. A regression here lets stale device-side push state
+/// drift away from the live conversation list — the same class of bug this
+/// PR was opened to fix.
+///
+/// The tests stub the XMTP client at the `XMTPClientProvider` level and
+/// observe the API calls that the production `PushTopicSubscriptionManager`
+/// emits, so they exercise the real wiring through `StreamProcessor` without
+/// touching the network.
+@Suite("SyncingManager Push Reconciliation Tests", .serialized, .timeLimit(.minutes(2)))
+struct SyncingManagerPushReconciliationTests {
+    @Test("Reconciles push subscriptions after initial sync")
+    func reconcilesAfterInitialSync() async throws {
+        let fixtures = TestFixtures()
+        let mockClient = TestableMockClient()
+        mockClient.streamBehavior = .neverClose
+        try await seedIdentity(matching: mockClient, into: fixtures)
+        let recordingAPI = RecordingPushAPIClientForReconciliationTests()
+
+        let syncingManager = SyncingManager(
+            identityStore: fixtures.identityStore,
+            databaseWriter: fixtures.databaseManager.dbWriter,
+            databaseReader: fixtures.databaseManager.dbReader,
+            deviceRegistrationManager: NoopDeviceRegistrationManager(),
+            notificationCenter: MockUserNotificationCenter()
+        )
+
+        await syncingManager.start(with: mockClient, apiClient: recordingAPI)
+
+        try await waitUntil(timeout: .seconds(15)) {
+            recordingAPI.subscribeCount >= 1
+        }
+
+        let calls = recordingAPI.subscribeCalls
+        #expect(calls.count >= 1, "Initial sync should have triggered at least one push reconcile")
+        #expect(
+            calls.first?.topics.contains(mockClient.installationId.xmtpWelcomeTopicFormat) == true,
+            "Reconcile must always include the welcome topic"
+        )
+
+        await syncingManager.stop()
+        try? await fixtures.cleanup()
+    }
+
+    @Test("Reconciles push subscriptions after resume")
+    func reconcilesAfterResume() async throws {
+        let fixtures = TestFixtures()
+        let mockClient = TestableMockClient()
+        mockClient.streamBehavior = .neverClose
+        try await seedIdentity(matching: mockClient, into: fixtures)
+        let recordingAPI = RecordingPushAPIClientForReconciliationTests()
+
+        let syncingManager = SyncingManager(
+            identityStore: fixtures.identityStore,
+            databaseWriter: fixtures.databaseManager.dbWriter,
+            databaseReader: fixtures.databaseManager.dbReader,
+            deviceRegistrationManager: NoopDeviceRegistrationManager(),
+            notificationCenter: MockUserNotificationCenter()
+        )
+
+        await syncingManager.start(with: mockClient, apiClient: recordingAPI)
+        try await waitUntil(timeout: .seconds(15)) { recordingAPI.subscribeCount >= 1 }
+        let countAfterStart = recordingAPI.subscribeCount
+
+        await syncingManager.pause()
+        await syncingManager.resume()
+
+        try await waitUntil(timeout: .seconds(15)) {
+            recordingAPI.subscribeCount > countAfterStart
+        }
+
+        #expect(
+            recordingAPI.subscribeCount > countAfterStart,
+            "Resume must trigger a fresh push topic reconcile"
+        )
+
+        await syncingManager.stop()
+        try? await fixtures.cleanup()
+    }
+
+    @Test("Reconciles push subscriptions after requestDiscovery")
+    func reconcilesAfterRequestDiscovery() async throws {
+        let fixtures = TestFixtures()
+        let mockClient = TestableMockClient()
+        mockClient.streamBehavior = .neverClose
+        try await seedIdentity(matching: mockClient, into: fixtures)
+        let recordingAPI = RecordingPushAPIClientForReconciliationTests()
+
+        let syncingManager = SyncingManager(
+            identityStore: fixtures.identityStore,
+            databaseWriter: fixtures.databaseManager.dbWriter,
+            databaseReader: fixtures.databaseManager.dbReader,
+            deviceRegistrationManager: NoopDeviceRegistrationManager(),
+            notificationCenter: MockUserNotificationCenter()
+        )
+
+        await syncingManager.start(with: mockClient, apiClient: recordingAPI)
+        try await waitUntil(timeout: .seconds(15)) { recordingAPI.subscribeCount >= 1 }
+        let countAfterStart = recordingAPI.subscribeCount
+
+        await syncingManager.requestDiscovery()
+
+        try await waitUntil(timeout: .seconds(15)) {
+            recordingAPI.subscribeCount > countAfterStart
+        }
+
+        #expect(
+            recordingAPI.subscribeCount > countAfterStart,
+            "requestDiscovery must trigger a fresh push topic reconcile"
+        )
+
+        await syncingManager.stop()
+        try? await fixtures.cleanup()
+    }
+
+    // MARK: - Helpers
+
+    private func seedIdentity(
+        matching client: TestableMockClient,
+        into fixtures: TestFixtures
+    ) async throws {
+        let keys = try await fixtures.identityStore.generateKeys()
+        _ = try await fixtures.identityStore.save(
+            inboxId: client.inboxId,
+            clientId: ClientId.generate().value,
+            keys: keys
+        )
+    }
+
+    private enum TestError: Error {
+        case timeout(String)
+    }
+
+    private func waitUntil(
+        timeout: Duration = .seconds(15),
+        interval: Duration = .milliseconds(50),
+        condition: () async -> Bool
+    ) async throws {
+        let deadline = ContinuousClock.now + timeout
+        while ContinuousClock.now < deadline {
+            if await condition() { return }
+            try await Task.sleep(for: interval)
+        }
+        throw TestError.timeout("Condition not met within \(timeout)")
+    }
+}
+
+/// `PushTopicSubscriptionManager.deviceIdentifier(context:)` returns nil
+/// when both `deviceInfoProvider` and `deviceRegistrationManager` are nil,
+/// short-circuiting the subscribe path before it can hit the API. Tests
+/// don't need real device registration, but they do need the manager
+/// reference to be non-nil so the fallback to `DeviceInfo.deviceIdentifier`
+/// is reached.
+private actor NoopDeviceRegistrationManager: DeviceRegistrationManagerProtocol {
+    func startObservingPushTokenChanges() {}
+    func stopObservingPushTokenChanges() {}
+    func registerDeviceIfNeeded() async {}
+    static func clearRegistrationState(deviceInfo: any DeviceInfoProviding) {}
+    static func hasRegisteredDevice(deviceInfo: any DeviceInfoProviding) -> Bool { false }
+}
+
+/// Records `subscribeToTopics` invocations so tests can assert that the
+/// production reconcile pipeline reached the API layer. Stubs every other
+/// `ConvosAPIClientProtocol` method as a no-op or trivial value.
+private final class RecordingPushAPIClientForReconciliationTests: ConvosAPIClientProtocol, @unchecked Sendable {
+    struct SubscribeCall: Sendable {
+        let deviceId: String
+        let clientId: String
+        let topics: [String]
+    }
+
+    private let state = OSAllocatedUnfairLock(initialState: [SubscribeCall]())
+
+    var subscribeCalls: [SubscribeCall] {
+        state.withLock { $0 }
+    }
+
+    var subscribeCount: Int {
+        state.withLock { $0.count }
+    }
+
+    func request(for path: String, method: String, queryParameters: [String: String]?) throws -> URLRequest {
+        guard let url = URL(string: "http://example.com") else {
+            throw NSError(domain: "test", code: 1)
+        }
+        return URLRequest(url: url)
+    }
+
+    func registerDevice(deviceId: String, pushToken: String?) async throws {}
+
+    func authenticate(appCheckToken: String, retryCount: Int) async throws -> String {
+        "mock-jwt-token"
+    }
+
+    func uploadAttachment(data: Data, filename: String, contentType: String, acl: String) async throws -> String {
+        ""
+    }
+
+    func uploadAttachmentAndExecute(
+        data: Data,
+        filename: String,
+        afterUpload: @escaping (String) async throws -> Void
+    ) async throws -> String {
+        ""
+    }
+
+    func subscribeToTopics(deviceId: String, clientId: String, topics: [String]) async throws {
+        state.withLock {
+            $0.append(SubscribeCall(deviceId: deviceId, clientId: clientId, topics: topics))
+        }
+    }
+
+    func unsubscribeFromTopics(clientId: String, topics: [String]) async throws {}
+
+    func unregisterInstallation(clientId: String) async throws {}
+
+    func renewAssetsBatch(assetKeys: [String]) async throws -> AssetRenewalResult {
+        AssetRenewalResult(renewed: assetKeys.count, failed: 0, expiredKeys: [])
+    }
+
+    func getPresignedUploadURL(filename: String, contentType: String) async throws -> (uploadURL: String, assetURL: String) {
+        ("https://example.com/upload/\(filename)", "https://example.com/assets/\(filename)")
+    }
+
+    func requestAgentJoin(slug: String, instructions: String, forceErrorCode: Int?) async throws -> ConvosAPI.AgentJoinResponse {
+        .init(success: true, joined: true)
+    }
+
+    func redeemInviteCode(_ code: String) async throws -> ConvosAPI.InviteCodeStatus {
+        .init(code: code, name: nil, maxRedemptions: 5, redemptionCount: 0, remainingRedemptions: 5)
+    }
+
+    func fetchInviteCodeStatus(_ code: String) async throws -> ConvosAPI.InviteCodeStatus {
+        .init(code: code, name: nil, maxRedemptions: 5, redemptionCount: 0, remainingRedemptions: 5)
+    }
+
+    func initiateConnection(serviceId: String, redirectUri: String) async throws -> ConnectionsAPI.InitiateResponse {
+        .init(connectionRequestId: "", redirectUrl: "")
+    }
+
+    func completeConnection(connectionRequestId: String) async throws -> ConnectionsAPI.CompleteResponse {
+        .init(connectionId: "", serviceId: "", serviceName: "", composioEntityId: "", composioConnectionId: "", status: "")
+    }
+
+    func listConnections() async throws -> [ConnectionsAPI.ConnectionResponse] { [] }
+
+    func revokeConnection(connectionId: String) async throws {}
+}

--- a/ConvosCore/Tests/ConvosCoreTests/TestHelpers.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/TestHelpers.swift
@@ -212,6 +212,7 @@ class TestFixtures {
             databaseReader: databaseManager.dbReader,
             identityStore: identityStore,
             environment: environment,
+            deviceInfoProvider: platformProviders.deviceInfo,
             backgroundUploadManager: UnavailableBackgroundUploadManager()
         )
     }

--- a/ConvosInvites/Sources/ConvosInvites/InviteCoordinator.swift
+++ b/ConvosInvites/Sources/ConvosInvites/InviteCoordinator.swift
@@ -135,7 +135,15 @@ public final class InviteCoordinator: @unchecked Sendable {
         _ message: XMTPiOS.DecodedMessage,
         client: any InviteClientProvider
     ) async -> JoinResult? {
-        guard message.senderInboxId != client.inviteInboxId else { return nil }
+        let outcome = await processMessageOutcome(message, client: client)
+        return outcome.joinResult
+    }
+
+    public func processMessageOutcome(
+        _ message: XMTPiOS.DecodedMessage,
+        client: any InviteClientProvider
+    ) async -> JoinRequestDMOutcome {
+        guard message.senderInboxId != client.inviteInboxId else { return .noJoinRequest }
 
         let slug: String
         var profile: JoinRequestProfile?
@@ -148,10 +156,12 @@ public final class InviteCoordinator: @unchecked Sendable {
         } else if let text: String = try? message.content() {
             slug = text
         } else {
-            return nil
+            return .noJoinRequest
         }
 
-        guard let signedInvite = try? SignedInvite.fromURLSafeSlug(slug) else { return nil }
+        guard let signedInvite = try? SignedInvite.fromURLSafeSlug(slug) else {
+            return .noJoinRequest
+        }
 
         let request = JoinRequest(
             joinerInboxId: message.senderInboxId,
@@ -169,23 +179,33 @@ public final class InviteCoordinator: @unchecked Sendable {
         since: Date?,
         client: any InviteClientProvider
     ) async -> [JoinResult] {
+        let outcomes = await processJoinRequestOutcomes(since: since, client: client)
+        return outcomes.compactMap(\.joinResult)
+    }
+
+    public func processJoinRequestOutcomes(
+        since: Date?,
+        client: any InviteClientProvider
+    ) async -> [JoinRequestDMOutcome] {
         guard let dms = try? client.listDms(
-            createdAfterNs: since?.nanosecondsSince1970,
+            createdAfterNs: nil,
             createdBeforeNs: nil,
             lastActivityBeforeNs: nil,
-            lastActivityAfterNs: nil,
+            lastActivityAfterNs: since?.nanosecondsSince1970,
             limit: nil,
-            consentStates: [.unknown],
+            consentStates: [.unknown, .allowed],
             orderBy: .lastActivity
         ) else { return [] }
 
-        var results: [JoinResult] = []
+        var outcomes: [JoinRequestDMOutcome] = []
         for dm in dms {
-            if let result = await processDm(dm, client: client) {
-                results.append(result)
+            let outcome = await processDm(dm, since: since, client: client)
+            if case .noJoinRequest = outcome {
+                continue
             }
+            outcomes.append(outcome)
         }
-        return results
+        return outcomes
     }
 
     public func hasOutgoingJoinRequest(
@@ -225,30 +245,30 @@ public final class InviteCoordinator: @unchecked Sendable {
     private func processJoinRequest(
         _ request: JoinRequest,
         client: any InviteClientProvider
-    ) async -> JoinResult? {
+    ) async -> JoinRequestDMOutcome {
         let signedInvite = request.signedInvite
 
         guard !signedInvite.hasExpired else {
             delegate?.coordinator(self, didRejectJoinRequest: request, error: .expired)
-            return nil
+            return benignFailure(request, error: .expired)
         }
 
         guard !signedInvite.conversationHasExpired else {
             await sendJoinError(.conversationExpired, for: request, client: client)
             delegate?.coordinator(self, didRejectJoinRequest: request, error: .conversationExpired)
-            return nil
+            return benignFailure(request, error: .conversationExpired)
         }
 
         let creatorInboxId = signedInvite.invitePayload.creatorInboxIdString
 
         guard !creatorInboxId.isEmpty else {
-            await blockSpammer(request, client: client)
-            return nil
+            delegate?.coordinator(self, didRejectJoinRequest: request, error: .invalidFormat)
+            return benignFailure(request, error: .invalidFormat)
         }
 
         guard creatorInboxId == client.inviteInboxId else {
-            await blockSpammer(request, client: client)
-            return nil
+            delegate?.coordinator(self, didRejectJoinRequest: request, error: .creatorMismatch)
+            return benignFailure(request, error: .creatorMismatch)
         }
 
         let privateKey: Data
@@ -256,28 +276,27 @@ public final class InviteCoordinator: @unchecked Sendable {
             privateKey = try await privateKeyProvider(creatorInboxId)
         } catch {
             await sendJoinError(.genericFailure, for: request, client: client)
-            delegate?.coordinator(self, didRejectJoinRequest: request, error: .invalidSignature)
-            return nil
+            delegate?.coordinator(self, didRejectJoinRequest: request, error: .processingFailed)
+            return benignFailure(request, error: .processingFailed)
         }
 
         do {
             let expectedPublicKey = try Data.derivePublicKey(from: privateKey)
             guard try signedInvite.verify(with: expectedPublicKey) else {
-                await blockSpammer(request, client: client)
-                return nil
+                return await denyDmForMaliciousInvite(request, client: client, error: .invalidSignature)
             }
         } catch let error as InviteSignatureError {
             switch error {
             case .invalidSignature, .verificationFailure:
-                await blockSpammer(request, client: client)
+                return await denyDmForMaliciousInvite(request, client: client, error: .invalidSignature)
             case .invalidContext, .invalidPublicKey, .invalidPrivateKey,
                  .invalidFormat, .signatureFailure, .encodingFailure:
-                delegate?.coordinator(self, didRejectJoinRequest: request, error: .invalidSignature)
+                delegate?.coordinator(self, didRejectJoinRequest: request, error: .processingFailed)
+                return benignFailure(request, error: .processingFailed)
             }
-            return nil
         } catch {
-            delegate?.coordinator(self, didRejectJoinRequest: request, error: .invalidSignature)
-            return nil
+            delegate?.coordinator(self, didRejectJoinRequest: request, error: .processingFailed)
+            return benignFailure(request, error: .processingFailed)
         }
 
         let conversationId: String
@@ -289,14 +308,14 @@ public final class InviteCoordinator: @unchecked Sendable {
             )
         } catch {
             delegate?.coordinator(self, didRejectJoinRequest: request, error: .invalidFormat)
-            return nil
+            return benignFailure(request, error: .invalidFormat)
         }
 
         guard let conversation = try? await client.findConversation(conversationId: conversationId) else {
             Log.warning("Rejecting join for \(conversationId) (inviteTag: \(request.signedInvite.invitePayload.tag)): conversation not found in local store")
             await sendJoinError(.conversationNotFound, for: request, client: client)
             delegate?.coordinator(self, didRejectJoinRequest: request, error: .conversationNotFound(conversationId))
-            return nil
+            return benignFailure(request, error: .conversationNotFound(conversationId))
         }
 
         let consent = (try? conversation.consentState()) ?? .unknown
@@ -304,13 +323,13 @@ public final class InviteCoordinator: @unchecked Sendable {
             Log.warning("Rejecting join for \(conversationId) (inviteTag: \(request.signedInvite.invitePayload.tag)): consent state '\(consent)' is not .allowed")
             await sendJoinError(.consentNotAllowed, for: request, client: client)
             delegate?.coordinator(self, didRejectJoinRequest: request, error: .consentNotAllowed(conversationId, consent))
-            return nil
+            return benignFailure(request, error: .consentNotAllowed(conversationId, consent))
         }
 
         guard case .group(let group) = conversation else {
             await sendJoinError(.genericFailure, for: request, client: client)
             delegate?.coordinator(self, didRejectJoinRequest: request, error: .invalidFormat)
-            return nil
+            return benignFailure(request, error: .invalidFormat)
         }
 
         try? await group.sync()
@@ -320,12 +339,12 @@ public final class InviteCoordinator: @unchecked Sendable {
             guard signedInvite.invitePayload.tag == currentTag else {
                 await sendJoinError(.conversationExpired, for: request, client: client)
                 delegate?.coordinator(self, didRejectJoinRequest: request, error: .revoked)
-                return nil
+                return benignFailure(request, error: .revoked)
             }
         } catch {
             await sendJoinError(.conversationExpired, for: request, client: client)
             delegate?.coordinator(self, didRejectJoinRequest: request, error: .revoked)
-            return nil
+            return benignFailure(request, error: .revoked)
         }
 
         do {
@@ -333,7 +352,7 @@ public final class InviteCoordinator: @unchecked Sendable {
         } catch {
             await sendJoinError(.genericFailure, for: request, client: client)
             delegate?.coordinator(self, didRejectJoinRequest: request, error: .addMemberFailed)
-            return nil
+            return benignFailure(request, error: .addMemberFailed)
         }
 
         if let dm = try? await client.findConversation(conversationId: request.dmConversationId) {
@@ -348,16 +367,23 @@ public final class InviteCoordinator: @unchecked Sendable {
             metadata: request.metadata
         )
         delegate?.coordinator(self, didAddMember: result)
-        return result
+        return .accepted(result, dmConversationId: request.dmConversationId)
     }
 
     // MARK: - Helpers
 
     private func processDm(
         _ dm: XMTPiOS.Dm,
+        since: Date?,
         client: any InviteClientProvider
-    ) async -> JoinResult? {
-        guard let messages = try? await dm.messages(afterNs: nil) else { return nil }
+    ) async -> JoinRequestDMOutcome {
+        guard let messages = try? await dm.messages(afterNs: since?.nanosecondsSince1970) else {
+            return .benignFailure(
+                dmConversationId: dm.id,
+                senderInboxId: nil,
+                error: .processingFailed
+            )
+        }
 
         let candidates = messages.filter { message in
             guard let contentType = try? message.encodedContent.type,
@@ -368,23 +394,50 @@ public final class InviteCoordinator: @unchecked Sendable {
             return true
         }
 
+        var firstBenignFailure: JoinRequestDMOutcome?
         for message in candidates {
-            if let result = await processMessage(message, client: client) {
+            let outcome = await processMessageOutcome(message, client: client)
+            switch outcome {
+            case .noJoinRequest:
+                continue
+            case .accepted:
                 try? await dm.updateConsentState(state: .allowed)
-                return result
+                return outcome
+            case .malicious:
+                return outcome
+            case .benignFailure:
+                firstBenignFailure = firstBenignFailure ?? outcome
+                continue
             }
         }
-        return nil
+        return firstBenignFailure ?? .noJoinRequest
     }
 
-    private func blockSpammer(
+    private func benignFailure(
         _ request: JoinRequest,
-        client: any InviteClientProvider
-    ) async {
+        error: JoinRequestError
+    ) -> JoinRequestDMOutcome {
+        .benignFailure(
+            dmConversationId: request.dmConversationId,
+            senderInboxId: request.joinerInboxId,
+            error: error
+        )
+    }
+
+    private func denyDmForMaliciousInvite(
+        _ request: JoinRequest,
+        client: any InviteClientProvider,
+        error: JoinRequestError
+    ) async -> JoinRequestDMOutcome {
         if let dm = try? await client.findConversation(conversationId: request.dmConversationId) {
             try? await dm.updateConsentState(state: .denied)
         }
         delegate?.coordinator(self, didBlockSpammer: request.joinerInboxId, in: request.dmConversationId)
+        return .malicious(
+            dmConversationId: request.dmConversationId,
+            senderInboxId: request.joinerInboxId,
+            error: error
+        )
     }
 
     private func sendJoinError(

--- a/ConvosInvites/Sources/ConvosInvites/InviteCoordinator.swift
+++ b/ConvosInvites/Sources/ConvosInvites/InviteCoordinator.swift
@@ -286,6 +286,15 @@ public final class InviteCoordinator: @unchecked Sendable {
                 return await denyDmForMaliciousInvite(request, client: client, error: .invalidSignature)
             }
         } catch let error as InviteSignatureError {
+            // Threat-model split:
+            // - `.invalidSignature` / `.verificationFailure` only occur once the
+            //   signature has been parsed and run against the expected key — a
+            //   mismatch here means the slug was tampered with, so we deny the
+            //   DM and unsubscribe from its push topic.
+            // - The remaining cases are parse / encoding / key-derivation
+            //   failures that can happen on benign inputs (corrupt slug, format
+            //   skew, transient keychain error). We treat these as recoverable
+            //   so the same joiner can retry without being blocked.
             switch error {
             case .invalidSignature, .verificationFailure:
                 return await denyDmForMaliciousInvite(request, client: client, error: .invalidSignature)

--- a/ConvosInvites/Sources/ConvosInvites/Models.swift
+++ b/ConvosInvites/Sources/ConvosInvites/Models.swift
@@ -135,6 +135,21 @@ public struct JoinResult: Sendable {
     }
 }
 
+/// Outcome of processing a candidate join-request message in a DM.
+///
+/// The cases drive both the user-visible result and the push-subscription
+/// policy on the host DM:
+///
+/// - `accepted`: Verified join succeeded; the joiner was added to the
+///   group. The DM stays subscribed for follow-up acceptance flows.
+/// - `benignFailure`: Local/transient failure (sync error, missing group,
+///   revoked tag, expired invite, etc). The DM stays subscribed because
+///   the request may legitimately retry from the same joiner — see
+///   `shouldKeepDMSubscribed`.
+/// - `malicious`: Signature verification failed in a way that indicates
+///   tampering. The DM is denied and the device unsubscribes from its
+///   topic so it can no longer wake the inbox.
+/// - `noJoinRequest`: The message was not a join-request candidate.
 public enum JoinRequestDMOutcome: Sendable {
     case accepted(JoinResult, dmConversationId: String)
     case benignFailure(dmConversationId: String, senderInboxId: String?, error: JoinRequestError)

--- a/ConvosInvites/Sources/ConvosInvites/Models.swift
+++ b/ConvosInvites/Sources/ConvosInvites/Models.swift
@@ -135,6 +135,45 @@ public struct JoinResult: Sendable {
     }
 }
 
+public enum JoinRequestDMOutcome: Sendable {
+    case accepted(JoinResult, dmConversationId: String)
+    case benignFailure(dmConversationId: String, senderInboxId: String?, error: JoinRequestError)
+    case malicious(dmConversationId: String, senderInboxId: String, error: JoinRequestError)
+    case noJoinRequest
+
+    public var joinResult: JoinResult? {
+        guard case .accepted(let result, dmConversationId: _) = self else { return nil }
+        return result
+    }
+
+    public var dmConversationId: String? {
+        switch self {
+        case .accepted(_, dmConversationId: let dmConversationId):
+            return dmConversationId
+        case .benignFailure(let dmConversationId, _, _):
+            return dmConversationId
+        case .malicious(let dmConversationId, _, _):
+            return dmConversationId
+        case .noJoinRequest:
+            return nil
+        }
+    }
+
+    public var shouldKeepDMSubscribed: Bool {
+        switch self {
+        case .accepted, .benignFailure:
+            return true
+        case .malicious, .noJoinRequest:
+            return false
+        }
+    }
+
+    public var isMalicious: Bool {
+        guard case .malicious = self else { return false }
+        return true
+    }
+}
+
 // MARK: - Join Errors
 
 /// Errors that can occur when processing join requests
@@ -165,6 +204,9 @@ public enum JoinRequestError: Error, Sendable {
 
     /// Failed to add the member to the group
     case addMemberFailed
+
+    /// The request could not be processed because of a local/transient error
+    case processingFailed
 }
 
 /// Error types sent back to joiners when their request fails.

--- a/ConvosInvites/Tests/ConvosInvitesTests/Integration/InviteCoordinatorIntegrationTests.swift
+++ b/ConvosInvites/Tests/ConvosInvitesTests/Integration/InviteCoordinatorIntegrationTests.swift
@@ -1,0 +1,107 @@
+@testable import ConvosInvites
+@testable import ConvosInvitesCore
+import Foundation
+import Testing
+@preconcurrency import XMTPiOS
+
+/// Integration tests for InviteCoordinator that exercise the full join-request
+/// flow against a local XMTP node (`./dev/up`). Add new cases here when the
+/// behavior depends on real DM/group state, MLS routing, or consent
+/// transitions — anything a pure mock can't simulate.
+@Suite("InviteCoordinator Integration Tests", .serialized)
+struct InviteCoordinatorIntegrationTests {
+    // Deterministic 32-byte secp256k1 key shared by every InviteCoordinator
+    // instance in this suite, regardless of which XMTP inbox is asking.
+    // The coordinator only uses it to sign / decrypt invite slugs; it does
+    // not need to match the XMTP wallet identity for the test flow.
+    private let creatorInviteKey: Data = Data((1...32).map { UInt8($0) })
+
+    private func createClient() async throws -> Client {
+        var keyBytes = [UInt8](repeating: 0, count: 32)
+        _ = SecRandomCopyBytes(kSecRandomDefault, 32, &keyBytes)
+        let dbKey = Data(keyBytes)
+        let options = ClientOptions(
+            api: .init(env: .local, appVersion: "convos-tests/1.0.0"),
+            codecs: [
+                TextCodec(),
+                JoinRequestCodec(),
+                InviteJoinErrorCodec(),
+            ],
+            dbEncryptionKey: dbKey
+        )
+        return try await Client.createInMemory(
+            account: try PrivateKey.generate(),
+            options: options
+        )
+    }
+
+    private func makeCoordinator() -> InviteCoordinator {
+        let key = creatorInviteKey
+        return InviteCoordinator(privateKeyProvider: { _ in key })
+    }
+
+    /// Repro for the bug fixed in 686bd9fa: after a creator accepted the
+    /// first join request through a DM, that DM's consent flipped to
+    /// `.allowed`. A second join request landing in the *same* DM (e.g.
+    /// the joiner using a new invite for a different group) was then
+    /// silently dropped by the NSE because `processJoinRequestOutcomes`
+    /// listed DMs with `consentStates: [.unknown]` and a `createdAfterNs`
+    /// time window that never matched the now-old DM.
+    @Test("Processes a second join request through a DM whose consent is already .allowed")
+    func processesSecondJoinThroughAlreadyAllowedDm() async throws {
+        let creatorClient = try await createClient()
+        let joinerClient = try await createClient()
+        defer {
+            try? creatorClient.deleteLocalDatabase()
+            try? joinerClient.deleteLocalDatabase()
+        }
+        let coordinator = makeCoordinator()
+
+        let group1 = try await creatorClient.conversations.newGroup(with: [])
+        try await group1.updateConsentState(state: .allowed)
+        _ = try await coordinator.revokeInvites(for: group1)
+        let invite1 = try await coordinator.createInvite(for: group1, client: creatorClient)
+
+        _ = try await coordinator.sendJoinRequest(
+            for: invite1.signedInvite,
+            client: joinerClient
+        )
+
+        _ = try await creatorClient.conversations.syncAllConversations(consentStates: nil)
+        let firstOutcomes = await coordinator.processJoinRequestOutcomes(
+            since: nil,
+            client: creatorClient
+        )
+        let firstAccepted = firstOutcomes.compactMap(\.joinResult)
+        #expect(firstAccepted.contains { $0.conversationId == group1.id })
+
+        // Mark the boundary between the two passes. After this point
+        // anything new on the DM should still surface to the creator.
+        let cutoff = Date()
+        try await Task.sleep(nanoseconds: 100_000_000)
+
+        let group2 = try await creatorClient.conversations.newGroup(with: [])
+        try await group2.updateConsentState(state: .allowed)
+        _ = try await coordinator.revokeInvites(for: group2)
+        let invite2 = try await coordinator.createInvite(for: group2, client: creatorClient)
+
+        _ = try await coordinator.sendJoinRequest(
+            for: invite2.signedInvite,
+            client: joinerClient
+        )
+
+        _ = try await creatorClient.conversations.syncAllConversations(consentStates: nil)
+        let secondOutcomes = await coordinator.processJoinRequestOutcomes(
+            since: cutoff,
+            client: creatorClient
+        )
+        let secondAccepted = secondOutcomes.compactMap(\.joinResult)
+        #expect(
+            secondAccepted.contains { $0.conversationId == group2.id },
+            "Second join request must be processed even though DM consent is .allowed"
+        )
+
+        // Sanity: the second pass should not double-emit the first join.
+        #expect(!secondAccepted.contains { $0.conversationId == group1.id })
+    }
+}

--- a/ConvosInvites/Tests/ConvosInvitesTests/JoinRequestProcessingTests.swift
+++ b/ConvosInvites/Tests/ConvosInvitesTests/JoinRequestProcessingTests.swift
@@ -307,6 +307,29 @@ struct JoinRequestProcessingTests {
 
     // MARK: - JoinRequestError
 
+    @Test("processJoinRequestOutcomes lists DMs with allowed consent and lastActivity window")
+    func processJoinRequestOutcomesListsAllowedDmsByLastActivity() async {
+        let client = RecordingListDmsClient(inviteInboxId: "creator-inbox")
+        let coordinator = InviteCoordinator(privateKeyProvider: { _ in Data() })
+        let since = Date(timeIntervalSince1970: 1_700_000_000)
+
+        let outcomes = await coordinator.processJoinRequestOutcomes(since: since, client: client)
+
+        #expect(outcomes.isEmpty)
+        let calls = client.listDmsCalls
+        #expect(calls.count == 1)
+        guard let call = calls.first else { return }
+        // The original bug: DMs were filtered to consentStates=[.unknown] only,
+        // so a DM whose consent was already flipped to .allowed (after the
+        // first accepted join) was silently dropped from a second pass.
+        #expect(call.consentStates == [.unknown, .allowed])
+        // The original bug: the time window was applied via createdAfterNs,
+        // which compares against DM creation, not new activity. A second
+        // join request landing in a year-old DM never re-surfaced.
+        #expect(call.createdAfterNs == nil)
+        #expect(call.lastActivityAfterNs == since.nanosecondsSince1970)
+    }
+
     @Test("Join request DM outcome subscription policy")
     func joinRequestDMOutcomeSubscriptionPolicy() {
         let result = JoinResult(
@@ -419,4 +442,59 @@ struct JoinRequestProcessingTests {
 
         #expect(date.nanosecondsSince1970 == 1_500_000_000)
     }
+}
+
+private final class RecordingListDmsClient: InviteClientProvider, @unchecked Sendable {
+    struct ListDmsCall {
+        let createdAfterNs: Int64?
+        let createdBeforeNs: Int64?
+        let lastActivityBeforeNs: Int64?
+        let lastActivityAfterNs: Int64?
+        let limit: Int?
+        let consentStates: [XMTPiOS.ConsentState]?
+        let orderBy: XMTPiOS.ConversationsOrderBy
+    }
+
+    let inviteInboxId: String
+    private(set) var listDmsCalls: [ListDmsCall] = []
+
+    init(inviteInboxId: String) {
+        self.inviteInboxId = inviteInboxId
+    }
+
+    func findConversation(conversationId: String) async throws -> XMTPiOS.Conversation? {
+        nil
+    }
+
+    func findOrCreateDm(with inboxId: String) async throws -> XMTPiOS.Dm {
+        throw RecordingListDmsClientError.notImplemented
+    }
+
+    // swiftlint:disable:next function_parameter_count
+    func listDms(
+        createdAfterNs: Int64?,
+        createdBeforeNs: Int64?,
+        lastActivityBeforeNs: Int64?,
+        lastActivityAfterNs: Int64?,
+        limit: Int?,
+        consentStates: [XMTPiOS.ConsentState]?,
+        orderBy: XMTPiOS.ConversationsOrderBy
+    ) throws -> [XMTPiOS.Dm] {
+        listDmsCalls.append(
+            ListDmsCall(
+                createdAfterNs: createdAfterNs,
+                createdBeforeNs: createdBeforeNs,
+                lastActivityBeforeNs: lastActivityBeforeNs,
+                lastActivityAfterNs: lastActivityAfterNs,
+                limit: limit,
+                consentStates: consentStates,
+                orderBy: orderBy
+            )
+        )
+        return []
+    }
+}
+
+private enum RecordingListDmsClientError: Error {
+    case notImplemented
 }

--- a/ConvosInvites/Tests/ConvosInvitesTests/JoinRequestProcessingTests.swift
+++ b/ConvosInvites/Tests/ConvosInvitesTests/JoinRequestProcessingTests.swift
@@ -307,24 +307,6 @@ struct JoinRequestProcessingTests {
 
     // MARK: - JoinRequestError
 
-    @Test("JoinRequestError cases")
-    func joinRequestErrorCases() {
-        let errors: [JoinRequestError] = [
-            .invalidSignature,
-            .expired,
-            .conversationExpired,
-            .conversationNotFound("conv-123"),
-            .consentNotAllowed("conv-123", .denied),
-            .invalidFormat,
-            .creatorMismatch,
-            .revoked,
-            .addMemberFailed,
-            .processingFailed,
-        ]
-
-        #expect(errors.count == 10)
-    }
-
     @Test("Join request DM outcome subscription policy")
     func joinRequestDMOutcomeSubscriptionPolicy() {
         let result = JoinResult(

--- a/ConvosInvites/Tests/ConvosInvitesTests/JoinRequestProcessingTests.swift
+++ b/ConvosInvites/Tests/ConvosInvitesTests/JoinRequestProcessingTests.swift
@@ -307,29 +307,6 @@ struct JoinRequestProcessingTests {
 
     // MARK: - JoinRequestError
 
-    @Test("processJoinRequestOutcomes lists DMs with allowed consent and lastActivity window")
-    func processJoinRequestOutcomesListsAllowedDmsByLastActivity() async {
-        let client = RecordingListDmsClient(inviteInboxId: "creator-inbox")
-        let coordinator = InviteCoordinator(privateKeyProvider: { _ in Data() })
-        let since = Date(timeIntervalSince1970: 1_700_000_000)
-
-        let outcomes = await coordinator.processJoinRequestOutcomes(since: since, client: client)
-
-        #expect(outcomes.isEmpty)
-        let calls = client.listDmsCalls
-        #expect(calls.count == 1)
-        guard let call = calls.first else { return }
-        // The original bug: DMs were filtered to consentStates=[.unknown] only,
-        // so a DM whose consent was already flipped to .allowed (after the
-        // first accepted join) was silently dropped from a second pass.
-        #expect(call.consentStates == [.unknown, .allowed])
-        // The original bug: the time window was applied via createdAfterNs,
-        // which compares against DM creation, not new activity. A second
-        // join request landing in a year-old DM never re-surfaced.
-        #expect(call.createdAfterNs == nil)
-        #expect(call.lastActivityAfterNs == since.nanosecondsSince1970)
-    }
-
     @Test("Join request DM outcome subscription policy")
     func joinRequestDMOutcomeSubscriptionPolicy() {
         let result = JoinResult(
@@ -442,59 +419,4 @@ struct JoinRequestProcessingTests {
 
         #expect(date.nanosecondsSince1970 == 1_500_000_000)
     }
-}
-
-private final class RecordingListDmsClient: InviteClientProvider, @unchecked Sendable {
-    struct ListDmsCall {
-        let createdAfterNs: Int64?
-        let createdBeforeNs: Int64?
-        let lastActivityBeforeNs: Int64?
-        let lastActivityAfterNs: Int64?
-        let limit: Int?
-        let consentStates: [XMTPiOS.ConsentState]?
-        let orderBy: XMTPiOS.ConversationsOrderBy
-    }
-
-    let inviteInboxId: String
-    private(set) var listDmsCalls: [ListDmsCall] = []
-
-    init(inviteInboxId: String) {
-        self.inviteInboxId = inviteInboxId
-    }
-
-    func findConversation(conversationId: String) async throws -> XMTPiOS.Conversation? {
-        nil
-    }
-
-    func findOrCreateDm(with inboxId: String) async throws -> XMTPiOS.Dm {
-        throw RecordingListDmsClientError.notImplemented
-    }
-
-    // swiftlint:disable:next function_parameter_count
-    func listDms(
-        createdAfterNs: Int64?,
-        createdBeforeNs: Int64?,
-        lastActivityBeforeNs: Int64?,
-        lastActivityAfterNs: Int64?,
-        limit: Int?,
-        consentStates: [XMTPiOS.ConsentState]?,
-        orderBy: XMTPiOS.ConversationsOrderBy
-    ) throws -> [XMTPiOS.Dm] {
-        listDmsCalls.append(
-            ListDmsCall(
-                createdAfterNs: createdAfterNs,
-                createdBeforeNs: createdBeforeNs,
-                lastActivityBeforeNs: lastActivityBeforeNs,
-                lastActivityAfterNs: lastActivityAfterNs,
-                limit: limit,
-                consentStates: consentStates,
-                orderBy: orderBy
-            )
-        )
-        return []
-    }
-}
-
-private enum RecordingListDmsClientError: Error {
-    case notImplemented
 }

--- a/ConvosInvites/Tests/ConvosInvitesTests/JoinRequestProcessingTests.swift
+++ b/ConvosInvites/Tests/ConvosInvitesTests/JoinRequestProcessingTests.swift
@@ -319,9 +319,38 @@ struct JoinRequestProcessingTests {
             .creatorMismatch,
             .revoked,
             .addMemberFailed,
+            .processingFailed,
         ]
 
-        #expect(errors.count == 9)
+        #expect(errors.count == 10)
+    }
+
+    @Test("Join request DM outcome subscription policy")
+    func joinRequestDMOutcomeSubscriptionPolicy() {
+        let result = JoinResult(
+            conversationId: "group-123",
+            joinerInboxId: "joiner-123",
+            conversationName: "Group"
+        )
+
+        let accepted = JoinRequestDMOutcome.accepted(result, dmConversationId: "dm-123")
+        let benignFailure = JoinRequestDMOutcome.benignFailure(
+            dmConversationId: "dm-123",
+            senderInboxId: "joiner-123",
+            error: .addMemberFailed
+        )
+        let malicious = JoinRequestDMOutcome.malicious(
+            dmConversationId: "dm-123",
+            senderInboxId: "joiner-123",
+            error: .invalidSignature
+        )
+
+        #expect(accepted.shouldKeepDMSubscribed)
+        #expect(accepted.dmConversationId == "dm-123")
+        #expect(accepted.joinResult?.conversationId == "group-123")
+        #expect(benignFailure.shouldKeepDMSubscribed)
+        #expect(!malicious.shouldKeepDMSubscribed)
+        #expect(malicious.isMalicious)
     }
 
     // MARK: - InviteJoinError Feedback


### PR DESCRIPTION
## Summary

Fixes join-request processing after the single-inbox identity refactor by keeping the invite DM push topic subscribed whenever join processing fails for a benign/transient reason, while only denying/unsubscribing the DM when the invite appears malicious through signature tampering.

## Root Cause

After the single-inbox identity model, repeated join requests between the same inviter and joiner reuse the same DM. The app/NSE were not reliably subscribing to invite DM topics, and welcome fallback scans only considered unknown DMs created after the last welcome timestamp. If the DM already existed or had been allowed by a previous join, later join requests could be missed. Non-malicious processing errors also risked blocking future retries.

## Changes

- Added outcome-aware join request processing: accepted, benign failure, malicious, and no request.
- Scans both unknown and allowed DMs by last activity, not just newly-created unknown DMs.
- Keeps invite DMs subscribed after accepted or benign-failure outcomes.
- Denies/unsubscribes invite DMs only for malicious/tampered signature outcomes.
- Centralized push topic subscription and reconciliation for welcome, group, and invite DM topics.
- Wired the main app stream path, sync reconciliation, and notification extension push paths through the new outcome/subscription flow.
- Added targeted tests for outcome subscription policy and push topic subscription behavior.

## Validation

- `swift test --package-path ConvosInvites`
- `swift build --package-path ConvosCore`
- `swift test --package-path ConvosCore --filter PushTopicSubscriptionManagerTests`
- `xcodebuild -project Convos.xcodeproj -scheme "Convos (Dev)" -configuration Dev -destination "platform=iOS Simulator,id=DBD5E6FD-E14E-467E-9F53-872CB4822BD9" -derivedDataPath /tmp/convos-ios-task-C-derived build`
- Installed and launched `org.convos.ios-preview` on `convos-join-debug-a` and `convos-join-debug-b`.

Note: the full `ConvosCore` test suite was attempted but the local XMTP service at `127.0.0.1:5556` was not running, so environment-dependent integration tests timed out with connection refused.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/780"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix invite DM push subscriptions by routing join-request outcomes to push topic management
> - Introduces `JoinRequestDMOutcome` in `ConvosInvites` to classify join-request results as `accepted`, `benignFailure`, `malicious`, or `noJoinRequest`, replacing bare `nil`/optional returns throughout `InviteCoordinator`.
> - Adds `PushTopicSubscriptionManager`, a new actor that centralizes APNS topic subscribe/unsubscribe logic for group, welcome, and invite DM topics.
> - `StreamProcessor` now calls `handleJoinRequestOutcome` after processing a DM message, subscribing to the invite DM topic on accepted/benign outcomes and unsubscribing on malicious ones.
> - `MessagingService` push handlers (welcome message and encrypted group message) are updated to process structured outcomes and drive `PushTopicSubscriptionManager` for subscribe/unsubscribe decisions in the Notification Service Extension path.
> - `SyncingManager` triggers `reconcilePushSubscriptions` after initial sync, resume, and on-demand discovery to keep topics consistent.
> - Batch DM scanning in `InviteCoordinator` now filters by last activity time and includes `consent == .allowed` conversations, fixing a regression where a second join request in an already-allowed DM was silently dropped.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 584a22b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->