### PR TITLE
Wrap messages and Stuff in a horizontal pager

### DIFF
--- a/Convos/Conversation Detail/AssistantFilesLinksView.swift
+++ b/Convos/Conversation Detail/AssistantFilesLinksView.swift
@@ -116,10 +116,16 @@ struct AssistantFilesLinksView: View {
     @State private var viewModel: AssistantFilesLinksViewModel
     @State private var presentingPreview: AttachmentPreviewPresentation?
     private let members: [ConversationMember]
+    private let usesInlineHeader: Bool
 
-    init(repository: AssistantFilesLinksRepository, members: [ConversationMember]) {
+    init(
+        repository: AssistantFilesLinksRepository,
+        members: [ConversationMember],
+        usesInlineHeader: Bool = false
+    ) {
         _viewModel = State(initialValue: AssistantFilesLinksViewModel(repository: repository))
         self.members = members
+        self.usesInlineHeader = usesInlineHeader
     }
 
     private func member(forInboxId inboxId: String) -> ConversationMember? {
@@ -127,11 +133,10 @@ struct AssistantFilesLinksView: View {
     }
 
     var body: some View {
-        content
+        bodyContent
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .background(.colorBackgroundRaisedSecondary)
-            .navigationTitle("Stuff")
-            .toolbarTitleDisplayMode(.large)
+            .applyTitle(usesInlineHeader: usesInlineHeader)
             .safeAreaBar(edge: .bottom) {
                 StuffSearchBar(
                     searchText: $viewModel.searchText,
@@ -160,6 +165,23 @@ struct AssistantFilesLinksView: View {
             } message: {
                 Text(viewModel.fileOpenError ?? "This file is no longer available on this device.")
             }
+    }
+
+    @ViewBuilder
+    private var bodyContent: some View {
+        if usesInlineHeader {
+            VStack(alignment: .leading, spacing: 0) {
+                Text("Stuff")
+                    .font(.largeTitle.bold())
+                    .foregroundStyle(.colorTextPrimary)
+                    .padding(.horizontal, DesignConstants.Spacing.step4x)
+                    .padding(.top, DesignConstants.Spacing.step2x)
+                    .padding(.bottom, DesignConstants.Spacing.step3x)
+                content
+            }
+        } else {
+            content
+        }
     }
 
     @ViewBuilder
@@ -468,6 +490,19 @@ private struct StuffRowContent<Thumbnail: View>: View {
         .padding(.horizontal, DesignConstants.Spacing.step4x)
         .padding(.vertical, DesignConstants.Spacing.step2x)
         .contentShape(Rectangle())
+    }
+}
+
+private extension View {
+    @ViewBuilder
+    func applyTitle(usesInlineHeader: Bool) -> some View {
+        if usesInlineHeader {
+            self
+        } else {
+            self
+                .navigationTitle("Stuff")
+                .toolbarTitleDisplayMode(.large)
+        }
     }
 }
 

--- a/Convos/Conversation Detail/AssistantFilesLinksView.swift
+++ b/Convos/Conversation Detail/AssistantFilesLinksView.swift
@@ -117,15 +117,18 @@ struct AssistantFilesLinksView: View {
     @State private var presentingPreview: AttachmentPreviewPresentation?
     private let members: [ConversationMember]
     private let usesInlineHeader: Bool
+    private let profileSheetContent: ((ConversationMember) -> AnyView)?
 
     init(
         repository: AssistantFilesLinksRepository,
         members: [ConversationMember],
-        usesInlineHeader: Bool = false
+        usesInlineHeader: Bool = false,
+        profileSheetContent: ((ConversationMember) -> AnyView)? = nil
     ) {
         _viewModel = State(initialValue: AssistantFilesLinksViewModel(repository: repository))
         self.members = members
         self.usesInlineHeader = usesInlineHeader
+        self.profileSheetContent = profileSheetContent
     }
 
     private func member(forInboxId inboxId: String) -> ConversationMember? {
@@ -151,7 +154,8 @@ struct AssistantFilesLinksView: View {
                     attachment: preview.attachment,
                     fileURL: preview.fileURL,
                     sender: preview.sender,
-                    sentAt: preview.sentAt
+                    sentAt: preview.sentAt,
+                    profileSheetContent: profileSheetContent
                 )
                 .presentationDetents([.large])
             }
@@ -201,11 +205,8 @@ struct AssistantFilesLinksView: View {
             LazyVStack(spacing: 0) {
                 ForEach(viewModel.filteredItems) { item in
                     row(for: item)
-                    Divider()
-                        .padding(.leading, Constant.dividerInset)
                 }
             }
-            .padding(.top, DesignConstants.Spacing.step2x)
         }
     }
 
@@ -322,12 +323,8 @@ struct AssistantFilesLinksView: View {
     }
 
     private var linkPlaceholder: some View {
-        RoundedRectangle(cornerRadius: DesignConstants.CornerRadius.small)
-            .fill(Color.colorFillMinimal)
-            .overlay {
-                Image(systemName: "link")
-                    .foregroundStyle(.colorTextSecondary)
-            }
+        Image(systemName: "link")
+            .foregroundStyle(.colorTextSecondary)
     }
 
     private func relativeDate(for date: Date) -> String {
@@ -338,10 +335,6 @@ struct AssistantFilesLinksView: View {
             return "\(days)d ago"
         }
         return date.formatted(.dateTime.month(.abbreviated).day().year(.twoDigits))
-    }
-
-    private enum Constant {
-        static let dividerInset: CGFloat = 80.0
     }
 }
 
@@ -360,7 +353,7 @@ private struct FileRow: View {
                 thumbnail: { thumbnail },
                 title: displayTitle,
                 subtitle: subtitle,
-                trailingSymbol: "doc"
+                trailingSymbol: isHTML ? "globe" : "doc"
             )
         }
         .buttonStyle(.plain)
@@ -381,24 +374,20 @@ private struct FileRow: View {
         if let renderedHTMLPreview {
             Image(uiImage: renderedHTMLPreview)
                 .resizable()
-                .aspectRatio(contentMode: .fill)
+                .aspectRatio(contentMode: .fit)
         } else if let renderedFilePreview {
             Image(uiImage: renderedFilePreview)
                 .resizable()
-                .aspectRatio(contentMode: .fill)
+                .aspectRatio(contentMode: .fit)
         } else if let base64 = file.thumbnailDataBase64,
                   let data = Data(base64Encoded: base64),
                   let uiImage = UIImage(data: data) {
             Image(uiImage: uiImage)
                 .resizable()
-                .aspectRatio(contentMode: .fill)
+                .aspectRatio(contentMode: .fit)
         } else {
-            RoundedRectangle(cornerRadius: DesignConstants.CornerRadius.small)
-                .fill(Color.colorFillMinimal)
-                .overlay {
-                    Image(systemName: "doc.fill")
-                        .foregroundStyle(.colorTextSecondary)
-                }
+            Image(systemName: "doc.fill")
+                .foregroundStyle(.colorTextSecondary)
         }
     }
 
@@ -419,10 +408,10 @@ private struct FileRow: View {
             renderedFilePreview = cached.image
         }
 
-        guard renderedHTMLPreview == nil
-            || resolvedHTMLTitle == nil
-            || (!isHTML && renderedFilePreview == nil)
-        else { return }
+        let needsLoad: Bool = isHTML
+            ? (renderedHTMLPreview == nil || resolvedHTMLTitle == nil)
+            : (renderedFilePreview == nil)
+        guard needsLoad else { return }
 
         do {
             let url = try await FileAttachmentPreviewLoader.loadPreviewURL(
@@ -467,10 +456,15 @@ private struct StuffRowContent<Thumbnail: View>: View {
     var body: some View {
         HStack(spacing: DesignConstants.Spacing.step3x) {
             thumbnail()
-                .frame(width: 56.0, height: 56.0)
-                .clipShape(RoundedRectangle(cornerRadius: DesignConstants.CornerRadius.small))
+                .frame(width: StuffRowMetrics.thumbnailSize, height: StuffRowMetrics.thumbnailSize)
+                .background(Color.colorFillMinimal)
+                .clipShape(RoundedRectangle(cornerRadius: StuffRowMetrics.thumbnailCornerRadius))
+                .overlay(
+                    RoundedRectangle(cornerRadius: StuffRowMetrics.thumbnailCornerRadius)
+                        .strokeBorder(Color.colorBorderEdge, lineWidth: 1.0)
+                )
 
-            VStack(alignment: .leading, spacing: DesignConstants.Spacing.stepHalf) {
+            VStack(alignment: .leading, spacing: StuffRowMetrics.titleSubtitleSpacing) {
                 Text(title)
                     .font(.body)
                     .foregroundStyle(.colorTextPrimary)
@@ -482,15 +476,21 @@ private struct StuffRowContent<Thumbnail: View>: View {
                     .lineLimit(1)
             }
 
-            Spacer()
+            Spacer(minLength: DesignConstants.Spacing.step3x)
 
             Image(systemName: trailingSymbol)
                 .foregroundStyle(.colorTextSecondary)
         }
-        .padding(.horizontal, DesignConstants.Spacing.step4x)
-        .padding(.vertical, DesignConstants.Spacing.step2x)
+        .padding(.horizontal, DesignConstants.Spacing.step6x)
+        .padding(.vertical, DesignConstants.Spacing.step3x)
         .contentShape(Rectangle())
     }
+}
+
+private enum StuffRowMetrics {
+    static let thumbnailSize: CGFloat = 47.0
+    static let thumbnailCornerRadius: CGFloat = 16.0
+    static let titleSubtitleSpacing: CGFloat = 3.0
 }
 
 private extension View {

--- a/Convos/Conversation Detail/AttachmentPreviewSheet.swift
+++ b/Convos/Conversation Detail/AttachmentPreviewSheet.swift
@@ -117,7 +117,8 @@ private struct AttachmentSenderIndicator: View {
                 ProfileAvatarView(
                     profile: sender.profile,
                     profileImage: nil,
-                    useSystemPlaceholder: false
+                    useSystemPlaceholder: false,
+                    agentVerification: sender.agentVerification
                 )
                 .frame(width: 36.0, height: 36.0)
 

--- a/Convos/Conversation Detail/ConversationInfoView.swift
+++ b/Convos/Conversation Detail/ConversationInfoView.swift
@@ -117,7 +117,19 @@ struct ConversationInfoView: View {
         NavigationLink {
             AssistantFilesLinksView(
                 repository: viewModel.makeAssistantFilesLinksRepository(),
-                members: viewModel.conversation.members
+                members: viewModel.conversation.members,
+                profileSheetContent: { member in
+                    AnyView(
+                        NavigationStack {
+                            ConversationMemberView(viewModel: viewModel, member: member)
+                                .toolbar {
+                                    ToolbarItem(placement: .cancellationAction) {
+                                        AttachmentProfileSheetCloseButton()
+                                    }
+                                }
+                        }
+                    )
+                }
             )
         } label: {
             FeatureRowItem(

--- a/Convos/Conversation Detail/ConversationPager.swift
+++ b/Convos/Conversation Detail/ConversationPager.swift
@@ -52,7 +52,7 @@ private struct ConversationPagerDots: View {
     @Binding var selectedPage: ConversationPagerPage
 
     var body: some View {
-        HStack(spacing: DesignConstants.Spacing.step2x) {
+        HStack(spacing: 10.0) {
             ForEach(ConversationPagerPage.allCases) { page in
                 let isSelected: Bool = page == selectedPage
                 let action = {
@@ -61,19 +61,38 @@ private struct ConversationPagerDots: View {
                     }
                 }
                 Button(action: action) {
-                    Capsule()
-                        .fill(isSelected ? Color.colorTextPrimary : Color.colorTextSecondary.opacity(0.3))
-                        .frame(width: isSelected ? 18.0 : 8.0, height: 8.0)
+                    pageShape(for: page)
+                        .fill(isSelected ? Color.colorFillSecondary : Color.colorFillTertiary)
+                        .frame(width: 8.0, height: 8.0)
                         .animation(.easeInOut(duration: 0.2), value: isSelected)
                 }
                 .buttonStyle(.plain)
                 .accessibilityLabel(label(for: page))
             }
         }
-        .padding(.horizontal, DesignConstants.Spacing.step2x)
-        .frame(height: 24.0)
+        .padding(.horizontal, 10.0)
+        .padding(.vertical, DesignConstants.Spacing.step2x)
         .glassEffect(.regular.interactive(), in: .capsule)
         .accessibilityIdentifier("conversation-pager-dots")
+    }
+
+    private func pageShape(for page: ConversationPagerPage) -> UnevenRoundedRectangle {
+        switch page {
+        case .messages:
+            return UnevenRoundedRectangle(cornerRadii: .init(
+                topLeading: 8.0,
+                bottomLeading: 2.0,
+                bottomTrailing: 8.0,
+                topTrailing: 8.0
+            ))
+        case .stuff:
+            return UnevenRoundedRectangle(cornerRadii: .init(
+                topLeading: 2.0,
+                bottomLeading: 2.0,
+                bottomTrailing: 2.0,
+                topTrailing: 2.0
+            ))
+        }
     }
 
     private func label(for page: ConversationPagerPage) -> String {

--- a/Convos/Conversation Detail/ConversationPager.swift
+++ b/Convos/Conversation Detail/ConversationPager.swift
@@ -1,0 +1,85 @@
+import ConvosCore
+import SwiftUI
+import SwiftUIIntrospect
+
+enum ConversationPagerPage: Int, CaseIterable, Identifiable {
+    case messages
+    case stuff
+
+    var id: Int { rawValue }
+}
+
+struct ConversationPager<MessagesPage: View, StuffPage: View>: View {
+    @Binding var selectedPage: ConversationPagerPage
+    let showsPageDots: Bool
+    @ViewBuilder let messagesPage: () -> MessagesPage
+    @ViewBuilder let stuffPage: () -> StuffPage
+
+    var body: some View {
+        GeometryReader { proxy in
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 0) {
+                    messagesPage()
+                        .frame(width: proxy.size.width, height: proxy.size.height)
+                        .id(ConversationPagerPage.messages)
+
+                    stuffPage()
+                        .frame(width: proxy.size.width, height: proxy.size.height)
+                        .id(ConversationPagerPage.stuff)
+                }
+                .scrollTargetLayout()
+            }
+            .scrollTargetBehavior(.paging)
+            .scrollPosition(id: Binding(
+                get: { selectedPage },
+                set: { newValue in
+                    if let newValue { selectedPage = newValue }
+                }
+            ))
+            .introspect(.scrollView, on: .iOS(.v26)) { (scrollView: UIScrollView) in
+                scrollView.bounces = false
+            }
+        }
+        .safeAreaInset(edge: .bottom, spacing: 0) {
+            if showsPageDots {
+                ConversationPagerDots(selectedPage: $selectedPage)
+            }
+        }
+    }
+}
+
+private struct ConversationPagerDots: View {
+    @Binding var selectedPage: ConversationPagerPage
+
+    var body: some View {
+        HStack(spacing: DesignConstants.Spacing.step2x) {
+            ForEach(ConversationPagerPage.allCases) { page in
+                let isSelected: Bool = page == selectedPage
+                let action = {
+                    withAnimation(.easeInOut(duration: 0.25)) {
+                        selectedPage = page
+                    }
+                }
+                Button(action: action) {
+                    Capsule()
+                        .fill(isSelected ? Color.colorTextPrimary : Color.colorTextSecondary.opacity(0.3))
+                        .frame(width: isSelected ? 18.0 : 8.0, height: 8.0)
+                        .animation(.easeInOut(duration: 0.2), value: isSelected)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(label(for: page))
+            }
+        }
+        .padding(.horizontal, DesignConstants.Spacing.step2x)
+        .frame(height: 24.0)
+        .glassEffect(.regular.interactive(), in: .capsule)
+        .accessibilityIdentifier("conversation-pager-dots")
+    }
+
+    private func label(for page: ConversationPagerPage) -> String {
+        switch page {
+        case .messages: return "Messages"
+        case .stuff: return "Stuff"
+        }
+    }
+}

--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -82,6 +82,7 @@ struct ConversationView<MessagesBottomBar: View>: View {
             onReaction: viewModel.onReaction(emoji:messageId:),
             onToggleReaction: viewModel.onReaction(emoji:messageId:),
             onTapReactions: viewModel.onTapReactions(_:),
+            onTapReadReceipts: viewModel.onTapReadReceipts(_:),
             onReply: { message in
                 viewModel.onReply(message)
                 focusCoordinator.moveFocus(to: .message)
@@ -119,18 +120,7 @@ struct ConversationView<MessagesBottomBar: View>: View {
             onRetryTranscript: { item in
                 viewModel.retryTranscript(for: item)
             },
-            profileSheetForMember: { member in
-                AnyView(
-                    NavigationStack {
-                        ConversationMemberView(viewModel: viewModel, member: member)
-                            .toolbar {
-                                ToolbarItem(placement: .cancellationAction) {
-                                    AttachmentProfileSheetCloseButton()
-                                }
-                            }
-                    }
-                )
-            },
+            profileSheetForMember: profileSheetForMember,
             hasAssistant: viewModel.conversation.hasAgent,
             isAssistantJoinPending: viewModel.isAssistantJoinPending,
             isAssistantEnabled: FeatureFlags.shared.isAssistantEnabled && GlobalConvoDefaults.shared.assistantsEnabled,
@@ -249,7 +239,21 @@ struct ConversationView<MessagesBottomBar: View>: View {
         AssistantFilesLinksView(
             repository: viewModel.makeAssistantFilesLinksRepository(),
             members: viewModel.conversation.members,
-            usesInlineHeader: true
+            usesInlineHeader: true,
+            profileSheetContent: profileSheetForMember
+        )
+    }
+
+    private func profileSheetForMember(_ member: ConversationMember) -> AnyView {
+        AnyView(
+            NavigationStack {
+                ConversationMemberView(viewModel: viewModel, member: member)
+                    .toolbar {
+                        ToolbarItem(placement: .cancellationAction) {
+                            AttachmentProfileSheetCloseButton()
+                        }
+                    }
+            }
         )
     }
 
@@ -343,6 +347,9 @@ struct ConversationView<MessagesBottomBar: View>: View {
                 viewModel.removeReaction(reaction, from: message)
             }
         }
+        .selfSizingSheet(item: $viewModel.presentingReadByForGroup) { group in
+            ReadByDrawerView(members: group.readByMembers)
+        }
         .selfSizingSheet(isPresented: $showingLockedInfo) {
             LockedConvoInfoView(
                 isCurrentUserSuperAdmin: viewModel.isCurrentUserSuperAdmin,
@@ -382,7 +389,7 @@ struct ConversationView<MessagesBottomBar: View>: View {
     }
 }
 
-private struct AttachmentProfileSheetCloseButton: View {
+struct AttachmentProfileSheetCloseButton: View {
     @Environment(\.dismiss) private var dismiss: DismissAction
 
     var body: some View {

--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -20,6 +20,8 @@ struct ConversationView<MessagesBottomBar: View>: View {
     @State private var showingAssistantsInfo: Bool = false
     @State private var scrollOverscrollAmount: CGFloat = 0.0
     @State private var didReleasePastThreshold: Bool = false
+    @State private var pagerSelectedPage: ConversationPagerPage = .messages
+    @State private var isKeyboardVisible: Bool = false
     @Environment(\.dismiss) private var dismiss: DismissAction
 
     private var showPullToAddAssistant: Bool {
@@ -148,6 +150,7 @@ struct ConversationView<MessagesBottomBar: View>: View {
             voiceMemoRecorder: viewModel.voiceMemoRecorder,
             onSendVoiceMemo: { viewModel.sendVoiceMemo() },
             onConvosAction: { viewModel.onConvosButtonTapped() },
+            extraBottomInset: pagerDotsInset,
             bottomBarContent: {
                 VStack(spacing: DesignConstants.Spacing.step3x) {
                     if showPullToAddAssistant {
@@ -242,8 +245,31 @@ struct ConversationView<MessagesBottomBar: View>: View {
         .accessibilityIdentifier("scan-invite-button")
     }
 
+    private var stuffPage: some View {
+        AssistantFilesLinksView(
+            repository: viewModel.makeAssistantFilesLinksRepository(),
+            members: viewModel.conversation.members,
+            usesInlineHeader: true
+        )
+    }
+
+    private var pagerDotsInset: CGFloat {
+        isKeyboardVisible ? 0.0 : 24.0
+    }
+
     var body: some View {
-        messagesView
+        ConversationPager(
+            selectedPage: $pagerSelectedPage,
+            showsPageDots: !isKeyboardVisible,
+            messagesPage: { messagesView },
+            stuffPage: { stuffPage }
+        )
+        .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillShowNotification)) { _ in
+            isKeyboardVisible = true
+        }
+        .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillHideNotification)) { _ in
+            isKeyboardVisible = false
+        }
         .onChange(of: viewModel.messageText) { _, _ in
             viewModel.checkForInviteURL()
             viewModel.checkForPastedLink()

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -407,6 +407,7 @@ class ConversationViewModel { // swiftlint:disable:this type_body_length
     }
     var presentingConversationForked: Bool = false
     var presentingReactionsForMessage: AnyMessage?
+    var presentingReadByForGroup: MessagesGroup?
     var replyingToMessage: AnyMessage?
     var presentingShareView: Bool = false
     var presentingRevealMediaInfoSheet: Bool = false
@@ -1921,6 +1922,10 @@ extension ConversationViewModel {
 
     func onTapReactions(_ message: AnyMessage) {
         presentingReactionsForMessage = message
+    }
+
+    func onTapReadReceipts(_ group: MessagesGroup) {
+        presentingReadByForGroup = group
     }
 
     func onToggleReaction(emoji: String, messageId: String) {

--- a/Convos/Conversation Detail/Messages/Messages View Controller/Reactions/ReactionsDrawerView.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/Reactions/ReactionsDrawerView.swift
@@ -58,7 +58,8 @@ private struct ReactionRowView: View {
             ProfileAvatarView(
                 profile: reaction.sender.profile,
                 profileImage: nil,
-                useSystemPlaceholder: false
+                useSystemPlaceholder: false,
+                agentVerification: reaction.sender.agentVerification
             )
             .frame(width: 40.0, height: 40.0)
 

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Cells/MessagesListItemTypeCell.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Cells/MessagesListItemTypeCell.swift
@@ -92,6 +92,7 @@ class MessagesListItemTypeCell: UICollectionViewCell {
                         onTapAvatar: config.onTapAvatar,
                         onTapInvite: config.onTapInvite,
                         onTapReactions: config.onTapReactions,
+                        onTapReadReceipts: config.onTapReadReceipts,
                         onReaction: config.onReaction,
                         onToggleReaction: config.onToggleReaction,
                         onReply: config.onReply,

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Data Source/CellFactory.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Data Source/CellFactory.swift
@@ -8,6 +8,7 @@ struct CellConfig {
     let onTapInvite: (MessageInvite) -> Void
     let onTapAvatar: (AnyMessage) -> Void
     let onTapReactions: (AnyMessage) -> Void
+    let onTapReadReceipts: (MessagesGroup) -> Void
     let onReaction: (String, String) -> Void
     let onToggleReaction: (String, String) -> Void
     let onReply: (AnyMessage) -> Void

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Data Source/MessagesCollectionDataSource.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Data Source/MessagesCollectionDataSource.swift
@@ -8,6 +8,7 @@ protocol MessagesCollectionDataSource: UICollectionViewDataSource, MessagesLayou
     var onTapInvite: ((MessageInvite) -> Void)? { get set }
     var onTapAvatar: ((ConversationMember) -> Void)? { get set }
     var onTapReactions: ((AnyMessage) -> Void)? { get set }
+    var onTapReadReceipts: ((MessagesGroup) -> Void)? { get set }
     var onReaction: ((String, String) -> Void)? { get set }
     var onToggleReaction: ((String, String) -> Void)? { get set }
     var onReply: ((AnyMessage) -> Void)? { get set }

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Data Source/MessagesCollectionViewDataSource.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Data Source/MessagesCollectionViewDataSource.swift
@@ -18,6 +18,7 @@ final class MessagesCollectionViewDataSource: NSObject {
     var onTapAvatar: ((ConversationMember) -> Void)?
     var onTapInvite: ((MessageInvite) -> Void)?
     var onTapReactions: ((AnyMessage) -> Void)?
+    var onTapReadReceipts: ((MessagesGroup) -> Void)?
     var onReaction: ((String, String) -> Void)?
     var onToggleReaction: ((String, String) -> Void)?
     var onReply: ((AnyMessage) -> Void)?
@@ -88,6 +89,9 @@ extension MessagesCollectionViewDataSource: UICollectionViewDataSource {
             },
             onTapReactions: { [weak self] message in
                 self?.onTapReactions?(message)
+            },
+            onTapReadReceipts: { [weak self] group in
+                self?.onTapReadReceipts?(group)
             },
             onReaction: { [weak self] emoji, messageId in
                 self?.onReaction?(emoji, messageId)

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/MessagesViewController.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/MessagesViewController.swift
@@ -16,10 +16,6 @@ private class ImmediateTouchGestureRecognizer: UIGestureRecognizer {
     }
 }
 
-/// Captures horizontal swipes on the collection view to prevent
-/// NavigationSplitView's back gesture from triggering mid-screen.
-private class HorizontalBlockerPanGestureRecognizer: UIPanGestureRecognizer {}
-
 final class MessagesViewController: UIViewController {
     struct MessagesState {
         let conversation: Conversation
@@ -395,7 +391,6 @@ final class MessagesViewController: UIViewController {
         }
 
         setupImmediateTouchGesture()
-        setupHorizontalBlockerGesture()
     }
 
     private func setupImmediateTouchGesture() {
@@ -405,12 +400,6 @@ final class MessagesViewController: UIViewController {
         gesture.delaysTouchesEnded = false
         gesture.delegate = self
         collectionView.addGestureRecognizer(gesture)
-    }
-
-    private func setupHorizontalBlockerGesture() {
-        let blocker = HorizontalBlockerPanGestureRecognizer(target: self, action: nil)
-        blocker.delegate = self
-        collectionView.addGestureRecognizer(blocker)
     }
 
     @objc private func handleImmediateTouch(_ gesture: UIGestureRecognizer) {
@@ -949,15 +938,6 @@ extension MessagesViewController {
 // MARK: - UIGestureRecognizerDelegate
 
 extension MessagesViewController: UIGestureRecognizerDelegate {
-    func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
-        guard let pan = gestureRecognizer as? HorizontalBlockerPanGestureRecognizer else { return true }
-        let velocity = pan.velocity(in: view)
-        let location = pan.location(in: view)
-        let isHorizontal = abs(velocity.x) > abs(velocity.y)
-        let isAwayFromEdge = location.x > 30
-        return isHorizontal && isAwayFromEdge
-    }
-
     func gestureRecognizer(
         _ gestureRecognizer: UIGestureRecognizer,
         shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/MessagesViewController.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/MessagesViewController.swift
@@ -173,6 +173,7 @@ final class MessagesViewController: UIViewController {
     var onReaction: ((String, String) -> Void)?
     var onToggleReaction: ((String, String) -> Void)?
     var onTapReactions: ((AnyMessage) -> Void)?
+    var onTapReadReceipts: ((MessagesGroup) -> Void)?
     var onReply: ((AnyMessage) -> Void)?
     var contextMenuState: MessageContextMenuState = .init() {
         didSet { dataSource.contextMenuState = contextMenuState }
@@ -337,6 +338,10 @@ final class MessagesViewController: UIViewController {
         dataSource.onTapReactions = { [weak self] message in
             guard let self = self else { return }
             self.onTapReactions?(message)
+        }
+        dataSource.onTapReadReceipts = { [weak self] group in
+            guard let self = self else { return }
+            self.onTapReadReceipts?(group)
         }
         dataSource.onReaction = { [weak self] emoji, messageId in
             guard let self = self else { return }

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesBottomBar.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesBottomBar.swift
@@ -513,6 +513,7 @@ struct MessagesBottomBar<BottomBarContent: View>: View {
             onReaction: { _, _ in },
             onToggleReaction: { _, _ in },
             onTapReactions: { _ in },
+            onTapReadReceipts: { _ in },
             onReply: { _ in },
             contextMenuState: .init(),
             onPhotoRevealed: { _ in },

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessageContextMenu/MessageContextMenuOverlay.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessageContextMenu/MessageContextMenuOverlay.swift
@@ -681,6 +681,7 @@ struct MessageContextMenuOverlay: View {
                 attachment: attachment,
                 profile: profile,
                 reactions: [],
+                agentVerification: message?.sender.agentVerification ?? .unverified,
                 cornerRadiusOverride: radius
             )
         } else if attachment.mediaType == .file {

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessageContextMenu/MessageContextMenuOverlay.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessageContextMenu/MessageContextMenuOverlay.swift
@@ -249,6 +249,22 @@ struct MessageContextMenuOverlay: View {
     }
 
     @ViewBuilder
+    private func reactionsBarMask(readerHeight: CGFloat) -> some View {
+        let gradientWidth: CGFloat = readerHeight * 0.3
+        HStack(spacing: 0) {
+            Rectangle().fill(.black)
+            LinearGradient(
+                colors: [.black, .black.opacity(0)],
+                startPoint: .leading,
+                endPoint: .trailing
+            )
+            .frame(width: gradientWidth)
+            Rectangle().fill(.clear)
+                .frame(width: readerHeight)
+        }
+    }
+
+    @ViewBuilder
     private func reactionsBarContent(messageId: String, width: CGFloat, height: CGFloat) -> some View {
         GeometryReader { reader in
             let readerHeight = max(reader.size.height - C.padding * 2, 0)
@@ -264,18 +280,7 @@ struct MessageContextMenuOverlay: View {
                 .frame(height: reader.size.height)
                 .scrollBounceBehavior(.basedOnSize)
                 .contentMargins(.trailing, readerHeight, for: .scrollContent)
-                .mask(
-                    HStack(spacing: 0) {
-                        Rectangle().fill(.black)
-                        LinearGradient(
-                            colors: [.black, .black.opacity(0)],
-                            startPoint: .leading, endPoint: .trailing
-                        )
-                        .frame(width: readerHeight * 0.3)
-                        Rectangle().fill(.clear)
-                            .frame(width: readerHeight)
-                    }
-                )
+                .mask(reactionsBarMask(readerHeight: readerHeight))
 
                 HStack(spacing: 0) {
                     Spacer()

--- a/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/HTMLAttachmentBubble.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/HTMLAttachmentBubble.swift
@@ -7,6 +7,7 @@ struct HTMLAttachmentBubble: View {
     let attachment: HydratedAttachment
     let profile: Profile
     let reactions: [MessageReaction]
+    var agentVerification: AgentVerification = .unverified
     var onTapAvatar: (() -> Void)?
     var onTapReactions: (() -> Void)?
     var cornerRadiusOverride: CGFloat?
@@ -70,7 +71,8 @@ struct HTMLAttachmentBubble: View {
                 ProfileAvatarView(
                     profile: profile,
                     profileImage: nil,
-                    useSystemPlaceholder: false
+                    useSystemPlaceholder: false,
+                    agentVerification: agentVerification
                 )
                 .frame(width: DesignConstants.ImageSizes.smallAvatar, height: DesignConstants.ImageSizes.smallAvatar)
                 Text(profile.displayName)

--- a/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/ReadByDrawerView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/ReadByDrawerView.swift
@@ -1,0 +1,84 @@
+import ConvosCore
+import SwiftUI
+
+struct ReadByDrawerView: View {
+    let members: [ConversationMember]
+
+    private var sortedMembers: [ConversationMember] {
+        members.sorted { lhs, rhs in
+            if lhs.isCurrentUser && !rhs.isCurrentUser { return true }
+            if !lhs.isCurrentUser && rhs.isCurrentUser { return false }
+            return lhs.profile.displayName.localizedCaseInsensitiveCompare(rhs.profile.displayName)
+                == .orderedAscending
+        }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: DesignConstants.Spacing.step4x) {
+            Text("Read by")
+                .font(.system(.largeTitle))
+                .fontWeight(.bold)
+                .padding(.bottom, DesignConstants.Spacing.step2x)
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: DesignConstants.Spacing.step4x) {
+                    ForEach(sortedMembers, id: \.self) { member in
+                        ReadByRowView(member: member)
+                    }
+                }
+            }
+            .scrollBounceBehavior(.basedOnSize)
+            .scrollIndicatorsFlash(onAppear: true)
+            .scrollContentBackground(.hidden)
+            .frame(maxHeight: 600)
+        }
+        .padding([.leading, .top, .trailing], DesignConstants.Spacing.step10x)
+        .padding(.bottom, DesignConstants.Spacing.step3x)
+    }
+}
+
+private struct ReadByRowView: View {
+    let member: ConversationMember
+
+    var body: some View {
+        HStack(spacing: DesignConstants.Spacing.step3x) {
+            ProfileAvatarView(
+                profile: member.profile,
+                profileImage: nil,
+                useSystemPlaceholder: false,
+                agentVerification: member.agentVerification
+            )
+            .frame(width: 40.0, height: 40.0)
+
+            Text(member.isCurrentUser ? "You" : member.profile.displayName.capitalized)
+                .font(.callout)
+                .foregroundStyle(.colorTextPrimary)
+
+            Spacer()
+        }
+        .contentShape(Rectangle())
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(member.isCurrentUser ? "You" : member.profile.displayName) read this message")
+    }
+}
+
+#Preview {
+    @Previewable @State var presenting: Bool = false
+
+    let members: [ConversationMember] = [
+        .mock(name: "Alice"),
+        .mock(name: "Convos Assistant", isAgent: true, agentVerification: .verified(.convos)),
+        .mock(name: "Bob"),
+        .mock(name: "OAuth Agent", isAgent: true, agentVerification: .verified(.userOAuth))
+    ]
+
+    VStack {
+        let action = { presenting.toggle() }
+        Button(action: action) {
+            Text("Show Read by")
+        }
+    }
+    .selfSizingSheet(isPresented: $presenting) {
+        ReadByDrawerView(members: members)
+    }
+}

--- a/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/ReplyReferenceView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/ReplyReferenceView.swift
@@ -90,7 +90,8 @@ struct ReplyReferenceView: View {
                     ProfileAvatarView(
                         profile: parentMessage.sender.profile,
                         profileImage: nil,
-                        useSystemPlaceholder: false
+                        useSystemPlaceholder: false,
+                        agentVerification: parentMessage.sender.agentVerification
                     )
                     .frame(width: 16.0, height: 16.0)
                 }

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
@@ -308,6 +308,7 @@ struct MessagesGroupItemView: View {
                 attachment: attachment,
                 profile: message.sender.profile,
                 reactions: message.reactions,
+                agentVerification: message.sender.agentVerification,
                 onTapAvatar: avatarTap,
                 onTapReactions: reactionsTap
             )

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupView.swift
@@ -9,6 +9,7 @@ struct MessagesGroupView: View {
     let onTapAvatar: (AnyMessage) -> Void
     let onTapInvite: (MessageInvite) -> Void
     let onTapReactions: (AnyMessage) -> Void
+    var onTapReadReceipts: ((MessagesGroup) -> Void)?
     let onReaction: (String, String) -> Void
     let onToggleReaction: (String, String) -> Void
     let onReply: (AnyMessage) -> Void
@@ -293,9 +294,17 @@ struct MessagesGroupView: View {
                     )
                     .frame(width: 16, height: 16)
                 } else if !group.readByMembers.isEmpty {
-                    Text("Read")
-                        .font(.caption)
-                    ReadReceiptAvatarsView(members: group.readByMembers)
+                    let readReceiptTap: () -> Void = { onTapReadReceipts?(group) }
+                    Button(action: readReceiptTap) {
+                        HStack(spacing: DesignConstants.Spacing.stepX) {
+                            Text("Read")
+                                .font(.caption)
+                            ReadReceiptAvatarsView(members: group.readByMembers)
+                        }
+                        .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityHint("Tap to see who read this message")
                 } else {
                     Text("Sent")
                         .font(.caption)

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessagesListView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessagesListView.swift
@@ -10,6 +10,7 @@ struct MessagesListView: View {
     let onTapAvatar: (AnyMessage) -> Void
     let onTapInvite: (MessageInvite) -> Void
     let onTapReactions: (AnyMessage) -> Void
+    let onTapReadReceipts: (MessagesGroup) -> Void
     let onReaction: (String, String) -> Void
     let onToggleReaction: (String, String) -> Void
     let onReply: (AnyMessage) -> Void
@@ -173,6 +174,7 @@ struct MessagesListView: View {
             onTapAvatar: onTapAvatar,
             onTapInvite: onTapInvite,
             onTapReactions: onTapReactions,
+            onTapReadReceipts: onTapReadReceipts,
             onReaction: onReaction,
             onToggleReaction: onToggleReaction,
             onReply: onReply,

--- a/Convos/Conversation Detail/Messages/MessagesView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesView.swift
@@ -79,6 +79,7 @@ struct MessagesView<BottomBarContent: View>: View {
     @Bindable var voiceMemoRecorder: VoiceMemoRecorder
     let onSendVoiceMemo: () -> Void
     let onConvosAction: () -> Void
+    var extraBottomInset: CGFloat = 0.0
     @ViewBuilder let bottomBarContent: () -> BottomBarContent
 
     @State private var bottomBarHeight: CGFloat = 0.0
@@ -119,7 +120,7 @@ struct MessagesView<BottomBarContent: View>: View {
             hasAssistant: hasAssistant,
             isAssistantJoinPending: isAssistantJoinPending,
             isAssistantEnabled: isAssistantEnabled,
-            bottomBarHeight: bottomBarHeight,
+            bottomBarHeight: bottomBarHeight + extraBottomInset,
             onBottomOverscrollChanged: onBottomOverscrollChanged,
             onBottomOverscrollReleased: onBottomOverscrollReleased,
             scrollToBottomTrigger: { scrollFn in

--- a/Convos/Conversation Detail/Messages/MessagesView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesView.swift
@@ -45,6 +45,7 @@ struct MessagesView<BottomBarContent: View>: View {
     let onReaction: (String, String) -> Void
     let onToggleReaction: (String, String) -> Void
     let onTapReactions: (AnyMessage) -> Void
+    let onTapReadReceipts: (MessagesGroup) -> Void
     let onReply: (AnyMessage) -> Void
     let replyingToMessage: AnyMessage?
     var replyingToAudioTranscriptText: String?
@@ -102,6 +103,7 @@ struct MessagesView<BottomBarContent: View>: View {
             onReaction: onReaction,
             onToggleReaction: onToggleReaction,
             onTapReactions: onTapReactions,
+            onTapReadReceipts: onTapReadReceipts,
             onReply: onReply,
             contextMenuState: contextMenuState,
             onPhotoRevealed: onPhotoRevealed,

--- a/Convos/Conversation Detail/Messages/MessagesViewRepresentable.swift
+++ b/Convos/Conversation Detail/Messages/MessagesViewRepresentable.swift
@@ -16,6 +16,7 @@ struct MessagesViewRepresentable: UIViewControllerRepresentable {
     let onReaction: (String, String) -> Void
     let onToggleReaction: (String, String) -> Void
     let onTapReactions: (AnyMessage) -> Void
+    let onTapReadReceipts: (MessagesGroup) -> Void
     let onReply: (AnyMessage) -> Void
     let contextMenuState: MessageContextMenuState
     let onPhotoRevealed: (String) -> Void
@@ -69,6 +70,7 @@ struct MessagesViewRepresentable: UIViewControllerRepresentable {
         messagesViewController.onReaction = onReaction
         messagesViewController.onToggleReaction = onToggleReaction
         messagesViewController.onTapReactions = onTapReactions
+        messagesViewController.onTapReadReceipts = onTapReadReceipts
         messagesViewController.onReply = onReply
         messagesViewController.shouldBlurPhotos = shouldBlurPhotos
         messagesViewController.onPhotoRevealed = { key in
@@ -141,6 +143,7 @@ struct MessagesViewRepresentable: UIViewControllerRepresentable {
         onReaction: { _, _ in },
         onToggleReaction: { _, _ in },
         onTapReactions: { _ in },
+        onTapReadReceipts: { _ in },
         onReply: { _ in },
         contextMenuState: .init(),
         onPhotoRevealed: { _ in },


### PR DESCRIPTION
ConversationView now hosts both the messages list and the Stuff list
in a paging horizontal ScrollView with .scrollTargetBehavior(.paging),
so the user can swipe left/right between the two. iOS 17+ paging
primitives handle the snap; underlying UIScrollView's bounce is
disabled via SwiftUIIntrospect so there's no rubber-band off the
leading or trailing edge.

Page dots:
- Rendered in a .safeAreaInset(.bottom) on the pager so they sit in
  their own strip below each page's bottom bar (composer or search).
- 24pt-tall glass capsule, hidden whenever the keyboard is up.
- Tapping a dot animates to that page.

Bottom inset:
- MessagesView gains an extraBottomInset parameter that ConversationView
  threads in (= dots strip height when visible). The collection view's
  contentInset.bottom is computed off this combined value so the last
  message still clears the composer + dots strip.

Stuff page:
- AssistantFilesLinksView gains a usesInlineHeader: Bool flag. When
  true (the pager case), the view renders a large inline "Stuff" header
  in its body instead of relying on a NavigationStack title. The
  navigation push from ConversationInfoView (existing call site) keeps
  the navigation-title styling.

Gestures:
- Removed MessagesViewController's HorizontalBlockerPanGestureRecognizer
  and its UIGestureRecognizerDelegate hook; with the pager owning
  horizontal swipes the blocker would have prevented the swipe from
  reaching the parent ScrollView.

Other:
- Extracted reactionsBarMask in MessageContextMenuOverlay so the
  enclosing reactionsBarContent stays under the 100ms type-checker
  threshold.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/814"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add horizontal pager to conversation screen to swipe between Messages and Stuff
> - Introduces [`ConversationPager`](https://github.com/xmtplabs/convos-ios/pull/814/files#diff-03e4d11d056ec2f477bbb87dfa9eec28918047846f1740694897f3d791f9dd37) with two pages — Messages and Stuff — using a `ScrollView` with paging behavior and bounce disabled via SwiftUIIntrospect.
> - Adds tappable [`ConversationPagerDots`](https://github.com/xmtplabs/convos-ios/pull/814/files#diff-03e4d11d056ec2f477bbb87dfa9eec28918047846f1740694897f3d791f9dd37) at the bottom; dots are hidden when the keyboard is visible and the messages view bottom inset adjusts to accommodate them when shown.
> - [`AssistantFilesLinksView`](https://github.com/xmtplabs/convos-ios/pull/814/files#diff-4289f3ee61e4ec048839c8b0b9390784403bb951765fad643cf402f07b530d27) gains a `usesInlineHeader` flag so it renders an inline "Stuff" title when shown as a pager page instead of using the navigation bar title.
> - Removes `HorizontalBlockerPanGestureRecognizer` from [`MessagesViewController`](https://github.com/xmtplabs/convos-ios/pull/814/files#diff-1427b816e5e93d8bc7ea882f5eabd9671135c6f9b9ebc6b0a6f7116a2f8a37c3) since horizontal swipes now drive the pager rather than being blocked.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #814 opened
>
> - Added tap handling for read receipts in message groups to display a drawer showing which members have read the message [2e3f46c]
> - Propagated agent verification state to profile avatars throughout message-related views [2e3f46c]
> - Added profile sheet presentation capability to attachment previews via injected closure [2e3f46c]
> - Refined file and link attachment row UI including thumbnail rendering, metrics, and layout [2e3f46c]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 85f7bc3.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->