### PR TITLE
Revert #779 and #765 (libxmtp 4.10.0 bump + test refactor)

### DIFF
--- a/.github/workflows/convoscore-tests.yml
+++ b/.github/workflows/convoscore-tests.yml
@@ -97,9 +97,9 @@ jobs:
       - name: Run integration tests
         env:
           XMTP_NODE_ADDRESS: ${{ needs.deploy-backend.outputs.xmtp_node_address }}
-          CONVOS_TEST_XMTP_LOG_LEVEL: debug
-          CONVOS_TEST_XMTP_LOG_DIR: ${{ github.workspace }}/xmtp-test-logs
-        run: ./ci/run-tests.sh --integration
+        run: |
+          echo $XMTP_NODE_ADDRESS
+          ./ci/run-tests.sh --integration
 
       - name: Upload test logs
         if: always()
@@ -108,7 +108,6 @@ jobs:
           name: integration-test-logs
           path: |
             ConvosCore/.build/debug/*.log
-            xmtp-test-logs/
           retention-days: 7
           if-no-files-found: ignore
 

--- a/Convos.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Convos.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "0b6c3910a59294d9f345ce5999ea43089b223783fba5d450e8d2f1e9b15fea62",
+  "originHash" : "c40fcb5279ffcf05994801de5933e258d72c7e21e5c777ef54ffb951d4469a38",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -44,15 +44,6 @@
       "state" : {
         "revision" : "cfbd6f540d5084bc96a60af841121472fbe725a3",
         "version" : "0.2.0"
-      }
-    },
-    {
-      "identity" : "devicekit",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/devicekit/DeviceKit.git",
-      "state" : {
-        "revision" : "56b997e8a61707218f9af09f32b2a1d1806fd792",
-        "version" : "5.8.0"
       }
     },
     {
@@ -160,7 +151,7 @@
       "location" : "https://github.com/xmtp/libxmtp.git",
       "state" : {
         "branch" : "ios-4.9.0-dev.88ddfad",
-        "revision" : "0b4dc376f139cd439319c2468cd51e5ce628bf2d"
+        "revision" : "899650a4189207ca2df515bf46beb549da07ff46"
       }
     },
     {

--- a/ConvosCore/Package.resolved
+++ b/ConvosCore/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "8d496cac4d4a881a4f40d87a07597e6233b5d7eda8dc2db9428e7733bca315ab",
+  "originHash" : "dac571861aac89d1f7bc34953a13e35a54819294b0aec0f4b460d532304d7420",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -44,15 +44,6 @@
       "state" : {
         "revision" : "cfbd6f540d5084bc96a60af841121472fbe725a3",
         "version" : "0.2.0"
-      }
-    },
-    {
-      "identity" : "devicekit",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/devicekit/DeviceKit.git",
-      "state" : {
-        "revision" : "56b997e8a61707218f9af09f32b2a1d1806fd792",
-        "version" : "5.8.0"
       }
     },
     {
@@ -151,7 +142,7 @@
       "location" : "https://github.com/xmtp/libxmtp.git",
       "state" : {
         "branch" : "ios-4.9.0-dev.88ddfad",
-        "revision" : "0b4dc376f139cd439319c2468cd51e5ce628bf2d"
+        "revision" : "899650a4189207ca2df515bf46beb549da07ff46"
       }
     },
     {

--- a/ConvosCore/Sources/ConvosCore/Inboxes/AuthorizeInboxOperation.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/AuthorizeInboxOperation.swift
@@ -45,8 +45,7 @@ final class AuthorizeInboxOperation: AuthorizeInboxOperationProtocol, @unchecked
         overrideJWTToken: String? = nil,
         platformProviders: PlatformProviders,
         deviceRegistrationManager: (any DeviceRegistrationManagerProtocol)? = nil,
-        apiClient: (any ConvosAPIClientProtocol)? = nil,
-        xmtpClientFactory: XMTPClientFactory = .onDisk
+        apiClient: (any ConvosAPIClientProtocol)? = nil
     ) -> AuthorizeInboxOperation {
         let operation = AuthorizeInboxOperation(
             clientId: clientId,
@@ -59,8 +58,7 @@ final class AuthorizeInboxOperation: AuthorizeInboxOperationProtocol, @unchecked
             overrideJWTToken: overrideJWTToken,
             platformProviders: platformProviders,
             deviceRegistrationManager: deviceRegistrationManager,
-            apiClient: apiClient,
-            xmtpClientFactory: xmtpClientFactory
+            apiClient: apiClient
         )
         operation.authorize(inboxId: inboxId)
         return operation
@@ -74,8 +72,7 @@ final class AuthorizeInboxOperation: AuthorizeInboxOperationProtocol, @unchecked
         environment: AppEnvironment,
         platformProviders: PlatformProviders,
         deviceRegistrationManager: (any DeviceRegistrationManagerProtocol)? = nil,
-        apiClient: (any ConvosAPIClientProtocol)? = nil,
-        xmtpClientFactory: XMTPClientFactory = .onDisk
+        apiClient: (any ConvosAPIClientProtocol)? = nil
     ) -> AuthorizeInboxOperation {
         // Generate clientId before creating state machine
         let clientId = ClientId.generate().value
@@ -89,8 +86,7 @@ final class AuthorizeInboxOperation: AuthorizeInboxOperationProtocol, @unchecked
             startsStreamingServices: true,
             platformProviders: platformProviders,
             deviceRegistrationManager: deviceRegistrationManager,
-            apiClient: apiClient,
-            xmtpClientFactory: xmtpClientFactory
+            apiClient: apiClient
         )
         operation.register()
         return operation
@@ -107,8 +103,7 @@ final class AuthorizeInboxOperation: AuthorizeInboxOperationProtocol, @unchecked
         overrideJWTToken: String? = nil,
         platformProviders: PlatformProviders,
         deviceRegistrationManager: (any DeviceRegistrationManagerProtocol)?,
-        apiClient: (any ConvosAPIClientProtocol)?,
-        xmtpClientFactory: XMTPClientFactory
+        apiClient: (any ConvosAPIClientProtocol)?
     ) {
         let syncingManager = startsStreamingServices ? SyncingManager(
             identityStore: identityStore,
@@ -128,8 +123,7 @@ final class AuthorizeInboxOperation: AuthorizeInboxOperationProtocol, @unchecked
             overrideJWTToken: overrideJWTToken,
             environment: environment,
             appLifecycle: platformProviders.appLifecycle,
-            apiClient: apiClient,
-            xmtpClientFactory: xmtpClientFactory
+            apiClient: apiClient
         )
     }
 

--- a/ConvosCore/Sources/ConvosCore/Inboxes/SessionStateMachine.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/SessionStateMachine.swift
@@ -26,10 +26,8 @@ public struct InboxReadyResult: @unchecked Sendable {
 typealias AnySyncingManager = (any SyncingManagerProtocol)
 typealias AnyInviteJoinRequestsManager = (any InviteJoinRequestsManagerProtocol)
 
-/// `.onDisk` routes through libxmtp's persistent SQLCipher path (production
-/// behavior). `.inMemory` routes through `Client.createInMemory`, where
-/// `dropLocalDatabaseConnection` and friends are no-ops — so the lifecycle-
-/// notification broadcast can't wedge a parallel test's pool.
+/// Tests inject `.inMemory` so libxmtp's pool-management surface is inert; the
+/// `dropLocalDatabaseConnection` broadcast can't wedge an in-memory pool.
 struct XMTPClientFactory: Sendable {
     typealias Create = @Sendable (SigningKey, ClientOptions) async throws -> any XMTPClientProvider
     typealias Build = @Sendable (String, PublicIdentity, SigningKey, ClientOptions) async throws -> any XMTPClientProvider
@@ -37,7 +35,7 @@ struct XMTPClientFactory: Sendable {
     let create: Create
     let build: Build
 
-    static let onDisk: XMTPClientFactory = XMTPClientFactory(
+    static let production: XMTPClientFactory = XMTPClientFactory(
         create: { signingKey, options in
             try await Client.create(account: signingKey, options: options)
         },
@@ -261,7 +259,7 @@ public actor SessionStateMachine: SessionStateManagerProtocol {
         environment: AppEnvironment,
         appLifecycle: any AppLifecycleProviding,
         apiClient: (any ConvosAPIClientProtocol)? = nil,
-        xmtpClientFactory: XMTPClientFactory = .onDisk
+        xmtpClientFactory: XMTPClientFactory = .production
     ) {
         let initialState: State = .idle
         self.initialClientId = clientId

--- a/ConvosCore/Sources/ConvosCore/Inboxes/SessionStateMachine.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/SessionStateMachine.swift
@@ -26,40 +26,6 @@ public struct InboxReadyResult: @unchecked Sendable {
 typealias AnySyncingManager = (any SyncingManagerProtocol)
 typealias AnyInviteJoinRequestsManager = (any InviteJoinRequestsManagerProtocol)
 
-/// Tests inject `.inMemory` so libxmtp's pool-management surface is inert; the
-/// `dropLocalDatabaseConnection` broadcast can't wedge an in-memory pool.
-struct XMTPClientFactory: Sendable {
-    typealias Create = @Sendable (SigningKey, ClientOptions) async throws -> any XMTPClientProvider
-    typealias Build = @Sendable (String, PublicIdentity, SigningKey, ClientOptions) async throws -> any XMTPClientProvider
-
-    let create: Create
-    let build: Build
-
-    static let production: XMTPClientFactory = XMTPClientFactory(
-        create: { signingKey, options in
-            try await Client.create(account: signingKey, options: options)
-        },
-        build: { inboxId, identity, _, options in
-            try await Client.build(publicIdentity: identity, options: options, inboxId: inboxId)
-        }
-    )
-
-    /// `build` reuses `createInMemory`: tests carry no on-disk history; inboxId
-    /// derives from signing key, preserving the `client.inboxId == identity.inboxId`
-    /// invariant in `authorize`.
-    static let inMemory: XMTPClientFactory = {
-        let createInMemory: Create = { signingKey, options in
-            try await Client.createInMemory(account: signingKey, options: options)
-        }
-        return XMTPClientFactory(
-            create: createInMemory,
-            build: { _, _, signingKey, options in
-                try await createInMemory(signingKey, options)
-            }
-        )
-    }()
-}
-
 // swiftlint:disable type_body_length
 
 /// Drives the XMTP inbox lifecycle: creating or loading a client,
@@ -104,7 +70,6 @@ public actor SessionStateMachine: SessionStateManagerProtocol {
     private let apiClient: any ConvosAPIClientProtocol
     private let networkMonitor: any NetworkMonitorProtocol
     private let appLifecycle: any AppLifecycleProviding
-    private let xmtpClientFactory: XMTPClientFactory
 
     private var currentTask: Task<Void, Never>?
     private var actionQueue: [Action] = []
@@ -258,8 +223,7 @@ public actor SessionStateMachine: SessionStateManagerProtocol {
         overrideJWTToken: String? = nil,
         environment: AppEnvironment,
         appLifecycle: any AppLifecycleProviding,
-        apiClient: (any ConvosAPIClientProtocol)? = nil,
-        xmtpClientFactory: XMTPClientFactory = .production
+        apiClient: (any ConvosAPIClientProtocol)? = nil
     ) {
         let initialState: State = .idle
         self.initialClientId = clientId
@@ -273,7 +237,6 @@ public actor SessionStateMachine: SessionStateManagerProtocol {
         self.overrideJWTToken = overrideJWTToken ?? environment.defaultOverrideJWTToken
         self.environment = environment
         self.appLifecycle = appLifecycle
-        self.xmtpClientFactory = xmtpClientFactory
 
         // Use provided API client or create a new one
         if let apiClient {
@@ -524,7 +487,6 @@ public actor SessionStateMachine: SessionStateManagerProtocol {
             client = try await buildXmtpClient(
                 inboxId: identity.inboxId,
                 identity: keys.signingKey.identity,
-                signingKey: keys.signingKey,
                 options: clientOptions
             )
         } catch {
@@ -991,7 +953,8 @@ public actor SessionStateMachine: SessionStateManagerProtocol {
             dbEncryptionKey: keys.databaseKey,
             dbDirectory: environment.defaultDatabasesDirectory,
             deviceSyncEnabled: true,
-            dbPoolOptions: DbPoolOptions(maxPoolSize: 10, minPoolSize: 3)
+            maxDbPoolSize: 10,
+            minDbPoolSize: 3
         )
     }
 
@@ -1010,17 +973,20 @@ public actor SessionStateMachine: SessionStateManagerProtocol {
     private func createXmtpClient(signingKey: SigningKey,
                                   options: ClientOptions) async throws -> any XMTPClientProvider {
         Log.info("Creating XMTP client...")
-        let client = try await xmtpClientFactory.create(signingKey, options)
+        let client = try await Client.create(account: signingKey, options: options)
         Log.info("XMTP Client created with app version: convos/\(Bundle.appVersion)")
         return client
     }
 
     private func buildXmtpClient(inboxId: String,
                                  identity: PublicIdentity,
-                                 signingKey: SigningKey,
                                  options: ClientOptions) async throws -> any XMTPClientProvider {
         Log.debug("Building XMTP client for \(inboxId)...")
-        let client = try await xmtpClientFactory.build(inboxId, identity, signingKey, options)
+        let client = try await Client.build(
+            publicIdentity: identity,
+            options: options,
+            inboxId: inboxId
+        )
         Log.debug("XMTP Client built.")
         return client
     }

--- a/ConvosCore/Sources/ConvosCore/Messaging/MessagingService.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/MessagingService.swift
@@ -42,8 +42,7 @@ final class MessagingService: MessagingServiceProtocol, @unchecked Sendable {
         overrideJWTToken: String? = nil,
         platformProviders: PlatformProviders,
         deviceRegistrationManager: (any DeviceRegistrationManagerProtocol)? = nil,
-        apiClient: (any ConvosAPIClientProtocol)? = nil,
-        xmtpClientFactory: XMTPClientFactory = .onDisk
+        apiClient: (any ConvosAPIClientProtocol)? = nil
     ) -> MessagingService {
         let authorizationOperation = AuthorizeInboxOperation.authorize(
             inboxId: inboxId,
@@ -56,8 +55,7 @@ final class MessagingService: MessagingServiceProtocol, @unchecked Sendable {
             overrideJWTToken: overrideJWTToken,
             platformProviders: platformProviders,
             deviceRegistrationManager: deviceRegistrationManager,
-            apiClient: apiClient,
-            xmtpClientFactory: xmtpClientFactory
+            apiClient: apiClient
         )
         return MessagingService(
             authorizationOperation: authorizationOperation,

--- a/ConvosCore/Sources/ConvosCore/PlatformProviders.swift
+++ b/ConvosCore/Sources/ConvosCore/PlatformProviders.swift
@@ -65,13 +65,7 @@ public struct PlatformProviders: Sendable {
 
 // MARK: - Test/Mock Support
 
-/// Mock app lifecycle provider for testing.
-///
-/// Each instance defaults to a UUID-suffixed notification name so that
-/// `SessionStateMachine` instances observing on `NotificationCenter.default`
-/// only receive lifecycle events from their own provider. Sharing a fixed
-/// name across instances would let one test's background event wedge another
-/// test's libxmtp DB pool via `dropLocalDatabaseConnection`.
+/// Mock app lifecycle provider for testing
 public final class MockAppLifecycleProvider: AppLifecycleProviding, @unchecked Sendable {
     public let didEnterBackgroundNotification: Notification.Name
     public let willEnterForegroundNotification: Notification.Name
@@ -84,18 +78,14 @@ public final class MockAppLifecycleProvider: AppLifecycleProviding, @unchecked S
 
     public init(
         currentState: AppState = .active,
-        didEnterBackgroundNotification: Notification.Name? = nil,
-        willEnterForegroundNotification: Notification.Name? = nil,
-        didBecomeActiveNotification: Notification.Name? = nil
+        didEnterBackgroundNotification: Notification.Name = Notification.Name("MockDidEnterBackground"),
+        willEnterForegroundNotification: Notification.Name = Notification.Name("MockWillEnterForeground"),
+        didBecomeActiveNotification: Notification.Name = Notification.Name("MockDidBecomeActive")
     ) {
-        let suffix = UUID().uuidString
         self._currentState = currentState
         self.didEnterBackgroundNotification = didEnterBackgroundNotification
-            ?? Notification.Name("MockDidEnterBackground.\(suffix)")
         self.willEnterForegroundNotification = willEnterForegroundNotification
-            ?? Notification.Name("MockWillEnterForeground.\(suffix)")
         self.didBecomeActiveNotification = didBecomeActiveNotification
-            ?? Notification.Name("MockDidBecomeActive.\(suffix)")
     }
 
     public func setCurrentState(_ state: AppState) {

--- a/ConvosCore/Tests/ConvosCoreTests/Integration/ProfileMessageIntegrationTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/Integration/ProfileMessageIntegrationTests.swift
@@ -19,7 +19,7 @@ struct ProfileMessageIntegrationTests {
             ],
             dbEncryptionKey: key
         )
-        return try await Client.createInMemory(
+        return try await Client.create(
             account: try PrivateKey.generate(),
             options: options
         )

--- a/ConvosCore/Tests/ConvosCoreTests/SessionStateMachineTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/SessionStateMachineTests.swift
@@ -40,8 +40,7 @@ struct SessionStateMachineTests {
             networkMonitor: networkMonitor,
             overrideJWTToken: "test-jwt-token",  // Skip backend auth for tests
             environment: .tests,
-            appLifecycle: testAppLifecycle,
-            xmtpClientFactory: .inMemory
+            appLifecycle: testAppLifecycle
         )
 
         // Start in idle state
@@ -100,8 +99,7 @@ struct SessionStateMachineTests {
             networkMonitor: networkMonitor,
             overrideJWTToken: "test-jwt-token",
             environment: .tests,
-            appLifecycle: testAppLifecycle,
-            xmtpClientFactory: .inMemory
+            appLifecycle: testAppLifecycle
         )
 
         await stateMachine.register()
@@ -164,8 +162,7 @@ struct SessionStateMachineTests {
             networkMonitor: networkMonitor,
             overrideJWTToken: "test-jwt-token",  // Skip backend auth for tests
             environment: .tests,
-            appLifecycle: testAppLifecycle,
-            xmtpClientFactory: .inMemory
+            appLifecycle: testAppLifecycle
         )
 
         // Authorize with the existing inbox
@@ -213,8 +210,7 @@ struct SessionStateMachineTests {
             syncingManager: nil,
             networkMonitor: networkMonitor,
             environment: .tests,
-            appLifecycle: testAppLifecycle,
-            xmtpClientFactory: .inMemory
+            appLifecycle: testAppLifecycle
         )
 
         // Try to authorize with wrong clientId. The state machine was
@@ -264,8 +260,7 @@ struct SessionStateMachineTests {
             networkMonitor: networkMonitor,
             overrideJWTToken: "test-jwt-token",  // Skip backend auth for tests
             environment: .tests,
-            appLifecycle: testAppLifecycle,
-            xmtpClientFactory: .inMemory
+            appLifecycle: testAppLifecycle
         )
 
         // Register and wait for ready
@@ -333,8 +328,7 @@ struct SessionStateMachineTests {
             networkMonitor: networkMonitor,
             overrideJWTToken: "test-jwt-token",  // Skip backend auth for tests
             environment: .tests,
-            appLifecycle: testAppLifecycle,
-            xmtpClientFactory: .inMemory
+            appLifecycle: testAppLifecycle
         )
 
         // Register and wait for ready
@@ -404,8 +398,7 @@ struct SessionStateMachineTests {
             networkMonitor: networkMonitor,
             overrideJWTToken: "test-jwt-token",  // Skip backend auth for tests
             environment: .tests,
-            appLifecycle: testAppLifecycle,
-            xmtpClientFactory: .inMemory
+            appLifecycle: testAppLifecycle
         )
 
         // Try to authorize with non-existent inboxId to trigger error
@@ -459,8 +452,7 @@ struct SessionStateMachineTests {
             syncingManager: nil,
             networkMonitor: networkMonitor,
             environment: .tests,
-            appLifecycle: testAppLifecycle,
-            xmtpClientFactory: .inMemory
+            appLifecycle: testAppLifecycle
         )
 
         actor StateCollector {
@@ -545,8 +537,7 @@ struct SessionStateMachineTests {
             networkMonitor: networkMonitor,
             overrideJWTToken: "test-jwt-token",  // Skip backend auth for tests
             environment: .tests,
-            appLifecycle: testAppLifecycle,
-            xmtpClientFactory: .inMemory
+            appLifecycle: testAppLifecycle
         )
 
         // Queue register and then stop
@@ -601,8 +592,7 @@ struct SessionStateMachineTests {
             networkMonitor: mockNetworkMonitor,
             overrideJWTToken: "test-jwt-token",
             environment: .tests,
-            appLifecycle: testAppLifecycle,
-            xmtpClientFactory: .inMemory
+            appLifecycle: testAppLifecycle
         )
 
         // Register and wait for ready
@@ -680,8 +670,7 @@ struct SessionStateMachineTests {
             networkMonitor: networkMonitor,
             overrideJWTToken: "test-jwt-token",
             environment: .tests,
-            appLifecycle: testAppLifecycle,
-            xmtpClientFactory: .inMemory
+            appLifecycle: testAppLifecycle
         )
 
         // Register and wait for ready
@@ -777,8 +766,7 @@ struct SessionStateMachineTests {
             networkMonitor: networkMonitor,
             overrideJWTToken: "test-jwt-token",
             environment: .tests,
-            appLifecycle: testAppLifecycle,
-            xmtpClientFactory: .inMemory
+            appLifecycle: testAppLifecycle
         )
 
         actor StateCollector {

--- a/ConvosCore/Tests/ConvosCoreTests/SessionStateMachineTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/SessionStateMachineTests.swift
@@ -372,12 +372,9 @@ struct SessionStateMachineTests {
         let syncIsStarted = await mockSync.isStarted
         #expect(!syncIsStarted, "Syncing should be stopped")
 
-        // Identity slot is deliberately preserved on local Reset — see
-        // SessionStateMachine.handleDelete: the synced keychain entry is the
-        // AES-GCM seal on every backup bundle, so deleting it would
-        // propagate via iCloud Keychain and orphan every existing backup.
+        // Verify identity was deleted
         let identityAfterDelete = try await fixtures.identityStore.load()
-        #expect(identityAfterDelete != nil, "Identity should be preserved on local delete")
+        #expect(identityAfterDelete == nil, "Identity should have been deleted")
 
         // Verify database record was deleted
         let dbInboxes = try await fixtures.databaseManager.dbReader.read { db in
@@ -674,14 +671,6 @@ struct SessionStateMachineTests {
         let mockInvites = MockInvitesRepository()
         let networkMonitor = NetworkMonitor()
 
-        // Uses `.onDisk` because `dropLocalDatabaseConnection` and
-        // `reconnectLocalDatabase` early-return as no-ops on in-memory
-        // clients (libxmtp Client.swift:959, 964). Backgrounding is the
-        // exact production path this test is meant to exercise, so the
-        // on-disk SQLCipher pool is the right backing. A dedicated
-        // lifecycle provider isolates this test's notifications from
-        // the suite-shared `testAppLifecycle`.
-        let appLifecycle = MockAppLifecycleProvider()
         let stateMachine = SessionStateMachine(
             clientId: clientId,
             identityStore: fixtures.identityStore,
@@ -691,8 +680,8 @@ struct SessionStateMachineTests {
             networkMonitor: networkMonitor,
             overrideJWTToken: "test-jwt-token",
             environment: .tests,
-            appLifecycle: appLifecycle,
-            xmtpClientFactory: .onDisk
+            appLifecycle: testAppLifecycle,
+            xmtpClientFactory: .inMemory
         )
 
         // Register and wait for ready
@@ -722,7 +711,7 @@ struct SessionStateMachineTests {
         try await Task.sleep(for: .milliseconds(100))
 
         // Simulate app entering background
-        NotificationCenter.default.post(name: appLifecycle.didEnterBackgroundNotification, object: nil)
+        NotificationCenter.default.post(name: testAppLifecycle.didEnterBackgroundNotification, object: nil)
 
         // Wait for backgrounded state
         let backgroundedState = try await waitForState(stateMachine, timeout: 5) { state in
@@ -744,7 +733,7 @@ struct SessionStateMachineTests {
         Log.info("App backgrounded, sync paused. Simulating app returning to foreground...")
 
         // Simulate app entering foreground
-        NotificationCenter.default.post(name: appLifecycle.willEnterForegroundNotification, object: nil)
+        NotificationCenter.default.post(name: testAppLifecycle.willEnterForegroundNotification, object: nil)
 
         // Wait for ready state again
         let foregroundState = try await waitForState(stateMachine, timeout: 5) { state in
@@ -779,13 +768,6 @@ struct SessionStateMachineTests {
         let mockInvites = MockInvitesRepository()
         let networkMonitor = NetworkMonitor()
 
-        // Uses `.onDisk` so the backgrounded → ready transition
-        // actually drops and reconnects libxmtp's SQLCipher pool, the
-        // production path. In-memory clients no-op those calls (libxmtp
-        // Client.swift:959, 964) and would let regressions in the real
-        // pool teardown slip through. Dedicated lifecycle provider so
-        // this test's notifications stay isolated.
-        let appLifecycle = MockAppLifecycleProvider()
         let stateMachine = SessionStateMachine(
             clientId: clientId,
             identityStore: fixtures.identityStore,
@@ -795,8 +777,8 @@ struct SessionStateMachineTests {
             networkMonitor: networkMonitor,
             overrideJWTToken: "test-jwt-token",
             environment: .tests,
-            appLifecycle: appLifecycle,
-            xmtpClientFactory: .onDisk
+            appLifecycle: testAppLifecycle,
+            xmtpClientFactory: .inMemory
         )
 
         actor StateCollector {
@@ -860,7 +842,7 @@ struct SessionStateMachineTests {
         try await Task.sleep(for: .milliseconds(100))
 
         // Simulate background
-        NotificationCenter.default.post(name: appLifecycle.didEnterBackgroundNotification, object: nil)
+        NotificationCenter.default.post(name: testAppLifecycle.didEnterBackgroundNotification, object: nil)
 
         // Wait for backgrounded
         _ = try await waitForState(stateMachine, timeout: 5) { state in
@@ -869,7 +851,7 @@ struct SessionStateMachineTests {
         }
 
         // Simulate foreground
-        NotificationCenter.default.post(name: appLifecycle.willEnterForegroundNotification, object: nil)
+        NotificationCenter.default.post(name: testAppLifecycle.willEnterForegroundNotification, object: nil)
 
         // Wait for ready again
         _ = try await waitForState(stateMachine, timeout: 5) { state in

--- a/ConvosCore/Tests/ConvosCoreTests/TestHelpers.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/TestHelpers.swift
@@ -194,11 +194,8 @@ class TestFixtures {
     /// Builds a fresh MessagingService for tests that previously used
     /// `UnusedConversationCache.consumeOrCreateMessagingService` as a
     /// bootstrap. Registers a new XMTP identity for the fixture.
-    /// Uses `XMTPClientFactory.inMemory` so libxmtp's pool-management
-    /// surface is inert across parallel tests in the same process.
     func makeFreshMessagingService(
-        platformProviders: PlatformProviders = .mock,
-        xmtpClientFactory: XMTPClientFactory = .inMemory
+        platformProviders: PlatformProviders = .mock
     ) -> MessagingService {
         let authorizationOperation = AuthorizeInboxOperation.register(
             identityStore: identityStore,
@@ -207,8 +204,7 @@ class TestFixtures {
             environment: environment,
             platformProviders: platformProviders,
             deviceRegistrationManager: nil,
-            apiClient: nil,
-            xmtpClientFactory: xmtpClientFactory
+            apiClient: nil
         )
         return MessagingService(
             authorizationOperation: authorizationOperation,

--- a/ConvosCore/Tests/ConvosCoreTests/TestHelpers.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/TestHelpers.swift
@@ -5,46 +5,13 @@ import GRDB
 import Testing
 @preconcurrency import XMTPiOS
 
+// Set custom XMTP endpoint at module load time (before any async code)
+// This runs synchronously when the test module is loaded
+// @preconcurrency import suppresses strict concurrency warnings for XMTP static properties
 private let _configureXMTPEndpoint: Void = {
     if let endpoint = ProcessInfo.processInfo.environment["XMTP_NODE_ADDRESS"] {
         XMTPEnvironment.customLocalAddress = endpoint
     }
-}()
-
-// Rust tracing only flows to os_log on iOS — gated by env var so CI can
-// capture libxmtp output to disk for artifact upload.
-private let _configureXMTPLogging: Void = {
-    let env = ProcessInfo.processInfo.environment
-    guard let levelString = env["CONVOS_TEST_XMTP_LOG_LEVEL"], !levelString.isEmpty else {
-        return
-    }
-
-    let logLevel: Client.LogLevel
-    switch levelString.lowercased() {
-    case "error": logLevel = .error
-    case "warn", "warning": logLevel = .warn
-    case "info": logLevel = .info
-    case "debug": logLevel = .debug
-    default:
-        print("Unknown CONVOS_TEST_XMTP_LOG_LEVEL '\(levelString)', skipping libxmtp log activation")
-        return
-    }
-
-    let directoryURL: URL = if let custom = env["CONVOS_TEST_XMTP_LOG_DIR"], !custom.isEmpty {
-        URL(fileURLWithPath: custom, isDirectory: true)
-    } else {
-        FileManager.default.temporaryDirectory
-            .appendingPathComponent("convos-test-xmtp-logs", isDirectory: true)
-    }
-
-    Client.activatePersistentLibXMTPLogWriter(
-        logLevel: logLevel,
-        rotationSchedule: .never,
-        maxFiles: 5,
-        customLogDirectory: directoryURL
-    )
-
-    print("libxmtp log writer activated at \(directoryURL.path) (level=\(levelString))")
 }()
 
 /// Waits until a condition becomes true, polling at a specified interval
@@ -115,8 +82,7 @@ class TestFixtures {
         PushNotificationRegistrar.resetForTesting()
         PushNotificationRegistrar.configure(MockPushNotificationRegistrarProvider())
 
-        _ = _configureXMTPEndpoint
-        _ = _configureXMTPLogging
+        // XMTP endpoint is configured at module load time via _configureXMTPEndpoint
     }
 
     /// Create a new XMTP client for testing
@@ -124,10 +90,6 @@ class TestFixtures {
         let keys = try await identityStore.generateKeys()
         let clientId = ClientId.generate().value
 
-        // Tests use in-memory libxmtp clients to avoid file-backed pool
-        // contention between parallel test suites. createInMemory ignores
-        // dbDirectory/dbEncryptionKey but the ClientOptions initializer still
-        // requires dbEncryptionKey, so we pass the generated key for shape.
         let clientOptions = ClientOptions(
             api: .init(
                 env: .local,
@@ -148,10 +110,11 @@ class TestFixtures {
                 JoinRequestCodec(),
                 TypingIndicatorCodec()
             ],
-            dbEncryptionKey: keys.databaseKey
+            dbEncryptionKey: keys.databaseKey,
+            dbDirectory: environment.defaultDatabasesDirectory
         )
 
-        let client = try await Client.createInMemory(account: keys.signingKey, options: clientOptions)
+        let client = try await Client.create(account: keys.signingKey, options: clientOptions)
 
         // Save to mock identity store. In the single-inbox model there is only one
         // slot; multi-client fixtures overwrite each other and the tests that rely


### PR DESCRIPTION
## Summary

Reverts #779 (`more test fixes`) and #765 (`bump to latest libxmtp main/fix integration tests`).

PR #783 reverted the libxmtp version pin from 4.10.0 back to 4.9.0 but left the source code calling 4.10.0-only APIs (`Client.createInMemory`, `ClientOptions(dbPoolOptions:)`), breaking the archive build with `type 'Client' has no member 'createInMemory'`. This PR completes the rollback by reverting the source-side changes and restoring the actual 4.9.0 HEAD SHA `899650a4...` in the workspace and `ConvosCore/Package.resolved` (which were stuck at the 4.10.0 SHA `0b4dc376...` after #783).

## Known follow-up

PR #780 (`Fix invite DM push subscriptions`) — not in the requested revert set — added two more `Client.createInMemory(...)` call sites that will still fail to compile against 4.9.0:

- `ConvosCore/Tests/ConvosCoreTests/Integration/InviteCoordinatorIntegrationTests.swift:32`
- `ConvosCore/Tests/ConvosCoreTests/Integration/PushTopicSubscriptionDeniedDMTests.swift:22`

The integration test target won't build until those are switched to `Client.create(...)` (or #780 is also reverted). The production app target should now build.

## Test plan

- [ ] CI archive build (`Convos (Dev)`) succeeds
- [ ] `swift build --package-path ConvosCore` succeeds
- [ ] Integration tests in PR #780 either patched to use `Client.create` or that PR is also reverted

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/784"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Revert libxmtp 4.10.0 bump and remove `XMTPClientFactory` abstraction from `SessionStateMachine`
> - Removes the `XMTPClientFactory` abstraction (on-disk/in-memory variants) from [`SessionStateMachine.swift`](https://github.com/xmtplabs/convos-ios/pull/784/files#diff-88a3691375b11b83b3fa12aab416b078bae5cc77821d7984f2c212efe87dd33e); client creation now always calls `Client.create` and `Client.build` directly.
> - Removes the `xmtpClientFactory` parameter from `AuthorizeInboxOperation`, `MessagingService.authorizedMessagingService`, and related test helpers.
> - Switches test client creation in [`TestHelpers.swift`](https://github.com/xmtplabs/convos-ios/pull/784/files#diff-30cc9de0f0791e7a8631762f4a7590db2b113ca47cb39aab76befa02b71b3eb8) and integration tests from `Client.createInMemory` to `Client.create` with an explicit `dbDirectory`.
> - Removes libxmtp persistent log configuration (`CONVOS_TEST_XMTP_LOG_LEVEL`/`CONVOS_TEST_XMTP_LOG_DIR`) from both the CI workflow and test setup.
> - Behavioral Change: delete flow in `SessionStateMachineTests` now asserts identity is deleted rather than preserved after deletion.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 98c9195.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->