### PR TITLE
Route Stuff search field through MessagesViewInputFocus / FocusCoordinator

### DIFF
--- a/Convos/Conversation Detail/AssistantFilesLinksView.swift
+++ b/Convos/Conversation Detail/AssistantFilesLinksView.swift
@@ -118,17 +118,20 @@ struct AssistantFilesLinksView: View {
     private let members: [ConversationMember]
     private let usesInlineHeader: Bool
     private let profileSheetContent: ((ConversationMember) -> AnyView)?
+    private let externalFocusBinding: FocusState<MessagesViewInputFocus?>.Binding?
 
     init(
         repository: AssistantFilesLinksRepository,
         members: [ConversationMember],
         usesInlineHeader: Bool = false,
-        profileSheetContent: ((ConversationMember) -> AnyView)? = nil
+        profileSheetContent: ((ConversationMember) -> AnyView)? = nil,
+        focusBinding: FocusState<MessagesViewInputFocus?>.Binding? = nil
     ) {
         _viewModel = State(initialValue: AssistantFilesLinksViewModel(repository: repository))
         self.members = members
         self.usesInlineHeader = usesInlineHeader
         self.profileSheetContent = profileSheetContent
+        self.externalFocusBinding = focusBinding
     }
 
     private func member(forInboxId inboxId: String) -> ConversationMember? {
@@ -143,7 +146,8 @@ struct AssistantFilesLinksView: View {
             .safeAreaBar(edge: .bottom) {
                 StuffSearchBar(
                     searchText: $viewModel.searchText,
-                    filter: $viewModel.filter
+                    filter: $viewModel.filter,
+                    focusBinding: externalFocusBinding
                 )
             }
             .task {
@@ -509,6 +513,7 @@ private extension View {
 private struct StuffSearchBar: View {
     @Binding var searchText: String
     @Binding var filter: StuffFilter
+    var focusBinding: FocusState<MessagesViewInputFocus?>.Binding?
 
     var body: some View {
         GlassEffectContainer {
@@ -516,9 +521,7 @@ private struct StuffSearchBar: View {
                 HStack(spacing: DesignConstants.Spacing.step2x) {
                     Image(systemName: "magnifyingglass")
                         .foregroundStyle(.colorTextSecondary)
-                    TextField("Search", text: $searchText)
-                        .textFieldStyle(.plain)
-                        .accessibilityIdentifier("stuff-search-field")
+                    searchTextField
                 }
                 .padding(.horizontal, DesignConstants.Spacing.step4x)
                 .padding(.vertical, DesignConstants.Spacing.step3x)
@@ -528,6 +531,18 @@ private struct StuffSearchBar: View {
             }
             .padding(.horizontal, DesignConstants.Spacing.step4x)
             .padding(.vertical, DesignConstants.Spacing.step2x)
+        }
+    }
+
+    @ViewBuilder
+    private var searchTextField: some View {
+        let textField = TextField("Search", text: $searchText)
+            .textFieldStyle(.plain)
+            .accessibilityIdentifier("stuff-search-field")
+        if let focusBinding {
+            textField.focused(focusBinding, equals: .stuffSearchBar)
+        } else {
+            textField
         }
     }
 

--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -240,7 +240,8 @@ struct ConversationView<MessagesBottomBar: View>: View {
             repository: viewModel.makeAssistantFilesLinksRepository(),
             members: viewModel.conversation.members,
             usesInlineHeader: true,
-            profileSheetContent: profileSheetForMember
+            profileSheetContent: profileSheetForMember,
+            focusBinding: $focusState
         )
     }
 
@@ -274,6 +275,11 @@ struct ConversationView<MessagesBottomBar: View>: View {
         .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillHideNotification)) { _ in
             isKeyboardVisible = false
         }
+        .onChange(of: pagerSelectedPage) { _, newPage in
+            if newPage != .stuff {
+                focusCoordinator.dismissStuffSearchIfNeeded()
+            }
+        }
         .onChange(of: viewModel.messageText) { _, _ in
             viewModel.checkForInviteURL()
             viewModel.checkForPastedLink()
@@ -281,7 +287,10 @@ struct ConversationView<MessagesBottomBar: View>: View {
         .animation(.easeOut, value: viewModel.explodeState)
         .dynamicTypeSize(...DynamicTypeSize.xxxLarge)
         .onAppear { viewModel.onConversationAppeared() }
-        .onDisappear { viewModel.onConversationDisappeared() }
+        .onDisappear {
+            focusCoordinator.dismissStuffSearchIfNeeded()
+            viewModel.onConversationDisappeared()
+        }
         .selfSizingSheet(isPresented: $viewModel.presentingConversationForked) {
             ConversationForkedInfoView {
                 viewModel.leaveConvo()

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesBottomBar.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesBottomBar.swift
@@ -5,7 +5,7 @@ import SwiftUI
 import UniformTypeIdentifiers
 
 enum MessagesViewInputFocus: Hashable {
-    case message, displayName, conversationName, voiceMemoRecording, sideConvoName
+    case message, displayName, conversationName, voiceMemoRecording, sideConvoName, stuffSearchBar
 }
 
 private let maxFileAttachmentSizeBytes: Int = 20 * 1024 * 1024

--- a/Convos/Shared Views/FocusCoordinator.swift
+++ b/Convos/Shared Views/FocusCoordinator.swift
@@ -126,9 +126,23 @@ final class FocusCoordinator {
             // Any non-quickEditor end of side-convo name editing falls through to default
             return defaultFocus
 
+        case (.stuffSearchBar, _):
+            // Stuff search lives in a peer page of the pager, not the messages composer.
+            // Don't pull focus back to .message — just dismiss.
+            return nil
+
         default:
             return defaultFocus
         }
+    }
+
+    /// Dismisses the Stuff search field if it currently holds focus. Used when the
+    /// conversation pager pages away from the Stuff page or the conversation
+    /// itself disappears, so the keyboard doesn't stay associated with a field on
+    /// an off-screen page and bump the messages bottom bar with a phantom inset.
+    func dismissStuffSearchIfNeeded() {
+        guard currentFocus == .stuffSearchBar else { return }
+        moveFocus(to: nil)
     }
 
     /// Moves focus to `message` if we're currently focusing a quick-editor field


### PR DESCRIPTION
The Stuff search bar's TextField was using SwiftUI's implicit focus —
no @FocusState binding back up to the parent. When the user opened the
field from the Stuff page of the conversation pager and then swiped
back to messages or popped out of the conversation, the field stayed
focused, the system kept the keyboard logically attached to it, and
.safeAreaBar(edge: .bottom) on the messages page rendered the bottom
bar with a phantom keyboard inset on the next visit.

Fix it the same way the messages composer and side-convo name editor
work — route the Stuff search bar through the conversation's shared
focus state:

- Add `.stuffSearchBar` to MessagesViewInputFocus (the source of truth
  for any TextField in the conversation hierarchy).
- Teach FocusCoordinator how to handle it: nextFocus returns nil
  (don't pull focus back to the messages composer when the search
  field dismisses) and a new dismissStuffSearchIfNeeded() helper
  clears focus only when it's actually parked on the search bar.
- AssistantFilesLinksView gains an optional focusBinding parameter.
  The pager call site passes $focusState; the nav-link site (from
  ConversationInfoView) leaves it nil so its self-contained navigation
  pop continues to work as before.
- StuffSearchBar applies .focused(binding, equals: .stuffSearchBar)
  when a binding is provided.
- ConversationView dismisses the search focus when the pager moves
  off the Stuff page and again on .onDisappear of the conversation as
  a belt-and-suspenders safeguard.

Future TextFields under the conversation hierarchy should follow the
same pattern: add a case to MessagesViewInputFocus and route through
FocusCoordinator. A local @FocusState that the coordinator can't see
is what allowed this regression in the first place.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/816"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Route Stuff search field focus through `MessagesViewInputFocus` and `FocusCoordinator`
> - Adds a `stuffSearchBar` case to the `MessagesViewInputFocus` enum in [MessagesBottomBar.swift](https://github.com/xmtplabs/convos-ios/pull/816/files#diff-b66861cd8ab11a6d499676511b14e2fba66afdb7467461c01255f35000b416a2) so the search field participates in the shared focus system.
> - Threads the focus binding from `ConversationView` through `AssistantFilesLinksView` down to `StuffSearchBar`, which conditionally applies `.focused(focusBinding, equals: .stuffSearchBar)` when a binding is provided.
> - Adds `FocusCoordinator.dismissStuffSearchIfNeeded()` to clear focus when the active focus is `.stuffSearchBar`; `nextFocusWhenEditingEnds` returns `nil` for this case so the keyboard does not shift back to the message composer.
> - `ConversationView` calls `dismissStuffSearchIfNeeded()` on page change (away from Stuff) and on `.onDisappear` to prevent the keyboard from persisting into the messages composer.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9154af1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->