### PR TITLE
Add multi-attachment support to message composer

### DIFF
--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -43,8 +43,7 @@ struct ConversationView<MessagesBottomBar: View>: View {
             conversationImage: $viewModel.conversationImage,
             displayName: $viewModel.myProfileViewModel.editingDisplayName,
             messageText: $viewModel.messageText,
-            selectedAttachmentImage: $viewModel.selectedAttachmentImage,
-            isVideoAttachment: viewModel.selectedVideoURL != nil,
+            pendingMediaAttachments: viewModel.pendingMediaAttachments,
             composerLinkPreview: viewModel.pastedLinkPreview,
             pendingInviteURL: viewModel.pendingInvite?.fullURL,
             pendingInviteEmoji: viewModel.conversation.conversationEmoji,
@@ -56,7 +55,6 @@ struct ConversationView<MessagesBottomBar: View>: View {
                 viewModel.updateLinkedConversationName(name)
                 focusCoordinator.endEditing(for: .sideConvoName, context: .quickEditor)
             },
-            pendingFileAttachment: viewModel.pendingFileAttachment,
             sendButtonEnabled: viewModel.sendButtonEnabled,
             profileImage: $viewModel.myProfileViewModel.profileImage,
             onboardingCoordinator: onboardingCoordinator,
@@ -76,7 +74,7 @@ struct ConversationView<MessagesBottomBar: View>: View {
             },
             onClearInvite: viewModel.clearPendingInvite,
             onClearLinkPreview: { viewModel.pastedLinkPreview = nil },
-            onClearFile: viewModel.clearPendingFile,
+            onClearMediaAttachment: viewModel.removeMediaAttachment(id:),
             onTapAvatar: viewModel.onTapAvatar(_:),
             onTapInvite: viewModel.onTapInvite(_:),
             onReaction: viewModel.onReaction(emoji:messageId:),
@@ -98,8 +96,9 @@ struct ConversationView<MessagesBottomBar: View>: View {
             onPhotoRevealed: viewModel.onPhotoRevealed(_:),
             onPhotoHidden: viewModel.onPhotoHidden(_:),
             onPhotoDimensionsLoaded: viewModel.onPhotoDimensionsLoaded(_:width:height:),
-            onVideoSelected: viewModel.onVideoSelected(_:),
-            onFileSelected: viewModel.onFileSelected(url:filename:mimeType:fileSize:),
+            onPhotoSelected: viewModel.addPhotoAttachment(_:),
+            onVideoSelected: viewModel.addVideoAttachment(url:),
+            onFileSelected: viewModel.addFileAttachment(url:filename:mimeType:fileSize:),
             onAboutAssistants: { showingAssistantsInfo = true },
             onAgentOutOfCredits: { showingProcessingPowerInfo = true },
             onTapUpdateMember: { viewModel.presentingProfileForMember = $0 },
@@ -233,13 +232,6 @@ struct ConversationView<MessagesBottomBar: View>: View {
 
     var body: some View {
         messagesView
-        .onChange(of: viewModel.selectedAttachmentImage) { oldValue, newValue in
-            if let image = newValue {
-                viewModel.onPhotoSelected(image)
-            } else if oldValue != nil {
-                viewModel.onPhotoRemoved()
-            }
-        }
         .onChange(of: viewModel.messageText) { _, _ in
             viewModel.checkForInviteURL()
             viewModel.checkForPastedLink()

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -1044,6 +1044,7 @@ extension ConversationViewModel {
         case .video(let video):
             videoThumbnailTasks[video.id]?.cancel()
             videoThumbnailTasks.removeValue(forKey: video.id)
+            try? FileManager.default.removeItem(at: video.url)
         case .file(let file):
             try? FileManager.default.removeItem(at: file.url)
         }

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -1322,7 +1322,12 @@ extension ConversationViewModel {
             }
             return true
         } catch {
-            for unsent in attachments[nextIndex...] {
+            // Include the failed attachment (at nextIndex - 1) in cleanup so its eager
+            // upload tracking key gets cancelled. The .file branch's inner do/catch
+            // already deletes its own temp; calling cleanupAttachment on it again is a
+            // benign no-op.
+            let failedAndUnsentStart: Int = max(0, nextIndex - 1)
+            for unsent in attachments[failedAndUnsentStart...] {
                 cleanupAttachment(unsent)
             }
             throw error

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -1294,30 +1294,39 @@ extension ConversationViewModel {
         isSendingPhoto = true
 
         var consumedReply = false
-        for attachment in attachments {
-            let attachmentReplyId: String? = consumedReply ? nil : replyTarget?.messageId
-            switch attachment {
-            case .photo(let photo):
-                try await sendStagedPhoto(photo, replyToMessageId: attachmentReplyId, messageWriter: messageWriter)
-            case .video(let video):
-                _ = try await messageWriter.sendVideo(at: video.url, replyToMessageId: attachmentReplyId)
-            case .file(let file):
-                do {
-                    _ = try await messageWriter.sendFile(
-                        at: file.url,
-                        filename: file.filename,
-                        mimeType: file.mimeType,
-                        replyToMessageId: attachmentReplyId
-                    )
-                    try? FileManager.default.removeItem(at: file.url)
-                } catch {
-                    try? FileManager.default.removeItem(at: file.url)
-                    throw error
+        var nextIndex: Int = 0
+        do {
+            for (index, attachment) in attachments.enumerated() {
+                nextIndex = index + 1
+                let attachmentReplyId: String? = consumedReply ? nil : replyTarget?.messageId
+                switch attachment {
+                case .photo(let photo):
+                    try await sendStagedPhoto(photo, replyToMessageId: attachmentReplyId, messageWriter: messageWriter)
+                case .video(let video):
+                    _ = try await messageWriter.sendVideo(at: video.url, replyToMessageId: attachmentReplyId)
+                case .file(let file):
+                    do {
+                        _ = try await messageWriter.sendFile(
+                            at: file.url,
+                            filename: file.filename,
+                            mimeType: file.mimeType,
+                            replyToMessageId: attachmentReplyId
+                        )
+                        try? FileManager.default.removeItem(at: file.url)
+                    } catch {
+                        try? FileManager.default.removeItem(at: file.url)
+                        throw error
+                    }
                 }
+                consumedReply = true
             }
-            consumedReply = true
+            return true
+        } catch {
+            for unsent in attachments[nextIndex...] {
+                cleanupAttachment(unsent)
+            }
+            throw error
         }
-        return true
     }
 
     private func sendStagedPhoto(

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -1371,15 +1371,28 @@ extension ConversationViewModel {
         // a fresh start if the upload hadn't kicked off yet (race: user staged + sent
         // before the eager-upload task had a chance to write back the tracking key).
         let trackingKey: String
+        let isFreshKey: Bool
         if let existing = photo.eagerUploadKey {
             trackingKey = existing
+            isFreshKey = false
         } else {
             trackingKey = try await messageWriter.startEagerUpload(image: photo.image)
+            isFreshKey = true
         }
-        if let replyToMessageId {
-            try await messageWriter.sendEagerPhotoReply(trackingKey: trackingKey, toMessageWithClientId: replyToMessageId)
-        } else {
-            try await messageWriter.sendEagerPhoto(trackingKey: trackingKey)
+        do {
+            if let replyToMessageId {
+                try await messageWriter.sendEagerPhotoReply(trackingKey: trackingKey, toMessageWithClientId: replyToMessageId)
+            } else {
+                try await messageWriter.sendEagerPhoto(trackingKey: trackingKey)
+            }
+        } catch {
+            // The freshly-obtained key isn't on the PendingPhotoAttachment yet,
+            // so cleanupAttachment in the outer catch wouldn't know to cancel
+            // it. Cancel directly so the pipeline doesn't orphan resources.
+            if isFreshKey {
+                await messageWriter.cancelEagerUpload(trackingKey: trackingKey)
+            }
+            throw error
         }
     }
 

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -394,7 +394,7 @@ class ConversationViewModel { // swiftlint:disable:this type_body_length
         pendingMediaAttachments.isEmpty
     }
 
-    private(set) var isSendingPhoto: Bool = false
+    private(set) var isSendingMedia: Bool = false
     var explodeState: ExplodeState = .ready
 
     var presentingConversationSettings: Bool = false
@@ -1194,7 +1194,7 @@ extension ConversationViewModel {
                 Log.error("Error sending message: \(error)")
             }
 
-            isSendingPhoto = false
+            isSendingMedia = false
         }
     }
 
@@ -1291,7 +1291,7 @@ extension ConversationViewModel {
         messageWriter: any OutgoingMessageWriterProtocol
     ) async throws -> Bool {
         guard !attachments.isEmpty else { return false }
-        isSendingPhoto = true
+        isSendingMedia = true
 
         var consumedReply = false
         var nextIndex: Int = 0
@@ -1305,27 +1305,21 @@ extension ConversationViewModel {
                 case .video(let video):
                     _ = try await messageWriter.sendVideo(at: video.url, replyToMessageId: attachmentReplyId)
                 case .file(let file):
-                    do {
-                        _ = try await messageWriter.sendFile(
-                            at: file.url,
-                            filename: file.filename,
-                            mimeType: file.mimeType,
-                            replyToMessageId: attachmentReplyId
-                        )
-                        try? FileManager.default.removeItem(at: file.url)
-                    } catch {
-                        try? FileManager.default.removeItem(at: file.url)
-                        throw error
-                    }
+                    _ = try await messageWriter.sendFile(
+                        at: file.url,
+                        filename: file.filename,
+                        mimeType: file.mimeType,
+                        replyToMessageId: attachmentReplyId
+                    )
+                    try? FileManager.default.removeItem(at: file.url)
                 }
                 consumedReply = true
             }
             return true
         } catch {
-            // Include the failed attachment (at nextIndex - 1) in cleanup so its eager
-            // upload tracking key gets cancelled. The .file branch's inner do/catch
-            // already deletes its own temp; calling cleanupAttachment on it again is a
-            // benign no-op.
+            // Include the failed attachment (at nextIndex - 1) so its eager upload
+            // tracking key gets cancelled / its temp file gets deleted alongside the
+            // unsent rest.
             let failedAndUnsentStart: Int = max(0, nextIndex - 1)
             for unsent in attachments[failedAndUnsentStart...] {
                 cleanupAttachment(unsent)

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -15,12 +15,73 @@ struct PendingInvite {
     var explodeDuration: ExplodeDuration?
 }
 
-struct PendingFileAttachment: Equatable {
+struct PendingFileAttachment: Identifiable, Equatable {
+    let id: UUID
     let url: URL
     let filename: String
     let mimeType: String
     let fileSize: Int
+
+    init(id: UUID = UUID(), url: URL, filename: String, mimeType: String, fileSize: Int) {
+        self.id = id
+        self.url = url
+        self.filename = filename
+        self.mimeType = mimeType
+        self.fileSize = fileSize
+    }
+
+    static func == (lhs: PendingFileAttachment, rhs: PendingFileAttachment) -> Bool {
+        lhs.id == rhs.id
+    }
 }
+
+struct PendingPhotoAttachment: Identifiable, Equatable {
+    let id: UUID
+    let image: UIImage
+    var eagerUploadKey: String?
+
+    init(id: UUID = UUID(), image: UIImage, eagerUploadKey: String? = nil) {
+        self.id = id
+        self.image = image
+        self.eagerUploadKey = eagerUploadKey
+    }
+
+    static func == (lhs: PendingPhotoAttachment, rhs: PendingPhotoAttachment) -> Bool {
+        lhs.id == rhs.id
+    }
+}
+
+struct PendingVideoAttachment: Identifiable, Equatable {
+    let id: UUID
+    let url: URL
+    var thumbnail: UIImage?
+
+    init(id: UUID = UUID(), url: URL, thumbnail: UIImage? = nil) {
+        self.id = id
+        self.url = url
+        self.thumbnail = thumbnail
+    }
+
+    static func == (lhs: PendingVideoAttachment, rhs: PendingVideoAttachment) -> Bool {
+        lhs.id == rhs.id
+    }
+}
+
+enum PendingMediaAttachment: Identifiable, Equatable {
+    case photo(PendingPhotoAttachment)
+    case video(PendingVideoAttachment)
+    case file(PendingFileAttachment)
+
+    var id: UUID {
+        switch self {
+        case .photo(let p): return p.id
+        case .video(let v): return v.id
+        case .file(let f): return f.id
+        }
+    }
+}
+
+let maxPendingMediaAttachments: Int = 8
 
 enum ExplodeDuration: CaseIterable {
     case sixtySeconds
@@ -259,19 +320,10 @@ class ConversationViewModel { // swiftlint:disable:this type_body_length
     @ObservationIgnored
     var typingThrottleDate: Date?
 
-    var selectedAttachmentImage: UIImage? {
-        didSet {
-            if selectedAttachmentImage != nil, oldValue == nil {
-                onPhotoAttached()
-            }
-        }
-    }
-    var selectedVideoURL: URL?
-    var selectedVideoThumbnail: UIImage?
-    private var videoThumbnailTask: Task<Void, Never>?
+    var pendingMediaAttachments: [PendingMediaAttachment] = []
+    @ObservationIgnored
+    private var videoThumbnailTasks: [UUID: Task<Void, Never>] = [:]
     var voiceMemoRecorder: VoiceMemoRecorder = VoiceMemoRecorder()
-    private(set) var currentEagerUploadKey: String?
-    var pendingFileAttachment: PendingFileAttachment?
     var canRemoveMembers: Bool {
         conversation.creator.isCurrentUser
     }
@@ -325,11 +377,23 @@ class ConversationViewModel { // swiftlint:disable:this type_body_length
 
     var sendButtonEnabled: Bool {
         !messageText.isEmpty
-            || selectedAttachmentImage != nil
+            || !pendingMediaAttachments.isEmpty
             || pendingInvite != nil
             || pastedLinkPreview != nil
-            || pendingFileAttachment != nil
     }
+
+    var canStageMoreMedia: Bool {
+        pendingMediaAttachments.count < maxPendingMediaAttachments
+    }
+
+    var canStageSideConvo: Bool {
+        pendingInvite == nil
+    }
+
+    var canRecordVoiceMemo: Bool {
+        pendingMediaAttachments.isEmpty
+    }
+
     private(set) var isSendingPhoto: Bool = false
     var explodeState: ExplodeState = .ready
 
@@ -897,51 +961,88 @@ extension ConversationViewModel {
         onDisplayNameEndedEditing(focusCoordinator: focusCoordinator, context: .editProfile)
     }
 
-    func onFileSelected(url: URL, filename: String, mimeType: String, fileSize: Int) {
-        if let existing = pendingFileAttachment {
-            try? FileManager.default.removeItem(at: existing.url)
+    func addFileAttachment(url: URL, filename: String, mimeType: String, fileSize: Int) {
+        guard canStageMoreMedia else {
+            try? FileManager.default.removeItem(at: url)
+            return
         }
-        // Files are mutually exclusive with photos and videos in send-time
-        // dispatch, so clear any staged photo/video here to avoid silently
-        // dropping it when the user taps Send. Setting selectedAttachmentImage
-        // to nil triggers the onChange in ConversationView which calls
-        // onPhotoRemoved and cancels any in-flight eager photo upload.
-        selectedAttachmentImage = nil
-        selectedVideoURL = nil
-        selectedVideoThumbnail = nil
-        pendingFileAttachment = PendingFileAttachment(
-            url: url,
-            filename: filename,
-            mimeType: mimeType,
-            fileSize: fileSize
-        )
+        let attachment = PendingFileAttachment(url: url, filename: filename, mimeType: mimeType, fileSize: fileSize)
+        pendingMediaAttachments.append(.file(attachment))
     }
 
-    func clearPendingFile() {
-        if let existing = pendingFileAttachment {
-            try? FileManager.default.removeItem(at: existing.url)
-        }
-        pendingFileAttachment = nil
-    }
+    func addVideoAttachment(url: URL) {
+        guard canStageMoreMedia else { return }
+        let attachment = PendingVideoAttachment(url: url)
+        let attachmentId = attachment.id
+        pendingMediaAttachments.append(.video(attachment))
 
-    func onVideoSelected(_ url: URL) {
-        if pendingFileAttachment != nil {
-            clearPendingFile()
-        }
-        selectedVideoURL = url
-        videoThumbnailTask?.cancel()
-        videoThumbnailTask = Task {
+        videoThumbnailTasks[attachmentId] = Task { [weak self] in
             do {
                 let service = VideoCompressionService()
                 let asset = AVURLAsset(url: url)
                 let thumbnailData = try await service.generateThumbnail(for: asset)
-                guard !Task.isCancelled, self.selectedVideoURL == url else { return }
-                self.selectedVideoThumbnail = UIImage(data: thumbnailData)
-                self.selectedAttachmentImage = self.selectedVideoThumbnail
-                self.onPhotoAttached()
+                guard !Task.isCancelled else { return }
+                await MainActor.run {
+                    guard let self else { return }
+                    guard let index = self.pendingMediaAttachments.firstIndex(where: { $0.id == attachmentId }),
+                          case .video(var video) = self.pendingMediaAttachments[index] else { return }
+                    video.thumbnail = UIImage(data: thumbnailData)
+                    self.pendingMediaAttachments[index] = .video(video)
+                    self.videoThumbnailTasks.removeValue(forKey: attachmentId)
+                }
             } catch {
                 Log.error("Failed to generate video thumbnail: \(error)")
             }
+        }
+        onPhotoAttached()
+    }
+
+    func addPhotoAttachment(_ image: UIImage) {
+        guard canStageMoreMedia else { return }
+        let attachment = PendingPhotoAttachment(image: image)
+        let attachmentId = attachment.id
+        pendingMediaAttachments.append(.photo(attachment))
+
+        let messageWriter = cachedMessageWriter
+        Task { [weak self] in
+            do {
+                let trackingKey = try await messageWriter.startEagerUpload(image: image)
+                await MainActor.run {
+                    guard let self else { return }
+                    guard let index = self.pendingMediaAttachments.firstIndex(where: { $0.id == attachmentId }),
+                          case .photo(var photo) = self.pendingMediaAttachments[index] else {
+                        // User removed the attachment before upload started. Cancel the upload.
+                        Task { await messageWriter.cancelEagerUpload(trackingKey: trackingKey) }
+                        return
+                    }
+                    photo.eagerUploadKey = trackingKey
+                    self.pendingMediaAttachments[index] = .photo(photo)
+                }
+            } catch {
+                Log.error("Error starting eager upload: \(error)")
+            }
+        }
+        onPhotoAttached()
+    }
+
+    func removeMediaAttachment(id: UUID) {
+        guard let index = pendingMediaAttachments.firstIndex(where: { $0.id == id }) else { return }
+        let attachment = pendingMediaAttachments.remove(at: index)
+        cleanupAttachment(attachment)
+    }
+
+    private func cleanupAttachment(_ attachment: PendingMediaAttachment) {
+        switch attachment {
+        case .photo(let photo):
+            if let trackingKey = photo.eagerUploadKey {
+                let messageWriter = cachedMessageWriter
+                Task { await messageWriter.cancelEagerUpload(trackingKey: trackingKey) }
+            }
+        case .video(let video):
+            videoThumbnailTasks[video.id]?.cancel()
+            videoThumbnailTasks.removeValue(forKey: video.id)
+        case .file(let file):
+            try? FileManager.default.removeItem(at: file.url)
         }
     }
 
@@ -1025,37 +1126,32 @@ extension ConversationViewModel {
 
     func onSendMessage(focusCoordinator: FocusCoordinator) {
         let hasText = !messageText.isEmpty
-        let hasAttachment = selectedAttachmentImage != nil || selectedVideoURL != nil || pendingFileAttachment != nil
+        let hasMedia = !pendingMediaAttachments.isEmpty
         let hasInvite = pendingInvite != nil
         let hasLinkPreview = pastedLinkPreview != nil
 
-        guard hasText || hasAttachment || hasInvite || hasLinkPreview else { return }
+        guard hasText || hasMedia || hasInvite || hasLinkPreview else { return }
 
         let prevMessageText = messageText
         let replyTarget = replyingToMessage
-        let prevAttachmentImage = selectedAttachmentImage
-        let eagerUploadKey = currentEagerUploadKey
+        let prevMediaAttachments = pendingMediaAttachments
         let prevInviteURL = pendingInvite?.fullURL
         let sideConvoName = pendingInviteConvoName
         let sideConvoLinkedId = pendingInvite?.linkedConversationId
         let sideConvoExplodeDuration = pendingInvite?.explodeDuration
         let sideConvoImage = pendingInviteImage
         let prevLinkURL = pastedLinkPreview?.url
-        let prevVideoURL = selectedVideoURL
-        let prevFileAttachment = pendingFileAttachment
 
         stopTyping()
         messageText = ""
         replyingToMessage = nil
-        selectedAttachmentImage = nil
-        selectedVideoURL = nil
-        selectedVideoThumbnail = nil
-        currentEagerUploadKey = nil
+        pendingMediaAttachments = []
+        videoThumbnailTasks.values.forEach { $0.cancel() }
+        videoThumbnailTasks.removeAll()
         pendingInvite = nil
         pendingInviteConvoName = ""
         pendingInviteImage = nil
         pastedLinkPreview = nil
-        pendingFileAttachment = nil
         focusCoordinator.endEditing(for: .message, context: .conversation)
 
         let messageWriter = cachedMessageWriter
@@ -1075,22 +1171,23 @@ extension ConversationViewModel {
             let pendingInviteMessageId = sideConvoResult.pendingMessageId
 
             do {
-                let photoTrackingKey = try await sendAttachmentIfNeeded(
-                    videoURL: prevVideoURL,
-                    attachmentImage: prevAttachmentImage,
-                    fileAttachment: prevFileAttachment,
-                    eagerUploadKey: eagerUploadKey,
+                // Send each media attachment as its own message, in bar order.
+                // The first attachment carries the reply target (if any); subsequent
+                // attachments and trailing text/invite/link are not replies.
+                let mediaTookReply = try await sendMediaAttachmentsSequentially(
+                    prevMediaAttachments,
                     replyTarget: replyTarget,
                     messageWriter: messageWriter
                 )
 
+                let trailingReplyTarget: AnyMessage? = mediaTookReply ? nil : replyTarget
                 let finalInviteURL = pendingInviteMessageId != nil ? nil : inviteURL
                 try await sendTextAndLinksIfNeeded(
                     text: hasText ? prevMessageText : nil,
                     inviteURL: finalInviteURL,
                     linkURL: prevLinkURL,
-                    photoTrackingKey: photoTrackingKey,
-                    replyTarget: replyTarget,
+                    photoTrackingKey: nil,
+                    replyTarget: trailingReplyTarget,
                     messageWriter: messageWriter
                 )
             } catch {
@@ -1180,45 +1277,68 @@ extension ConversationViewModel {
         return (inviteURL, pendingMessageId)
     }
 
-    private func sendAttachmentIfNeeded(
-        videoURL: URL?,
-        attachmentImage: UIImage?,
-        fileAttachment: PendingFileAttachment?,
-        eagerUploadKey: String?,
+    /// Send each staged media attachment as its own message, in bar order, awaiting each
+    /// publish so they arrive in order on the recipient. The first attachment carries the
+    /// reply target (if any). Returns true if a media attachment was sent and consumed
+    /// the reply target.
+    ///
+    /// If any attachment fails, the chain stops — that attachment surfaces as a failed
+    /// bubble via the existing markMessageFailed path inside the writer; subsequent
+    /// attachments and the trailing text/invite/link are not sent.
+    private func sendMediaAttachmentsSequentially(
+        _ attachments: [PendingMediaAttachment],
         replyTarget: AnyMessage?,
         messageWriter: any OutgoingMessageWriterProtocol
-    ) async throws -> String? {
-        if let fileAttachment {
-            defer { try? FileManager.default.removeItem(at: fileAttachment.url) }
-            return try await messageWriter.sendFile(
-                at: fileAttachment.url,
-                filename: fileAttachment.filename,
-                mimeType: fileAttachment.mimeType,
-                replyToMessageId: replyTarget?.messageId
-            )
-        } else if let videoURL {
-            isSendingPhoto = true
-            return try await messageWriter.sendVideo(at: videoURL, replyToMessageId: replyTarget?.messageId)
-        } else if attachmentImage != nil {
-            isSendingPhoto = true
-            if let trackingKey = eagerUploadKey {
-                if let replyTarget {
-                    try await messageWriter.sendEagerPhotoReply(trackingKey: trackingKey, toMessageWithClientId: replyTarget.messageId)
-                } else {
-                    try await messageWriter.sendEagerPhoto(trackingKey: trackingKey)
+    ) async throws -> Bool {
+        guard !attachments.isEmpty else { return false }
+        isSendingPhoto = true
+
+        var consumedReply = false
+        for attachment in attachments {
+            let attachmentReplyId: String? = consumedReply ? nil : replyTarget?.messageId
+            switch attachment {
+            case .photo(let photo):
+                try await sendStagedPhoto(photo, replyToMessageId: attachmentReplyId, messageWriter: messageWriter)
+            case .video(let video):
+                _ = try await messageWriter.sendVideo(at: video.url, replyToMessageId: attachmentReplyId)
+            case .file(let file):
+                do {
+                    _ = try await messageWriter.sendFile(
+                        at: file.url,
+                        filename: file.filename,
+                        mimeType: file.mimeType,
+                        replyToMessageId: attachmentReplyId
+                    )
+                    try? FileManager.default.removeItem(at: file.url)
+                } catch {
+                    try? FileManager.default.removeItem(at: file.url)
+                    throw error
                 }
-                return trackingKey
-            } else if let image = attachmentImage {
-                let key = try await messageWriter.startEagerUpload(image: image)
-                if let replyTarget {
-                    try await messageWriter.sendEagerPhotoReply(trackingKey: key, toMessageWithClientId: replyTarget.messageId)
-                } else {
-                    try await messageWriter.sendEagerPhoto(trackingKey: key)
-                }
-                return key
             }
+            consumedReply = true
         }
-        return nil
+        return true
+    }
+
+    private func sendStagedPhoto(
+        _ photo: PendingPhotoAttachment,
+        replyToMessageId: String?,
+        messageWriter: any OutgoingMessageWriterProtocol
+    ) async throws {
+        // Reuse the eager upload that started when the photo was staged, falling back to
+        // a fresh start if the upload hadn't kicked off yet (race: user staged + sent
+        // before the eager-upload task had a chance to write back the tracking key).
+        let trackingKey: String
+        if let existing = photo.eagerUploadKey {
+            trackingKey = existing
+        } else {
+            trackingKey = try await messageWriter.startEagerUpload(image: photo.image)
+        }
+        if let replyToMessageId {
+            try await messageWriter.sendEagerPhotoReply(trackingKey: trackingKey, toMessageWithClientId: replyToMessageId)
+        } else {
+            try await messageWriter.sendEagerPhoto(trackingKey: trackingKey)
+        }
     }
 
     private func sendTextAndLinksIfNeeded(
@@ -1323,32 +1443,6 @@ extension ConversationViewModel {
                 Log.error("Failed to delete message: \(error.localizedDescription)")
             }
         }
-    }
-
-    func onPhotoSelected(_ image: UIImage) {
-        if pendingFileAttachment != nil {
-            clearPendingFile()
-        }
-        let messageWriter = cachedMessageWriter
-        if let existingKey = currentEagerUploadKey {
-            currentEagerUploadKey = nil
-            Task { await messageWriter.cancelEagerUpload(trackingKey: existingKey) }
-        }
-        Task { [weak self] in
-            guard let self else { return }
-            do {
-                let trackingKey = try await messageWriter.startEagerUpload(image: image)
-                await MainActor.run { self.currentEagerUploadKey = trackingKey }
-            } catch {
-                Log.error("Error starting eager upload: \(error)")
-            }
-        }
-    }
-
-    func onPhotoRemoved() {
-        guard let trackingKey = currentEagerUploadKey else { return }
-        currentEagerUploadKey = nil
-        Task { await cachedMessageWriter.cancelEagerUpload(trackingKey: trackingKey) }
     }
 
     func onUseProfile(_ profile: Profile, _ profileImage: UIImage?) {

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -971,7 +971,10 @@ extension ConversationViewModel {
     }
 
     func addVideoAttachment(url: URL) {
-        guard canStageMoreMedia else { return }
+        guard canStageMoreMedia else {
+            try? FileManager.default.removeItem(at: url)
+            return
+        }
         let attachment = PendingVideoAttachment(url: url)
         let attachmentId = attachment.id
         pendingMediaAttachments.append(.video(attachment))

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -1391,15 +1391,28 @@ extension ConversationViewModel {
         // Reuse the eager pipeline started at staging time, falling back to a
         // fresh start if Send happened before the tracking key was written back.
         let trackingKey: String
+        let isFreshKey: Bool
         if let existing = video.eagerUploadKey {
             trackingKey = existing
+            isFreshKey = false
         } else {
             trackingKey = try await messageWriter.startEagerVideoUpload(at: video.url)
+            isFreshKey = true
         }
-        if let replyToMessageId {
-            try await messageWriter.sendEagerVideoReply(trackingKey: trackingKey, toMessageWithClientId: replyToMessageId)
-        } else {
-            try await messageWriter.sendEagerVideo(trackingKey: trackingKey)
+        do {
+            if let replyToMessageId {
+                try await messageWriter.sendEagerVideoReply(trackingKey: trackingKey, toMessageWithClientId: replyToMessageId)
+            } else {
+                try await messageWriter.sendEagerVideo(trackingKey: trackingKey)
+            }
+        } catch {
+            // The freshly-obtained key isn't on the PendingVideoAttachment yet,
+            // so cleanupAttachment in the outer catch wouldn't know to cancel
+            // it. Cancel directly so the pipeline doesn't orphan resources.
+            if isFreshKey {
+                await messageWriter.cancelEagerUpload(trackingKey: trackingKey)
+            }
+            throw error
         }
     }
 

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -1308,6 +1308,7 @@ extension ConversationViewModel {
                     try await sendStagedPhoto(photo, replyToMessageId: attachmentReplyId, messageWriter: messageWriter)
                 case .video(let video):
                     _ = try await messageWriter.sendVideo(at: video.url, replyToMessageId: attachmentReplyId)
+                    try? FileManager.default.removeItem(at: video.url)
                 case .file(let file):
                     _ = try await messageWriter.sendFile(
                         at: file.url,

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -55,11 +55,13 @@ struct PendingVideoAttachment: Identifiable, Equatable {
     let id: UUID
     let url: URL
     var thumbnail: UIImage?
+    var eagerUploadKey: String?
 
-    init(id: UUID = UUID(), url: URL, thumbnail: UIImage? = nil) {
+    init(id: UUID = UUID(), url: URL, thumbnail: UIImage? = nil, eagerUploadKey: String? = nil) {
         self.id = id
         self.url = url
         self.thumbnail = thumbnail
+        self.eagerUploadKey = eagerUploadKey
     }
 
     static func == (lhs: PendingVideoAttachment, rhs: PendingVideoAttachment) -> Bool {
@@ -997,6 +999,27 @@ extension ConversationViewModel {
                 Log.error("Failed to generate video thumbnail: \(error)")
             }
         }
+
+        let messageWriter = cachedMessageWriter
+        Task { [weak self] in
+            do {
+                let trackingKey = try await messageWriter.startEagerVideoUpload(at: url)
+                await MainActor.run {
+                    guard let self else { return }
+                    guard let index = self.pendingMediaAttachments.firstIndex(where: { $0.id == attachmentId }),
+                          case .video(var video) = self.pendingMediaAttachments[index] else {
+                        // User removed the attachment before the eager upload tracking
+                        // key was written back. Cancel the in-flight pipeline.
+                        Task { await messageWriter.cancelEagerUpload(trackingKey: trackingKey) }
+                        return
+                    }
+                    video.eagerUploadKey = trackingKey
+                    self.pendingMediaAttachments[index] = .video(video)
+                }
+            } catch {
+                Log.error("Error starting eager video upload: \(error)")
+            }
+        }
         onPhotoAttached()
     }
 
@@ -1044,7 +1067,14 @@ extension ConversationViewModel {
         case .video(let video):
             videoThumbnailTasks[video.id]?.cancel()
             videoThumbnailTasks.removeValue(forKey: video.id)
-            try? FileManager.default.removeItem(at: video.url)
+            if let trackingKey = video.eagerUploadKey {
+                let messageWriter = cachedMessageWriter
+                Task { await messageWriter.cancelEagerUpload(trackingKey: trackingKey) }
+            } else {
+                // Pipeline hadn't returned a tracking key yet; the source temp is
+                // still ours to clean up.
+                try? FileManager.default.removeItem(at: video.url)
+            }
         case .file(let file):
             try? FileManager.default.removeItem(at: file.url)
         }
@@ -1307,8 +1337,7 @@ extension ConversationViewModel {
                 case .photo(let photo):
                     try await sendStagedPhoto(photo, replyToMessageId: attachmentReplyId, messageWriter: messageWriter)
                 case .video(let video):
-                    _ = try await messageWriter.sendVideo(at: video.url, replyToMessageId: attachmentReplyId)
-                    try? FileManager.default.removeItem(at: video.url)
+                    try await sendStagedVideo(video, replyToMessageId: attachmentReplyId, messageWriter: messageWriter)
                 case .file(let file):
                     _ = try await messageWriter.sendFile(
                         at: file.url,
@@ -1351,6 +1380,26 @@ extension ConversationViewModel {
             try await messageWriter.sendEagerPhotoReply(trackingKey: trackingKey, toMessageWithClientId: replyToMessageId)
         } else {
             try await messageWriter.sendEagerPhoto(trackingKey: trackingKey)
+        }
+    }
+
+    private func sendStagedVideo(
+        _ video: PendingVideoAttachment,
+        replyToMessageId: String?,
+        messageWriter: any OutgoingMessageWriterProtocol
+    ) async throws {
+        // Reuse the eager pipeline started at staging time, falling back to a
+        // fresh start if Send happened before the tracking key was written back.
+        let trackingKey: String
+        if let existing = video.eagerUploadKey {
+            trackingKey = existing
+        } else {
+            trackingKey = try await messageWriter.startEagerVideoUpload(at: video.url)
+        }
+        if let replyToMessageId {
+            try await messageWriter.sendEagerVideoReply(trackingKey: trackingKey, toMessageWithClientId: replyToMessageId)
+        } else {
+            try await messageWriter.sendEagerVideo(trackingKey: trackingKey)
         }
     }
 

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesBottomBar.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesBottomBar.swift
@@ -13,6 +13,7 @@ private let maxFileAttachmentSizeBytes: Int = 20 * 1024 * 1024
 private struct FilePickerModifier: ViewModifier {
     @Binding var isPresented: Bool
     @Binding var showTooLargeAlert: Bool
+    @Binding var showTruncatedAlert: Bool
     let onResult: (Result<[URL], Error>) -> Void
 
     func body(content: Content) -> some View {
@@ -20,13 +21,18 @@ private struct FilePickerModifier: ViewModifier {
             .fileImporter(
                 isPresented: $isPresented,
                 allowedContentTypes: [.item],
-                allowsMultipleSelection: false,
+                allowsMultipleSelection: true,
                 onCompletion: onResult
             )
             .alert("File too large", isPresented: $showTooLargeAlert) {
                 Button("OK", role: .cancel) {}
             } message: {
                 Text("Files must be 20 MB or smaller.")
+            }
+            .alert("Some files weren't added", isPresented: $showTruncatedAlert) {
+                Button("OK", role: .cancel) {}
+            } message: {
+                Text("You can attach up to \(maxPendingMediaAttachments) photos, videos, and files in one message.")
             }
     }
 }
@@ -78,7 +84,8 @@ struct MessagesBottomBar<BottomBarContent: View>: View {
     @State private var isCameraPresented: Bool = false
     @State private var isFilePickerPresented: Bool = false
     @State private var showFileTooLargeAlert: Bool = false
-    @State private var selectedPhoto: PhotosPickerItem?
+    @State private var showFileTruncatedAlert: Bool = false
+    @State private var selectedPhotos: [PhotosPickerItem] = []
     @State private var previousFocus: MessagesViewInputFocus?
     @State private var voiceMemoReturnFocus: MessagesViewInputFocus?
     @State private var didSelectPhotoThisSession: Bool = false
@@ -151,24 +158,27 @@ struct MessagesBottomBar<BottomBarContent: View>: View {
                 }
             }
         }
-        .photosPicker(isPresented: $isPhotoPickerPresented, selection: $selectedPhoto, matching: .any(of: [.images, .videos]))
-        .onChange(of: selectedPhoto) { _, newValue in
+        .photosPicker(
+            isPresented: $isPhotoPickerPresented,
+            selection: $selectedPhotos,
+            maxSelectionCount: max(1, maxPendingMediaAttachments - pendingMediaAttachments.count),
+            matching: .any(of: [.images, .videos])
+        )
+        .onChange(of: selectedPhotos) { _, newValue in
+            guard !newValue.isEmpty else { return }
+            let items = newValue
+            selectedPhotos = []
+            didSelectPhotoThisSession = true
+            isPhotoPickerPresented = false
+            focusCoordinator.moveFocus(to: .message)
             Task {
-                guard let newValue else { return }
-
-                if let videoFile = try? await newValue.loadTransferable(type: VideoFile.self) {
-                    onVideoSelected(videoFile.url)
-                    selectedPhoto = nil
-                    didSelectPhotoThisSession = true
-                    isPhotoPickerPresented = false
-                    focusCoordinator.moveFocus(to: .message)
-                } else if let data = try? await newValue.loadTransferable(type: Data.self),
-                          let image = UIImage(data: data) {
-                    onPhotoSelected(image)
-                    selectedPhoto = nil
-                    didSelectPhotoThisSession = true
-                    isPhotoPickerPresented = false
-                    focusCoordinator.moveFocus(to: .message)
+                for item in items {
+                    if let videoFile = try? await item.loadTransferable(type: VideoFile.self) {
+                        await MainActor.run { onVideoSelected(videoFile.url) }
+                    } else if let data = try? await item.loadTransferable(type: Data.self),
+                              let image = UIImage(data: data) {
+                        await MainActor.run { onPhotoSelected(image) }
+                    }
                 }
             }
         }
@@ -193,6 +203,7 @@ struct MessagesBottomBar<BottomBarContent: View>: View {
         FilePickerModifier(
             isPresented: $isFilePickerPresented,
             showTooLargeAlert: $showFileTooLargeAlert,
+            showTruncatedAlert: $showFileTruncatedAlert,
             onResult: handleFileImporterResult
         )
     }
@@ -200,8 +211,15 @@ struct MessagesBottomBar<BottomBarContent: View>: View {
     private func handleFileImporterResult(_ result: Result<[URL], Error>) {
         switch result {
         case .success(let urls):
-            guard let url = urls.first else { return }
-            stageFile(at: url)
+            let remaining = maxPendingMediaAttachments - pendingMediaAttachments.count
+            guard remaining > 0 else { return }
+            let toStage = Array(urls.prefix(remaining))
+            if urls.count > toStage.count {
+                showFileTruncatedAlert = true
+            }
+            for url in toStage {
+                stageFile(at: url)
+            }
         case .failure(let error):
             Log.error("File picker error: \(error)")
         }
@@ -352,6 +370,8 @@ struct MessagesBottomBar<BottomBarContent: View>: View {
                         }
                         onConvosAction()
                     },
+                    isMediaCapacityFull: pendingMediaAttachments.count >= maxPendingMediaAttachments,
+                    isVoiceMemoDisabled: !pendingMediaAttachments.isEmpty,
                     isSideConvoDisabled: pendingInviteURL != nil
                 )
                 .opacity(messagesTextFieldEnabled ? 1.0 : 0.4)

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesBottomBar.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesBottomBar.swift
@@ -110,12 +110,10 @@ struct MessagesBottomBar<BottomBarContent: View>: View {
             )
             GlassEffectContainer {
                 ZStack {
-                    if !isExpanded {
-                        collapsedInputView
-                    }
-
                     if isExpanded {
                         expandedQuickEditView
+                    } else {
+                        collapsedInputView
                     }
                 }
             }

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesBottomBar.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesBottomBar.swift
@@ -36,8 +36,7 @@ struct MessagesBottomBar<BottomBarContent: View>: View {
     @Binding var displayName: String
     let emptyDisplayNamePlaceholder: String = "Somebody"
     @Binding var messageText: String
-    @Binding var selectedAttachmentImage: UIImage?
-    var isVideoAttachment: Bool = false
+    var pendingMediaAttachments: [PendingMediaAttachment] = []
     var composerLinkPreview: LinkPreview?
     var pendingInviteURL: String?
     var pendingInviteEmoji: String?
@@ -46,7 +45,6 @@ struct MessagesBottomBar<BottomBarContent: View>: View {
     var pendingInviteExplodeDuration: ExplodeDuration?
     var onSetInviteExplodeDuration: ((ExplodeDuration?) -> Void)?
     var onInviteConvoNameEditingEnded: ((String) -> Void)?
-    var pendingFileAttachment: PendingFileAttachment?
     let sendButtonEnabled: Bool
     @Binding var profileImage: UIImage?
     @Binding var isPhotoPickerPresented: Bool
@@ -58,8 +56,9 @@ struct MessagesBottomBar<BottomBarContent: View>: View {
     let onSendMessage: () -> Void
     let onClearInvite: () -> Void
     let onClearLinkPreview: () -> Void
-    let onClearFile: () -> Void
+    let onClearMediaAttachment: (UUID) -> Void
     let onDisplayNameEndedEditing: () -> Void
+    let onPhotoSelected: (UIImage) -> Void
     let onVideoSelected: (URL) -> Void
     let onFileSelected: (URL, String, String, Int) -> Void
     let onProfileSettings: () -> Void
@@ -165,7 +164,7 @@ struct MessagesBottomBar<BottomBarContent: View>: View {
                     focusCoordinator.moveFocus(to: .message)
                 } else if let data = try? await newValue.loadTransferable(type: Data.self),
                           let image = UIImage(data: data) {
-                    selectedAttachmentImage = image
+                    onPhotoSelected(image)
                     selectedPhoto = nil
                     didSelectPhotoThisSession = true
                     isPhotoPickerPresented = false
@@ -176,7 +175,7 @@ struct MessagesBottomBar<BottomBarContent: View>: View {
         .fullScreenCover(isPresented: $isCameraPresented) {
             CameraPickerView(
                 onImageCaptured: { image in
-                    selectedAttachmentImage = image
+                    onPhotoSelected(image)
                     isCameraPresented = false
                     focusCoordinator.moveFocus(to: .message)
                 },
@@ -369,8 +368,7 @@ struct MessagesBottomBar<BottomBarContent: View>: View {
                 displayName: $displayName,
                 emptyDisplayNamePlaceholder: emptyDisplayNamePlaceholder,
                 messageText: $messageText,
-                selectedAttachmentImage: $selectedAttachmentImage,
-                isVideoAttachment: isVideoAttachment,
+                pendingMediaAttachments: pendingMediaAttachments,
                 composerLinkPreview: composerLinkPreview,
                 pendingInviteURL: pendingInviteURL,
                 pendingInviteEmoji: pendingInviteEmoji,
@@ -379,7 +377,6 @@ struct MessagesBottomBar<BottomBarContent: View>: View {
                 pendingInviteExplodeDuration: pendingInviteExplodeDuration,
                 onSetInviteExplodeDuration: onSetInviteExplodeDuration,
                 onInviteConvoNameEditingEnded: onInviteConvoNameEditingEnded,
-                pendingFileAttachment: pendingFileAttachment,
                 sendButtonEnabled: sendButtonEnabled,
                 focusState: $focusState,
                 animateAvatarForProfileSetup: onboardingCoordinator.shouldAnimateAvatarForProfileSetup,
@@ -390,7 +387,7 @@ struct MessagesBottomBar<BottomBarContent: View>: View {
                 onSendMessage: onSendMessage,
                 onClearInvite: onClearInvite,
                 onClearLinkPreview: onClearLinkPreview,
-                onClearFile: onClearFile
+                onClearMediaAttachment: onClearMediaAttachment
             )
             .opacity(messagesTextFieldEnabled ? 1.0 : 0.4)
             .fixedSize(horizontal: false, vertical: true)
@@ -441,7 +438,6 @@ struct MessagesBottomBar<BottomBarContent: View>: View {
     @Previewable @State var profile: Profile = .mock()
     @Previewable @State var profileName: String = ""
     @Previewable @State var messageText: String = ""
-    @Previewable @State var selectedAttachmentImage: UIImage?
     @Previewable @State var pendingInviteURLPreview: String?
     @Previewable @State var sendButtonEnabled: Bool = false
     @Previewable @State var profileImage: UIImage?
@@ -495,7 +491,6 @@ struct MessagesBottomBar<BottomBarContent: View>: View {
             profile: profile,
             displayName: $profileName,
             messageText: $messageText,
-            selectedAttachmentImage: $selectedAttachmentImage,
             pendingInviteURL: pendingInviteURLPreview,
             pendingInviteConvoName: .constant(""),
             pendingInviteImage: .constant(nil),
@@ -512,10 +507,11 @@ struct MessagesBottomBar<BottomBarContent: View>: View {
             onSendMessage: {},
             onClearInvite: { pendingInviteURLPreview = nil },
             onClearLinkPreview: {},
-            onClearFile: {},
+            onClearMediaAttachment: { _ in },
             onDisplayNameEndedEditing: {
                 focusCoordinator.endEditing(for: .displayName)
             },
+            onPhotoSelected: { _ in },
             onVideoSelected: { _ in },
             onFileSelected: { _, _, _, _ in },
             onProfileSettings: {},

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesBottomBar.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesBottomBar.swift
@@ -356,6 +356,12 @@ struct MessagesBottomBar<BottomBarContent: View>: View {
                 .glassEffectID("media", in: namespace)
                 .glassEffectTransition(.matchedGeometry)
             } else {
+                let hasSideConvo: Bool = pendingInviteURL != nil
+                let hasMedia: Bool = !pendingMediaAttachments.isEmpty
+                let isMediaCapacityFull: Bool = pendingMediaAttachments.count >= maxPendingMediaAttachments
+                let mediaButtonsDisabled: Bool = isMediaCapacityFull || hasSideConvo
+                let voiceMemoDisabled: Bool = hasMedia || hasSideConvo
+                let sideConvoDisabled: Bool = hasSideConvo || hasMedia
                 MessagesMediaButtonsView(
                     isPhotoPickerPresented: $isPhotoPickerPresented,
                     isCameraPresented: $isCameraPresented,
@@ -370,9 +376,9 @@ struct MessagesBottomBar<BottomBarContent: View>: View {
                         }
                         onConvosAction()
                     },
-                    isMediaCapacityFull: pendingMediaAttachments.count >= maxPendingMediaAttachments,
-                    isVoiceMemoDisabled: !pendingMediaAttachments.isEmpty,
-                    isSideConvoDisabled: pendingInviteURL != nil
+                    isMediaCapacityFull: mediaButtonsDisabled,
+                    isVoiceMemoDisabled: voiceMemoDisabled,
+                    isSideConvoDisabled: sideConvoDisabled
                 )
                 .opacity(messagesTextFieldEnabled ? 1.0 : 0.4)
                 .frame(height: DesignConstants.Spacing.step12x)

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesInputView.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesInputView.swift
@@ -9,8 +9,7 @@ struct MessagesInputView: View {
     @Binding var displayName: String
     let emptyDisplayNamePlaceholder: String
     @Binding var messageText: String
-    @Binding var selectedAttachmentImage: UIImage?
-    var isVideoAttachment: Bool = false
+    var pendingMediaAttachments: [PendingMediaAttachment] = []
     var composerLinkPreview: LinkPreview?
     var pendingInviteURL: String?
     var pendingInviteEmoji: String?
@@ -19,7 +18,6 @@ struct MessagesInputView: View {
     var pendingInviteExplodeDuration: ExplodeDuration?
     var onSetInviteExplodeDuration: ((ExplodeDuration?) -> Void)?
     var onInviteConvoNameEditingEnded: ((String) -> Void)?
-    var pendingFileAttachment: PendingFileAttachment?
     let sendButtonEnabled: Bool
     @FocusState.Binding var focusState: MessagesViewInputFocus?
     let animateAvatarForProfileSetup: Bool
@@ -31,12 +29,11 @@ struct MessagesInputView: View {
     let onSendMessage: () -> Void
     let onClearInvite: () -> Void
     var onClearLinkPreview: (() -> Void)?
-    var onClearFile: (() -> Void)?
+    var onClearMediaAttachment: ((UUID) -> Void)?
 
     private let attachmentPreviewSize: CGFloat = 80.0
-    @State private var isPoofing: Bool = false
+    @State private var poofingAttachmentIds: Set<UUID> = []
     @State private var isPoofingInvite: Bool = false
-    @State private var isPoofingFile: Bool = false
 
     static var defaultHeight: CGFloat {
         32.0
@@ -61,10 +58,9 @@ struct MessagesInputView: View {
     }
 
     private var hasAttachments: Bool {
-        selectedAttachmentImage != nil
+        !pendingMediaAttachments.isEmpty
             || pendingInviteURL != nil
             || composerLinkPreview != nil
-            || pendingFileAttachment != nil
     }
 
     private var avatarButton: some View {
@@ -155,17 +151,14 @@ struct MessagesInputView: View {
     private var attachmentPreviewArea: some View {
         ScrollView(.horizontal, showsIndicators: false) {
             HStack(spacing: DesignConstants.Spacing.step2x) {
-                if let image = selectedAttachmentImage {
-                    attachmentPreview(image: image)
+                ForEach(pendingMediaAttachments) { attachment in
+                    mediaAttachmentPreview(attachment)
                 }
                 if let pendingInviteURL {
                     inviteAttachmentPreview(url: pendingInviteURL)
                 }
                 if let composerLinkPreview {
                     linkPreviewAttachment(preview: composerLinkPreview)
-                }
-                if let pendingFileAttachment {
-                    fileAttachmentPreview(file: pendingFileAttachment)
                 }
             }
             .padding(.horizontal, DesignConstants.Spacing.step2x)
@@ -176,7 +169,66 @@ struct MessagesInputView: View {
     }
 
     @ViewBuilder
-    private func fileAttachmentPreview(file: PendingFileAttachment) -> some View {
+    private func mediaAttachmentPreview(_ attachment: PendingMediaAttachment) -> some View {
+        switch attachment {
+        case .photo(let photo):
+            photoVideoPreview(image: photo.image, isVideo: false, attachmentId: attachment.id)
+        case .video(let video):
+            photoVideoPreview(image: video.thumbnail, isVideo: true, attachmentId: attachment.id)
+        case .file(let file):
+            filePreview(file: file)
+        }
+    }
+
+    @ViewBuilder
+    private func photoVideoPreview(image: UIImage?, isVideo: Bool, attachmentId: UUID) -> some View {
+        let isPoof: Bool = poofingAttachmentIds.contains(attachmentId)
+        let scale: CGFloat = isPoof ? 1.3 : 1.0
+        let blur: CGFloat = isPoof ? 12.0 : 0.0
+        let opacity: Double = isPoof ? 0.0 : 1.0
+        ZStack(alignment: .topTrailing) {
+            Group {
+                if let image {
+                    Image(uiImage: image)
+                        .resizable()
+                        .aspectRatio(contentMode: .fill)
+                } else {
+                    Color.colorFillSubtle
+                }
+            }
+            .frame(width: attachmentPreviewSize, height: attachmentPreviewSize)
+            .clipShape(.rect(cornerRadius: DesignConstants.Spacing.step4x))
+            .scaleEffect(scale)
+            .blur(radius: blur)
+            .opacity(opacity)
+            .accessibilityLabel(isVideo ? "Video attachment preview" : "Attachment preview")
+            .accessibilityIdentifier("attachment-preview-image")
+            .overlay(alignment: .bottomLeading) {
+                if isVideo {
+                    Image(systemName: "video.fill")
+                        .font(.system(size: 16.0, weight: .bold))
+                        .foregroundStyle(.white)
+                        .shadow(color: .black.opacity(0.5), radius: 2, x: 0, y: 1)
+                        .padding(.bottom, DesignConstants.Spacing.step2x)
+                        .padding(.leading, DesignConstants.Spacing.step2x)
+                        .accessibilityHidden(true)
+                }
+            }
+
+            removeAttachmentButton(
+                attachmentId: attachmentId,
+                label: "Remove attachment",
+                identifier: "remove-attachment-button"
+            )
+        }
+    }
+
+    @ViewBuilder
+    private func filePreview(file: PendingFileAttachment) -> some View {
+        let isPoof: Bool = poofingAttachmentIds.contains(file.id)
+        let scale: CGFloat = isPoof ? 1.3 : 1.0
+        let blur: CGFloat = isPoof ? 12.0 : 0.0
+        let opacity: Double = isPoof ? 0.0 : 1.0
         ZStack(alignment: .topTrailing) {
             FileAttachmentRow(
                 filename: file.filename,
@@ -188,85 +240,45 @@ struct MessagesInputView: View {
             .frame(maxWidth: 240.0)
             .background(.colorFillSubtle)
             .clipShape(.rect(cornerRadius: DesignConstants.Spacing.step4x))
-            .scaleEffect(isPoofingFile ? 1.3 : 1.0)
-            .blur(radius: isPoofingFile ? 12.0 : 0.0)
-            .opacity(isPoofingFile ? 0.0 : 1.0)
+            .scaleEffect(scale)
+            .blur(radius: blur)
+            .opacity(opacity)
             .accessibilityElement(children: .contain)
             .accessibilityIdentifier("file-attachment-preview")
 
-            Button {
-                withAnimation(.easeOut(duration: 0.2)) {
-                    isPoofingFile = true
-                }
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
-                    onClearFile?()
-                    isPoofingFile = false
-                }
-            } label: {
-                Image(systemName: "xmark")
-                    .font(.system(size: 10.0, weight: .bold))
-                    .foregroundStyle(.white)
-                    .frame(width: 20.0, height: 20.0)
-                    .background(.black)
-                    .clipShape(.circle)
-                    .overlay(Circle().stroke(.white.opacity(0.6), lineWidth: 1.0))
-            }
-            .opacity(isPoofingFile ? 0.0 : 1.0)
-            .padding(.top, DesignConstants.Spacing.step2x)
-            .padding(.trailing, DesignConstants.Spacing.step2x)
-            .accessibilityLabel("Remove file attachment")
-            .accessibilityIdentifier("remove-file-attachment-button")
+            removeAttachmentButton(
+                attachmentId: file.id,
+                label: "Remove file attachment",
+                identifier: "remove-file-attachment-button"
+            )
         }
     }
 
     @ViewBuilder
-    private func attachmentPreview(image: UIImage) -> some View {
-        ZStack(alignment: .topTrailing) {
-            Image(uiImage: image)
-                .resizable()
-                .aspectRatio(contentMode: .fill)
-                .frame(width: attachmentPreviewSize, height: attachmentPreviewSize)
-                .clipShape(.rect(cornerRadius: DesignConstants.Spacing.step4x))
-                .scaleEffect(isPoofing ? 1.3 : 1.0)
-                .blur(radius: isPoofing ? 12.0 : 0.0)
-                .opacity(isPoofing ? 0.0 : 1.0)
-                .accessibilityLabel(isVideoAttachment ? "Video attachment preview" : "Attachment preview")
-                .accessibilityIdentifier("attachment-preview-image")
-                .overlay(alignment: .bottomLeading) {
-                    if isVideoAttachment {
-                        Image(systemName: "video.fill")
-                            .font(.system(size: 16.0, weight: .bold))
-                            .foregroundStyle(.white)
-                            .shadow(color: .black.opacity(0.5), radius: 2, x: 0, y: 1)
-                            .padding(.bottom, DesignConstants.Spacing.step2x)
-                            .padding(.leading, DesignConstants.Spacing.step2x)
-                            .accessibilityHidden(true)
-                    }
-                }
-
-            Button {
-                withAnimation(.easeOut(duration: 0.2)) {
-                    isPoofing = true
-                }
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
-                    selectedAttachmentImage = nil
-                    isPoofing = false
-                }
-            } label: {
-                Image(systemName: "xmark")
-                    .font(.system(size: 10.0, weight: .bold))
-                    .foregroundStyle(.white)
-                    .frame(width: 20.0, height: 20.0)
-                    .background(.black)
-                    .clipShape(.circle)
-                    .overlay(Circle().stroke(.white.opacity(0.6), lineWidth: 1.0))
+    private func removeAttachmentButton(attachmentId: UUID, label: String, identifier: String) -> some View {
+        let isPoof: Bool = poofingAttachmentIds.contains(attachmentId)
+        Button {
+            withAnimation(.easeOut(duration: 0.2)) {
+                _ = poofingAttachmentIds.insert(attachmentId)
             }
-            .opacity(isPoofing ? 0.0 : 1.0)
-            .padding(.top, DesignConstants.Spacing.step2x)
-            .padding(.trailing, DesignConstants.Spacing.step2x)
-            .accessibilityLabel("Remove attachment")
-            .accessibilityIdentifier("remove-attachment-button")
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+                onClearMediaAttachment?(attachmentId)
+                poofingAttachmentIds.remove(attachmentId)
+            }
+        } label: {
+            Image(systemName: "xmark")
+                .font(.system(size: 10.0, weight: .bold))
+                .foregroundStyle(.white)
+                .frame(width: 20.0, height: 20.0)
+                .background(.black)
+                .clipShape(.circle)
+                .overlay(Circle().stroke(.white.opacity(0.6), lineWidth: 1.0))
         }
+        .opacity(isPoof ? 0.0 : 1.0)
+        .padding(.top, DesignConstants.Spacing.step2x)
+        .padding(.trailing, DesignConstants.Spacing.step2x)
+        .accessibilityLabel(label)
+        .accessibilityIdentifier(identifier)
     }
 
     @ViewBuilder
@@ -616,7 +628,6 @@ private struct ComposerSideConvoCard: View {
     @Previewable @State var messageText: String = ""
     @Previewable @State var sendButtonEnabled: Bool = false
     @Previewable @State var profileImage: UIImage?
-    @Previewable @State var selectedAttachmentImage: UIImage?
     @Previewable @State var pendingInviteURLPreview: String? = "https://convos.xyz/invite/test-code"
     @Previewable @State var animateAvatarForProfileSetup: Bool = false
     @Previewable @FocusState var focusState: MessagesViewInputFocus?
@@ -639,7 +650,6 @@ private struct ComposerSideConvoCard: View {
             displayName: $displayName,
             emptyDisplayNamePlaceholder: "Somebody",
             messageText: $messageText,
-            selectedAttachmentImage: $selectedAttachmentImage,
             pendingInviteURL: pendingInviteURLPreview,
             pendingInviteConvoName: .constant(""),
             pendingInviteImage: .constant(nil),

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesMediaInputView.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesMediaInputView.swift
@@ -6,7 +6,17 @@ struct MessagesMediaButtonsView: View {
     let onVoiceMemoTap: () -> Void
     let onFilePickerTap: () -> Void
     let onConvosAction: () -> Void
+    var isMediaCapacityFull: Bool = false
+    var isVoiceMemoDisabled: Bool = false
     var isSideConvoDisabled: Bool = false
+
+    private var mediaTint: Color {
+        isMediaCapacityFull ? Color.colorTextPrimary.opacity(0.3) : Color.colorTextPrimary
+    }
+
+    private var voiceMemoTint: Color {
+        isVoiceMemoDisabled ? Color.colorTextPrimary.opacity(0.3) : Color.colorTextPrimary
+    }
 
     var body: some View {
         HStack(spacing: DesignConstants.Spacing.step2x) {
@@ -15,11 +25,12 @@ struct MessagesMediaButtonsView: View {
             } label: {
                 Image(systemName: "photo.fill")
                     .font(.system(size: 18.0, weight: .medium))
-                    .foregroundStyle(Color.colorTextPrimary)
+                    .foregroundStyle(mediaTint)
                     .frame(width: Constant.buttonSize, height: Constant.buttonSize)
                     .contentShape(.circle)
             }
             .buttonStyle(.plain)
+            .disabled(isMediaCapacityFull)
             .accessibilityLabel("Photo library")
             .accessibilityIdentifier("photo-picker-button")
 
@@ -28,11 +39,12 @@ struct MessagesMediaButtonsView: View {
             } label: {
                 Image(systemName: "camera.fill")
                     .font(.system(size: 18.0, weight: .medium))
-                    .foregroundStyle(Color.colorTextPrimary)
+                    .foregroundStyle(mediaTint)
                     .frame(width: Constant.buttonSize, height: Constant.buttonSize)
                     .contentShape(.circle)
             }
             .buttonStyle(.plain)
+            .disabled(isMediaCapacityFull)
             .accessibilityLabel("Camera")
             .accessibilityIdentifier("camera-button")
 
@@ -41,11 +53,12 @@ struct MessagesMediaButtonsView: View {
             } label: {
                 Image(systemName: "waveform")
                     .font(.system(size: 18.0, weight: .medium))
-                    .foregroundStyle(Color.colorTextPrimary)
+                    .foregroundStyle(voiceMemoTint)
                     .frame(width: Constant.buttonSize, height: Constant.buttonSize)
                     .contentShape(.circle)
             }
             .buttonStyle(.plain)
+            .disabled(isVoiceMemoDisabled)
             .accessibilityLabel("Voice memo")
             .accessibilityIdentifier("voice-memo-button")
 
@@ -54,11 +67,12 @@ struct MessagesMediaButtonsView: View {
             } label: {
                 Image(systemName: "document.fill")
                     .font(.system(size: 18.0, weight: .medium))
-                    .foregroundStyle(Color.colorTextPrimary)
+                    .foregroundStyle(mediaTint)
                     .frame(width: Constant.buttonSize, height: Constant.buttonSize)
                     .contentShape(.circle)
             }
             .buttonStyle(.plain)
+            .disabled(isMediaCapacityFull)
             .accessibilityLabel("Attach file")
             .accessibilityIdentifier("file-picker-button")
 

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
@@ -924,6 +924,10 @@ private struct AttachmentPlaceholder: View {
             try data.write(to: tempURL)
             return tempURL
         }
+        if let local = await OutgoingMediaLocalCache.shared.url(for: key),
+           FileManager.default.fileExists(atPath: local.path) {
+            return local
+        }
         if let cached = await VideoURLCache.shared.url(for: key) {
             return cached
         }

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
@@ -773,13 +773,16 @@ private struct AttachmentPlaceholder: View {
         }
     }
 
-    // Returns false if the in-flight local file never showed up (timeout or
-    // task cancellation). Returns true when the file is on disk or the key
-    // doesn't point to a local file at all.
-    private func waitForLocalVideoFileIfNeeded() async -> Bool {
-        guard attachment.key.hasPrefix("file://") else { return true }
+    private enum LocalVideoWaitResult {
+        case ready
+        case timedOut
+        case cancelled
+    }
+
+    private func waitForLocalVideoFileIfNeeded() async -> LocalVideoWaitResult {
+        guard attachment.key.hasPrefix("file://") else { return .ready }
         let path = String(attachment.key.dropFirst("file://".count))
-        if FileManager.default.fileExists(atPath: path) { return true }
+        if FileManager.default.fileExists(atPath: path) { return .ready }
         isLoadingVideo = true
         let deadline = Date().addingTimeInterval(60)
         while !FileManager.default.fileExists(atPath: path),
@@ -787,7 +790,9 @@ private struct AttachmentPlaceholder: View {
               Date() < deadline {
             try? await Task.sleep(nanoseconds: 250_000_000)
         }
-        return FileManager.default.fileExists(atPath: path) && !Task.isCancelled
+        if FileManager.default.fileExists(atPath: path) { return .ready }
+        if Task.isCancelled { return .cancelled }
+        return .timedOut
     }
 
     private func loadVideoAttachment() async {
@@ -814,8 +819,17 @@ private struct AttachmentPlaceholder: View {
             }
         }
 
-        if !(await waitForLocalVideoFileIfNeeded()) {
+        switch await waitForLocalVideoFileIfNeeded() {
+        case .ready:
+            break
+        case .cancelled:
             isLoadingVideo = false
+            return
+        case .timedOut:
+            isLoading = false
+            isLoadingVideo = false
+            videoLoadFailed = true
+            Log.error("Timed out waiting for local video file: \(attachment.key)")
             return
         }
 

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
@@ -775,6 +775,29 @@ private struct AttachmentPlaceholder: View {
             if attachment.width == nil {
                 onDimensionsLoaded(Int(thumb.size.width), Int(thumb.size.height))
             }
+        } else if let cachedThumb = await ImageCache.shared.imageAsync(for: cacheKey) {
+            // Thumbnail was cached at staging time by the eager video pipeline.
+            // Render it so the bubble has content while compression / upload
+            // run in the background.
+            loadedImage = cachedThumb
+            isLoading = false
+            isLoadingVideo = true
+            videoLoadFailed = false
+            if attachment.width == nil {
+                onDimensionsLoaded(Int(cachedThumb.size.width), Int(cachedThumb.size.height))
+            }
+        }
+
+        // If the message points to a local file that isn't on disk yet (eager
+        // pipeline still preparing it) and we already have a thumbnail loaded,
+        // skip the video-URL resolution. The message will refresh once
+        // publishAttachment updates it with the remote asset URL.
+        if loadedImage != nil, attachment.key.hasPrefix("file://") {
+            let path = String(attachment.key.dropFirst("file://".count))
+            if !FileManager.default.fileExists(atPath: path) {
+                isLoadingVideo = false
+                return
+            }
         }
 
         do {

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
@@ -672,7 +672,7 @@ private struct AttachmentPlaceholder: View {
             inlinePlayer?.pause()
             isPlaying = false
         }
-        .task {
+        .task(id: attachment.key) {
             await loadAttachment()
         }
     }

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
@@ -754,6 +754,15 @@ private struct AttachmentPlaceholder: View {
     }
 
     private func loadAttachment() async {
+        // Reset all per-attachment state so a re-fire from .task(id:) on a
+        // changed key (e.g. file:// → https:// once the upload publishes)
+        // doesn't show stale visuals or hold onto the previous AVPlayer.
+        inlinePlayer?.pause()
+        inlinePlayer = nil
+        isPlaying = false
+        loadedImage = nil
+        isLoadingVideo = false
+        videoLoadFailed = false
         isLoading = true
         loadError = nil
 
@@ -762,6 +771,23 @@ private struct AttachmentPlaceholder: View {
         } else {
             await loadPhotoAttachment()
         }
+    }
+
+    // Returns false if the in-flight local file never showed up (timeout or
+    // task cancellation). Returns true when the file is on disk or the key
+    // doesn't point to a local file at all.
+    private func waitForLocalVideoFileIfNeeded() async -> Bool {
+        guard attachment.key.hasPrefix("file://") else { return true }
+        let path = String(attachment.key.dropFirst("file://".count))
+        if FileManager.default.fileExists(atPath: path) { return true }
+        isLoadingVideo = true
+        let deadline = Date().addingTimeInterval(60)
+        while !FileManager.default.fileExists(atPath: path),
+              !Task.isCancelled,
+              Date() < deadline {
+            try? await Task.sleep(nanoseconds: 250_000_000)
+        }
+        return FileManager.default.fileExists(atPath: path) && !Task.isCancelled
     }
 
     private func loadVideoAttachment() async {
@@ -788,16 +814,9 @@ private struct AttachmentPlaceholder: View {
             }
         }
 
-        // If the message points to a local file that isn't on disk yet (eager
-        // pipeline still preparing it) and we already have a thumbnail loaded,
-        // skip the video-URL resolution. The message will refresh once
-        // publishAttachment updates it with the remote asset URL.
-        if loadedImage != nil, attachment.key.hasPrefix("file://") {
-            let path = String(attachment.key.dropFirst("file://".count))
-            if !FileManager.default.fileExists(atPath: path) {
-                isLoadingVideo = false
-                return
-            }
+        if !(await waitForLocalVideoFileIfNeeded()) {
+            isLoadingVideo = false
+            return
         }
 
         do {

--- a/Convos/Conversation Detail/Messages/MessagesView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesView.swift
@@ -19,8 +19,7 @@ struct MessagesView<BottomBarContent: View>: View {
     @Binding var conversationImage: UIImage?
     @Binding var displayName: String
     @Binding var messageText: String
-    @Binding var selectedAttachmentImage: UIImage?
-    var isVideoAttachment: Bool = false
+    var pendingMediaAttachments: [PendingMediaAttachment] = []
     var composerLinkPreview: LinkPreview?
     var pendingInviteURL: String?
     var pendingInviteEmoji: String?
@@ -29,7 +28,6 @@ struct MessagesView<BottomBarContent: View>: View {
     var pendingInviteExplodeDuration: ExplodeDuration?
     var onSetInviteExplodeDuration: ((ExplodeDuration?) -> Void)?
     var onInviteConvoNameEditingEnded: ((String) -> Void)?
-    var pendingFileAttachment: PendingFileAttachment?
     let sendButtonEnabled: Bool
     @Binding var profileImage: UIImage?
     let onboardingCoordinator: ConversationOnboardingCoordinator
@@ -41,7 +39,7 @@ struct MessagesView<BottomBarContent: View>: View {
     let onSendMessage: () -> Void
     let onClearInvite: () -> Void
     let onClearLinkPreview: () -> Void
-    let onClearFile: () -> Void
+    let onClearMediaAttachment: (UUID) -> Void
     let onTapAvatar: (ConversationMember) -> Void
     let onTapInvite: (MessageInvite) -> Void
     let onReaction: (String, String) -> Void
@@ -58,6 +56,7 @@ struct MessagesView<BottomBarContent: View>: View {
     let onPhotoRevealed: (String) -> Void
     let onPhotoHidden: (String) -> Void
     let onPhotoDimensionsLoaded: (String, Int, Int) -> Void
+    let onPhotoSelected: (UIImage) -> Void
     let onVideoSelected: (URL) -> Void
     let onFileSelected: (URL, String, String, Int) -> Void
     let onAboutAssistants: () -> Void
@@ -131,8 +130,7 @@ struct MessagesView<BottomBarContent: View>: View {
                 profile: profile,
                 displayName: $displayName,
                 messageText: $messageText,
-                selectedAttachmentImage: $selectedAttachmentImage,
-                isVideoAttachment: isVideoAttachment,
+                pendingMediaAttachments: pendingMediaAttachments,
                 composerLinkPreview: composerLinkPreview,
                 pendingInviteURL: pendingInviteURL,
                 pendingInviteEmoji: pendingInviteEmoji,
@@ -141,7 +139,6 @@ struct MessagesView<BottomBarContent: View>: View {
                 pendingInviteExplodeDuration: pendingInviteExplodeDuration,
                 onSetInviteExplodeDuration: onSetInviteExplodeDuration,
                 onInviteConvoNameEditingEnded: onInviteConvoNameEditingEnded,
-                pendingFileAttachment: pendingFileAttachment,
                 sendButtonEnabled: sendButtonEnabled,
                 profileImage: $profileImage,
                 isPhotoPickerPresented: $isPhotoPickerPresented,
@@ -156,8 +153,9 @@ struct MessagesView<BottomBarContent: View>: View {
                 },
                 onClearInvite: onClearInvite,
                 onClearLinkPreview: onClearLinkPreview,
-                onClearFile: onClearFile,
+                onClearMediaAttachment: onClearMediaAttachment,
                 onDisplayNameEndedEditing: onDisplayNameEndedEditing,
+                onPhotoSelected: onPhotoSelected,
                 onVideoSelected: onVideoSelected,
                 onFileSelected: onFileSelected,
                 onProfileSettings: onProfileSettings,

--- a/ConvosCore/Sources/ConvosCore/Inboxes/ConversationStateMachine.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/ConversationStateMachine.swift
@@ -267,6 +267,21 @@ public actor ConversationStateMachine {
         try await writer.sendEagerPhoto(trackingKey: trackingKey)
     }
 
+    func startEagerVideoUpload(at fileURL: URL) async throws -> String {
+        let writer = try await getOrCreateMessageWriter()
+        return try await writer.startEagerVideoUpload(at: fileURL)
+    }
+
+    func sendEagerVideo(trackingKey: String) async throws {
+        let writer = try await getOrCreateMessageWriter()
+        try await writer.sendEagerVideo(trackingKey: trackingKey)
+    }
+
+    func sendEagerVideoReply(trackingKey: String, toMessageWithClientId parentClientMessageId: String) async throws {
+        let writer = try await getOrCreateMessageWriter()
+        try await writer.sendEagerVideoReply(trackingKey: trackingKey, toMessageWithClientId: parentClientMessageId)
+    }
+
     func cancelEagerUpload(trackingKey: String) async {
         guard let writer = cachedMessageWriter else { return }
         await writer.cancelEagerUpload(trackingKey: trackingKey)

--- a/ConvosCore/Sources/ConvosCore/Messaging/OutgoingMediaLocalCache.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/OutgoingMediaLocalCache.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+/// In-memory map from a published attachment's StoredRemoteAttachment JSON key to the
+/// sender's local copy of the file. Populated by the message writer at publish time
+/// so outgoing video bubbles can play directly from disk instead of re-downloading the
+/// encrypted asset from the storage backend on first render.
+public actor OutgoingMediaLocalCache {
+    public static let shared: OutgoingMediaLocalCache = .init()
+
+    private var cache: [String: URL] = [:]
+
+    public init() {}
+
+    public func register(_ url: URL, for key: String) {
+        cache[key] = url
+    }
+
+    public func url(for key: String) -> URL? {
+        cache[key]
+    }
+
+    public func clear() {
+        cache.removeAll()
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Messaging/VideoCompressionService.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/VideoCompressionService.swift
@@ -49,7 +49,7 @@ public protocol VideoCompressionServiceProtocol: Sendable {
 }
 
 public final class VideoCompressionService: VideoCompressionServiceProtocol, Sendable {
-    public static let maxFileSizeBytes: Int64 = 25 * 1024 * 1024
+    public static let maxFileSizeBytes: Int64 = 50 * 1024 * 1024
     private static let thumbnailMaxDimension: CGFloat = 400
 
     public init() {}
@@ -76,7 +76,7 @@ public final class VideoCompressionService: VideoCompressionServiceProtocol, Sen
 
         guard let exportSession = AVAssetExportSession(
             asset: asset,
-            presetName: AVAssetExportPresetMediumQuality
+            presetName: AVAssetExportPresetHEVC1920x1080
         ) else {
             throw VideoCompressionError.exportSessionCreationFailed
         }

--- a/ConvosCore/Sources/ConvosCore/Mocks/MockConversationStateManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Mocks/MockConversationStateManager.swift
@@ -100,6 +100,9 @@ public final class MockConversationStateManager: ConversationStateManagerProtoco
     }
 
     public func sendEagerPhoto(trackingKey: String) async throws {}
+    public func startEagerVideoUpload(at fileURL: URL) async throws -> String { UUID().uuidString }
+    public func sendEagerVideo(trackingKey: String) async throws {}
+    public func sendEagerVideoReply(trackingKey: String, toMessageWithClientId parentClientMessageId: String) async throws {}
     public func cancelEagerUpload(trackingKey: String) async {}
     public func sendVideo(at fileURL: URL, replyToMessageId: String?) async throws -> String { UUID().uuidString }
     public func sendVoiceMemo(at fileURL: URL, duration: TimeInterval, waveformLevels: [Float]?, replyToMessageId: String?) async throws -> String { UUID().uuidString }

--- a/ConvosCore/Sources/ConvosCore/Mocks/MockOutgoingMessageWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Mocks/MockOutgoingMessageWriter.swift
@@ -39,6 +39,20 @@ public final class MockOutgoingMessageWriter: OutgoingMessageWriterProtocol, @un
         sentMessageSubject.send(mockURL)
     }
 
+    public func startEagerVideoUpload(at fileURL: URL) async throws -> String {
+        UUID().uuidString
+    }
+
+    public func sendEagerVideo(trackingKey: String) async throws {
+        sentImageCount += 1
+        let mockURL = "https://example.com/videos/mock_video_\(sentImageCount).mp4"
+        sentMessageSubject.send(mockURL)
+    }
+
+    public func sendEagerVideoReply(trackingKey: String, toMessageWithClientId parentClientMessageId: String) async throws {
+        try await sendEagerVideo(trackingKey: trackingKey)
+    }
+
     public func cancelEagerUpload(trackingKey: String) async {}
 
     public func sendVideo(at fileURL: URL, replyToMessageId: String?) async throws -> String {

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationStateManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationStateManager.swift
@@ -223,6 +223,18 @@ public final class ConversationStateManager: ConversationStateManagerProtocol, @
         try await stateMachine.sendEagerPhoto(trackingKey: trackingKey)
     }
 
+    public func startEagerVideoUpload(at fileURL: URL) async throws -> String {
+        try await stateMachine.startEagerVideoUpload(at: fileURL)
+    }
+
+    public func sendEagerVideo(trackingKey: String) async throws {
+        try await stateMachine.sendEagerVideo(trackingKey: trackingKey)
+    }
+
+    public func sendEagerVideoReply(trackingKey: String, toMessageWithClientId parentClientMessageId: String) async throws {
+        try await stateMachine.sendEagerVideoReply(trackingKey: trackingKey, toMessageWithClientId: parentClientMessageId)
+    }
+
     public func cancelEagerUpload(trackingKey: String) async {
         await stateMachine.cancelEagerUpload(trackingKey: trackingKey)
     }

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/OutgoingMessageWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/OutgoingMessageWriter.swift
@@ -21,7 +21,21 @@ public protocol OutgoingMessageWriterProtocol: Sendable {
     /// Waits for upload to complete if still in progress, then sends via XMTP.
     func sendEagerPhoto(trackingKey: String) async throws
 
-    /// Cancel an eager upload that was started but not sent.
+    /// Start the compress-encrypt-upload pipeline for a video eagerly (before user
+    /// taps Send). Returns a tracking key usable with `sendEagerVideo` /
+    /// `sendEagerVideoReply` / `cancelEagerUpload`. The thumbnail and dimensions
+    /// are captured synchronously so the bubble can render immediately on Send;
+    /// compression and upload run in the background.
+    func startEagerVideoUpload(at fileURL: URL) async throws -> String
+
+    /// Send a video that was already started with `startEagerVideoUpload`.
+    /// Waits for the background pipeline to finish if still in progress.
+    func sendEagerVideo(trackingKey: String) async throws
+
+    /// Send a video reply that was already started with `startEagerVideoUpload`.
+    func sendEagerVideoReply(trackingKey: String, toMessageWithClientId parentClientMessageId: String) async throws
+
+    /// Cancel an eager upload (photo or video) that was started but not sent.
     func cancelEagerUpload(trackingKey: String) async
 
     // MARK: - Replies
@@ -124,12 +138,34 @@ actor OutgoingMessageWriter: OutgoingMessageWriterProtocol {
         let trackingKey: String
     }
 
+    private struct EagerVideoUploadState {
+        let clientMessageId: String
+        let originalURL: URL
+        let localCacheURL: URL
+        let filename: String
+        let thumbnailData: Data
+        let width: Int
+        let height: Int
+        let duration: Double
+        var prepared: PreparedBackgroundUpload?
+        var compressedFileURL: URL?
+        var processingCompleted: Bool = false
+        var processingError: Error?
+        var waitingContinuation: CheckedContinuation<Void, Error>?
+        var replyContext: ReplyContext?
+    }
+
+    private struct QueuedEagerVideo {
+        let trackingKey: String
+    }
+
     private enum QueuedMessage {
         case text(QueuedTextMessage)
         case photo(QueuedPhotoMessage)
         case video(QueuedVideoMessage)
         case audio(QueuedAudioMessage)
         case eagerPhoto(QueuedEagerPhoto)
+        case eagerVideo(QueuedEagerVideo)
     }
 
     private let sessionStateManager: any SessionStateManagerProtocol
@@ -143,6 +179,7 @@ actor OutgoingMessageWriter: OutgoingMessageWriterProtocol {
     private var messageQueue: [QueuedMessage] = []
     private var isProcessingQueue: Bool = false
     private var eagerUploads: [String: EagerUploadState] = [:]
+    private var eagerVideoUploads: [String: EagerVideoUploadState] = [:]
     private var publishedPhotoKeys: Set<String> = []
     private var pendingTexts: [QueuedTextMessage] = []
 
@@ -462,22 +499,318 @@ actor OutgoingMessageWriter: OutgoingMessageWriterProtocol {
     }
 
     func cancelEagerUpload(trackingKey: String) async {
-        guard let state = eagerUploads[trackingKey] else { return }
+        if let state = eagerUploads[trackingKey] {
+            Log.debug("Cancelling eager upload for: \(trackingKey)")
 
-        Log.debug("Cancelling eager upload for: \(trackingKey)")
+            await backgroundUploadManager.cancelUpload(taskId: state.prepared.taskId)
 
-        await backgroundUploadManager.cancelUpload(taskId: state.prepared.taskId)
+            try? await pendingUploadWriter.delete(taskId: state.prepared.taskId)
+            try? FileManager.default.removeItem(at: state.prepared.encryptedFileURL)
 
-        try? await pendingUploadWriter.delete(taskId: state.prepared.taskId)
-        try? FileManager.default.removeItem(at: state.prepared.encryptedFileURL)
+            // Note: No need to delete from DBMessage - the message was never saved to the database
+            // (that only happens in sendEagerPhoto when user taps Send)
 
-        // Note: No need to delete from DBMessage - the message was never saved to the database
-        // (that only happens in sendEagerPhoto when user taps Send)
+            PhotoUploadProgressTracker.shared.clear(key: trackingKey)
 
-        PhotoUploadProgressTracker.shared.clear(key: trackingKey)
+            await markPhotoFailed(trackingKey: trackingKey)
+            eagerUploads.removeValue(forKey: trackingKey)
+        } else if let state = eagerVideoUploads[trackingKey] {
+            Log.debug("Cancelling eager video upload for: \(trackingKey)")
 
-        await markPhotoFailed(trackingKey: trackingKey)
-        eagerUploads.removeValue(forKey: trackingKey)
+            if let prepared = state.prepared {
+                await backgroundUploadManager.cancelUpload(taskId: prepared.taskId)
+                try? await pendingUploadWriter.delete(taskId: prepared.taskId)
+                try? FileManager.default.removeItem(at: prepared.encryptedFileURL)
+            }
+            if let compressedFileURL = state.compressedFileURL {
+                try? FileManager.default.removeItem(at: compressedFileURL)
+            }
+            try? FileManager.default.removeItem(at: state.originalURL)
+
+            PhotoUploadProgressTracker.shared.clear(key: trackingKey)
+
+            await markPhotoFailed(trackingKey: trackingKey)
+            eagerVideoUploads.removeValue(forKey: trackingKey)
+        }
+    }
+
+    // MARK: - Eager Video Upload
+
+    func startEagerVideoUpload(at fileURL: URL) async throws -> String {
+        let clientMessageId = UUID().uuidString
+        let filename = "video_\(Int(Date().timeIntervalSince1970))_\(UUID().uuidString.prefix(8)).mp4"
+        let localCacheURL = try photoService.localCacheURL(for: filename)
+        let trackingKey = localCacheURL.absoluteString
+
+        Log.debug("Starting eager video upload for: \(trackingKey)")
+
+        // Probe dimensions and generate thumbnail synchronously so the bubble
+        // has content to render the moment the user taps Send. Compression and
+        // upload run in the background.
+        let asset = AVURLAsset(url: fileURL)
+        guard let videoTrack = try await asset.loadTracks(withMediaType: .video).first else {
+            throw VideoCompressionError.invalidAsset
+        }
+        let naturalSize = try await videoTrack.load(.naturalSize)
+        let transform = try await videoTrack.load(.preferredTransform)
+        let transformedSize = naturalSize.applying(transform)
+        let width: Int = Int(abs(transformedSize.width))
+        let height: Int = Int(abs(transformedSize.height))
+        let durationCMTime = try await asset.load(.duration)
+        let duration: Double = CMTimeGetSeconds(durationCMTime)
+
+        let compressionService = VideoCompressionService()
+        let thumbnailData = try await compressionService.generateThumbnail(for: asset)
+
+        if let thumbnailImage = ImageType(data: thumbnailData) {
+            ImageCacheContainer.shared.cacheImage(thumbnailImage, for: trackingKey, storageTier: .persistent)
+        }
+
+        PhotoUploadProgressTracker.shared.setStage(.preparing, for: trackingKey)
+
+        let state = EagerVideoUploadState(
+            clientMessageId: clientMessageId,
+            originalURL: fileURL,
+            localCacheURL: localCacheURL,
+            filename: filename,
+            thumbnailData: thumbnailData,
+            width: width,
+            height: height,
+            duration: duration
+        )
+        eagerVideoUploads[trackingKey] = state
+
+        Task { [weak self] in
+            guard let self else { return }
+            await self.runEagerVideoPipeline(trackingKey: trackingKey)
+        }
+
+        return trackingKey
+    }
+
+    private func runEagerVideoPipeline(trackingKey: String) async {
+        let tracker = PhotoUploadProgressTracker.shared
+        do {
+            guard let state = eagerVideoUploads[trackingKey] else { return }
+
+            let compressionService = VideoCompressionService()
+            let compressed = try await compressionService.compressVideo(at: state.originalURL)
+
+            // Mirror the compressed file into the local cache so the renderer can
+            // resolve the message's attachment URL once Send happens.
+            try FileManager.default.createDirectory(
+                at: state.localCacheURL.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            try? FileManager.default.removeItem(at: state.localCacheURL)
+            try FileManager.default.copyItem(at: compressed.fileURL, to: state.localCacheURL)
+
+            try await attachmentLocalStateWriter.saveWithDimensions(
+                attachmentKey: trackingKey,
+                conversationId: conversationId,
+                width: state.width,
+                height: state.height,
+                mimeType: "video/mp4"
+            )
+            try? await attachmentLocalStateWriter.saveDuration(state.duration, for: trackingKey)
+
+            let inboxReady = try await sessionStateManager.waitForInboxReadyResult()
+            let fileData = try Data(contentsOf: compressed.fileURL)
+            let attachment = Attachment(
+                filename: state.filename,
+                mimeType: "video/mp4",
+                data: fileData
+            )
+            let encrypted = try RemoteAttachment.encodeEncrypted(
+                content: attachment,
+                codec: AttachmentCodec()
+            )
+            let presignedURLs = try await inboxReady.apiClient.getPresignedUploadURL(
+                filename: state.filename,
+                contentType: "application/octet-stream"
+            )
+            guard let uploadURL = URL(string: presignedURLs.uploadURL) else {
+                throw PhotoAttachmentError.invalidURL
+            }
+
+            let taskId = UUID().uuidString
+            let encryptedFileURL = try saveToTemp(data: encrypted.payload, taskId: taskId)
+
+            let prepared = PreparedBackgroundUpload(
+                taskId: taskId,
+                encryptedFileURL: encryptedFileURL,
+                presignedUploadURL: uploadURL,
+                assetURL: presignedURLs.assetURL,
+                encryptionSecret: encrypted.secret,
+                encryptionSalt: encrypted.salt,
+                encryptionNonce: encrypted.nonce,
+                contentDigest: encrypted.digest,
+                filename: state.filename
+            )
+
+            let pendingUpload = DBPendingPhotoUpload(
+                id: prepared.taskId,
+                clientMessageId: state.clientMessageId,
+                conversationId: conversationId,
+                localCacheURL: trackingKey,
+                state: .uploading
+            )
+            try await pendingUploadWriter.create(pendingUpload)
+
+            tracker.setProgress(stage: .uploading, percentage: 0, for: trackingKey)
+
+            try await backgroundUploadManager.startUpload(
+                fileURL: prepared.encryptedFileURL,
+                uploadURL: prepared.presignedUploadURL,
+                contentType: "application/octet-stream",
+                taskId: prepared.taskId
+            )
+
+            if var s = eagerVideoUploads[trackingKey] {
+                s.prepared = prepared
+                s.compressedFileURL = compressed.fileURL
+                eagerVideoUploads[trackingKey] = s
+            }
+
+            let result = await backgroundUploadManager.waitForCompletion(taskId: prepared.taskId)
+
+            if result.success {
+                try? await pendingUploadWriter.updateState(taskId: prepared.taskId, state: .sending, errorMessage: nil)
+                if var s = eagerVideoUploads[trackingKey] {
+                    s.processingCompleted = true
+                    let cont = s.waitingContinuation
+                    s.waitingContinuation = nil
+                    eagerVideoUploads[trackingKey] = s
+                    cont?.resume()
+                }
+            } else {
+                tracker.setStage(.failed, for: trackingKey)
+                try? await pendingUploadWriter.updateState(
+                    taskId: prepared.taskId,
+                    state: .failed,
+                    errorMessage: result.error?.localizedDescription
+                )
+                if var s = eagerVideoUploads[trackingKey] {
+                    s.processingError = result.error
+                    let cont = s.waitingContinuation
+                    s.waitingContinuation = nil
+                    eagerVideoUploads[trackingKey] = s
+                    let error: Error = result.error ?? PhotoAttachmentError.uploadFailed("Eager video upload failed")
+                    cont?.resume(throwing: error)
+                    try? await markMessageFailed(clientMessageId: s.clientMessageId)
+                }
+                await markPhotoFailed(trackingKey: trackingKey)
+            }
+        } catch {
+            if var state = eagerVideoUploads[trackingKey] {
+                state.processingError = error
+                let cont = state.waitingContinuation
+                state.waitingContinuation = nil
+                eagerVideoUploads[trackingKey] = state
+                cont?.resume(throwing: error)
+                try? await markMessageFailed(clientMessageId: state.clientMessageId)
+            }
+            await markPhotoFailed(trackingKey: trackingKey)
+            Log.error("Eager video pipeline failed: \(error)")
+        }
+    }
+
+    func sendEagerVideo(trackingKey: String) async throws {
+        guard let state = eagerVideoUploads[trackingKey] else {
+            throw OutgoingMessageWriterError.eagerUploadNotFound
+        }
+
+        // saveWithDimensions is idempotent — call it here too in case Send
+        // happened before the pipeline got far enough to write it.
+        try await attachmentLocalStateWriter.saveWithDimensions(
+            attachmentKey: trackingKey,
+            conversationId: conversationId,
+            width: state.width,
+            height: state.height,
+            mimeType: "video/mp4"
+        )
+        try? await attachmentLocalStateWriter.saveDuration(state.duration, for: trackingKey)
+
+        try await savePhotoToDatabase(
+            clientMessageId: state.clientMessageId,
+            localCacheURL: state.localCacheURL,
+            replyContext: state.replyContext
+        )
+
+        messageQueue.append(.eagerVideo(QueuedEagerVideo(trackingKey: trackingKey)))
+        startProcessingIfNeeded()
+    }
+
+    func sendEagerVideoReply(trackingKey: String, toMessageWithClientId parentClientMessageId: String) async throws {
+        let replyContext = try await resolveReplyContext(parentClientMessageId: parentClientMessageId)
+        guard var state = eagerVideoUploads[trackingKey] else {
+            throw OutgoingMessageWriterError.eagerUploadNotFound
+        }
+        state.replyContext = replyContext
+        eagerVideoUploads[trackingKey] = state
+        try await sendEagerVideo(trackingKey: trackingKey)
+    }
+
+    private func processEagerVideo(trackingKey: String) async throws {
+        guard var state = eagerVideoUploads[trackingKey] else {
+            throw OutgoingMessageWriterError.eagerUploadNotFound
+        }
+
+        if !state.processingCompleted && state.processingError == nil {
+            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+                state.waitingContinuation = continuation
+                eagerVideoUploads[trackingKey] = state
+            }
+            guard let updated = eagerVideoUploads[trackingKey] else {
+                throw OutgoingMessageWriterError.eagerUploadNotFound
+            }
+            state = updated
+        }
+
+        if let error = state.processingError {
+            throw error
+        }
+
+        guard let prepared = state.prepared else {
+            throw OutgoingMessageWriterError.eagerUploadNotFound
+        }
+
+        PhotoUploadProgressTracker.shared.setStage(.publishing, for: trackingKey)
+
+        let inboxReady = try await sessionStateManager.waitForInboxReadyResult()
+
+        let storedAttachment = StoredRemoteAttachment(
+            url: prepared.assetURL,
+            contentDigest: prepared.contentDigest,
+            secret: prepared.encryptionSecret,
+            salt: prepared.encryptionSalt,
+            nonce: prepared.encryptionNonce,
+            filename: state.filename,
+            mimeType: "video/mp4",
+            mediaWidth: state.width,
+            mediaHeight: state.height,
+            mediaDuration: state.duration,
+            thumbnailDataBase64: state.thumbnailData.base64EncodedString()
+        )
+
+        let thumbnailImage: ImageType? = ImageType(data: state.thumbnailData)
+
+        _ = try await publishAttachment(
+            storedAttachment: storedAttachment,
+            clientMessageId: state.clientMessageId,
+            trackingKey: trackingKey,
+            thumbnailImage: thumbnailImage,
+            inboxReady: inboxReady,
+            replyContext: state.replyContext,
+            mediaType: "video"
+        )
+
+        try? FileManager.default.removeItem(at: prepared.encryptedFileURL)
+        if let compressedFileURL = state.compressedFileURL {
+            try? FileManager.default.removeItem(at: compressedFileURL)
+        }
+        try? FileManager.default.removeItem(at: state.originalURL)
+        eagerVideoUploads.removeValue(forKey: trackingKey)
     }
 
     // MARK: - File Attachment Upload (shared by video, voice memo, and future types)
@@ -829,6 +1162,8 @@ actor OutgoingMessageWriter: OutgoingMessageWriterProtocol {
                     try await publishAudio(queued)
                 case .eagerPhoto(let queued):
                     try await processEagerPhoto(trackingKey: queued.trackingKey)
+                case .eagerVideo(let queued):
+                    try await processEagerVideo(trackingKey: queued.trackingKey)
                 }
             } catch {
                 switch message {
@@ -839,6 +1174,8 @@ actor OutgoingMessageWriter: OutgoingMessageWriterProtocol {
                 case .audio(let queued):
                     await markPhotoFailed(trackingKey: queued.trackingKey)
                 case .eagerPhoto(let queued):
+                    await markPhotoFailed(trackingKey: queued.trackingKey)
+                case .eagerVideo(let queued):
                     await markPhotoFailed(trackingKey: queued.trackingKey)
                 case .text:
                     break

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/OutgoingMessageWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/OutgoingMessageWriter.swift
@@ -655,6 +655,16 @@ actor OutgoingMessageWriter: OutgoingMessageWriterProtocol {
                 filename: state.filename
             )
 
+            // Publish prepared + compressed URL into the shared state BEFORE the
+            // upload await so that a cancelEagerUpload mid-upload can find and
+            // delete the encrypted file, the compressed file, and the
+            // DBPendingPhotoUpload row instead of orphaning them.
+            if var s = eagerVideoUploads[trackingKey] {
+                s.prepared = prepared
+                s.compressedFileURL = compressed.fileURL
+                eagerVideoUploads[trackingKey] = s
+            }
+
             let pendingUpload = DBPendingPhotoUpload(
                 id: prepared.taskId,
                 clientMessageId: state.clientMessageId,
@@ -672,12 +682,6 @@ actor OutgoingMessageWriter: OutgoingMessageWriterProtocol {
                 contentType: "application/octet-stream",
                 taskId: prepared.taskId
             )
-
-            if var s = eagerVideoUploads[trackingKey] {
-                s.prepared = prepared
-                s.compressedFileURL = compressed.fileURL
-                eagerVideoUploads[trackingKey] = s
-            }
 
             let result = await backgroundUploadManager.waitForCompletion(taskId: prepared.taskId)
 

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/OutgoingMessageWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/OutgoingMessageWriter.swift
@@ -69,6 +69,7 @@ enum OutgoingMessageWriterError: Error, CustomStringConvertible {
     case conversationNotFound(conversationId: String)
     case eagerUploadNotFound
     case parentMessageNotFound
+    case eagerUploadCancelled
 
     var description: String {
         switch self {
@@ -78,6 +79,8 @@ enum OutgoingMessageWriterError: Error, CustomStringConvertible {
             return "Eager upload not found"
         case .parentMessageNotFound:
             return "Parent message not found"
+        case .eagerUploadCancelled:
+            return "Eager upload was cancelled"
         }
     }
 }
@@ -514,7 +517,7 @@ actor OutgoingMessageWriter: OutgoingMessageWriterProtocol {
 
             await markPhotoFailed(trackingKey: trackingKey)
             eagerUploads.removeValue(forKey: trackingKey)
-        } else if let state = eagerVideoUploads[trackingKey] {
+        } else if var state = eagerVideoUploads[trackingKey] {
             Log.debug("Cancelling eager video upload for: \(trackingKey)")
 
             if let prepared = state.prepared {
@@ -530,7 +533,11 @@ actor OutgoingMessageWriter: OutgoingMessageWriterProtocol {
             PhotoUploadProgressTracker.shared.clear(key: trackingKey)
 
             await markPhotoFailed(trackingKey: trackingKey)
+
+            let waitingContinuation = state.waitingContinuation
+            state.waitingContinuation = nil
             eagerVideoUploads.removeValue(forKey: trackingKey)
+            waitingContinuation?.resume(throwing: OutgoingMessageWriterError.eagerUploadCancelled)
         }
     }
 

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/OutgoingMessageWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/OutgoingMessageWriter.swift
@@ -690,29 +690,39 @@ actor OutgoingMessageWriter: OutgoingMessageWriterProtocol {
                     state: .failed,
                     errorMessage: result.error?.localizedDescription
                 )
-                if var s = eagerVideoUploads[trackingKey] {
-                    s.processingError = result.error
-                    let cont = s.waitingContinuation
-                    s.waitingContinuation = nil
-                    eagerVideoUploads[trackingKey] = s
-                    let error: Error = result.error ?? PhotoAttachmentError.uploadFailed("Eager video upload failed")
-                    cont?.resume(throwing: error)
-                    try? await markMessageFailed(clientMessageId: s.clientMessageId)
-                }
-                await markPhotoFailed(trackingKey: trackingKey)
+                let uploadError: Error = result.error ?? PhotoAttachmentError.uploadFailed("Eager video upload failed")
+                await failEagerVideoPipeline(trackingKey: trackingKey, error: uploadError)
             }
         } catch {
-            if var state = eagerVideoUploads[trackingKey] {
-                state.processingError = error
-                let cont = state.waitingContinuation
-                state.waitingContinuation = nil
-                eagerVideoUploads[trackingKey] = state
-                cont?.resume(throwing: error)
-                try? await markMessageFailed(clientMessageId: state.clientMessageId)
-            }
-            await markPhotoFailed(trackingKey: trackingKey)
+            await failEagerVideoPipeline(trackingKey: trackingKey, error: error)
             Log.error("Eager video pipeline failed: \(error)")
         }
+    }
+
+    private func failEagerVideoPipeline(trackingKey: String, error: Error) async {
+        guard var state = eagerVideoUploads[trackingKey] else {
+            await markPhotoFailed(trackingKey: trackingKey)
+            return
+        }
+        state.processingError = error
+        let cont = state.waitingContinuation
+        state.waitingContinuation = nil
+        eagerVideoUploads[trackingKey] = state
+        cont?.resume(throwing: error)
+        try? await markMessageFailed(clientMessageId: state.clientMessageId)
+        await markPhotoFailed(trackingKey: trackingKey)
+
+        // Reclaim disk + drop the dict entry so failures don't pile up. If
+        // processEagerVideo is going to consume the continuation it has
+        // already received the error and won't read these.
+        if let prepared = state.prepared {
+            try? FileManager.default.removeItem(at: prepared.encryptedFileURL)
+        }
+        if let compressedFileURL = state.compressedFileURL {
+            try? FileManager.default.removeItem(at: compressedFileURL)
+        }
+        try? FileManager.default.removeItem(at: state.originalURL)
+        eagerVideoUploads.removeValue(forKey: trackingKey)
     }
 
     func sendEagerVideo(trackingKey: String) async throws {

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/OutgoingMessageWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/OutgoingMessageWriter.swift
@@ -1062,6 +1062,15 @@ actor OutgoingMessageWriter: OutgoingMessageWriterProtocol {
             sentMessageSubject.send(json)
             markPhotoPublished(trackingKey: trackingKey)
 
+            // For media we still have on disk locally (trackingKey is the
+            // file:// URL of the local cached copy), publish the mapping so
+            // the renderer can play from disk without re-downloading.
+            if let trackingURL = URL(string: trackingKey),
+               trackingURL.isFileURL,
+               FileManager.default.fileExists(atPath: trackingURL.path) {
+                await OutgoingMediaLocalCache.shared.register(trackingURL, for: json)
+            }
+
             return messageId
         } catch {
             tracker.setStage(.failed, for: trackingKey)

--- a/ConvosCore/Tests/ConvosCoreTests/VideoMessageTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/VideoMessageTests.swift
@@ -177,9 +177,9 @@ struct VideoMessageTests {
 
     // MARK: - VideoCompressionService
 
-    @Test("VideoCompressionService max file size is 25MB")
+    @Test("VideoCompressionService max file size is 50MB")
     func testMaxFileSize() {
-        #expect(VideoCompressionService.maxFileSizeBytes == 25 * 1024 * 1024)
+        #expect(VideoCompressionService.maxFileSizeBytes == 50 * 1024 * 1024)
     }
 
     @Test("loadVideoDimensions throws for a non-video URL")

--- a/docs/plans/multi-attachment-composer.md
+++ b/docs/plans/multi-attachment-composer.md
@@ -61,7 +61,7 @@ The current `currentEagerUploadKey` singleton becomes per-photo state inside `Pe
 ## UI changes
 
 - **`MessagesInputView.attachmentPreviewArea`** iterates over `pendingMediaAttachments` (one preview card per item) instead of branching on three optional fields. Each card has the existing poof-to-dismiss pattern and removes by `id` from the array. Side convo and link preview cards continue to render at fixed positions.
-- **`MessagesMediaButtonsView`** — photo, camera, and file buttons disabled when `mediaCount == 8`. Side convo button disabled when a side convo is staged. Voice memo button disabled when any media attachments are staged, per the coexistence rule above.
+- **`MessagesMediaButtonsView`** — photo, camera, and file buttons disabled when `mediaCount == 8` **or when a side convo is staged**. Side convo button disabled when a side convo is staged **or when any media attachments are staged**. Voice memo button disabled when any media attachments are staged or when a side convo is staged, per the coexistence rules above.
 - **PhotosPicker** — pass `maxSelectionCount: 8 - mediaCount`.
 - **`.fileImporter`** — enable `allowsMultipleSelection: true`. The callback truncates the picked URLs to remaining capacity and shows a brief alert when truncation happens.
 

--- a/docs/plans/multi-attachment-composer.md
+++ b/docs/plans/multi-attachment-composer.md
@@ -1,0 +1,82 @@
+# Multi-attachment composer
+
+## Problem
+
+The composer in a conversation can stage at most one attachment at a time today — either one photo, one video, one file, one side-convo invite, or one link preview. Users routinely want to send several photos or files in a single composing session and currently have to send each one as its own send action, which is friction-heavy on mobile and produces noisy chat history when they get it wrong (e.g. forgetting to attach the third photo).
+
+## Goal
+
+Let the user stage up to **8** photos / videos / files at once (any mix), in an explicit order, and send them with a single tap. Side convo invites and link previews retain their existing single-instance semantics.
+
+## Rules
+
+- **Max 1 side convo** per send. The side-convo button is disabled while one is staged.
+- **Max 8 photos + videos + files combined** per send. Reaching 8 disables the photo, camera, and file buttons.
+- **Voice memo stays as its own one-off thing.** Recording takes over the input bar today; that doesn't change. Voice memos do not count toward the 8 and cannot coexist with other staged attachments.
+- **Send order = the order attachments appear in the bar.** Text always sends last.
+- **Pickers respect remaining capacity.** If 2 photos are staged, the photos picker offers `maxSelectionCount: 6` and the file picker truncates the selection to 6 (with a notification if more were picked).
+
+## Wire format: separate messages, not MultiRemoteAttachment
+
+XMTP's `MultiRemoteAttachment` codec bundles N attachments into a single message. Reactions and replies in XMTP target a `messageId` only — there is no `subreference` or `attachmentIndex`, so a reaction on a `MultiRemoteAttachment` message reacts to the bundle as a unit, not to one item within it.
+
+iMessage and WhatsApp both let users react to and reply to individual photos in a multi-photo send. To match that, **we send each staged attachment as its own message**, sequenced in bar order. Per-item reactions and replies then work natively because each attachment is its own message with its own ID. The receiving render path also requires no changes — it already handles single-attachment messages.
+
+The cost is N publishes instead of 1: more network chatter, more potential partial-failure points, and the total "send time" is the sum of upload times rather than the max. Eager upload (already wired for photos) mitigates this — uploading happens during composition, leaving only `publish()` to serialize at send time. Extending eager upload to videos and files is a follow-up.
+
+## Send sequence
+
+For a send with staged state `[photo, video, file]` + side convo + text:
+
+1. Side convo invite publishes first (existing path)
+2. Each media attachment publishes as its own message, in bar order, **awaited sequentially** so they land in order on the recipient
+3. Text + link preview publishes last (existing path)
+
+If attachment N of M fails to upload or publish, the chain stops. The failed attachment surfaces as a failed-message bubble using the existing failed-message UI (which already supports retry and delete per item). Subsequent attachments and the trailing text are not sent — the user sees the failed bubble in chat and can decide whether to retry it or recompose.
+
+## State model
+
+Replace the three single-attachment fields on `ConversationViewModel` with one ordered array:
+
+```swift
+enum PendingMediaAttachment: Identifiable, Equatable {
+    case photo(PendingPhotoAttachment)   // image + per-item eager upload key + tracking key
+    case video(PendingVideoAttachment)   // URL + thumbnail
+    case file(PendingFileAttachment)
+    var id: UUID { ... }
+}
+var pendingMediaAttachments: [PendingMediaAttachment] = []  // ordered, capped at 8
+```
+
+`pendingInvite` and `pastedLinkPreview` stay separate — they are singletons with dedicated UI and different lifecycle.
+
+The current `currentEagerUploadKey` singleton becomes per-photo state inside `PendingPhotoAttachment`. Each photo entry tracks its own eager upload independently so the user can stage several photos in parallel.
+
+## UI changes
+
+- **`MessagesInputView.attachmentPreviewArea`** iterates over `pendingMediaAttachments` (one preview card per item) instead of branching on three optional fields. Each card has the existing poof-to-dismiss pattern and removes by `id` from the array. Side convo and link preview cards continue to render at fixed positions.
+- **`MessagesMediaButtonsView`** — photo, camera, and file buttons disabled when `mediaCount == 8`. Side convo button disabled when a side convo is staged. Voice memo button unaffected.
+- **PhotosPicker** — pass `maxSelectionCount: 8 - mediaCount`.
+- **`.fileImporter`** — enable `allowsMultipleSelection: true`. The callback truncates the picked URLs to remaining capacity and shows a brief alert when truncation happens.
+
+## Receiving side
+
+No changes. Each attachment arrives as its own message; existing single-attachment rendering handles them. Per-item reactions and replies work naturally.
+
+(Optional follow-up someday: client-side visual grouping — render N consecutive media messages from the same sender within a short window with shared rounded corners, WhatsApp-style. Pure render-layer change, no protocol change. Out of scope here.)
+
+## Stacked PRs
+
+1. **State model refactor.** Replace `selectedAttachmentImage` / `selectedVideoURL` / `pendingFileAttachment` with `pendingMediaAttachments`. UI still allows only one staged at a time. Send path extracts the head element to call existing single-attachment writers. Pure refactor, no behavior change.
+2. **Sequential multi-send.** New `OutgoingMessageWriter.sendMediaAttachments(_:replyToMessageId:)` loops the existing per-type writers, awaiting each. `ConversationViewModel.onSendMessage` switches to it. UI still 1-at-a-time, but the writer can handle N. Per-photo eager-upload tracking moves from singleton key to dictionary keyed by attachment id.
+3. **Multi-select UI.** Picker capacity wiring, button disabled states, preview-area iteration. This is when the cap actually lifts to 8 from the user's perspective.
+4. **Polish.** Mid-upload cancellation when removing from the bar, optional eager upload extended to videos and files, any partial-failure UX gaps that surfaced during dogfooding.
+
+Drag-to-reorder and visual grouping of received multi-attachment sequences are deferred and not in this stack.
+
+## Out of scope
+
+- Reordering staged attachments (defer until users ask)
+- Visual grouping of received media (render-layer follow-up)
+- Voice memo as a multi-slot media type (recording UX is its own surface)
+- Captions on the wire (text remains a separate trailing message)

--- a/docs/plans/multi-attachment-composer.md
+++ b/docs/plans/multi-attachment-composer.md
@@ -55,7 +55,7 @@ The current `currentEagerUploadKey` singleton becomes per-photo state inside `Pe
 ## UI changes
 
 - **`MessagesInputView.attachmentPreviewArea`** iterates over `pendingMediaAttachments` (one preview card per item) instead of branching on three optional fields. Each card has the existing poof-to-dismiss pattern and removes by `id` from the array. Side convo and link preview cards continue to render at fixed positions.
-- **`MessagesMediaButtonsView`** — photo, camera, and file buttons disabled when `mediaCount == 8`. Side convo button disabled when a side convo is staged. Voice memo button unaffected.
+- **`MessagesMediaButtonsView`** — photo, camera, and file buttons disabled when `mediaCount == 8`. Side convo button disabled when a side convo is staged. Voice memo button disabled when any media attachments are staged, per the coexistence rule above.
 - **PhotosPicker** — pass `maxSelectionCount: 8 - mediaCount`.
 - **`.fileImporter`** — enable `allowsMultipleSelection: true`. The callback truncates the picked URLs to remaining capacity and shows a brief alert when truncation happens.
 

--- a/docs/plans/multi-attachment-composer.md
+++ b/docs/plans/multi-attachment-composer.md
@@ -10,9 +10,9 @@ Let the user stage up to **8** photos / videos / files at once (any mix), in an 
 
 ## Rules
 
-- **Max 1 side convo** per send. The side-convo button is disabled while one is staged.
+- **Max 1 side convo** per send. Side convos and media attachments are mutually exclusive: staging a side convo disables the photo, camera, file, and voice memo buttons; staging any media disables the side convo button. (Side convo cards visually overlap awkwardly with media tiles, and the resulting send would be a confusing mix of "invite + carousel" semantics — easier to keep them as distinct send modes.)
 - **Max 8 photos + videos + files combined** per send. Reaching 8 disables the photo, camera, and file buttons.
-- **Voice memo stays as its own one-off thing.** Recording takes over the input bar today; that doesn't change. Voice memos do not count toward the 8 and cannot coexist with other staged attachments.
+- **Voice memo stays as its own one-off thing.** Recording takes over the input bar today; that doesn't change. Voice memos do not count toward the 8 and cannot coexist with other staged attachments or with a side convo.
 - **Send order = the order attachments appear in the bar.** Text always sends last.
 - **Pickers respect remaining capacity.** If 2 photos are staged, the photos picker offers `maxSelectionCount: 6` and the file picker truncates the selection to 6 (with a notification if more were picked).
 

--- a/docs/plans/multi-attachment-composer.md
+++ b/docs/plans/multi-attachment-composer.md
@@ -26,11 +26,17 @@ The cost is N publishes instead of 1: more network chatter, more potential parti
 
 ## Send sequence
 
-For a send with staged state `[photo, video, file]` + side convo + text:
+Side convo and media are mutually exclusive (see Rules), so there are two send paths.
+
+**Media path** — staged state `[photo, video, file]` + text:
+
+1. Each media attachment publishes as its own message, in bar order, **awaited sequentially** so they land in order on the recipient
+2. Text + link preview publishes last (existing path)
+
+**Side convo path** — staged side convo + text:
 
 1. Side convo invite publishes first (existing path)
-2. Each media attachment publishes as its own message, in bar order, **awaited sequentially** so they land in order on the recipient
-3. Text + link preview publishes last (existing path)
+2. Text + link preview publishes last (existing path)
 
 If attachment N of M fails to upload or publish, the chain stops. The failed attachment surfaces as a failed-message bubble using the existing failed-message UI (which already supports retry and delete per item). Subsequent attachments and the trailing text are not sent — the user sees the failed bubble in chat and can decide whether to retry it or recompose.
 


### PR DESCRIPTION
## Summary

Adds multi-attachment support to the message composer. Users can stage up to 8 photos / videos / files (any mix) in a single send action; each attachment publishes as its own XMTP message in bar order so per-item reactions and replies work natively. Side convo and voice memo semantics are unchanged.

See [docs/plans/multi-attachment-composer.md](docs/plans/multi-attachment-composer.md) (commit 1) for the full PRD — wire-format decision, send sequence, partial-failure behavior, etc.

### Commits

1. **PRD** (`6c186e53`) — design doc capturing the rules and the wire-format decision (separate messages over MultiRemoteAttachment so reactions and replies can target individual attachments).
2. **PRD reconciliation** (`1ea3664d`) — voice memo button rule made consistent with the coexistence rule.
3. **State model + sequential send pipeline** (`1a06ff81`) — collapse the three single-attachment fields into one ordered `pendingMediaAttachments` array of `PendingMediaAttachment` (.photo / .video / .file). `OnSendMessage` walks the array in bar order via `sendMediaAttachmentsSequentially`, awaiting each per-type writer (`sendEagerPhoto` / `sendVideo` / `sendFile`) so attachments arrive in order. The first attachment carries the reply target; trailing text/invite/link follow only if there were no media. Per-photo eager-upload tracking moves from a singleton key to per-attachment state, so multiple photos can pre-upload during composition. `removeMediaAttachment` cleans up the right per-type resource (cancels eager photo upload, cancels video thumbnail task, deletes file temp copy). View layer (`MessagesBottomBar` / `MessagesInputView` / `MessagesView` / `ConversationView`) refactored to take the array end-to-end; pickers hand off via callbacks; preview area iterates with per-item poof-to-dismiss.
4. **Multi-select UI** (`94bd9916`) — lifts the user-facing cap to 8. `PhotosPicker` switches to multi-selection with `maxSelectionCount: max(1, 8 - currentMediaCount)`. `.fileImporter` allows multiple selection, truncates picked URLs to remaining capacity, and shows an alert if anything was dropped. Photo, camera, and file buttons grey out at capacity; voice memo button greys out whenever any media is staged (per the coexistence rule); side-convo button continues to grey out when a side convo is staged.

Mid-upload cancellation (removing a staged photo cancels its in-flight eager upload) was naturally covered by the state refactor's `cleanupAttachment` and didn't need a separate commit. Extending eager upload to videos and files is deferred to a follow-up PR.

## Test plan

- [ ] Stage a single photo, send — works as before
- [ ] Stage 3 photos, send — three messages arrive in order
- [ ] Stage 2 photos + 1 video + 1 file, send — four messages arrive in attachment-bar order
- [ ] Stage 8 attachments — photo, camera, and file buttons grey out; tapping disabled buttons does nothing
- [ ] Stage 6 photos, open file picker — try to pick 5 files; only 2 stage and the "Some files weren't added" alert appears
- [ ] Stage attachments + text, send — text message arrives last
- [ ] Stage attachments + side convo + text — side convo invite first, then attachments, then text
- [ ] Cause one attachment upload to fail mid-batch (e.g., kill the network) — failed bubble appears for that attachment, subsequent attachments and trailing text not sent
- [ ] Stage 2 photos, remove the first one mid-upload — eager upload cancels; remaining photo still sends correctly on tap Send
- [ ] Stage media + try to record a voice memo — voice memo button is disabled
- [ ] Per-attachment reactions work on multi-photo sends (recipient side)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add multi-attachment support to the message composer with eager video upload pipeline
> - Replaces single-attachment staging in `ConversationViewModel` with a `pendingMediaAttachments` array (up to 8 items) of typed `PendingPhotoAttachment`, `PendingVideoAttachment`, and `PendingFileAttachment` values, each tracked by UUID.
> - Adds a full eager video upload pipeline in `OutgoingMessageWriter` mirroring the existing photo pipeline: compress, encrypt, upload in background, then publish on send; cancellation cleans up temp/encrypted/compressed files.
> - On send, staged media are published sequentially as individual messages (first consumes the reply target); failures stop the chain and clean up unsent attachments.
> - Updates `MessagesBottomBar`, `MessagesInputView`, and `MessagesMediaButtonsView` to support multi-select from Photos, camera, and file picker, per-item removal with poof animation, and disabled states when capacity is full.
> - Increases video compression limit to 50 MB and switches export preset to `AVAssetExportPresetHEVC1920x1080`.
> - Adds `OutgoingMediaLocalCache` so sent local video files are reused for playback without re-downloading.
> - Risk: voice memo recording is disabled whenever any media attachment is staged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0762b9b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->