### PR TITLE
Add concrete pre-write triggers for SwiftUI type-check timeouts

### DIFF
--- a/.claude/agents/swiftui-specialist.md
+++ b/.claude/agents/swiftui-specialist.md
@@ -58,9 +58,74 @@ The project uses custom colors and components:
 - Components: `AvatarView`, shared views in `Convos/Shared Views/`
 - Check `Convos/Design System/` for design tokens
 
+## Type-Check Performance (CRITICAL)
+
+The project builds with `-warn-long-expression-type-checking 100` and `SWIFT_TREAT_WARNINGS_AS_ERRORS=YES`. Any expression the type-checker takes more than 100ms on becomes a hard CI failure. The threshold is a cliff — chains commonly sit at 80–95ms locally and trip at 107ms in CI archive. **You cannot rely on a local build to catch this.**
+
+Before you append a modifier to an existing view body, count what's already there. If **any** of these are true, extract first, then add:
+
+- The chain already has **≥ 4 `.onChange` modifiers**, or **≥ 6 chained modifiers total**
+- A modifier argument contains **inline arithmetic, `max`/`min`, or method calls** — hoist to a typed computed property
+- A **`.sheet` / `.fullScreenCover` / `.alert` / `.popover` content closure** contains more than a single view constructor — extract to `@ViewBuilder` computed property
+- An **`.onChange` closure body is more than 3 lines** or contains `for`/`while`/`Task { ... }` — extract to `private func handleXChanged(...)`
+- A modifier closure contains an inline `Task { for item in items { ... } }` — extract the whole closure body
+
+```swift
+// ❌ — long chain with inline arithmetic and nested closure with its own callbacks
+content
+    .onChange(of: a) { ... }
+    .onChange(of: b) { ... }
+    .onChange(of: c) { ... }
+    .onChange(of: d) { ... }
+    .photosPicker(
+        isPresented: $isPresented,
+        selection: $selection,
+        maxSelectionCount: max(1, maxAttachments - attachments.count),
+        matching: .any(of: [.images, .videos])
+    )
+    .fullScreenCover(isPresented: $isCameraPresented) {
+        CameraPickerView(
+            onImageCaptured: { image in onPhotoSelected(image); isCameraPresented = false },
+            onVideoCaptured: { url in onVideoSelected(url); isCameraPresented = false }
+        )
+    }
+
+// ✅ — handlers and content extracted, modifier args are bare property accesses
+content
+    .onChange(of: a) { _, new in handleAChanged(to: new) }
+    .onChange(of: b) { _, new in handleBChanged(to: new) }
+    .onChange(of: c) { _, new in handleCChanged(to: new) }
+    .onChange(of: d) { _, new in handleDChanged(to: new) }
+    .photosPicker(
+        isPresented: $isPresented,
+        selection: $selection,
+        maxSelectionCount: photoPickerMaxSelectionCount,
+        matching: .any(of: [.images, .videos])
+    )
+    .fullScreenCover(isPresented: $isCameraPresented) {
+        cameraPickerCover
+    }
+
+private var photoPickerMaxSelectionCount: Int { max(1, maxAttachments - attachments.count) }
+
+@ViewBuilder
+private var cameraPickerCover: some View { ... }
+```
+
+Other rules from CLAUDE.md (see "Build Performance: Type-Check Time"):
+- Annotate the type on any non-trivial `let`
+- Never stack ternaries inside SwiftUI modifier arguments — hoist to typed `let`s
+- No nested ternaries; cap at one per expression
+- Cap `body` / `body(content:)` at ~50 lines or ~10 modifiers
+- For `@ViewBuilder switch` statements, extract any case with > 3 modifiers or a conditional argument
+
 ## Implementation Checklist
 
 For any SwiftUI work:
