### PR TITLE
Re-anchor messages list to bottom when keyboard appears

### DIFF
--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/MessagesViewController.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/MessagesViewController.swift
@@ -65,6 +65,7 @@ final class MessagesViewController: UIViewController {
     private var hasPendingInterrupt: Bool = false
     private var previousLastMessageId: String?
     private var previousFocusState: MessagesViewInputFocus?
+    private var pendingScrollToBottomAfterKeyboard: Bool = false
 
     /// Whether the user is near the bottom of the scroll view (within one screen height)
     private var isNearBottom: Bool {
@@ -242,6 +243,13 @@ final class MessagesViewController: UIViewController {
         super.viewWillTransition(to: size, with: coordinator)
     }
 
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        // Drop the flag so an interrupted keyboard transition doesn't surface a
+        // stale scroll-to-bottom on the next appearance.
+        pendingScrollToBottomAfterKeyboard = false
+    }
+
     // MARK: - Private Setup Methods
 
     private func setupUI() {
@@ -273,6 +281,15 @@ final class MessagesViewController: UIViewController {
         }
 
         startObservingFocus()
+    }
+
+    /// Called from MessagesView via the representable when SwiftUI's @FocusState
+    /// transitions into the composer. The synchronous scrollToBottom typically no-ops
+    /// because the keyboard hasn't yet expanded the bottom inset; setting the pending
+    /// flag lets keyboardDidChangeFrame re-anchor once the keyboard frame settles.
+    func messageInputDidBecomeFocused() {
+        pendingScrollToBottomAfterKeyboard = true
+        scrollToBottom()
     }
 
     private func setupCollectionView() {
@@ -797,6 +814,18 @@ extension MessagesViewController: KeyboardListenerDelegate {
 
         currentInterfaceActions.options.insert(.changingKeyboardFrame)
         let newBottomInset = calculateNewBottomInset(for: info)
+        // If the keyboard is growing the bottom inset (appearing or expanding),
+        // queue a scroll-to-bottom for after the inset animation. SwiftUI's
+        // @FocusState may not transition (e.g. when iOS restores first-responder
+        // and just re-shows the keyboard), so we trigger off the keyboard frame
+        // change directly rather than relying on focus events. Only flip the
+        // flag once per keyboard show; rapid frame changes (emoji ↔ standard
+        // keyboard, accessory bar resize) shouldn't queue duplicate scrolls.
+        let insetGrowth = newBottomInset - collectionView.contentInset.bottom
+        if !pendingScrollToBottomAfterKeyboard,
+           insetGrowth > Constant.minKeyboardInsetGrowthForScrollAnchor {
+            pendingScrollToBottomAfterKeyboard = true
+        }
         updateBottomInset(inset: newBottomInset, info: info)
     }
 
@@ -812,6 +841,11 @@ extension MessagesViewController: KeyboardListenerDelegate {
     func keyboardDidChangeFrame(info: KeyboardInfo) {
         if currentInterfaceActions.options.contains(.changingKeyboardFrame) {
             currentInterfaceActions.options.remove(.changingKeyboardFrame)
+        }
+
+        if pendingScrollToBottomAfterKeyboard {
+            pendingScrollToBottomAfterKeyboard = false
+            scrollToBottom()
         }
     }
 
@@ -881,6 +915,13 @@ extension MessagesViewController: KeyboardListenerDelegate {
         }, completion: { _ in
             self.currentInterfaceActions.options.remove(.changingContentInsets)
         })
+    }
+
+    private enum Constant {
+        // Floating-point slop for distinguishing "keyboard appearing" from
+        // micro adjustments (e.g. autocorrect bar resizes, sub-point
+        // accessory-view recalculations).
+        static let minKeyboardInsetGrowthForScrollAnchor: CGFloat = 1.0
     }
 }
 

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesBottomBar.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesBottomBar.swift
@@ -535,7 +535,8 @@ struct MessagesBottomBar<BottomBarContent: View>: View {
             bottomBarHeight: bottomBarHeight,
             onBottomOverscrollChanged: { _ in },
             onBottomOverscrollReleased: { _ in },
-            scrollToBottomTrigger: { _ in }
+            scrollToBottomTrigger: { _ in },
+            messageInputFocusTrigger: { _ in }
         )
         .ignoresSafeArea()
     }

