### PR TITLE
only enable libxmtp auto updates

### DIFF
--- a/.github/workflows/firebase-pr.yml
+++ b/.github/workflows/firebase-pr.yml
@@ -38,11 +38,14 @@ jobs:
     name: Build & upload to Firebase App Distribution
     runs-on: warp-macos-latest-arm64-12x
     timeout-minutes: 25
+    permissions:
+      id-token: write
+      contents: read
     env:
-      # Bump together when Xcode upgrades; the hash and cache key are derived
-      # from `nix store add /Applications/Xcode_NN.N.app`.
+      # Bump both together when Xcode upgrades; the hash is from
+      # `nix store add /Applications/Xcode_NN.N.app`.
+      XCODE_APP_PATH: /Applications/Xcode_26.3.app
       XCODE_NIX_PATH: /nix/store/x9hdz5mfp44i9b05sswp271jdv68r8vx-Xcode.app
-      XCODE_CACHE_KEY: xcode-nix-store-zst-x9hdz5mfp44i9b05sswp271jdv68r8vx
     steps:
       - uses: actions/checkout@v6
 
@@ -60,53 +63,11 @@ jobs:
           nix_conf: |
             experimental-features = nix-command flakes
 
-      # zstd over gzip: multithreaded decompression on Apple Silicon ~5x faster.
-      - name: Restore pinned Xcode from cache
-        id: xcode-cache
-        uses: WarpBuilds/cache/restore@v1
+      - name: Pin Xcode into /nix/store
+        uses: xmtplabs/xmtp-cache-apple@v1
         with:
-          path: ~/xcode-store.nar.zst
-          key: ${{ env.XCODE_CACHE_KEY }}
-
-      - name: Import cached Xcode into Nix store
-        if: steps.xcode-cache.outputs.cache-hit == 'true'
-        run: |
-          if nix path-info "$XCODE_NIX_PATH" >/dev/null 2>&1; then
-            echo "Already in store — skipping import"
-          else
-            echo "Importing cached NAR…"
-            zstd -d -T0 -c ~/xcode-store.nar.zst | nix-store --import
-          fi
-
-      - name: Pin system Xcode into the Nix store
-        env:
-          XCODE_APP_PATH: /Applications/Xcode_26.3.app
-        run: |
-          if nix path-info "$XCODE_NIX_PATH" >/dev/null 2>&1; then
-            echo "Xcode already in store at $XCODE_NIX_PATH — skipping import"
-          else
-            echo "Importing $XCODE_APP_PATH (slow on first run)…"
-            STORE_PATH=$(nix store add --name Xcode.app "$XCODE_APP_PATH")
-            echo "Pinned at: $STORE_PATH"
-            if [ "$STORE_PATH" != "$XCODE_NIX_PATH" ]; then
-              echo "::warning::Resulting store path $STORE_PATH does not match the pinned XCODE_NIX_PATH; update the workflow."
-            fi
-          fi
-
-      - name: Export pinned Xcode for cache save
-        if: steps.xcode-cache.outputs.cache-hit != 'true'
-        run: |
-          # -19 is highest standard zstd level; -T0 = all cores.
-          nix-store --export "$XCODE_NIX_PATH" | zstd -T0 -19 > ~/xcode-store.nar.zst
-          ls -lh ~/xcode-store.nar.zst
-
-      # Save now so cache lands even if later steps fail.
-      - name: Save pinned Xcode to cache
-        if: steps.xcode-cache.outputs.cache-hit != 'true'
-        uses: WarpBuilds/cache/save@v1
-        with:
-          path: ~/xcode-store.nar.zst
-          key: ${{ env.XCODE_CACHE_KEY }}
+          xcode-path: ${{ env.XCODE_APP_PATH }}
+          xcode-nix-path: ${{ env.XCODE_NIX_PATH }}
 
       # Action installs cachix + substituter; push happens manually after
       # the build so we can exclude Xcode's closure (EULA + 11 GiB).

