### PR TITLE
Estimate HTML attachment cell height at 500pt instead of 60pt

### DIFF
--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Data Source/DefaultMessagesLayoutDelegate.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Data Source/DefaultMessagesLayoutDelegate.swift
@@ -97,6 +97,11 @@ final class DefaultMessagesLayoutDelegate: MessagesLayoutDelegate {
     }
 
     private func estimatedAttachmentHeight(for attachment: HydratedAttachment, width: CGFloat) -> CGFloat {
+        // HTML attachments render via HTMLAttachmentBubble at a fixed 500pt cellHeight
+        // regardless of mediaType, so check before falling into the .file branch.
+        if attachment.isHTMLFile {
+            return 500.0
+        }
         switch attachment.mediaType {
         case .audio:
             // VoiceMemoBubbleContent: 12pt top padding + 36pt play button + 12pt


### PR DESCRIPTION
estimatedAttachmentHeight returned 60pt for any .file mediaType, but
HTML attachments render via HTMLAttachmentBubble at a fixed 500pt
cellHeight. The 5–8× under-estimate per HTML cell meant initial
contentSize was hundreds of points smaller than reality, so the explicit
scrollToBottom on convo open landed above the actual bottom whenever
self-sizing for the bottom-region HTML cells happened after our scroll
(or fell outside the keepContentOffsetAtBottomOnBatchUpdates compensation
window).

Fix: branch on attachment.isHTMLFile before the mediaType switch and
return 500.0 to match HTMLAttachmentBubble.Constant.cellHeight.
Verified via [ScrollDebug] capture: a .html cell that previously logged
estimatedH=76 / preferredH=508.33 (delta=-432) now seats the content
size correctly on initial load, and the convo opens flush at the bottom.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/821"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Estimate HTML attachment cell height at 500pt instead of 60pt
> In `DefaultMessagesLayoutDelegate.estimatedAttachmentHeight`, adds an early check for `attachment.isHTMLFile` that returns 500pt before the `mediaType` switch is evaluated. Previously, HTML attachments fell through to the `.file` branch and returned 60pt, mismatching the fixed height used by `HTMLAttachmentBubble`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7eec9c0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->