### PR TITLE
fix main camera scanner button so it also works on agent qr code

### DIFF
--- a/Convos/Conversation Creation/NewConversationView.swift
+++ b/Convos/Conversation Creation/NewConversationView.swift
@@ -25,8 +25,8 @@ struct NewConversationView: View {
                         JoinConversationView(
                             viewModel: viewModel.qrScannerViewModel,
                             allowsDismissal: viewModel.allowsDismissingScanner,
-                            onScannedCode: { inviteCode in
-                                viewModel.joinConversation(inviteCode: inviteCode)
+                            onScannedCode: { scannedCode in
+                                viewModel.handleScannedCode(scannedCode)
                             }
                         )
                     } else if let conversationViewModel = viewModel.conversationViewModel {
@@ -59,8 +59,8 @@ struct NewConversationView: View {
                 }
                 .background(.colorBackgroundSurfaceless)
                 .sheet(isPresented: $viewModel.presentingJoinConversationSheet) {
-                    JoinConversationView(viewModel: viewModel.qrScannerViewModel, allowsDismissal: true) { inviteCode in
-                        viewModel.joinConversation(inviteCode: inviteCode)
+                    JoinConversationView(viewModel: viewModel.qrScannerViewModel, allowsDismissal: true) { scannedCode in
+                        viewModel.handleScannedCode(scannedCode)
                     }
                 }
                 .selfSizingSheet(item: $viewModel.displayError) { error in

--- a/Convos/Conversation Creation/NewConversationViewModel.swift
+++ b/Convos/Conversation Creation/NewConversationViewModel.swift
@@ -97,9 +97,15 @@ class NewConversationViewModel: Identifiable {
     private var conversationStateManager: (any ConversationStateManagerProtocol)?
     private var acquiredMessagingService: AnyMessagingService?
     /// Agent template id to provision into the conversation once it
-    /// reaches `.ready`. Set only for `.newConversationWithTemplate`.
+    /// reaches `.ready`. Set for the `.newConversationWithTemplate`
+    /// deeplink mode and when a `convos://template/<id>` QR is scanned.
     @ObservationIgnored
     private var pendingAgentTemplateId: String?
+    /// Set when a template QR is scanned before the messaging service
+    /// (and `conversationStateManager`) has been acquired; the create is
+    /// kicked off once configuration completes. Mirrors `pendingInviteCode`.
+    @ObservationIgnored
+    private var pendingAgentTemplateCreate: Bool = false
     /// One-shot guard so a re-emitted `.ready` state doesn't request the
     /// agent join twice.
     @ObservationIgnored
@@ -313,6 +319,11 @@ class NewConversationViewModel: Identifiable {
             joinConversation(inviteCode: pendingCode)
         }
 
+        if pendingAgentTemplateCreate {
+            pendingAgentTemplateCreate = false
+            createConversationForAgentTemplate()
+        }
+
         if autoCreateConversation && existingConversationId == nil {
             newConversationTask = Task { [weak self, stateManager] in
                 guard self != nil else { return }
@@ -335,6 +346,53 @@ class NewConversationViewModel: Identifiable {
 
     func onScanInviteCode() {
         presentingJoinConversationSheet = true
+    }
+
+    /// Routes a scanned QR payload. A `convos://template/<id>` code
+    /// pivots the scanner into the agent-template spawn flow; anything
+    /// else is treated as a conversation invite, exactly as before.
+    func handleScannedCode(_ code: String) {
+        if let url = URL(string: code), let templateId = DeepLinkHandler.agentTemplateId(from: url) {
+            startAgentTemplateConversation(templateId: templateId)
+        } else {
+            joinConversation(inviteCode: code)
+        }
+    }
+
+    /// Pivots a scanner-mode flow into the agent-template spawn path when
+    /// the user scans a template QR. Mirrors the
+    /// `.newConversationWithTemplate` deeplink mode: create a fresh
+    /// conversation, then request an instance of the template into it
+    /// once it reaches `.ready` (handled in `handleStateChange`).
+    private func startAgentTemplateConversation(templateId: String) {
+        pendingAgentTemplateId = templateId
+        showingFullScreenScanner = false
+        isCreatingConversation = true
+
+        guard conversationStateManager != nil else {
+            pendingAgentTemplateCreate = true
+            return
+        }
+        createConversationForAgentTemplate()
+    }
+
+    private func createConversationForAgentTemplate() {
+        guard let conversationStateManager else { return }
+        newConversationTask?.cancel()
+        newConversationTask = Task { [weak self, conversationStateManager] in
+            guard self != nil else { return }
+            guard !Task.isCancelled else { return }
+            do {
+                try await conversationStateManager.createConversation()
+                await self?.applyGlobalConversationDefaultsIfNeeded(using: conversationStateManager)
+            } catch {
+                Log.error("Error creating conversation for agent template: \(error.localizedDescription)")
+                guard !Task.isCancelled else { return }
+                await MainActor.run { [weak self] in
+                    self?.handleCreationError(error)
+                }
+            }
+        }
     }
 
     func joinConversation(inviteCode: String) {
@@ -591,7 +649,11 @@ class NewConversationViewModel: Identifiable {
             Log.error("Error applying global auto reveal preference: \(error)")
         }
 
-        guard autoCreateConversation else { return }
+        // The include-info default applies to every conversation this VM
+        // creates - the auto-create modes and the scanned-template path
+        // (which sets `pendingAgentTemplateId` but is not an auto-create
+        // mode). It does not apply when joining an existing invite.
+        guard autoCreateConversation || pendingAgentTemplateId != nil else { return }
 
         do {
             try await stateManager.conversationMetadataWriter.updateIncludeInfoInPublicPreview(

--- a/Convos/DeepLinking/DeepLinkHandler.swift
+++ b/Convos/DeepLinking/DeepLinkHandler.swift
@@ -90,6 +90,19 @@ final class DeepLinkHandler {
 
     // MARK: - Agent template deep links
 
+    /// Narrow agent-template check for callers (e.g. the QR scanner) that
+    /// already have a candidate URL and want only the template id.
+    /// Unlike `destination(for:)`, this does not fall through to invite
+    /// parsing and logs nothing when `url` is not a template link, so a
+    /// scanned conversation invite does not produce spurious warnings.
+    @MainActor
+    static func agentTemplateId(from url: URL) -> String? {
+        guard case .agentTemplate(let templateId)? = parseAgentTemplate(from: url) else {
+            return nil
+        }
+        return templateId
+    }
+
     /// Parses agent-template deep links of the form
     /// `convos[-{env}]://template/<templateId>`, where `<templateId>` is
     /// the backend's `AgentTemplate.id` (a UUID).

--- a/ConvosTests/DeepLinkHandlerTests.swift
+++ b/ConvosTests/DeepLinkHandlerTests.swift
@@ -186,6 +186,29 @@ final class DeepLinkHandlerTests: XCTestCase {
         }
     }
 
+    // MARK: - DeepLinkHandler.agentTemplateId(from:)
+
+    func testAgentTemplateId_ReturnsTemplateIdForTemplateURL() throws {
+        let url = try XCTUnwrap(URL(string: "\(appUrlScheme)://template/\(sampleTemplateId)"))
+        XCTAssertEqual(DeepLinkHandler.agentTemplateId(from: url), sampleTemplateId)
+    }
+
+    func testAgentTemplateId_ReturnsNilForNonTemplateDeepLink() throws {
+        // A non-template deep link (here a connection grant) must not
+        // resolve to a template id - the QR scanner relies on this so a
+        // scanned conversation invite keeps routing through the invite
+        // path unchanged.
+        let url = try XCTUnwrap(
+            URL(string: "\(appUrlScheme)://connections/grant?service=google_calendar&conversationId=abc123")
+        )
+        XCTAssertNil(DeepLinkHandler.agentTemplateId(from: url))
+    }
+
+    func testAgentTemplateId_ReturnsNilForMalformedId() throws {
+        let url = try XCTUnwrap(URL(string: "\(appUrlScheme)://template/not-a-uuid"))
+        XCTAssertNil(DeepLinkHandler.agentTemplateId(from: url))
+    }
+
     // MARK: - ConversationsViewModel.handleURL validation
 
     @MainActor


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/853"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1781909863&installation_id=128169237&pr_number=853&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F853&signature=41ec9f6673cd323f6cc2dcd9c95fb07f4cd3e4a144baa706123097a69c522e8b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix camera scanner button to handle agent template QR codes in new conversation flow
> - Adds `handleScannedCode(_:)` to `NewConversationViewModel` to route scanned QR payloads: parses `convos://template/<id>` URLs and starts a template conversation, falling back to join-by-invite-code for other payloads.
> - Adds `DeepLinkHandler.agentTemplateId(from:)`, a non-logging static method to extract a template ID from a URL, used by the scanner flow.
> - Updates `NewConversationView` to call `handleScannedCode` instead of `joinConversation(inviteCode:)` for both the full-screen scanner and sheet presentation.
> - Handles the case where the messaging service is not yet available when a template QR is scanned by deferring creation until setup completes.
> - Adds unit tests in `ConvosTests/DeepLinkHandlerTests.swift` covering valid, non-template, and malformed-UUID URL cases.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 75ded3e. 3 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->