+- [ ] Counted modifiers in any view body you're editing — extracted before adding if at the limits above
+- [ ] Inline arithmetic / `max` / `min` in modifier args is hoisted to typed computed properties
+- [ ] `.sheet` / `.fullScreenCover` / `.alert` content with nested closures is extracted to `@ViewBuilder`
+- [ ] `.onChange` bodies > 3 lines or with `Task`/`for` are extracted to methods
 - [ ] Uses `@Observable` + `@State` (not `ObservableObject`)
 - [ ] Button actions are extracted to variables
 - [ ] Previews use `@Previewable` for state

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -328,6 +328,20 @@ The two patterns that consume nearly all of these errors:
 
 - **Build arrays and dicts with `var` + `append`, not conditional `+` chains.**
 
+### Before you edit a SwiftUI view body
+
+The 100ms threshold is a cliff, not a slope — chains routinely sit at 80–95ms and a single new modifier tips them over. Treat appending to an existing body as the dangerous operation. Before you add a modifier, count what's already there. If **any** of these are true, extract first, then add:
+
+- The chain already has **≥ 4 `.onChange` modifiers**, or **≥ 6 chained modifiers total**.
+- The body uses **inline arithmetic, `max`/`min`, or method calls inside a modifier argument** (e.g. `maxSelectionCount: max(1, a - b.count)`). Hoist to a typed computed property of the exact return type the modifier expects.
+- A **`.sheet` / `.fullScreenCover` / `.alert` / `.popover` content closure** contains more than a single view constructor — anything with its own closures (`onImageCaptured:`, `onVideoCaptured:`) goes into a `@ViewBuilder` computed property.
+- An **`.onChange` closure body is more than 3 lines** or contains a `for`/`while`/`Task { ... }` block — extract to a `private func handleXChanged(...)` method and call it from the closure.
+- The body uses **`Task { for item in items { ... } }`** inline inside a modifier closure — extract the whole closure body.
+
+Counting takes a few seconds and is much cheaper than diagnosing a CI archive failure after the fact. The local simulator build often passes at 95ms; the CI archive trips at 107ms — you cannot rely on local builds to catch this.
+
+When extracting, name the helpers descriptively (`photoPickerMaxSelectionCount: Int`, `cameraPickerCover: some View`, `handleSelectedPhotosChanged(to:)`) so the call site at the modifier reads cleanly.
+
 ### When you hit a type-check timeout
 
 Fix the expression. Do not bump the threshold and do not `// swiftlint:disable` past it.


### PR DESCRIPTION
The existing CLAUDE.md "Build Performance: Type-Check Time" rules
describe what a slow expression looks like, but we kept tripping the
100ms threshold anyway because chains routinely sit at 80–95ms locally
and only fail in CI archive (e.g. bodyContent at 107ms). The local
simulator build cannot be relied on to catch this.

Add a "Before you edit a SwiftUI view body" subsection with concrete
pre-write triggers (≥4 .onChange, ≥6 chained modifiers, inline
arithmetic in modifier args, sheet/fullScreenCover content with nested
closures, .onChange bodies > 3 lines or containing Task/for) that say
when to extract before appending, not just what slow expressions look
like.

Mirror the same triggers and a worked before/after example in the
swiftui-specialist subagent so SwiftUI work delegated to it applies the
rules at the right moment.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/795"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add pre-write extraction rules for SwiftUI type-check timeouts in engineering guidelines
> - Adds a 'Before you edit a SwiftUI view body' subsection to [CLAUDE.md](https://github.com/xmtplabs/convos-ios/pull/795/files#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7) with concrete rules for counting modifiers, hoisting inline arithmetic to computed properties, and extracting closure-heavy content before appending new modifiers.
> - Expands [swiftui-specialist.md](https://github.com/xmtplabs/convos-ios/pull/795/files#diff-51c046b763453b69d910a1175f2c86da399c2fc6fde9b6be9aef88d4fba92b3c) with a 'Type-Check Performance (CRITICAL)' section including before/after code examples for extracting handlers, computed properties, and `@ViewBuilder` content.
> - Adds four new checklist items to the implementation checklist covering modifier counts, inline arithmetic in modifier arguments, `.sheet`/`.fullScreenCover`/`.alert` content extraction, and long `.onChange` bodies.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8db7f59.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->