### PR TITLE
feat(agent-templates): spawn an agent from the contact card pop up a convo button

### DIFF
--- a/Convos/Contacts/ContactCardView.swift
+++ b/Convos/Contacts/ContactCardView.swift
@@ -19,10 +19,15 @@ import SwiftUI
 //   - Share - both modes, when the contact is a template-backed agent
 //     (`contact.agentTemplatePublishedURL != nil`); presents the system
 //     share sheet seeded with the template's web link
-//   - Pop up a convo - both modes; calls `contactsWriter.upsertContact(...)`
-//     before opening the picker so a synthetic / non-yet-stored contact is
-//     promoted to a real one (the narrow per-person upsert documented in
-//     the contacts PRD, "Send-message on a non-contact" section)
+//   - Pop up a convo - both modes. For a human contact it calls
+//     `contactsWriter.upsertContact(...)` before opening the picker so a
+//     synthetic / non-yet-stored contact is promoted to a real one (the
+//     narrow per-person upsert documented in the contacts PRD,
+//     "Send-message on a non-contact" section). For a template-backed
+//     agent (`contact.agentTemplateId != nil`) it instead posts
+//     `.contactsRequestedAgentTemplateConversation`, spawning a fresh
+//     agent instance into a new conversation - the same path the
+//     `convos://template/<id>` deeplink takes.
 //   - Block / Unblock - both modes
 //   - Remove from convo - scoped mode only, when the viewer is an admin
 //     (`canRemoveMembers`) and the tapped member is not the current user