--- a/Convos/Conversation Detail/Messages/MessagesView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesView.swift
@@ -87,6 +87,7 @@ struct MessagesView<BottomBarContent: View>: View {
     @State private var contextMenuState: MessageContextMenuState = .init()
     @State private var isPhotoPickerPresented: Bool = false
     @State private var scrollToBottom: (() -> Void)?
+    @State private var notifyMessageInputFocused: (() -> Void)?
 
     var body: some View {
         MessagesViewRepresentable(
@@ -127,9 +128,17 @@ struct MessagesView<BottomBarContent: View>: View {
             onBottomOverscrollReleased: onBottomOverscrollReleased,
             scrollToBottomTrigger: { scrollFn in
                 scrollToBottom = scrollFn
+            },
+            messageInputFocusTrigger: { fn in
+                notifyMessageInputFocused = fn
             }
         )
         .ignoresSafeArea()
+        .onChange(of: focusState) { oldValue, newValue in
+            if newValue == .message && oldValue != .message {
+                notifyMessageInputFocused?()
+            }
+        }
         .safeAreaBar(edge: .bottom) {
             MessagesBottomBar(
                 profile: profile,

--- a/Convos/Conversation Detail/Messages/MessagesViewRepresentable.swift
+++ b/Convos/Conversation Detail/Messages/MessagesViewRepresentable.swift
@@ -39,9 +39,11 @@ struct MessagesViewRepresentable: UIViewControllerRepresentable {
     let onBottomOverscrollChanged: (CGFloat) -> Void
     let onBottomOverscrollReleased: (CGFloat) -> Void
     let scrollToBottomTrigger: (@escaping () -> Void) -> Void
+    let messageInputFocusTrigger: (@escaping () -> Void) -> Void
 
     class Coordinator {
         var scrollToBottomFunction: (() -> Void)?
+        var messageInputFocusFunction: (() -> Void)?
     }
 
     func makeCoordinator() -> Coordinator {
@@ -54,7 +56,11 @@ struct MessagesViewRepresentable: UIViewControllerRepresentable {
         context.coordinator.scrollToBottomFunction = { [weak viewController] in
             viewController?.scrollToBottomForSend()
         }
+        context.coordinator.messageInputFocusFunction = { [weak viewController] in
+            viewController?.messageInputDidBecomeFocused()
+        }
         scrollToBottomTrigger { context.coordinator.scrollToBottomFunction?() }
+        messageInputFocusTrigger { context.coordinator.messageInputFocusFunction?() }
         return viewController
     }
 
@@ -165,7 +171,8 @@ struct MessagesViewRepresentable: UIViewControllerRepresentable {
         bottomBarHeight: bottomBarHeight,
         onBottomOverscrollChanged: { _ in },
         onBottomOverscrollReleased: { _ in },
-        scrollToBottomTrigger: { _ in }
+        scrollToBottomTrigger: { _ in },
+        messageInputFocusTrigger: { _ in }
     )
     .ignoresSafeArea()
 }


### PR DESCRIPTION
The `handleFocusChange` path in `MessagesViewController` relied on `focusCoordinator.currentFocus`, but `FocusCoordinator` can get stuck in a programmatic transition — the keyboard-type detection (`unknown → standard`) begins a transition to `nil` that never completes when `currentFocus` was already `nil`. Every subsequent keyboard event then logs `Skipping keyboard type changed focus sync, in transition…` and `currentFocus` never moves to `.message`, so `handleFocusChange` never fires the scroll. Even SwiftUI's `@FocusState` doesn't always transition: when iOS restores first-responder and just re-shows the keyboard, the focus state can stay put.

Fix: trigger off the keyboard frame change itself.

- In `keyboardWillChangeFrame`, if `newBottomInset > current contentInset.bottom` (keyboard appearing or expanding), set `pendingScrollToBottomAfterKeyboard`.
- In `keyboardDidChangeFrame`, consume the flag and call `scrollToBottom()` so the anchor runs against the post-keyboard inset.

Also expose a new `messageInputDidBecomeFocused()` entry point on the VC and wire it from `MessagesView` via `.onChange(of: focusState)`. When the SwiftUI focus path does fire, the synchronous `scrollToBottom` usually no-ops (keyboard hasn't expanded yet) but the pending flag retries once the keyboard frame settles. This covers the iPad-with-hardware-keyboard case where the keyboard frame doesn't change but focus does.

Verified live with the QA Bot 240-message convo: scrolled up to read older messages, tapped composer, keyboard slides up, "PAGINATION FINAL MARKER" lands flush above the composer — was previously stuck at whatever message the user had been reading.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/822"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Re-anchor messages list to bottom when keyboard appears in conversation detail
> - Adds a `pendingScrollToBottomAfterKeyboard` flag in [`MessagesViewController`](https://github.com/xmtplabs/convos-ios/pull/822/files#diff-1427b816e5e93d8bc7ea882f5eabd9671135c6f9b9ebc6b0a6f7116a2f8a37c3) that queues a `scrollToBottom()` call when the keyboard inset grows by more than 1pt.
> - Adds a `messageInputDidBecomeFocused()` method that triggers an immediate scroll and sets the pending flag so the list re-anchors after the keyboard finishes animating in.
> - Wires a `messageInputFocusTrigger` closure from SwiftUI's `@FocusState` through [`MessagesViewRepresentable`](https://github.com/xmtplabs/convos-ios/pull/822/files#diff-8bd43c70f5fc921339d47bb5561db6bbb15e52ac55cfbdd958cc982716cd77e4) to call the new UIKit method when the composer gains focus.
> - Clears the pending flag in `viewWillDisappear` to prevent a stale scroll from firing on a future appearance.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8e90fbe.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->