### PR TITLE
Fix side-convo invite-tag wipe

### DIFF
--- a/ConvosCore/Sources/ConvosCore/Invites & Custom Metadata/ConversationCustomMetadataError.swift
+++ b/ConvosCore/Sources/ConvosCore/Invites & Custom Metadata/ConversationCustomMetadataError.swift
@@ -9,6 +9,7 @@ enum ConversationCustomMetadataError: Error, LocalizedError {
     case appDataLimitExceeded(limit: Int, actualSize: Int)
     case invalidInviteTag(String)
     case metadataUpdateFailed
+    case refusedToPublishEmptyInviteTag(cachedTag: String)
 
     var errorDescription: String? {
         switch self {
@@ -24,6 +25,8 @@ enum ConversationCustomMetadataError: Error, LocalizedError {
             return "Invalid invite tag: \(tag)"
         case .metadataUpdateFailed:
             return "Failed to update conversation metadata after multiple retries"
+        case .refusedToPublishEmptyInviteTag(let cachedTag):
+            return "Refused to publish empty invite tag (cached non-empty tag: \(cachedTag))"
         }
     }
 }
@@ -39,6 +42,7 @@ extension ConversationCustomMetadataError: DisplayError {
         case .invalidInboxIdHex: return "Invalid profile"
         case .invalidInviteTag: return "Invalid invite tag"
         case .metadataUpdateFailed: return "Update failed"
+        case .refusedToPublishEmptyInviteTag: return "Update failed"
         }
     }
 
@@ -55,6 +59,8 @@ extension ConversationCustomMetadataError: DisplayError {
         case .invalidInviteTag:
             return "Invalid invite tag format"
         case .metadataUpdateFailed:
+            return "Failed to update conversation. Please try again."
+        case .refusedToPublishEmptyInviteTag:
             return "Failed to update conversation. Please try again."
         }
     }

--- a/ConvosCore/Sources/ConvosCore/Invites & Custom Metadata/XMTPGroup+CustomMetadata.swift
+++ b/ConvosCore/Sources/ConvosCore/Invites & Custom Metadata/XMTPGroup+CustomMetadata.swift
@@ -2,7 +2,6 @@ import ConvosAppData
 import Foundation
 import XMTPiOS
 
-// swiftlint:disable:next orphaned_doc_comment
 /// XMTP groups expose an 8 KB `appData` field that Convos uses to store structured
 /// metadata as a compressed, base64-encoded protobuf. This metadata includes:
 /// - Invite tag: Unique identifier linking invites to conversations
