### PR TITLE
Route Save action to Files for non-photo attachments

### DIFF
--- a/Convos/Conversation Detail/Messages/MessagesListView/MessageContextMenu/MessageContextMenuOverlay.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessageContextMenu/MessageContextMenuOverlay.swift
@@ -538,11 +538,7 @@ struct MessageContextMenuOverlay: View {
 
                 if let attachment = photoAttachment {
                     let saveAction = {
-                        if attachment.mediaType == .video {
-                            saveVideoToPhotoLibrary(key: attachment.key)
-                        } else {
-                            saveAttachmentToPhotoLibrary(key: attachment.key)
-                        }
+                        saveAttachment(attachment)
                         dismissMenu()
                     }
                     ContextMenuRow(icon: "square.and.arrow.down", title: "Save", action: saveAction)
@@ -776,6 +772,17 @@ private func recoverInlineAttachmentData(fromPath path: String) async throws -> 
     }
     let messageId = String(filename[filename.startIndex..<underscoreIndex])
     return try await InlineAttachmentRecovery.shared.recoverData(messageId: messageId)
+}
+
+private func saveAttachment(_ attachment: HydratedAttachment) {
+    switch attachment.mediaType {
+    case .image:
+        saveAttachmentToPhotoLibrary(key: attachment.key)
+    case .video:
+        saveVideoToPhotoLibrary(key: attachment.key)
+    case .file, .audio, .unknown:
+        saveFileToFiles(key: attachment.key, filename: attachment.filename)
+    }
 }
 
 private func saveAttachmentToPhotoLibrary(key: String) {


### PR DESCRIPTION
The Save row in the message context menu always called
saveAttachmentToPhotoLibrary (for non-video) or saveVideoToPhotoLibrary,
so tapping Save on a file/audio attachment hit ImageCache.shared.image,
got nil, and silently returned — Save did nothing.

Branch on attachment.mediaType: images go to Photo Library, videos go
to Photo Library, and file/audio/unknown go through saveFileToFiles
which presents UIDocumentPickerViewController(forExporting:) — the
helper was already there, just unused for these media types.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/820"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Route Save action to Files for non-photo attachments in message context menu
> The Save action in `MessageContextMenuOverlay` previously only handled images and videos (both saved to the photo library). File, audio, and unknown attachment types are now saved to the Files app via `saveFileToFiles`.
>
> A new private helper `saveAttachment(_:)` centralizes the dispatch logic, switching on `attachment.mediaType` to route each type to the correct save destination.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 48e2f59.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->