--- a/.github/workflows/warm-xcode-cache.yml
+++ b/.github/workflows/warm-xcode-cache.yml
@@ -1,0 +1,51 @@
+# Warms the WarpBuilds cache scope for the default branch (dev) so that
+# subsequent PR runs hit on first try. Without this, GHA-style caches are
+# branch-scoped: a cache populated by a PR run is only visible to that PR.
+#
+# Runs:
+#   - On a daily schedule (cheap insurance against eviction).
+#   - When this workflow itself or the firebase-pr workflow changes (so
+#     cache-key drift on Xcode bumps gets re-warmed without waiting a day).
+#   - On manual dispatch.
+
+name: Warm Xcode Cache
+
+on:
+  schedule:
+    - cron: '0 6 * * *'  # 06:00 UTC daily
+  push:
+    # `dev` is the default branch; warming it makes the cache visible to
+    # every PR (and stacked PRs, which fall back to default-branch scope).
+    branches: [dev]
+    paths:
+      - .github/workflows/warm-xcode-cache.yml
+      - .github/workflows/firebase-pr.yml
+  workflow_dispatch:
+
+concurrency:
+  group: warm-xcode-cache
+  cancel-in-progress: true
+
+jobs:
+  warm:
+    name: Pin Xcode and seed WarpBuilds cache
+    runs-on: warp-macos-latest-arm64-12x
+    timeout-minutes: 10
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Nix
+        uses: nixbuild/nix-quick-install-action@v33
+        with:
+          nix_conf: |
+            experimental-features = nix-command flakes
+
+      # Keep these env values in sync with firebase-pr.yml.
+      - name: Pin Xcode into /nix/store
+        uses: xmtplabs/xmtp-cache-apple@v1
+        with:
+          xcode-path: /Applications/Xcode_26.3.app
+          xcode-nix-path: /nix/store/x9hdz5mfp44i9b05sswp271jdv68r8vx-Xcode.app

--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
   "labels": ["dependencies"],
+  "enabledManagers": ["custom.regex"],
   "customManagers": [
     {
       "customType": "regex",
@@ -30,14 +31,13 @@
     {
       "matchPackageNames": ["https://github.com/xmtp/libxmtp"],
       "groupName": "libxmtp",
-      "branchName": "renovate/libxmtp",
+      "branchTopic": "libxmtp",
       "prConcurrentLimit": 1,
       "prCreation": "immediate",
       "rebaseWhen": "behind-base-branch",
       "allowedVersions": "/^ios-\\d+\\.\\d+\\.\\d+-nightly\\.\\d{8}\\.[a-f0-9]+$/",
       "commitMessageTopic": "libxmtp",
-      "commitMessageExtra": "to {{newValue}}",
-      "prTitle": "chore(deps): update libxmtp to {{newValue}}"
+      "commitMessageExtra": "to {{newValue}}"
     }
   ]
 }


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/805"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restrict Renovate auto-updates to libxmtp and replace manual Xcode caching with `xmtp-cache-apple` action
> - Updates [renovate.json](https://github.com/xmtplabs/convos-ios/pull/805/files#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57) to enable only the `custom.regex` manager, scoping auto-updates to libxmtp, and switches from a fixed `branchName` to a `branchTopic` of `libxmtp`.
> - Replaces the manual WarpBuilds cache restore/save and Nix store import/export steps in [firebase-pr.yml](https://github.com/xmtplabs/convos-ios/pull/805/files#diff-0d20b86744c45067dfae1ad0950c24de08b31999a9c9b103ddafed83de455c7a) with the `xmtplabs/xmtp-cache-apple@v1` action using Xcode 26.3.
> - Adds a new [warm-xcode-cache.yml](https://github.com/xmtplabs/convos-ios/pull/805/files#diff-71b754c757cff2b7a34e74368ae14109a0c74c097e8a4e945b260d6354e8f491) workflow that runs daily at 06:00 UTC (and on relevant file changes) to pre-seed the cache with the pinned Xcode version.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 561fbf7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->