### PR TITLE
Hide debug injector button behind a Debug toggle

### DIFF
--- a/Convos/Config/FeatureFlags.swift
+++ b/Convos/Config/FeatureFlags.swift
@@ -1,3 +1,4 @@
+import ConvosCore
 import Foundation
 
 @MainActor @Observable
@@ -17,10 +18,18 @@ final class FeatureFlags {
     }
 
     /// Off by default — gates the testtube debug-injector button in the composer
-    /// media bar (and its DEBUG-only sheet). Toggle from App Settings → Debug.
+    /// media bar. Toggle from App Settings → Debug. Hard-locked off in production
+    /// builds so the flag can never be `true` for end users, even if a UserDefaults
+    /// value somehow leaks in from a dev build with the same bundle id.
     var isDebugInjectorEnabled: Bool {
-        get { UserDefaults.standard.bool(forKey: Constant.debugInjectorEnabledKey) }
-        set { UserDefaults.standard.set(newValue, forKey: Constant.debugInjectorEnabledKey) }
+        get {
+            guard !ConfigManager.shared.currentEnvironment.isProduction else { return false }
+            return UserDefaults.standard.bool(forKey: Constant.debugInjectorEnabledKey)
+        }
+        set {
+            guard !ConfigManager.shared.currentEnvironment.isProduction else { return }
+            UserDefaults.standard.set(newValue, forKey: Constant.debugInjectorEnabledKey)
+        }
     }
 
     private enum Constant {

--- a/Convos/Config/FeatureFlags.swift
+++ b/Convos/Config/FeatureFlags.swift
@@ -16,7 +16,15 @@ final class FeatureFlags {
         }
     }
 
+    /// Off by default — gates the testtube debug-injector button in the composer
+    /// media bar (and its DEBUG-only sheet). Toggle from App Settings → Debug.
+    var isDebugInjectorEnabled: Bool {
+        get { UserDefaults.standard.bool(forKey: Constant.debugInjectorEnabledKey) }
+        set { UserDefaults.standard.set(newValue, forKey: Constant.debugInjectorEnabledKey) }
+    }
+
     private enum Constant {
         static let assistantEnabledKey: String = "featureFlags.assistantEnabled"
+        static let debugInjectorEnabledKey: String = "featureFlags.debugInjectorEnabled"
     }
 }

