### PR TITLE
trigger firebase build with `adhoc-build` label

### DIFF
--- a/.github/workflows/firebase-pr.yml
+++ b/.github/workflows/firebase-pr.yml
@@ -28,6 +28,9 @@ on:
   workflow_dispatch:
   pull_request:
     branches: ["main", "dev"]
+    # `labeled` lets contributors trigger a build by adding the
+    # `adhoc-build` label without re-pushing. Filtered in the job's `if:`.
+    types: [opened, synchronize, reopened, labeled]
 
 concurrency:
   group: firebase-pr-${{ github.event.pull_request.number || github.ref }}
@@ -36,6 +39,9 @@ concurrency:
 jobs:
   firebase_pr:
     name: Build & upload to Firebase App Distribution
+    # On `labeled`, only run when the `adhoc-build` label is the one being
+    # added — otherwise unrelated labels (bug, wip, etc.) would also fire.
+    if: github.event.action != 'labeled' || github.event.label.name == 'adhoc-build'
     runs-on: warp-macos-latest-arm64-12x
     timeout-minutes: 25
     permissions:


### PR DESCRIPTION
this pr adds firebase adhoc builds to any pr with `adhoc-build` label in addition to the workflow dispatch / any pr against dev

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/808"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Trigger Firebase PR workflow on `adhoc-build` label
> Updates [firebase-pr.yml](https://github.com/xmtplabs/convos-ios/pull/808/files#diff-0d20b86744c45067dfae1ad0950c24de08b31999a9c9b103ddafed83de455c7a) to explicitly listen for `opened`, `synchronize`, `reopened`, and `labeled` pull request event types. Adds a job-level condition so the `firebase_pr` job only runs on `labeled` events when the added label is `adhoc-build`, skipping all other label additions.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 068cfe4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->