### PR TITLE
feat(agents): agent-template deeplink => new conversation with the agent

### DIFF
--- a/Convos/Conversation Creation/NewConversationViewModel.swift
+++ b/Convos/Conversation Creation/NewConversationViewModel.swift
@@ -35,6 +35,11 @@ enum NewConversationMode {
     /// conversation arrives at `.ready` with the picked members already
     /// in it.
     case newConversationWithMembers(initialMemberInboxIds: [String])
+    /// Same instant-placeholder flow as `.newConversation`; once the
+    /// conversation reaches `.ready`, a fresh instance of the given
+    /// agent template is requested into it. Used by the agent-template
+    /// deeplink (`convos://template/<id>`).
+    case newConversationWithTemplate(templateId: String)
     case scanner
     case joinInvite(code: String)
 }
@@ -91,6 +96,14 @@ class NewConversationViewModel: Identifiable {
 
     private var conversationStateManager: (any ConversationStateManagerProtocol)?
     private var acquiredMessagingService: AnyMessagingService?
+    /// Agent template id to provision into the conversation once it
+    /// reaches `.ready`. Set only for `.newConversationWithTemplate`.
+    @ObservationIgnored
+    private var pendingAgentTemplateId: String?
+    /// One-shot guard so a re-emitted `.ready` state doesn't request the
+    /// agent join twice.
+    @ObservationIgnored
+    private var didTriggerAgentJoin: Bool = false
     @ObservationIgnored
     nonisolated(unsafe) private var _reachedReadyState: Bool = false
     @ObservationIgnored
@@ -123,8 +136,12 @@ class NewConversationViewModel: Identifiable {
         self.session = session
         self.qrScannerViewModel = QRScannerViewModel()
 
+        if case .newConversationWithTemplate(let templateId) = mode {
+            self.pendingAgentTemplateId = templateId
+        }
+
         switch mode {
-        case .newConversation, .newConversationWithMembers:
+        case .newConversation, .newConversationWithMembers, .newConversationWithTemplate:
             self.autoCreateConversation = true
             self.startedWithFullscreenScanner = false
             self.showingFullScreenScanner = false
@@ -192,7 +209,7 @@ class NewConversationViewModel: Identifiable {
             guard let self else { return }
 
             switch mode {
-            case .newConversation:
+            case .newConversation, .newConversationWithTemplate:
                 let (messagingService, existingConversationId) = await session.prepareNewConversation()
                 guard !Task.isCancelled else { return }
                 let inboxElapsed = (CFAbsoluteTimeGetCurrent() - perfStartTime) * 1000
@@ -546,6 +563,14 @@ class NewConversationViewModel: Identifiable {
             Log.info("[PERF] NewConversation.ready: \(String(format: "%.0f", readyElapsed))ms (origin: \(result.origin))")
             Log.info("Conversation ready!")
 
+            // Agent-template deeplink: the conversation now exists with a
+            // shareable invite, so request a fresh instance of the
+            // template into it. One-shot - `.ready` may re-emit.
+            if let pendingAgentTemplateId, !didTriggerAgentJoin {
+                didTriggerAgentJoin = true
+                conversationViewModel?.requestAgentJoin(templateId: pendingAgentTemplateId)
+            }
+
         case .joinFailed(_, let error):
             consecutiveFailureCount += 1
             handleJoinFailedState(error)
@@ -715,7 +740,7 @@ class NewConversationViewModel: Identifiable {
 private extension NewConversationMode {
     var isNewConversation: Bool {
         switch self {
-        case .newConversation, .newConversationWithMembers:
+        case .newConversation, .newConversationWithMembers, .newConversationWithTemplate:
             return true
         case .scanner, .joinInvite:
             return false

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -2218,7 +2218,11 @@ extension ConversationViewModel {
         try await metadataWriter.addMembers(inboxIds, to: conversation.id)
     }
 
-    func requestAssistantJoin() {
+    /// Requests an agent join into this conversation. `templateId == nil`
+    /// is a bare join (the backend provisions its default agent); a
+    /// non-nil id provisions a fresh instance of that template. The
+    /// caller-facing `agents/join` body no longer accepts `instructions`.
+    func requestAgentJoin(templateId: String?) {
         let slug = invite.urlSlug
         guard !slug.isEmpty else { return }
 
@@ -2237,7 +2241,7 @@ extension ConversationViewModel {
             do {
                 _ = try await session.requestAgentJoin(
                     slug: slug,
-                    instructions: "You're a Convos Assistant",
+                    templateId: templateId,
                     forceErrorCode: forceErrorCode
                 )
             } catch is CancellationError {
@@ -2269,6 +2273,12 @@ extension ConversationViewModel {
             await MainActor.run { self?.clearAssistantJoinTask(id: taskId) }
         }
         assistantJoinTaskId = taskId
+    }
+
+    /// Bare-join convenience for the in-conversation "add an assistant"
+    /// affordances. Kept so their call sites don't change.
+    func requestAssistantJoin() {
+        requestAgentJoin(templateId: nil)
     }
 
     private static func broadcastAssistantJoinRequest(

--- a/Convos/Conversations List/ConversationsViewModel.swift
+++ b/Convos/Conversations List/ConversationsViewModel.swift
@@ -285,6 +285,8 @@ final class ConversationsViewModel {
                 serviceId: serviceId,
                 conversationId: conversationId
             )
+        case .agentTemplate(templateId: let templateId):
+            startConversation(withAgentTemplateId: templateId)
         }
     }
 
@@ -306,6 +308,16 @@ final class ConversationsViewModel {
         newConversationViewModel = NewConversationViewModel(
             session: session,
             mode: .joinInvite(code: inviteCode)
+        )
+    }
+
+    /// Opens a new conversation and, once it is ready, requests a fresh
+    /// instance of the given agent template into it. Entry point for the
+    /// `convos://template/<id>` deeplink.
+    private func startConversation(withAgentTemplateId templateId: String) {
+        newConversationViewModel = NewConversationViewModel(
+            session: session,
+            mode: .newConversationWithTemplate(templateId: templateId)
         )
     }
 

--- a/Convos/DeepLinking/DeepLinkHandler.swift
+++ b/Convos/DeepLinking/DeepLinkHandler.swift
@@ -5,6 +5,7 @@ import SwiftUI
 enum DeepLinkDestination {
     case joinConversation(inviteCode: String)
     case connectionGrant(serviceId: String, conversationId: String)
+    case agentTemplate(templateId: String)
 }
 
 final class DeepLinkHandler {
@@ -21,6 +22,10 @@ final class DeepLinkHandler {
 
         if let connectionGrantDestination = parseConnectionGrant(from: url) {
             return connectionGrantDestination
+        }
+
+        if let agentTemplateDestination = parseAgentTemplate(from: url) {
+            return agentTemplateDestination
         }
 
         guard let inviteCode = url.convosInviteCode else {
@@ -81,6 +86,51 @@ final class DeepLinkHandler {
             return nil
         }
         return (service, conversationId)
+    }
+
+    // MARK: - Agent template deep links
+
+    /// Parses agent-template deep links of the form
+    /// `convos[-{env}]://template/<templateId>`, where `<templateId>` is
+    /// the backend's `AgentTemplate.id` (a UUID).
+    ///
+    /// V1 handles the custom URL scheme only. A Universal Link form
+    /// (`https://.../<templateId>`) is a planned follow-up.
+    ///
+    /// See `docs/plans/agent-templates-phase-1-prd.md`.
+    @MainActor
+    private static func parseAgentTemplate(from url: URL) -> DeepLinkDestination? {
+        guard url.scheme == ConfigManager.shared.appUrlScheme,
+              let templateId = customSchemeAgentTemplateId(from: url),
+              isValidTemplateId(templateId) else {
+            return nil
+        }
+        return .agentTemplate(templateId: templateId)
+    }
+
+    /// `convos[-{env}]://template/<id>` — host is `template`, single
+    /// path component is the id.
+    private static func customSchemeAgentTemplateId(from url: URL) -> String? {
+        guard url.host == "template" else { return nil }
+        let components = url.pathComponents.filter { $0 != "/" }
+        guard components.count == 1 else { return nil }
+        return components[0]
+    }
+
+    private static let uuidPattern: NSRegularExpression? = {
+        // RFC 4122 v4 UUID, hex digits, case-insensitive — matches the
+        // template id format the backend's resolver uses
+        // (convos-backend/src/api/v2/agent-templates/lib/resolve-id-or-hashed-slug.ts).
+        try? NSRegularExpression(
+            pattern: "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+            options: [.caseInsensitive]
+        )
+    }()
+
+    private static func isValidTemplateId(_ value: String) -> Bool {
+        guard let pattern = uuidPattern else { return false }
+        let range = NSRange(value.startIndex..., in: value)
+        return pattern.firstMatch(in: value, options: [], range: range) != nil
     }
 
     private static let maxConversationIdLength: Int = 256

--- a/ConvosCore/Package.resolved
+++ b/ConvosCore/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "3c48de41849916d194dc33c39c2d4a0ee8ed62c58829c9e239400db4c6790359",
+  "originHash" : "596a9de200b071262cadc68f1399f3097d53c0ed82208de3a325f27f8dba7cf9",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -44,15 +44,6 @@
       "state" : {
         "revision" : "cfbd6f540d5084bc96a60af841121472fbe725a3",
         "version" : "0.2.0"
-      }
-    },
-    {
-      "identity" : "differencekit",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/ra1028/DifferenceKit.git",
-      "state" : {
-        "revision" : "073b9671ce2b9b5b96398611427a1f929927e428",
-        "version" : "1.3.0"
       }
     },
     {
@@ -251,15 +242,6 @@
       "state" : {
         "revision" : "7c6ad0fc39d0763e0b699210e4124afd5041c5df",
         "version" : "1.6.4"
-      }
-    },
-    {
-      "identity" : "swiftui-introspect",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/siteline/swiftui-introspect.git",
-      "state" : {
-        "revision" : "9bedf1e79c7b7c34b35b74bef126f56d2400ef7f",
-        "version" : "1.4.0-beta.4"
       }
     }
   ],

--- a/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient+Models.swift
+++ b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient+Models.swift
@@ -162,14 +162,18 @@ public enum ConvosAPI {
 
     // MARK: - v2/agents/join
     // POST /v2/agents/join
+    // The body is validated strictly server-side: unknown keys are rejected.
+    // `templateId` is optional - omitting it requests a bare join (the
+    // backend provisions a default agent). A nil `templateId` is omitted
+    // from the encoded JSON by Codable's synthesized encoder.
 
     public struct AgentJoinRequest: Codable {
         public let slug: String
-        public let instructions: String
+        public let templateId: String?
 
-        public init(slug: String, instructions: String) {
+        public init(slug: String, templateId: String?) {
             self.slug = slug
-            self.instructions = instructions
+            self.templateId = templateId
         }
     }
 

--- a/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift
+++ b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift
@@ -83,7 +83,7 @@ public protocol ConvosAPIClientProtocol: AnyObject, Sendable {
     func renewAssetsBatch(assetKeys: [String]) async throws -> AssetRenewalResult
 
     // Agents
-    func requestAgentJoin(slug: String, instructions: String, forceErrorCode: Int?) async throws -> ConvosAPI.AgentJoinResponse
+    func requestAgentJoin(slug: String, templateId: String?, forceErrorCode: Int?) async throws -> ConvosAPI.AgentJoinResponse
 
     // Connections
     func initiateCloudConnection(serviceId: String, redirectUri: String) async throws -> CloudConnectionsAPI.InitiateResponse
@@ -93,8 +93,8 @@ public protocol ConvosAPIClientProtocol: AnyObject, Sendable {
 }
 
 extension ConvosAPIClientProtocol {
-    func requestAgentJoin(slug: String, instructions: String) async throws -> ConvosAPI.AgentJoinResponse {
-        try await requestAgentJoin(slug: slug, instructions: instructions, forceErrorCode: nil)
+    func requestAgentJoin(slug: String, templateId: String?) async throws -> ConvosAPI.AgentJoinResponse {
+        try await requestAgentJoin(slug: slug, templateId: templateId, forceErrorCode: nil)
     }
 }
 
@@ -666,7 +666,7 @@ final class ConvosAPIClient: ConvosAPIClientProtocol, Sendable {
 
     // MARK: - Agents
 
-    func requestAgentJoin(slug: String, instructions: String, forceErrorCode: Int? = nil) async throws -> ConvosAPI.AgentJoinResponse {
+    func requestAgentJoin(slug: String, templateId: String?, forceErrorCode: Int? = nil) async throws -> ConvosAPI.AgentJoinResponse {
         var request = try authenticatedRequest(for: "v2/agents/join", method: "POST")
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         // Backend pool timeout is 30s; give 5s buffer so backend returns a proper 504 before iOS times out
@@ -679,7 +679,7 @@ final class ConvosAPIClient: ConvosAPIClientProtocol, Sendable {
         request.httpBody = try JSONEncoder().encode(
             ConvosAPI.AgentJoinRequest(
                 slug: slug,
-                instructions: instructions
+                templateId: templateId
             )
         )
 
@@ -701,6 +701,10 @@ final class ConvosAPIClient: ConvosAPIClientProtocol, Sendable {
             throw APIError.forbidden
         case 404:
             throw APIError.notFound
+        case 410:
+            // Template resolved but is archived - the backend won't
+            // provision an instance from it.
+            throw APIError.templateArchived
         default:
             throw APIError.serverError(parseErrorMessage(from: data))
         }
@@ -778,6 +782,7 @@ public enum APIError: Error {
     case noAgentsAvailable
     case agentPoolTimeout
     case agentProvisionFailed
+    case templateArchived
 }
 
 extension APIError: DisplayError {
@@ -811,6 +816,8 @@ extension APIError: DisplayError {
             return "Assistant timed out"
         case .agentProvisionFailed:
             return "Couldn't add assistant"
+        case .templateArchived:
+            return "Agent unavailable"
         }
     }
 
@@ -844,6 +851,8 @@ extension APIError: DisplayError {
             return "Assistant setup took too long. Please try again."
         case .agentProvisionFailed:
             return "Something went wrong while adding an assistant. Please try again."
+        case .templateArchived:
+            return "This agent has been archived and can't be added to a conversation."
         }
     }
 }

--- a/ConvosCore/Sources/ConvosCore/API/MockAPIClient.swift
+++ b/ConvosCore/Sources/ConvosCore/API/MockAPIClient.swift
@@ -95,7 +95,7 @@ final class MockAPIClient: ConvosAPIClientProtocol, Sendable {
         AssetRenewalResult(renewed: assetKeys.count, failed: 0, expiredKeys: [])
     }
 
-    func requestAgentJoin(slug: String, instructions: String, forceErrorCode: Int? = nil) async throws -> ConvosAPI.AgentJoinResponse {
+    func requestAgentJoin(slug: String, templateId: String?, forceErrorCode: Int? = nil) async throws -> ConvosAPI.AgentJoinResponse {
         .init(success: true, joined: true)
     }
 

--- a/ConvosCore/Sources/ConvosCore/Inboxes/MockInboxesService.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/MockInboxesService.swift
@@ -67,7 +67,7 @@ public final class MockInboxesService: SessionManagerProtocol, @unchecked Sendab
         MockInviteRepository()
     }
 
-    public func requestAgentJoin(slug: String, instructions: String, forceErrorCode: Int? = nil) async throws -> ConvosAPI.AgentJoinResponse {
+    public func requestAgentJoin(slug: String, templateId: String?, forceErrorCode: Int? = nil) async throws -> ConvosAPI.AgentJoinResponse {
         if let forceErrorCode {
             switch forceErrorCode {
             case 502: throw APIError.agentProvisionFailed

--- a/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
@@ -550,8 +550,8 @@ public final class SessionManager: SessionManagerProtocol, @unchecked Sendable {
         )
     }
 
-    public func requestAgentJoin(slug: String, instructions: String, forceErrorCode: Int? = nil) async throws -> ConvosAPI.AgentJoinResponse {
-        try await apiClient.requestAgentJoin(slug: slug, instructions: instructions, forceErrorCode: forceErrorCode)
+    public func requestAgentJoin(slug: String, templateId: String?, forceErrorCode: Int? = nil) async throws -> ConvosAPI.AgentJoinResponse {
+        try await apiClient.requestAgentJoin(slug: slug, templateId: templateId, forceErrorCode: forceErrorCode)
     }
 
     public func conversationRepository(for conversationId: String) -> any ConversationRepositoryProtocol {

--- a/ConvosCore/Sources/ConvosCore/Sessions/SessionManagerProtocol.swift
+++ b/ConvosCore/Sources/ConvosCore/Sessions/SessionManagerProtocol.swift
@@ -30,7 +30,7 @@ public protocol SessionManagerProtocol: AnyObject, Sendable {
     // MARK: Factory methods for repositories
 
     func inviteRepository(for conversationId: String) -> any InviteRepositoryProtocol
-    func requestAgentJoin(slug: String, instructions: String, forceErrorCode: Int?) async throws -> ConvosAPI.AgentJoinResponse
+    func requestAgentJoin(slug: String, templateId: String?, forceErrorCode: Int?) async throws -> ConvosAPI.AgentJoinResponse
 
     func conversationRepository(for conversationId: String) -> any ConversationRepositoryProtocol
 
@@ -116,7 +116,7 @@ public protocol SessionManagerProtocol: AnyObject, Sendable {
 }
 
 extension SessionManagerProtocol {
-    public func requestAgentJoin(slug: String, instructions: String) async throws -> ConvosAPI.AgentJoinResponse {
-        try await requestAgentJoin(slug: slug, instructions: instructions, forceErrorCode: nil)
+    public func requestAgentJoin(slug: String, templateId: String?) async throws -> ConvosAPI.AgentJoinResponse {
+        try await requestAgentJoin(slug: slug, templateId: templateId, forceErrorCode: nil)
     }
 }

--- a/ConvosCore/Tests/ConvosCoreTests/Assets/AssetRenewalManagerTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/Assets/AssetRenewalManagerTests.swift
@@ -483,7 +483,7 @@ final class ConfigurableMockAPIClient: ConvosAPIClientProtocol, @unchecked Senda
     func getPresignedUploadURL(filename: String, contentType: String) async throws -> (uploadURL: String, assetURL: String) {
         ("https://example.com/upload/\(filename)", "https://example.com/assets/\(filename)")
     }
-    func requestAgentJoin(slug: String, instructions: String, forceErrorCode: Int? = nil) async throws -> ConvosAPI.AgentJoinResponse {
+    func requestAgentJoin(slug: String, templateId: String?, forceErrorCode: Int? = nil) async throws -> ConvosAPI.AgentJoinResponse {
         .init(success: true, joined: true)
     }
 

--- a/ConvosCore/Tests/ConvosCoreTests/ConnectionManagerTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ConnectionManagerTests.swift
@@ -622,7 +622,7 @@ private final class StubAPIClient: ConvosAPIClientProtocol, @unchecked Sendable 
         AssetRenewalResult(renewed: assetKeys.count, failed: 0, expiredKeys: [])
     }
 
-    func requestAgentJoin(slug: String, instructions: String, forceErrorCode: Int?) async throws -> ConvosAPI.AgentJoinResponse {
+    func requestAgentJoin(slug: String, templateId: String?, forceErrorCode: Int?) async throws -> ConvosAPI.AgentJoinResponse {
         .init(success: true, joined: true)
     }
 

--- a/ConvosCore/Tests/ConvosCoreTests/Integration/PushTopicSubscriptionDeniedDMTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/Integration/PushTopicSubscriptionDeniedDMTests.swift
@@ -184,7 +184,7 @@ private final class ThrowawayPushAPIClient: ConvosAPIClientProtocol, @unchecked 
         ("https://example.com/upload/\(filename)", "https://example.com/assets/\(filename)")
     }
 
-    func requestAgentJoin(slug: String, instructions: String, forceErrorCode: Int?) async throws -> ConvosAPI.AgentJoinResponse {
+    func requestAgentJoin(slug: String, templateId: String?, forceErrorCode: Int?) async throws -> ConvosAPI.AgentJoinResponse {
         .init(success: true, joined: true)
     }
 

--- a/ConvosCore/Tests/ConvosCoreTests/PushTopicSubscriptionManagerTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/PushTopicSubscriptionManagerTests.swift
@@ -305,7 +305,7 @@ private final class RecordingPushAPIClient: ConvosAPIClientProtocol, @unchecked 
         ("https://example.com/upload/\(filename)", "https://example.com/assets/\(filename)")
     }
 
-    func requestAgentJoin(slug: String, instructions: String, forceErrorCode: Int?) async throws -> ConvosAPI.AgentJoinResponse {
+    func requestAgentJoin(slug: String, templateId: String?, forceErrorCode: Int?) async throws -> ConvosAPI.AgentJoinResponse {
         .init(success: true, joined: true)
     }
 
@@ -380,7 +380,7 @@ private final class ThrowingPushAPIClient: ConvosAPIClientProtocol, @unchecked S
         ("https://example.com/upload/\(filename)", "https://example.com/assets/\(filename)")
     }
 
-    func requestAgentJoin(slug: String, instructions: String, forceErrorCode: Int?) async throws -> ConvosAPI.AgentJoinResponse {
+    func requestAgentJoin(slug: String, templateId: String?, forceErrorCode: Int?) async throws -> ConvosAPI.AgentJoinResponse {
         .init(success: true, joined: true)
     }
 

--- a/ConvosCore/Tests/ConvosCoreTests/SyncingManagerPushReconciliationTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/SyncingManagerPushReconciliationTests.swift
@@ -239,7 +239,7 @@ private final class RecordingPushAPIClientForReconciliationTests: ConvosAPIClien
         ("https://example.com/upload/\(filename)", "https://example.com/assets/\(filename)")
     }
 
-    func requestAgentJoin(slug: String, instructions: String, forceErrorCode: Int?) async throws -> ConvosAPI.AgentJoinResponse {
+    func requestAgentJoin(slug: String, templateId: String?, forceErrorCode: Int?) async throws -> ConvosAPI.AgentJoinResponse {
         .init(success: true, joined: true)
     }
 

--- a/ConvosCore/Tests/ConvosCoreTests/SyncingManagerTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/SyncingManagerTests.swift
@@ -383,7 +383,7 @@ final class TestableMockAPIClient: ConvosAPIClientProtocol, @unchecked Sendable 
         ("https://mock-api.example.com/upload/\(filename)", "https://mock-api.example.com/assets/\(filename)")
     }
 
-    func requestAgentJoin(slug: String, instructions: String, forceErrorCode: Int? = nil) async throws -> ConvosAPI.AgentJoinResponse {
+    func requestAgentJoin(slug: String, templateId: String?, forceErrorCode: Int? = nil) async throws -> ConvosAPI.AgentJoinResponse {
         .init(success: true, joined: true)
     }
 

--- a/ConvosTests/ConversationViewModelGlobalDefaultsTests.swift
+++ b/ConvosTests/ConversationViewModelGlobalDefaultsTests.swift
@@ -224,8 +224,8 @@ private final class TestSessionManager: SessionManagerProtocol, @unchecked Senda
         await base.inboxId(for: conversationId)
     }
 
-    func requestAgentJoin(slug: String, instructions: String, forceErrorCode: Int? = nil) async throws -> ConvosAPI.AgentJoinResponse {
-        try await base.requestAgentJoin(slug: slug, instructions: instructions, forceErrorCode: forceErrorCode)
+    func requestAgentJoin(slug: String, templateId: String?, forceErrorCode: Int? = nil) async throws -> ConvosAPI.AgentJoinResponse {
+        try await base.requestAgentJoin(slug: slug, templateId: templateId, forceErrorCode: forceErrorCode)
     }
 
     func redeemInviteCode(_ code: String) async throws -> ConvosAPI.InviteCodeStatus {

--- a/ConvosTests/ConversationsViewModelDeleteTests.swift
+++ b/ConvosTests/ConversationsViewModelDeleteTests.swift
@@ -292,8 +292,8 @@ private final class TestSessionManager: SessionManagerProtocol, @unchecked Senda
         await base.inboxId(for: conversationId)
     }
 
-    func requestAgentJoin(slug: String, instructions: String, forceErrorCode: Int? = nil) async throws -> ConvosAPI.AgentJoinResponse {
-        try await base.requestAgentJoin(slug: slug, instructions: instructions, forceErrorCode: forceErrorCode)
+    func requestAgentJoin(slug: String, templateId: String?, forceErrorCode: Int? = nil) async throws -> ConvosAPI.AgentJoinResponse {
+        try await base.requestAgentJoin(slug: slug, templateId: templateId, forceErrorCode: forceErrorCode)
     }
 
     func redeemInviteCode(_ code: String) async throws -> ConvosAPI.InviteCodeStatus {

--- a/ConvosTests/DeepLinkHandlerTests.swift
+++ b/ConvosTests/DeepLinkHandlerTests.swift
@@ -12,6 +12,8 @@ final class DeepLinkHandlerTests: XCTestCase {
         ConfigManager.shared.associatedDomain
     }
 
+    private let sampleTemplateId: String = "200e27dc-badc-429f-a431-b01b0281ec95"
+
     // MARK: - Connection Grant Deep Links (custom scheme)
 
     func testCustomSchemeConnectionGrant_ParsesServiceAndConversationId() throws {
@@ -123,6 +125,65 @@ final class DeepLinkHandlerTests: XCTestCase {
         let longId = String(repeating: "a", count: 600)
         let url = try XCTUnwrap(URL(string: "\(appUrlScheme)://connections/grant?service=google_calendar&conversationId=\(longId)"))
         XCTAssertNil(DeepLinkHandler.destination(for: url))
+    }
+
+    // MARK: - Agent template deep links (custom scheme)
+
+    func testCustomSchemeAgentTemplate_ParsesTemplateId() throws {
+        let url = try XCTUnwrap(URL(string: "\(appUrlScheme)://template/\(sampleTemplateId)"))
+        let destination = DeepLinkHandler.destination(for: url)
+
+        guard case let .agentTemplate(templateId) = destination else {
+            XCTFail("Expected .agentTemplate, got \(String(describing: destination))")
+            return
+        }
+        XCTAssertEqual(templateId, sampleTemplateId)
+    }
+
+    func testCustomSchemeAgentTemplate_UppercaseTemplateIdAccepted() throws {
+        // The backend treats UUIDs case-insensitively per its uuidPattern regex;
+        // mirror that on the client so a recipient on a slightly-quirky email
+        // client that uppercased the URL doesn't get a 404.
+        let uppercased = sampleTemplateId.uppercased()
+        let url = try XCTUnwrap(URL(string: "\(appUrlScheme)://template/\(uppercased)"))
+        guard case let .agentTemplate(templateId) = DeepLinkHandler.destination(for: url) else {
+            XCTFail("Expected .agentTemplate for uppercase UUID")
+            return
+        }
+        XCTAssertEqual(templateId, uppercased)
+    }
+
+    func testCustomSchemeAgentTemplate_MissingIdReturnsNil() throws {
+        let url = try XCTUnwrap(URL(string: "\(appUrlScheme)://template/"))
+        XCTAssertNil(DeepLinkHandler.destination(for: url))
+    }
+
+    func testCustomSchemeAgentTemplate_MalformedIdReturnsNil() throws {
+        let url = try XCTUnwrap(URL(string: "\(appUrlScheme)://template/not-a-uuid"))
+        XCTAssertNil(DeepLinkHandler.destination(for: url))
+    }
+
+    func testCustomSchemeAgentTemplate_HashedSlugRejected() throws {
+        // V1 handles UUID template ids only. The pretty `<base>.<hash>`
+        // slug form the backend resolver also accepts is a follow-up;
+        // reject it for now rather than route to a destination we can't
+        // yet resolve client-side.
+        let url = try XCTUnwrap(URL(string: "\(appUrlScheme)://template/anchor.pnw1o"))
+        XCTAssertNil(DeepLinkHandler.destination(for: url))
+    }
+
+    func testCustomSchemeAgentTemplate_ExtraPathSegmentsRejected() throws {
+        let url = try XCTUnwrap(URL(string: "\(appUrlScheme)://template/\(sampleTemplateId)/extra"))
+        XCTAssertNil(DeepLinkHandler.destination(for: url))
+    }
+
+    func testCustomSchemeAgentTemplate_WrongHostReturnsNil() throws {
+        // `convos://templates/<id>` (plural) is not a route we recognise.
+        let url = try XCTUnwrap(URL(string: "\(appUrlScheme)://templates/\(sampleTemplateId)"))
+        let destination = DeepLinkHandler.destination(for: url)
+        if case .agentTemplate = destination {
+            XCTFail("Unknown host should not produce an .agentTemplate destination")
+        }
     }
 
     // MARK: - ConversationsViewModel.handleURL validation


### PR DESCRIPTION
## What

Tapping a `convos://template/<id>` deeplink opens the app, creates a new
conversation, and joins a fresh instance of that agent template into it.

## Changes

**Deeplink → spawn**
- `DeepLinkHandler`: new `.agentTemplate(templateId:)` destination,
  parsing `convos[-{env}]://template/<uuid>` with UUID validation.
- `ConversationsViewModel.handleURL` routes it to a new
  `startConversation(withAgentTemplateId:)`.
- `NewConversationMode.newConversationWithTemplate(templateId:)`: same
  instant-placeholder flow as `.newConversation`; on `.ready`, requests
  the agent join.

**agents/join API**
- `AgentJoinRequest` drops `instructions`, adds optional `templateId`
  (the backend body is now strict and 400s on `instructions`).
- `requestAgentJoin(slug:templateId:forceErrorCode:)` — signature change
  rippled through the protocol, `SessionManager`, and the mocks.
- `ConversationViewModel.requestAssistantJoin()` refactored into
  `requestAgentJoin(templateId:)` with a thin `requestAssistantJoin()`
  wrapper, so the 5 existing assistant-button call sites are unchanged
  (bare join, `templateId: nil`).
- New `APIError.templateArchived` for the backend's 410.

## Scope

Custom URL scheme only — Universal Links deferred. Every deeplink tap
creates a fresh conversation + instance; no existing-1:1 short-circuit.

## Depends on / rollout

- Backend `agents/join` templateId resolution + the SIWE-context auth
  fix (#846) so the JWT carries `accountId`.
- The `instructions` removal is a breaking change vs. the old backend
  contract — this build must reach users before the prod backend
  enforces the strict body.

## Testing

- [ ] `swift build --package-path ConvosCore --build-tests`, `/build`,
      `./dev/test`, `/lint`
- [ ] `ConvosTests/DeepLinkHandlerTests`
- [ ] Manual: `convos-dev://template/<id>` → app opens → conversation
      created → agent joins (confirm it's the template's agent, not a
      generic Assistant)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/847"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1781897410&installation_id=128169237&pr_number=847&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F847&signature=4e0468f282549c57f5cfa037e70172c9f2fc7e9639d097c15df02b5b9f9c321d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add agent-template deep link support to start new conversations with a specific agent
> - Adds a new `DeepLinkDestination.agentTemplate(templateId:)` case and URL parser in [DeepLinkHandler.swift](https://github.com/xmtplabs/convos-ios/pull/847/files#diff-262e2f8dbcd00d6d932e4f36e4ac9d7bb8d3e2cc29e15ec625ec9d57ed612a8a) that accepts custom-scheme URLs matching `<scheme>://template/<uuid>`.
> - Adds `NewConversationMode.newConversationWithTemplate(templateId:)` so a new conversation auto-creates and then requests an agent join for the given template once ready.
> - Replaces the `instructions` field in `ConvosAPI.AgentJoinRequest` with an optional `templateId`; a 410 response now surfaces as `APIError.templateArchived` with a user-facing error message.
> - `ConversationViewModel.requestAssistantJoin()` is preserved as a convenience wrapper around the new `requestAgentJoin(templateId:)` method for existing call sites.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized eec850d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->