### PR TITLE
Scope capability grants and resolutions per agent

### DIFF
--- a/Convos/App Settings/CloudConnectionGrantRequestSheet.swift
+++ b/Convos/App Settings/CloudConnectionGrantRequestSheet.swift
@@ -69,14 +69,32 @@ final class CloudConnectionGrantRequestSheetViewModel {
         connection != nil
     }
 
+    /// Inbox ids for every agent currently in the conversation. The grant fans out
+    /// to each so the user's "share with this conversation" action behaves the same
+    /// as the in-conversation toggle. If the conversation has no agents (or hasn't
+    /// hydrated yet), the share is a no-op — there's nobody to grant to.
+    private var agentInboxIds: [String] {
+        guard let conversation else { return [] }
+        return conversation.members
+            .filter { $0.isAgent }
+            .map { $0.profile.inboxId }
+    }
+
     func share() {
         guard let connection else { return }
         isBusy = true
         error = nil
+        let agents = agentInboxIds
         Task {
             do {
                 let writer = resolveGrantWriter()
-                try await writer.grantConnection(connection.id, to: conversationId)
+                for agent in agents {
+                    try await writer.grantConnection(
+                        connection.id,
+                        to: conversationId,
+                        grantedToInboxId: agent
+                    )
+                }
                 didComplete = true
             } catch {
                 self.error = error
@@ -88,11 +106,18 @@ final class CloudConnectionGrantRequestSheetViewModel {
     func connectAndShare() {
         isBusy = true
         error = nil
+        let agents = agentInboxIds
         Task {
             do {
                 let newConnection = try await cloudConnectionManager.connect(serviceId: serviceId)
                 let writer = resolveGrantWriter()
-                try await writer.grantConnection(newConnection.id, to: conversationId)
+                for agent in agents {
+                    try await writer.grantConnection(
+                        newConnection.id,
+                        to: conversationId,
+                        grantedToInboxId: agent
+                    )
+                }
                 didComplete = true
             } catch let oauthError as OAuthError {
                 if case .cancelled = oauthError {

--- a/Convos/Capabilities/CapabilityPickerCardView.swift
+++ b/Convos/Capabilities/CapabilityPickerCardView.swift
@@ -356,6 +356,7 @@ private extension CapabilityRequest {
     ) -> CapabilityRequest {
         CapabilityRequest(
             requestId: "preview-1",
+            askerInboxId: "preview-asker",
             subject: subject,
             capability: capability,
             rationale: rationale

--- a/Convos/Conversation Detail/ConversationConnectionsSection.swift
+++ b/Convos/Conversation Detail/ConversationConnectionsSection.swift
@@ -116,7 +116,7 @@ final class ConversationConnectionsViewModel {
             // `.read` here silently dropped the revoke event when the user revoked
             // a write-only kind.
             let anyWasEnabled = await isAnyCapabilityEnabled(kind: kind, agents: agents)
-            await forEachAgent(agents: agents, label: "set enablement \(kind.rawValue)") { agent in
+            let written = await forEachAgent(agents: agents, label: "set enablement \(kind.rawValue)") { agent in
                 for capability in ConnectionCapability.allCases {
                     await enablementStore.setEnabled(
                         newValue,
@@ -127,11 +127,11 @@ final class ConversationConnectionsViewModel {
                     )
                 }
             }
-            if newValue != anyWasEnabled {
+            if newValue != anyWasEnabled, !written.isEmpty {
                 await postRepresentativeEvent(
                     granted: newValue,
                     providerId: "device.\(kind.rawValue)",
-                    representative: agents.first
+                    representative: written.first
                 )
             }
             await MainActor.run {
@@ -152,7 +152,7 @@ final class ConversationConnectionsViewModel {
                 try await grantWriter.grantConnection(connectionId, to: conversationId, grantedToInboxId: agent)
             }
             if !written.isEmpty {
-                await postRepresentativeEvent(granted: true, providerId: providerId.rawValue, representative: agents.first)
+                await postRepresentativeEvent(granted: true, providerId: providerId.rawValue, representative: written.first)
             }
         }
     }
@@ -211,7 +211,7 @@ final class ConversationConnectionsViewModel {
                     await postRepresentativeEvent(
                         granted: true,
                         providerId: providerId.rawValue,
-                        representative: agents.first
+                        representative: written.first
                     )
                 }
             } catch let oauthError as OAuthError {

--- a/Convos/Conversation Detail/ConversationConnectionsSection.swift
+++ b/Convos/Conversation Detail/ConversationConnectionsSection.swift
@@ -39,6 +39,14 @@ final class ConversationConnectionsViewModel {
     /// Inbox ids of every agent in this conversation at view-model construction. Each
     /// per-conversation toggle fans out one grant row per agent so the model stays
     /// consistent with the per-agent grant scoping introduced alongside.
+    ///
+    /// Snapshotted at construction — agents that join the conversation after this view
+    /// model is built will not receive grants from subsequent toggles until the model
+    /// is recreated. Acceptable because Conversation Info presentations build a fresh
+    /// view model each time, but if the membership shifts during the lifetime of an
+    /// open settings sheet the user may need to dismiss + reopen for the new agents
+    /// to be reachable from the toggle. Tracked as a follow-up if it becomes a real
+    /// pain point in multi-agent conversations.
     private let agentInboxIds: [String]
     private let cloudConnectionManager: any CloudConnectionManagerProtocol
     private let cloudConnectionRepository: any CloudConnectionRepositoryProtocol
@@ -102,15 +110,12 @@ final class ConversationConnectionsViewModel {
 
     func toggleDeviceConnection(_ kind: ConnectionKind) {
         guard let index = deviceConnections.firstIndex(where: { $0.kind == kind }) else { return }
+        let agents = agentInboxIds
+        // No agents → nothing to grant or revoke against. Bail before mutating local
+        // state so the toggle doesn't visually flip while storage stays untouched.
+        guard !agents.isEmpty else { return }
         let newValue = !deviceConnections[index].isEnabled
         deviceConnections[index] = DeviceConnection(kind: kind, isEnabled: newValue)
-
-        let agents = agentInboxIds
-        // No agents → nothing to grant or revoke against. Skip the storage writes
-        // and the event so we don't surface a subject-less "has access to …" line.
-        guard !agents.isEmpty else {
-            return
-        }
         Task {
             // Snapshot per-agent state once before mutating so we only emit one
             // group-update line per state-change, not one per agent and not one per
@@ -289,6 +294,7 @@ final class ConversationConnectionsViewModel {
                         anyWritten = true
                     } catch {
                         Log.error("Failed to grant fresh connection \(connection.id) to \(agent): \(error.localizedDescription)")
+                        self.error = error
                     }
                 }
                 if anyWritten {

--- a/Convos/Conversation Detail/ConversationConnectionsSection.swift
+++ b/Convos/Conversation Detail/ConversationConnectionsSection.swift
@@ -109,17 +109,13 @@ final class ConversationConnectionsViewModel {
         deviceConnections[index] = DeviceConnection(kind: kind, isEnabled: newValue)
         Task {
             // any-agent-was-enabled snapshot taken before mutation: if at least one
-            // agent had the capability, the conversation already showed it on, and
-            // toggling off should fire a single revoked event.
-            var anyWasEnabled = false
-            for agent in agents where !anyWasEnabled {
-                anyWasEnabled = await enablementStore.isEnabled(
-                    kind: kind,
-                    capability: .read,
-                    conversationId: conversationId,
-                    grantedToInboxId: agent
-                )
-            }
+            // agent had any capability for this kind, the conversation already
+            // showed the toggle on, and toggling off should fire a single revoked
+            // event. Mirrors `refreshDeviceConnections`'s display semantics
+            // (read or any write) so the two paths can't drift — checking only
+            // `.read` here silently dropped the revoke event when the user revoked
+            // a write-only kind.
+            let anyWasEnabled = await isAnyCapabilityEnabled(kind: kind, agents: agents)
             await forEachAgent(agents: agents, label: "set enablement \(kind.rawValue)") { agent in
                 for capability in ConnectionCapability.allCases {
                     await enablementStore.setEnabled(
@@ -258,42 +254,33 @@ final class ConversationConnectionsViewModel {
         Task { [self] in
             var items: [DeviceConnection] = []
             for kind in ConnectionKind.allCases where SupportedConnections.isSupported(kind) {
-                // The toggle reads on for the conversation if any agent has it enabled —
-                // matches the per-conversation UX even though storage is per-agent.
-                // The `where !isReadEnabled` clause short-circuits once any agent reports
-                // enabled.
-                var isReadEnabled = false
-                for agent in agents where !isReadEnabled {
-                    isReadEnabled = await self.enablementStore.isEnabled(
-                        kind: kind,
-                        capability: .read,
-                        conversationId: self.conversationId,
-                        grantedToInboxId: agent
-                    )
-                }
-                var hasWrite = false
-                if !isReadEnabled {
-                    for agent in agents {
-                        for capability in ConnectionCapability.allCases where capability.isWrite {
-                            if await self.enablementStore.isEnabled(
-                                kind: kind,
-                                capability: capability,
-                                conversationId: self.conversationId,
-                                grantedToInboxId: agent
-                            ) {
-                                hasWrite = true
-                                break
-                            }
-                        }
-                        if hasWrite { break }
-                    }
-                }
-                items.append(DeviceConnection(kind: kind, isEnabled: isReadEnabled || hasWrite))
+                let isEnabled = await self.isAnyCapabilityEnabled(kind: kind, agents: agents)
+                items.append(DeviceConnection(kind: kind, isEnabled: isEnabled))
             }
             await MainActor.run {
                 self.deviceConnections = items.sorted { $0.kind.displayName < $1.kind.displayName }
             }
         }
+    }
+
+    /// True when at least one agent has any capability enabled for `kind`. The toggle
+    /// reads on for the conversation under that condition, matching the per-conversation
+    /// UX even though storage is per-agent. Shared between the display path
+    /// (`refreshDeviceConnections`) and the toggle-off snapshot in
+    /// `toggleDeviceConnection` so the two can't drift on which capabilities count.
+    private func isAnyCapabilityEnabled(kind: ConnectionKind, agents: [String]) async -> Bool {
+        for agent in agents {
+            for capability in ConnectionCapability.allCases {
+                let enabled = await enablementStore.isEnabled(
+                    kind: kind,
+                    capability: capability,
+                    conversationId: conversationId,
+                    grantedToInboxId: agent
+                )
+                guard !enabled else { return true }
+            }
+        }
+        return false
     }
 
     /// Run `body` once per agent. Logs and stores `self.error` on per-agent failures

--- a/Convos/Conversation Detail/ConversationConnectionsSection.swift
+++ b/Convos/Conversation Detail/ConversationConnectionsSection.swift
@@ -36,6 +36,10 @@ final class ConversationConnectionsViewModel {
     private var grantedConnectionIds: Set<String> = []
 
     private let conversationId: String
+    /// Inbox ids of every agent in this conversation at view-model construction. Each
+    /// per-conversation toggle fans out one grant row per agent so the model stays
+    /// consistent with the per-agent grant scoping introduced alongside.
+    private let agentInboxIds: [String]
     private let cloudConnectionManager: any CloudConnectionManagerProtocol
     private let cloudConnectionRepository: any CloudConnectionRepositoryProtocol
     private let grantWriter: any CloudConnectionGrantWriterProtocol
@@ -47,6 +51,7 @@ final class ConversationConnectionsViewModel {
 
     init(
         conversationId: String,
+        agentInboxIds: [String],
         cloudConnectionManager: any CloudConnectionManagerProtocol,
         cloudConnectionRepository: any CloudConnectionRepositoryProtocol,
         grantWriter: any CloudConnectionGrantWriterProtocol,
@@ -55,6 +60,7 @@ final class ConversationConnectionsViewModel {
         capabilityResolver: any CapabilityResolver
     ) {
         self.conversationId = conversationId
+        self.agentInboxIds = agentInboxIds
         self.cloudConnectionManager = cloudConnectionManager
         self.cloudConnectionRepository = cloudConnectionRepository
         self.grantWriter = grantWriter
@@ -99,21 +105,61 @@ final class ConversationConnectionsViewModel {
         let newValue = !deviceConnections[index].isEnabled
         deviceConnections[index] = DeviceConnection(kind: kind, isEnabled: newValue)
 
+        let agents = agentInboxIds
+        // No agents → nothing to grant or revoke against. Skip the storage writes
+        // and the event so we don't surface a subject-less "has access to …" line.
+        guard !agents.isEmpty else {
+            return
+        }
         Task {
-            // Read the store-side state once at the top so we can decide whether to emit
-            // a grant/revoke event only when the persisted state actually changes. Without
-            // this, rapid toggling fires redundant connection_event messages even when
-            // every store write is a no-op (e.g. tap-on then tap-off before either Task
-            // runs).
-            let wasEnabled = await enablementStore.isEnabled(kind: kind, capability: .read, conversationId: conversationId)
-            for capability in ConnectionCapability.allCases {
-                await enablementStore.setEnabled(newValue, kind: kind, capability: capability, conversationId: conversationId)
+            // Snapshot per-agent state once before mutating so we only emit one
+            // group-update line per state-change, not one per agent and not one per
+            // redundant tap. The snapshot uses any-agent-was-enabled semantics — if at
+            // least one agent had the capability, the conversation already showed it on
+            // and the user toggling off should fire a single revoked event. The
+            // `where !anyWasEnabled` clause short-circuits the loop once any agent
+            // reports enabled.
+            var anyWasEnabled = false
+            for agent in agents where !anyWasEnabled {
+                anyWasEnabled = await enablementStore.isEnabled(
+                    kind: kind,
+                    capability: .read,
+                    conversationId: conversationId,
+                    grantedToInboxId: agent
+                )
             }
-            if newValue != wasEnabled {
+            for agent in agents {
+                for capability in ConnectionCapability.allCases {
+                    await enablementStore.setEnabled(
+                        newValue,
+                        kind: kind,
+                        capability: capability,
+                        conversationId: conversationId,
+                        grantedToInboxId: agent
+                    )
+                }
+            }
+            if newValue != anyWasEnabled {
+                // Credit the first agent so the rendered text reads as
+                // "<agent name> has access to …" instead of a subject-less phrase.
+                // With multiple agents this is imprecise — every agent really did get
+                // the grant — but the chat shows one event per state change, and one
+                // representative actor matches the prior single-actor display.
+                let representativeAgent = agents.first
                 if newValue {
-                    try? await connectionEventWriter.sendGranted(providerId: "device.\(kind.rawValue)", in: conversationId)
+                    try? await connectionEventWriter.sendGranted(
+                        providerId: "device.\(kind.rawValue)",
+                        capability: nil,
+                        grantedToInboxId: representativeAgent,
+                        in: conversationId
+                    )
                 } else {
-                    try? await connectionEventWriter.sendRevoked(providerId: "device.\(kind.rawValue)", in: conversationId)
+                    try? await connectionEventWriter.sendRevoked(
+                        providerId: "device.\(kind.rawValue)",
+                        capability: nil,
+                        grantedToInboxId: representativeAgent,
+                        in: conversationId
+                    )
                 }
             }
             await MainActor.run {
@@ -127,64 +173,97 @@ final class ConversationConnectionsViewModel {
     }
 
     private func grant(connectionId: String, providerId: ProviderID) {
+        let agents = agentInboxIds
+        guard !agents.isEmpty else { return }
         Task {
-            do {
-                try await grantWriter.grantConnection(connectionId, to: conversationId)
-                try? await connectionEventWriter.sendGranted(providerId: providerId.rawValue, in: conversationId)
-            } catch {
-                Log.error("Failed to grant connection: \(error.localizedDescription)")
-                self.error = error
+            var anyWritten = false
+            for agent in agents {
+                do {
+                    try await grantWriter.grantConnection(connectionId, to: conversationId, grantedToInboxId: agent)
+                    anyWritten = true
+                } catch {
+                    Log.error("Failed to grant connection \(connectionId) to \(agent): \(error.localizedDescription)")
+                    self.error = error
+                }
+            }
+            if anyWritten {
+                try? await connectionEventWriter.sendGranted(
+                    providerId: providerId.rawValue,
+                    capability: nil,
+                    grantedToInboxId: agents.first,
+                    in: conversationId
+                )
             }
         }
     }
 
     private func revokeGrant(connectionId: String, providerId: ProviderID) {
+        let agents = agentInboxIds
+        guard !agents.isEmpty else { return }
         Task {
-            do {
-                try await grantWriter.revokeGrant(connectionId: connectionId, from: conversationId)
+            var anyRemoved = false
+            for agent in agents {
+                do {
+                    try await grantWriter.revokeGrant(connectionId: connectionId, from: conversationId, grantedToInboxId: agent)
+                    anyRemoved = true
+                } catch {
+                    Log.error("Failed to revoke grant \(connectionId) from \(agent): \(error.localizedDescription)")
+                    self.error = error
+                }
+            }
+            if anyRemoved {
                 // Order matches CloudConnectionManager.postRevocationSideEffects:
                 // post the user-visible group-update line first, then drop the
-                // provider from every (subject, verb) row scoped to this
+                // provider from every (subject, verb, agent) row scoped to this
                 // conversation. Resolver-cleanup is what unblocks
                 // persistApprovedCloudCapabilities' idempotency gate so a
                 // follow-up capability_request approval re-emits its own
-                // group-update line.
-                try? await connectionEventWriter.sendRevoked(providerId: providerId.rawValue, in: conversationId)
-                await clearResolverEntriesForProvider(providerId)
-            } catch {
-                Log.error("Failed to revoke connection grant: \(error.localizedDescription)")
-                self.error = error
+                // group-update line. Revoke text is a complete sentence
+                // ("Calendar connection removed") so it reads fine without an actor —
+                // we leave grantedToInboxId nil to keep the message conversation-level.
+                try? await connectionEventWriter.sendRevoked(
+                    providerId: providerId.rawValue,
+                    capability: nil,
+                    grantedToInboxId: nil,
+                    in: conversationId
+                )
+                await clearResolverEntriesForProvider(providerId, agents: agents)
             }
         }
     }
 
-    private func clearResolverEntriesForProvider(_ providerId: ProviderID) async {
+    private func clearResolverEntriesForProvider(_ providerId: ProviderID, agents: [String]) async {
         for subject in CapabilitySubject.allCases {
             for capability in ConnectionCapability.allCases {
-                let current = await capabilityResolver.resolution(
-                    subject: subject,
-                    capability: capability,
-                    conversationId: conversationId
-                )
-                guard current.contains(providerId) else { continue }
-                let shrunk = current.subtracting([providerId])
-                do {
-                    if shrunk.isEmpty {
-                        try await capabilityResolver.clearResolution(
-                            subject: subject,
-                            capability: capability,
-                            conversationId: conversationId
-                        )
-                    } else {
-                        try await capabilityResolver.setResolution(
-                            shrunk,
-                            subject: subject,
-                            capability: capability,
-                            conversationId: conversationId
-                        )
+                for agent in agents {
+                    let current = await capabilityResolver.resolution(
+                        subject: subject,
+                        capability: capability,
+                        conversationId: conversationId,
+                        grantedToInboxId: agent
+                    )
+                    guard current.contains(providerId) else { continue }
+                    let shrunk = current.subtracting([providerId])
+                    do {
+                        if shrunk.isEmpty {
+                            try await capabilityResolver.clearResolution(
+                                subject: subject,
+                                capability: capability,
+                                conversationId: conversationId,
+                                grantedToInboxId: agent
+                            )
+                        } else {
+                            try await capabilityResolver.setResolution(
+                                shrunk,
+                                subject: subject,
+                                capability: capability,
+                                conversationId: conversationId,
+                                grantedToInboxId: agent
+                            )
+                        }
+                    } catch {
+                        Log.warning("Failed to clear resolver entry for \(providerId.rawValue) (\(subject), \(capability), \(agent)): \(error.localizedDescription)")
                     }
-                } catch {
-                    Log.warning("Failed to clear resolver entry for \(providerId.rawValue) (\(subject), \(capability)): \(error.localizedDescription)")
                 }
             }
         }
@@ -193,15 +272,33 @@ final class ConversationConnectionsViewModel {
     /// First-link path: run the OAuth flow, then immediately grant the resulting
     /// connection for this conversation so the user's intent ("turn it on for
     /// this convo") completes in one tap. Mirrors what the App Settings list
-    /// would do followed by the conversation-info toggle, just chained.
+    /// would do followed by the conversation-info toggle, just chained — fanning
+    /// out the grant across every agent currently in the conversation.
     private func connectAndGrant(serviceId: String, providerId: ProviderID) {
+        let agents = agentInboxIds
+        guard !agents.isEmpty else { return }
         isConnecting = true
         error = nil
         Task {
             do {
                 let connection = try await cloudConnectionManager.connect(serviceId: serviceId)
-                try await grantWriter.grantConnection(connection.id, to: conversationId)
-                try? await connectionEventWriter.sendGranted(providerId: providerId.rawValue, in: conversationId)
+                var anyWritten = false
+                for agent in agents {
+                    do {
+                        try await grantWriter.grantConnection(connection.id, to: conversationId, grantedToInboxId: agent)
+                        anyWritten = true
+                    } catch {
+                        Log.error("Failed to grant fresh connection \(connection.id) to \(agent): \(error.localizedDescription)")
+                    }
+                }
+                if anyWritten {
+                    try? await connectionEventWriter.sendGranted(
+                        providerId: providerId.rawValue,
+                        capability: nil,
+                        grantedToInboxId: agents.first,
+                        in: conversationId
+                    )
+                }
             } catch let oauthError as OAuthError {
                 if case .cancelled = oauthError {
                 } else {
@@ -238,15 +335,38 @@ final class ConversationConnectionsViewModel {
     }
 
     private func refreshDeviceConnections() {
+        let agents = agentInboxIds
         Task { [self] in
             var items: [DeviceConnection] = []
             for kind in ConnectionKind.allCases where SupportedConnections.isSupported(kind) {
-                let isReadEnabled = await self.enablementStore.isEnabled(kind: kind, capability: .read, conversationId: self.conversationId)
+                // The toggle reads on for the conversation if any agent has it enabled —
+                // matches the per-conversation UX even though storage is per-agent.
+                // The `where !isReadEnabled` clause short-circuits once any agent reports
+                // enabled.
+                var isReadEnabled = false
+                for agent in agents where !isReadEnabled {
+                    isReadEnabled = await self.enablementStore.isEnabled(
+                        kind: kind,
+                        capability: .read,
+                        conversationId: self.conversationId,
+                        grantedToInboxId: agent
+                    )
+                }
                 var hasWrite = false
-                for capability in ConnectionCapability.allCases where capability.isWrite {
-                    if await self.enablementStore.isEnabled(kind: kind, capability: capability, conversationId: self.conversationId) {
-                        hasWrite = true
-                        break
+                if !isReadEnabled {
+                    for agent in agents {
+                        for capability in ConnectionCapability.allCases where capability.isWrite {
+                            if await self.enablementStore.isEnabled(
+                                kind: kind,
+                                capability: capability,
+                                conversationId: self.conversationId,
+                                grantedToInboxId: agent
+                            ) {
+                                hasWrite = true
+                                break
+                            }
+                        }
+                        if hasWrite { break }
                     }
                 }
                 items.append(DeviceConnection(kind: kind, isEnabled: isReadEnabled || hasWrite))

--- a/Convos/Conversation Detail/ConversationConnectionsSection.swift
+++ b/Convos/Conversation Detail/ConversationConnectionsSection.swift
@@ -36,17 +36,8 @@ final class ConversationConnectionsViewModel {
     private var grantedConnectionIds: Set<String> = []
 
     private let conversationId: String
-    /// Inbox ids of every agent in this conversation at view-model construction. Each
-    /// per-conversation toggle fans out one grant row per agent so the model stays
-    /// consistent with the per-agent grant scoping introduced alongside.
-    ///
-    /// Snapshotted at construction — agents that join the conversation after this view
-    /// model is built will not receive grants from subsequent toggles until the model
-    /// is recreated. Acceptable because Conversation Info presentations build a fresh
-    /// view model each time, but if the membership shifts during the lifetime of an
-    /// open settings sheet the user may need to dismiss + reopen for the new agents
-    /// to be reachable from the toggle. Tracked as a follow-up if it becomes a real
-    /// pain point in multi-agent conversations.
+    /// Inbox ids of every agent in this conversation, snapshotted at construction.
+    /// Per-conversation toggles fan out one grant row per agent.
     private let agentInboxIds: [String]
     private let cloudConnectionManager: any CloudConnectionManagerProtocol
     private let cloudConnectionRepository: any CloudConnectionRepositoryProtocol
@@ -117,13 +108,9 @@ final class ConversationConnectionsViewModel {
         let newValue = !deviceConnections[index].isEnabled
         deviceConnections[index] = DeviceConnection(kind: kind, isEnabled: newValue)
         Task {
-            // Snapshot per-agent state once before mutating so we only emit one
-            // group-update line per state-change, not one per agent and not one per
-            // redundant tap. The snapshot uses any-agent-was-enabled semantics — if at
-            // least one agent had the capability, the conversation already showed it on
-            // and the user toggling off should fire a single revoked event. The
-            // `where !anyWasEnabled` clause short-circuits the loop once any agent
-            // reports enabled.
+            // any-agent-was-enabled snapshot taken before mutation: if at least one
+            // agent had the capability, the conversation already showed it on, and
+            // toggling off should fire a single revoked event.
             var anyWasEnabled = false
             for agent in agents where !anyWasEnabled {
                 anyWasEnabled = await enablementStore.isEnabled(
@@ -133,7 +120,7 @@ final class ConversationConnectionsViewModel {
                     grantedToInboxId: agent
                 )
             }
-            for agent in agents {
+            await forEachAgent(agents: agents, label: "set enablement \(kind.rawValue)") { agent in
                 for capability in ConnectionCapability.allCases {
                     await enablementStore.setEnabled(
                         newValue,
@@ -145,27 +132,11 @@ final class ConversationConnectionsViewModel {
                 }
             }
             if newValue != anyWasEnabled {
-                // Credit the first agent so the rendered text reads as
-                // "<agent name> has access to …" instead of a subject-less phrase.
-                // With multiple agents this is imprecise — every agent really did get
-                // the grant — but the chat shows one event per state change, and one
-                // representative actor matches the prior single-actor display.
-                let representativeAgent = agents.first
-                if newValue {
-                    try? await connectionEventWriter.sendGranted(
-                        providerId: "device.\(kind.rawValue)",
-                        capability: nil,
-                        grantedToInboxId: representativeAgent,
-                        in: conversationId
-                    )
-                } else {
-                    try? await connectionEventWriter.sendRevoked(
-                        providerId: "device.\(kind.rawValue)",
-                        capability: nil,
-                        grantedToInboxId: representativeAgent,
-                        in: conversationId
-                    )
-                }
+                await postRepresentativeEvent(
+                    granted: newValue,
+                    providerId: "device.\(kind.rawValue)",
+                    representative: agents.first
+                )
             }
             await MainActor.run {
                 refreshDeviceConnections()
@@ -181,23 +152,11 @@ final class ConversationConnectionsViewModel {
         let agents = agentInboxIds
         guard !agents.isEmpty else { return }
         Task {
-            var anyWritten = false
-            for agent in agents {
-                do {
-                    try await grantWriter.grantConnection(connectionId, to: conversationId, grantedToInboxId: agent)
-                    anyWritten = true
-                } catch {
-                    Log.error("Failed to grant connection \(connectionId) to \(agent): \(error.localizedDescription)")
-                    self.error = error
-                }
+            let written = await forEachAgent(agents: agents, label: "grant \(connectionId)") { agent in
+                try await grantWriter.grantConnection(connectionId, to: conversationId, grantedToInboxId: agent)
             }
-            if anyWritten {
-                try? await connectionEventWriter.sendGranted(
-                    providerId: providerId.rawValue,
-                    capability: nil,
-                    grantedToInboxId: agents.first,
-                    in: conversationId
-                )
+            if !written.isEmpty {
+                await postRepresentativeEvent(granted: true, providerId: providerId.rawValue, representative: agents.first)
             }
         }
     }
@@ -206,69 +165,28 @@ final class ConversationConnectionsViewModel {
         let agents = agentInboxIds
         guard !agents.isEmpty else { return }
         Task {
-            var anyRemoved = false
-            for agent in agents {
-                do {
-                    try await grantWriter.revokeGrant(connectionId: connectionId, from: conversationId, grantedToInboxId: agent)
-                    anyRemoved = true
-                } catch {
-                    Log.error("Failed to revoke grant \(connectionId) from \(agent): \(error.localizedDescription)")
-                    self.error = error
-                }
+            let removed = await forEachAgent(agents: agents, label: "revoke \(connectionId)") { agent in
+                try await grantWriter.revokeGrant(connectionId: connectionId, from: conversationId, grantedToInboxId: agent)
             }
-            if anyRemoved {
+            if !removed.isEmpty {
                 // Order matches CloudConnectionManager.postRevocationSideEffects:
                 // post the user-visible group-update line first, then drop the
-                // provider from every (subject, verb, agent) row scoped to this
-                // conversation. Resolver-cleanup is what unblocks
-                // persistApprovedCloudCapabilities' idempotency gate so a
-                // follow-up capability_request approval re-emits its own
-                // group-update line. Revoke text is a complete sentence
-                // ("Calendar connection removed") so it reads fine without an actor —
-                // we leave grantedToInboxId nil to keep the message conversation-level.
+                // provider from every (subject, verb, agent) row in this conversation.
+                // Resolver-cleanup is what unblocks persistApprovedCloudCapabilities'
+                // idempotency gate so a follow-up capability_request approval re-emits
+                // its own group-update line. Revoke text is a complete sentence
+                // ("Calendar connection removed") so we keep grantedToInboxId nil and
+                // render it conversation-level.
                 try? await connectionEventWriter.sendRevoked(
                     providerId: providerId.rawValue,
                     capability: nil,
                     grantedToInboxId: nil,
                     in: conversationId
                 )
-                await clearResolverEntriesForProvider(providerId, agents: agents)
-            }
-        }
-    }
-
-    private func clearResolverEntriesForProvider(_ providerId: ProviderID, agents: [String]) async {
-        for subject in CapabilitySubject.allCases {
-            for capability in ConnectionCapability.allCases {
-                for agent in agents {
-                    let current = await capabilityResolver.resolution(
-                        subject: subject,
-                        capability: capability,
-                        conversationId: conversationId,
-                        grantedToInboxId: agent
-                    )
-                    guard current.contains(providerId) else { continue }
-                    let shrunk = current.subtracting([providerId])
-                    do {
-                        if shrunk.isEmpty {
-                            try await capabilityResolver.clearResolution(
-                                subject: subject,
-                                capability: capability,
-                                conversationId: conversationId,
-                                grantedToInboxId: agent
-                            )
-                        } else {
-                            try await capabilityResolver.setResolution(
-                                shrunk,
-                                subject: subject,
-                                capability: capability,
-                                conversationId: conversationId,
-                                grantedToInboxId: agent
-                            )
-                        }
-                    } catch {
-                        Log.warning("Failed to clear resolver entry for \(providerId.rawValue) (\(subject), \(capability), \(agent)): \(error.localizedDescription)")
-                    }
+                do {
+                    try await capabilityResolver.removeProvider(providerId, fromConversation: conversationId)
+                } catch {
+                    Log.warning("Failed to clear resolver entries for \(providerId.rawValue): \(error.localizedDescription)")
                 }
             }
         }
@@ -287,22 +205,17 @@ final class ConversationConnectionsViewModel {
         Task {
             do {
                 let connection = try await cloudConnectionManager.connect(serviceId: serviceId)
-                var anyWritten = false
-                for agent in agents {
-                    do {
-                        try await grantWriter.grantConnection(connection.id, to: conversationId, grantedToInboxId: agent)
-                        anyWritten = true
-                    } catch {
-                        Log.error("Failed to grant fresh connection \(connection.id) to \(agent): \(error.localizedDescription)")
-                        self.error = error
-                    }
+                let written = await forEachAgent(
+                    agents: agents,
+                    label: "grant fresh connection \(connection.id)"
+                ) { agent in
+                    try await grantWriter.grantConnection(connection.id, to: conversationId, grantedToInboxId: agent)
                 }
-                if anyWritten {
-                    try? await connectionEventWriter.sendGranted(
+                if !written.isEmpty {
+                    await postRepresentativeEvent(
+                        granted: true,
                         providerId: providerId.rawValue,
-                        capability: nil,
-                        grantedToInboxId: agents.first,
-                        in: conversationId
+                        representative: agents.first
                     )
                 }
             } catch let oauthError as OAuthError {
@@ -380,6 +293,57 @@ final class ConversationConnectionsViewModel {
             await MainActor.run {
                 self.deviceConnections = items.sorted { $0.kind.displayName < $1.kind.displayName }
             }
+        }
+    }
+
+    /// Run `body` once per agent. Logs and stores `self.error` on per-agent failures
+    /// without short-circuiting the loop, returns the agents the body completed for.
+    /// Caller decides whether the resulting list is "good enough" to emit a
+    /// representative connection_event. `Void` body returns `[String]` of completed
+    /// agents.
+    @discardableResult
+    private func forEachAgent(
+        agents: [String],
+        label: String,
+        _ body: (String) async throws -> Void
+    ) async -> [String] {
+        var succeeded: [String] = []
+        for agent in agents {
+            do {
+                try await body(agent)
+                succeeded.append(agent)
+            } catch {
+                Log.error("\(label) failed for \(agent): \(error.localizedDescription)")
+                self.error = error
+            }
+        }
+        return succeeded
+    }
+
+    /// Post a single conversation-level connection_event crediting one representative
+    /// agent. The chat shows one event per state change with the agent's name, instead
+    /// of a subject-less phrase ("has access to …"); with multiple agents this is
+    /// imprecise — every agent really did get the grant — but matches the prior
+    /// single-actor display.
+    private func postRepresentativeEvent(
+        granted: Bool,
+        providerId: String,
+        representative: String?
+    ) async {
+        if granted {
+            try? await connectionEventWriter.sendGranted(
+                providerId: providerId,
+                capability: nil,
+                grantedToInboxId: representative,
+                in: conversationId
+            )
+        } else {
+            try? await connectionEventWriter.sendRevoked(
+                providerId: providerId,
+                capability: nil,
+                grantedToInboxId: representative,
+                in: conversationId
+            )
         }
     }
 }

--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -123,7 +123,6 @@ struct ConversationView<MessagesBottomBar: View>: View {
             hasAssistant: viewModel.conversation.hasAgent,
             isAssistantJoinPending: viewModel.isAssistantJoinPending,
             isAssistantEnabled: FeatureFlags.shared.isAssistantEnabled && GlobalConvoDefaults.shared.assistantsEnabled,
-            agentNamesByInboxId: viewModel.agentNamesByInboxId,
             onBottomOverscrollChanged: { overscroll in
                 scrollOverscrollAmount = overscroll
                 if overscroll == 0 {
@@ -165,7 +164,7 @@ struct ConversationView<MessagesBottomBar: View>: View {
                         } else if let layout = viewModel.pendingCapabilityPickerLayout {
                             CapabilityPickerCardView(
                                 layout: layout,
-                                assistantName: viewModel.agentNamesByInboxId[layout.request.askerInboxId],
+                                assistantName: viewModel.askerDisplayName(for: layout.request),
                                 onApprove: { providerIds in
                                     viewModel.onCapabilityApprove(providerIds: providerIds)
                                 },

--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -123,7 +123,7 @@ struct ConversationView<MessagesBottomBar: View>: View {
             hasAssistant: viewModel.conversation.hasAgent,
             isAssistantJoinPending: viewModel.isAssistantJoinPending,
             isAssistantEnabled: FeatureFlags.shared.isAssistantEnabled && GlobalConvoDefaults.shared.assistantsEnabled,
-            verifiedAssistantName: viewModel.verifiedAssistantName,
+            agentNamesByInboxId: viewModel.agentNamesByInboxId,
             onBottomOverscrollChanged: { overscroll in
                 scrollOverscrollAmount = overscroll
                 if overscroll == 0 {
@@ -165,7 +165,7 @@ struct ConversationView<MessagesBottomBar: View>: View {
                         } else if let layout = viewModel.pendingCapabilityPickerLayout {
                             CapabilityPickerCardView(
                                 layout: layout,
-                                assistantName: viewModel.verifiedAssistantName,
+                                assistantName: viewModel.agentNamesByInboxId[layout.request.askerInboxId],
                                 onApprove: { providerIds in
                                     viewModel.onCapabilityApprove(providerIds: providerIds)
                                 },

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -2333,18 +2333,14 @@ extension ConversationViewModel {
         return value
     }
 
-    /// Live map of agent inbox id → display name, sourced from the conversation's
-    /// current members. Consumed by the messages list to render
-    /// `.grantedAgent`-actor connection_event summaries with the granted agent's
-    /// name, and by the capability picker card to label the asker. Inbox-id keying
-    /// keeps the rendered text in sync with ProfileUpdate-driven renames without
-    /// re-running the messages-list processor.
-    var agentNamesByInboxId: [String: String] {
-        Dictionary(
-            uniqueKeysWithValues: conversation.members
-                .filter { $0.isAgent }
-                .map { ($0.profile.inboxId, $0.displayName) }
-        )
+    /// Resolved display name for the agent that emitted `request`, or nil if the agent
+    /// is not (or no longer) in the conversation. Used by the capability picker card to
+    /// label the asker. Connection-event summaries do their own name resolution at
+    /// processor time via `MemberProfileInfo`.
+    func askerDisplayName(for request: CapabilityRequest) -> String? {
+        conversation.members
+            .first(where: { $0.profile.inboxId == request.askerInboxId })?
+            .displayName
     }
 
     func makeAssistantFilesLinksRepository() -> AssistantFilesLinksRepository {

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -1018,12 +1018,14 @@ class ConversationViewModel { // swiftlint:disable:this type_body_length
             // connection_event — fan-in semantics are per-(provider, verb), so a
             // second verb approval on a provider already granted at the connection
             // level still needs its own group-update line.
+            let askerInboxId = request.askerInboxId
             let previouslyApproved: Set<ProviderID>
             if status == .approved {
                 previouslyApproved = await resolver.resolution(
                     subject: request.subject,
                     capability: request.capability,
-                    conversationId: conversationId
+                    conversationId: conversationId,
+                    grantedToInboxId: askerInboxId
                 )
             } else {
                 previouslyApproved = []
@@ -1037,13 +1039,15 @@ class ConversationViewModel { // swiftlint:disable:this type_body_length
                         providerIds,
                         subject: request.subject,
                         capability: request.capability,
-                        conversationId: conversationId
+                        conversationId: conversationId,
+                        grantedToInboxId: askerInboxId
                     )
                 case .denied, .cancelled:
                     try await resolver.clearResolution(
                         subject: request.subject,
                         capability: request.capability,
-                        conversationId: conversationId
+                        conversationId: conversationId,
+                        grantedToInboxId: askerInboxId
                     )
                 }
             } catch {
@@ -1068,6 +1072,7 @@ class ConversationViewModel { // swiftlint:disable:this type_body_length
                     providerIds: sortedIds,
                     capability: request.capability,
                     conversationId: conversationId,
+                    grantedToInboxId: askerInboxId,
                     session: session
                 )
                 await Self.persistApprovedCloudCapabilities(
@@ -1075,6 +1080,7 @@ class ConversationViewModel { // swiftlint:disable:this type_body_length
                     newlyApprovedProviderIds: newlyApprovedProviderIds,
                     capability: request.capability,
                     conversationId: conversationId,
+                    grantedToInboxId: askerInboxId,
                     session: session
                 )
             }
@@ -1149,18 +1155,31 @@ class ConversationViewModel { // swiftlint:disable:this type_body_length
         providerIds: [ProviderID],
         capability: ConnectionCapability,
         conversationId: String,
+        grantedToInboxId: String,
         session: any SessionManagerProtocol
     ) async {
         let store = session.connectionEnablementStore()
         let eventWriter = session.messagingService().connectionEventWriter()
         for providerId in providerIds {
             guard let kind = ConnectionKind.fromDeviceProviderId(providerId) else { continue }
-            let wasEnabled = await store.isEnabled(kind: kind, capability: capability, conversationId: conversationId)
-            await store.setEnabled(true, kind: kind, capability: capability, conversationId: conversationId)
+            let wasEnabled = await store.isEnabled(
+                kind: kind,
+                capability: capability,
+                conversationId: conversationId,
+                grantedToInboxId: grantedToInboxId
+            )
+            await store.setEnabled(
+                true,
+                kind: kind,
+                capability: capability,
+                conversationId: conversationId,
+                grantedToInboxId: grantedToInboxId
+            )
             if !wasEnabled {
                 try? await eventWriter.sendGranted(
                     providerId: providerId.rawValue,
                     capability: capability,
+                    grantedToInboxId: grantedToInboxId,
                     in: conversationId
                 )
             }
@@ -1178,6 +1197,7 @@ class ConversationViewModel { // swiftlint:disable:this type_body_length
         newlyApprovedProviderIds: Set<ProviderID>,
         capability: ConnectionCapability,
         conversationId: String,
+        grantedToInboxId: String,
         session: any SessionManagerProtocol
     ) async {
         let messagingService = session.messagingService()
@@ -1186,23 +1206,26 @@ class ConversationViewModel { // swiftlint:disable:this type_body_length
         let repository = session.cloudConnectionRepository()
         let activeConnections = (try? await repository.connections()) ?? []
         let existingGrants = (try? await repository.grants(for: conversationId)) ?? []
-        let existingGrantedConnectionIds = Set(existingGrants.map(\.connectionId))
+        let existingGrantedKeys = Set(existingGrants.map { GrantKey(connectionId: $0.connectionId, grantedToInboxId: $0.grantedToInboxId) })
 
         for providerId in providerIds {
             guard let serviceId = providerId.cloudServiceId else { continue }
             guard let connection = activeConnections.first(where: { $0.serviceId == serviceId }) else { continue }
 
-            // The grant row is connection-level (composio.<service>) and
-            // capability-agnostic, so only write it the first time the
-            // provider gets approved on this conversation. Subsequent verb
-            // approvals on the same provider must skip the grant write —
-            // otherwise grantConnection fails because the row already exists
-            // — but they still need to fire their own connection_event.
-            if !existingGrantedConnectionIds.contains(connection.id) {
+            // The grant row is per-(connection, conversation, agent). Two agents
+            // approved for the same connection get two rows; the same agent re-
+            // approving the same connection is a no-op for the grant write but
+            // still needs its own connection_event.
+            let grantKey = GrantKey(connectionId: connection.id, grantedToInboxId: grantedToInboxId)
+            if !existingGrantedKeys.contains(grantKey) {
                 do {
-                    try await grantWriter.grantConnection(connection.id, to: conversationId)
+                    try await grantWriter.grantConnection(
+                        connection.id,
+                        to: conversationId,
+                        grantedToInboxId: grantedToInboxId
+                    )
                 } catch {
-                    Log.error("Failed to persist cloud grant for \(providerId.rawValue): \(error.localizedDescription)")
+                    Log.error("Failed to persist cloud grant for \(providerId.rawValue) → \(grantedToInboxId): \(error.localizedDescription)")
                     continue
                 }
             }
@@ -1214,9 +1237,15 @@ class ConversationViewModel { // swiftlint:disable:this type_body_length
             try? await eventWriter.sendGranted(
                 providerId: providerId.rawValue,
                 capability: capability,
+                grantedToInboxId: grantedToInboxId,
                 in: conversationId
             )
         }
+    }
+
+    private struct GrantKey: Hashable {
+        let connectionId: String
+        let grantedToInboxId: String
     }
 
     private static func capabilityActionParameter(
@@ -2304,17 +2333,18 @@ extension ConversationViewModel {
         return value
     }
 
-    var verifiedAssistantName: String? {
-        // Prefer the verified-assistant member, but fall back to ANY agent
-        // member when verification flaps to false during attestation
-        // re-checks. `isAgent` is a static profile property that doesn't
-        // depend on the periodic attestation cycle, so the fallback keeps
-        // the displayed name stable even when `agentVerification`
-        // momentarily reports the agent as unverified.
-        if let verified = conversation.members.first(where: \.isVerifiedAssistant) {
-            return verified.displayName
-        }
-        return conversation.members.first(where: \.isAgent)?.displayName
+    /// Live map of agent inbox id → display name, sourced from the conversation's
+    /// current members. Consumed by the messages list to render
+    /// `.grantedAgent`-actor connection_event summaries with the granted agent's
+    /// name, and by the capability picker card to label the asker. Inbox-id keying
+    /// keeps the rendered text in sync with ProfileUpdate-driven renames without
+    /// re-running the messages-list processor.
+    var agentNamesByInboxId: [String: String] {
+        Dictionary(
+            uniqueKeysWithValues: conversation.members
+                .filter { $0.isAgent }
+                .map { ($0.profile.inboxId, $0.displayName) }
+        )
     }
 
     func makeAssistantFilesLinksRepository() -> AssistantFilesLinksRepository {
@@ -2322,8 +2352,16 @@ extension ConversationViewModel {
     }
 
     func makeConversationConnectionsViewModel() -> ConversationConnectionsViewModel {
-        ConversationConnectionsViewModel(
+        // Snapshot of agent inbox ids at view-model creation. Per-conversation toggles
+        // fan out one grant row per agent currently in the conversation; if membership
+        // changes mid-life of the view model, callers can recreate it (the view model is
+        // shaped per ConversationInfo presentation, so that already happens naturally).
+        let agentInboxIds = conversation.members
+            .filter { $0.isAgent }
+            .map { $0.profile.inboxId }
+        return ConversationConnectionsViewModel(
             conversationId: conversation.id,
+            agentInboxIds: agentInboxIds,
             cloudConnectionManager: session.cloudConnectionManager(callbackURLScheme: ConfigManager.shared.appUrlScheme),
             cloudConnectionRepository: session.cloudConnectionRepository(),
             grantWriter: messagingService.connectionGrantWriter(),

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Cells/MessagesListItemTypeCell.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Cells/MessagesListItemTypeCell.swift
@@ -166,12 +166,9 @@ class MessagesListItemTypeCell: UICollectionViewCell {
                     }
 
                 case let .connectionEvent(_, summary, _):
-                    ConnectionEventSummaryView(
-                        summary: summary,
-                        agentNamesByInboxId: config.agentNamesByInboxId
-                    )
-                    .padding(.vertical, DesignConstants.Spacing.step4x)
-                    .padding(.horizontal, DesignConstants.Spacing.step4x)
+                    ConnectionEventSummaryView(summary: summary)
+                        .padding(.vertical, DesignConstants.Spacing.step4x)
+                        .padding(.horizontal, DesignConstants.Spacing.step4x)
 
                 case .typingIndicator:
                     EmptyView()

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Cells/MessagesListItemTypeCell.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Cells/MessagesListItemTypeCell.swift
@@ -168,7 +168,7 @@ class MessagesListItemTypeCell: UICollectionViewCell {
                 case let .connectionEvent(_, summary, _):
                     ConnectionEventSummaryView(
                         summary: summary,
-                        verifiedAssistantName: config.verifiedAssistantName
+                        agentNamesByInboxId: config.agentNamesByInboxId
                     )
                     .padding(.vertical, DesignConstants.Spacing.step4x)
                     .padding(.horizontal, DesignConstants.Spacing.step4x)

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Data Source/CellFactory.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Data Source/CellFactory.swift
@@ -29,11 +29,11 @@ struct CellConfig {
     let hasAssistant: Bool
     let isAssistantJoinPending: Bool
     let isAssistantEnabled: Bool
-    /// Live verified-assistant display name; consumed by
+    /// Live agent display names keyed by inbox id. Consumed by
     /// `ConnectionEventSummaryView` to prepend the actor on
-    /// `.verifiedAssistant`-actor summaries at render time. Sourced from
-    /// `ConversationViewModel.verifiedAssistantName`.
-    let verifiedAssistantName: String?
+    /// `.grantedAgent`-actor summaries at render time so ProfileUpdate-driven
+    /// renames propagate without re-running the messages-list processor.
+    let agentNamesByInboxId: [String: String]
 }
 
 // swiftlint:disable force_cast

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Data Source/CellFactory.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Data Source/CellFactory.swift
@@ -29,11 +29,6 @@ struct CellConfig {
     let hasAssistant: Bool
     let isAssistantJoinPending: Bool
     let isAssistantEnabled: Bool
-    /// Live agent display names keyed by inbox id. Consumed by
-    /// `ConnectionEventSummaryView` to prepend the actor on
-    /// `.grantedAgent`-actor summaries at render time so ProfileUpdate-driven
-    /// renames propagate without re-running the messages-list processor.
-    let agentNamesByInboxId: [String: String]
 }
 
 // swiftlint:disable force_cast

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Data Source/MessagesCollectionDataSource.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Data Source/MessagesCollectionDataSource.swift
@@ -30,5 +30,4 @@ protocol MessagesCollectionDataSource: UICollectionViewDataSource, MessagesLayou
     var hasAssistant: Bool { get set }
     var isAssistantJoinPending: Bool { get set }
     var isAssistantEnabled: Bool { get set }
-    var agentNamesByInboxId: [String: String] { get set }
 }

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Data Source/MessagesCollectionDataSource.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Data Source/MessagesCollectionDataSource.swift
@@ -30,5 +30,5 @@ protocol MessagesCollectionDataSource: UICollectionViewDataSource, MessagesLayou
     var hasAssistant: Bool { get set }
     var isAssistantJoinPending: Bool { get set }
     var isAssistantEnabled: Bool { get set }
-    var verifiedAssistantName: String? { get set }
+    var agentNamesByInboxId: [String: String] { get set }
 }

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Data Source/MessagesCollectionViewDataSource.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Data Source/MessagesCollectionViewDataSource.swift
@@ -38,7 +38,7 @@ final class MessagesCollectionViewDataSource: NSObject {
     var hasAssistant: Bool = false
     var isAssistantJoinPending: Bool = false
     var isAssistantEnabled: Bool = false
-    var verifiedAssistantName: String?
+    var agentNamesByInboxId: [String: String] = [:]
 
     var allVoiceMemoTranscripts: [String: VoiceMemoTranscriptListItem] {
         sections.flatMap(\.cells).reduce(into: [:]) { result, item in
@@ -145,7 +145,7 @@ extension MessagesCollectionViewDataSource: UICollectionViewDataSource {
             hasAssistant: hasAssistant,
             isAssistantJoinPending: isAssistantJoinPending,
             isAssistantEnabled: isAssistantEnabled,
-            verifiedAssistantName: verifiedAssistantName
+            agentNamesByInboxId: agentNamesByInboxId
         )
         return CellFactory.createCell(
             in: collectionView,

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Data Source/MessagesCollectionViewDataSource.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Data Source/MessagesCollectionViewDataSource.swift
@@ -38,7 +38,6 @@ final class MessagesCollectionViewDataSource: NSObject {
     var hasAssistant: Bool = false
     var isAssistantJoinPending: Bool = false
     var isAssistantEnabled: Bool = false
-    var agentNamesByInboxId: [String: String] = [:]
 
     var allVoiceMemoTranscripts: [String: VoiceMemoTranscriptListItem] {
         sections.flatMap(\.cells).reduce(into: [:]) { result, item in
@@ -144,8 +143,7 @@ extension MessagesCollectionViewDataSource: UICollectionViewDataSource {
             allVoiceMemoTranscripts: allVoiceMemoTranscripts,
             hasAssistant: hasAssistant,
             isAssistantJoinPending: isAssistantJoinPending,
-            isAssistantEnabled: isAssistantEnabled,
-            agentNamesByInboxId: agentNamesByInboxId
+            isAssistantEnabled: isAssistantEnabled
         )
         return CellFactory.createCell(
             in: collectionView,

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/MessagesViewController.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/MessagesViewController.swift
@@ -207,8 +207,8 @@ final class MessagesViewController: UIViewController {
     var isAssistantEnabled: Bool = false {
         didSet { dataSource.isAssistantEnabled = isAssistantEnabled }
     }
-    var verifiedAssistantName: String? {
-        didSet { dataSource.verifiedAssistantName = verifiedAssistantName }
+    var agentNamesByInboxId: [String: String] = [:] {
+        didSet { dataSource.agentNamesByInboxId = agentNamesByInboxId }
     }
     var shouldBlurPhotos: Bool = true {
         didSet {

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/MessagesViewController.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/MessagesViewController.swift
@@ -207,9 +207,6 @@ final class MessagesViewController: UIViewController {
     var isAssistantEnabled: Bool = false {
         didSet { dataSource.isAssistantEnabled = isAssistantEnabled }
     }
-    var agentNamesByInboxId: [String: String] = [:] {
-        didSet { dataSource.agentNamesByInboxId = agentNamesByInboxId }
-    }
     var shouldBlurPhotos: Bool = true {
         didSet {
             guard oldValue != shouldBlurPhotos else { return }

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesBottomBar.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesBottomBar.swift
@@ -533,7 +533,7 @@ struct MessagesBottomBar<BottomBarContent: View>: View {
             hasAssistant: false,
             isAssistantJoinPending: false,
             isAssistantEnabled: true,
-            verifiedAssistantName: nil,
+            agentNamesByInboxId: [:],
             bottomBarHeight: bottomBarHeight,
             onBottomOverscrollChanged: { _ in },
             onBottomOverscrollReleased: { _ in },

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesBottomBar.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesBottomBar.swift
@@ -533,7 +533,6 @@ struct MessagesBottomBar<BottomBarContent: View>: View {
             hasAssistant: false,
             isAssistantJoinPending: false,
             isAssistantEnabled: true,
-            agentNamesByInboxId: [:],
             bottomBarHeight: bottomBarHeight,
             onBottomOverscrollChanged: { _ in },
             onBottomOverscrollReleased: { _ in },

--- a/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/ConnectionEventSummaryView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/ConnectionEventSummaryView.swift
@@ -3,13 +3,6 @@ import SwiftUI
 
 struct ConnectionEventSummaryView: View {
     let summary: ConnectionEventSummary
-    /// Live agent display names keyed by inbox id, sourced from the
-    /// conversation's current members. The renderer prepends the resolved
-    /// name for `.grantedAgent`-actor summaries so ProfileUpdate-driven
-    /// renames propagate without reprocessing the message list. Pass an
-    /// empty dictionary if no agents are in the conversation; the view
-    /// falls back to rendering `summary.text` as-is.
-    var agentNamesByInboxId: [String: String]
 
     var body: some View {
         HStack(spacing: DesignConstants.Spacing.stepX) {
@@ -17,24 +10,14 @@ struct ConnectionEventSummaryView: View {
                 .font(.caption)
                 .foregroundStyle(iconColor)
 
-            Text(renderedText)
+            Text(summary.text)
                 .lineLimit(1)
                 .font(.caption)
                 .foregroundStyle(.colorTextSecondary)
         }
         .frame(maxWidth: .infinity, alignment: .center)
         .accessibilityElement(children: .combine)
-        .accessibilityLabel(renderedText)
-    }
-
-    private var renderedText: String {
-        guard summary.actor == .grantedAgent,
-              let inboxId = summary.grantedToInboxId,
-              let name = agentNamesByInboxId[inboxId],
-              !name.isEmpty else {
-            return summary.text
-        }
-        return "\(name) \(summary.text)"
+        .accessibilityLabel(summary.text)
     }
 
     private var iconName: String {

--- a/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/ConnectionEventSummaryView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/ConnectionEventSummaryView.swift
@@ -3,14 +3,13 @@ import SwiftUI
 
 struct ConnectionEventSummaryView: View {
     let summary: ConnectionEventSummary
-    /// Live name of the verified assistant in the current conversation. The
-    /// processor leaves `.verifiedAssistant`-actor summaries unprefixed and
-    /// this view prepends the name at render time so the rendered text stays
-    /// in sync with the conversation's stable membership snapshot, instead of
-    /// flapping with the per-emission `agentVerification` state in
-    /// memberProfiles. Pass `nil` if no verified assistant is in the
-    /// conversation; the view falls back to rendering `summary.text` as-is.
-    var verifiedAssistantName: String?
+    /// Live agent display names keyed by inbox id, sourced from the
+    /// conversation's current members. The renderer prepends the resolved
+    /// name for `.grantedAgent`-actor summaries so ProfileUpdate-driven
+    /// renames propagate without reprocessing the message list. Pass an
+    /// empty dictionary if no agents are in the conversation; the view
+    /// falls back to rendering `summary.text` as-is.
+    var agentNamesByInboxId: [String: String]
 
     var body: some View {
         HStack(spacing: DesignConstants.Spacing.stepX) {
@@ -29,8 +28,9 @@ struct ConnectionEventSummaryView: View {
     }
 
     private var renderedText: String {
-        guard summary.actor == .verifiedAssistant,
-              let name = verifiedAssistantName,
+        guard summary.actor == .grantedAgent,
+              let inboxId = summary.grantedToInboxId,
+              let name = agentNamesByInboxId[inboxId],
               !name.isEmpty else {
             return summary.text
         }

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessagesListView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessagesListView.swift
@@ -31,18 +31,7 @@ struct MessagesListView: View {
     @State private var scrollPosition: ScrollPosition = ScrollPosition(edge: .bottom)
     @State private var lastItemIndex: Int?
 
-    /// Live agent display names keyed by inbox id, sourced from the
-    /// conversation's current members. Drives `.grantedAgent`-actor connection
-    /// event rendering so ProfileUpdate-driven renames propagate immediately.
-    private var agentNamesByInboxId: [String: String] {
-        Dictionary(
-            uniqueKeysWithValues: conversation.members
-                .filter { $0.isAgent }
-                .map { ($0.profile.inboxId, $0.displayName) }
-        )
-    }
-
-    var body: some View {
+var body: some View {
         ScrollViewReader { _ in
             ScrollView {
                 LazyVStack(spacing: 0.0) {
@@ -136,11 +125,8 @@ struct MessagesListView: View {
             assistantPresentView(agent: agent, inviterName: inviterName)
 
         case let .connectionEvent(_, summary, _):
-            ConnectionEventSummaryView(
-                summary: summary,
-                agentNamesByInboxId: agentNamesByInboxId
-            )
-            .padding(.vertical, DesignConstants.Spacing.step2x)
+            ConnectionEventSummaryView(summary: summary)
+                .padding(.vertical, DesignConstants.Spacing.step2x)
 
         case .typingIndicator:
             EmptyView()

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessagesListView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessagesListView.swift
@@ -31,15 +31,15 @@ struct MessagesListView: View {
     @State private var scrollPosition: ScrollPosition = ScrollPosition(edge: .bottom)
     @State private var lastItemIndex: Int?
 
-    /// Stable verified-assistant display name derived from the conversation's
-    /// membership. Falls back through `isVerifiedAssistant` → `isAgent` so the
-    /// name doesn't flip to nil while attestation re-verification is in
-    /// progress.
-    private var verifiedAssistantName: String? {
-        if let verified = conversation.members.first(where: \.isVerifiedAssistant) {
-            return verified.displayName
-        }
-        return conversation.members.first(where: \.isAgent)?.displayName
+    /// Live agent display names keyed by inbox id, sourced from the
+    /// conversation's current members. Drives `.grantedAgent`-actor connection
+    /// event rendering so ProfileUpdate-driven renames propagate immediately.
+    private var agentNamesByInboxId: [String: String] {
+        Dictionary(
+            uniqueKeysWithValues: conversation.members
+                .filter { $0.isAgent }
+                .map { ($0.profile.inboxId, $0.displayName) }
+        )
     }
 
     var body: some View {
@@ -138,7 +138,7 @@ struct MessagesListView: View {
         case let .connectionEvent(_, summary, _):
             ConnectionEventSummaryView(
                 summary: summary,
-                verifiedAssistantName: verifiedAssistantName
+                agentNamesByInboxId: agentNamesByInboxId
             )
             .padding(.vertical, DesignConstants.Spacing.step2x)
 

--- a/Convos/Conversation Detail/Messages/MessagesView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesView.swift
@@ -72,7 +72,6 @@ struct MessagesView<BottomBarContent: View>: View {
     let hasAssistant: Bool
     let isAssistantJoinPending: Bool
     let isAssistantEnabled: Bool
-    let agentNamesByInboxId: [String: String]
     let onBottomOverscrollChanged: (CGFloat) -> Void
     let onBottomOverscrollReleased: (CGFloat) -> Void
     let onVoiceMemoTap: () -> Void
@@ -120,7 +119,6 @@ struct MessagesView<BottomBarContent: View>: View {
             hasAssistant: hasAssistant,
             isAssistantJoinPending: isAssistantJoinPending,
             isAssistantEnabled: isAssistantEnabled,
-            agentNamesByInboxId: agentNamesByInboxId,
             bottomBarHeight: bottomBarHeight,
             onBottomOverscrollChanged: onBottomOverscrollChanged,
             onBottomOverscrollReleased: onBottomOverscrollReleased,

--- a/Convos/Conversation Detail/Messages/MessagesView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesView.swift
@@ -72,7 +72,7 @@ struct MessagesView<BottomBarContent: View>: View {
     let hasAssistant: Bool
     let isAssistantJoinPending: Bool
     let isAssistantEnabled: Bool
-    let verifiedAssistantName: String?
+    let agentNamesByInboxId: [String: String]
     let onBottomOverscrollChanged: (CGFloat) -> Void
     let onBottomOverscrollReleased: (CGFloat) -> Void
     let onVoiceMemoTap: () -> Void
@@ -120,7 +120,7 @@ struct MessagesView<BottomBarContent: View>: View {
             hasAssistant: hasAssistant,
             isAssistantJoinPending: isAssistantJoinPending,
             isAssistantEnabled: isAssistantEnabled,
-            verifiedAssistantName: verifiedAssistantName,
+            agentNamesByInboxId: agentNamesByInboxId,
             bottomBarHeight: bottomBarHeight,
             onBottomOverscrollChanged: onBottomOverscrollChanged,
             onBottomOverscrollReleased: onBottomOverscrollReleased,

--- a/Convos/Conversation Detail/Messages/MessagesViewRepresentable.swift
+++ b/Convos/Conversation Detail/Messages/MessagesViewRepresentable.swift
@@ -33,7 +33,6 @@ struct MessagesViewRepresentable: UIViewControllerRepresentable {
     let hasAssistant: Bool
     let isAssistantJoinPending: Bool
     let isAssistantEnabled: Bool
-    let agentNamesByInboxId: [String: String]
     let bottomBarHeight: CGFloat
     let onBottomOverscrollChanged: (CGFloat) -> Void
     let onBottomOverscrollReleased: (CGFloat) -> Void
@@ -102,8 +101,7 @@ struct MessagesViewRepresentable: UIViewControllerRepresentable {
         messagesViewController.hasAssistant = hasAssistant
         messagesViewController.isAssistantJoinPending = isAssistantJoinPending
         messagesViewController.isAssistantEnabled = isAssistantEnabled
-        messagesViewController.agentNamesByInboxId = agentNamesByInboxId
-        let menuPresented = contextMenuState.isPresented
+let menuPresented = contextMenuState.isPresented
         let wasMenuPresented = !messagesViewController.view.isUserInteractionEnabled
         messagesViewController.view.isUserInteractionEnabled = !menuPresented
         if menuPresented {
@@ -158,7 +156,6 @@ struct MessagesViewRepresentable: UIViewControllerRepresentable {
         hasAssistant: false,
         isAssistantJoinPending: false,
         isAssistantEnabled: true,
-        agentNamesByInboxId: [:],
         bottomBarHeight: bottomBarHeight,
         onBottomOverscrollChanged: { _ in },
         onBottomOverscrollReleased: { _ in },

--- a/Convos/Conversation Detail/Messages/MessagesViewRepresentable.swift
+++ b/Convos/Conversation Detail/Messages/MessagesViewRepresentable.swift
@@ -33,7 +33,7 @@ struct MessagesViewRepresentable: UIViewControllerRepresentable {
     let hasAssistant: Bool
     let isAssistantJoinPending: Bool
     let isAssistantEnabled: Bool
-    let verifiedAssistantName: String?
+    let agentNamesByInboxId: [String: String]
     let bottomBarHeight: CGFloat
     let onBottomOverscrollChanged: (CGFloat) -> Void
     let onBottomOverscrollReleased: (CGFloat) -> Void
@@ -102,7 +102,7 @@ struct MessagesViewRepresentable: UIViewControllerRepresentable {
         messagesViewController.hasAssistant = hasAssistant
         messagesViewController.isAssistantJoinPending = isAssistantJoinPending
         messagesViewController.isAssistantEnabled = isAssistantEnabled
-        messagesViewController.verifiedAssistantName = verifiedAssistantName
+        messagesViewController.agentNamesByInboxId = agentNamesByInboxId
         let menuPresented = contextMenuState.isPresented
         let wasMenuPresented = !messagesViewController.view.isUserInteractionEnabled
         messagesViewController.view.isUserInteractionEnabled = !menuPresented
@@ -158,7 +158,7 @@ struct MessagesViewRepresentable: UIViewControllerRepresentable {
         hasAssistant: false,
         isAssistantJoinPending: false,
         isAssistantEnabled: true,
-        verifiedAssistantName: nil,
+        agentNamesByInboxId: [:],
         bottomBarHeight: bottomBarHeight,
         onBottomOverscrollChanged: { _ in },
         onBottomOverscrollReleased: { _ in },

--- a/ConvosConnections/Example/ConvosConnectionsExample/UserDefaultsEnablementStore.swift
+++ b/ConvosConnections/Example/ConvosConnectionsExample/UserDefaultsEnablementStore.swift
@@ -1,12 +1,13 @@
 import ConvosConnections
 import Foundation
 
-/// `EnablementStore` backed by `UserDefaults`. Keeps per-(connection, capability, conversation)
-/// toggle state and the per-(connection, conversation) always-confirm flag across app
-/// relaunches so users don't have to re-toggle every session.
+/// `EnablementStore` backed by `UserDefaults`. Keeps per-(connection, capability,
+/// conversation, agent) toggle state and the per-(connection, conversation)
+/// always-confirm flag across app relaunches so users don't have to re-toggle every
+/// session.
 ///
-/// The example app uses this instead of `InMemoryEnablementStore` so toggle state survives
-/// backgrounding, relaunches, and reinstalls with the same bundle id.
+/// The example app uses this instead of `InMemoryEnablementStore` so toggle state
+/// survives backgrounding, relaunches, and reinstalls with the same bundle id.
 final class UserDefaultsEnablementStore: EnablementStore, @unchecked Sendable {
     private struct PersistedShape: Codable {
         var enablements: [Enablement]
@@ -22,23 +23,44 @@ final class UserDefaultsEnablementStore: EnablementStore, @unchecked Sendable {
     private let key: String
     private let lock: NSLock = NSLock()
 
-    init(defaults: UserDefaults = .standard, key: String = "ConvosConnectionsExample.enablements.v2") {
+    init(defaults: UserDefaults = .standard, key: String = "ConvosConnectionsExample.enablements.v3") {
         self.defaults = defaults
         self.key = key
     }
 
-    func isEnabled(kind: ConnectionKind, capability: ConnectionCapability, conversationId: String) async -> Bool {
+    func isEnabled(
+        kind: ConnectionKind,
+        capability: ConnectionCapability,
+        conversationId: String,
+        grantedToInboxId: String
+    ) async -> Bool {
         lock.lock()
         defer { lock.unlock() }
-        return read().enablements.contains(Enablement(kind: kind, capability: capability, conversationId: conversationId))
+        return read().enablements.contains(Enablement(
+            kind: kind,
+            capability: capability,
+            conversationId: conversationId,
+            grantedToInboxId: grantedToInboxId
+        ))
     }
 
-    func setEnabled(_ enabled: Bool, kind: ConnectionKind, capability: ConnectionCapability, conversationId: String) async {
+    func setEnabled(
+        _ enabled: Bool,
+        kind: ConnectionKind,
+        capability: ConnectionCapability,
+        conversationId: String,
+        grantedToInboxId: String
+    ) async {
         lock.lock()
         defer { lock.unlock() }
         var shape = read()
         var enablementSet = Set(shape.enablements)
-        let enablement = Enablement(kind: kind, capability: capability, conversationId: conversationId)
+        let enablement = Enablement(
+            kind: kind,
+            capability: capability,
+            conversationId: conversationId,
+            grantedToInboxId: grantedToInboxId
+        )
         if enabled {
             enablementSet.insert(enablement)
         } else {
@@ -47,7 +69,8 @@ final class UserDefaultsEnablementStore: EnablementStore, @unchecked Sendable {
         shape.enablements = enablementSet.sorted(by: { lhs, rhs in
             if lhs.kind.rawValue != rhs.kind.rawValue { return lhs.kind.rawValue < rhs.kind.rawValue }
             if lhs.capability.rawValue != rhs.capability.rawValue { return lhs.capability.rawValue < rhs.capability.rawValue }
-            return lhs.conversationId < rhs.conversationId
+            if lhs.conversationId != rhs.conversationId { return lhs.conversationId < rhs.conversationId }
+            return lhs.grantedToInboxId < rhs.grantedToInboxId
         })
         write(shape)
     }
@@ -55,10 +78,11 @@ final class UserDefaultsEnablementStore: EnablementStore, @unchecked Sendable {
     func conversationIds(enabledFor kind: ConnectionKind, capability: ConnectionCapability) async -> [String] {
         lock.lock()
         defer { lock.unlock() }
-        return read().enablements
-            .filter { $0.kind == kind && $0.capability == capability }
-            .map(\.conversationId)
-            .sorted()
+        var ids: Set<String> = []
+        for e in read().enablements where e.kind == kind && e.capability == capability {
+            ids.insert(e.conversationId)
+        }
+        return ids.sorted()
     }
 
     func allEnablements() async -> [Enablement] {

--- a/ConvosConnections/Sources/ConvosConnections/Core/ConnectionsManager.swift
+++ b/ConvosConnections/Sources/ConvosConnections/Core/ConnectionsManager.swift
@@ -110,12 +110,23 @@ public actor ConnectionsManager {
 
     // MARK: - Read enablement (capability = .read)
 
-    public func isEnabled(_ kind: ConnectionKind, conversationId: String) async -> Bool {
-        await store.isEnabled(kind: kind, capability: .read, conversationId: conversationId)
+    public func isEnabled(_ kind: ConnectionKind, conversationId: String, grantedToInboxId: String) async -> Bool {
+        await store.isEnabled(
+            kind: kind,
+            capability: .read,
+            conversationId: conversationId,
+            grantedToInboxId: grantedToInboxId
+        )
     }
 
-    public func setEnabled(_ enabled: Bool, kind: ConnectionKind, conversationId: String) async {
-        await store.setEnabled(enabled, kind: kind, capability: .read, conversationId: conversationId)
+    public func setEnabled(_ enabled: Bool, kind: ConnectionKind, conversationId: String, grantedToInboxId: String) async {
+        await store.setEnabled(
+            enabled,
+            kind: kind,
+            capability: .read,
+            conversationId: conversationId,
+            grantedToInboxId: grantedToInboxId
+        )
     }
 
     public func enabledConversationIds(for kind: ConnectionKind) async -> [String] {
@@ -128,12 +139,34 @@ public actor ConnectionsManager {
 
     // MARK: - Per-capability enablement
 
-    public func isEnabled(_ kind: ConnectionKind, capability: ConnectionCapability, conversationId: String) async -> Bool {
-        await store.isEnabled(kind: kind, capability: capability, conversationId: conversationId)
+    public func isEnabled(
+        _ kind: ConnectionKind,
+        capability: ConnectionCapability,
+        conversationId: String,
+        grantedToInboxId: String
+    ) async -> Bool {
+        await store.isEnabled(
+            kind: kind,
+            capability: capability,
+            conversationId: conversationId,
+            grantedToInboxId: grantedToInboxId
+        )
     }
 
-    public func setEnabled(_ enabled: Bool, kind: ConnectionKind, capability: ConnectionCapability, conversationId: String) async {
-        await store.setEnabled(enabled, kind: kind, capability: capability, conversationId: conversationId)
+    public func setEnabled(
+        _ enabled: Bool,
+        kind: ConnectionKind,
+        capability: ConnectionCapability,
+        conversationId: String,
+        grantedToInboxId: String
+    ) async {
+        await store.setEnabled(
+            enabled,
+            kind: kind,
+            capability: capability,
+            conversationId: conversationId,
+            grantedToInboxId: grantedToInboxId
+        )
     }
 
     public func enabledConversationIds(for kind: ConnectionKind, capability: ConnectionCapability) async -> [String] {
@@ -215,8 +248,12 @@ public actor ConnectionsManager {
     ///
     /// Never throws: all failure modes surface through the returned/delivered result.
     @discardableResult
-    public func handleInvocation(_ invocation: ConnectionInvocation, from conversationId: String) async -> ConnectionInvocationResult {
-        let result = await routeInvocation(invocation, from: conversationId)
+    public func handleInvocation(
+        _ invocation: ConnectionInvocation,
+        from conversationId: String,
+        invokerInboxId: String
+    ) async -> ConnectionInvocationResult {
+        let result = await routeInvocation(invocation, from: conversationId, invokerInboxId: invokerInboxId)
         var deliveryError: String?
         do {
             try await delivery.deliver(result, to: conversationId)
@@ -236,7 +273,11 @@ public actor ConnectionsManager {
         return result
     }
 
-    private func routeInvocation(_ invocation: ConnectionInvocation, from conversationId: String) async -> ConnectionInvocationResult {
+    private func routeInvocation(
+        _ invocation: ConnectionInvocation,
+        from conversationId: String,
+        invokerInboxId: String
+    ) async -> ConnectionInvocationResult {
         guard let sink = sinks[invocation.kind] else {
             return Self.makeResult(
                 for: invocation,
@@ -253,12 +294,17 @@ public actor ConnectionsManager {
             )
         }
         let capability = schema.capability
-        let enabledBefore = await store.isEnabled(kind: invocation.kind, capability: capability, conversationId: conversationId)
+        let enabledBefore = await store.isEnabled(
+            kind: invocation.kind,
+            capability: capability,
+            conversationId: conversationId,
+            grantedToInboxId: invokerInboxId
+        )
         guard enabledBefore else {
             return Self.makeResult(
                 for: invocation,
                 status: .capabilityNotEnabled,
-                errorMessage: "Capability \(capability.rawValue) is not enabled for this conversation."
+                errorMessage: "Capability \(capability.rawValue) is not enabled for this agent in this conversation."
             )
         }
 
@@ -285,7 +331,12 @@ public actor ConnectionsManager {
                 )
             }
 
-            let enabledAfter = await store.isEnabled(kind: invocation.kind, capability: capability, conversationId: conversationId)
+            let enabledAfter = await store.isEnabled(
+                kind: invocation.kind,
+                capability: capability,
+                conversationId: conversationId,
+                grantedToInboxId: invokerInboxId
+            )
             guard enabledAfter else {
                 return Self.makeResult(
                     for: invocation,

--- a/ConvosConnections/Sources/ConvosConnections/Core/EnablementStore.swift
+++ b/ConvosConnections/Sources/ConvosConnections/Core/EnablementStore.swift
@@ -1,56 +1,63 @@
 import Foundation
 
-/// A single `(connection, capability, conversation)` enablement triple.
+/// A single `(kind, capability, conversation, grantedToInboxId)` enablement quadruple.
 ///
-/// Per-assistant scoping is deliberately omitted; everyone in an XMTP conversation sees
-/// every message, so a per-assistant gate would give a false sense of control.
+/// Each row binds a verb on a connection kind to one specific agent within a
+/// conversation. Two agents in the same conversation have independent rows; a grant
+/// for one doesn't authorize the other. The cloud subsystem mirrors the same scoping
+/// via `CloudConnectionGrantEntry.grantedToInboxId` and the runtime's
+/// agent-ignorable rule.
 public struct Enablement: Sendable, Hashable, Codable {
     public let kind: ConnectionKind
     public let capability: ConnectionCapability
     public let conversationId: String
+    public let grantedToInboxId: String
 
-    public init(kind: ConnectionKind, capability: ConnectionCapability, conversationId: String) {
+    public init(
+        kind: ConnectionKind,
+        capability: ConnectionCapability,
+        conversationId: String,
+        grantedToInboxId: String
+    ) {
         self.kind = kind
         self.capability = capability
         self.conversationId = conversationId
-    }
-
-    /// Backward-compatible init: call sites that predate the capability model are
-    /// implicitly talking about `.read`.
-    public init(kind: ConnectionKind, conversationId: String) {
-        self.init(kind: kind, capability: .read, conversationId: conversationId)
+        self.grantedToInboxId = grantedToInboxId
     }
 }
 
-/// Persists `(kind, capability, conversation)` enablement state plus a per-`(kind, conversation)`
-/// "always confirm writes" flag.
+/// Persists `(kind, capability, conversation, grantedToInboxId)` enablement state
+/// plus a per-`(kind, conversation)` "always confirm writes" flag.
 ///
-/// Backward compatibility: conforming types only need to implement the per-capability
-/// methods; the legacy three-argument methods get default-implementation shims that
-/// delegate to the `.read` capability so existing call sites continue to work.
+/// Resolution lookups always include `grantedToInboxId`. The data-source fan-out
+/// helper `conversationIds(enabledFor:capability:)` returns deduplicated conversation
+/// ids — every conversation that has at least one agent enabled — because XMTP
+/// broadcasts to the whole group anyway and the runtime's agent-ignorable rule scopes
+/// the action.
 public protocol EnablementStore: Sendable {
-    // Per-capability API (required).
-    func isEnabled(kind: ConnectionKind, capability: ConnectionCapability, conversationId: String) async -> Bool
-    func setEnabled(_ enabled: Bool, kind: ConnectionKind, capability: ConnectionCapability, conversationId: String) async
+    func isEnabled(
+        kind: ConnectionKind,
+        capability: ConnectionCapability,
+        conversationId: String,
+        grantedToInboxId: String
+    ) async -> Bool
+
+    func setEnabled(
+        _ enabled: Bool,
+        kind: ConnectionKind,
+        capability: ConnectionCapability,
+        conversationId: String,
+        grantedToInboxId: String
+    ) async
+
+    /// Conversations that have at least one agent enabled for this `(kind, capability)`.
+    /// Used by data sources for fan-out — they don't need agent identity because the
+    /// XMTP broadcast carries to the whole group.
     func conversationIds(enabledFor kind: ConnectionKind, capability: ConnectionCapability) async -> [String]
+
     func allEnablements() async -> [Enablement]
 
-    // Always-confirm flag, scoped per `(kind, conversationId)` — not per capability.
+    // Always-confirm flag, scoped per `(kind, conversationId)` — not per capability or agent.
     func alwaysConfirmWrites(kind: ConnectionKind, conversationId: String) async -> Bool
     func setAlwaysConfirmWrites(_ alwaysConfirm: Bool, kind: ConnectionKind, conversationId: String) async
-}
-
-public extension EnablementStore {
-    // Backward-compatible read-only shims. Existing call sites keep compiling.
-    func isEnabled(kind: ConnectionKind, conversationId: String) async -> Bool {
-        await isEnabled(kind: kind, capability: .read, conversationId: conversationId)
-    }
-
-    func setEnabled(_ enabled: Bool, kind: ConnectionKind, conversationId: String) async {
-        await setEnabled(enabled, kind: kind, capability: .read, conversationId: conversationId)
-    }
-
-    func conversationIds(enabledFor kind: ConnectionKind) async -> [String] {
-        await conversationIds(enabledFor: kind, capability: .read)
-    }
 }

--- a/ConvosConnections/Sources/ConvosConnections/Debug/ConnectionsDebugView.swift
+++ b/ConvosConnections/Sources/ConvosConnections/Debug/ConnectionsDebugView.swift
@@ -201,8 +201,18 @@ private final class DebugModel {
         await refresh()
     }
 
+    /// Stub inbox id used for the debug toggle's per-agent grant entry. Production
+    /// code routes through real agent inbox ids supplied by the assistants backend;
+    /// the debug view only needs a stable key so toggles persist across refreshes.
+    private static let debugStubInboxId: String = "debug-stub-agent"
+
     func setEnabled(_ enabled: Bool, kind: ConnectionKind, conversationId: String) async {
-        await manager.setEnabled(enabled, kind: kind, conversationId: conversationId)
+        await manager.setEnabled(
+            enabled,
+            kind: kind,
+            conversationId: conversationId,
+            grantedToInboxId: Self.debugStubInboxId
+        )
         if enabled {
             try? await manager.startSource(kind: kind)
         } else if await manager.enabledConversationIds(for: kind).isEmpty {

--- a/ConvosConnections/Sources/ConvosConnections/Storage/InMemoryEnablementStore.swift
+++ b/ConvosConnections/Sources/ConvosConnections/Storage/InMemoryEnablementStore.swift
@@ -3,8 +3,8 @@ import Foundation
 /// In-memory `EnablementStore` used by tests, previews, and the debug view.
 ///
 /// The host app (Convos) supplies a persistent implementation backed by GRDB. This
-/// in-memory variant is intentionally simple: a `Set<Enablement>` for the triples plus a
-/// `[AlwaysConfirmKey: Bool]` for the always-confirm flag.
+/// in-memory variant is intentionally simple: a `Set<Enablement>` for the quadruples
+/// plus a `[AlwaysConfirmKey: Bool]` for the always-confirm flag.
 public actor InMemoryEnablementStore: EnablementStore {
     private var enablements: Set<Enablement>
     private var alwaysConfirm: [AlwaysConfirmKey: Bool]
@@ -38,12 +38,33 @@ public actor InMemoryEnablementStore: EnablementStore {
         self.alwaysConfirm = dict
     }
 
-    public func isEnabled(kind: ConnectionKind, capability: ConnectionCapability, conversationId: String) async -> Bool {
-        enablements.contains(Enablement(kind: kind, capability: capability, conversationId: conversationId))
+    public func isEnabled(
+        kind: ConnectionKind,
+        capability: ConnectionCapability,
+        conversationId: String,
+        grantedToInboxId: String
+    ) async -> Bool {
+        enablements.contains(Enablement(
+            kind: kind,
+            capability: capability,
+            conversationId: conversationId,
+            grantedToInboxId: grantedToInboxId
+        ))
     }
 
-    public func setEnabled(_ enabled: Bool, kind: ConnectionKind, capability: ConnectionCapability, conversationId: String) async {
-        let enablement = Enablement(kind: kind, capability: capability, conversationId: conversationId)
+    public func setEnabled(
+        _ enabled: Bool,
+        kind: ConnectionKind,
+        capability: ConnectionCapability,
+        conversationId: String,
+        grantedToInboxId: String
+    ) async {
+        let enablement = Enablement(
+            kind: kind,
+            capability: capability,
+            conversationId: conversationId,
+            grantedToInboxId: grantedToInboxId
+        )
         if enabled {
             enablements.insert(enablement)
         } else {
@@ -52,10 +73,11 @@ public actor InMemoryEnablementStore: EnablementStore {
     }
 
     public func conversationIds(enabledFor kind: ConnectionKind, capability: ConnectionCapability) async -> [String] {
-        enablements
-            .filter { $0.kind == kind && $0.capability == capability }
-            .map(\.conversationId)
-            .sorted()
+        var ids: Set<String> = []
+        for e in enablements where e.kind == kind && e.capability == capability {
+            ids.insert(e.conversationId)
+        }
+        return ids.sorted()
     }
 
     public func allEnablements() async -> [Enablement] {
@@ -66,7 +88,10 @@ public actor InMemoryEnablementStore: EnablementStore {
             if lhs.capability.rawValue != rhs.capability.rawValue {
                 return lhs.capability.rawValue < rhs.capability.rawValue
             }
-            return lhs.conversationId < rhs.conversationId
+            if lhs.conversationId != rhs.conversationId {
+                return lhs.conversationId < rhs.conversationId
+            }
+            return lhs.grantedToInboxId < rhs.grantedToInboxId
         })
     }
 

--- a/ConvosCore/Sources/ConvosConnectionsXMTP/Listener/XMTPInvocationListener.swift
+++ b/ConvosCore/Sources/ConvosConnectionsXMTP/Listener/XMTPInvocationListener.swift
@@ -29,7 +29,9 @@ public final class XMTPInvocationListener: @unchecked Sendable {
         self.delivery = delivery
     }
 
-    /// Process a decoded XMTP message. No-ops for content types that aren't ours.
+    /// Process a decoded XMTP message. No-ops for content types that aren't ours. The
+    /// `senderInboxId` from the envelope is treated as the authoritative invoker — it
+    /// flows through to the manager as `invokerInboxId` for per-agent gating.
     public func processIncoming(message: DecodedMessage, conversationId: String) async {
         let encoded: EncodedContent
         do {
@@ -47,12 +49,20 @@ public final class XMTPInvocationListener: @unchecked Sendable {
             return
         }
 
-        await handle(invocation: invocation, conversationId: conversationId)
+        await handle(
+            invocation: invocation,
+            conversationId: conversationId,
+            invokerInboxId: message.senderInboxId
+        )
     }
 
     /// Visible for testing. Schema-version gate + manager routing, without the XMTP
     /// decoding step. Exercised by the public `processIncoming` after decoding.
-    internal func handle(invocation: ConnectionInvocation, conversationId: String) async {
+    internal func handle(
+        invocation: ConnectionInvocation,
+        conversationId: String,
+        invokerInboxId: String
+    ) async {
         if invocation.schemaVersion > ConnectionInvocation.currentSchemaVersion {
             let result = ConnectionInvocationResult(
                 invocationId: invocation.invocationId,
@@ -77,6 +87,10 @@ public final class XMTPInvocationListener: @unchecked Sendable {
         // Route through the manager's gating chain. The manager auto-delivers the result
         // via whatever `ConnectionDelivering` it was constructed with — so long as the
         // host passed `self.delivery` as that value, the agent gets its reply.
-        _ = await manager.handleInvocation(invocation, from: conversationId)
+        _ = await manager.handleInvocation(
+            invocation,
+            from: conversationId,
+            invokerInboxId: invokerInboxId
+        )
     }
 }

--- a/ConvosCore/Sources/ConvosCore/CapabilityResolution/CapabilityInvocationRouter.swift
+++ b/ConvosCore/Sources/ConvosCore/CapabilityResolution/CapabilityInvocationRouter.swift
@@ -2,7 +2,11 @@ import ConvosConnections
 import Foundation
 
 /// Routes a `ConnectionInvocation` (agent → device) to the right execution path based on
-/// the per-conversation `CapabilityResolution`.
+/// the per-(agent, conversation) `CapabilityResolution`.
+///
+/// `invokerInboxId` comes from the XMTP message envelope's `senderInboxId`. The router
+/// looks up the resolution for that exact agent — another agent's grant in the same
+/// conversation never authorizes this invocation.
 ///
 /// Cloud federation is the agent runtime's concern — when the agent has both a device
 /// and a cloud provider resolved for a federating-subject read, it sends the device
@@ -10,7 +14,7 @@ import Foundation
 /// results itself. The iOS device only ever owns its local slice of any federation.
 public final class CapabilityInvocationRouter: Sendable {
     public typealias CapabilityLookup = @Sendable (ConnectionInvocation) async -> ConnectionCapability?
-    public typealias DeviceDispatch = @Sendable (ConnectionInvocation, String) async -> ConnectionInvocationResult
+    public typealias DeviceDispatch = @Sendable (ConnectionInvocation, String, String) async -> ConnectionInvocationResult
 
     private let resolver: any CapabilityResolver
     private let capabilityLookup: CapabilityLookup
@@ -28,7 +32,8 @@ public final class CapabilityInvocationRouter: Sendable {
 
     public func route(
         _ invocation: ConnectionInvocation,
-        conversationId: String
+        conversationId: String,
+        invokerInboxId: String
     ) async -> ConnectionInvocationResult {
         guard let subject = DeviceCapabilityProvider.subject(for: invocation.kind) else {
             return Self.makeResult(
@@ -49,14 +54,15 @@ public final class CapabilityInvocationRouter: Sendable {
         let resolution = await resolver.resolution(
             subject: subject,
             capability: capability,
-            conversationId: conversationId
+            conversationId: conversationId,
+            grantedToInboxId: invokerInboxId
         )
 
         if resolution.isEmpty {
             return Self.makeResult(
                 for: invocation,
                 status: .capabilityNotEnabled,
-                errorMessage: "No resolution for \(subject.rawValue)/\(capability.rawValue) in this conversation. Agents should send a capability_request first."
+                errorMessage: "No resolution for \(subject.rawValue)/\(capability.rawValue) for this agent in this conversation. Agents should send a capability_request first."
             )
         }
 
@@ -65,7 +71,7 @@ public final class CapabilityInvocationRouter: Sendable {
             // Either the resolution is exactly this device provider, or it's a federated
             // read where this device is one of N participants. Either way the device's
             // job is to execute its slice; the agent merges across providers.
-            return await deviceDispatch(invocation, conversationId)
+            return await deviceDispatch(invocation, conversationId, invokerInboxId)
         }
 
         // Resolution exists but doesn't include this device — every member is a cloud

--- a/ConvosCore/Sources/ConvosCore/CapabilityResolution/CapabilityManifestBuilder.swift
+++ b/ConvosCore/Sources/ConvosCore/CapabilityResolution/CapabilityManifestBuilder.swift
@@ -7,17 +7,18 @@ import Foundation
 public struct CapabilityManifestBuilder: Sendable {
     public init() {}
 
-    /// Build the manifest for one conversation. Walks every subject, every registered
-    /// provider, and every capability verb the provider declares — for each verb, looks
-    /// up the resolution and marks `resolved[verb] = true` if this provider is in the
-    /// resolution set.
+    /// Build the manifest for one (conversation, agent) pair. Walks every subject, every
+    /// registered provider, and every capability verb the provider declares — for each
+    /// verb, looks up the resolution scoped to `grantedToInboxId` and marks
+    /// `resolved[verb] = true` if this provider is in the resolution set.
     ///
     /// Provider-list ordering is alphabetical by `id.rawValue` so re-publishes with
     /// equivalent state produce byte-identical JSON (no spurious `ProfileUpdate` writes).
     public func build(
         registry: any CapabilityProviderRegistry,
         resolver: any CapabilityResolver,
-        conversationId: String
+        conversationId: String,
+        grantedToInboxId: String
     ) async -> CapabilityManifest {
         var entries: [CapabilityManifest.Entry] = []
 
@@ -28,6 +29,7 @@ public struct CapabilityManifestBuilder: Sendable {
             let resolutionsByCapability = await resolutions(
                 for: subject,
                 conversationId: conversationId,
+                grantedToInboxId: grantedToInboxId,
                 resolver: resolver
             )
 
@@ -60,6 +62,7 @@ public struct CapabilityManifestBuilder: Sendable {
     private func resolutions(
         for subject: CapabilitySubject,
         conversationId: String,
+        grantedToInboxId: String,
         resolver: any CapabilityResolver
     ) async -> [ConnectionCapability: Set<ProviderID>] {
         var result: [ConnectionCapability: Set<ProviderID>] = [:]
@@ -67,7 +70,8 @@ public struct CapabilityManifestBuilder: Sendable {
             let providers = await resolver.resolution(
                 subject: subject,
                 capability: capability,
-                conversationId: conversationId
+                conversationId: conversationId,
+                grantedToInboxId: grantedToInboxId
             )
             if !providers.isEmpty {
                 result[capability] = providers

--- a/ConvosCore/Sources/ConvosCore/CapabilityResolution/CapabilityRequest.swift
+++ b/ConvosCore/Sources/ConvosCore/CapabilityResolution/CapabilityRequest.swift
@@ -27,6 +27,13 @@ public struct CapabilityRequest: Codable, Sendable, Hashable {
     /// agree on the asking identity even when the message hasn't been verified yet —
     /// and so that the persisted grant row, the connection_event credit, and the
     /// resolver lookup all key off the same value the sender chose to publish.
+    ///
+    /// During the bridge period when JS-side agents may not yet populate this field,
+    /// `init(from:)` decodes it as optional with an empty-string default; the
+    /// `CapabilityRequestRepository` backfills the empty value from the DB row's
+    /// `senderId` (the XMTP envelope's `senderInboxId`) so downstream code always sees
+    /// a non-empty value. Once every shipped agent populates the field, the decode can
+    /// be tightened back to required.
     public let askerInboxId: String
     public let subject: CapabilitySubject
     public let capability: ConnectionCapability
@@ -66,13 +73,28 @@ public struct CapabilityRequest: Codable, Sendable, Hashable {
             )
         }
         self.requestId = try container.decode(String.self, forKey: .requestId)
-        self.askerInboxId = try container.decode(String.self, forKey: .askerInboxId)
+        self.askerInboxId = try container.decodeIfPresent(String.self, forKey: .askerInboxId) ?? ""
         self.subject = try container.decode(CapabilitySubject.self, forKey: .subject)
         self.capability = try container.decode(ConnectionCapability.self, forKey: .capability)
         let rawRationale = try container.decode(String.self, forKey: .rationale)
         self.rationale = Self.truncatedRationale(rawRationale)
         let rawPreferred = try container.decodeIfPresent([ProviderID].self, forKey: .preferredProviders)
         self.preferredProviders = Self.truncatedProviders(rawPreferred)
+    }
+
+    /// Returns a copy with `askerInboxId` replaced. Used by the repository to backfill
+    /// the field from the XMTP envelope's senderInboxId when an older agent emitted a
+    /// request without populating the wire payload.
+    func withAskerInboxId(_ newValue: String) -> CapabilityRequest {
+        CapabilityRequest(
+            version: version,
+            requestId: requestId,
+            askerInboxId: newValue,
+            subject: subject,
+            capability: capability,
+            rationale: rationale,
+            preferredProviders: preferredProviders
+        )
     }
 
     private static func truncatedRationale(_ rationale: String) -> String {

--- a/ConvosCore/Sources/ConvosCore/CapabilityResolution/CapabilityRequest.swift
+++ b/ConvosCore/Sources/ConvosCore/CapabilityResolution/CapabilityRequest.swift
@@ -27,13 +27,6 @@ public struct CapabilityRequest: Codable, Sendable, Hashable {
     /// agree on the asking identity even when the message hasn't been verified yet —
     /// and so that the persisted grant row, the connection_event credit, and the
     /// resolver lookup all key off the same value the sender chose to publish.
-    ///
-    /// During the bridge period when JS-side agents may not yet populate this field,
-    /// `init(from:)` decodes it as optional with an empty-string default; the
-    /// `CapabilityRequestRepository` backfills the empty value from the DB row's
-    /// `senderId` (the XMTP envelope's `senderInboxId`) so downstream code always sees
-    /// a non-empty value. Once every shipped agent populates the field, the decode can
-    /// be tightened back to required.
     public let askerInboxId: String
     public let subject: CapabilitySubject
     public let capability: ConnectionCapability
@@ -73,28 +66,13 @@ public struct CapabilityRequest: Codable, Sendable, Hashable {
             )
         }
         self.requestId = try container.decode(String.self, forKey: .requestId)
-        self.askerInboxId = try container.decodeIfPresent(String.self, forKey: .askerInboxId) ?? ""
+        self.askerInboxId = try container.decode(String.self, forKey: .askerInboxId)
         self.subject = try container.decode(CapabilitySubject.self, forKey: .subject)
         self.capability = try container.decode(ConnectionCapability.self, forKey: .capability)
         let rawRationale = try container.decode(String.self, forKey: .rationale)
         self.rationale = Self.truncatedRationale(rawRationale)
         let rawPreferred = try container.decodeIfPresent([ProviderID].self, forKey: .preferredProviders)
         self.preferredProviders = Self.truncatedProviders(rawPreferred)
-    }
-
-    /// Returns a copy with `askerInboxId` replaced. Used by the repository to backfill
-    /// the field from the XMTP envelope's senderInboxId when an older agent emitted a
-    /// request without populating the wire payload.
-    func withAskerInboxId(_ newValue: String) -> CapabilityRequest {
-        CapabilityRequest(
-            version: version,
-            requestId: requestId,
-            askerInboxId: newValue,
-            subject: subject,
-            capability: capability,
-            rationale: rationale,
-            preferredProviders: preferredProviders
-        )
     }
 
     private static func truncatedRationale(_ rationale: String) -> String {

--- a/ConvosCore/Sources/ConvosCore/CapabilityResolution/CapabilityRequest.swift
+++ b/ConvosCore/Sources/ConvosCore/CapabilityResolution/CapabilityRequest.swift
@@ -22,6 +22,12 @@ public struct CapabilityRequest: Codable, Sendable, Hashable {
 
     public let version: Int
     public let requestId: String
+    /// Inbox id of the agent making the request. Bound on the wire (rather than relying
+    /// on the XMTP envelope's `senderInboxId` alone) so the runtime, CLI, and iOS all
+    /// agree on the asking identity even when the message hasn't been verified yet —
+    /// and so that the persisted grant row, the connection_event credit, and the
+    /// resolver lookup all key off the same value the sender chose to publish.
+    public let askerInboxId: String
     public let subject: CapabilitySubject
     public let capability: ConnectionCapability
     public let rationale: String
@@ -30,6 +36,7 @@ public struct CapabilityRequest: Codable, Sendable, Hashable {
     public init(
         version: Int = CapabilityRequest.supportedVersion,
         requestId: String,
+        askerInboxId: String,
         subject: CapabilitySubject,
         capability: ConnectionCapability,
         rationale: String,
@@ -37,6 +44,7 @@ public struct CapabilityRequest: Codable, Sendable, Hashable {
     ) {
         self.version = version
         self.requestId = requestId
+        self.askerInboxId = askerInboxId
         self.subject = subject
         self.capability = capability
         self.rationale = Self.truncatedRationale(rationale)
@@ -44,7 +52,7 @@ public struct CapabilityRequest: Codable, Sendable, Hashable {
     }
 
     private enum CodingKeys: String, CodingKey {
-        case version, requestId, subject, capability, rationale, preferredProviders
+        case version, requestId, askerInboxId, subject, capability, rationale, preferredProviders
     }
 
     public init(from decoder: Decoder) throws {
@@ -58,6 +66,7 @@ public struct CapabilityRequest: Codable, Sendable, Hashable {
             )
         }
         self.requestId = try container.decode(String.self, forKey: .requestId)
+        self.askerInboxId = try container.decode(String.self, forKey: .askerInboxId)
         self.subject = try container.decode(CapabilitySubject.self, forKey: .subject)
         self.capability = try container.decode(ConnectionCapability.self, forKey: .capability)
         let rawRationale = try container.decode(String.self, forKey: .rationale)

--- a/ConvosCore/Sources/ConvosCore/CapabilityResolution/CapabilityRequestHandler.swift
+++ b/ConvosCore/Sources/ConvosCore/CapabilityResolution/CapabilityRequestHandler.swift
@@ -31,10 +31,12 @@ public struct CapabilityRequestHandler: Sendable {
 
         // Look at existing resolutions on this subject so we can short-circuit to the
         // verb-consent card when the answer is already implied by a previous verb's
-        // resolution.
+        // resolution. Scoped to the asking agent — another agent's resolutions don't
+        // imply this agent's consent.
         let existingResolutions = await Self.resolutionsForSubject(
             subject: request.subject,
             conversationId: conversationId,
+            grantedToInboxId: request.askerInboxId,
             resolver: resolver
         )
 
@@ -88,7 +90,8 @@ public struct CapabilityRequestHandler: Sendable {
     }
 
     /// User tapped Approve. Validates the selection against the cardinality rules,
-    /// persists it through the resolver, and returns the `.approved` result envelope.
+    /// persists it through the resolver scoped to the asking agent, and returns the
+    /// `.approved` result envelope.
     public func commit(
         request: CapabilityRequest,
         approvedProviderIds: Set<ProviderID>,
@@ -99,7 +102,8 @@ public struct CapabilityRequestHandler: Sendable {
             approvedProviderIds,
             subject: request.subject,
             capability: request.capability,
-            conversationId: conversationId
+            conversationId: conversationId,
+            grantedToInboxId: request.askerInboxId
         )
         return CapabilityRequestResult(
             requestId: request.requestId,
@@ -159,6 +163,7 @@ public struct CapabilityRequestHandler: Sendable {
     private static func resolutionsForSubject(
         subject: CapabilitySubject,
         conversationId: String,
+        grantedToInboxId: String,
         resolver: any CapabilityResolver
     ) async -> [ConnectionCapability: Set<ProviderID>] {
         var result: [ConnectionCapability: Set<ProviderID>] = [:]
@@ -166,7 +171,8 @@ public struct CapabilityRequestHandler: Sendable {
             let providers = await resolver.resolution(
                 subject: subject,
                 capability: verb,
-                conversationId: conversationId
+                conversationId: conversationId,
+                grantedToInboxId: grantedToInboxId
             )
             if !providers.isEmpty {
                 result[verb] = providers

--- a/ConvosCore/Sources/ConvosCore/CapabilityResolution/CapabilityRequestRepository.swift
+++ b/ConvosCore/Sources/ConvosCore/CapabilityResolution/CapabilityRequestRepository.swift
@@ -39,10 +39,6 @@ public final class CapabilityRequestRepository: CapabilityRequestRepositoryProto
     /// capability_request message for the conversation in descending date order, and
     /// returns the first one whose `requestId` doesn't appear in any
     /// capability_request_result row.
-    ///
-    /// If the decoded request has an empty `askerInboxId` (older agents that don't
-    /// populate the wire field yet), the row's `senderId` is used as a fallback so
-    /// downstream resolver / picker code always sees a concrete inbox id.
     static func computeLatestPendingRequest(conversationId: String, db: Database) -> CapabilityRequest? {
         do {
             let resolvedIds = try resolvedRequestIds(conversationId: conversationId, db: db)
@@ -54,12 +50,9 @@ public final class CapabilityRequestRepository: CapabilityRequestRepositoryProto
             for row in requests {
                 guard let text = row.text,
                       let data = text.data(using: .utf8),
-                      let decoded = try? JSONDecoder().decode(CapabilityRequest.self, from: data) else {
+                      let request = try? JSONDecoder().decode(CapabilityRequest.self, from: data) else {
                     continue
                 }
-                let request = decoded.askerInboxId.isEmpty
-                    ? decoded.withAskerInboxId(row.senderId)
-                    : decoded
                 if !resolvedIds.contains(request.requestId) {
                     return request
                 }

--- a/ConvosCore/Sources/ConvosCore/CapabilityResolution/CapabilityRequestRepository.swift
+++ b/ConvosCore/Sources/ConvosCore/CapabilityResolution/CapabilityRequestRepository.swift
@@ -39,6 +39,10 @@ public final class CapabilityRequestRepository: CapabilityRequestRepositoryProto
     /// capability_request message for the conversation in descending date order, and
     /// returns the first one whose `requestId` doesn't appear in any
     /// capability_request_result row.
+    ///
+    /// If the decoded request has an empty `askerInboxId` (older agents that don't
+    /// populate the wire field yet), the row's `senderId` is used as a fallback so
+    /// downstream resolver / picker code always sees a concrete inbox id.
     static func computeLatestPendingRequest(conversationId: String, db: Database) -> CapabilityRequest? {
         do {
             let resolvedIds = try resolvedRequestIds(conversationId: conversationId, db: db)
@@ -50,9 +54,12 @@ public final class CapabilityRequestRepository: CapabilityRequestRepositoryProto
             for row in requests {
                 guard let text = row.text,
                       let data = text.data(using: .utf8),
-                      let request = try? JSONDecoder().decode(CapabilityRequest.self, from: data) else {
+                      let decoded = try? JSONDecoder().decode(CapabilityRequest.self, from: data) else {
                     continue
                 }
+                let request = decoded.askerInboxId.isEmpty
+                    ? decoded.withAskerInboxId(row.senderId)
+                    : decoded
                 if !resolvedIds.contains(request.requestId) {
                     return request
                 }

--- a/ConvosCore/Sources/ConvosCore/CapabilityResolution/CapabilityResolution.swift
+++ b/ConvosCore/Sources/ConvosCore/CapabilityResolution/CapabilityResolution.swift
@@ -1,11 +1,12 @@
 import ConvosConnections
 import Foundation
 
-/// A persisted decision binding `(subject, conversationId, capability)` to one or more
-/// providers.
+/// A persisted decision binding `(subject, conversationId, capability, grantedToInboxId)`
+/// to one or more providers.
 ///
-/// The set's allowed cardinality depends on the subject's `allowsReadFederation` flag and
-/// the capability verb shape:
+/// `grantedToInboxId` scopes the grant to a single agent within the conversation. Two
+/// agents in the same conversation have independent rows; one's resolution doesn't
+/// authorize the other. The cardinality matrix below applies *within* each row:
 ///
 /// | `allowsReadFederation` | verb     | size  |
 /// |------------------------|----------|-------|
@@ -20,17 +21,20 @@ public struct CapabilityResolution: Sendable, Equatable, Hashable {
     public let subject: CapabilitySubject
     public let conversationId: String
     public let capability: ConnectionCapability
+    public let grantedToInboxId: String
     public let providerIds: Set<ProviderID>
 
     public init(
         subject: CapabilitySubject,
         conversationId: String,
         capability: ConnectionCapability,
+        grantedToInboxId: String,
         providerIds: Set<ProviderID>
     ) {
         self.subject = subject
         self.conversationId = conversationId
         self.capability = capability
+        self.grantedToInboxId = grantedToInboxId
         self.providerIds = providerIds
     }
 }

--- a/ConvosCore/Sources/ConvosCore/CapabilityResolution/CapabilityResolutionsRepository.swift
+++ b/ConvosCore/Sources/ConvosCore/CapabilityResolution/CapabilityResolutionsRepository.swift
@@ -25,7 +25,11 @@ public final class CapabilityResolutionsRepository: CapabilityResolutionsReposit
             .tracking { db -> [CapabilityResolution] in
                 try DBCapabilityResolution
                     .filter(DBCapabilityResolution.Columns.conversationId == conversationId)
-                    .order(DBCapabilityResolution.Columns.subject.asc, DBCapabilityResolution.Columns.capability.asc)
+                    .order(
+                        DBCapabilityResolution.Columns.subject.asc,
+                        DBCapabilityResolution.Columns.capability.asc,
+                        DBCapabilityResolution.Columns.grantedToInboxId.asc
+                    )
                     .fetchAll(db)
                     .compactMap { $0.toResolution() }
             }

--- a/ConvosCore/Sources/ConvosCore/CapabilityResolution/CapabilityResolver.swift
+++ b/ConvosCore/Sources/ConvosCore/CapabilityResolution/CapabilityResolver.swift
@@ -5,6 +5,12 @@ import Foundation
 /// `ConnectionInvocation` messages and the two underlying systems
 /// (`ConvosConnections`, cloud OAuth).
 ///
+/// Every method takes `grantedToInboxId` because resolutions are scoped per-agent — two
+/// agents in the same conversation have independent rows. The cloud-side enforcement
+/// honors the same scoping via the runtime's agent-ignorable rule (each agent only
+/// reads grants targeted to its inbox); the device side enforces strictly by routing
+/// through `CapabilityInvocationRouter` with the invoker's inbox id.
+///
 /// Belongs to neither package; lives in ConvosCore so it can refer to both subsystems by
 /// type without inducing a cycle.
 public protocol CapabilityResolver: Sendable {
@@ -12,12 +18,14 @@ public protocol CapabilityResolver: Sendable {
     /// user has linked it.
     func availableProviders(for subject: CapabilitySubject) async -> [any CapabilityProvider]
 
-    /// What the user picked previously for this `(subject, conversation, capability)`.
-    /// Empty set means they've never been asked for this verb.
+    /// What the user picked previously for this `(subject, conversation, capability,
+    /// grantedToInboxId)`. Empty set means they've never been asked for this verb on
+    /// behalf of this agent.
     func resolution(
         subject: CapabilitySubject,
         capability: ConnectionCapability,
-        conversationId: String
+        conversationId: String,
+        grantedToInboxId: String
     ) async -> Set<ProviderID>
 
     /// User has just approved the picker / confirmation card. Validates the set against
@@ -27,7 +35,8 @@ public protocol CapabilityResolver: Sendable {
         _ providerIds: Set<ProviderID>,
         subject: CapabilitySubject,
         capability: ConnectionCapability,
-        conversationId: String
+        conversationId: String,
+        grantedToInboxId: String
     ) async throws
 
     /// Clear a resolution for one verb (e.g. user revoked write access in Conversation
@@ -35,18 +44,21 @@ public protocol CapabilityResolver: Sendable {
     func clearResolution(
         subject: CapabilitySubject,
         capability: ConnectionCapability,
-        conversationId: String
+        conversationId: String,
+        grantedToInboxId: String
     ) async throws
 
-    /// Clear every verb's resolution for a subject in a conversation (user toggled the
-    /// subject off entirely from Conversation Info).
+    /// Clear every verb's resolution for a subject in a conversation, scoped to a single
+    /// agent. Other agents' rows on the same subject + conversation are untouched.
     func clearAllResolutions(
         subject: CapabilitySubject,
-        conversationId: String
+        conversationId: String,
+        grantedToInboxId: String
     ) async throws
 
     /// Remove a single provider from any resolution rows that reference it. Called when a
-    /// provider is unlinked (cloud OAuth revoked, device permission removed). If a row's
+    /// provider is unlinked (cloud OAuth revoked, device permission removed). Scrubs
+    /// across every agent — the underlying credential is gone for everyone. If a row's
     /// resulting set is empty, the row is deleted; otherwise the row's set shrinks.
     func removeProviderFromAllResolutions(_ providerId: ProviderID) async throws
 }
@@ -61,6 +73,7 @@ public actor InMemoryCapabilityResolver: CapabilityResolver {
         let subject: CapabilitySubject
         let conversationId: String
         let capability: ConnectionCapability
+        let grantedToInboxId: String
     }
 
     public init(registry: any CapabilityProviderRegistry) {
@@ -74,39 +87,60 @@ public actor InMemoryCapabilityResolver: CapabilityResolver {
     public func resolution(
         subject: CapabilitySubject,
         capability: ConnectionCapability,
-        conversationId: String
+        conversationId: String,
+        grantedToInboxId: String
     ) async -> Set<ProviderID> {
-        resolutions[Key(subject: subject, conversationId: conversationId, capability: capability)] ?? []
+        resolutions[Key(
+            subject: subject,
+            conversationId: conversationId,
+            capability: capability,
+            grantedToInboxId: grantedToInboxId
+        )] ?? []
     }
 
     public func setResolution(
         _ providerIds: Set<ProviderID>,
         subject: CapabilitySubject,
         capability: ConnectionCapability,
-        conversationId: String
+        conversationId: String,
+        grantedToInboxId: String
     ) async throws {
         try CapabilityResolutionValidator.validate(
             providerIds: providerIds,
             subject: subject,
             capability: capability
         )
-        resolutions[Key(subject: subject, conversationId: conversationId, capability: capability)] = providerIds
+        resolutions[Key(
+            subject: subject,
+            conversationId: conversationId,
+            capability: capability,
+            grantedToInboxId: grantedToInboxId
+        )] = providerIds
     }
 
     public func clearResolution(
         subject: CapabilitySubject,
         capability: ConnectionCapability,
-        conversationId: String
+        conversationId: String,
+        grantedToInboxId: String
     ) async throws {
-        resolutions.removeValue(forKey: Key(subject: subject, conversationId: conversationId, capability: capability))
+        resolutions.removeValue(forKey: Key(
+            subject: subject,
+            conversationId: conversationId,
+            capability: capability,
+            grantedToInboxId: grantedToInboxId
+        ))
     }
 
     public func clearAllResolutions(
         subject: CapabilitySubject,
-        conversationId: String
+        conversationId: String,
+        grantedToInboxId: String
     ) async throws {
         resolutions = resolutions.filter { key, _ in
-            !(key.subject == subject && key.conversationId == conversationId)
+            !(key.subject == subject
+                && key.conversationId == conversationId
+                && key.grantedToInboxId == grantedToInboxId)
         }
     }
 

--- a/ConvosCore/Sources/ConvosCore/CapabilityResolution/CapabilityResolver.swift
+++ b/ConvosCore/Sources/ConvosCore/CapabilityResolution/CapabilityResolver.swift
@@ -61,6 +61,12 @@ public protocol CapabilityResolver: Sendable {
     /// across every agent — the underlying credential is gone for everyone. If a row's
     /// resulting set is empty, the row is deleted; otherwise the row's set shrinks.
     func removeProviderFromAllResolutions(_ providerId: ProviderID) async throws
+
+    /// Same as `removeProviderFromAllResolutions` but scoped to one conversation. Used
+    /// when a per-conversation grant is revoked: the credential may still be linked to
+    /// other conversations, so we only scrub rows belonging to this one. Walks every
+    /// agent in this conversation; rows with shrunk-to-empty sets are deleted.
+    func removeProvider(_ providerId: ProviderID, fromConversation conversationId: String) async throws
 }
 
 /// In-memory `CapabilityResolver` for tests and bring-up scenarios. The production
@@ -145,7 +151,15 @@ public actor InMemoryCapabilityResolver: CapabilityResolver {
     }
 
     public func removeProviderFromAllResolutions(_ providerId: ProviderID) async throws {
-        for (key, providerIds) in resolutions {
+        shrinkOrClear(providerId) { _ in true }
+    }
+
+    public func removeProvider(_ providerId: ProviderID, fromConversation conversationId: String) async throws {
+        shrinkOrClear(providerId) { $0.conversationId == conversationId }
+    }
+
+    private func shrinkOrClear(_ providerId: ProviderID, where matches: (Key) -> Bool) {
+        for (key, providerIds) in resolutions where matches(key) {
             guard providerIds.contains(providerId) else { continue }
             let shrunk = providerIds.subtracting([providerId])
             if shrunk.isEmpty {

--- a/ConvosCore/Sources/ConvosCore/CapabilityResolution/GRDBCapabilityResolver.swift
+++ b/ConvosCore/Sources/ConvosCore/CapabilityResolution/GRDBCapabilityResolver.swift
@@ -112,12 +112,24 @@ public final class GRDBCapabilityResolver: CapabilityResolver, @unchecked Sendab
     }
 
     public func removeProviderFromAllResolutions(_ providerId: ProviderID) async throws {
+        try await shrinkOrClear(providerId, in: DBCapabilityResolution.all())
+    }
+
+    public func removeProvider(_ providerId: ProviderID, fromConversation conversationId: String) async throws {
+        try await shrinkOrClear(
+            providerId,
+            in: DBCapabilityResolution
+                .filter(DBCapabilityResolution.Columns.conversationId == conversationId)
+        )
+    }
+
+    private func shrinkOrClear(_ providerId: ProviderID, in scope: QueryInterfaceRequest<DBCapabilityResolution>) async throws {
         let timestamp = now()
         try await database.write { db in
-            // Read every row, rewrite the ones that reference the provider. Number of rows
-            // is bounded by (subjects × conversations × verbs × agents) which stays small.
-            let rows = try DBCapabilityResolution.fetchAll(db)
-            for row in rows {
+            // Read every matching row, rewrite the ones that reference the provider.
+            // Number of rows is bounded by (subjects × conversations × verbs × agents)
+            // which stays small.
+            for row in try scope.fetchAll(db) {
                 let providers = row.providerIds
                     .split(separator: DBCapabilityResolution.providerIdsSeparator, omittingEmptySubsequences: true)
                     .map(String.init)

--- a/ConvosCore/Sources/ConvosCore/CapabilityResolution/GRDBCapabilityResolver.swift
+++ b/ConvosCore/Sources/ConvosCore/CapabilityResolution/GRDBCapabilityResolver.swift
@@ -26,7 +26,8 @@ public final class GRDBCapabilityResolver: CapabilityResolver, @unchecked Sendab
     public func resolution(
         subject: CapabilitySubject,
         capability: ConnectionCapability,
-        conversationId: String
+        conversationId: String,
+        grantedToInboxId: String
     ) async -> Set<ProviderID> {
         do {
             return try await database.read { db in
@@ -34,6 +35,7 @@ public final class GRDBCapabilityResolver: CapabilityResolver, @unchecked Sendab
                     .filter(DBCapabilityResolution.Columns.subject == subject.rawValue)
                     .filter(DBCapabilityResolution.Columns.conversationId == conversationId)
                     .filter(DBCapabilityResolution.Columns.capability == capability.rawValue)
+                    .filter(DBCapabilityResolution.Columns.grantedToInboxId == grantedToInboxId)
                     .fetchOne(db)
                 return Set(
                     row?.providerIds
@@ -50,7 +52,8 @@ public final class GRDBCapabilityResolver: CapabilityResolver, @unchecked Sendab
         _ providerIds: Set<ProviderID>,
         subject: CapabilitySubject,
         capability: ConnectionCapability,
-        conversationId: String
+        conversationId: String,
+        grantedToInboxId: String
     ) async throws {
         try CapabilityResolutionValidator.validate(
             providerIds: providerIds,
@@ -63,11 +66,13 @@ public final class GRDBCapabilityResolver: CapabilityResolver, @unchecked Sendab
                 .filter(DBCapabilityResolution.Columns.subject == subject.rawValue)
                 .filter(DBCapabilityResolution.Columns.conversationId == conversationId)
                 .filter(DBCapabilityResolution.Columns.capability == capability.rawValue)
+                .filter(DBCapabilityResolution.Columns.grantedToInboxId == grantedToInboxId)
                 .fetchOne(db)
             let row = DBCapabilityResolution(
                 subject: subject,
                 conversationId: conversationId,
                 capability: capability,
+                grantedToInboxId: grantedToInboxId,
                 providerIds: providerIds,
                 createdAt: existing?.createdAt ?? timestamp,
                 updatedAt: timestamp
@@ -79,25 +84,29 @@ public final class GRDBCapabilityResolver: CapabilityResolver, @unchecked Sendab
     public func clearResolution(
         subject: CapabilitySubject,
         capability: ConnectionCapability,
-        conversationId: String
+        conversationId: String,
+        grantedToInboxId: String
     ) async throws {
         _ = try await database.write { db in
             try DBCapabilityResolution
                 .filter(DBCapabilityResolution.Columns.subject == subject.rawValue)
                 .filter(DBCapabilityResolution.Columns.conversationId == conversationId)
                 .filter(DBCapabilityResolution.Columns.capability == capability.rawValue)
+                .filter(DBCapabilityResolution.Columns.grantedToInboxId == grantedToInboxId)
                 .deleteAll(db)
         }
     }
 
     public func clearAllResolutions(
         subject: CapabilitySubject,
-        conversationId: String
+        conversationId: String,
+        grantedToInboxId: String
     ) async throws {
         _ = try await database.write { db in
             try DBCapabilityResolution
                 .filter(DBCapabilityResolution.Columns.subject == subject.rawValue)
                 .filter(DBCapabilityResolution.Columns.conversationId == conversationId)
+                .filter(DBCapabilityResolution.Columns.grantedToInboxId == grantedToInboxId)
                 .deleteAll(db)
         }
     }
@@ -106,7 +115,7 @@ public final class GRDBCapabilityResolver: CapabilityResolver, @unchecked Sendab
         let timestamp = now()
         try await database.write { db in
             // Read every row, rewrite the ones that reference the provider. Number of rows
-            // is bounded by (subjects × conversations × verbs) which stays small.
+            // is bounded by (subjects × conversations × verbs × agents) which stays small.
             let rows = try DBCapabilityResolution.fetchAll(db)
             for row in rows {
                 let providers = row.providerIds
@@ -121,6 +130,7 @@ public final class GRDBCapabilityResolver: CapabilityResolver, @unchecked Sendab
                         subject: row.subject,
                         conversationId: row.conversationId,
                         capability: row.capability,
+                        grantedToInboxId: row.grantedToInboxId,
                         providerIds: remaining.sorted().joined(separator: DBCapabilityResolution.providerIdsSeparator),
                         createdAt: row.createdAt,
                         updatedAt: timestamp

--- a/ConvosCore/Sources/ConvosCore/CloudConnections/CloudConnectionGrant.swift
+++ b/ConvosCore/Sources/ConvosCore/CloudConnections/CloudConnectionGrant.swift
@@ -4,17 +4,22 @@ public struct CloudConnectionGrant: Codable, Sendable, Hashable {
     public let connectionId: String
     public let conversationId: String
     public let serviceId: String
+    /// Inbox id of the agent the grant authorizes. Two agents in the same conversation
+    /// have independent grant rows; a grant for one doesn't authorize the other.
+    public let grantedToInboxId: String
     public let grantedAt: Date
 
     public init(
         connectionId: String,
         conversationId: String,
         serviceId: String,
+        grantedToInboxId: String,
         grantedAt: Date
     ) {
         self.connectionId = connectionId
         self.conversationId = conversationId
         self.serviceId = serviceId
+        self.grantedToInboxId = grantedToInboxId
         self.grantedAt = grantedAt
     }
 }

--- a/ConvosCore/Sources/ConvosCore/CloudConnections/CloudConnectionGrantWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/CloudConnections/CloudConnectionGrantWriter.swift
@@ -3,8 +3,16 @@ import GRDB
 @preconcurrency import XMTPiOS
 
 public protocol CloudConnectionGrantWriterProtocol: Sendable {
-    func grantConnection(_ connectionId: String, to conversationId: String) async throws
-    func revokeGrant(connectionId: String, from conversationId: String) async throws
+    func grantConnection(
+        _ connectionId: String,
+        to conversationId: String,
+        grantedToInboxId: String
+    ) async throws
+    func revokeGrant(
+        connectionId: String,
+        from conversationId: String,
+        grantedToInboxId: String
+    ) async throws
 }
 
 final class CloudConnectionGrantWriter: CloudConnectionGrantWriterProtocol, @unchecked Sendable {
@@ -25,7 +33,11 @@ final class CloudConnectionGrantWriter: CloudConnectionGrantWriterProtocol, @unc
         self.myProfileWriter = myProfileWriter
     }
 
-    func grantConnection(_ connectionId: String, to conversationId: String) async throws {
+    func grantConnection(
+        _ connectionId: String,
+        to conversationId: String,
+        grantedToInboxId: String
+    ) async throws {
         let connection = try await databaseReader.read { db in
             try DBCloudConnection.fetchOne(db, key: connectionId)
         }
@@ -40,6 +52,7 @@ final class CloudConnectionGrantWriter: CloudConnectionGrantWriterProtocol, @unc
             connectionId: connectionId,
             conversationId: conversationId,
             serviceId: connection.serviceId,
+            grantedToInboxId: grantedToInboxId,
             grantedAt: Date()
         )
 
@@ -58,12 +71,17 @@ final class CloudConnectionGrantWriter: CloudConnectionGrantWriterProtocol, @unc
         }
     }
 
-    func revokeGrant(connectionId: String, from conversationId: String) async throws {
+    func revokeGrant(
+        connectionId: String,
+        from conversationId: String,
+        grantedToInboxId: String
+    ) async throws {
         let existing = try await databaseReader.read { db in
             try DBCloudConnectionGrant
                 .filter(
                     DBCloudConnectionGrant.Columns.connectionId == connectionId
                         && DBCloudConnectionGrant.Columns.conversationId == conversationId
+                        && DBCloudConnectionGrant.Columns.grantedToInboxId == grantedToInboxId
                 )
                 .fetchOne(db)
         }
@@ -78,7 +96,7 @@ final class CloudConnectionGrantWriter: CloudConnectionGrantWriterProtocol, @unc
         let targetGrants = try await projectedGrants(
             for: conversationId,
             addingOrReplacing: nil,
-            removing: (connectionId: connectionId, conversationId: conversationId)
+            removing: (connectionId: connectionId, conversationId: conversationId, grantedToInboxId: grantedToInboxId)
         )
         try await syncGrantsToMetadata(for: conversationId, desiredGrants: targetGrants)
 
@@ -87,6 +105,7 @@ final class CloudConnectionGrantWriter: CloudConnectionGrantWriterProtocol, @unc
                 .filter(
                     DBCloudConnectionGrant.Columns.connectionId == connectionId
                         && DBCloudConnectionGrant.Columns.conversationId == conversationId
+                        && DBCloudConnectionGrant.Columns.grantedToInboxId == grantedToInboxId
                 )
                 .deleteAll(db)
         }
@@ -95,7 +114,7 @@ final class CloudConnectionGrantWriter: CloudConnectionGrantWriterProtocol, @unc
     private func projectedGrants(
         for conversationId: String,
         addingOrReplacing addition: DBCloudConnectionGrant?,
-        removing removal: (connectionId: String, conversationId: String)?
+        removing removal: (connectionId: String, conversationId: String, grantedToInboxId: String)?
     ) async throws -> [DBCloudConnectionGrant] {
         let existing = try await databaseReader.read { db in
             try DBCloudConnectionGrant
@@ -108,12 +127,14 @@ final class CloudConnectionGrantWriter: CloudConnectionGrantWriterProtocol, @unc
             projected.removeAll {
                 $0.connectionId == removal.connectionId
                     && $0.conversationId == removal.conversationId
+                    && $0.grantedToInboxId == removal.grantedToInboxId
             }
         }
         if let addition {
             projected.removeAll {
                 $0.connectionId == addition.connectionId
                     && $0.conversationId == addition.conversationId
+                    && $0.grantedToInboxId == addition.grantedToInboxId
             }
             projected.append(addition)
         }
@@ -141,8 +162,9 @@ final class CloudConnectionGrantWriter: CloudConnectionGrantWriterProtocol, @unc
             // stored serviceId is a Composio toolkit slug, translate back to canonical.
             let canonicalService = CloudConnectionServiceNaming.canonicalService(fromComposioSlug: conn.serviceId)
             return CloudConnectionGrantEntry(
-                id: "grant_\(grant.connectionId)_\(conversationId)",
+                id: "grant_\(grant.connectionId)_\(conversationId)_\(grant.grantedToInboxId)",
                 senderId: senderId,
+                grantedToInboxId: grant.grantedToInboxId,
                 service: canonicalService,
                 provider: conn.provider,
                 scope: "conversation",

--- a/ConvosCore/Sources/ConvosCore/CloudConnections/CloudConnectionGrantWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/CloudConnections/CloudConnectionGrantWriter.swift
@@ -38,6 +38,9 @@ final class CloudConnectionGrantWriter: CloudConnectionGrantWriterProtocol, @unc
         to conversationId: String,
         grantedToInboxId: String
     ) async throws {
+        guard !grantedToInboxId.isEmpty else {
+            throw CloudConnectionGrantError.missingGrantedToInboxId
+        }
         let connection = try await databaseReader.read { db in
             try DBCloudConnection.fetchOne(db, key: connectionId)
         }
@@ -76,6 +79,9 @@ final class CloudConnectionGrantWriter: CloudConnectionGrantWriterProtocol, @unc
         from conversationId: String,
         grantedToInboxId: String
     ) async throws {
+        guard !grantedToInboxId.isEmpty else {
+            throw CloudConnectionGrantError.missingGrantedToInboxId
+        }
         let existing = try await databaseReader.read { db in
             try DBCloudConnectionGrant
                 .filter(
@@ -96,7 +102,7 @@ final class CloudConnectionGrantWriter: CloudConnectionGrantWriterProtocol, @unc
         let targetGrants = try await projectedGrants(
             for: conversationId,
             addingOrReplacing: nil,
-            removing: (connectionId: connectionId, conversationId: conversationId, grantedToInboxId: grantedToInboxId)
+            removing: GrantKey(connectionId: connectionId, conversationId: conversationId, grantedToInboxId: grantedToInboxId)
         )
         try await syncGrantsToMetadata(for: conversationId, desiredGrants: targetGrants)
 
@@ -111,10 +117,16 @@ final class CloudConnectionGrantWriter: CloudConnectionGrantWriterProtocol, @unc
         }
     }
 
+    private struct GrantKey {
+        let connectionId: String
+        let conversationId: String
+        let grantedToInboxId: String
+    }
+
     private func projectedGrants(
         for conversationId: String,
         addingOrReplacing addition: DBCloudConnectionGrant?,
-        removing removal: (connectionId: String, conversationId: String, grantedToInboxId: String)?
+        removing removal: GrantKey?
     ) async throws -> [DBCloudConnectionGrant] {
         let existing = try await databaseReader.read { db in
             try DBCloudConnectionGrant
@@ -257,6 +269,7 @@ enum CloudConnectionGrantError: LocalizedError {
     case connectionNotFound(String)
     case connectionNotActive(String, status: String)
     case conversationNotFound(String)
+    case missingGrantedToInboxId
 
     var errorDescription: String? {
         switch self {
@@ -266,6 +279,8 @@ enum CloudConnectionGrantError: LocalizedError {
             "CloudConnection not active (\(status)): \(id)"
         case .conversationNotFound(let id):
             "Conversation not found: \(id)"
+        case .missingGrantedToInboxId:
+            "grantedToInboxId is required and cannot be empty"
         }
     }
 }

--- a/ConvosCore/Sources/ConvosCore/CloudConnections/CloudConnectionManager.swift
+++ b/ConvosCore/Sources/ConvosCore/CloudConnections/CloudConnectionManager.swift
@@ -91,50 +91,18 @@ public final class CloudConnectionManager: CloudConnectionManagerProtocol, @unch
         // would keep using them. With per-agent grants, the same conversation can
         // have several rows (one per agent), and each must be revoked individually
         // so the metadata payload's per-agent entries all go away.
-        let affectedGrants: [(conversationId: String, grantedToInboxId: String)] = try await databaseWriter.read { db in
+        let affectedGrants: [DBCloudConnectionGrant] = try await databaseWriter.read { db in
             try DBCloudConnectionGrant
                 .filter(DBCloudConnectionGrant.Columns.connectionId == connectionId)
                 .fetchAll(db)
-                .map { ($0.conversationId, $0.grantedToInboxId) }
         }
-        let uniqueConversationIds = Array(Set(affectedGrants.map(\.conversationId)))
 
-        // revokeGrant deletes the row and republishes metadata for that
-        // conversation. We go through the public writer interface so the two
-        // paths stay in sync. A republish failure here is logged but doesn't
-        // block the subsequent DBCloudConnection delete — the ON DELETE CASCADE
-        // guarantees any grant revokeGrant restored on failure still gets
-        // removed locally. The stale metadata on XMTP is the best we can do
-        // if the sync is down at wipe time.
-        if let grantWriter = grantWriterProvider() {
-            for grant in affectedGrants {
-                do {
-                    try await grantWriter.revokeGrant(
-                        connectionId: connectionId,
-                        from: grant.conversationId,
-                        grantedToInboxId: grant.grantedToInboxId
-                    )
-                } catch {
-                    Log.warning(
-                        "[CloudConnections] failed to republish grants after disconnect " +
-                        "(connectionId=\(connectionId), conversationId=\(grant.conversationId), " +
-                        "grantedToInboxId=\(grant.grantedToInboxId)): \(error.localizedDescription)"
-                    )
-                }
-            }
-        } else if !affectedGrants.isEmpty {
-            let conversationCount = uniqueConversationIds.count
-            Log.warning(
-                "[CloudConnections] disconnect had no grant writer injected; metadata for " +
-                "\(conversationCount) conversation(s) will remain stale until the next grant/revoke " +
-                "on the affected conversations"
-            )
-        }
+        await republishRevokedGrants(affectedGrants, context: "after disconnect")
 
         await postRevocationSideEffects(
             connectionId: connectionId,
             serviceId: serviceId,
-            conversationIds: uniqueConversationIds
+            conversationIds: Array(Set(affectedGrants.map(\.conversationId)))
         )
 
         // Idempotent: GRDB's deleteOne returns false when the row is already
@@ -190,30 +158,7 @@ public final class CloudConnectionManager: CloudConnectionManagerProtocol, @unch
                     .fetchAll(db)
             }
 
-        if !orphanedGrants.isEmpty {
-            if let grantWriter = grantWriterProvider() {
-                for grant in orphanedGrants {
-                    do {
-                        try await grantWriter.revokeGrant(
-                            connectionId: grant.connectionId,
-                            from: grant.conversationId,
-                            grantedToInboxId: grant.grantedToInboxId
-                        )
-                    } catch {
-                        Log.warning(
-                            "[CloudConnections] failed to republish grants during refresh " +
-                            "(connectionId=\(grant.connectionId), conversationId=\(grant.conversationId), " +
-                            "grantedToInboxId=\(grant.grantedToInboxId)): \(error.localizedDescription)"
-                        )
-                    }
-                }
-            } else {
-                Log.warning(
-                    "[CloudConnections] refresh had \(orphanedGrants.count) orphaned grant(s) but no grant writer was " +
-                    "injected; metadata for the affected conversation(s) will remain stale until the next grant/revoke"
-                )
-            }
-        }
+        await republishRevokedGrants(orphanedGrants, context: "during refresh")
 
         for orphan in orphanedConnections {
             let conversationIds = Array(Set(
@@ -270,6 +215,38 @@ public final class CloudConnectionManager: CloudConnectionManagerProtocol, @unch
     }
 
     /// Posts `connection_event.revoked` to every affected conversation and
+    /// Walks `grants`, calling `revokeGrant` on the injected writer for each so the
+    /// per-conversation ProfileUpdate metadata reflects the deletion. Best-effort:
+    /// per-grant failures are logged and don't propagate. `context` is a short noun
+    /// phrase ("after disconnect", "during refresh") used for log-message disambiguation
+    /// when both call sites land in the same log file.
+    private func republishRevokedGrants(_ grants: [DBCloudConnectionGrant], context: String) async {
+        guard !grants.isEmpty else { return }
+        guard let grantWriter = grantWriterProvider() else {
+            let conversationCount = Set(grants.map(\.conversationId)).count
+            Log.warning(
+                "[CloudConnections] \(context) had no grant writer injected; metadata for " +
+                "\(conversationCount) conversation(s) will remain stale until the next grant/revoke"
+            )
+            return
+        }
+        for grant in grants {
+            do {
+                try await grantWriter.revokeGrant(
+                    connectionId: grant.connectionId,
+                    from: grant.conversationId,
+                    grantedToInboxId: grant.grantedToInboxId
+                )
+            } catch {
+                Log.warning(
+                    "[CloudConnections] failed to republish grants \(context) " +
+                    "(connectionId=\(grant.connectionId), conversationId=\(grant.conversationId), " +
+                    "grantedToInboxId=\(grant.grantedToInboxId)): \(error.localizedDescription)"
+                )
+            }
+        }
+    }
+
     /// clears the provider from every CapabilityResolution. Best-effort —
     /// failures are logged but never propagate, matching the existing grant-
     /// republish behavior. `serviceId == nil` is the "row already deleted"

--- a/ConvosCore/Sources/ConvosCore/CloudConnections/CloudConnectionManager.swift
+++ b/ConvosCore/Sources/ConvosCore/CloudConnections/CloudConnectionManager.swift
@@ -84,18 +84,20 @@ public final class CloudConnectionManager: CloudConnectionManagerProtocol, @unch
             try DBCloudConnection.fetchOne(db, key: connectionId)?.serviceId
         }
 
-        // Collect conversations that currently reference this connection so we
-        // can republish per-conversation metadata after the local rows are gone.
-        // Without this, the ProfileUpdate metadata previously published to XMTP
-        // groups still carries the revoked grants and the agent would keep
-        // using them.
-        let affectedConversationIds = try await databaseWriter.read { db in
+        // Collect every (conversation, agent) grant row that currently references
+        // this connection so we can republish per-conversation metadata after the
+        // local rows are gone. Without this, the ProfileUpdate metadata previously
+        // published to XMTP groups still carries the revoked grants and the agent
+        // would keep using them. With per-agent grants, the same conversation can
+        // have several rows (one per agent), and each must be revoked individually
+        // so the metadata payload's per-agent entries all go away.
+        let affectedGrants: [(conversationId: String, grantedToInboxId: String)] = try await databaseWriter.read { db in
             try DBCloudConnectionGrant
                 .filter(DBCloudConnectionGrant.Columns.connectionId == connectionId)
                 .fetchAll(db)
-                .map { $0.conversationId }
+                .map { ($0.conversationId, $0.grantedToInboxId) }
         }
-        let uniqueConversationIds = Array(Set(affectedConversationIds))
+        let uniqueConversationIds = Array(Set(affectedGrants.map(\.conversationId)))
 
         // revokeGrant deletes the row and republishes metadata for that
         // conversation. We go through the public writer interface so the two
@@ -105,17 +107,22 @@ public final class CloudConnectionManager: CloudConnectionManagerProtocol, @unch
         // removed locally. The stale metadata on XMTP is the best we can do
         // if the sync is down at wipe time.
         if let grantWriter = grantWriterProvider() {
-            for conversationId in uniqueConversationIds {
+            for grant in affectedGrants {
                 do {
                     try await grantWriter.revokeGrant(
                         connectionId: connectionId,
-                        from: conversationId
+                        from: grant.conversationId,
+                        grantedToInboxId: grant.grantedToInboxId
                     )
                 } catch {
-                    Log.warning("[CloudConnections] failed to republish grants after disconnect (connectionId=\(connectionId), conversationId=\(conversationId)): \(error.localizedDescription)")
+                    Log.warning(
+                        "[CloudConnections] failed to republish grants after disconnect " +
+                        "(connectionId=\(connectionId), conversationId=\(grant.conversationId), " +
+                        "grantedToInboxId=\(grant.grantedToInboxId)): \(error.localizedDescription)"
+                    )
                 }
             }
-        } else if !uniqueConversationIds.isEmpty {
+        } else if !affectedGrants.isEmpty {
             let conversationCount = uniqueConversationIds.count
             Log.warning(
                 "[CloudConnections] disconnect had no grant writer injected; metadata for " +
@@ -189,11 +196,14 @@ public final class CloudConnectionManager: CloudConnectionManagerProtocol, @unch
                     do {
                         try await grantWriter.revokeGrant(
                             connectionId: grant.connectionId,
-                            from: grant.conversationId
+                            from: grant.conversationId,
+                            grantedToInboxId: grant.grantedToInboxId
                         )
                     } catch {
                         Log.warning(
-                            "[CloudConnections] failed to republish grants during refresh (connectionId=\(grant.connectionId), conversationId=\(grant.conversationId)): \(error.localizedDescription)"
+                            "[CloudConnections] failed to republish grants during refresh " +
+                            "(connectionId=\(grant.connectionId), conversationId=\(grant.conversationId), " +
+                            "grantedToInboxId=\(grant.grantedToInboxId)): \(error.localizedDescription)"
                         )
                     }
                 }
@@ -277,6 +287,7 @@ public final class CloudConnectionManager: CloudConnectionManagerProtocol, @unch
                     try await eventWriter.sendRevoked(
                         providerId: providerId.rawValue,
                         capability: nil,
+                        grantedToInboxId: nil,
                         in: conversationId
                     )
                 } catch {

--- a/ConvosCore/Sources/ConvosCore/CloudConnections/CloudConnectionsMetadataPayload.swift
+++ b/ConvosCore/Sources/ConvosCore/CloudConnections/CloudConnectionsMetadataPayload.swift
@@ -4,9 +4,16 @@ import Foundation
 ///
 /// Shape matches the runtime's expected format exactly. See:
 /// `runtime/convos-platform/skills/connections/scripts/connections.mjs`.
+///
+/// `grantedToInboxId` scopes the grant to a single agent within the conversation.
+/// XMTP group metadata is broadcast to every member, so any agent in the conversation
+/// can technically read every grant entry; the runtime's agent-ignorable rule filters
+/// to only entries where `grantedToInboxId == myInboxId`. iOS publishes one entry per
+/// (agent, connection, conversation) tuple so the runtime sees the right scope.
 public struct CloudConnectionGrantEntry: Codable, Sendable, Hashable {
     public let id: String                    // grant identifier (grant_…)
     public let senderId: String               // XMTP inbox ID of the user who granted
+    public let grantedToInboxId: String       // XMTP inbox ID of the agent the grant authorizes
     public let service: String                // canonical service name, e.g. "google_calendar"
     public let provider: String               // e.g. "composio"
     public let scope: String                  // "conversation" for v0.1
@@ -17,6 +24,7 @@ public struct CloudConnectionGrantEntry: Codable, Sendable, Hashable {
     public init(
         id: String,
         senderId: String,
+        grantedToInboxId: String,
         service: String,
         provider: String,
         scope: String = "conversation",
@@ -26,6 +34,7 @@ public struct CloudConnectionGrantEntry: Codable, Sendable, Hashable {
     ) {
         self.id = id
         self.senderId = senderId
+        self.grantedToInboxId = grantedToInboxId
         self.service = service
         self.provider = provider
         self.scope = scope

--- a/ConvosCore/Sources/ConvosCore/CloudConnections/MockCloudConnectionManager.swift
+++ b/ConvosCore/Sources/ConvosCore/CloudConnections/MockCloudConnectionManager.swift
@@ -50,7 +50,15 @@ public final class MockConnectionRepository: CloudConnectionRepositoryProtocol, 
 public final class MockConnectionGrantWriter: CloudConnectionGrantWriterProtocol, Sendable {
     public init() {}
 
-    public func grantConnection(_ connectionId: String, to conversationId: String) async throws {}
+    public func grantConnection(
+        _ connectionId: String,
+        to conversationId: String,
+        grantedToInboxId: String
+    ) async throws {}
 
-    public func revokeGrant(connectionId: String, from conversationId: String) async throws {}
+    public func revokeGrant(
+        connectionId: String,
+        from conversationId: String,
+        grantedToInboxId: String
+    ) async throws {}
 }

--- a/ConvosCore/Sources/ConvosCore/Connections/ConnectionEventCodec.swift
+++ b/ConvosCore/Sources/ConvosCore/Connections/ConnectionEventCodec.swift
@@ -17,21 +17,29 @@ public struct ConnectionEvent: Codable, Sendable, Hashable {
     /// don't tag events with a capability still decode cleanly; the formatter
     /// falls back to a generic phrase when nil.
     public let capability: ConnectionCapability?
+    /// Inbox id of the agent the event concerns. For `.granted` this is the agent
+    /// gaining access; for `.revoked` it's the agent losing access. Optional on
+    /// the wire so app-level / multi-agent revoke events (where no specific agent
+    /// is meaningful — e.g. the user disconnected the underlying OAuth) can
+    /// continue to omit it.
+    public let grantedToInboxId: String?
 
     public init(
         version: Int = ConnectionEvent.supportedVersion,
         providerId: String,
         action: Action,
-        capability: ConnectionCapability? = nil
+        capability: ConnectionCapability? = nil,
+        grantedToInboxId: String? = nil
     ) {
         self.version = version
         self.providerId = providerId
         self.action = action
         self.capability = capability
+        self.grantedToInboxId = grantedToInboxId
     }
 
     private enum CodingKeys: String, CodingKey {
-        case version, providerId, action, capability
+        case version, providerId, action, capability, grantedToInboxId
     }
 
     public init(from decoder: Decoder) throws {
@@ -40,6 +48,7 @@ public struct ConnectionEvent: Codable, Sendable, Hashable {
         self.providerId = try container.decode(String.self, forKey: .providerId)
         self.action = try container.decode(Action.self, forKey: .action)
         self.capability = try container.decodeIfPresent(ConnectionCapability.self, forKey: .capability)
+        self.grantedToInboxId = try container.decodeIfPresent(String.self, forKey: .grantedToInboxId)
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -48,6 +57,7 @@ public struct ConnectionEvent: Codable, Sendable, Hashable {
         try container.encode(providerId, forKey: .providerId)
         try container.encode(action, forKey: .action)
         try container.encodeIfPresent(capability, forKey: .capability)
+        try container.encodeIfPresent(grantedToInboxId, forKey: .grantedToInboxId)
     }
 }
 

--- a/ConvosCore/Sources/ConvosCore/Connections/ConnectionEventWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Connections/ConnectionEventWriter.swift
@@ -2,17 +2,27 @@ import ConvosConnections
 import Foundation
 
 public protocol ConnectionEventWriterProtocol: Sendable {
-    func sendGranted(providerId: String, capability: ConnectionCapability?, in conversationId: String) async throws
-    func sendRevoked(providerId: String, capability: ConnectionCapability?, in conversationId: String) async throws
+    func sendGranted(
+        providerId: String,
+        capability: ConnectionCapability?,
+        grantedToInboxId: String?,
+        in conversationId: String
+    ) async throws
+    func sendRevoked(
+        providerId: String,
+        capability: ConnectionCapability?,
+        grantedToInboxId: String?,
+        in conversationId: String
+    ) async throws
 }
 
 public extension ConnectionEventWriterProtocol {
     func sendGranted(providerId: String, in conversationId: String) async throws {
-        try await sendGranted(providerId: providerId, capability: nil, in: conversationId)
+        try await sendGranted(providerId: providerId, capability: nil, grantedToInboxId: nil, in: conversationId)
     }
 
     func sendRevoked(providerId: String, in conversationId: String) async throws {
-        try await sendRevoked(providerId: providerId, capability: nil, in: conversationId)
+        try await sendRevoked(providerId: providerId, capability: nil, grantedToInboxId: nil, in: conversationId)
     }
 }
 
@@ -34,18 +44,41 @@ final class ConnectionEventWriter: ConnectionEventWriterProtocol, Sendable {
         self.sessionStateManager = sessionStateManager
     }
 
-    func sendGranted(providerId: String, capability: ConnectionCapability?, in conversationId: String) async throws {
-        try await sendEvent(.granted, providerId: providerId, capability: capability, in: conversationId)
+    func sendGranted(
+        providerId: String,
+        capability: ConnectionCapability?,
+        grantedToInboxId: String?,
+        in conversationId: String
+    ) async throws {
+        try await sendEvent(
+            .granted,
+            providerId: providerId,
+            capability: capability,
+            grantedToInboxId: grantedToInboxId,
+            in: conversationId
+        )
     }
 
-    func sendRevoked(providerId: String, capability: ConnectionCapability?, in conversationId: String) async throws {
-        try await sendEvent(.revoked, providerId: providerId, capability: capability, in: conversationId)
+    func sendRevoked(
+        providerId: String,
+        capability: ConnectionCapability?,
+        grantedToInboxId: String?,
+        in conversationId: String
+    ) async throws {
+        try await sendEvent(
+            .revoked,
+            providerId: providerId,
+            capability: capability,
+            grantedToInboxId: grantedToInboxId,
+            in: conversationId
+        )
     }
 
     private func sendEvent(
         _ action: ConnectionEvent.Action,
         providerId: String,
         capability: ConnectionCapability?,
+        grantedToInboxId: String?,
         in conversationId: String
     ) async throws {
         let inboxReady = try await sessionStateManager.waitForInboxReadyResult()
@@ -55,7 +88,12 @@ final class ConnectionEventWriter: ConnectionEventWriterProtocol, Sendable {
             throw ConnectionEventWriterError.conversationNotFound(conversationId: conversationId)
         }
 
-        let event = ConnectionEvent(providerId: providerId, action: action, capability: capability)
+        let event = ConnectionEvent(
+            providerId: providerId,
+            action: action,
+            capability: capability,
+            grantedToInboxId: grantedToInboxId
+        )
         let encoded = try ConnectionEventCodec().encode(content: event)
         try await conversation.send(encodedContent: encoded)
     }

--- a/ConvosCore/Sources/ConvosCore/Connections/ConnectionMessageSummaryFormatter.swift
+++ b/ConvosCore/Sources/ConvosCore/Connections/ConnectionMessageSummaryFormatter.swift
@@ -5,18 +5,22 @@ public enum ConnectionMessageSummaryFormatter {
     public static func eventSummary(_ event: ConnectionEvent) -> ConnectionEventSummary {
         switch event.action {
         case .granted:
+            let actor: ConnectionEventSummary.Actor? = event.grantedToInboxId == nil ? nil : .grantedAgent
             return .init(
                 text: grantedText(forProviderId: event.providerId, capability: event.capability),
                 outcome: .success,
                 icon: icon(forProviderId: event.providerId),
-                actor: .verifiedAssistant
+                actor: actor,
+                grantedToInboxId: event.grantedToInboxId
             )
         case .revoked:
+            let actor: ConnectionEventSummary.Actor? = event.grantedToInboxId == nil ? nil : .grantedAgent
             return .init(
                 text: revokedText(forProviderId: event.providerId, capability: event.capability),
                 outcome: .success,
                 icon: icon(forProviderId: event.providerId),
-                actor: nil
+                actor: actor,
+                grantedToInboxId: event.grantedToInboxId
             )
         }
     }

--- a/ConvosCore/Sources/ConvosCore/Connections/GRDBEnablementStore.swift
+++ b/ConvosCore/Sources/ConvosCore/Connections/GRDBEnablementStore.swift
@@ -11,23 +11,36 @@ public actor GRDBEnablementStore: EnablementStore {
         self.dbReader = dbReader
     }
 
-    public func isEnabled(kind: ConnectionKind, capability: ConnectionCapability, conversationId: String) async -> Bool {
+    public func isEnabled(
+        kind: ConnectionKind,
+        capability: ConnectionCapability,
+        conversationId: String,
+        grantedToInboxId: String
+    ) async -> Bool {
         (try? await dbReader.read { db in
             try DBConnectionEnablement
                 .filter(DBConnectionEnablement.Columns.kind == kind.rawValue)
                 .filter(DBConnectionEnablement.Columns.capability == capability.rawValue)
                 .filter(DBConnectionEnablement.Columns.conversationId == conversationId)
+                .filter(DBConnectionEnablement.Columns.grantedToInboxId == grantedToInboxId)
                 .fetchOne(db) != nil
         }) ?? false
     }
 
-    public func setEnabled(_ enabled: Bool, kind: ConnectionKind, capability: ConnectionCapability, conversationId: String) async {
+    public func setEnabled(
+        _ enabled: Bool,
+        kind: ConnectionKind,
+        capability: ConnectionCapability,
+        conversationId: String,
+        grantedToInboxId: String
+    ) async {
         try? await dbWriter.write { db in
             if enabled {
                 try DBConnectionEnablement(
                     kind: kind.rawValue,
                     capability: capability.rawValue,
                     conversationId: conversationId,
+                    grantedToInboxId: grantedToInboxId,
                     createdAt: Date(),
                     updatedAt: Date()
                 ).save(db, onConflict: .replace)
@@ -36,13 +49,14 @@ public actor GRDBEnablementStore: EnablementStore {
                     .filter(DBConnectionEnablement.Columns.kind == kind.rawValue)
                     .filter(DBConnectionEnablement.Columns.capability == capability.rawValue)
                     .filter(DBConnectionEnablement.Columns.conversationId == conversationId)
+                    .filter(DBConnectionEnablement.Columns.grantedToInboxId == grantedToInboxId)
                     .deleteAll(db)
             }
         }
     }
 
     public func conversationIds(enabledFor kind: ConnectionKind, capability: ConnectionCapability) async -> [String] {
-        (try? await dbReader.read { db in
+        let raw = (try? await dbReader.read { db in
             try String.fetchAll(
                 db,
                 DBConnectionEnablement
@@ -51,6 +65,9 @@ public actor GRDBEnablementStore: EnablementStore {
                     .select(DBConnectionEnablement.Columns.conversationId)
             )
         }) ?? []
+        // Deduplicate — multiple agents enabled in the same conversation produce one
+        // fan-out target per the (kind, capability) bucket.
+        return Array(Set(raw)).sorted()
     }
 
     public func allEnablements() async -> [Enablement] {
@@ -60,7 +77,12 @@ public actor GRDBEnablementStore: EnablementStore {
                       let capability = ConnectionCapability(rawValue: row.capability) else {
                     return nil
                 }
-                return Enablement(kind: kind, capability: capability, conversationId: row.conversationId)
+                return Enablement(
+                    kind: kind,
+                    capability: capability,
+                    conversationId: row.conversationId,
+                    grantedToInboxId: row.grantedToInboxId
+                )
             }
         }) ?? []
     }
@@ -101,11 +123,13 @@ struct DBConnectionEnablement: Codable, FetchableRecord, PersistableRecord, Hash
         static let kind: Column = Column(CodingKeys.kind)
         static let capability: Column = Column(CodingKeys.capability)
         static let conversationId: Column = Column(CodingKeys.conversationId)
+        static let grantedToInboxId: Column = Column(CodingKeys.grantedToInboxId)
     }
 
     let kind: String
     let capability: String
     let conversationId: String
+    let grantedToInboxId: String
     let createdAt: Date
     let updatedAt: Date
 }

--- a/ConvosCore/Sources/ConvosCore/Mocks/MockMessagingService.swift
+++ b/ConvosCore/Sources/ConvosCore/Mocks/MockMessagingService.swift
@@ -169,9 +169,19 @@ public final class MockMessagingService: MessagingServiceProtocol, @unchecked Se
 public final class MockConnectionEventWriter: ConnectionEventWriterProtocol, @unchecked Sendable {
     public init() {}
 
-    public func sendGranted(providerId: String, capability: ConnectionCapability?, in conversationId: String) async throws {}
+    public func sendGranted(
+        providerId: String,
+        capability: ConnectionCapability?,
+        grantedToInboxId: String?,
+        in conversationId: String
+    ) async throws {}
 
-    public func sendRevoked(providerId: String, capability: ConnectionCapability?, in conversationId: String) async throws {}
+    public func sendRevoked(
+        providerId: String,
+        capability: ConnectionCapability?,
+        grantedToInboxId: String?,
+        in conversationId: String
+    ) async throws {}
 }
 
 public final class MockCapabilityRequestResultWriter: CapabilityRequestResultWriterProtocol, @unchecked Sendable {

--- a/ConvosCore/Sources/ConvosCore/Storage/Database Models/DBCapabilityResolution.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Database Models/DBCapabilityResolution.swift
@@ -6,8 +6,12 @@ import GRDB
 /// comma-joined string so the same schema can hold both single-provider rows (the common
 /// case) and federated-read rows (currently only `.fitness`).
 ///
-/// Cardinality is enforced in `CapabilityResolutionValidator`, not the schema — that
-/// keeps the on-disk shape stable when more subjects opt into federation.
+/// Primary key is `(subject, conversationId, capability, grantedToInboxId)` — every row
+/// is scoped to a single agent. Two agents in the same conversation have independent
+/// rows; one's resolution doesn't authorize the other.
+///
+/// Cardinality (set arity) is enforced in `CapabilityResolutionValidator`, not the
+/// schema — that keeps the on-disk shape stable when more subjects opt into federation.
 struct DBCapabilityResolution: Codable, FetchableRecord, PersistableRecord, Hashable {
     static let databaseTableName: String = "capabilityResolution"
 
@@ -15,6 +19,7 @@ struct DBCapabilityResolution: Codable, FetchableRecord, PersistableRecord, Hash
         static let subject: Column = Column(CodingKeys.subject)
         static let conversationId: Column = Column(CodingKeys.conversationId)
         static let capability: Column = Column(CodingKeys.capability)
+        static let grantedToInboxId: Column = Column(CodingKeys.grantedToInboxId)
         static let providerIds: Column = Column(CodingKeys.providerIds)
         static let createdAt: Column = Column(CodingKeys.createdAt)
         static let updatedAt: Column = Column(CodingKeys.updatedAt)
@@ -23,6 +28,7 @@ struct DBCapabilityResolution: Codable, FetchableRecord, PersistableRecord, Hash
     let subject: String
     let conversationId: String
     let capability: String
+    let grantedToInboxId: String
     let providerIds: String
     let createdAt: Date
     let updatedAt: Date
@@ -37,6 +43,7 @@ extension DBCapabilityResolution {
         subject: CapabilitySubject,
         conversationId: String,
         capability: ConnectionCapability,
+        grantedToInboxId: String,
         providerIds: Set<ProviderID>,
         createdAt: Date,
         updatedAt: Date
@@ -44,6 +51,7 @@ extension DBCapabilityResolution {
         self.subject = subject.rawValue
         self.conversationId = conversationId
         self.capability = capability.rawValue
+        self.grantedToInboxId = grantedToInboxId
         // Sort for stable on-disk representation; resolver consumers treat it as a Set.
         self.providerIds = providerIds
             .map(\.rawValue)
@@ -65,6 +73,7 @@ extension DBCapabilityResolution {
             subject: subjectValue,
             conversationId: conversationId,
             capability: capabilityValue,
+            grantedToInboxId: grantedToInboxId,
             providerIds: Set(providers)
         )
     }

--- a/ConvosCore/Sources/ConvosCore/Storage/Database Models/DBCloudConnectionGrant.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Database Models/DBCloudConnectionGrant.swift
@@ -8,12 +8,14 @@ struct DBCloudConnectionGrant: Codable, FetchableRecord, PersistableRecord, Hash
         static let connectionId: Column = Column(CodingKeys.connectionId)
         static let conversationId: Column = Column(CodingKeys.conversationId)
         static let serviceId: Column = Column(CodingKeys.serviceId)
+        static let grantedToInboxId: Column = Column(CodingKeys.grantedToInboxId)
         static let grantedAt: Column = Column(CodingKeys.grantedAt)
     }
 
     let connectionId: String
     let conversationId: String
     let serviceId: String
+    let grantedToInboxId: String
     let grantedAt: Date
 }
 
@@ -23,6 +25,7 @@ extension DBCloudConnectionGrant {
             connectionId: connectionId,
             conversationId: conversationId,
             serviceId: serviceId,
+            grantedToInboxId: grantedToInboxId,
             grantedAt: grantedAt
         )
     }
@@ -31,6 +34,7 @@ extension DBCloudConnectionGrant {
         self.connectionId = grant.connectionId
         self.conversationId = grant.conversationId
         self.serviceId = grant.serviceId
+        self.grantedToInboxId = grant.grantedToInboxId
         self.grantedAt = grant.grantedAt
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/MessageContent.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/MessageContent.swift
@@ -19,15 +19,15 @@ public struct ConnectionEventSummary: Hashable, Codable, Sendable {
     }
 
     /// Marker for an actor placeholder the renderer needs to resolve from
-    /// conversation context. `text` carries an actor-less phrase ("has access to
-    /// calendar data", "read last 24 hours of health data"); the renderer
-    /// prepends the resolved name. `nil` means no actor is expected — render the
-    /// `text` verbatim.
+    /// conversation context. `text` carries an actor-less phrase ("can read calendar
+    /// events"); the renderer prepends the resolved name. `nil` means no actor is
+    /// expected — render `text` verbatim (used for connection-disconnected events).
     public enum Actor: String, Hashable, Codable, Sendable {
-        /// The conversation's verified assistant member. Used for grant/revoke
-        /// events where the actor is the agent gaining or losing access, not the
-        /// underlying message's sender (which is the user granting).
-        case verifiedAssistant = "verified_assistant"
+        /// A specific agent identified by `grantedToInboxId`. The renderer looks the
+        /// inbox id up against the conversation's members and prepends the agent's
+        /// current display name; ProfileUpdate-driven renames propagate live, and
+        /// the lookup is deterministic with N agents in a conversation.
+        case grantedAgent = "granted_agent"
         /// The sender of the underlying message — resolved by the renderer via
         /// `msg.sender`.
         case messageSender = "message_sender"
@@ -37,12 +37,23 @@ public struct ConnectionEventSummary: Hashable, Codable, Sendable {
     public let outcome: Outcome
     public let icon: Icon
     public let actor: Actor?
+    /// Identifies the agent the event concerns. Required for `actor == .grantedAgent`,
+    /// nil otherwise. Renderer prefers a live member-list lookup keyed off this id and
+    /// falls back to bare text only when the agent is no longer in the conversation.
+    public let grantedToInboxId: String?
 
-    public init(text: String, outcome: Outcome, icon: Icon, actor: Actor? = nil) {
+    public init(
+        text: String,
+        outcome: Outcome,
+        icon: Icon,
+        actor: Actor? = nil,
+        grantedToInboxId: String? = nil
+    ) {
         self.text = text
         self.outcome = outcome
         self.icon = icon
         self.actor = actor
+        self.grantedToInboxId = grantedToInboxId
     }
 }
 

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/MessagesListProcessor.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/MessagesListProcessor.swift
@@ -147,7 +147,7 @@ public final class MessagesListProcessor: Sendable {
                     currentGroupMessages.removeAll(keepingCapacity: true)
                     currentSenderId = nil
                 }
-                let resolvedSummary = resolvingActor(in: eventSummary, sender: msg.sender)
+                let resolvedSummary = resolvingActor(in: eventSummary, sender: msg.sender, memberProfiles: memberProfiles)
                 items.append(.connectionEvent(id: msg.messageId, summary: resolvedSummary, origin: msg.origin))
                 lastWasAttachment = false
                 continue
@@ -164,7 +164,7 @@ public final class MessagesListProcessor: Sendable {
                     currentGroupMessages.removeAll(keepingCapacity: true)
                     currentSenderId = nil
                 }
-                let resolvedSummary = resolvingActor(in: resultSummary, sender: msg.sender)
+                let resolvedSummary = resolvingActor(in: resultSummary, sender: msg.sender, memberProfiles: memberProfiles)
                 items.append(.connectionEvent(id: msg.messageId, summary: resolvedSummary, origin: msg.origin))
                 lastWasAttachment = false
                 continue
@@ -187,7 +187,7 @@ public final class MessagesListProcessor: Sendable {
                     currentGroupMessages.removeAll(keepingCapacity: true)
                     currentSenderId = nil
                 }
-                let resolvedSummary = resolvingActor(in: payloadSummary, sender: msg.sender)
+                let resolvedSummary = resolvingActor(in: payloadSummary, sender: msg.sender, memberProfiles: memberProfiles)
                 items.append(.connectionEvent(id: msg.messageId, summary: resolvedSummary, origin: msg.origin))
                 lastWasAttachment = false
                 continue
@@ -412,21 +412,33 @@ public final class MessagesListProcessor: Sendable {
     /// Materialize the actor for a `ConnectionEventSummary` whose `text` is an
     /// actor-less phrase.
     ///
-    /// - `.messageSender` is resolved here using the message's own sender
-    ///   snapshot. That snapshot is per-message and stable, so prepending at
-    ///   processing time is fine.
-    /// - `.grantedAgent` is **not** resolved here. The renderer looks the
-    ///   `grantedToInboxId` up against the conversation's live members so
-    ///   ProfileUpdate-driven renames propagate without re-running the
-    ///   processor.
-    /// - `nil` actor (legacy summary or no actor expected) is returned
-    ///   unchanged.
+    /// - `.messageSender` is resolved using the message's own sender snapshot. That
+    ///   snapshot is per-message and stable.
+    /// - `.grantedAgent` is resolved by inbox-id-keyed lookup against `memberProfiles`.
+    ///   The lookup is by stable inbox id (not the verification flag), so it doesn't
+    ///   flap during attestation re-verification; ProfileUpdates that rename the agent
+    ///   trigger a `memberProfiles` change which re-runs the processor and re-bakes the
+    ///   text — same path `.messageSender` uses.
+    /// - `nil` actor (no actor expected) is returned unchanged.
     private static func resolvingActor(
         in summary: ConnectionEventSummary,
-        sender: ConversationMember
+        sender: ConversationMember,
+        memberProfiles: [String: MemberProfileInfo]
     ) -> ConnectionEventSummary {
-        guard summary.actor == .messageSender else { return summary }
-        let actorName = sender.isCurrentUser ? "You" : sender.profile.displayName
+        let actorName: String
+        switch summary.actor {
+        case .messageSender:
+            actorName = sender.isCurrentUser ? "You" : sender.profile.displayName
+        case .grantedAgent:
+            guard let inboxId = summary.grantedToInboxId,
+                  let name = memberProfiles[inboxId]?.name,
+                  !name.isEmpty else {
+                return summary
+            }
+            actorName = name
+        case .none:
+            return summary
+        }
         guard !actorName.isEmpty else { return summary }
         return ConnectionEventSummary(
             text: "\(actorName) \(summary.text)",

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/MessagesListProcessor.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/MessagesListProcessor.swift
@@ -67,24 +67,6 @@ public final class MessagesListProcessor: Sendable {
         }
         trackedMemberCount = max(0, trackedMemberCount)
 
-        // Resolve the verified-assistant displayName once for the whole pass.
-        // Used by `connection_event` summaries whose `actor` field is
-        // `.verifiedAssistant` — the formatter doesn't have conversation context,
-        // so the real name is filled in here. Prefer `memberProfiles` (carries
-        // verification state for every member) over iterating messages, since
-        // some agent-authored content types (`capabilityRequest`) are filtered
-        // out at the repo layer and never appear in `messages`.
-        var verifiedAssistantName: String? = memberProfiles.values
-            .first(where: \.isVerifiedAssistant)?
-            .name
-            .flatMap { $0.isEmpty ? nil : $0 }
-        if verifiedAssistantName == nil {
-            for msg in messages where msg.sender.isVerifiedAssistant {
-                verifiedAssistantName = msg.sender.displayName
-                break
-            }
-        }
-
         var items: [MessagesListItemType] = []
         items.reserveCapacity(messageCount)
 
@@ -165,11 +147,7 @@ public final class MessagesListProcessor: Sendable {
                     currentGroupMessages.removeAll(keepingCapacity: true)
                     currentSenderId = nil
                 }
-                let resolvedSummary = resolvingActor(
-                    in: eventSummary,
-                    sender: msg.sender,
-                    verifiedAssistantName: verifiedAssistantName
-                )
+                let resolvedSummary = resolvingActor(in: eventSummary, sender: msg.sender)
                 items.append(.connectionEvent(id: msg.messageId, summary: resolvedSummary, origin: msg.origin))
                 lastWasAttachment = false
                 continue
@@ -186,11 +164,7 @@ public final class MessagesListProcessor: Sendable {
                     currentGroupMessages.removeAll(keepingCapacity: true)
                     currentSenderId = nil
                 }
-                let resolvedSummary = resolvingActor(
-                    in: resultSummary,
-                    sender: msg.sender,
-                    verifiedAssistantName: verifiedAssistantName
-                )
+                let resolvedSummary = resolvingActor(in: resultSummary, sender: msg.sender)
                 items.append(.connectionEvent(id: msg.messageId, summary: resolvedSummary, origin: msg.origin))
                 lastWasAttachment = false
                 continue
@@ -213,11 +187,7 @@ public final class MessagesListProcessor: Sendable {
                     currentGroupMessages.removeAll(keepingCapacity: true)
                     currentSenderId = nil
                 }
-                let resolvedSummary = resolvingActor(
-                    in: payloadSummary,
-                    sender: msg.sender,
-                    verifiedAssistantName: verifiedAssistantName
-                )
+                let resolvedSummary = resolvingActor(in: payloadSummary, sender: msg.sender)
                 items.append(.connectionEvent(id: msg.messageId, summary: resolvedSummary, origin: msg.origin))
                 lastWasAttachment = false
                 continue
@@ -445,19 +415,15 @@ public final class MessagesListProcessor: Sendable {
     /// - `.messageSender` is resolved here using the message's own sender
     ///   snapshot. That snapshot is per-message and stable, so prepending at
     ///   processing time is fine.
-    /// - `.verifiedAssistant` is **not** resolved here. The view layer reads a
-    ///   live verified-assistant name from the conversation's membership
-    ///   (which is plumbed through the SwiftUI tree) and prepends it at
-    ///   render time. Resolving here would couple the rendered text to the
-    ///   per-emission `agentVerification` snapshot in memberProfiles, which
-    ///   flaps during periodic attestation re-verification and produced a
-    ///   visible flicker between "Assistant" and the agent's profile name.
+    /// - `.grantedAgent` is **not** resolved here. The renderer looks the
+    ///   `grantedToInboxId` up against the conversation's live members so
+    ///   ProfileUpdate-driven renames propagate without re-running the
+    ///   processor.
     /// - `nil` actor (legacy summary or no actor expected) is returned
     ///   unchanged.
     private static func resolvingActor(
         in summary: ConnectionEventSummary,
-        sender: ConversationMember,
-        verifiedAssistantName: String?
+        sender: ConversationMember
     ) -> ConnectionEventSummary {
         guard summary.actor == .messageSender else { return summary }
         let actorName = sender.isCurrentUser ? "You" : sender.profile.displayName
@@ -466,7 +432,8 @@ public final class MessagesListProcessor: Sendable {
             text: "\(actorName) \(summary.text)",
             outcome: summary.outcome,
             icon: summary.icon,
-            actor: summary.actor
+            actor: summary.actor,
+            grantedToInboxId: summary.grantedToInboxId
         )
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Storage/SharedDatabaseMigrator.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/SharedDatabaseMigrator.swift
@@ -170,7 +170,68 @@ extension SharedDatabaseMigrator {
             )
         }
 
+        migrator.registerMigration("scopeGrantsToAgentInboxId", migrate: Self.scopeGrantsToAgentInboxId)
+
         return migrator
+    }
+
+    /// Tighten capabilityResolution + connectionEnablement + connectionGrant so a grant
+    /// is bound to a specific agent's inboxId instead of being conversation-wide. Two
+    /// agents in the same conversation now have independent rows; one's grant doesn't
+    /// authorize the other. Drop+recreate is acceptable here because no production data
+    /// exists for these tables yet (the connections feature is still on a feature branch).
+    private static func scopeGrantsToAgentInboxId(_ db: Database) throws {
+        try db.drop(table: "capabilityResolution")
+        try db.create(table: "capabilityResolution") { t in
+            t.column("subject", .text).notNull()
+            t.column("conversationId", .text).notNull()
+                .references("conversation", onDelete: .cascade)
+            t.column("capability", .text).notNull()
+            t.column("grantedToInboxId", .text).notNull()
+            t.column("providerIds", .text).notNull()
+            t.column("createdAt", .datetime).notNull()
+            t.column("updatedAt", .datetime).notNull()
+            t.primaryKey(["subject", "conversationId", "capability", "grantedToInboxId"])
+        }
+        try db.create(
+            index: "capabilityResolution_conversationId",
+            on: "capabilityResolution",
+            columns: ["conversationId"]
+        )
+
+        try db.drop(table: "connectionEnablement")
+        try db.create(table: "connectionEnablement") { t in
+            t.column("kind", .text).notNull()
+            t.column("capability", .text).notNull()
+            t.column("conversationId", .text).notNull()
+                .references("conversation", onDelete: .cascade)
+            t.column("grantedToInboxId", .text).notNull()
+            t.column("createdAt", .datetime).notNull()
+            t.column("updatedAt", .datetime).notNull()
+            t.primaryKey(["kind", "capability", "conversationId", "grantedToInboxId"])
+        }
+        try db.create(
+            index: "connectionEnablement_conversationId",
+            on: "connectionEnablement",
+            columns: ["conversationId"]
+        )
+
+        try db.drop(table: "connectionGrant")
+        try db.create(table: "connectionGrant") { t in
+            t.column("connectionId", .text).notNull()
+                .references("connection", onDelete: .cascade)
+            t.column("conversationId", .text).notNull()
+                .references("conversation", onDelete: .cascade)
+            t.column("serviceId", .text).notNull()
+            t.column("grantedToInboxId", .text).notNull()
+            t.column("grantedAt", .datetime).notNull()
+            t.primaryKey(["connectionId", "conversationId", "grantedToInboxId"])
+        }
+        try db.create(
+            index: "connectionGrant_conversationId",
+            on: "connectionGrant",
+            columns: ["conversationId"]
+        )
     }
 
     // swiftlint:disable:next function_body_length

--- a/ConvosCore/Sources/ConvosCore/Syncing/HealthInvocationRouter.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/HealthInvocationRouter.swift
@@ -48,7 +48,8 @@ actor HealthInvocationRouter {
         let enabled = await enablementStore.isEnabled(
             kind: .health,
             capability: .read,
-            conversationId: conversationId
+            conversationId: conversationId,
+            grantedToInboxId: agentInboxId
         )
         guard enabled else {
             let result = ConnectionInvocationResult(
@@ -56,7 +57,7 @@ actor HealthInvocationRouter {
                 kind: .health,
                 actionName: actionName,
                 status: .capabilityNotEnabled,
-                errorMessage: "Capability \(ConnectionCapability.read.rawValue) is not enabled for this conversation."
+                errorMessage: "Capability \(ConnectionCapability.read.rawValue) is not enabled for this agent in this conversation."
             )
             try? await delivery.deliver(result, to: conversationId)
             return result

--- a/ConvosCore/Tests/ConvosConnectionsXMTPTests/XMTPInvocationListenerTests.swift
+++ b/ConvosCore/Tests/ConvosConnectionsXMTPTests/XMTPInvocationListenerTests.swift
@@ -30,7 +30,7 @@ struct XMTPInvocationListenerTests {
         """.utf8)
         let invocation = try JSONDecoder().decode(ConnectionInvocation.self, from: futureJSON)
 
-        await listener.handle(invocation: invocation, conversationId: "conv-1")
+        await listener.handle(invocation: invocation, conversationId: "conv-1", invokerInboxId: "agent-1")
 
         let results = await recorder.results()
         #expect(results.count == 1)
@@ -45,7 +45,13 @@ struct XMTPInvocationListenerTests {
         let sink = CountingSink()
         let store = InMemoryEnablementStore()
         // Enable the capability so the manager's gate passes and the sink is hit.
-        await store.setEnabled(true, kind: .contacts, capability: .writeCreate, conversationId: "conv-1")
+        await store.setEnabled(
+            true,
+            kind: .contacts,
+            capability: .writeCreate,
+            conversationId: "conv-1",
+            grantedToInboxId: "agent-1"
+        )
 
         let manager = ConnectionsManager(
             sources: [],
@@ -61,7 +67,7 @@ struct XMTPInvocationListenerTests {
             action: ConnectionAction(name: "create_contact", arguments: [:])
         )
 
-        await listener.handle(invocation: invocation, conversationId: "conv-1")
+        await listener.handle(invocation: invocation, conversationId: "conv-1", invokerInboxId: "agent-1")
 
         #expect(await sink.invokeCount() == 1)
         let results = await recorder.results()

--- a/ConvosCore/Tests/ConvosCoreTests/CapabilityInvocationRouterTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/CapabilityInvocationRouterTests.swift
@@ -6,6 +6,7 @@ import Testing
 @Suite("CapabilityInvocationRouter")
 struct CapabilityInvocationRouterTests {
     private let conversationId: String = "conv-1"
+    private let invokerInboxId: String = "agent-1"
 
     private func makeInvocation(
         kind: ConnectionKind = .calendar,
@@ -35,7 +36,7 @@ struct CapabilityInvocationRouterTests {
             capabilityLookup: { invocation in
                 capabilityFor[invocation.action.name]
             },
-            deviceDispatch: { invocation, _ in
+            deviceDispatch: { invocation, _, _ in
                 await spy.record(invocation.action.name)
                 return ConnectionInvocationResult(
                     invocationId: invocation.invocationId,
@@ -52,7 +53,11 @@ struct CapabilityInvocationRouterTests {
         let resolver = InMemoryCapabilityResolver(registry: InMemoryCapabilityProviderRegistry())
         let spy = DeviceDispatchSpy()
         let router = makeRouter(resolver: resolver, spy: spy)
-        let result = await router.route(makeInvocation(kind: .motion), conversationId: conversationId)
+        let result = await router.route(
+            makeInvocation(kind: .motion),
+            conversationId: conversationId,
+            invokerInboxId: invokerInboxId
+        )
         #expect(result.status == .unknownAction)
         let calls = await spy.calls
         #expect(calls.isEmpty)
@@ -63,7 +68,11 @@ struct CapabilityInvocationRouterTests {
         let resolver = InMemoryCapabilityResolver(registry: InMemoryCapabilityProviderRegistry())
         let spy = DeviceDispatchSpy()
         let router = makeRouter(resolver: resolver, capabilityFor: [:], spy: spy)
-        let result = await router.route(makeInvocation(actionName: "fictional_action"), conversationId: conversationId)
+        let result = await router.route(
+            makeInvocation(actionName: "fictional_action"),
+            conversationId: conversationId,
+            invokerInboxId: invokerInboxId
+        )
         #expect(result.status == .unknownAction)
         let calls = await spy.calls
         #expect(calls.isEmpty)
@@ -78,7 +87,11 @@ struct CapabilityInvocationRouterTests {
             capabilityFor: ["create_event": .writeCreate],
             spy: spy
         )
-        let result = await router.route(makeInvocation(actionName: "create_event"), conversationId: conversationId)
+        let result = await router.route(
+            makeInvocation(actionName: "create_event"),
+            conversationId: conversationId,
+            invokerInboxId: invokerInboxId
+        )
         #expect(result.status == .capabilityNotEnabled)
         let calls = await spy.calls
         #expect(calls.isEmpty)
@@ -91,7 +104,8 @@ struct CapabilityInvocationRouterTests {
             [DeviceCapabilityProvider.providerId(for: .calendar)],
             subject: .calendar,
             capability: .writeCreate,
-            conversationId: conversationId
+            conversationId: conversationId,
+            grantedToInboxId: invokerInboxId
         )
         let spy = DeviceDispatchSpy()
         let router = makeRouter(
@@ -99,7 +113,11 @@ struct CapabilityInvocationRouterTests {
             capabilityFor: ["create_event": .writeCreate],
             spy: spy
         )
-        let result = await router.route(makeInvocation(actionName: "create_event"), conversationId: conversationId)
+        let result = await router.route(
+            makeInvocation(actionName: "create_event"),
+            conversationId: conversationId,
+            invokerInboxId: invokerInboxId
+        )
         #expect(result.status == .success)
         let calls = await spy.calls
         #expect(calls == ["create_event"])
@@ -115,7 +133,8 @@ struct CapabilityInvocationRouterTests {
             ],
             subject: .fitness,
             capability: .read,
-            conversationId: conversationId
+            conversationId: conversationId,
+            grantedToInboxId: invokerInboxId
         )
         let spy = DeviceDispatchSpy()
         let router = makeRouter(
@@ -125,7 +144,8 @@ struct CapabilityInvocationRouterTests {
         )
         let result = await router.route(
             makeInvocation(kind: .health, actionName: "list_recent_workouts"),
-            conversationId: conversationId
+            conversationId: conversationId,
+            invokerInboxId: invokerInboxId
         )
         #expect(result.status == .success)
         let calls = await spy.calls
@@ -139,7 +159,8 @@ struct CapabilityInvocationRouterTests {
             [ProviderID(rawValue: "composio.google_calendar")],
             subject: .calendar,
             capability: .writeCreate,
-            conversationId: conversationId
+            conversationId: conversationId,
+            grantedToInboxId: invokerInboxId
         )
         let spy = DeviceDispatchSpy()
         let router = makeRouter(
@@ -147,7 +168,11 @@ struct CapabilityInvocationRouterTests {
             capabilityFor: ["create_event": .writeCreate],
             spy: spy
         )
-        let result = await router.route(makeInvocation(actionName: "create_event"), conversationId: conversationId)
+        let result = await router.route(
+            makeInvocation(actionName: "create_event"),
+            conversationId: conversationId,
+            invokerInboxId: invokerInboxId
+        )
         #expect(result.status == .executionFailed)
         #expect(result.errorMessage?.contains("composio.google_calendar") == true)
         let calls = await spy.calls
@@ -164,7 +189,8 @@ struct CapabilityInvocationRouterTests {
             ],
             subject: .fitness,
             capability: .read,
-            conversationId: conversationId
+            conversationId: conversationId,
+            grantedToInboxId: invokerInboxId
         )
         let spy = DeviceDispatchSpy()
         let router = makeRouter(
@@ -174,7 +200,8 @@ struct CapabilityInvocationRouterTests {
         )
         let result = await router.route(
             makeInvocation(kind: .health, actionName: "list_recent_workouts"),
-            conversationId: conversationId
+            conversationId: conversationId,
+            invokerInboxId: invokerInboxId
         )
         #expect(result.status == .executionFailed)
         let calls = await spy.calls
@@ -188,7 +215,8 @@ struct CapabilityInvocationRouterTests {
             [DeviceCapabilityProvider.providerId(for: .calendar)],
             subject: .calendar,
             capability: .writeCreate,
-            conversationId: "conv-a"
+            conversationId: "conv-a",
+            grantedToInboxId: invokerInboxId
         )
         let spy = DeviceDispatchSpy()
         let router = makeRouter(
@@ -196,9 +224,39 @@ struct CapabilityInvocationRouterTests {
             capabilityFor: ["create_event": .writeCreate],
             spy: spy
         )
-        let result = await router.route(makeInvocation(actionName: "create_event"), conversationId: "conv-b")
+        let result = await router.route(
+            makeInvocation(actionName: "create_event"),
+            conversationId: "conv-b",
+            invokerInboxId: invokerInboxId
+        )
         #expect(result.status == .capabilityNotEnabled)
         let calls = await spy.calls
         #expect(calls.isEmpty)
+    }
+
+    @Test("agent scoping — agent A's resolution doesn't satisfy agent B's invocation")
+    func agentScoped() async throws {
+        let resolver = InMemoryCapabilityResolver(registry: InMemoryCapabilityProviderRegistry())
+        try await resolver.setResolution(
+            [DeviceCapabilityProvider.providerId(for: .calendar)],
+            subject: .calendar,
+            capability: .writeCreate,
+            conversationId: conversationId,
+            grantedToInboxId: "agent-a"
+        )
+        let spy = DeviceDispatchSpy()
+        let router = makeRouter(
+            resolver: resolver,
+            capabilityFor: ["create_event": .writeCreate],
+            spy: spy
+        )
+        let result = await router.route(
+            makeInvocation(actionName: "create_event"),
+            conversationId: conversationId,
+            invokerInboxId: "agent-b"
+        )
+        #expect(result.status == .capabilityNotEnabled)
+        let calls = await spy.calls
+        #expect(calls.isEmpty, "agent-b should not see agent-a's grant")
     }
 }

--- a/ConvosCore/Tests/ConvosCoreTests/CapabilityManifestTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/CapabilityManifestTests.swift
@@ -126,7 +126,8 @@ struct CapabilityManifestBuilderTests {
         let manifest = await CapabilityManifestBuilder().build(
             registry: registry,
             resolver: resolver,
-            conversationId: "conv-1"
+            conversationId: "conv-1",
+            grantedToInboxId: "agent-1"
         )
         #expect(manifest.providers.isEmpty)
         #expect(manifest.version == CapabilityManifest.supportedVersion)
@@ -148,7 +149,8 @@ struct CapabilityManifestBuilderTests {
         let manifest = await CapabilityManifestBuilder().build(
             registry: registry,
             resolver: resolver,
-            conversationId: "conv-1"
+            conversationId: "conv-1",
+            grantedToInboxId: "agent-1"
         )
         let entry = try? #require(manifest.providers.first)
         #expect(entry?.id == appleCalendar)
@@ -177,13 +179,15 @@ struct CapabilityManifestBuilderTests {
             [appleCalendar],
             subject: .calendar,
             capability: .read,
-            conversationId: "conv-1"
+            conversationId: "conv-1",
+            grantedToInboxId: "agent-1"
         )
 
         let manifest = await CapabilityManifestBuilder().build(
             registry: registry,
             resolver: resolver,
-            conversationId: "conv-1"
+            conversationId: "conv-1",
+            grantedToInboxId: "agent-1"
         )
         let entry = try #require(manifest.providers.first)
         #expect(entry.resolved == ["read": true, "write_create": false])
@@ -215,13 +219,15 @@ struct CapabilityManifestBuilderTests {
             [strava.id, fitbit.id],
             subject: .fitness,
             capability: .read,
-            conversationId: "conv-1"
+            conversationId: "conv-1",
+            grantedToInboxId: "agent-1"
         )
 
         let manifest = await CapabilityManifestBuilder().build(
             registry: registry,
             resolver: resolver,
-            conversationId: "conv-1"
+            conversationId: "conv-1",
+            grantedToInboxId: "agent-1"
         )
         let resolvedReads = manifest.providers.map { $0.resolved["read"] }
         #expect(resolvedReads == [true, true])
@@ -244,18 +250,21 @@ struct CapabilityManifestBuilderTests {
             [appleCalendar],
             subject: .calendar,
             capability: .read,
-            conversationId: "conv-1"
+            conversationId: "conv-1",
+            grantedToInboxId: "agent-1"
         )
 
         let conv1Manifest = await CapabilityManifestBuilder().build(
             registry: registry,
             resolver: resolver,
-            conversationId: "conv-1"
+            conversationId: "conv-1",
+            grantedToInboxId: "agent-1"
         )
         let conv2Manifest = await CapabilityManifestBuilder().build(
             registry: registry,
             resolver: resolver,
-            conversationId: "conv-2"
+            conversationId: "conv-2",
+            grantedToInboxId: "agent-1"
         )
         #expect(conv1Manifest.providers.first?.resolved["read"] == true)
         #expect(conv2Manifest.providers.first?.resolved["read"] == false)
@@ -297,7 +306,8 @@ struct CapabilityManifestBuilderTests {
         let manifest = await CapabilityManifestBuilder().build(
             registry: registry,
             resolver: resolver,
-            conversationId: "conv-1"
+            conversationId: "conv-1",
+            grantedToInboxId: "agent-1"
         )
         let ids = manifest.providers.map(\.id.rawValue)
         #expect(ids == ["composio.fitbit", "composio.strava", "device.calendar"])
@@ -319,7 +329,8 @@ struct CapabilityManifestBuilderTests {
         let manifest = await CapabilityManifestBuilder().build(
             registry: registry,
             resolver: resolver,
-            conversationId: "conv-1"
+            conversationId: "conv-1",
+            grantedToInboxId: "agent-1"
         )
         let entry = try? #require(manifest.providers.first)
         #expect(entry?.available == false)

--- a/ConvosCore/Tests/ConvosCoreTests/CapabilityRequestCodecTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/CapabilityRequestCodecTests.swift
@@ -11,6 +11,7 @@ struct CapabilityRequestCodecTests {
         let codec = CapabilityRequestCodec()
         let request = CapabilityRequest(
             requestId: "req-1",
+            askerInboxId: "agent-1",
             subject: .calendar,
             capability: .read,
             rationale: "To summarize your week",
@@ -27,6 +28,7 @@ struct CapabilityRequestCodecTests {
         let codec = CapabilityRequestCodec()
         let request = CapabilityRequest(
             requestId: "req-1",
+            askerInboxId: "agent-1",
             subject: .calendar,
             capability: .read,
             rationale: "To summarize your week"
@@ -41,6 +43,7 @@ struct CapabilityRequestCodecTests {
         let bloated = String(repeating: "x", count: CapabilityRequest.maxRationaleLength + 100)
         let request = CapabilityRequest(
             requestId: "req-1",
+            askerInboxId: "agent-1",
             subject: .calendar,
             capability: .read,
             rationale: bloated
@@ -56,6 +59,7 @@ struct CapabilityRequestCodecTests {
             .map { ProviderID(rawValue: "composio.x\($0)") }
         let request = CapabilityRequest(
             requestId: "req-1",
+            askerInboxId: "agent-1",
             subject: .calendar,
             capability: .read,
             rationale: "ok",
@@ -81,6 +85,7 @@ struct CapabilityRequestCodecTests {
         let request = CapabilityRequest(
             version: CapabilityRequest.supportedVersion + 1,
             requestId: "req-1",
+            askerInboxId: "agent-1",
             subject: .calendar,
             capability: .read,
             rationale: "ok"
@@ -96,6 +101,7 @@ struct CapabilityRequestCodecTests {
         let codec = CapabilityRequestCodec()
         let request = CapabilityRequest(
             requestId: "req-1",
+            askerInboxId: "agent-1",
             subject: .fitness,
             capability: .read,
             rationale: "ok"
@@ -109,6 +115,7 @@ struct CapabilityRequestCodecTests {
         let codec = CapabilityRequestCodec()
         let request = CapabilityRequest(
             requestId: "req-1",
+            askerInboxId: "agent-1",
             subject: .calendar,
             capability: .read,
             rationale: "ok"

--- a/ConvosCore/Tests/ConvosCoreTests/CapabilityRequestHandlerTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/CapabilityRequestHandlerTests.swift
@@ -34,10 +34,12 @@ struct ComputeLayoutVariantTests {
     private func makeRequest(
         subject: CapabilitySubject = .calendar,
         capability: ConnectionCapability = .read,
-        preferredProviders: [ProviderID]? = nil
+        preferredProviders: [ProviderID]? = nil,
+        askerInboxId: String = "agent-1"
     ) -> CapabilityRequest {
         CapabilityRequest(
             requestId: "req-1",
+            askerInboxId: askerInboxId,
             subject: subject,
             capability: capability,
             rationale: "test",
@@ -161,6 +163,7 @@ struct ComputeLayoutPreferredProvidersTests {
         let layout = await handler.computeLayout(
             request: CapabilityRequest(
                 requestId: "req-1",
+                askerInboxId: "agent-1",
                 subject: .calendar,
                 capability: .read,
                 rationale: "test",
@@ -187,6 +190,7 @@ struct ComputeLayoutPreferredProvidersTests {
         let layout = await handler.computeLayout(
             request: CapabilityRequest(
                 requestId: "req-1",
+                askerInboxId: "agent-1",
                 subject: .fitness,
                 capability: .read,
                 rationale: "test",
@@ -213,6 +217,7 @@ struct ComputeLayoutPreferredProvidersTests {
         let layout = await handler.computeLayout(
             request: CapabilityRequest(
                 requestId: "req-1",
+                askerInboxId: "agent-1",
                 subject: .calendar,
                 capability: .read,
                 rationale: "test",
@@ -248,12 +253,14 @@ struct ComputeLayoutVerbConsentTests {
             [appleCalendar],
             subject: .calendar,
             capability: .read,
-            conversationId: conversationId
+            conversationId: conversationId,
+            grantedToInboxId: "agent-1"
         )
 
         let layout = await handler.computeLayout(
             request: CapabilityRequest(
                 requestId: "req-1",
+                askerInboxId: "agent-1",
                 subject: .calendar,
                 capability: .writeCreate,
                 rationale: "Add an event"
@@ -280,12 +287,14 @@ struct ComputeLayoutVerbConsentTests {
             [strava, fitbit],
             subject: .fitness,
             capability: .read,
-            conversationId: conversationId
+            conversationId: conversationId,
+            grantedToInboxId: "agent-1"
         )
 
         let layout = await handler.computeLayout(
             request: CapabilityRequest(
                 requestId: "req-1",
+                askerInboxId: "agent-1",
                 subject: .fitness,
                 capability: .writeCreate,
                 rationale: "Log a workout"
@@ -311,12 +320,14 @@ struct ComputeLayoutVerbConsentTests {
             [appleCalendar],
             subject: .calendar,
             capability: .read,
-            conversationId: conversationId
+            conversationId: conversationId,
+            grantedToInboxId: "agent-1"
         )
 
         let layout = await handler.computeLayout(
             request: CapabilityRequest(
                 requestId: "req-1",
+                askerInboxId: "agent-1",
                 subject: .calendar,
                 capability: .read,
                 rationale: "test"
@@ -339,6 +350,7 @@ struct ComputeLayoutVerbConsentTests {
         let layout = await handler.computeLayout(
             request: CapabilityRequest(
                 requestId: "req-1",
+                askerInboxId: "agent-1",
                 subject: .calendar,
                 capability: .read,
                 rationale: "test"
@@ -362,6 +374,7 @@ struct CommitDenyCancelTests {
         let resolver = InMemoryCapabilityResolver(registry: registry)
         let request = CapabilityRequest(
             requestId: "req-1",
+            askerInboxId: "agent-1",
             subject: .calendar,
             capability: .read,
             rationale: "test"
@@ -375,7 +388,12 @@ struct CommitDenyCancelTests {
         #expect(result.status == .approved)
         #expect(result.providers == [appleCalendar])
 
-        let stored = await resolver.resolution(subject: .calendar, capability: .read, conversationId: "conv-1")
+        let stored = await resolver.resolution(
+            subject: .calendar,
+            capability: .read,
+            conversationId: "conv-1",
+            grantedToInboxId: "agent-1"
+        )
         #expect(stored == [appleCalendar])
     }
 
@@ -385,6 +403,7 @@ struct CommitDenyCancelTests {
         let resolver = InMemoryCapabilityResolver(registry: registry)
         let request = CapabilityRequest(
             requestId: "req-1",
+            askerInboxId: "agent-1",
             subject: .calendar,
             capability: .read,
             rationale: "test"
@@ -397,7 +416,12 @@ struct CommitDenyCancelTests {
                 conversationId: "conv-1"
             )
         }
-        let stored = await resolver.resolution(subject: .calendar, capability: .read, conversationId: "conv-1")
+        let stored = await resolver.resolution(
+            subject: .calendar,
+            capability: .read,
+            conversationId: "conv-1",
+            grantedToInboxId: "agent-1"
+        )
         #expect(stored.isEmpty, "rejected commit must not persist anything")
     }
 
@@ -407,6 +431,7 @@ struct CommitDenyCancelTests {
         let resolver = InMemoryCapabilityResolver(registry: registry)
         let request = CapabilityRequest(
             requestId: "req-1",
+            askerInboxId: "agent-1",
             subject: .calendar,
             capability: .read,
             rationale: "test"
@@ -414,7 +439,12 @@ struct CommitDenyCancelTests {
         let result = handler.deny(request: request)
         #expect(result.status == .denied)
         #expect(result.providers.isEmpty)
-        let stored = await resolver.resolution(subject: .calendar, capability: .read, conversationId: "conv-1")
+        let stored = await resolver.resolution(
+            subject: .calendar,
+            capability: .read,
+            conversationId: "conv-1",
+            grantedToInboxId: "agent-1"
+        )
         #expect(stored.isEmpty)
     }
 
@@ -422,6 +452,7 @@ struct CommitDenyCancelTests {
     func cancelMatchesShape() {
         let request = CapabilityRequest(
             requestId: "req-1",
+            askerInboxId: "agent-1",
             subject: .calendar,
             capability: .read,
             rationale: "test"

--- a/ConvosCore/Tests/ConvosCoreTests/CapabilityResolutionTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/CapabilityResolutionTests.swift
@@ -184,7 +184,12 @@ struct InMemoryCapabilityResolverTests {
     @Test("empty resolution by default")
     func emptyByDefault() async {
         let resolver = InMemoryCapabilityResolver(registry: InMemoryCapabilityProviderRegistry())
-        let result = await resolver.resolution(subject: .calendar, capability: .read, conversationId: "x")
+        let result = await resolver.resolution(
+            subject: .calendar,
+            capability: .read,
+            conversationId: "x",
+            grantedToInboxId: "agent-1"
+        )
         #expect(result.isEmpty)
     }
 
@@ -195,9 +200,15 @@ struct InMemoryCapabilityResolverTests {
             [appleCalendar],
             subject: .calendar,
             capability: .read,
-            conversationId: "x"
+            conversationId: "x",
+            grantedToInboxId: "agent-1"
         )
-        let result = await resolver.resolution(subject: .calendar, capability: .read, conversationId: "x")
+        let result = await resolver.resolution(
+            subject: .calendar,
+            capability: .read,
+            conversationId: "x",
+            grantedToInboxId: "agent-1"
+        )
         #expect(result == [appleCalendar])
     }
 
@@ -209,7 +220,8 @@ struct InMemoryCapabilityResolverTests {
                 [appleCalendar, googleCalendar],
                 subject: .calendar,
                 capability: .read,
-                conversationId: "x"
+                conversationId: "x",
+                grantedToInboxId: "agent-1"
             )
         }
     }
@@ -221,9 +233,15 @@ struct InMemoryCapabilityResolverTests {
             [strava, fitbit],
             subject: .fitness,
             capability: .read,
-            conversationId: "x"
+            conversationId: "x",
+            grantedToInboxId: "agent-1"
         )
-        let result = await resolver.resolution(subject: .fitness, capability: .read, conversationId: "x")
+        let result = await resolver.resolution(
+            subject: .fitness,
+            capability: .read,
+            conversationId: "x",
+            grantedToInboxId: "agent-1"
+        )
         #expect(result == [strava, fitbit])
     }
 
@@ -235,39 +253,114 @@ struct InMemoryCapabilityResolverTests {
             [strava],
             subject: .fitness,
             capability: .writeCreate,
-            conversationId: "x"
+            conversationId: "x",
+            grantedToInboxId: "agent-1"
         )
         // Federated resolution that should shrink to {fitbit}
         try await resolver.setResolution(
             [strava, fitbit],
             subject: .fitness,
             capability: .read,
-            conversationId: "x"
+            conversationId: "x",
+            grantedToInboxId: "agent-1"
         )
 
         try await resolver.removeProviderFromAllResolutions(strava)
 
-        let writeResult = await resolver.resolution(subject: .fitness, capability: .writeCreate, conversationId: "x")
+        let writeResult = await resolver.resolution(
+            subject: .fitness,
+            capability: .writeCreate,
+            conversationId: "x",
+            grantedToInboxId: "agent-1"
+        )
         #expect(writeResult.isEmpty, "singleton resolution referencing the removed provider should be cleared")
 
-        let readResult = await resolver.resolution(subject: .fitness, capability: .read, conversationId: "x")
+        let readResult = await resolver.resolution(
+            subject: .fitness,
+            capability: .read,
+            conversationId: "x",
+            grantedToInboxId: "agent-1"
+        )
         #expect(readResult == [fitbit], "federated resolution should shrink to remaining providers")
     }
 
     @Test("clearAllResolutions removes every verb for one (subject, conversation)")
     func clearAll() async throws {
         let resolver = InMemoryCapabilityResolver(registry: InMemoryCapabilityProviderRegistry())
-        try await resolver.setResolution([appleCalendar], subject: .calendar, capability: .read, conversationId: "x")
-        try await resolver.setResolution([appleCalendar], subject: .calendar, capability: .writeCreate, conversationId: "x")
-        try await resolver.setResolution([appleCalendar], subject: .calendar, capability: .read, conversationId: "y")
+        try await resolver.setResolution(
+            [appleCalendar],
+            subject: .calendar,
+            capability: .read,
+            conversationId: "x",
+            grantedToInboxId: "agent-1"
+        )
+        try await resolver.setResolution(
+            [appleCalendar],
+            subject: .calendar,
+            capability: .writeCreate,
+            conversationId: "x",
+            grantedToInboxId: "agent-1"
+        )
+        try await resolver.setResolution(
+            [appleCalendar],
+            subject: .calendar,
+            capability: .read,
+            conversationId: "y",
+            grantedToInboxId: "agent-1"
+        )
 
-        try await resolver.clearAllResolutions(subject: .calendar, conversationId: "x")
+        try await resolver.clearAllResolutions(
+            subject: .calendar,
+            conversationId: "x",
+            grantedToInboxId: "agent-1"
+        )
 
-        let xRead = await resolver.resolution(subject: .calendar, capability: .read, conversationId: "x")
-        let xWrite = await resolver.resolution(subject: .calendar, capability: .writeCreate, conversationId: "x")
-        let yRead = await resolver.resolution(subject: .calendar, capability: .read, conversationId: "y")
+        let xRead = await resolver.resolution(
+            subject: .calendar,
+            capability: .read,
+            conversationId: "x",
+            grantedToInboxId: "agent-1"
+        )
+        let xWrite = await resolver.resolution(
+            subject: .calendar,
+            capability: .writeCreate,
+            conversationId: "x",
+            grantedToInboxId: "agent-1"
+        )
+        let yRead = await resolver.resolution(
+            subject: .calendar,
+            capability: .read,
+            conversationId: "y",
+            grantedToInboxId: "agent-1"
+        )
         #expect(xRead.isEmpty)
         #expect(xWrite.isEmpty)
         #expect(yRead == [appleCalendar], "other conversation untouched")
+    }
+
+    @Test("agent scoping — agent A's resolution doesn't bleed into agent B")
+    func agentScoped() async throws {
+        let resolver = InMemoryCapabilityResolver(registry: InMemoryCapabilityProviderRegistry())
+        try await resolver.setResolution(
+            [appleCalendar],
+            subject: .calendar,
+            capability: .read,
+            conversationId: "x",
+            grantedToInboxId: "agent-a"
+        )
+        let bRead = await resolver.resolution(
+            subject: .calendar,
+            capability: .read,
+            conversationId: "x",
+            grantedToInboxId: "agent-b"
+        )
+        #expect(bRead.isEmpty, "agent-b should not see agent-a's grant")
+        let aRead = await resolver.resolution(
+            subject: .calendar,
+            capability: .read,
+            conversationId: "x",
+            grantedToInboxId: "agent-a"
+        )
+        #expect(aRead == [appleCalendar])
     }
 }

--- a/ConvosCore/Tests/ConvosCoreTests/ConnectionGrantWriterTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ConnectionGrantWriterTests.swift
@@ -90,12 +90,14 @@ struct ConnectionGrantWriterTests {
         func seedGrant(
             connectionId: String,
             conversationId: String,
-            serviceId: String
+            serviceId: String,
+            grantedToInboxId: String = "agent-1"
         ) throws {
             let grant = DBCloudConnectionGrant(
                 connectionId: connectionId,
                 conversationId: conversationId,
                 serviceId: serviceId,
+                grantedToInboxId: grantedToInboxId,
                 grantedAt: Date()
             )
             try databaseManager.dbWriter.write { db in
@@ -127,7 +129,7 @@ struct ConnectionGrantWriterTests {
         let conversationId = "conv_1"
         try fixture.seedConversation(id: conversationId)
 
-        try await fixture.writer.grantConnection(connection.id, to: conversationId)
+        try await fixture.writer.grantConnection(connection.id, to: conversationId, grantedToInboxId: "agent-1")
 
         let stored = try fixture.storedGrants(for: conversationId)
         #expect(stored.count == 1)
@@ -162,7 +164,7 @@ struct ConnectionGrantWriterTests {
 
         var caughtExpectedError: Bool = false
         do {
-            try await fixture.writer.grantConnection(connection.id, to: conversationId)
+            try await fixture.writer.grantConnection(connection.id, to: conversationId, grantedToInboxId: "agent-1")
             Issue.record("Expected grantConnection to throw")
         } catch is PublishFailure {
             caughtExpectedError = true
@@ -181,7 +183,7 @@ struct ConnectionGrantWriterTests {
         defer { fixture.cleanup() }
 
         await #expect(throws: CloudConnectionGrantError.self) {
-            try await fixture.writer.grantConnection("missing", to: "conv_x")
+            try await fixture.writer.grantConnection("missing", to: "conv_x", grantedToInboxId: "agent-1")
         }
         #expect(fixture.profileWriter.publishedMetadata.isEmpty)
         let stored = try fixture.storedGrants(for: "conv_x")
@@ -196,7 +198,7 @@ struct ConnectionGrantWriterTests {
         let connection = try fixture.seedConnection(id: "conn_inactive", status: .revoked)
 
         await #expect(throws: CloudConnectionGrantError.self) {
-            try await fixture.writer.grantConnection(connection.id, to: "conv_x")
+            try await fixture.writer.grantConnection(connection.id, to: "conv_x", grantedToInboxId: "agent-1")
         }
         #expect(fixture.profileWriter.publishedMetadata.isEmpty)
     }
@@ -217,7 +219,7 @@ struct ConnectionGrantWriterTests {
             serviceId: connection.serviceId
         )
 
-        try await fixture.writer.revokeGrant(connectionId: connection.id, from: conversationId)
+        try await fixture.writer.revokeGrant(connectionId: connection.id, from: conversationId, grantedToInboxId: "agent-1")
 
         let stored = try fixture.storedGrants(for: conversationId)
         #expect(stored.isEmpty)
@@ -249,7 +251,7 @@ struct ConnectionGrantWriterTests {
 
         var caughtExpectedError: Bool = false
         do {
-            try await fixture.writer.revokeGrant(connectionId: connection.id, from: conversationId)
+            try await fixture.writer.revokeGrant(connectionId: connection.id, from: conversationId, grantedToInboxId: "agent-1")
             Issue.record("Expected revokeGrant to throw")
         } catch is PublishFailure {
             caughtExpectedError = true
@@ -268,7 +270,7 @@ struct ConnectionGrantWriterTests {
         let fixture = Fixture()
         defer { fixture.cleanup() }
 
-        try await fixture.writer.revokeGrant(connectionId: "nope", from: "conv_nope")
+        try await fixture.writer.revokeGrant(connectionId: "nope", from: "conv_nope", grantedToInboxId: "agent-1")
 
         #expect(fixture.profileWriter.publishedMetadata.isEmpty)
         let stored = try fixture.storedGrants(for: "conv_nope")
@@ -287,8 +289,8 @@ struct ConnectionGrantWriterTests {
         let conversationId = "conv_multi"
         try fixture.seedConversation(id: conversationId)
 
-        try await fixture.writer.grantConnection(first.id, to: conversationId)
-        try await fixture.writer.grantConnection(second.id, to: conversationId)
+        try await fixture.writer.grantConnection(first.id, to: conversationId, grantedToInboxId: "agent-1")
+        try await fixture.writer.grantConnection(second.id, to: conversationId, grantedToInboxId: "agent-1")
 
         let stored = try fixture.storedGrants(for: conversationId)
         #expect(stored.count == 2)

--- a/ConvosCore/Tests/ConvosCoreTests/ConnectionManagerTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ConnectionManagerTests.swift
@@ -26,6 +26,7 @@ struct ConnectionManagerTests {
                 connectionId: connectionId,
                 conversationId: conversationId,
                 serviceId: "google_calendar",
+                grantedToInboxId: "agent-1",
                 grantedAt: Date()
             ).insert(db)
         }
@@ -153,6 +154,7 @@ struct ConnectionManagerTests {
                 connectionId: connectionId,
                 conversationId: conversationId,
                 serviceId: "google_calendar",
+                grantedToInboxId: "agent-1",
                 grantedAt: Date()
             ).insert(db)
         }
@@ -202,12 +204,14 @@ struct ConnectionManagerTests {
                 connectionId: staleId,
                 conversationId: "convo-a",
                 serviceId: "google_calendar",
+                grantedToInboxId: "agent-1",
                 grantedAt: Date()
             ).insert(db)
             try DBCloudConnectionGrant(
                 connectionId: staleId,
                 conversationId: "convo-b",
                 serviceId: "google_calendar",
+                grantedToInboxId: "agent-1",
                 grantedAt: Date()
             ).insert(db)
             // Grant on a kept connection — must not trigger any revoke side-effects.
@@ -215,6 +219,7 @@ struct ConnectionManagerTests {
                 connectionId: keepId,
                 conversationId: "convo-a",
                 serviceId: "google_calendar",
+                grantedToInboxId: "agent-1",
                 grantedAt: Date()
             ).insert(db)
         }
@@ -258,12 +263,14 @@ struct ConnectionManagerTests {
                 connectionId: connectionId,
                 conversationId: "convo-a",
                 serviceId: "google_calendar",
+                grantedToInboxId: "agent-1",
                 grantedAt: Date()
             ).insert(db)
             try DBCloudConnectionGrant(
                 connectionId: connectionId,
                 conversationId: "convo-b",
                 serviceId: "google_calendar",
+                grantedToInboxId: "agent-1",
                 grantedAt: Date()
             ).insert(db)
             // Unrelated grant for a different connection — must not trigger republish.
@@ -271,6 +278,7 @@ struct ConnectionManagerTests {
                 connectionId: "conn-other",
                 conversationId: "convo-a",
                 serviceId: "google_calendar",
+                grantedToInboxId: "agent-1",
                 grantedAt: Date()
             ).insert(db)
         }
@@ -340,12 +348,14 @@ struct ConnectionManagerTests {
                 connectionId: connectionId,
                 conversationId: "convo-a",
                 serviceId: "google_calendar",
+                grantedToInboxId: "agent-1",
                 grantedAt: Date()
             ).insert(db)
             try DBCloudConnectionGrant(
                 connectionId: connectionId,
                 conversationId: "convo-b",
                 serviceId: "google_calendar",
+                grantedToInboxId: "agent-1",
                 grantedAt: Date()
             ).insert(db)
         }
@@ -383,6 +393,7 @@ struct ConnectionManagerTests {
                 connectionId: connectionId,
                 conversationId: "convo-a",
                 serviceId: "google_calendar",
+                grantedToInboxId: "agent-1",
                 grantedAt: Date()
             ).insert(db)
         }
@@ -420,6 +431,7 @@ struct ConnectionManagerTests {
                 connectionId: connectionId,
                 conversationId: "convo-a",
                 serviceId: "google_calendar",
+                grantedToInboxId: "agent-1",
                 grantedAt: Date()
             ).insert(db)
         }
@@ -450,6 +462,7 @@ struct ConnectionManagerTests {
                 connectionId: connectionId,
                 conversationId: "convo-a",
                 serviceId: "google_calendar",
+                grantedToInboxId: "agent-1",
                 grantedAt: Date()
             ).insert(db)
         }
@@ -643,6 +656,7 @@ private actor RecordingGrantWriter: CloudConnectionGrantWriterProtocol {
     struct Call: Sendable, Equatable {
         let connectionId: String
         let conversationId: String
+        let grantedToInboxId: String
     }
 
     private var calls: [Call] = []
@@ -656,10 +670,24 @@ private actor RecordingGrantWriter: CloudConnectionGrantWriterProtocol {
         calls
     }
 
-    nonisolated func grantConnection(_ connectionId: String, to conversationId: String) async throws {}
+    nonisolated func grantConnection(
+        _ connectionId: String,
+        to conversationId: String,
+        grantedToInboxId: String
+    ) async throws {}
 
-    func revokeGrant(connectionId: String, from conversationId: String) async throws {
-        calls.append(Call(connectionId: connectionId, conversationId: conversationId))
+    func revokeGrant(
+        connectionId: String,
+        from conversationId: String,
+        grantedToInboxId: String
+    ) async throws {
+        calls.append(
+            Call(
+                connectionId: connectionId,
+                conversationId: conversationId,
+                grantedToInboxId: grantedToInboxId
+            )
+        )
         if shouldThrow {
             throw StubError.republishFailed
         }
@@ -680,6 +708,7 @@ private actor RecordingEventWriter: ConnectionEventWriterProtocol {
     struct Call: Sendable, Equatable {
         let providerId: String
         let capability: ConnectionCapability?
+        let grantedToInboxId: String?
         let conversationId: String
     }
 
@@ -694,13 +723,37 @@ private actor RecordingEventWriter: ConnectionEventWriterProtocol {
     func grantedEvents() -> [Call] { grants }
     func revokedEvents() -> [Call] { revocations }
 
-    func sendGranted(providerId: String, capability: ConnectionCapability?, in conversationId: String) async throws {
-        grants.append(Call(providerId: providerId, capability: capability, conversationId: conversationId))
+    func sendGranted(
+        providerId: String,
+        capability: ConnectionCapability?,
+        grantedToInboxId: String?,
+        in conversationId: String
+    ) async throws {
+        grants.append(
+            Call(
+                providerId: providerId,
+                capability: capability,
+                grantedToInboxId: grantedToInboxId,
+                conversationId: conversationId
+            )
+        )
         if shouldThrow { throw StubError.sendFailed }
     }
 
-    func sendRevoked(providerId: String, capability: ConnectionCapability?, in conversationId: String) async throws {
-        revocations.append(Call(providerId: providerId, capability: capability, conversationId: conversationId))
+    func sendRevoked(
+        providerId: String,
+        capability: ConnectionCapability?,
+        grantedToInboxId: String?,
+        in conversationId: String
+    ) async throws {
+        revocations.append(
+            Call(
+                providerId: providerId,
+                capability: capability,
+                grantedToInboxId: grantedToInboxId,
+                conversationId: conversationId
+            )
+        )
         if shouldThrow { throw StubError.sendFailed }
     }
 
@@ -724,25 +777,29 @@ private actor RecordingResolver: CapabilityResolver {
     func resolution(
         subject: CapabilitySubject,
         capability: ConnectionCapability,
-        conversationId: String
+        conversationId: String,
+        grantedToInboxId: String
     ) async -> Set<ProviderID> { [] }
 
     func setResolution(
         _ providerIds: Set<ProviderID>,
         subject: CapabilitySubject,
         capability: ConnectionCapability,
-        conversationId: String
+        conversationId: String,
+        grantedToInboxId: String
     ) async throws {}
 
     func clearResolution(
         subject: CapabilitySubject,
         capability: ConnectionCapability,
-        conversationId: String
+        conversationId: String,
+        grantedToInboxId: String
     ) async throws {}
 
     func clearAllResolutions(
         subject: CapabilitySubject,
-        conversationId: String
+        conversationId: String,
+        grantedToInboxId: String
     ) async throws {}
 
     func removeProviderFromAllResolutions(_ providerId: ProviderID) async throws {

--- a/ConvosCore/Tests/ConvosCoreTests/ConnectionManagerTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ConnectionManagerTests.swift
@@ -807,6 +807,11 @@ private actor RecordingResolver: CapabilityResolver {
         if shouldThrow { throw StubError.removeFailed }
     }
 
+    func removeProvider(_ providerId: ProviderID, fromConversation conversationId: String) async throws {
+        removed.append(providerId)
+        if shouldThrow { throw StubError.removeFailed }
+    }
+
     enum StubError: Error {
         case removeFailed
     }

--- a/ConvosCore/Tests/ConvosCoreTests/ConnectionRepositoryTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ConnectionRepositoryTests.swift
@@ -77,12 +77,14 @@ struct ConnectionRepositoryTests {
         func seedGrant(
             connectionId: String = "conn_google_cal",
             conversationId: String,
-            serviceId: String = "google_calendar"
+            serviceId: String = "google_calendar",
+            grantedToInboxId: String = "agent-1"
         ) throws {
             let grant = DBCloudConnectionGrant(
                 connectionId: connectionId,
                 conversationId: conversationId,
                 serviceId: serviceId,
+                grantedToInboxId: grantedToInboxId,
                 grantedAt: Date()
             )
             try databaseManager.dbWriter.write { db in

--- a/ConvosCore/Tests/ConvosCoreTests/ConnectionsMetadataPayloadTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ConnectionsMetadataPayloadTests.swift
@@ -7,6 +7,7 @@ struct ConnectionsMetadataPayloadTests {
     private func entry(
         id: String = "grant_conn_123",
         senderId: String = "sender_abc",
+        grantedToInboxId: String = "agent_xyz",
         service: String = "google_calendar",
         provider: String = "composio",
         scope: String = "conversation",
@@ -17,6 +18,7 @@ struct ConnectionsMetadataPayloadTests {
         CloudConnectionGrantEntry(
             id: id,
             senderId: senderId,
+            grantedToInboxId: grantedToInboxId,
             service: service,
             provider: provider,
             scope: scope,
@@ -80,6 +82,7 @@ struct ConnectionsMetadataPayloadTests {
               "scope": "conversation",
               "composioEntityId": "B8813E83",
               "composioConnectionId": "ca_foo",
+              "grantedToInboxId": "agent_inbox_99",
               "grantedAt": "2026-04-21T15:33:01Z"
             }
           ]
@@ -97,6 +100,7 @@ struct ConnectionsMetadataPayloadTests {
         #expect(grant.scope == "conversation")
         #expect(grant.composioEntityId == "B8813E83")
         #expect(grant.composioConnectionId == "ca_foo")
+        #expect(grant.grantedToInboxId == "agent_inbox_99")
         #expect(grant.grantedAt == "2026-04-21T15:33:01Z")
     }
 

--- a/ConvosCore/Tests/ConvosCoreTests/GRDBCapabilityResolverTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/GRDBCapabilityResolverTests.swift
@@ -9,6 +9,7 @@ struct GRDBCapabilityResolverTests {
     private let strava: ProviderID = ProviderID(rawValue: "composio.strava")
     private let fitbit: ProviderID = ProviderID(rawValue: "composio.fitbit")
     private let appleCalendar: ProviderID = ProviderID(rawValue: "device.calendar")
+    private let agent: String = "agent-1"
 
     private func makeDatabase() throws -> DatabaseQueue {
         let dbQueue = try DatabaseQueue(configuration: {
@@ -45,7 +46,12 @@ struct GRDBCapabilityResolverTests {
     func emptyByDefault() async throws {
         let db = try makeDatabase()
         let resolver = makeResolver(db)
-        let result = await resolver.resolution(subject: .calendar, capability: .read, conversationId: "conv-1")
+        let result = await resolver.resolution(
+            subject: .calendar,
+            capability: .read,
+            conversationId: "conv-1",
+            grantedToInboxId: agent
+        )
         #expect(result.isEmpty)
     }
 
@@ -57,9 +63,15 @@ struct GRDBCapabilityResolverTests {
             [appleCalendar],
             subject: .calendar,
             capability: .read,
-            conversationId: "conv-1"
+            conversationId: "conv-1",
+            grantedToInboxId: agent
         )
-        let result = await resolver.resolution(subject: .calendar, capability: .read, conversationId: "conv-1")
+        let result = await resolver.resolution(
+            subject: .calendar,
+            capability: .read,
+            conversationId: "conv-1",
+            grantedToInboxId: agent
+        )
         #expect(result == [appleCalendar])
     }
 
@@ -71,9 +83,15 @@ struct GRDBCapabilityResolverTests {
             [strava, fitbit],
             subject: .fitness,
             capability: .read,
-            conversationId: "conv-1"
+            conversationId: "conv-1",
+            grantedToInboxId: agent
         )
-        let result = await resolver.resolution(subject: .fitness, capability: .read, conversationId: "conv-1")
+        let result = await resolver.resolution(
+            subject: .fitness,
+            capability: .read,
+            conversationId: "conv-1",
+            grantedToInboxId: agent
+        )
         #expect(result == [strava, fitbit])
     }
 
@@ -86,11 +104,17 @@ struct GRDBCapabilityResolverTests {
                 [appleCalendar, ProviderID(rawValue: "composio.google_calendar")],
                 subject: .calendar,
                 capability: .read,
-                conversationId: "conv-1"
+                conversationId: "conv-1",
+                grantedToInboxId: agent
             )
         }
         // And the row was never persisted.
-        let result = await resolver.resolution(subject: .calendar, capability: .read, conversationId: "conv-1")
+        let result = await resolver.resolution(
+            subject: .calendar,
+            capability: .read,
+            conversationId: "conv-1",
+            grantedToInboxId: agent
+        )
         #expect(result.isEmpty)
     }
 
@@ -113,13 +137,15 @@ struct GRDBCapabilityResolverTests {
             [strava],
             subject: .fitness,
             capability: .read,
-            conversationId: "conv-1"
+            conversationId: "conv-1",
+            grantedToInboxId: agent
         )
         try await resolver.setResolution(
             [strava, fitbit],
             subject: .fitness,
             capability: .read,
-            conversationId: "conv-1"
+            conversationId: "conv-1",
+            grantedToInboxId: agent
         )
 
         let row = try await db.read { db in
@@ -141,48 +167,186 @@ struct GRDBCapabilityResolverTests {
     func clearOneVerb() async throws {
         let db = try makeDatabase()
         let resolver = makeResolver(db)
-        try await resolver.setResolution([appleCalendar], subject: .calendar, capability: .read, conversationId: "conv-1")
-        try await resolver.setResolution([appleCalendar], subject: .calendar, capability: .writeCreate, conversationId: "conv-1")
+        try await resolver.setResolution(
+            [appleCalendar],
+            subject: .calendar,
+            capability: .read,
+            conversationId: "conv-1",
+            grantedToInboxId: agent
+        )
+        try await resolver.setResolution(
+            [appleCalendar],
+            subject: .calendar,
+            capability: .writeCreate,
+            conversationId: "conv-1",
+            grantedToInboxId: agent
+        )
 
-        try await resolver.clearResolution(subject: .calendar, capability: .read, conversationId: "conv-1")
+        try await resolver.clearResolution(
+            subject: .calendar,
+            capability: .read,
+            conversationId: "conv-1",
+            grantedToInboxId: agent
+        )
 
-        let read = await resolver.resolution(subject: .calendar, capability: .read, conversationId: "conv-1")
-        let write = await resolver.resolution(subject: .calendar, capability: .writeCreate, conversationId: "conv-1")
+        let read = await resolver.resolution(
+            subject: .calendar,
+            capability: .read,
+            conversationId: "conv-1",
+            grantedToInboxId: agent
+        )
+        let write = await resolver.resolution(
+            subject: .calendar,
+            capability: .writeCreate,
+            conversationId: "conv-1",
+            grantedToInboxId: agent
+        )
         #expect(read.isEmpty)
         #expect(write == [appleCalendar])
     }
 
-    @Test("clearAllResolutions scoped to one (subject, conversation)")
+    @Test("clearAllResolutions scoped to one (subject, conversation, agent)")
     func clearAllScoped() async throws {
         let db = try makeDatabase()
         let resolver = makeResolver(db)
-        try await resolver.setResolution([appleCalendar], subject: .calendar, capability: .read, conversationId: "conv-1")
-        try await resolver.setResolution([appleCalendar], subject: .calendar, capability: .writeCreate, conversationId: "conv-1")
-        try await resolver.setResolution([appleCalendar], subject: .calendar, capability: .read, conversationId: "conv-2")
+        try await resolver.setResolution(
+            [appleCalendar],
+            subject: .calendar,
+            capability: .read,
+            conversationId: "conv-1",
+            grantedToInboxId: agent
+        )
+        try await resolver.setResolution(
+            [appleCalendar],
+            subject: .calendar,
+            capability: .writeCreate,
+            conversationId: "conv-1",
+            grantedToInboxId: agent
+        )
+        try await resolver.setResolution(
+            [appleCalendar],
+            subject: .calendar,
+            capability: .read,
+            conversationId: "conv-2",
+            grantedToInboxId: agent
+        )
 
-        try await resolver.clearAllResolutions(subject: .calendar, conversationId: "conv-1")
+        try await resolver.clearAllResolutions(
+            subject: .calendar,
+            conversationId: "conv-1",
+            grantedToInboxId: agent
+        )
 
-        let conv1Read = await resolver.resolution(subject: .calendar, capability: .read, conversationId: "conv-1")
-        let conv1Write = await resolver.resolution(subject: .calendar, capability: .writeCreate, conversationId: "conv-1")
-        let conv2Read = await resolver.resolution(subject: .calendar, capability: .read, conversationId: "conv-2")
+        let conv1Read = await resolver.resolution(
+            subject: .calendar,
+            capability: .read,
+            conversationId: "conv-1",
+            grantedToInboxId: agent
+        )
+        let conv1Write = await resolver.resolution(
+            subject: .calendar,
+            capability: .writeCreate,
+            conversationId: "conv-1",
+            grantedToInboxId: agent
+        )
+        let conv2Read = await resolver.resolution(
+            subject: .calendar,
+            capability: .read,
+            conversationId: "conv-2",
+            grantedToInboxId: agent
+        )
         #expect(conv1Read.isEmpty)
         #expect(conv1Write.isEmpty)
         #expect(conv2Read == [appleCalendar], "other conversation untouched")
+    }
+
+    @Test("clearAllResolutions for one agent leaves a peer agent's rows intact")
+    func clearAllScopedToAgent() async throws {
+        let db = try makeDatabase()
+        let resolver = makeResolver(db)
+        try await resolver.setResolution(
+            [appleCalendar],
+            subject: .calendar,
+            capability: .read,
+            conversationId: "conv-1",
+            grantedToInboxId: "agent-a"
+        )
+        try await resolver.setResolution(
+            [appleCalendar],
+            subject: .calendar,
+            capability: .read,
+            conversationId: "conv-1",
+            grantedToInboxId: "agent-b"
+        )
+
+        try await resolver.clearAllResolutions(
+            subject: .calendar,
+            conversationId: "conv-1",
+            grantedToInboxId: "agent-a"
+        )
+
+        let aRead = await resolver.resolution(
+            subject: .calendar,
+            capability: .read,
+            conversationId: "conv-1",
+            grantedToInboxId: "agent-a"
+        )
+        let bRead = await resolver.resolution(
+            subject: .calendar,
+            capability: .read,
+            conversationId: "conv-1",
+            grantedToInboxId: "agent-b"
+        )
+        #expect(aRead.isEmpty)
+        #expect(bRead == [appleCalendar], "peer agent's grant untouched")
     }
 
     @Test("removeProviderFromAllResolutions shrinks federated sets and clears singletons")
     func removeProvider() async throws {
         let db = try makeDatabase()
         let resolver = makeResolver(db)
-        try await resolver.setResolution([strava, fitbit], subject: .fitness, capability: .read, conversationId: "conv-1")
-        try await resolver.setResolution([strava], subject: .fitness, capability: .writeCreate, conversationId: "conv-1")
-        try await resolver.setResolution([appleCalendar], subject: .calendar, capability: .read, conversationId: "conv-1")
+        try await resolver.setResolution(
+            [strava, fitbit],
+            subject: .fitness,
+            capability: .read,
+            conversationId: "conv-1",
+            grantedToInboxId: agent
+        )
+        try await resolver.setResolution(
+            [strava],
+            subject: .fitness,
+            capability: .writeCreate,
+            conversationId: "conv-1",
+            grantedToInboxId: agent
+        )
+        try await resolver.setResolution(
+            [appleCalendar],
+            subject: .calendar,
+            capability: .read,
+            conversationId: "conv-1",
+            grantedToInboxId: agent
+        )
 
         try await resolver.removeProviderFromAllResolutions(strava)
 
-        let read = await resolver.resolution(subject: .fitness, capability: .read, conversationId: "conv-1")
-        let write = await resolver.resolution(subject: .fitness, capability: .writeCreate, conversationId: "conv-1")
-        let calendar = await resolver.resolution(subject: .calendar, capability: .read, conversationId: "conv-1")
+        let read = await resolver.resolution(
+            subject: .fitness,
+            capability: .read,
+            conversationId: "conv-1",
+            grantedToInboxId: agent
+        )
+        let write = await resolver.resolution(
+            subject: .fitness,
+            capability: .writeCreate,
+            conversationId: "conv-1",
+            grantedToInboxId: agent
+        )
+        let calendar = await resolver.resolution(
+            subject: .calendar,
+            capability: .read,
+            conversationId: "conv-1",
+            grantedToInboxId: agent
+        )
         #expect(read == [fitbit], "federated set should shrink to remaining providers")
         #expect(write.isEmpty, "singleton resolution referencing removed provider should be cleared")
         #expect(calendar == [appleCalendar], "unrelated row untouched")
@@ -196,14 +360,20 @@ struct GRDBCapabilityResolverTests {
             [appleCalendar],
             subject: .calendar,
             capability: .read,
-            conversationId: "conv-1"
+            conversationId: "conv-1",
+            grantedToInboxId: agent
         )
 
         try await db.write { db in
             try db.execute(sql: "DELETE FROM conversation WHERE id = ?", arguments: ["conv-1"])
         }
 
-        let result = await resolver.resolution(subject: .calendar, capability: .read, conversationId: "conv-1")
+        let result = await resolver.resolution(
+            subject: .calendar,
+            capability: .read,
+            conversationId: "conv-1",
+            grantedToInboxId: agent
+        )
         #expect(result.isEmpty)
     }
 }

--- a/ConvosCore/Tests/ConvosCoreTests/HealthInvocationRouterTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/HealthInvocationRouterTests.swift
@@ -6,6 +6,7 @@ import Testing
 @Suite("HealthInvocationRouter")
 struct HealthInvocationRouterTests {
     private static let conversationId: String = "conv-1"
+    static let invokerInboxId: String = "agent-1"
     private static let agentInboxId: String = "agent-1"
 
     // MARK: - intercepts(_:)
@@ -134,7 +135,12 @@ struct HealthInvocationRouterTests {
         static func make(readEnabled: Bool, tests: HealthInvocationRouterTests = .init()) async -> Harness {
             let enablementStore = readEnabled
                 ? InMemoryEnablementStore(initial: [
-                    Enablement(kind: .health, capability: .read, conversationId: HealthInvocationRouterTests.conversationId),
+                    Enablement(
+                        kind: .health,
+                        capability: .read,
+                        conversationId: HealthInvocationRouterTests.conversationId,
+                        grantedToInboxId: HealthInvocationRouterTests.invokerInboxId
+                    ),
                 ])
                 : InMemoryEnablementStore()
 


### PR DESCRIPTION
## Summary
- Pivots `CapabilityResolution`, `ConnectionEnablement`, and `CloudConnectionGrant` from per-conversation to per-(conversation, agent). Each agent in a conversation now has independent rows; one agent's grant no longer authorizes another.
- Adds required `askerInboxId` to `capability_request` and optional `grantedToInboxId` to `connection_event` + the `CloudConnectionGrantEntry` metadata payload.
- Replaces the snapshot-flicker `.verifiedAssistant` actor with live `agentNamesByInboxId` lookup so ProfileUpdate-driven renames propagate without re-running `MessagesListProcessor`.
- Drop+recreate GRDB migration `scopeGrantsToAgentInboxId` (acceptable since the connections feature hasn't shipped).

## Why
Two assistants in the same conversation should not share grants. With the old per-conversation scoping, granting calendar to Fitness Trainer also implicitly authorized Calendar Buddy. This rewires storage + wire payloads + UI so `(conversation, agent, capability)` is the unit, with the runtime enforcing per-agent targeting via the existing agent-ignorable validation rule.

The renderer rebuild is paired with this work because the old `.first(where: \\.isVerifiedAssistant)` plumbing flickered between "Assistant" and the agent's profile name during attestation re-verification cycles. Replacing it with `agentNamesByInboxId[summary.grantedToInboxId]` keyed off the conversation's live members eliminates the flicker and correctly credits *which* agent received a grant.

## Wire-contract changes
- **`CapabilityRequest`**: required new field `askerInboxId: String`. Agents emitting requests MUST populate; iOS now decodes as required.
- **`ConnectionEvent`**: optional new field `grantedToInboxId: String?`. Backward-compatible (decodeIfPresent / encodeIfPresent).
- **`CloudConnectionsMetadataPayload.CloudConnectionGrantEntry`**: required new field `grantedToInboxId: String`. iOS publishes one entry per (agent × connection × conversation). The agent-side runtime should filter to entries where `grantedToInboxId == myInboxId`.

## Cross-repo impact
The JS side (`convos-cli`, `convos-assistants`) needs paired updates so the runtime stays in sync — see the punch list in this PR's review thread for concrete files/lines. The iOS PR can land first only if `askerInboxId` is loosened to optional on decode as a bridge; current iOS commit makes it required. Recommended order:
1. Land convos-cli decode-loosening + filter updates first.
2. Land iOS PR after (3) below is deployed.
3. Land convos-cli emit-populate (`askerInboxId`).

## Test plan
- [x] `xcodebuild build -scheme \"Convos (Dev)\"` clean.
- [x] `swift test --package-path ConvosCore` — 819 tests pass (110 suites). Includes new agent-scoping tests for `InMemoryCapabilityResolver`, `GRDBCapabilityResolver`, `CapabilityInvocationRouter`, plus `clearAllResolutions` peer-isolation.
- [x] `swiftlint` clean.
- [ ] Manual: in a conversation with two verified agents, approve a capability request from agent A — verify agent B does not see the grant exercised on its behalf.
- [ ] Manual: rename an agent via ProfileUpdate while a `connection_event` is on screen — verify the rendered name updates without re-running the messages list.
- [ ] Manual: toggle a device connection in Conversation Info with two agents present — verify a single connection_event line ("<first agent name> has access to …") rather than N noisy duplicates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/812"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Scope capability grants, enablement checks, and connection events per agent inbox ID
> - Adds `grantedToInboxId` to capability resolutions, enablement records, connection grants, and connection events so that grants are distinct per agent rather than per conversation.
> - A new database migration (`scopeGrantsToAgentInboxId`) drops and recreates `capabilityResolution`, `connectionEnablement`, and `connectionGrant` tables with `grantedToInboxId` as part of the primary key; existing data is lost.
> - `ConversationConnectionsViewModel` fans out enable/disable, grant, and revoke operations to every agent in the conversation, then emits a single representative connection event.
> - `CapabilityRequest` now carries `askerInboxId` on the wire; `CapabilityRequestHandler` and `CapabilityInvocationRouter` use it so one agent's approval does not satisfy another agent's invocation.
> - `ConnectionEventSummaryView` and related cell/data-source types drop `verifiedAssistantName`; grant/revoke summaries now resolve the agent display name from `memberProfiles` via the new `.grantedAgent` actor.
> - Risk: the database migration is destructive — all existing capability resolution, enablement, and connection grant rows are dropped on upgrade.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #812 opened
>
> - Fixed `ConversationConnectionsViewModel.toggleDeviceConnection` to correctly send a revoke event when any agent had any capability enabled for a device connection kind, regardless of whether read capability was enabled [c910805]
> - Added `ConversationConnectionsViewModel.isAnyCapabilityEnabled(kind:agents:)` helper method and refactored `ConversationConnectionsViewModel.refreshDeviceConnections` to use it [c910805]
> - Modified `ConversationConnectionsViewModel` to use the first agent that was actually written to as the representative when posting capability grant and revoke events [13e33d9]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 834f7c7.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->