### PR TITLE
Don't drop libxmtp DB on .inactive launches

### DIFF
--- a/ConvosCore/Sources/ConvosCore/Inboxes/SessionStateMachine.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/SessionStateMachine.swift
@@ -600,7 +600,13 @@ public actor SessionStateMachine: SessionStateManagerProtocol {
         emitStateChange(.ready(result))
         await startNetworkMonitoring()
         startAppLifecycleObservation()
-        if await appLifecycle.currentState != .active {
+        // .inactive is a transient state during launch (scene activating) and
+        // routine interruptions (control center, notifications). Only treat
+        // .background as a real background launch — otherwise we drop the
+        // libxmtp DB pool here, never receive a willEnterForeground (the OS
+        // doesn't post it on a fresh launch), and every worker spins on
+        // PoolNeedsConnection until the next process restart.
+        if await appLifecycle.currentState == .background {
             enqueueAction(.enterBackground)
         }
     }


### PR DESCRIPTION
handleAuthorized() was treating any non-.active app lifecycle state as
"backgrounded" and firing dropLocalDatabaseConnection(). At process
launch UIApplication.applicationState is briefly .inactive (the scene
is activating), so the inbox would race the scene transition: if it
authorized fast enough, we'd shove the state machine into .backgrounded
immediately, release the libxmtp connection pool, and then never
recover — willEnterForeground only fires on a real return from
background, not on a fresh launch.

After that, every libxmtp worker (KeyPackageCleaner, DeviceSync, the
expired-message sweep, message and conversation streams) failed once
per second with Platform(PoolNeedsConnection) until the process
restarted.

Narrow the check to .background only. Genuine background launches
(push notification wake, BGTask) still go through enterBackground;
.inactive at launch is left alone so the scene can finish activating
without tearing down the DB.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/815"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix libxmtp DB drop on `.inactive` app lifecycle launches
> In `SessionStateMachine.handleAuthorized`, the condition that enqueues `.enterBackground` after authorization now checks for `.background` explicitly instead of "not `.active`". This prevents the DB from being dropped when the app launches in the `.inactive` state (e.g. during notifications or mid-transition).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 18b49f2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->