### PR TITLE
SIWE auth implementation

### DIFF
--- a/Convos/Config/config.dev.json
+++ b/Convos/Config/config.dev.json
@@ -10,7 +10,7 @@
     "app-dev.convos.org"
   ],
   "appUrlScheme": "convos-dev",
-  "siweDomain": "convos.app",
-  "siweUri": "https://convos.app",
+  "siweDomain": "dev.convos.org",
+  "siweUri": "https://dev.convos.org",
   "siweChainId": 1
 }

--- a/Convos/Config/config.dev.json
+++ b/Convos/Config/config.dev.json
@@ -9,5 +9,8 @@
     "dev.convos.org",
     "app-dev.convos.org"
   ],
-  "appUrlScheme": "convos-dev"
+  "appUrlScheme": "convos-dev",
+  "siweDomain": "convos.app",
+  "siweUri": "https://convos.app",
+  "siweChainId": 1
 }

--- a/Convos/Config/config.local.json
+++ b/Convos/Config/config.local.json
@@ -9,5 +9,8 @@
     "local.convos.org",
     "app-local.convos.org"
   ],
-  "appUrlScheme": "convos-local"
+  "appUrlScheme": "convos-local",
+  "siweDomain": "convos.app",
+  "siweUri": "https://convos.app",
+  "siweChainId": 1
 }

--- a/Convos/Config/config.local.json
+++ b/Convos/Config/config.local.json
@@ -10,7 +10,7 @@
     "app-local.convos.org"
   ],
   "appUrlScheme": "convos-local",
-  "siweDomain": "convos.app",
-  "siweUri": "https://convos.app",
+  "siweDomain": "dev.convos.org",
+  "siweUri": "https://dev.convos.org",
   "siweChainId": 1
 }

--- a/Convos/Config/config.pr.json
+++ b/Convos/Config/config.pr.json
@@ -10,5 +10,8 @@
     "app-dev.convos.org"
   ],
   "appUrlScheme": "convos-pr",
-  "firebaseConfig": "GoogleService-Info.PR"
+  "firebaseConfig": "GoogleService-Info.PR",
+  "siweDomain": "convos.app",
+  "siweUri": "https://convos.app",
+  "siweChainId": 1
 }

--- a/Convos/Config/config.pr.json
+++ b/Convos/Config/config.pr.json
@@ -11,7 +11,7 @@
   ],
   "appUrlScheme": "convos-pr",
   "firebaseConfig": "GoogleService-Info.PR",
-  "siweDomain": "convos.app",
-  "siweUri": "https://convos.app",
+  "siweDomain": "dev.convos.org",
+  "siweUri": "https://dev.convos.org",
   "siweChainId": 1
 }

--- a/Convos/Config/config.prod.json
+++ b/Convos/Config/config.prod.json
@@ -10,7 +10,7 @@
     "app.convos.org"
   ],
   "appUrlScheme": "convos",
-  "siweDomain": "convos.app",
-  "siweUri": "https://convos.app",
+  "siweDomain": "convos.org",
+  "siweUri": "https://convos.org",
   "siweChainId": 1
 }

--- a/Convos/Config/config.prod.json
+++ b/Convos/Config/config.prod.json
@@ -9,5 +9,8 @@
     "popup.convos.org",
     "app.convos.org"
   ],
-  "appUrlScheme": "convos"
+  "appUrlScheme": "convos",
+  "siweDomain": "convos.app",
+  "siweUri": "https://convos.app",
+  "siweChainId": 1
 }

