### PR TITLE
Render HTML thumbnails at the artifact's design viewport

### DIFF
--- a/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/HTMLThumbnailRenderer.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/HTMLThumbnailRenderer.swift
@@ -8,10 +8,15 @@ import WebKit
 final class HTMLThumbnailRenderer {
     static let shared: HTMLThumbnailRenderer = HTMLThumbnailRenderer()
 
-    private static let renderSize: CGSize = CGSize(width: 720, height: 1200)
+    // Matches the artifact's design viewport so `<meta name="viewport">`
+    // resolves to its intended logical width without WebKit's auto-scale
+    // kicking in. The PDF stays vector, so we rasterize at 2× below for
+    // retina sharpness in the chat cell.
+    private static let renderSize: CGSize = CGSize(width: 393, height: 655)
+    fileprivate static let rasterScale: CGFloat = 2.0
     fileprivate static let paintDelay: TimeInterval = 0.5
     private static let loadTimeout: TimeInterval = 15.0
-    private static let cacheKeyPrefix: String = "html-thumb-v3-"
+    private static let cacheKeyPrefix: String = "html-thumb-v4-"
     private static let injectionScript: String = """
     (function() {
         var css = 'html, body { margin-top: 0 !important; padding-top: 0 !important; } ' +
@@ -170,8 +175,11 @@ private final class LoadCoordinator: NSObject, WKNavigationDelegate {
         }
         // page.thumbnail draws onto an opaque white background, which matches
         // the prior takeSnapshot behavior for HTML that doesn't set its own
-        // body background.
-        let image = page.thumbnail(of: size, for: .mediaBox)
+        // body background. The PDF is vector, so 2× rasterization is free
+        // quality for retina displays.
+        let scale = HTMLThumbnailRenderer.rasterScale
+        let rasterSize = CGSize(width: size.width * scale, height: size.height * scale)
+        let image = page.thumbnail(of: rasterSize, for: .mediaBox)
         return image
     }
 


### PR DESCRIPTION
The renderer's WKWebView was sized 720×1200pt while the artifacts
declare <meta name="viewport" content="width=393, ..."> for a 393pt
design width. Detached from any UIWindowScene the auto-scale path
never fires, so layout happened at 720pt logical and the resulting
bitmap then aspect-fit into a ~393pt cell — shrinking fonts and
spacing by 0.546× and forcing a brittle CSS-transform workaround
on the artifact side to compensate.

Size the WebView at 393×655 so layout matches the design viewport
directly, and rasterize the vector PDF at 2× for retina sharpness
in the chat cell. Bump cache prefix to v4 so previously rendered
v3 thumbnails (at the wrong scale) are not served.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/828"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Render HTML thumbnails at the artifact's design viewport size with 2× rasterization
> - Changes `HTMLThumbnailRenderer.renderSize` from 720×1200 to 393×655 to match the artifact's design viewport.
> - Rasterizes at 2× scale via a new `rasterScale` constant, so output images are 786×1310 px.
> - Bumps `cacheKeyPrefix` to `html-thumb-v4-`, bypassing all previously cached thumbnails.
> - Behavioral Change: existing cached thumbnails are invalidated and will be regenerated on next access.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 12d7750.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->