### PR TITLE
Fix bodyContent type-check timeout in MessagesBottomBar

### DIFF
--- a/.claude/agents/swiftui-specialist.md
+++ b/.claude/agents/swiftui-specialist.md
@@ -58,9 +58,74 @@ The project uses custom colors and components:
 - Components: `AvatarView`, shared views in `Convos/Shared Views/`
 - Check `Convos/Design System/` for design tokens
 
+## Type-Check Performance (CRITICAL)
+
+The project builds with `-warn-long-expression-type-checking 100` and `SWIFT_TREAT_WARNINGS_AS_ERRORS=YES`. Any expression the type-checker takes more than 100ms on becomes a hard CI failure. The threshold is a cliff — chains commonly sit at 80–95ms locally and trip at 107ms in CI archive. **You cannot rely on a local build to catch this.**
+
+Before you append a modifier to an existing view body, count what's already there. If **any** of these are true, extract first, then add:
+
+- The chain already has **≥ 4 `.onChange` modifiers**, or **≥ 6 chained modifiers total**
+- A modifier argument contains **inline arithmetic, `max`/`min`, or method calls** — hoist to a typed computed property
+- A **`.sheet` / `.fullScreenCover` / `.alert` / `.popover` content closure** contains more than a single view constructor — extract to `@ViewBuilder` computed property
+- An **`.onChange` closure body is more than 3 lines** or contains `for`/`while`/`Task { ... }` — extract to `private func handleXChanged(...)`
+- A modifier closure contains an inline `Task { for item in items { ... } }` — extract the whole closure body
+
+```swift
+// ❌ — long chain with inline arithmetic and nested closure with its own callbacks
+content
+    .onChange(of: a) { ... }
+    .onChange(of: b) { ... }
+    .onChange(of: c) { ... }
+    .onChange(of: d) { ... }
+    .photosPicker(
+        isPresented: $isPresented,
+        selection: $selection,
+        maxSelectionCount: max(1, maxAttachments - attachments.count),
+        matching: .any(of: [.images, .videos])
+    )
+    .fullScreenCover(isPresented: $isCameraPresented) {
+        CameraPickerView(
+            onImageCaptured: { image in onPhotoSelected(image); isCameraPresented = false },
+            onVideoCaptured: { url in onVideoSelected(url); isCameraPresented = false }
+        )
+    }
+
+// ✅ — handlers and content extracted, modifier args are bare property accesses
+content
+    .onChange(of: a) { _, new in handleAChanged(to: new) }
+    .onChange(of: b) { _, new in handleBChanged(to: new) }
+    .onChange(of: c) { _, new in handleCChanged(to: new) }
+    .onChange(of: d) { _, new in handleDChanged(to: new) }
+    .photosPicker(
+        isPresented: $isPresented,
+        selection: $selection,
+        maxSelectionCount: photoPickerMaxSelectionCount,
+        matching: .any(of: [.images, .videos])
+    )
+    .fullScreenCover(isPresented: $isCameraPresented) {
+        cameraPickerCover
+    }
+
+private var photoPickerMaxSelectionCount: Int { max(1, maxAttachments - attachments.count) }
+
+@ViewBuilder
+private var cameraPickerCover: some View { ... }
+```
+
+Other rules from CLAUDE.md (see "Build Performance: Type-Check Time"):
+- Annotate the type on any non-trivial `let`
+- Never stack ternaries inside SwiftUI modifier arguments — hoist to typed `let`s
+- No nested ternaries; cap at one per expression
+- Cap `body` / `body(content:)` at ~50 lines or ~10 modifiers
+- For `@ViewBuilder switch` statements, extract any case with > 3 modifiers or a conditional argument
+
 ## Implementation Checklist
 
 For any SwiftUI work:
