### PR TITLE
Fix drawer title clipping; extract deleteAllData to satisfy type-checker

### DIFF
--- a/Convos/App Settings/AppSettingsViewModel.swift
+++ b/Convos/App Settings/AppSettingsViewModel.swift
@@ -36,6 +36,11 @@ final class AppSettingsViewModel {
 
     func deleteAllData(onComplete: @escaping () -> Void) {
         guard !isDeleting else { return }
+        prepareForDeletion()
+        Task { await runDeletion(onComplete: onComplete) }
+    }
+
+    private func prepareForDeletion() {
         isDeleting = true
         deletionError = nil
         deletionProgress = nil
@@ -45,18 +50,18 @@ final class AppSettingsViewModel {
         ConversationsViewModel.resetUserDefaults()
         ConversationOnboardingCoordinator.resetUserDefaults()
         GlobalConvoDefaults.shared.reset()
+    }
 
-        Task {
-            do {
-                for try await progress in session.deleteAllInboxesWithProgress() {
-                    deletionProgress = progress
-                }
-                isDeleting = false
-                onComplete()
-            } catch {
-                deletionError = error
-                isDeleting = false
+    private func runDeletion(onComplete: @escaping () -> Void) async {
+        do {
+            for try await progress in session.deleteAllInboxesWithProgress() {
+                deletionProgress = progress
             }
+            isDeleting = false
+            onComplete()
+        } catch {
+            deletionError = error
+            isDeleting = false
         }
     }
 }

--- a/Convos/Conversation Detail/Messages/Messages View Controller/Reactions/ReactionsDrawerView.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/Reactions/ReactionsDrawerView.swift
@@ -29,7 +29,7 @@ struct ReactionsDrawerView: View {
                 .fontWeight(.bold)
                 .padding(.bottom, DesignConstants.Spacing.step2x)
 
-            ScrollView {
+            BoundedScrollView(maxHeight: 600.0) {
                 VStack(alignment: .leading, spacing: DesignConstants.Spacing.step4x) {
                     ForEach(sortedReactions, id: \.id) { reaction in
                         ReactionRowView(
@@ -39,10 +39,6 @@ struct ReactionsDrawerView: View {
                     }
                 }
             }
-            .scrollBounceBehavior(.basedOnSize)
-            .scrollIndicatorsFlash(onAppear: true)
-            .scrollContentBackground(.hidden)
-            .frame(maxHeight: 600)
         }
         .padding([.leading, .top, .trailing], DesignConstants.Spacing.step10x)
         .padding(.bottom, DesignConstants.Spacing.step3x)

--- a/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/ReadByDrawerView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/ReadByDrawerView.swift
@@ -20,17 +20,13 @@ struct ReadByDrawerView: View {
                 .fontWeight(.bold)
                 .padding(.bottom, DesignConstants.Spacing.step2x)
 
-            ScrollView {
+            BoundedScrollView(maxHeight: 600.0) {
                 VStack(alignment: .leading, spacing: DesignConstants.Spacing.step4x) {
                     ForEach(sortedMembers, id: \.self) { member in
                         ReadByRowView(member: member)
                     }
                 }
             }
-            .scrollBounceBehavior(.basedOnSize)
-            .scrollIndicatorsFlash(onAppear: true)
-            .scrollContentBackground(.hidden)
-            .frame(maxHeight: 600)
         }
         .padding([.leading, .top, .trailing], DesignConstants.Spacing.step10x)
         .padding(.bottom, DesignConstants.Spacing.step3x)

--- a/Convos/Shared Views/BoundedScrollView.swift
+++ b/Convos/Shared Views/BoundedScrollView.swift
@@ -1,0 +1,41 @@
+import SwiftUI
+
+/// A `ScrollView` that reports a definite vertical intrinsic size — the
+/// content's natural height clamped to `maxHeight`. Used inside drawer-style
+/// sheets where the parent applies `.fixedSize(horizontal: false, vertical: true)`
+/// to compute its presentation detent: a plain `ScrollView` with
+/// `.frame(maxHeight:)` reports an unbounded intrinsic size in that context,
+/// which lets the parent request a sheet detent taller than the screen and
+/// pushes the top of the content (e.g. the drawer's title) out of the visible
+/// area.
+struct BoundedScrollView<Content: View>: View {
+    let maxHeight: CGFloat
+    @ViewBuilder let content: () -> Content
+    @State private var contentHeight: CGFloat = 0
+
+    var body: some View {
+        ScrollView {
+            content()
+                .background(
+                    GeometryReader { proxy in
+                        Color.clear.preference(
+                            key: BoundedScrollContentHeightKey.self,
+                            value: proxy.size.height
+                        )
+                    }
+                )
+        }
+        .scrollBounceBehavior(.basedOnSize)
+        .scrollIndicatorsFlash(onAppear: true)
+        .scrollContentBackground(.hidden)
+        .frame(height: min(max(contentHeight, 1.0), maxHeight))
+        .onPreferenceChange(BoundedScrollContentHeightKey.self) { contentHeight = $0 }
+    }
+}
+
+private struct BoundedScrollContentHeightKey: PreferenceKey {
+    static let defaultValue: CGFloat = 0
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = max(value, nextValue())
+    }
+}


### PR DESCRIPTION
The Reactions and Read-by drawers were rendering with their large-title
"Reactions" / "Read by" pushed above the visible sheet area when the
member or reaction list was tall. selfSizingSheet wraps every sheet
content in `.fixedSize(horizontal: false, vertical: true)` so the
detent can be sized to the content, then reads the resulting height.
A plain `ScrollView { ... }.frame(maxHeight: 600)` reports an
unbounded vertical intrinsic size in that context — `maxHeight` is a
flex upper bound, not a fixed dimension — so the parent ends up
requesting a sheet detent taller than the screen, the layout starts
above the visible region, and the title at the top of the VStack is
clipped.

Add `BoundedScrollView` — a ScrollView wrapper that measures its
inner content's height with its own scoped PreferenceKey (so it
doesn't poison `selfSizingSheet`'s shared HeightPreferenceKey) and
applies `.frame(height: min(contentHeight, maxHeight))`. Now the
parent sees a definite intrinsic vertical size for the scrollable
region and the title stays inside the visible sheet.

Both drawers swap their `ScrollView { ... }.frame(maxHeight: 600)` for
`BoundedScrollView(maxHeight: 600.0) { ... }`.

Drive-by: extract `AppSettingsViewModel.deleteAllData` into a sync
prelude (`prepareForDeletion()`) and an async helper
(`runDeletion(onComplete:)`). The shrunken `SessionManagerProtocol`
that landed yesterday (the invite-code removal) tipped this one method
above the project's 100ms type-check threshold (~115-139ms across
attempts) and was failing the build with warnings-as-errors. Splitting
into smaller method bodies brings each piece comfortably under the
limit.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/818"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix drawer title clipping by replacing unbounded ScrollView with `BoundedScrollView`
> - Adds [`BoundedScrollView`](https://github.com/xmtplabs/convos-ios/pull/818/files#diff-3c2bbc0fac4158ba44ce3a8109b1845b3ce6fb8e43f05aa0d296687822a67c33), a reusable view that measures content height via a `PreferenceKey` and constrains itself to a concrete height clamped between 1pt and a caller-supplied `maxHeight`.
> - Replaces the `ScrollView` + `.frame(maxHeight: 600)` pattern in [`ReactionsDrawerView`](https://github.com/xmtplabs/convos-ios/pull/818/files#diff-88381b66065b4ece75e23e2a886812e1256a994b3f015fb285a7bf767cc96ef0) and [`ReadByDrawerView`](https://github.com/xmtplabs/convos-ios/pull/818/files#diff-dbfdca9d299979236a1f95ef0cde0d9cbd44d466ed8a5d9514517d46adc7dfb2) with `BoundedScrollView(maxHeight: 600)`, giving the drawer a definite vertical size and fixing title clipping.
> - Extracts inline deletion logic in `AppSettingsViewModel` into private `prepareForDeletion()` and `runDeletion(onComplete:)` methods to satisfy the type-checker.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ca04522.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->