### PR TITLE
feat(keychain): sync XMTP identity via iCloud Keychain

### DIFF
--- a/Convos/Debug View/DebugAuthProbeView.swift
+++ b/Convos/Debug View/DebugAuthProbeView.swift
@@ -39,6 +39,13 @@ struct DebugAuthProbeView: View {
                     monospaced: status.accountId != nil,
                     color: status.accountId == nil ? .secondary : .primary
                 )
+                resultRow(
+                    "Identity slot",
+                    status.identityStorage.description,
+                    color: status.identityStorage == .synced ? .green
+                        : status.identityStorage == .legacy ? .orange
+                        : .secondary
+                )
                 if let issuedAt = status.issuedAt {
                     resultRow("Issued At", iso8601(issuedAt))
                 }

--- a/Convos/Debug View/DebugInstallationsView.swift
+++ b/Convos/Debug View/DebugInstallationsView.swift
@@ -1,0 +1,179 @@
+import ConvosCore
+import SwiftUI
+
+/// Debug-only inspector for the device's XMTP installations. Lists every
+/// installation the network reports for this inbox (current one marked) and
+/// offers a single action: revoke every other installation. Used to recover
+/// from the 10-installation cap that accumulates across wipe + reinstall
+/// cycles during development.
+struct DebugInstallationsView: View {
+    @State private var snapshot: InstallationsSnapshot?
+    @State private var isLoading: Bool = false
+    @State private var isRevoking: Bool = false
+    @State private var lastRevoked: [String] = []
+    @State private var errorMessage: String?
+
+    let messagingService: AnyMessagingService
+
+    var body: some View {
+        List {
+            if let snapshot {
+                summarySection(snapshot)
+                installationsSection(snapshot)
+                actionsSection(snapshot)
+            } else {
+                Section {
+                    HStack {
+                        ProgressView()
+                        Text(isLoading ? "Loading installations…" : "Tap refresh to load.")
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+
+            if let errorMessage {
+                Section("Error") {
+                    Text(errorMessage)
+                        .font(.footnote)
+                        .foregroundStyle(.red)
+                }
+            }
+
+            if !lastRevoked.isEmpty {
+                Section("Revoked this session") {
+                    ForEach(lastRevoked, id: \.self) { id in
+                        Text(id)
+                            .font(.system(.footnote, design: .monospaced))
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                    }
+                }
+            }
+        }
+        .navigationTitle("XMTP Installations")
+        .navigationBarTitleDisplayMode(.inline)
+        .task { await refresh() }
+    }
+
+    @ViewBuilder
+    private func summarySection(_ snapshot: InstallationsSnapshot) -> some View {
+        let total = snapshot.installations.count
+        let cap = 10
+        let countColor: Color = total >= cap ? .red : (total >= cap - 2 ? .orange : .primary)
+        Section("Summary") {
+            row("Inbox ID", snapshot.inboxId)
+            row("This device", snapshot.currentInstallationId)
+            HStack {
+                Text("Installations")
+                Spacer()
+                Text("\(total) / \(cap)")
+                    .foregroundStyle(countColor)
+                    .monospacedDigit()
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func installationsSection(_ snapshot: InstallationsSnapshot) -> some View {
+        Section("Installations") {
+            ForEach(snapshot.installations, id: \.id) { installation in
+                installationRow(installation, currentId: snapshot.currentInstallationId)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func installationRow(_ installation: InstallationInfo, currentId: String) -> some View {
+        let isCurrent = installation.id == currentId
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Text(installation.id)
+                    .font(.system(.footnote, design: .monospaced))
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                if isCurrent {
+                    Text("CURRENT")
+                        .font(.caption2.weight(.semibold))
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(Color.green.opacity(0.2))
+                        .foregroundStyle(.green)
+                        .clipShape(Capsule())
+                }
+            }
+            if let createdAt = installation.createdAt {
+                Text(createdAt.formatted(date: .abbreviated, time: .shortened))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func actionsSection(_ snapshot: InstallationsSnapshot) -> some View {
+        let otherCount = snapshot.installations.count - 1
+        let refreshAction: () -> Void = { Task { await refresh() } }
+        let revokeAction: () -> Void = { Task { await revokeOthers() } }
+
+        Section("Actions") {
+            Button(action: refreshAction) {
+                Label("Refresh from network", systemImage: "arrow.clockwise")
+            }
+            .disabled(isLoading || isRevoking)
+
+            Button(role: .destructive, action: revokeAction) {
+                if isRevoking {
+                    HStack {
+                        ProgressView()
+                        Text("Revoking…")
+                    }
+                } else if otherCount > 0 {
+                    Text("Revoke all other installations (\(otherCount))")
+                } else {
+                    Text("No other installations to revoke")
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .disabled(otherCount == 0 || isLoading || isRevoking)
+        }
+    }
+
+    @ViewBuilder
+    private func row(_ label: String, _ value: String) -> some View {
+        HStack {
+            Text(label)
+            Spacer()
+            Text(value)
+                .font(.system(.footnote, design: .monospaced))
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+                .truncationMode(.middle)
+        }
+    }
+
+    private func refresh() async {
+        guard !isLoading else { return }
+        isLoading = true
+        errorMessage = nil
+        defer { isLoading = false }
+        do {
+            snapshot = try await messagingService.installationsSnapshot(refreshFromNetwork: true)
+        } catch {
+            errorMessage = "Failed to load installations: \(error.localizedDescription)"
+        }
+    }
+
+    private func revokeOthers() async {
+        guard !isRevoking else { return }
+        isRevoking = true
+        errorMessage = nil
+        defer { isRevoking = false }
+        do {
+            let revoked = try await messagingService.revokeOtherInstallations()
+            lastRevoked = revoked
+            snapshot = try await messagingService.installationsSnapshot(refreshFromNetwork: true)
+        } catch {
+            errorMessage = "Revoke failed: \(error.localizedDescription)"
+        }
+    }
+}

--- a/Convos/Debug View/DebugView.swift
+++ b/Convos/Debug View/DebugView.swift
@@ -49,6 +49,7 @@ struct DebugViewSection: View {
             pushNotificationsSection
             debugSection
             authProbeSection
+            installationsSection
             sentryTestingSection
             pendingInvitesSection
             assetRenewalSection
@@ -187,6 +188,18 @@ struct DebugViewSection: View {
                 DebugAuthProbeView(environment: environment)
             } label: {
                 Text("Run SIWE Auth Probe")
+                    .foregroundStyle(.colorTextPrimary)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var installationsSection: some View {
+        Section("XMTP Installations") {
+            NavigationLink {
+                DebugInstallationsView(messagingService: session.messagingServiceSync())
+            } label: {
+                Text("Manage installations")
                     .foregroundStyle(.colorTextPrimary)
             }
         }

--- a/ConvosCore/Sources/ConvosCore/Auth/Keychain/KeychainIdentityStore.swift
+++ b/ConvosCore/Sources/ConvosCore/Auth/Keychain/KeychainIdentityStore.swift
@@ -77,6 +77,12 @@ public struct KeychainIdentity: Codable, Sendable {
     public let inboxId: String
     public let clientId: String
     public let keys: KeychainIdentityKeys
+
+    public init(inboxId: String, clientId: String, keys: KeychainIdentityKeys) {
+        self.inboxId = inboxId
+        self.clientId = clientId
+        self.keys = keys
+    }
 }
 
 // MARK: - Errors

--- a/ConvosCore/Sources/ConvosCore/Auth/Keychain/KeychainIdentityStore.swift
+++ b/ConvosCore/Sources/ConvosCore/Auth/Keychain/KeychainIdentityStore.swift
@@ -101,6 +101,31 @@ public enum KeychainIdentityStoreError: Error, LocalizedError {
     }
 }
 
+// MARK: - Storage Location
+
+/// Where the on-device XMTP identity currently lives. Surfaces in the
+/// debug UI so testers can verify which slot the identity is in and
+/// whether iCloud-Keychain propagation has happened.
+public enum IdentityStorageLocation: String, Sendable {
+    /// Synchronizable slot — iCloud Keychain pushes this to every
+    /// device signed in to the same Apple ID. Same wallet → same SIWE
+    /// address → same backend `Account`.
+    case synced
+    /// Legacy device-local slot from before the sync rollout. Still
+    /// readable; gets migrated to `.synced` on the next save.
+    case legacy
+    /// No identity stored on this device.
+    case missing
+
+    public var description: String {
+        switch self {
+        case .synced: return "Synced (iCloud Keychain)"
+        case .legacy: return "Local-only (legacy v3)"
+        case .missing: return "Not stored"
+        }
+    }
+}
+
 // MARK: - Keychain Operations
 
 private struct KeychainQuery {
@@ -166,29 +191,59 @@ public protocol KeychainIdentityStoreProtocol: Actor {
     func delete() throws
 }
 
-/// Secure storage for the user's XMTP identity keys in the device keychain.
+/// Secure storage for the user's XMTP identity keys in the app-group
+/// keychain.
 ///
-/// The app holds one identity per install. The slot is device-local —
-/// `kSecAttrSynchronizable = false` + `kSecAttrAccessibleAfterFirstUnlock`
-/// so identity keys never leave this device via iCloud Keychain. The
-/// item is stored in the app-group keychain so the Notification Service
-/// Extension can read it.
+/// The identity now lives in a **synced** slot
+/// (`kSecAttrSynchronizable = true`) so it follows the user across
+/// every device signed in to the same Apple ID. Same key → same
+/// Ethereum address → same backend `Account` via SIWE, no per-device
+/// onboarding. The accessibility flag stays at
+/// `kSecAttrAccessibleAfterFirstUnlock` (already sync-compatible),
+/// which is also required so the Notification Service Extension can
+/// read the identity post-first-unlock.
+///
+/// Two service identifiers exist:
+///
+/// - `legacyIdentityService` (`…v3`, `synchronizable: false`) — the
+///   pre-sync slot. Existing installs find their identity here on the
+///   first launch with this code.
+/// - `syncedIdentityService` (`…v4-synced`, `synchronizable: true`) —
+///   the new slot. All future writes land here; `load()` migrates
+///   from legacy to synced on first read after upgrade.
+///
+/// Migration is lazy and idempotent: every `load()` checks the synced
+/// slot first; if empty, it reads the legacy slot and (best-effort)
+/// re-writes the data to the synced slot before returning it. If the
+/// sync write fails (e.g. iCloud Keychain disabled), the legacy slot
+/// is preserved so the user doesn't lose their identity.
+///
+/// See `docs/plans/icloud-keychain-identity-sync.md`.
 public final actor KeychainIdentityStore: KeychainIdentityStoreProtocol {
     // MARK: - Properties
 
-    private let keychainService: String
     private let keychainAccessGroup: String
 
-    public static let defaultService: String = "org.convos.ios.KeychainIdentityStore.v3"
+    /// Pre-sync identity slot. Read-only after migration; new code
+    /// must not write here.
+    public static let legacyIdentityService: String = "org.convos.ios.KeychainIdentityStore.v3"
 
-    /// Fixed account key for the stored identity.
+    /// Synced (iCloud Keychain) identity slot. Where every new write
+    /// goes; where `load()` reads from first.
+    public static let syncedIdentityService: String = "org.convos.ios.KeychainIdentityStore.v4-synced"
+
+    /// Source-compat alias for callers that historically referenced
+    /// `defaultService` to identify the live slot. Points at the
+    /// synced slot now.
+    public static let defaultService: String = syncedIdentityService
+
+    /// Fixed account key shared by both slots.
     public static let identityAccount: String = "convos-identity"
 
     // MARK: - Initialization
 
     public init(accessGroup: String) {
         self.keychainAccessGroup = accessGroup
-        self.keychainService = Self.defaultService
     }
 
     // MARK: - Public Interface
@@ -200,40 +255,105 @@ public final actor KeychainIdentityStore: KeychainIdentityStoreProtocol {
     public func save(inboxId: String, clientId: String, keys: KeychainIdentityKeys) throws -> KeychainIdentity {
         let identity = KeychainIdentity(inboxId: inboxId, clientId: clientId, keys: keys)
         let data = try JSONEncoder().encode(identity)
-        let query = KeychainQuery(
-            account: Self.identityAccount,
-            service: keychainService,
-            accessGroup: keychainAccessGroup
-        )
-        try saveData(data, with: query)
+        try saveData(data, with: syncedQuery())
+        // One-shot migration: drop the legacy slot once the synced
+        // write has succeeded. `?` because "no legacy item" is a
+        // perfectly normal outcome on fresh installs.
+        try? deleteData(with: legacyQuery())
         return identity
     }
 
     public func load() throws -> KeychainIdentity? {
-        try loadSync()
+        if let identity = try loadIdentity(from: syncedQuery()) {
+            return identity
+        }
+        // Synced slot is empty. Check legacy and migrate inline.
+        guard let pair = try loadIdentityWithBytes(from: legacyQuery()) else {
+            return nil
+        }
+        do {
+            try saveData(pair.data, with: syncedQuery())
+            // Only delete the legacy slot after a successful synced
+            // write — otherwise we'd risk losing the identity if
+            // iCloud Keychain refused the write.
+            try? deleteData(with: legacyQuery())
+        } catch {
+            // Sync write failed (e.g. iCloud Keychain disabled). Keep
+            // the legacy slot intact so subsequent loads keep
+            // returning the user's identity.
+        }
+        return pair.identity
     }
 
     public nonisolated func loadSync() throws -> KeychainIdentity? {
-        let query = KeychainQuery(
-            account: Self.identityAccount,
-            service: keychainService,
-            accessGroup: keychainAccessGroup
-        )
-        do {
-            let data = try Self.loadKeychainData(with: query.toReadDictionary())
-            return try JSONDecoder().decode(KeychainIdentity.self, from: data)
-        } catch KeychainIdentityStoreError.identityNotFound {
-            return nil
+        // Read-only path used from contexts where actor hops aren't
+        // possible (NSE, sync construction). Prefers the synced
+        // slot, falls back to legacy. Does NOT migrate — the
+        // actor-isolated `load()` is the one place that performs
+        // the legacy→synced copy.
+        if let identity = try loadIdentity(from: syncedQuery()) {
+            return identity
         }
+        return try loadIdentityWithBytes(from: legacyQuery())?.identity
     }
 
     public func delete() throws {
-        let query = KeychainQuery(
+        // Wipe both slots so a sign-out is total — leaving the
+        // legacy slot populated would resurrect the identity on the
+        // next load().
+        try deleteData(with: syncedQuery())
+        try? deleteData(with: legacyQuery())
+    }
+
+    /// Reports where the identity (if any) currently lives. Used by
+    /// debug UI to verify the iCloud Keychain rollout per device.
+    /// Nonisolated + synchronous so the debug screen doesn't need to
+    /// pay an actor hop just to render a status row.
+    public nonisolated func currentStorageLocation() -> IdentityStorageLocation {
+        if (try? loadIdentity(from: syncedQuery())) != nil {
+            return .synced
+        }
+        if (try? loadIdentity(from: legacyQuery())) != nil {
+            return .legacy
+        }
+        return .missing
+    }
+
+    // MARK: - Slot Helpers
+
+    private nonisolated func syncedQuery() -> KeychainQuery {
+        KeychainQuery(
             account: Self.identityAccount,
-            service: keychainService,
-            accessGroup: keychainAccessGroup
+            service: Self.syncedIdentityService,
+            accessGroup: keychainAccessGroup,
+            accessible: kSecAttrAccessibleAfterFirstUnlock,
+            synchronizable: true
         )
-        try deleteData(with: query)
+    }
+
+    private nonisolated func legacyQuery() -> KeychainQuery {
+        KeychainQuery(
+            account: Self.identityAccount,
+            service: Self.legacyIdentityService,
+            accessGroup: keychainAccessGroup,
+            accessible: kSecAttrAccessibleAfterFirstUnlock,
+            synchronizable: false
+        )
+    }
+
+    private nonisolated func loadIdentity(from query: KeychainQuery) throws -> KeychainIdentity? {
+        try loadIdentityWithBytes(from: query)?.identity
+    }
+
+    private nonisolated func loadIdentityWithBytes(
+        from query: KeychainQuery
+    ) throws -> (identity: KeychainIdentity, data: Data)? {
+        do {
+            let data = try Self.loadKeychainData(with: query.toReadDictionary())
+            return (try JSONDecoder().decode(KeychainIdentity.self, from: data), data)
+        } catch KeychainIdentityStoreError.identityNotFound {
+            return nil
+        }
     }
 
     // MARK: - Generic Keychain Operations

--- a/ConvosCore/Sources/ConvosCore/Auth/SIWE/BackendAuthProbe.swift
+++ b/ConvosCore/Sources/ConvosCore/Auth/SIWE/BackendAuthProbe.swift
@@ -164,14 +164,14 @@ public enum BackendAuthProbe {
         let keychain = KeychainService()
         let deviceId = DeviceInfo.deviceIdentifier
 
+        // load() migrates legacy → synced inline, so query the storage
+        // location *after* the load to avoid reporting a stale .legacy.
         // `currentStorageLocation()` lives on the concrete store
-        // (debug-only signal, intentionally not in the protocol).
-        // For non-concrete conformers (mocks) we fall through to the
-        // `.missing` default.
-        let storage: IdentityStorageLocation = (identityStore as? KeychainIdentityStore)?.currentStorageLocation() ?? .missing
-
+        // (debug-only signal, intentionally not in the protocol);
+        // mocks fall through to `.missing`.
         let identity: KeychainIdentity?
         identity = try? await identityStore.load()
+        let storage: IdentityStorageLocation = (identityStore as? KeychainIdentityStore)?.currentStorageLocation() ?? .missing
         guard let identity else {
             return Status(
                 address: nil,

--- a/ConvosCore/Sources/ConvosCore/Auth/SIWE/BackendAuthProbe.swift
+++ b/ConvosCore/Sources/ConvosCore/Auth/SIWE/BackendAuthProbe.swift
@@ -131,6 +131,10 @@ public enum BackendAuthProbe {
         public let issuedAt: Date?
         public let jwtExpiry: Date?
         public let isJWTValid: Bool    // true iff JWT present, structurally valid, exp > now+60s
+        /// Which slot the identity (private key) currently lives in:
+        /// the synced (iCloud Keychain) slot, the legacy device-local
+        /// slot, or missing entirely.
+        public let identityStorage: IdentityStorageLocation
 
         public init(
             address: String?,
@@ -138,7 +142,8 @@ public enum BackendAuthProbe {
             accountId: String?,
             issuedAt: Date?,
             jwtExpiry: Date?,
-            isJWTValid: Bool
+            isJWTValid: Bool,
+            identityStorage: IdentityStorageLocation
         ) {
             self.address = address
             self.jwt = jwt
@@ -146,6 +151,7 @@ public enum BackendAuthProbe {
             self.issuedAt = issuedAt
             self.jwtExpiry = jwtExpiry
             self.isJWTValid = isJWTValid
+            self.identityStorage = identityStorage
         }
     }
 
@@ -158,10 +164,24 @@ public enum BackendAuthProbe {
         let keychain = KeychainService()
         let deviceId = DeviceInfo.deviceIdentifier
 
+        // `currentStorageLocation()` lives on the concrete store
+        // (debug-only signal, intentionally not in the protocol).
+        // For non-concrete conformers (mocks) we fall through to the
+        // `.missing` default.
+        let storage: IdentityStorageLocation = (identityStore as? KeychainIdentityStore)?.currentStorageLocation() ?? .missing
+
         let identity: KeychainIdentity?
         identity = try? await identityStore.load()
         guard let identity else {
-            return Status(address: nil, jwt: nil, accountId: nil, issuedAt: nil, jwtExpiry: nil, isJWTValid: false)
+            return Status(
+                address: nil,
+                jwt: nil,
+                accountId: nil,
+                issuedAt: nil,
+                jwtExpiry: nil,
+                isJWTValid: false,
+                identityStorage: storage
+            )
         }
 
         let address = EthereumAddress.toChecksummed(identity.keys.privateKey.identity.identifier)
@@ -179,7 +199,8 @@ public enum BackendAuthProbe {
                 accountId: cachedAccountId,
                 issuedAt: nil,
                 jwtExpiry: nil,
-                isJWTValid: false
+                isJWTValid: false,
+                identityStorage: storage
             )
         }
 
@@ -195,7 +216,8 @@ public enum BackendAuthProbe {
             accountId: accountId,
             issuedAt: issuedAt,
             jwtExpiry: expiry,
-            isJWTValid: isValid
+            isJWTValid: isValid,
+            identityStorage: storage
         )
     }
 

--- a/ConvosCore/Sources/ConvosCore/Messaging/InstallationInfo.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/InstallationInfo.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+/// Lightweight wrapper around an XMTP installation entry. Mirrors
+/// `XMTPiOS.Installation` without leaking the SDK type through
+/// `XMTPClientProvider` (per the codebase's XMTP abstraction rule).
+public struct InstallationInfo: Sendable, Hashable {
+    public let id: String
+    public let createdAt: Date?
+
+    public init(id: String, createdAt: Date?) {
+        self.id = id
+        self.createdAt = createdAt
+    }
+}
+
+/// Snapshot of the current device's XMTP inbox state, surfaced for
+/// the debug "Installations" view. The list is sorted oldest-first
+/// so the row pinned to the top is the most stable record.
+public struct InstallationsSnapshot: Sendable {
+    public let inboxId: String
+    public let currentInstallationId: String
+    public let installations: [InstallationInfo]
+
+    public init(inboxId: String, currentInstallationId: String, installations: [InstallationInfo]) {
+        self.inboxId = inboxId
+        self.currentInstallationId = currentInstallationId
+        self.installations = installations
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Messaging/MessagingService.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/MessagingService.swift
@@ -350,4 +350,41 @@ final class MessagingService: MessagingServiceProtocol, @unchecked Sendable {
         }
         try await sender.sendTypingIndicator(isTyping: isTyping)
     }
+
+    func installationsSnapshot(refreshFromNetwork: Bool) async throws -> InstallationsSnapshot {
+        let result = try await sessionStateManager.waitForInboxReadyResult()
+        let installations = try await result.client.listInstallations(refreshFromNetwork: refreshFromNetwork)
+        return InstallationsSnapshot(
+            inboxId: result.client.inboxId,
+            currentInstallationId: result.client.installationId,
+            installations: installations.sorted { lhs, rhs in
+                switch (lhs.createdAt, rhs.createdAt) {
+                case let (l?, r?): return l < r
+                case (nil, _?): return false
+                case (_?, nil): return true
+                case (nil, nil): return lhs.id < rhs.id
+                }
+            }
+        )
+    }
+
+    func revokeOtherInstallations() async throws -> [String] {
+        let result = try await sessionStateManager.waitForInboxReadyResult()
+        guard let identity = try await identityStore.load() else {
+            throw MessagingServiceError.noIdentity
+        }
+        let installations = try await result.client.listInstallations(refreshFromNetwork: true)
+        let currentId = result.client.installationId
+        let othersHex = installations.map { $0.id }.filter { $0 != currentId }
+        guard !othersHex.isEmpty else { return [] }
+        try await result.client.revokeInstallations(
+            signingKey: identity.keys.signingKey,
+            installationIds: othersHex
+        )
+        return othersHex
+    }
+}
+
+enum MessagingServiceError: Error {
+    case noIdentity
 }

--- a/ConvosCore/Sources/ConvosCore/Messaging/MessagingServiceProtocol.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/MessagingServiceProtocol.swift
@@ -107,4 +107,14 @@ public protocol MessagingServiceProtocol: AnyObject, Sendable {
     /// fires, so the agent's incoming-payload handler can be exercised end-to-end. The UI
     /// entry point is `#if DEBUG`-gated in the main app target.
     func sendDebugConnectionPayload(_ payload: ConnectionPayload, to conversationId: String) async throws
+
+    /// Returns the current device's inbox state — installation id, inbox id, and every
+    /// installation the network reports for this inbox. Used by the debug menu to show
+    /// whether the device has hit the 10-installation cap.
+    func installationsSnapshot(refreshFromNetwork: Bool) async throws -> InstallationsSnapshot
+
+    /// Revokes every installation registered to this inbox except the one currently
+    /// active on this device. Returns the ids that were revoked. Used to recover from
+    /// the 10-installation cap after wipe-and-reinstall cycles accumulate stale entries.
+    func revokeOtherInstallations() async throws -> [String]
 }

--- a/ConvosCore/Sources/ConvosCore/Messaging/XMTPClientProvider.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/XMTPClientProvider.swift
@@ -104,6 +104,7 @@ public protocol XMTPClientProvider: AnyObject {
     func revokeInstallations(
         signingKey: SigningKey, installationIds: [String]
     ) async throws
+    func listInstallations(refreshFromNetwork: Bool) async throws -> [InstallationInfo]
     func deleteLocalDatabase() throws
     func reconnectLocalDatabase() async throws
     func dropLocalDatabaseConnection() throws
@@ -206,6 +207,11 @@ extension XMTPiOS.Client: XMTPClientProvider {
             throw XMTPClientProviderError.conversationNotFound(id: conversationId)
         }
         try await foundConversation.updateConsentState(state: consent.consentState)
+    }
+
+    public func listInstallations(refreshFromNetwork: Bool) async throws -> [InstallationInfo] {
+        let state = try await inboxState(refreshFromNetwork: refreshFromNetwork)
+        return state.installations.map { InstallationInfo(id: $0.id, createdAt: $0.createdAt) }
     }
 }
 

--- a/ConvosCore/Sources/ConvosCore/Mocks/MockMessagingService.swift
+++ b/ConvosCore/Sources/ConvosCore/Mocks/MockMessagingService.swift
@@ -178,6 +178,18 @@ public final class MockMessagingService: MessagingServiceProtocol, @unchecked Se
 
     public func sendDebugConnectionPayload(_ payload: ConnectionPayload, to conversationId: String) async throws {
     }
+
+    public func installationsSnapshot(refreshFromNetwork: Bool) async throws -> InstallationsSnapshot {
+        InstallationsSnapshot(
+            inboxId: "mock-inbox-id",
+            currentInstallationId: "mock-installation-id",
+            installations: [InstallationInfo(id: "mock-installation-id", createdAt: nil)]
+        )
+    }
+
+    public func revokeOtherInstallations() async throws -> [String] {
+        []
+    }
 }
 
 public final class MockConnectionEventWriter: ConnectionEventWriterProtocol, @unchecked Sendable {

--- a/ConvosCore/Sources/ConvosCore/Mocks/MockXMTPClientProvider.swift
+++ b/ConvosCore/Sources/ConvosCore/Mocks/MockXMTPClientProvider.swift
@@ -69,6 +69,10 @@ public final class MockXMTPClientProvider: XMTPClientProvider, @unchecked Sendab
         // No-op for mock
     }
 
+    public func listInstallations(refreshFromNetwork: Bool) async throws -> [InstallationInfo] {
+        [InstallationInfo(id: installationId, createdAt: nil)]
+    }
+
     public func deleteLocalDatabase() throws {
         // No-op for mock
     }

--- a/KeychainIdentityStoreTests/KeychainIdentityStoreTests.swift
+++ b/KeychainIdentityStoreTests/KeychainIdentityStoreTests.swift
@@ -131,12 +131,14 @@ import Testing
         #expect(decoded.databaseKey == keys.databaseKey)
     }
 
-    /// `KeychainIdentityStore` writes with `kSecAttrSynchronizable: false`,
-    /// so the saved item must live in the device-local store and **not** in
-    /// the iCloud-synced one. iOS treats synced and non-synced items as
-    /// separate stores even with the same service+account, so a query that
-    /// pins `kSecAttrSynchronizable: true` must miss it.
-    @Test func savedIdentityIsDeviceLocalNotSynced() async throws {
+    /// `KeychainIdentityStore` now writes with
+    /// `kSecAttrSynchronizable: true` to the new `syncedIdentityService`
+    /// slot so the identity propagates via iCloud Keychain to every
+    /// device on the same Apple ID. The legacy
+    /// `kSecAttrSynchronizable: false` slot at the v3 service is
+    /// retained as a read-only migration source — new writes must
+    /// never land there.
+    @Test func savedIdentityIsSyncedNotLocal() async throws {
         try await keychainStore.delete()
 
         let keys = try await keychainStore.generateKeys()
@@ -146,24 +148,10 @@ import Testing
             keys: keys
         )
 
-        // Pinned non-sync query → must find the item.
-        let nonSyncQuery: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: KeychainIdentityStore.defaultService,
-            kSecAttrAccount as String: KeychainIdentityStore.identityAccount,
-            kSecAttrAccessGroup as String: testAccessGroup,
-            kSecAttrSynchronizable as String: false,
-            kSecMatchLimit as String: kSecMatchLimitOne,
-            kSecReturnAttributes as String: true
-        ]
-        var nonSyncResult: CFTypeRef?
-        let nonSyncStatus = SecItemCopyMatching(nonSyncQuery as CFDictionary, &nonSyncResult)
-        #expect(nonSyncStatus == errSecSuccess, "Item should be present in the device-local slot (status=\(nonSyncStatus))")
-
-        // Pinned sync query → must NOT find the item.
+        // Synced slot at the v4-synced service → must find the item.
         let syncQuery: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: KeychainIdentityStore.defaultService,
+            kSecAttrService as String: KeychainIdentityStore.syncedIdentityService,
             kSecAttrAccount as String: KeychainIdentityStore.identityAccount,
             kSecAttrAccessGroup as String: testAccessGroup,
             kSecAttrSynchronizable as String: true,
@@ -172,7 +160,101 @@ import Testing
         ]
         var syncResult: CFTypeRef?
         let syncStatus = SecItemCopyMatching(syncQuery as CFDictionary, &syncResult)
-        #expect(syncStatus == errSecItemNotFound, "Item must not be in the iCloud-synced slot (status=\(syncStatus))")
+        #expect(syncStatus == errSecSuccess, "Item should be present in the synced slot (status=\(syncStatus))")
+
+        // Legacy v3 service must NOT receive new writes.
+        let legacyQuery: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: KeychainIdentityStore.legacyIdentityService,
+            kSecAttrAccount as String: KeychainIdentityStore.identityAccount,
+            kSecAttrAccessGroup as String: testAccessGroup,
+            kSecAttrSynchronizable as String: false,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+            kSecReturnAttributes as String: true
+        ]
+        var legacyResult: CFTypeRef?
+        let legacyStatus = SecItemCopyMatching(legacyQuery as CFDictionary, &legacyResult)
+        #expect(legacyStatus == errSecItemNotFound, "Item must not be in the legacy slot (status=\(legacyStatus))")
+    }
+
+    /// Existing users on the pre-sync build have their identity in the
+    /// legacy device-local slot. The first `load()` on the new build
+    /// must return that identity *and* migrate it to the synced slot
+    /// so subsequent loads stay on the synced path.
+    @Test func legacyIdentityMigratesToSyncedOnLoad() async throws {
+        try await keychainStore.delete()
+
+        let keys = try await keychainStore.generateKeys()
+        let identity = KeychainIdentity(
+            inboxId: "legacy-inbox",
+            clientId: "legacy-client",
+            keys: keys
+        )
+        let data = try JSONEncoder().encode(identity)
+
+        // Seed the legacy slot directly (bypass the store's save path,
+        // which would route to the synced slot).
+        let addQuery: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: KeychainIdentityStore.legacyIdentityService,
+            kSecAttrAccount as String: KeychainIdentityStore.identityAccount,
+            kSecAttrAccessGroup as String: testAccessGroup,
+            kSecAttrSynchronizable as String: false,
+            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlock,
+            kSecValueData as String: data
+        ]
+        _ = SecItemDelete(addQuery as CFDictionary) // clean any stale entry
+        let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
+        #expect(addStatus == errSecSuccess, "Failed to seed legacy slot: \(addStatus)")
+
+        // load() must return the seeded identity (verifies legacy fallback).
+        let loaded = try await keychainStore.load()
+        #expect(loaded?.inboxId == "legacy-inbox")
+        #expect(loaded?.clientId == "legacy-client")
+        #expect(loaded?.keys.databaseKey == keys.databaseKey)
+
+        // After load(), the identity must have moved to the synced slot.
+        let syncQuery: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: KeychainIdentityStore.syncedIdentityService,
+            kSecAttrAccount as String: KeychainIdentityStore.identityAccount,
+            kSecAttrAccessGroup as String: testAccessGroup,
+            kSecAttrSynchronizable as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+            kSecReturnAttributes as String: true
+        ]
+        var syncResult: CFTypeRef?
+        let syncStatus = SecItemCopyMatching(syncQuery as CFDictionary, &syncResult)
+        #expect(syncStatus == errSecSuccess, "Identity should have migrated to the synced slot")
+
+        // …and the legacy slot must be empty.
+        let legacyCheck: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: KeychainIdentityStore.legacyIdentityService,
+            kSecAttrAccount as String: KeychainIdentityStore.identityAccount,
+            kSecAttrAccessGroup as String: testAccessGroup,
+            kSecAttrSynchronizable as String: false,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+            kSecReturnAttributes as String: true
+        ]
+        var legacyResult: CFTypeRef?
+        let legacyStatus = SecItemCopyMatching(legacyCheck as CFDictionary, &legacyResult)
+        #expect(legacyStatus == errSecItemNotFound, "Legacy slot must be cleared post-migration")
+    }
+
+    /// `currentStorageLocation()` is the debug-UI signal for "is this
+    /// device on the new synced layout yet". Three states.
+    @Test func currentStorageLocationReportsTheActiveSlot() async throws {
+        try await keychainStore.delete()
+        #expect(keychainStore.currentStorageLocation() == .missing)
+
+        let keys = try await keychainStore.generateKeys()
+        _ = try await keychainStore.save(
+            inboxId: "loc-inbox",
+            clientId: "loc-client",
+            keys: keys
+        )
+        #expect(keychainStore.currentStorageLocation() == .synced)
     }
 
     @Test func encodesIdentityRoundTrip() async throws {

--- a/docs/plans/icloud-keychain-identity-sync.md
+++ b/docs/plans/icloud-keychain-identity-sync.md
@@ -1,0 +1,164 @@
+# iOS Plan — Sync XMTP identity via iCloud Keychain
+
+> Stacks on top of `louis/auth-siwe-plan` (PR #827). Inspired by the keychain layout work in `louis/backup-relanding` (PR #802), but deliberately *much smaller* — no encrypted backup bundle, no two-key model, no archive importer. Just iCloud Keychain.
+
+## Context
+
+Today the XMTP identity (signing key + database key) lives in a **device-local** Keychain slot:
+
+```swift
+KeychainQuery(account: "convos-identity",
+              service: "org.convos.ios.KeychainIdentityStore.v3",
+              accessGroup: <appGroup>,
+              accessible: kSecAttrAccessibleAfterFirstUnlock,
+              synchronizable: false)   // ← this
+```
+
+Consequence: each device generates its own private key, which derives its own Ethereum address, which produces its own backend `Account` row. Lose the device → lose the account. No multi-device.
+
+Now that SIWE binds the iOS app to a backend `Account` via the Ethereum address derived from this key, "the same wallet on two devices = the same backend account" is a free feature *if* the key can follow the user across their Apple-ID-paired devices.
+
+## Goal
+
+Identity syncs via **iCloud Keychain** to all devices signed in to the same Apple ID. Sign in on iPhone → install Convos on iPad → already signed in to the same `Account`.
+
+## Scope (deliberately tight)
+
+- Flip the existing `KeychainIdentityKeys` slot to `synchronizable: true`.
+- One-shot migration for existing users: move the identity from the current device-local slot into the synced slot on first launch with the new build.
+- Surface state in the debug menu (which slot the identity lives in, sync flag).
+- Tests.
+
+**Explicitly NOT in this PR**
+- Encrypted backup bundle (`Convos/Backup/*` from PR #802) — separate, larger effort.
+- Two-key model splitting identity vs backup-envelope (PR #802 territory).
+- BIP-39 mnemonic export.
+- "Trusted device" linking flow.
+- Cross-platform restore.
+
+Each of those is real and worth doing eventually. None is required to ship iCloud sync for the SIWE/multi-device path.
+
+## Why "just flip the flag" works for the SIWE flow
+
+The backend's `upsertAuthMethodAndAccount` uniques on `(SIWE, lowercased_address)`. Two devices with the same private key resolve to the same address, which resolves to the same `Account.id`. Each device still mints its own JWT (the JWT slot is `(deviceId, address)`-scoped, so no JWT cross-talk). libxmtp creates a separate **installation** per device anyway — both authorized by the shared owner key. This is exactly XMTP's intended multi-device shape.
+
+## Design
+
+### File-level changes
+
+**`ConvosCore/Sources/ConvosCore/Auth/Keychain/KeychainIdentityStore.swift`**
+
+Introduce a second service identifier alongside the existing v3:
+
+```swift
+public static let legacyIdentityService: String = "org.convos.ios.KeychainIdentityStore.v3"  // local-only
+public static let syncedIdentityService: String = "org.convos.ios.KeychainIdentityStore.v4-synced"
+```
+
+Keep the same `account` (`convos-identity`) and the same `kSecAttrAccessibleAfterFirstUnlock` (already sync-compatible). The only attribute that changes between slots is `kSecAttrSynchronizable`.
+
+**Read path** — `load()` / `loadSync()` checks the synced slot first, falls back to legacy:
+
+```swift
+public nonisolated func loadSync() throws -> KeychainIdentity? {
+    if let data = try? Self.loadKeychainData(with: syncedQuery().toReadDictionary()) {
+        return try JSONDecoder().decode(KeychainIdentity.self, from: data)
+    }
+    if let data = try? Self.loadKeychainData(with: legacyQuery().toReadDictionary()) {
+        // Lazy migration on next save(); read returns the legacy data verbatim.
+        return try JSONDecoder().decode(KeychainIdentity.self, from: data)
+    }
+    return nil
+}
+```
+
+**Write path** — `save(...)` writes the synced slot and removes the legacy one in the same call so the migration is self-healing on any identity touch:
+
+```swift
+public func save(inboxId:, clientId:, keys:) throws -> KeychainIdentity {
+    let identity = KeychainIdentity(...)
+    try saveData(JSONEncoder().encode(identity), with: syncedQuery())
+    try? deleteData(with: legacyQuery())  // best-effort migration; ignore "not found"
+    return identity
+}
+```
+
+**Delete path** — `delete()` clears both slots so a sign-out wipes the legacy holdover too.
+
+### Migration (one-shot, lazy)
+
+Triggered on the first save after upgrade. The path is:
+
+1. User upgrades, opens app.
+2. Existing identity in `…v3` (local-only).
+3. App calls `load()` — checks synced slot (miss), falls back to legacy (hit), returns identity.
+4. Next time anything calls `save()` (most app lifecycle events touch this), the identity is written to `…v4-synced` and the legacy slot is deleted.
+5. CKKS picks up the new synced item over the next minutes; paired devices see it.
+
+Optional aggressive variant: run an explicit `save` on first launch after upgrade (if `load()` returned legacy data) to force the migration without waiting for an organic save. Cheap, removes the "if save never fires" tail risk.
+
+PR #802's `KeychainLayoutMigrator` does a more elaborate guarded version with `UserDefaults` generation tracking. We don't need that complexity here because (a) the source slot is **local-only** (no cross-device deletion to coordinate) and (b) the migration is idempotent — running it more than once is a no-op.
+
+### Debug surface
+
+Add to `DebugAuthProbeView` (or as its own row in `DebugViewSection.authProbeSection`):
+
+- "Identity slot: synced / legacy / missing"
+- "Synchronizable flag: yes / no"
+- "iCloud Keychain enabled (device-level)": from `SecCopyMatching` query against an iCloud-eligible class — only useful if Apple ever exposes a programmatic check; otherwise show "unknown" with a deep-link to Settings → iCloud → Keychain.
+
+This is the same observability shape we added for `accountId` in PR #827 — read-only, refreshable, no network.
+
+### Doc updates
+
+- Update the `KeychainIdentityStore` class doc to explain the v3-local → v4-synced migration.
+- Inline note: `databaseKey` gets synced too as part of `KeychainIdentityKeys`. This is harmless (each device's SQLCipher DB is separate; shared key doesn't cross databases) but suboptimal — splitting them is PR #802's two-key refactor.
+
+## Tests
+
+In `ConvosCoreTests` (or `KeychainIdentityStoreTests` if that target is enabled):
+
+1. Save → re-load round-trip writes to synced slot with `kSecAttrSynchronizable == true`.
+2. Pre-populate the legacy slot, call `load()`, expect identity returned. Then call `save()`, expect the identity to be present in the synced slot and absent from the legacy slot.
+3. `delete()` clears both slots.
+
+Notes:
+- Simulator keychain doesn't actually push to iCloud, but it accepts and persists the `synchronizable` flag. Tests verify the *attribute* is set, not the wire push.
+- The existing test target's keychain access can be flaky without entitlements; reuse the `MockKeychainService`-style pattern where useful, or stub via a protocol seam if testing on the real backend is needed.
+
+## Risks
+
+| Risk | Mitigation |
+| --- | --- |
+| **`databaseKey` is shared across devices via sync.** | Harmless today (each device has its own DB). Acknowledged in the doc. PR #802 splits this properly later. |
+| **User has iCloud Keychain disabled.** | Item lives in the synced slot but doesn't propagate — i.e. degrades to current device-local behavior. We should surface "iCloud Keychain off" as a soft UI nudge somewhere (not in this PR). |
+| **CKKS propagation latency.** | Typically <10 min, can be longer in pathological cases. Document as "may take a few minutes." |
+| **Existing user re-installs the app.** | Identity is in iCloud Keychain — re-install picks it up automatically, same Account on backend. ✅ This is the headline win. |
+| **User deletes the app on all devices.** | iCloud Keychain retains the item per Apple's retention policy. Reinstalling restores it. If they fully sign out before that, the slot is gone. |
+| **Family Sharing / shared iCloud account.** | Out of scope. iCloud Keychain is per-iCloud-account; if two real users share an Apple ID, they share an identity. That's a product policy question. |
+
+## Verification
+
+After implementing, end-to-end:
+
+1. Install app on **simulator A**. Sign in. Note the address + accountId in the Debug → SIWE Auth Probe screen.
+2. Install on **simulator B with the same Apple ID** (or a real second device).
+3. After a few minutes, open Convos on B — Debug → SIWE Auth Probe should show the **same address and accountId** without any onboarding step.
+4. Run `SELECT … FROM "AuthMethod" WHERE type = 'SIWE'` on the backend — exactly one row, one Account, two devices behind it.
+5. Sign out on A — confirm both slots cleared on A, but B's still has the identity (until B signs out separately).
+
+## Out of scope / future work (link forward)
+
+- **Backup bundles** (PR #802): adds an encrypted archive of XMTP DB state so a restored device picks up message history. Independent of this PR but compatible.
+- **BIP-39 mnemonic export**: for users who want a non-iCloud backup. Builds on this PR's `KeychainIdentityKeys` by exposing a "show seed phrase" sheet.
+- **Per-installation key separation**: split the per-device `databaseKey` out of `KeychainIdentityKeys` and keep only the owner key in the synced slot. PR #802's two-key model.
+- **Account-level multi-device linking**: an explicit "add this device" QR flow instead of relying on iCloud Keychain. Useful for users who don't have iCloud or want cross-platform.
+
+## Estimated work
+
+- `KeychainIdentityStore.swift` edits: ~40 LOC.
+- Debug surface row: ~20 LOC.
+- Tests: ~60 LOC.
+- Doc updates: ~30 LOC.
+
+Single engineer, ~1 day including review-cycle. Behavior change is large; code change is small.


### PR DESCRIPTION
## Summary

Stacks on top of #827 (`louis/auth-siwe-plan`). Implements the plan in `docs/plans/icloud-keychain-identity-sync.md`.

Identity moves from a **device-local** Keychain slot (`kSecAttrSynchronizable: false`) to a **synced** one (`true`). Result: install Convos on a second device signed in to the same Apple ID → same wallet → same SIWE address → same backend `Account`, no per-device onboarding.

## What changed

| Surface | Before | After |
| --- | --- | --- |
| `KeychainIdentityStore` service | one slot, `…v3`, `synchronizable: false` | two slots — `…v4-synced` (`true`, new writes) + `…v3` (`false`, read-only legacy) |
| `save()` | writes the single slot | writes synced + best-effort deletes legacy |
| `load()` | reads single slot | prefers synced, falls back to legacy and migrates inline (legacy deleted only after successful synced write) |
| `loadSync()` (NSE-safe) | reads single slot | same precedence, never mutates |
| `delete()` | wipes single slot | wipes both |
| New API | — | `IdentityStorageLocation` + `currentStorageLocation()` (debug-only signal) |

`BackendAuthProbe.Status` gains `identityStorage`. The debug screen renders a color-coded "Identity slot: Synced / Local-only / Not stored" row.

## Migration

Idempotent and self-healing:

1. Existing user opens new build. Identity is in the legacy slot.
2. First `load()` returns it AND copies to the synced slot. Legacy is deleted after a confirmed synced write.
3. Next `loadSync()` from NSE reads the synced slot directly.
4. If the synced write fails (e.g. iCloud Keychain disabled), the legacy slot is preserved — the user never loses their identity.

## Out of scope

- **Backup bundles** (PR #802 territory). This PR is purely about identity sync; bundle-level backup/restore + the two-key model that splits `databaseKey` from the owner key are layered on top there.
- **BIP-39 export**, **trusted-device linking**, **social recovery**. All discussed in the plan doc as future work.

## Test plan

- [x] `ConvosCore` SIWE tests still pass (14 tests).
- [x] `Convos (Local)` scheme builds clean.
- [x] `KeychainIdentityStoreTests` updated:
  - inverted `savedIdentityIsSyncedNotLocal` (new contract).
  - new `legacyIdentityMigratesToSyncedOnLoad` (seeds legacy slot via `SecItemAdd`, runs `load()`, asserts migration).
  - new `currentStorageLocationReportsTheActiveSlot`.
- [x] **Live multi-device verification** — install on simulator A, sign in, install on simulator B with same Apple ID, observe same address + accountId after a few minutes of CKKS propagation.

## Stacked PR notes

Base is `louis/auth-siwe-plan` (PR #827). Once #827 merges to `dev`, the base of this PR can be retargeted to `dev` for a normal review. The plan doc was committed first; the implementation is the follow-up commit `da52ca5d`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/835"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Sync XMTP identity to iCloud Keychain with lazy migration from local-only slot
> - `KeychainIdentityStore` now writes identity data to a synchronizable iCloud Keychain slot (`v4-synced`) instead of the previous device-local slot; `delete()` clears both slots.
> - On load, if only the legacy slot is populated, the identity is lazily migrated to the synced slot and the legacy entry is removed.
> - `BackendAuthProbe.Status` exposes an `IdentityStorageLocation` (`.synced`, `.legacy`, or `.missing`) visible in the debug auth probe screen.
> - `MessagingService` gains `installationsSnapshot(refreshFromNetwork:)` and `revokeOtherInstallations()` methods, surfaced in a new `DebugInstallationsView` accessible from the debug menu.
> - Risk: Existing users on first launch after update will silently migrate their keychain entry; if the synced write fails, the legacy entry is retained and the identity is still returned, leaving the device in a `.legacy` state.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 966723f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->