### PR TITLE
Render HTML thumbnails via detached WKWebView + createPDF + PDFKit

### DIFF
--- a/Convos/Conversation Detail/AssistantFilesLinksView.swift
+++ b/Convos/Conversation Detail/AssistantFilesLinksView.swift
@@ -363,6 +363,7 @@ private struct FileRow: View {
     let subtitle: String
     let onTap: () -> Void
 
+    @Environment(\.colorScheme) private var colorScheme: ColorScheme
     @State private var renderedHTMLPreview: UIImage?
     @State private var resolvedHTMLTitle: String?
     @State private var renderedFilePreview: UIImage?
@@ -377,7 +378,7 @@ private struct FileRow: View {
             )
         }
         .buttonStyle(.plain)
-        .task(id: file.attachmentKey) {
+        .task(id: AttachmentColorSchemeKey(key: file.attachmentKey, scheme: colorScheme)) {
             await loadHTMLMetadataIfNeeded()
         }
     }
@@ -420,8 +421,12 @@ private struct FileRow: View {
     }
 
     private func loadHTMLMetadataIfNeeded() async {
+        let appearance = colorScheme.uiUserInterfaceStyle
         if isHTML {
-            renderedHTMLPreview = HTMLThumbnailRenderer.shared.cachedThumbnail(for: file.attachmentKey)
+            renderedHTMLPreview = HTMLThumbnailRenderer.shared.cachedThumbnail(
+                for: file.attachmentKey,
+                appearance: appearance
+            )
             resolvedHTMLTitle = HTMLPageMetadata.shared.cachedTitle(for: file.attachmentKey)
         } else if let cached = FileThumbnailRenderer.shared.cachedThumbnail(for: file.attachmentKey),
                   cached.isContentThumbnail {
@@ -443,7 +448,8 @@ private struct FileRow: View {
                 if renderedHTMLPreview == nil {
                     renderedHTMLPreview = await HTMLThumbnailRenderer.shared.thumbnail(
                         for: file.attachmentKey,
-                        fileURL: url
+                        fileURL: url,
+                        appearance: appearance
                     )
                 }
                 if resolvedHTMLTitle == nil {

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/ReplyComposerBar.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/ReplyComposerBar.swift
@@ -172,13 +172,17 @@ struct ReplyComposerBar: View {
 private struct ReplyHTMLThumbnail: View {
     let attachment: HydratedAttachment
 
+    @Environment(\.colorScheme) private var colorScheme: ColorScheme
     @State private var loadedImage: UIImage?
 
     private static let thumbnailSize: CGFloat = 40.0
 
     init(attachment: HydratedAttachment) {
         self.attachment = attachment
-        _loadedImage = State(initialValue: HTMLThumbnailRenderer.shared.cachedThumbnail(for: attachment.key))
+        _loadedImage = State(initialValue: HTMLThumbnailRenderer.shared.cachedThumbnail(
+            for: attachment.key,
+            appearance: .light
+        ))
     }
 
     var body: some View {
@@ -195,14 +199,19 @@ private struct ReplyHTMLThumbnail: View {
                     .frame(width: Self.thumbnailSize, height: Self.thumbnailSize)
             }
         }
-        .task(id: attachment.key) {
-            loadedImage = HTMLThumbnailRenderer.shared.cachedThumbnail(for: attachment.key)
+        .task(id: AttachmentColorSchemeKey(key: attachment.key, scheme: colorScheme)) {
+            let appearance = colorScheme.uiUserInterfaceStyle
+            loadedImage = HTMLThumbnailRenderer.shared.cachedThumbnail(
+                for: attachment.key,
+                appearance: appearance
+            )
             guard loadedImage == nil else { return }
             do {
                 let fileURL = try await FileAttachmentLoader.loadFile(for: attachment)
                 loadedImage = await HTMLThumbnailRenderer.shared.thumbnail(
                     for: attachment.key,
-                    fileURL: fileURL
+                    fileURL: fileURL,
+                    appearance: appearance
                 )
             } catch {
                 Log.error("Failed to load HTML reply composer thumbnail: \(error)")

--- a/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/HTMLAttachmentBubble.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/HTMLAttachmentBubble.swift
@@ -13,6 +13,7 @@ struct HTMLAttachmentBubble: View {
     var cornerRadiusOverride: CGFloat?
 
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass: UserInterfaceSizeClass?
+    @Environment(\.colorScheme) private var colorScheme: ColorScheme
     @State private var renderedImage: UIImage?
     @State private var hasLoadFailed: Bool = false
     @State private var bottomEdgeColor: Color?
@@ -39,7 +40,7 @@ struct HTMLAttachmentBubble: View {
         }
         .accessibilityIdentifier("html-attachment-bubble")
         .accessibilityLabel("HTML page from \(profile.displayName)")
-        .task(id: attachment.key) {
+        .task(id: AttachmentColorSchemeKey(key: attachment.key, scheme: colorScheme)) {
             await loadThumbnail()
         }
     }
@@ -142,10 +143,14 @@ struct HTMLAttachmentBubble: View {
     }
 
     private func loadThumbnail() async {
+        let appearance = colorScheme.uiUserInterfaceStyle
         renderedImage = nil
         bottomEdgeColor = nil
         hasLoadFailed = false
-        if let cached = HTMLThumbnailRenderer.shared.cachedThumbnail(for: attachment.key) {
+        if let cached = HTMLThumbnailRenderer.shared.cachedThumbnail(
+            for: attachment.key,
+            appearance: appearance
+        ) {
             renderedImage = cached
             bottomEdgeColor = cached.convos_bottomCenterColor()
             return
@@ -154,7 +159,8 @@ struct HTMLAttachmentBubble: View {
             let fileURL = try await FileAttachmentLoader.loadFile(for: attachment)
             let image = await HTMLThumbnailRenderer.shared.thumbnail(
                 for: attachment.key,
-                fileURL: fileURL
+                fileURL: fileURL,
+                appearance: appearance
             )
             renderedImage = image
             bottomEdgeColor = image?.convos_bottomCenterColor()
@@ -170,6 +176,24 @@ struct HTMLAttachmentBubble: View {
         static let cellHeight: CGFloat = 500.0
         static let fadeHeight: CGFloat = 68.0
         static let borderHeight: CGFloat = 1.0
+    }
+}
+
+/// Composite key so `.task(id:)` re-fires when either the attachment or the
+/// SwiftUI color scheme changes — the renderer keys its cache on appearance
+/// too, so toggling dark mode swaps to a freshly-rendered thumbnail.
+struct AttachmentColorSchemeKey: Hashable {
+    let key: String
+    let scheme: ColorScheme
+}
+
+extension ColorScheme {
+    var uiUserInterfaceStyle: UIUserInterfaceStyle {
+        switch self {
+        case .dark: return .dark
+        case .light: return .light
+        @unknown default: return .light
+        }
     }
 }
 

--- a/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/HTMLThumbnailRenderer.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/HTMLThumbnailRenderer.swift
@@ -24,35 +24,46 @@ final class HTMLThumbnailRenderer {
 
     private var inflight: [String: Task<UIImage?, Never>] = [:]
 
-    static func cacheKey(for attachmentKey: String) -> String {
-        cacheKeyPrefix + attachmentKey
+    static func cacheKey(for attachmentKey: String, appearance: UIUserInterfaceStyle) -> String {
+        cacheKeyPrefix + attachmentKey + "-" + appearanceSuffix(for: appearance)
     }
 
-    func cachedThumbnail(for attachmentKey: String) -> UIImage? {
-        ImageCache.shared.image(for: Self.cacheKey(for: attachmentKey))
+    private static func appearanceSuffix(for appearance: UIUserInterfaceStyle) -> String {
+        switch appearance {
+        case .dark: return "dark"
+        case .light, .unspecified: return "light"
+        @unknown default: return "light"
+        }
     }
 
-    func thumbnail(for attachmentKey: String, fileURL: URL) async -> UIImage? {
-        let cacheKey = Self.cacheKey(for: attachmentKey)
+    func cachedThumbnail(for attachmentKey: String, appearance: UIUserInterfaceStyle) -> UIImage? {
+        ImageCache.shared.image(for: Self.cacheKey(for: attachmentKey, appearance: appearance))
+    }
+
+    func thumbnail(for attachmentKey: String, fileURL: URL, appearance: UIUserInterfaceStyle) async -> UIImage? {
+        let cacheKey = Self.cacheKey(for: attachmentKey, appearance: appearance)
         if let cached = await ImageCache.shared.imageAsync(for: cacheKey) {
             return cached
         }
 
-        if let existing = inflight[attachmentKey] {
+        // Inflight key includes appearance so a concurrent dark-mode request
+        // doesn't await a light-mode render (or vice versa).
+        let inflightKey = attachmentKey + "-" + Self.appearanceSuffix(for: appearance)
+        if let existing = inflight[inflightKey] {
             return await existing.value
         }
 
         let task = Task<UIImage?, Never> { [weak self] in
             guard let self else { return nil }
-            let image = await self.renderSnapshot(fileURL: fileURL)
+            let image = await self.renderSnapshot(fileURL: fileURL, appearance: appearance)
             if let image {
                 ImageCache.shared.cacheImage(image, for: cacheKey, storageTier: .cache)
             }
             return image
         }
-        inflight[attachmentKey] = task
+        inflight[inflightKey] = task
         let result = await task.value
-        inflight.removeValue(forKey: attachmentKey)
+        inflight.removeValue(forKey: inflightKey)
         return result
     }
 
@@ -61,7 +72,7 @@ final class HTMLThumbnailRenderer {
     /// object: it loads the HTML, hands a vector PDF to PDFKit on
     /// `didFinish`, and is deallocated. There is no scene attachment and no
     /// `UIWindowScene.keyboardLayoutGuide` reservation to leak.
-    private func renderSnapshot(fileURL: URL) async -> UIImage? {
+    private func renderSnapshot(fileURL: URL, appearance: UIUserInterfaceStyle) async -> UIImage? {
         let config = WKWebViewConfiguration()
         let userScript = WKUserScript(
             source: Self.injectionScript,
@@ -78,6 +89,10 @@ final class HTMLThumbnailRenderer {
         webView.scrollView.bounces = false
         webView.isOpaque = true
         webView.isUserInteractionEnabled = false
+        // Drives `@media (prefers-color-scheme: ...)` resolution inside the
+        // loaded HTML — the WebView's traitCollection determines what
+        // matchMedia returns regardless of view-hierarchy attachment.
+        webView.overrideUserInterfaceStyle = appearance
 
         return await withCheckedContinuation { (continuation: CheckedContinuation<UIImage?, Never>) in
             let coordinator = LoadCoordinator(renderSize: Self.renderSize) { result in

--- a/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/HTMLThumbnailRenderer.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/HTMLThumbnailRenderer.swift
@@ -1,5 +1,6 @@
 import ConvosCore
 import ConvosLogging
+import PDFKit
 import UIKit
 import WebKit
 
@@ -8,9 +9,9 @@ final class HTMLThumbnailRenderer {
     static let shared: HTMLThumbnailRenderer = HTMLThumbnailRenderer()
 
     private static let renderSize: CGSize = CGSize(width: 720, height: 1200)
-    private static let paintDelay: TimeInterval = 0.5
+    fileprivate static let paintDelay: TimeInterval = 0.5
     private static let loadTimeout: TimeInterval = 15.0
-    private static let cacheKeyPrefix: String = "html-thumb-v2-"
+    private static let cacheKeyPrefix: String = "html-thumb-v3-"
     private static let injectionScript: String = """
     (function() {
         var css = 'html, body { margin-top: 0 !important; padding-top: 0 !important; } ' +
@@ -22,25 +23,6 @@ final class HTMLThumbnailRenderer {
     """
 
     private var inflight: [String: Task<UIImage?, Never>] = [:]
-    private var cachedRenderWindow: UIWindow?
-
-    private var renderWindow: UIWindow? {
-        if let cachedRenderWindow, cachedRenderWindow.windowScene != nil {
-            return cachedRenderWindow
-        }
-        let scene = UIApplication.shared.connectedScenes
-            .compactMap { $0 as? UIWindowScene }
-            .first { $0.activationState != .background }
-        guard let scene else { return nil }
-        let window = UIWindow(windowScene: scene)
-        window.frame = CGRect(origin: .zero, size: Self.renderSize)
-        window.windowLevel = UIWindow.Level(rawValue: -1)
-        window.alpha = 0.01
-        window.rootViewController = UIViewController()
-        window.isHidden = false
-        cachedRenderWindow = window
-        return window
-    }
 
     static func cacheKey(for attachmentKey: String) -> String {
         cacheKeyPrefix + attachmentKey
@@ -74,12 +56,12 @@ final class HTMLThumbnailRenderer {
         return result
     }
 
+    /// Renders the file at `fileURL` to a `UIImage` without ever attaching a
+    /// `WKWebView` to a `UIWindow`. The WebView lives only as an in-memory
+    /// object: it loads the HTML, hands a vector PDF to PDFKit on
+    /// `didFinish`, and is deallocated. There is no scene attachment and no
+    /// `UIWindowScene.keyboardLayoutGuide` reservation to leak.
     private func renderSnapshot(fileURL: URL) async -> UIImage? {
-        guard let window = renderWindow, let rootView = window.rootViewController?.view else {
-            Log.error("HTMLThumbnailRenderer: no render window available")
-            return nil
-        }
-
         let config = WKWebViewConfiguration()
         let userScript = WKUserScript(
             source: Self.injectionScript,
@@ -96,12 +78,9 @@ final class HTMLThumbnailRenderer {
         webView.scrollView.bounces = false
         webView.isOpaque = true
         webView.isUserInteractionEnabled = false
-        rootView.addSubview(webView)
-
-        defer { webView.removeFromSuperview() }
 
         return await withCheckedContinuation { (continuation: CheckedContinuation<UIImage?, Never>) in
-            let coordinator = LoadCoordinator { result in
+            let coordinator = LoadCoordinator(renderSize: Self.renderSize) { result in
                 continuation.resume(returning: result)
             }
             // Retain coordinator for the duration of the load via objc association.
@@ -111,11 +90,11 @@ final class HTMLThumbnailRenderer {
             let readAccessURL = fileURL.deletingLastPathComponent()
             webView.loadFileURL(fileURL, allowingReadAccessTo: readAccessURL)
 
-            // Safety net: if the load never finishes or fails, resume with nil so the
-            // webView can be torn down by the surrounding `defer` rather than living
-            // forever as a subview of the render window.
-            DispatchQueue.main.asyncAfter(deadline: .now() + Self.loadTimeout) { [weak coordinator] in
-                coordinator?.resumeIfNeeded(image: nil, reason: "load timed out")
+            // Safety net: if the load never finishes or fails, resume with nil so
+            // the WebView is released by the surrounding closure rather than
+            // living forever.
+            DispatchQueue.main.asyncAfter(deadline: .now() + Self.loadTimeout) { [weak coordinator, weak webView] in
+                coordinator?.resumeIfNeeded(webView: webView, image: nil, reason: "load timed out")
             }
         }
     }
@@ -125,25 +104,32 @@ final class HTMLThumbnailRenderer {
 
 private final class LoadCoordinator: NSObject, WKNavigationDelegate {
     private let completion: (UIImage?) -> Void
+    private let renderSize: CGSize
     private var hasResumed: Bool = false
 
-    init(completion: @escaping (UIImage?) -> Void) {
+    init(renderSize: CGSize, completion: @escaping (UIImage?) -> Void) {
+        self.renderSize = renderSize
         self.completion = completion
     }
 
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation?) {
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self, weak webView] in
+        let renderSize = renderSize
+        DispatchQueue.main.asyncAfter(deadline: .now() + HTMLThumbnailRenderer.paintDelay) { [weak self, weak webView] in
             guard let self, !self.hasResumed, let webView else {
                 self?.resume(image: nil)
                 return
             }
-            let config = WKSnapshotConfiguration()
-            config.rect = webView.bounds
-            webView.takeSnapshot(with: config) { image, error in
-                if let error {
-                    Log.error("HTMLThumbnailRenderer snapshot failed: \(error)")
+            let pdfConfig = WKPDFConfiguration()
+            pdfConfig.rect = CGRect(origin: .zero, size: renderSize)
+            webView.createPDF(configuration: pdfConfig) { result in
+                switch result {
+                case .success(let data):
+                    let image = Self.rasterize(pdfData: data, at: renderSize)
+                    self.resume(image: image)
+                case .failure(let error):
+                    Log.error("HTMLThumbnailRenderer createPDF failed: \(error)")
+                    self.resume(image: nil)
                 }
-                self.resume(image: image)
             }
         }
     }
@@ -162,15 +148,30 @@ private final class LoadCoordinator: NSObject, WKNavigationDelegate {
         resume(image: nil)
     }
 
+    private static func rasterize(pdfData: Data, at size: CGSize) -> UIImage? {
+        guard let document = PDFDocument(data: pdfData), let page = document.page(at: 0) else {
+            Log.error("HTMLThumbnailRenderer PDF had no first page")
+            return nil
+        }
+        // page.thumbnail draws onto an opaque white background, which matches
+        // the prior takeSnapshot behavior for HTML that doesn't set its own
+        // body background.
+        let image = page.thumbnail(of: size, for: .mediaBox)
+        return image
+    }
+
     private func resume(image: UIImage?) {
         guard !hasResumed else { return }
         hasResumed = true
         completion(image)
     }
 
-    func resumeIfNeeded(image: UIImage?, reason: String) {
+    func resumeIfNeeded(webView: WKWebView?, image: UIImage?, reason: String) {
         guard !hasResumed else { return }
         Log.error("HTMLThumbnailRenderer resuming early: \(reason)")
+        // Stop loading so the in-memory WebView releases its network/JS work
+        // before the closure releases it.
+        webView?.stopLoading()
         resume(image: image)
     }
 }

--- a/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/ReplyReferenceView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/ReplyReferenceView.swift
@@ -538,6 +538,7 @@ private struct ReplyReferenceHTMLPreview: View {
     let attachment: HydratedAttachment
     let onTap: () -> Void
 
+    @Environment(\.colorScheme) private var colorScheme: ColorScheme
     @State private var loadedImage: UIImage?
 
     private static let maxHeight: CGFloat = 80.0
@@ -545,7 +546,12 @@ private struct ReplyReferenceHTMLPreview: View {
     init(attachment: HydratedAttachment, onTap: @escaping () -> Void) {
         self.attachment = attachment
         self.onTap = onTap
-        _loadedImage = State(initialValue: HTMLThumbnailRenderer.shared.cachedThumbnail(for: attachment.key))
+        // Seed from light cache; the .task below will swap in the correct
+        // appearance variant once the environment is read.
+        _loadedImage = State(initialValue: HTMLThumbnailRenderer.shared.cachedThumbnail(
+            for: attachment.key,
+            appearance: .light
+        ))
     }
 
     var body: some View {
@@ -565,14 +571,19 @@ private struct ReplyReferenceHTMLPreview: View {
                 .buttonStyle(.plain)
             }
         }
-        .task(id: attachment.key) {
-            loadedImage = HTMLThumbnailRenderer.shared.cachedThumbnail(for: attachment.key)
+        .task(id: AttachmentColorSchemeKey(key: attachment.key, scheme: colorScheme)) {
+            let appearance = colorScheme.uiUserInterfaceStyle
+            loadedImage = HTMLThumbnailRenderer.shared.cachedThumbnail(
+                for: attachment.key,
+                appearance: appearance
+            )
             guard loadedImage == nil else { return }
             do {
                 let fileURL = try await FileAttachmentLoader.loadFile(for: attachment)
                 let image = await HTMLThumbnailRenderer.shared.thumbnail(
                     for: attachment.key,
-                    fileURL: fileURL
+                    fileURL: fileURL,
+                    appearance: appearance
                 )
                 loadedImage = image
             } catch {


### PR DESCRIPTION
## Problem

`HTMLThumbnailRenderer`'s previous `takeSnapshot` path required the `WKWebView` to be added to a `UIWindow` attached to the user-facing `UIWindowScene` so on-screen painting could happen. The cached render window stayed attached to the scene for the lifetime of the app.

When loaded HTML ever auto-focused an `<input>`, ran `focus()` in JS, or otherwise drove `WKWebView`'s internal `WKContentView` to claim first responder, the scene-level `UIWindowScene.keyboardLayoutGuide` registered a keyboard reservation that never unwound — even though the hidden window was at `windowLevel: -1` / `alpha: 0.01` so the keyboard never drew. SwiftUI's `safeAreaInsets.bottom` reads from that scene-scoped guide, so **every view in the scene** — the messages composer, the app settings sheet, the conversations list — saw an inflated bottom inset with no visible keyboard. The composer drifted to the middle of the screen, app settings rows pushed up.

## Architectural fix

Move HTML thumbnail rendering to a window-free pipeline:

1. Construct the `WKWebView` with an explicit frame but **never add it to any view, window, or scene**.
2. On `WKNavigationDelegate.didFinish` + the existing 0.5s paint settle, call `WKWebView.createPDF(configuration:)` — the PDF generation pipeline lays out and rasterizes through a separate code path that does not require window attachment.
3. Feed the PDF data to `PDFKit.PDFPage.thumbnail(of:for:)` for the final `UIImage`.

This makes the leak structurally impossible: there is no `UIWindow` for `keyboardLayoutGuide` to attach to, so a future auto-focus event in HTML content has nowhere to register.

## Changes

- `HTMLThumbnailRenderer.swift` only.
- Removed `cachedRenderWindow` and the `renderWindow` computed property.
- `renderSnapshot` now allocates an in-memory `WKWebView` with no view-hierarchy attachment, loads the file, and uses `createPDF` + `PDFKit`.
- `LoadCoordinator` swaps the snapshot completion for a `createPDF` completion that rasterizes via `PDFKit`.
- Bumped the cache key prefix to `html-thumb-v3-` so stale `takeSnapshot`-rendered images don't sit alongside `createPDF`-rendered ones.
- No callsite changes (`HTMLAttachmentBubble`, `ReplyHTMLThumbnail`, `ReplyReferenceHTMLPreview`, `ReplyComposerBar` keep their `cachedThumbnail` / `await thumbnail(for:fileURL:)` interface).

## Verification

Joined a fresh convo from the iOS app via CLI invite, sent short / long / stylized HTML attachments, opened the convo and the Stuff list. Thumbnails render correctly via the new pipeline, composer stays anchored to the bottom, and app settings no longer reports an inflated bottom safe-area inset.

## Risks

- **iOS version floor**: `createPDF` is iOS 14+. The project minimum is iOS 26, so this is free.
- **Output quality**: `PDFPage.thumbnail` rasterizes with proper anti-aliasing. PDFs default to white background; HTML that sets its own `body` background renders that color into the rasterized PDF, so the existing bottom-fade `bottomCenterColor` sampling continues to work.
- **JS-heavy pages**: `createPDF` reads the laid-out tree, so anything that depends on JS to populate the DOM completes via the same `didFinish` + paint-settle flow as before.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Render HTML thumbnails via detached WKWebView PDF rasterization with per-appearance caching
> - Replaces the offscreen `UIWindow`-based `WKWebView` snapshot approach in [`HTMLThumbnailRenderer`](https://github.com/xmtplabs/convos-ios/pull/825/files#diff-96e548fad1e9c41e89533dcd4ed532c527bb892ad625efe13c7d6396461e4bd8) with `createPDF` + `PDFKit` rasterization, rendering entirely without attaching the web view to a window.
> - Adds appearance-aware (dark/light) cache keys (bumped to `v3`) so each color scheme gets its own cached thumbnail; concurrent requests for different appearances no longer block each other.
> - Introduces `AttachmentColorSchemeKey` and a `ColorScheme.uiUserInterfaceStyle` extension used across all HTML thumbnail views to re-trigger async tasks and cache lookups when the system appearance changes.
> - Applies appearance-aware rendering to all four call sites: `HTMLAttachmentBubble`, `AssistantFilesLinksView`, `ReplyComposerBar`, and `ReplyReferenceView`.
> - Behavioral Change: cache entries from `v2` are invalidated by the prefix bump; all HTML thumbnails will re-render on first load after update.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dc69f0c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->