### PR TITLE
Share Stuff thumbnail image instead of HTML file

### DIFF
--- a/Convos/Conversation Detail/AttachmentPreviewSheet.swift
+++ b/Convos/Conversation Detail/AttachmentPreviewSheet.swift
@@ -16,6 +16,9 @@ struct AttachmentPreviewSheet: View {
     @State private var resolvedHTMLTitle: String?
     @State private var htmlBodyBackgroundColor: Color?
     @State private var presentingProfileForMember: ConversationMember?
+    @State private var sharedImage: UIImage?
+    @State private var sharedImageURL: URL?
+    @State private var markdownHasContentThumbnail: Bool = false
 
     var body: some View {
         NavigationStack {
@@ -45,15 +48,7 @@ struct AttachmentPreviewSheet: View {
                             )
                         }
                     }
-                    if showsShareButton {
-                        ToolbarItem(placement: .confirmationAction) {
-                            ShareLink(item: fileURL) {
-                                Image(systemName: "square.and.arrow.up")
-                            }
-                            .accessibilityLabel("Share")
-                            .accessibilityIdentifier("attachment-preview-share")
-                        }
-                    }
+                    shareToolbarItem
                 }
         }
         .accessibilityElement(children: .contain)
@@ -63,19 +58,127 @@ struct AttachmentPreviewSheet: View {
             }
         }
         .task(id: attachment.key) {
-            guard attachment.isHTMLFile else { return }
-            if let cached = HTMLPageMetadata.shared.cachedTitle(for: attachment.key) {
-                resolvedHTMLTitle = cached
-                return
-            }
-            resolvedHTMLTitle = await HTMLPageMetadata.shared.title(for: attachment.key, fileURL: fileURL)
+            await resolveTitleIfNeeded()
+            await resolveShareImageIfNeeded()
         }
     }
 
