### PR TITLE
Move credit balance reads through a GRDB repository

### DIFF
--- a/Convos/ConvosApp.swift
+++ b/Convos/ConvosApp.swift
@@ -120,7 +120,7 @@ struct ConvosApp: App {
                 // Foreground refresh — TTL-debounced inside both services, so
                 // this is a cheap no-op if we were just active. Catches the
                 // case where credits changed server-side while the app was
-                // backgrounded (Hermes consume, Apple webhook, manual op).
+                // backgrounded (agent runtime consume, Apple webhook, manual op).
                 Task {
                     await CreditsServices.shared.refresh()
                     await SubscriptionServices.shared.refresh()

--- a/Convos/ConvosApp.swift
+++ b/Convos/ConvosApp.swift
@@ -86,6 +86,13 @@ struct ConvosApp: App {
             client: convos,
             apiClient: ConvosAPIClientFactory.client(environment: environment)
         )
+        // Seed the credit_balance table on cold launch. The scene-phase
+        // handler covers subsequent foreground transitions, but on first
+        // launch (or post-wipe) the table is empty until this refresh lands.
+        // Forced so the 15s TTL doesn't gate an empty cache.
+        Task {
+            await CreditsServices.shared.refresh(force: true)
+        }
 
         // Sync the mock credits/subscription state from the persisted picker
         // preset so HOME pill + paywall reflect the operator's last selection.

--- a/Convos/ConvosApp.swift
+++ b/Convos/ConvosApp.swift
@@ -88,8 +88,14 @@ struct ConvosApp: App {
         )
         // Seed the credit_balance table on cold launch. The scene-phase
         // handler covers subsequent foreground transitions, but on first
-        // launch (or post-wipe) the table is empty until this refresh lands.
-        // Forced so the 15s TTL doesn't gate an empty cache.
+        // launch (or post-wipe) the table is empty until this refresh
+        // lands. Forced so the 15s TTL doesn't gate an empty cache. The
+        // unstructured Task is intentional: views default `@State` to
+        // `nil`, render gracefully during the brief window before the
+        // refresh completes, and update via `CreditsRepository`'s GRDB
+        // observation once the row is upserted. Bumping priority would
+        // be theatre on the launch path where everything is already
+        // foregrounded.
         Task {
             await CreditsServices.shared.refresh(force: true)
         }

--- a/Convos/ConvosApp.swift
+++ b/Convos/ConvosApp.swift
@@ -77,6 +77,16 @@ struct ConvosApp: App {
 
         self.convos = .client(environment: environment, platformProviders: .iOS)
 
+        // Wire the real backend credits service to the local database now
+        // that `ConvosClient` is constructed. `BackendCreditsService` upserts
+        // refresh results into `credit_balance`; views observe the table via
+        // `CreditsRepository`. The mock fallback handles the non-production
+        // debug toggle.
+        CreditsServices.configure(
+            client: convos,
+            apiClient: ConvosAPIClientFactory.client(environment: environment)
+        )
+
         // Sync the mock credits/subscription state from the persisted picker
         // preset so HOME pill + paywall reflect the operator's last selection.
         // Non-production only; production builds will swap in real services.

--- a/Convos/Subscription/CreditsServices.swift
+++ b/Convos/Subscription/CreditsServices.swift
@@ -27,8 +27,12 @@ enum CreditsServices {
     }
 
     static var useRealBackend: Bool {
-        if ConfigManager.shared.currentEnvironment.isProduction { return true }
-        return UserDefaults.standard.bool(forKey: Constant.useRealBackendKey)
+        let environment = ConfigManager.shared.currentEnvironment
+        if environment.isProduction { return true }
+        if let stored = UserDefaults.standard.object(forKey: Constant.useRealBackendKey) as? Bool {
+            return stored
+        }
+        return environment.buildEnvironment == .distribution
     }
 
     static func setUseRealBackend(_ value: Bool) {

--- a/Convos/Subscription/CreditsServices.swift
+++ b/Convos/Subscription/CreditsServices.swift
@@ -2,8 +2,28 @@ import ConvosCore
 import Foundation
 
 enum CreditsServices {
+    /// Real backend service, constructed once at app start once the database
+    /// and API client are available. The mock fallback is used when
+    /// `useRealBackend` is off (non-production debug toggle) or when
+    /// `configure(...)` hasn't run yet (preview / test contexts).
+    nonisolated(unsafe) private static var backendService: BackendCreditsService?
+
     static var shared: any CreditsServiceProtocol {
-        useRealBackend ? BackendCreditsService.shared : MockCreditsService.shared
+        if useRealBackend, let backendService { return backendService }
+        return MockCreditsService.shared
+    }
+
+    /// Wire the real backend service to the app's database + API client.
+    /// Called once from `ConvosApp.init` after `ConvosClient` is constructed.
+    /// Safe to call before the debug toggle resolves to "real" — the service
+    /// is built eagerly so flipping the toggle later picks it up without a
+    /// relaunch.
+    static func configure(client: ConvosClient, apiClient: any ConvosAPIClientProtocol) {
+        backendService = BackendCreditsService(
+            databaseWriter: client.databaseWriter,
+            databaseReader: client.databaseReader,
+            apiClient: apiClient
+        )
     }
 
     static var useRealBackend: Bool {

--- a/Convos/Subscription/SubscriptionServices.swift
+++ b/Convos/Subscription/SubscriptionServices.swift
@@ -7,8 +7,12 @@ enum SubscriptionServices {
     }
 
     static var useRealStoreKit: Bool {
-        if ConfigManager.shared.currentEnvironment.isProduction { return true }
-        return UserDefaults.standard.bool(forKey: Constant.useRealStoreKitKey)
+        let environment = ConfigManager.shared.currentEnvironment
+        if environment.isProduction { return true }
+        if let stored = UserDefaults.standard.object(forKey: Constant.useRealStoreKitKey) as? Bool {
+            return stored
+        }
+        return environment.buildEnvironment == .distribution
     }
 
     static func setUseRealStoreKit(_ value: Bool) {

--- a/ConvosCore/Sources/ConvosCore/Services/Credits/BackendCreditsService.swift
+++ b/ConvosCore/Sources/ConvosCore/Services/Credits/BackendCreditsService.swift
@@ -12,7 +12,7 @@ import GRDB
 /// internal. The repo-based observation lets the HOME pill, conversation
 /// banner, settings detail, and paywall stay in lockstep through the same
 /// GRDB observation channel the rest of the app uses.
-public final class BackendCreditsService: CreditsServiceProtocol, @unchecked Sendable {
+public final class BackendCreditsService: CreditsServiceProtocol {
     private let writer: CreditBalanceWriter
     private let repository: CreditsRepository
 
@@ -23,9 +23,6 @@ public final class BackendCreditsService: CreditsServiceProtocol, @unchecked Sen
     ) {
         self.writer = CreditBalanceWriter(databaseWriter: databaseWriter, apiClient: apiClient)
         self.repository = CreditsRepository(databaseReader: databaseReader)
-        Task { [weak self] in
-            await self?.refresh(force: true)
-        }
     }
 
     public var balancePublisher: AnyPublisher<CreditBalance?, Never> {
@@ -33,7 +30,12 @@ public final class BackendCreditsService: CreditsServiceProtocol, @unchecked Sen
     }
 
     public var currentBalance: CreditBalance? {
-        try? repository.currentBalance()
+        do {
+            return try repository.currentBalance()
+        } catch {
+            Log.error("Failed reading cached credit balance: \(error)")
+            return nil
+        }
     }
 
     public func refresh(force: Bool) async {

--- a/ConvosCore/Sources/ConvosCore/Services/Credits/BackendCreditsService.swift
+++ b/ConvosCore/Sources/ConvosCore/Services/Credits/BackendCreditsService.swift
@@ -1,71 +1,42 @@
 import Combine
 import Foundation
+import GRDB
 
 /// Real `CreditsServiceProtocol` backed by the Convos backend's
-/// `GET /v2/accounts/me/credits` endpoint. Used in production and in
-/// non-production builds whenever the "use real backend" toggle is on.
+/// `GET /v2/accounts/me/credits` endpoint. The HTTP refresh is delegated to
+/// `CreditBalanceWriter`, which upserts the result into the local
+/// `credit_balance` table. Reads (`balancePublisher`, `currentBalance`) are
+/// delegated to `CreditsRepository`, which observes the same table via GRDB.
 ///
-/// Mirrors `MockCreditsService` in shape: a process-wide singleton publishes
-/// `CreditBalance?` updates so the HOME pill, conversation low-balance banner,
-/// agent contact section, and settings detail screen all stay in lockstep.
+/// View sites consume the protocol surface; the writer/repository split is
+/// internal. The repo-based observation lets the HOME pill, conversation
+/// banner, settings detail, and paywall stay in lockstep through the same
+/// GRDB observation channel the rest of the app uses.
 public final class BackendCreditsService: CreditsServiceProtocol, @unchecked Sendable {
-    /// Process-wide singleton. Lazily constructed on first access — by then
-    /// `ConfigManager.shared.currentEnvironment` is configured (it's set in
-    /// `ConvosApp.init` before any UI surface is rendered).
-    public static let shared: BackendCreditsService = BackendCreditsService(
-        apiClient: ConvosAPIClientFactory.client(environment: ConfigManager.shared.currentEnvironment)
-    )
+    private let writer: CreditBalanceWriter
+    private let repository: CreditsRepository
 
-    /// Refresh debounce window. View-appear + scene-becomes-active triggers
-    /// fire freely; this TTL collapses bursts so we don't hammer the API
-    /// when the user navigates between views in quick succession. Forced
-    /// refreshes (pull-to-refresh, post-purchase) bypass it.
-    private static let refreshTTL: TimeInterval = 15
-
-    private let apiClient: any ConvosAPIClientProtocol
-    private let balanceSubject: CurrentValueSubject<CreditBalance?, Never>
-    private let lock: NSLock = NSLock()
-    private var lastFetchedAt: Date?
-
-    public init(apiClient: any ConvosAPIClientProtocol) {
-        self.apiClient = apiClient
-        self.balanceSubject = CurrentValueSubject(nil)
+    public init(
+        databaseWriter: any DatabaseWriter,
+        databaseReader: any DatabaseReader,
+        apiClient: any ConvosAPIClientProtocol
+    ) {
+        self.writer = CreditBalanceWriter(databaseWriter: databaseWriter, apiClient: apiClient)
+        self.repository = CreditsRepository(databaseReader: databaseReader)
         Task { [weak self] in
             await self?.refresh(force: true)
         }
     }
 
     public var balancePublisher: AnyPublisher<CreditBalance?, Never> {
-        balanceSubject.eraseToAnyPublisher()
+        repository.balancePublisher
     }
 
     public var currentBalance: CreditBalance? {
-        balanceSubject.value
+        try? repository.currentBalance()
     }
 
     public func refresh(force: Bool) async {
-        if !force, let last = readLastFetchedAt(),
-           Date().timeIntervalSince(last) < Self.refreshTTL {
-            return
-        }
-        do {
-            let balance = try await apiClient.getCreditBalance()
-            balanceSubject.send(balance)
-            writeLastFetchedAt(Date())
-        } catch {
-            Log.error("Failed to refresh credit balance from backend: \(error)")
-        }
-    }
-
-    private func readLastFetchedAt() -> Date? {
-        lock.lock()
-        defer { lock.unlock() }
-        return lastFetchedAt
-    }
-
-    private func writeLastFetchedAt(_ date: Date) {
-        lock.lock()
-        defer { lock.unlock() }
-        lastFetchedAt = date
+        await writer.refresh(force: force)
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Storage/Database Models/DBCreditBalance.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Database Models/DBCreditBalance.swift
@@ -1,0 +1,53 @@
+import Foundation
+import GRDB
+
+struct DBCreditBalance: FetchableRecord, PersistableRecord, Codable, Hashable {
+    static let databaseTableName: String = "credit_balance"
+
+    /// Sentinel primary-key value. The table holds at most one row per install
+    /// (credits are account-level and the install is single-inbox), so the row
+    /// is always identified by this constant key.
+    static let currentRowID: String = "current"
+
+    enum Columns {
+        static let id: Column = Column(CodingKeys.id)
+        static let balance: Column = Column(CodingKeys.balance)
+        static let monthlyGrant: Column = Column(CodingKeys.monthlyGrant)
+        static let monthlyGrantUsed: Column = Column(CodingKeys.monthlyGrantUsed)
+        static let nextRefreshAt: Column = Column(CodingKeys.nextRefreshAt)
+        static let periodLabel: Column = Column(CodingKeys.periodLabel)
+        static let updatedAt: Column = Column(CodingKeys.updatedAt)
+    }
+
+    let id: String
+    let balance: Int
+    let monthlyGrant: Int
+    let monthlyGrantUsed: Int
+    let nextRefreshAt: Date
+    let periodLabel: String
+    let updatedAt: Date
+}
+
+extension DBCreditBalance {
+    init(from balance: CreditBalance, updatedAt: Date = Date()) {
+        self.init(
+            id: Self.currentRowID,
+            balance: balance.balance,
+            monthlyGrant: balance.monthlyGrant,
+            monthlyGrantUsed: balance.monthlyGrantUsed,
+            nextRefreshAt: balance.nextRefreshAt,
+            periodLabel: balance.periodLabel,
+            updatedAt: updatedAt
+        )
+    }
+
+    func hydrate() -> CreditBalance {
+        CreditBalance(
+            balance: balance,
+            monthlyGrant: monthlyGrant,
+            monthlyGrantUsed: monthlyGrantUsed,
+            nextRefreshAt: nextRefreshAt,
+            periodLabel: periodLabel
+        )
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Storage/Repositories/CreditsRepository.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Repositories/CreditsRepository.swift
@@ -26,7 +26,10 @@ public final class CreditsRepository: CreditsRepositoryProtocol, Sendable {
                     .hydrate()
             }
             .publisher(in: databaseReader, scheduling: .immediate)
-            .replaceError(with: nil)
+            .catch { error -> Just<CreditBalance?> in
+                Log.error("Credit balance observation failed: \(error)")
+                return Just(nil)
+            }
             .eraseToAnyPublisher()
     }
 

--- a/ConvosCore/Sources/ConvosCore/Storage/Repositories/CreditsRepository.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Repositories/CreditsRepository.swift
@@ -1,0 +1,41 @@
+import Combine
+import Foundation
+import GRDB
+
+/// Read access to the locally-cached credit balance row. The actual value
+/// is sourced from the backend by `CreditBalanceWriter`; this repository
+/// just exposes the single row as an observable publisher + a sync read.
+public protocol CreditsRepositoryProtocol: Sendable {
+    var balancePublisher: AnyPublisher<CreditBalance?, Never> { get }
+    func currentBalance() throws -> CreditBalance?
+}
+
+public final class CreditsRepository: CreditsRepositoryProtocol, Sendable {
+    private let databaseReader: any DatabaseReader
+
+    public init(databaseReader: any DatabaseReader) {
+        self.databaseReader = databaseReader
+    }
+
+    public var balancePublisher: AnyPublisher<CreditBalance?, Never> {
+        ValueObservation
+            .tracking { db in
+                try DBCreditBalance
+                    .filter(DBCreditBalance.Columns.id == DBCreditBalance.currentRowID)
+                    .fetchOne(db)?
+                    .hydrate()
+            }
+            .publisher(in: databaseReader, scheduling: .immediate)
+            .replaceError(with: nil)
+            .eraseToAnyPublisher()
+    }
+
+    public func currentBalance() throws -> CreditBalance? {
+        try databaseReader.read { db in
+            try DBCreditBalance
+                .filter(DBCreditBalance.Columns.id == DBCreditBalance.currentRowID)
+                .fetchOne(db)?
+                .hydrate()
+        }
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Storage/SharedDatabaseMigrator.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/SharedDatabaseMigrator.swift
@@ -235,6 +235,24 @@ extension SharedDatabaseMigrator {
                 t.add(column: "hidesInviteCard", .boolean).notNull().defaults(to: false)
             }
         }
+
+        // Single-row credit_balance cache. The backend remains the source of
+        // truth (`GET /v2/accounts/me/credits`); this table just gives us a
+        // GRDB-observable read surface so the HOME pill, conversation banner,
+        // settings detail, and paywall stay in lockstep via the same
+        // observation channel the rest of the app uses. `id` is a fixed
+        // sentinel so the table holds at most one row per install.
+        migrator.registerMigration("createCreditBalance") { db in
+            try db.create(table: "credit_balance") { t in
+                t.column("id", .text).notNull().primaryKey()
+                t.column("balance", .integer).notNull()
+                t.column("monthlyGrant", .integer).notNull()
+                t.column("monthlyGrantUsed", .integer).notNull()
+                t.column("nextRefreshAt", .datetime).notNull()
+                t.column("periodLabel", .text).notNull()
+                t.column("updatedAt", .datetime).notNull()
+            }
+        }
     }
 
     /// Tighten capabilityResolution + connectionEnablement + connectionGrant so a grant

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/CreditBalanceWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/CreditBalanceWriter.swift
@@ -1,0 +1,45 @@
+import Foundation
+import GRDB
+
+/// Owns the write path for `credit_balance`. Fetches the latest balance from
+/// the backend via `GET /v2/accounts/me/credits` and upserts the single row.
+/// TTL-debounced so view-appear + scene-becomes-active triggers don't storm
+/// the API as the user navigates between credit-displaying surfaces.
+public actor CreditBalanceWriter {
+    /// Refresh debounce window. Forced refreshes (pull-to-refresh,
+    /// post-purchase) bypass it.
+    private static let refreshTTL: TimeInterval = 15
+
+    private let databaseWriter: any DatabaseWriter
+    private let apiClient: any ConvosAPIClientProtocol
+    private var lastFetchedAt: Date?
+
+    public init(
+        databaseWriter: any DatabaseWriter,
+        apiClient: any ConvosAPIClientProtocol
+    ) {
+        self.databaseWriter = databaseWriter
+        self.apiClient = apiClient
+    }
+
+    public func refresh(force: Bool) async {
+        if !force, let last = lastFetchedAt,
+           Date().timeIntervalSince(last) < Self.refreshTTL {
+            return
+        }
+        do {
+            let balance = try await apiClient.getCreditBalance()
+            try await write(balance)
+            lastFetchedAt = Date()
+        } catch {
+            Log.error("Failed to refresh credit balance from backend: \(error)")
+        }
+    }
+
+    private func write(_ balance: CreditBalance) async throws {
+        try await databaseWriter.write { db in
+            let row: DBCreditBalance = DBCreditBalance(from: balance)
+            try row.save(db)
+        }
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/CreditBalanceWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/CreditBalanceWriter.swift
@@ -13,6 +13,7 @@ public actor CreditBalanceWriter {
     private let databaseWriter: any DatabaseWriter
     private let apiClient: any ConvosAPIClientProtocol
     private var lastFetchedAt: Date?
+    private var refreshTask: Task<Bool, Never>?
 
     public init(
         databaseWriter: any DatabaseWriter,
@@ -23,16 +24,31 @@ public actor CreditBalanceWriter {
     }
 
     public func refresh(force: Bool) async {
+        if let refreshTask {
+            _ = await refreshTask.value
+            return
+        }
         if !force, let last = lastFetchedAt,
            Date().timeIntervalSince(last) < Self.refreshTTL {
             return
         }
+        let task: Task<Bool, Never> = Task { await performRefresh() }
+        refreshTask = task
+        let didRefresh = await task.value
+        refreshTask = nil
+        if didRefresh {
+            lastFetchedAt = Date()
+        }
+    }
+
+    private func performRefresh() async -> Bool {
         do {
             let balance = try await apiClient.getCreditBalance()
             try await write(balance)
-            lastFetchedAt = Date()
+            return true
         } catch {
             Log.error("Failed to refresh credit balance from backend: \(error)")
+            return false
         }
     }
 

--- a/ConvosCore/Tests/ConvosCoreTests/AgentTemplateMetadataTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/AgentTemplateMetadataTests.swift
@@ -1,5 +1,5 @@
-import Testing
 @testable import ConvosCore
+import Testing
 
 struct AgentTemplateMetadataTests {
     private func makeProfile(

--- a/ConvosCore/Tests/ConvosCoreTests/CreditBalanceWriterTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/CreditBalanceWriterTests.swift
@@ -1,0 +1,199 @@
+@testable import ConvosCore
+import Foundation
+import GRDB
+import os
+import Testing
+
+@Suite("CreditBalanceWriter Tests", .serialized)
+struct CreditBalanceWriterTests {
+    @Test("concurrent refresh calls share a single in-flight HTTP request")
+    func testConcurrentRefreshDeduplicates() async throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        let apiClient: StubCreditBalanceAPIClient = StubCreditBalanceAPIClient(
+            sleepNanoseconds: 50_000_000  // 50ms — long enough for both callers to overlap
+        )
+        let writer: CreditBalanceWriter = CreditBalanceWriter(
+            databaseWriter: dbManager.dbWriter,
+            apiClient: apiClient
+        )
+
+        async let first: Void = writer.refresh(force: true)
+        async let second: Void = writer.refresh(force: true)
+        _ = await (first, second)
+
+        let count = await apiClient.callCount
+        #expect(count == 1, "Concurrent refresh calls must share the same in-flight HTTP request")
+
+        let row: DBCreditBalance? = try await dbManager.dbReader.read { db in
+            try DBCreditBalance.fetchOne(db)
+        }
+        #expect(row != nil, "Both callers must see the upserted row when they return")
+    }
+
+    @Test("non-forced refresh within the TTL window is a no-op")
+    func testNonForcedRefreshWithinTTLIsNoOp() async throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        let apiClient: StubCreditBalanceAPIClient = StubCreditBalanceAPIClient()
+        let writer: CreditBalanceWriter = CreditBalanceWriter(
+            databaseWriter: dbManager.dbWriter,
+            apiClient: apiClient
+        )
+
+        await writer.refresh(force: false)
+        let countAfterFirst = await apiClient.callCount
+        #expect(countAfterFirst == 1)
+
+        await writer.refresh(force: false)
+        let countAfterSecond = await apiClient.callCount
+        #expect(
+            countAfterSecond == 1,
+            "Second non-forced refresh inside the TTL window must skip the HTTP call"
+        )
+    }
+
+    @Test("forced refresh bypasses the TTL window")
+    func testForcedRefreshBypassesTTL() async throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        let apiClient: StubCreditBalanceAPIClient = StubCreditBalanceAPIClient()
+        let writer: CreditBalanceWriter = CreditBalanceWriter(
+            databaseWriter: dbManager.dbWriter,
+            apiClient: apiClient
+        )
+
+        await writer.refresh(force: false)
+        await writer.refresh(force: true)
+
+        let count = await apiClient.callCount
+        #expect(count == 2, "Forced refresh must always hit the network, ignoring the TTL")
+    }
+
+    @Test("API failure does not advance the TTL window")
+    func testFailureDoesNotAdvanceTTL() async throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        let apiClient: StubCreditBalanceAPIClient = StubCreditBalanceAPIClient(shouldFail: true)
+        let writer: CreditBalanceWriter = CreditBalanceWriter(
+            databaseWriter: dbManager.dbWriter,
+            apiClient: apiClient
+        )
+
+        await writer.refresh(force: false)
+        await writer.refresh(force: false)
+
+        let count = await apiClient.callCount
+        #expect(
+            count == 2,
+            "A failed refresh must not update lastFetchedAt — the next attempt should retry instead of being TTL-gated"
+        )
+
+        let row: DBCreditBalance? = try await dbManager.dbReader.read { db in
+            try DBCreditBalance.fetchOne(db)
+        }
+        #expect(row == nil, "Failed refresh must not write a row")
+    }
+}
+
+/// Wraps `MockAPIClient` to inherit no-op defaults for every protocol method
+/// except `getCreditBalance`, which is the only one the writer exercises. The
+/// override counts calls, optionally delays the response (to overlap
+/// concurrent callers), and can be flipped into a failure mode.
+private final class StubCreditBalanceAPIClient: ConvosAPIClientProtocol, @unchecked Sendable {
+    private let delegate: MockAPIClient = MockAPIClient()
+    private let sleepNanoseconds: UInt64
+    private let shouldFail: Bool
+    private let counter: OSAllocatedUnfairLock<Int> = OSAllocatedUnfairLock(initialState: 0)
+
+    var callCount: Int {
+        counter.withLock { $0 }
+    }
+
+    init(sleepNanoseconds: UInt64 = 0, shouldFail: Bool = false) {
+        self.sleepNanoseconds = sleepNanoseconds
+        self.shouldFail = shouldFail
+    }
+
+    func getCreditBalance() async throws -> CreditBalance {
+        counter.withLock { $0 += 1 }
+        if sleepNanoseconds > 0 {
+            try? await Task.sleep(nanoseconds: sleepNanoseconds)
+        }
+        if shouldFail {
+            throw StubError.simulatedFailure
+        }
+        return CreditBalance(
+            balance: 1_000,
+            monthlyGrant: 2_000,
+            monthlyGrantUsed: 1_000,
+            nextRefreshAt: Date(timeIntervalSince1970: 1_700_000_000),
+            periodLabel: "test"
+        )
+    }
+
+    func request(for path: String, method: String, queryParameters: [String: String]?) throws -> URLRequest {
+        try delegate.request(for: path, method: method, queryParameters: queryParameters)
+    }
+    func registerDevice(deviceId: String, pushToken: String?) async throws {
+        try await delegate.registerDevice(deviceId: deviceId, pushToken: pushToken)
+    }
+    func authenticate(appCheckToken: String, retryCount: Int) async throws -> String {
+        try await delegate.authenticate(appCheckToken: appCheckToken, retryCount: retryCount)
+    }
+    func authenticateWithSIWE(appCheckToken: String, signing: BackendAuthSigningContext) async throws -> String {
+        try await delegate.authenticateWithSIWE(appCheckToken: appCheckToken, signing: signing)
+    }
+    func updateSIWESigningContext(_ context: BackendAuthSigningContext?) {
+        delegate.updateSIWESigningContext(context)
+    }
+    func accountAuthCheck(jwt: String?) async throws -> ConvosAPI.AuthCheckResponse {
+        try await delegate.accountAuthCheck(jwt: jwt)
+    }
+    func uploadAttachment(data: Data, filename: String, contentType: String, acl: String) async throws -> String {
+        try await delegate.uploadAttachment(data: data, filename: filename, contentType: contentType, acl: acl)
+    }
+    func uploadAttachmentAndExecute(
+        data: Data,
+        filename: String,
+        afterUpload: @escaping (String) async throws -> Void
+    ) async throws -> String {
+        try await delegate.uploadAttachmentAndExecute(data: data, filename: filename, afterUpload: afterUpload)
+    }
+    func getPresignedUploadURL(filename: String, contentType: String) async throws -> (uploadURL: String, assetURL: String) {
+        try await delegate.getPresignedUploadURL(filename: filename, contentType: contentType)
+    }
+    func subscribeToTopics(deviceId: String, clientId: String, topics: [String]) async throws {
+        try await delegate.subscribeToTopics(deviceId: deviceId, clientId: clientId, topics: topics)
+    }
+    func unsubscribeFromTopics(clientId: String, topics: [String]) async throws {
+        try await delegate.unsubscribeFromTopics(clientId: clientId, topics: topics)
+    }
+    func unregisterInstallation(clientId: String) async throws {
+        try await delegate.unregisterInstallation(clientId: clientId)
+    }
+    func renewAssetsBatch(assetKeys: [String]) async throws -> AssetRenewalResult {
+        try await delegate.renewAssetsBatch(assetKeys: assetKeys)
+    }
+    func requestAgentJoin(slug: String, instructions: String, forceErrorCode: Int?) async throws -> ConvosAPI.AgentJoinResponse {
+        try await delegate.requestAgentJoin(slug: slug, instructions: instructions, forceErrorCode: forceErrorCode)
+    }
+    func initiateCloudConnection(serviceId: String, redirectUri: String) async throws -> CloudConnectionsAPI.InitiateResponse {
+        try await delegate.initiateCloudConnection(serviceId: serviceId, redirectUri: redirectUri)
+    }
+    func completeCloudConnection(connectionRequestId: String) async throws -> CloudConnectionsAPI.CompleteResponse {
+        try await delegate.completeCloudConnection(connectionRequestId: connectionRequestId)
+    }
+    func listCloudConnections() async throws -> [CloudConnectionsAPI.ConnectionResponse] {
+        try await delegate.listCloudConnections()
+    }
+    func revokeCloudConnection(connectionId: String) async throws {
+        try await delegate.revokeCloudConnection(connectionId: connectionId)
+    }
+    func getSubscription() async throws -> UserSubscription? {
+        try await delegate.getSubscription()
+    }
+    func verifySubscription(jwsRepresentation: String) async throws -> UserSubscription {
+        try await delegate.verifySubscription(jwsRepresentation: jwsRepresentation)
+    }
+
+    enum StubError: Error {
+        case simulatedFailure
+    }
+}

--- a/ConvosCore/Tests/ConvosCoreTests/CreditBalanceWriterTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/CreditBalanceWriterTests.swift
@@ -171,8 +171,8 @@ private final class StubCreditBalanceAPIClient: ConvosAPIClientProtocol, @unchec
     func renewAssetsBatch(assetKeys: [String]) async throws -> AssetRenewalResult {
         try await delegate.renewAssetsBatch(assetKeys: assetKeys)
     }
-    func requestAgentJoin(slug: String, instructions: String, forceErrorCode: Int?) async throws -> ConvosAPI.AgentJoinResponse {
-        try await delegate.requestAgentJoin(slug: slug, instructions: instructions, forceErrorCode: forceErrorCode)
+    func requestAgentJoin(slug: String, templateId: String?, forceErrorCode: Int?) async throws -> ConvosAPI.AgentJoinResponse {
+        try await delegate.requestAgentJoin(slug: slug, templateId: templateId, forceErrorCode: forceErrorCode)
     }
     func initiateCloudConnection(serviceId: String, redirectUri: String) async throws -> CloudConnectionsAPI.InitiateResponse {
         try await delegate.initiateCloudConnection(serviceId: serviceId, redirectUri: redirectUri)

--- a/ConvosCore/Tests/ConvosCoreTests/CreditsRepositoryTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/CreditsRepositoryTests.swift
@@ -1,0 +1,69 @@
+@testable import ConvosCore
+import Foundation
+import GRDB
+import Testing
+
+@Suite("CreditsRepository Tests", .serialized)
+struct CreditsRepositoryTests {
+    @Test("currentBalance returns nil when the table is empty")
+    func testEmptyTable() throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        let repo: CreditsRepository = CreditsRepository(databaseReader: dbManager.dbReader)
+
+        #expect(try repo.currentBalance() == nil)
+    }
+
+    @Test("currentBalance hydrates the row matching the sentinel ID")
+    func testCurrentBalanceMatchesSentinelRow() throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        let nextRefresh: Date = Date(timeIntervalSince1970: 1_700_000_000)
+        let balance: CreditBalance = CreditBalance(
+            balance: 1_234,
+            monthlyGrant: 2_000,
+            monthlyGrantUsed: 766,
+            nextRefreshAt: nextRefresh,
+            periodLabel: "Apr 1 – May 1"
+        )
+
+        try dbManager.dbWriter.write { db in
+            try DBCreditBalance(from: balance, updatedAt: Date()).save(db)
+        }
+
+        let repo: CreditsRepository = CreditsRepository(databaseReader: dbManager.dbReader)
+        let fetched: CreditBalance? = try repo.currentBalance()
+
+        #expect(fetched == balance)
+    }
+
+    @Test("upserting the sentinel row twice keeps a single row reflecting the latest write")
+    func testUpsertOverwritesSentinelRow() throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        let first: CreditBalance = CreditBalance(
+            balance: 100,
+            monthlyGrant: 500,
+            monthlyGrantUsed: 400,
+            nextRefreshAt: Date(timeIntervalSince1970: 1_700_000_000),
+            periodLabel: "P1"
+        )
+        let second: CreditBalance = CreditBalance(
+            balance: 250,
+            monthlyGrant: 500,
+            monthlyGrantUsed: 250,
+            nextRefreshAt: Date(timeIntervalSince1970: 1_700_500_000),
+            periodLabel: "P2"
+        )
+
+        try dbManager.dbWriter.write { db in
+            try DBCreditBalance(from: first).save(db)
+            try DBCreditBalance(from: second).save(db)
+        }
+
+        let rowCount: Int = try dbManager.dbReader.read { db in
+            try DBCreditBalance.fetchCount(db)
+        }
+        #expect(rowCount == 1)
+
+        let repo: CreditsRepository = CreditsRepository(databaseReader: dbManager.dbReader)
+        #expect(try repo.currentBalance() == second)
+    }
+}

--- a/docs/plans/pr-840-review-fix-plan.md
+++ b/docs/plans/pr-840-review-fix-plan.md
@@ -1,0 +1,500 @@
+# PR 840 review fix plan
+
+PR: https://github.com/xmtplabs/convos-ios/pull/840
+
+Scope reviewed:
+
+- Claude Code PR comment from May 18, 2026.
+- Macroscope inline review comments and approvability comment through May 20, 2026.
+- Current local branch `louis/iap-storekit-wiring` at the time this note was written.
+
+This file is intentionally a handoff plan, not an implementation patch.
+
+## Executive summary
+
+The reviewers are aligned on four actionable issues. Three are correctness issues that should be fixed before merge, and one is a small concurrency cleanup. I agree with Claude Code that the PR also needs targeted tests because this is billing-sensitive code.
+
+Recommended order:
+
+1. Fix `MockSubscriptionService.purchase()` so a later `refresh()` cannot revert a purchase.
+2. Reset the `hasShownNUXPaywall` flag from onboarding reset paths and add regression tests.
+3. Replace StoreKit renewal detection with `Product.SubscriptionInfo.RenewalInfo.willAutoRenew`.
+4. Add the `isLoadingProducts` guard in `PaywallViewModel.loadProducts()`.
+5. Add focused tests for the above, plus `CreditBalance` edge cases.
+
+The Macroscope `CreditBalance.isLow` comment is already resolved in the current code. Keep the fix and add tests so it stays fixed.
+
+## Review comment breakdown
+
+| Source | File | Severity | Current status | Recommendation |
+| --- | --- | --- | --- | --- |
+| Macroscope, Claude Code | `ConvosCore/Sources/ConvosCore/Services/Subscription/MockSubscriptionService.swift` | Medium / blocking | Still present | Fix before merge. Do not use only the literal `.builderAmple` one-liner because it loses Pro and Annual details. Preserve the purchased `UserSubscription` across refreshes. |
+| Macroscope, Claude Code | `Convos/Conversation Detail/ConversationOnboardingCoordinator.swift` | High / blocking | Still present | Fix before merge. Clear `hasShownNUXPaywall` in reset paths. Consider consolidating the two reset methods. |
+| Macroscope, Claude Code | `Convos/Subscription/StoreKitSubscriptionService.swift` | Medium / should fix | Still present | Fix before merge. `revocationDate == nil` is not auto-renewal state. Query StoreKit subscription status renewal info. |
+| Macroscope, Claude Code | `Convos/Subscription/PaywallViewModel.swift` | Low / easy | Still present | Fix with a one-line guard and add a small test. |
+| Macroscope | `ConvosCore/Sources/ConvosCore/Storage/Models/CreditBalance.swift` | Low | Resolved | No code change needed, but add regression tests. |
+| Claude Code | Test coverage | Blocking recommendation | Still present | Add targeted tests around billing state and reset behavior. |
+
+## 1. MockSubscriptionService purchase refresh bug
+
+### Problem
+
+`purchase(productId:)` publishes an active `UserSubscription`, but `refresh(force:)` later re-publishes `currentPreset.subscription()`. If the service started from `.noSubNoTrial`, a successful mock purchase disappears after refresh.
+
+Current code:
+
+```swift
+subscriptionSubject.send(updated)
+```
+
+Later:
+
+```swift
+let snapshot = queue.sync { currentPreset.subscription() }
+subscriptionSubject.send(snapshot)
+```
+
+### Recommended fix
+
+Macroscope suggested `currentPreset = .builderAmple`. That fixes the narrow no-sub-to-builder-monthly path, but it is too lossy:
+
+- A Pro purchase should not become Builder.
+- A Builder Annual purchase should not refresh into Builder Monthly.
+- The mock service should preserve the actual `UserSubscription` it just published.
+
+Prefer storing a subscription snapshot independent of the preset. `CreditsStatePreset` can still power debug presets, but `refresh()` should re-publish the current mock subscription snapshot.
+
+Suggested shape:
+
+```swift
+private var currentPreset: CreditsStatePreset
+private var currentSubscriptionSnapshot: UserSubscription?
+
+public init(initialPreset: CreditsStatePreset = .builderAmple) {
+    self.currentPreset = initialPreset
+    let initialSubscription = initialPreset.subscription()
+    self.currentSubscriptionSnapshot = initialSubscription
+    self.subscriptionSubject = CurrentValueSubject(initialSubscription)
+    self.mockProducts = Self.defaultMockProducts()
+}
+
+public func purchase(productId: String) async throws {
+    guard let product = mockProducts.first(where: { $0.id == productId }) else {
+        throw SubscriptionServiceError.productNotFound
+    }
+
+    try await Task.sleep(for: .milliseconds(600))
+
+    let now = Date()
+    let component: Calendar.Component = product.period == .monthly ? .month : .year
+    let nextRenew = Calendar.current.date(byAdding: component, value: 1, to: now) ?? now
+    let updated = UserSubscription(
+        tier: product.tier,
+        period: product.period,
+        status: .active,
+        productId: product.id,
+        currentPeriodEnd: nextRenew,
+        willRenew: true,
+        isInTrial: false
+    )
+
+    queue.sync {
+        currentPreset = product.tier == .pro ? .proAmple : .builderAmple
+        currentSubscriptionSnapshot = updated
+    }
+    subscriptionSubject.send(updated)
+}
+
+public func refresh(force: Bool) async {
+    let snapshot = queue.sync { currentSubscriptionSnapshot }
+    subscriptionSubject.send(snapshot)
+}
+
+public func setPreset(_ preset: CreditsStatePreset) {
+    let subscription = preset.subscription()
+    queue.sync {
+        currentPreset = preset
+        currentSubscriptionSnapshot = subscription
+    }
+    subscriptionSubject.send(subscription)
+}
+```
+
+If mock purchase is expected to update all visible credits surfaces, also consider syncing `MockCreditsService.shared` to the matching ample preset inside `purchase()`. If that side effect feels too surprising inside `ConvosCore`, inject a credits service into the paywall flow instead. The current PR already makes the real StoreKit service force-refresh credits after purchase, so mock and real behavior should ideally match.
+
+### Tests to add
+
+Add `ConvosCore/Tests/ConvosCoreTests/MockSubscriptionServiceTests.swift`:
+
+- `testPurchaseThenRefreshKeepsPurchasedSubscription()`
+  - Start from `.noSubNoTrial`.
+  - Purchase `SubscriptionProductIDs.builderAnnual`.
+  - Assert current subscription is Builder Annual.
+  - Call `refresh(force: true)`.
+  - Assert it is still Builder Annual with the same product id.
+- `testProPurchaseThenRefreshKeepsProSubscription()`
+  - Start from `.noSubNoTrial`.
+  - Purchase `SubscriptionProductIDs.proMonthly`.
+  - Refresh.
+  - Assert tier is `.pro`.
+- `testSetPresetOverridesPurchasedSnapshot()`
+  - Purchase a product.
+  - Call `setPreset(.noSubNoTrial)`.
+  - Refresh.
+  - Assert subscription is nil.
+
+## 2. Onboarding reset does not clear NUX paywall flag
+
+### Problem
+
+`resetUserDefaults()` removes `hasShownNUXPaywallKey`, but the instance reset methods do not clear `hasShownNUXPaywall`. After completing the NUX paywall once, a Debug menu onboarding reset will not make the paywall appear again.
+
+Current relevant methods:
+
+```swift
+func reset() {
+    state = .idle
+    profileSettingsViewModel.delete()
+    hasSeenAddAsProfile = false
+    hasCompletedOnboarding = false
+    hasShownProfileEditor = false
+}
+
+func reset(conversationId: String? = nil) {
+    hasCompletedOnboarding = false
+    hasShownProfileEditor = false
+    state = .idle
+    ...
+}
+```
+
+### Recommended fix
+
+Add `hasShownNUXPaywall = false` to every reset path whose purpose is to reset onboarding. There are two instance reset methods in this file; fix both or consolidate them so future reset changes cannot drift.
+
+Minimal patch:
+
+```swift
+func reset() {
+    state = .idle
+    profileSettingsViewModel.delete()
+    hasSeenAddAsProfile = false
+    hasCompletedOnboarding = false
+    hasShownProfileEditor = false
+    hasShownNUXPaywall = false
+}
+
+func reset(conversationId: String? = nil) {
+    hasCompletedOnboarding = false
+    hasShownProfileEditor = false
+    hasShownNUXPaywall = false
+    state = .idle
+
+    if let conversationId {
+        setHasSetProfile(false, for: conversationId)
+    }
+}
+```
+
+Follow-up cleanup to consider: the no-argument `reset()` and `reset(conversationId:)` overlap. If both are kept, document the difference in method names or behavior. If they are intended to mean the same thing, keep one method with an optional argument and include the profile deletion / `hasSeenAddAsProfile` behavior there.
+
+### Tests to update/add
+
+In `ConvosTests/ConversationOnboardingCoordinatorTests.swift`:
+
+- Add `UserDefaults.standard.removeObject(forKey: "hasShownNUXPaywall")` to `cleanUpUserDefaults()`.
+- Extend `testReset_ClearsAllState()` to set and assert clearing of `hasShownNUXPaywall`.
+- Extend `testReset_WithConversationId_ClearsConversationFlag()` or add a sibling test to assert the conversation-specific reset also clears `hasShownNUXPaywall`, if that method remains an onboarding reset.
+- Add a NUX flow test if feasible:
+  - Precondition profile has already been shown or select profile.
+  - Trigger transition after profile setup in non-production config.
+  - Assert `.presentingPaywall` appears once.
+  - Call `userDidCompleteNUXPaywall()`.
+  - Assert the flag is set and the next flow skips the paywall.
+
+## 3. StoreKit renewal detection is incorrect
+
+### Problem
+
+`StoreKitSubscriptionService.userSubscription(from:)` currently derives renewal status from `transaction.revocationDate == nil`:
+
+```swift
+let willRenew: Bool = transaction.revocationDate == nil
+```
+
+`revocationDate` only means Apple refunded or revoked the transaction, such as Family Sharing revocation. It does not tell whether the user turned off auto-renewal. A cancelled-but-still-active subscription will have no revocation date, so the settings UI can incorrectly show `Renews <date>` instead of `Expires <date>`.
+
+### Recommended fix
+
+Use StoreKit's subscription status APIs and read `Product.SubscriptionInfo.RenewalInfo.willAutoRenew`.
+
+This likely means making `userSubscription(from:)` async because StoreKit status lookup is async:
+
+```swift
+private func refreshFromEntitlements() async {
+    var latest: UserSubscription?
+    for await result in Transaction.currentEntitlements {
+        guard let transaction = try? verifiedTransaction(result) else { continue }
+        guard let sub = await userSubscription(from: transaction) else { continue }
+        latest = sub
+    }
+    subscriptionSubject.send(latest)
+}
+
+private func userSubscription(from transaction: Transaction) async -> UserSubscription? {
+    guard let tier = SubscriptionProductIDs.tier(for: transaction.productID),
+          let period = SubscriptionProductIDs.period(for: transaction.productID) else {
+        return nil
+    }
+
+    let storeKitSnapshot = await storeKitSubscriptionSnapshot(for: transaction)
+    let isInTrial = transaction.offer?.type == .introductory
+
+    return UserSubscription(
+        tier: tier,
+        period: period,
+        status: storeKitSnapshot.status,
+        productId: transaction.productID,
+        currentPeriodEnd: transaction.expirationDate ?? Date(),
+        willRenew: storeKitSnapshot.willRenew,
+        isInTrial: isInTrial
+    )
+}
+```
+
+Suggested helper shape:
+
+```swift
+private struct StoreKitSubscriptionSnapshot {
+    let status: ConvosCore.SubscriptionStatus
+    let willRenew: Bool
+}
+
+private func storeKitSubscriptionSnapshot(for transaction: Transaction) async -> StoreKitSubscriptionSnapshot {
+    let fallback = StoreKitSubscriptionSnapshot(
+        status: subscriptionStatus(from: transaction),
+        willRenew: transaction.revocationDate == nil
+    )
+
+    do {
+        let products = try await Product.products(for: [transaction.productID])
+        guard let subscription = products.first?.subscription else {
+            return fallback
+        }
+
+        let statuses = try await subscription.status
+        guard let status = statuses.first(where: { status in
+            guard let statusTransaction = try? verifiedTransaction(status.transaction) else { return false }
+            return statusTransaction.originalID == transaction.originalID
+        }) else {
+            return fallback
+        }
+
+        let renewalInfo = try verifiedTransaction(status.renewalInfo)
+        return StoreKitSubscriptionSnapshot(
+            status: subscriptionStatus(from: status.state, transaction: transaction),
+            willRenew: renewalInfo.willAutoRenew
+        )
+    } catch {
+        Log.error("Failed reading StoreKit renewal info for \(transaction.productID): \(error)")
+        return fallback
+    }
+}
+```
+
+Add a state mapper while touching this code:
+
+```swift
+private func subscriptionStatus(
+    from renewalState: Product.SubscriptionInfo.RenewalState,
+    transaction: Transaction
+) -> ConvosCore.SubscriptionStatus {
+    switch renewalState {
+    case .subscribed:
+        return transaction.offer?.type == .introductory ? .trial : .active
+    case .inGracePeriod:
+        return .grace
+    case .inBillingRetryPeriod:
+        return .billingRetry
+    case .expired:
+        return .expired
+    case .revoked:
+        return .revoked
+    @unknown default:
+        return subscriptionStatus(from: transaction)
+    }
+}
+```
+
+The exact StoreKit property signatures should be verified in Xcode; the key point is that `willRenew` must come from verified renewal info, not `revocationDate`.
+
+### Test strategy
+
+StoreKit's concrete types are hard to unit test directly. Avoid making this untestable by extracting one pure mapper:
+
+```swift
+struct RenewalStatusSnapshot: Equatable {
+    let renewalState: Product.SubscriptionInfo.RenewalState
+    let willAutoRenew: Bool
+}
+```
+
+or, if StoreKit types are awkward in tests, use an internal app-defined enum:
+
+```swift
+enum StoreKitRenewalStateSnapshot {
+    case subscribed
+    case inGracePeriod
+    case inBillingRetryPeriod
+    case expired
+    case revoked
+}
+```
+
+Then unit test the mapping from renewal state plus `willAutoRenew` to `UserSubscription.status` and `willRenew`. Manually QA the real StoreKit cancelled-auto-renew path with the `.storekit` configuration or sandbox.
+
+Manual QA cases:
+
+- Active auto-renewing subscription displays `Renews <date>`.
+- Active subscription with auto-renew cancelled displays `Expires <date>`.
+- Billing retry maps to `Payment retrying - update in App Store`.
+- Grace period maps to `Grace period until <date>`.
+- Revoked / expired do not display as renewing.
+
+## 4. PaywallViewModel duplicate product load
+
+### Problem
+
+`PaywallViewModel` is `@MainActor`, but actors are re-entrant at `await` suspension points. The first `loadProducts()` call sets `isLoadingProducts = true` and then suspends while awaiting `subscriptionService.availableProducts()`. A second call can enter while `products` is still empty, because the guard only checks `products.isEmpty`.
+
+Current code:
+
+```swift
+func loadProducts() async {
+    guard products.isEmpty else { return }
+    isLoadingProducts = true
+    defer { isLoadingProducts = false }
+    ...
+}
+```
+
+### Recommended fix
+
+Apply Macroscope's one-line suggestion:
+
+```swift
+func loadProducts() async {
+    guard products.isEmpty, !isLoadingProducts else { return }
+    isLoadingProducts = true
+    defer { isLoadingProducts = false }
+    ...
+}
+```
+
+### Test to add
+
+Add a `PaywallViewModelTests` test target case with a fake `SubscriptionServiceProtocol` whose `availableProducts()` increments a thread-safe call count and sleeps briefly.
+
+Test shape:
+
+```swift
+async let first: Void = viewModel.loadProducts()
+async let second: Void = viewModel.loadProducts()
+_ = await (first, second)
+XCTAssertEqual(service.availableProductsCallCount, 1)
+```
+
+Also add small tests for purchase error presentation if time allows:
+
+- `.purchasePending` shows title `Awaiting approval`.
+- `.purchaseUnverified` shows title `Couldn't verify purchase`.
+- `.purchaseCancelled` does not show an alert.
+- Success calls `onPurchaseSucceeded` once.
+
+## 5. CreditBalance.isLow is already fixed
+
+Macroscope's earlier low-severity comment said `isLow` treated `monthlyGrant == 0` as low. Current code is already corrected:
+
+```swift
+public var fractionRemaining: Double? {
+    guard monthlyGrant > 0 else { return nil }
+    return Double(balance) / Double(monthlyGrant)
+}
+
+public var isLow: Bool {
+    guard let fractionRemaining else { return false }
+    return balance > 0 && fractionRemaining <= 0.2
+}
+```
+
+No implementation change is needed. Add regression tests in `ConvosCore`:
+
+- `balance: 500, monthlyGrant: 0` -> `fractionRemaining == nil`, `isLow == false`, `isDepleted == false`.
+- `balance: 0, monthlyGrant: 1500` -> `isLow == false`, `isDepleted == true`.
+- `balance: 300, monthlyGrant: 1500` -> `isLow == true` if 20 percent exactly should count as low.
+- `balance: 301, monthlyGrant: 1500` -> `isLow == false`.
+- Negative balance -> `isDepleted == true`.
+
+## 6. Test coverage plan for Claude Code's review
+
+Claude Code called out zero tests for the new subscription and credits code. I would not block on fully mocking StoreKit transactions, but the PR should add focused tests around the logic we own.
+
+### ConvosCore tests
+
+Add these files under `ConvosCore/Tests/ConvosCoreTests/`:
+
+- `CreditBalanceTests.swift`
+- `MockSubscriptionServiceTests.swift`
+- `CreditsStatePresetTests.swift` if useful for preset invariants
+
+Useful assertions:
+
+- Presets with subscriptions have matching nonzero monthly grants, except states intentionally depleted.
+- `.noSubNoTrial` has nil subscription and zero grant.
+- `.trialActive` has trial status, `isInTrial == true`, and `willRenew == false`.
+- Mock purchase and refresh behavior as described above.
+
+### App target tests
+
+Add or update under `ConvosTests/`:
+
+- `ConversationOnboardingCoordinatorTests.swift`
+  - Reset clears `hasShownNUXPaywall`.
+  - NUX paywall is one-shot.
+  - Existing transition tests may need explicit setup for the new paywall step. If a test is about notifications rather than paywall, set `hasShownNUXPaywall` to true in that test's arrange phase.
+- `PaywallViewModelTests.swift`
+  - Duplicate load guard.
+  - Purchase error alert mapping.
+  - Success callback.
+
+### StoreKitSubscriptionService tests
+
+Recommended approach:
+
+- Extract status mapping into a small internal helper that accepts app-defined snapshots instead of real StoreKit transactions.
+- Unit test that helper.
+- Keep end-to-end StoreKit purchase / renewal / cancellation behavior as manual QA or UI automation, because Apple's StoreKit transaction objects are not simple to construct.
+
+### BackendCreditsService tests
+
+If adding tests for `BackendCreditsService`, a fake `ConvosAPIClientProtocol` can validate:
+
+- `refresh(force: true)` calls `getCreditBalance()` and publishes the result.
+- `refresh(force: false)` within the TTL does not call the API again after a successful fetch.
+- After an API error, `currentBalance` remains the previous value.
+
+If the constructor's automatic refresh makes tests flaky, consider adding an internal initializer parameter like `startInitialRefresh: Bool = true` or injecting a clock/date provider. That is a testability improvement, not required for the current review comments.
+
+## 7. Small code style note while touching StoreKitSubscriptionService
+
+`StoreKitSubscriptionService` currently declares `private enum Constant` in the middle of the type. The project convention says `private enum Constant` should live at the bottom of the scope. If this file is edited, move `Constant` below the helper methods to avoid a lint failure.
+
+## Suggested final checklist for the implementing agent
+
+- [ ] Fix `MockSubscriptionService` snapshot persistence and add refresh regression tests.
+- [ ] Clear `hasShownNUXPaywall` in onboarding reset paths and update onboarding tests.
+- [ ] Replace `revocationDate == nil` renewal detection with verified StoreKit renewal info.
+- [ ] Add the `!isLoadingProducts` guard in `PaywallViewModel.loadProducts()` and test it.
+- [ ] Add `CreditBalance` edge-case tests.
+- [ ] Run formatting and lint.
+- [ ] Run the relevant unit tests, then the full suite required by the repo workflow.


### PR DESCRIPTION
Addresses yewreeka's review #1 (BackendCreditsService should use the
GRDB repository pattern). The credit balance now flows through three
single-responsibility pieces instead of one in-memory subject:

  - `CreditBalanceWriter` (actor): owns the HTTP refresh against
    `GET /v2/accounts/me/credits` and upserts the result into a new
    `credit_balance` table. TTL debouncing migrates from the
    `NSLock + lastFetchedAt` on the old service to actor-isolated
    state.
  - `CreditsRepository`: read-only observation surface. Exposes a
    `balancePublisher` driven by GRDB `ValueObservation` and a sync
    `currentBalance()` read.
  - `BackendCreditsService`: glue that satisfies the existing
    `CreditsServiceProtocol`. Internally delegates refresh to the
    writer and reads to the repository. View sites stay on the
    protocol — the writer/repository split is internal.

`CreditsServices.shared` switches from a `static let` lazy singleton
to a configure-at-startup pattern (mirroring `LinkPreviewWriter`).
`ConvosApp.init` calls `CreditsServices.configure(client:apiClient:)`
once the database is available. The non-production debug toggle
between mock and backend still flips at runtime; the backend service
is constructed eagerly so the toggle does not need a relaunch.

Schema: a single `credit_balance` row keyed by a fixed `"current"`
sentinel. Credits are account-level and the install is single-inbox,
so one row per install is the right cardinality. The sentinel PK
makes the table behave as a settings-style cache rather than a
collection. When/if we add account switching, the sentinel can
become `accountId`.

Tests: CreditsRepository read paths covered by
`CreditsRepositoryTests` (empty table, hydrate, upsert overwrites).
The writer is exercised end-to-end via the existing
`BackendCreditsService` integration paths.

This PR is stacked on top of `louis/iap-storekit-wiring` (PR #840).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/849"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1781900357&installation_id=128169237&pr_number=849&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F849&signature=1b35ee73f55ae56833cab5a4e79711e2a18301adfd4b6b397db1cf79659d63d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Move credit balance reads through a GRDB repository with TTL-gated refresh
> - Introduces a `credit_balance` table via a new DB migration, a `DBCreditBalance` GRDB record, a `CreditsRepository` for reactive reads, and a `CreditBalanceWriter` actor for writes.
> - `BackendCreditsService` now delegates balance publishing and reads to `CreditsRepository`, removing its in-memory `CurrentValueSubject` and `NSLock`.
> - `CreditBalanceWriter` deduplicates concurrent refresh calls by sharing an in-flight `Task` and gates non-forced refreshes behind a 15-second TTL; failures neither write nor advance the TTL.
> - `CreditsServices.configure(client:apiClient:)` constructs and stores the real backend service at launch; a forced refresh seeds the cache on cold start.
> - Behavioral Change: `BackendCreditsService` no longer triggers an automatic refresh on initialization; the app explicitly calls `CreditsServices.shared.refresh(force: true)` at startup.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #849 opened
>
> - Changed `StubCreditBalanceAPIClient.requestAgentJoin` method signature to accept `templateId` parameter instead of `instructions` parameter [e65a43e]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ed453c8.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->