### PR TITLE
Allow sending Files

### DIFF
--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -56,6 +56,7 @@ struct ConversationView<MessagesBottomBar: View>: View {
                 viewModel.updateLinkedConversationName(name)
                 focusCoordinator.endEditing(for: .sideConvoName, context: .quickEditor)
             },
+            pendingFileAttachment: viewModel.pendingFileAttachment,
             sendButtonEnabled: viewModel.sendButtonEnabled,
             profileImage: $viewModel.myProfileViewModel.profileImage,
             onboardingCoordinator: onboardingCoordinator,
@@ -75,6 +76,7 @@ struct ConversationView<MessagesBottomBar: View>: View {
             },
             onClearInvite: viewModel.clearPendingInvite,
             onClearLinkPreview: { viewModel.pastedLinkPreview = nil },
+            onClearFile: viewModel.clearPendingFile,
             onTapAvatar: viewModel.onTapAvatar(_:),
             onTapInvite: viewModel.onTapInvite(_:),
             onReaction: viewModel.onReaction(emoji:messageId:),
@@ -97,6 +99,7 @@ struct ConversationView<MessagesBottomBar: View>: View {
             onPhotoHidden: viewModel.onPhotoHidden(_:),
             onPhotoDimensionsLoaded: viewModel.onPhotoDimensionsLoaded(_:width:height:),
             onVideoSelected: viewModel.onVideoSelected(_:),
+            onFileSelected: viewModel.onFileSelected(url:filename:mimeType:fileSize:),
             onAboutAssistants: { showingAssistantsInfo = true },
             onAgentOutOfCredits: { showingProcessingPowerInfo = true },
             onTapUpdateMember: { viewModel.presentingProfileForMember = $0 },

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -15,6 +15,13 @@ struct PendingInvite {
     var explodeDuration: ExplodeDuration?
 }
 
+struct PendingFileAttachment: Equatable {
+    let url: URL
+    let filename: String
+    let mimeType: String
+    let fileSize: Int
+}
+
 enum ExplodeDuration: CaseIterable {
     case sixtySeconds
     case oneHour
@@ -264,6 +271,7 @@ class ConversationViewModel { // swiftlint:disable:this type_body_length
     private var videoThumbnailTask: Task<Void, Never>?
     var voiceMemoRecorder: VoiceMemoRecorder = VoiceMemoRecorder()
     private(set) var currentEagerUploadKey: String?
+    var pendingFileAttachment: PendingFileAttachment?
     var canRemoveMembers: Bool {
         conversation.creator.isCurrentUser
     }
@@ -316,7 +324,11 @@ class ConversationViewModel { // swiftlint:disable:this type_body_length
     var pendingInviteImage: UIImage?
 
     var sendButtonEnabled: Bool {
-        !messageText.isEmpty || selectedAttachmentImage != nil || pendingInvite != nil || pastedLinkPreview != nil
+        !messageText.isEmpty
+            || selectedAttachmentImage != nil
+            || pendingInvite != nil
+            || pastedLinkPreview != nil
+            || pendingFileAttachment != nil
     }
     private(set) var isSendingPhoto: Bool = false
     var explodeState: ExplodeState = .ready
@@ -885,6 +897,25 @@ extension ConversationViewModel {
         onDisplayNameEndedEditing(focusCoordinator: focusCoordinator, context: .editProfile)
     }
 
+    func onFileSelected(url: URL, filename: String, mimeType: String, fileSize: Int) {
+        if let existing = pendingFileAttachment {
+            try? FileManager.default.removeItem(at: existing.url)
+        }
+        pendingFileAttachment = PendingFileAttachment(
+            url: url,
+            filename: filename,
+            mimeType: mimeType,
+            fileSize: fileSize
+        )
+    }
+
+    func clearPendingFile() {
+        if let existing = pendingFileAttachment {
+            try? FileManager.default.removeItem(at: existing.url)
+        }
+        pendingFileAttachment = nil
+    }
+
     func onVideoSelected(_ url: URL) {
         selectedVideoURL = url
         videoThumbnailTask?.cancel()
@@ -983,7 +1014,7 @@ extension ConversationViewModel {
 
     func onSendMessage(focusCoordinator: FocusCoordinator) {
         let hasText = !messageText.isEmpty
-        let hasAttachment = selectedAttachmentImage != nil || selectedVideoURL != nil
+        let hasAttachment = selectedAttachmentImage != nil || selectedVideoURL != nil || pendingFileAttachment != nil
         let hasInvite = pendingInvite != nil
         let hasLinkPreview = pastedLinkPreview != nil
 
@@ -1000,6 +1031,7 @@ extension ConversationViewModel {
         let sideConvoImage = pendingInviteImage
         let prevLinkURL = pastedLinkPreview?.url
         let prevVideoURL = selectedVideoURL
+        let prevFileAttachment = pendingFileAttachment
 
         stopTyping()
         messageText = ""
@@ -1012,6 +1044,7 @@ extension ConversationViewModel {
         pendingInviteConvoName = ""
         pendingInviteImage = nil
         pastedLinkPreview = nil
+        pendingFileAttachment = nil
         focusCoordinator.endEditing(for: .message, context: .conversation)
 
         let messageWriter = cachedMessageWriter
@@ -1034,6 +1067,7 @@ extension ConversationViewModel {
                 let photoTrackingKey = try await sendAttachmentIfNeeded(
                     videoURL: prevVideoURL,
                     attachmentImage: prevAttachmentImage,
+                    fileAttachment: prevFileAttachment,
                     eagerUploadKey: eagerUploadKey,
                     replyTarget: replyTarget,
                     messageWriter: messageWriter
@@ -1138,11 +1172,20 @@ extension ConversationViewModel {
     private func sendAttachmentIfNeeded(
         videoURL: URL?,
         attachmentImage: UIImage?,
+        fileAttachment: PendingFileAttachment?,
         eagerUploadKey: String?,
         replyTarget: AnyMessage?,
         messageWriter: any OutgoingMessageWriterProtocol
     ) async throws -> String? {
-        if let videoURL {
+        if let fileAttachment {
+            defer { try? FileManager.default.removeItem(at: fileAttachment.url) }
+            return try await messageWriter.sendFile(
+                at: fileAttachment.url,
+                filename: fileAttachment.filename,
+                mimeType: fileAttachment.mimeType,
+                replyToMessageId: replyTarget?.messageId
+            )
+        } else if let videoURL {
             isSendingPhoto = true
             return try await messageWriter.sendVideo(at: videoURL, replyToMessageId: replyTarget?.messageId)
         } else if attachmentImage != nil {

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -901,6 +901,14 @@ extension ConversationViewModel {
         if let existing = pendingFileAttachment {
             try? FileManager.default.removeItem(at: existing.url)
         }
+        // Files are mutually exclusive with photos and videos in send-time
+        // dispatch, so clear any staged photo/video here to avoid silently
+        // dropping it when the user taps Send. Setting selectedAttachmentImage
+        // to nil triggers the onChange in ConversationView which calls
+        // onPhotoRemoved and cancels any in-flight eager photo upload.
+        selectedAttachmentImage = nil
+        selectedVideoURL = nil
+        selectedVideoThumbnail = nil
         pendingFileAttachment = PendingFileAttachment(
             url: url,
             filename: filename,
@@ -917,6 +925,9 @@ extension ConversationViewModel {
     }
 
     func onVideoSelected(_ url: URL) {
+        if pendingFileAttachment != nil {
+            clearPendingFile()
+        }
         selectedVideoURL = url
         videoThumbnailTask?.cancel()
         videoThumbnailTask = Task {
@@ -1315,6 +1326,9 @@ extension ConversationViewModel {
     }
 
     func onPhotoSelected(_ image: UIImage) {
+        if pendingFileAttachment != nil {
+            clearPendingFile()
+        }
         let messageWriter = cachedMessageWriter
         if let existingKey = currentEagerUploadKey {
             currentEagerUploadKey = nil

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesBottomBar.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesBottomBar.swift
@@ -2,9 +2,33 @@ import ConvosCore
 import ConvosCoreiOS
 import PhotosUI
 import SwiftUI
+import UniformTypeIdentifiers
 
 enum MessagesViewInputFocus: Hashable {
     case message, displayName, conversationName, voiceMemoRecording, sideConvoName
+}
+
+private let maxFileAttachmentSizeBytes: Int = 20 * 1024 * 1024
+
+private struct FilePickerModifier: ViewModifier {
+    @Binding var isPresented: Bool
+    @Binding var showTooLargeAlert: Bool
+    let onResult: (Result<[URL], Error>) -> Void
+
+    func body(content: Content) -> some View {
+        content
+            .fileImporter(
+                isPresented: $isPresented,
+                allowedContentTypes: [.item],
+                allowsMultipleSelection: false,
+                onCompletion: onResult
+            )
+            .alert("File too large", isPresented: $showTooLargeAlert) {
+                Button("OK", role: .cancel) {}
+            } message: {
+                Text("Files must be 20 MB or smaller.")
+            }
+    }
 }
 
 struct MessagesBottomBar<BottomBarContent: View>: View {
@@ -22,6 +46,7 @@ struct MessagesBottomBar<BottomBarContent: View>: View {
     var pendingInviteExplodeDuration: ExplodeDuration?
     var onSetInviteExplodeDuration: ((ExplodeDuration?) -> Void)?
     var onInviteConvoNameEditingEnded: ((String) -> Void)?
+    var pendingFileAttachment: PendingFileAttachment?
     let sendButtonEnabled: Bool
     @Binding var profileImage: UIImage?
     @Binding var isPhotoPickerPresented: Bool
@@ -33,8 +58,10 @@ struct MessagesBottomBar<BottomBarContent: View>: View {
     let onSendMessage: () -> Void
     let onClearInvite: () -> Void
     let onClearLinkPreview: () -> Void
+    let onClearFile: () -> Void
     let onDisplayNameEndedEditing: () -> Void
     let onVideoSelected: (URL) -> Void
+    let onFileSelected: (URL, String, String, Int) -> Void
     let onProfileSettings: () -> Void
     let onVoiceMemoTap: () -> Void
     @Bindable var voiceMemoRecorder: VoiceMemoRecorder
@@ -50,6 +77,8 @@ struct MessagesBottomBar<BottomBarContent: View>: View {
     @State private var isMessageInputFocused: Bool = false
     @State private var isImagePickerPresented: Bool = false
     @State private var isCameraPresented: Bool = false
+    @State private var isFilePickerPresented: Bool = false
+    @State private var showFileTooLargeAlert: Bool = false
     @State private var selectedPhoto: PhotosPickerItem?
     @State private var previousFocus: MessagesViewInputFocus?
     @State private var voiceMemoReturnFocus: MessagesViewInputFocus?
@@ -61,6 +90,12 @@ struct MessagesBottomBar<BottomBarContent: View>: View {
     }
 
     var body: some View {
+        bodyContent
+            .modifier(filePickerModifier)
+    }
+
+    @ViewBuilder
+    private var bodyContent: some View {
         VStack(spacing: 0) {
             bottomBarContent()
             VoiceMemoKeyboardFocusKeeper(
@@ -153,6 +188,59 @@ struct MessagesBottomBar<BottomBarContent: View>: View {
             )
             .ignoresSafeArea()
         }
+    }
+
+    private var filePickerModifier: FilePickerModifier {
+        FilePickerModifier(
+            isPresented: $isFilePickerPresented,
+            showTooLargeAlert: $showFileTooLargeAlert,
+            onResult: handleFileImporterResult
+        )
+    }
+
+    private func handleFileImporterResult(_ result: Result<[URL], Error>) {
+        switch result {
+        case .success(let urls):
+            guard let url = urls.first else { return }
+            stageFile(at: url)
+        case .failure(let error):
+            Log.error("File picker error: \(error)")
+        }
+    }
+
+    private func stageFile(at sourceURL: URL) {
+        let didStartAccess = sourceURL.startAccessingSecurityScopedResource()
+        defer {
+            if didStartAccess {
+                sourceURL.stopAccessingSecurityScopedResource()
+            }
+        }
+
+        let attributes = try? FileManager.default.attributesOfItem(atPath: sourceURL.path)
+        let fileSize = (attributes?[.size] as? NSNumber)?.intValue ?? 0
+        guard fileSize > 0 else {
+            Log.error("File picker: failed to read file size for \(sourceURL.lastPathComponent)")
+            return
+        }
+        guard fileSize <= maxFileAttachmentSizeBytes else {
+            showFileTooLargeAlert = true
+            return
+        }
+
+        let tempURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(UUID().uuidString)-\(sourceURL.lastPathComponent)")
+        do {
+            try FileManager.default.copyItem(at: sourceURL, to: tempURL)
+        } catch {
+            Log.error("Failed to copy picked file to temp: \(error)")
+            return
+        }
+
+        let mimeType = UTType(filenameExtension: sourceURL.pathExtension)?.preferredMIMEType
+            ?? "application/octet-stream"
+
+        onFileSelected(tempURL, sourceURL.lastPathComponent, mimeType, fileSize)
+        focusCoordinator.moveFocus(to: .message)
     }
 
     private var isVoiceMemoActive: Bool {
@@ -255,6 +343,9 @@ struct MessagesBottomBar<BottomBarContent: View>: View {
                     isPhotoPickerPresented: $isPhotoPickerPresented,
                     isCameraPresented: $isCameraPresented,
                     onVoiceMemoTap: startVoiceMemoRecording,
+                    onFilePickerTap: {
+                        isFilePickerPresented = true
+                    },
                     onConvosAction: {
                         guard pendingInviteURL == nil else { return }
                         withAnimation(.bouncy(duration: 0.4, extraBounce: 0.01)) {
@@ -288,6 +379,7 @@ struct MessagesBottomBar<BottomBarContent: View>: View {
                 pendingInviteExplodeDuration: pendingInviteExplodeDuration,
                 onSetInviteExplodeDuration: onSetInviteExplodeDuration,
                 onInviteConvoNameEditingEnded: onInviteConvoNameEditingEnded,
+                pendingFileAttachment: pendingFileAttachment,
                 sendButtonEnabled: sendButtonEnabled,
                 focusState: $focusState,
                 animateAvatarForProfileSetup: onboardingCoordinator.shouldAnimateAvatarForProfileSetup,
@@ -297,7 +389,8 @@ struct MessagesBottomBar<BottomBarContent: View>: View {
                 onProfilePhotoTap: onProfilePhotoTap,
                 onSendMessage: onSendMessage,
                 onClearInvite: onClearInvite,
-                onClearLinkPreview: onClearLinkPreview
+                onClearLinkPreview: onClearLinkPreview,
+                onClearFile: onClearFile
             )
             .opacity(messagesTextFieldEnabled ? 1.0 : 0.4)
             .fixedSize(horizontal: false, vertical: true)
@@ -419,10 +512,12 @@ struct MessagesBottomBar<BottomBarContent: View>: View {
             onSendMessage: {},
             onClearInvite: { pendingInviteURLPreview = nil },
             onClearLinkPreview: {},
+            onClearFile: {},
             onDisplayNameEndedEditing: {
                 focusCoordinator.endEditing(for: .displayName)
             },
             onVideoSelected: { _ in },
+            onFileSelected: { _, _, _, _ in },
             onProfileSettings: {},
             onVoiceMemoTap: {},
             voiceMemoRecorder: VoiceMemoRecorder(),

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesInputView.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesInputView.swift
@@ -19,6 +19,7 @@ struct MessagesInputView: View {
     var pendingInviteExplodeDuration: ExplodeDuration?
     var onSetInviteExplodeDuration: ((ExplodeDuration?) -> Void)?
     var onInviteConvoNameEditingEnded: ((String) -> Void)?
+    var pendingFileAttachment: PendingFileAttachment?
     let sendButtonEnabled: Bool
     @FocusState.Binding var focusState: MessagesViewInputFocus?
     let animateAvatarForProfileSetup: Bool
@@ -30,10 +31,12 @@ struct MessagesInputView: View {
     let onSendMessage: () -> Void
     let onClearInvite: () -> Void
     var onClearLinkPreview: (() -> Void)?
+    var onClearFile: (() -> Void)?
 
     private let attachmentPreviewSize: CGFloat = 80.0
     @State private var isPoofing: Bool = false
     @State private var isPoofingInvite: Bool = false
+    @State private var isPoofingFile: Bool = false
 
     static var defaultHeight: CGFloat {
         32.0
@@ -58,7 +61,10 @@ struct MessagesInputView: View {
     }
 
     private var hasAttachments: Bool {
-        selectedAttachmentImage != nil || pendingInviteURL != nil || composerLinkPreview != nil
+        selectedAttachmentImage != nil
+            || pendingInviteURL != nil
+            || composerLinkPreview != nil
+            || pendingFileAttachment != nil
     }
 
     private var avatarButton: some View {
@@ -158,12 +164,59 @@ struct MessagesInputView: View {
                 if let composerLinkPreview {
                     linkPreviewAttachment(preview: composerLinkPreview)
                 }
+                if let pendingFileAttachment {
+                    fileAttachmentPreview(file: pendingFileAttachment)
+                }
             }
             .padding(.horizontal, DesignConstants.Spacing.step2x)
             .padding(.bottom, DesignConstants.Spacing.step2x)
         }
         .scrollClipDisabled()
         .padding(.horizontal, -DesignConstants.Spacing.step2x)
+    }
+
+    @ViewBuilder
+    private func fileAttachmentPreview(file: PendingFileAttachment) -> some View {
+        ZStack(alignment: .topTrailing) {
+            FileAttachmentRow(
+                filename: file.filename,
+                mimeType: file.mimeType,
+                fileSize: file.fileSize
+            )
+            .padding(.horizontal, DesignConstants.Spacing.step3x)
+            .padding(.vertical, DesignConstants.Spacing.step2x)
+            .frame(maxWidth: 240.0)
+            .background(.colorFillSubtle)
+            .clipShape(.rect(cornerRadius: DesignConstants.Spacing.step4x))
+            .scaleEffect(isPoofingFile ? 1.3 : 1.0)
+            .blur(radius: isPoofingFile ? 12.0 : 0.0)
+            .opacity(isPoofingFile ? 0.0 : 1.0)
+            .accessibilityElement(children: .contain)
+            .accessibilityIdentifier("file-attachment-preview")
+
+            Button {
+                withAnimation(.easeOut(duration: 0.2)) {
+                    isPoofingFile = true
+                }
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+                    onClearFile?()
+                    isPoofingFile = false
+                }
+            } label: {
+                Image(systemName: "xmark")
+                    .font(.system(size: 10.0, weight: .bold))
+                    .foregroundStyle(.white)
+                    .frame(width: 20.0, height: 20.0)
+                    .background(.black)
+                    .clipShape(.circle)
+                    .overlay(Circle().stroke(.white.opacity(0.6), lineWidth: 1.0))
+            }
+            .opacity(isPoofingFile ? 0.0 : 1.0)
+            .padding(.top, DesignConstants.Spacing.step2x)
+            .padding(.trailing, DesignConstants.Spacing.step2x)
+            .accessibilityLabel("Remove file attachment")
+            .accessibilityIdentifier("remove-file-attachment-button")
+        }
     }
 
     @ViewBuilder

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesMediaInputView.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesMediaInputView.swift
@@ -4,6 +4,7 @@ struct MessagesMediaButtonsView: View {
     @Binding var isPhotoPickerPresented: Bool
     @Binding var isCameraPresented: Bool
     let onVoiceMemoTap: () -> Void
+    let onFilePickerTap: () -> Void
     let onConvosAction: () -> Void
     var isSideConvoDisabled: Bool = false
 
@@ -49,6 +50,19 @@ struct MessagesMediaButtonsView: View {
             .accessibilityIdentifier("voice-memo-button")
 
             Button {
+                onFilePickerTap()
+            } label: {
+                Image(systemName: "document.fill")
+                    .font(.system(size: 18.0, weight: .medium))
+                    .foregroundStyle(Color.colorTextPrimary)
+                    .frame(width: Constant.buttonSize, height: Constant.buttonSize)
+                    .contentShape(.circle)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Attach file")
+            .accessibilityIdentifier("file-picker-button")
+
+            Button {
                 onConvosAction()
             } label: {
                 Image("convosOrangeIcon")
@@ -84,6 +98,7 @@ struct MessagesMediaButtonsView: View {
         isPhotoPickerPresented: $isPhotoPickerPresented,
         isCameraPresented: $isCameraPresented,
         onVoiceMemoTap: {},
+        onFilePickerTap: {},
         onConvosAction: {}
     )
     .padding()

--- a/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/FileAttachmentBubble.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/FileAttachmentBubble.swift
@@ -9,9 +9,6 @@ struct FileAttachmentBubble: View {
     let profile: Profile
 
     var body: some View {
-        let trailingPadding: CGFloat = isOutgoing
-            ? DesignConstants.Spacing.step5x
-            : DesignConstants.Spacing.step3x
         MessageContainer(style: style, isOutgoing: isOutgoing) {
             FileAttachmentRow(
                 filename: attachment.filename,
@@ -20,8 +17,7 @@ struct FileAttachmentBubble: View {
                 fileTypeLabel: attachment.fileTypeLabel,
                 isOutgoing: isOutgoing
             )
-            .padding(.leading, DesignConstants.Spacing.step3x)
-            .padding(.trailing, trailingPadding)
+            .padding(.horizontal, DesignConstants.Spacing.step3x)
             .padding(.vertical, DesignConstants.Spacing.step2x)
         }
         .accessibilityIdentifier("file-attachment-bubble")

--- a/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/FileAttachmentBubble.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/FileAttachmentBubble.swift
@@ -17,7 +17,8 @@ struct FileAttachmentBubble: View {
                 fileTypeLabel: attachment.fileTypeLabel,
                 isOutgoing: isOutgoing
             )
-            .padding(.horizontal, DesignConstants.Spacing.step3x)
+            .padding(.leading, DesignConstants.Spacing.step3x)
+            .padding(.trailing, DesignConstants.Spacing.step4x)
             .padding(.vertical, DesignConstants.Spacing.step2x)
         }
         .accessibilityIdentifier("file-attachment-bubble")

--- a/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/FileAttachmentBubble.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/FileAttachmentBubble.swift
@@ -9,6 +9,9 @@ struct FileAttachmentBubble: View {
     let profile: Profile
 
     var body: some View {
+        let trailingPadding: CGFloat = isOutgoing
+            ? DesignConstants.Spacing.step5x
+            : DesignConstants.Spacing.step3x
         MessageContainer(style: style, isOutgoing: isOutgoing) {
             FileAttachmentRow(
                 filename: attachment.filename,
@@ -18,7 +21,7 @@ struct FileAttachmentBubble: View {
                 isOutgoing: isOutgoing
             )
             .padding(.leading, DesignConstants.Spacing.step3x)
-            .padding(.trailing, DesignConstants.Spacing.step4x)
+            .padding(.trailing, trailingPadding)
             .padding(.vertical, DesignConstants.Spacing.step2x)
         }
         .accessibilityIdentifier("file-attachment-bubble")

--- a/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/FileAttachmentBubble.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/FileAttachmentBubble.swift
@@ -8,6 +8,30 @@ struct FileAttachmentBubble: View {
     let isOutgoing: Bool
     let profile: Profile
 
+    var body: some View {
+        MessageContainer(style: style, isOutgoing: isOutgoing) {
+            FileAttachmentRow(
+                filename: attachment.filename,
+                mimeType: attachment.mimeType,
+                fileSize: attachment.fileSize,
+                fileTypeLabel: attachment.fileTypeLabel,
+                isOutgoing: isOutgoing
+            )
+            .padding(.horizontal, DesignConstants.Spacing.step3x)
+            .padding(.vertical, DesignConstants.Spacing.step2x)
+        }
+        .accessibilityIdentifier("file-attachment-bubble")
+        .accessibilityLabel("File: \(attachment.filename ?? "Unknown file")")
+    }
+}
+
+struct FileAttachmentRow: View {
+    let filename: String?
+    let mimeType: String?
+    let fileSize: Int?
+    var fileTypeLabel: String?
+    var isOutgoing: Bool = false
+
     private var textColor: Color {
         isOutgoing ? .colorTextPrimaryInverted : .colorTextPrimary
     }
@@ -24,52 +48,52 @@ struct FileAttachmentBubble: View {
         isOutgoing ? .colorTextPrimaryInverted.opacity(0.8) : .secondary
     }
 
-    var body: some View {
-        MessageContainer(style: style, isOutgoing: isOutgoing) {
-            HStack(spacing: DesignConstants.Spacing.step2x) {
-                fileIcon
-                    .frame(width: 44, height: 44)
-                    .accessibilityIdentifier("file-attachment-icon")
-
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(displayFilename)
-                        .font(.subheadline.weight(.semibold))
-                        .foregroundStyle(textColor)
-                        .lineLimit(2)
-                        .accessibilityIdentifier("file-attachment-filename")
-
-                    Text(subtitleText)
-                        .font(.caption)
-                        .foregroundStyle(secondaryTextColor)
-                        .lineLimit(1)
-                        .accessibilityIdentifier("file-attachment-subtitle")
-                }
-            }
-            .padding(.horizontal, DesignConstants.Spacing.step3x)
-            .padding(.vertical, DesignConstants.Spacing.step2x)
-        }
-        .accessibilityIdentifier("file-attachment-bubble")
-        .accessibilityLabel("File: \(displayFilename)")
+    private var displayFilename: String {
+        filename ?? "Unknown file"
     }
 
-    private var displayFilename: String {
-        attachment.filename ?? "Unknown file"
+    private var filenameExtension: String? {
+        guard let filename, let dotIndex = filename.lastIndex(of: ".") else { return nil }
+        let ext = filename[filename.index(after: dotIndex)...]
+        return ext.isEmpty ? nil : String(ext).lowercased()
     }
 
     private var subtitleText: String {
         var parts: [String] = []
-        if let label = attachment.fileTypeLabel {
-            parts.append(label)
-        } else if let ext = attachment.filenameExtension {
+        if let fileTypeLabel {
+            parts.append(fileTypeLabel)
+        } else if let ext = filenameExtension {
             parts.append(ext.uppercased())
         }
-        if let size = attachment.fileSize {
-            parts.append(ByteCountFormatter.string(fromByteCount: Int64(size), countStyle: .file))
+        if let fileSize {
+            parts.append(ByteCountFormatter.string(fromByteCount: Int64(fileSize), countStyle: .file))
         }
         if parts.isEmpty {
             return "File"
         }
         return parts.joined(separator: " · ")
+    }
+
+    var body: some View {
+        HStack(spacing: DesignConstants.Spacing.step2x) {
+            fileIcon
+                .frame(width: 44, height: 44)
+                .accessibilityIdentifier("file-attachment-icon")
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(displayFilename)
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(textColor)
+                    .lineLimit(2)
+                    .accessibilityIdentifier("file-attachment-filename")
+
+                Text(subtitleText)
+                    .font(.caption)
+                    .foregroundStyle(secondaryTextColor)
+                    .lineLimit(1)
+                    .accessibilityIdentifier("file-attachment-subtitle")
+            }
+        }
     }
 
     @ViewBuilder
@@ -84,7 +108,7 @@ struct FileAttachmentBubble: View {
     }
 
     private var fileIconSymbol: String {
-        if let ext = attachment.filenameExtension {
+        if let ext = filenameExtension {
             switch ext {
             case "pdf":
                 return "doc.text.fill"
@@ -113,7 +137,7 @@ struct FileAttachmentBubble: View {
             }
         }
 
-        if let mimeType = attachment.mimeType {
+        if let mimeType {
             if mimeType.hasPrefix("text/") { return "doc.plaintext.fill" }
             if mimeType.hasPrefix("application/json") { return "curlybraces" }
             if mimeType.hasPrefix("application/pdf") { return "doc.text.fill" }

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
@@ -307,6 +307,7 @@ struct MessagesGroupItemView: View {
                 isOutgoing: message.sender.isCurrentUser,
                 profile: message.sender.profile
             )
+            .padding(.trailing, message.sender.isCurrentUser ? DesignConstants.Spacing.step4x : 0)
             .messageGesture(
                 message: message,
                 bubbleStyle: bubbleType,

--- a/Convos/Conversation Detail/Messages/MessagesView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesView.swift
@@ -29,6 +29,7 @@ struct MessagesView<BottomBarContent: View>: View {
     var pendingInviteExplodeDuration: ExplodeDuration?
     var onSetInviteExplodeDuration: ((ExplodeDuration?) -> Void)?
     var onInviteConvoNameEditingEnded: ((String) -> Void)?
+    var pendingFileAttachment: PendingFileAttachment?
     let sendButtonEnabled: Bool
     @Binding var profileImage: UIImage?
     let onboardingCoordinator: ConversationOnboardingCoordinator
@@ -40,6 +41,7 @@ struct MessagesView<BottomBarContent: View>: View {
     let onSendMessage: () -> Void
     let onClearInvite: () -> Void
     let onClearLinkPreview: () -> Void
+    let onClearFile: () -> Void
     let onTapAvatar: (ConversationMember) -> Void
     let onTapInvite: (MessageInvite) -> Void
     let onReaction: (String, String) -> Void
@@ -57,6 +59,7 @@ struct MessagesView<BottomBarContent: View>: View {
     let onPhotoHidden: (String) -> Void
     let onPhotoDimensionsLoaded: (String, Int, Int) -> Void
     let onVideoSelected: (URL) -> Void
+    let onFileSelected: (URL, String, String, Int) -> Void
     let onAboutAssistants: () -> Void
     let onAgentOutOfCredits: () -> Void
     let onTapUpdateMember: (ConversationMember) -> Void
@@ -138,6 +141,7 @@ struct MessagesView<BottomBarContent: View>: View {
                 pendingInviteExplodeDuration: pendingInviteExplodeDuration,
                 onSetInviteExplodeDuration: onSetInviteExplodeDuration,
                 onInviteConvoNameEditingEnded: onInviteConvoNameEditingEnded,
+                pendingFileAttachment: pendingFileAttachment,
                 sendButtonEnabled: sendButtonEnabled,
                 profileImage: $profileImage,
                 isPhotoPickerPresented: $isPhotoPickerPresented,
@@ -152,8 +156,10 @@ struct MessagesView<BottomBarContent: View>: View {
                 },
                 onClearInvite: onClearInvite,
                 onClearLinkPreview: onClearLinkPreview,
+                onClearFile: onClearFile,
                 onDisplayNameEndedEditing: onDisplayNameEndedEditing,
                 onVideoSelected: onVideoSelected,
+                onFileSelected: onFileSelected,
                 onProfileSettings: onProfileSettings,
                 onVoiceMemoTap: onVoiceMemoTap,
                 voiceMemoRecorder: voiceMemoRecorder,

--- a/ConvosCore/Sources/ConvosCore/Inboxes/ConversationStateMachine.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/ConversationStateMachine.swift
@@ -282,6 +282,11 @@ public actor ConversationStateMachine {
         return try await writer.sendVoiceMemo(at: fileURL, duration: duration, waveformLevels: waveformLevels, replyToMessageId: replyToMessageId)
     }
 
+    func sendFile(at fileURL: URL, filename: String, mimeType: String, replyToMessageId: String? = nil) async throws -> String {
+        let writer = try await getOrCreateMessageWriter()
+        return try await writer.sendFile(at: fileURL, filename: filename, mimeType: mimeType, replyToMessageId: replyToMessageId)
+    }
+
     func sendReply(text: String, toMessageWithClientId parentClientMessageId: String) async throws {
         let writer = try await getOrCreateMessageWriter()
         try await writer.sendReply(text: text, toMessageWithClientId: parentClientMessageId)

--- a/ConvosCore/Sources/ConvosCore/Mocks/MockConversationStateManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Mocks/MockConversationStateManager.swift
@@ -103,6 +103,7 @@ public final class MockConversationStateManager: ConversationStateManagerProtoco
     public func cancelEagerUpload(trackingKey: String) async {}
     public func sendVideo(at fileURL: URL, replyToMessageId: String?) async throws -> String { UUID().uuidString }
     public func sendVoiceMemo(at fileURL: URL, duration: TimeInterval, waveformLevels: [Float]?, replyToMessageId: String?) async throws -> String { UUID().uuidString }
+    public func sendFile(at fileURL: URL, filename: String, mimeType: String, replyToMessageId: String?) async throws -> String { UUID().uuidString }
     public func sendReply(text: String, toMessageWithClientId parentClientMessageId: String) async throws {}
     public func sendEagerPhotoReply(trackingKey: String, toMessageWithClientId parentClientMessageId: String) async throws {}
     public func sendReply(text: String, afterPhoto trackingKey: String?, toMessageWithClientId parentClientMessageId: String) async throws {}

--- a/ConvosCore/Sources/ConvosCore/Mocks/MockOutgoingMessageWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Mocks/MockOutgoingMessageWriter.swift
@@ -50,6 +50,10 @@ public final class MockOutgoingMessageWriter: OutgoingMessageWriterProtocol, @un
         return UUID().uuidString
     }
 
+    public func sendFile(at fileURL: URL, filename: String, mimeType: String, replyToMessageId: String?) async throws -> String {
+        return UUID().uuidString
+    }
+
     public func sendReply(text: String, toMessageWithClientId parentClientMessageId: String) async throws {
         try await send(text: text)
     }

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationStateManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationStateManager.swift
@@ -235,6 +235,10 @@ public final class ConversationStateManager: ConversationStateManagerProtocol, @
         try await stateMachine.sendVoiceMemo(at: fileURL, duration: duration, waveformLevels: waveformLevels, replyToMessageId: replyToMessageId)
     }
 
+    public func sendFile(at fileURL: URL, filename: String, mimeType: String, replyToMessageId: String?) async throws -> String {
+        try await stateMachine.sendFile(at: fileURL, filename: filename, mimeType: mimeType, replyToMessageId: replyToMessageId)
+    }
+
     public func sendReply(text: String, toMessageWithClientId parentClientMessageId: String) async throws {
         try await stateMachine.sendReply(text: text, toMessageWithClientId: parentClientMessageId)
     }

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/OutgoingMessageWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/OutgoingMessageWriter.swift
@@ -33,6 +33,9 @@ public protocol OutgoingMessageWriterProtocol: Sendable {
     /// Send a voice memo from a local audio file URL.
     func sendVoiceMemo(at fileURL: URL, duration: TimeInterval, waveformLevels: [Float]?, replyToMessageId: String?) async throws -> String
 
+    /// Send a generic file attachment from a local file URL.
+    func sendFile(at fileURL: URL, filename: String, mimeType: String, replyToMessageId: String?) async throws -> String
+
     /// Send a text reply to an existing message.
     func sendReply(text: String, toMessageWithClientId parentClientMessageId: String) async throws
 
@@ -738,6 +741,19 @@ actor OutgoingMessageWriter: OutgoingMessageWriterProtocol {
             duration: duration,
             waveformLevels: waveformLevels,
             mediaTypeLabel: "voice_memo"
+        )
+
+        return try await sendFileAttachment(params: params, replyToMessageId: replyToMessageId)
+    }
+
+    // MARK: - File
+
+    func sendFile(at fileURL: URL, filename: String, mimeType: String, replyToMessageId: String? = nil) async throws -> String {
+        let params = AttachmentUploadParams(
+            dataURL: fileURL,
+            filename: filename,
+            mimeType: mimeType,
+            mediaTypeLabel: "file"
         )
 
         return try await sendFileAttachment(params: params, replyToMessageId: replyToMessageId)

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/OutgoingMessageWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/OutgoingMessageWriter.swift
@@ -752,12 +752,16 @@ actor OutgoingMessageWriter: OutgoingMessageWriterProtocol {
     // MARK: - File
 
     func sendFile(at fileURL: URL, filename: String, mimeType: String, replyToMessageId: String? = nil) async throws -> String {
+        // The hydrator in MessagesRepository strips everything before the first underscore
+        // when deriving a display filename from a local file:// key, so the prefix here
+        // must contain no underscores — only a single one separating prefix from filename.
+        let uniquePrefix = "\(Int(Date().timeIntervalSince1970))-\(UUID().uuidString.prefix(8))"
         let params = AttachmentUploadParams(
             dataURL: fileURL,
             filename: filename,
             mimeType: mimeType,
             mediaTypeLabel: "file",
-            cacheFilename: "\(Int(Date().timeIntervalSince1970))_\(UUID().uuidString.prefix(8))_\(filename)"
+            cacheFilename: "\(uniquePrefix)_\(filename)"
         )
 
         return try await sendFileAttachment(params: params, replyToMessageId: replyToMessageId)

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/OutgoingMessageWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/OutgoingMessageWriter.swift
@@ -492,6 +492,9 @@ actor OutgoingMessageWriter: OutgoingMessageWriterProtocol {
         var thumbnailData: Data?
         var waveformLevels: [Float]?
         var mediaTypeLabel: String = "attachment"
+        /// Filename used for the local cache copy / tracking key. Defaults to `filename`.
+        /// Override when `filename` may collide across sends (e.g. user-picked files).
+        var cacheFilename: String?
     }
 
     private func sendFileAttachment(
@@ -499,7 +502,7 @@ actor OutgoingMessageWriter: OutgoingMessageWriterProtocol {
         replyToMessageId: String?
     ) async throws -> String {
         let clientMessageId = UUID().uuidString
-        let localCacheURL = try photoService.localCacheURL(for: params.filename)
+        let localCacheURL = try photoService.localCacheURL(for: params.cacheFilename ?? params.filename)
 
         try FileManager.default.createDirectory(
             at: localCacheURL.deletingLastPathComponent(),
@@ -753,7 +756,8 @@ actor OutgoingMessageWriter: OutgoingMessageWriterProtocol {
             dataURL: fileURL,
             filename: filename,
             mimeType: mimeType,
-            mediaTypeLabel: "file"
+            mediaTypeLabel: "file",
+            cacheFilename: "\(Int(Date().timeIntervalSince1970))_\(UUID().uuidString.prefix(8))_\(filename)"
         )
 
         return try await sendFileAttachment(params: params, replyToMessageId: replyToMessageId)


### PR DESCRIPTION
## Summary

Adds a file attachment button (document.fill) to the media buttons row in the message composer, between the voice memo and side convo buttons. Tapping it presents the system file importer (`.fileImporter`); selected files are staged in the composer with a preview card and sent via the existing remote-attachment pipeline (same path used for voice memos and videos).

- New \`sendFile(at:filename:mimeType:replyToMessageId:)\` on \`OutgoingMessageWriterProtocol\`, threaded through \`ConversationStateMachine\` and \`ConversationStateManager\`. It builds an \`AttachmentUploadParams\` with \`mediaTypeLabel: \"file\"\` and routes through the existing private \`sendFileAttachment\` helper, so file attachments share the encrypt → presigned upload → publish flow with video and voice memo.
- New \`PendingFileAttachment\` value on \`ConversationViewModel\` (URL + filename + mime type + size). \`sendButtonEnabled\` and \`onSendMessage\` now branch on it; \`sendAttachmentIfNeeded\` cleans up the temp copy after upload.
- Reuses the incoming file UI: extracted a \`FileAttachmentRow\` subview out of \`FileAttachmentBubble\` so both the message bubble and the new composer preview render the same icon + filename + size layout.
- \`.fileImporter\` accepts any content type (\`UTType.item\`). Files larger than 20 MB are rejected at selection time with an alert; smaller files are copied to the temp directory before staging so the picker's security-scoped URL can be released immediately.
- The \`.fileImporter\` + alert are wrapped in a small \`FilePickerModifier\` to keep \`MessagesBottomBar.body\` under the 100 ms type-checker budget.

## Test plan

- [ ] Open a conversation, tap the new document button, pick a file from the Files app, and verify the preview shows the correct icon, filename, and size
- [ ] Tap the X on the preview and confirm the file clears (and the temp copy is removed)
- [ ] Send the file and confirm it arrives on another device as a tappable file message
- [ ] Try sending a file larger than 20 MB and confirm the alert appears with no staging
- [ ] Stage a file together with text and verify both send

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add file attachment button to the message composer
> - Adds a document button to `MessagesMediaButtonsView` that opens the system file picker, allowing users to attach files up to 20 MB to a conversation message.
> - Introduces `PendingFileAttachment` in `ConversationViewModel` to stage a selected file; selecting a file replaces any staged photo/video, and the send button activates when a file is pending.
> - Copies the selected file to a unique temp URL, derives MIME type via `UTType`, and sends it through a new `OutgoingMessageWriterProtocol.sendFile(at:filename:mimeType:replyToMessageId:)` method with a collision-resistant cache key.
> - Adds a `FileAttachmentRow` preview with filename, type, and size in the input view, with an animated remove action that also deletes the temp file.
> - Risk: files over 20 MB show an alert and are rejected client-side; the limit is hardcoded in `MessagesBottomBar`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fa7f967.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->