### PR TITLE
Fix ConvosCoreTests build: drop removed Client.createInMemory

### DIFF
--- a/ConvosCore/Tests/ConvosCoreTests/Integration/InviteCoordinatorIntegrationTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/Integration/InviteCoordinatorIntegrationTests.swift
@@ -20,6 +20,9 @@ struct InviteCoordinatorIntegrationTests {
         var keyBytes = [UInt8](repeating: 0, count: 32)
         _ = SecRandomCopyBytes(kSecRandomDefault, 32, &keyBytes)
         let dbKey = Data(keyBytes)
+        let tmpDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
         let options = ClientOptions(
             api: .init(env: .local, appVersion: "convos-tests/1.0.0"),
             codecs: [
@@ -27,9 +30,10 @@ struct InviteCoordinatorIntegrationTests {
                 JoinRequestCodec(),
                 InviteJoinErrorCodec(),
             ],
-            dbEncryptionKey: dbKey
+            dbEncryptionKey: dbKey,
+            dbDirectory: tmpDir.path
         )
-        return try await Client.createInMemory(
+        return try await Client.create(
             account: try PrivateKey.generate(),
             options: options
         )

--- a/ConvosCore/Tests/ConvosCoreTests/Integration/PushTopicSubscriptionDeniedDMTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/Integration/PushTopicSubscriptionDeniedDMTests.swift
@@ -14,12 +14,16 @@ struct PushTopicSubscriptionDeniedDMTests {
         var keyBytes = [UInt8](repeating: 0, count: 32)
         _ = SecRandomCopyBytes(kSecRandomDefault, 32, &keyBytes)
         let dbKey = Data(keyBytes)
+        let tmpDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
         let options = ClientOptions(
             api: .init(env: .local, appVersion: "convos-tests/1.0.0"),
             codecs: [TextCodec()],
-            dbEncryptionKey: dbKey
+            dbEncryptionKey: dbKey,
+            dbDirectory: tmpDir.path
         )
-        return try await Client.createInMemory(
+        return try await Client.create(
             account: try PrivateKey.generate(),
             options: options
         )


### PR DESCRIPTION
PR #780 added two integration test files that called
Client.createInMemory(account:options:), an API introduced by the
libxmtp 4.10 bump in PR #779. PR #784 reverted #779 (and #765) to
restore libxmtp 4.9 but did not also revert the test files in #780,
so ConvosCoreTests has not compiled on dev since.

Replace the removed createInMemory call with Client.create(...) plus a
unique UUID-named tmp directory passed as ClientOptions.dbDirectory.
This matches the existing pattern in TestHelpers.swift. The existing
defer { try? client.deleteLocalDatabase() } cleanup still applies, so
there is no new lifecycle to manage.

Verified: ./dev/test now builds and runs the suite end to end. Both
touched suites pass ("InviteCoordinator Integration Tests", "Push
Topic Subscription Denied DM Tests"). Pre-existing unrelated failures
remain in RestoreManager / ConsumedConversation / ProfilePersistence
(xmtp-stash / identity-table issues) and ConversationStateMachine /
SessionStateMachine — all out of scope for this fix.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/786"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `ConvosCoreTests` build by replacing `Client.createInMemory` with `Client.create`
> `Client.createInMemory` has been removed from the SDK, breaking the test build. The `createClient` helpers in [InviteCoordinatorIntegrationTests.swift](https://github.com/xmtplabs/convos-ios/pull/786/files#diff-93d77f6f0ad34d3eb607a79da30273e314c6d0aa539ec463e4043165ba444c76) and [PushTopicSubscriptionDeniedDMTests.swift](https://github.com/xmtplabs/convos-ios/pull/786/files#diff-87a78ed5b6aa08ee7a8c90655c9912010730c5f3ddb9c1f163a9a5a221fd775d) now create a UUID-named subdirectory under the system temp directory and pass it as `dbDirectory` in `ClientOptions`. Behavioral Change: test clients now use a file-backed database instead of an in-memory one.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5f66d7d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->