### PR TITLE
fix renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,14 +5,14 @@
   "customManagers": [
     {
       "customType": "regex",
-      "description": "Match the libxmtp tag in Package.swift `revision:` pins. Both -dev and -nightly tags are recognized as currentValue so manual dev pins aren't dropped; the versioningTemplate constrains *update candidates* to nightly only.",
+      "description": "Match the libxmtp tag in Package.swift `revision:` pins. Recognizes both -dev and -nightly tags as currentValue; allowedVersions in the package rule restricts update candidates to nightly only.",
       "managerFilePatterns": ["/Package\\.swift$/"],
       "matchStrings": [
         "url:\\s*\"https://github\\.com/xmtp/libxmtp\\.git\"[\\s\\S]*?revision:\\s*\"(?<currentValue>ios-[^\"]+)\""
       ],
       "datasourceTemplate": "git-tags",
       "depNameTemplate": "https://github.com/xmtp/libxmtp",
-      "versioningTemplate": "regex:^ios-(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-nightly\\.(?<build>\\d{8}\\.[a-f0-9]+)$"
+      "versioningTemplate": "regex:^ios-(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-(?:dev|nightly)\\.(?<build>\\d{8}\\.[a-f0-9]+|[a-f0-9]+)$"
     },
     {
       "customType": "regex",
@@ -23,7 +23,7 @@
       ],
       "datasourceTemplate": "git-tags",
       "depNameTemplate": "https://github.com/xmtp/libxmtp",
-      "versioningTemplate": "regex:^ios-(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-nightly\\.(?<build>\\d{8}\\.[a-f0-9]+)$"
+      "versioningTemplate": "regex:^ios-(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-(?:dev|nightly)\\.(?<build>\\d{8}\\.[a-f0-9]+|[a-f0-9]+)$"
     }
   ],
   "packageRules": [
@@ -32,9 +32,9 @@
       "groupName": "libxmtp",
       "branchName": "renovate/libxmtp",
       "prConcurrentLimit": 1,
+      "prCreation": "immediate",
       "rebaseWhen": "behind-base-branch",
-      "schedule": ["after 7am and before 9am every weekday"],
-      "timezone": "UTC",
+      "allowedVersions": "/^ios-\\d+\\.\\d+\\.\\d+-nightly\\.\\d{8}\\.[a-f0-9]+$/",
       "commitMessageTopic": "libxmtp",
       "commitMessageExtra": "to {{newValue}}",
       "prTitle": "chore(deps): update libxmtp to {{newValue}}"


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/792"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Renovate config for libxmtp nightly pin updates
> - Broadens `versioningTemplate` regexes in [renovate.json](https://github.com/xmtplabs/convos-ios/pull/792/files#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57) to accept both `-dev` and `-nightly` tags, and allows the build component to be a dated hash or plain hash.
> - Restricts update candidates to nightly tags with a dated hash via `allowedVersions`, replacing the previous `schedule`/`timezone` approach.
> - Adds `prCreation: "immediate"` so matching updates create PRs without scheduling delays.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1c30a4a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->