### PR TITLE
Add whiteboard attachment

### DIFF
--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesBottomBar.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesBottomBar.swift
@@ -85,6 +85,7 @@ struct MessagesBottomBar<BottomBarContent: View>: View {
     @State private var isMessageInputFocused: Bool = false
     @State private var isImagePickerPresented: Bool = false
     @State private var isCameraPresented: Bool = false
+    @State private var isWhiteboardPresented: Bool = false
     @State private var isFilePickerPresented: Bool = false
     @State private var showFileTooLargeAlert: Bool = false
     @State private var showFileTruncatedAlert: Bool = false
@@ -135,6 +136,9 @@ struct MessagesBottomBar<BottomBarContent: View>: View {
             .fullScreenCover(isPresented: $isCameraPresented) {
                 cameraPickerCover
             }
+            .fullScreenCover(isPresented: $isWhiteboardPresented) {
+                whiteboardCover
+            }
     }
 
     @ViewBuilder
@@ -175,6 +179,22 @@ struct MessagesBottomBar<BottomBarContent: View>: View {
             onVideoCaptured: { url in
                 onVideoSelected(url)
                 isCameraPresented = false
+                focusCoordinator.moveFocus(to: .message)
+            }
+        )
+        .ignoresSafeArea()
+    }
+
+    @ViewBuilder
+    private var whiteboardCover: some View {
+        WhiteboardView(
+            onImageCreated: { image in
+                onPhotoSelected(image)
+                isWhiteboardPresented = false
+                focusCoordinator.moveFocus(to: .message)
+            },
+            onCancel: {
+                isWhiteboardPresented = false
                 focusCoordinator.moveFocus(to: .message)
             }
         )
@@ -393,6 +413,7 @@ struct MessagesBottomBar<BottomBarContent: View>: View {
                 MessagesMediaButtonsView(
                     isPhotoPickerPresented: $isPhotoPickerPresented,
                     isCameraPresented: $isCameraPresented,
+                    isWhiteboardPresented: $isWhiteboardPresented,
                     onVoiceMemoTap: startVoiceMemoRecording,
                     onFilePickerTap: {
                         isFilePickerPresented = true

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesMediaInputView.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesMediaInputView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct MessagesMediaButtonsView: View {
     @Binding var isPhotoPickerPresented: Bool
     @Binding var isCameraPresented: Bool
+    @Binding var isWhiteboardPresented: Bool
     let onVoiceMemoTap: () -> Void
     let onFilePickerTap: () -> Void
     let onConvosAction: () -> Void
@@ -49,6 +50,20 @@ struct MessagesMediaButtonsView: View {
             .disabled(isMediaCapacityFull)
             .accessibilityLabel("Camera")
             .accessibilityIdentifier("camera-button")
+
+            Button {
+                isWhiteboardPresented = true
+            } label: {
+                Image(systemName: "pencil.tip.crop.circle")
+                    .font(.system(size: 18.0, weight: .medium))
+                    .foregroundStyle(mediaTint)
+                    .frame(width: Constant.buttonSize, height: Constant.buttonSize)
+                    .contentShape(.circle)
+            }
+            .buttonStyle(.plain)
+            .disabled(isMediaCapacityFull)
+            .accessibilityLabel("Whiteboard")
+            .accessibilityIdentifier("whiteboard-button")
 
             Button {
                 onVoiceMemoTap()
@@ -124,10 +139,12 @@ struct MessagesMediaButtonsView: View {
 #Preview {
     @Previewable @State var isPhotoPickerPresented: Bool = false
     @Previewable @State var isCameraPresented: Bool = false
+    @Previewable @State var isWhiteboardPresented: Bool = false
 
     MessagesMediaButtonsView(
         isPhotoPickerPresented: $isPhotoPickerPresented,
         isCameraPresented: $isCameraPresented,
+        isWhiteboardPresented: $isWhiteboardPresented,
         onVoiceMemoTap: {},
         onFilePickerTap: {},
         onConvosAction: {}

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/WhiteboardView.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/WhiteboardView.swift
@@ -57,16 +57,21 @@ final class WhiteboardViewController: UIViewController {
         view.backgroundColor = .white
         title = "Whiteboard"
 
-        navigationItem.leftBarButtonItem = UIBarButtonItem(
+        let cancelButton = UIBarButtonItem(
             barButtonSystemItem: .cancel,
             target: self,
             action: #selector(handleCancel)
         )
-        navigationItem.rightBarButtonItem = UIBarButtonItem(
+        cancelButton.accessibilityIdentifier = "whiteboard-cancel-button"
+        navigationItem.leftBarButtonItem = cancelButton
+
+        let doneButton = UIBarButtonItem(
             barButtonSystemItem: .done,
             target: self,
             action: #selector(handleDone)
         )
+        doneButton.accessibilityIdentifier = "whiteboard-done-button"
+        navigationItem.rightBarButtonItem = doneButton
 
         view.addSubview(canvasView)
         NSLayoutConstraint.activate([

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/WhiteboardView.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/WhiteboardView.swift
@@ -1,0 +1,136 @@
+import PencilKit
+import SwiftUI
+import UIKit
+
+struct WhiteboardView: UIViewControllerRepresentable {
+    let onImageCreated: (UIImage) -> Void
+    let onCancel: () -> Void
+
+    @Environment(\.dismiss) private var dismiss: DismissAction
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(onImageCreated: onImageCreated, onCancel: onCancel, dismiss: dismiss)
+    }
+
+    func makeUIViewController(context: Context) -> UINavigationController {
+        let canvasController = WhiteboardViewController()
+        canvasController.coordinator = context.coordinator
+        let navigationController = UINavigationController(rootViewController: canvasController)
+        navigationController.modalPresentationStyle = .fullScreen
+        return navigationController
+    }
+
+    func updateUIViewController(_: UINavigationController, context _: Context) {}
+
+    final class Coordinator {
+        let onImageCreated: (UIImage) -> Void
+        let onCancel: () -> Void
+        let dismiss: DismissAction
+
+        init(
+            onImageCreated: @escaping (UIImage) -> Void,
+            onCancel: @escaping () -> Void,
+            dismiss: DismissAction
+        ) {
+            self.onImageCreated = onImageCreated
+            self.onCancel = onCancel
+            self.dismiss = dismiss
+        }
+    }
+}
+
+final class WhiteboardViewController: UIViewController {
+    weak var coordinator: WhiteboardView.Coordinator?
+
+    private let canvasView: PKCanvasView = {
+        let view = PKCanvasView()
+        view.backgroundColor = .white
+        view.drawingPolicy = .anyInput
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
+    private let toolPicker: PKToolPicker = PKToolPicker()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .white
+        title = "Whiteboard"
+
+        navigationItem.leftBarButtonItem = UIBarButtonItem(
+            barButtonSystemItem: .cancel,
+            target: self,
+            action: #selector(handleCancel)
+        )
+        navigationItem.rightBarButtonItem = UIBarButtonItem(
+            barButtonSystemItem: .done,
+            target: self,
+            action: #selector(handleDone)
+        )
+
+        view.addSubview(canvasView)
+        NSLayoutConstraint.activate([
+            canvasView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            canvasView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            canvasView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            canvasView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+        ])
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        toolPicker.setVisible(true, forFirstResponder: canvasView)
+        toolPicker.addObserver(canvasView)
+        canvasView.becomeFirstResponder()
+    }
+
+    @objc
+    private func handleCancel() {
+        guard !canvasView.drawing.strokes.isEmpty else {
+            coordinator?.onCancel()
+            coordinator?.dismiss()
+            return
+        }
+        let alert = UIAlertController(
+            title: "Discard drawing?",
+            message: "Your drawing will be lost.",
+            preferredStyle: .alert
+        )
+        alert.addAction(UIAlertAction(title: "Keep editing", style: .cancel))
+        alert.addAction(UIAlertAction(title: "Discard", style: .destructive) { [weak self] _ in
+            self?.coordinator?.onCancel()
+            self?.coordinator?.dismiss()
+        })
+        present(alert, animated: true)
+    }
+
+    @objc
+    private func handleDone() {
+        let drawing: PKDrawing = canvasView.drawing
+        let scale: CGFloat = traitCollection.displayScale
+
+        guard !drawing.strokes.isEmpty else {
+            coordinator?.onCancel()
+            coordinator?.dismiss()
+            return
+        }
+
+        let padding: CGFloat = Constant.cropPadding
+        let strokeBounds: CGRect = drawing.bounds.insetBy(dx: -padding, dy: -padding)
+        let cropRect: CGRect = strokeBounds.intersection(canvasView.bounds)
+
+        let renderer = UIGraphicsImageRenderer(size: cropRect.size)
+        let image: UIImage = renderer.image { _ in
+            UIColor.white.setFill()
+            UIRectFill(CGRect(origin: .zero, size: cropRect.size))
+            drawing.image(from: cropRect, scale: scale).draw(at: .zero)
+        }
+
+        coordinator?.onImageCreated(image)
+        coordinator?.dismiss()
+    }
+
+    private enum Constant {
+        static let cropPadding: CGFloat = 32.0
+    }
+}

--- a/docs/plans/whiteboard-attachment.md
+++ b/docs/plans/whiteboard-attachment.md
@@ -1,0 +1,205 @@
+# Whiteboard Attachment
+
+## User Story
+
+**As a user, I want to draw something on a whiteboard and send it as an attachment in a conversation.**
+
+Flow: Attach → Camera Roll / **Whiteboard** → Whiteboard → Draw → Send
+
+## Problem
+
+Users currently have no way to quickly sketch, annotate, or hand-draw something inline in a conversation. The only image sources are the photo library and the camera. A whiteboard fills the gap for quick diagrams, doodles, handwritten notes, or visual explanations without leaving the app.
+
+## Existing Architecture
+
+### Attachment pipeline
+
+The entire image-send flow is driven by a single binding:
+
+```swift
+@Binding var selectedAttachmentImage: UIImage?
+```
+
+When this value is set (from any source — photo picker, camera, or a future whiteboard), the following happens automatically:
+
+1. A thumbnail preview appears in the composer (`MessagesInputView.attachmentPreviewArea`)
+2. The user can remove it via the X button before sending
+3. On send, `ConversationViewModel.sendAttachmentIfNeeded()` fires
+4. The image is compressed, encrypted, and uploaded via `PhotoAttachmentService`
+5. A `RemoteAttachment` is published over XMTP
+6. Recipients see it as a normal image bubble
+
+No changes to the send pipeline, encryption, XMTP encoding, or receiving/rendering are required. The whiteboard is just another `UIImage` source.
+
+### Media buttons
+
+`MessagesMediaButtonsView` renders the row of attachment actions (photo library, camera, voice memo, Convos action). Each button toggles a `@State` bool that presents a picker or full-screen cover. Adding a whiteboard button follows the same pattern.
+
+### Key files
+
+| File | Role |
+|------|------|
+| `Convos/.../Views/MessagesMediaInputView.swift` | Media button row (`MessagesMediaButtonsView`) |
+| `Convos/.../Views/MessagesBottomBar.swift` | Wires pickers, camera, and media buttons; manages `selectedAttachmentImage` |
+| `Convos/.../Views/MessagesInputView.swift` | Composer with attachment preview strip |
+| `Convos/.../Views/CameraPickerView.swift` | Reference pattern — `UIViewControllerRepresentable` that returns a `UIImage` |
+| `Convos/Conversation Detail/ConversationViewModel.swift` | Send orchestration; `onPhotoSelected`, `sendAttachmentIfNeeded` |
+| `ConvosCore/.../Writers/OutgoingMessageWriter.swift` | Eager upload, encryption, XMTP publish |
+| `ConvosCore/.../Messaging/PhotoAttachmentService.swift` | Compression, encryption, upload |
+
+## Design
+
+### Entry point
+
+Add a whiteboard button to `MessagesMediaButtonsView`, between the camera and voice memo buttons.
+
+- SF Symbol: `pencil.tip.crop.circle` (or `scribble.variable` — designer's call)
+- Accessibility label: "Whiteboard"
+- Behavior: sets `isWhiteboardPresented = true`
+
+### Whiteboard screen
+
+Presented as a `.fullScreenCover` (same as the camera), containing a drawing canvas.
+
+**Technology:** PencilKit (`PKCanvasView`). It provides:
+
+- Finger and Apple Pencil drawing out of the box
+- Pen, marker, and eraser tools
+- Pressure and tilt sensitivity (Apple Pencil)
+- Programmatic undo/redo
+- Rendering to `UIImage` via `PKDrawing.image(from:scale:)`
+
+**Layout:**
+
+```
+┌──────────────────────────────────┐
+│  Cancel              Done        │  ← Navigation bar
+├──────────────────────────────────┤
+│                                  │
+│                                  │
+│         PKCanvasView             │  ← Drawing area (white background)
+│                                  │
+│                                  │
+├──────────────────────────────────┤
+│  Undo   Redo   Color   Tool     │  ← Toolbar
+└──────────────────────────────────┘
+```
+
+**Controls:**
+
+| Control | Behavior |
+|---------|----------|
+| Cancel | Dismiss without sending. If the canvas has strokes, show a confirmation alert. |
+| Done | Render the canvas to `UIImage`, pass it back, dismiss. |
+| Undo / Redo | `PKCanvasView.undoManager` (built-in) |
+| Tool picker | Pen / Marker / Eraser. Can use `PKToolPicker` (system-provided floating palette) or a custom segmented control. |
+| Color | A small palette of preset colors (black, red, blue, green, orange, purple) + optional custom color via `ColorPicker`. |
+
+**Canvas rendering:**
+
+```swift
+let image = drawing.image(from: canvasView.bounds, scale: UIScreen.main.scale)
+```
+
+This produces a `UIImage` at screen resolution — the same type the rest of the pipeline expects.
+
+### Wiring
+
+In `MessagesBottomBar`:
+
+```swift
+@State private var isWhiteboardPresented: Bool = false
+
+// In the .fullScreenCover chain:
+.fullScreenCover(isPresented: $isWhiteboardPresented) {
+    WhiteboardView(
+        onImageCreated: { image in
+            selectedAttachmentImage = image
+            isWhiteboardPresented = false
+            focusCoordinator.moveFocus(to: .message)
+        }
+    )
+    .ignoresSafeArea()
+}
+```
+
+In `MessagesMediaButtonsView`, add the binding and a new button.
+
+### What the recipient sees
+
+The drawing is sent as a standard image attachment (`RemoteAttachment` with JPEG/PNG data). Recipients see it in a normal image bubble — no special rendering needed. They can long-press to save it to their photo library, same as any other image.
+
+## Scope
+
+### In scope (v1)
+
+- Whiteboard button in the media button row
+- Full-screen drawing canvas using PencilKit
+- Pen tool with a small color palette
+- Eraser tool
+- Undo / redo
+- Cancel with discard confirmation (if canvas is not empty)
+- Done → renders to `UIImage` → sets `selectedAttachmentImage`
+- User can add text in the composer alongside the drawing before sending
+- Preview thumbnail in the composer (existing behavior)
+- Remove drawing before sending (existing X button behavior)
+
+### Out of scope (future)
+
+- Drawing annotations on top of photos
+- Background color or template options (grid paper, dot grid)
+- Text tool on the canvas
+- Shape recognition / straight-line assist
+- Custom XMTP content type for vector drawings
+- Collaborative / real-time shared whiteboard
+- Recipient-side "Whiteboard" label or badge on the bubble
+
+## Implementation Plan
+
+### 1. `WhiteboardView` (new file)
+
+Create `Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/WhiteboardView.swift`.
+
+- `UIViewControllerRepresentable` wrapping a view controller that hosts `PKCanvasView`
+- Callback: `onImageCreated: (UIImage) -> Void`
+- Navigation bar with Cancel and Done
+- Bottom toolbar with undo, redo, color picker, tool selector
+- `PKToolPicker` attached to the canvas for the system tool palette (alternatively, a custom toolbar if we want tighter design control)
+
+### 2. Update `MessagesMediaButtonsView`
+
+- Add `@Binding var isWhiteboardPresented: Bool`
+- Add a button between camera and voice memo
+
+### 3. Update `MessagesBottomBar`
+
+- Add `@State private var isWhiteboardPresented: Bool`
+- Pass the binding to `MessagesMediaButtonsView`
+- Add `.fullScreenCover` for `WhiteboardView`
+- On image created: set `selectedAttachmentImage`, dismiss, move focus
+
+### 4. Update `MessagesView` / parent wiring
+
+- Thread the new binding through if needed (check if `MessagesMediaButtonsView` is used elsewhere)
+
+### 5. Preview updates
+
+- Update `#Preview` blocks in modified files to include the new binding
+
+## Estimated Effort
+
+| Task | Estimate |
+|------|----------|
+| `WhiteboardView` with PencilKit canvas | 1 day |
+| Media button + `MessagesBottomBar` wiring | 2 hours |
+| Polish (transitions, discard confirmation, toolbar design) | 0.5 day |
+| Testing (device + simulator, finger + Apple Pencil) | 0.5 day |
+| **Total** | **~2 days** |
+
+## Open Questions
+
+1. **Tool palette style:** Use the system `PKToolPicker` (floating, Apple-standard, supports Apple Pencil hover) or a custom fixed toolbar (more design control, consistent with app aesthetic)?
+2. **Canvas background:** Always white? Or offer a dark option for dark mode? A transparent background would render as white in JPEG but could be PNG with transparency.
+3. **Image format:** JPEG (smaller, lossy, no transparency) or PNG (lossless, supports transparency, larger)? The existing photo pipeline uses JPEG compression — drawings with flat colors compress well either way.
+4. **Button placement:** Where exactly in the media row? Between camera and voice memo? Replace the Convos action button? Add to an overflow menu if the row gets crowded?
+5. **Canvas size / aspect ratio:** Full-screen canvas rendered at screen resolution? Or a fixed aspect ratio (e.g., 4:3, square) for more predictable bubble sizing on the recipient side?


### PR DESCRIPTION
## Summary

- New pencil-tip button in the message composer media row opens a fullscreen PencilKit canvas with `PKToolPicker` (pen, marker, eraser, undo).
- `Done` renders the drawing cropped to its bounding box (32pt padding, clamped to canvas) and feeds it through the existing photo attachment pipeline. Recipients see a standard image bubble.
- `Cancel` with strokes prompts to discard. Empty canvas dismisses without sending.

Plan: `docs/plans/whiteboard-attachment.md`.

## Test plan

- [ ] Tap whiteboard button in composer; canvas opens with tool picker.
- [ ] Draw with finger and Apple Pencil; pressure/tilt respected.
- [ ] Pen, marker, eraser, undo, redo from `PKToolPicker` work.
- [ ] `Done` returns to composer with thumbnail; sending publishes a normal image bubble.
- [ ] `Cancel` on empty canvas dismisses instantly.
- [ ] `Cancel` with strokes shows discard confirmation; "Keep editing" stays, "Discard" dismisses.
- [ ] Sent image is cropped to drawing bounds (not full canvas).
- [ ] Rotate device mid-draw; drawing retained.
- [ ] Lint blocked locally by a `xcode-select` mismatch on the author's machine; CI lint will run before merge.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/837"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add whiteboard attachment to conversation message composer
> - Adds a `WhiteboardView` ([WhiteboardView.swift](https://github.com/xmtplabs/convos-ios/pull/837/files#diff-508dfb7615abd6acc7560724044b948c6cfdb9e719ed0680bb53c6721ba4519f)) that wraps a `PKCanvasView`-based `WhiteboardViewController` using `UIViewControllerRepresentable`, providing a full-screen PencilKit drawing experience with a tool picker, cancel with discard confirmation, and export to `UIImage`.
> - Adds a Whiteboard button (`pencil.tip.crop.circle`) to `MessagesMediaButtonsView` that is disabled when media capacity is full.
> - Presents the whiteboard as a `fullScreenCover` from `MessagesBottomBar`; on completion, the drawing is forwarded through `onPhotoSelected` and focus returns to the message field.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fabbe74.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->