### PR TITLE
Replace tabbed Files & Links with unified Stuff view

### DIFF
--- a/Convos/Conversation Detail/AssistantFilesLinksView.swift
+++ b/Convos/Conversation Detail/AssistantFilesLinksView.swift
@@ -231,46 +231,42 @@ struct AssistantFilesLinksView: View {
     }
 
     private func fileRow(_ file: AssistantFile) -> some View {
-        let action = {
-            Task {
-                do {
-                    let url = try await FileAttachmentPreviewLoader.loadPreviewURL(
+        FileRow(
+            file: file,
+            subtitle: relativeDate(for: file.date),
+            onTap: { openFile(file) }
+        )
+    }
+
+    private func openFile(_ file: AssistantFile) {
+        Task {
+            do {
+                let url = try await FileAttachmentPreviewLoader.loadPreviewURL(
+                    key: file.attachmentKey,
+                    filename: file.filename
+                )
+                await MainActor.run {
+                    let hydrated = HydratedAttachment(
                         key: file.attachmentKey,
+                        mimeType: file.mimeType,
+                        thumbnailDataBase64: file.thumbnailDataBase64,
                         filename: file.filename
                     )
-                    await MainActor.run {
-                        let hydrated = HydratedAttachment(
-                            key: file.attachmentKey,
-                            mimeType: file.mimeType,
-                            thumbnailDataBase64: file.thumbnailDataBase64,
-                            filename: file.filename
-                        )
-                        presentingPreview = AttachmentPreviewPresentation(
-                            id: file.id,
-                            attachment: hydrated,
-                            fileURL: url,
-                            sender: member(forInboxId: file.senderInboxId),
-                            sentAt: file.date
-                        )
-                    }
-                } catch {
-                    Log.error("Failed to open assistant file: \(error)")
-                    await MainActor.run {
-                        viewModel.fileOpenError = "This file is no longer available on this device."
-                    }
+                    presentingPreview = AttachmentPreviewPresentation(
+                        id: file.id,
+                        attachment: hydrated,
+                        fileURL: url,
+                        sender: member(forInboxId: file.senderInboxId),
+                        sentAt: file.date
+                    )
+                }
+            } catch {
+                Log.error("Failed to open assistant file: \(error)")
+                await MainActor.run {
+                    viewModel.fileOpenError = "This file is no longer available on this device."
                 }
             }
-            return
         }
-        return Button(action: action) {
-            StuffRowContent(
-                thumbnail: { fileThumbnail(file) },
-                title: file.displayName,
-                subtitle: relativeDate(for: file.date),
-                trailingSymbol: "doc"
-            )
-        }
-        .buttonStyle(.plain)
     }
 
     private func linkRow(_ link: AssistantLink) -> some View {
@@ -288,41 +284,6 @@ struct AssistantFilesLinksView: View {
             )
         }
         .buttonStyle(.plain)
-    }
-
-    @ViewBuilder
-    private func fileThumbnail(_ file: AssistantFile) -> some View {
-        if let cached = htmlPreview(for: file) {
-            Image(uiImage: cached)
-                .resizable()
-                .aspectRatio(contentMode: .fill)
-        } else if let base64 = file.thumbnailDataBase64,
-                  let data = Data(base64Encoded: base64),
-                  let uiImage = UIImage(data: data) {
-            Image(uiImage: uiImage)
-                .resizable()
-                .aspectRatio(contentMode: .fill)
-        } else {
-            RoundedRectangle(cornerRadius: DesignConstants.CornerRadius.small)
-                .fill(Color.colorFillMinimal)
-                .overlay {
-                    Image(systemName: "doc.fill")
-                        .foregroundStyle(.colorTextSecondary)
-                }
-        }
-    }
-
-    private func htmlPreview(for file: AssistantFile) -> UIImage? {
-        guard isHTML(file: file) else { return nil }
-        return HTMLThumbnailRenderer.shared.cachedThumbnail(for: file.attachmentKey)
-    }
-
-    private func isHTML(file: AssistantFile) -> Bool {
-        if let filename = file.filename {
-            let ext = (filename as NSString).pathExtension.lowercased()
-            if ["html", "htm"].contains(ext) { return true }
-        }
-        return file.mimeType?.lowercased() == "text/html"
     }
 
     @ViewBuilder
@@ -359,6 +320,98 @@ struct AssistantFilesLinksView: View {
 
     private enum Constant {
         static let dividerInset: CGFloat = 80.0
+    }
+}
+
+private struct FileRow: View {
+    let file: AssistantFile
+    let subtitle: String
+    let onTap: () -> Void
+
+    @State private var renderedHTMLPreview: UIImage?
+    @State private var resolvedHTMLTitle: String?
+
+    var body: some View {
+        Button(action: onTap) {
+            StuffRowContent(
+                thumbnail: { thumbnail },
+                title: displayTitle,
+                subtitle: subtitle,
+                trailingSymbol: "doc"
+            )
+        }
+        .buttonStyle(.plain)
+        .task(id: file.attachmentKey) {
+            await loadHTMLMetadataIfNeeded()
+        }
+    }
+
+    private var displayTitle: String {
+        if let resolvedHTMLTitle, !resolvedHTMLTitle.isEmpty {
+            return resolvedHTMLTitle
+        }
+        return file.displayName
+    }
+
+    @ViewBuilder
+    private var thumbnail: some View {
+        if let renderedHTMLPreview {
+            Image(uiImage: renderedHTMLPreview)
+                .resizable()
+                .aspectRatio(contentMode: .fill)
+        } else if let base64 = file.thumbnailDataBase64,
+                  let data = Data(base64Encoded: base64),
+                  let uiImage = UIImage(data: data) {
+            Image(uiImage: uiImage)
+                .resizable()
+                .aspectRatio(contentMode: .fill)
+        } else {
+            RoundedRectangle(cornerRadius: DesignConstants.CornerRadius.small)
+                .fill(Color.colorFillMinimal)
+                .overlay {
+                    Image(systemName: "doc.fill")
+                        .foregroundStyle(.colorTextSecondary)
+                }
+        }
+    }
+
+    private var isHTML: Bool {
+        if let filename = file.filename {
+            let ext = (filename as NSString).pathExtension.lowercased()
+            if ["html", "htm"].contains(ext) { return true }
+        }
+        return file.mimeType?.lowercased() == "text/html"
+    }
+
+    private func loadHTMLMetadataIfNeeded() async {
+        guard isHTML else { return }
+
+        renderedHTMLPreview = HTMLThumbnailRenderer.shared.cachedThumbnail(for: file.attachmentKey)
+        resolvedHTMLTitle = HTMLPageMetadata.shared.cachedTitle(for: file.attachmentKey)
+
+        if renderedHTMLPreview != nil, resolvedHTMLTitle != nil { return }
+
+        do {
+            let url = try await FileAttachmentPreviewLoader.loadPreviewURL(
+                key: file.attachmentKey,
+                filename: file.filename
+            )
+
+            if renderedHTMLPreview == nil {
+                renderedHTMLPreview = await HTMLThumbnailRenderer.shared.thumbnail(
+                    for: file.attachmentKey,
+                    fileURL: url
+                )
+            }
+            if resolvedHTMLTitle == nil {
+                resolvedHTMLTitle = await HTMLPageMetadata.shared.title(
+                    for: file.attachmentKey,
+                    fileURL: url
+                )
+            }
+        } catch {
+            Log.error("Failed to load Stuff list HTML metadata: \(error)")
+        }
     }
 }
 

--- a/Convos/Conversation Detail/AssistantFilesLinksView.swift
+++ b/Convos/Conversation Detail/AssistantFilesLinksView.swift
@@ -494,6 +494,7 @@ private struct StuffSearchBar: View {
                 .glassEffect(.regular.interactive(), in: .circle)
         }
         .accessibilityLabel("Filter")
+        .accessibilityValue(filter.rawValue)
         .accessibilityIdentifier("stuff-filter-button")
     }
 }

--- a/Convos/Conversation Detail/AssistantFilesLinksView.swift
+++ b/Convos/Conversation Detail/AssistantFilesLinksView.swift
@@ -2,15 +2,37 @@ import ConvosCore
 import SwiftUI
 import UniformTypeIdentifiers
 
-enum AssistantFilesLinksTab: String, CaseIterable {
-    case files = "Files"
+enum StuffFilter: String, CaseIterable, Identifiable {
+    case all = "All"
     case links = "Links"
+    case files = "Files"
+
+    var id: String { rawValue }
+}
+
+enum StuffItem: Identifiable {
+    case file(AssistantFile)
+    case link(AssistantLink)
+
+    var id: String {
+        switch self {
+        case .file(let file): return "file-\(file.id)"
+        case .link(let link): return "link-\(link.id)"
+        }
+    }
+
+    var date: Date {
+        switch self {
+        case .file(let file): return file.date
+        case .link(let link): return link.date
+        }
+    }
 }
 
 @MainActor
 @Observable
 class AssistantFilesLinksViewModel {
-    var selectedTab: AssistantFilesLinksTab = .files
+    var filter: StuffFilter = .all
     var searchText: String = ""
     var files: [AssistantFile] = []
     var links: [AssistantLink] = []
@@ -23,19 +45,36 @@ class AssistantFilesLinksViewModel {
         self.repository = repository
     }
 
-    var filteredFiles: [AssistantFile] {
-        guard !searchText.isEmpty else { return files }
+    var filteredItems: [StuffItem] {
         let query = searchText.lowercased()
-        return files.filter { $0.displayName.lowercased().contains(query) }
+
+        var items: [StuffItem] = []
+
+        if filter == .all || filter == .files {
+            for file in files where matches(file: file, query: query) {
+                items.append(.file(file))
+            }
+        }
+
+        if filter == .all || filter == .links {
+            for link in links where matches(link: link, query: query) {
+                items.append(.link(link))
+            }
+        }
+
+        items.sort { $0.date > $1.date }
+        return items
     }
 
-    var filteredLinks: [AssistantLink] {
-        guard !searchText.isEmpty else { return links }
-        let query = searchText.lowercased()
-        return links.filter {
-            $0.displayTitle.lowercased().contains(query)
-            || $0.url.lowercased().contains(query)
-        }
+    private func matches(file: AssistantFile, query: String) -> Bool {
+        guard !query.isEmpty else { return true }
+        return file.displayName.lowercased().contains(query)
+    }
+
+    private func matches(link: AssistantLink, query: String) -> Bool {
+        guard !query.isEmpty else { return true }
+        return link.displayTitle.lowercased().contains(query)
+            || link.url.lowercased().contains(query)
     }
 
     func load() async {
@@ -60,47 +99,25 @@ struct AssistantFilesLinksView: View {
     }
 
     var body: some View {
-        VStack(spacing: 0) {
-            Picker("", selection: $viewModel.selectedTab) {
-                ForEach(AssistantFilesLinksTab.allCases, id: \.self) { tab in
-                    Text(tab.rawValue).tag(tab)
-                }
-            }
-            .pickerStyle(.segmented)
-            .padding(.horizontal, DesignConstants.Spacing.step4x)
-            .padding(.vertical, DesignConstants.Spacing.step2x)
-
-            HStack(spacing: DesignConstants.Spacing.step2x) {
-                Image(systemName: "magnifyingglass")
-                    .foregroundStyle(.colorTextSecondary)
-                TextField("Search", text: $viewModel.searchText)
-                    .textFieldStyle(.plain)
-                    .accessibilityIdentifier("files-links-search-field")
-            }
-            .padding(.horizontal, DesignConstants.Spacing.step3x)
-            .padding(.vertical, DesignConstants.Spacing.step2x)
-            .background(
-                RoundedRectangle(cornerRadius: DesignConstants.CornerRadius.regular)
-                    .fill(Color.colorFillMinimal)
-            )
-            .padding(.horizontal, DesignConstants.Spacing.step4x)
-
+        Group {
             if viewModel.isLoading {
-                Spacer()
                 ProgressView()
-                Spacer()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else if viewModel.filteredItems.isEmpty {
+                emptyState
             } else {
-                switch viewModel.selectedTab {
-                case .files:
-                    filesTab
-                case .links:
-                    linksTab
-                }
+                itemList
             }
         }
-        .navigationTitle("Files & Links")
-        .navigationBarTitleDisplayMode(.inline)
+        .navigationTitle("Stuff")
+        .navigationBarTitleDisplayMode(.large)
         .background(.colorBackgroundRaisedSecondary)
+        .safeAreaInset(edge: .bottom) {
+            StuffSearchBar(
+                searchText: $viewModel.searchText,
+                filter: $viewModel.filter
+            )
+        }
         .task {
             await viewModel.load()
         }
@@ -116,39 +133,45 @@ struct AssistantFilesLinksView: View {
         }
     }
 
-    @ViewBuilder
-    private var filesTab: some View {
-        if viewModel.filteredFiles.isEmpty {
-            emptyState(text: viewModel.searchText.isEmpty ? "No files yet" : "No files match your search")
-        } else {
-            ScrollView {
-                LazyVStack(spacing: 0) {
-                    ForEach(viewModel.filteredFiles) { file in
-                        fileRow(file)
-                        Divider()
-                            .padding(.leading, 80.0)
-                    }
+    private var itemList: some View {
+        ScrollView {
+            LazyVStack(spacing: 0) {
+                ForEach(viewModel.filteredItems) { item in
+                    row(for: item)
+                    Divider()
+                        .padding(.leading, Constant.dividerInset)
                 }
-                .padding(.top, DesignConstants.Spacing.step2x)
             }
+            .padding(.top, DesignConstants.Spacing.step2x)
+        }
+    }
+
+    private var emptyState: some View {
+        VStack {
+            Spacer()
+            Text(emptyStateText)
+                .font(.body)
+                .foregroundStyle(.colorTextSecondary)
+            Spacer()
+        }
+    }
+
+    private var emptyStateText: String {
+        if !viewModel.searchText.isEmpty { return "Nothing matches your search" }
+        switch viewModel.filter {
+        case .all: return "Nothing here yet"
+        case .files: return "No files yet"
+        case .links: return "No links yet"
         }
     }
 
     @ViewBuilder
-    private var linksTab: some View {
-        if viewModel.filteredLinks.isEmpty {
-            emptyState(text: viewModel.searchText.isEmpty ? "No links yet" : "No links match your search")
-        } else {
-            ScrollView {
-                LazyVStack(spacing: 0) {
-                    ForEach(viewModel.filteredLinks) { link in
-                        linkRow(link)
-                        Divider()
-                            .padding(.leading, 80.0)
-                    }
-                }
-                .padding(.top, DesignConstants.Spacing.step2x)
-            }
+    private func row(for item: StuffItem) -> some View {
+        switch item {
+        case .file(let file):
+            fileRow(file)
+        case .link(let link):
+            linkRow(link)
         }
     }
 
@@ -175,47 +198,31 @@ struct AssistantFilesLinksView: View {
             return
         }
         return Button(action: action) {
-            HStack(spacing: DesignConstants.Spacing.step3x) {
-                fileThumbnail(file)
-                    .frame(width: 56.0, height: 56.0)
-                    .clipShape(RoundedRectangle(cornerRadius: DesignConstants.CornerRadius.small))
-
-                VStack(alignment: .leading, spacing: DesignConstants.Spacing.stepHalf) {
-                    Text(file.displayName)
-                        .font(.body)
-                        .foregroundStyle(.colorTextPrimary)
-                        .lineLimit(1)
-
-                    Text(fileSubtitle(file))
-                        .font(.caption)
-                        .foregroundStyle(.colorTextSecondary)
-                        .lineLimit(1)
-                }
-
-                Spacer()
-
-                Image(systemName: "chevron.right")
-                    .font(.footnote.weight(.semibold))
-                    .foregroundStyle(.colorTextSecondary)
-            }
-            .padding(.horizontal, DesignConstants.Spacing.step4x)
-            .padding(.vertical, DesignConstants.Spacing.step2x)
-            .contentShape(Rectangle())
+            StuffRowContent(
+                thumbnail: { fileThumbnail(file) },
+                title: file.displayName,
+                subtitle: relativeDate(for: file.date),
+                trailingSymbol: "doc"
+            )
         }
         .buttonStyle(.plain)
     }
 
-    private func fileSubtitle(_ file: AssistantFile) -> String {
-        var parts: [String] = []
-        if let mimeType = file.mimeType,
-           let utType = UTType(mimeType: mimeType),
-           let ext = utType.preferredFilenameExtension {
-            parts.append(ext.uppercased())
-        } else if let ext = (file.filename as NSString?)?.pathExtension, !ext.isEmpty {
-            parts.append(ext.uppercased())
+    private func linkRow(_ link: AssistantLink) -> some View {
+        let action = {
+            if let url = link.resolvedURL {
+                UIApplication.shared.open(url)
+            }
         }
-        parts.append(file.formattedDate)
-        return parts.joined(separator: " · ")
+        return Button(action: action) {
+            StuffRowContent(
+                thumbnail: { linkThumbnail(link) },
+                title: link.displayTitle,
+                subtitle: relativeDate(for: link.date),
+                trailingSymbol: "globe"
+            )
+        }
+        .buttonStyle(.plain)
     }
 
     @ViewBuilder
@@ -234,42 +241,6 @@ struct AssistantFilesLinksView: View {
                         .foregroundStyle(.colorTextSecondary)
                 }
         }
-    }
-
-    private func linkRow(_ link: AssistantLink) -> some View {
-        let action = {
-            if let url = link.resolvedURL {
-                UIApplication.shared.open(url)
-            }
-        }
-        return Button(action: action) {
-            HStack(spacing: DesignConstants.Spacing.step3x) {
-                linkThumbnail(link)
-                    .frame(width: 56.0, height: 56.0)
-                    .clipShape(RoundedRectangle(cornerRadius: DesignConstants.CornerRadius.small))
-
-                VStack(alignment: .leading, spacing: DesignConstants.Spacing.stepHalf) {
-                    Text(link.displayTitle)
-                        .font(.body)
-                        .foregroundStyle(.colorTextPrimary)
-                        .lineLimit(1)
-
-                    Text(link.displayHost)
-                        .font(.caption)
-                        .foregroundStyle(.colorTextSecondary)
-                        .lineLimit(1)
-                }
-
-                Spacer()
-
-                Image(systemName: "safari")
-                    .foregroundStyle(.colorTextSecondary)
-            }
-            .padding(.horizontal, DesignConstants.Spacing.step4x)
-            .padding(.vertical, DesignConstants.Spacing.step2x)
-            .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
     }
 
     @ViewBuilder
@@ -294,13 +265,98 @@ struct AssistantFilesLinksView: View {
             }
     }
 
-    private func emptyState(text: String) -> some View {
-        VStack {
-            Spacer()
-            Text(text)
-                .font(.body)
-                .foregroundStyle(.colorTextSecondary)
-            Spacer()
+    private func relativeDate(for date: Date) -> String {
+        let calendar = Calendar.current
+        if calendar.isDateInToday(date) { return "Today" }
+        if calendar.isDateInYesterday(date) { return "Yesterday" }
+        if let days = calendar.dateComponents([.day], from: date, to: .now).day, (1..<7).contains(days) {
+            return "\(days)d ago"
         }
+        return date.formatted(.dateTime.month(.abbreviated).day().year(.twoDigits))
+    }
+
+    private enum Constant {
+        static let dividerInset: CGFloat = 80.0
+    }
+}
+
+private struct StuffRowContent<Thumbnail: View>: View {
+    @ViewBuilder let thumbnail: () -> Thumbnail
+    let title: String
+    let subtitle: String
+    let trailingSymbol: String
+
+    var body: some View {
+        HStack(spacing: DesignConstants.Spacing.step3x) {
+            thumbnail()
+                .frame(width: 56.0, height: 56.0)
+                .clipShape(RoundedRectangle(cornerRadius: DesignConstants.CornerRadius.small))
+
+            VStack(alignment: .leading, spacing: DesignConstants.Spacing.stepHalf) {
+                Text(title)
+                    .font(.body)
+                    .foregroundStyle(.colorTextPrimary)
+                    .lineLimit(1)
+
+                Text(subtitle)
+                    .font(.caption)
+                    .foregroundStyle(.colorTextSecondary)
+                    .lineLimit(1)
+            }
+
+            Spacer()
+
+            Image(systemName: trailingSymbol)
+                .foregroundStyle(.colorTextSecondary)
+        }
+        .padding(.horizontal, DesignConstants.Spacing.step4x)
+        .padding(.vertical, DesignConstants.Spacing.step2x)
+        .contentShape(Rectangle())
+    }
+}
+
+private struct StuffSearchBar: View {
+    @Binding var searchText: String
+    @Binding var filter: StuffFilter
+
+    var body: some View {
+        HStack(spacing: DesignConstants.Spacing.step3x) {
+            HStack(spacing: DesignConstants.Spacing.step2x) {
+                Image(systemName: "magnifyingglass")
+                    .foregroundStyle(.colorTextSecondary)
+                TextField("Search", text: $searchText)
+                    .textFieldStyle(.plain)
+                    .accessibilityIdentifier("stuff-search-field")
+            }
+            .padding(.horizontal, DesignConstants.Spacing.step4x)
+            .padding(.vertical, DesignConstants.Spacing.step3x)
+            .glassEffect(.regular.interactive(), in: .capsule)
+
+            filterMenu
+        }
+        .padding(.horizontal, DesignConstants.Spacing.step4x)
+        .padding(.bottom, DesignConstants.Spacing.step2x)
+    }
+
+    private var filterMenu: some View {
+        Menu {
+            ForEach(StuffFilter.allCases) { option in
+                let action = { filter = option }
+                Button(action: action) {
+                    if option == filter {
+                        Label(option.rawValue, systemImage: "checkmark")
+                    } else {
+                        Text(option.rawValue)
+                    }
+                }
+            }
+        } label: {
+            Image(systemName: "line.3.horizontal.decrease")
+                .foregroundStyle(.colorTextPrimary)
+                .frame(width: 48.0, height: 48.0)
+                .glassEffect(.regular.interactive(), in: .circle)
+        }
+        .accessibilityLabel("Filter")
+        .accessibilityIdentifier("stuff-filter-button")
     }
 }

--- a/Convos/Conversation Detail/AssistantFilesLinksView.swift
+++ b/Convos/Conversation Detail/AssistantFilesLinksView.swift
@@ -216,7 +216,7 @@ struct AssistantFilesLinksView: View {
         switch viewModel.filter {
         case .all: return "Nothing matches"
         case .files: return "No files match"
-        case .links: return "No links match"
+        case .links: return "No links"
         }
     }
 

--- a/Convos/Conversation Detail/AssistantFilesLinksView.swift
+++ b/Convos/Conversation Detail/AssistantFilesLinksView.swift
@@ -330,6 +330,7 @@ private struct FileRow: View {
 
     @State private var renderedHTMLPreview: UIImage?
     @State private var resolvedHTMLTitle: String?
+    @State private var renderedFilePreview: UIImage?
 
     var body: some View {
         Button(action: onTap) {
@@ -359,6 +360,10 @@ private struct FileRow: View {
             Image(uiImage: renderedHTMLPreview)
                 .resizable()
                 .aspectRatio(contentMode: .fill)
+        } else if let renderedFilePreview {
+            Image(uiImage: renderedFilePreview)
+                .resizable()
+                .aspectRatio(contentMode: .fill)
         } else if let base64 = file.thumbnailDataBase64,
                   let data = Data(base64Encoded: base64),
                   let uiImage = UIImage(data: data) {
@@ -384,12 +389,18 @@ private struct FileRow: View {
     }
 
     private func loadHTMLMetadataIfNeeded() async {
-        guard isHTML else { return }
+        if isHTML {
+            renderedHTMLPreview = HTMLThumbnailRenderer.shared.cachedThumbnail(for: file.attachmentKey)
+            resolvedHTMLTitle = HTMLPageMetadata.shared.cachedTitle(for: file.attachmentKey)
+        } else if let cached = FileThumbnailRenderer.shared.cachedThumbnail(for: file.attachmentKey),
+                  cached.isContentThumbnail {
+            renderedFilePreview = cached.image
+        }
 
-        renderedHTMLPreview = HTMLThumbnailRenderer.shared.cachedThumbnail(for: file.attachmentKey)
-        resolvedHTMLTitle = HTMLPageMetadata.shared.cachedTitle(for: file.attachmentKey)
-
-        if renderedHTMLPreview != nil, resolvedHTMLTitle != nil { return }
+        guard renderedHTMLPreview == nil
+            || resolvedHTMLTitle == nil
+            || (!isHTML && renderedFilePreview == nil)
+        else { return }
 
         do {
             let url = try await FileAttachmentPreviewLoader.loadPreviewURL(
@@ -397,20 +408,30 @@ private struct FileRow: View {
                 filename: file.filename
             )
 
-            if renderedHTMLPreview == nil {
-                renderedHTMLPreview = await HTMLThumbnailRenderer.shared.thumbnail(
+            if isHTML {
+                if renderedHTMLPreview == nil {
+                    renderedHTMLPreview = await HTMLThumbnailRenderer.shared.thumbnail(
+                        for: file.attachmentKey,
+                        fileURL: url
+                    )
+                }
+                if resolvedHTMLTitle == nil {
+                    resolvedHTMLTitle = await HTMLPageMetadata.shared.title(
+                        for: file.attachmentKey,
+                        fileURL: url
+                    )
+                }
+            } else if renderedFilePreview == nil {
+                let result = await FileThumbnailRenderer.shared.thumbnail(
                     for: file.attachmentKey,
                     fileURL: url
                 )
-            }
-            if resolvedHTMLTitle == nil {
-                resolvedHTMLTitle = await HTMLPageMetadata.shared.title(
-                    for: file.attachmentKey,
-                    fileURL: url
-                )
+                if let result, result.isContentThumbnail {
+                    renderedFilePreview = result.image
+                }
             }
         } catch {
-            Log.error("Failed to load Stuff list HTML metadata: \(error)")
+            Log.error("Failed to load Stuff list file metadata: \(error)")
         }
     }
 }

--- a/Convos/Conversation Detail/AssistantFilesLinksView.swift
+++ b/Convos/Conversation Detail/AssistantFilesLinksView.swift
@@ -45,6 +45,14 @@ class AssistantFilesLinksViewModel {
         self.repository = repository
     }
 
+    var hasAnyItems: Bool {
+        !files.isEmpty || !links.isEmpty
+    }
+
+    var isFiltering: Bool {
+        filter != .all || !searchText.isEmpty
+    }
+
     var filteredItems: [StuffItem] {
         let query = searchText.lowercased()
 
@@ -64,6 +72,11 @@ class AssistantFilesLinksViewModel {
 
         items.sort { $0.date > $1.date }
         return items
+    }
+
+    func clearFilters() {
+        filter = .all
+        searchText = ""
     }
 
     private func matches(file: AssistantFile, query: String) -> Bool {
@@ -99,37 +112,41 @@ struct AssistantFilesLinksView: View {
     }
 
     var body: some View {
-        Group {
-            if viewModel.isLoading {
-                ProgressView()
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-            } else if viewModel.filteredItems.isEmpty {
-                emptyState
-            } else {
-                itemList
+        content
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(.colorBackgroundRaisedSecondary)
+            .navigationTitle("Stuff")
+            .toolbarTitleDisplayMode(.large)
+            .safeAreaBar(edge: .bottom) {
+                StuffSearchBar(
+                    searchText: $viewModel.searchText,
+                    filter: $viewModel.filter
+                )
             }
-        }
-        .navigationTitle("Stuff")
-        .navigationBarTitleDisplayMode(.large)
-        .background(.colorBackgroundRaisedSecondary)
-        .safeAreaInset(edge: .bottom) {
-            StuffSearchBar(
-                searchText: $viewModel.searchText,
-                filter: $viewModel.filter
-            )
-        }
-        .task {
-            await viewModel.load()
-        }
-        .alert("File Unavailable", isPresented: Binding(
-            get: { viewModel.fileOpenError != nil },
-            set: { if !$0 { viewModel.fileOpenError = nil } }
-        )) {
-            Button("OK", role: .cancel) {
-                viewModel.fileOpenError = nil
+            .task {
+                await viewModel.load()
             }
-        } message: {
-            Text(viewModel.fileOpenError ?? "This file is no longer available on this device.")
+            .alert("File Unavailable", isPresented: Binding(
+                get: { viewModel.fileOpenError != nil },
+                set: { if !$0 { viewModel.fileOpenError = nil } }
+            )) {
+                Button("OK", role: .cancel) {
+                    viewModel.fileOpenError = nil
+                }
+            } message: {
+                Text(viewModel.fileOpenError ?? "This file is no longer available on this device.")
+            }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if viewModel.isLoading {
+            ProgressView()
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else if viewModel.filteredItems.isEmpty {
+            emptyState
+        } else {
+            itemList
         }
     }
 
@@ -146,22 +163,36 @@ struct AssistantFilesLinksView: View {
         }
     }
 
+    @ViewBuilder
     private var emptyState: some View {
-        VStack {
-            Spacer()
-            Text(emptyStateText)
-                .font(.body)
-                .foregroundStyle(.colorTextSecondary)
-            Spacer()
+        if viewModel.isFiltering {
+            VStack {
+                Spacer()
+                FilteredEmptyStateView(message: filteredEmptyMessage) {
+                    viewModel.clearFilters()
+                }
+                .padding(.horizontal, DesignConstants.Spacing.step6x)
+                Spacer()
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else {
+            VStack {
+                Spacer()
+                Text("Nothing here yet")
+                    .font(.body)
+                    .foregroundStyle(.colorTextSecondary)
+                Spacer()
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
     }
 
-    private var emptyStateText: String {
+    private var filteredEmptyMessage: String {
         if !viewModel.searchText.isEmpty { return "Nothing matches your search" }
         switch viewModel.filter {
-        case .all: return "Nothing here yet"
-        case .files: return "No files yet"
-        case .links: return "No links yet"
+        case .all: return "Nothing matches"
+        case .files: return "No files match"
+        case .links: return "No links match"
         }
     }
 
@@ -320,22 +351,24 @@ private struct StuffSearchBar: View {
     @Binding var filter: StuffFilter
 
     var body: some View {
-        HStack(spacing: DesignConstants.Spacing.step3x) {
-            HStack(spacing: DesignConstants.Spacing.step2x) {
-                Image(systemName: "magnifyingglass")
-                    .foregroundStyle(.colorTextSecondary)
-                TextField("Search", text: $searchText)
-                    .textFieldStyle(.plain)
-                    .accessibilityIdentifier("stuff-search-field")
+        GlassEffectContainer {
+            HStack(spacing: DesignConstants.Spacing.step3x) {
+                HStack(spacing: DesignConstants.Spacing.step2x) {
+                    Image(systemName: "magnifyingglass")
+                        .foregroundStyle(.colorTextSecondary)
+                    TextField("Search", text: $searchText)
+                        .textFieldStyle(.plain)
+                        .accessibilityIdentifier("stuff-search-field")
+                }
+                .padding(.horizontal, DesignConstants.Spacing.step4x)
+                .padding(.vertical, DesignConstants.Spacing.step3x)
+                .glassEffect(.regular.interactive(), in: .capsule)
+
+                filterMenu
             }
             .padding(.horizontal, DesignConstants.Spacing.step4x)
-            .padding(.vertical, DesignConstants.Spacing.step3x)
-            .glassEffect(.regular.interactive(), in: .capsule)
-
-            filterMenu
+            .padding(.vertical, DesignConstants.Spacing.step2x)
         }
-        .padding(.horizontal, DesignConstants.Spacing.step4x)
-        .padding(.bottom, DesignConstants.Spacing.step2x)
     }
 
     private var filterMenu: some View {

--- a/Convos/Conversation Detail/AssistantFilesLinksView.swift
+++ b/Convos/Conversation Detail/AssistantFilesLinksView.swift
@@ -108,15 +108,22 @@ struct AttachmentPreviewPresentation: Identifiable {
     let id: String
     let attachment: HydratedAttachment
     let fileURL: URL
+    let sender: ConversationMember?
     let sentAt: Date
 }
 
 struct AssistantFilesLinksView: View {
     @State private var viewModel: AssistantFilesLinksViewModel
     @State private var presentingPreview: AttachmentPreviewPresentation?
+    private let members: [ConversationMember]
 
-    init(repository: AssistantFilesLinksRepository) {
+    init(repository: AssistantFilesLinksRepository, members: [ConversationMember]) {
         _viewModel = State(initialValue: AssistantFilesLinksViewModel(repository: repository))
+        self.members = members
+    }
+
+    private func member(forInboxId inboxId: String) -> ConversationMember? {
+        members.first { $0.profile.inboxId == inboxId }
     }
 
     var body: some View {
@@ -138,7 +145,7 @@ struct AssistantFilesLinksView: View {
                 AttachmentPreviewSheet(
                     attachment: preview.attachment,
                     fileURL: preview.fileURL,
-                    sender: nil,
+                    sender: preview.sender,
                     sentAt: preview.sentAt
                 )
                 .presentationDetents([.large])
@@ -242,6 +249,7 @@ struct AssistantFilesLinksView: View {
                             id: file.id,
                             attachment: hydrated,
                             fileURL: url,
+                            sender: member(forInboxId: file.senderInboxId),
                             sentAt: file.date
                         )
                     }

--- a/Convos/Conversation Detail/AssistantFilesLinksView.swift
+++ b/Convos/Conversation Detail/AssistantFilesLinksView.swift
@@ -215,7 +215,7 @@ struct AssistantFilesLinksView: View {
         if !viewModel.searchText.isEmpty { return "Nothing matches your search" }
         switch viewModel.filter {
         case .all: return "Nothing matches"
-        case .files: return "No files match"
+        case .files: return "No files"
         case .links: return "No links"
         }
     }
@@ -292,9 +292,13 @@ struct AssistantFilesLinksView: View {
 
     @ViewBuilder
     private func fileThumbnail(_ file: AssistantFile) -> some View {
-        if let base64 = file.thumbnailDataBase64,
-           let data = Data(base64Encoded: base64),
-           let uiImage = UIImage(data: data) {
+        if let cached = htmlPreview(for: file) {
+            Image(uiImage: cached)
+                .resizable()
+                .aspectRatio(contentMode: .fill)
+        } else if let base64 = file.thumbnailDataBase64,
+                  let data = Data(base64Encoded: base64),
+                  let uiImage = UIImage(data: data) {
             Image(uiImage: uiImage)
                 .resizable()
                 .aspectRatio(contentMode: .fill)
@@ -306,6 +310,19 @@ struct AssistantFilesLinksView: View {
                         .foregroundStyle(.colorTextSecondary)
                 }
         }
+    }
+
+    private func htmlPreview(for file: AssistantFile) -> UIImage? {
+        guard isHTML(file: file) else { return nil }
+        return HTMLThumbnailRenderer.shared.cachedThumbnail(for: file.attachmentKey)
+    }
+
+    private func isHTML(file: AssistantFile) -> Bool {
+        if let filename = file.filename {
+            let ext = (filename as NSString).pathExtension.lowercased()
+            if ["html", "htm"].contains(ext) { return true }
+        }
+        return file.mimeType?.lowercased() == "text/html"
     }
 
     @ViewBuilder

--- a/Convos/Conversation Detail/AssistantFilesLinksView.swift
+++ b/Convos/Conversation Detail/AssistantFilesLinksView.swift
@@ -116,10 +116,19 @@ struct AssistantFilesLinksView: View {
     @State private var viewModel: AssistantFilesLinksViewModel
     @State private var presentingPreview: AttachmentPreviewPresentation?
     private let members: [ConversationMember]
+    private let usesInlineHeader: Bool
+    private let profileSheetContent: ((ConversationMember) -> AnyView)?
 
-    init(repository: AssistantFilesLinksRepository, members: [ConversationMember]) {
+    init(
+        repository: AssistantFilesLinksRepository,
+        members: [ConversationMember],
+        usesInlineHeader: Bool = false,
+        profileSheetContent: ((ConversationMember) -> AnyView)? = nil
+    ) {
         _viewModel = State(initialValue: AssistantFilesLinksViewModel(repository: repository))
         self.members = members
+        self.usesInlineHeader = usesInlineHeader
+        self.profileSheetContent = profileSheetContent
     }
 
     private func member(forInboxId inboxId: String) -> ConversationMember? {
@@ -127,11 +136,10 @@ struct AssistantFilesLinksView: View {
     }
 
     var body: some View {
-        content
+        bodyContent
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .background(.colorBackgroundRaisedSecondary)
-            .navigationTitle("Stuff")
-            .toolbarTitleDisplayMode(.large)
+            .applyTitle(usesInlineHeader: usesInlineHeader)
             .safeAreaBar(edge: .bottom) {
                 StuffSearchBar(
                     searchText: $viewModel.searchText,
@@ -146,7 +154,8 @@ struct AssistantFilesLinksView: View {
                     attachment: preview.attachment,
                     fileURL: preview.fileURL,
                     sender: preview.sender,
-                    sentAt: preview.sentAt
+                    sentAt: preview.sentAt,
+                    profileSheetContent: profileSheetContent
                 )
                 .presentationDetents([.large])
             }
@@ -160,6 +169,23 @@ struct AssistantFilesLinksView: View {
             } message: {
                 Text(viewModel.fileOpenError ?? "This file is no longer available on this device.")
             }
+    }
+
+    @ViewBuilder
+    private var bodyContent: some View {
+        if usesInlineHeader {
+            VStack(alignment: .leading, spacing: 0) {
+                Text("Stuff")
+                    .font(.largeTitle.bold())
+                    .foregroundStyle(.colorTextPrimary)
+                    .padding(.horizontal, DesignConstants.Spacing.step4x)
+                    .padding(.top, DesignConstants.Spacing.step2x)
+                    .padding(.bottom, DesignConstants.Spacing.step3x)
+                content
+            }
+        } else {
+            content
+        }
     }
 
     @ViewBuilder
@@ -179,11 +205,8 @@ struct AssistantFilesLinksView: View {
             LazyVStack(spacing: 0) {
                 ForEach(viewModel.filteredItems) { item in
                     row(for: item)
-                    Divider()
-                        .padding(.leading, Constant.dividerInset)
                 }
             }
-            .padding(.top, DesignConstants.Spacing.step2x)
         }
     }
 
@@ -300,12 +323,8 @@ struct AssistantFilesLinksView: View {
     }
 
     private var linkPlaceholder: some View {
-        RoundedRectangle(cornerRadius: DesignConstants.CornerRadius.small)
-            .fill(Color.colorFillMinimal)
-            .overlay {
-                Image(systemName: "link")
-                    .foregroundStyle(.colorTextSecondary)
-            }
+        Image(systemName: "link")
+            .foregroundStyle(.colorTextSecondary)
     }
 
     private func relativeDate(for date: Date) -> String {
@@ -316,10 +335,6 @@ struct AssistantFilesLinksView: View {
             return "\(days)d ago"
         }
         return date.formatted(.dateTime.month(.abbreviated).day().year(.twoDigits))
-    }
-
-    private enum Constant {
-        static let dividerInset: CGFloat = 80.0
     }
 }
 
@@ -338,7 +353,7 @@ private struct FileRow: View {
                 thumbnail: { thumbnail },
                 title: displayTitle,
                 subtitle: subtitle,
-                trailingSymbol: "doc"
+                trailingSymbol: isHTML ? "globe" : "doc"
             )
         }
         .buttonStyle(.plain)
@@ -359,24 +374,20 @@ private struct FileRow: View {
         if let renderedHTMLPreview {
             Image(uiImage: renderedHTMLPreview)
                 .resizable()
-                .aspectRatio(contentMode: .fill)
+                .aspectRatio(contentMode: .fit)
         } else if let renderedFilePreview {
             Image(uiImage: renderedFilePreview)
                 .resizable()
-                .aspectRatio(contentMode: .fill)
+                .aspectRatio(contentMode: .fit)
         } else if let base64 = file.thumbnailDataBase64,
                   let data = Data(base64Encoded: base64),
                   let uiImage = UIImage(data: data) {
             Image(uiImage: uiImage)
                 .resizable()
-                .aspectRatio(contentMode: .fill)
+                .aspectRatio(contentMode: .fit)
         } else {
-            RoundedRectangle(cornerRadius: DesignConstants.CornerRadius.small)
-                .fill(Color.colorFillMinimal)
-                .overlay {
-                    Image(systemName: "doc.fill")
-                        .foregroundStyle(.colorTextSecondary)
-                }
+            Image(systemName: "doc.fill")
+                .foregroundStyle(.colorTextSecondary)
         }
     }
 
@@ -397,10 +408,10 @@ private struct FileRow: View {
             renderedFilePreview = cached.image
         }
 
-        guard renderedHTMLPreview == nil
-            || resolvedHTMLTitle == nil
-            || (!isHTML && renderedFilePreview == nil)
-        else { return }
+        let needsLoad: Bool = isHTML
+            ? (renderedHTMLPreview == nil || resolvedHTMLTitle == nil)
+            : (renderedFilePreview == nil)
+        guard needsLoad else { return }
 
         do {
             let url = try await FileAttachmentPreviewLoader.loadPreviewURL(
@@ -445,10 +456,15 @@ private struct StuffRowContent<Thumbnail: View>: View {
     var body: some View {
         HStack(spacing: DesignConstants.Spacing.step3x) {
             thumbnail()
-                .frame(width: 56.0, height: 56.0)
-                .clipShape(RoundedRectangle(cornerRadius: DesignConstants.CornerRadius.small))
+                .frame(width: StuffRowMetrics.thumbnailSize, height: StuffRowMetrics.thumbnailSize)
+                .background(Color.colorFillMinimal)
+                .clipShape(RoundedRectangle(cornerRadius: StuffRowMetrics.thumbnailCornerRadius))
+                .overlay(
+                    RoundedRectangle(cornerRadius: StuffRowMetrics.thumbnailCornerRadius)
+                        .strokeBorder(Color.colorBorderEdge, lineWidth: 1.0)
+                )
 
-            VStack(alignment: .leading, spacing: DesignConstants.Spacing.stepHalf) {
+            VStack(alignment: .leading, spacing: StuffRowMetrics.titleSubtitleSpacing) {
                 Text(title)
                     .font(.body)
                     .foregroundStyle(.colorTextPrimary)
@@ -460,14 +476,33 @@ private struct StuffRowContent<Thumbnail: View>: View {
                     .lineLimit(1)
             }
 
-            Spacer()
+            Spacer(minLength: DesignConstants.Spacing.step3x)
 
             Image(systemName: trailingSymbol)
                 .foregroundStyle(.colorTextSecondary)
         }
-        .padding(.horizontal, DesignConstants.Spacing.step4x)
-        .padding(.vertical, DesignConstants.Spacing.step2x)
+        .padding(.horizontal, DesignConstants.Spacing.step6x)
+        .padding(.vertical, DesignConstants.Spacing.step3x)
         .contentShape(Rectangle())
+    }
+}
+
+private enum StuffRowMetrics {
+    static let thumbnailSize: CGFloat = 47.0
+    static let thumbnailCornerRadius: CGFloat = 16.0
+    static let titleSubtitleSpacing: CGFloat = 3.0
+}
+
+private extension View {
+    @ViewBuilder
+    func applyTitle(usesInlineHeader: Bool) -> some View {
+        if usesInlineHeader {
+            self
+        } else {
+            self
+                .navigationTitle("Stuff")
+                .toolbarTitleDisplayMode(.large)
+        }
     }
 }
 

--- a/Convos/Conversation Detail/AssistantFilesLinksView.swift
+++ b/Convos/Conversation Detail/AssistantFilesLinksView.swift
@@ -104,8 +104,16 @@ class AssistantFilesLinksViewModel {
     }
 }
 
+struct AttachmentPreviewPresentation: Identifiable {
+    let id: String
+    let attachment: HydratedAttachment
+    let fileURL: URL
+    let sentAt: Date
+}
+
 struct AssistantFilesLinksView: View {
     @State private var viewModel: AssistantFilesLinksViewModel
+    @State private var presentingPreview: AttachmentPreviewPresentation?
 
     init(repository: AssistantFilesLinksRepository) {
         _viewModel = State(initialValue: AssistantFilesLinksViewModel(repository: repository))
@@ -125,6 +133,15 @@ struct AssistantFilesLinksView: View {
             }
             .task {
                 await viewModel.load()
+            }
+            .sheet(item: $presentingPreview) { preview in
+                AttachmentPreviewSheet(
+                    attachment: preview.attachment,
+                    fileURL: preview.fileURL,
+                    sender: nil,
+                    sentAt: preview.sentAt
+                )
+                .presentationDetents([.large])
             }
             .alert("File Unavailable", isPresented: Binding(
                 get: { viewModel.fileOpenError != nil },
@@ -215,9 +232,18 @@ struct AssistantFilesLinksView: View {
                         filename: file.filename
                     )
                     await MainActor.run {
-                        if let presenter = UIApplication.shared.topMostViewController() {
-                            FileAttachmentQuickLookCoordinator.shared.present(fileURL: url, from: presenter)
-                        }
+                        let hydrated = HydratedAttachment(
+                            key: file.attachmentKey,
+                            mimeType: file.mimeType,
+                            thumbnailDataBase64: file.thumbnailDataBase64,
+                            filename: file.filename
+                        )
+                        presentingPreview = AttachmentPreviewPresentation(
+                            id: file.id,
+                            attachment: hydrated,
+                            fileURL: url,
+                            sentAt: file.date
+                        )
                     }
                 } catch {
                     Log.error("Failed to open assistant file: \(error)")

--- a/Convos/Conversation Detail/AttachmentPreviewSheet.swift
+++ b/Convos/Conversation Detail/AttachmentPreviewSheet.swift
@@ -117,7 +117,8 @@ private struct AttachmentSenderIndicator: View {
                 ProfileAvatarView(
                     profile: sender.profile,
                     profileImage: nil,
-                    useSystemPlaceholder: false
+                    useSystemPlaceholder: false,
+                    agentVerification: sender.agentVerification
                 )
                 .frame(width: 36.0, height: 36.0)
 

--- a/Convos/Conversation Detail/AttachmentPreviewSheet.swift
+++ b/Convos/Conversation Detail/AttachmentPreviewSheet.swift
@@ -8,7 +8,7 @@ import WebKit
 struct AttachmentPreviewSheet: View {
     let attachment: HydratedAttachment
     let fileURL: URL
-    let sender: ConversationMember
+    var sender: ConversationMember?
     let sentAt: Date
     var profileSheetContent: ((ConversationMember) -> AnyView)?
 
@@ -33,15 +33,17 @@ struct AttachmentPreviewSheet: View {
                         .accessibilityLabel("Close")
                         .accessibilityIdentifier("attachment-preview-close")
                     }
-                    ToolbarItem(placement: .principal) {
-                        let tap: ((ConversationMember) -> Void)? = profileSheetContent == nil
-                            ? nil
-                            : { tapped in presentingProfileForMember = tapped }
-                        AttachmentSenderIndicator(
-                            sender: sender,
-                            sentAt: sentAt,
-                            onTap: tap
-                        )
+                    if let sender {
+                        ToolbarItem(placement: .principal) {
+                            let tap: ((ConversationMember) -> Void)? = profileSheetContent == nil
+                                ? nil
+                                : { tapped in presentingProfileForMember = tapped }
+                            AttachmentSenderIndicator(
+                                sender: sender,
+                                sentAt: sentAt,
+                                onTap: tap
+                            )
+                        }
                     }
                     if showsShareButton {
                         ToolbarItem(placement: .confirmationAction) {

--- a/Convos/Conversation Detail/AttachmentPreviewSheet.swift
+++ b/Convos/Conversation Detail/AttachmentPreviewSheet.swift
@@ -482,8 +482,7 @@ private struct AttachmentQuickLookContent: UIViewControllerRepresentable {
     func makeUIViewController(context: Context) -> UINavigationController {
         let preview = QLPreviewController()
         preview.dataSource = context.coordinator
-        let nav = UINavigationController(rootViewController: preview)
-        nav.isNavigationBarHidden = true
+        let nav = HiddenBarNavigationController(rootViewController: preview)
         nav.setToolbarHidden(true, animated: false)
         return nav
     }
@@ -514,5 +513,16 @@ private struct AttachmentQuickLookContent: UIViewControllerRepresentable {
         ) -> any QLPreviewItem {
             fileURL as NSURL
         }
+    }
+}
+
+private final class HiddenBarNavigationController: UINavigationController {
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        super.setNavigationBarHidden(true, animated: false)
+    }
+
+    override func setNavigationBarHidden(_ hidden: Bool, animated: Bool) {
+        super.setNavigationBarHidden(true, animated: false)
     }
 }

--- a/Convos/Conversation Detail/ConversationInfoView.swift
+++ b/Convos/Conversation Detail/ConversationInfoView.swift
@@ -116,7 +116,8 @@ struct ConversationInfoView: View {
     private var filesAndLinksRow: some View {
         NavigationLink {
             AssistantFilesLinksView(
-                repository: viewModel.makeAssistantFilesLinksRepository()
+                repository: viewModel.makeAssistantFilesLinksRepository(),
+                members: viewModel.conversation.members
             )
         } label: {
             FeatureRowItem(

--- a/Convos/Conversation Detail/ConversationInfoView.swift
+++ b/Convos/Conversation Detail/ConversationInfoView.swift
@@ -117,7 +117,19 @@ struct ConversationInfoView: View {
         NavigationLink {
             AssistantFilesLinksView(
                 repository: viewModel.makeAssistantFilesLinksRepository(),
-                members: viewModel.conversation.members
+                members: viewModel.conversation.members,
+                profileSheetContent: { member in
+                    AnyView(
+                        NavigationStack {
+                            ConversationMemberView(viewModel: viewModel, member: member)
+                                .toolbar {
+                                    ToolbarItem(placement: .cancellationAction) {
+                                        AttachmentProfileSheetCloseButton()
+                                    }
+                                }
+                        }
+                    )
+                }
             )
         } label: {
             FeatureRowItem(

--- a/Convos/Conversation Detail/ConversationPager.swift
+++ b/Convos/Conversation Detail/ConversationPager.swift
@@ -1,0 +1,104 @@
+import ConvosCore
+import SwiftUI
+import SwiftUIIntrospect
+
+enum ConversationPagerPage: Int, CaseIterable, Identifiable {
+    case messages
+    case stuff
+
+    var id: Int { rawValue }
+}
+
+struct ConversationPager<MessagesPage: View, StuffPage: View>: View {
+    @Binding var selectedPage: ConversationPagerPage
+    let showsPageDots: Bool
+    @ViewBuilder let messagesPage: () -> MessagesPage
+    @ViewBuilder let stuffPage: () -> StuffPage
+
+    var body: some View {
+        GeometryReader { proxy in
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 0) {
+                    messagesPage()
+                        .frame(width: proxy.size.width, height: proxy.size.height)
+                        .id(ConversationPagerPage.messages)
+
+                    stuffPage()
+                        .frame(width: proxy.size.width, height: proxy.size.height)
+                        .id(ConversationPagerPage.stuff)
+                }
+                .scrollTargetLayout()
+            }
+            .scrollTargetBehavior(.paging)
+            .scrollPosition(id: Binding(
+                get: { selectedPage },
+                set: { newValue in
+                    if let newValue { selectedPage = newValue }
+                }
+            ))
+            .introspect(.scrollView, on: .iOS(.v26)) { (scrollView: UIScrollView) in
+                scrollView.bounces = false
+            }
+        }
+        .safeAreaInset(edge: .bottom, spacing: 0) {
+            if showsPageDots {
+                ConversationPagerDots(selectedPage: $selectedPage)
+            }
+        }
+    }
+}
+
+private struct ConversationPagerDots: View {
+    @Binding var selectedPage: ConversationPagerPage
+
+    var body: some View {
+        HStack(spacing: 10.0) {
+            ForEach(ConversationPagerPage.allCases) { page in
+                let isSelected: Bool = page == selectedPage
+                let action = {
+                    withAnimation(.easeInOut(duration: 0.25)) {
+                        selectedPage = page
+                    }
+                }
+                Button(action: action) {
+                    pageShape(for: page)
+                        .fill(isSelected ? Color.colorFillSecondary : Color.colorFillTertiary)
+                        .frame(width: 8.0, height: 8.0)
+                        .animation(.easeInOut(duration: 0.2), value: isSelected)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(label(for: page))
+            }
+        }
+        .padding(.horizontal, 10.0)
+        .padding(.vertical, DesignConstants.Spacing.step2x)
+        .glassEffect(.regular.interactive(), in: .capsule)
+        .accessibilityIdentifier("conversation-pager-dots")
+    }
+
+    private func pageShape(for page: ConversationPagerPage) -> UnevenRoundedRectangle {
+        switch page {
+        case .messages:
+            return UnevenRoundedRectangle(cornerRadii: .init(
+                topLeading: 8.0,
+                bottomLeading: 2.0,
+                bottomTrailing: 8.0,
+                topTrailing: 8.0
+            ))
+        case .stuff:
+            return UnevenRoundedRectangle(cornerRadii: .init(
+                topLeading: 2.0,
+                bottomLeading: 2.0,
+                bottomTrailing: 2.0,
+                topTrailing: 2.0
+            ))
+        }
+    }
+
+    private func label(for page: ConversationPagerPage) -> String {
+        switch page {
+        case .messages: return "Messages"
+        case .stuff: return "Stuff"
+        }
+    }
+}

--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -20,6 +20,8 @@ struct ConversationView<MessagesBottomBar: View>: View {
     @State private var showingAssistantsInfo: Bool = false
     @State private var scrollOverscrollAmount: CGFloat = 0.0
     @State private var didReleasePastThreshold: Bool = false
+    @State private var pagerSelectedPage: ConversationPagerPage = .messages
+    @State private var isKeyboardVisible: Bool = false
     @Environment(\.dismiss) private var dismiss: DismissAction
 
     private var showPullToAddAssistant: Bool {
@@ -80,6 +82,7 @@ struct ConversationView<MessagesBottomBar: View>: View {
             onReaction: viewModel.onReaction(emoji:messageId:),
             onToggleReaction: viewModel.onReaction(emoji:messageId:),
             onTapReactions: viewModel.onTapReactions(_:),
+            onTapReadReceipts: viewModel.onTapReadReceipts(_:),
             onReply: { message in
                 viewModel.onReply(message)
                 focusCoordinator.moveFocus(to: .message)
@@ -117,18 +120,7 @@ struct ConversationView<MessagesBottomBar: View>: View {
             onRetryTranscript: { item in
                 viewModel.retryTranscript(for: item)
             },
-            profileSheetForMember: { member in
-                AnyView(
-                    NavigationStack {
-                        ConversationMemberView(viewModel: viewModel, member: member)
-                            .toolbar {
-                                ToolbarItem(placement: .cancellationAction) {
-                                    AttachmentProfileSheetCloseButton()
-                                }
-                            }
-                    }
-                )
-            },
+            profileSheetForMember: profileSheetForMember,
             hasAssistant: viewModel.conversation.hasAgent,
             isAssistantJoinPending: viewModel.isAssistantJoinPending,
             isAssistantEnabled: FeatureFlags.shared.isAssistantEnabled && GlobalConvoDefaults.shared.assistantsEnabled,
@@ -148,6 +140,7 @@ struct ConversationView<MessagesBottomBar: View>: View {
             voiceMemoRecorder: viewModel.voiceMemoRecorder,
             onSendVoiceMemo: { viewModel.sendVoiceMemo() },
             onConvosAction: { viewModel.onConvosButtonTapped() },
+            extraBottomInset: pagerDotsInset,
             bottomBarContent: {
                 VStack(spacing: DesignConstants.Spacing.step3x) {
                     if showPullToAddAssistant {
@@ -242,8 +235,45 @@ struct ConversationView<MessagesBottomBar: View>: View {
         .accessibilityIdentifier("scan-invite-button")
     }
 
+    private var stuffPage: some View {
+        AssistantFilesLinksView(
+            repository: viewModel.makeAssistantFilesLinksRepository(),
+            members: viewModel.conversation.members,
+            usesInlineHeader: true,
+            profileSheetContent: profileSheetForMember
+        )
+    }
+
+    private func profileSheetForMember(_ member: ConversationMember) -> AnyView {
+        AnyView(
+            NavigationStack {
+                ConversationMemberView(viewModel: viewModel, member: member)
+                    .toolbar {
+                        ToolbarItem(placement: .cancellationAction) {
+                            AttachmentProfileSheetCloseButton()
+                        }
+                    }
+            }
+        )
+    }
+
+    private var pagerDotsInset: CGFloat {
+        isKeyboardVisible ? 0.0 : 24.0
+    }
+
     var body: some View {
-        messagesView
+        ConversationPager(
+            selectedPage: $pagerSelectedPage,
+            showsPageDots: !isKeyboardVisible,
+            messagesPage: { messagesView },
+            stuffPage: { stuffPage }
+        )
+        .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillShowNotification)) { _ in
+            isKeyboardVisible = true
+        }
+        .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillHideNotification)) { _ in
+            isKeyboardVisible = false
+        }
         .onChange(of: viewModel.messageText) { _, _ in
             viewModel.checkForInviteURL()
             viewModel.checkForPastedLink()
@@ -317,6 +347,9 @@ struct ConversationView<MessagesBottomBar: View>: View {
                 viewModel.removeReaction(reaction, from: message)
             }
         }
+        .selfSizingSheet(item: $viewModel.presentingReadByForGroup) { group in
+            ReadByDrawerView(members: group.readByMembers)
+        }
         .selfSizingSheet(isPresented: $showingLockedInfo) {
             LockedConvoInfoView(
                 isCurrentUserSuperAdmin: viewModel.isCurrentUserSuperAdmin,
@@ -356,7 +389,7 @@ struct ConversationView<MessagesBottomBar: View>: View {
     }
 }
 
-private struct AttachmentProfileSheetCloseButton: View {
+struct AttachmentProfileSheetCloseButton: View {
     @Environment(\.dismiss) private var dismiss: DismissAction
 
     var body: some View {

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -407,6 +407,7 @@ class ConversationViewModel { // swiftlint:disable:this type_body_length
     }
     var presentingConversationForked: Bool = false
     var presentingReactionsForMessage: AnyMessage?
+    var presentingReadByForGroup: MessagesGroup?
     var replyingToMessage: AnyMessage?
     var presentingShareView: Bool = false
     var presentingRevealMediaInfoSheet: Bool = false
@@ -1921,6 +1922,10 @@ extension ConversationViewModel {
 
     func onTapReactions(_ message: AnyMessage) {
         presentingReactionsForMessage = message
+    }
+
+    func onTapReadReceipts(_ group: MessagesGroup) {
+        presentingReadByForGroup = group
     }
 
     func onToggleReaction(emoji: String, messageId: String) {

--- a/Convos/Conversation Detail/Messages/Messages View Controller/Reactions/ReactionsDrawerView.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/Reactions/ReactionsDrawerView.swift
@@ -58,7 +58,8 @@ private struct ReactionRowView: View {
             ProfileAvatarView(
                 profile: reaction.sender.profile,
                 profileImage: nil,
-                useSystemPlaceholder: false
+                useSystemPlaceholder: false,
+                agentVerification: reaction.sender.agentVerification
             )
             .frame(width: 40.0, height: 40.0)
 

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Cells/MessagesListItemTypeCell.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Cells/MessagesListItemTypeCell.swift
@@ -92,6 +92,7 @@ class MessagesListItemTypeCell: UICollectionViewCell {
                         onTapAvatar: config.onTapAvatar,
                         onTapInvite: config.onTapInvite,
                         onTapReactions: config.onTapReactions,
+                        onTapReadReceipts: config.onTapReadReceipts,
                         onReaction: config.onReaction,
                         onToggleReaction: config.onToggleReaction,
                         onReply: config.onReply,

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Data Source/CellFactory.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Data Source/CellFactory.swift
@@ -8,6 +8,7 @@ struct CellConfig {
     let onTapInvite: (MessageInvite) -> Void
     let onTapAvatar: (AnyMessage) -> Void
     let onTapReactions: (AnyMessage) -> Void
+    let onTapReadReceipts: (MessagesGroup) -> Void
     let onReaction: (String, String) -> Void
     let onToggleReaction: (String, String) -> Void
     let onReply: (AnyMessage) -> Void

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Data Source/MessagesCollectionDataSource.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Data Source/MessagesCollectionDataSource.swift
@@ -8,6 +8,7 @@ protocol MessagesCollectionDataSource: UICollectionViewDataSource, MessagesLayou
     var onTapInvite: ((MessageInvite) -> Void)? { get set }
     var onTapAvatar: ((ConversationMember) -> Void)? { get set }
     var onTapReactions: ((AnyMessage) -> Void)? { get set }
+    var onTapReadReceipts: ((MessagesGroup) -> Void)? { get set }
     var onReaction: ((String, String) -> Void)? { get set }
     var onToggleReaction: ((String, String) -> Void)? { get set }
     var onReply: ((AnyMessage) -> Void)? { get set }

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Data Source/MessagesCollectionViewDataSource.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Data Source/MessagesCollectionViewDataSource.swift
@@ -18,6 +18,7 @@ final class MessagesCollectionViewDataSource: NSObject {
     var onTapAvatar: ((ConversationMember) -> Void)?
     var onTapInvite: ((MessageInvite) -> Void)?
     var onTapReactions: ((AnyMessage) -> Void)?
+    var onTapReadReceipts: ((MessagesGroup) -> Void)?
     var onReaction: ((String, String) -> Void)?
     var onToggleReaction: ((String, String) -> Void)?
     var onReply: ((AnyMessage) -> Void)?
@@ -88,6 +89,9 @@ extension MessagesCollectionViewDataSource: UICollectionViewDataSource {
             },
             onTapReactions: { [weak self] message in
                 self?.onTapReactions?(message)
+            },
+            onTapReadReceipts: { [weak self] group in
+                self?.onTapReadReceipts?(group)
             },
             onReaction: { [weak self] emoji, messageId in
                 self?.onReaction?(emoji, messageId)

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/MessagesViewController.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/MessagesViewController.swift
@@ -16,10 +16,6 @@ private class ImmediateTouchGestureRecognizer: UIGestureRecognizer {
     }
 }
 
-/// Captures horizontal swipes on the collection view to prevent
-/// NavigationSplitView's back gesture from triggering mid-screen.
-private class HorizontalBlockerPanGestureRecognizer: UIPanGestureRecognizer {}
-
 final class MessagesViewController: UIViewController {
     struct MessagesState {
         let conversation: Conversation
@@ -177,6 +173,7 @@ final class MessagesViewController: UIViewController {
     var onReaction: ((String, String) -> Void)?
     var onToggleReaction: ((String, String) -> Void)?
     var onTapReactions: ((AnyMessage) -> Void)?
+    var onTapReadReceipts: ((MessagesGroup) -> Void)?
     var onReply: ((AnyMessage) -> Void)?
     var contextMenuState: MessageContextMenuState = .init() {
         didSet { dataSource.contextMenuState = contextMenuState }
@@ -342,6 +339,10 @@ final class MessagesViewController: UIViewController {
             guard let self = self else { return }
             self.onTapReactions?(message)
         }
+        dataSource.onTapReadReceipts = { [weak self] group in
+            guard let self = self else { return }
+            self.onTapReadReceipts?(group)
+        }
         dataSource.onReaction = { [weak self] emoji, messageId in
             guard let self = self else { return }
             self.onReaction?(emoji, messageId)
@@ -395,7 +396,6 @@ final class MessagesViewController: UIViewController {
         }
 
         setupImmediateTouchGesture()
-        setupHorizontalBlockerGesture()
     }
 
     private func setupImmediateTouchGesture() {
@@ -405,12 +405,6 @@ final class MessagesViewController: UIViewController {
         gesture.delaysTouchesEnded = false
         gesture.delegate = self
         collectionView.addGestureRecognizer(gesture)
-    }
-
-    private func setupHorizontalBlockerGesture() {
-        let blocker = HorizontalBlockerPanGestureRecognizer(target: self, action: nil)
-        blocker.delegate = self
-        collectionView.addGestureRecognizer(blocker)
     }
 
     @objc private func handleImmediateTouch(_ gesture: UIGestureRecognizer) {
@@ -949,15 +943,6 @@ extension MessagesViewController {
 // MARK: - UIGestureRecognizerDelegate
 
 extension MessagesViewController: UIGestureRecognizerDelegate {
-    func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
-        guard let pan = gestureRecognizer as? HorizontalBlockerPanGestureRecognizer else { return true }
-        let velocity = pan.velocity(in: view)
-        let location = pan.location(in: view)
-        let isHorizontal = abs(velocity.x) > abs(velocity.y)
-        let isAwayFromEdge = location.x > 30
-        return isHorizontal && isAwayFromEdge
-    }
-
     func gestureRecognizer(
         _ gestureRecognizer: UIGestureRecognizer,
         shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesBottomBar.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesBottomBar.swift
@@ -513,6 +513,7 @@ struct MessagesBottomBar<BottomBarContent: View>: View {
             onReaction: { _, _ in },
             onToggleReaction: { _, _ in },
             onTapReactions: { _ in },
+            onTapReadReceipts: { _ in },
             onReply: { _ in },
             contextMenuState: .init(),
             onPhotoRevealed: { _ in },

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessageContextMenu/MessageContextMenuOverlay.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessageContextMenu/MessageContextMenuOverlay.swift
@@ -249,6 +249,22 @@ struct MessageContextMenuOverlay: View {
     }
 
     @ViewBuilder
+    private func reactionsBarMask(readerHeight: CGFloat) -> some View {
+        let gradientWidth: CGFloat = readerHeight * 0.3
+        HStack(spacing: 0) {
+            Rectangle().fill(.black)
+            LinearGradient(
+                colors: [.black, .black.opacity(0)],
+                startPoint: .leading,
+                endPoint: .trailing
+            )
+            .frame(width: gradientWidth)
+            Rectangle().fill(.clear)
+                .frame(width: readerHeight)
+        }
+    }
+
+    @ViewBuilder
     private func reactionsBarContent(messageId: String, width: CGFloat, height: CGFloat) -> some View {
         GeometryReader { reader in
             let readerHeight = max(reader.size.height - C.padding * 2, 0)
@@ -264,18 +280,7 @@ struct MessageContextMenuOverlay: View {
                 .frame(height: reader.size.height)
                 .scrollBounceBehavior(.basedOnSize)
                 .contentMargins(.trailing, readerHeight, for: .scrollContent)
-                .mask(
-                    HStack(spacing: 0) {
-                        Rectangle().fill(.black)
-                        LinearGradient(
-                            colors: [.black, .black.opacity(0)],
-                            startPoint: .leading, endPoint: .trailing
-                        )
-                        .frame(width: readerHeight * 0.3)
-                        Rectangle().fill(.clear)
-                            .frame(width: readerHeight)
-                    }
-                )
+                .mask(reactionsBarMask(readerHeight: readerHeight))
 
                 HStack(spacing: 0) {
                     Spacer()
@@ -676,6 +681,7 @@ struct MessageContextMenuOverlay: View {
                 attachment: attachment,
                 profile: profile,
                 reactions: [],
+                agentVerification: message?.sender.agentVerification ?? .unverified,
                 cornerRadiusOverride: radius
             )
         } else if attachment.mediaType == .file {

--- a/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/FileThumbnailRenderer.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/FileThumbnailRenderer.swift
@@ -1,0 +1,90 @@
+import ConvosCore
+import ConvosLogging
+import QuickLookThumbnailing
+import UIKit
+
+@MainActor
+final class FileThumbnailRenderer {
+    static let shared: FileThumbnailRenderer = FileThumbnailRenderer()
+
+    struct Result: Sendable {
+        let image: UIImage
+        let isContentThumbnail: Bool
+    }
+
+    private static let renderSize: CGSize = CGSize(width: 720, height: 1200)
+
+    private var inflight: [String: Task<Result?, Never>] = [:]
+
+    nonisolated static func cacheKey(for attachmentKey: String) -> String {
+        "file-thumb-v1-" + attachmentKey
+    }
+
+    nonisolated private static func contentMetadataKey(for attachmentKey: String) -> String {
+        "file-thumb-iscontent-v1-" + attachmentKey
+    }
+
+    func cachedThumbnail(for attachmentKey: String) -> Result? {
+        guard let image = ImageCache.shared.image(for: Self.cacheKey(for: attachmentKey)) else { return nil }
+        let isContent = UserDefaults.standard.bool(forKey: Self.contentMetadataKey(for: attachmentKey))
+        return Result(image: image, isContentThumbnail: isContent)
+    }
+
+    func thumbnail(for attachmentKey: String, fileURL: URL) async -> Result? {
+        let cacheKey = Self.cacheKey(for: attachmentKey)
+        if let cachedImage = await ImageCache.shared.imageAsync(for: cacheKey) {
+            let isContent = UserDefaults.standard.bool(forKey: Self.contentMetadataKey(for: attachmentKey))
+            return Result(image: cachedImage, isContentThumbnail: isContent)
+        }
+
+        if let existing = inflight[attachmentKey] {
+            return await existing.value
+        }
+
+        let task = Task<Result?, Never> { [weak self] in
+            guard let self else { return nil }
+            return await self.renderThumbnail(attachmentKey: attachmentKey, fileURL: fileURL)
+        }
+        inflight[attachmentKey] = task
+        let result = await task.value
+        inflight.removeValue(forKey: attachmentKey)
+        return result
+    }
+
+    private func renderThumbnail(attachmentKey: String, fileURL: URL) async -> Result? {
+        let scale = (UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .first?.screen.scale) ?? 2.0
+        let request = QLThumbnailGenerator.Request(
+            fileAt: fileURL,
+            size: Self.renderSize,
+            scale: scale,
+            representationTypes: [.thumbnail, .lowQualityThumbnail, .icon]
+        )
+
+        return await withCheckedContinuation { (continuation: CheckedContinuation<Result?, Never>) in
+            QLThumbnailGenerator.shared.generateBestRepresentation(for: request) { representation, error in
+                if let error {
+                    Log.error("FileThumbnailRenderer failed for \(attachmentKey): \(error)")
+                }
+                guard let representation else {
+                    continuation.resume(returning: nil)
+                    return
+                }
+                let isContent: Bool
+                switch representation.type {
+                case .thumbnail, .lowQualityThumbnail:
+                    isContent = true
+                case .icon:
+                    isContent = false
+                @unknown default:
+                    isContent = false
+                }
+                let image = representation.uiImage
+                ImageCache.shared.cacheImage(image, for: Self.cacheKey(for: attachmentKey), storageTier: .cache)
+                UserDefaults.standard.set(isContent, forKey: Self.contentMetadataKey(for: attachmentKey))
+                continuation.resume(returning: Result(image: image, isContentThumbnail: isContent))
+            }
+        }
+    }
+}

--- a/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/HTMLAttachmentBubble.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/HTMLAttachmentBubble.swift
@@ -7,6 +7,7 @@ struct HTMLAttachmentBubble: View {
     let attachment: HydratedAttachment
     let profile: Profile
     let reactions: [MessageReaction]
+    var agentVerification: AgentVerification = .unverified
     var onTapAvatar: (() -> Void)?
     var onTapReactions: (() -> Void)?
     var cornerRadiusOverride: CGFloat?
@@ -70,7 +71,8 @@ struct HTMLAttachmentBubble: View {
                 ProfileAvatarView(
                     profile: profile,
                     profileImage: nil,
-                    useSystemPlaceholder: false
+                    useSystemPlaceholder: false,
+                    agentVerification: agentVerification
                 )
                 .frame(width: DesignConstants.ImageSizes.smallAvatar, height: DesignConstants.ImageSizes.smallAvatar)
                 Text(profile.displayName)

--- a/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/ReadByDrawerView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/ReadByDrawerView.swift
@@ -1,0 +1,84 @@
+import ConvosCore
+import SwiftUI
+
+struct ReadByDrawerView: View {
+    let members: [ConversationMember]
+
+    private var sortedMembers: [ConversationMember] {
+        members.sorted { lhs, rhs in
+            if lhs.isCurrentUser && !rhs.isCurrentUser { return true }
+            if !lhs.isCurrentUser && rhs.isCurrentUser { return false }
+            return lhs.profile.displayName.localizedCaseInsensitiveCompare(rhs.profile.displayName)
+                == .orderedAscending
+        }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: DesignConstants.Spacing.step4x) {
+            Text("Read by")
+                .font(.system(.largeTitle))
+                .fontWeight(.bold)
+                .padding(.bottom, DesignConstants.Spacing.step2x)
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: DesignConstants.Spacing.step4x) {
+                    ForEach(sortedMembers, id: \.self) { member in
+                        ReadByRowView(member: member)
+                    }
+                }
+            }
+            .scrollBounceBehavior(.basedOnSize)
+            .scrollIndicatorsFlash(onAppear: true)
+            .scrollContentBackground(.hidden)
+            .frame(maxHeight: 600)
+        }
+        .padding([.leading, .top, .trailing], DesignConstants.Spacing.step10x)
+        .padding(.bottom, DesignConstants.Spacing.step3x)
+    }
+}
+
+private struct ReadByRowView: View {
+    let member: ConversationMember
+
+    var body: some View {
+        HStack(spacing: DesignConstants.Spacing.step3x) {
+            ProfileAvatarView(
+                profile: member.profile,
+                profileImage: nil,
+                useSystemPlaceholder: false,
+                agentVerification: member.agentVerification
+            )
+            .frame(width: 40.0, height: 40.0)
+
+            Text(member.isCurrentUser ? "You" : member.profile.displayName.capitalized)
+                .font(.callout)
+                .foregroundStyle(.colorTextPrimary)
+
+            Spacer()
+        }
+        .contentShape(Rectangle())
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(member.isCurrentUser ? "You" : member.profile.displayName) read this message")
+    }
+}
+
+#Preview {
+    @Previewable @State var presenting: Bool = false
+
+    let members: [ConversationMember] = [
+        .mock(name: "Alice"),
+        .mock(name: "Convos Assistant", isAgent: true, agentVerification: .verified(.convos)),
+        .mock(name: "Bob"),
+        .mock(name: "OAuth Agent", isAgent: true, agentVerification: .verified(.userOAuth))
+    ]
+
+    VStack {
+        let action = { presenting.toggle() }
+        Button(action: action) {
+            Text("Show Read by")
+        }
+    }
+    .selfSizingSheet(isPresented: $presenting) {
+        ReadByDrawerView(members: members)
+    }
+}

--- a/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/ReplyReferenceView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/ReplyReferenceView.swift
@@ -90,7 +90,8 @@ struct ReplyReferenceView: View {
                     ProfileAvatarView(
                         profile: parentMessage.sender.profile,
                         profileImage: nil,
-                        useSystemPlaceholder: false
+                        useSystemPlaceholder: false,
+                        agentVerification: parentMessage.sender.agentVerification
                     )
                     .frame(width: 16.0, height: 16.0)
                 }

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
@@ -308,6 +308,7 @@ struct MessagesGroupItemView: View {
                 attachment: attachment,
                 profile: message.sender.profile,
                 reactions: message.reactions,
+                agentVerification: message.sender.agentVerification,
                 onTapAvatar: avatarTap,
                 onTapReactions: reactionsTap
             )

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupView.swift
@@ -9,6 +9,7 @@ struct MessagesGroupView: View {
     let onTapAvatar: (AnyMessage) -> Void
     let onTapInvite: (MessageInvite) -> Void
     let onTapReactions: (AnyMessage) -> Void
+    var onTapReadReceipts: ((MessagesGroup) -> Void)?
     let onReaction: (String, String) -> Void
     let onToggleReaction: (String, String) -> Void
     let onReply: (AnyMessage) -> Void
@@ -293,9 +294,17 @@ struct MessagesGroupView: View {
                     )
                     .frame(width: 16, height: 16)
                 } else if !group.readByMembers.isEmpty {
-                    Text("Read")
-                        .font(.caption)
-                    ReadReceiptAvatarsView(members: group.readByMembers)
+                    let readReceiptTap: () -> Void = { onTapReadReceipts?(group) }
+                    Button(action: readReceiptTap) {
+                        HStack(spacing: DesignConstants.Spacing.stepX) {
+                            Text("Read")
+                                .font(.caption)
+                            ReadReceiptAvatarsView(members: group.readByMembers)
+                        }
+                        .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityHint("Tap to see who read this message")
                 } else {
                     Text("Sent")
                         .font(.caption)

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessagesListView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessagesListView.swift
@@ -10,6 +10,7 @@ struct MessagesListView: View {
     let onTapAvatar: (AnyMessage) -> Void
     let onTapInvite: (MessageInvite) -> Void
     let onTapReactions: (AnyMessage) -> Void
+    let onTapReadReceipts: (MessagesGroup) -> Void
     let onReaction: (String, String) -> Void
     let onToggleReaction: (String, String) -> Void
     let onReply: (AnyMessage) -> Void
@@ -173,6 +174,7 @@ struct MessagesListView: View {
             onTapAvatar: onTapAvatar,
             onTapInvite: onTapInvite,
             onTapReactions: onTapReactions,
+            onTapReadReceipts: onTapReadReceipts,
             onReaction: onReaction,
             onToggleReaction: onToggleReaction,
             onReply: onReply,

--- a/Convos/Conversation Detail/Messages/MessagesView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesView.swift
@@ -45,6 +45,7 @@ struct MessagesView<BottomBarContent: View>: View {
     let onReaction: (String, String) -> Void
     let onToggleReaction: (String, String) -> Void
     let onTapReactions: (AnyMessage) -> Void
+    let onTapReadReceipts: (MessagesGroup) -> Void
     let onReply: (AnyMessage) -> Void
     let replyingToMessage: AnyMessage?
     var replyingToAudioTranscriptText: String?
@@ -79,6 +80,7 @@ struct MessagesView<BottomBarContent: View>: View {
     @Bindable var voiceMemoRecorder: VoiceMemoRecorder
     let onSendVoiceMemo: () -> Void
     let onConvosAction: () -> Void
+    var extraBottomInset: CGFloat = 0.0
     @ViewBuilder let bottomBarContent: () -> BottomBarContent
 
     @State private var bottomBarHeight: CGFloat = 0.0
@@ -101,6 +103,7 @@ struct MessagesView<BottomBarContent: View>: View {
             onReaction: onReaction,
             onToggleReaction: onToggleReaction,
             onTapReactions: onTapReactions,
+            onTapReadReceipts: onTapReadReceipts,
             onReply: onReply,
             contextMenuState: contextMenuState,
             onPhotoRevealed: onPhotoRevealed,
@@ -119,7 +122,7 @@ struct MessagesView<BottomBarContent: View>: View {
             hasAssistant: hasAssistant,
             isAssistantJoinPending: isAssistantJoinPending,
             isAssistantEnabled: isAssistantEnabled,
-            bottomBarHeight: bottomBarHeight,
+            bottomBarHeight: bottomBarHeight + extraBottomInset,
             onBottomOverscrollChanged: onBottomOverscrollChanged,
             onBottomOverscrollReleased: onBottomOverscrollReleased,
             scrollToBottomTrigger: { scrollFn in

--- a/Convos/Conversation Detail/Messages/MessagesViewRepresentable.swift
+++ b/Convos/Conversation Detail/Messages/MessagesViewRepresentable.swift
@@ -16,6 +16,7 @@ struct MessagesViewRepresentable: UIViewControllerRepresentable {
     let onReaction: (String, String) -> Void
     let onToggleReaction: (String, String) -> Void
     let onTapReactions: (AnyMessage) -> Void
+    let onTapReadReceipts: (MessagesGroup) -> Void
     let onReply: (AnyMessage) -> Void
     let contextMenuState: MessageContextMenuState
     let onPhotoRevealed: (String) -> Void
@@ -69,6 +70,7 @@ struct MessagesViewRepresentable: UIViewControllerRepresentable {
         messagesViewController.onReaction = onReaction
         messagesViewController.onToggleReaction = onToggleReaction
         messagesViewController.onTapReactions = onTapReactions
+        messagesViewController.onTapReadReceipts = onTapReadReceipts
         messagesViewController.onReply = onReply
         messagesViewController.shouldBlurPhotos = shouldBlurPhotos
         messagesViewController.onPhotoRevealed = { key in
@@ -141,6 +143,7 @@ struct MessagesViewRepresentable: UIViewControllerRepresentable {
         onReaction: { _, _ in },
         onToggleReaction: { _, _ in },
         onTapReactions: { _ in },
+        onTapReadReceipts: { _ in },
         onReply: { _ in },
         contextMenuState: .init(),
         onPhotoRevealed: { _ in },

--- a/ConvosCore/Sources/ConvosCore/Storage/Repositories/AssistantFilesLinksRepository.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Repositories/AssistantFilesLinksRepository.swift
@@ -4,6 +4,7 @@ import UniformTypeIdentifiers
 
 public struct AssistantFile: Sendable, Hashable, Identifiable {
     public let id: String
+    public let senderInboxId: String
     public let filename: String?
     public let mimeType: String?
     public let date: Date
@@ -21,6 +22,7 @@ public struct AssistantFile: Sendable, Hashable, Identifiable {
 
 public struct AssistantLink: Sendable, Hashable, Identifiable {
     public let id: String
+    public let senderInboxId: String
     public let url: String
     public let title: String?
     public let siteName: String?
@@ -56,7 +58,7 @@ public final class AssistantFilesLinksRepository: Sendable {
     public func fetchFiles() async throws -> [AssistantFile] {
         try await dbReader.read { [conversationId] db in
             let rows = try Row.fetchAll(db, sql: """
-                SELECT m.id, m.date, m.attachmentUrls
+                SELECT m.id, m.date, m.attachmentUrls, m.senderId
                 FROM message m
                 WHERE m.conversationId = ?
                     AND m.contentType = 'attachments'
@@ -75,6 +77,7 @@ public final class AssistantFilesLinksRepository: Sendable {
             return rows.compactMap { row -> AssistantFile? in
                 guard let id: String = row["id"],
                       let date: Date = row["date"],
+                      let senderInboxId: String = row["senderId"],
                       let attachmentUrlsJson: String = row["attachmentUrls"],
                       let keys = try? JSONDecoder().decode([String].self, from: Data(attachmentUrlsJson.utf8)),
                       let firstKey = keys.first
@@ -83,6 +86,7 @@ public final class AssistantFilesLinksRepository: Sendable {
                 let parsed = Self.parseAttachmentKey(firstKey)
                 return AssistantFile(
                     id: id,
+                    senderInboxId: senderInboxId,
                     filename: parsed.filename,
                     mimeType: parsed.mimeType,
                     date: date,
@@ -96,7 +100,7 @@ public final class AssistantFilesLinksRepository: Sendable {
     public func fetchLinks() async throws -> [AssistantLink] {
         try await dbReader.read { [conversationId] db in
             let rows = try Row.fetchAll(db, sql: """
-                SELECT m.id, m.date, m.linkPreview
+                SELECT m.id, m.date, m.linkPreview, m.senderId
                 FROM message m
                 WHERE m.conversationId = ?
                     AND m.contentType = 'linkPreview'
@@ -115,12 +119,14 @@ public final class AssistantFilesLinksRepository: Sendable {
             return rows.compactMap { row -> AssistantLink? in
                 guard let id: String = row["id"],
                       let date: Date = row["date"],
+                      let senderInboxId: String = row["senderId"],
                       let linkPreviewJson: String = row["linkPreview"],
                       let data = linkPreviewJson.data(using: .utf8),
                       let preview = try? JSONDecoder().decode(LinkPreview.self, from: data)
                 else { return nil }
                 return AssistantLink(
                     id: id,
+                    senderInboxId: senderInboxId,
                     url: preview.url,
                     title: preview.title,
                     siteName: preview.siteName,


### PR DESCRIPTION
The view formerly known as AssistantFilesLinksView is now titled
"Stuff" and displays files and links in a single chronological list
instead of a tabbed Files / Links picker. The search bar moves to the
bottom of the screen as a glass capsule with a circular filter menu
button next to it (All / Files / Links).

Date subtitles are formatted relative to now (Today / Yesterday / Nd
ago / dated) so the list matches the Stuff design from the spec.

This is the first step of the bigger conversation-segmented-control
feature; subsequent PRs will mount this as a tab below the messages
bottom bar.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/813"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace tabbed Files & Links view with unified 'Stuff' view with search and filter
> - Replaces the segmented tab picker in `AssistantFilesLinksView` with a unified list combining files and links, sorted by recency, with a bottom `StuffSearchBar` for text search and a filter menu (All / Files / Links).
> - File rows now show thumbnails (including HTML snapshots via `HTMLThumbnailRenderer` and a new `FileThumbnailRenderer` singleton) and resolved HTML titles; tapping a file opens `AttachmentPreviewSheet` with optional sender info.
> - `AssistantFile` and `AssistantLink` now carry `senderInboxId`, populated from the database in `AssistantFilesLinksRepository`, so the preview sheet can show who sent each item.
> - `AttachmentPreviewSheet` now accepts an optional sender and uses `HiddenBarNavigationController` to prevent the navigation bar from reappearing in Quick Look.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #813 opened
>
> - Added horizontal paging between Messages and Stuff views in conversation screen [4dc1bb0]
> - Implemented tappable read receipts with drawer view to show who read messages [4dc1bb0]
> - Added agent verification display to profile avatars throughout conversation views [4dc1bb0]
> - Refactored `AssistantFilesLinksView` to support inline headers and customizable profile sheets [4dc1bb0]
> - Added profile sheet presentation from Files & Links screen to member profiles [4dc1bb0]
> - Removed horizontal pan gesture blocking from messages view controller [4dc1bb0]
> - Extracted reusable view-builder for reactions bar mask gradient [4dc1bb0]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized d1e9a8d. 2 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->