### PR TITLE
Render HTML attachments in a WKWebView sheet

### DIFF
--- a/Convos/Conversation Detail/HTMLAttachmentPreviewSheet.swift
+++ b/Convos/Conversation Detail/HTMLAttachmentPreviewSheet.swift
@@ -1,0 +1,75 @@
+import SwiftUI
+import WebKit
+
+struct HTMLAttachmentPreviewSheet: View {
+    let fileURL: URL
+    let filename: String
+    @Environment(\.dismiss) private var dismiss: DismissAction
+
+    var body: some View {
+        NavigationStack {
+            HTMLAttachmentWebView(fileURL: fileURL)
+                .ignoresSafeArea(edges: .bottom)
+                .navigationTitle(filename)
+                .navigationBarTitleDisplayMode(.inline)
+                .toolbar {
+                    ToolbarItem(placement: .topBarLeading) {
+                        ShareLink(item: fileURL) {
+                            Image(systemName: "square.and.arrow.up")
+                        }
+                    }
+                    ToolbarItem(placement: .topBarTrailing) {
+                        let action = { dismiss() }
+                        Button("Done", action: action)
+                    }
+                }
+        }
+    }
+}
+
+private struct HTMLAttachmentWebView: UIViewRepresentable {
+    let fileURL: URL
+
+    func makeUIView(context: Context) -> WKWebView {
+        let config = WKWebViewConfiguration()
+        let webView = WKWebView(frame: .zero, configuration: config)
+        webView.isOpaque = false
+        webView.backgroundColor = .clear
+        webView.scrollView.backgroundColor = .clear
+        webView.navigationDelegate = context.coordinator
+        return webView
+    }
+
+    func updateUIView(_ webView: WKWebView, context: Context) {
+        guard context.coordinator.loadedFileURL != fileURL else { return }
+        context.coordinator.loadedFileURL = fileURL
+        let readAccessURL = fileURL.deletingLastPathComponent()
+        webView.loadFileURL(fileURL, allowingReadAccessTo: readAccessURL)
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator()
+    }
+
+    final class Coordinator: NSObject, WKNavigationDelegate {
+        var loadedFileURL: URL?
+
+        func webView(
+            _ webView: WKWebView,
+            decidePolicyFor navigationAction: WKNavigationAction
+        ) async -> WKNavigationActionPolicy {
+            guard navigationAction.navigationType == .linkActivated,
+                  let url = navigationAction.request.url else {
+                return .allow
+            }
+
+            guard let scheme = url.scheme?.lowercased(),
+                  ["http", "https", "mailto"].contains(scheme) else {
+                return .cancel
+            }
+
+            await UIApplication.shared.open(url)
+            return .cancel
+        }
+    }
+}

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/MessagesViewController.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/MessagesViewController.swift
@@ -899,6 +899,8 @@ extension MessagesViewController {
                 await MainActor.run {
                     if attachment.isMarkdownFile {
                         presentMarkdownPreview(fileURL: fileURL, filename: attachment.filename ?? "Markdown")
+                    } else if attachment.isHTMLFile {
+                        presentHTMLPreview(fileURL: fileURL, filename: attachment.filename ?? "Web Page")
                     } else {
                         FileAttachmentQuickLookCoordinator.shared.present(fileURL: fileURL, from: self)
                     }
@@ -919,6 +921,20 @@ extension MessagesViewController {
 
     private func presentMarkdownPreview(fileURL: URL, filename: String) {
         let preview = MarkdownAttachmentPreviewSheet(
+            fileURL: fileURL,
+            filename: filename
+        )
+        let controller = UIHostingController(rootView: preview)
+        controller.modalPresentationStyle = .pageSheet
+        if let sheet = controller.sheetPresentationController {
+            sheet.detents = [.medium(), .large()]
+            sheet.prefersGrabberVisible = false
+        }
+        present(controller, animated: true)
+    }
+
+    private func presentHTMLPreview(fileURL: URL, filename: String) {
+        let preview = HTMLAttachmentPreviewSheet(
             fileURL: fileURL,
             filename: filename
         )

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/HydratedAttachment.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/HydratedAttachment.swift
@@ -64,6 +64,14 @@ public struct HydratedAttachment: Hashable, Codable, Sendable {
         return normalizedMimeType == "text/markdown" || normalizedMimeType == "text/x-markdown"
     }
 
+    public var isHTMLFile: Bool {
+        if let ext = filenameExtension, ["html", "htm"].contains(ext) {
+            return true
+        }
+        guard let mimeType else { return false }
+        return mimeType.lowercased() == "text/html"
+    }
+
     public var mediaType: MediaType {
         guard let mimeType else { return .image }
         if mimeType.hasPrefix("image/") { return .image }

--- a/ConvosCore/Tests/ConvosCoreTests/HydratedAttachmentTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/HydratedAttachmentTests.swift
@@ -75,3 +75,62 @@ struct HydratedAttachmentIsMarkdownFileTests {
         #expect(attachment.isMarkdownFile)
     }
 }
+
+@Suite("HydratedAttachment.isHTMLFile")
+struct HydratedAttachmentIsHTMLFileTests {
+    @Test("detects .html extension")
+    func htmlExtension() {
+        let attachment = HydratedAttachment(key: "test", filename: "page.html")
+        #expect(attachment.isHTMLFile)
+    }
+
+    @Test("detects .htm extension")
+    func htmExtension() {
+        let attachment = HydratedAttachment(key: "test", filename: "legacy.htm")
+        #expect(attachment.isHTMLFile)
+    }
+
+    @Test("detects .html extension case-insensitively")
+    func htmlExtensionUppercase() {
+        let attachment = HydratedAttachment(key: "test", filename: "INDEX.HTML")
+        #expect(attachment.isHTMLFile)
+    }
+
+    @Test("detects text/html mime type")
+    func textHTMLMime() {
+        let attachment = HydratedAttachment(key: "test", mimeType: "text/html", filename: "file")
+        #expect(attachment.isHTMLFile)
+    }
+
+    @Test("detects text/html mime type case-insensitively")
+    func textHTMLMimeCaseInsensitive() {
+        let attachment = HydratedAttachment(key: "test", mimeType: "Text/HTML", filename: "file")
+        #expect(attachment.isHTMLFile)
+    }
+
+    @Test("returns false for non-html files")
+    func nonHTML() {
+        let pdf = HydratedAttachment(key: "test", filename: "document.pdf")
+        let md = HydratedAttachment(key: "test", filename: "readme.md")
+        #expect(!pdf.isHTMLFile)
+        #expect(!md.isHTMLFile)
+    }
+
+    @Test("returns false for nil filename and nil mime type")
+    func nilFilenameAndMime() {
+        let attachment = HydratedAttachment(key: "test")
+        #expect(!attachment.isHTMLFile)
+    }
+
+    @Test("mime type detection works without filename extension")
+    func mimeWithoutExtension() {
+        let attachment = HydratedAttachment(key: "test", mimeType: "text/html", filename: "file-no-ext")
+        #expect(attachment.isHTMLFile)
+    }
+
+    @Test("extension takes priority even with wrong mime type")
+    func extensionOverridesMime() {
+        let attachment = HydratedAttachment(key: "test", mimeType: "application/octet-stream", filename: "page.html")
+        #expect(attachment.isHTMLFile)
+    }
+}


### PR DESCRIPTION
Introduces HTMLAttachmentPreviewSheet, a SwiftUI sheet that renders
.html / .htm / text/html attachments via WKWebView (loadFileURL with
the parent dir as readAccessURL). MessagesViewController.openFileAttachment
branches to the new sheet for HTML, mirroring the existing markdown
branch; everything else still routes through QuickLook.

Link clicks open externally (http/https/mailto) and other schemes are
blocked, matching the markdown viewer.

This lays the groundwork for the .artifact bundle viewer, where the
extracted artifact.html will be presented through this same sheet.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/803"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Render HTML file attachments in a `WKWebView` sheet
> - Adds `HTMLAttachmentPreviewSheet`, a SwiftUI sheet wrapping a `WKWebView` that loads local HTML files, with a share button and dismiss control in the toolbar.
> - Adds `HydratedAttachment.isHTMLFile` to detect HTML attachments by `.html`/`.htm` extension or `text/html` MIME type; `MessagesViewController` routes these to the new sheet instead of Quick Look.
> - Links in the HTML preview open externally (http/https/mailto only); all other schemes and in-page navigations are blocked or handled inside the web view.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d88ed94.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->