### PR TITLE
Paywall UI + mock credits/subscription services

### DIFF
--- a/Convos/Config/FeatureFlags.swift
+++ b/Convos/Config/FeatureFlags.swift
@@ -32,8 +32,22 @@ final class FeatureFlags {
         }
     }
 
+    /// Mock credits/subscription state used by the in-app paywall preview surface
+    /// in the Debug menu. Non-production only; defaults to `.builderAmple`.
+    var mockCreditsPreset: CreditsStatePreset {
+        get {
+            let raw = UserDefaults.standard.string(forKey: Constant.mockCreditsPresetKey)
+                ?? CreditsStatePreset.builderAmple.rawValue
+            return CreditsStatePreset(rawValue: raw) ?? .builderAmple
+        }
+        set {
+            UserDefaults.standard.set(newValue.rawValue, forKey: Constant.mockCreditsPresetKey)
+        }
+    }
+
     private enum Constant {
         static let assistantEnabledKey: String = "featureFlags.assistantEnabled"
         static let debugInjectorEnabledKey: String = "featureFlags.debugInjectorEnabled"
+        static let mockCreditsPresetKey: String = "featureFlags.mockCreditsPreset"
     }
 }

--- a/Convos/Conversations List/ConversationsView.swift
+++ b/Convos/Conversations List/ConversationsView.swift
@@ -157,6 +157,10 @@ struct ConversationsView: View {
         .matchedTransitionSource(id: "app-settings-transition-source", in: namespace)
 
         ToolbarItem(placement: .topBarTrailing) {
+            CreditsBadge()
+        }
+
+        ToolbarItem(placement: .topBarTrailing) {
             filterMenu
         }
         .matchedTransitionSource(id: "filter-view-transition-source", in: namespace)

--- a/Convos/ConvosApp.swift
+++ b/Convos/ConvosApp.swift
@@ -76,6 +76,15 @@ struct ConvosApp: App {
 
         self.convos = .client(environment: environment, platformProviders: .iOS)
 
+        // Sync the mock credits/subscription state from the persisted picker
+        // preset so HOME pill + paywall reflect the operator's last selection.
+        // Non-production only; production builds will swap in real services.
+        if !environment.isProduction {
+            let persistedPreset = FeatureFlags.shared.mockCreditsPreset
+            MockCreditsService.shared.setPreset(persistedPreset)
+            MockSubscriptionService.shared.setPreset(persistedPreset)
+        }
+
         let dbWriter = convos.databaseWriter
         Task {
             await agentKeyset.prefetch()

--- a/Convos/Debug View/DebugView.swift
+++ b/Convos/Debug View/DebugView.swift
@@ -43,6 +43,7 @@ struct DebugViewSection: View {
     @State private var showingAssistantsInfoSheet: Bool = false
     @State private var showingSafariTestSheet: Bool = false
     @State private var presentingPaywall: Bool = false
+    @State private var creditsPresetSelection: CreditsStatePreset = FeatureFlags.shared.mockCreditsPreset
 
     var body: some View {
         Group {
@@ -91,10 +92,15 @@ struct DebugViewSection: View {
     @ViewBuilder
     private var subscriptionSection: some View {
         Section("Subscription (mock)") {
-            Picker("Credits state", selection: Bindable(FeatureFlags.shared).mockCreditsPreset) {
+            Picker("Credits state", selection: $creditsPresetSelection) {
                 ForEach(CreditsStatePreset.allCases) { preset in
                     Text(preset.displayName).tag(preset)
                 }
+            }
+            .onChange(of: creditsPresetSelection) { _, newValue in
+                FeatureFlags.shared.mockCreditsPreset = newValue
+                MockCreditsService.shared.setPreset(newValue)
+                MockSubscriptionService.shared.setPreset(newValue)
             }
 
             let openPaywallAction = { presentingPaywall = true }
@@ -103,8 +109,7 @@ struct DebugViewSection: View {
                     .foregroundStyle(.colorTextPrimary)
             }
             .sheet(isPresented: $presentingPaywall) {
-                let mockService = MockSubscriptionService(initialPreset: FeatureFlags.shared.mockCreditsPreset)
-                let viewModel = PaywallViewModel(subscriptionService: mockService)
+                let viewModel = PaywallViewModel(subscriptionService: MockSubscriptionService.shared)
                 PaywallView(viewModel: viewModel)
             }
         }

--- a/Convos/Debug View/DebugView.swift
+++ b/Convos/Debug View/DebugView.swift
@@ -42,10 +42,12 @@ struct DebugViewSection: View {
     @State private var logStorageInfo: DebugLogExporter.LogStorageInfo?
     @State private var showingAssistantsInfoSheet: Bool = false
     @State private var showingSafariTestSheet: Bool = false
+    @State private var presentingPaywall: Bool = false
 
     var body: some View {
         Group {
             featuresSection
+            subscriptionSection
             pushNotificationsSection
             debugSection
             sentryTestingSection
@@ -82,6 +84,28 @@ struct DebugViewSection: View {
             }
             .sheet(isPresented: $showingSafariTestSheet) {
                 SafariTestSheet()
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var subscriptionSection: some View {
+        Section("Subscription (mock)") {
+            Picker("Credits state", selection: Bindable(FeatureFlags.shared).mockCreditsPreset) {
+                ForEach(CreditsStatePreset.allCases) { preset in
+                    Text(preset.displayName).tag(preset)
+                }
+            }
+
+            let openPaywallAction = { presentingPaywall = true }
+            Button(action: openPaywallAction) {
+                Text("Show Paywall")
+                    .foregroundStyle(.colorTextPrimary)
+            }
+            .sheet(isPresented: $presentingPaywall) {
+                let mockService = MockSubscriptionService(initialPreset: FeatureFlags.shared.mockCreditsPreset)
+                let viewModel = PaywallViewModel(subscriptionService: mockService)
+                PaywallView(viewModel: viewModel)
             }
         }
     }

--- a/Convos/Subscription/CreditsBadge.swift
+++ b/Convos/Subscription/CreditsBadge.swift
@@ -1,0 +1,56 @@
+import ConvosCore
+import SwiftUI
+
+struct CreditsBadge: View {
+    @State private var balance: CreditBalance?
+
+    var body: some View {
+        Group {
+            if let balance, !ConfigManager.shared.currentEnvironment.isProduction {
+                CreditsBadgePill(balance: balance)
+            }
+        }
+        .onReceive(MockCreditsService.shared.balancePublisher) { newBalance in
+            balance = newBalance
+        }
+    }
+}
+
+private struct CreditsBadgePill: View {
+    let balance: CreditBalance
+
+    var body: some View {
+        HStack(spacing: DesignConstants.Spacing.stepX) {
+            Image(systemName: "sparkles")
+                .font(.subheadline)
+                .foregroundStyle(.colorRed)
+            Text(balance.balance, format: .number)
+                .font(.subheadline.weight(.medium))
+                .foregroundStyle(.colorTextPrimary)
+                .monospacedDigit()
+        }
+        .padding(.horizontal, DesignConstants.Spacing.step3x)
+        .padding(.vertical, DesignConstants.Spacing.stepHalf)
+        .background(background)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(balance.balance) credits remaining")
+    }
+
+    @ViewBuilder
+    private var background: some View {
+        Capsule()
+            .fill(Color.colorFillMinimal)
+    }
+}
+
+#Preview {
+    let balance = CreditBalance(
+        balance: 1_400,
+        monthlyGrant: 1_500,
+        monthlyGrantUsed: 100,
+        nextRefreshAt: Date(),
+        periodLabel: "May 2026"
+    )
+    return CreditsBadgePill(balance: balance)
+        .padding()
+}

--- a/Convos/Subscription/PaywallView.swift
+++ b/Convos/Subscription/PaywallView.swift
@@ -3,7 +3,7 @@ import SwiftUI
 
 struct PaywallView: View {
     @State private var viewModel: PaywallViewModel
-    @Environment(\.dismiss) private var dismiss
+    @Environment(\.dismiss) private var dismiss: DismissAction
 
     init(viewModel: PaywallViewModel) {
         self._viewModel = State(initialValue: viewModel)

--- a/Convos/Subscription/PaywallView.swift
+++ b/Convos/Subscription/PaywallView.swift
@@ -1,0 +1,128 @@
+import ConvosCore
+import SwiftUI
+
+struct PaywallView: View {
+    @State private var viewModel: PaywallViewModel
+    @Environment(\.dismiss) private var dismiss
+
+    init(viewModel: PaywallViewModel) {
+        self._viewModel = State(initialValue: viewModel)
+    }
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(spacing: 32) {
+                    hero
+                    periodPicker
+                    tierStack
+                    legal
+                }
+                .padding(.horizontal)
+                .padding(.vertical, 32)
+            }
+            .navigationTitle("")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar { closeButton }
+        }
+        .task { await viewModel.loadProducts() }
+        .alert(
+            "Something went wrong",
+            isPresented: $viewModel.isShowingError,
+            presenting: viewModel.errorMessage
+        ) { _ in
+            Button("OK", role: .cancel) {}
+        } message: { message in
+            Text(message)
+        }
+    }
+
+    @ViewBuilder
+    private var hero: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "sparkles")
+                .font(.system(size: 56))
+                .foregroundStyle(.tint)
+            Text(SubscriptionCopy.heroTitle)
+                .font(.largeTitle.bold())
+                .multilineTextAlignment(.center)
+            Text(SubscriptionCopy.heroSubtitle)
+                .multilineTextAlignment(.center)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    @ViewBuilder
+    private var periodPicker: some View {
+        Picker("Period", selection: $viewModel.selectedPeriod) {
+            Text("Monthly").tag(SubscriptionPeriod.monthly)
+            Text("Annual").tag(SubscriptionPeriod.annual)
+        }
+        .pickerStyle(.segmented)
+    }
+
+    @ViewBuilder
+    private var tierStack: some View {
+        VStack(spacing: 16) {
+            ForEach(SubscriptionTier.allCases, id: \.self) { tier in
+                tierCard(for: tier)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func tierCard(for tier: SubscriptionTier) -> some View {
+        let product: PaywallProduct? = viewModel.product(for: tier, period: viewModel.selectedPeriod)
+        let isCurrent: Bool = viewModel.currentTier == tier
+        let isPurchasing: Bool = viewModel.purchasingProductId == product?.id
+        let purchaseHandler: (PaywallProduct) -> Void = { product in
+            Task { await viewModel.purchase(product: product) }
+        }
+        TierCard(
+            tier: tier,
+            product: product,
+            isCurrent: isCurrent,
+            isPurchasing: isPurchasing,
+            onPurchase: purchaseHandler
+        )
+    }
+
+    @ViewBuilder
+    private var legal: some View {
+        VStack(spacing: 12) {
+            HStack(spacing: 24) {
+                if let url = URL(string: "https://convos.org/terms") {
+                    Link("Terms", destination: url)
+                }
+                if let url = URL(string: "https://convos.org/privacy") {
+                    Link("Privacy", destination: url)
+                }
+                Button("Restore", action: viewModel.restoreTapped)
+            }
+            .font(.caption)
+            .foregroundStyle(.secondary)
+
+            Text(viewModel.legalDisclaimer)
+                .font(.caption2)
+                .foregroundStyle(.tertiary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal)
+        }
+    }
+
+    @ToolbarContentBuilder
+    private var closeButton: some ToolbarContent {
+        ToolbarItem(placement: .topBarTrailing) {
+            let dismissAction = { dismiss() }
+            Button(action: dismissAction) {
+                Image(systemName: "xmark")
+            }
+        }
+    }
+}
+
+#Preview {
+    let service = MockSubscriptionService(initialPreset: .noSubNoTrial)
+    let viewModel = PaywallViewModel(subscriptionService: service)
+    return PaywallView(viewModel: viewModel)
+}

--- a/Convos/Subscription/PaywallView.swift
+++ b/Convos/Subscription/PaywallView.swift
@@ -12,14 +12,16 @@ struct PaywallView: View {
     var body: some View {
         NavigationStack {
             ScrollView {
-                VStack(spacing: 32) {
+                VStack(alignment: .leading, spacing: DesignConstants.Spacing.step8x) {
                     hero
                     periodPicker
                     tierStack
                     legal
                 }
-                .padding(.horizontal)
-                .padding(.vertical, 32)
+                .padding(.horizontal, DesignConstants.Spacing.step6x)
+                .padding(.top, DesignConstants.Spacing.step6x)
+                .padding(.bottom, DesignConstants.Spacing.step10x)
+                .frame(maxWidth: .infinity, alignment: .leading)
             }
             .navigationTitle("")
             .navigationBarTitleDisplayMode(.inline)
@@ -39,16 +41,19 @@ struct PaywallView: View {
 
     @ViewBuilder
     private var hero: some View {
-        VStack(spacing: 12) {
-            Image(systemName: "sparkles")
-                .font(.system(size: 56))
-                .foregroundStyle(.tint)
+        VStack(alignment: .leading, spacing: DesignConstants.Spacing.step3x) {
+            Text("Subscription")
+                .font(.caption)
+                .foregroundStyle(.colorTextSecondary)
+
             Text(SubscriptionCopy.heroTitle)
-                .font(.largeTitle.bold())
-                .multilineTextAlignment(.center)
+                .font(.convosTitle)
+                .tracking(Font.convosTitleTracking)
+                .foregroundStyle(.colorTextPrimary)
+
             Text(SubscriptionCopy.heroSubtitle)
-                .multilineTextAlignment(.center)
-                .foregroundStyle(.secondary)
+                .font(.body)
+                .foregroundStyle(.colorTextSecondary)
         }
     }
 
@@ -63,7 +68,7 @@ struct PaywallView: View {
 
     @ViewBuilder
     private var tierStack: some View {
-        VStack(spacing: 16) {
+        VStack(spacing: DesignConstants.Spacing.step4x) {
             ForEach(SubscriptionTier.allCases, id: \.self) { tier in
                 tierCard(for: tier)
             }
@@ -89,25 +94,29 @@ struct PaywallView: View {
 
     @ViewBuilder
     private var legal: some View {
-        VStack(spacing: 12) {
-            HStack(spacing: 24) {
+        VStack(spacing: DesignConstants.Spacing.step3x) {
+            HStack(spacing: DesignConstants.Spacing.step6x) {
                 if let url = URL(string: "https://convos.org/terms") {
                     Link("Terms", destination: url)
+                        .font(.caption)
+                        .foregroundStyle(.colorTextSecondary)
                 }
                 if let url = URL(string: "https://convos.org/privacy") {
                     Link("Privacy", destination: url)
+                        .font(.caption)
+                        .foregroundStyle(.colorTextSecondary)
                 }
                 Button("Restore", action: viewModel.restoreTapped)
+                    .convosButtonStyle(.text)
             }
-            .font(.caption)
-            .foregroundStyle(.secondary)
+            .frame(maxWidth: .infinity)
 
             Text(viewModel.legalDisclaimer)
                 .font(.caption2)
-                .foregroundStyle(.tertiary)
+                .foregroundStyle(.colorTextTertiary)
                 .multilineTextAlignment(.center)
-                .padding(.horizontal)
         }
+        .padding(.top, DesignConstants.Spacing.step2x)
     }
 
     @ToolbarContentBuilder
@@ -116,6 +125,7 @@ struct PaywallView: View {
             let dismissAction = { dismiss() }
             Button(action: dismissAction) {
                 Image(systemName: "xmark")
+                    .foregroundStyle(.colorTextPrimary)
             }
         }
     }

--- a/Convos/Subscription/PaywallViewModel.swift
+++ b/Convos/Subscription/PaywallViewModel.swift
@@ -1,9 +1,11 @@
+import Combine
 import ConvosCore
 import Foundation
 
 @MainActor @Observable
 final class PaywallViewModel {
     private let subscriptionService: any SubscriptionServiceProtocol
+    @ObservationIgnored private var cancellables: Set<AnyCancellable> = []
 
     var selectedPeriod: SubscriptionPeriod = .monthly
     var purchasingProductId: String?
@@ -11,17 +13,27 @@ final class PaywallViewModel {
     var errorMessage: String?
     private(set) var products: [PaywallProduct] = []
     private(set) var isLoadingProducts: Bool = false
+    private(set) var currentSubscription: Subscription?
 
     init(subscriptionService: any SubscriptionServiceProtocol) {
         self.subscriptionService = subscriptionService
+        self.currentSubscription = subscriptionService.currentSubscription
+        subscriptionService.subscriptionPublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] sub in
+                Task { @MainActor [weak self] in
+                    self?.currentSubscription = sub
+                }
+            }
+            .store(in: &cancellables)
     }
 
     var currentTier: SubscriptionTier? {
-        subscriptionService.currentSubscription?.tier
+        currentSubscription?.tier
     }
 
     var hasActiveSubscription: Bool {
-        subscriptionService.currentSubscription != nil
+        currentSubscription != nil
     }
 
     var legalDisclaimer: String {

--- a/Convos/Subscription/PaywallViewModel.swift
+++ b/Convos/Subscription/PaywallViewModel.swift
@@ -13,7 +13,7 @@ final class PaywallViewModel {
     var errorMessage: String?
     private(set) var products: [PaywallProduct] = []
     private(set) var isLoadingProducts: Bool = false
-    private(set) var currentSubscription: Subscription?
+    private(set) var currentSubscription: UserSubscription?
 
     init(subscriptionService: any SubscriptionServiceProtocol) {
         self.subscriptionService = subscriptionService

--- a/Convos/Subscription/PaywallViewModel.swift
+++ b/Convos/Subscription/PaywallViewModel.swift
@@ -1,0 +1,76 @@
+import ConvosCore
+import Foundation
+
+@MainActor @Observable
+final class PaywallViewModel {
+    private let subscriptionService: any SubscriptionServiceProtocol
+
+    var selectedPeriod: SubscriptionPeriod = .monthly
+    var purchasingProductId: String?
+    var isShowingError: Bool = false
+    var errorMessage: String?
+    private(set) var products: [PaywallProduct] = []
+    private(set) var isLoadingProducts: Bool = false
+
+    init(subscriptionService: any SubscriptionServiceProtocol) {
+        self.subscriptionService = subscriptionService
+    }
+
+    var currentTier: SubscriptionTier? {
+        subscriptionService.currentSubscription?.tier
+    }
+
+    var hasActiveSubscription: Bool {
+        subscriptionService.currentSubscription != nil
+    }
+
+    var legalDisclaimer: String {
+        SubscriptionCopy.legalDisclaimer
+    }
+
+    func product(for tier: SubscriptionTier, period: SubscriptionPeriod) -> PaywallProduct? {
+        products.first { $0.tier == tier && $0.period == period }
+    }
+
+    func loadProducts() async {
+        guard products.isEmpty else { return }
+        isLoadingProducts = true
+        defer { isLoadingProducts = false }
+        do {
+            products = try await subscriptionService.availableProducts()
+        } catch {
+            Log.error("Paywall failed to load products: \(error)")
+            errorMessage = "Couldn't load plans. Pull to retry or try again later."
+            isShowingError = true
+        }
+    }
+
+    func purchase(product: PaywallProduct) async {
+        guard purchasingProductId == nil else { return }
+        purchasingProductId = product.id
+        defer { purchasingProductId = nil }
+        do {
+            try await subscriptionService.purchase(productId: product.id)
+        } catch SubscriptionServiceError.purchaseCancelled {
+            // user cancelled — no-op, silently dismiss CTA spinner
+        } catch {
+            Log.error("Paywall purchase failed for \(product.id): \(error)")
+            errorMessage = "Purchase failed. Please try again."
+            isShowingError = true
+        }
+    }
+
+    func restoreTapped() {
+        Task { await restore() }
+    }
+
+    private func restore() async {
+        do {
+            try await subscriptionService.restorePurchases()
+        } catch {
+            Log.error("Paywall restore failed: \(error)")
+            errorMessage = "Restore failed."
+            isShowingError = true
+        }
+    }
+}

--- a/Convos/Subscription/SubscriptionCopy.swift
+++ b/Convos/Subscription/SubscriptionCopy.swift
@@ -1,0 +1,36 @@
+import ConvosCore
+import Foundation
+
+enum SubscriptionCopy {
+    static let heroTitle: String = "Power your agents"
+    static let heroSubtitle: String = "Subscribe to keep your assistants sharp."
+    static let legalDisclaimer: String = """
+        Auto-renewing subscription. You'll be charged at the rate shown until you cancel. \
+        Manage in Settings → Apple ID → Subscriptions on your device.
+        """
+
+    static func displayName(for tier: SubscriptionTier) -> String {
+        switch tier {
+        case .builder: return "Builder"
+        case .pro: return "Pro"
+        }
+    }
+
+    static func bullets(for tier: SubscriptionTier) -> [String] {
+        switch tier {
+        case .builder:
+            return [
+                "1,500 credits / month",
+                "Standard model on every reply",
+                "Free slow-mode when credits run low",
+            ]
+        case .pro:
+            return [
+                "5,000 credits / month",
+                "Standard + premium model access",
+                "Free slow-mode when credits run low",
+                "Priority support",
+            ]
+        }
+    }
+}

--- a/Convos/Subscription/SubscriptionCopy.swift
+++ b/Convos/Subscription/SubscriptionCopy.swift
@@ -2,7 +2,7 @@ import ConvosCore
 import Foundation
 
 enum SubscriptionCopy {
-    static let heroTitle: String = "Power your agents"
+    static let heroTitle: String = "Power your assistants"
     static let heroSubtitle: String = "Subscribe to keep your assistants sharp."
     static let legalDisclaimer: String = """
         Auto-renewing subscription. You'll be charged at the rate shown until you cancel. \

--- a/Convos/Subscription/TierCard.swift
+++ b/Convos/Subscription/TierCard.swift
@@ -9,13 +9,14 @@ struct TierCard: View {
     let onPurchase: (PaywallProduct) -> Void
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
+        VStack(alignment: .leading, spacing: DesignConstants.Spacing.step4x) {
             header
-            Divider()
             bullets
-            cta
+            if !isCurrent {
+                purchaseButton
+            }
         }
-        .padding(16)
+        .padding(DesignConstants.Spacing.step5x)
         .background(background)
         .overlay(border)
     }
@@ -23,24 +24,26 @@ struct TierCard: View {
     @ViewBuilder
     private var header: some View {
         HStack(alignment: .firstTextBaseline) {
-            VStack(alignment: .leading, spacing: 4) {
+            VStack(alignment: .leading, spacing: DesignConstants.Spacing.stepHalf) {
                 Text(SubscriptionCopy.displayName(for: tier))
                     .font(.title3.bold())
+                    .foregroundStyle(.colorTextPrimary)
                 if isCurrent {
                     Text("Current plan")
                         .font(.caption.weight(.semibold))
-                        .foregroundStyle(.tint)
+                        .foregroundStyle(.colorRed)
                 }
             }
             Spacer()
-            VStack(alignment: .trailing, spacing: 4) {
+            VStack(alignment: .trailing, spacing: DesignConstants.Spacing.stepHalf) {
                 Text(priceText)
                     .font(.title3.weight(.medium))
+                    .foregroundStyle(.colorTextPrimary)
                     .monospacedDigit()
                 if let perMonth = product?.pricePerMonthDisplay {
                     Text(perMonth)
                         .font(.caption)
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(.colorTextSecondary)
                 }
             }
         }
@@ -48,22 +51,22 @@ struct TierCard: View {
 
     @ViewBuilder
     private var bullets: some View {
-        VStack(alignment: .leading, spacing: 8) {
+        VStack(alignment: .leading, spacing: DesignConstants.Spacing.step2x) {
             ForEach(SubscriptionCopy.bullets(for: tier), id: \.self) { bullet in
-                HStack(alignment: .top, spacing: 8) {
+                HStack(alignment: .top, spacing: DesignConstants.Spacing.step2x) {
                     Image(systemName: "checkmark.circle.fill")
-                        .foregroundStyle(.green)
+                        .foregroundStyle(.colorRed)
                     Text(bullet)
                         .font(.subheadline)
+                        .foregroundStyle(.colorTextPrimary)
                 }
             }
         }
     }
 
     @ViewBuilder
-    private var cta: some View {
-        let label: String = ctaLabel
-        let isDisabled: Bool = product == nil || isCurrent || isPurchasing
+    private var purchaseButton: some View {
+        let isDisabled: Bool = product == nil || isPurchasing
         let purchaseAction = {
             if let product { onPurchase(product) }
         }
@@ -71,38 +74,32 @@ struct TierCard: View {
             ZStack {
                 if isPurchasing {
                     ProgressView()
+                        .tint(.colorTextPrimaryInverted)
                 } else {
-                    Text(label)
+                    Text("Subscribe")
                 }
             }
-            .frame(maxWidth: .infinity)
         }
-        .buttonStyle(.borderedProminent)
-        .controlSize(.large)
+        .convosButtonStyle(.rounded(fullWidth: true, backgroundColor: .colorRed))
         .disabled(isDisabled)
     }
 
     @ViewBuilder
     private var background: some View {
-        RoundedRectangle(cornerRadius: 16)
-            .fill(.thinMaterial)
+        RoundedRectangle(cornerRadius: DesignConstants.CornerRadius.medium)
+            .fill(Color.colorBackgroundRaised)
     }
 
     @ViewBuilder
     private var border: some View {
-        let strokeColor: Color = isCurrent ? Color.accentColor : Color.clear
-        RoundedRectangle(cornerRadius: 16)
-            .stroke(strokeColor, lineWidth: 2)
+        let strokeColor: Color = isCurrent ? Color.colorRed : Color.colorBorderSubtle
+        let lineWidth: CGFloat = isCurrent ? 2 : 1
+        RoundedRectangle(cornerRadius: DesignConstants.CornerRadius.medium)
+            .stroke(strokeColor, lineWidth: lineWidth)
     }
 
     private var priceText: String {
         product?.displayPrice ?? "—"
-    }
-
-    private var ctaLabel: String {
-        if isCurrent { return "Current" }
-        if isPurchasing { return "Purchasing…" }
-        return "Subscribe"
     }
 }
 

--- a/Convos/Subscription/TierCard.swift
+++ b/Convos/Subscription/TierCard.swift
@@ -1,0 +1,135 @@
+import ConvosCore
+import SwiftUI
+
+struct TierCard: View {
+    let tier: SubscriptionTier
+    let product: PaywallProduct?
+    let isCurrent: Bool
+    let isPurchasing: Bool
+    let onPurchase: (PaywallProduct) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            header
+            Divider()
+            bullets
+            cta
+        }
+        .padding(16)
+        .background(background)
+        .overlay(border)
+    }
+
+    @ViewBuilder
+    private var header: some View {
+        HStack(alignment: .firstTextBaseline) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(SubscriptionCopy.displayName(for: tier))
+                    .font(.title3.bold())
+                if isCurrent {
+                    Text("Current plan")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.tint)
+                }
+            }
+            Spacer()
+            VStack(alignment: .trailing, spacing: 4) {
+                Text(priceText)
+                    .font(.title3.weight(.medium))
+                    .monospacedDigit()
+                if let perMonth = product?.pricePerMonthDisplay {
+                    Text(perMonth)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var bullets: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            ForEach(SubscriptionCopy.bullets(for: tier), id: \.self) { bullet in
+                HStack(alignment: .top, spacing: 8) {
+                    Image(systemName: "checkmark.circle.fill")
+                        .foregroundStyle(.green)
+                    Text(bullet)
+                        .font(.subheadline)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var cta: some View {
+        let label: String = ctaLabel
+        let isDisabled: Bool = product == nil || isCurrent || isPurchasing
+        let purchaseAction = {
+            if let product { onPurchase(product) }
+        }
+        Button(action: purchaseAction) {
+            ZStack {
+                if isPurchasing {
+                    ProgressView()
+                } else {
+                    Text(label)
+                }
+            }
+            .frame(maxWidth: .infinity)
+        }
+        .buttonStyle(.borderedProminent)
+        .controlSize(.large)
+        .disabled(isDisabled)
+    }
+
+    @ViewBuilder
+    private var background: some View {
+        RoundedRectangle(cornerRadius: 16)
+            .fill(.thinMaterial)
+    }
+
+    @ViewBuilder
+    private var border: some View {
+        let strokeColor: Color = isCurrent ? Color.accentColor : Color.clear
+        RoundedRectangle(cornerRadius: 16)
+            .stroke(strokeColor, lineWidth: 2)
+    }
+
+    private var priceText: String {
+        product?.displayPrice ?? "—"
+    }
+
+    private var ctaLabel: String {
+        if isCurrent { return "Current" }
+        if isPurchasing { return "Purchasing…" }
+        return "Subscribe"
+    }
+}
+
+#Preview {
+    let product = PaywallProduct(
+        id: "app.convos.subs.builder.monthly",
+        tier: .builder,
+        period: .monthly,
+        displayPrice: "$9.99",
+        pricePerMonthDisplay: nil,
+        currencyCode: "USD"
+    )
+    return VStack(spacing: 16) {
+        TierCard(
+            tier: .builder,
+            product: product,
+            isCurrent: false,
+            isPurchasing: false,
+            onPurchase: { _ in }
+        )
+        TierCard(
+            tier: .pro,
+            product: nil,
+            isCurrent: true,
+            isPurchasing: false,
+            onPurchase: { _ in }
+        )
+    }
+    .padding()
+}

--- a/ConvosCore/Sources/ConvosCore/Services/Credits/CreditsServiceProtocol.swift
+++ b/ConvosCore/Sources/ConvosCore/Services/Credits/CreditsServiceProtocol.swift
@@ -1,0 +1,9 @@
+import Combine
+import Foundation
+
+public protocol CreditsServiceProtocol: AnyObject, Sendable {
+    var balancePublisher: AnyPublisher<CreditBalance?, Never> { get }
+    var currentBalance: CreditBalance? { get }
+
+    func refresh() async
+}

--- a/ConvosCore/Sources/ConvosCore/Services/Credits/CreditsStatePreset.swift
+++ b/ConvosCore/Sources/ConvosCore/Services/Credits/CreditsStatePreset.swift
@@ -96,7 +96,7 @@ public enum CreditsStatePreset: String, CaseIterable, Identifiable, Sendable {
         }
     }
 
-    public func subscription() -> Subscription? {
+    public func subscription() -> UserSubscription? {
         let now = Date()
         let monthEnd = Calendar.current.date(byAdding: .day, value: 14, to: now) ?? now
         let trialEnd = Calendar.current.date(byAdding: .day, value: 4, to: now) ?? now
@@ -104,7 +104,7 @@ public enum CreditsStatePreset: String, CaseIterable, Identifiable, Sendable {
 
         switch self {
         case .builderAmple, .builderLow, .builderDepleted:
-            return Subscription(
+            return UserSubscription(
                 tier: .builder,
                 period: .monthly,
                 status: .active,
@@ -114,7 +114,7 @@ public enum CreditsStatePreset: String, CaseIterable, Identifiable, Sendable {
                 isInTrial: false
             )
         case .proAmple:
-            return Subscription(
+            return UserSubscription(
                 tier: .pro,
                 period: .monthly,
                 status: .active,
@@ -124,7 +124,7 @@ public enum CreditsStatePreset: String, CaseIterable, Identifiable, Sendable {
                 isInTrial: false
             )
         case .trialActive:
-            return Subscription(
+            return UserSubscription(
                 tier: .builder,
                 period: .monthly,
                 status: .trial,
@@ -134,7 +134,7 @@ public enum CreditsStatePreset: String, CaseIterable, Identifiable, Sendable {
                 isInTrial: true
             )
         case .billingRetry:
-            return Subscription(
+            return UserSubscription(
                 tier: .pro,
                 period: .monthly,
                 status: .billingRetry,
@@ -144,7 +144,7 @@ public enum CreditsStatePreset: String, CaseIterable, Identifiable, Sendable {
                 isInTrial: false
             )
         case .gracePeriod:
-            return Subscription(
+            return UserSubscription(
                 tier: .builder,
                 period: .monthly,
                 status: .grace,

--- a/ConvosCore/Sources/ConvosCore/Services/Credits/CreditsStatePreset.swift
+++ b/ConvosCore/Sources/ConvosCore/Services/Credits/CreditsStatePreset.swift
@@ -1,0 +1,166 @@
+import Foundation
+
+/// A set of canned credit + subscription states used by mocks and the debug
+/// menu state picker. Lets designers and QA dogfood every UI permutation
+/// without touching the backend or the App Store sandbox.
+public enum CreditsStatePreset: String, CaseIterable, Identifiable, Sendable {
+    case builderAmple
+    case builderLow
+    case builderDepleted
+    case proAmple
+    case trialActive
+    case trialExpired
+    case billingRetry
+    case gracePeriod
+    case noSubNoTrial
+
+    public var id: String { rawValue }
+
+    public var displayName: String {
+        switch self {
+        case .builderAmple: return "Builder — ample"
+        case .builderLow: return "Builder — low"
+        case .builderDepleted: return "Builder — depleted"
+        case .proAmple: return "Pro — ample"
+        case .trialActive: return "Trial — active"
+        case .trialExpired: return "Trial — expired"
+        case .billingRetry: return "Pro — billing retry"
+        case .gracePeriod: return "Builder — grace period"
+        case .noSubNoTrial: return "No sub / no trial"
+        }
+    }
+
+    public func balance() -> CreditBalance {
+        let now = Date()
+        let nextRefresh = Calendar.current.date(byAdding: .day, value: 14, to: now) ?? now
+        let trialEnd = Calendar.current.date(byAdding: .day, value: 4, to: now) ?? now
+        let periodLabel = Self.periodLabelFormatter.string(from: now)
+
+        switch self {
+        case .builderAmple:
+            return CreditBalance(
+                balance: 1_400,
+                monthlyGrant: 1_500,
+                monthlyGrantUsed: 100,
+                nextRefreshAt: nextRefresh,
+                periodLabel: periodLabel
+            )
+        case .builderLow:
+            return CreditBalance(
+                balance: 180,
+                monthlyGrant: 1_500,
+                monthlyGrantUsed: 1_320,
+                nextRefreshAt: nextRefresh,
+                periodLabel: periodLabel
+            )
+        case .builderDepleted, .gracePeriod:
+            return CreditBalance(
+                balance: 0,
+                monthlyGrant: 1_500,
+                monthlyGrantUsed: 1_500,
+                nextRefreshAt: nextRefresh,
+                periodLabel: periodLabel
+            )
+        case .proAmple:
+            return CreditBalance(
+                balance: 4_500,
+                monthlyGrant: 5_000,
+                monthlyGrantUsed: 500,
+                nextRefreshAt: nextRefresh,
+                periodLabel: periodLabel
+            )
+        case .billingRetry:
+            return CreditBalance(
+                balance: 0,
+                monthlyGrant: 5_000,
+                monthlyGrantUsed: 5_000,
+                nextRefreshAt: nextRefresh,
+                periodLabel: periodLabel
+            )
+        case .trialActive:
+            return CreditBalance(
+                balance: 350,
+                monthlyGrant: 500,
+                monthlyGrantUsed: 150,
+                nextRefreshAt: trialEnd,
+                periodLabel: "Trial"
+            )
+        case .trialExpired, .noSubNoTrial:
+            return CreditBalance(
+                balance: 0,
+                monthlyGrant: 0,
+                monthlyGrantUsed: 0,
+                nextRefreshAt: now,
+                periodLabel: "—"
+            )
+        }
+    }
+
+    public func subscription() -> Subscription? {
+        let now = Date()
+        let monthEnd = Calendar.current.date(byAdding: .day, value: 14, to: now) ?? now
+        let trialEnd = Calendar.current.date(byAdding: .day, value: 4, to: now) ?? now
+        let graceEnd = Calendar.current.date(byAdding: .day, value: 2, to: now) ?? now
+
+        switch self {
+        case .builderAmple, .builderLow, .builderDepleted:
+            return Subscription(
+                tier: .builder,
+                period: .monthly,
+                status: .active,
+                productId: "app.convos.subs.builder.monthly",
+                currentPeriodEnd: monthEnd,
+                willRenew: true,
+                isInTrial: false
+            )
+        case .proAmple:
+            return Subscription(
+                tier: .pro,
+                period: .monthly,
+                status: .active,
+                productId: "app.convos.subs.pro.monthly",
+                currentPeriodEnd: monthEnd,
+                willRenew: true,
+                isInTrial: false
+            )
+        case .trialActive:
+            return Subscription(
+                tier: .builder,
+                period: .monthly,
+                status: .trial,
+                productId: "app.convos.subs.builder.monthly",
+                currentPeriodEnd: trialEnd,
+                willRenew: false,
+                isInTrial: true
+            )
+        case .billingRetry:
+            return Subscription(
+                tier: .pro,
+                period: .monthly,
+                status: .billingRetry,
+                productId: "app.convos.subs.pro.monthly",
+                currentPeriodEnd: monthEnd,
+                willRenew: false,
+                isInTrial: false
+            )
+        case .gracePeriod:
+            return Subscription(
+                tier: .builder,
+                period: .monthly,
+                status: .grace,
+                productId: "app.convos.subs.builder.monthly",
+                currentPeriodEnd: graceEnd,
+                willRenew: false,
+                isInTrial: false
+            )
+        case .trialExpired, .noSubNoTrial:
+            return nil
+        }
+    }
+
+    private static let periodLabelFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "MMMM yyyy"
+        return formatter
+    }()
+}

--- a/ConvosCore/Sources/ConvosCore/Services/Credits/MockCreditsService.swift
+++ b/ConvosCore/Sources/ConvosCore/Services/Credits/MockCreditsService.swift
@@ -2,6 +2,12 @@ import Combine
 import Foundation
 
 public final class MockCreditsService: CreditsServiceProtocol, @unchecked Sendable {
+    /// Process-wide singleton used by the Debug menu's preset picker and the
+    /// in-app credits surfaces (HOME pill, etc.) so they share one observable
+    /// state. Replace with a real `CreditsServiceProtocol` once the backend
+    /// HTTP wrappers land.
+    public static let shared: MockCreditsService = MockCreditsService()
+
     private let balanceSubject: CurrentValueSubject<CreditBalance?, Never>
     private let queue: DispatchQueue = DispatchQueue(label: "convos.mock-credits-service")
     private var currentPreset: CreditsStatePreset

--- a/ConvosCore/Sources/ConvosCore/Services/Credits/MockCreditsService.swift
+++ b/ConvosCore/Sources/ConvosCore/Services/Credits/MockCreditsService.swift
@@ -1,0 +1,35 @@
+import Combine
+import Foundation
+
+public final class MockCreditsService: CreditsServiceProtocol, @unchecked Sendable {
+    private let balanceSubject: CurrentValueSubject<CreditBalance?, Never>
+    private let queue: DispatchQueue = DispatchQueue(label: "convos.mock-credits-service")
+    private var currentPreset: CreditsStatePreset
+
+    public init(initialPreset: CreditsStatePreset = .builderAmple) {
+        self.currentPreset = initialPreset
+        self.balanceSubject = CurrentValueSubject(initialPreset.balance())
+    }
+
+    public var balancePublisher: AnyPublisher<CreditBalance?, Never> {
+        balanceSubject.eraseToAnyPublisher()
+    }
+
+    public var currentBalance: CreditBalance? {
+        balanceSubject.value
+    }
+
+    public var preset: CreditsStatePreset {
+        queue.sync { currentPreset }
+    }
+
+    public func refresh() async {
+        let snapshot = queue.sync { currentPreset.balance() }
+        balanceSubject.send(snapshot)
+    }
+
+    public func setPreset(_ preset: CreditsStatePreset) {
+        queue.sync { currentPreset = preset }
+        balanceSubject.send(preset.balance())
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Services/Subscription/MockSubscriptionService.swift
+++ b/ConvosCore/Sources/ConvosCore/Services/Subscription/MockSubscriptionService.swift
@@ -1,0 +1,94 @@
+import Combine
+import Foundation
+
+public final class MockSubscriptionService: SubscriptionServiceProtocol, @unchecked Sendable {
+    private let subscriptionSubject: CurrentValueSubject<Subscription?, Never>
+    private let queue: DispatchQueue = DispatchQueue(label: "convos.mock-subscription-service")
+    private var currentPreset: CreditsStatePreset
+    private let mockProducts: [PaywallProduct]
+
+    public init(initialPreset: CreditsStatePreset = .builderAmple) {
+        self.currentPreset = initialPreset
+        self.subscriptionSubject = CurrentValueSubject(initialPreset.subscription())
+        self.mockProducts = Self.defaultMockProducts()
+    }
+
+    public var subscriptionPublisher: AnyPublisher<Subscription?, Never> {
+        subscriptionSubject.eraseToAnyPublisher()
+    }
+
+    public var currentSubscription: Subscription? {
+        subscriptionSubject.value
+    }
+
+    public func availableProducts() async throws -> [PaywallProduct] {
+        try await Task.sleep(for: .milliseconds(150))
+        return mockProducts
+    }
+
+    public func purchase(productId: String) async throws {
+        guard let product = mockProducts.first(where: { $0.id == productId }) else {
+            throw SubscriptionServiceError.productNotFound
+        }
+        try await Task.sleep(for: .milliseconds(600))
+        let now = Date()
+        let component: Calendar.Component = product.period == .monthly ? .month : .year
+        let nextRenew = Calendar.current.date(byAdding: component, value: 1, to: now) ?? now
+        let updated = Subscription(
+            tier: product.tier,
+            period: product.period,
+            status: .active,
+            productId: product.id,
+            currentPeriodEnd: nextRenew,
+            willRenew: true,
+            isInTrial: false
+        )
+        subscriptionSubject.send(updated)
+    }
+
+    public func restorePurchases() async throws {
+        try await Task.sleep(for: .milliseconds(300))
+    }
+
+    public func setPreset(_ preset: CreditsStatePreset) {
+        queue.sync { currentPreset = preset }
+        subscriptionSubject.send(preset.subscription())
+    }
+
+    private static func defaultMockProducts() -> [PaywallProduct] {
+        [
+            PaywallProduct(
+                id: "app.convos.subs.builder.monthly",
+                tier: .builder,
+                period: .monthly,
+                displayPrice: "$9.99",
+                pricePerMonthDisplay: nil,
+                currencyCode: "USD"
+            ),
+            PaywallProduct(
+                id: "app.convos.subs.builder.annual",
+                tier: .builder,
+                period: .annual,
+                displayPrice: "$79.99",
+                pricePerMonthDisplay: "$6.67/mo",
+                currencyCode: "USD"
+            ),
+            PaywallProduct(
+                id: "app.convos.subs.pro.monthly",
+                tier: .pro,
+                period: .monthly,
+                displayPrice: "$29.99",
+                pricePerMonthDisplay: nil,
+                currencyCode: "USD"
+            ),
+            PaywallProduct(
+                id: "app.convos.subs.pro.annual",
+                tier: .pro,
+                period: .annual,
+                displayPrice: "$239.99",
+                pricePerMonthDisplay: "$20.00/mo",
+                currencyCode: "USD"
+            ),
+        ]
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Services/Subscription/MockSubscriptionService.swift
+++ b/ConvosCore/Sources/ConvosCore/Services/Subscription/MockSubscriptionService.swift
@@ -2,6 +2,9 @@ import Combine
 import Foundation
 
 public final class MockSubscriptionService: SubscriptionServiceProtocol, @unchecked Sendable {
+    /// Process-wide singleton — see `MockCreditsService.shared` for rationale.
+    public static let shared: MockSubscriptionService = MockSubscriptionService()
+
     private let subscriptionSubject: CurrentValueSubject<Subscription?, Never>
     private let queue: DispatchQueue = DispatchQueue(label: "convos.mock-subscription-service")
     private var currentPreset: CreditsStatePreset

--- a/ConvosCore/Sources/ConvosCore/Services/Subscription/MockSubscriptionService.swift
+++ b/ConvosCore/Sources/ConvosCore/Services/Subscription/MockSubscriptionService.swift
@@ -5,7 +5,7 @@ public final class MockSubscriptionService: SubscriptionServiceProtocol, @unchec
     /// Process-wide singleton — see `MockCreditsService.shared` for rationale.
     public static let shared: MockSubscriptionService = MockSubscriptionService()
 
-    private let subscriptionSubject: CurrentValueSubject<Subscription?, Never>
+    private let subscriptionSubject: CurrentValueSubject<UserSubscription?, Never>
     private let queue: DispatchQueue = DispatchQueue(label: "convos.mock-subscription-service")
     private var currentPreset: CreditsStatePreset
     private let mockProducts: [PaywallProduct]
@@ -16,11 +16,11 @@ public final class MockSubscriptionService: SubscriptionServiceProtocol, @unchec
         self.mockProducts = Self.defaultMockProducts()
     }
 
-    public var subscriptionPublisher: AnyPublisher<Subscription?, Never> {
+    public var subscriptionPublisher: AnyPublisher<UserSubscription?, Never> {
         subscriptionSubject.eraseToAnyPublisher()
     }
 
-    public var currentSubscription: Subscription? {
+    public var currentSubscription: UserSubscription? {
         subscriptionSubject.value
     }
 
@@ -37,7 +37,7 @@ public final class MockSubscriptionService: SubscriptionServiceProtocol, @unchec
         let now = Date()
         let component: Calendar.Component = product.period == .monthly ? .month : .year
         let nextRenew = Calendar.current.date(byAdding: component, value: 1, to: now) ?? now
-        let updated = Subscription(
+        let updated = UserSubscription(
             tier: product.tier,
             period: product.period,
             status: .active,

--- a/ConvosCore/Sources/ConvosCore/Services/Subscription/SubscriptionServiceProtocol.swift
+++ b/ConvosCore/Sources/ConvosCore/Services/Subscription/SubscriptionServiceProtocol.swift
@@ -2,8 +2,8 @@ import Combine
 import Foundation
 
 public protocol SubscriptionServiceProtocol: AnyObject, Sendable {
-    var subscriptionPublisher: AnyPublisher<Subscription?, Never> { get }
-    var currentSubscription: Subscription? { get }
+    var subscriptionPublisher: AnyPublisher<UserSubscription?, Never> { get }
+    var currentSubscription: UserSubscription? { get }
 
     func availableProducts() async throws -> [PaywallProduct]
     func purchase(productId: String) async throws

--- a/ConvosCore/Sources/ConvosCore/Services/Subscription/SubscriptionServiceProtocol.swift
+++ b/ConvosCore/Sources/ConvosCore/Services/Subscription/SubscriptionServiceProtocol.swift
@@ -1,0 +1,18 @@
+import Combine
+import Foundation
+
+public protocol SubscriptionServiceProtocol: AnyObject, Sendable {
+    var subscriptionPublisher: AnyPublisher<Subscription?, Never> { get }
+    var currentSubscription: Subscription? { get }
+
+    func availableProducts() async throws -> [PaywallProduct]
+    func purchase(productId: String) async throws
+    func restorePurchases() async throws
+}
+
+public enum SubscriptionServiceError: Error, Equatable, Sendable {
+    case productNotFound
+    case purchaseCancelled
+    case purchaseFailed(reason: String)
+    case notImplemented
+}

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/CreditBalance.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/CreditBalance.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+public struct CreditBalance: Codable, Equatable, Hashable, Sendable {
+    public let balance: Int
+    public let monthlyGrant: Int
+    public let monthlyGrantUsed: Int
+    public let nextRefreshAt: Date
+    public let periodLabel: String
+
+    public init(
+        balance: Int,
+        monthlyGrant: Int,
+        monthlyGrantUsed: Int,
+        nextRefreshAt: Date,
+        periodLabel: String
+    ) {
+        self.balance = balance
+        self.monthlyGrant = monthlyGrant
+        self.monthlyGrantUsed = monthlyGrantUsed
+        self.nextRefreshAt = nextRefreshAt
+        self.periodLabel = periodLabel
+    }
+
+    public var fractionRemaining: Double {
+        guard monthlyGrant > 0 else { return 0 }
+        return Double(balance) / Double(monthlyGrant)
+    }
+
+    public var isLow: Bool {
+        balance > 0 && fractionRemaining <= 0.2
+    }
+
+    public var isDepleted: Bool {
+        balance <= 0
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/PaywallProduct.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/PaywallProduct.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+/// A catalog entry shown on the paywall. Decouples the UI from StoreKit's
+/// `Product` so the same view can render mock products in dev/preview and real
+/// products in production.
+public struct PaywallProduct: Identifiable, Equatable, Hashable, Sendable {
+    public let id: String
+    public let tier: SubscriptionTier
+    public let period: SubscriptionPeriod
+    public let displayPrice: String
+    public let pricePerMonthDisplay: String?
+    public let currencyCode: String
+
+    public init(
+        id: String,
+        tier: SubscriptionTier,
+        period: SubscriptionPeriod,
+        displayPrice: String,
+        pricePerMonthDisplay: String?,
+        currencyCode: String
+    ) {
+        self.id = id
+        self.tier = tier
+        self.period = period
+        self.displayPrice = displayPrice
+        self.pricePerMonthDisplay = pricePerMonthDisplay
+        self.currencyCode = currencyCode
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/Subscription.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/Subscription.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+public enum SubscriptionTier: String, Codable, Hashable, Sendable, CaseIterable {
+    case builder
+    case pro
+}
+
+public enum SubscriptionPeriod: String, Codable, Hashable, Sendable, CaseIterable {
+    case monthly
+    case annual
+}
+
+public enum SubscriptionStatus: String, Codable, Hashable, Sendable {
+    case trial
+    case active
+    case grace
+    case billingRetry
+    case expired
+    case revoked
+}
+
+public struct Subscription: Codable, Equatable, Hashable, Sendable {
+    public let tier: SubscriptionTier
+    public let period: SubscriptionPeriod
+    public let status: SubscriptionStatus
+    public let productId: String
+    public let currentPeriodEnd: Date
+    public let willRenew: Bool
+    public let isInTrial: Bool
+
+    public init(
+        tier: SubscriptionTier,
+        period: SubscriptionPeriod,
+        status: SubscriptionStatus,
+        productId: String,
+        currentPeriodEnd: Date,
+        willRenew: Bool,
+        isInTrial: Bool
+    ) {
+        self.tier = tier
+        self.period = period
+        self.status = status
+        self.productId = productId
+        self.currentPeriodEnd = currentPeriodEnd
+        self.willRenew = willRenew
+        self.isInTrial = isInTrial
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/Subscription.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/Subscription.swift
@@ -14,12 +14,16 @@ public enum SubscriptionStatus: String, Codable, Hashable, Sendable {
     case trial
     case active
     case grace
+    // swiftlint:disable:next raw_value_for_camel_cased_codable_enum
     case billingRetry
     case expired
     case revoked
 }
 
-public struct Subscription: Codable, Equatable, Hashable, Sendable {
+/// User-facing subscription state. Named `UserSubscription` (not `Subscription`)
+/// to avoid a name collision with `Combine.Subscription` in any file that
+/// imports both ConvosCore and Combine.
+public struct UserSubscription: Codable, Equatable, Hashable, Sendable {
     public let tier: SubscriptionTier
     public let period: SubscriptionPeriod
     public let status: SubscriptionStatus


### PR DESCRIPTION
Paywall UI + mock credits/subscription services

Frame 7 of the IAP plan (docs/plans/in-app-purchases-and-credits.md), plus
the foundations every subsequent UI surface depends on. No StoreKit and no
backend yet — paywall presents from the Debug menu against a MockSubscription
service so designers/QA can dogfood every state.

Adds (ConvosCore):
  - CreditBalance, Subscription (tier/period/status), PaywallProduct models
  - CreditsServiceProtocol + MockCreditsService
  - SubscriptionServiceProtocol + MockSubscriptionService
  - CreditsStatePreset (9 canned states: builder ample/low/depleted,
    pro ample, trial active/expired, billing retry, grace period,
    no-sub no-trial)

Adds (main app, Convos/Subscription/):
  - PaywallView (Monthly/Annual segmented picker, two TierCards, legal
    + Restore + dismiss). NavigationStack-based sheet. Uses
    PaywallViewModel (@Observable @MainActor)
  - TierCard (per-tier card with header, bullets, CTA, current-plan
    border)
  - SubscriptionCopy (tier display names + bullets + legal disclaimer)

Wires:
  - FeatureFlags.mockCreditsPreset (UserDefaults-backed enum)
  - DebugView "Subscription (mock)" section with preset picker + Show
    Paywall button presenting the live sheet

Stacked on louis/iap-credits-plan.

HOME credits pill + paywall restyle (design system, colorRed)

UI changes:
- New CreditsBadge in ConversationsView toolbar (.topBarTrailing, left of
  the filter button) — capsule pill with sparkles icon + balance, hidden
  on production. Updates live as the Debug picker changes preset.
- Paywall restyled with app design tokens: convosTitle hero, eyebrow
  "Subscription" caption, colorTextPrimary/Secondary throughout,
  DesignConstants.Spacing.stepNx everywhere, colorRed for accent.
- TierCard: colorBackgroundRaised fill, colorRed checkmarks, colorRed
  border (2pt) when current, colorBorderSubtle (1pt) otherwise. Subscribe
  CTA uses convosButtonStyle(.rounded(fullWidth: true, backgroundColor:
  .colorRed)). Current tier hides the CTA (header badge + red border
  signal current state).
- Restore button uses convosButtonStyle(.text).
- "Power your agents" → "Power your assistants" (matches app vocabulary).

Wiring:
- MockCreditsService.shared + MockSubscriptionService.shared (process-wide
  singletons) so the Debug picker, HOME pill, and Paywall observe one
  source of truth.
- ConvosApp.init() syncs the shared mocks with the persisted picker
  preset on launch (non-prod only).
- DebugView picker now writes to @State + .onChange propagates to
  FeatureFlags + both shared mocks. Previously only persisted to
  UserDefaults — the pill change is what makes the picker visibly work.
- PaywallViewModel subscribes to subscriptionPublisher so post-purchase
  the tier card flips to "Current plan" without reopening the sheet.

Rename Subscription struct to UserSubscription

Fixes "'Subscription' is ambiguous for type lookup" in PaywallViewModel
where Combine.Subscription (protocol) collides with our struct in any
file that imports both Combine and ConvosCore. The @ObservationTracked
macro expansion couldn't resolve which type to use.

UserSubscription is also more specific — distinguishes our user-facing
sub state from StoreKit's Product.SubscriptionInfo and Combine's
Subscription protocol.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/839"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add paywall UI and mock credits/subscription services for non-production testing
> - Adds a `PaywallView` with tier cards, period picker, purchase flow, and error handling, backed by `PaywallViewModel` which interacts with a `SubscriptionServiceProtocol`.
> - Introduces `MockSubscriptionService` and `MockCreditsService` singletons that simulate product fetches, purchases, restores, and balance updates via `CreditsStatePreset` presets.
> - Adds a `CreditsBadge` pill to the conversations sidebar toolbar in non-production that updates live via `MockCreditsService.balancePublisher`.
> - Extends the debug menu with a subscription section: a preset picker that persists selection via `FeatureFlags.mockCreditsPreset` and a button to open the paywall sheet.
> - On app launch in non-production, `MockCreditsService` and `MockSubscriptionService` are synced to the last persisted preset.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 0f0eb92. 16 files reviewed, 8 issues evaluated, 1 issue filtered, 2 comments posted</summary> (Automatic summaries will resume when PR exits draft mode or review begins).
>
> ### 🗂️ Filtered Issues
> <details>
> <summary>Convos/Debug View/DebugView.swift — 0 comments posted, 2 evaluated, 1 filtered</summary>
>
> - [line 46](https://github.com/xmtplabs/convos-ios/blob/c61b5012e277f3caea37ef9ccad7bc77edb2d890/Convos/Debug View/DebugView.swift#L46): On fresh app launch, `creditsPresetSelection` is initialized from `FeatureFlags.shared.mockCreditsPreset` (which reads persisted `UserDefaults`), but `MockCreditsService.shared` and `MockSubscriptionService.shared` are singletons initialized with the hardcoded default `.builderAmple`. The `onChange(of: creditsPresetSelection)` handler only fires when the picker value *changes*, not on initial load. This means if a user previously selected `.proAmple` and relaunches the app, the picker displays `.proAmple` but both mock services remain at `.builderAmple` until the user manually changes the picker. Tapping "Show Paywall" would then display incorrect mock subscription data. <b>[ Out of scope (triage) ]</b>
> </details>
>
>
> </details><!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->