### PR TITLE
fix(auth): share SIWE signing context across ConvosAPIClient instances

### DIFF
--- a/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift
+++ b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift
@@ -115,7 +115,20 @@ extension ConvosAPIClientProtocol {
 /// state we need so the authenticated request path and the 401 refresh
 /// path can pick up the same context the session-level auth call used,
 /// without exposing libxmtp / KeychainIdentity through the protocol.
+///
+/// Shared across all `ConvosAPIClient` instances via `.shared`. Multiple
+/// services in the app (`SessionManager` and any non-session services
+/// that construct their own `ConvosAPIClient` via the factory — e.g.
+/// `BackendCreditsService`, `StoreKitSubscriptionService` on the IAP
+/// credits branch) each get their own client. Per-instance slots meant
+/// only the SessionManager's client saw the registered context, and the
+/// others silently fell back to legacy device-only auth on 401 refresh,
+/// minting JWTs without `accountId` and 403-ing every `requireAccount`-
+/// gated call. The static singleton keeps the registered context visible
+/// to all clients in the process.
 final class LockedSigningContext: @unchecked Sendable {
+    static let shared: LockedSigningContext = LockedSigningContext()
+
     private let lock: NSLock = NSLock()
     private var value: BackendAuthSigningContext?
 
@@ -137,7 +150,7 @@ final class ConvosAPIClient: ConvosAPIClientProtocol, Sendable {
     let keychainService: any KeychainServiceProtocol = KeychainService()
     private let overrideJWTToken: String?  // Immutable JWT override from APNS payload
     let maxRetryCount: Int = 3
-    let siweSigningContext: LockedSigningContext = LockedSigningContext()
+    let siweSigningContext: LockedSigningContext = .shared
 
     fileprivate init(environment: AppEnvironment, overrideJWTToken: String? = nil) {
         guard let apiBaseURL = URL(string: environment.apiBaseURL) else {


### PR DESCRIPTION
## Summary

`LockedSigningContext` was a per-instance slot on every `ConvosAPIClient`. The session-level auth call registered the SIWE signing context only on the `SessionManager`'s client. Any other client built via `ConvosAPIClientFactory.client(environment:)` had an empty signing-context slot, so on a 401 refresh it silently fell back to legacy device-only auth — minting a JWT **without** `accountId`. That JWT overwrote the keychain entry, and every subsequent `requireAccount`-gated route returned **403 Account required**.

Fix promotes the slot to a process-wide singleton via `LockedSigningContext.shared`. Every `ConvosAPIClient` in the process now sees the registered context. One-file, 14-line change.

## Why a singleton is acceptable today

One user per app process today → one SIWE signing context per process is a defensible invariant. If multi-user ever lands, the cleaner path is consolidating to a single shared `ConvosAPIClient` instance (with the slot scoped per-instance again). Out of scope here.

## How this was found

Caught on PR #840 (IAP credits) when `BackendCreditsService.refresh()` started 403-ing. iOS logs from that branch:

```
reAuthenticate: no SIWE signing context; falling back to legacy device-only auth
Legacy device-only auth: minting JWT without accountId (hasSiwe: false)
/api/v2/accounts/me/credits → { \"error\": \"Account required\" }
```

A temporary fix lives on PR #840 at commit `9c5d9dac`. Once this PR lands on `dev`, that branch should `git revert 9c5d9dac` so the auth fix lives in its proper place and the credits branch stays unencumbered.

## Test plan

- [ ] Build green on `Convos (Dev)` scheme ✅ (verified locally, 132s)
- [ ] Run `KeychainIdentityStoreTests` scheme — no regression
- [ ] On a SIWE-authed device, hit `GET /v2/accounts/me/credits` (or any other `requireAccount`-gated route from a non-session service path) — confirm **200**, not 403
- [ ] Force-quit + relaunch, confirm cached SIWE JWT picks up correctly
- [ ] The line `reAuthenticate: no SIWE signing context; falling back to legacy device-only auth` should never fire in iOS logs once a session has registered context

## Follow-up (optional, larger)

The deeper architectural issue is that multiple `ConvosAPIClient` instances exist at all. They share keychain JWTs but not in-memory state. Long-term fix is exposing `apiClient` on `ConvosClient` publicly and injecting it into non-session services (e.g. `BackendCreditsService`, `StoreKitSubscriptionService`) at app init, instead of letting them construct their own via the factory. Not blocking the singleton fix — they compose.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/846"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1781886761&installation_id=128169237&pr_number=846&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F846&signature=59b77945776f061c26315fb7f988664c47642a77a2d318fafd802625ccce692c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Share a single SIWE signing context across all `ConvosAPIClient` instances
> Previously, each `ConvosAPIClient` constructed its own `LockedSigningContext`, so signing state was not shared between instances. Now all clients reference `LockedSigningContext.shared`, a process-wide singleton defined in [ConvosAPIClient.swift](https://github.com/xmtplabs/convos-ios/pull/846/files#diff-d9c911c02b64ae370c51a1048b35e6e5dfc05805b43efd9be61a31fa422500b8). Behavioral Change: any signing context set on one `ConvosAPIClient` instance is now visible to all other instances.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2d3caf0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->