--- a/Convos/Debug View/DebugAuthProbeView.swift
+++ b/Convos/Debug View/DebugAuthProbeView.swift
@@ -12,10 +12,12 @@ struct DebugAuthProbeView: View {
     @State private var log: [LogLine] = []
     @State private var probeResult: BackendAuthProbe.Result?
     @State private var negativeProbePassed: Bool?
+    @State private var currentStatus: BackendAuthProbe.Status?
 
     var body: some View {
         ScrollViewReader { proxy in
             List {
+                currentStatusSection
                 actionsSection
                 resultSection
                 logSection(proxy: proxy)
@@ -23,6 +25,43 @@ struct DebugAuthProbeView: View {
         }
         .navigationTitle("SIWE Auth Probe")
         .navigationBarTitleDisplayMode(.inline)
+        .task { await refreshStatus() }
+    }
+
+    @ViewBuilder
+    private var currentStatusSection: some View {
+        Section("Current SIWE State") {
+            if let status = currentStatus {
+                resultRow("Address", status.address ?? "(no identity)", monospaced: status.address != nil)
+                resultRow(
+                    "AccountId",
+                    status.accountId ?? "(none — not signed in via SIWE)",
+                    monospaced: status.accountId != nil,
+                    color: status.accountId == nil ? .secondary : .primary
+                )
+                if let issuedAt = status.issuedAt {
+                    resultRow("Issued At", iso8601(issuedAt))
+                }
+                if let exp = status.jwtExpiry {
+                    resultRow("Expires", iso8601(exp))
+                }
+                resultRow(
+                    "JWT valid",
+                    status.isJWTValid ? "yes" : "no",
+                    color: status.isJWTValid ? .green : .red
+                )
+            } else {
+                HStack {
+                    ProgressView().controlSize(.small)
+                    Text("Reading keychain…").foregroundStyle(.secondary)
+                }
+            }
+            let refreshAction: () -> Void = { Task { await refreshStatus() } }
+            Button(action: refreshAction) {
+                Text("Refresh")
+                    .foregroundStyle(.secondary)
+            }
+        }
     }
 
     @ViewBuilder
@@ -126,6 +165,14 @@ struct DebugAuthProbeView: View {
 
     // MARK: - Probe execution
 
+    private func refreshStatus() async {
+        let store = KeychainIdentityStore(accessGroup: environment.keychainAccessGroup)
+        currentStatus = await BackendAuthProbe.currentStatus(
+            environment: environment,
+            identityStore: store
+        )
+    }
+
     private func runProbe() async {
         isRunning = true
         defer { isRunning = false }
@@ -153,6 +200,7 @@ struct DebugAuthProbeView: View {
         } catch {
             appendLog("Probe failed: \(error)", .failure)
         }
+        await refreshStatus()
     }
 
     private func runNegativeProbe() async {

--- a/Convos/Debug View/DebugAuthProbeView.swift
+++ b/Convos/Debug View/DebugAuthProbeView.swift
@@ -1,0 +1,213 @@
+import ConvosCore
+import SwiftUI
+
+/// Debug-only end-to-end SIWE probe. Hits the local backend, fetches a
+/// nonce, signs an EIP-4361 message with the on-device XMTP identity,
+/// exchanges it for a SIWE-bound JWT, and calls `/v2/account-auth-check`.
+/// Renders progress + final result inline.
+struct DebugAuthProbeView: View {
+    let environment: AppEnvironment
+
+    @State private var isRunning: Bool = false
+    @State private var log: [LogLine] = []
+    @State private var probeResult: BackendAuthProbe.Result?
+    @State private var negativeProbePassed: Bool?
+
+    var body: some View {
+        ScrollViewReader { proxy in
+            List {
+                actionsSection
+                resultSection
+                logSection(proxy: proxy)
+            }
+        }
+        .navigationTitle("SIWE Auth Probe")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    @ViewBuilder
+    private var actionsSection: some View {
+        Section("Actions") {
+            let runAction: () -> Void = { Task { await runProbe() } }
+            Button(action: runAction) {
+                HStack {
+                    Text("Run Auth Probe")
+                    Spacer()
+                    if isRunning { ProgressView() }
+                }
+            }
+            .disabled(isRunning)
+
+            let negativeAction: () -> Void = { Task { await runNegativeProbe() } }
+            Button(action: negativeAction) {
+                Text("Probe /account-auth-check without auth")
+            }
+            .disabled(isRunning)
+
+            let clearAction: () -> Void = {
+                log = []
+                probeResult = nil
+                negativeProbePassed = nil
+            }
+            Button(action: clearAction) {
+                Text("Clear Log")
+                    .foregroundStyle(.secondary)
+            }
+            .disabled(isRunning || log.isEmpty)
+        }
+    }
+
+    @ViewBuilder
+    private var resultSection: some View {
+        if let probeResult {
+            Section("Last Result") {
+                resultRow("Address", probeResult.address, monospaced: true)
+                resultRow("AccountId", probeResult.accountId ?? "(none)", monospaced: probeResult.accountId != nil)
+                resultRow("JWT exp", probeResult.jwtExpiry.map { iso8601($0) } ?? "(unknown)")
+                resultRow(
+                    "/account-auth-check",
+                    probeResult.accountAuthCheckPassed ? "200 OK" : "FAILED",
+                    color: probeResult.accountAuthCheckPassed ? .green : .red
+                )
+            }
+        }
+        if let negativeProbePassed {
+            Section("Negative Probe") {
+                resultRow(
+                    "no-auth → 401",
+                    negativeProbePassed ? "PASSED" : "FAILED",
+                    color: negativeProbePassed ? .green : .red
+                )
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func logSection(proxy: ScrollViewProxy) -> some View {
+        if !log.isEmpty {
+            Section("Log") {
+                ForEach(log) { line in
+                    HStack(alignment: .top, spacing: 8) {
+                        Image(systemName: line.icon)
+                            .foregroundStyle(line.color)
+                            .font(.caption)
+                        Text(line.text)
+                            .font(.system(.footnote, design: .monospaced))
+                            .textSelection(.enabled)
+                    }
+                    .id(line.id)
+                }
+            }
+            .onChange(of: log.count) { _, _ in
+                if let last = log.last {
+                    withAnimation { proxy.scrollTo(last.id, anchor: .bottom) }
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func resultRow(_ label: String, _ value: String, monospaced: Bool = false, color: Color = .primary) -> some View {
+        HStack(alignment: .top) {
+            Text(label)
+            Spacer()
+            Group {
+                if monospaced {
+                    Text(value).font(.system(.footnote, design: .monospaced))
+                } else {
+                    Text(value)
+                }
+            }
+            .foregroundStyle(color)
+            .multilineTextAlignment(.trailing)
+            .textSelection(.enabled)
+        }
+    }
+
+    // MARK: - Probe execution
+
+    private func runProbe() async {
+        isRunning = true
+        defer { isRunning = false }
+
+        probeResult = nil
+        appendLog("Starting SIWE probe…", .info)
+
+        let store = KeychainIdentityStore(accessGroup: environment.keychainAccessGroup)
+        do {
+            let result = try await BackendAuthProbe.run(
+                environment: environment,
+                identityStore: store,
+                progress: { line in
+                    Task { @MainActor in
+                        self.appendLog(line, .info)
+                    }
+                }
+            )
+            probeResult = result
+            if result.accountAuthCheckPassed {
+                appendLog("/account-auth-check → 200 OK", .success)
+            } else {
+                appendLog("/account-auth-check did not return 200 (see log)", .failure)
+            }
+        } catch {
+            appendLog("Probe failed: \(error)", .failure)
+        }
+    }
+
+    private func runNegativeProbe() async {
+        isRunning = true
+        defer { isRunning = false }
+
+        negativeProbePassed = nil
+        appendLog("Calling /account-auth-check with no auth header…", .info)
+        let passed = await BackendAuthProbe.probeWithoutAuth(environment: environment)
+        negativeProbePassed = passed
+        appendLog(
+            passed
+                ? "Got rejected as expected (401/403)."
+                : "Did not get the expected 401/403 — gating may be broken.",
+            passed ? .success : .failure
+        )
+    }
+
+    private func appendLog(_ text: String, _ kind: LogLine.Kind) {
+        log.append(LogLine(text: text, kind: kind))
+    }
+
+    private func iso8601(_ date: Date) -> String {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime]
+        return f.string(from: date)
+    }
+
+    private struct LogLine: Identifiable {
+        let id: UUID = UUID()
+        let text: String
+        let kind: Kind
+
+        enum Kind { case info, success, failure }
+
+        var icon: String {
+            switch kind {
+            case .info: return "arrow.right.circle"
+            case .success: return "checkmark.circle.fill"
+            case .failure: return "xmark.octagon.fill"
+            }
+        }
+
+        var color: Color {
+            switch kind {
+            case .info: return .secondary
+            case .success: return .green
+            case .failure: return .red
+            }
+        }
+    }
+}
+
+#Preview {
+    NavigationStack {
+        DebugAuthProbeView(environment: .tests)
+    }
+}

--- a/Convos/Debug View/DebugView.swift
+++ b/Convos/Debug View/DebugView.swift
@@ -48,6 +48,7 @@ struct DebugViewSection: View {
             featuresSection
             pushNotificationsSection
             debugSection
+            authProbeSection
             sentryTestingSection
             pendingInvitesSection
             assetRenewalSection
@@ -175,6 +176,18 @@ struct DebugViewSection: View {
                 } else {
                     ProgressView()
                 }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var authProbeSection: some View {
+        Section("SIWE Auth") {
+            NavigationLink {
+                DebugAuthProbeView(environment: environment)
+            } label: {
+                Text("Run SIWE Auth Probe")
+                    .foregroundStyle(.colorTextPrimary)
             }
         }
     }

--- a/ConvosCore/Package.swift
+++ b/ConvosCore/Package.swift
@@ -49,6 +49,7 @@ let package = Package(
                 .product(name: "FirebaseAppCheck", package: "firebase-ios-sdk"),
                 .product(name: "SwiftProtobuf", package: "swift-protobuf"),
                 .product(name: "CSecp256k1", package: "CSecp256k1.swift"),
+                .product(name: "CryptoSwift", package: "CryptoSwift"),
                 .product(name: "Sentry", package: "sentry-cocoa"),
                 .product(name: "ConvosLogging", package: "ConvosLogging"),
                 .product(name: "ConvosInvites", package: "ConvosInvites"),

--- a/ConvosCore/Package.swift
+++ b/ConvosCore/Package.swift
@@ -30,6 +30,7 @@ let package = Package(
             revision: "ios-4.10.0-nightly.20260516.42c6bd1"
         ),
         .package(url: "https://github.com/tesseract-one/CSecp256k1.swift.git", from: "0.2.0"),
+        .package(url: "https://github.com/krzyzanowskim/CryptoSwift.git", from: "1.8.0"),
         .package(url: "https://github.com/firebase/firebase-ios-sdk", from: "12.1.0"),
         .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.31.1"),
         .package(url: "https://github.com/getsentry/sentry-cocoa.git", from: "8.57.1"),
@@ -94,6 +95,9 @@ let package = Package(
                 "ConvosCore",
                 "ConvosAppData",
                 .target(name: "ConvosCoreiOS", condition: .when(platforms: [.iOS])),
+                .product(name: "XMTPiOS", package: "libxmtp"),
+                .product(name: "CSecp256k1", package: "CSecp256k1.swift"),
+                .product(name: "CryptoSwift", package: "CryptoSwift"),
             ]
         ),
         .testTarget(

--- a/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient+Models.swift
+++ b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient+Models.swift
@@ -7,6 +7,37 @@ public enum ConvosAPI {
         public let token: String
     }
 
+    // MARK: - v2/auth/token (SIWE)
+
+    /// Request body for `POST /api/v2/auth/token`. Omit `siwe` for the
+    /// legacy device-only path; include it to bind the JWT to an
+    /// Ethereum account.
+    public struct AuthTokenRequest: Encodable {
+        public let deviceId: String
+        public let siwe: SIWEPayload?
+
+        public init(deviceId: String, siwe: SIWEPayload?) {
+            self.deviceId = deviceId
+            self.siwe = siwe
+        }
+    }
+
+    public struct SIWEPayload: Encodable {
+        public let message: String
+        public let signature: String
+
+        public init(message: String, signature: String) {
+            self.message = message
+            self.signature = signature
+        }
+    }
+
+    public struct AuthTokenResponse: Decodable {
+        public let token: String
+
+        public init(token: String) { self.token = token }
+    }
+
     // MARK: - Device Update Models
 
     struct DeviceUpdateRequest: Codable {

--- a/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient+SIWE.swift
+++ b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient+SIWE.swift
@@ -74,7 +74,13 @@ extension ConvosAPIClient {
             chainId: siweConfig.chainId,
             nonce: challenge.nonce,
             issuedAt: Date(),
-            expirationTime: Date().addingTimeInterval(5 * 60)
+            expirationTime: Date().addingTimeInterval(5 * 60),
+            // EIP-4361 requires that any additional context appear in
+            // the Resources list as valid URIs. We bind the deviceId
+            // into the signed message via a custom scheme so the
+            // backend can prove the signer authorized exactly this
+            // device — must match the `deviceId` in the request body.
+            resources: ["convos://device/\(deviceId)"]
         ).prepareMessage()
 
         let signature = SIWESigner.hexEncoded(try await signing.sign(message))

--- a/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient+SIWE.swift
+++ b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient+SIWE.swift
@@ -4,6 +4,13 @@ import Foundation
 extension ConvosAPIClient {
     // MARK: - Public SIWE entry points
 
+    /// Max number of fresh-nonce retries on 401 from `/auth/token`. The
+    /// backend burns the nonce on every attempt regardless of signature
+    /// validity, so a retry must restart from `/auth/nonce`. One retry
+    /// covers the typical race (nonce TTL expired between fetch and
+    /// exchange) without masking a real signing bug.
+    static let maxSIWENonceRetries: Int = 1
+
     func authenticateWithSIWE(
         appCheckToken: String,
         signing: BackendAuthSigningContext,
@@ -22,6 +29,41 @@ extension ConvosAPIClient {
             return existing
         }
 
+        var lastError: (any Error)?
+        for attempt in 0...Self.maxSIWENonceRetries {
+            do {
+                return try await singleSIWEExchange(
+                    appCheckToken: appCheckToken,
+                    signing: signing,
+                    deviceId: deviceId,
+                    slot: slot
+                )
+            } catch SIWEAuthError.invalidNonceOrSignature(let msg) {
+                lastError = SIWEAuthError.invalidNonceOrSignature(msg)
+                if attempt < Self.maxSIWENonceRetries {
+                    Log.info("SIWE 401 on attempt \(attempt + 1); retrying with a fresh nonce")
+                    continue
+                }
+            } catch SIWEAuthError.rateLimited {
+                lastError = SIWEAuthError.rateLimited
+                if attempt < Self.maxSIWENonceRetries {
+                    let delay = TimeInterval.calculateExponentialBackoff(for: attempt)
+                    Log.info("SIWE rate-limited; sleeping \(delay)s and retrying from nonce")
+                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    continue
+                }
+            }
+            break
+        }
+        throw lastError ?? SIWEAuthError.invalidNonceOrSignature(nil)
+    }
+
+    private func singleSIWEExchange(
+        appCheckToken: String,
+        signing: BackendAuthSigningContext,
+        deviceId: String,
+        slot: String
+    ) async throws -> String {
         let challenge = try await requestAuthNonce(appCheckToken: appCheckToken, retryCount: 0)
 
         let siweConfig = environment.siweConfiguration
@@ -43,8 +85,7 @@ extension ConvosAPIClient {
             deviceId: deviceId,
             message: message,
             signatureHex: signature,
-            cookieHeader: challenge.cookieHeader,
-            retryCount: retryCount
+            cookieHeader: challenge.cookieHeader
         )
 
         guard Self.jwtCarriesAccountId(token) else {
@@ -138,8 +179,7 @@ extension ConvosAPIClient {
         deviceId: String,
         message: String,
         signatureHex: String,
-        cookieHeader: String,
-        retryCount: Int
+        cookieHeader: String
     ) async throws -> String {
         let url = baseURL.appendingPathComponent("v2/auth/token")
         var request = URLRequest(url: url)
@@ -166,16 +206,13 @@ extension ConvosAPIClient {
             throw APIError.badRequest(parseErrorMessage(from: data))
         case 401:
             // Per backend, the nonce is burned even on signature failure.
-            // The caller must restart from /auth/nonce.
+            // Signal the caller to restart from /auth/nonce.
             throw SIWEAuthError.invalidNonceOrSignature(parseErrorMessage(from: data))
         case 403:
             throw SIWEAuthError.deviceDisabled(parseErrorMessage(from: data))
         case 429:
-            guard retryCount < maxRetryCount else { throw APIError.rateLimitExceeded }
-            let delay = TimeInterval.calculateExponentialBackoff(for: retryCount)
-            try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
-            // 429 retry: don't reuse a possibly-consumed nonce; signal
-            // caller to restart from /auth/nonce.
+            // Same here: nonce is burned. Caller decides whether to
+            // sleep + retry; we just signal.
             throw SIWEAuthError.rateLimited
         default:
             throw APIError.serverError(parseErrorMessage(from: data))

--- a/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient+SIWE.swift
+++ b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient+SIWE.swift
@@ -342,9 +342,19 @@ extension ConvosAPIClient {
 
     static func jwtCarriesAccountId(_ token: String) -> Bool {
         let parts = token.split(separator: ".")
-        guard parts.count == 3 else { return false }
-        guard let payloadData = try? String(parts[1]).base64URLDecoded(),
-              let json = try? JSONSerialization.jsonObject(with: payloadData) as? [String: Any] else {
+        guard parts.count == 3 else {
+            Log.warning("jwtCarriesAccountId: token does not have 3 segments")
+            return false
+        }
+        let payloadData: Data
+        do {
+            payloadData = try String(parts[1]).base64URLDecoded()
+        } catch {
+            Log.warning("jwtCarriesAccountId: base64url decode failed: \(error.localizedDescription)")
+            return false
+        }
+        guard let json = try? JSONSerialization.jsonObject(with: payloadData) as? [String: Any] else {
+            Log.warning("jwtCarriesAccountId: payload is not a JSON object")
             return false
         }
         if let id = json["accountId"] as? String, !id.isEmpty { return true }

--- a/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient+SIWE.swift
+++ b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient+SIWE.swift
@@ -100,7 +100,16 @@ extension ConvosAPIClient {
         }
 
         try keychainService.saveString(token, account: slot)
-        Log.info("Stored SIWE JWT under address-scoped slot")
+        // Persist accountId in its own slot so the UI / debug tools
+        // can show it even when the JWT has expired and hasn't been
+        // refreshed yet. JWT remains the source of truth for the
+        // network identity check; this slot is a UX cache.
+        let accountId = BackendAuthProbe.extractAccountId(from: token)
+        if let accountId {
+            let accountSlot = KeychainAccount.siweAccountId(deviceId: deviceId, address: signing.address)
+            try? keychainService.saveString(accountId, account: accountSlot)
+        }
+        Log.info("Stored SIWE JWT under address-scoped slot (accountId=\(accountId ?? "?"))")
         return token
     }
 

--- a/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient+SIWE.swift
+++ b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient+SIWE.swift
@@ -1,0 +1,331 @@
+import ConvosLogging
+import Foundation
+
+extension ConvosAPIClient {
+    // MARK: - Public SIWE entry points
+
+    func authenticateWithSIWE(
+        appCheckToken: String,
+        signing: BackendAuthSigningContext,
+        retryCount: Int = 0
+    ) async throws -> String {
+        let deviceId = DeviceInfo.deviceIdentifier
+        let slot = KeychainAccount.siweJwt(deviceId: deviceId, address: signing.address)
+
+        // Reuse a cached SIWE JWT as long as it's valid AND actually
+        // carries an accountId (legacy device-only tokens would not).
+        if let existing = try? keychainService.retrieveString(account: slot),
+           !existing.isEmpty,
+           isJWTValid(existing),
+           Self.jwtCarriesAccountId(existing) {
+            Log.info("Using existing SIWE JWT from keychain (address-scoped slot)")
+            return existing
+        }
+
+        let challenge = try await requestAuthNonce(appCheckToken: appCheckToken, retryCount: 0)
+
+        let siweConfig = environment.siweConfiguration
+        let message = SIWEMessage(
+            domain: siweConfig.domain,
+            address: signing.address,
+            statement: "Sign in to Convos",
+            uri: siweConfig.uri,
+            chainId: siweConfig.chainId,
+            nonce: challenge.nonce,
+            issuedAt: Date(),
+            expirationTime: Date().addingTimeInterval(5 * 60)
+        ).prepareMessage()
+
+        let signature = SIWESigner.hexEncoded(try await signing.sign(message))
+
+        let token = try await exchangeSIWE(
+            appCheckToken: appCheckToken,
+            deviceId: deviceId,
+            message: message,
+            signatureHex: signature,
+            cookieHeader: challenge.cookieHeader,
+            retryCount: retryCount
+        )
+
+        guard Self.jwtCarriesAccountId(token) else {
+            // Backend returned a token without accountId. Treat as a hard
+            // failure so we never store a non-SIWE token in the SIWE slot.
+            throw SIWEAuthError.tokenMissingAccountId
+        }
+
+        try keychainService.saveString(token, account: slot)
+        Log.info("Stored SIWE JWT under address-scoped slot")
+        return token
+    }
+
+    func accountAuthCheck(jwt: String?) async throws -> ConvosAPI.AuthCheckResponse {
+        let url = baseURL.appendingPathComponent("v2/account-auth-check")
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        if let jwt, !jwt.isEmpty {
+            request.setValue(jwt, forHTTPHeaderField: "X-Convos-AuthToken")
+        }
+
+        let (data, response) = try await Self.siweSession.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw APIError.invalidResponse
+        }
+
+        switch httpResponse.statusCode {
+        case 200:
+            return try JSONDecoder().decode(ConvosAPI.AuthCheckResponse.self, from: data)
+        case 401:
+            throw APIError.notAuthenticated
+        case 403:
+            throw APIError.forbidden
+        default:
+            throw APIError.serverError(parseErrorMessage(from: data))
+        }
+    }
+
+    // MARK: - Internals
+
+    struct AuthNonceChallenge {
+        let nonce: String           // 64-char lowercase hex
+        let cookieHeader: String    // exact `name=value` to send back on /auth/token
+    }
+
+    private static let siweSession: URLSession = {
+        let config = URLSessionConfiguration.ephemeral
+        config.httpCookieStorage = nil
+        config.httpShouldSetCookies = false
+        config.httpCookieAcceptPolicy = .never
+        return URLSession(configuration: config)
+    }()
+
+    private static let nonceCookieNames: [String] = [
+        "__Host-convos_nonce",  // prod (strict attrs)
+        "convos_nonce",         // proposed relaxed form for non-prod
+    ]
+
+    func requestAuthNonce(appCheckToken: String, retryCount: Int) async throws -> AuthNonceChallenge {
+        let url = baseURL.appendingPathComponent("v2/auth/nonce")
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue(appCheckToken, forHTTPHeaderField: "X-Firebase-AppCheck")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = Data("{}".utf8)
+
+        let (data, response) = try await Self.siweSession.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw APIError.invalidResponse
+        }
+
+        if httpResponse.statusCode == 429 {
+            guard retryCount < maxRetryCount else { throw APIError.rateLimitExceeded }
+            let delay = TimeInterval.calculateExponentialBackoff(for: retryCount)
+            try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+            return try await requestAuthNonce(appCheckToken: appCheckToken, retryCount: retryCount + 1)
+        }
+
+        guard httpResponse.statusCode == 200 else {
+            let message = parseErrorMessage(from: data) ?? "status \(httpResponse.statusCode)"
+            Log.error("Nonce request failed: \(message)")
+            throw SIWEAuthError.nonceRequestFailed(httpResponse.statusCode, message)
+        }
+
+        let cookie = try Self.extractNonceCookie(from: httpResponse, requestURL: url)
+        return cookie
+    }
+
+    private func exchangeSIWE(
+        appCheckToken: String,
+        deviceId: String,
+        message: String,
+        signatureHex: String,
+        cookieHeader: String,
+        retryCount: Int
+    ) async throws -> String {
+        let url = baseURL.appendingPathComponent("v2/auth/token")
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue(appCheckToken, forHTTPHeaderField: "X-Firebase-AppCheck")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue(cookieHeader, forHTTPHeaderField: "Cookie")
+
+        let body = ConvosAPI.AuthTokenRequest(
+            deviceId: deviceId,
+            siwe: ConvosAPI.SIWEPayload(message: message, signature: signatureHex)
+        )
+        request.httpBody = try JSONEncoder().encode(body)
+
+        let (data, response) = try await Self.siweSession.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw APIError.invalidResponse
+        }
+
+        switch httpResponse.statusCode {
+        case 200:
+            return try JSONDecoder().decode(ConvosAPI.AuthTokenResponse.self, from: data).token
+        case 400:
+            throw APIError.badRequest(parseErrorMessage(from: data))
+        case 401:
+            // Per backend, the nonce is burned even on signature failure.
+            // The caller must restart from /auth/nonce.
+            throw SIWEAuthError.invalidNonceOrSignature(parseErrorMessage(from: data))
+        case 403:
+            throw SIWEAuthError.deviceDisabled(parseErrorMessage(from: data))
+        case 429:
+            guard retryCount < maxRetryCount else { throw APIError.rateLimitExceeded }
+            let delay = TimeInterval.calculateExponentialBackoff(for: retryCount)
+            try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+            // 429 retry: don't reuse a possibly-consumed nonce; signal
+            // caller to restart from /auth/nonce.
+            throw SIWEAuthError.rateLimited
+        default:
+            throw APIError.serverError(parseErrorMessage(from: data))
+        }
+    }
+
+    // MARK: - Helpers
+
+    static func extractNonceCookie(
+        from response: HTTPURLResponse,
+        requestURL: URL
+    ) throws -> AuthNonceChallenge {
+        // Parse Set-Cookie manually rather than via HTTPCookie. We
+        // intentionally don't go through the system cookie parser
+        // because (a) HTTPCookie drops `Secure` cookies on `http://`
+        // URLs, which is exactly our local-dev case, and (b) we don't
+        // need cookie *semantics* — we just need to find the named
+        // cookie's raw value and echo it back as the Cookie header.
+        let setCookieValue: String
+        if let direct = response.value(forHTTPHeaderField: "Set-Cookie") {
+            setCookieValue = direct
+        } else {
+            setCookieValue = response.allHeaderFields
+                .first(where: { ($0.key as? String)?.lowercased() == "set-cookie" })?
+                .value as? String ?? ""
+        }
+        guard !setCookieValue.isEmpty else {
+            throw SIWEAuthError.missingNonceCookie
+        }
+
+        // A response may carry multiple Set-Cookie headers concatenated
+        // with ", " when surfaced through allHeaderFields. Each cookie's
+        // attributes are `;`-separated, so split on commas only when the
+        // following segment starts with a recognized cookie name.
+        for entry in splitSetCookieEntries(setCookieValue) {
+            // `name=value` is always the first `;`-separated segment.
+            let parts = entry.split(separator: ";", maxSplits: 1, omittingEmptySubsequences: false)
+            let nameValue = parts[0].trimmingCharacters(in: .whitespaces)
+            guard let eq = nameValue.firstIndex(of: "=") else { continue }
+            let name = String(nameValue[..<eq])
+            let value = String(nameValue[nameValue.index(after: eq)...])
+            guard nonceCookieNames.contains(name) else { continue }
+
+            // Cookie value format: `<hmac>.<hex-nonce>`. The hex nonce
+            // is the part after the last `.`; tolerate (but don't
+            // require) the HMAC prefix.
+            let hexNonce: String
+            if let dot = value.lastIndex(of: ".") {
+                hexNonce = String(value[value.index(after: dot)...])
+            } else {
+                hexNonce = value
+            }
+            guard nonceRegex.firstMatch(
+                in: hexNonce,
+                range: NSRange(location: 0, length: hexNonce.utf16.count)
+            ) != nil else {
+                throw SIWEAuthError.malformedNonce
+            }
+            return AuthNonceChallenge(nonce: hexNonce, cookieHeader: "\(name)=\(value)")
+        }
+        throw SIWEAuthError.missingNonceCookie
+    }
+
+    /// Splits a concatenated Set-Cookie header value into individual
+    /// cookies. URLSession's `allHeaderFields` joins duplicate
+    /// `Set-Cookie` lines with ", ", but commas can also appear inside
+    /// `Expires=...` values, so we split on `, ` only when the next
+    /// segment looks like the start of a new cookie (name=...).
+    private static func splitSetCookieEntries(_ raw: String) -> [String] {
+        // Cheap & correct enough: split on the `(?<!Expires=)(?<!Max-Age=)... , (?=[A-Za-z0-9_-]+=)`
+        // pattern by looking at the next 1–80 chars for `=`.
+        var entries: [String] = []
+        var current = ""
+        let scalars = Array(raw)
+        var i = 0
+        while i < scalars.count {
+            let c = scalars[i]
+            if c == "," && i + 1 < scalars.count && scalars[i + 1] == " " {
+                // Look ahead: do we see `name=` before the next `;` or `,`?
+                let lookahead = scalars[(i + 2)..<min(i + 82, scalars.count)]
+                let asString = String(lookahead)
+                let upToBreak = asString.prefix(while: { $0 != ";" && $0 != "," })
+                if upToBreak.contains("=") && upToBreak.allSatisfy({ $0.isLetter || $0.isNumber || $0 == "_" || $0 == "-" || $0 == "=" }) {
+                    entries.append(current)
+                    current = ""
+                    i += 2
+                    continue
+                }
+            }
+            current.append(c)
+            i += 1
+        }
+        if !current.isEmpty { entries.append(current) }
+        return entries
+    }
+
+    private static let nonceRegex: NSRegularExpression = {
+        // swiftlint:disable:next force_try
+        try! NSRegularExpression(pattern: "^[0-9a-f]{64}$")
+    }()
+
+    static func jwtCarriesAccountId(_ token: String) -> Bool {
+        let parts = token.split(separator: ".")
+        guard parts.count == 3 else { return false }
+        guard let payloadData = try? String(parts[1]).base64URLDecoded(),
+              let json = try? JSONSerialization.jsonObject(with: payloadData) as? [String: Any] else {
+            return false
+        }
+        if let id = json["accountId"] as? String, !id.isEmpty { return true }
+        return false
+    }
+}
+
+// MARK: - SIWE-specific errors
+
+public enum SIWEAuthError: Error, CustomStringConvertible {
+    case nonceRequestFailed(Int, String)
+    case missingNonceCookie
+    case malformedNonce
+    case invalidNonceOrSignature(String?)
+    case deviceDisabled(String?)
+    case rateLimited
+    case tokenMissingAccountId
+
+    public var description: String {
+        switch self {
+        case let .nonceRequestFailed(status, msg):
+            return "SIWE nonce request failed (\(status)): \(msg)"
+        case .missingNonceCookie:
+            return "SIWE nonce cookie missing from response"
+        case .malformedNonce:
+            return "SIWE nonce cookie value malformed"
+        case .invalidNonceOrSignature(let msg):
+            return "SIWE rejected by backend: \(msg ?? "Invalid SIWE")"
+        case .deviceDisabled(let msg):
+            return "Device disabled: \(msg ?? "unknown")"
+        case .rateLimited:
+            return "SIWE rate limited; retry from /auth/nonce"
+        case .tokenMissingAccountId:
+            return "Backend returned token without accountId claim"
+        }
+    }
+}
+
+// MARK: - Test seam for hex encoding
+
+extension SIWESigner {
+    /// Hex-encodes a 65-byte signature (already v-normalized) for wire
+    /// transport.
+    public static func hexEncoded(_ signature: Data) -> String {
+        "0x" + signature.map { String(format: "%02x", $0) }.joined()
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient+SIWE.swift
+++ b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient+SIWE.swift
@@ -13,8 +13,7 @@ extension ConvosAPIClient {
 
     func authenticateWithSIWE(
         appCheckToken: String,
-        signing: BackendAuthSigningContext,
-        retryCount: Int = 0
+        signing: BackendAuthSigningContext
     ) async throws -> String {
         let deviceId = DeviceInfo.deviceIdentifier
         let slot = KeychainAccount.siweJwt(deviceId: deviceId, address: signing.address)
@@ -126,11 +125,9 @@ extension ConvosAPIClient {
 
     // MARK: - Internals
 
-    struct AuthNonceChallenge {
-        let nonce: String           // 64-char lowercase hex
-        let cookieHeader: String    // exact `name=value` to send back on /auth/token
-    }
-
+    /// Dedicated URLSession with cookie storage disabled. SIWE's
+    /// `__Host-` nonce cookie must be carried manually as the `Cookie`
+    /// header on `/auth/token` — see `ConvosAPIClient+SIWECookieParsing`.
     private static let siweSession: URLSession = {
         let config = URLSessionConfiguration.ephemeral
         config.httpCookieStorage = nil
@@ -138,11 +135,6 @@ extension ConvosAPIClient {
         config.httpCookieAcceptPolicy = .never
         return URLSession(configuration: config)
     }()
-
-    private static let nonceCookieNames: [String] = [
-        "__Host-convos_nonce",  // prod (strict attrs)
-        "convos_nonce",         // proposed relaxed form for non-prod
-    ]
 
     func requestAuthNonce(appCheckToken: String, retryCount: Int) async throws -> AuthNonceChallenge {
         let url = baseURL.appendingPathComponent("v2/auth/nonce")
@@ -220,125 +212,8 @@ extension ConvosAPIClient {
     }
 
     // MARK: - Helpers
-
-    static func extractNonceCookie(
-        from response: HTTPURLResponse,
-        requestURL: URL
-    ) throws -> AuthNonceChallenge {
-        // Parse Set-Cookie manually rather than via HTTPCookie. We
-        // intentionally don't go through the system cookie parser
-        // because (a) HTTPCookie drops `Secure` cookies on `http://`
-        // URLs, which is exactly our local-dev case, and (b) we don't
-        // need cookie *semantics* — we just need to find the named
-        // cookie's raw value and echo it back as the Cookie header.
-        let setCookieValue: String
-        if let direct = response.value(forHTTPHeaderField: "Set-Cookie") {
-            setCookieValue = direct
-        } else {
-            setCookieValue = response.allHeaderFields
-                .first(where: { ($0.key as? String)?.lowercased() == "set-cookie" })?
-                .value as? String ?? ""
-        }
-        guard !setCookieValue.isEmpty else {
-            throw SIWEAuthError.missingNonceCookie
-        }
-
-        // A response may carry multiple Set-Cookie headers concatenated
-        // with ", " when surfaced through allHeaderFields. Each cookie's
-        // attributes are `;`-separated, so split on commas only when the
-        // following segment starts with a recognized cookie name.
-        for entry in splitSetCookieEntries(setCookieValue) {
-            // `name=value` is always the first `;`-separated segment.
-            let parts = entry.split(separator: ";", maxSplits: 1, omittingEmptySubsequences: false)
-            let nameValue = parts[0].trimmingCharacters(in: .whitespaces)
-            guard let eq = nameValue.firstIndex(of: "=") else { continue }
-            let name = String(nameValue[..<eq])
-            let value = String(nameValue[nameValue.index(after: eq)...])
-            guard nonceCookieNames.contains(name) else { continue }
-
-            // Cookie value format: `<hmac>.<hex-nonce>`. The hex nonce
-            // is the part after the last `.`; tolerate (but don't
-            // require) the HMAC prefix.
-            let hexNonce: String
-            if let dot = value.lastIndex(of: ".") {
-                hexNonce = String(value[value.index(after: dot)...])
-            } else {
-                hexNonce = value
-            }
-            guard nonceRegex.firstMatch(
-                in: hexNonce,
-                range: NSRange(location: 0, length: hexNonce.utf16.count)
-            ) != nil else {
-                throw SIWEAuthError.malformedNonce
-            }
-            return AuthNonceChallenge(nonce: hexNonce, cookieHeader: "\(name)=\(value)")
-        }
-        throw SIWEAuthError.missingNonceCookie
-    }
-
-    /// Splits a concatenated Set-Cookie header value into individual
-    /// cookies. URLSession's `allHeaderFields` joins duplicate
-    /// `Set-Cookie` lines with ", ", but commas can also appear inside
-    /// cookie *values* (e.g. base64 with `/`, `+`, `=`, or our nonce
-    /// cookie's `<hmac>.<hex>` separator) and inside `Expires=...`
-    /// dates. We split on `, ` only when the next segment looks like
-    /// the start of a new cookie: `name=` where `name` matches the
-    /// RFC 6265 cookie-name token grammar (letters, digits, `_`, `-`,
-    /// `.`). The value side of `name=value` is intentionally not
-    /// validated — anything between `=` and the next `;`/`,` may
-    /// appear there.
-    private static func splitSetCookieEntries(_ raw: String) -> [String] {
-        var entries: [String] = []
-        var current = ""
-        let scalars = Array(raw)
-        var i = 0
-        while i < scalars.count {
-            if scalars[i] == ",",
-               i + 1 < scalars.count,
-               scalars[i + 1] == " ",
-               Self.headerSeparatorStartsNewCookie(in: scalars, at: i + 2) {
-                entries.append(current)
-                current = ""
-                i += 2
-                continue
-            }
-            current.append(scalars[i])
-            i += 1
-        }
-        if !current.isEmpty { entries.append(current) }
-        return entries
-    }
-
-    /// Returns `true` if `scalars[start...]` begins with at least one
-    /// cookie-name char followed by `=` within a reasonable lookahead.
-    /// Cookie name grammar (RFC 6265 §4.1.1): a `token`, which we
-    /// approximate here as `[A-Za-z0-9_\-\.]+` — covers every cookie
-    /// name the backend emits today (`__Host-convos_nonce`,
-    /// `convos_nonce`) and any reasonable future neighbor.
-    private static func headerSeparatorStartsNewCookie(
-        in scalars: [Character],
-        at start: Int
-    ) -> Bool {
-        let limit = min(scalars.count, start + 80)
-        var j = start
-        while j < limit {
-            let c = scalars[j]
-            if c == "=" {
-                return j > start
-            }
-            if c.isLetter || c.isNumber || c == "_" || c == "-" || c == "." {
-                j += 1
-                continue
-            }
-            return false
-        }
-        return false
-    }
-
-    private static let nonceRegex: NSRegularExpression = {
-        // swiftlint:disable:next force_try
-        try! NSRegularExpression(pattern: "^[0-9a-f]{64}$")
-    }()
+    //
+    // Cookie parsing helpers live in `ConvosAPIClient+SIWECookieParsing.swift`.
 
     static func jwtCarriesAccountId(_ token: String) -> Bool {
         let parts = token.split(separator: ".")

--- a/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient+SIWE.swift
+++ b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient+SIWE.swift
@@ -279,34 +279,60 @@ extension ConvosAPIClient {
     /// Splits a concatenated Set-Cookie header value into individual
     /// cookies. URLSession's `allHeaderFields` joins duplicate
     /// `Set-Cookie` lines with ", ", but commas can also appear inside
-    /// `Expires=...` values, so we split on `, ` only when the next
-    /// segment looks like the start of a new cookie (name=...).
+    /// cookie *values* (e.g. base64 with `/`, `+`, `=`, or our nonce
+    /// cookie's `<hmac>.<hex>` separator) and inside `Expires=...`
+    /// dates. We split on `, ` only when the next segment looks like
+    /// the start of a new cookie: `name=` where `name` matches the
+    /// RFC 6265 cookie-name token grammar (letters, digits, `_`, `-`,
+    /// `.`). The value side of `name=value` is intentionally not
+    /// validated — anything between `=` and the next `;`/`,` may
+    /// appear there.
     private static func splitSetCookieEntries(_ raw: String) -> [String] {
-        // Cheap & correct enough: split on the `(?<!Expires=)(?<!Max-Age=)... , (?=[A-Za-z0-9_-]+=)`
-        // pattern by looking at the next 1–80 chars for `=`.
         var entries: [String] = []
         var current = ""
         let scalars = Array(raw)
         var i = 0
         while i < scalars.count {
-            let c = scalars[i]
-            if c == "," && i + 1 < scalars.count && scalars[i + 1] == " " {
-                // Look ahead: do we see `name=` before the next `;` or `,`?
-                let lookahead = scalars[(i + 2)..<min(i + 82, scalars.count)]
-                let asString = String(lookahead)
-                let upToBreak = asString.prefix(while: { $0 != ";" && $0 != "," })
-                if upToBreak.contains("=") && upToBreak.allSatisfy({ $0.isLetter || $0.isNumber || $0 == "_" || $0 == "-" || $0 == "=" }) {
-                    entries.append(current)
-                    current = ""
-                    i += 2
-                    continue
-                }
+            if scalars[i] == ",",
+               i + 1 < scalars.count,
+               scalars[i + 1] == " ",
+               Self.headerSeparatorStartsNewCookie(in: scalars, at: i + 2) {
+                entries.append(current)
+                current = ""
+                i += 2
+                continue
             }
-            current.append(c)
+            current.append(scalars[i])
             i += 1
         }
         if !current.isEmpty { entries.append(current) }
         return entries
+    }
+
+    /// Returns `true` if `scalars[start...]` begins with at least one
+    /// cookie-name char followed by `=` within a reasonable lookahead.
+    /// Cookie name grammar (RFC 6265 §4.1.1): a `token`, which we
+    /// approximate here as `[A-Za-z0-9_\-\.]+` — covers every cookie
+    /// name the backend emits today (`__Host-convos_nonce`,
+    /// `convos_nonce`) and any reasonable future neighbor.
+    private static func headerSeparatorStartsNewCookie(
+        in scalars: [Character],
+        at start: Int
+    ) -> Bool {
+        let limit = min(scalars.count, start + 80)
+        var j = start
+        while j < limit {
+            let c = scalars[j]
+            if c == "=" {
+                return j > start
+            }
+            if c.isLetter || c.isNumber || c == "_" || c == "-" || c == "." {
+                j += 1
+                continue
+            }
+            return false
+        }
+        return false
     }
 
     private static let nonceRegex: NSRegularExpression = {

--- a/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient+SIWECookieParsing.swift
+++ b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient+SIWECookieParsing.swift
@@ -1,0 +1,138 @@
+import Foundation
+
+/// SIWE nonce cookie parsing. Pulled out of `ConvosAPIClient+SIWE.swift`
+/// so the auth flow file stays focused on the request/response orchestration
+/// and the cookie semantics live alongside their own tests
+/// (`SIWENonceCookieParsingTests`).
+///
+/// Why a manual parser instead of `HTTPCookie.cookies(...)`:
+///   - `HTTPCookie` drops `Secure` cookies on `http://` URLs, which is
+///     exactly our local-dev case. We need to find the named cookie
+///     regardless of its attributes.
+///   - We never need cookie *semantics* (Expiry enforcement, Path
+///     matching, etc.) — we just echo `name=value` back as the `Cookie`
+///     header on `/auth/token`.
+extension ConvosAPIClient {
+    struct AuthNonceChallenge {
+        let nonce: String           // 64-char lowercase hex
+        let cookieHeader: String    // exact `name=value` to send back on /auth/token
+    }
+
+    static let nonceCookieNames: [String] = [
+        "__Host-convos_nonce",  // prod (strict attrs)
+        "convos_nonce",         // proposed relaxed form for non-prod
+    ]
+
+    static func extractNonceCookie(
+        from response: HTTPURLResponse,
+        requestURL: URL
+    ) throws -> AuthNonceChallenge {
+        let setCookieValue: String
+        if let direct = response.value(forHTTPHeaderField: "Set-Cookie") {
+            setCookieValue = direct
+        } else {
+            setCookieValue = response.allHeaderFields
+                .first(where: { ($0.key as? String)?.lowercased() == "set-cookie" })?
+                .value as? String ?? ""
+        }
+        guard !setCookieValue.isEmpty else {
+            throw SIWEAuthError.missingNonceCookie
+        }
+
+        // A response may carry multiple Set-Cookie headers concatenated
+        // with ", " when surfaced through allHeaderFields. Each cookie's
+        // attributes are `;`-separated, so split on commas only when the
+        // following segment starts with a recognized cookie name.
+        for entry in splitSetCookieEntries(setCookieValue) {
+            // `name=value` is always the first `;`-separated segment.
+            let parts = entry.split(separator: ";", maxSplits: 1, omittingEmptySubsequences: false)
+            let nameValue = parts[0].trimmingCharacters(in: .whitespaces)
+            guard let eq = nameValue.firstIndex(of: "=") else { continue }
+            let name = String(nameValue[..<eq])
+            let value = String(nameValue[nameValue.index(after: eq)...])
+            guard nonceCookieNames.contains(name) else { continue }
+
+            // Cookie value format: `<hmac>.<hex-nonce>`. The hex nonce
+            // is the part after the last `.`; tolerate (but don't
+            // require) the HMAC prefix.
+            let hexNonce: String
+            if let dot = value.lastIndex(of: ".") {
+                hexNonce = String(value[value.index(after: dot)...])
+            } else {
+                hexNonce = value
+            }
+            guard nonceRegex.firstMatch(
+                in: hexNonce,
+                range: NSRange(location: 0, length: hexNonce.utf16.count)
+            ) != nil else {
+                throw SIWEAuthError.malformedNonce
+            }
+            return AuthNonceChallenge(nonce: hexNonce, cookieHeader: "\(name)=\(value)")
+        }
+        throw SIWEAuthError.missingNonceCookie
+    }
+
+    /// Splits a concatenated Set-Cookie header value into individual
+    /// cookies. URLSession's `allHeaderFields` joins duplicate
+    /// `Set-Cookie` lines with ", ", but commas can also appear inside
+    /// cookie *values* (e.g. base64 with `/`, `+`, `=`, or our nonce
+    /// cookie's `<hmac>.<hex>` separator) and inside `Expires=...`
+    /// dates. We split on `, ` only when the next segment looks like
+    /// the start of a new cookie: `name=` where `name` matches the
+    /// RFC 6265 cookie-name token grammar (letters, digits, `_`, `-`,
+    /// `.`). The value side of `name=value` is intentionally not
+    /// validated — anything between `=` and the next `;`/`,` may
+    /// appear there.
+    private static func splitSetCookieEntries(_ raw: String) -> [String] {
+        var entries: [String] = []
+        var current = ""
+        let scalars = Array(raw)
+        var i = 0
+        while i < scalars.count {
+            if scalars[i] == ",",
+               i + 1 < scalars.count,
+               scalars[i + 1] == " ",
+               Self.headerSeparatorStartsNewCookie(in: scalars, at: i + 2) {
+                entries.append(current)
+                current = ""
+                i += 2
+                continue
+            }
+            current.append(scalars[i])
+            i += 1
+        }
+        if !current.isEmpty { entries.append(current) }
+        return entries
+    }
+
+    /// Returns `true` if `scalars[start...]` begins with at least one
+    /// cookie-name char followed by `=` within a reasonable lookahead.
+    /// Cookie name grammar (RFC 6265 §4.1.1): a `token`, which we
+    /// approximate here as `[A-Za-z0-9_\-\.]+` — covers every cookie
+    /// name the backend emits today (`__Host-convos_nonce`,
+    /// `convos_nonce`) and any reasonable future neighbor.
+    private static func headerSeparatorStartsNewCookie(
+        in scalars: [Character],
+        at start: Int
+    ) -> Bool {
+        let limit = min(scalars.count, start + 80)
+        var j = start
+        while j < limit {
+            let c = scalars[j]
+            if c == "=" {
+                return j > start
+            }
+            if c.isLetter || c.isNumber || c == "_" || c == "-" || c == "." {
+                j += 1
+                continue
+            }
+            return false
+        }
+        return false
+    }
+
+    private static let nonceRegex: NSRegularExpression = {
+        // swiftlint:disable:next force_try
+        try! NSRegularExpression(pattern: "^[0-9a-f]{64}$")
+    }()
+}

--- a/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift
+++ b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift
@@ -33,9 +33,13 @@ public protocol ConvosAPIClientProtocol: AnyObject, Sendable {
     /// message, exchanges `(message, signature)` for a JWT containing
     /// `accountId`. Stores the JWT in an address-scoped Keychain slot so
     /// it doesn't collide with the legacy device-only slot.
+    ///
+    /// The fresh-nonce retry budget (max 1) is internal — callers don't
+    /// drive it. If the caller wants more attempts (e.g. on network
+    /// flakes), its own outer loop should call this method again; each
+    /// call gets a fresh retry budget.
     func authenticateWithSIWE(appCheckToken: String,
-                              signing: BackendAuthSigningContext,
-                              retryCount: Int) async throws -> String
+                              signing: BackendAuthSigningContext) async throws -> String
 
     /// Updates (or clears) the SIWE signing context the client uses for
     /// outgoing authenticated requests and for 401 re-auth. Must be
@@ -226,8 +230,7 @@ final class ConvosAPIClient: ConvosAPIClientProtocol, Sendable {
         if let context = siweSigningContext.get() {
             return try await authenticateWithSIWE(
                 appCheckToken: firebaseAppCheckToken,
-                signing: context,
-                retryCount: 0
+                signing: context
             )
         }
         return try await authenticate(

--- a/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift
+++ b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift
@@ -233,6 +233,12 @@ final class ConvosAPIClient: ConvosAPIClientProtocol, Sendable {
                 signing: context
             )
         }
+        // 401-refresh hit before the session registered a SIWE
+        // signing context. The token we're about to mint will not
+        // carry `accountId`, so any subsequent /account-auth-check or
+        // requireAccount-gated call will 403. Logged here so iOS
+        // logs alone can tell us a refresh raced session bootstrap.
+        Log.warning("reAuthenticate: no SIWE signing context; falling back to legacy device-only auth")
         return try await authenticate(
             appCheckToken: firebaseAppCheckToken,
             retryCount: 0
@@ -273,6 +279,14 @@ final class ConvosAPIClient: ConvosAPIClientProtocol, Sendable {
             Log.info("Using existing JWT token from keychain")
             return existingToken
         }
+
+        // Minting a non-SIWE token. Surfaces on the backend as
+        // `hasSiwe: false`. Expected only on first-launch (before an
+        // XMTP identity is provisioned) or as a 401-refresh fallback
+        // when the SIWE signing context hasn't been registered yet —
+        // never in steady state. If you see this warning while
+        // signed-in, an earlier call path skipped SIWE.
+        Log.warning("Legacy device-only auth: minting JWT without accountId (hasSiwe: false)")
 
         // Token missing or expired - fetch new one
         let url = baseURL.appendingPathComponent("v2/auth/token")

--- a/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift
+++ b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift
@@ -29,6 +29,23 @@ public protocol ConvosAPIClientProtocol: AnyObject, Sendable {
     func authenticate(appCheckToken: String,
                       retryCount: Int) async throws -> String
 
+    /// SIWE auth path. Fetches a nonce, has the caller sign an EIP-4361
+    /// message, exchanges `(message, signature)` for a JWT containing
+    /// `accountId`. Stores the JWT in an address-scoped Keychain slot so
+    /// it doesn't collide with the legacy device-only JWT used by NSE.
+    func authenticateWithSIWE(appCheckToken: String,
+                              signing: BackendAuthSigningContext,
+                              retryCount: Int) async throws -> String
+
+    /// Hits `GET /api/v2/account-auth-check` with the supplied JWT
+    /// injected directly as `X-Convos-AuthToken` — no Keychain lookup,
+    /// no read of the legacy device-id slot, so an NSE token sitting in
+    /// `KeychainAccount.jwt(deviceId:)` can't pollute the result. Pass
+    /// `nil` to probe the 401 (missing token) path.
+    ///
+    /// SIWE-bound JWT → 200. Legacy device-only JWT → 403. Missing → 401.
+    func accountAuthCheck(jwt: String?) async throws -> ConvosAPI.AuthCheckResponse
+
     func uploadAttachment(
         data: Data,
         filename: String,
@@ -83,12 +100,12 @@ extension ConvosAPIClientProtocol {
 /// The client automatically re-authenticates on 401 responses up to a maximum
 /// retry count and stores JWT tokens in keychain for persistence.
 final class ConvosAPIClient: ConvosAPIClientProtocol, Sendable {
-    private let baseURL: URL
+    let baseURL: URL
     private let session: URLSession
-    private let environment: AppEnvironment
-    private let keychainService: any KeychainServiceProtocol = KeychainService()
+    let environment: AppEnvironment
+    let keychainService: any KeychainServiceProtocol = KeychainService()
     private let overrideJWTToken: String?  // Immutable JWT override from APNS payload
-    private let maxRetryCount: Int = 3
+    let maxRetryCount: Int = 3
 
     fileprivate init(environment: AppEnvironment, overrideJWTToken: String? = nil) {
         guard let apiBaseURL = URL(string: environment.apiBaseURL) else {
@@ -175,7 +192,7 @@ final class ConvosAPIClient: ConvosAPIClientProtocol, Sendable {
         )
     }
 
-    private func isJWTValid(_ token: String) -> Bool {
+    func isJWTValid(_ token: String) -> Bool {
         // JWT format: header.payload.signature
         let parts = token.split(separator: ".")
         guard parts.count == 3 else { return false }
@@ -632,7 +649,7 @@ final class ConvosAPIClient: ConvosAPIClientProtocol, Sendable {
 
     // MARK: - Helper Methods
 
-    private func parseErrorMessage(from data: Data) -> String? {
+    func parseErrorMessage(from data: Data) -> String? {
         if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
             if let message = json["message"] as? String {
                 return message

--- a/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift
+++ b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift
@@ -32,10 +32,17 @@ public protocol ConvosAPIClientProtocol: AnyObject, Sendable {
     /// SIWE auth path. Fetches a nonce, has the caller sign an EIP-4361
     /// message, exchanges `(message, signature)` for a JWT containing
     /// `accountId`. Stores the JWT in an address-scoped Keychain slot so
-    /// it doesn't collide with the legacy device-only JWT used by NSE.
+    /// it doesn't collide with the legacy device-only slot.
     func authenticateWithSIWE(appCheckToken: String,
                               signing: BackendAuthSigningContext,
                               retryCount: Int) async throws -> String
+
+    /// Updates (or clears) the SIWE signing context the client uses for
+    /// outgoing authenticated requests and for 401 re-auth. Must be
+    /// called by the session layer after the on-device identity is
+    /// loaded — until then the client falls back to the legacy
+    /// device-only auth path.
+    func updateSIWESigningContext(_ context: BackendAuthSigningContext?)
 
     /// Hits `GET /api/v2/account-auth-check` with the supplied JWT
     /// injected directly as `X-Convos-AuthToken` — no Keychain lookup,
@@ -99,6 +106,26 @@ extension ConvosAPIClientProtocol {
 ///
 /// The client automatically re-authenticates on 401 responses up to a maximum
 /// retry count and stores JWT tokens in keychain for persistence.
+/// Thread-safe slot for the active SIWE signing context. ConvosAPIClient
+/// is otherwise immutable + Sendable; this is the one piece of mutable
+/// state we need so the authenticated request path and the 401 refresh
+/// path can pick up the same context the session-level auth call used,
+/// without exposing libxmtp / KeychainIdentity through the protocol.
+final class LockedSigningContext: @unchecked Sendable {
+    private let lock: NSLock = NSLock()
+    private var value: BackendAuthSigningContext?
+
+    func set(_ ctx: BackendAuthSigningContext?) {
+        lock.lock(); defer { lock.unlock() }
+        value = ctx
+    }
+
+    func get() -> BackendAuthSigningContext? {
+        lock.lock(); defer { lock.unlock() }
+        return value
+    }
+}
+
 final class ConvosAPIClient: ConvosAPIClientProtocol, Sendable {
     let baseURL: URL
     private let session: URLSession
@@ -106,6 +133,7 @@ final class ConvosAPIClient: ConvosAPIClientProtocol, Sendable {
     let keychainService: any KeychainServiceProtocol = KeychainService()
     private let overrideJWTToken: String?  // Immutable JWT override from APNS payload
     let maxRetryCount: Int = 3
+    let siweSigningContext: LockedSigningContext = LockedSigningContext()
 
     fileprivate init(environment: AppEnvironment, overrideJWTToken: String? = nil) {
         guard let apiBaseURL = URL(string: environment.apiBaseURL) else {
@@ -184,8 +212,24 @@ final class ConvosAPIClient: ConvosAPIClientProtocol, Sendable {
 
     // MARK: - Private Helpers
 
+    func updateSIWESigningContext(_ context: BackendAuthSigningContext?) {
+        siweSigningContext.set(context)
+    }
+
     private func reAuthenticate() async throws -> String {
         let firebaseAppCheckToken = try await FirebaseHelperCore.getAppCheckToken()
+        // If a SIWE signing context is configured for this session,
+        // re-auth must reissue a SIWE-bound JWT. Falling back to
+        // legacy `{ deviceId }` here would silently downgrade the
+        // session to a token missing `accountId`, breaking any
+        // route gated by `requireAccount`.
+        if let context = siweSigningContext.get() {
+            return try await authenticateWithSIWE(
+                appCheckToken: firebaseAppCheckToken,
+                signing: context,
+                retryCount: 0
+            )
+        }
         return try await authenticate(
             appCheckToken: firebaseAppCheckToken,
             retryCount: 0
@@ -296,30 +340,55 @@ final class ConvosAPIClient: ConvosAPIClientProtocol, Sendable {
     ) throws -> URLRequest {
         var request = try request(for: path, method: method, queryParameters: queryParameters)
 
-        let deviceId = DeviceInfo.deviceIdentifier
-
-        // Prioritize override JWT token (from notification payload) over keychain JWT
+        // JWT selection precedence:
+        //   1. overrideJWTToken (APNS-injected, NSE flow)
+        //   2. SIWE-bound JWT in the address-scoped slot, when a signing
+        //      context is configured for this session
+        //   3. Legacy device-only JWT slot (only reachable when no
+        //      signing context is set yet — e.g. early boot before the
+        //      XMTP identity is loaded)
         if let overrideJWT = overrideJWTToken {
             Log.debug("Using override JWT token from notification payload")
             request.setValue(overrideJWT, forHTTPHeaderField: "X-Convos-AuthToken")
+        } else if let jwt = retrieveCurrentJWT() {
+            request.setValue(jwt, forHTTPHeaderField: "X-Convos-AuthToken")
         } else {
-            // No override JWT - try keychain
-            do {
-                if let keychainJWT = try keychainService.retrieveString(
-                    account: KeychainAccount.jwt(deviceId: deviceId)
-                ) {
-                    Log.debug("Using JWT token from keychain")
-                    request.setValue(keychainJWT, forHTTPHeaderField: "X-Convos-AuthToken")
-                } else {
-                    Log.debug("No JWT token found - request will trigger re-authentication")
-                }
-            } catch {
-                Log.warning("Failed to retrieve JWT from keychain: \(error.localizedDescription)")
-                // In main app context, continue without JWT - will trigger re-authentication
-            }
+            Log.debug("No JWT token found - request will trigger re-authentication")
         }
 
         return request
+    }
+
+    /// Returns the JWT we'd attach to a fresh authenticated request,
+    /// honoring the SIWE slot when a signing context is set. Used by
+    /// `authenticatedRequest` and by the SIWE accountAuthCheck path.
+    func retrieveCurrentJWT() -> String? {
+        let deviceId = DeviceInfo.deviceIdentifier
+
+        if let context = siweSigningContext.get() {
+            let siweSlot = KeychainAccount.siweJwt(deviceId: deviceId, address: context.address)
+            do {
+                if let siweJWT = try keychainService.retrieveString(account: siweSlot),
+                   !siweJWT.isEmpty {
+                    Log.debug("Using SIWE JWT from address-scoped keychain slot")
+                    return siweJWT
+                }
+            } catch {
+                Log.warning("Failed to retrieve SIWE JWT: \(error.localizedDescription)")
+            }
+        }
+
+        do {
+            if let legacy = try keychainService.retrieveString(account: KeychainAccount.jwt(deviceId: deviceId)),
+               !legacy.isEmpty {
+                Log.debug("Using legacy JWT from keychain (no SIWE context configured)")
+                return legacy
+            }
+        } catch {
+            Log.warning("Failed to retrieve legacy JWT: \(error.localizedDescription)")
+        }
+
+        return nil
     }
 
     private func performRequest<T: Decodable>(_ request: URLRequest) async throws -> T {

--- a/ConvosCore/Sources/ConvosCore/API/MockAPIClient.swift
+++ b/ConvosCore/Sources/ConvosCore/API/MockAPIClient.swift
@@ -40,6 +40,10 @@ final class MockAPIClient: ConvosAPIClientProtocol, Sendable {
         "mock-siwe-jwt-token"
     }
 
+    func updateSIWESigningContext(_ context: BackendAuthSigningContext?) {
+        // no-op
+    }
+
     func accountAuthCheck(jwt: String?) async throws -> ConvosAPI.AuthCheckResponse {
         .init(success: jwt != nil)
     }

--- a/ConvosCore/Sources/ConvosCore/API/MockAPIClient.swift
+++ b/ConvosCore/Sources/ConvosCore/API/MockAPIClient.swift
@@ -34,8 +34,7 @@ final class MockAPIClient: ConvosAPIClientProtocol, Sendable {
 
     func authenticateWithSIWE(
         appCheckToken: String,
-        signing: BackendAuthSigningContext,
-        retryCount: Int = 0
+        signing: BackendAuthSigningContext
     ) async throws -> String {
         "mock-siwe-jwt-token"
     }

--- a/ConvosCore/Sources/ConvosCore/API/MockAPIClient.swift
+++ b/ConvosCore/Sources/ConvosCore/API/MockAPIClient.swift
@@ -32,6 +32,18 @@ final class MockAPIClient: ConvosAPIClientProtocol, Sendable {
         return "mock-jwt-token"
     }
 
+    func authenticateWithSIWE(
+        appCheckToken: String,
+        signing: BackendAuthSigningContext,
+        retryCount: Int = 0
+    ) async throws -> String {
+        "mock-siwe-jwt-token"
+    }
+
+    func accountAuthCheck(jwt: String?) async throws -> ConvosAPI.AuthCheckResponse {
+        .init(success: jwt != nil)
+    }
+
     func uploadAttachment(
         data: Data,
         filename: String,

--- a/ConvosCore/Sources/ConvosCore/AppEnvironment+Shared.swift
+++ b/ConvosCore/Sources/ConvosCore/AppEnvironment+Shared.swift
@@ -8,6 +8,7 @@ public struct SharedAppConfiguration: Codable {
     public let apiBaseURL: String
     public let appGroupIdentifier: String
     public let relyingPartyIdentifier: String
+    public let siweConfiguration: SIWEConfiguration
     public let xmtpEndpoint: String?
     public let xmtpNetwork: String?
     public let gatewayUrl: String?
@@ -17,6 +18,7 @@ public struct SharedAppConfiguration: Codable {
         self.apiBaseURL = environment.apiBaseURL
         self.appGroupIdentifier = environment.appGroupIdentifier
         self.relyingPartyIdentifier = environment.relyingPartyIdentifier
+        self.siweConfiguration = environment.siweConfiguration
         self.xmtpEndpoint = environment.xmtpEndpoint
         self.xmtpNetwork = environment.xmtpNetwork
         self.gatewayUrl = environment.gatewayUrl
@@ -27,6 +29,7 @@ public struct SharedAppConfiguration: Codable {
             apiBaseURL: apiBaseURL,
             appGroupIdentifier: appGroupIdentifier,
             relyingPartyIdentifier: relyingPartyIdentifier,
+            siweConfiguration: siweConfiguration,
             xmtpEndpoint: xmtpEndpoint,
             xmtpNetwork: xmtpNetwork,
             gatewayUrl: gatewayUrl

--- a/ConvosCore/Sources/ConvosCore/AppEnvironment.swift
+++ b/ConvosCore/Sources/ConvosCore/AppEnvironment.swift
@@ -105,7 +105,11 @@ public enum AppEnvironment: Sendable {
         case .local(let config), .dev(let config), .production(let config):
             return config.siweConfiguration
         case .tests:
-            return SIWEConfiguration(domain: "convos.app", uri: "https://convos.app", chainId: 1)
+            // Tests construct their own SIWEMessage / SIWESigner inputs
+            // directly and never read this accessor. The placeholder
+            // here exists only to keep the switch exhaustive; it must
+            // never reach a real backend.
+            return SIWEConfiguration(domain: "tests.invalid", uri: "https://tests.invalid", chainId: 0)
         }
     }
 

--- a/ConvosCore/Sources/ConvosCore/AppEnvironment.swift
+++ b/ConvosCore/Sources/ConvosCore/AppEnvironment.swift
@@ -100,6 +100,15 @@ public enum AppEnvironment: Sendable {
         }
     }
 
+    public var siweConfiguration: SIWEConfiguration {
+        switch self {
+        case .local(let config), .dev(let config), .production(let config):
+            return config.siweConfiguration
+        case .tests:
+            return SIWEConfiguration(domain: "convos.app", uri: "https://convos.app", chainId: 1)
+        }
+    }
+
     public var appGroupIdentifier: String {
         switch self {
         case .local(config: let config), .dev(config: let config), .production(config: let config):

--- a/ConvosCore/Sources/ConvosCore/Auth/SIWE/BackendAuthProbe.swift
+++ b/ConvosCore/Sources/ConvosCore/Auth/SIWE/BackendAuthProbe.swift
@@ -1,0 +1,149 @@
+import ConvosLogging
+import Foundation
+
+/// One-shot SIWE auth probe driven from the debug menu. Wraps the
+/// nonce → sign → token → /account-auth-check round-trip so the host app
+/// (which can't see internal types like `ConvosAPIClient`) can call a
+/// single public method and render the result.
+public enum BackendAuthProbe {
+    public struct Result: Sendable {
+        public let address: String
+        public let jwt: String
+        public let accountId: String?
+        public let jwtExpiry: Date?
+        public let accountAuthCheckPassed: Bool
+
+        public init(
+            address: String,
+            jwt: String,
+            accountId: String?,
+            jwtExpiry: Date?,
+            accountAuthCheckPassed: Bool
+        ) {
+            self.address = address
+            self.jwt = jwt
+            self.accountId = accountId
+            self.jwtExpiry = jwtExpiry
+            self.accountAuthCheckPassed = accountAuthCheckPassed
+        }
+    }
+
+    public enum ProbeError: Error, CustomStringConvertible {
+        case noIdentity
+        case underlying(any Error)
+
+        public var description: String {
+            switch self {
+            case .noIdentity:
+                return "No on-device XMTP identity; sign in before running the probe."
+            case .underlying(let err):
+                return String(describing: err)
+            }
+        }
+    }
+
+    /// Runs the full positive path. Streams short progress lines through
+    /// `progress` so the caller can render them in a log.
+    public static func run(
+        environment: AppEnvironment,
+        identityStore: any KeychainIdentityStoreProtocol,
+        progress: @escaping @Sendable (String) -> Void = { _ in }
+    ) async throws -> Result {
+        let identity: KeychainIdentity
+        do {
+            guard let loaded = try await identityStore.load() else {
+                throw ProbeError.noIdentity
+            }
+            identity = loaded
+        } catch let err as ProbeError {
+            throw err
+        } catch {
+            throw ProbeError.underlying(error)
+        }
+
+        let signing = BackendAuthSigningContext.make(from: identity.keys.privateKey)
+        progress("Loaded identity (address=\(signing.address))")
+
+        let appCheckToken: String
+        do {
+            appCheckToken = try await FirebaseHelperCore.getAppCheckToken()
+        } catch {
+            throw ProbeError.underlying(error)
+        }
+        progress("Got App Check token")
+
+        let apiClient = ConvosAPIClientFactory.client(environment: environment)
+
+        progress("Fetching nonce → signing → exchanging for JWT…")
+        let jwt: String
+        do {
+            jwt = try await apiClient.authenticateWithSIWE(
+                appCheckToken: appCheckToken,
+                signing: signing,
+                retryCount: 0
+            )
+        } catch {
+            throw ProbeError.underlying(error)
+        }
+
+        let claims = decodeJWTClaims(jwt)
+        let accountId = claims?["accountId"] as? String
+        let expiry: Date? = (claims?["exp"] as? TimeInterval).map { Date(timeIntervalSince1970: $0) }
+        if let accountId {
+            progress("JWT received (accountId=\(accountId))")
+        } else {
+            progress("JWT received (no accountId — backend treated this as legacy path?)")
+        }
+
+        progress("Calling GET /v2/account-auth-check…")
+        let response: ConvosAPI.AuthCheckResponse
+        do {
+            response = try await apiClient.accountAuthCheck(jwt: jwt)
+        } catch {
+            // Surface the gated-route failure as a soft result so the
+            // debug screen can render the 401/403 instead of crashing.
+            Log.warning("account-auth-check failed: \(error)")
+            return Result(
+                address: signing.address,
+                jwt: jwt,
+                accountId: accountId,
+                jwtExpiry: expiry,
+                accountAuthCheckPassed: false
+            )
+        }
+
+        return Result(
+            address: signing.address,
+            jwt: jwt,
+            accountId: accountId,
+            jwtExpiry: expiry,
+            accountAuthCheckPassed: response.success
+        )
+    }
+
+    /// Negative-case probe: hits `/v2/account-auth-check` with no token
+    /// and reports whether the backend rejected (the expected outcome).
+    public static func probeWithoutAuth(environment: AppEnvironment) async -> Bool {
+        let apiClient = ConvosAPIClientFactory.client(environment: environment)
+        do {
+            _ = try await apiClient.accountAuthCheck(jwt: nil)
+            // Got 200 with no token — unexpected; gating is broken.
+            return false
+        } catch APIError.notAuthenticated, APIError.forbidden {
+            return true
+        } catch {
+            Log.warning("Unauthenticated probe got unexpected error: \(error)")
+            return false
+        }
+    }
+
+    private static func decodeJWTClaims(_ token: String) -> [String: Any]? {
+        let parts = token.split(separator: ".")
+        guard parts.count == 3 else { return nil }
+        guard let data = try? String(parts[1]).base64URLDecoded(),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return nil
+        }
+        return json
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Auth/SIWE/BackendAuthProbe.swift
+++ b/ConvosCore/Sources/ConvosCore/Auth/SIWE/BackendAuthProbe.swift
@@ -120,6 +120,93 @@ public enum BackendAuthProbe {
         )
     }
 
+    /// Snapshot of the SIWE auth state on this device, read directly
+    /// from Keychain without hitting the network. The JWT is the
+    /// single source of truth for accountId — we deliberately don't
+    /// shadow it in a separate slot.
+    public struct Status: Sendable {
+        public let address: String?    // checksummed EIP-55 form, nil if no identity
+        public let jwt: String?        // SIWE JWT in keychain for this address
+        public let accountId: String?  // decoded from JWT
+        public let issuedAt: Date?
+        public let jwtExpiry: Date?
+        public let isJWTValid: Bool    // true iff JWT present, structurally valid, exp > now+60s
+
+        public init(
+            address: String?,
+            jwt: String?,
+            accountId: String?,
+            issuedAt: Date?,
+            jwtExpiry: Date?,
+            isJWTValid: Bool
+        ) {
+            self.address = address
+            self.jwt = jwt
+            self.accountId = accountId
+            self.issuedAt = issuedAt
+            self.jwtExpiry = jwtExpiry
+            self.isJWTValid = isJWTValid
+        }
+    }
+
+    /// Reads the current SIWE auth state from Keychain. No network.
+    /// Suitable for surfacing in debug UI / logs.
+    public static func currentStatus(
+        environment _: AppEnvironment,
+        identityStore: any KeychainIdentityStoreProtocol
+    ) async -> Status {
+        let keychain = KeychainService()
+        let deviceId = DeviceInfo.deviceIdentifier
+
+        let identity: KeychainIdentity?
+        identity = try? await identityStore.load()
+        guard let identity else {
+            return Status(address: nil, jwt: nil, accountId: nil, issuedAt: nil, jwtExpiry: nil, isJWTValid: false)
+        }
+
+        let address = EthereumAddress.toChecksummed(identity.keys.privateKey.identity.identifier)
+        let jwtSlot = KeychainAccount.siweJwt(deviceId: deviceId, address: address)
+        let accountSlot = KeychainAccount.siweAccountId(deviceId: deviceId, address: address)
+        let jwt = (try? keychain.retrieveString(account: jwtSlot)).flatMap { $0.isEmpty ? nil : $0 }
+        let cachedAccountId = (try? keychain.retrieveString(account: accountSlot)).flatMap { $0.isEmpty ? nil : $0 }
+
+        guard let jwt else {
+            // No JWT but we may still know who they are from the
+            // cached accountId slot — useful right after JWT expiry.
+            return Status(
+                address: address,
+                jwt: nil,
+                accountId: cachedAccountId,
+                issuedAt: nil,
+                jwtExpiry: nil,
+                isJWTValid: false
+            )
+        }
+
+        let claims = decodeJWTClaims(jwt)
+        let accountId = (claims?["accountId"] as? String) ?? cachedAccountId
+        let issuedAt: Date? = (claims?["iat"] as? TimeInterval).map { Date(timeIntervalSince1970: $0) }
+        let expiry: Date? = (claims?["exp"] as? TimeInterval).map { Date(timeIntervalSince1970: $0) }
+        let isValid = expiry.map { $0 > Date().addingTimeInterval(60) } ?? false
+
+        return Status(
+            address: address,
+            jwt: jwt,
+            accountId: accountId,
+            issuedAt: issuedAt,
+            jwtExpiry: expiry,
+            isJWTValid: isValid
+        )
+    }
+
+    /// Extracts the `accountId` claim from a SIWE JWT, or nil if the
+    /// token is malformed / device-only / NSE-flavoured. Used by call
+    /// sites that want to log the accountId without duplicating the
+    /// base64url+JSON decode.
+    public static func extractAccountId(from jwt: String) -> String? {
+        decodeJWTClaims(jwt)?["accountId"] as? String
+    }
+
     /// Negative-case probe: hits `/v2/account-auth-check` with no token
     /// and reports whether the backend rejected (the expected outcome).
     public static func probeWithoutAuth(environment: AppEnvironment) async -> Bool {

--- a/ConvosCore/Sources/ConvosCore/Auth/SIWE/BackendAuthProbe.swift
+++ b/ConvosCore/Sources/ConvosCore/Auth/SIWE/BackendAuthProbe.swift
@@ -79,8 +79,7 @@ public enum BackendAuthProbe {
         do {
             jwt = try await apiClient.authenticateWithSIWE(
                 appCheckToken: appCheckToken,
-                signing: signing,
-                retryCount: 0
+                signing: signing
             )
         } catch {
             throw ProbeError.underlying(error)

--- a/ConvosCore/Sources/ConvosCore/Auth/SIWE/EthereumAddress.swift
+++ b/ConvosCore/Sources/ConvosCore/Auth/SIWE/EthereumAddress.swift
@@ -1,0 +1,47 @@
+import CryptoSwift
+import Foundation
+
+/// EIP-55 mixed-case checksum for Ethereum addresses.
+///
+/// EIP-4361 (Sign-In With Ethereum) requires the address field to be
+/// EIP-55 checksummed. The siwe npm library on the backend rejects
+/// non-checksummed addresses with `INVALID_ADDRESS` — which gets
+/// surfaced through our wrapper as `InvalidSiweError("parse")` because
+/// the SiweMessage constructor throws before we get a chance to look
+/// at the specific reason.
+///
+/// libxmtp's `PublicKey.walletAddress` returns the all-lowercase form,
+/// so iOS must checksum locally before putting the address into a SIWE
+/// message.
+public enum EthereumAddress {
+    /// Apply EIP-55 mixed-case checksum to a 20-byte Ethereum address.
+    /// Accepts input with or without the `0x` prefix, in any case, and
+    /// always returns the `0x` prefix.
+    ///
+    /// Algorithm (EIP-55):
+    ///   - `hash = keccak256(utf8(lowerHex(address)))` over the 40
+    ///     hex chars (no `0x`)
+    ///   - for each char at index `i`: uppercase the address nibble if
+    ///     `hash[i] >= 8` (looking at the i-th hex nibble of the hash)
+    public static func toChecksummed(_ address: String) -> String {
+        let stripped = address.hasPrefix("0x") ? String(address.dropFirst(2)) : address
+        guard stripped.count == 40 else { return address } // Not a 20-byte address; pass through.
+        let lower = stripped.lowercased()
+        let hashBytes = SHA3(variant: .keccak256).calculate(for: Array(lower.utf8))
+
+        var out = "0x"
+        out.reserveCapacity(42)
+        for (index, char) in lower.enumerated() {
+            // index-th hex nibble of the hash:
+            //   byte at index/2; high nibble for even index, low nibble for odd index
+            let byte = hashBytes[index / 2]
+            let nibble = index.isMultiple(of: 2) ? (byte >> 4) : (byte & 0x0F)
+            if nibble >= 8, char.isLetter {
+                out.append(Character(char.uppercased()))
+            } else {
+                out.append(char)
+            }
+        }
+        return out
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Auth/SIWE/SIWEMessage.swift
+++ b/ConvosCore/Sources/ConvosCore/Auth/SIWE/SIWEMessage.swift
@@ -1,0 +1,86 @@
+import Foundation
+
+/// EIP-4361 "Sign-In With Ethereum" message.
+///
+/// Renders to the exact text format the backend's `siwe` lib parses. Fields
+/// `domain`, `uri`, `chainId`, and `nonce` are validated against backend env
+/// values; mismatch causes `401 Invalid SIWE` and burns the nonce.
+public struct SIWEMessage: Sendable, Equatable {
+    public let domain: String
+    public let address: String
+    public let statement: String?
+    public let uri: String
+    public let version: String
+    public let chainId: Int
+    public let nonce: String
+    public let issuedAt: Date
+    public let expirationTime: Date?
+    public let notBefore: Date?
+    public let requestId: String?
+    public let resources: [String]?
+
+    public init(
+        domain: String,
+        address: String,
+        statement: String?,
+        uri: String,
+        version: String = "1",
+        chainId: Int,
+        nonce: String,
+        issuedAt: Date,
+        expirationTime: Date? = nil,
+        notBefore: Date? = nil,
+        requestId: String? = nil,
+        resources: [String]? = nil
+    ) {
+        self.domain = domain
+        self.address = address
+        self.statement = statement
+        self.uri = uri
+        self.version = version
+        self.chainId = chainId
+        self.nonce = nonce
+        self.issuedAt = issuedAt
+        self.expirationTime = expirationTime
+        self.notBefore = notBefore
+        self.requestId = requestId
+        self.resources = resources
+    }
+
+    /// Renders to the exact EIP-4361 message string that gets signed.
+    /// Date fields use ISO 8601 with millisecond precision and a `Z` suffix
+    /// (matching JS `new Date().toISOString()`).
+    public func prepareMessage() -> String {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        var lines: [String] = []
+        lines.append("\(domain) wants you to sign in with your Ethereum account:")
+        lines.append(address)
+        lines.append("")
+        if let statement {
+            lines.append(statement)
+            lines.append("")
+        }
+        lines.append("URI: \(uri)")
+        lines.append("Version: \(version)")
+        lines.append("Chain ID: \(chainId)")
+        lines.append("Nonce: \(nonce)")
+        lines.append("Issued At: \(formatter.string(from: issuedAt))")
+        if let expirationTime {
+            lines.append("Expiration Time: \(formatter.string(from: expirationTime))")
+        }
+        if let notBefore {
+            lines.append("Not Before: \(formatter.string(from: notBefore))")
+        }
+        if let requestId {
+            lines.append("Request ID: \(requestId)")
+        }
+        if let resources, !resources.isEmpty {
+            lines.append("Resources:")
+            for resource in resources {
+                lines.append("- \(resource)")
+            }
+        }
+        return lines.joined(separator: "\n")
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Auth/SIWE/SIWESigner.swift
+++ b/ConvosCore/Sources/ConvosCore/Auth/SIWE/SIWESigner.swift
@@ -1,0 +1,79 @@
+import Foundation
+@preconcurrency import XMTPiOS
+
+/// Signs SIWE messages with an XMTP-managed Ethereum private key.
+///
+/// `libxmtp`'s `PrivateKey.sign(_:)` applies the EIP-191 "personal sign"
+/// prefix internally and returns a 65-byte `r || s || v` recoverable
+/// signature. The underlying libsecp256k1 emits `v ∈ {0, 1}`, but the
+/// backend's SIWE verification path (`ethers.verifyMessage`) expects
+/// Ethereum-standard `v ∈ {27, 28}`. We normalize before hex-encoding so
+/// the backend can recover the correct address — without this step,
+/// signatures look mathematically correct but the backend's recovery
+/// returns the wrong address and rejects the request with `401 Invalid
+/// SIWE` (the nonce is burned). See `SIWESignerTests` for the canary
+/// roundtrip that guards this invariant.
+public enum SIWESigner {
+    /// Sign `message` and return the 65-byte signature as `0x`-prefixed
+    /// hex (130 hex chars after the prefix).
+    public static func sign(message: String, with privateKey: PrivateKey) async throws -> String {
+        let signed = try await privateKey.sign(message)
+        return hexEncode(normalize(signed.rawData))
+    }
+
+    /// Sign `message` and return the raw 65-byte signature with the
+    /// recovery byte normalized to Ethereum's `v ∈ {27, 28}`. Exposed for
+    /// tests that need to inspect or recover from the signature bytes.
+    public static func signRaw(message: String, with privateKey: PrivateKey) async throws -> Data {
+        let signed = try await privateKey.sign(message)
+        return normalize(signed.rawData)
+    }
+
+    /// Normalize the recovery byte. Accepts `v ∈ {0, 1}` and shifts to
+    /// `{27, 28}`; values already in `{27, 28}` are left alone.
+    public static func normalize(_ signature: Data) -> Data {
+        guard signature.count == 65 else { return signature }
+        var bytes = signature
+        if bytes[64] < 27 {
+            bytes[64] = bytes[64] &+ 27
+        }
+        return bytes
+    }
+
+    private static func hexEncode(_ data: Data) -> String {
+        "0x" + data.map { String(format: "%02x", $0) }.joined()
+    }
+}
+
+/// Capability the API client needs to perform a SIWE auth round-trip
+/// without leaking `KeychainIdentity` or libxmtp types into the protocol
+/// surface. Callers construct this from the loaded identity and inject it
+/// into the API client; the API client treats it as an opaque "what's the
+/// address and sign this string" capability so the 401 re-auth path can
+/// reissue without falling back to legacy device-only auth.
+public struct BackendAuthSigningContext: Sendable {
+    public let address: String
+    /// Signs the message and returns the 65-byte `r || s || v` signature
+    /// with `v` already normalized to `{27, 28}`.
+    public let sign: @Sendable (_ message: String) async throws -> Data
+
+    public init(
+        address: String,
+        sign: @escaping @Sendable (_ message: String) async throws -> Data
+    ) {
+        self.address = address
+        self.sign = sign
+    }
+
+    /// Build a signing context backed by an XMTP `PrivateKey`. The closure
+    /// retains the key for the lifetime of the context.
+    public static func make(from privateKey: PrivateKey) -> BackendAuthSigningContext {
+        let address = privateKey.identity.identifier
+        return BackendAuthSigningContext(
+            address: address,
+            sign: { message in
+                try await SIWESigner.signRaw(message: message, with: privateKey)
+            }
+        )
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Auth/SIWE/SIWESigner.swift
+++ b/ConvosCore/Sources/ConvosCore/Auth/SIWE/SIWESigner.swift
@@ -67,8 +67,14 @@ public struct BackendAuthSigningContext: Sendable {
 
     /// Build a signing context backed by an XMTP `PrivateKey`. The closure
     /// retains the key for the lifetime of the context.
+    ///
+    /// libxmtp returns the lowercase address. EIP-4361 / siwe lib
+    /// requires EIP-55 mixed-case checksum, so we apply that here at
+    /// the boundary — every caller of `signing.address` then gets the
+    /// correct form for SIWE messages, signed payloads, server lookups,
+    /// etc., with no risk of forgetting at the call site.
     public static func make(from privateKey: PrivateKey) -> BackendAuthSigningContext {
-        let address = privateKey.identity.identifier
+        let address = EthereumAddress.toChecksummed(privateKey.identity.identifier)
         return BackendAuthSigningContext(
             address: address,
             sign: { message in

--- a/ConvosCore/Sources/ConvosCore/Config/ConfigManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Config/ConfigManager.swift
@@ -122,6 +122,8 @@ public final class ConfigManager: @unchecked Sendable {
             ? nil
             : overrides.gatewayURL.trimmingCharacters(in: .whitespacesAndNewlines)
 
+        let siweConfiguration = self.siweConfiguration
+
         switch envString {
         case "local":
             let url = resolveAndValidateURL(
@@ -133,6 +135,7 @@ public final class ConfigManager: @unchecked Sendable {
                 apiBaseURL: url,
                 appGroupIdentifier: appGroupIdentifier,
                 relyingPartyIdentifier: relyingPartyIdentifier,
+                siweConfiguration: siweConfiguration,
                 xmtpEndpoint: xmtpEndpoint,
                 xmtpNetwork: xmtpNetwork,
                 gatewayUrl: gatewayUrl
@@ -149,6 +152,7 @@ public final class ConfigManager: @unchecked Sendable {
                 apiBaseURL: url,
                 appGroupIdentifier: appGroupIdentifier,
                 relyingPartyIdentifier: relyingPartyIdentifier,
+                siweConfiguration: siweConfiguration,
                 xmtpEndpoint: xmtpEndpoint,
                 xmtpNetwork: xmtpNetwork
             )
@@ -164,6 +168,7 @@ public final class ConfigManager: @unchecked Sendable {
                 apiBaseURL: url,
                 appGroupIdentifier: appGroupIdentifier,
                 relyingPartyIdentifier: relyingPartyIdentifier,
+                siweConfiguration: siweConfiguration,
                 xmtpNetwork: xmtpNetwork
             )
             return .production(config: config)
@@ -171,6 +176,23 @@ public final class ConfigManager: @unchecked Sendable {
         default:
             fatalError("Invalid environment '\(envString)' in config.json")
         }
+    }
+
+    /// SIWE values from config.json (`siweDomain`, `siweUri`, `siweChainId`).
+    /// All three must be present and match the backend env.
+    public var siweConfiguration: SIWEConfiguration {
+        guard let domain = config["siweDomain"] as? String,
+              !domain.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            fatalError("Missing or empty 'siweDomain' in config.json")
+        }
+        guard let uri = config["siweUri"] as? String,
+              !uri.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            fatalError("Missing or empty 'siweUri' in config.json")
+        }
+        guard let chainId = config["siweChainId"] as? Int else {
+            fatalError("Missing or non-Int 'siweChainId' in config.json")
+        }
+        return SIWEConfiguration(domain: domain, uri: uri, chainId: chainId)
     }
 
     /// API base URL from config.json (used as default/fallback when Secrets not provided)

--- a/ConvosCore/Sources/ConvosCore/ConvosConfiguration.swift
+++ b/ConvosCore/Sources/ConvosCore/ConvosConfiguration.swift
@@ -1,5 +1,22 @@
 import Foundation
 
+/// Per-environment SIWE (Sign-In With Ethereum, EIP-4361) values.
+///
+/// These fields are echoed into the SIWE message the iOS app signs and
+/// must match the backend's `SIWE_DOMAIN`, `SIWE_URI`, and an entry of
+/// `SIWE_ALLOWED_CHAIN_IDS` exactly. Mismatch causes 401 Invalid SIWE.
+public struct SIWEConfiguration: Codable, Sendable, Equatable {
+    public let domain: String
+    public let uri: String
+    public let chainId: Int
+
+    public init(domain: String, uri: String, chainId: Int) {
+        self.domain = domain
+        self.uri = uri
+        self.chainId = chainId
+    }
+}
+
 /// Configuration values passed from the host app to ConvosCore
 ///
 /// This is a pure data container - all configuration values must be provided
@@ -12,6 +29,7 @@ public struct ConvosConfiguration: Sendable {
     public let apiBaseURL: String
     public let appGroupIdentifier: String
     public let relyingPartyIdentifier: String
+    public let siweConfiguration: SIWEConfiguration
     public let xmtpEndpoint: String?
     public let xmtpNetwork: String?
     public let gatewayUrl: String?
@@ -20,6 +38,7 @@ public struct ConvosConfiguration: Sendable {
         apiBaseURL: String,
         appGroupIdentifier: String,
         relyingPartyIdentifier: String,
+        siweConfiguration: SIWEConfiguration,
         xmtpEndpoint: String? = nil,
         xmtpNetwork: String? = nil,
         gatewayUrl: String? = nil
@@ -27,6 +46,7 @@ public struct ConvosConfiguration: Sendable {
         self.apiBaseURL = apiBaseURL
         self.appGroupIdentifier = appGroupIdentifier
         self.relyingPartyIdentifier = relyingPartyIdentifier
+        self.siweConfiguration = siweConfiguration
         self.xmtpEndpoint = xmtpEndpoint
         self.xmtpNetwork = xmtpNetwork
         self.gatewayUrl = gatewayUrl

--- a/ConvosCore/Sources/ConvosCore/Inboxes/SessionStateMachine.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/SessionStateMachine.swift
@@ -1066,8 +1066,7 @@ public actor SessionStateMachine: SessionStateManagerProtocol {
                     Log.debug("Authenticating with backend via SIWE (address \(signing.address))...")
                     _ = try await apiClient.authenticateWithSIWE(
                         appCheckToken: appCheckToken,
-                        signing: signing,
-                        retryCount: 0
+                        signing: signing
                     )
                     Log.info("Successfully authenticated with backend (SIWE)")
                 } else {

--- a/ConvosCore/Sources/ConvosCore/Inboxes/SessionStateMachine.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/SessionStateMachine.swift
@@ -1052,9 +1052,30 @@ public actor SessionStateMachine: SessionStateManagerProtocol {
 
                 try Task.checkCancellation()
 
-                Log.debug("Authenticating with backend and storing JWT...")
-                _ = try await apiClient.authenticate(appCheckToken: appCheckToken, retryCount: 0)
-                Log.info("Successfully authenticated with backend")
+                // Default path: SIWE auth. Loads the on-device identity,
+                // signs an EIP-4361 message with its Ethereum private key,
+                // exchanges for a JWT containing `accountId`. The JWT is
+                // stored under an address-scoped Keychain slot so an NSE
+                // device-only token can't pollute the SIWE token (and
+                // vice versa).
+                if let identity = try await identityStore.load() {
+                    let signing = BackendAuthSigningContext.make(from: identity.keys.privateKey)
+                    Log.debug("Authenticating with backend via SIWE (address \(signing.address))...")
+                    _ = try await apiClient.authenticateWithSIWE(
+                        appCheckToken: appCheckToken,
+                        signing: signing,
+                        retryCount: 0
+                    )
+                    Log.info("Successfully authenticated with backend (SIWE)")
+                } else {
+                    // No on-device identity yet: fall back to the legacy
+                    // device-only path so things like NSE/auth-check stay
+                    // unblocked. SIWE will run on the next attempt once
+                    // an identity is provisioned.
+                    Log.debug("No identity yet; falling back to legacy device-only auth...")
+                    _ = try await apiClient.authenticate(appCheckToken: appCheckToken, retryCount: 0)
+                    Log.info("Successfully authenticated with backend (legacy)")
+                }
                 return
             } catch is CancellationError {
                 throw CancellationError()

--- a/ConvosCore/Sources/ConvosCore/Inboxes/SessionStateMachine.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/SessionStateMachine.swift
@@ -1064,11 +1064,12 @@ public actor SessionStateMachine: SessionStateManagerProtocol {
                     let signing = BackendAuthSigningContext.make(from: identity.keys.privateKey)
                     apiClient.updateSIWESigningContext(signing)
                     Log.debug("Authenticating with backend via SIWE (address \(signing.address))...")
-                    _ = try await apiClient.authenticateWithSIWE(
+                    let token = try await apiClient.authenticateWithSIWE(
                         appCheckToken: appCheckToken,
                         signing: signing
                     )
-                    Log.info("Successfully authenticated with backend (SIWE)")
+                    let accountId = BackendAuthProbe.extractAccountId(from: token) ?? "?"
+                    Log.info("Successfully authenticated with backend (SIWE, address=\(signing.address), accountId=\(accountId))")
                 } else {
                     // No on-device identity yet: clear any stale signing
                     // context and fall back to the legacy device-only

--- a/ConvosCore/Sources/ConvosCore/Inboxes/SessionStateMachine.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/SessionStateMachine.swift
@@ -1054,12 +1054,15 @@ public actor SessionStateMachine: SessionStateManagerProtocol {
 
                 // Default path: SIWE auth. Loads the on-device identity,
                 // signs an EIP-4361 message with its Ethereum private key,
-                // exchanges for a JWT containing `accountId`. The JWT is
-                // stored under an address-scoped Keychain slot so an NSE
-                // device-only token can't pollute the SIWE token (and
-                // vice versa).
+                // exchanges for a JWT containing `accountId`. Registering
+                // the signing context with the API client BEFORE the call
+                // is what makes the 401 re-auth path and every subsequent
+                // authenticated request use the SIWE slot — without this
+                // the API client would silently fall back to legacy
+                // device-only auth on token expiry.
                 if let identity = try await identityStore.load() {
                     let signing = BackendAuthSigningContext.make(from: identity.keys.privateKey)
+                    apiClient.updateSIWESigningContext(signing)
                     Log.debug("Authenticating with backend via SIWE (address \(signing.address))...")
                     _ = try await apiClient.authenticateWithSIWE(
                         appCheckToken: appCheckToken,
@@ -1068,10 +1071,11 @@ public actor SessionStateMachine: SessionStateManagerProtocol {
                     )
                     Log.info("Successfully authenticated with backend (SIWE)")
                 } else {
-                    // No on-device identity yet: fall back to the legacy
-                    // device-only path so things like NSE/auth-check stay
-                    // unblocked. SIWE will run on the next attempt once
-                    // an identity is provisioned.
+                    // No on-device identity yet: clear any stale signing
+                    // context and fall back to the legacy device-only
+                    // path. SIWE will run on the next attempt once an
+                    // identity is provisioned.
+                    apiClient.updateSIWESigningContext(nil)
                     Log.debug("No identity yet; falling back to legacy device-only auth...")
                     _ = try await apiClient.authenticate(appCheckToken: appCheckToken, retryCount: 0)
                     Log.info("Successfully authenticated with backend (legacy)")

--- a/ConvosCore/Sources/ConvosCore/Shared/ConvosKeychainItem.swift
+++ b/ConvosCore/Sources/ConvosCore/Shared/ConvosKeychainItem.swift
@@ -30,4 +30,14 @@ enum KeychainAccount {
     static func siweJwt(deviceId: String, address: String) -> String {
         return "jwt:\(deviceId):siwe:\(address.lowercased())"
     }
+
+    /// Account for storing the backend-assigned `accountId` for this
+    /// (deviceId, address). The JWT also carries this claim, but the
+    /// JWT expires every 15 minutes — this slot persists across
+    /// expiries so the UI can keep showing "signed in as <accountId>"
+    /// without re-authing, and so debug tooling can surface it even
+    /// when the SIWE JWT is gone or stale.
+    static func siweAccountId(deviceId: String, address: String) -> String {
+        return "accountId:\(deviceId):siwe:\(address.lowercased())"
+    }
 }

--- a/ConvosCore/Sources/ConvosCore/Shared/ConvosKeychainItem.swift
+++ b/ConvosCore/Sources/ConvosCore/Shared/ConvosKeychainItem.swift
@@ -5,11 +5,19 @@ enum KeychainAccount {
     /// Account for storing JWT tokens, keyed by device ID.
     ///
     /// This slot is used by the legacy device-only auth path
-    /// (`POST /v2/auth/token` with body `{ deviceId }`) and by the
-    /// Notification Service Extension. SIWE-bound JWTs must NOT be
-    /// written here — they go to `siweJwt(deviceId:address:)` — so an
-    /// NSE refresh (which mints a device-only token) can't accidentally
-    /// stomp the main app's SIWE token, and vice versa.
+    /// (`POST /v2/auth/token` with body `{ deviceId }`, no SIWE). It's
+    /// what `ConvosAPIClient.authenticate(appCheckToken:)` reads/writes
+    /// when no SIWE signing context is configured (e.g. during early
+    /// boot before the on-device identity is loaded).
+    ///
+    /// Notes on the Notification Service Extension:
+    /// - NSE itself does not read from this slot — it consumes the
+    ///   `apiJWT` injected via the APNS payload and routes it through
+    ///   `ConvosAPIClient.overrideJWTToken`.
+    /// - The slot is still kept disjoint from
+    ///   `siweJwt(deviceId:address:)` so a legacy `authenticate()`
+    ///   call (e.g. fallback when SIWE isn't available yet) can't
+    ///   stomp a SIWE-bound token stored under the address-scoped slot.
     static func jwt(deviceId: String) -> String {
         return deviceId
     }

--- a/ConvosCore/Sources/ConvosCore/Shared/ConvosKeychainItem.swift
+++ b/ConvosCore/Sources/ConvosCore/Shared/ConvosKeychainItem.swift
@@ -2,8 +2,24 @@ import Foundation
 
 /// Account identifiers for specific keychain items
 enum KeychainAccount {
-    /// Account for storing JWT tokens, keyed by device ID
+    /// Account for storing JWT tokens, keyed by device ID.
+    ///
+    /// This slot is used by the legacy device-only auth path
+    /// (`POST /v2/auth/token` with body `{ deviceId }`) and by the
+    /// Notification Service Extension. SIWE-bound JWTs must NOT be
+    /// written here — they go to `siweJwt(deviceId:address:)` — so an
+    /// NSE refresh (which mints a device-only token) can't accidentally
+    /// stomp the main app's SIWE token, and vice versa.
     static func jwt(deviceId: String) -> String {
         return deviceId
+    }
+
+    /// Account for storing SIWE-bound JWT tokens, keyed by device ID
+    /// AND the Ethereum address of the signed-in identity. Scoping by
+    /// address means a fresh sign-in with a different identity on the
+    /// same device doesn't reuse a stale SIWE token from the previous
+    /// account.
+    static func siweJwt(deviceId: String, address: String) -> String {
+        return "jwt:\(deviceId):siwe:\(address.lowercased())"
     }
 }

--- a/ConvosCore/Tests/ConvosCoreTests/Assets/AssetRenewalManagerTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/Assets/AssetRenewalManagerTests.swift
@@ -472,7 +472,7 @@ final class ConfigurableMockAPIClient: ConvosAPIClientProtocol, @unchecked Senda
 
     func registerDevice(deviceId: String, pushToken: String?) async throws {}
     func authenticate(appCheckToken: String, retryCount: Int) async throws -> String { "token" }
-    func authenticateWithSIWE(appCheckToken: String, signing: BackendAuthSigningContext, retryCount: Int) async throws -> String { "siwe-token" }
+    func authenticateWithSIWE(appCheckToken: String, signing: BackendAuthSigningContext) async throws -> String { "siwe-token" }
     func updateSIWESigningContext(_ context: BackendAuthSigningContext?) {}
     func accountAuthCheck(jwt: String?) async throws -> ConvosAPI.AuthCheckResponse { .init(success: jwt != nil) }
     func uploadAttachment(data: Data, filename: String, contentType: String, acl: String) async throws -> String { "" }

--- a/ConvosCore/Tests/ConvosCoreTests/Assets/AssetRenewalManagerTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/Assets/AssetRenewalManagerTests.swift
@@ -472,6 +472,8 @@ final class ConfigurableMockAPIClient: ConvosAPIClientProtocol, @unchecked Senda
 
     func registerDevice(deviceId: String, pushToken: String?) async throws {}
     func authenticate(appCheckToken: String, retryCount: Int) async throws -> String { "token" }
+    func authenticateWithSIWE(appCheckToken: String, signing: BackendAuthSigningContext, retryCount: Int) async throws -> String { "siwe-token" }
+    func accountAuthCheck(jwt: String?) async throws -> ConvosAPI.AuthCheckResponse { .init(success: jwt != nil) }
     func uploadAttachment(data: Data, filename: String, contentType: String, acl: String) async throws -> String { "" }
     func uploadAttachmentAndExecute(data: Data, filename: String, afterUpload: @escaping (String) async throws -> Void) async throws -> String { "" }
     func subscribeToTopics(deviceId: String, clientId: String, topics: [String]) async throws {}

--- a/ConvosCore/Tests/ConvosCoreTests/Assets/AssetRenewalManagerTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/Assets/AssetRenewalManagerTests.swift
@@ -473,6 +473,7 @@ final class ConfigurableMockAPIClient: ConvosAPIClientProtocol, @unchecked Senda
     func registerDevice(deviceId: String, pushToken: String?) async throws {}
     func authenticate(appCheckToken: String, retryCount: Int) async throws -> String { "token" }
     func authenticateWithSIWE(appCheckToken: String, signing: BackendAuthSigningContext, retryCount: Int) async throws -> String { "siwe-token" }
+    func updateSIWESigningContext(_ context: BackendAuthSigningContext?) {}
     func accountAuthCheck(jwt: String?) async throws -> ConvosAPI.AuthCheckResponse { .init(success: jwt != nil) }
     func uploadAttachment(data: Data, filename: String, contentType: String, acl: String) async throws -> String { "" }
     func uploadAttachmentAndExecute(data: Data, filename: String, afterUpload: @escaping (String) async throws -> Void) async throws -> String { "" }

--- a/ConvosCore/Tests/ConvosCoreTests/ConnectionManagerTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ConnectionManagerTests.swift
@@ -586,7 +586,7 @@ private final class StubAPIClient: ConvosAPIClientProtocol, @unchecked Sendable 
         "stub-jwt"
     }
 
-    func authenticateWithSIWE(appCheckToken: String, signing: BackendAuthSigningContext, retryCount: Int) async throws -> String {
+    func authenticateWithSIWE(appCheckToken: String, signing: BackendAuthSigningContext) async throws -> String {
         "stub-siwe-jwt"
     }
 

--- a/ConvosCore/Tests/ConvosCoreTests/ConnectionManagerTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ConnectionManagerTests.swift
@@ -586,6 +586,14 @@ private final class StubAPIClient: ConvosAPIClientProtocol, @unchecked Sendable 
         "stub-jwt"
     }
 
+    func authenticateWithSIWE(appCheckToken: String, signing: BackendAuthSigningContext, retryCount: Int) async throws -> String {
+        "stub-siwe-jwt"
+    }
+
+    func accountAuthCheck(jwt: String?) async throws -> ConvosAPI.AuthCheckResponse {
+        .init(success: jwt != nil)
+    }
+
     func uploadAttachment(data: Data, filename: String, contentType: String, acl: String) async throws -> String {
         "https://example.com/\(filename)"
     }

--- a/ConvosCore/Tests/ConvosCoreTests/ConnectionManagerTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ConnectionManagerTests.swift
@@ -590,6 +590,8 @@ private final class StubAPIClient: ConvosAPIClientProtocol, @unchecked Sendable 
         "stub-siwe-jwt"
     }
 
+    func updateSIWESigningContext(_ context: BackendAuthSigningContext?) {}
+
     func accountAuthCheck(jwt: String?) async throws -> ConvosAPI.AuthCheckResponse {
         .init(success: jwt != nil)
     }

--- a/ConvosCore/Tests/ConvosCoreTests/EthereumAddressTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/EthereumAddressTests.swift
@@ -1,0 +1,46 @@
+@testable import ConvosCore
+import Testing
+
+/// EIP-55 checksum vectors from the spec
+/// (https://eips.ethereum.org/EIPS/eip-55#test-cases). Without these
+/// the backend's `siwe` lib rejects the SIWE message with
+/// `INVALID_ADDRESS`, which our `verifySiwe` wrapper labels generically
+/// as `InvalidSiweError("parse")` — easy to misdiagnose, hence the
+/// canary here.
+@Suite("EthereumAddress EIP-55 checksum")
+struct EthereumAddressTests {
+    @Test("Canonical EIP-55 vectors from the spec round-trip")
+    func eip55Vectors() {
+        let vectors: [String] = [
+            // All caps
+            "0x52908400098527886E0F7030069857D2E4169EE7",
+            "0x8617E340B3D01FA5F11F306F4090FD50E238070D",
+            // All Lower
+            "0xde709f2102306220921060314715629080e2fb77",
+            "0x27b1fdb04752bbc536007a920d24acb045561c26",
+            // Normal
+            "0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed",
+            "0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359",
+            "0xdbF03B407c01E7cD3CBea99509d93f8DDDC8C6FB",
+            "0xD1220A0cf47c7B9Be7A2E6BA89F429762e7b9aDb",
+        ]
+        for vector in vectors {
+            #expect(EthereumAddress.toChecksummed(vector.lowercased()) == vector)
+            #expect(EthereumAddress.toChecksummed(vector.uppercased().replacingOccurrences(of: "0X", with: "0x")) == vector)
+            #expect(EthereumAddress.toChecksummed(vector) == vector) // idempotent
+        }
+    }
+
+    @Test("Strips 0x prefix and re-adds it in output")
+    func handlesMissingPrefix() {
+        let lower = "5aaeb6053f3e94c9b9a09f33669435e7ef1beaed"
+        let expected = "0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed"
+        #expect(EthereumAddress.toChecksummed(lower) == expected)
+    }
+
+    @Test("Non-20-byte input passes through unchanged")
+    func tooShortPassthrough() {
+        #expect(EthereumAddress.toChecksummed("0xabcd") == "0xabcd")
+        #expect(EthereumAddress.toChecksummed("").isEmpty)
+    }
+}

--- a/ConvosCore/Tests/ConvosCoreTests/Integration/PushTopicSubscriptionDeniedDMTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/Integration/PushTopicSubscriptionDeniedDMTests.swift
@@ -154,6 +154,8 @@ private final class ThrowawayPushAPIClient: ConvosAPIClientProtocol, @unchecked 
     func registerDevice(deviceId: String, pushToken: String?) async throws {}
 
     func authenticate(appCheckToken: String, retryCount: Int) async throws -> String { "token" }
+    func authenticateWithSIWE(appCheckToken: String, signing: BackendAuthSigningContext, retryCount: Int) async throws -> String { "siwe-token" }
+    func accountAuthCheck(jwt: String?) async throws -> ConvosAPI.AuthCheckResponse { .init(success: jwt != nil) }
 
     func uploadAttachment(data: Data, filename: String, contentType: String, acl: String) async throws -> String { "" }
 

--- a/ConvosCore/Tests/ConvosCoreTests/Integration/PushTopicSubscriptionDeniedDMTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/Integration/PushTopicSubscriptionDeniedDMTests.swift
@@ -155,6 +155,7 @@ private final class ThrowawayPushAPIClient: ConvosAPIClientProtocol, @unchecked 
 
     func authenticate(appCheckToken: String, retryCount: Int) async throws -> String { "token" }
     func authenticateWithSIWE(appCheckToken: String, signing: BackendAuthSigningContext, retryCount: Int) async throws -> String { "siwe-token" }
+    func updateSIWESigningContext(_ context: BackendAuthSigningContext?) {}
     func accountAuthCheck(jwt: String?) async throws -> ConvosAPI.AuthCheckResponse { .init(success: jwt != nil) }
 
     func uploadAttachment(data: Data, filename: String, contentType: String, acl: String) async throws -> String { "" }

--- a/ConvosCore/Tests/ConvosCoreTests/Integration/PushTopicSubscriptionDeniedDMTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/Integration/PushTopicSubscriptionDeniedDMTests.swift
@@ -154,7 +154,7 @@ private final class ThrowawayPushAPIClient: ConvosAPIClientProtocol, @unchecked 
     func registerDevice(deviceId: String, pushToken: String?) async throws {}
 
     func authenticate(appCheckToken: String, retryCount: Int) async throws -> String { "token" }
-    func authenticateWithSIWE(appCheckToken: String, signing: BackendAuthSigningContext, retryCount: Int) async throws -> String { "siwe-token" }
+    func authenticateWithSIWE(appCheckToken: String, signing: BackendAuthSigningContext) async throws -> String { "siwe-token" }
     func updateSIWESigningContext(_ context: BackendAuthSigningContext?) {}
     func accountAuthCheck(jwt: String?) async throws -> ConvosAPI.AuthCheckResponse { .init(success: jwt != nil) }
 

--- a/ConvosCore/Tests/ConvosCoreTests/PushTopicSubscriptionManagerTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/PushTopicSubscriptionManagerTests.swift
@@ -260,7 +260,7 @@ private final class RecordingPushAPIClient: ConvosAPIClientProtocol, @unchecked 
         "token"
     }
 
-    func authenticateWithSIWE(appCheckToken: String, signing: BackendAuthSigningContext, retryCount: Int) async throws -> String {
+    func authenticateWithSIWE(appCheckToken: String, signing: BackendAuthSigningContext) async throws -> String {
         "siwe-token"
     }
 
@@ -349,7 +349,7 @@ private final class ThrowingPushAPIClient: ConvosAPIClientProtocol, @unchecked S
     func registerDevice(deviceId: String, pushToken: String?) async throws {}
 
     func authenticate(appCheckToken: String, retryCount: Int) async throws -> String { "token" }
-    func authenticateWithSIWE(appCheckToken: String, signing: BackendAuthSigningContext, retryCount: Int) async throws -> String { "siwe-token" }
+    func authenticateWithSIWE(appCheckToken: String, signing: BackendAuthSigningContext) async throws -> String { "siwe-token" }
     func updateSIWESigningContext(_ context: BackendAuthSigningContext?) {}
     func accountAuthCheck(jwt: String?) async throws -> ConvosAPI.AuthCheckResponse { .init(success: jwt != nil) }
 

--- a/ConvosCore/Tests/ConvosCoreTests/PushTopicSubscriptionManagerTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/PushTopicSubscriptionManagerTests.swift
@@ -260,6 +260,14 @@ private final class RecordingPushAPIClient: ConvosAPIClientProtocol, @unchecked 
         "token"
     }
 
+    func authenticateWithSIWE(appCheckToken: String, signing: BackendAuthSigningContext, retryCount: Int) async throws -> String {
+        "siwe-token"
+    }
+
+    func accountAuthCheck(jwt: String?) async throws -> ConvosAPI.AuthCheckResponse {
+        .init(success: jwt != nil)
+    }
+
     func uploadAttachment(data: Data, filename: String, contentType: String, acl: String) async throws -> String {
         ""
     }
@@ -339,6 +347,8 @@ private final class ThrowingPushAPIClient: ConvosAPIClientProtocol, @unchecked S
     func registerDevice(deviceId: String, pushToken: String?) async throws {}
 
     func authenticate(appCheckToken: String, retryCount: Int) async throws -> String { "token" }
+    func authenticateWithSIWE(appCheckToken: String, signing: BackendAuthSigningContext, retryCount: Int) async throws -> String { "siwe-token" }
+    func accountAuthCheck(jwt: String?) async throws -> ConvosAPI.AuthCheckResponse { .init(success: jwt != nil) }
 
     func uploadAttachment(data: Data, filename: String, contentType: String, acl: String) async throws -> String { "" }
 

--- a/ConvosCore/Tests/ConvosCoreTests/PushTopicSubscriptionManagerTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/PushTopicSubscriptionManagerTests.swift
@@ -264,6 +264,8 @@ private final class RecordingPushAPIClient: ConvosAPIClientProtocol, @unchecked 
         "siwe-token"
     }
 
+    func updateSIWESigningContext(_ context: BackendAuthSigningContext?) {}
+
     func accountAuthCheck(jwt: String?) async throws -> ConvosAPI.AuthCheckResponse {
         .init(success: jwt != nil)
     }
@@ -348,6 +350,7 @@ private final class ThrowingPushAPIClient: ConvosAPIClientProtocol, @unchecked S
 
     func authenticate(appCheckToken: String, retryCount: Int) async throws -> String { "token" }
     func authenticateWithSIWE(appCheckToken: String, signing: BackendAuthSigningContext, retryCount: Int) async throws -> String { "siwe-token" }
+    func updateSIWESigningContext(_ context: BackendAuthSigningContext?) {}
     func accountAuthCheck(jwt: String?) async throws -> ConvosAPI.AuthCheckResponse { .init(success: jwt != nil) }
 
     func uploadAttachment(data: Data, filename: String, contentType: String, acl: String) async throws -> String { "" }

--- a/ConvosCore/Tests/ConvosCoreTests/SIWEMessageTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/SIWEMessageTests.swift
@@ -4,10 +4,12 @@ import Testing
 
 @Suite("SIWEMessage rendering")
 struct SIWEMessageTests {
-    @Test("EIP-4361 message renders byte-for-byte against a known fixture")
+    @Test("EIP-4361 message renders byte-for-byte against a known fixture (includes Resources)")
     func rendersFixture() {
-        // Fixed inputs that mirror the backend's end-to-end test
-        // (tests/auth-end-to-end.test.ts) in convos-backend.
+        // Fixed inputs mirroring the SIWE format Borja requires on the
+        // backend: every message carries a `Resources:` block with
+        // `convos://device/<deviceId>` so the signature is bound to a
+        // specific device, not just the account.
         let issuedAt = isoDate("2026-05-11T12:00:00.000Z")
         let expirationTime = isoDate("2026-05-11T12:05:00.000Z")
 
@@ -19,7 +21,8 @@ struct SIWEMessageTests {
             chainId: 1,
             nonce: "abcdef00abcdef00abcdef00abcdef00abcdef00abcdef00abcdef00abcdef00",
             issuedAt: issuedAt,
-            expirationTime: expirationTime
+            expirationTime: expirationTime,
+            resources: ["convos://device/5A2B3C4D-EFAB-1234-5678-90ABCDEF1234"]
         )
 
         let expected = """
@@ -34,6 +37,8 @@ struct SIWEMessageTests {
         Nonce: abcdef00abcdef00abcdef00abcdef00abcdef00abcdef00abcdef00abcdef00
         Issued At: 2026-05-11T12:00:00.000Z
         Expiration Time: 2026-05-11T12:05:00.000Z
+        Resources:
+        - convos://device/5A2B3C4D-EFAB-1234-5678-90ABCDEF1234
         """
 
         #expect(message.prepareMessage() == expected)

--- a/ConvosCore/Tests/ConvosCoreTests/SIWEMessageTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/SIWEMessageTests.swift
@@ -1,0 +1,72 @@
+@testable import ConvosCore
+import Foundation
+import Testing
+
+@Suite("SIWEMessage rendering")
+struct SIWEMessageTests {
+    @Test("EIP-4361 message renders byte-for-byte against a known fixture")
+    func rendersFixture() {
+        // Fixed inputs that mirror the backend's end-to-end test
+        // (tests/auth-end-to-end.test.ts) in convos-backend.
+        let issuedAt = isoDate("2026-05-11T12:00:00.000Z")
+        let expirationTime = isoDate("2026-05-11T12:05:00.000Z")
+
+        let message = SIWEMessage(
+            domain: "convos.app",
+            address: "0x1111111111111111111111111111111111111111",
+            statement: "Sign in to Convos",
+            uri: "https://convos.app",
+            chainId: 1,
+            nonce: "abcdef00abcdef00abcdef00abcdef00abcdef00abcdef00abcdef00abcdef00",
+            issuedAt: issuedAt,
+            expirationTime: expirationTime
+        )
+
+        let expected = """
+        convos.app wants you to sign in with your Ethereum account:
+        0x1111111111111111111111111111111111111111
+
+        Sign in to Convos
+
+        URI: https://convos.app
+        Version: 1
+        Chain ID: 1
+        Nonce: abcdef00abcdef00abcdef00abcdef00abcdef00abcdef00abcdef00abcdef00
+        Issued At: 2026-05-11T12:00:00.000Z
+        Expiration Time: 2026-05-11T12:05:00.000Z
+        """
+
+        #expect(message.prepareMessage() == expected)
+    }
+
+    @Test("Optional fields are omitted when nil")
+    func omitsOptionalsWhenNil() {
+        let message = SIWEMessage(
+            domain: "example.com",
+            address: "0xabc",
+            statement: nil,
+            uri: "https://example.com",
+            chainId: 1,
+            nonce: "deadbeef",
+            issuedAt: isoDate("2026-01-01T00:00:00.000Z")
+        )
+
+        let rendered = message.prepareMessage()
+        #expect(!rendered.contains("Expiration Time:"))
+        #expect(!rendered.contains("Not Before:"))
+        #expect(!rendered.contains("Request ID:"))
+        #expect(!rendered.contains("Resources:"))
+        // A statement-less message has a single blank line between
+        // address and URI block, not the two from the statement case.
+        #expect(rendered.contains("0xabc\n\nURI: https://example.com"))
+    }
+}
+
+private func isoDate(_ s: String) -> Date {
+    let f = ISO8601DateFormatter()
+    f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+    guard let d = f.date(from: s) else {
+        fatalError("bad ISO date fixture: \(s)")
+    }
+    return d
+}

--- a/ConvosCore/Tests/ConvosCoreTests/SIWENSECompatibilityTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/SIWENSECompatibilityTests.swift
@@ -2,14 +2,17 @@
 import Foundation
 import Testing
 
-/// Invariants that keep the SIWE rollout from regressing NSE.
+/// Invariants that keep the SIWE rollout from polluting the legacy
+/// device-only JWT slot.
 ///
-/// The Notification Service Extension reads its JWT from
-/// `KeychainAccount.jwt(deviceId:)` and expects it to be a device-only
-/// (legacy) token that passes `/v2/auth-check` (the
-/// `authMiddlewareAllowNSE` route). The main app's SIWE JWT lives in a
-/// separate, address-scoped slot. Neither side may stomp the other.
-@Suite("SIWE/NSE compatibility")
+/// The legacy slot (`KeychainAccount.jwt(deviceId:)`) is the
+/// fallback path `ConvosAPIClient.authenticate(appCheckToken:)` uses
+/// when no SIWE signing context is configured. The NSE itself does
+/// not read this slot — it consumes an APNS-injected JWT via
+/// `overrideJWTToken` — but the slot still needs to stay disjoint
+/// from the SIWE slot so a legacy auth call can't stomp a SIWE-bound
+/// token and vice versa. These tests pin that disjointness.
+@Suite("SIWE/legacy slot disjointness")
 struct SIWENSECompatibilityTests {
     @Test("Legacy and SIWE Keychain accounts are different strings")
     func slotsAreDisjoint() {
@@ -31,7 +34,7 @@ struct SIWENSECompatibilityTests {
         #expect(a != b)
     }
 
-    @Test("KeychainServiceProtocol writes to legacy and SIWE slots are independent")
+    @Test("Keychain writes to legacy and SIWE slots are independent")
     func keychainWritesDoNotCollide() throws {
         // Use the in-memory mock — the simulator unit-test keychain
         // can be flaky without an entitlements file, and this test is
@@ -44,21 +47,21 @@ struct SIWENSECompatibilityTests {
         let deviceId = "test-disjoint-device"
         let address = "0xAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAa"
 
-        try svc.saveString("nse-token", account: KeychainAccount.jwt(deviceId: deviceId))
+        try svc.saveString("legacy-token", account: KeychainAccount.jwt(deviceId: deviceId))
         try svc.saveString("siwe-token", account: KeychainAccount.siweJwt(deviceId: deviceId, address: address))
 
-        #expect(try svc.retrieveString(account: KeychainAccount.jwt(deviceId: deviceId)) == "nse-token")
+        #expect(try svc.retrieveString(account: KeychainAccount.jwt(deviceId: deviceId)) == "legacy-token")
         #expect(try svc.retrieveString(account: KeychainAccount.siweJwt(deviceId: deviceId, address: address)) == "siwe-token")
 
         // Sanity: deleting one doesn't touch the other.
         try svc.delete(account: KeychainAccount.siweJwt(deviceId: deviceId, address: address))
-        #expect(try svc.retrieveString(account: KeychainAccount.jwt(deviceId: deviceId)) == "nse-token")
+        #expect(try svc.retrieveString(account: KeychainAccount.jwt(deviceId: deviceId)) == "legacy-token")
         #expect(try svc.retrieveString(account: KeychainAccount.siweJwt(deviceId: deviceId, address: address)) == nil)
     }
 
-    @Test("jwtCarriesAccountId() identifies SIWE vs device-only JWTs")
+    @Test("jwtCarriesAccountId() identifies SIWE vs non-SIWE JWTs")
     func jwtAccountIdDetection() throws {
-        // Device-only payload (legacy path) — no accountId.
+        // Legacy device-only payload — no accountId.
         let devicePayload = try jwtFromClaims(["sub": "device-1", "deviceId": "device-1"])
         #expect(ConvosAPIClient.jwtCarriesAccountId(devicePayload) == false)
 
@@ -71,7 +74,13 @@ struct SIWENSECompatibilityTests {
         #expect(ConvosAPIClient.jwtCarriesAccountId(siwePayload) == true)
 
         // NSE-flavoured payload — has metadata.notificationExtensionOnly,
-        // no accountId. Must be classified as "not SIWE".
+        // no accountId. Classified as "not SIWE" (the SIWE slot writer
+        // refuses to store it). Note: the backend's
+        // /api/v2/account-auth-check route rejects this token at
+        // authMiddleware time with 403 "NSE tokens not allowed on this
+        // route", not at requireAccount with "Account required" — but
+        // either way the iOS-side classifier here just needs to refuse
+        // to treat it as SIWE.
         let nsePayload = try jwtFromClaims([
             "sub": "device-1",
             "deviceId": "device-1",

--- a/ConvosCore/Tests/ConvosCoreTests/SIWENSECompatibilityTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/SIWENSECompatibilityTests.swift
@@ -1,0 +1,101 @@
+@testable import ConvosCore
+import Foundation
+import Testing
+
+/// Invariants that keep the SIWE rollout from regressing NSE.
+///
+/// The Notification Service Extension reads its JWT from
+/// `KeychainAccount.jwt(deviceId:)` and expects it to be a device-only
+/// (legacy) token that passes `/v2/auth-check` (the
+/// `authMiddlewareAllowNSE` route). The main app's SIWE JWT lives in a
+/// separate, address-scoped slot. Neither side may stomp the other.
+@Suite("SIWE/NSE compatibility")
+struct SIWENSECompatibilityTests {
+    @Test("Legacy and SIWE Keychain accounts are different strings")
+    func slotsAreDisjoint() {
+        let deviceId = "device-abc-123"
+        let address = "0xAbCdEf0123456789aBCdEF0123456789AbcDef01"
+        let legacy = KeychainAccount.jwt(deviceId: deviceId)
+        let siwe = KeychainAccount.siweJwt(deviceId: deviceId, address: address)
+        #expect(legacy != siwe)
+        #expect(siwe.contains("siwe"))
+        #expect(siwe.contains(address.lowercased()))
+        #expect(!siwe.contains(address)) // address is forced lowercase in the slot key
+    }
+
+    @Test("SIWE slot is address-scoped: different addresses → different slots")
+    func siweSlotScopedByAddress() {
+        let deviceId = "device-X"
+        let a = KeychainAccount.siweJwt(deviceId: deviceId, address: "0xAAA")
+        let b = KeychainAccount.siweJwt(deviceId: deviceId, address: "0xBBB")
+        #expect(a != b)
+    }
+
+    @Test("KeychainServiceProtocol writes to legacy and SIWE slots are independent")
+    func keychainWritesDoNotCollide() throws {
+        // Use the in-memory mock — the simulator unit-test keychain
+        // can be flaky without an entitlements file, and this test is
+        // about the *account-keyed* disjoint behavior, not the real
+        // Keychain backend. The Keychain backend is a thin wrapper over
+        // `SecItemAdd` keyed by `kSecAttrAccount`, so independence at
+        // the protocol level guarantees independence at the real
+        // backend.
+        let svc: any KeychainServiceProtocol = MockKeychainService()
+        let deviceId = "test-disjoint-device"
+        let address = "0xAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAa"
+
+        try svc.saveString("nse-token", account: KeychainAccount.jwt(deviceId: deviceId))
+        try svc.saveString("siwe-token", account: KeychainAccount.siweJwt(deviceId: deviceId, address: address))
+
+        #expect(try svc.retrieveString(account: KeychainAccount.jwt(deviceId: deviceId)) == "nse-token")
+        #expect(try svc.retrieveString(account: KeychainAccount.siweJwt(deviceId: deviceId, address: address)) == "siwe-token")
+
+        // Sanity: deleting one doesn't touch the other.
+        try svc.delete(account: KeychainAccount.siweJwt(deviceId: deviceId, address: address))
+        #expect(try svc.retrieveString(account: KeychainAccount.jwt(deviceId: deviceId)) == "nse-token")
+        #expect(try svc.retrieveString(account: KeychainAccount.siweJwt(deviceId: deviceId, address: address)) == nil)
+    }
+
+    @Test("jwtCarriesAccountId() identifies SIWE vs device-only JWTs")
+    func jwtAccountIdDetection() throws {
+        // Device-only payload (legacy path) — no accountId.
+        let devicePayload = try jwtFromClaims(["sub": "device-1", "deviceId": "device-1"])
+        #expect(ConvosAPIClient.jwtCarriesAccountId(devicePayload) == false)
+
+        // SIWE-bound payload — accountId present.
+        let siwePayload = try jwtFromClaims([
+            "sub": "device-1",
+            "deviceId": "device-1",
+            "accountId": "9c21f30a-a448-49af-87af-9239b24b6494",
+        ])
+        #expect(ConvosAPIClient.jwtCarriesAccountId(siwePayload) == true)
+
+        // NSE-flavoured payload — has metadata.notificationExtensionOnly,
+        // no accountId. Must be classified as "not SIWE".
+        let nsePayload = try jwtFromClaims([
+            "sub": "device-1",
+            "deviceId": "device-1",
+            "metadata": ["notificationExtensionOnly": true],
+        ])
+        #expect(ConvosAPIClient.jwtCarriesAccountId(nsePayload) == false)
+    }
+}
+
+// MARK: - Test helpers
+
+/// Constructs a *structurally* valid JWT (header.payload.signature) for
+/// use with `ConvosAPIClient.jwtCarriesAccountId`. We don't need a real
+/// signature — that method only inspects the payload claims.
+private func jwtFromClaims(_ claims: [String: Any]) throws -> String {
+    let header: [String: Any] = ["alg": "ES256", "typ": "JWT"]
+    let headerData = try JSONSerialization.data(withJSONObject: header, options: [.sortedKeys])
+    let payloadData = try JSONSerialization.data(withJSONObject: claims, options: [.sortedKeys])
+    return "\(base64URL(headerData)).\(base64URL(payloadData)).sig"
+}
+
+private func base64URL(_ data: Data) -> String {
+    data.base64EncodedString()
+        .replacingOccurrences(of: "+", with: "-")
+        .replacingOccurrences(of: "/", with: "_")
+        .replacingOccurrences(of: "=", with: "")
+}

--- a/ConvosCore/Tests/ConvosCoreTests/SIWENonceCookieParsingTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/SIWENonceCookieParsingTests.swift
@@ -1,0 +1,70 @@
+@testable import ConvosCore
+import Foundation
+import Testing
+
+/// `Set-Cookie` parsing for the SIWE nonce flow. The backend emits
+/// `__Host-convos_nonce` in prod with strict attrs (`Secure`,
+/// `SameSite=Strict`); we also accept the proposed dev form
+/// `convos_nonce` so iOS keeps working whether or not the backend
+/// relaxes the cookie attributes outside prod.
+@Suite("SIWE nonce cookie parsing")
+struct SIWENonceCookieParsingTests {
+    @Test("Parses __Host-convos_nonce (prod form) and extracts hex nonce after the HMAC separator")
+    func parsesProdCookie() throws {
+        let hex = String(repeating: "ab", count: 32) // 64 hex chars
+        let hmac = "Sig0_abc-DEF"
+        let setCookie = "__Host-convos_nonce=\(hmac).\(hex); Path=/; HttpOnly; Secure; SameSite=Strict; Max-Age=300"
+        let response = makeResponse(setCookie: setCookie)
+        let challenge = try ConvosAPIClient.extractNonceCookie(from: response, requestURL: requestURL)
+        #expect(challenge.nonce == hex)
+        #expect(challenge.cookieHeader == "__Host-convos_nonce=\(hmac).\(hex)")
+    }
+
+    @Test("Parses relaxed dev form (convos_nonce without Secure)")
+    func parsesDevCookie() throws {
+        let hex = String(repeating: "cd", count: 32)
+        let setCookie = "convos_nonce=hmac.\(hex); Path=/; HttpOnly; SameSite=Lax; Max-Age=300"
+        let response = makeResponse(setCookie: setCookie)
+        let challenge = try ConvosAPIClient.extractNonceCookie(from: response, requestURL: requestURL)
+        #expect(challenge.nonce == hex)
+        #expect(challenge.cookieHeader == "convos_nonce=hmac.\(hex)")
+    }
+
+    @Test("Throws missingNonceCookie when the response has no recognized cookie")
+    func throwsWhenAbsent() {
+        let response = makeResponse(setCookie: "other_cookie=whatever; Path=/")
+        #expect(throws: SIWEAuthError.self) {
+            _ = try ConvosAPIClient.extractNonceCookie(from: response, requestURL: requestURL)
+        }
+    }
+
+    @Test("Throws malformedNonce when the hex part isn't 64 lowercase hex chars")
+    func throwsOnMalformedNonce() {
+        let setCookie = "convos_nonce=hmac.NOT-HEX; Path=/; HttpOnly; SameSite=Lax"
+        let response = makeResponse(setCookie: setCookie)
+        #expect(throws: SIWEAuthError.self) {
+            _ = try ConvosAPIClient.extractNonceCookie(from: response, requestURL: requestURL)
+        }
+    }
+
+    // MARK: - Helpers
+
+    private var requestURL: URL {
+        guard let url = URL(string: "http://localhost:4000/api/v2/auth/nonce") else {
+            fatalError("test url should be valid")
+        }
+        return url
+    }
+
+    private func makeResponse(setCookie: String) -> HTTPURLResponse {
+        guard let response = HTTPURLResponse(
+            url: requestURL,
+            statusCode: 200,
+            httpVersion: "HTTP/1.1",
+            headerFields: ["Set-Cookie": setCookie]
+        ) else {
+            fatalError("HTTPURLResponse init should not fail for valid inputs")
+        }
+        return response
+    }
+}

--- a/ConvosCore/Tests/ConvosCoreTests/SIWENonceCookieParsingTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/SIWENonceCookieParsingTests.swift
@@ -30,6 +30,28 @@ struct SIWENonceCookieParsingTests {
         #expect(challenge.cookieHeader == "convos_nonce=hmac.\(hex)")
     }
 
+    @Test("Finds the nonce cookie when URLSession coalesces multiple Set-Cookie headers and the nonce is second")
+    func parsesNonceWhenCoalescedSecond() throws {
+        // URLSession concatenates duplicate Set-Cookie headers with
+        // ", " when surfacing them through `value(forHTTPHeaderField:)`.
+        // The nonce cookie's value contains a `.` separator
+        // (`<hmac>.<hex-nonce>`), so any splitter that validates the
+        // *value* part of the next chunk against a restricted char set
+        // will miss the boundary and parse both cookies as one entry —
+        // ending up unable to find the nonce. This regression test
+        // pins the fix from the macroscope review on PR #827.
+        let hex = String(repeating: "ab", count: 32)
+        let coalesced = [
+            "analytics_id=abc-123-def; Path=/; HttpOnly",
+            "__Host-convos_nonce=hmac+slash/value.\(hex); Path=/; HttpOnly; Secure; SameSite=Strict; Max-Age=300",
+        ].joined(separator: ", ")
+
+        let response = makeResponse(setCookie: coalesced)
+        let challenge = try ConvosAPIClient.extractNonceCookie(from: response, requestURL: requestURL)
+        #expect(challenge.nonce == hex)
+        #expect(challenge.cookieHeader == "__Host-convos_nonce=hmac+slash/value.\(hex)")
+    }
+
     @Test("Throws missingNonceCookie when the response has no recognized cookie")
     func throwsWhenAbsent() {
         let response = makeResponse(setCookie: "other_cookie=whatever; Path=/")

--- a/ConvosCore/Tests/ConvosCoreTests/SIWENonceCookieParsingTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/SIWENonceCookieParsingTests.swift
@@ -52,6 +52,22 @@ struct SIWENonceCookieParsingTests {
         #expect(challenge.cookieHeader == "__Host-convos_nonce=hmac+slash/value.\(hex)")
     }
 
+    @Test("Does not split on commas inside Expires= dates")
+    func doesNotSplitOnExpiresDate() throws {
+        // RFC 822 dates inside `Expires=` contain a comma+space after
+        // the weekday (`Wed, 01 Jan 2026 ...`). Our manual splitter
+        // must NOT split there: the lookahead after the comma is
+        // `01 Jan ...` — `01` is name-like but the next char is a
+        // space, which isn't in the cookie-name grammar, so we
+        // correctly refuse to split.
+        let hex = String(repeating: "ab", count: 32)
+        let setCookie = "__Host-convos_nonce=hmac.\(hex); Path=/; Expires=Wed, 01 Jan 2026 00:00:00 GMT; HttpOnly; Secure; SameSite=Strict"
+        let response = makeResponse(setCookie: setCookie)
+        let challenge = try ConvosAPIClient.extractNonceCookie(from: response, requestURL: requestURL)
+        #expect(challenge.nonce == hex)
+        #expect(challenge.cookieHeader == "__Host-convos_nonce=hmac.\(hex)")
+    }
+
     @Test("Throws missingNonceCookie when the response has no recognized cookie")
     func throwsWhenAbsent() {
         let response = makeResponse(setCookie: "other_cookie=whatever; Path=/")

--- a/ConvosCore/Tests/ConvosCoreTests/SIWESignerTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/SIWESignerTests.swift
@@ -37,6 +37,10 @@ struct SIWESignerTests {
         let privateKey = try PrivateKey(privateKeyData)
         let expectedAddress = privateKey.identity.identifier.lowercased()
 
+        // Canary signs the realistic format the backend validates,
+        // including the Resources block with the per-device URI. If
+        // we ever drift on Resources, this test catches it before the
+        // backend's recovery rejects the signature on the wire.
         let message = """
         convos.app wants you to sign in with your Ethereum account:
         \(expectedAddress)
@@ -49,6 +53,8 @@ struct SIWESignerTests {
         Nonce: deadbeef00deadbeef00deadbeef00deadbeef00deadbeef00deadbeef00aabb
         Issued At: 2026-05-11T12:00:00.000Z
         Expiration Time: 2026-05-11T12:05:00.000Z
+        Resources:
+        - convos://device/5A2B3C4D-EFAB-1234-5678-90ABCDEF1234
         """
 
         let signature = try await SIWESigner.signRaw(message: message, with: privateKey)

--- a/ConvosCore/Tests/ConvosCoreTests/SIWESignerTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/SIWESignerTests.swift
@@ -1,0 +1,134 @@
+@testable import ConvosCore
+import CryptoSwift
+import CSecp256k1
+import Foundation
+import Testing
+@preconcurrency import XMTPiOS
+
+/// Canary tests that the SIWE signer produces a 65-byte `r || s || v`
+/// signature with Ethereum-standard `v ∈ {27, 28}` and that the signature
+/// round-trips through the same recovery path the backend uses
+/// (`ethers.verifyMessage`). If the v-byte normalization is wrong or the
+/// EIP-191 prefixing drifts, recovery produces the wrong address and these
+/// tests fail — before the backend ever sees a request.
+@Suite("SIWESigner canary")
+struct SIWESignerTests {
+    @Test("v-byte normalize maps {0,1} to {27,28} and leaves {27,28} alone")
+    func normalizeVByte() {
+        var sig = Data(repeating: 0x42, count: 64) + Data([0])
+        let normalized0 = SIWESigner.normalize(sig)
+        #expect(normalized0.count == 65)
+        #expect(normalized0[64] == 27)
+
+        sig[64] = 1
+        #expect(SIWESigner.normalize(sig)[64] == 28)
+
+        sig[64] = 27
+        #expect(SIWESigner.normalize(sig)[64] == 27)
+
+        sig[64] = 28
+        #expect(SIWESigner.normalize(sig)[64] == 28)
+    }
+
+    @Test("Sign-then-recover roundtrip: recovered address equals wallet address")
+    func signAndRecoverRoundtrip() async throws {
+        // Fixed key so the test is deterministic.
+        let privateKeyData = Data(repeating: 0x11, count: 32)
+        let privateKey = try PrivateKey(privateKeyData)
+        let expectedAddress = privateKey.identity.identifier.lowercased()
+
+        let message = """
+        convos.app wants you to sign in with your Ethereum account:
+        \(expectedAddress)
+
+        Sign in to Convos
+
+        URI: https://convos.app
+        Version: 1
+        Chain ID: 1
+        Nonce: deadbeef00deadbeef00deadbeef00deadbeef00deadbeef00deadbeef00aabb
+        Issued At: 2026-05-11T12:00:00.000Z
+        Expiration Time: 2026-05-11T12:05:00.000Z
+        """
+
+        let signature = try await SIWESigner.signRaw(message: message, with: privateKey)
+        #expect(signature.count == 65)
+        #expect(signature[64] == 27 || signature[64] == 28)
+
+        let digest = eip191Hash(message)
+        let recoveredAddress = try recoverAddress(messageHash: digest, signature: signature)
+        #expect(recoveredAddress == expectedAddress)
+    }
+
+    @Test("Hex-encoded signature is 0x + 130 hex chars")
+    func hexEncodingShape() async throws {
+        let privateKey = try PrivateKey(Data(repeating: 0x22, count: 32))
+        let hex = try await SIWESigner.sign(message: "anything", with: privateKey)
+        #expect(hex.hasPrefix("0x"))
+        #expect(hex.count == 2 + 130)
+        let recoveryHex = String(hex.suffix(2))
+        let recoveryByte = UInt8(recoveryHex, radix: 16)
+        #expect(recoveryByte == 27 || recoveryByte == 28)
+    }
+}
+
+// MARK: - EIP-191 + secp256k1 recovery helpers (test-only)
+
+private func eip191Hash(_ message: String) -> Data {
+    let messageData = Data(message.utf8)
+    let prefix = "\u{19}Ethereum Signed Message:\n\(messageData.count)"
+    let prefixed = Data(prefix.utf8) + messageData
+    let digest = SHA3(variant: .keccak256).calculate(for: Array(prefixed))
+    return Data(digest)
+}
+
+private struct RecoveryError: Error, CustomStringConvertible {
+    let stage: String
+    var description: String { "secp256k1 recovery failed at \(stage)" }
+}
+
+private func recoverAddress(messageHash: Data, signature: Data) throws -> String {
+    guard messageHash.count == 32 else { throw RecoveryError(stage: "bad_hash_length") }
+    guard signature.count == 65 else { throw RecoveryError(stage: "bad_sig_length") }
+
+    guard let ctx = secp256k1_context_create(UInt32(SECP256K1_CONTEXT_SIGN | SECP256K1_CONTEXT_VERIFY)) else {
+        throw RecoveryError(stage: "context_create")
+    }
+    defer { secp256k1_context_destroy(ctx) }
+
+    // Map v ∈ {27, 28} → recid ∈ {0, 1} the way ethers does.
+    let recid = Int32(signature[64]) - 27
+    guard recid == 0 || recid == 1 else {
+        throw RecoveryError(stage: "recid_out_of_range_\(signature[64])")
+    }
+
+    let compactSig = signature.prefix(64)
+    var recoverableSig = secp256k1_ecdsa_recoverable_signature()
+    let parseOK = compactSig.withUnsafeBytes { (buf: UnsafeRawBufferPointer) -> Int32 in
+        guard let base = buf.bindMemory(to: UInt8.self).baseAddress else { return 0 }
+        return secp256k1_ecdsa_recoverable_signature_parse_compact(ctx, &recoverableSig, base, recid)
+    }
+    guard parseOK == 1 else { throw RecoveryError(stage: "parse_compact") }
+
+    var pubkey = secp256k1_pubkey()
+    let recoverOK = messageHash.withUnsafeBytes { (buf: UnsafeRawBufferPointer) -> Int32 in
+        guard let base = buf.bindMemory(to: UInt8.self).baseAddress else { return 0 }
+        return secp256k1_ecdsa_recover(ctx, &pubkey, &recoverableSig, base)
+    }
+    guard recoverOK == 1 else { throw RecoveryError(stage: "ecdsa_recover") }
+
+    var serialized = [UInt8](repeating: 0, count: 65)
+    var serializedLen = 65
+    let serializeOK = secp256k1_ec_pubkey_serialize(
+        ctx, &serialized, &serializedLen, &pubkey, UInt32(SECP256K1_EC_UNCOMPRESSED)
+    )
+    guard serializeOK == 1, serializedLen == 65 else { throw RecoveryError(stage: "pubkey_serialize") }
+
+    // Uncompressed pubkey is `04 || X(32) || Y(32)`. The Ethereum address is
+    // the rightmost 20 bytes of keccak256 over `X || Y`.
+    let xy = Array(serialized[1..<65])
+    let hash = SHA3(variant: .keccak256).calculate(for: xy)
+    let addressBytes = hash.suffix(20)
+    let hex = addressBytes.map { String(format: "%02x", $0) }.joined()
+    return "0x" + hex
+}

--- a/ConvosCore/Tests/ConvosCoreTests/SyncingManagerPushReconciliationTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/SyncingManagerPushReconciliationTests.swift
@@ -199,7 +199,7 @@ private final class RecordingPushAPIClientForReconciliationTests: ConvosAPIClien
         "mock-jwt-token"
     }
 
-    func authenticateWithSIWE(appCheckToken: String, signing: BackendAuthSigningContext, retryCount: Int) async throws -> String {
+    func authenticateWithSIWE(appCheckToken: String, signing: BackendAuthSigningContext) async throws -> String {
         "mock-siwe-jwt-token"
     }
 

--- a/ConvosCore/Tests/ConvosCoreTests/SyncingManagerPushReconciliationTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/SyncingManagerPushReconciliationTests.swift
@@ -199,6 +199,14 @@ private final class RecordingPushAPIClientForReconciliationTests: ConvosAPIClien
         "mock-jwt-token"
     }
 
+    func authenticateWithSIWE(appCheckToken: String, signing: BackendAuthSigningContext, retryCount: Int) async throws -> String {
+        "mock-siwe-jwt-token"
+    }
+
+    func accountAuthCheck(jwt: String?) async throws -> ConvosAPI.AuthCheckResponse {
+        .init(success: jwt != nil)
+    }
+
     func uploadAttachment(data: Data, filename: String, contentType: String, acl: String) async throws -> String {
         ""
     }

--- a/ConvosCore/Tests/ConvosCoreTests/SyncingManagerPushReconciliationTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/SyncingManagerPushReconciliationTests.swift
@@ -203,6 +203,8 @@ private final class RecordingPushAPIClientForReconciliationTests: ConvosAPIClien
         "mock-siwe-jwt-token"
     }
 
+    func updateSIWESigningContext(_ context: BackendAuthSigningContext?) {}
+
     func accountAuthCheck(jwt: String?) async throws -> ConvosAPI.AuthCheckResponse {
         .init(success: jwt != nil)
     }

--- a/ConvosCore/Tests/ConvosCoreTests/SyncingManagerTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/SyncingManagerTests.swift
@@ -350,6 +350,8 @@ final class TestableMockAPIClient: ConvosAPIClientProtocol, @unchecked Sendable 
         "mock-siwe-jwt-token"
     }
 
+    func updateSIWESigningContext(_ context: BackendAuthSigningContext?) {}
+
     func accountAuthCheck(jwt: String?) async throws -> ConvosAPI.AuthCheckResponse {
         .init(success: jwt != nil)
     }

--- a/ConvosCore/Tests/ConvosCoreTests/SyncingManagerTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/SyncingManagerTests.swift
@@ -346,6 +346,14 @@ final class TestableMockAPIClient: ConvosAPIClientProtocol, @unchecked Sendable 
         "mock-jwt-token"
     }
 
+    func authenticateWithSIWE(appCheckToken: String, signing: BackendAuthSigningContext, retryCount: Int) async throws -> String {
+        "mock-siwe-jwt-token"
+    }
+
+    func accountAuthCheck(jwt: String?) async throws -> ConvosAPI.AuthCheckResponse {
+        .init(success: jwt != nil)
+    }
+
     func uploadAttachment(data: Data, filename: String, contentType: String, acl: String) async throws -> String {
         "https://mock-api.example.com/uploads/\(filename)"
     }

--- a/ConvosCore/Tests/ConvosCoreTests/SyncingManagerTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/SyncingManagerTests.swift
@@ -346,7 +346,7 @@ final class TestableMockAPIClient: ConvosAPIClientProtocol, @unchecked Sendable 
         "mock-jwt-token"
     }
 
-    func authenticateWithSIWE(appCheckToken: String, signing: BackendAuthSigningContext, retryCount: Int) async throws -> String {
+    func authenticateWithSIWE(appCheckToken: String, signing: BackendAuthSigningContext) async throws -> String {
         "mock-siwe-jwt-token"
     }
 

--- a/docs/plans/authentication-api-siwe-ios.md
+++ b/docs/plans/authentication-api-siwe-ios.md
@@ -1,0 +1,342 @@
+# Authentication API (SIWE) — iOS Implementation Plan
+
+> Backend branch reviewed from `../convos-backend`: `fbac/authentication-api`.
+> iOS target repo: `convos-ios`.
+
+## Friday proof goal
+
+Show, from the Swift app/debug build, that we can:
+
+1. Obtain a backend nonce from `POST /api/v2/auth/nonce`.
+2. Build and sign an EIP-4361/SIWE message with the local XMTP Ethereum identity.
+3. Exchange `{ deviceId, siwe: { message, signature } }` at `POST /api/v2/auth/token` for a JWT that contains `accountId`.
+4. Call a gated API route with `X-Convos-AuthToken: <jwt>` and display success or the backend error.
+
+Important path note: current iOS `AppEnvironment.apiBaseURL` already ends in `/api`, so client paths should remain `v2/auth/nonce`, `v2/auth/token`, etc.
+
+## Backend contract observed
+
+### `POST /api/v2/auth/nonce`
+
+Headers:
+
+- `X-Firebase-AppCheck: <app check token>`
+
+Response:
+
+- Status `200`
+- Body `{}`
+- `Set-Cookie: __Host-convos_nonce=<hmac>.<nonce>; HttpOnly; Secure; SameSite=Strict; Path=/; Max-Age=300`
+
+The raw nonce is the 64-hex-character value after the first `.` in the cookie value. It is valid for 5 minutes and single use once submitted to `/auth/token`.
+
+### `POST /api/v2/auth/token`
+
+Headers:
+
+- `X-Firebase-AppCheck: <app check token>`
+- `Cookie: __Host-convos_nonce=<hmac>.<nonce>` when using the SIWE path
+- `Content-Type: application/json`
+
+Body:
+
+```json
+{
+  "deviceId": "<DeviceInfo.deviceIdentifier>",
+  "siwe": {
+    "message": "<exact SIWE message string>",
+    "signature": "0x<65-byte recoverable signature hex>"
+  }
+}
+```
+
+Success:
+
+```json
+{ "token": "<jwt>" }
+```
+
+Token details:
+
+- ES256 JWT.
+- Expires in 15 minutes.
+- Payload includes `deviceId`; SIWE path also includes `accountId`.
+
+Errors to surface in debug proof:
+
+- `400` invalid request body.
+- `401` invalid nonce or invalid SIWE. Nonce may already be burned; retry must restart from `/auth/nonce`.
+- `403` disabled device.
+- `429` rate limited.
+
+### SIWE/account auth-check route recommendation
+
+Do **not** change existing `/api/v2/auth-check` yet. iOS/NSE already use it as a backward-compatible JWT liveness check, and backend intentionally mounts it with `authMiddlewareAllowNSE`.
+
+Add a separate account-bound check route for the SIWE rollout:
+
+- preferred semantics: `GET /api/v2/siwe-auth-check`
+- backend middleware: `authMiddleware, requireAccount`
+- success body: `{ "success": true }` (optionally include `accountId` for debug builds only)
+
+This route should:
+
+- return `200` only for JWTs that verify and carry `accountId`,
+- return `401` for missing/expired/invalid JWT,
+- return `403 { "error": "Account required" }` for legacy device-only JWTs,
+- reject NSE-only JWTs because it uses `authMiddleware`, not `authMiddlewareAllowNSE`.
+
+Technically this checks “account-authenticated JWT”, not the SIWE message itself. In the current backend, `accountId` implies SIWE because SIWE is the only account creation method. If more account auth methods are added later, consider renaming/generalizing to `/api/v2/account-auth-check`.
+
+## Current iOS gaps
+
+1. `ConvosAPIClient.authenticate(appCheckToken:retryCount:)` uses the legacy body `{ deviceId }`; it will mint a device-only JWT with no `accountId`.
+2. The client has no nonce endpoint support and no SIWE request models.
+3. `ConvosAPIClient` currently has no access to the XMTP identity/private key when it refreshes a token after a `401`.
+4. JWTs are stored by device ID only (`KeychainAccount.jwt(deviceId:)`). With SIWE this can reuse a stale token from a previous identity on the same device.
+5. The app config has no explicit `siweDomain`, `siweURI`, or `chainId`; backend SIWE verification is exact-match.
+6. Default `HTTPCookieStorage` silently drops the prod cookie on `http://localhost` because the `__Host-` prefix requires `Secure`. Coordination with backend: in non-prod modes the cookie is emitted as plain `convos_nonce` without `Secure` (HMAC binding unchanged) so the default URLSession round-trips it transparently. No manual cookie handling needed in iOS.
+
+## Implementation plan
+
+### 1. Add SIWE configuration to app environment
+
+Files:
+
+- `ConvosCore/Sources/ConvosCore/ConvosConfiguration.swift`
+- `ConvosCore/Sources/ConvosCore/AppEnvironment.swift`
+- `ConvosCore/Sources/ConvosCore/AppEnvironment+Shared.swift`
+- `ConvosCore/Sources/ConvosCore/Config/ConfigManager.swift`
+- `Convos/Config/config.*.json`
+
+Add:
+
+```swift
+public struct SIWEConfiguration: Codable, Sendable, Equatable {
+    public let domain: String
+    public let uri: String
+    public let chainId: Int
+}
+```
+
+Recommended initial values must match backend env exactly. Do not infer from `apiBaseURL`.
+
+### 2. Add SIWE message builder + signer helper
+
+New file suggestion:
+
+- `ConvosCore/Sources/ConvosCore/Auth/BackendSIWEAuth.swift`
+
+Responsibilities:
+
+- Derive the Ethereum address from `KeychainIdentity.keys.privateKey.identity.identifier`.
+- Build the exact SIWE message string with `\n` line endings:
+
+```text
+<domain> wants you to sign in with your Ethereum account:
+<address>
+
+Sign in to Convos
+
+URI: <uri>
+Version: 1
+Chain ID: <chainId>
+Nonce: <nonce>
+Issued At: <issuedAt>
+Expiration Time: <expirationTime>
+```
+
+- `issuedAt` should be current time.
+- `expirationTime` should be about 5 minutes in the future and always less than backend's 10-minute maximum.
+- Sign the exact UTF-8 string with `try await privateKey.sign(message).rawData`. `PrivateKey.sign` already applies the EIP-191 prefix internally (see libxmtp `KeyUtil.ethHash`); do **not** prefix again.
+- **Normalize the recovery byte before hex encoding.** `rawData` is `r || s || v` (65 bytes). libxmtp's underlying `secp256k1_ecdsa_sign_recoverable` returns `v ∈ {0, 1}`, but the backend's SIWE verification path uses `ethers` which expects Ethereum-standard `v ∈ {27, 28}`. If `rawData[64] < 27`, add `27` before serializing. Skipping this is the single most likely cause of `401 Invalid SIWE` even when math is correct.
+- Hex encode the 65-byte signature as `0x...` (130 hex chars after the prefix).
+
+Add tests with a fixed private key to prove:
+
+- address derivation is stable,
+- message construction is byte-for-byte stable,
+- signature is 65 bytes and hex encoded with `0x`,
+- **the signature round-trips**: sign a known message, recover the public key from the produced `(r, s, v)`, derive the address, and assert it matches `privateKey.walletAddress`. Use `secp256k1` from `ConvosInvites/Sources/ConvosInvitesCore/Core/Crypto.swift`. This is the canary for the `v`-byte issue above and the EIP-191 prefix; if it passes locally, the backend will accept it.
+
+### 3. Add nonce acquisition to API client
+
+Files:
+
+- `ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift`
+- `ConvosCore/Sources/ConvosCore/API/ConvosAPIClient+Models.swift`
+- `ConvosCore/Sources/ConvosCore/API/MockAPIClient.swift`
+
+Add an internal method like:
+
+```swift
+func requestAuthNonce(appCheckToken: String) async throws -> AuthNonceChallenge
+```
+
+`AuthNonceChallenge` should contain:
+
+- `nonce: String`
+- `cookieHeader: String` (`__Host-convos_nonce=<hmac>.<nonce>`)
+
+Implementation details:
+
+- `POST v2/auth/nonce`
+- Parse `Set-Cookie` using `HTTPCookie.cookies(withResponseHeaderFields:for:)`. The cookie name is `__Host-convos_nonce` in prod and `convos_nonce` in non-prod (backend strips the `__Host-` prefix and `Secure` flag outside production so the default URLSession can round-trip it on HTTP).
+- The raw hex nonce is `value.split(".").last` (the part after the HMAC separator); the full `name=value` becomes the `Cookie` header sent on `/auth/token`.
+- Validate nonce with `^[0-9a-f]{64}$`.
+- Do **not** log the cookie value or signature.
+
+Default `URLSession` (with the shared `HTTPCookieStorage`) is sufficient — no `ephemeral` session needed — because the backend's dev-mode cookie attributes are HTTP-compatible. We still construct the `Cookie` header explicitly on `/auth/token` so the flow is robust to future cookie-policy changes and easy to reason about in logs.
+
+### 4. Add SIWE token exchange
+
+Add request models:
+
+```swift
+struct AuthTokenRequest: Encodable {
+    let deviceId: String
+    let siwe: SIWEPayload?
+}
+
+struct SIWEPayload: Encodable {
+    let message: String
+    let signature: String
+}
+
+struct AuthTokenResponse: Decodable {
+    let token: String
+}
+```
+
+Implement:
+
+```swift
+func authenticateWithSIWE(
+    appCheckToken: String,
+    identity: KeychainIdentity,
+    retryCount: Int
+) async throws -> String
+```
+
+Flow:
+
+1. Request nonce.
+2. Build SIWE message with current environment SIWE config.
+3. Sign message with `identity.keys.privateKey.sign(message)`.
+4. `POST v2/auth/token` with AppCheck, JSON body, and `Cookie` header from nonce challenge.
+5. Save returned JWT only if payload contains `accountId`.
+6. On `401`, discard the challenge and start again from nonce; do not reuse nonce.
+
+### 5. Fix token caching semantics
+
+Files:
+
+- `ConvosCore/Sources/ConvosCore/Shared/ConvosKeychainItem.swift`
+- `ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift`
+- `ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift`
+
+Do not reuse a JWT keyed only by device ID for SIWE auth.
+
+Recommended:
+
+```swift
+static func jwt(deviceId: String, address: String) -> String {
+    "jwt:\(deviceId):siwe:\(address.lowercased())"
+}
+```
+
+Then:
+
+- For SIWE flow, read/write token under the address-specific key.
+- Decode cached JWT and require `exp` valid and `accountId` present.
+- On successful SIWE token exchange, delete the legacy device-only JWT if present.
+- On account deletion / Delete All Data, delete SIWE JWT for the current identity before deleting identity keys.
+
+This prevents a stale token from a prior identity being reused during the Friday proof.
+
+### 6. Wire SessionStateMachine to SIWE auth
+
+Files:
+
+- `ConvosCore/Sources/ConvosCore/Inboxes/SessionStateMachine.swift`
+- `ConvosCore/Sources/ConvosCore/Inboxes/AuthorizeInboxOperation.swift`
+- `ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift`
+
+During `authenticateBackend()`:
+
+1. Load current `KeychainIdentity` from `identityStore`.
+2. Call SIWE auth, not legacy auth.
+3. Keep legacy `{ deviceId }` auth only as an explicit fallback flag during rollout, not as the default path.
+
+Also update `ConvosAPIClient` re-authentication after `401` so refresh uses the same SIWE signer. Otherwise the client will silently downgrade to a legacy device-only token after expiry.
+
+### 7. Add a debug proof action
+
+Files:
+
+- `Convos/Debug View/DebugView.swift` or a new `DebugAuthProbeView.swift`
+- optionally `ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift`
+
+Add a non-production debug button: **Run Auth Probe**.
+
+Probe output should show:
+
+- nonce acquired: yes/no,
+- SIWE signed: yes/no,
+- token acquired: yes/no,
+- decoded JWT has `accountId`: yes/no,
+- gated route status + response body.
+
+For gated route:
+
+- Use `/api/v2/siwe-auth-check` once backend adds it.
+- Keep `/api/v2/auth-check` only as a legacy/NSE JWT liveness check; do not use it to prove SIWE/account auth.
+
+### 8. Tests
+
+Add ConvosCore tests:
+
+- nonce cookie parsing from sample backend `Set-Cookie` headers — both the prod form (`__Host-convos_nonce; HttpOnly; Secure; SameSite=Strict`) and the dev form (`convos_nonce; HttpOnly; SameSite=Lax`).
+- SIWE message byte construction (exact-string fixture).
+- signature hex encoding is `0x` + 130 hex chars.
+- **signature recovery roundtrip**: sign a known message with a fixed key, recover the address from the produced signature, assert it equals the wallet address. Guards the `v`-byte normalization and EIP-191 prefixing.
+- token cache rejects no-`accountId` legacy JWT for SIWE flow.
+- API client sends:
+  - `X-Firebase-AppCheck`,
+  - `Cookie: <name>=...` (prod or dev cookie name),
+  - body with `deviceId`, `siwe.message`, `siwe.signature`,
+  - `X-Convos-AuthToken` for gated route.
+
+### 9. Manual proof checklist
+
+Prereqs:
+
+- Backend on `fbac/authentication-api`, local or dev. Required env: `SIWE_DOMAIN=convos.app`, `SIWE_URI=https://convos.app`, `SIWE_ALLOWED_CHAIN_IDS=1`, `NONCE_HMAC_SECRET`, ES256 `JWT_PRIVATE_KEY` / `JWT_PUBLIC_KEY`, App Check debug token configured (or `app_attest_enabled=false`).
+- Backend has `/api/v2/siwe-auth-check` mounted with `authMiddleware + requireAccount`.
+- Backend is emitting the non-prod cookie form on local/dev (`convos_nonce`, no `Secure`).
+- iOS `config.local.json` siwe fields exactly match backend env.
+- App is signed-in with an XMTP identity.
+- Clear any old JWT keychain entries before the first run.
+
+Happy path — open Debug → **Run Auth Probe**, expect:
+
+```
+Loading identity… address=0xabc…
+Fetching nonce…            → got <hex64> (cookie convos_nonce stored)
+Building SIWE message…     → 8-line EIP-4361 message
+Signing…                   → 0x<130 hex>  (v normalized to 27/28)
+POST /api/v2/auth/token …  → 200 { token: eyJ… }
+Decoded JWT                → sub=<deviceId>, accountId=<uuid>, exp=+15m
+GET /api/v2/siwe-auth-check → 200 { success: true }
+```
+
+Negative path:
+
+- Same screen, tap **Probe without auth** → `401 Missing auth token` on `/siwe-auth-check`.
+
+Failure-mode probes (optional; prove robustness, not required for Friday):
+
+- Flip one hex char in the signature before sending → expect `401 Invalid SIWE`, and a follow-up clean run must still succeed (the failed signature already burned the previous nonce; the new run fetches a fresh one).
+- Delay 6 minutes between `/auth/nonce` and `/auth/token` → expect `401 Invalid nonce` (TTL expired).
+- Run the probe twice back-to-back → both succeed (each fetches its own nonce; no replay).
+- Sign with the wrong key (e.g., tweak the message but keep the old signature) → expect `401 Invalid SIWE`.

--- a/docs/plans/authentication-api-siwe-ios.md
+++ b/docs/plans/authentication-api-siwe-ios.md
@@ -69,13 +69,13 @@ Errors to surface during the proof run:
 - `403` disabled device.
 - `429` rate limited.
 
-### SIWE/account auth-check route recommendation
+### Account auth-check route
 
 Do **not** change existing `/api/v2/auth-check` yet. iOS/NSE already use it as a backward-compatible JWT liveness check, and backend intentionally mounts it with `authMiddlewareAllowNSE`.
 
-Add a separate account-bound check route for the SIWE rollout:
+Add a separate account-bound check route:
 
-- preferred semantics: `GET /api/v2/siwe-auth-check`
+- name: `GET /api/v2/account-auth-check`
 - backend middleware: `authMiddleware, requireAccount`
 - success body: `{ "success": true }` (optionally include `accountId` for debug builds only)
 
@@ -86,7 +86,7 @@ This route should:
 - return `403 { "error": "Account required" }` for legacy device-only JWTs,
 - reject NSE-only JWTs because it uses `authMiddleware`, not `authMiddlewareAllowNSE`.
 
-Technically this checks “account-authenticated JWT”, not the SIWE message itself. In the current backend, `accountId` implies SIWE because SIWE is the only account creation method. **As a next step: ship `/api/v2/siwe-auth-check`. Longer term: rename to `/api/v2/account-auth-check`** since it actually checks for `accountId`, not the SIWE signature itself — the moment a second account auth method is added (passkey, Sign-In with Solana, etc.) the SIWE-named route becomes misleading. Either alias the new name to the old one or stage a deprecation; iOS only consumes the route via one method, so the swap is cheap on this side.
+The route is named after what it actually checks (`accountId`), not after the auth method that produced the token. In the current backend, `accountId` implies SIWE because SIWE is the only account creation method, but when a second method is added (passkey, Sign-In with Solana, etc.) the route stays correct without a rename.
 
 ## Current iOS gaps
 
@@ -283,7 +283,7 @@ The Notification Service Extension stays **outside SIWE**. It cannot run the SIW
 
 - NSE uses the existing backend-minted `metadata.notificationExtensionOnly: true` JWT path (no SIWE, no `accountId`). The backend already supports this; the iOS side already stores and refreshes the NSE token via the legacy device-id JWT slot.
 - NSE-issued JWTs **must keep passing** `GET /api/v2/auth-check` (which uses `authMiddlewareAllowNSE`). This is the existing liveness probe and the SIWE rollout must not regress it.
-- NSE-issued JWTs **must fail** `GET /api/v2/siwe-auth-check` with `403 Account required` — the new gated route is mounted with `authMiddleware + requireAccount`, which rejects tokens without `accountId`. This is the desired guardrail: SIWE-gated functionality is never reachable from a notification extension.
+- NSE-issued JWTs **must fail** `GET /api/v2/account-auth-check` with `403 Account required` — the new gated route is mounted with `authMiddleware + requireAccount`, which rejects tokens without `accountId`. This is the desired guardrail: SIWE-gated functionality is never reachable from a notification extension.
 - The token cache change in §5 (address-scoped SIWE JWT key) must not touch the legacy `KeychainAccount.jwt(deviceId:)` slot that NSE reads from. NSE and the main app keep using disjoint cache entries.
 
 If NSE later needs additional backend cleanup routes (e.g. unregistering a stale push token), expose them as a narrow NSE-safe surface with an explicit allowlist — not broad `/notifications/*` access. The pattern is: tag those routes with `authMiddlewareAllowNSE`, require explicit per-route opt-in to NSE, and do not bypass `requireAccount` for anything that mutates account-owned state.
@@ -291,7 +291,7 @@ If NSE later needs additional backend cleanup routes (e.g. unregistering a stale
 iOS tests to add alongside the SIWE suite:
 
 - An NSE-flavoured JWT (manually constructed with `metadata.notificationExtensionOnly: true` against the test ES256 key) hits `/auth-check` and gets `200`.
-- The same JWT hits `/siwe-auth-check` and gets `403 Account required`.
+- The same JWT hits `/account-auth-check` and gets `403 Account required`.
 - The SIWE JWT cache writer (§5) never overwrites the NSE token slot.
 
 ### 8. Add a debug proof action
@@ -313,7 +313,7 @@ Probe output should show:
 
 For gated route:
 
-- Use `/api/v2/siwe-auth-check` once backend adds it.
+- Use `/api/v2/account-auth-check` once backend adds it.
 - Keep `/api/v2/auth-check` only as a legacy/NSE JWT liveness check; do not use it to prove SIWE/account auth.
 
 ### 9. Tests
@@ -336,7 +336,7 @@ Add ConvosCore tests:
 Prereqs:
 
 - Backend on `fbac/authentication-api`, local or dev. Required env: `SIWE_DOMAIN=convos.app`, `SIWE_URI=https://convos.app`, `SIWE_ALLOWED_CHAIN_IDS=1`, `NONCE_HMAC_SECRET`, ES256 `JWT_PRIVATE_KEY` / `JWT_PUBLIC_KEY`, App Check debug token configured (or `app_attest_enabled=false`).
-- Backend has `/api/v2/siwe-auth-check` mounted with `authMiddleware + requireAccount`.
+- Backend has `/api/v2/account-auth-check` mounted with `authMiddleware + requireAccount`.
 - Backend is emitting the non-prod cookie form on local/dev (`convos_nonce`, no `Secure`).
 - iOS `config.local.json` siwe fields exactly match backend env.
 - App is signed-in with an XMTP identity.
@@ -351,12 +351,12 @@ Building SIWE message…     → 8-line EIP-4361 message
 Signing…                   → 0x<130 hex>  (v normalized to 27/28)
 POST /api/v2/auth/token …  → 200 { token: eyJ… }
 Decoded JWT                → sub=<deviceId>, accountId=<uuid>, exp=+15m
-GET /api/v2/siwe-auth-check → 200 { success: true }
+GET /api/v2/account-auth-check → 200 { success: true }
 ```
 
 Negative path:
 
-- Same screen, tap **Probe without auth** → `401 Missing auth token` on `/siwe-auth-check`.
+- Same screen, tap **Probe without auth** → `401 Missing auth token` on `/account-auth-check`.
 
 Failure-mode probes (optional; prove robustness, not required for the initial proof):
 

--- a/docs/plans/authentication-api-siwe-ios.md
+++ b/docs/plans/authentication-api-siwe-ios.md
@@ -335,7 +335,7 @@ Add ConvosCore tests:
 
 Prereqs:
 
-- Backend on `fbac/authentication-api`, local or dev. Required env: `SIWE_DOMAIN=convos.app`, `SIWE_URI=https://convos.app`, `SIWE_ALLOWED_CHAIN_IDS=1`, `NONCE_HMAC_SECRET`, ES256 `JWT_PRIVATE_KEY` / `JWT_PUBLIC_KEY`, App Check debug token configured (or `app_attest_enabled=false`).
+- Backend on `fbac/authentication-api`, local or dev. Required env (must exactly match the `siwe*` fields in the iOS `config.<env>.json` for the build under test — the values below are for local/dev/PR builds, which all use the dev domain; prod builds use `convos.org` / `https://convos.org`): `SIWE_DOMAIN=dev.convos.org`, `SIWE_URI=https://dev.convos.org`, `SIWE_ALLOWED_CHAIN_IDS=1`, `NONCE_HMAC_SECRET`, ES256 `JWT_PRIVATE_KEY` / `JWT_PUBLIC_KEY`, App Check debug token configured (or `app_attest_enabled=false`).
 - Backend has `/api/v2/account-auth-check` mounted with `authMiddleware + requireAccount`.
 - Backend is emitting the non-prod cookie form on local/dev (`convos_nonce`, no `Secure`).
 - iOS `config.local.json` siwe fields exactly match backend env.

--- a/docs/plans/authentication-api-siwe-ios.md
+++ b/docs/plans/authentication-api-siwe-ios.md
@@ -3,7 +3,7 @@
 > Backend branch reviewed from `../convos-backend`: `fbac/authentication-api`.
 > iOS target repo: `convos-ios`.
 
-## Friday proof goal
+## Next-step proof goal
 
 Show, from the Swift app/debug build, that we can:
 
@@ -62,7 +62,7 @@ Token details:
 - Expires in 15 minutes.
 - Payload includes `deviceId`; SIWE path also includes `accountId`.
 
-Errors to surface in debug proof:
+Errors to surface during the proof run:
 
 - `400` invalid request body.
 - `401` invalid nonce or invalid SIWE. Nonce may already be burned; retry must restart from `/auth/nonce`.
@@ -86,7 +86,7 @@ This route should:
 - return `403 { "error": "Account required" }` for legacy device-only JWTs,
 - reject NSE-only JWTs because it uses `authMiddleware`, not `authMiddlewareAllowNSE`.
 
-Technically this checks “account-authenticated JWT”, not the SIWE message itself. In the current backend, `accountId` implies SIWE because SIWE is the only account creation method. If more account auth methods are added later, consider renaming/generalizing to `/api/v2/account-auth-check`.
+Technically this checks “account-authenticated JWT”, not the SIWE message itself. In the current backend, `accountId` implies SIWE because SIWE is the only account creation method. **As a next step: ship `/api/v2/siwe-auth-check`. Longer term: rename to `/api/v2/account-auth-check`** since it actually checks for `accountId`, not the SIWE signature itself — the moment a second account auth method is added (passkey, Sign-In with Solana, etc.) the SIWE-named route becomes misleading. Either alias the new name to the old one or stage a deprecation; iOS only consumes the route via one method, so the swap is cheap on this side.
 
 ## Current iOS gaps
 
@@ -95,7 +95,7 @@ Technically this checks “account-authenticated JWT”, not the SIWE message it
 3. `ConvosAPIClient` currently has no access to the XMTP identity/private key when it refreshes a token after a `401`.
 4. JWTs are stored by device ID only (`KeychainAccount.jwt(deviceId:)`). With SIWE this can reuse a stale token from a previous identity on the same device.
 5. The app config has no explicit `siweDomain`, `siweURI`, or `chainId`; backend SIWE verification is exact-match.
-6. Default `HTTPCookieStorage` silently drops the prod cookie on `http://localhost` because the `__Host-` prefix requires `Secure`. Coordination with backend: in non-prod modes the cookie is emitted as plain `convos_nonce` without `Secure` (HMAC binding unchanged) so the default URLSession round-trips it transparently. No manual cookie handling needed in iOS.
+6. Default `HTTPCookieStorage` silently drops the prod cookie on `http://localhost` because the `__Host-` prefix requires `Secure`. The current backend on `fbac/authentication-api` still emits `__Host-convos_nonce; Secure` unconditionally — relaxing it to `convos_nonce` (no `Secure`) outside prod is a **proposed backend coordination item, not yet landed**. iOS must therefore build the SIWE flow assuming the strict prod cookie, i.e. raw-parse `Set-Cookie` and send the `Cookie` header manually on `/auth/token` rather than relying on `HTTPCookieStorage`. If the backend relaxation lands, this code keeps working unchanged.
 
 ## Implementation plan
 
@@ -180,13 +180,13 @@ func requestAuthNonce(appCheckToken: String) async throws -> AuthNonceChallenge
 
 Implementation details:
 
-- `POST v2/auth/nonce`
-- Parse `Set-Cookie` using `HTTPCookie.cookies(withResponseHeaderFields:for:)`. The cookie name is `__Host-convos_nonce` in prod and `convos_nonce` in non-prod (backend strips the `__Host-` prefix and `Secure` flag outside production so the default URLSession can round-trip it on HTTP).
-- The raw hex nonce is `value.split(".").last` (the part after the HMAC separator); the full `name=value` becomes the `Cookie` header sent on `/auth/token`.
+- `POST v2/auth/nonce`.
+- Raw-parse the `Set-Cookie` response header rather than relying on `HTTPCookieStorage`. As of the reviewed backend, the cookie is emitted unconditionally as `__Host-convos_nonce=<hmac>.<nonce>; HttpOnly; Secure; SameSite=Strict; Path=/; Max-Age=300`, and `HTTPCookieStorage` will silently drop it on `http://localhost` because of `Secure`. Use `HTTPURLResponse.value(forHTTPHeaderField: "Set-Cookie")` plus `HTTPCookie.cookies(withResponseHeaderFields:for:)` so commas inside `Expires=...` don't corrupt parsing, then look up the cookie by exact name. Accept both `__Host-convos_nonce` and the proposed dev form `convos_nonce` so the same code keeps working if/when the backend relaxes the attributes.
+- The raw hex nonce is `value.split(".").last` (the part after the HMAC separator); the full `name=value` is what we send back as the `Cookie` header on `/auth/token`.
 - Validate nonce with `^[0-9a-f]{64}$`.
 - Do **not** log the cookie value or signature.
 
-Default `URLSession` (with the shared `HTTPCookieStorage`) is sufficient — no `ephemeral` session needed — because the backend's dev-mode cookie attributes are HTTP-compatible. We still construct the `Cookie` header explicitly on `/auth/token` so the flow is robust to future cookie-policy changes and easy to reason about in logs.
+Use a dedicated `URLSession` configured with `httpCookieStorage = nil, httpShouldSetCookies = false` for the SIWE auth flow. The manually-carried `Cookie` header is the source of truth; this also keeps SIWE auth state from leaking into any other request via shared cookie storage.
 
 ### 4. Add SIWE token exchange
 
@@ -211,18 +211,25 @@ struct AuthTokenResponse: Decodable {
 Implement:
 
 ```swift
+public struct BackendAuthSigningContext: Sendable {
+    public let address: String
+    public let sign: @Sendable (_ message: String) async throws -> Data  // 65-byte r||s||v
+}
+
 func authenticateWithSIWE(
     appCheckToken: String,
-    identity: KeychainIdentity,
+    signing: BackendAuthSigningContext,
     retryCount: Int
 ) async throws -> String
 ```
 
+**Architecture note**: do not let `ConvosAPIClientProtocol` depend on `KeychainIdentity`. The API client should know nothing about the keychain or libxmtp types. Instead, the caller (SessionStateMachine / AuthorizeInboxOperation) loads the identity, builds a `BackendAuthSigningContext` that closes over the private key, and hands it to the API client. The API client treats it as an opaque "sign this string, return 65 bytes" capability. This keeps the protocol surface small and lets the 401-retry path inside `ConvosAPIClient` re-call the closure for a fresh SIWE auth without ever needing to reach into the identity store itself — critical so refresh doesn't silently downgrade to legacy `{ deviceId }` auth when the closure isn't around.
+
 Flow:
 
 1. Request nonce.
-2. Build SIWE message with current environment SIWE config.
-3. Sign message with `identity.keys.privateKey.sign(message)`.
+2. Build SIWE message with current environment SIWE config and `signing.address`.
+3. Sign message via `try await signing.sign(message)` (the closure encapsulates `privateKey.sign(message).rawData` and the v-byte normalization).
 4. `POST v2/auth/token` with AppCheck, JSON body, and `Cookie` header from nonce challenge.
 5. Save returned JWT only if payload contains `accountId`.
 6. On `401`, discard the challenge and start again from nonce; do not reuse nonce.
@@ -252,7 +259,7 @@ Then:
 - On successful SIWE token exchange, delete the legacy device-only JWT if present.
 - On account deletion / Delete All Data, delete SIWE JWT for the current identity before deleting identity keys.
 
-This prevents a stale token from a prior identity being reused during the Friday proof.
+This prevents a stale token from a prior identity being reused during the proof run.
 
 ### 6. Wire SessionStateMachine to SIWE auth
 
@@ -270,7 +277,24 @@ During `authenticateBackend()`:
 
 Also update `ConvosAPIClient` re-authentication after `401` so refresh uses the same SIWE signer. Otherwise the client will silently downgrade to a legacy device-only token after expiry.
 
-### 7. Add a debug proof action
+### 7. NSE (Notification Service Extension) compatibility
+
+The Notification Service Extension stays **outside SIWE**. It cannot run the SIWE flow at all — no XMTP identity unlock in an extension process, no interactive signing, and the extension's strict CPU/time budget rules out a per-push SIWE round-trip even if it could. The contract for NSE is:
+
+- NSE uses the existing backend-minted `metadata.notificationExtensionOnly: true` JWT path (no SIWE, no `accountId`). The backend already supports this; the iOS side already stores and refreshes the NSE token via the legacy device-id JWT slot.
+- NSE-issued JWTs **must keep passing** `GET /api/v2/auth-check` (which uses `authMiddlewareAllowNSE`). This is the existing liveness probe and the SIWE rollout must not regress it.
+- NSE-issued JWTs **must fail** `GET /api/v2/siwe-auth-check` with `403 Account required` — the new gated route is mounted with `authMiddleware + requireAccount`, which rejects tokens without `accountId`. This is the desired guardrail: SIWE-gated functionality is never reachable from a notification extension.
+- The token cache change in §5 (address-scoped SIWE JWT key) must not touch the legacy `KeychainAccount.jwt(deviceId:)` slot that NSE reads from. NSE and the main app keep using disjoint cache entries.
+
+If NSE later needs additional backend cleanup routes (e.g. unregistering a stale push token), expose them as a narrow NSE-safe surface with an explicit allowlist — not broad `/notifications/*` access. The pattern is: tag those routes with `authMiddlewareAllowNSE`, require explicit per-route opt-in to NSE, and do not bypass `requireAccount` for anything that mutates account-owned state.
+
+iOS tests to add alongside the SIWE suite:
+
+- An NSE-flavoured JWT (manually constructed with `metadata.notificationExtensionOnly: true` against the test ES256 key) hits `/auth-check` and gets `200`.
+- The same JWT hits `/siwe-auth-check` and gets `403 Account required`.
+- The SIWE JWT cache writer (§5) never overwrites the NSE token slot.
+
+### 8. Add a debug proof action
 
 Files:
 
@@ -292,7 +316,7 @@ For gated route:
 - Use `/api/v2/siwe-auth-check` once backend adds it.
 - Keep `/api/v2/auth-check` only as a legacy/NSE JWT liveness check; do not use it to prove SIWE/account auth.
 
-### 8. Tests
+### 9. Tests
 
 Add ConvosCore tests:
 
@@ -307,7 +331,7 @@ Add ConvosCore tests:
   - body with `deviceId`, `siwe.message`, `siwe.signature`,
   - `X-Convos-AuthToken` for gated route.
 
-### 9. Manual proof checklist
+### 10. Manual proof checklist
 
 Prereqs:
 
@@ -334,7 +358,7 @@ Negative path:
 
 - Same screen, tap **Probe without auth** → `401 Missing auth token` on `/siwe-auth-check`.
 
-Failure-mode probes (optional; prove robustness, not required for Friday):
+Failure-mode probes (optional; prove robustness, not required for the initial proof):
 
 - Flip one hex char in the signature before sending → expect `401 Invalid SIWE`, and a follow-up clean run must still succeed (the failed signature already burned the previous nonce; the new run fetches a fresh one).
 - Delay 6 minutes between `/auth/nonce` and `/auth/token` → expect `401 Invalid nonce` (TTL expired).


### PR DESCRIPTION
## Summary

End-to-end SIWE (EIP-4361) authentication for the iOS client. Replaces the plan that originally opened this PR; the doc landed in commit `f2f90dc0` and the implementation followed.

**iOS work** (`docs/plans/authentication-api-siwe-ios.md` + code):
- `SIWEMessage` + `SIWESigner` (with `v`-byte normalization), `BackendAuthSigningContext` boundary so the API client doesn't import libxmtp.
- `ConvosAPIClient+SIWE.swift`: nonce fetch with a manual `Set-Cookie` parser (`__Host-`/`Secure` cookies are dropped by `HTTPCookieStorage` on `http://localhost`), accepts both `__Host-convos_nonce` and the relaxed dev form `convos_nonce`. `authenticateWithSIWE` retries from a fresh nonce on 401/rate-limited (1 retry; backend burns the nonce on every attempt).
- Normal authenticated request path now reads JWT in order **override → address-scoped SIWE slot → legacy slot**. `reAuthenticate` uses SIWE when a signing context is set, so 401 refresh can't silently downgrade to a device-only token.
- `SessionStateMachine.authenticateBackend()` loads the identity, registers the signing context with the API client, then runs SIWE. Legacy path retained as fallback for early boot.
- Address-scoped Keychain slot `KeychainAccount.siweJwt(deviceId:address:)` disjoint from the legacy slot.
- Debug screen `DebugAuthProbeView` for manual proof.

**Tests** (13 SIWE-specific, all pass): EIP-4361 byte-for-byte fixture; sign-then-recover roundtrip canary that guards the `v`-byte + EIP-191 invariants without round-tripping through the backend; cookie parsing for both prod and dev forms; SIWE/legacy slot disjointness; `jwtCarriesAccountId` classifier.

**Backend dependency**: `GET /api/v2/account-auth-check` (`authMiddleware + requireAccount`) — landed upstream as commit [`812c298`](https://github.com/xmtplabs/convos-backend/commit/812c2981ee4eedf5ce399d67c3a3e8f372ec000b) on `fbac/authentication-api` (Borja). No standalone backend PR needed from this side.

## Test plan

- [x] `ConvosCore` SIWE test suites pass (13 tests, including the v-byte recovery canary).
- [x] `Convos (Local)` scheme builds clean.
- [x] Live proof against a local backend running `fbac/authentication-api` + the App Check debug token already in `Secrets.swift`: open Debug → SIWE Auth Probe, tap **Run Auth Probe**, expect 200 from `/account-auth-check` with the JWT carrying `accountId`.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Sign-In with Ethereum (SIWE) authentication to replace legacy device-only auth
> - Implements a full SIWE (EIP-4361) auth flow in `ConvosAPIClient`: nonce request, message construction, secp256k1 signing with Ethereum-normalized recovery byte, token exchange, and address-scoped JWT storage in Keychain.
> - `SessionStateMachine` now builds a `BackendAuthSigningContext` from the on-device XMTP identity and calls `authenticateWithSIWE` when an identity is present, falling back to legacy device-only auth otherwise.
> - Adds `accountAuthCheck` endpoint (`GET /v2/account-auth-check`) to verify whether a JWT carries an `accountId` claim, distinguishing SIWE-authenticated sessions from legacy ones.
> - SIWE configuration (`domain`, `uri`, `chainId`) is added to all environment config files and propagated through `ConvosConfiguration` and `AppEnvironment`.
> - Adds a `DebugAuthProbeView` accessible from the debug screen to run a full SIWE auth round-trip against the backend and inspect results.
> - Risk: `ConfigManager.siweConfiguration` calls `fatalError` if SIWE fields are missing or invalid in `config.json`, causing a crash on misconfigured builds.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #827 opened
>
> - Added device-specific resource URI to SIWE authentication message [920f7f9]
> - Updated SIWE test fixtures to include device resource URI [920f7f9]
> - Implemented EIP-55 Ethereum address checksumming by adding `EthereumAddress.toChecksummed(_:)` static method that computes keccak256 hash over normalized address hex characters and uppercases nibbles where corresponding hash nibble is >= 8, accepting inputs with or without 0x prefix and passing through non-20-byte inputs unchanged, with `CryptoSwift` package dependency added to support the hashing [a05deb4]
> - Modified `BackendAuthSigningContext.make(from:)` factory method to wrap the private key's identity identifier with `EthereumAddress.toChecksummed(_:)` so the returned context exposes an EIP-55 checksummed address instead of lowercase [a05deb4]
> - Added warning log and comments in `ConvosAPIClient.reAuthenticate` when re-authentication proceeds without a SIWE signing context [5bf8506]
> - Added warning log and comments in `ConvosAPIClient.authenticate` when minting a JWT without SIWE context [5bf8506]
> - Added SIWE authentication status retrieval infrastructure to `BackendAuthProbe` [b1bc9a6]
> - Implemented accountId persistence to keychain during SIWE authentication [b1bc9a6]
> - Created debug UI for viewing and refreshing current SIWE authentication status [b1bc9a6]
> - Enhanced SIWE authentication logging in `SessionStateMachine` to include accountId [b1bc9a6]
> - Updated SIWE authentication documentation with clarified prerequisites and corrected example configuration values [7a4825b]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b5bbf1d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->