### PR TITLE
revert back to ios-4.9.0-dev.88ddfad

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,4 @@ qa/cxdb/qa.sqlite-shm
 
 # Runtime artifacts
 .claude/scheduled_tasks.lock
+.gems/**

--- a/Convos.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Convos.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -150,7 +150,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/xmtp/libxmtp.git",
       "state" : {
-        "branch" : "ios-4.10.0-dev.d991b8a",
+        "branch" : "ios-4.9.0-dev.88ddfad",
         "revision" : "0b4dc376f139cd439319c2468cd51e5ce628bf2d"
       }
     },

--- a/ConvosCore/Package.resolved
+++ b/ConvosCore/Package.resolved
@@ -141,7 +141,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/xmtp/libxmtp.git",
       "state" : {
-        "branch" : "ios-4.10.0-dev.d991b8a",
+        "branch" : "ios-4.9.0-dev.88ddfad",
         "revision" : "0b4dc376f139cd439319c2468cd51e5ce628bf2d"
       }
     },

--- a/ConvosCore/Package.swift
+++ b/ConvosCore/Package.swift
@@ -23,7 +23,7 @@ let package = Package(
         .package(url: "https://github.com/groue/GRDB.swift.git", exact: "7.5.0"),
         .package(
             url: "https://github.com/xmtp/libxmtp.git",
-            revision: "ios-4.10.0-dev.d991b8a"
+            revision: "ios-4.9.0-dev.88ddfad"
         ),
         .package(url: "https://github.com/tesseract-one/CSecp256k1.swift.git", from: "0.2.0"),
         .package(url: "https://github.com/firebase/firebase-ios-sdk", from: "12.1.0"),

--- a/ConvosInvites/Package.resolved
+++ b/ConvosInvites/Package.resolved
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/xmtp/libxmtp.git",
       "state" : {
-        "branch" : "ios-4.10.0-dev.d991b8a",
-        "revision" : "0b4dc376f139cd439319c2468cd51e5ce628bf2d"
+        "branch" : "ios-4.9.0-dev.88ddfad",
+        "revision" : "899650a4189207ca2df515bf46beb549da07ff46"
       }
     },
     {

--- a/ConvosInvites/Package.swift
+++ b/ConvosInvites/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-log", from: "1.6.0"),
         .package(
             url: "https://github.com/xmtp/libxmtp.git",
-            revision: "ios-4.10.0-dev.d991b8a"
+            revision: "ios-4.9.0-dev.88ddfad"
         ),
         .package(path: "../ConvosAppData"),
     ],


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/783"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Revert dependency pin to `ios-4.9.0-dev.88ddfad`
> Rolls back the SwiftPM dependency revision in [ConvosCore/Package.swift](https://github.com/xmtplabs/convos-ios/pull/783/files#diff-a2bdca0eaceddfb5e4fbd6afdf3047a9c23f261d60140456b61baada4a24caa3) and [ConvosInvites/Package.swift](https://github.com/xmtplabs/convos-ios/pull/783/files#diff-d4750024712f96fb2f92c7de6b61dc8dee585572e6f28f155e99eaf0fbf171e7) from `ios-4.10.0-dev.d991b8a` to `ios-4.9.0-dev.88ddfad`. Also adds `.gems/**` to [.gitignore](https://github.com/xmtplabs/convos-ios/pull/783/files#diff-bc37d034bad564583790a46f19d807abfe519c5671395fd494d8cce506c42947).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 61514f0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->