### PR TITLE
(ci/test) integration test fixes

### DIFF
--- a/.github/workflows/convoscore-tests.yml
+++ b/.github/workflows/convoscore-tests.yml
@@ -97,9 +97,9 @@ jobs:
       - name: Run integration tests
         env:
           XMTP_NODE_ADDRESS: ${{ needs.deploy-backend.outputs.xmtp_node_address }}
-        run: |
-          echo $XMTP_NODE_ADDRESS
-          ./ci/run-tests.sh --integration
+          CONVOS_TEST_XMTP_LOG_LEVEL: debug
+          CONVOS_TEST_XMTP_LOG_DIR: ${{ github.workspace }}/xmtp-test-logs
+        run: ./ci/run-tests.sh --integration
 
       - name: Upload test logs
         if: always()
@@ -108,6 +108,7 @@ jobs:
           name: integration-test-logs
           path: |
             ConvosCore/.build/debug/*.log
+            xmtp-test-logs/
           retention-days: 7
           if-no-files-found: ignore
 

--- a/ConvosCore/Package.resolved
+++ b/ConvosCore/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "dac571861aac89d1f7bc34953a13e35a54819294b0aec0f4b460d532304d7420",
+  "originHash" : "3c48de41849916d194dc33c39c2d4a0ee8ed62c58829c9e239400db4c6790359",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -141,8 +141,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/xmtp/libxmtp.git",
       "state" : {
-        "branch" : "ios-4.10.0-nightly.20260506.601a29b",
-        "revision" : "8b8669f61e9d2b2b2d1723dab1720eb1c97e7397"
+        "branch" : "ios-4.10.0-nightly.20260514.3249eec",
+        "revision" : "a5a6447f684d2dff2237177768ed158935ce84a4"
       }
     },
     {

--- a/ConvosCore/Sources/ConvosCore/Inboxes/AuthorizeInboxOperation.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/AuthorizeInboxOperation.swift
@@ -45,7 +45,8 @@ final class AuthorizeInboxOperation: AuthorizeInboxOperationProtocol, @unchecked
         overrideJWTToken: String? = nil,
         platformProviders: PlatformProviders,
         deviceRegistrationManager: (any DeviceRegistrationManagerProtocol)? = nil,
-        apiClient: (any ConvosAPIClientProtocol)? = nil
+        apiClient: (any ConvosAPIClientProtocol)? = nil,
+        xmtpClientFactory: XMTPClientFactory = .onDisk
     ) -> AuthorizeInboxOperation {
         let operation = AuthorizeInboxOperation(
             clientId: clientId,
@@ -58,7 +59,8 @@ final class AuthorizeInboxOperation: AuthorizeInboxOperationProtocol, @unchecked
             overrideJWTToken: overrideJWTToken,
             platformProviders: platformProviders,
             deviceRegistrationManager: deviceRegistrationManager,
-            apiClient: apiClient
+            apiClient: apiClient,
+            xmtpClientFactory: xmtpClientFactory
         )
         operation.authorize(inboxId: inboxId)
         return operation
@@ -72,7 +74,8 @@ final class AuthorizeInboxOperation: AuthorizeInboxOperationProtocol, @unchecked
         environment: AppEnvironment,
         platformProviders: PlatformProviders,
         deviceRegistrationManager: (any DeviceRegistrationManagerProtocol)? = nil,
-        apiClient: (any ConvosAPIClientProtocol)? = nil
+        apiClient: (any ConvosAPIClientProtocol)? = nil,
+        xmtpClientFactory: XMTPClientFactory = .onDisk
     ) -> AuthorizeInboxOperation {
         // Generate clientId before creating state machine
         let clientId = ClientId.generate().value
@@ -86,7 +89,8 @@ final class AuthorizeInboxOperation: AuthorizeInboxOperationProtocol, @unchecked
             startsStreamingServices: true,
             platformProviders: platformProviders,
             deviceRegistrationManager: deviceRegistrationManager,
-            apiClient: apiClient
+            apiClient: apiClient,
+            xmtpClientFactory: xmtpClientFactory
         )
         operation.register()
         return operation
@@ -103,7 +107,8 @@ final class AuthorizeInboxOperation: AuthorizeInboxOperationProtocol, @unchecked
         overrideJWTToken: String? = nil,
         platformProviders: PlatformProviders,
         deviceRegistrationManager: (any DeviceRegistrationManagerProtocol)?,
-        apiClient: (any ConvosAPIClientProtocol)?
+        apiClient: (any ConvosAPIClientProtocol)?,
+        xmtpClientFactory: XMTPClientFactory
     ) {
         let syncingManager = startsStreamingServices ? SyncingManager(
             identityStore: identityStore,
@@ -123,7 +128,8 @@ final class AuthorizeInboxOperation: AuthorizeInboxOperationProtocol, @unchecked
             overrideJWTToken: overrideJWTToken,
             environment: environment,
             appLifecycle: platformProviders.appLifecycle,
-            apiClient: apiClient
+            apiClient: apiClient,
+            xmtpClientFactory: xmtpClientFactory
         )
     }
 

--- a/ConvosCore/Sources/ConvosCore/Inboxes/SessionStateMachine.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/SessionStateMachine.swift
@@ -26,6 +26,42 @@ public struct InboxReadyResult: @unchecked Sendable {
 typealias AnySyncingManager = (any SyncingManagerProtocol)
 typealias AnyInviteJoinRequestsManager = (any InviteJoinRequestsManagerProtocol)
 
+/// `.onDisk` routes through libxmtp's persistent SQLCipher path (production
+/// behavior). `.inMemory` routes through `Client.createInMemory`, where
+/// `dropLocalDatabaseConnection` and friends are no-ops — so the lifecycle-
+/// notification broadcast cannot wedge a parallel test's pool.
+struct XMTPClientFactory: Sendable {
+    typealias Create = @Sendable (SigningKey, ClientOptions) async throws -> any XMTPClientProvider
+    typealias Build = @Sendable (String, PublicIdentity, SigningKey, ClientOptions) async throws -> any XMTPClientProvider
+
+    let create: Create
+    let build: Build
+
+    static let onDisk: XMTPClientFactory = XMTPClientFactory(
+        create: { signingKey, options in
+            try await Client.create(account: signingKey, options: options)
+        },
+        build: { inboxId, identity, _, options in
+            try await Client.build(publicIdentity: identity, options: options, inboxId: inboxId)
+        }
+    )
+
+    /// `build` reuses `createInMemory` because tests carry no on-disk history;
+    /// inboxId derives from signing key, preserving the
+    /// `client.inboxId == identity.inboxId` invariant in `authorize`.
+    static let inMemory: XMTPClientFactory = {
+        let createInMemory: Create = { signingKey, options in
+            try await Client.createInMemory(account: signingKey, options: options)
+        }
+        return XMTPClientFactory(
+            create: createInMemory,
+            build: { _, _, signingKey, options in
+                try await createInMemory(signingKey, options)
+            }
+        )
+    }()
+}
+
 // swiftlint:disable type_body_length
 
 /// Drives the XMTP inbox lifecycle: creating or loading a client,
@@ -70,6 +106,7 @@ public actor SessionStateMachine: SessionStateManagerProtocol {
     private let apiClient: any ConvosAPIClientProtocol
     private let networkMonitor: any NetworkMonitorProtocol
     private let appLifecycle: any AppLifecycleProviding
+    private let xmtpClientFactory: XMTPClientFactory
 
     private var currentTask: Task<Void, Never>?
     private var actionQueue: [Action] = []
@@ -223,7 +260,8 @@ public actor SessionStateMachine: SessionStateManagerProtocol {
         overrideJWTToken: String? = nil,
         environment: AppEnvironment,
         appLifecycle: any AppLifecycleProviding,
-        apiClient: (any ConvosAPIClientProtocol)? = nil
+        apiClient: (any ConvosAPIClientProtocol)? = nil,
+        xmtpClientFactory: XMTPClientFactory = .onDisk
     ) {
         let initialState: State = .idle
         self.initialClientId = clientId
@@ -237,6 +275,7 @@ public actor SessionStateMachine: SessionStateManagerProtocol {
         self.overrideJWTToken = overrideJWTToken ?? environment.defaultOverrideJWTToken
         self.environment = environment
         self.appLifecycle = appLifecycle
+        self.xmtpClientFactory = xmtpClientFactory
 
         // Use provided API client or create a new one
         if let apiClient {
@@ -487,6 +526,7 @@ public actor SessionStateMachine: SessionStateManagerProtocol {
             client = try await buildXmtpClient(
                 inboxId: identity.inboxId,
                 identity: keys.signingKey.identity,
+                signingKey: keys.signingKey,
                 options: clientOptions
             )
         } catch {
@@ -953,20 +993,17 @@ public actor SessionStateMachine: SessionStateManagerProtocol {
     private func createXmtpClient(signingKey: SigningKey,
                                   options: ClientOptions) async throws -> any XMTPClientProvider {
         Log.info("Creating XMTP client...")
-        let client = try await Client.create(account: signingKey, options: options)
+        let client = try await xmtpClientFactory.create(signingKey, options)
         Log.info("XMTP Client created with app version: convos/\(Bundle.appVersion)")
         return client
     }
 
     private func buildXmtpClient(inboxId: String,
                                  identity: PublicIdentity,
+                                 signingKey: SigningKey,
                                  options: ClientOptions) async throws -> any XMTPClientProvider {
         Log.debug("Building XMTP client for \(inboxId)...")
-        let client = try await Client.build(
-            publicIdentity: identity,
-            options: options,
-            inboxId: inboxId
-        )
+        let client = try await xmtpClientFactory.build(inboxId, identity, signingKey, options)
         Log.debug("XMTP Client built.")
         return client
     }

--- a/ConvosCore/Sources/ConvosCore/Messaging/MessagingService.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/MessagingService.swift
@@ -42,7 +42,8 @@ final class MessagingService: MessagingServiceProtocol, @unchecked Sendable {
         overrideJWTToken: String? = nil,
         platformProviders: PlatformProviders,
         deviceRegistrationManager: (any DeviceRegistrationManagerProtocol)? = nil,
-        apiClient: (any ConvosAPIClientProtocol)? = nil
+        apiClient: (any ConvosAPIClientProtocol)? = nil,
+        xmtpClientFactory: XMTPClientFactory = .onDisk
     ) -> MessagingService {
         let authorizationOperation = AuthorizeInboxOperation.authorize(
             inboxId: inboxId,
@@ -55,7 +56,8 @@ final class MessagingService: MessagingServiceProtocol, @unchecked Sendable {
             overrideJWTToken: overrideJWTToken,
             platformProviders: platformProviders,
             deviceRegistrationManager: deviceRegistrationManager,
-            apiClient: apiClient
+            apiClient: apiClient,
+            xmtpClientFactory: xmtpClientFactory
         )
         return MessagingService(
             authorizationOperation: authorizationOperation,

--- a/ConvosCore/Tests/ConvosCoreTests/SessionStateMachineTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/SessionStateMachineTests.swift
@@ -40,7 +40,8 @@ struct SessionStateMachineTests {
             networkMonitor: networkMonitor,
             overrideJWTToken: "test-jwt-token",  // Skip backend auth for tests
             environment: .tests,
-            appLifecycle: testAppLifecycle
+            appLifecycle: testAppLifecycle,
+            xmtpClientFactory: .inMemory
         )
 
         // Start in idle state
@@ -99,7 +100,8 @@ struct SessionStateMachineTests {
             networkMonitor: networkMonitor,
             overrideJWTToken: "test-jwt-token",
             environment: .tests,
-            appLifecycle: testAppLifecycle
+            appLifecycle: testAppLifecycle,
+            xmtpClientFactory: .inMemory
         )
 
         await stateMachine.register()
@@ -162,7 +164,8 @@ struct SessionStateMachineTests {
             networkMonitor: networkMonitor,
             overrideJWTToken: "test-jwt-token",  // Skip backend auth for tests
             environment: .tests,
-            appLifecycle: testAppLifecycle
+            appLifecycle: testAppLifecycle,
+            xmtpClientFactory: .inMemory
         )
 
         // Authorize with the existing inbox
@@ -210,7 +213,8 @@ struct SessionStateMachineTests {
             syncingManager: nil,
             networkMonitor: networkMonitor,
             environment: .tests,
-            appLifecycle: testAppLifecycle
+            appLifecycle: testAppLifecycle,
+            xmtpClientFactory: .inMemory
         )
 
         // Try to authorize with wrong clientId. The state machine was
@@ -260,7 +264,8 @@ struct SessionStateMachineTests {
             networkMonitor: networkMonitor,
             overrideJWTToken: "test-jwt-token",  // Skip backend auth for tests
             environment: .tests,
-            appLifecycle: testAppLifecycle
+            appLifecycle: testAppLifecycle,
+            xmtpClientFactory: .inMemory
         )
 
         // Register and wait for ready
@@ -328,7 +333,8 @@ struct SessionStateMachineTests {
             networkMonitor: networkMonitor,
             overrideJWTToken: "test-jwt-token",  // Skip backend auth for tests
             environment: .tests,
-            appLifecycle: testAppLifecycle
+            appLifecycle: testAppLifecycle,
+            xmtpClientFactory: .inMemory
         )
 
         // Register and wait for ready
@@ -398,7 +404,8 @@ struct SessionStateMachineTests {
             networkMonitor: networkMonitor,
             overrideJWTToken: "test-jwt-token",  // Skip backend auth for tests
             environment: .tests,
-            appLifecycle: testAppLifecycle
+            appLifecycle: testAppLifecycle,
+            xmtpClientFactory: .inMemory
         )
 
         // Try to authorize with non-existent inboxId to trigger error
@@ -452,7 +459,8 @@ struct SessionStateMachineTests {
             syncingManager: nil,
             networkMonitor: networkMonitor,
             environment: .tests,
-            appLifecycle: testAppLifecycle
+            appLifecycle: testAppLifecycle,
+            xmtpClientFactory: .inMemory
         )
 
         actor StateCollector {
@@ -537,7 +545,8 @@ struct SessionStateMachineTests {
             networkMonitor: networkMonitor,
             overrideJWTToken: "test-jwt-token",  // Skip backend auth for tests
             environment: .tests,
-            appLifecycle: testAppLifecycle
+            appLifecycle: testAppLifecycle,
+            xmtpClientFactory: .inMemory
         )
 
         // Queue register and then stop
@@ -592,7 +601,8 @@ struct SessionStateMachineTests {
             networkMonitor: mockNetworkMonitor,
             overrideJWTToken: "test-jwt-token",
             environment: .tests,
-            appLifecycle: testAppLifecycle
+            appLifecycle: testAppLifecycle,
+            xmtpClientFactory: .inMemory
         )
 
         // Register and wait for ready
@@ -661,6 +671,13 @@ struct SessionStateMachineTests {
         let mockInvites = MockInvitesRepository()
         let networkMonitor = NetworkMonitor()
 
+        // Uses `.onDisk` because `dropLocalDatabaseConnection` and
+        // `reconnectLocalDatabase` early-return as no-ops on in-memory
+        // clients. Backgrounding is the production code path this test
+        // exercises, so the on-disk SQLCipher pool is the right backing.
+        // A dedicated lifecycle provider isolates this test's notifications
+        // from the suite-shared `testAppLifecycle`.
+        let appLifecycle = MockAppLifecycleProvider()
         let stateMachine = SessionStateMachine(
             clientId: clientId,
             identityStore: fixtures.identityStore,
@@ -670,7 +687,8 @@ struct SessionStateMachineTests {
             networkMonitor: networkMonitor,
             overrideJWTToken: "test-jwt-token",
             environment: .tests,
-            appLifecycle: testAppLifecycle
+            appLifecycle: appLifecycle,
+            xmtpClientFactory: .onDisk
         )
 
         // Register and wait for ready
@@ -700,7 +718,7 @@ struct SessionStateMachineTests {
         try await Task.sleep(for: .milliseconds(100))
 
         // Simulate app entering background
-        NotificationCenter.default.post(name: testAppLifecycle.didEnterBackgroundNotification, object: nil)
+        NotificationCenter.default.post(name: appLifecycle.didEnterBackgroundNotification, object: nil)
 
         // Wait for backgrounded state
         let backgroundedState = try await waitForState(stateMachine, timeout: 5) { state in
@@ -722,7 +740,7 @@ struct SessionStateMachineTests {
         Log.info("App backgrounded, sync paused. Simulating app returning to foreground...")
 
         // Simulate app entering foreground
-        NotificationCenter.default.post(name: testAppLifecycle.willEnterForegroundNotification, object: nil)
+        NotificationCenter.default.post(name: appLifecycle.willEnterForegroundNotification, object: nil)
 
         // Wait for ready state again
         let foregroundState = try await waitForState(stateMachine, timeout: 5) { state in
@@ -757,6 +775,12 @@ struct SessionStateMachineTests {
         let mockInvites = MockInvitesRepository()
         let networkMonitor = NetworkMonitor()
 
+        // Uses `.onDisk` so the backgrounded → ready transition actually
+        // drops and reconnects libxmtp's SQLCipher pool, the production
+        // path. In-memory clients no-op those calls. Dedicated lifecycle
+        // provider so this test's notifications stay isolated from other
+        // suites' state machines.
+        let appLifecycle = MockAppLifecycleProvider()
         let stateMachine = SessionStateMachine(
             clientId: clientId,
             identityStore: fixtures.identityStore,
@@ -766,7 +790,8 @@ struct SessionStateMachineTests {
             networkMonitor: networkMonitor,
             overrideJWTToken: "test-jwt-token",
             environment: .tests,
-            appLifecycle: testAppLifecycle
+            appLifecycle: appLifecycle,
+            xmtpClientFactory: .onDisk
         )
 
         actor StateCollector {
@@ -830,7 +855,7 @@ struct SessionStateMachineTests {
         try await Task.sleep(for: .milliseconds(100))
 
         // Simulate background
-        NotificationCenter.default.post(name: testAppLifecycle.didEnterBackgroundNotification, object: nil)
+        NotificationCenter.default.post(name: appLifecycle.didEnterBackgroundNotification, object: nil)
 
         // Wait for backgrounded
         _ = try await waitForState(stateMachine, timeout: 5) { state in
@@ -839,7 +864,7 @@ struct SessionStateMachineTests {
         }
 
         // Simulate foreground
-        NotificationCenter.default.post(name: testAppLifecycle.willEnterForegroundNotification, object: nil)
+        NotificationCenter.default.post(name: appLifecycle.willEnterForegroundNotification, object: nil)
 
         // Wait for ready again
         _ = try await waitForState(stateMachine, timeout: 5) { state in

--- a/ConvosCore/Tests/ConvosCoreTests/TestHelpers.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/TestHelpers.swift
@@ -194,8 +194,11 @@ class TestFixtures {
     /// Builds a fresh MessagingService for tests that previously used
     /// `UnusedConversationCache.consumeOrCreateMessagingService` as a
     /// bootstrap. Registers a new XMTP identity for the fixture.
+    /// Defaults to `XMTPClientFactory.inMemory` so libxmtp's pool-management
+    /// surface is inert across parallel tests in the same process.
     func makeFreshMessagingService(
-        platformProviders: PlatformProviders = .mock
+        platformProviders: PlatformProviders = .mock,
+        xmtpClientFactory: XMTPClientFactory = .inMemory
     ) -> MessagingService {
         let authorizationOperation = AuthorizeInboxOperation.register(
             identityStore: identityStore,
@@ -204,7 +207,8 @@ class TestFixtures {
             environment: environment,
             platformProviders: platformProviders,
             deviceRegistrationManager: nil,
-            apiClient: nil
+            apiClient: nil,
+            xmtpClientFactory: xmtpClientFactory
         )
         return MessagingService(
             authorizationOperation: authorizationOperation,


### PR DESCRIPTION
This re-adds the integration test fixes from before the reversions


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/833"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix integration tests by adding in-memory XMTP client factory support
> - Introduces `XMTPClientFactory` in [`SessionStateMachine.swift`](https://github.com/xmtplabs/convos-ios/pull/833/files#diff-2e582e2b8786d8337f7b6cc98769794a740c6440e832967fadebc179146c5891) with `.onDisk` and `.inMemory` strategies, and threads the factory parameter through `AuthorizeInboxOperation`, `SessionStateMachine`, and `MessagingService`.
> - Updates [`SessionStateMachineTests.swift`](https://github.com/xmtplabs/convos-ios/pull/833/files#diff-8c6e25f55e67e2bb90b97f024f6c766aecc293542e52a0d476770a07f79c5dff) and [`TestHelpers.swift`](https://github.com/xmtplabs/convos-ios/pull/833/files#diff-30cc9de0f0791e7a8631762f4a7590db2b113ca47cb39aab76befa02b71b3eb8) to use `.inMemory` clients by default, preventing SQLite connection pool conflicts in parallel tests.
> - Adds XMTP debug logging env vars and uploads `xmtp-test-logs/` as a CI artifact in the integration test workflow.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fed8bc5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->