### PR TITLE
Cache HTML thumbnails per appearance and re-render on toggle

### DIFF
--- a/Convos/Conversation Detail/AssistantFilesLinksView.swift
+++ b/Convos/Conversation Detail/AssistantFilesLinksView.swift
@@ -363,6 +363,7 @@ private struct FileRow: View {
     let subtitle: String
     let onTap: () -> Void
 
+    @Environment(\.colorScheme) private var colorScheme: ColorScheme
     @State private var renderedHTMLPreview: UIImage?
     @State private var resolvedHTMLTitle: String?
     @State private var renderedFilePreview: UIImage?
@@ -377,7 +378,7 @@ private struct FileRow: View {
             )
         }
         .buttonStyle(.plain)
-        .task(id: file.attachmentKey) {
+        .task(id: AttachmentColorSchemeKey(key: file.attachmentKey, scheme: colorScheme)) {
             await loadHTMLMetadataIfNeeded()
         }
     }
@@ -420,8 +421,12 @@ private struct FileRow: View {
     }
 
     private func loadHTMLMetadataIfNeeded() async {
+        let appearance = colorScheme.uiUserInterfaceStyle
         if isHTML {
-            renderedHTMLPreview = HTMLThumbnailRenderer.shared.cachedThumbnail(for: file.attachmentKey)
+            renderedHTMLPreview = HTMLThumbnailRenderer.shared.cachedThumbnail(
+                for: file.attachmentKey,
+                appearance: appearance
+            )
             resolvedHTMLTitle = HTMLPageMetadata.shared.cachedTitle(for: file.attachmentKey)
         } else if let cached = FileThumbnailRenderer.shared.cachedThumbnail(for: file.attachmentKey),
                   cached.isContentThumbnail {
@@ -443,7 +448,8 @@ private struct FileRow: View {
                 if renderedHTMLPreview == nil {
                     renderedHTMLPreview = await HTMLThumbnailRenderer.shared.thumbnail(
                         for: file.attachmentKey,
-                        fileURL: url
+                        fileURL: url,
+                        appearance: appearance
                     )
                 }
                 if resolvedHTMLTitle == nil {

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/ReplyComposerBar.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/ReplyComposerBar.swift
@@ -172,13 +172,17 @@ struct ReplyComposerBar: View {
 private struct ReplyHTMLThumbnail: View {
     let attachment: HydratedAttachment
 
+    @Environment(\.colorScheme) private var colorScheme: ColorScheme
     @State private var loadedImage: UIImage?
 
     private static let thumbnailSize: CGFloat = 40.0
 
     init(attachment: HydratedAttachment) {
         self.attachment = attachment
-        _loadedImage = State(initialValue: HTMLThumbnailRenderer.shared.cachedThumbnail(for: attachment.key))
+        _loadedImage = State(initialValue: HTMLThumbnailRenderer.shared.cachedThumbnail(
+            for: attachment.key,
+            appearance: .light
+        ))
     }
 
     var body: some View {
@@ -195,14 +199,19 @@ private struct ReplyHTMLThumbnail: View {
                     .frame(width: Self.thumbnailSize, height: Self.thumbnailSize)
             }
         }
-        .task(id: attachment.key) {
-            loadedImage = HTMLThumbnailRenderer.shared.cachedThumbnail(for: attachment.key)
+        .task(id: AttachmentColorSchemeKey(key: attachment.key, scheme: colorScheme)) {
+            let appearance = colorScheme.uiUserInterfaceStyle
+            loadedImage = HTMLThumbnailRenderer.shared.cachedThumbnail(
+                for: attachment.key,
+                appearance: appearance
+            )
             guard loadedImage == nil else { return }
             do {
                 let fileURL = try await FileAttachmentLoader.loadFile(for: attachment)
                 loadedImage = await HTMLThumbnailRenderer.shared.thumbnail(
                     for: attachment.key,
-                    fileURL: fileURL
+                    fileURL: fileURL,
+                    appearance: appearance
                 )
             } catch {
                 Log.error("Failed to load HTML reply composer thumbnail: \(error)")

--- a/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/HTMLAttachmentBubble.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/HTMLAttachmentBubble.swift
@@ -13,6 +13,7 @@ struct HTMLAttachmentBubble: View {
     var cornerRadiusOverride: CGFloat?
 
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass: UserInterfaceSizeClass?
+    @Environment(\.colorScheme) private var colorScheme: ColorScheme
     @State private var renderedImage: UIImage?
     @State private var hasLoadFailed: Bool = false
     @State private var bottomEdgeColor: Color?
@@ -39,7 +40,7 @@ struct HTMLAttachmentBubble: View {
         }
         .accessibilityIdentifier("html-attachment-bubble")
         .accessibilityLabel("HTML page from \(profile.displayName)")
-        .task(id: attachment.key) {
+        .task(id: AttachmentColorSchemeKey(key: attachment.key, scheme: colorScheme)) {
             await loadThumbnail()
         }
     }
@@ -142,10 +143,14 @@ struct HTMLAttachmentBubble: View {
     }
 
     private func loadThumbnail() async {
+        let appearance = colorScheme.uiUserInterfaceStyle
         renderedImage = nil
         bottomEdgeColor = nil
         hasLoadFailed = false
-        if let cached = HTMLThumbnailRenderer.shared.cachedThumbnail(for: attachment.key) {
+        if let cached = HTMLThumbnailRenderer.shared.cachedThumbnail(
+            for: attachment.key,
+            appearance: appearance
+        ) {
             renderedImage = cached
             bottomEdgeColor = cached.convos_bottomCenterColor()
             return
@@ -154,7 +159,8 @@ struct HTMLAttachmentBubble: View {
             let fileURL = try await FileAttachmentLoader.loadFile(for: attachment)
             let image = await HTMLThumbnailRenderer.shared.thumbnail(
                 for: attachment.key,
-                fileURL: fileURL
+                fileURL: fileURL,
+                appearance: appearance
             )
             renderedImage = image
             bottomEdgeColor = image?.convos_bottomCenterColor()
@@ -170,6 +176,24 @@ struct HTMLAttachmentBubble: View {
         static let cellHeight: CGFloat = 500.0
         static let fadeHeight: CGFloat = 68.0
         static let borderHeight: CGFloat = 1.0
+    }
+}
+
+/// Composite key so `.task(id:)` re-fires when either the attachment or the
+/// SwiftUI color scheme changes — the renderer keys its cache on appearance
+/// too, so toggling dark mode swaps to a freshly-rendered thumbnail.
+struct AttachmentColorSchemeKey: Hashable {
+    let key: String
+    let scheme: ColorScheme
+}
+
+extension ColorScheme {
+    var uiUserInterfaceStyle: UIUserInterfaceStyle {
+        switch self {
+        case .dark: return .dark
+        case .light: return .light
+        @unknown default: return .light
+        }
     }
 }
 

--- a/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/HTMLThumbnailRenderer.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/HTMLThumbnailRenderer.swift
@@ -24,35 +24,46 @@ final class HTMLThumbnailRenderer {
 
     private var inflight: [String: Task<UIImage?, Never>] = [:]
 
-    static func cacheKey(for attachmentKey: String) -> String {
-        cacheKeyPrefix + attachmentKey
+    static func cacheKey(for attachmentKey: String, appearance: UIUserInterfaceStyle) -> String {
+        cacheKeyPrefix + attachmentKey + "-" + appearanceSuffix(for: appearance)
     }
 
-    func cachedThumbnail(for attachmentKey: String) -> UIImage? {
-        ImageCache.shared.image(for: Self.cacheKey(for: attachmentKey))
+    private static func appearanceSuffix(for appearance: UIUserInterfaceStyle) -> String {
+        switch appearance {
+        case .dark: return "dark"
+        case .light, .unspecified: return "light"
+        @unknown default: return "light"
+        }
     }
 
-    func thumbnail(for attachmentKey: String, fileURL: URL) async -> UIImage? {
-        let cacheKey = Self.cacheKey(for: attachmentKey)
+    func cachedThumbnail(for attachmentKey: String, appearance: UIUserInterfaceStyle) -> UIImage? {
+        ImageCache.shared.image(for: Self.cacheKey(for: attachmentKey, appearance: appearance))
+    }
+
+    func thumbnail(for attachmentKey: String, fileURL: URL, appearance: UIUserInterfaceStyle) async -> UIImage? {
+        let cacheKey = Self.cacheKey(for: attachmentKey, appearance: appearance)
         if let cached = await ImageCache.shared.imageAsync(for: cacheKey) {
             return cached
         }
 
-        if let existing = inflight[attachmentKey] {
+        // Inflight key includes appearance so a concurrent dark-mode request
+        // doesn't await a light-mode render (or vice versa).
+        let inflightKey = attachmentKey + "-" + Self.appearanceSuffix(for: appearance)
+        if let existing = inflight[inflightKey] {
             return await existing.value
         }
 
         let task = Task<UIImage?, Never> { [weak self] in
             guard let self else { return nil }
-            let image = await self.renderSnapshot(fileURL: fileURL)
+            let image = await self.renderSnapshot(fileURL: fileURL, appearance: appearance)
             if let image {
                 ImageCache.shared.cacheImage(image, for: cacheKey, storageTier: .cache)
             }
             return image
         }
-        inflight[attachmentKey] = task
+        inflight[inflightKey] = task
         let result = await task.value
-        inflight.removeValue(forKey: attachmentKey)
+        inflight.removeValue(forKey: inflightKey)
         return result
     }
 
@@ -61,7 +72,7 @@ final class HTMLThumbnailRenderer {
     /// object: it loads the HTML, hands a vector PDF to PDFKit on
     /// `didFinish`, and is deallocated. There is no scene attachment and no
     /// `UIWindowScene.keyboardLayoutGuide` reservation to leak.
-    private func renderSnapshot(fileURL: URL) async -> UIImage? {
+    private func renderSnapshot(fileURL: URL, appearance: UIUserInterfaceStyle) async -> UIImage? {
         let config = WKWebViewConfiguration()
         let userScript = WKUserScript(
             source: Self.injectionScript,
@@ -78,6 +89,10 @@ final class HTMLThumbnailRenderer {
         webView.scrollView.bounces = false
         webView.isOpaque = true
         webView.isUserInteractionEnabled = false
+        // Drives `@media (prefers-color-scheme: ...)` resolution inside the
+        // loaded HTML — the WebView's traitCollection determines what
+        // matchMedia returns regardless of view-hierarchy attachment.
+        webView.overrideUserInterfaceStyle = appearance
 
         return await withCheckedContinuation { (continuation: CheckedContinuation<UIImage?, Never>) in
             let coordinator = LoadCoordinator(renderSize: Self.renderSize) { result in

--- a/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/ReplyReferenceView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/ReplyReferenceView.swift
@@ -538,6 +538,7 @@ private struct ReplyReferenceHTMLPreview: View {
     let attachment: HydratedAttachment
     let onTap: () -> Void
 
+    @Environment(\.colorScheme) private var colorScheme: ColorScheme
     @State private var loadedImage: UIImage?
 
     private static let maxHeight: CGFloat = 80.0
@@ -545,7 +546,12 @@ private struct ReplyReferenceHTMLPreview: View {
     init(attachment: HydratedAttachment, onTap: @escaping () -> Void) {
         self.attachment = attachment
         self.onTap = onTap
-        _loadedImage = State(initialValue: HTMLThumbnailRenderer.shared.cachedThumbnail(for: attachment.key))
+        // Seed from light cache; the .task below will swap in the correct
+        // appearance variant once the environment is read.
+        _loadedImage = State(initialValue: HTMLThumbnailRenderer.shared.cachedThumbnail(
+            for: attachment.key,
+            appearance: .light
+        ))
     }
 
     var body: some View {
@@ -565,14 +571,19 @@ private struct ReplyReferenceHTMLPreview: View {
                 .buttonStyle(.plain)
             }
         }
-        .task(id: attachment.key) {
-            loadedImage = HTMLThumbnailRenderer.shared.cachedThumbnail(for: attachment.key)
+        .task(id: AttachmentColorSchemeKey(key: attachment.key, scheme: colorScheme)) {
+            let appearance = colorScheme.uiUserInterfaceStyle
+            loadedImage = HTMLThumbnailRenderer.shared.cachedThumbnail(
+                for: attachment.key,
+                appearance: appearance
+            )
             guard loadedImage == nil else { return }
             do {
                 let fileURL = try await FileAttachmentLoader.loadFile(for: attachment)
                 let image = await HTMLThumbnailRenderer.shared.thumbnail(
                     for: attachment.key,
-                    fileURL: fileURL
+                    fileURL: fileURL,
+                    appearance: appearance
                 )
                 loadedImage = image
             } catch {


### PR DESCRIPTION
The thumbnail cache was keyed only by attachment key, so a thumbnail
rendered in light mode would persist across an appearance change to
dark — the cached light render kept showing until the cache evicted.

Key the cache by (attachmentKey, appearance) and drive the WKWebView's
prefers-color-scheme via overrideUserInterfaceStyle. Consumers observe
@Environment(\.colorScheme) and use a composite .task(id:) so a system
appearance toggle re-fires the load and swaps in the matching variant.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/826"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Cache and re-render HTML thumbnails per light/dark appearance
> - `HTMLThumbnailRenderer` now includes an appearance suffix (`light`/`dark`) in cache keys and inflight task keys, so light and dark thumbnails are stored and fetched independently.
> - During offscreen rendering, `renderSnapshot` sets `webView.overrideUserInterfaceStyle` to force the correct appearance, ensuring `prefers-color-scheme` CSS resolves correctly.
> - All HTML thumbnail views (`HTMLAttachmentBubble`, `ReplyHTMLThumbnail`, `ReplyReferenceHTMLPreview`, and `FileRow`) observe the SwiftUI `colorScheme` environment and use a composite `AttachmentColorSchemeKey` as the `.task` id, triggering a re-render when the system appearance changes.
> - A `ColorScheme.uiUserInterfaceStyle` extension maps SwiftUI `ColorScheme` to `UIUserInterfaceStyle` for use with UIKit APIs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 05c3067.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->