### PR TITLE
add contact pills on contact picker during selection, visual tweaks

### DIFF
--- a/Convos/Contacts/ContactCardView.swift
+++ b/Convos/Contacts/ContactCardView.swift
@@ -7,21 +7,22 @@ import SwiftUI
 // in the app. It is invoked from two entry points, parameterized by
 // `ContactCardMode`:
 //
-//   1. **Contacts list** (`ContactsView`) → `mode: .standalone`. Default.
-//   2. **Member-avatar tap inside a chat** (`ConversationView` → presenting
-//      `presentingProfileForMember`) → `mode: .scopedToConversation(...)`.
+//   1. Contacts list (`ContactsView`) -> `mode: .standalone`. Default.
+//   2. Member-avatar tap inside a chat (`ConversationView` presents
+//      `presentingProfileForMember`) -> `mode: .scopedToConversation(...)`.
 //
 // Section visibility is driven by the mode plus the contact's stored state:
 //
-//   - Header (avatar / name) — always
-//   - Agent rows (Get skills / Learn about assistants) — both modes, when
+//   - Header (avatar / name) - always
+//   - Agent rows (Get skills / Learn about assistants) - both modes, when
 //     `contact.agentVerification?.isVerified == true`
-//   - Send a message — both modes, calls `contactsWriter.upsertContact(...)`
+//   - Pop up a convo - both modes; calls `contactsWriter.upsertContact(...)`
 //     before opening the picker so a synthetic / non-yet-stored contact is
 //     promoted to a real one (the narrow per-person upsert documented in
 //     the contacts PRD, "Send-message on a non-contact" section)
-//   - Block / Unblock — both modes
-//   - Group actions (Remove, Block-and-leave) — scoped mode only
+//   - Block / Unblock - both modes
+//   - Remove from convo - scoped mode only, when the viewer is an admin
+//     (`canRemoveMembers`) and the tapped member is not the current user
 //
 // Mirrors `ContactsPickerMode`'s "one component, two entry points" pattern.
 
