### PR TITLE
Route to existing DMs when tapping "Chat"

### DIFF
--- a/Convos/Contacts/ContactDetailView.swift
+++ b/Convos/Contacts/ContactDetailView.swift
@@ -226,9 +226,55 @@ struct ContactDetailView: View {
                 return
             }
             await MainActor.run {
-                presentingPicker = true
+                routeToChat()
             }
         }
+    }
+
+    /// Decides where "Chat" lands the user. If the current user
+    /// already has a 1:1 with this contact, the existing conversation
+    /// opens in the same sheet anchor we use for the new-convo flow -
+    /// otherwise the picker takes over (preselected with this contact)
+    /// so the standard new-convo creation path runs. Prevents the
+    /// "tap Chat twice, end up with two 1:1s with the same person"
+    /// regression.
+    private func routeToChat() {
+        if let session, let existing = findExistingOneToOne(session: session) {
+            presentingNewConvo = NewConversationViewModel(
+                session: session,
+                mode: .existingConversation(conversationId: existing.id)
+            )
+        } else {
+            presentingPicker = true
+        }
+    }
+
+    /// Looks for an active 1:1 (current user + this contact, no other
+    /// non-self members) in the user's accepted *and* pending
+    /// conversations. The repository pushes the predicate into SQL so
+    /// we don't hydrate every conversation just to find one match.
+    ///
+    /// `.unknown` is included alongside `.allowed` so an outstanding
+    /// invite from this contact routes "Chat" into that pending
+    /// thread instead of letting the user create a duplicate convo
+    /// alongside it; the chat's own consent gate handles the accept /
+    /// decline flow from there. Locked conversations are intentionally
+    /// included - "locked" only freezes invite-code minting; the chat
+    /// itself still works, and routing to an existing locked 1:1 is
+    /// preferable to spinning up a second one. Drafts, expired,
+    /// quarantined, and unused conversations are excluded upstream.
+    ///
+    /// When this view is opened scoped to a conversation
+    /// (`mode.conversationId != nil`) the source conversation is
+    /// excluded from the search - if the user is already chatting in
+    /// a 1:1 with this contact and taps "Chat", they almost certainly
+    /// want a different chat, so falling through to the picker is the
+    /// right move. Multiple 1:1s with the same person are allowed; the
+    /// SQL ordering picks the most-recently-active alternative.
+    private func findExistingOneToOne(session: any SessionManagerProtocol) -> Conversation? {
+        try? session
+            .conversationsRepository(for: [.allowed, .unknown])
+            .findOneToOne(with: contact.inboxId, excluding: mode.conversationId)
     }
 
     private func handleBlockTap() {

--- a/Convos/Conversation Creation/NewConversationViewModel.swift
+++ b/Convos/Conversation Creation/NewConversationViewModel.swift
@@ -35,6 +35,13 @@ enum NewConversationMode {
     /// conversation arrives at `.ready` with the picked members already
     /// in it.
     case newConversationWithMembers(initialMemberInboxIds: [String])
+    /// Opens an existing conversation in the same sheet presentation we
+    /// use for the new-convo flows. Used when "Chat" on a contact card
+    /// resolves to a 1:1 the user already has with that person, so the
+    /// app doesn't let them spin up a second redundant 1:1. The state
+    /// machine uses `.useExisting` (no create, no addMembers), and the
+    /// conversation publisher emits `.ready` against the existing row.
+    case existingConversation(conversationId: String)
     case scanner
     case joinInvite(code: String)
 }
@@ -56,6 +63,15 @@ class NewConversationViewModel: Identifiable {
     /// `ConversationViewModel.hidesInviteCard` so the QR header isn't
     /// rendered on top of a chat that already has members.
     private let startedWithSeededMembers: Bool
+    /// True when this VM was created with `.existingConversation` -
+    /// i.e. the sheet is *opening* an existing 1:1, not creating one.
+    /// `cleanUpIfNeeded` checks this so a sheet dismissed before the
+    /// state machine emits `.ready` can never delete the real
+    /// conversation behind it. Today `deleteConversation()` happens to
+    /// be a no-op (it only cancels in-flight tasks), but the guard
+    /// here is the contract that anchors that safety regardless of
+    /// what `deleteConversation()` does in the future.
+    private let isExistingConversation: Bool
     /// Captured initial-member inbox ids for the seeded-members flow.
     /// Used to seed each draft `Conversation` with contact-derived
     /// members so the chat header renders the contact's name and
@@ -142,6 +158,12 @@ class NewConversationViewModel: Identifiable {
             self.showingFullScreenScanner = false
             self.allowsDismissingScanner = true
 
+        case .existingConversation:
+            self.autoCreateConversation = false
+            self.startedWithFullscreenScanner = false
+            self.showingFullScreenScanner = false
+            self.allowsDismissingScanner = true
+
         case .scanner:
             self.autoCreateConversation = false
             self.startedWithFullscreenScanner = true
@@ -163,6 +185,12 @@ class NewConversationViewModel: Identifiable {
             self.seededMemberInboxIds = []
         }
 
+        if case .existingConversation = mode {
+            self.isExistingConversation = true
+        } else {
+            self.isExistingConversation = false
+        }
+
         self.isCreatingConversation = mode.isNewConversation
         createPlaceholderConversationViewModel()
         acquireInbox(mode: mode)
@@ -182,6 +210,11 @@ class NewConversationViewModel: Identifiable {
         self.startedWithFullscreenScanner = showingFullScreenScanner
         self.startedWithSeededMembers = false
         self.seededMemberInboxIds = []
+        // This internal init is used by tests / warm-cache paths that
+        // construct against a draft id, not a user-existing 1:1.
+        // Leave the existing-conversation guard off so the cleanup
+        // semantics match the historical behavior.
+        self.isExistingConversation = false
         self.showingFullScreenScanner = showingFullScreenScanner
         self.allowsDismissingScanner = allowsDismissingScanner
 
@@ -202,6 +235,12 @@ class NewConversationViewModel: Identifiable {
 
     func cleanUpIfNeeded() {
         guard !_reachedReadyState, !_reachedJoiningState, !_cleanedUp else { return }
+        // `deleteConversation` is currently a no-op (only cancels
+        // in-flight tasks), but never call it when the sheet was just
+        // *opening* an existing 1:1 - if that contract ever changes,
+        // dismissing the sheet before the state machine emits `.ready`
+        // would silently destroy the real conversation behind it.
+        guard !isExistingConversation else { return }
         _cleanedUp = true
         deleteConversation()
     }
@@ -233,6 +272,16 @@ class NewConversationViewModel: Identifiable {
                     messagingService,
                     existingConversationId: existingConversationId,
                     initialMemberInboxIds: initialMemberInboxIds
+                )
+
+            case .existingConversation(let conversationId):
+                let messagingService = session.messagingService()
+                guard !Task.isCancelled else { return }
+                let inboxElapsed = (CFAbsoluteTimeGetCurrent() - perfStartTime) * 1000
+                Log.info("[PERF] NewConversation.inboxAcquired: \(String(format: "%.0f", inboxElapsed))ms")
+                configureWithMessagingService(
+                    messagingService,
+                    existingConversationId: conversationId
                 )
 
             case .scanner, .joinInvite:
@@ -813,7 +862,7 @@ private extension NewConversationMode {
         switch self {
         case .newConversation, .newConversationWithMembers:
             return true
-        case .scanner, .joinInvite:
+        case .existingConversation, .scanner, .joinInvite:
             return false
         }
     }

--- a/Convos/Conversation Creation/NewConversationViewModel.swift
+++ b/Convos/Conversation Creation/NewConversationViewModel.swift
@@ -210,10 +210,12 @@ class NewConversationViewModel: Identifiable {
         self.startedWithFullscreenScanner = showingFullScreenScanner
         self.startedWithSeededMembers = false
         self.seededMemberInboxIds = []
-        // This internal init is used by tests / warm-cache paths that
-        // construct against a draft id, not a user-existing 1:1.
-        // Leave the existing-conversation guard off so the cleanup
-        // semantics match the historical behavior.
+        // This internal init is tests-only - the warm-cache path goes
+        // through the public init + `prepareNewConversation` +
+        // `configureWithMessagingService(_:existingConversationId:)`,
+        // not here. Tests construct against a draft id, not a
+        // user-existing 1:1, so the existing-conversation cleanup
+        // guard stays off.
         self.isExistingConversation = false
         self.showingFullScreenScanner = showingFullScreenScanner
         self.allowsDismissingScanner = allowsDismissingScanner
@@ -235,11 +237,15 @@ class NewConversationViewModel: Identifiable {
 
     func cleanUpIfNeeded() {
         guard !_reachedReadyState, !_reachedJoiningState, !_cleanedUp else { return }
-        // `deleteConversation` is currently a no-op (only cancels
-        // in-flight tasks), but never call it when the sheet was just
-        // *opening* an existing 1:1 - if that contract ever changes,
-        // dismissing the sheet before the state machine emits `.ready`
-        // would silently destroy the real conversation behind it.
+        // Belt-and-braces guard for the `.existingConversation` flow.
+        // `ConversationStateMachine.useExisting` reliably transitions
+        // to `.ready` against a real conversation, so the first guard
+        // above would normally short-circuit before we got here.
+        // Independently, `deleteConversation` is currently a no-op
+        // that only cancels in-flight tasks. This guard exists so
+        // that if either contract ever drifts, dismissing the sheet
+        // before `.ready` lands can't silently destroy the real
+        // conversation behind it.
         guard !isExistingConversation else { return }
         _cleanedUp = true
         deleteConversation()

--- a/Convos/Conversation Creation/NewConversationViewModel.swift
+++ b/Convos/Conversation Creation/NewConversationViewModel.swift
@@ -63,14 +63,9 @@ class NewConversationViewModel: Identifiable {
     /// `ConversationViewModel.hidesInviteCard` so the QR header isn't
     /// rendered on top of a chat that already has members.
     private let startedWithSeededMembers: Bool
-    /// True when this VM was created with `.existingConversation` -
-    /// i.e. the sheet is *opening* an existing 1:1, not creating one.
-    /// `cleanUpIfNeeded` checks this so a sheet dismissed before the
-    /// state machine emits `.ready` can never delete the real
-    /// conversation behind it. Today `deleteConversation()` happens to
-    /// be a no-op (it only cancels in-flight tasks), but the guard
-    /// here is the contract that anchors that safety regardless of
-    /// what `deleteConversation()` does in the future.
+    /// True when this VM was constructed with `.existingConversation`.
+    /// Belt-and-braces guard against `cleanUpIfNeeded` ever destroying
+    /// the real conversation behind the sheet - see comment there.
     private let isExistingConversation: Bool
     /// Captured initial-member inbox ids for the seeded-members flow.
     /// Used to seed each draft `Conversation` with contact-derived
@@ -158,19 +153,16 @@ class NewConversationViewModel: Identifiable {
             self.showingFullScreenScanner = false
             self.allowsDismissingScanner = true
 
-        case .existingConversation:
-            self.autoCreateConversation = false
-            self.startedWithFullscreenScanner = false
-            self.showingFullScreenScanner = false
-            self.allowsDismissingScanner = true
-
         case .scanner:
             self.autoCreateConversation = false
             self.startedWithFullscreenScanner = true
             self.showingFullScreenScanner = true
             self.allowsDismissingScanner = true
 
-        case .joinInvite:
+        // `.existingConversation` and `.joinInvite` both open / join
+        // an existing chat without creating one - same scanner-off
+        // configuration.
+        case .existingConversation, .joinInvite:
             self.autoCreateConversation = false
             self.startedWithFullscreenScanner = false
             self.showingFullScreenScanner = false
@@ -185,11 +177,7 @@ class NewConversationViewModel: Identifiable {
             self.seededMemberInboxIds = []
         }
 
-        if case .existingConversation = mode {
-            self.isExistingConversation = true
-        } else {
-            self.isExistingConversation = false
-        }
+        self.isExistingConversation = if case .existingConversation = mode { true } else { false }
 
         self.isCreatingConversation = mode.isNewConversation
         createPlaceholderConversationViewModel()
@@ -210,12 +198,8 @@ class NewConversationViewModel: Identifiable {
         self.startedWithFullscreenScanner = showingFullScreenScanner
         self.startedWithSeededMembers = false
         self.seededMemberInboxIds = []
-        // This internal init is tests-only - the warm-cache path goes
-        // through the public init + `prepareNewConversation` +
-        // `configureWithMessagingService(_:existingConversationId:)`,
-        // not here. Tests construct against a draft id, not a
-        // user-existing 1:1, so the existing-conversation cleanup
-        // guard stays off.
+        // Tests-only init - the warm-cache flow goes through the
+        // public init. Existing-conversation cleanup guard stays off.
         self.isExistingConversation = false
         self.showingFullScreenScanner = showingFullScreenScanner
         self.allowsDismissingScanner = allowsDismissingScanner
@@ -237,15 +221,11 @@ class NewConversationViewModel: Identifiable {
 
     func cleanUpIfNeeded() {
         guard !_reachedReadyState, !_reachedJoiningState, !_cleanedUp else { return }
-        // Belt-and-braces guard for the `.existingConversation` flow.
-        // `ConversationStateMachine.useExisting` reliably transitions
-        // to `.ready` against a real conversation, so the first guard
-        // above would normally short-circuit before we got here.
-        // Independently, `deleteConversation` is currently a no-op
-        // that only cancels in-flight tasks. This guard exists so
-        // that if either contract ever drifts, dismissing the sheet
-        // before `.ready` lands can't silently destroy the real
-        // conversation behind it.
+        // Defensive: `.existingConversation` flows should already exit
+        // via `_reachedReadyState` (useExisting emits .ready). If that
+        // ever drifts and `deleteConversation` stops being a no-op,
+        // this prevents destroying the real conversation behind the
+        // sheet on dismiss-before-ready.
         guard !isExistingConversation else { return }
         _cleanedUp = true
         deleteConversation()
@@ -281,12 +261,8 @@ class NewConversationViewModel: Identifiable {
                 )
 
             case .existingConversation(let conversationId):
-                let messagingService = session.messagingService()
-                guard !Task.isCancelled else { return }
-                let inboxElapsed = (CFAbsoluteTimeGetCurrent() - perfStartTime) * 1000
-                Log.info("[PERF] NewConversation.inboxAcquired: \(String(format: "%.0f", inboxElapsed))ms")
                 configureWithMessagingService(
-                    messagingService,
+                    session.messagingService(),
                     existingConversationId: conversationId
                 )
 

--- a/Convos/Conversation Creation/NewConversationViewModel.swift
+++ b/Convos/Conversation Creation/NewConversationViewModel.swift
@@ -261,10 +261,7 @@ class NewConversationViewModel: Identifiable {
                 )
 
             case .existingConversation(let conversationId):
-                configureWithMessagingService(
-                    session.messagingService(),
-                    existingConversationId: conversationId
-                )
+                configureWithMessagingService(session.messagingService(), existingConversationId: conversationId)
 
             case .scanner, .joinInvite:
                 let messagingService = session.messagingService()

--- a/ConvosCore/Sources/ConvosCore/Mocks/MockRepositories.swift
+++ b/ConvosCore/Sources/ConvosCore/Mocks/MockRepositories.swift
@@ -18,6 +18,20 @@ public final class MockConversationsRepository: ConversationsRepositoryProtocol,
     public func fetchAll() throws -> [Conversation] {
         mockConversations
     }
+
+    /// Note: this mock doesn't model the repo's `consent` scope, so a
+    /// test that injects conversations with mixed consent values and
+    /// queries with a narrow scope (e.g. `[.allowed]`) will see false
+    /// positives. The production `ConversationsRepository` enforces
+    /// the scope via the `WHERE consent IN (...)` clause in
+    /// `composeOneToOne`.
+    public func findOneToOne(with inboxId: String, excluding excludedConversationId: String?) throws -> Conversation? {
+        mockConversations.first { conversation in
+            guard conversation.id != excludedConversationId else { return false }
+            let others = conversation.membersWithoutCurrent
+            return others.count == 1 && others.first?.profile.inboxId == inboxId
+        }
+    }
 }
 
 // MARK: - Mock Conversations Count Repository

--- a/ConvosCore/Sources/ConvosCore/Storage/Repositories/ConversationsRepository.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Repositories/ConversationsRepository.swift
@@ -5,6 +5,19 @@ import GRDB
 public protocol ConversationsRepositoryProtocol {
     var conversationsPublisher: AnyPublisher<[Conversation], Never> { get }
     func fetchAll() throws -> [Conversation]
+    /// Returns the most-recently-active conversation that consists of
+    /// exactly the current user and the supplied inbox - i.e. the
+    /// existing 1:1 to route "Chat" taps from a contact card into so
+    /// the app doesn't let the user spin up a second redundant 1:1
+    /// with the same person. `excluding`, when non-nil, skips that
+    /// conversation in the search - the caller passes the
+    /// currently-open conversation's id so tapping "Chat" while
+    /// already in a 1:1 with this person falls through to the picker
+    /// (the user clearly wants to start a different chat). Honours
+    /// the repo's `consent` scope and the same draft / expired /
+    /// quarantined / unused exclusions as `fetchAll`. Returns nil
+    /// when no other match exists.
+    func findOneToOne(with inboxId: String, excluding excludedConversationId: String?) throws -> Conversation?
 }
 
 final class ConversationsRepository: ConversationsRepositoryProtocol {
@@ -34,6 +47,16 @@ final class ConversationsRepository: ConversationsRepositoryProtocol {
         try dbReader.read { [weak self] db in
             guard let self else { return [] }
             return try db.composeAllConversations(consent: consent)
+        }
+    }
+
+    func findOneToOne(with inboxId: String, excluding excludedConversationId: String?) throws -> Conversation? {
+        try dbReader.read { [consent] db in
+            try db.composeOneToOne(
+                with: inboxId,
+                excluding: excludedConversationId,
+                consent: consent
+            )
         }
     }
 }
@@ -76,6 +99,64 @@ fileprivate extension Database {
             .detailedConversationQuery()
             .fetchAll(self)
         return try dbConversationDetails.composeConversations(from: self)
+    }
+
+    func composeOneToOne(
+        with otherInboxId: String,
+        excluding excludedConversationId: String?,
+        consent: [Consent]
+    ) throws -> Conversation? {
+        // SQL-pushed predicate so we don't hydrate every conversation
+        // the user has just to find the 1:1 with one specific inbox.
+        // We require the other inbox to be a member and the total
+        // member count to be 2 - the existing rule that the local DB
+        // only carries conversations the current user is a member of
+        // means that pair is self + other. `detailedConversationQuery`
+        // orders by COALESCE(lastMessageDate, createdAt) DESC, so the
+        // first row is the most-recently-active match. The optional
+        // `excluding` is the source-conversation id when "Chat" was
+        // tapped from inside a 1:1 with the same person - skipping
+        // that row lets the user fall through to the picker to start
+        // a fresh chat.
+        let oneToOnePredicate: SQL = """
+            EXISTS (
+                SELECT 1 FROM conversation_members AS cm_other
+                WHERE cm_other.conversationId = conversation.id
+                AND cm_other.inboxId = \(otherInboxId)
+            )
+            AND EXISTS (
+                SELECT 1 FROM conversation_members AS cm_self
+                WHERE cm_self.conversationId = conversation.id
+                AND cm_self.inboxId IN (SELECT inboxId FROM inbox)
+            )
+            AND (
+                SELECT COUNT(*) FROM conversation_members AS cm_count
+                WHERE cm_count.conversationId = conversation.id
+            ) = 2
+            """
+        var request = DBConversation
+            .filter(
+                !DBConversation.Columns.id.like("draft-%")
+                || (DBConversation.Columns.inviteTag != nil
+                    && length(DBConversation.Columns.inviteTag) > 0)
+            )
+            .filter(consent.contains(DBConversation.Columns.consent))
+            .filter(DBConversation.Columns.expiresAt == nil || DBConversation.Columns.expiresAt > Date())
+            .filter(DBConversation.Columns.isUnused == false)
+            .filter(
+                DBConversation.Columns.quarantinedAt == nil
+                || DBConversation.Columns.quarantineReleasedAt != nil
+            )
+            .filter(literal: oneToOnePredicate)
+        if let excludedConversationId {
+            request = request.filter(DBConversation.Columns.id != excludedConversationId)
+        }
+        let dbConversationDetails = try request
+            .detailedConversationQuery()
+            .fetchOne(self)
+        guard let details = dbConversationDetails else { return nil }
+        let currentInboxId = try DBInbox.fetchAll(self).first?.inboxId ?? ""
+        return details.hydrateConversation(currentInboxId: currentInboxId)
     }
 }
 

--- a/ConvosCore/Tests/ConvosCoreTests/ConversationsRepositoryFindOneToOneTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ConversationsRepositoryFindOneToOneTests.swift
@@ -1,0 +1,245 @@
+@testable import ConvosCore
+import Foundation
+import GRDB
+import Testing
+
+/// Coverage for `ConversationsRepository.findOneToOne(with:excluding:)` -
+/// the SQL-pushed lookup that lets "Chat" on a contact card route into
+/// an existing 1:1 instead of letting the picker create a duplicate.
+@Suite("ConversationsRepository.findOneToOne Tests", .serialized)
+struct ConversationsRepositoryFindOneToOneTests {
+    private static let currentInboxId: String = "inbox-current"
+    private static let otherInboxId: String = "inbox-other"
+
+    /// Inserts a 1:1 between the current user and `other`, with all the
+    /// rows `detailedConversationQuery` joins to as `required` (creator
+    /// member + member profile, conversation local state). Returns the
+    /// inserted conversation id so the caller can correlate it back.
+    @discardableResult
+    private static func seedOneToOne(
+        db: Database,
+        id: String,
+        with other: String = otherInboxId,
+        createdAt: Date,
+        consent: Consent = .allowed,
+        isUnused: Bool = false,
+        expiresAt: Date? = nil,
+        quarantinedAt: Date? = nil,
+        quarantineReleasedAt: Date? = nil,
+        inviteTag: String? = nil
+    ) throws -> String {
+        try seedInbox(db: db)
+        try DBMember(inboxId: other).save(db, onConflict: .ignore)
+
+        try DBConversation(
+            id: id,
+            clientConversationId: "client-\(id)",
+            inviteTag: inviteTag ?? "tag-\(id)",
+            creatorId: currentInboxId,
+            kind: .group,
+            consent: consent,
+            createdAt: createdAt,
+            name: nil,
+            description: nil,
+            imageURLString: nil,
+            publicImageURLString: nil,
+            includeInfoInPublicPreview: false,
+            expiresAt: expiresAt,
+            debugInfo: .empty,
+            isLocked: false,
+            imageSalt: nil,
+            imageNonce: nil,
+            imageEncryptionKey: nil,
+            conversationEmoji: nil,
+            imageLastRenewed: nil,
+            isUnused: isUnused,
+            hasHadVerifiedAssistant: false,
+            quarantinedAt: quarantinedAt,
+            quarantineReleasedAt: quarantineReleasedAt
+        ).insert(db)
+
+        try ConversationLocalState(
+            conversationId: id,
+            isPinned: false,
+            isUnread: false,
+            isUnreadUpdatedAt: createdAt,
+            isMuted: false,
+            pinnedOrder: nil,
+            hidesInviteCard: false
+        ).insert(db)
+
+        try addMember(db: db, conversationId: id, inboxId: currentInboxId, role: .superAdmin)
+        try addMember(db: db, conversationId: id, inboxId: other, role: .member)
+
+        return id
+    }
+
+    private static func addMember(
+        db: Database,
+        conversationId: String,
+        inboxId: String,
+        role: MemberRole
+    ) throws {
+        try DBConversationMember(
+            conversationId: conversationId,
+            inboxId: inboxId,
+            role: role,
+            consent: .allowed,
+            createdAt: Date(),
+            invitedByInboxId: nil
+        ).insert(db)
+        try DBMemberProfile(
+            conversationId: conversationId,
+            inboxId: inboxId,
+            name: inboxId,
+            avatar: nil
+        ).insert(db, onConflict: .ignore)
+    }
+
+    private static func seedInbox(db: Database) throws {
+        try DBMember(inboxId: currentInboxId).save(db, onConflict: .ignore)
+        try DBInbox(
+            inboxId: currentInboxId,
+            clientId: "client-current",
+            createdAt: Date()
+        ).save(db, onConflict: .ignore)
+    }
+
+    // MARK: - Tests
+
+    @Test("Returns the existing 1:1 when one exists with the given inbox")
+    func testReturnsExistingOneToOne() throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        try dbManager.dbWriter.write { db in
+            try Self.seedOneToOne(db: db, id: "convo-match", createdAt: Date())
+        }
+
+        let repo = ConversationsRepository(dbReader: dbManager.dbReader, consent: [.allowed])
+        let match = try repo.findOneToOne(with: Self.otherInboxId, excluding: nil)
+
+        #expect(match?.id == "convo-match")
+        #expect(match?.membersWithoutCurrent.count == 1)
+        #expect(match?.membersWithoutCurrent.first?.profile.inboxId == Self.otherInboxId)
+    }
+
+    @Test("Returns nil when no 1:1 exists with the given inbox")
+    func testReturnsNilWhenNoMatch() throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        try dbManager.dbWriter.write { db in
+            try Self.seedOneToOne(db: db, id: "convo-with-someone-else", with: "inbox-someone-else", createdAt: Date())
+        }
+
+        let repo = ConversationsRepository(dbReader: dbManager.dbReader, consent: [.allowed])
+        let match = try repo.findOneToOne(with: Self.otherInboxId, excluding: nil)
+
+        #expect(match == nil)
+    }
+
+    @Test("Skips the excluded conversation so member-tap-from-inside-the-1:1 falls through to the picker")
+    func testExcludingFiltersOutTheCurrentConversation() throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        try dbManager.dbWriter.write { db in
+            try Self.seedOneToOne(db: db, id: "convo-current", createdAt: Date())
+        }
+
+        let repo = ConversationsRepository(dbReader: dbManager.dbReader, consent: [.allowed])
+        let match = try repo.findOneToOne(with: Self.otherInboxId, excluding: "convo-current")
+
+        #expect(match == nil)
+    }
+
+    @Test("Returns the most-recently-created 1:1 when multiple match")
+    func testMostRecentWinsWhenMultipleMatch() throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        let older = Date(timeIntervalSince1970: 1_700_000_000)
+        let newer = Date(timeIntervalSince1970: 1_800_000_000)
+
+        try dbManager.dbWriter.write { db in
+            try Self.seedOneToOne(db: db, id: "convo-older", createdAt: older)
+            try Self.seedOneToOne(db: db, id: "convo-newer", createdAt: newer)
+        }
+
+        let repo = ConversationsRepository(dbReader: dbManager.dbReader, consent: [.allowed])
+        let match = try repo.findOneToOne(with: Self.otherInboxId, excluding: nil)
+
+        #expect(match?.id == "convo-newer")
+    }
+
+    @Test("Excluding the newest match lets the next-most-recent 1:1 surface")
+    func testExcludingFallsThroughToNextMatch() throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        let older = Date(timeIntervalSince1970: 1_700_000_000)
+        let newer = Date(timeIntervalSince1970: 1_800_000_000)
+
+        try dbManager.dbWriter.write { db in
+            try Self.seedOneToOne(db: db, id: "convo-older", createdAt: older)
+            try Self.seedOneToOne(db: db, id: "convo-newer", createdAt: newer)
+        }
+
+        let repo = ConversationsRepository(dbReader: dbManager.dbReader, consent: [.allowed])
+        let match = try repo.findOneToOne(with: Self.otherInboxId, excluding: "convo-newer")
+
+        #expect(match?.id == "convo-older")
+    }
+
+    @Test("Three-member group with the inbox does not count as a 1:1")
+    func testGroupOfThreeIsNotAOneToOne() throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        try dbManager.dbWriter.write { db in
+            try Self.seedOneToOne(db: db, id: "convo-group", createdAt: Date())
+            try DBMember(inboxId: "inbox-third").save(db, onConflict: .ignore)
+            try Self.addMember(db: db, conversationId: "convo-group", inboxId: "inbox-third", role: .member)
+        }
+
+        let repo = ConversationsRepository(dbReader: dbManager.dbReader, consent: [.allowed])
+        let match = try repo.findOneToOne(with: Self.otherInboxId, excluding: nil)
+
+        #expect(match == nil)
+    }
+
+    @Test("Honours the consent scope - a denied 1:1 is not returned when querying allowed")
+    func testConsentScopeHonoured() throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        try dbManager.dbWriter.write { db in
+            try Self.seedOneToOne(db: db, id: "convo-denied", createdAt: Date(), consent: .denied)
+        }
+
+        let repo = ConversationsRepository(dbReader: dbManager.dbReader, consent: [.allowed])
+        #expect(try repo.findOneToOne(with: Self.otherInboxId, excluding: nil) == nil)
+
+        let repoIncludingDenied = ConversationsRepository(
+            dbReader: dbManager.dbReader,
+            consent: [.allowed, .denied]
+        )
+        #expect(try repoIncludingDenied.findOneToOne(with: Self.otherInboxId, excluding: nil)?.id == "convo-denied")
+    }
+
+    @Test("Honours the [.allowed, .unknown] scope so a pending invite from this inbox matches")
+    func testUnknownConsentInclusionMatches() throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        try dbManager.dbWriter.write { db in
+            try Self.seedOneToOne(db: db, id: "convo-pending", createdAt: Date(), consent: .unknown)
+        }
+
+        let repo = ConversationsRepository(dbReader: dbManager.dbReader, consent: [.allowed, .unknown])
+        let match = try repo.findOneToOne(with: Self.otherInboxId, excluding: nil)
+
+        #expect(match?.id == "convo-pending")
+    }
+
+    @Test("isUnused, expired, and quarantined-without-release rows are excluded")
+    func testHiddenRowsAreExcluded() throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        let now = Date()
+        try dbManager.dbWriter.write { db in
+            try Self.seedOneToOne(db: db, id: "convo-unused", createdAt: now, isUnused: true)
+            try Self.seedOneToOne(db: db, id: "convo-expired", createdAt: now, expiresAt: Date(timeIntervalSince1970: 1))
+            try Self.seedOneToOne(db: db, id: "convo-quarantined", createdAt: now, quarantinedAt: now)
+        }
+
+        let repo = ConversationsRepository(dbReader: dbManager.dbReader, consent: [.allowed])
+        let match = try repo.findOneToOne(with: Self.otherInboxId, excluding: nil)
+
+        #expect(match == nil)
+    }
+}


### PR DESCRIPTION
Tapping "Chat" on a contact card now opens the user's existing 1:1 with that person (if one exists) in the same sheet anchor we use for the new-convo flow, instead of letting the picker spin up a second redundant 1:1. The repository handles the lookup in SQL.

New API on `ConversationsRepositoryProtocol`:

  findOneToOne(with inboxId: String, excluding: String?) throws -> Conversation?

The SQL pushed by `ConversationsRepository.composeOneToOne` matches the same draft / expired / quarantined / unused / consent filters the conversation list uses, plus three additional clauses:

  EXISTS (member is the other inbox)
  EXISTS (member is the current user, defensive)
  COUNT(*) members = 2

`detailedConversationQuery` orders by COALESCE(lastMessage.date, createdAt) DESC, so the most-recently-active 1:1 wins when multiple exist (the app allows that today). `excluding`, when non-nil, skips the given conversation id - the caller passes
`ContactDetailMode.conversationId` so tapping "Chat" while already inside a 1:1 with this same contact falls through to the picker (the user clearly wants to start a different chat).

Locked conversations are intentionally included - locking only freezes invite-code minting; the chat itself still works, and routing to an existing locked 1:1 is preferable to a duplicate. The lookup queries `[.allowed, .unknown]` so an outstanding invite from this contact routes "Chat" into that pending thread; the chat's own consent gate handles accept / decline from there.

New mode on `NewConversationViewModel`: `.existingConversation (conversationId:)`. `autoCreateConversation = false`, `acquireInbox` grabs `session.messagingService()` synchronously and threads the existing id into `configureWithMessagingService`, which routes through `messagingService.conversationStateManager(for:)` (the same `useExisting` path the warm-cache flow uses - no create, no addMembers). `cleanUpIfNeeded` short-circuits when the VM was opened against an existing 1:1 so a sheet dismissed before `.ready` can never destroy the real conversation behind it, even if `deleteConversation()` ever stops being a no-op.

`MockConversationsRepository` mirrors the predicate in Swift and documents that it does not honor the repo's consent scope.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/850"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1781900798&installation_id=128169237&pr_number=850&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F850&signature=3048cbdc2baf7f8866170cc3d82e2ece6d55d2060af50579c4b9a8c3448cd344"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Route the 'Chat' button to existing 1:1 conversations in ContactDetailView
> - Tapping "Chat" in `ContactDetailView` now checks for an existing 1:1 with the contact before opening the picker. If a match is found, it opens that conversation in a sheet via `NewConversationViewModel(mode: .existingConversation(conversationId:))`; otherwise it falls back to the contacts picker.
> - Adds `findOneToOne(with:excluding:)` to `ConversationsRepositoryProtocol`, implemented with a SQL-side query that filters by consent scope, visibility rules, and optionally excludes a given conversation ID.
> - `NewConversationViewModel` gains an `.existingConversation` mode that skips conversation creation and prevents cleanup deletion on dismissal.
> - New test suite in `ConversationsRepositoryFindOneToOneTests` covers match, no-match, exclusion, consent scoping, and group/hidden-row filtering.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #850 opened
>
> - Removed performance logging and cancellation checks from the existing conversation inbox acquisition flow in `NewConversationViewModel.acquireInbox(mode:)` [de38337]
> - Consolidated switch case handling in `NewConversationViewModel` public initializer by merging `.existingConversation` and `.joinInvite` cases [de38337]
> - Updated comments and documentation in `NewConversationViewModel` for clarity [de38337]
> - Reformatted method call in `NewConversationViewModel` conversation creation mode switch statement [c42110a]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b59136d.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->