@@ -96,14 +101,17 @@ struct ContactCardView: View {
                 isBlocked: isBlocked,
                 isApplyingBlockChange: isApplyingBlockChange,
                 // Verified agents (Convos / OAuth-verified) don't accept
-                // 1:1 DMs today, so the Pop-up-a-convo CTA would open a
-                // conversation that goes nowhere. Disable until DM support
-                // for agents lands; the "Get skills" / "Learn about
-                // assistants" rows above remain the right way to interact.
+                // 1:1 DMs today, so for a non-template verified agent the
+                // Pop-up-a-convo CTA would open a conversation that goes
+                // nowhere - keep it disabled. A template-backed agent
+                // overrides this: the row spawns a fresh instance instead
+                // (see `isAgentTemplate` / `handleChatWithAgentTemplate`).
                 canSendMessage: session != nil && !isVerifiedAgent,
+                isAgentTemplate: isAgentTemplate,
                 contactDisplayName: contact.resolvedDisplayName,
                 agentTemplateShareURL: agentTemplateShareURL,
                 onSendMessage: handleSendMessage,
+                onChatWithAgentTemplate: handleChatWithAgentTemplate,
                 onToggleBlock: handleBlockTap
             )
             if mode.isScopedToConversation && !mode.isCurrentUser && mode.canRemoveMembers {
@@ -120,6 +128,13 @@ struct ContactCardView: View {
 
     private var isVerifiedAgent: Bool {
         contact.isVerifiedAgent
+    }
+
+    /// True when this contact is a template-backed agent - it carries the
+    /// `templateId` needed to spawn a fresh instance. Drives the
+    /// Pop-up-a-convo row's behavior (spawn vs. open the picker).
+    private var isAgentTemplate: Bool {
+        contact.agentTemplateId != nil
     }
 
     /// The template share link for a template-backed agent, ready for the
@@ -200,6 +215,22 @@ struct ContactCardView: View {
                 presentingPicker = true
             }
         }
+    }
+
+    /// Spawn-and-join for a template-backed agent. Posts
+    /// `.contactsRequestedAgentTemplateConversation`; `ConversationsViewModel`
+    /// picks it up and routes into a fresh conversation with a new
+    /// instance of the template - the same path the
+    /// `convos://template/<id>` deeplink takes. The containing
+    /// contact-card sheet is torn down by `ConversationView`'s `.onReceive`
+    /// for the same notification.
+    private func handleChatWithAgentTemplate() {
+        guard let templateId = contact.agentTemplateId else { return }
+        NotificationCenter.default.post(
+            name: .contactsRequestedAgentTemplateConversation,
+            object: nil,
+            userInfo: ["templateId": templateId]
+        )
     }
 
     private func handleBlockTap() {
@@ -405,10 +436,15 @@ private struct ContactCardActions: View {
     let isBlocked: Bool
     let isApplyingBlockChange: Bool
     let canSendMessage: Bool
+    /// When true, the Pop-up-a-convo row spawns a fresh agent instance
+    /// (`onChatWithAgentTemplate`) instead of opening the contacts picker;
+    /// the row is always enabled in this case.
+    let isAgentTemplate: Bool
     let contactDisplayName: String
     /// Non-nil only for template-backed agents; drives the Share row.
     let agentTemplateShareURL: URL?
     let onSendMessage: () -> Void
+    let onChatWithAgentTemplate: () -> Void
     let onToggleBlock: () -> Void
 
     var body: some View {
@@ -427,14 +463,22 @@ private struct ContactCardActions: View {
     }
 
     private var popUpConvoRow: some View {
-        ContactCardActionRow(
+        let footer: String = isAgentTemplate
+            ? "Start a new convo with \(contactDisplayName)"
+            : "Message \(contactDisplayName)"
+        let identifier: String = isAgentTemplate
+            ? "contact-card-chat-agent-template"
+            : "contact-card-send-message"
+        let isDisabled: Bool = isAgentTemplate ? false : !canSendMessage
+        let action: () -> Void = isAgentTemplate ? onChatWithAgentTemplate : onSendMessage
+        return ContactCardActionRow(
             label: "Pop up a convo",
-            footer: "Message \(contactDisplayName)",
+            footer: footer,
             color: .colorTextPrimary,
-            isDisabled: !canSendMessage,
+            isDisabled: isDisabled,
             accessibilityLabel: "Pop up a convo with \(contactDisplayName)",
-            accessibilityIdentifier: "contact-card-send-message",
-            action: onSendMessage
+            accessibilityIdentifier: identifier,
+            action: action
         )
     }
 
@@ -612,6 +656,7 @@ extension Contact {
         avatarKey: Data? = nil,
         addedViaConversationId: String?,
         agentVerification: AgentVerification?,
+        agentTemplateId: String? = nil,
         agentTemplatePublishedURL: String? = nil
     ) -> Contact {
         Contact(
@@ -625,6 +670,7 @@ extension Contact {
             addedViaConversationId: addedViaConversationId,
             isBlocked: false,
             agentVerification: agentVerification,
+            agentTemplateId: agentTemplateId,
             agentTemplatePublishedURL: agentTemplatePublishedURL
         )
     }
@@ -638,18 +684,21 @@ extension Contact {
     /// members and non-contact members. The synthetic fallback is
     /// promoted to a real contact when the user taps "Send a message".
     ///
-    /// The agent-template `publishedUrl` lives only in the per-conversation
-    /// member profile metadata (`DBContact` has no template column), so it
-    /// is overlaid here onto whichever contact is returned - stored or
-    /// synthetic - from the freshest source.
+    /// The agent-template `templateId` and `publishedUrl` live only in the
+    /// per-conversation member profile metadata (`DBContact` has no
+    /// template column), so they are overlaid here onto whichever contact
+    /// is returned - stored or synthetic - from the freshest source.
     public static func resolved(
         member: ConversationMember,
         in conversationId: String,
         contactsRepository: any ContactsRepositoryProtocol
     ) -> Contact {
+        let templateId: String? = member.profile.agentTemplateId
         let templatePublishedURL: String? = member.profile.agentTemplatePublishedURL
         if let stored = try? contactsRepository.fetchContact(inboxId: member.profile.inboxId) {
-            return stored.with(agentTemplatePublishedURL: templatePublishedURL)
+            return stored
+                .with(agentTemplateId: templateId)
+                .with(agentTemplatePublishedURL: templatePublishedURL)
         }
         return .synthetic(
             inboxId: member.profile.inboxId,
@@ -660,6 +709,7 @@ extension Contact {
             avatarKey: member.profile.avatarKey,
             addedViaConversationId: conversationId,
             agentVerification: member.agentVerification,
+            agentTemplateId: templateId,
             agentTemplatePublishedURL: templatePublishedURL
         )
     }
@@ -704,6 +754,7 @@ extension Contact {
             contact: .mock(
                 displayName: "Tifoso",
                 agentVerification: .verified(.convos),
+                agentTemplateId: "200e27dc-badc-429f-a431-b01b0281ec95",
                 agentTemplatePublishedURL: "https://agents-dev.convos.org/tifoso.pnw1o"
             ),
             contactsWriter: MockContactsWriter(),

--- a/Convos/Contacts/ContactsNotifications.swift
+++ b/Convos/Contacts/ContactsNotifications.swift
@@ -15,6 +15,20 @@ extension Notification.Name {
         "ContactsRequestedNewConversation"
     )
 
+    /// Posted by the agent contact card (`ContactCardView`) when the user
+    /// taps "Pop up a convo" on a template-backed agent. Carries
+    /// `["templateId": String]` in `userInfo`.
+    ///
+    /// `ConversationsViewModel` listens for this and presents a
+    /// `NewConversationView` driven by
+    /// `NewConversationViewModel(mode: .newConversationWithTemplate(...))` -
+    /// the same spawn-and-join path the `convos://template/<id>` deeplink
+    /// uses. Each post spawns a fresh agent instance into a new
+    /// conversation; there is no existing-1:1 short-circuit.
+    static let contactsRequestedAgentTemplateConversation: Notification.Name = Notification.Name(
+        "ContactsRequestedAgentTemplateConversation"
+    )
+
     /// Posted by surfaces inside an active chat (e.g. the "Add from Contacts"
     /// row in `NewConvoIdentityView`'s invite-members menu) to ask the
     /// containing `ConversationView` to present its contacts picker. Avoids

--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -374,14 +374,18 @@ struct ConversationView<MessagesBottomBar: View>: View {
             // chat plus-menu's "Add from Contacts" row drives.
             presentingAddFromContactsPicker = true
         }
-        .onReceive(NotificationCenter.default.publisher(for: .contactsRequestedNewConversation)) { _ in
-            // The picker may have been presented over a contact-card sheet
-            // (member avatar tap, "Send a message", picker). When the user
-            // confirms, the conversations-list layer is about to present
-            // `NewConversationView` from its own sheet anchor; tear our
-            // contact-card sheet down in the same render pass so SwiftUI
-            // runs the dismissals in parallel rather than serially, which
-            // eliminates the brief conversation-list flash between sheets.
+        .onReceive(
+            NotificationCenter.default.publisher(for: .contactsRequestedNewConversation)
+                .merge(with: NotificationCenter.default.publisher(for: .contactsRequestedAgentTemplateConversation))
+        ) { _ in
+            // The contacts picker or the agent-template "Pop up a convo"
+            // row may have been driven from a contact-card sheet (member
+            // avatar tap). When the user confirms, the conversations-list
+            // layer is about to present `NewConversationView` from its own
+            // sheet anchor; tear our contact-card sheet down in the same
+            // render pass so SwiftUI runs the dismissals in parallel rather
+            // than serially, which eliminates the brief conversation-list
+            // flash between sheets.
             viewModel.presentingProfileForMember = nil
         }
         .addFromContactsPicker(

--- a/Convos/Conversations List/ConversationsViewModel.swift
+++ b/Convos/Conversations List/ConversationsViewModel.swift
@@ -362,6 +362,14 @@ final class ConversationsViewModel {
             }
             .store(in: &cancellables)
 
+        NotificationCenter.default
+            .publisher(for: .contactsRequestedAgentTemplateConversation)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] notification in
+                self?.handleContactsRequestedAgentTemplateConversation(notification)
+            }
+            .store(in: &cancellables)
+
         leftConversationObserver = NotificationCenter.default
             .addObserver(forName: .leftConversationNotification, object: nil, queue: .main) { [weak self] notification in
                 guard let conversationId = notification.userInfo?["conversationId"] as? String else {
@@ -461,6 +469,24 @@ final class ConversationsViewModel {
             session: session,
             mode: .newConversationWithMembers(initialMemberInboxIds: inboxIds)
         )
+    }
+
+    /// Spawns a fresh instance of an agent template into a new
+    /// conversation when the user taps "Pop up a convo" on a
+    /// template-backed agent's contact card. Routes through the same
+    /// `startConversation(withAgentTemplateId:)` path the
+    /// `convos://template/<id>` deeplink uses, so the spawn-and-join
+    /// behavior is identical regardless of entry point.
+    private func handleContactsRequestedAgentTemplateConversation(_ notification: Notification) {
+        guard let templateId = notification.userInfo?["templateId"] as? String, !templateId.isEmpty else {
+            Log.warning("contactsRequestedAgentTemplateConversation fired without templateId")
+            return
+        }
+        Log.info("Starting new conversation from agent template")
+        if selectedConversationId != nil {
+            selectedConversationId = nil
+        }
+        startConversation(withAgentTemplateId: templateId)
     }
 
     private func handleConversationNotificationTap(_ notification: Notification) {

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/Contact.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/Contact.swift
@@ -27,6 +27,13 @@ public struct Contact: Hashable, Identifiable, Sendable {
     /// card surfaces verified-agent affordances (Get skills, Learn about
     /// assistants) iff `agentVerification?.isVerified == true`.
     public let agentVerification: AgentVerification?
+    /// The backend `AgentTemplate.id` a template-backed agent was
+    /// provisioned from. `nil` for human contacts and for agents that do
+    /// not carry a template. Not persisted on `DBContact`; it is overlaid
+    /// onto the contact at resolution time from the per-conversation
+    /// member profile metadata (see `Contact.resolved(member:...)`), which
+    /// is the freshest source. Drives the contact card's Chat action.
+    public let agentTemplateId: String?
     /// The shareable web URL for a template-backed agent (the backend's
     /// `publishedUrl`). `nil` for human contacts and for agents that do
     /// not carry a template. Not persisted on `DBContact`; it is overlaid
@@ -46,6 +53,7 @@ public struct Contact: Hashable, Identifiable, Sendable {
         addedViaConversationId: String?,
         isBlocked: Bool = false,
         agentVerification: AgentVerification? = nil,
+        agentTemplateId: String? = nil,
         agentTemplatePublishedURL: String? = nil
     ) {
         self.inboxId = inboxId
@@ -58,6 +66,7 @@ public struct Contact: Hashable, Identifiable, Sendable {
         self.addedViaConversationId = addedViaConversationId
         self.isBlocked = isBlocked
         self.agentVerification = agentVerification
+        self.agentTemplateId = agentTemplateId
         self.agentTemplatePublishedURL = agentTemplatePublishedURL
     }
 
@@ -138,6 +147,7 @@ extension Contact {
         addedViaConversationId: String? = nil,
         isBlocked: Bool = false,
         agentVerification: AgentVerification? = nil,
+        agentTemplateId: String? = nil,
         agentTemplatePublishedURL: String? = nil
     ) -> Contact {
         Contact(
@@ -151,6 +161,28 @@ extension Contact {
             addedViaConversationId: addedViaConversationId,
             isBlocked: isBlocked,
             agentVerification: agentVerification,
+            agentTemplateId: agentTemplateId,
+            agentTemplatePublishedURL: agentTemplatePublishedURL
+        )
+    }
+
+    /// Returns a copy with `agentTemplateId` overlaid. Used by
+    /// `Contact.resolved(member:...)` to carry the freshest template id
+    /// from the per-conversation member profile onto a stored contact,
+    /// which has no template column of its own.
+    public func with(agentTemplateId: String?) -> Contact {
+        Contact(
+            inboxId: inboxId,
+            displayName: displayName,
+            avatarURL: avatarURL,
+            avatarSalt: avatarSalt,
+            avatarNonce: avatarNonce,
+            avatarKey: avatarKey,
+            addedAt: addedAt,
+            addedViaConversationId: addedViaConversationId,
+            isBlocked: isBlocked,
+            agentVerification: agentVerification,
+            agentTemplateId: agentTemplateId,
             agentTemplatePublishedURL: agentTemplatePublishedURL
         )
     }
@@ -171,6 +203,7 @@ extension Contact {
             addedViaConversationId: addedViaConversationId,
             isBlocked: isBlocked,
             agentVerification: agentVerification,
+            agentTemplateId: agentTemplateId,
             agentTemplatePublishedURL: agentTemplatePublishedURL
         )
     }

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/Profile.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/Profile.swift
@@ -207,6 +207,7 @@ public struct Profile: Codable, Identifiable, Hashable, Sendable {
 
     private enum Constant {
         static let emojiMetadataKey: String = "emoji"
+        static let templateIdKey: String = "templateId"
         static let publishedURLKey: String = "publishedUrl"
     }
 }
@@ -214,6 +215,17 @@ public struct Profile: Codable, Identifiable, Hashable, Sendable {
 // MARK: - Agent template metadata
 
 extension Profile {
+    /// The backend `AgentTemplate.id` a template-backed agent was
+    /// provisioned from, read from the agent's per-conversation profile
+    /// `metadata`. Drives the contact card's Chat action (spawn a fresh
+    /// instance of the same template). nil for human members and for
+    /// legacy agents that do not carry a template. The metadata key must
+    /// match the agent runtime's profile builder; see the matching
+    /// accessor on `DBMemberProfile`.
+    public var agentTemplateId: String? {
+        metadata?[Constant.templateIdKey]?.stringValue
+    }
+
     /// The shareable web URL for a template-backed agent (the backend's
     /// `publishedUrl`), read from the agent's per-conversation profile
     /// `metadata`. Drives the contact card's Share button. nil for human

--- a/ConvosCore/Tests/ConvosCoreTests/AgentTemplateMetadataTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/AgentTemplateMetadataTests.swift
@@ -89,32 +89,61 @@ struct ProfileAgentTemplateMetadataTests {
         )
     }
 
-    @Test("A template-backed agent profile exposes the published URL")
-    func templateBackedAgentExposesPublishedURL() {
+    @Test("A template-backed agent profile exposes the template id and published URL")
+    func templateBackedAgentExposesFields() {
         let profile = makeProfile(
             isAgent: true,
-            metadata: ["publishedUrl": .string("https://agents-dev.convos.org/tifoso.pnw1o")]
+            metadata: [
+                "templateId": .string("200e27dc-badc-429f-a431-b01b0281ec95"),
+                "publishedUrl": .string("https://agents-dev.convos.org/tifoso.pnw1o")
+            ]
         )
+        #expect(profile.agentTemplateId == "200e27dc-badc-429f-a431-b01b0281ec95")
         #expect(profile.agentTemplatePublishedURL == "https://agents-dev.convos.org/tifoso.pnw1o")
     }
 
-    @Test("A human profile exposes no published URL")
-    func humanProfileHasNoPublishedURL() {
+    @Test("A human profile exposes no agent-template fields")
+    func humanProfileHasNoTemplateFields() {
         let profile = makeProfile(isAgent: false, metadata: nil)
+        #expect(profile.agentTemplateId == nil)
         #expect(profile.agentTemplatePublishedURL == nil)
     }
 
-    @Test("A non-string publishedUrl value does not resolve")
-    func nonStringPublishedURLIgnored() {
+    @Test("A non-string metadata value does not resolve")
+    func nonStringMetadataValueIgnored() {
         let profile = makeProfile(
             isAgent: true,
-            metadata: ["publishedUrl": .number(42)]
+            metadata: ["templateId": .number(42), "publishedUrl": .number(42)]
         )
+        #expect(profile.agentTemplateId == nil)
         #expect(profile.agentTemplatePublishedURL == nil)
     }
 }
 
 struct ContactAgentTemplateTests {
+    @Test("with(agentTemplateId:) overlays the id onto a copy")
+    func withOverlaysTemplateId() {
+        let base = Contact.mock(displayName: "Tifoso")
+        #expect(base.agentTemplateId == nil)
+
+        let overlaid = base.with(agentTemplateId: "200e27dc-badc-429f-a431-b01b0281ec95")
+        #expect(overlaid.agentTemplateId == "200e27dc-badc-429f-a431-b01b0281ec95")
+        #expect(overlaid.inboxId == base.inboxId)
+        #expect(overlaid.displayName == base.displayName)
+        #expect(overlaid.isBlocked == base.isBlocked)
+    }
+
+    @Test("with(agentTemplateId:) preserves an existing published URL")
+    func withTemplateIdPreservesPublishedURL() {
+        let base = Contact.mock(
+            displayName: "Tifoso",
+            agentTemplatePublishedURL: "https://agents-dev.convos.org/tifoso.pnw1o"
+        )
+        let overlaid = base.with(agentTemplateId: "200e27dc-badc-429f-a431-b01b0281ec95")
+        #expect(overlaid.agentTemplateId == "200e27dc-badc-429f-a431-b01b0281ec95")
+        #expect(overlaid.agentTemplatePublishedURL == "https://agents-dev.convos.org/tifoso.pnw1o")
+    }
+
     @Test("with(agentTemplatePublishedURL:) overlays the URL onto a copy")
     func withOverlaysPublishedURL() {
         let base = Contact.mock(displayName: "Tifoso")


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/852"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1781905580&installation_id=128169237&pr_number=852&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F852&signature=7c12c18d6688a7f3f10148d11c14eb43dd2d2af5dfacf5387a1a2fb8948b90c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add agent template conversation spawn from contact card pop-up button
> - Adds `isAgentTemplate` detection to `ContactCardView` based on `contact.agentTemplateId`; when set, the 'Pop up a convo' button is always enabled and triggers a new `contactsRequestedAgentTemplateConversation` notification instead of the contacts picker flow.
> - `ConversationsViewModel` subscribes to the new notification and calls `startConversation(withAgentTemplateId:)` to spawn a fresh agent instance.
> - `Contact` and `Profile` models gain `agentTemplateId` sourced from member profile metadata, with copy helpers and test coverage.
> - `ConversationView` dismisses the contact-card sheet on receipt of either the new agent-template notification or the existing new-conversation notification.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 18db897.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->