@@ -34,12 +35,10 @@ struct ContactCardView: View {
     private let contactsRepository: any ContactsRepositoryProtocol
     private let session: (any SessionManagerProtocol)?
     private let onRemove: (() -> Void)?
-    private let onBlockAndLeave: (() -> Void)?
 
     @State private var isBlocked: Bool
     @State private var isApplyingBlockChange: Bool = false
     @State private var presentingBlockConfirmation: Bool = false
-    @State private var presentingBlockAndLeaveConfirmation: Bool = false
     @State private var presentingPicker: Bool = false
     @State private var presentingSendMessageError: Bool = false
     @State private var sendMessageErrorMessage: String?
@@ -50,8 +49,7 @@ struct ContactCardView: View {
         contactsWriter: any ContactsWriterProtocol,
         contactsRepository: any ContactsRepositoryProtocol,
         session: (any SessionManagerProtocol)? = nil,
-        onRemove: (() -> Void)? = nil,
-        onBlockAndLeave: (() -> Void)? = nil
+        onRemove: (() -> Void)? = nil
     ) {
         self.contact = contact
         self.mode = mode
@@ -59,7 +57,6 @@ struct ContactCardView: View {
         self.contactsRepository = contactsRepository
         self.session = session
         self.onRemove = onRemove
-        self.onBlockAndLeave = onBlockAndLeave
         _isBlocked = State(initialValue: contact.isBlocked)
     }
 
@@ -67,20 +64,16 @@ struct ContactCardView: View {
         bodyContent
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .background(.colorBackgroundRaisedSecondary)
-            .navigationTitle("Contact")
+            .navigationTitle("")
             .navigationBarTitleDisplayMode(.inline)
             .modifier(ContactCardModalsModifier(
                 presentingBlockConfirmation: $presentingBlockConfirmation,
-                presentingBlockAndLeaveConfirmation: $presentingBlockAndLeaveConfirmation,
                 presentingPicker: $presentingPicker,
                 presentingSendMessageError: $presentingSendMessageError,
                 sendMessageErrorMessage: sendMessageErrorMessage,
                 blockAlertTitle: blockAlertTitle,
                 blockAlertMessage: blockAlertMessage,
                 blockAlertActions: { blockAlertActions },
-                blockAndLeaveAlertTitle: blockAndLeaveAlertTitle,
-                blockAndLeaveAlertMessage: blockAndLeaveAlertMessage,
-                blockAndLeaveAlertActions: { blockAndLeaveAlertActions },
                 pickerSheet: { pickerSheet }
             ))
             .task(id: contact.inboxId) { await syncBlockedState() }
@@ -89,8 +82,10 @@ struct ContactCardView: View {
     @ViewBuilder
     private var bodyContent: some View {
         VStack(spacing: DesignConstants.Spacing.step3x) {
-            ContactCardHeader(contact: contact)
-            ContactCardMetadata(addedAt: contact.addedAt, isBlocked: isBlocked)
+            VStack(spacing: DesignConstants.Spacing.stepX) {
+                ContactCardHeader(contact: contact)
+                ContactCardMetadata(addedAt: contact.addedAt, isBlocked: isBlocked)
+            }
             if isVerifiedAgent {
                 ContactCardAgentLinks()
             }
@@ -98,20 +93,19 @@ struct ContactCardView: View {
                 isBlocked: isBlocked,
                 isApplyingBlockChange: isApplyingBlockChange,
                 // Verified agents (Convos / OAuth-verified) don't accept
-                // 1:1 DMs today, so the Send-a-message CTA would open a
+                // 1:1 DMs today, so the Pop-up-a-convo CTA would open a
                 // conversation that goes nowhere. Disable until DM support
                 // for agents lands; the "Get skills" / "Learn about
                 // assistants" rows above remain the right way to interact.
                 canSendMessage: session != nil && !isVerifiedAgent,
+                contactDisplayName: contact.resolvedDisplayName,
                 onSendMessage: handleSendMessage,
                 onToggleBlock: handleBlockTap
             )
-            if mode.isScopedToConversation && !mode.isCurrentUser {
+            if mode.isScopedToConversation && !mode.isCurrentUser && mode.canRemoveMembers {
                 ContactCardGroupActions(
-                    canRemoveMembers: mode.canRemoveMembers,
                     contactDisplayName: contact.resolvedDisplayName,
-                    onRemove: handleRemoveTap,
-                    onBlockAndLeave: handleBlockAndLeaveTap
+                    onRemove: handleRemoveTap
                 )
             }
             Spacer()
@@ -157,22 +151,6 @@ struct ContactCardView: View {
         } else {
             Button("Block", role: .destructive, action: handleBlockConfirmed)
         }
-    }
-
-    // MARK: - Block-and-leave alert content
-
-    private var blockAndLeaveAlertTitle: String {
-        "Block \(contact.resolvedDisplayName) and leave convo?"
-    }
-
-    private var blockAndLeaveAlertMessage: String {
-        "They won't know they're blocked, and you'll leave this conversation so they can't reach you here."
-    }
-
-    @ViewBuilder
-    private var blockAndLeaveAlertActions: some View {
-        Button("Cancel", role: .cancel) {}
-        Button("Confirm", role: .destructive, action: handleBlockAndLeaveConfirmed)
     }
 
     // MARK: - Actions
@@ -229,14 +207,6 @@ struct ContactCardView: View {
         onRemove?()
     }
 
-    private func handleBlockAndLeaveTap() {
-        presentingBlockAndLeaveConfirmation = true
-    }
-
-    private func handleBlockAndLeaveConfirmed() {
-        onBlockAndLeave?()
-    }
-
     private func applyBlockChange(block: Bool) {
         guard !isApplyingBlockChange else { return }
         isApplyingBlockChange = true
@@ -287,11 +257,11 @@ private struct ContactCardHeader: View {
     var body: some View {
         VStack(spacing: DesignConstants.Spacing.step2x) {
             ContactAvatarView(contact: contact)
-                .frame(width: 96.0, height: 96.0)
+                .frame(width: 140.0, height: 140.0)
                 .padding(.top, DesignConstants.Spacing.step6x)
 
             Text(contact.resolvedDisplayName)
-                .font(.title2.weight(.semibold))
+                .font(.largeTitle.weight(.bold))
                 .foregroundStyle(.colorTextPrimary)
 
             if let roleLabel = contact.agentVerification?.roleLabel {
@@ -315,32 +285,32 @@ private struct ContactCardMetadata: View {
 
     var body: some View {
         VStack(spacing: DesignConstants.Spacing.stepX) {
-            HStack {
-                Text("Added")
-                    .foregroundStyle(.colorTextSecondary)
-                Spacer()
-                Text(addedAt.formatted(date: .abbreviated, time: .omitted))
-                    .foregroundStyle(.colorTextPrimary)
-            }
+            Text("Added \(relativeAddedAt)")
+                .foregroundStyle(.colorTextSecondary)
             if isBlocked {
                 blockedRow
             }
         }
         .font(.subheadline)
-        .padding(DesignConstants.Spacing.step3x)
+        .frame(maxWidth: .infinity)
+        .padding(.horizontal, DesignConstants.Spacing.step3x)
+    }
+
+    /// Mirrors the `RelativeDateTimeFormatter(.abbreviated)` convention from
+    /// `ConversationMemberView`'s "Added X by Y" subtitle so the contact card
+    /// reads the same way ("Added 20m ago", "Added 3h ago", "Added 2w ago").
+    private var relativeAddedAt: String {
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .abbreviated
+        return formatter.localizedString(for: addedAt, relativeTo: Date())
     }
 
     private var blockedRow: some View {
-        HStack {
-            Text("Status")
-                .foregroundStyle(.colorTextSecondary)
-            Spacer()
-            HStack(spacing: 4.0) {
-                Image(systemName: "nosign")
-                Text("Blocked")
-            }
-            .foregroundStyle(.colorCaution)
+        HStack(spacing: 4.0) {
+            Image(systemName: "nosign")
+            Text("Blocked")
         }
+        .foregroundStyle(.colorCaution)
     }
 }
 
@@ -404,104 +374,106 @@ private struct ContactCardActions: View {
     let isBlocked: Bool
     let isApplyingBlockChange: Bool
     let canSendMessage: Bool
+    let contactDisplayName: String
     let onSendMessage: () -> Void
     let onToggleBlock: () -> Void
 
     var body: some View {
-        VStack(spacing: DesignConstants.Spacing.step2x) {
-            sendMessageButton
-            blockButton
+        VStack(spacing: DesignConstants.Spacing.step4x) {
+            popUpConvoRow
+            blockRow
         }
         .padding(.horizontal, DesignConstants.Spacing.step4x)
+        .padding(.top, DesignConstants.Spacing.step4x)
     }
 
-    private var sendMessageButton: some View {
-        let foreground: Color = canSendMessage ? .colorTextPrimaryInverted : .colorTextTertiary
-        let background: Color = canSendMessage ? .colorTextPrimary : .colorFillMinimal
-        return Button(action: onSendMessage) {
-            Label("Send a message", systemImage: "paperplane.fill")
-                .font(.body.weight(.semibold))
-                .foregroundStyle(foreground)
-                .frame(maxWidth: .infinity)
-                .padding(.vertical, DesignConstants.Spacing.step3x)
-                .background(
-                    RoundedRectangle(cornerRadius: 22.0)
-                        .fill(background)
-                )
-        }
-        .disabled(!canSendMessage)
-        .accessibilityIdentifier("contact-card-send-message")
+    private var popUpConvoRow: some View {
+        ContactCardActionRow(
+            label: "Pop up a convo",
+            footer: "Message \(contactDisplayName)",
+            color: .colorTextPrimary,
+            isDisabled: !canSendMessage,
+            accessibilityLabel: "Pop up a convo with \(contactDisplayName)",
+            accessibilityIdentifier: "contact-card-send-message",
+            action: onSendMessage
+        )
     }
 
-    private var blockButton: some View {
+    private var blockRow: some View {
         let label: String = isBlocked ? "Unblock" : "Block"
-        let foreground: Color = isBlocked ? .colorTextPrimary : .colorCaution
-        return Button(action: onToggleBlock) {
-            Text(label)
-                .font(.body.weight(.medium))
-                .foregroundStyle(foreground)
-                .frame(maxWidth: .infinity)
-                .padding(.vertical, DesignConstants.Spacing.step3x)
-                .background(
-                    RoundedRectangle(cornerRadius: 22.0)
-                        .stroke(foreground.opacity(0.4), lineWidth: 1.0)
-                )
-        }
-        .disabled(isApplyingBlockChange)
-        .accessibilityIdentifier(isBlocked ? "contact-card-unblock" : "contact-card-block")
+        let footer: String = isBlocked
+            ? "Start receiving convo invites from \(contactDisplayName) again"
+            : "Block all future convo invites from \(contactDisplayName)"
+        let identifier: String = isBlocked ? "contact-card-unblock" : "contact-card-block"
+        return ContactCardActionRow(
+            label: label,
+            footer: footer,
+            color: .colorCaution,
+            isDisabled: isApplyingBlockChange,
+            accessibilityLabel: "\(label) \(contactDisplayName)",
+            accessibilityIdentifier: identifier,
+            action: onToggleBlock
+        )
     }
 }
 
 // MARK: - Group actions (scoped mode only)
 
+/// Renders conversation-scoped actions on the contact card. Today only
+/// "Remove" lives here; it appears when the viewer is an admin who can
+/// remove the tapped member. The plain Block row (above, in
+/// `ContactCardActions`) covers the block intent in every mode, so this
+/// view stays focused on conversation-scope-specific affordances.
 private struct ContactCardGroupActions: View {
-    let canRemoveMembers: Bool
     let contactDisplayName: String
     let onRemove: () -> Void
-    let onBlockAndLeave: () -> Void
 
     var body: some View {
-        VStack(spacing: DesignConstants.Spacing.step2x) {
-            if canRemoveMembers {
-                groupActionRow(
-                    label: "Remove from convo",
-                    footer: "Remove \(contactDisplayName) from this conversation",
-                    accessibilityLabel: "Remove \(contactDisplayName)",
-                    accessibilityIdentifier: "remove-member-button",
-                    action: onRemove
-                )
-            }
-            groupActionRow(
-                label: "Block and leave",
-                footer: "Leave this convo and block \(contactDisplayName)",
-                accessibilityLabel: "Block \(contactDisplayName)",
-                accessibilityIdentifier: "block-member-button",
-                action: onBlockAndLeave
-            )
-        }
+        ContactCardActionRow(
+            label: "Remove",
+            footer: "Remove \(contactDisplayName) from the convo",
+            color: .colorCaution,
+            isDisabled: false,
+            accessibilityLabel: "Remove \(contactDisplayName)",
+            accessibilityIdentifier: "remove-member-button",
+            action: onRemove
+        )
         .padding(.horizontal, DesignConstants.Spacing.step4x)
         .padding(.top, DesignConstants.Spacing.step2x)
     }
+}
 
-    private func groupActionRow(
-        label: String,
-        footer: String,
-        accessibilityLabel: String,
-        accessibilityIdentifier: String,
-        action: @escaping () -> Void
-    ) -> some View {
-        VStack(alignment: .leading, spacing: 4.0) {
+// MARK: - Shared action row
+
+/// Reusable row used by both `ContactCardActions` (Pop up a convo, Block)
+/// and `ContactCardGroupActions` (Remove, Block and leave). The shape -
+/// rounded white pill on top with a small grey footer caption below - is
+/// the canonical card action style. The label color is the only knob: dark
+/// primary for affirmative actions, caution red for destructive.
+private struct ContactCardActionRow: View {
+    let label: String
+    let footer: String
+    let color: Color
+    let isDisabled: Bool
+    let accessibilityLabel: String
+    let accessibilityIdentifier: String
+    let action: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: DesignConstants.Spacing.stepX) {
             Button(action: action) {
                 Text(label)
-                    .font(.body)
-                    .foregroundStyle(.colorCaution)
+                    .font(.body.weight(.medium))
+                    .foregroundStyle(color)
                     .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(.vertical, DesignConstants.Spacing.step2x)
+                    .padding(.vertical, DesignConstants.Spacing.step4x)
                     .padding(.horizontal, DesignConstants.Spacing.step3x)
                     .background(
                         RoundedRectangle(cornerRadius: 12.0).fill(.colorFillMinimal)
                     )
             }
+            .buttonStyle(.plain)
+            .disabled(isDisabled)
             .accessibilityLabel(accessibilityLabel)
             .accessibilityIdentifier(accessibilityIdentifier)
             Text(footer)
@@ -516,20 +488,15 @@ private struct ContactCardGroupActions: View {
 
 private struct ContactCardModalsModifier<
     BlockActions: View,
-    BlockLeaveActions: View,
     PickerContent: View
 >: ViewModifier {
     @Binding var presentingBlockConfirmation: Bool
-    @Binding var presentingBlockAndLeaveConfirmation: Bool
     @Binding var presentingPicker: Bool
     @Binding var presentingSendMessageError: Bool
     let sendMessageErrorMessage: String?
     let blockAlertTitle: String
     let blockAlertMessage: String
     let blockAlertActions: () -> BlockActions
-    let blockAndLeaveAlertTitle: String
-    let blockAndLeaveAlertMessage: String
-    let blockAndLeaveAlertActions: () -> BlockLeaveActions
     let pickerSheet: () -> PickerContent
 
     func body(content: Content) -> some View {
@@ -538,11 +505,6 @@ private struct ContactCardModalsModifier<
                 blockAlertActions()
             } message: {
                 Text(blockAlertMessage)
-            }
-            .alert(blockAndLeaveAlertTitle, isPresented: $presentingBlockAndLeaveConfirmation) {
-                blockAndLeaveAlertActions()
-            } message: {
-                Text(blockAndLeaveAlertMessage)
             }
             .alert(
                 "Couldn't open message picker",
@@ -664,8 +626,7 @@ extension Contact {
             ),
             contactsWriter: MockContactsWriter(),
             contactsRepository: MockContactsRepository(),
-            onRemove: {},
-            onBlockAndLeave: {}
+            onRemove: {}
         )
     }
 }

--- a/Convos/Contacts/ContactsPickerSelectedPills.swift
+++ b/Convos/Contacts/ContactsPickerSelectedPills.swift
@@ -1,0 +1,233 @@
+import ConvosCore
+import SwiftUI
+
+// MARK: - Module overview
+//
+// `ContactsPickerSelectedPills` renders the row of selected-contact pills
+// that sits directly below the `ContactsPickerSearchBar` in
+// `ContactsPickerView`. Each pill shows the contact's avatar and display
+// name with a trailing x hint; tapping anywhere on the pill removes the
+// contact from the selection. Pills wrap to multiple rows when they
+// overflow the available width (via the private `SelectedPillsFlowLayout`
+// below), so the full selection is always visible.
+//
+// The view is presentation-only: `contacts` (the current selection) and
+// `onRemove` (the deselect callback) come from the caller. It renders
+// nothing when `contacts` is empty so the search bar sits flush against
+// the list.
+
+/// Wrapping row of selected-contact pills shown below the picker search bar.
+/// Tapping anywhere on a pill removes the contact from the selection.
+struct ContactsPickerSelectedPills: View {
+    let contacts: [Contact]
+    let onRemove: (String) -> Void
+
+    var body: some View {
+        if !contacts.isEmpty {
+            SelectedPillsFlowLayout(
+                horizontalSpacing: DesignConstants.Spacing.step2x,
+                verticalSpacing: DesignConstants.Spacing.step2x
+            ) {
+                ForEach(contacts, id: \.inboxId) { contact in
+                    SelectedContactPill(
+                        contact: contact,
+                        onRemove: removeAction(for: contact.inboxId)
+                    )
+                }
+            }
+            .padding(.horizontal, DesignConstants.Spacing.step3x)
+            .padding(.bottom, DesignConstants.Spacing.step2x)
+            .accessibilityIdentifier("contacts-picker-selected-pills")
+        }
+    }
+
+    private func removeAction(for inboxId: String) -> () -> Void {
+        { onRemove(inboxId) }
+    }
+}
+
+// MARK: - Pill
+
+private struct SelectedContactPill: View {
+    let contact: Contact
+    let onRemove: () -> Void
+
+    var body: some View {
+        Button(action: onRemove) {
+            HStack(spacing: DesignConstants.Spacing.step3x) {
+                ContactAvatarView(contact: contact)
+                    .frame(width: Constant.avatarSize, height: Constant.avatarSize)
+
+                Text(truncatedDisplayName)
+                    .font(.subheadline.weight(.medium))
+                    .foregroundStyle(.colorTextPrimaryInverted)
+                    .lineLimit(1)
+
+                Image(systemName: "xmark.circle.fill")
+                    .font(.subheadline)
+                    .foregroundStyle(.colorTextPrimaryInverted.opacity(Constant.removeIconOpacity))
+            }
+            .padding(.leading, DesignConstants.Spacing.step2x)
+            .padding(.trailing, DesignConstants.Spacing.step3x)
+            .padding(.vertical, DesignConstants.Spacing.step2x)
+            .background(
+                Capsule().fill(.colorTextPrimary)
+            )
+            .contentShape(Capsule())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Remove \(contact.resolvedDisplayName)")
+        .accessibilityIdentifier("contacts-picker-pill-\(contact.inboxId)")
+    }
+
+    /// Caps the pill's visible name so the trailing x stays in-bounds even
+    /// for unusually long display names. The cap is character-based (rather
+    /// than width-based) for predictable layout across locales and dynamic
+    /// type sizes; tune `Constant.maxDisplayNameLength` to widen or tighten.
+    private var truncatedDisplayName: String {
+        let name = contact.resolvedDisplayName
+        let limit = Constant.maxDisplayNameLength
+        guard name.count > limit else { return name }
+        return String(name.prefix(limit - 1)) + "\u{2026}"
+    }
+
+    private enum Constant {
+        static let avatarSize: CGFloat = 24.0
+        static let removeIconOpacity: Double = 0.6
+        static let maxDisplayNameLength: Int = 20
+    }
+}
+
+// MARK: - Layout
+
+/// Private wrapping layout used by `ContactsPickerSelectedPills` to flow
+/// pills onto multiple rows when they overflow the available width. Kept
+/// private because the project's shared `FlowLayout` (in `Shared Views/`)
+/// is excluded from the Convos target's build; this duplicates just the
+/// behavior we need.
+private struct SelectedPillsFlowLayout: Layout {
+    var horizontalSpacing: CGFloat
+    var verticalSpacing: CGFloat
+
+    func sizeThatFits(
+        proposal: ProposedViewSize,
+        subviews: Subviews,
+        cache: inout ()
+    ) -> CGSize {
+        let maxWidth: CGFloat = proposal.width ?? .infinity
+        var rowWidth: CGFloat = 0.0
+        var totalHeight: CGFloat = 0.0
+        var rowHeight: CGFloat = 0.0
+        var hasItemOnRow: Bool = false
+
+        for subview in subviews {
+            let size: CGSize = subview.sizeThatFits(.unspecified)
+            let needsWrap: Bool = hasItemOnRow && (rowWidth + horizontalSpacing + size.width > maxWidth)
+            if needsWrap {
+                totalHeight += rowHeight + verticalSpacing
+                rowWidth = size.width
+                rowHeight = size.height
+                hasItemOnRow = true
+            } else {
+                if hasItemOnRow {
+                    rowWidth += horizontalSpacing
+                }
+                rowWidth += size.width
+                rowHeight = max(rowHeight, size.height)
+                hasItemOnRow = true
+            }
+        }
+
+        let resolvedWidth: CGFloat = proposal.width ?? rowWidth
+        return CGSize(width: resolvedWidth, height: totalHeight + rowHeight)
+    }
+
+    func placeSubviews(
+        in bounds: CGRect,
+        proposal: ProposedViewSize,
+        subviews: Subviews,
+        cache: inout ()
+    ) {
+        let maxX: CGFloat = bounds.maxX
+        var x: CGFloat = bounds.minX
+        var y: CGFloat = bounds.minY
+        var rowHeight: CGFloat = 0.0
+        var hasItemOnRow: Bool = false
+
+        for subview in subviews {
+            let size: CGSize = subview.sizeThatFits(.unspecified)
+            let needsWrap: Bool = hasItemOnRow && (x + horizontalSpacing + size.width > maxX)
+            if needsWrap {
+                x = bounds.minX
+                y += rowHeight + verticalSpacing
+                rowHeight = 0.0
+                hasItemOnRow = false
+            }
+            if hasItemOnRow {
+                x += horizontalSpacing
+            }
+            subview.place(
+                at: CGPoint(x: x, y: y),
+                anchor: .topLeading,
+                proposal: ProposedViewSize(size)
+            )
+            x += size.width
+            rowHeight = max(rowHeight, size.height)
+            hasItemOnRow = true
+        }
+    }
+}
+
+// MARK: - Previews
+
+#Preview("Few pills") {
+    ContactsPickerSelectedPills(
+        contacts: [
+            .mock(displayName: "Zed"),
+            .mock(displayName: "Andy"),
+        ],
+        onRemove: { _ in }
+    )
+    .padding()
+    .background(.colorBackgroundRaisedSecondary)
+}
+
+#Preview("Many pills (wrap)") {
+    ContactsPickerSelectedPills(
+        contacts: [
+            .mock(displayName: "Alice"),
+            .mock(displayName: "Bob"),
+            .mock(displayName: "Carol"),
+            .mock(displayName: "Daniel"),
+            .mock(displayName: "Evelyn"),
+            .mock(displayName: "Frederick"),
+            .mock(displayName: "Genevieve"),
+            .mock(displayName: "Hieronymus"),
+        ],
+        onRemove: { _ in }
+    )
+    .padding()
+    .background(.colorBackgroundRaisedSecondary)
+}
+
+#Preview("Empty (renders nothing)") {
+    ContactsPickerSelectedPills(
+        contacts: [],
+        onRemove: { _ in }
+    )
+    .padding()
+    .background(.colorBackgroundRaisedSecondary)
+}
+
+#Preview("Long names truncate") {
+    ContactsPickerSelectedPills(
+        contacts: [
+            .mock(displayName: "Alice"),
+            .mock(displayName: "Fitzwilliam-Bartholomew Maximilian Featherington"),
+            .mock(displayName: "Rumpelstiltskin"),
+        ],
+        onRemove: { _ in }
+    )
+    .padding()
+    .background(.colorBackgroundRaisedSecondary)
+}

--- a/Convos/Contacts/ContactsPickerView.swift
+++ b/Convos/Contacts/ContactsPickerView.swift
@@ -62,8 +62,11 @@ struct ContactsPickerView: View {
     @ViewBuilder
     private var content: some View {
         VStack(spacing: 0.0) {
-            ContactsPickerSubtitle(text: viewModel.subtitleText)
             ContactsPickerSearchBar(query: $viewModel.searchQuery)
+            ContactsPickerSelectedPills(
+                contacts: viewModel.selectedContacts,
+                onRemove: handleRemove
+            )
             ContactsPickerList(
                 viewModel: viewModel,
                 onToggle: handleToggle
@@ -89,6 +92,10 @@ struct ContactsPickerView: View {
         viewModel.toggleSelection(for: inboxId)
     }
 
+    private func handleRemove(_ inboxId: String) {
+        viewModel.deselect(inboxId: inboxId)
+    }
+
     private func handleConfirm() {
         let ids = viewModel.selectedInboxIds
         guard !ids.isEmpty else { return }
@@ -98,21 +105,6 @@ struct ContactsPickerView: View {
 
     private func handleCancel() {
         dismiss()
-    }
-}
-
-// MARK: - Subtitle
-
-private struct ContactsPickerSubtitle: View {
-    let text: String
-
-    var body: some View {
-        Text(text)
-            .font(.footnote)
-            .foregroundStyle(.colorTextSecondary)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(.horizontal, DesignConstants.Spacing.step3x)
-            .padding(.vertical, DesignConstants.Spacing.stepX)
     }
 }
 
@@ -277,6 +269,26 @@ private struct ContactsPickerConfirmButton: View {
     ContactsPickerView(
         mode: .newConversation,
         contactsRepository: MockContactsRepository(contacts: []),
+        onConfirm: { _ in }
+    )
+}
+
+#Preview("Many pills wrap") {
+    let contacts: [Contact] = [
+        .mock(displayName: "Alice"),
+        .mock(displayName: "Bob"),
+        .mock(displayName: "Carol"),
+        .mock(displayName: "Daniel"),
+        .mock(displayName: "Evelyn"),
+        .mock(displayName: "Frederick"),
+        .mock(displayName: "Genevieve"),
+        .mock(displayName: "Hieronymus"),
+    ]
+    let preselected: Set<String> = Set(contacts.map(\.inboxId))
+    return ContactsPickerView(
+        mode: .newConversation,
+        contactsRepository: MockContactsRepository(contacts: contacts),
+        preselectedInboxIds: preselected,
         onConfirm: { _ in }
     )
 }

--- a/Convos/Contacts/ContactsPickerView.swift
+++ b/Convos/Contacts/ContactsPickerView.swift
@@ -53,7 +53,6 @@ struct ContactsPickerView: View {
         NavigationStack {
             content
                 .background(.colorBackgroundRaisedSecondary)
-                .navigationTitle(viewModel.headerTitle)
                 .navigationBarTitleDisplayMode(.inline)
                 .toolbar { toolbarContent }
         }
@@ -62,7 +61,11 @@ struct ContactsPickerView: View {
     @ViewBuilder
     private var content: some View {
         VStack(spacing: 0.0) {
-            ContactsPickerSearchBar(query: $viewModel.searchQuery)
+            ContactsSearchBar(
+                query: $viewModel.searchQuery,
+                placeholder: "Contacts",
+                accessibilityIdentifier: "contacts-picker-search-field"
+            )
             ContactsPickerSelectedPills(
                 contacts: viewModel.selectedContacts,
                 onRemove: handleRemove
@@ -82,7 +85,13 @@ struct ContactsPickerView: View {
     @ToolbarContentBuilder
     private var toolbarContent: some ToolbarContent {
         ToolbarItem(placement: .cancellationAction) {
-            Button("Cancel", action: handleCancel)
+            Button(role: .cancel, action: handleCancel)
+        }
+        ToolbarItem(placement: .principal) {
+            ContactsPickerTitlePill(
+                title: viewModel.pillTitle,
+                subtitle: viewModel.pillSubtitle
+            )
         }
     }
 
@@ -108,40 +117,35 @@ struct ContactsPickerView: View {
     }
 }
 
-// MARK: - Search bar
+// MARK: - Title pill
 
-private struct ContactsPickerSearchBar: View {
-    @Binding var query: String
+/// Elevated capsule shown in the navigation bar's principal slot. Two-line
+/// layout: pill title on top ("New convo" / "Add to convo"), member-count
+/// subtitle below. Replaces the standard nav title to match the design.
+private struct ContactsPickerTitlePill: View {
+    let title: String
+    let subtitle: String
 
     var body: some View {
-        HStack(spacing: DesignConstants.Spacing.step2x) {
-            Image(systemName: "magnifyingglass")
-                .foregroundStyle(.colorTextTertiary)
-            TextField("Search contacts", text: $query)
-                .textFieldStyle(.plain)
-                .autocorrectionDisabled()
-                .textInputAutocapitalization(.never)
-                .accessibilityIdentifier("contacts-picker-search-field")
-            if !query.isEmpty {
-                Button(action: clearAction) {
-                    Image(systemName: "xmark.circle.fill")
-                        .foregroundStyle(.colorTextTertiary)
-                }
-                .accessibilityLabel("Clear search")
-            }
+        VStack(spacing: 0.0) {
+            Text(title)
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(.colorTextPrimary)
+            Text(subtitle)
+                .font(.caption2)
+                .foregroundStyle(.colorTextSecondary)
         }
         .padding(.horizontal, DesignConstants.Spacing.step3x)
-        .padding(.vertical, DesignConstants.Spacing.step2x)
+        .padding(.vertical, DesignConstants.Spacing.stepX)
         .background(
-            RoundedRectangle(cornerRadius: 16.0)
-                .fill(.colorFillMinimal)
+            Capsule().fill(.colorBackgroundRaisedSecondary)
         )
-        .padding(.horizontal, DesignConstants.Spacing.step3x)
-        .padding(.bottom, DesignConstants.Spacing.step2x)
-    }
-
-    private var clearAction: () -> Void {
-        { query = "" }
+        .overlay(
+            Capsule().stroke(.colorTextTertiary.opacity(0.15), lineWidth: 0.5)
+        )
+        .shadow(color: .black.opacity(0.08), radius: 6.0, x: 0.0, y: 2.0)
+        .accessibilityElement(children: .combine)
+        .accessibilityIdentifier("contacts-picker-title-pill")
     }
 }
 
@@ -171,6 +175,7 @@ private struct ContactsPickerList: View {
                             onTap: rowTapAction(for: row)
                         )
                         .listRowBackground(Color.clear)
+                        .listRowSeparator(.hidden)
                     }
                 }
             }
@@ -233,9 +238,9 @@ private struct ContactsPickerConfirmButton: View {
                 .font(.body.weight(.semibold))
                 .foregroundStyle(.colorTextPrimaryInverted)
                 .frame(maxWidth: .infinity)
-                .padding(.vertical, DesignConstants.Spacing.step3x)
+                .padding(.vertical, DesignConstants.Spacing.step6x)
                 .background(
-                    RoundedRectangle(cornerRadius: 22.0)
+                    RoundedRectangle(cornerRadius: 32.0)
                         .fill(.colorTextPrimary.opacity(backgroundOpacity))
                 )
         }

--- a/Convos/Contacts/ContactsPickerViewModel.swift
+++ b/Convos/Contacts/ContactsPickerViewModel.swift
@@ -104,21 +104,12 @@ final class ContactsPickerViewModel {
         }
     }
 
-    var subtitleText: String {
-        let count = selectionCount
-        if count == 0 {
-            return "Tap to select"
-        }
-        return "\(count) selected · tap to add or remove"
-    }
-
     var confirmButtonTitle: String {
-        let count = selectionCount
         switch mode {
         case .newConversation:
-            return count == 1 ? "Start conversation" : "Start group"
+            return "Start a convo"
         case .addToConversation:
-            return "Add \(count) to convo"
+            return "Add \(selectionCount) to convo"
         }
     }
 

--- a/Convos/Contacts/ContactsPickerViewModel.swift
+++ b/Convos/Contacts/ContactsPickerViewModel.swift
@@ -104,13 +104,36 @@ final class ContactsPickerViewModel {
         }
     }
 
-    var confirmButtonTitle: String {
+    /// Top-line text for the elevated pill in the picker toolbar. Mirrors the
+    /// "New convo" / "Add to convo" framing used in the existing UI copy.
+    var pillTitle: String {
         switch mode {
         case .newConversation:
-            return "Start a convo"
-        case .addToConversation:
-            return "Add \(selectionCount) to convo"
+            return "New convo"
+        case .addToConversation(_, let title):
+            if let title, !title.isEmpty {
+                return "Add to \(title)"
+            }
+            return "Add to convo"
         }
+    }
+
+    /// Subtitle inside the elevated pill. For new conversations the local user
+    /// is implicit, so the total membership count is `selectionCount + 1`. For
+    /// the add-to-conversation flow we only count members being added since the
+    /// existing chat membership is already known to the user.
+    var pillSubtitle: String {
+        switch mode {
+        case .newConversation:
+            let total = selectionCount + 1
+            return "\(total) \(total == 1 ? "member" : "members")"
+        case .addToConversation:
+            return "\(selectionCount) selected"
+        }
+    }
+
+    var confirmButtonTitle: String {
+        "Continue"
     }
 
     // MARK: - Mutations

--- a/Convos/Contacts/ContactsSearchBar.swift
+++ b/Convos/Contacts/ContactsSearchBar.swift
@@ -1,0 +1,55 @@
+import ConvosCore
+import SwiftUI
+
+/// Shared search-bar component used by both the contacts list (`ContactsView`)
+/// and the contacts picker (`ContactsPickerView`). The two surfaces only
+/// differ in placeholder copy, so the styling lives here and the placeholder
+/// is the single configurable knob.
+///
+/// Visually: a pill-shaped capsule filled with `.colorFillMinimal`, with the
+/// text field on the left and a clear-X button on the right that only appears
+/// once the user has typed something.
+struct ContactsSearchBar: View {
+    @Binding var query: String
+    let placeholder: String
+    let accessibilityIdentifier: String
+
+    init(
+        query: Binding<String>,
+        placeholder: String,
+        accessibilityIdentifier: String
+    ) {
+        self._query = query
+        self.placeholder = placeholder
+        self.accessibilityIdentifier = accessibilityIdentifier
+    }
+
+    var body: some View {
+        HStack(spacing: DesignConstants.Spacing.step2x) {
+            TextField(placeholder, text: $query)
+                .textFieldStyle(.plain)
+                .autocorrectionDisabled()
+                .textInputAutocapitalization(.never)
+                .accessibilityIdentifier(accessibilityIdentifier)
+            if !query.isEmpty {
+                Button(action: clearAction) {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundStyle(.colorTextTertiary)
+                }
+                .accessibilityLabel("Clear search")
+            }
+        }
+        .padding(.horizontal, DesignConstants.Spacing.step3x)
+        .padding(.vertical, DesignConstants.Spacing.step2x)
+        .background(
+            RoundedRectangle(cornerRadius: 16.0)
+                .fill(.colorFillMinimal)
+        )
+        .padding(.horizontal, DesignConstants.Spacing.step3x)
+        .padding(.bottom, DesignConstants.Spacing.step2x)
+    }
+
+    private var clearAction: () -> Void {
+        { query = "" }
+    }
+}

--- a/Convos/Contacts/ContactsView.swift
+++ b/Convos/Contacts/ContactsView.swift
@@ -25,7 +25,7 @@ struct ContactsView: View {
             if viewModel.contactCount == 0 {
                 emptyState
             } else {
-                contactList
+                contactsContent
             }
         }
         .navigationTitle("Contacts")
@@ -37,10 +37,23 @@ struct ContactsView: View {
     // MARK: - List
 
     @ViewBuilder
+    private var contactsContent: some View {
+        VStack(spacing: 0.0) {
+            ContactsSearchBar(
+                query: $viewModel.searchQuery,
+                placeholder: "Search",
+                accessibilityIdentifier: "contacts-search-field"
+            )
+            contactList
+        }
+        .background(.colorBackgroundRaisedSecondary)
+    }
+
+    @ViewBuilder
     private var contactList: some View {
         List {
             ForEach(viewModel.sections) { section in
-                Section(header: Text(section.title)) {
+                Section(header: ContactsListSectionHeader(title: section.title)) {
                     ForEach(section.contacts) { contact in
                         NavigationLink {
                             ContactCardView(
@@ -52,13 +65,19 @@ struct ContactsView: View {
                         } label: {
                             ContactRowView(contact: contact)
                         }
+                        .listRowBackground(Color.clear)
+                        .listRowSeparator(.hidden)
                     }
                 }
             }
         }
-        .listStyle(.insetGrouped)
+        .listStyle(.plain)
         .scrollContentBackground(.hidden)
-        .background(.colorBackgroundRaisedSecondary)
+        .background(
+            RoundedRectangle(cornerRadius: 16.0)
+                .fill(.colorFillMinimal)
+                .padding(.horizontal, DesignConstants.Spacing.step3x)
+        )
     }
 
     private var emptyState: some View {
@@ -127,6 +146,24 @@ struct ContactsView: View {
             object: nil,
             userInfo: ["inboxIds": ids]
         )
+    }
+}
+
+// MARK: - Section header
+
+/// Compact section header rendered inside the unified white card. Matches
+/// the picker's `ContactsPickerSectionHeader` styling so the two surfaces
+/// look the same.
+private struct ContactsListSectionHeader: View {
+    let title: String
+
+    var body: some View {
+        Text(title)
+            .font(.caption)
+            .foregroundStyle(.colorTextSecondary)
+            .textCase(nil)
+            .padding(.leading, DesignConstants.Spacing.step2x)
+            .listRowBackground(Color.clear)
     }
 }
 

--- a/Convos/Contacts/ContactsViewModel.swift
+++ b/Convos/Contacts/ContactsViewModel.swift
@@ -18,9 +18,13 @@ final class ContactsViewModel {
     var sections: [Section] = []
     var contactCount: Int = 0
     var isLoading: Bool = true
+    var searchQuery: String = "" {
+        didSet { rebuildSections() }
+    }
 
     private let contactsRepository: any ContactsRepositoryProtocol
     private var cancellable: AnyCancellable?
+    private var allContacts: [Contact] = []
 
     init(contactsRepository: any ContactsRepositoryProtocol) {
         self.contactsRepository = contactsRepository
@@ -39,7 +43,18 @@ final class ContactsViewModel {
     }
 
     private func applyContacts(_ contacts: [Contact]) {
-        let grouped: [String: [Contact]] = Dictionary(grouping: contacts) { $0.alphabeticalSectionKey }
+        allContacts = contacts
+        contactCount = contacts.count
+        rebuildSections()
+        isLoading = false
+    }
+
+    /// Recomputes `sections` from `allContacts` honoring the current
+    /// `searchQuery`. Mirrors the picker's filter/group pipeline so both
+    /// surfaces sort and bucket identically.
+    private func rebuildSections() {
+        let filtered = filterByQuery(allContacts)
+        let grouped: [String: [Contact]] = Dictionary(grouping: filtered) { $0.alphabeticalSectionKey }
         let sortedKeys = grouped.keys.sorted { lhs, rhs in
             // "#" sorts last so non-alpha names land after Z.
             switch (lhs, rhs) {
@@ -52,7 +67,13 @@ final class ContactsViewModel {
         sections = sortedKeys.map { key in
             Section(id: key, title: key, contacts: grouped[key] ?? [])
         }
-        contactCount = contacts.count
-        isLoading = false
+    }
+
+    private func filterByQuery(_ contacts: [Contact]) -> [Contact] {
+        let trimmed = searchQuery.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return contacts }
+        return contacts.filter { contact in
+            contact.resolvedDisplayName.localizedCaseInsensitiveContains(trimmed)
+        }
     }
 }

--- a/Convos/Conversation Detail/ConversationMembersListView.swift
+++ b/Convos/Conversation Detail/ConversationMembersListView.swift
@@ -103,9 +103,6 @@ struct ConversationMembersListView: View {
             contactsRepository: contactsRepository
         )
         let onRemove: () -> Void = { viewModel.remove(member: member) }
-        let onBlockAndLeave: () -> Void = {
-            viewModel.blockAndLeaveConvo(inboxId: member.profile.inboxId)
-        }
         ContactCardView(
             contact: resolvedContact,
             mode: .scopedToConversation(
@@ -116,8 +113,7 @@ struct ConversationMembersListView: View {
             contactsWriter: contactsWriter,
             contactsRepository: contactsRepository,
             session: viewModel.session,
-            onRemove: onRemove,
-            onBlockAndLeave: onBlockAndLeave
+            onRemove: onRemove
         )
     }
 }

--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -495,10 +495,6 @@ struct MemberContactCardSheetContent: View {
             viewModel.remove(member: member)
             dismiss()
         }
-        let onBlockAndLeave: () -> Void = {
-            viewModel.blockAndLeaveConvo(inboxId: member.profile.inboxId)
-            dismiss()
-        }
         NavigationStack {
             ContactCardView(
                 contact: resolvedContact,
@@ -510,8 +506,7 @@ struct MemberContactCardSheetContent: View {
                 contactsWriter: contactsWriter,
                 contactsRepository: contactsRepository,
                 session: viewModel.session,
-                onRemove: onRemove,
-                onBlockAndLeave: onBlockAndLeave
+                onRemove: onRemove
             )
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {

--- a/ConvosTests/ContactsPickerViewModelTests.swift
+++ b/ConvosTests/ContactsPickerViewModelTests.swift
@@ -1,7 +1,7 @@
 import Combine
+@testable import Convos
 import ConvosCore
 import XCTest
-@testable import Convos
 
 @MainActor
 final class ContactsPickerViewModelTests: XCTestCase {
@@ -57,11 +57,11 @@ final class ContactsPickerViewModelTests: XCTestCase {
 
         let firstId = MockContactsRepository.defaultMockContacts[0].inboxId
         viewModel.toggleSelection(for: firstId)
-        XCTAssertEqual(viewModel.confirmButtonTitle, "Start conversation")
+        XCTAssertEqual(viewModel.confirmButtonTitle, "Start a convo")
 
         let secondId = MockContactsRepository.defaultMockContacts[1].inboxId
         viewModel.toggleSelection(for: secondId)
-        XCTAssertEqual(viewModel.confirmButtonTitle, "Start group")
+        XCTAssertEqual(viewModel.confirmButtonTitle, "Start a convo")
     }
 
     func testHeaderTitleAndConfirmCopyForAddToConversationMode() {
@@ -75,6 +75,10 @@ final class ContactsPickerViewModelTests: XCTestCase {
         let firstId = MockContactsRepository.defaultMockContacts[0].inboxId
         viewModel.toggleSelection(for: firstId)
         XCTAssertEqual(viewModel.confirmButtonTitle, "Add 1 to convo")
+
+        let secondId = MockContactsRepository.defaultMockContacts[1].inboxId
+        viewModel.toggleSelection(for: secondId)
+        XCTAssertEqual(viewModel.confirmButtonTitle, "Add 2 to convo")
     }
 
     func testHeaderTitleFallsBackWhenConversationTitleMissing() {

--- a/ConvosTests/ContactsPickerViewModelTests.swift
+++ b/ConvosTests/ContactsPickerViewModelTests.swift
@@ -57,11 +57,11 @@ final class ContactsPickerViewModelTests: XCTestCase {
 
         let firstId = MockContactsRepository.defaultMockContacts[0].inboxId
         viewModel.toggleSelection(for: firstId)
-        XCTAssertEqual(viewModel.confirmButtonTitle, "Start a convo")
+        XCTAssertEqual(viewModel.confirmButtonTitle, "Continue")
 
         let secondId = MockContactsRepository.defaultMockContacts[1].inboxId
         viewModel.toggleSelection(for: secondId)
-        XCTAssertEqual(viewModel.confirmButtonTitle, "Start a convo")
+        XCTAssertEqual(viewModel.confirmButtonTitle, "Continue")
     }
 
     func testHeaderTitleAndConfirmCopyForAddToConversationMode() {
@@ -74,11 +74,11 @@ final class ContactsPickerViewModelTests: XCTestCase {
 
         let firstId = MockContactsRepository.defaultMockContacts[0].inboxId
         viewModel.toggleSelection(for: firstId)
-        XCTAssertEqual(viewModel.confirmButtonTitle, "Add 1 to convo")
+        XCTAssertEqual(viewModel.confirmButtonTitle, "Continue")
 
         let secondId = MockContactsRepository.defaultMockContacts[1].inboxId
         viewModel.toggleSelection(for: secondId)
-        XCTAssertEqual(viewModel.confirmButtonTitle, "Add 2 to convo")
+        XCTAssertEqual(viewModel.confirmButtonTitle, "Continue")
     }
 
     func testHeaderTitleFallsBackWhenConversationTitleMissing() {

--- a/docs/plans/contact-list-prd.md
+++ b/docs/plans/contact-list-prd.md
@@ -206,6 +206,7 @@ Wireframes are in `contact-list-mocks/`; the picker design is updated to match t
 - A right-edge alphabetical index strip (★ A B C … Z #) for fast scrolling.
 - Selected rows show a filled checkmark on the right; unselected rows show no indicator.
 - In **scoped (add-to-chat) mode**, members already in the destination chat are inline-disabled with an "in chat" badge instead of a checkbox.
+- **Selected contact pills below the search bar.** Each selected contact renders as a removable pill (avatar + display name + trailing × glyph) in a horizontally-scrollable row directly below the "Contacts" search bar. The pills row stays visible above the list as the user scrolls, so the current selection is always glanceable. Tapping the × on a pill removes that contact from the selection (the corresponding row in the list returns to its unselected state). This supersedes the prior treatment of showing only a numeric count ("N members") above the search bar, which hid identity once the selected rows scrolled out of view in long lists. Applies to both `.newConversation` and `.addToConversation(conversationId:)` picker modes; in scoped mode, members already in the destination chat are never represented as pills (they are not part of the user's selection — they are pre-existing).
 
 **Browse list (screen 2)** — simpler than the picker:
 
@@ -706,7 +707,8 @@ Ship-readiness: data layer ready for the filter and the contact-card block affor
 
 - [ ] `ContactsPickerView` matching the attached mock — "To" pill header, Favorites section (V1 may render empty), alphabetical main list, side-letter index, multi-select check indicators.
 - [ ] `ContactsPickerViewModel` parameterized by `ContactsPickerMode` (`.newConversation` vs `.addToConversation`).
-- [ ] SwiftUI Previews with `.mock` data for both modes.
+- [ ] **Selected contact pills row below the search bar.** Replace the existing "N members" count treatment above the search bar with a horizontally-scrollable row of pills directly beneath the "Contacts" search field. Each pill shows the contact's avatar and display name with a trailing × that removes the contact from the selection on tap (toggling the matching list row back to unselected). Wire the pills row to the picker view model's selected-`inboxId`s set so add / remove stays consistent across the pills, the list checkmarks, and the bottom CTA's enabled state. Applies to both `.newConversation` and `.addToConversation` modes.
+- [ ] SwiftUI Previews with `.mock` data for both modes, including a preview with 5+ pills to exercise the horizontal-scroll behavior.
 
 Ship-readiness: picker renders and supports multi-select; no integration with conversation creation or member-add yet.
 


### PR DESCRIPTION
Latest contact card, figma on the left, app on the right:

<img width="794" height="807" alt="image" src="https://github.com/user-attachments/assets/fc736fc4-561d-4b9f-a0a3-2bb1de1d9292" />

Contact list old on left, new on right (fixed gray spacing and added search bar)
<img width="930" height="1012" alt="image" src="https://github.com/user-attachments/assets/acf8770f-f558-40e7-9c57-ee28680e0209" />


Contact Picker old on left, new on right
<img width="930" height="1012" alt="image" src="https://github.com/user-attachments/assets/cab88d5b-4c5f-4f0c-af26-69e4bae544a1" />


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/831"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add contact pills to the contacts picker and visual tweaks to the contact card
> - Adds [ContactsPickerSelectedPills.swift](https://github.com/xmtplabs/convos-ios/pull/831/files#diff-69db8e399231efa46aecd6c73071313d46da0951c2ca77e6f4d225d5683219c7) with a flow-layout row of removable capsule pills that appear below the search bar as contacts are selected in the picker.
> - Replaces the picker's plain navigation title with an elevated `ContactsPickerTitlePill` capsule showing a dynamic title and selection count subtitle.
> - Extracts a shared `ContactsSearchBar` component used in both the picker and the contacts list; the contacts list also gains real-time search filtering and a card-styled layout.
> - Redesigns the contact card with a larger avatar (140×140), bolder name typography, relative 'Added X ago' metadata, and a new `ContactCardActionRow` pill-button layout; removes the 'Block and leave' action throughout.
> - Behavioral Change: the confirm button in the contacts picker now always reads 'Continue' instead of a dynamic label.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c0766e5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->