-    private var showsShareButton: Bool {
+    private var canShareImage: Bool {
         // QuickLook renders its own bottom share toolbar, so suppress ours when it
-        // owns the preview. HTML and Markdown branches don't, so we keep ours.
-        attachment.isHTMLFile || attachment.isMarkdownFile
+        // owns the preview. For HTML and Markdown branches, we share the rendered
+        // thumbnail image instead of the underlying file. Markdown only qualifies
+        // when QLThumbnailGenerator returns a content thumbnail, not a doc icon.
+        if attachment.isHTMLFile { return true }
+        if attachment.isMarkdownFile { return markdownHasContentThumbnail }
+        return false
+    }
+
+    @ToolbarContentBuilder
+    private var shareToolbarItem: some ToolbarContent {
+        if canShareImage {
+            ToolbarItem(placement: .confirmationAction) {
+                shareButton
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var shareButton: some View {
+        let title: String = resolvedHTMLTitle ?? attachment.filename ?? "Image"
+        if let url = sharedImageURL, let image = sharedImage {
+            let previewImage: Image = Image(uiImage: image)
+            ShareLink(item: url, preview: SharePreview(title, image: previewImage)) {
+                Image(systemName: "square.and.arrow.up")
+            }
+            .accessibilityLabel("Share")
+            .accessibilityIdentifier("attachment-preview-share")
+        } else {
+            Image(systemName: "square.and.arrow.up")
+                .foregroundStyle(.secondary)
+                .accessibilityLabel("Share")
+                .accessibilityIdentifier("attachment-preview-share")
+        }
+    }
+
+    private func resolveTitleIfNeeded() async {
+        guard attachment.isHTMLFile else { return }
+        if let cached = HTMLPageMetadata.shared.cachedTitle(for: attachment.key) {
+            resolvedHTMLTitle = cached
+            return
+        }
+        resolvedHTMLTitle = await HTMLPageMetadata.shared.title(for: attachment.key, fileURL: fileURL)
+    }
+
+    private func resolveShareImageIfNeeded() async {
+        let image: UIImage?
+        if attachment.isHTMLFile {
+            image = await resolveHTMLShareImage()
+        } else if attachment.isMarkdownFile {
+            image = await resolveMarkdownShareImage()
+        } else {
+            return
+        }
+        guard let image else { return }
+        let basename: String = shareImageBasename()
+        let url: URL? = await writeSharePNG(image: image, basename: basename)
+        sharedImage = image
+        sharedImageURL = url
+    }
+
+    private func resolveHTMLShareImage() async -> UIImage? {
+        if let cached = HTMLThumbnailRenderer.shared.cachedThumbnail(for: attachment.key) {
+            return cached
+        }
+        return await HTMLThumbnailRenderer.shared.thumbnail(for: attachment.key, fileURL: fileURL)
+    }
+
+    private func resolveMarkdownShareImage() async -> UIImage? {
+        if let cached = FileThumbnailRenderer.shared.cachedThumbnail(for: attachment.key),
+           cached.isContentThumbnail {
+            markdownHasContentThumbnail = true
+            return cached.image
+        }
+        guard let result = await FileThumbnailRenderer.shared.thumbnail(for: attachment.key, fileURL: fileURL),
+              result.isContentThumbnail else {
+            return nil
+        }
+        markdownHasContentThumbnail = true
+        return result.image
+    }
+
+    private func shareImageBasename() -> String {
+        let raw: String
+        if let filename = attachment.filename, !filename.isEmpty {
+            raw = (filename as NSString).deletingPathExtension
+        } else {
+            raw = String(attachment.key.prefix(32))
+        }
+        return sanitizeFilename(raw)
+    }
+
+    private func sanitizeFilename(_ raw: String) -> String {
+        let allowed: CharacterSet = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "-_."))
+        var output: String = ""
+        for scalar in raw.unicodeScalars {
+            output.append(allowed.contains(scalar) ? Character(scalar) : "_")
+        }
+        let trimmed: String = output.isEmpty ? "image" : output
+        return String(trimmed.prefix(64))
+    }
+
+    private func writeSharePNG(image: UIImage, basename: String) async -> URL? {
+        guard let pngData = image.pngData() else {
+            Log.error("AttachmentPreviewSheet: failed to encode share image PNG")
+            return nil
+        }
+        let url: URL = FileManager.default.temporaryDirectory.appendingPathComponent("\(basename).png")
+        do {
+            try pngData.write(to: url, options: .atomic)
+            return url
+        } catch {
+            Log.error("AttachmentPreviewSheet: failed to write share PNG: \(error)")
+            return nil
+        }
     }
 
     @ViewBuilder


### PR DESCRIPTION
## Summary

- The Stuff preview's share button shared the underlying HTML file (e.g., `sausage-garden.html`, 446 KB) — now shares the rendered page-snapshot PNG already used as the row thumbnail.
- For HTML uses `HTMLThumbnailRenderer`'s cached image; for Markdown uses `FileThumbnailRenderer` only when QuickLook returned a real content thumbnail (not a doc icon).
- PNG is written to `FileManager.default.temporaryDirectory` with a sanitized basename derived from the attachment filename (or page title), and shared via `ShareLink(item: url, preview: SharePreview(title, image:))` so Save-to-Files / AirDrop / Messages all get a properly named `.png`.
- The toolbar share icon stays visible but inert until the thumbnail resolves; never falls back to the HTML.

## Test plan

- [ ] Open a conversation with HTML stuff (e.g., "The Sausage Garden — Concept...") → Stuff drawer → tap row → tap share. Confirm share sheet shows the page snapshot PNG titled with the page title, not the 446 KB HTML.
- [ ] Save to Files → confirm a `.png` is saved with the expected name.
- [ ] Send via Messages → recipient receives an image, not an HTML attachment.
- [ ] Open a `.md` file: share button only appears when QuickLook produced a content thumbnail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/823"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Share a rendered PNG thumbnail instead of the HTML file from AttachmentPreviewSheet
> - Replaces the raw HTML file share with a `ShareLink` targeting a rendered PNG thumbnail, using `HTMLThumbnailRenderer` for HTML attachments and `FileThumbnailRenderer` for Markdown.
> - The share button only appears once the thumbnail is ready; until then a non-interactive share icon is shown. Markdown attachments only show the share button if a content thumbnail (not a placeholder) is available.
> - Shared PNG filenames are derived from the attachment filename, sanitized to `[A-Za-z0-9-_.]`, and capped at 64 characters.
> - Behavioral Change: sharing an HTML or qualifying Markdown attachment now delivers a PNG image rather than the original file.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6e91bba.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->