+- [ ] Counted modifiers in any view body you're editing — extracted before adding if at the limits above
+- [ ] Inline arithmetic / `max` / `min` in modifier args is hoisted to typed computed properties
+- [ ] `.sheet` / `.fullScreenCover` / `.alert` content with nested closures is extracted to `@ViewBuilder`
+- [ ] `.onChange` bodies > 3 lines or with `Task`/`for` are extracted to methods
 - [ ] Uses `@Observable` + `@State` (not `ObservableObject`)
 - [ ] Button actions are extracted to variables
 - [ ] Previews use `@Previewable` for state

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -328,6 +328,20 @@ The two patterns that consume nearly all of these errors:
 
 - **Build arrays and dicts with `var` + `append`, not conditional `+` chains.**
 
+### Before you edit a SwiftUI view body
+
+The 100ms threshold is a cliff, not a slope — chains routinely sit at 80–95ms and a single new modifier tips them over. Treat appending to an existing body as the dangerous operation. Before you add a modifier, count what's already there. If **any** of these are true, extract first, then add:
+
+- The chain already has **≥ 4 `.onChange` modifiers**, or **≥ 6 chained modifiers total**.
+- The body uses **inline arithmetic, `max`/`min`, or method calls inside a modifier argument** (e.g. `maxSelectionCount: max(1, a - b.count)`). Hoist to a typed computed property of the exact return type the modifier expects.
+- A **`.sheet` / `.fullScreenCover` / `.alert` / `.popover` content closure** contains more than a single view constructor — anything with its own closures (`onImageCaptured:`, `onVideoCaptured:`) goes into a `@ViewBuilder` computed property.
+- An **`.onChange` closure body is more than 3 lines** or contains a `for`/`while`/`Task { ... }` block — extract to a `private func handleXChanged(...)` method and call it from the closure.
+- The body uses **`Task { for item in items { ... } }`** inline inside a modifier closure — extract the whole closure body.
+
+Counting takes a few seconds and is much cheaper than diagnosing a CI archive failure after the fact. The local simulator build often passes at 95ms; the CI archive trips at 107ms — you cannot rely on local builds to catch this.
+
+When extracting, name the helpers descriptively (`photoPickerMaxSelectionCount: Int`, `cameraPickerCover: some View`, `handleSelectedPhotosChanged(to:)`) so the call site at the modifier reads cleanly.
+
 ### When you hit a type-check timeout
 
 Fix the expression. Do not bump the threshold and do not `// swiftlint:disable` past it.

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesBottomBar.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesBottomBar.swift
@@ -102,6 +102,40 @@ struct MessagesBottomBar<BottomBarContent: View>: View {
 
     @ViewBuilder
     private var bodyContent: some View {
+        bodyStack
+            .background(HeightReader())
+            .onPreferenceChange(HeightPreferenceKey.self) { height in
+                onBaseHeightChanged(height)
+            }
+            .onChange(of: focusCoordinator.currentFocus) { _, newValue in
+                handleFocusChanged(to: newValue)
+            }
+            .onChange(of: messageText) { _, _ in
+                handleMessageTextChanged()
+            }
+            .onChange(of: isVoiceMemoActive) { wasActive, isActive in
+                guard wasActive, !isActive else { return }
+                restoreVoiceMemoFocusIfNeeded()
+            }
+            .onChange(of: isPhotoPickerPresented) { _, newValue in
+                handlePhotoPickerPresentationChanged(to: newValue)
+            }
+            .photosPicker(
+                isPresented: $isPhotoPickerPresented,
+                selection: $selectedPhotos,
+                maxSelectionCount: photoPickerMaxSelectionCount,
+                matching: .any(of: [.images, .videos])
+            )
+            .onChange(of: selectedPhotos) { _, newValue in
+                handleSelectedPhotosChanged(to: newValue)
+            }
+            .fullScreenCover(isPresented: $isCameraPresented) {
+                cameraPickerCover
+            }
+    }
+
+    @ViewBuilder
+    private var bodyStack: some View {
         VStack(spacing: 0) {
             bottomBarContent()
             VoiceMemoKeyboardFocusKeeper(
@@ -121,79 +155,72 @@ struct MessagesBottomBar<BottomBarContent: View>: View {
             .padding(.top, DesignConstants.Spacing.step2x)
             .padding(.bottom, DesignConstants.Spacing.step4x)
         }
-        .background(HeightReader())
-        .onPreferenceChange(HeightPreferenceKey.self) { height in
-            onBaseHeightChanged(height)
-        }
-        .onChange(of: focusCoordinator.currentFocus) { _, newValue in
-            guard !isImagePickerPresented else { return }
+    }
 
-            withAnimation(.bouncy(duration: 0.4, extraBounce: 0.01)) {
-                isExpanded = newValue == .displayName
-                isMessageInputFocused = newValue == .message
-                    || newValue == .voiceMemoRecording
-                    || newValue == .sideConvoName
+    private var photoPickerMaxSelectionCount: Int {
+        max(1, maxPendingMediaAttachments - pendingMediaAttachments.count)
+    }
+
+    @ViewBuilder
+    private var cameraPickerCover: some View {
+        CameraPickerView(
+            onImageCaptured: { image in
+                onPhotoSelected(image)
+                isCameraPresented = false
+                focusCoordinator.moveFocus(to: .message)
+            },
+            onVideoCaptured: { url in
+                onVideoSelected(url)
+                isCameraPresented = false
+                focusCoordinator.moveFocus(to: .message)
             }
-        }
-        .onChange(of: messageText) { _, _ in
-            guard !isMessageInputFocused, focusCoordinator.currentFocus != .displayName else { return }
-            withAnimation(.bouncy(duration: 0.4, extraBounce: 0.01)) {
-                isMessageInputFocused = true
-            }
-        }
-        .onChange(of: isVoiceMemoActive) { wasActive, isActive in
-            guard wasActive, !isActive else { return }
-            restoreVoiceMemoFocusIfNeeded()
-        }
-        .onChange(of: isPhotoPickerPresented) { _, newValue in
-            if newValue {
-                previousFocus = focusCoordinator.currentFocus
-                didSelectPhotoThisSession = false
-                focusState = nil
-            } else {
-                if !didSelectPhotoThisSession, let previousFocus {
-                    focusCoordinator.moveFocus(to: previousFocus)
-                }
-            }
-        }
-        .photosPicker(
-            isPresented: $isPhotoPickerPresented,
-            selection: $selectedPhotos,
-            maxSelectionCount: max(1, maxPendingMediaAttachments - pendingMediaAttachments.count),
-            matching: .any(of: [.images, .videos])
         )
-        .onChange(of: selectedPhotos) { _, newValue in
-            guard !newValue.isEmpty else { return }
-            let items = newValue
-            selectedPhotos = []
-            didSelectPhotoThisSession = true
-            isPhotoPickerPresented = false
-            focusCoordinator.moveFocus(to: .message)
-            Task {
-                for item in items {
-                    if let videoFile = try? await item.loadTransferable(type: VideoFile.self) {
-                        await MainActor.run { onVideoSelected(videoFile.url) }
-                    } else if let data = try? await item.loadTransferable(type: Data.self),
-                              let image = UIImage(data: data) {
-                        await MainActor.run { onPhotoSelected(image) }
-                    }
+        .ignoresSafeArea()
+    }
+
+    private func handleFocusChanged(to newValue: MessagesViewInputFocus?) {
+        guard !isImagePickerPresented else { return }
+        withAnimation(.bouncy(duration: 0.4, extraBounce: 0.01)) {
+            isExpanded = newValue == .displayName
+            isMessageInputFocused = newValue == .message
+                || newValue == .voiceMemoRecording
+                || newValue == .sideConvoName
+        }
+    }
+
+    private func handleMessageTextChanged() {
+        guard !isMessageInputFocused, focusCoordinator.currentFocus != .displayName else { return }
+        withAnimation(.bouncy(duration: 0.4, extraBounce: 0.01)) {
+            isMessageInputFocused = true
+        }
+    }
+
+    private func handlePhotoPickerPresentationChanged(to newValue: Bool) {
+        if newValue {
+            previousFocus = focusCoordinator.currentFocus
+            didSelectPhotoThisSession = false
+            focusState = nil
+        } else if !didSelectPhotoThisSession, let previousFocus {
+            focusCoordinator.moveFocus(to: previousFocus)
+        }
+    }
+
+    private func handleSelectedPhotosChanged(to newValue: [PhotosPickerItem]) {
+        guard !newValue.isEmpty else { return }
+        let items = newValue
+        selectedPhotos = []
+        didSelectPhotoThisSession = true
+        isPhotoPickerPresented = false
+        focusCoordinator.moveFocus(to: .message)
+        Task {
+            for item in items {
+                if let videoFile = try? await item.loadTransferable(type: VideoFile.self) {
+                    await MainActor.run { onVideoSelected(videoFile.url) }
+                } else if let data = try? await item.loadTransferable(type: Data.self),
+                          let image = UIImage(data: data) {
+                    await MainActor.run { onPhotoSelected(image) }
                 }
             }
-        }
-        .fullScreenCover(isPresented: $isCameraPresented) {
-            CameraPickerView(
-                onImageCaptured: { image in
-                    onPhotoSelected(image)
-                    isCameraPresented = false
-                    focusCoordinator.moveFocus(to: .message)
-                },
-                onVideoCaptured: { url in
-                    onVideoSelected(url)
-                    isCameraPresented = false
-                    focusCoordinator.moveFocus(to: .message)
-                }
-            )
-            .ignoresSafeArea()
         }
     }
 


### PR DESCRIPTION
CI archive failed with "getter for property 'bodyContent' took 107ms to
type-check (limit: 100ms)". The body had a long chain of modifiers
(VStack + 5 .onChange handlers + .photosPicker + .fullScreenCover) plus
inline arithmetic and nested closures, which pushed the type-check just
over the 100ms threshold.

Break the body into smaller helpers so each subexpression is small
enough for the solver:

- Extract the inner VStack to bodyStack
- Extract the .photosPicker max-selection arithmetic to a typed Int
  computed property
- Extract the .fullScreenCover content to cameraPickerCover
- Extract every .onChange closure body to a named method

No behavior change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/794"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix type-check timeout in `MessagesBottomBar` by extracting helpers and hoisting expressions
> - Extracts inline `onChange` and `fullScreenCover` closures into private helpers (`handleFocusChanged(to:)`, `handleMessageTextChanged()`, `handlePhotoPickerPresentationChanged(to:)`, `handleSelectedPhotosChanged(to:)`) to reduce SwiftUI type-checker complexity in [MessagesBottomBar.swift](https://github.com/xmtplabs/convos-ios/pull/794/files#diff-b66861cd8ab11a6d499676511b14e2fba66afdb7467461c01255f35000b416a2).
> - Introduces `bodyContent` and `bodyStack` to flatten the modifier chain, moving background, preference, and picker modifiers out of the inner `VStack`.
> - Hoists `photosPicker` `maxSelectionCount` into a typed computed property `photoPickerMaxSelectionCount` and wraps `CameraPickerView` in a `@ViewBuilder cameraPickerCover`.
> - Updates type-check performance guidelines in [CLAUDE.md](https://github.com/xmtplabs/convos-ios/pull/794/files#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7) and [swiftui-specialist.md](https://github.com/xmtplabs/convos-ios/pull/794/files#diff-51c046b763453b69d910a1175f2c86da399c2fc6fde9b6be9aef88d4fba92b3c) with a 100ms solver threshold and concrete refactoring rules.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 329151a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->