@@ -25,7 +24,7 @@ import XMTPiOS
 /// that consults this cache.
 private final class LastObservedInviteTagCache: @unchecked Sendable {
     private var storage: [String: String] = [:]
-    private let lock = NSLock()
+    private let lock: NSLock = NSLock()
 
     func set(_ tag: String, forGroupId groupId: String) {
         lock.lock(); defer { lock.unlock() }
@@ -51,7 +50,12 @@ extension XMTPiOS.Group {
     /// already have.
     private static let lastObservedInviteTagCache: LastObservedInviteTagCache = .init()
 
-    fileprivate static func recordObservedInviteTag(_ tag: String, groupId: String) {
+    /// Records a non-empty invite tag we have observed for a group. Empty tags
+    /// are ignored — caching empty would defeat the post-modify guard. Callable
+    /// from anywhere in ConvosCore so non-XMTP code paths (e.g. local-DB
+    /// writes in `ConversationWriter`) can seed the cache after a cold start
+    /// before any wire read has occurred.
+    static func recordObservedInviteTag(_ tag: String, groupId: String) {
         guard !tag.isEmpty else { return }
         lastObservedInviteTagCache.set(tag, forGroupId: groupId)
     }
@@ -403,7 +407,7 @@ extension XMTPiOS.Group {
                 Log.error(
                     "[MetadataDebug] operation=\(operation) groupId=\(id) attempt=\(attempt + 1) refusing to write — would publish empty-tag metadata but lastObservedInviteTag=\(lastObserved)"
                 )
-                throw ConversationCustomMetadataError.metadataUpdateFailed
+                throw ConversationCustomMetadataError.refusedToPublishEmptyInviteTag(cachedTag: lastObserved)
             }
 
             try await updateMetadata(metadata)
@@ -446,7 +450,7 @@ extension XMTPiOS.Group {
             Log.error(
                 "[MetadataDebug] updateMetadata refusing to publish empty-tag metadata for groupId=\(id) — lastObservedInviteTag=\(lastObserved)"
             )
-            throw ConversationCustomMetadataError.metadataUpdateFailed
+            throw ConversationCustomMetadataError.refusedToPublishEmptyInviteTag(cachedTag: lastObserved)
         }
 
         let encodedMetadata = try metadata.toCompactString()

--- a/ConvosCore/Sources/ConvosCore/Invites & Custom Metadata/XMTPGroup+CustomMetadata.swift
+++ b/ConvosCore/Sources/ConvosCore/Invites & Custom Metadata/XMTPGroup+CustomMetadata.swift
@@ -18,16 +18,55 @@ import XMTPiOS
 ///
 /// This allows Convos to store rich conversation metadata without requiring a backend.
 
+/// Process-wide, thread-safe cache of the last non-empty invite tag we have
+/// ever observed per group. Survives only as long as the process — that is
+/// fine, since the worst case on cold start is the unguarded behavior we
+/// already have. See `XMTPiOS.Group.atomicUpdateMetadata` for the guard
+/// that consults this cache.
+private final class LastObservedInviteTagCache: @unchecked Sendable {
+    private var storage: [String: String] = [:]
+    private let lock = NSLock()
+
+    func set(_ tag: String, forGroupId groupId: String) {
+        lock.lock(); defer { lock.unlock() }
+        storage[groupId] = tag
+    }
+
+    func get(groupId: String) -> String? {
+        lock.lock(); defer { lock.unlock() }
+        return storage[groupId]
+    }
+}
+
 // MARK: - XMTPiOS.Group + CustomMetadata
 
 extension XMTPiOS.Group {
     private static let appDataByteLimit: Int = 8 * 1024
 
+    /// Process-wide cache of the most recent non-empty invite tag we have ever
+    /// observed for each group, keyed by `group.id`. Populated by
+    /// `atomicUpdateMetadata` on every successful read, and consulted by the
+    /// pre-write guard below. Survives only as long as the process — that is
+    /// fine, since the worst case on cold start is the unguarded behavior we
+    /// already have.
+    private static let lastObservedInviteTagCache: LastObservedInviteTagCache = .init()
+
+    fileprivate static func recordObservedInviteTag(_ tag: String, groupId: String) {
+        guard !tag.isEmpty else { return }
+        lastObservedInviteTagCache.set(tag, forGroupId: groupId)
+    }
+
+    fileprivate static func lastObservedInviteTag(groupId: String) -> String? {
+        lastObservedInviteTagCache.get(groupId: groupId)
+    }
+
     var currentCustomMetadata: ConversationCustomMetadata {
         get throws {
             do {
                 let currentAppData = try self.appData()
-                return ConversationCustomMetadata.parseAppData(currentAppData)
+                let parsed = ConversationCustomMetadata.parseAppData(currentAppData)
+                Self.recordObservedInviteTag(parsed.tag, groupId: id)
+                return parsed
             } catch {
                 Log.error("Failed to read custom metadata: \(error)")
                 return .init()
@@ -330,6 +369,11 @@ extension XMTPiOS.Group {
         for attempt in 0..<maxRetries {
             let beforeAppData = try appData()
             let beforeMetadata = ConversationCustomMetadata.parseAppData(beforeAppData)
+
+            // Record any non-empty tag we observe so subsequent writes can
+            // detect a stale empty read and refuse to wipe.
+            Self.recordObservedInviteTag(beforeMetadata.tag, groupId: id)
+
             var metadata = beforeMetadata
             modify(&metadata)
 
@@ -338,6 +382,27 @@ extension XMTPiOS.Group {
             )
             if !beforeMetadata.tag.isEmpty && metadata.tag.isEmpty {
                 Log.error("[MetadataDebug] operation=\(operation) cleared invite tag for groupId=\(id)")
+                throw ConversationCustomMetadataError.metadataUpdateFailed
+            }
+
+            // Post-modify guard: if the read returned empty but the
+            // closure also produced empty (e.g. `updateProfile` only
+            // touches `profiles`), and we have ever observed a non-empty
+            // tag for this group, the wire read is stale and committing
+            // now would publish empty-tag metadata that finalizes the
+            // wipe for every other member. This was the side-convo
+            // failure mode in convos-logs-BD663A2F (8dbded shrunk
+            // 303 → 24 bytes after a peer commit, every later join
+            // request was rejected as `conversationExpired`).
+            //
+            // Legitimate restore paths (e.g. `restoreInviteTagIfMissing`)
+            // set `metadata.tag` inside `modify` and therefore pass.
+            if metadata.tag.isEmpty,
+               let lastObserved = Self.lastObservedInviteTag(groupId: id),
+               !lastObserved.isEmpty {
+                Log.error(
+                    "[MetadataDebug] operation=\(operation) groupId=\(id) attempt=\(attempt + 1) refusing to write — would publish empty-tag metadata but lastObservedInviteTag=\(lastObserved)"
+                )
                 throw ConversationCustomMetadataError.metadataUpdateFailed
             }
 
@@ -366,6 +431,21 @@ extension XMTPiOS.Group {
            !currentTag.isEmpty,
            metadata.tag.isEmpty {
             Log.error("[MetadataDebug] updateMetadata refusing to clear invite tag for groupId=\(id)")
+            throw ConversationCustomMetadataError.metadataUpdateFailed
+        }
+
+        // Second-line guard: if the on-wire read returned empty but we
+        // have ever observed a non-empty tag for this group, refuse to
+        // publish empty-tag metadata. The first-line guard above only
+        // fires when the on-wire read currently returns the non-empty
+        // tag — it cannot detect a wipe that already landed remotely
+        // and is silently propagating through this writer.
+        if metadata.tag.isEmpty,
+           let lastObserved = Self.lastObservedInviteTag(groupId: id),
+           !lastObserved.isEmpty {
+            Log.error(
+                "[MetadataDebug] updateMetadata refusing to publish empty-tag metadata for groupId=\(id) — lastObservedInviteTag=\(lastObserved)"
+            )
             throw ConversationCustomMetadataError.metadataUpdateFailed
         }
 

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationWriter.swift
@@ -569,10 +569,29 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
             Log.debug("Encountered expired conversation for the first time.")
         }
 
+        seedInviteTagCacheIfNeeded(for: conversationToSave)
+
         return ConversationSaveResult(
             clientConversationId: actualClientConversationId,
             oldImageURL: oldImageURL,
             preservedInviteTag: preservedInviteTag
+        )
+    }
+
+    /// Mirror the saved invite tag into the process-wide cache that
+    /// `XMTPGroup.atomicUpdateMetadata` consults. Closes the cold-start
+    /// gap where an invitee receives a welcome with empty appData and
+    /// writes metadata before any wire read populates the cache: the
+    /// local DB is the authoritative record of every tag we have ever
+    /// known, so seeding from here gives the guard a value to compare
+    /// against on the very first write. Skips drafts — their id has no
+    /// matching XMTPiOS.Group.
+    private func seedInviteTagCacheIfNeeded(for conversation: DBConversation) {
+        guard !conversation.inviteTag.isEmpty,
+              !DBConversation.isDraft(id: conversation.id) else { return }
+        XMTPiOS.Group.recordObservedInviteTag(
+            conversation.inviteTag,
+            groupId: conversation.id
         )
     }
 

--- a/ConvosCore/Tests/ConvosCoreTests/Integration/SideConvoInviteTagWipeTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/Integration/SideConvoInviteTagWipeTests.swift
@@ -1,0 +1,168 @@
+@testable import ConvosCore
+import ConvosAppData
+import Foundation
+import GRDB
+import Testing
+@preconcurrency import XMTPiOS
+
+/// Reproduces the side-convo invite-tag wipe observed in
+/// `convos-logs-BD663A2F` and `convos-logs-65D971ED`:
+///
+/// - Creator creates a side convo and stamps an invite tag (`YFqUSVvgLD`
+///   in the captured logs).
+/// - A member added to the side convo immediately runs a metadata write
+///   (`MyProfileWriter.updateProfile` on join). That write goes through
+///   `XMTPGroup.atomicUpdateMetadata`, which reads `appData()` first.
+/// - When that read returns an empty / parse-failed value (silent
+///   fallback in `ConvosAppData.parseAppData` →
+///   `XMTPGroup.currentCustomMetadata`), the closure modifies an empty
+///   `ConversationCustomMetadata`, and the guard at
+///   `XMTPGroup+CustomMetadata.swift:339` does not fire because
+///   `beforeMetadata.tag` itself was empty. The commit is published with
+///   `metadata.tag = ""`, wiping the on-wire tag for everyone.
+/// - Subsequent join attempts using the original invite URL fail with
+///   `InviteJoinError.conversationExpired` because the side convo's
+///   current tag no longer matches the tag baked into the URL.
+///
+/// This test forces the empty-`appData` precondition deterministically
+/// (by writing empty appData from the creator and then syncing the
+/// member) and asserts the **correct** behavior: the member's
+/// metadata write must not wipe the on-wire tag. With the current
+/// code this assertion fails, so the test reproduces the bug; once the
+/// `atomicUpdateMetadata` guard is strengthened (cross-check the local
+/// DB tag and refuse to commit a tag-clear) the test passes.
+@Suite("Side Convo Invite Tag Wipe Tests", .serialized)
+struct SideConvoInviteTagWipeTests {
+    private enum TestError: Error {
+        case missingClients
+    }
+
+    @Test("Member's metadata write must not wipe the side convo invite tag")
+    func memberMetadataWriteMustNotWipeInviteTag() async throws {
+        let fixtures = TestFixtures()
+        try await fixtures.createTestClients()
+
+        guard let clientA = fixtures.clientA as? Client,
+              let clientB = fixtures.clientB as? Client else {
+            throw TestError.missingClients
+        }
+
+        // Creator (A) creates the side convo and stamps an invite tag.
+        let groupA = try await clientA.conversations.newGroup(
+            with: [clientB.inboxID],
+            name: "Side Convo"
+        )
+        try await groupA.ensureInviteTag()
+        let originalTag = try groupA.inviteTag
+        #expect(!originalTag.isEmpty, "ensureInviteTag must produce a non-empty tag")
+
+        // Member (B) syncs and resolves the same group.
+        try await clientB.conversations.sync()
+        let groupB = try #require(
+            try clientB.conversations.listGroups().first { $0.id == groupA.id }
+        )
+        try await groupB.sync()
+
+        // Reproduce the in-the-wild precondition (BD663A2F log: 8dbded's
+        // appData shrunk from 303 → 24 bytes after a peer commit). We
+        // force the on-wire appData to empty — this is the same state
+        // `atomicUpdateMetadata` would observe whenever
+        // `parseAppData` silently fails (decompression error, transient
+        // MLS state lag right after a welcome, corrupt commit) and falls
+        // back to `ConversationCustomMetadata()`.
+        try await groupA.updateAppData(appData: "")
+        try await clientB.conversations.sync()
+        try await groupB.sync()
+
+        // Member runs a benign metadata write — exactly what
+        // `MyProfileWriter.updateProfile` does on join. With the bug
+        // present this commit publishes empty-tag metadata, finalizing
+        // the wipe; every subsequent join with `originalTag` will fail
+        // with `InviteJoinError.conversationExpired`.
+        try await groupB.updateProfile(
+            DBMemberProfile(
+                conversationId: groupB.id,
+                inboxId: clientB.inboxID,
+                name: "Bob",
+                avatar: nil
+            )
+        )
+
+        // Sync the creator and re-read the on-wire tag.
+        try await clientA.conversations.sync()
+        try await groupA.sync()
+        let tagAfterMemberWrite = try groupA.inviteTag
+
+        // After the fix this assertion passes (the member's write is
+        // rejected before it can commit empty-tag metadata). With the
+        // current code the assertion fails — `tagAfterMemberWrite` is
+        // empty, reproducing the bug.
+        #expect(
+            tagAfterMemberWrite == originalTag,
+            """
+            Side convo invite tag was wiped by a member's metadata write.
+            originalTag=\(originalTag)
+            tagAfterMemberWrite=\(tagAfterMemberWrite)
+            Subsequent joins with originalTag will be rejected as
+            InviteJoinError.conversationExpired (see investigation logs
+            convos-logs-BD663A2F).
+            """
+        )
+
+        try? await fixtures.cleanup()
+    }
+
+    /// Direct unit-style coverage of the same defect at the
+    /// `atomicUpdateMetadata` level — no second client required. Reads a
+    /// group whose `appData` was just emptied, runs a metadata write
+    /// (e.g. `updateProfile`) on the local handle, and asserts the
+    /// existing non-empty tag survives. Today this fails for the same
+    /// reason the multi-client test fails: the empty-tag guard at
+    /// `XMTPGroup+CustomMetadata.swift:339` only fires when
+    /// `beforeMetadata.tag` was already non-empty in the read.
+    @Test("Local metadata write on a group whose appData is empty must not wipe a previously-stamped tag")
+    func localMetadataWriteOnEmptyAppDataMustNotWipePreviouslyStampedTag() async throws {
+        let fixtures = TestFixtures()
+        try await fixtures.createTestClients()
+
+        guard let clientA = fixtures.clientA as? Client,
+              let clientB = fixtures.clientB as? Client else {
+            throw TestError.missingClients
+        }
+
+        let group = try await clientA.conversations.newGroup(
+            with: [clientB.inboxID],
+            name: "Side Convo"
+        )
+        try await group.ensureInviteTag()
+        let originalTag = try group.inviteTag
+        #expect(!originalTag.isEmpty)
+
+        // Force `appData` empty from the same client. `atomicUpdateMetadata`
+        // re-reads on every attempt; subsequent writes will see an empty
+        // `beforeMetadata` and the guard at line 339 will not catch the
+        // wipe.
+        try await group.updateAppData(appData: "")
+
+        try await group.updateProfile(
+            DBMemberProfile(
+                conversationId: group.id,
+                inboxId: clientA.inboxID,
+                name: "Alice",
+                avatar: nil
+            )
+        )
+
+        let tagAfterWrite = try group.inviteTag
+        #expect(
+            tagAfterWrite == originalTag,
+            """
+            atomicUpdateMetadata committed an empty-tag write because the
+            stale `appData` read returned an empty `ConversationCustomMetadata`.
+            originalTag=\(originalTag) tagAfterWrite=\(tagAfterWrite)
+            """
+        )
+
+        try? await fixtures.cleanup()
+    }
+}

--- a/ConvosCore/Tests/ConvosCoreTests/Integration/SideConvoInviteTagWipeTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/Integration/SideConvoInviteTagWipeTests.swift
@@ -79,31 +79,43 @@ struct SideConvoInviteTagWipeTests {
         // present this commit publishes empty-tag metadata, finalizing
         // the wipe; every subsequent join with `originalTag` will fail
         // with `InviteJoinError.conversationExpired`.
-        try await groupB.updateProfile(
-            DBMemberProfile(
-                conversationId: groupB.id,
-                inboxId: clientB.inboxID,
-                name: "Bob",
-                avatar: nil
+        //
+        // The fix in `XMTPGroup+CustomMetadata.atomicUpdateMetadata`
+        // refuses the write when the wire read came back empty but we
+        // have a cached non-empty tag (from when B initially synced and
+        // saw the group). The expected outcome is therefore EITHER:
+        //   (a) the write throws, OR
+        //   (b) the write succeeds but the on-wire tag is preserved.
+        // Both satisfy the invariant "a member's write must not wipe
+        // the side convo's invite tag." Today both fail.
+        var memberWriteThrew = false
+        do {
+            try await groupB.updateProfile(
+                DBMemberProfile(
+                    conversationId: groupB.id,
+                    inboxId: clientB.inboxID,
+                    name: "Bob",
+                    avatar: nil
+                )
             )
-        )
+        } catch {
+            memberWriteThrew = true
+        }
 
         // Sync the creator and re-read the on-wire tag.
         try await clientA.conversations.sync()
         try await groupA.sync()
         let tagAfterMemberWrite = try groupA.inviteTag
 
-        // After the fix this assertion passes (the member's write is
-        // rejected before it can commit empty-tag metadata). With the
-        // current code the assertion fails — `tagAfterMemberWrite` is
-        // empty, reproducing the bug.
+        let invariantHolds = memberWriteThrew || (tagAfterMemberWrite == originalTag)
         #expect(
-            tagAfterMemberWrite == originalTag,
+            invariantHolds,
             """
             Side convo invite tag was wiped by a member's metadata write.
             originalTag=\(originalTag)
             tagAfterMemberWrite=\(tagAfterMemberWrite)
-            Subsequent joins with originalTag will be rejected as
+            memberWriteThrew=\(memberWriteThrew)
+            Subsequent joins with originalTag would be rejected as
             InviteJoinError.conversationExpired (see investigation logs
             convos-logs-BD663A2F).
             """
@@ -140,26 +152,34 @@ struct SideConvoInviteTagWipeTests {
 
         // Force `appData` empty from the same client. `atomicUpdateMetadata`
         // re-reads on every attempt; subsequent writes will see an empty
-        // `beforeMetadata` and the guard at line 339 will not catch the
-        // wipe.
+        // `beforeMetadata`. With the fix in place the cached
+        // `lastObservedInviteTag` (populated by `ensureInviteTag` above)
+        // makes `atomicUpdateMetadata` refuse the write rather than
+        // commit empty-tag metadata.
         try await group.updateAppData(appData: "")
 
-        try await group.updateProfile(
-            DBMemberProfile(
-                conversationId: group.id,
-                inboxId: clientA.inboxID,
-                name: "Alice",
-                avatar: nil
+        var writeThrew = false
+        do {
+            try await group.updateProfile(
+                DBMemberProfile(
+                    conversationId: group.id,
+                    inboxId: clientA.inboxID,
+                    name: "Alice",
+                    avatar: nil
+                )
             )
-        )
+        } catch {
+            writeThrew = true
+        }
 
         let tagAfterWrite = try group.inviteTag
+        let invariantHolds = writeThrew || (tagAfterWrite == originalTag)
         #expect(
-            tagAfterWrite == originalTag,
+            invariantHolds,
             """
             atomicUpdateMetadata committed an empty-tag write because the
             stale `appData` read returned an empty `ConversationCustomMetadata`.
-            originalTag=\(originalTag) tagAfterWrite=\(tagAfterWrite)
+            originalTag=\(originalTag) tagAfterWrite=\(tagAfterWrite) writeThrew=\(writeThrew)
             """
         )
 


### PR DESCRIPTION
## Summary

Side-convo invites silently break for the 3rd+ joiner: the side convo is created with tag `T1`, the first one or two members join, then a peer commit shrinks the on-wire `appData` to 24 bytes and rotates the tag to a fresh value. Every later join with the originally-shared invite URL fails with `InviteJoinError.conversationExpired`. Captured in `convos-logs-BD663A2F` (creator) and `convos-logs-65D971ED` (joiner).

**Root cause** is in `ConvosCore/Sources/ConvosCore/Invites & Custom Metadata/XMTPGroup+CustomMetadata.swift`:

- `ConvosAppData.parseAppData` silently returns an empty `ConversationCustomMetadata()` on parse / decompression failures (`ConvosAppData/Sources/ConvosAppData/AppDataSerialization.swift:56-66`).
- `XMTPGroup.currentCustomMetadata` catches `appData()` errors and returns `.init()` (line 26-36).
- `atomicUpdateMetadata`'s empty-tag guard (line 339, before this PR) only fires when `beforeMetadata.tag` was non-empty in the read. A stale empty read followed by a no-op closure (`updateProfile`, `ensureImageEncryptionKey`, `updateExpiresAt`) publishes empty-tag metadata and finalizes the wipe for everyone.

**Fix:** cache the most recent non-empty invite tag we have ever observed per group (`LastObservedInviteTagCache`, process-wide, `NSLock`-protected). Populated by every successful read inside `atomicUpdateMetadata` and `currentCustomMetadata`. After the closure runs, refuse to commit if `metadata.tag` is empty AND the cache has a non-empty entry for this group; `updateMetadata` enforces the same guard for any direct caller. Legitimate restore paths (`restoreInviteTagIfMissing`) set `metadata.tag` inside their modify closure and are unaffected.

Two integration tests in `SideConvoInviteTagWipeTests`:

- `memberMetadataWriteMustNotWipeInviteTag` — full multi-client repro: A creates side convo + tag, A adds B, on-wire `appData` becomes empty, B calls `updateProfile`, original tag must be preserved (or the write must throw).
- `localMetadataWriteOnEmptyAppDataMustNotWipePreviouslyStampedTag` — single-client deterministic variant (no XMTP sync timing involved). Runs in ~110ms.

Both fail before the fix; both pass after. Pre-existing `InviteTagSelfHealingTests.preservesLocalInviteTagWhenIncomingTagIsEmpty` continues to pass — its self-heal path runs through `restoreInviteTagIfMissing` which sets `metadata.tag` inside its modify closure.

## Out of scope

The agent server-side wipe itself (whatever code on the agent published the wiping commit in the captured logs) is in a different repo. This PR is *defense in depth* for the iOS app: it ensures the iOS app never publishes a tag-clearing commit, and prevents it from compounding a peer's wipe on its next metadata write. A follow-on improvement worth considering is a ConversationWriter-level self-heal that calls `restoreInviteTagIfMissing` whenever a remote tag rotation is observed and the local DB still holds the originally-stamped tag — that would recover from a peer wipe rather than just refusing to participate.

## Test plan

- [x] `swift test --package-path ConvosCore --filter SideConvoInviteTagWipeTests` — both new tests pass
- [x] `swift test --package-path ConvosCore --filter InviteTagSelfHealingTests` — pre-existing self-heal test still passes
- [x] Full `swift test --package-path ConvosCore` — 685 tests pass
- [ ] Manual: create a side convo with several invitees, watch the third joiner succeed where they previously failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/789"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix side-convo invite-tag wipe by refusing empty-tag metadata publishes
> - Introduces a process-wide, thread-safe cache (`LastObservedInviteTagCache`) that tracks the last non-empty invite tag per group, seeded from `currentCustomMetadata` reads and conversation saves in [`ConversationWriter`](https://github.com/xmtplabs/convos-ios/pull/789/files#diff-113bfd0c28b1a3b561f19e4574a0937082fe5c92a262e57573eee7728940a726).
> - `atomicUpdateMetadata` and `updateMetadata` in [`XMTPGroup+CustomMetadata.swift`](https://github.com/xmtplabs/convos-ios/pull/789/files#diff-531b5042f2639e0a548e07f4a8bbe3b6e8a8ed4a8e2c9b643211b6d00ba5ec85) now throw `ConversationCustomMetadataError.refusedToPublishEmptyInviteTag` when a metadata write would clear a previously observed non-empty invite tag.
> - Adds integration tests in [`SideConvoInviteTagWipeTests`](https://github.com/xmtplabs/convos-ios/pull/789/files#diff-0eb0fe99ac4c7a965af6e607935950588f44be5939916ff1b46a1ba754e56390) covering member and local metadata write paths that previously wiped invite tags under empty `appData` conditions.
> - Behavioral Change: metadata updates that produce an empty invite tag when a non-empty one was previously observed will now fail with an error instead of silently publishing.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 55f1603.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->