### PR TITLE
Make Stuff list reactive and route URL taps to in-app browser

### DIFF
--- a/Convos/Conversation Detail/AssistantFilesLinksView.swift
+++ b/Convos/Conversation Detail/AssistantFilesLinksView.swift
@@ -1,3 +1,4 @@
+import Combine
 import ConvosCore
 import SwiftUI
 import UniformTypeIdentifiers
@@ -40,9 +41,33 @@ class AssistantFilesLinksViewModel {
     var fileOpenError: String?
 
     private let repository: AssistantFilesLinksRepository
+    @ObservationIgnored private var cancellables: Set<AnyCancellable> = []
 
     init(repository: AssistantFilesLinksRepository) {
         self.repository = repository
+        subscribe()
+    }
+
+    private func subscribe() {
+        // Both publishers wrap GRDB ValueObservation with replaceError(with: [])
+        // so they cannot fail and each emits an initial value (possibly empty).
+        // First emission from either is enough to leave the loading state — the
+        // empty-state UI handles the "files arrived, links pending" race.
+        repository.filesPublisher()
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] newFiles in
+                self?.files = newFiles
+                self?.isLoading = false
+            }
+            .store(in: &cancellables)
+
+        repository.linksPublisher()
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] newLinks in
+                self?.links = newLinks
+                self?.isLoading = false
+            }
+            .store(in: &cancellables)
     }
 
     var hasAnyItems: Bool {
@@ -81,26 +106,20 @@ class AssistantFilesLinksViewModel {
 
     private func matches(file: AssistantFile, query: String) -> Bool {
         guard !query.isEmpty else { return true }
-        return file.displayName.lowercased().contains(query)
+        if file.displayName.lowercased().contains(query) {
+            return true
+        }
+        if let htmlTitle = HTMLPageMetadata.shared.cachedTitle(for: file.attachmentKey),
+           htmlTitle.lowercased().contains(query) {
+            return true
+        }
+        return false
     }
 
     private func matches(link: AssistantLink, query: String) -> Bool {
         guard !query.isEmpty else { return true }
         return link.displayTitle.lowercased().contains(query)
             || link.url.lowercased().contains(query)
-    }
-
-    func load() async {
-        isLoading = true
-        do {
-            async let fetchedFiles = repository.fetchFiles()
-            async let fetchedLinks = repository.fetchLinks()
-            files = try await fetchedFiles
-            links = try await fetchedLinks
-        } catch {
-            Log.error("Failed to load assistant files and links: \(error.localizedDescription)")
-        }
-        isLoading = false
     }
 }
 
@@ -149,9 +168,6 @@ struct AssistantFilesLinksView: View {
                     filter: $viewModel.filter,
                     focusBinding: externalFocusBinding
                 )
-            }
-            .task {
-                await viewModel.load()
             }
             .sheet(item: $presentingPreview) { preview in
                 AttachmentPreviewSheet(
@@ -299,7 +315,7 @@ struct AssistantFilesLinksView: View {
     private func linkRow(_ link: AssistantLink) -> some View {
         let action = {
             if let url = link.resolvedURL {
-                UIApplication.shared.open(url)
+                InAppBrowser.open(url)
             }
         }
         return Button(action: action) {

--- a/Convos/Conversation Detail/AttachmentPreviewSheet.swift
+++ b/Convos/Conversation Detail/AttachmentPreviewSheet.swift
@@ -247,7 +247,7 @@ private struct AttachmentHTMLContent: UIViewRepresentable {
                   ["http", "https", "mailto"].contains(scheme) else {
                 return .cancel
             }
-            await UIApplication.shared.open(url)
+            InAppBrowser.open(url)
             return .cancel
         }
 
@@ -473,7 +473,7 @@ private struct MarkdownWebView: UIViewRepresentable {
                   ["http", "https", "mailto"].contains(scheme) else {
                 return .cancel
             }
-            await UIApplication.shared.open(url)
+            InAppBrowser.open(url)
             return .cancel
         }
     }

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
@@ -220,7 +220,7 @@ struct MessagesGroupItemView: View {
     private func linkPreviewBubble(preview: LinkPreview) -> some View {
         let openLink: () -> Void = {
             if let url = preview.resolvedURL {
-                UIApplication.shared.open(url)
+                InAppBrowser.open(url)
             }
         }
         LinkPreviewBubbleView(

--- a/Convos/Shared Views/InAppBrowser.swift
+++ b/Convos/Shared Views/InAppBrowser.swift
@@ -1,0 +1,40 @@
+import ConvosCore
+import SafariServices
+import UIKit
+
+enum InAppBrowser {
+    static func open(_ url: URL) {
+        let scheme = url.scheme?.lowercased() ?? ""
+        guard ["http", "https"].contains(scheme) else {
+            Task { @MainActor in
+                UIApplication.shared.open(url)
+            }
+            return
+        }
+        Task { @MainActor in
+            guard let presenter = topPresentedViewController() else {
+                Log.warning("InAppBrowser: no presenter found, falling back to system browser for \(url.host ?? "")")
+                UIApplication.shared.open(url)
+                return
+            }
+            let safari = SFSafariViewController(url: url)
+            presenter.present(safari, animated: true)
+        }
+    }
+
+    @MainActor
+    private static func topPresentedViewController() -> UIViewController? {
+        let scene = UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .first(where: { $0.activationState == .foregroundActive })
+            ?? UIApplication.shared.connectedScenes.first as? UIWindowScene
+        guard let root = scene?.keyWindow?.rootViewController ?? scene?.windows.first?.rootViewController else {
+            return nil
+        }
+        var presenter = root
+        while let presented = presenter.presentedViewController {
+            presenter = presented
+        }
+        return presenter
+    }
+}

--- a/Convos/Shared Views/LinkDetectingTextView.swift
+++ b/Convos/Shared Views/LinkDetectingTextView.swift
@@ -89,7 +89,7 @@ private struct LinkTextViewRepresentable: UIViewRepresentable {
         ) -> UIAction? {
             guard case .link(let url) = textItem.content else { return defaultAction }
             return UIAction { _ in
-                UIApplication.shared.open(url)
+                InAppBrowser.open(url)
             }
         }
     }

--- a/ConvosCore/Sources/ConvosCore/Storage/Repositories/AssistantFilesLinksRepository.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Repositories/AssistantFilesLinksRepository.swift
@@ -1,3 +1,4 @@
+import Combine
 import Foundation
 import GRDB
 import UniformTypeIdentifiers
@@ -55,85 +56,119 @@ public final class AssistantFilesLinksRepository: Sendable {
         self.conversationId = conversationId
     }
 
-    public func fetchFiles() async throws -> [AssistantFile] {
-        try await dbReader.read { [conversationId] db in
-            let rows = try Row.fetchAll(db, sql: """
-                SELECT m.id, m.date, m.attachmentUrls, m.senderId
-                FROM message m
-                WHERE m.conversationId = ?
-                    AND m.contentType = 'attachments'
-                    AND EXISTS (
-                        SELECT 1
-                        FROM memberProfile mp
-                        WHERE mp.conversationId = m.conversationId
-                            AND mp.inboxId = m.senderId
-                            AND mp.memberKind IN ('agent:convos', 'agent:user-oauth')
-                    )
-                ORDER BY m.date DESC
-                """,
-                arguments: [conversationId]
-            )
-
-            return rows.compactMap { row -> AssistantFile? in
-                guard let id: String = row["id"],
-                      let date: Date = row["date"],
-                      let senderInboxId: String = row["senderId"],
-                      let attachmentUrlsJson: String = row["attachmentUrls"],
-                      let keys = try? JSONDecoder().decode([String].self, from: Data(attachmentUrlsJson.utf8)),
-                      let firstKey = keys.first
-                else { return nil }
-
-                let parsed = Self.parseAttachmentKey(firstKey)
-                return AssistantFile(
-                    id: id,
-                    senderInboxId: senderInboxId,
-                    filename: parsed.filename,
-                    mimeType: parsed.mimeType,
-                    date: date,
-                    attachmentKey: firstKey,
-                    thumbnailDataBase64: parsed.thumbnailDataBase64
-                )
+    public func filesPublisher() -> AnyPublisher<[AssistantFile], Never> {
+        let conversationId = conversationId
+        return ValueObservation
+            .tracking { db in
+                try Self.loadFiles(db: db, conversationId: conversationId)
             }
-        }
+            .publisher(in: dbReader, scheduling: .immediate)
+            .replaceError(with: [])
+            .eraseToAnyPublisher()
     }
 
-    public func fetchLinks() async throws -> [AssistantLink] {
-        try await dbReader.read { [conversationId] db in
-            let rows = try Row.fetchAll(db, sql: """
-                SELECT m.id, m.date, m.linkPreview, m.senderId
-                FROM message m
-                WHERE m.conversationId = ?
-                    AND m.contentType = 'linkPreview'
-                    AND EXISTS (
-                        SELECT 1
-                        FROM memberProfile mp
-                        WHERE mp.conversationId = m.conversationId
-                            AND mp.inboxId = m.senderId
-                            AND mp.memberKind IN ('agent:convos', 'agent:user-oauth')
-                    )
-                ORDER BY m.date DESC
-                """,
-                arguments: [conversationId]
-            )
-
-            return rows.compactMap { row -> AssistantLink? in
-                guard let id: String = row["id"],
-                      let date: Date = row["date"],
-                      let senderInboxId: String = row["senderId"],
-                      let linkPreviewJson: String = row["linkPreview"],
-                      let data = linkPreviewJson.data(using: .utf8),
-                      let preview = try? JSONDecoder().decode(LinkPreview.self, from: data)
-                else { return nil }
-                return AssistantLink(
-                    id: id,
-                    senderInboxId: senderInboxId,
-                    url: preview.url,
-                    title: preview.title,
-                    siteName: preview.siteName,
-                    imageURL: preview.imageURL,
-                    date: date
-                )
+    public func linksPublisher() -> AnyPublisher<[AssistantLink], Never> {
+        let conversationId = conversationId
+        return ValueObservation
+            .tracking { db in
+                try Self.loadLinks(db: db, conversationId: conversationId)
             }
+            .publisher(in: dbReader, scheduling: .immediate)
+            .replaceError(with: [])
+            .eraseToAnyPublisher()
+    }
+
+    private static func loadFiles(db: Database, conversationId: String) throws -> [AssistantFile] {
+        let rows = try Row.fetchAll(db, sql: """
+            SELECT m.id, m.date, m.attachmentUrls, m.senderId
+            FROM message m
+            WHERE m.conversationId = ?
+                AND m.contentType = 'attachments'
+                AND EXISTS (
+                    SELECT 1
+                    FROM memberProfile mp
+                    WHERE mp.conversationId = m.conversationId
+                        AND mp.inboxId = m.senderId
+                        AND mp.memberKind IN ('agent:convos', 'agent:user-oauth')
+                )
+            ORDER BY m.date DESC
+            """,
+            arguments: [conversationId]
+        )
+
+        let files: [AssistantFile] = rows.compactMap { row -> AssistantFile? in
+            guard let id: String = row["id"],
+                  let date: Date = row["date"],
+                  let senderInboxId: String = row["senderId"],
+                  let attachmentUrlsJson: String = row["attachmentUrls"],
+                  let keys = try? JSONDecoder().decode([String].self, from: Data(attachmentUrlsJson.utf8)),
+                  let firstKey = keys.first
+            else { return nil }
+
+            let parsed = parseAttachmentKey(firstKey)
+            return AssistantFile(
+                id: id,
+                senderInboxId: senderInboxId,
+                filename: parsed.filename,
+                mimeType: parsed.mimeType,
+                date: date,
+                attachmentKey: firstKey,
+                thumbnailDataBase64: parsed.thumbnailDataBase64
+            )
+        }
+
+        // Rows arrive newest first, so the first occurrence of each filename is the
+        // most recent send. Files with no filename pass through individually since
+        // we can't tell duplicates apart.
+        var seenFilenames: Set<String> = []
+        var deduped: [AssistantFile] = []
+        for file in files {
+            if let filename = file.filename {
+                if seenFilenames.insert(filename).inserted {
+                    deduped.append(file)
+                }
+            } else {
+                deduped.append(file)
+            }
+        }
+        return deduped
+    }
+
+    private static func loadLinks(db: Database, conversationId: String) throws -> [AssistantLink] {
+        let rows = try Row.fetchAll(db, sql: """
+            SELECT m.id, m.date, m.linkPreview, m.senderId
+            FROM message m
+            WHERE m.conversationId = ?
+                AND m.contentType = 'linkPreview'
+                AND EXISTS (
+                    SELECT 1
+                    FROM memberProfile mp
+                    WHERE mp.conversationId = m.conversationId
+                        AND mp.inboxId = m.senderId
+                        AND mp.memberKind IN ('agent:convos', 'agent:user-oauth')
+                )
+            ORDER BY m.date DESC
+            """,
+            arguments: [conversationId]
+        )
+
+        return rows.compactMap { row -> AssistantLink? in
+            guard let id: String = row["id"],
+                  let date: Date = row["date"],
+                  let senderInboxId: String = row["senderId"],
+                  let linkPreviewJson: String = row["linkPreview"],
+                  let data = linkPreviewJson.data(using: .utf8),
+                  let preview = try? JSONDecoder().decode(LinkPreview.self, from: data)
+            else { return nil }
+            return AssistantLink(
+                id: id,
+                senderInboxId: senderInboxId,
+                url: preview.url,
+                title: preview.title,
+                siteName: preview.siteName,
+                imageURL: preview.imageURL,
+                date: date
+            )
         }
     }
 


### PR DESCRIPTION
- Replace one-shot `fetchFiles`/`fetchLinks` reads in `AssistantFilesLinksRepository` with GRDB `ValueObservation` publishers, so the Stuff list reflects new attachments and link previews live. Filename dedup (most-recent wins) moves into the observation closure.
- Subscribe to the new publishers from `AssistantFilesLinksViewModel` via Combine. `isLoading` clears on the first emission from either publisher (both publishers `replaceError(with: [])` so they cannot fail; the empty-state UI handles the brief "files arrived, links pending" window).
- Stuff search now matches the resolved HTML `<title>` (when cached) in addition to the filename, so HTML attachments are findable by the title shown in the row.
- Add `InAppBrowser` helper that presents `SFSafariViewController` on the topmost view controller, and route conversation-context URL taps through it: `AssistantFilesLinksView` link rows, `MessagesGroupItemView` link previews, `LinkDetectingTextView`, and the two HTML link-activated handlers in `AttachmentPreviewSheet`. If no presenter is found, log a warning and fall back to the system browser. Settings-URL openings in `JoinConversationView` and `ConversationOnboardingCoordinator` are left alone since they intentionally leave the app.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make the Stuff list reactive and open URL taps in an in-app browser
> - Adds [InAppBrowser.swift](https://github.com/xmtplabs/convos-ios/pull/819/files#diff-361c0f030d5df334ac1f4a0a1058a9d7f079e75e352aa7796d7a0ebb51c22223), a utility that presents `SFSafariViewController` for http/https URLs using the top-most view controller, falling back to `UIApplication.shared.open` for other schemes.
> - Replaces all `UIApplication.shared.open(url)` call sites (link rows, message bubbles, web views, text views) with `InAppBrowser.open(url)`.
> - Replaces one-shot async `fetchFiles()`/`fetchLinks()` in `AssistantFilesLinksRepository` with Combine publishers backed by GRDB `ValueObservation`, so the Stuff list updates live as the database changes.
> - File deduplication by filename is now applied in the repository, keeping the newest occurrence.
> - Search in `AssistantFilesLinksViewModel.matches(file:)` now also checks cached HTML page titles via `HTMLPageMetadata`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c5ee0ce.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->