--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -22,9 +22,7 @@ struct ConversationView<MessagesBottomBar: View>: View {
     @State private var didReleasePastThreshold: Bool = false
     @State private var pagerSelectedPage: ConversationPagerPage = .messages
     @State private var isKeyboardVisible: Bool = false
-    #if DEBUG
     @State private var showingDebugInjector: Bool = false
-    #endif
     @Environment(\.dismiss) private var dismiss: DismissAction
 
     private var showPullToAddAssistant: Bool {
@@ -265,20 +263,13 @@ struct ConversationView<MessagesBottomBar: View>: View {
     }
 
     private var debugAttachmentTapHandler: (() -> Void)? {
-        #if DEBUG
         guard FeatureFlags.shared.isDebugInjectorEnabled else { return nil }
         return { showingDebugInjector = true }
-        #else
-        return nil
-        #endif
     }
 
     private var debugInjectorBinding: Binding<Bool> {
-        #if DEBUG
+        guard FeatureFlags.shared.isDebugInjectorEnabled else { return .constant(false) }
         return $showingDebugInjector
-        #else
-        return .constant(false)
-        #endif
     }
 
     private var stuffPage: some View {

--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -266,6 +266,7 @@ struct ConversationView<MessagesBottomBar: View>: View {
 
     private var debugAttachmentTapHandler: (() -> Void)? {
         #if DEBUG
+        guard FeatureFlags.shared.isDebugInjectorEnabled else { return nil }
         return { showingDebugInjector = true }
         #else
         return nil

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesBottomBar.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesBottomBar.swift
@@ -72,7 +72,8 @@ struct MessagesBottomBar<BottomBarContent: View>: View {
     @Bindable var voiceMemoRecorder: VoiceMemoRecorder
     let onSendVoiceMemo: () -> Void
     let onConvosAction: () -> Void
-    /// Only wired up in DEBUG builds; nil in Release so the testtube button stays hidden.
+    /// `nil` unless `FeatureFlags.isDebugInjectorEnabled` is on (hard-locked off
+    /// in production); the testtube button stays hidden in any other case.
     var onDebugAttachmentTap: (() -> Void)?
     let onBaseHeightChanged: (CGFloat) -> Void
     @ViewBuilder let bottomBarContent: () -> BottomBarContent

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesMediaInputView.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesMediaInputView.swift
@@ -95,9 +95,6 @@ struct MessagesMediaButtonsView: View {
             .accessibilityLabel("Side convo")
             .accessibilityIdentifier("side-convo-button")
 
-            // Gated at the source: `onDebugAttachmentTap` is only non-nil when
-            // FeatureFlags.isDebugInjectorEnabled is on, which is hard-locked off
-            // in production. No #if DEBUG needed.
             if let onDebugAttachmentTap {
                 Button {
                     onDebugAttachmentTap()

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesMediaInputView.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesMediaInputView.swift
@@ -95,7 +95,9 @@ struct MessagesMediaButtonsView: View {
             .accessibilityLabel("Side convo")
             .accessibilityIdentifier("side-convo-button")
 
-            #if DEBUG
+            // Gated at the source: `onDebugAttachmentTap` is only non-nil when
+            // FeatureFlags.isDebugInjectorEnabled is on, which is hard-locked off
+            // in production. No #if DEBUG needed.
             if let onDebugAttachmentTap {
                 Button {
                     onDebugAttachmentTap()
@@ -110,7 +112,6 @@ struct MessagesMediaButtonsView: View {
                 .accessibilityLabel("Debug test attachment")
                 .accessibilityIdentifier("debug-test-attachment-button")
             }
-            #endif
         }
         .buttonStyle(.plain)
         .accessibilityLabel("Media buttons")

--- a/Convos/Conversation Detail/Messages/MessagesView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesView.swift
@@ -80,7 +80,8 @@ struct MessagesView<BottomBarContent: View>: View {
     @Bindable var voiceMemoRecorder: VoiceMemoRecorder
     let onSendVoiceMemo: () -> Void
     let onConvosAction: () -> Void
-    /// Only wired up in DEBUG builds; nil in Release so the testtube button stays hidden.
+    /// `nil` unless `FeatureFlags.isDebugInjectorEnabled` is on (hard-locked off
+    /// in production); the testtube button stays hidden in any other case.
     var onDebugAttachmentTap: (() -> Void)?
     var extraBottomInset: CGFloat = 0.0
     @ViewBuilder let bottomBarContent: () -> BottomBarContent

--- a/Convos/Debug View/DebugView.swift
+++ b/Convos/Debug View/DebugView.swift
@@ -65,6 +65,8 @@ struct DebugViewSection: View {
         Section("Features") {
             Toggle("Assistant enabled", isOn: Bindable(FeatureFlags.shared).isAssistantEnabled)
 
+            Toggle("Debug injector button", isOn: Bindable(FeatureFlags.shared).isDebugInjectorEnabled)
+
             let showInfoAction = { showingAssistantsInfoSheet = true }
             Button(action: showInfoAction) {
                 Text("Show Assistants Info Sheet")


### PR DESCRIPTION
## Summary
- The testtube debug-injector button in the composer media bar was always visible in DEBUG builds. Now off by default, gated by a new `FeatureFlags.isDebugInjectorEnabled` flag.
- Toggle lives in **App Settings → Debug → Features** ("Debug injector button"). Flip it on to surface the testtube; off (default) hides it.
- Release builds are unaffected — the whole closure is still wrapped in `#if DEBUG`.

## Test plan
- [ ] Fresh launch → testtube button is hidden in the composer.
- [ ] App Settings → Debug → Features → toggle "Debug injector button" on → testtube button appears immediately.
- [ ] Toggle off → button disappears.
- [ ] Setting persists across app relaunch (UserDefaults).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/824"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Hide debug injector button behind a runtime `FeatureFlags.isDebugInjectorEnabled` toggle
> - Adds `FeatureFlags.isDebugInjectorEnabled`, a `UserDefaults`-backed bool that is always `false` in production and togglable in non-production environments via a new toggle in [DebugView.swift](https://github.com/xmtplabs/convos-ios/pull/824/files#diff-c45ca903f9cc34fa316deb294404f56695ab7914c8a43563ade3081b646368aa).
> - Replaces compile-time `#if DEBUG` guards in [ConversationView.swift](https://github.com/xmtplabs/convos-ios/pull/824/files#diff-8d85226aa6385ce7a0aca11596c32eb20e3c3e89b37f51651c35fceb5e28f6bc) and [MessagesMediaInputView.swift](https://github.com/xmtplabs/convos-ios/pull/824/files#diff-2ef425132cd324e2bdecf8896c7f1faefde0b87061f46c59e109b152dd6f68ed) with runtime checks against the feature flag.
> - Behavioral Change: the debug injector button is now hidden by default even in debug builds until explicitly enabled via the Debug view toggle.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ceb3672.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->