### PR TITLE
feat: agent template phase 2 - agent contacts

### DIFF
--- a/Convos/App Settings/AppSettingsView.swift
+++ b/Convos/App Settings/AppSettingsView.swift
@@ -178,6 +178,8 @@ struct AppSettingsView: View {
             contactsWriter: messagingService.contactsWriter(),
             session: session,
             profileSettingsViewModel: profileSettingsViewModel
+            agentTemplateContactsRepository: messagingService.agentTemplateContactsRepository(),
+            agentTemplateContactsWriter: messagingService.agentTemplateContactsWriter()
         )
     }
 

--- a/Convos/App Settings/AppSettingsView.swift
+++ b/Convos/App Settings/AppSettingsView.swift
@@ -177,7 +177,7 @@ struct AppSettingsView: View {
             contactsRepository: messagingService.contactsRepository(),
             contactsWriter: messagingService.contactsWriter(),
             session: session,
-            profileSettingsViewModel: profileSettingsViewModel
+            profileSettingsViewModel: profileSettingsViewModel,
             agentTemplateContactsRepository: messagingService.agentTemplateContactsRepository(),
             agentTemplateContactsWriter: messagingService.agentTemplateContactsWriter()
         )

--- a/Convos/App Settings/AppSettingsView.swift
+++ b/Convos/App Settings/AppSettingsView.swift
@@ -82,7 +82,17 @@ struct AppSettingsView: View {
             .toolbar { topToolbar }
             .onReceive(CreditsServices.shared.balancePublisher) { creditBalance = $0 }
             .onReceive(SubscriptionServices.shared.subscriptionPublisher) { currentSubscription = $0 }
-            .onReceive(session.messagingService().contactsRepository().contactsPublisher) { contactsCount = $0.count }
+            .onReceive(session.messagingService().contactsRepository().contactsPublisher) { contacts in
+                // Mirror `ContactsViewModel.isVisibleInList` so this badge
+                // matches the count shown on the Contacts list: verified
+                // agents stay in `DBContact` for chat-side resolution but
+                // are excluded from the human browser, and unnamed
+                // contacts ("Somebody") are hidden too.
+                visibleHumansCount = contacts.filter(ContactsViewModel.isVisibleInList).count
+            }
+            .onReceive(session.messagingService().agentTemplateContactsRepository().agentTemplateContactsPublisher) { agentTemplates in
+                agentTemplatesCount = agentTemplates.count
+            }
         }
     }
 
@@ -126,7 +136,15 @@ struct AppSettingsView: View {
         }
     }
 
-    @State private var contactsCount: Int = 0
+    @State private var visibleHumansCount: Int = 0
+    @State private var agentTemplatesCount: Int = 0
+
+    /// Number rendered on the "Contacts" row in App Settings. Matches
+    /// `ContactsViewModel.contactCount` exactly so the badge and the
+    /// destination list never disagree.
+    private var contactsCount: Int {
+        visibleHumansCount + agentTemplatesCount
+    }
 
     @ViewBuilder
     private var devicesSection: some View {

--- a/Convos/Contacts/AddFromContactsPickerModifier.swift
+++ b/Convos/Contacts/AddFromContactsPickerModifier.swift
@@ -63,17 +63,31 @@ private struct AddFromContactsPickerModifier: ViewModifier {
                 conversationTitle: viewModel.conversation.name
             ),
             contactsRepository: viewModel.messagingService.contactsRepository(),
+            agentTemplateContactsRepository: viewModel.messagingService.agentTemplateContactsRepository(),
             alreadyInChatInboxIds: alreadyInChat,
             onConfirm: handleConfirm
         )
     }
 
-    private func handleConfirm(_ inboxIds: Set<String>) {
-        let ids = Array(inboxIds)
-        guard !ids.isEmpty else { return }
+    /// Splits the mixed selection into humans and agent templates. Humans
+    /// go through the existing `addMembersFromContacts` flow. Templates are
+    /// dispatched via `requestAgentJoin(templateId:)` per id, which reuses
+    /// the existing conversation's invite slug to spawn a fresh instance
+    /// into this conversation (no new backend endpoint - see Phase 2 PRD
+    /// add-to-existing question 1).
+    private func handleConfirm(_ selection: Set<ContactsPickerViewModel.Selection>) {
+        let humanInboxIds: [String] = selection.compactMap(\.inboxId)
+        let templateIds: [String] = selection.compactMap(\.templateId)
+        guard !humanInboxIds.isEmpty || !templateIds.isEmpty else { return }
+
+        for templateId in templateIds {
+            viewModel.requestAgentJoin(templateId: templateId)
+        }
+
+        guard !humanInboxIds.isEmpty else { return }
         Task {
             do {
-                try await viewModel.addMembersFromContacts(ids)
+                try await viewModel.addMembersFromContacts(humanInboxIds)
             } catch {
                 Log.error("Add from contacts failed: \(error.localizedDescription)")
                 errorMessage = "We couldn't add those contacts. Please try again."

--- a/Convos/Contacts/AddFromContactsPickerModifier.swift
+++ b/Convos/Contacts/AddFromContactsPickerModifier.swift
@@ -70,18 +70,24 @@ private struct AddFromContactsPickerModifier: ViewModifier {
     }
 
     /// Splits the mixed selection into humans and agent templates. Humans
-    /// go through the existing `addMembersFromContacts` flow. Templates are
-    /// dispatched via `requestAgentJoin(templateId:)` per id, which reuses
-    /// the existing conversation's invite slug to spawn a fresh instance
-    /// into this conversation (no new backend endpoint - see Phase 2 PRD
-    /// add-to-existing question 1).
+    /// go through the existing `addMembersFromContacts` flow. Templates go
+    /// through `requestAgentJoins(templateIds:)` -- the batched (serialized)
+    /// variant -- which reuses the existing conversation's invite slug to
+    /// spawn a fresh instance per templateId (no new backend endpoint, see
+    /// Phase 2 PRD add-to-existing question 1).
+    ///
+    /// Important: do NOT loop `requestAgentJoin(templateId:)` here. That
+    /// method is single-flight (each call cancels the prior task), so a
+    /// for-loop ends up running only the LAST templateId to completion --
+    /// every prior call gets `URLError.cancelled` mid-dispatch and silently
+    /// dropped.
     private func handleConfirm(_ selection: Set<ContactsPickerViewModel.Selection>) {
         let humanInboxIds: [String] = selection.compactMap(\.inboxId)
         let templateIds: [String] = selection.compactMap(\.templateId)
         guard !humanInboxIds.isEmpty || !templateIds.isEmpty else { return }
 
-        for templateId in templateIds {
-            viewModel.requestAgentJoin(templateId: templateId)
+        if !templateIds.isEmpty {
+            viewModel.requestAgentJoins(templateIds: templateIds)
         }
 
         guard !humanInboxIds.isEmpty else { return }

--- a/Convos/Contacts/AgentTemplateContactCardView.swift
+++ b/Convos/Contacts/AgentTemplateContactCardView.swift
@@ -1,5 +1,6 @@
 import ConvosCore
 import SwiftUI
+import UIKit
 
 /// Standalone contact card for a template-backed agent, opened by tapping
 /// an agent row in the contacts list.
@@ -11,6 +12,11 @@ import SwiftUI
 ///
 /// Actions:
 ///   - Share - the iOS share sheet seeded with the template `publishedUrl`.
+///     If the contact does not yet carry a `publishedURL` (builder-flow
+///     templates land on the device without one), the row instead drives a
+///     PATCH /api/v2/agent-templates/:id flipping the template to
+///     `published`, persists the returned URL onto the contact, and
+///     auto-presents the share sheet.
 ///   - Pop up a convo - spawns a fresh instance via a local
 ///     `NewConversationViewModel` presentation, same path the chat-side
 ///     agent card uses (`ContactDetailView.handleChatWithAgentTemplate`).
@@ -26,6 +32,16 @@ struct AgentTemplateContactCardView: View {
     @State private var presentingRemoveConfirmation: Bool = false
     @State private var isRemoving: Bool = false
     @State private var presentingNewConvo: NewConversationViewModel?
+
+    // Share / publish state. `resolvedShareURL` is seeded from the contact's
+    // published URL on appear and updated locally after a successful publish
+    // so the row flips from publish-and-share to plain share without
+    // waiting for the next contact sync.
+    @State private var resolvedShareURL: URL?
+    @State private var isPublishing: Bool = false
+    @State private var isShareSheetPresented: Bool = false
+    @State private var publishErrorMessage: String?
+
     @Environment(\.dismiss) private var dismiss: DismissAction
 
     init(
@@ -41,16 +57,28 @@ struct AgentTemplateContactCardView: View {
     }
 
     var body: some View {
+        let isPublishErrorPresented: Binding<Bool> = Binding(
+            get: { publishErrorMessage != nil },
+            set: { newValue in
+                if !newValue { publishErrorMessage = nil }
+            }
+        )
         bodyContent
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .background(.colorBackgroundRaisedSecondary)
             .navigationTitle("")
             .navigationBarTitleDisplayMode(.inline)
+            .onAppear(perform: seedShareURLIfNeeded)
             .alert(removeAlertTitle, isPresented: $presentingRemoveConfirmation) {
                 Button("Cancel", role: .cancel) {}
                 Button("Remove", role: .destructive, action: handleRemoveConfirmed)
             } message: {
                 Text(removeAlertMessage)
+            }
+            .alert("Couldn't share", isPresented: isPublishErrorPresented) {
+                Button("OK", role: .cancel) {}
+            } message: {
+                Text(publishErrorMessage ?? "")
             }
             .sheet(item: $presentingNewConvo) { vm in
                 NewConversationView(
@@ -59,6 +87,17 @@ struct AgentTemplateContactCardView: View {
                 )
                 .background(.colorBackgroundSurfaceless)
             }
+            .background(shareSheetPresenter)
+    }
+
+    @ViewBuilder
+    private var shareSheetPresenter: some View {
+        if let url = resolvedShareURL {
+            ShareSheetPresenter(
+                activityItems: [url],
+                isPresented: $isShareSheetPresented
+            )
+        }
     }
 
     @ViewBuilder
@@ -98,12 +137,7 @@ struct AgentTemplateContactCardView: View {
     @ViewBuilder
     private var actions: some View {
         VStack(spacing: DesignConstants.Spacing.step4x) {
-            if let shareURL {
-                ContactDetailShareRow(
-                    url: shareURL,
-                    contactDisplayName: agentTemplateContact.resolvedDisplayName
-                )
-            }
+            shareRow
             ContactDetailActionRow(
                 label: "Pop up a convo",
                 footer: "Start a new convo with \(agentTemplateContact.resolvedDisplayName)",
@@ -127,8 +161,36 @@ struct AgentTemplateContactCardView: View {
         .padding(.top, DesignConstants.Spacing.step4x)
     }
 
-    private var shareURL: URL? {
-        agentTemplateContact.publishedURL.flatMap { URL(string: $0) }
+    @ViewBuilder
+    private var shareRow: some View {
+        if let url = resolvedShareURL {
+            ContactDetailShareRow(
+                url: url,
+                contactDisplayName: agentTemplateContact.resolvedDisplayName
+            )
+        } else {
+            // Two-state share button: the "Share" label stays the same so a
+            // user who has seen the published-state row recognises this row
+            // as the share affordance. The footer carries the differentiator
+            // - it hints at the publish step (which needs network), so a
+            // user on a flaky connection sees the cause if it fails.
+            let publishLabel: String = isPublishing ? "Sharing..." : "Share"
+            let publishFooter: String = "Publish to share a link adding \(agentTemplateContact.resolvedDisplayName) to a convo"
+            ContactDetailActionRow(
+                label: publishLabel,
+                footer: publishFooter,
+                color: .colorTextPrimary,
+                isDisabled: isPublishing || session == nil,
+                accessibilityLabel: "Publish and share \(agentTemplateContact.resolvedDisplayName)",
+                accessibilityIdentifier: "agent-template-card-publish-share",
+                action: handlePublishAndShare
+            )
+        }
+    }
+
+    private func seedShareURLIfNeeded() {
+        guard resolvedShareURL == nil else { return }
+        resolvedShareURL = agentTemplateContact.publishedURL.flatMap { URL(string: $0) }
     }
 
     private var removeAlertTitle: String {
@@ -152,6 +214,53 @@ struct AgentTemplateContactCardView: View {
         )
     }
 
+    private func handlePublishAndShare() {
+        guard !isPublishing, let session else { return }
+        let templateId = agentTemplateContact.templateId
+        isPublishing = true
+        Task { @MainActor in
+            defer { isPublishing = false }
+            do {
+                let template = try await session.publishAgentTemplate(id: templateId)
+                guard let urlString = template.publishedUrl,
+                      let url = URL(string: urlString) else {
+                    Log.error("publishAgentTemplate returned no publishedUrl for templateId=\(templateId), status=\(template.status), urlString=\(template.publishedUrl ?? "<nil>")")
+                    publishErrorMessage = "Couldn't share right now, try again."
+                    return
+                }
+                await persistPublishedURL(urlString)
+                resolvedShareURL = url
+                isShareSheetPresented = true
+            } catch {
+                Log.error("publishAgentTemplate failed for templateId=\(templateId): \(String(describing: error))")
+                publishErrorMessage = "Couldn't share right now, try again."
+            }
+        }
+    }
+
+    private func persistPublishedURL(_ urlString: String) async {
+        let snapshot = AgentTemplateContactSnapshot(
+            displayName: agentTemplateContact.displayName,
+            emoji: agentTemplateContact.emoji,
+            descriptionText: agentTemplateContact.descriptionText,
+            publishedURL: urlString,
+            avatarURL: agentTemplateContact.avatarURL,
+            agentVerification: agentTemplateContact.agentVerification,
+            profileUpdatedAt: Date()
+        )
+        do {
+            try await agentTemplateContactsWriter.upsert(
+                templateId: agentTemplateContact.templateId,
+                addedViaConversationId: agentTemplateContact.addedViaConversationId,
+                profile: snapshot
+            )
+        } catch {
+            // Persistence is a UX optimization; the in-memory
+            // `resolvedShareURL` still drives the rest of this session.
+            Log.error("Failed to persist publishedURL for templateId=\(agentTemplateContact.templateId): \(error.localizedDescription)")
+        }
+    }
+
     private func handleRemoveTap() {
         presentingRemoveConfirmation = true
     }
@@ -172,7 +281,46 @@ struct AgentTemplateContactCardView: View {
     }
 }
 
-#Preview("Agent template card") {
+/// Thin UIActivityViewController wrapper for presenting the system share
+/// sheet imperatively after the publish API call returns. Mirrors the
+/// `ShareSheetPresenter` in `ConversationShareView.swift`; kept file-local
+/// here so the agent-template card doesn't depend on the conversation
+/// share overlay's other state.
+private struct ShareSheetPresenter: UIViewControllerRepresentable {
+    let activityItems: [Any]
+    @Binding var isPresented: Bool
+
+    func makeUIViewController(context: Context) -> UIViewController {
+        UIViewController()
+    }
+
+    func updateUIViewController(_ uiViewController: UIViewController, context: Context) {
+        guard isPresented, uiViewController.presentedViewController == nil else { return }
+        let activityVC = UIActivityViewController(
+            activityItems: activityItems,
+            applicationActivities: nil
+        )
+
+        if let popover = activityVC.popoverPresentationController {
+            popover.sourceView = uiViewController.view
+            popover.sourceRect = CGRect(
+                x: uiViewController.view.bounds.midX,
+                y: uiViewController.view.bounds.maxY,
+                width: 0,
+                height: 0
+            )
+            popover.permittedArrowDirections = .up
+        }
+
+        activityVC.completionWithItemsHandler = { _, _, _, _ in
+            isPresented = false
+        }
+
+        uiViewController.present(activityVC, animated: true)
+    }
+}
+
+#Preview("Agent template card - published") {
     NavigationStack {
         AgentTemplateContactCardView(
             agentTemplateContact: .mock(
@@ -180,6 +328,20 @@ struct AgentTemplateContactCardView: View {
                 emoji: "🚴",
                 descriptionText: "Pro cycling expert and race-day strategist.",
                 publishedURL: "https://agents-dev.convos.org/tifoso.pnw1o"
+            ),
+            agentTemplateContactsWriter: MockAgentTemplateContactsWriter()
+        )
+    }
+}
+
+#Preview("Agent template card - unpublished") {
+    NavigationStack {
+        AgentTemplateContactCardView(
+            agentTemplateContact: .mock(
+                displayName: "Tifoso",
+                emoji: "🚴",
+                descriptionText: "Pro cycling expert and race-day strategist.",
+                publishedURL: nil
             ),
             agentTemplateContactsWriter: MockAgentTemplateContactsWriter()
         )

--- a/Convos/Contacts/AgentTemplateContactCardView.swift
+++ b/Convos/Contacts/AgentTemplateContactCardView.swift
@@ -4,33 +4,40 @@ import SwiftUI
 /// Standalone contact card for a template-backed agent, opened by tapping
 /// an agent row in the contacts list.
 ///
-/// A deliberate sibling of `ContactCardView` (which is built around the
+/// A deliberate sibling of `ContactDetailView` (which is built around the
 /// human `Contact` type) rather than a generalization of it - the two
-/// share the `ContactCardActionRow` / `ContactCardShareRow` building
+/// share the `ContactDetailActionRow` / `ContactDetailShareRow` building
 /// blocks but keep their type models separate.
 ///
 /// Actions:
 ///   - Share - the iOS share sheet seeded with the template `publishedUrl`.
-///   - Pop up a convo - spawns a fresh instance by posting
-///     `.contactsRequestedAgentTemplateConversation`, the same spawn-and-join
-///     path the `convos://template/<id>` deeplink and the chat-side card use.
+///   - Pop up a convo - spawns a fresh instance via a local
+///     `NewConversationViewModel` presentation, same path the chat-side
+///     agent card uses (`ContactDetailView.handleChatWithAgentTemplate`).
 ///   - Remove - deletes the local agent-template contact row. If a shared
 ///     conversation still contains an instance, the next membership sync
-///     re-adds it (the eventual-consistency story from the agent-templates PRD).
+///     re-adds it (the eventual-consistency story from the PRD).
 struct AgentTemplateContactCardView: View {
     let agentTemplateContact: AgentTemplateContact
     private let agentTemplateContactsWriter: any AgentTemplateContactsWriterProtocol
+    private let session: (any SessionManagerProtocol)?
+    private let profileSettingsViewModel: ProfileSettingsViewModel
 
     @State private var presentingRemoveConfirmation: Bool = false
     @State private var isRemoving: Bool = false
+    @State private var presentingNewConvo: NewConversationViewModel?
     @Environment(\.dismiss) private var dismiss: DismissAction
 
     init(
         agentTemplateContact: AgentTemplateContact,
-        agentTemplateContactsWriter: any AgentTemplateContactsWriterProtocol
+        agentTemplateContactsWriter: any AgentTemplateContactsWriterProtocol,
+        session: (any SessionManagerProtocol)? = nil,
+        profileSettingsViewModel: ProfileSettingsViewModel = .shared
     ) {
         self.agentTemplateContact = agentTemplateContact
         self.agentTemplateContactsWriter = agentTemplateContactsWriter
+        self.session = session
+        self.profileSettingsViewModel = profileSettingsViewModel
     }
 
     var body: some View {
@@ -44,6 +51,13 @@ struct AgentTemplateContactCardView: View {
                 Button("Remove", role: .destructive, action: handleRemoveConfirmed)
             } message: {
                 Text(removeAlertMessage)
+            }
+            .sheet(item: $presentingNewConvo) { vm in
+                NewConversationView(
+                    viewModel: vm,
+                    profileSettingsViewModel: profileSettingsViewModel
+                )
+                .background(.colorBackgroundSurfaceless)
             }
     }
 
@@ -85,21 +99,21 @@ struct AgentTemplateContactCardView: View {
     private var actions: some View {
         VStack(spacing: DesignConstants.Spacing.step4x) {
             if let shareURL {
-                ContactCardShareRow(
+                ContactDetailShareRow(
                     url: shareURL,
                     contactDisplayName: agentTemplateContact.resolvedDisplayName
                 )
             }
-            ContactCardActionRow(
+            ContactDetailActionRow(
                 label: "Pop up a convo",
                 footer: "Start a new convo with \(agentTemplateContact.resolvedDisplayName)",
                 color: .colorTextPrimary,
-                isDisabled: false,
+                isDisabled: session == nil,
                 accessibilityLabel: "Pop up a convo with \(agentTemplateContact.resolvedDisplayName)",
                 accessibilityIdentifier: "agent-template-card-chat",
                 action: handleChat
             )
-            ContactCardActionRow(
+            ContactDetailActionRow(
                 label: "Remove",
                 footer: "Remove \(agentTemplateContact.resolvedDisplayName) from your contacts",
                 color: .colorCaution,
@@ -125,11 +139,16 @@ struct AgentTemplateContactCardView: View {
         "This removes the agent from your contacts. It re-appears if you're still in a conversation that has it."
     }
 
+    /// Spawns a fresh instance of this template into a new conversation by
+    /// presenting a `NewConversationViewModel` locally. The model's
+    /// `.newConversationWithTemplate` mode creates the conversation and
+    /// requests the agent join once it reaches `.ready`, the same path the
+    /// chat-side agent card uses.
     private func handleChat() {
-        NotificationCenter.default.post(
-            name: .contactsRequestedAgentTemplateConversation,
-            object: nil,
-            userInfo: ["templateId": agentTemplateContact.templateId]
+        guard let session else { return }
+        presentingNewConvo = NewConversationViewModel(
+            session: session,
+            mode: .newConversationWithTemplate(templateId: agentTemplateContact.templateId)
         )
     }
 

--- a/Convos/Contacts/AgentTemplateContactCardView.swift
+++ b/Convos/Contacts/AgentTemplateContactCardView.swift
@@ -1,0 +1,168 @@
+import ConvosCore
+import SwiftUI
+
+/// Standalone contact card for a template-backed agent, opened by tapping
+/// an agent row in the contacts list.
+///
+/// A deliberate sibling of `ContactCardView` (which is built around the
+/// human `Contact` type) rather than a generalization of it - the two
+/// share the `ContactCardActionRow` / `ContactCardShareRow` building
+/// blocks but keep their type models separate.
+///
+/// Actions:
+///   - Share - the iOS share sheet seeded with the template `publishedUrl`.
+///   - Pop up a convo - spawns a fresh instance by posting
+///     `.contactsRequestedAgentTemplateConversation`, the same spawn-and-join
+///     path the `convos://template/<id>` deeplink and the chat-side card use.
+///   - Remove - deletes the local agent-template contact row. If a shared
+///     conversation still contains an instance, the next membership sync
+///     re-adds it (the eventual-consistency story from the agent-templates PRD).
+struct AgentTemplateContactCardView: View {
+    let agentTemplateContact: AgentTemplateContact
+    private let agentTemplateContactsWriter: any AgentTemplateContactsWriterProtocol
+
+    @State private var presentingRemoveConfirmation: Bool = false
+    @State private var isRemoving: Bool = false
+    @Environment(\.dismiss) private var dismiss: DismissAction
+
+    init(
+        agentTemplateContact: AgentTemplateContact,
+        agentTemplateContactsWriter: any AgentTemplateContactsWriterProtocol
+    ) {
+        self.agentTemplateContact = agentTemplateContact
+        self.agentTemplateContactsWriter = agentTemplateContactsWriter
+    }
+
+    var body: some View {
+        bodyContent
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(.colorBackgroundRaisedSecondary)
+            .navigationTitle("")
+            .navigationBarTitleDisplayMode(.inline)
+            .alert(removeAlertTitle, isPresented: $presentingRemoveConfirmation) {
+                Button("Cancel", role: .cancel) {}
+                Button("Remove", role: .destructive, action: handleRemoveConfirmed)
+            } message: {
+                Text(removeAlertMessage)
+            }
+    }
+
+    @ViewBuilder
+    private var bodyContent: some View {
+        VStack(spacing: DesignConstants.Spacing.step3x) {
+            header
+            actions
+            Spacer()
+        }
+    }
+
+    private var header: some View {
+        VStack(spacing: DesignConstants.Spacing.step2x) {
+            AgentTemplateAvatarView(
+                agentTemplateContact: agentTemplateContact,
+                emojiPointSize: 64.0
+            )
+            .frame(width: 140.0, height: 140.0)
+            .padding(.top, DesignConstants.Spacing.step6x)
+
+            Text(agentTemplateContact.resolvedDisplayName)
+                .font(.largeTitle.weight(.bold))
+                .foregroundStyle(.colorTextPrimary)
+
+            AgentBadge()
+
+            if let description = agentTemplateContact.descriptionText, !description.isEmpty {
+                Text(description)
+                    .font(.subheadline)
+                    .foregroundStyle(.colorTextSecondary)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, DesignConstants.Spacing.step6x)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var actions: some View {
+        VStack(spacing: DesignConstants.Spacing.step4x) {
+            if let shareURL {
+                ContactCardShareRow(
+                    url: shareURL,
+                    contactDisplayName: agentTemplateContact.resolvedDisplayName
+                )
+            }
+            ContactCardActionRow(
+                label: "Pop up a convo",
+                footer: "Start a new convo with \(agentTemplateContact.resolvedDisplayName)",
+                color: .colorTextPrimary,
+                isDisabled: false,
+                accessibilityLabel: "Pop up a convo with \(agentTemplateContact.resolvedDisplayName)",
+                accessibilityIdentifier: "agent-template-card-chat",
+                action: handleChat
+            )
+            ContactCardActionRow(
+                label: "Remove",
+                footer: "Remove \(agentTemplateContact.resolvedDisplayName) from your contacts",
+                color: .colorCaution,
+                isDisabled: isRemoving,
+                accessibilityLabel: "Remove \(agentTemplateContact.resolvedDisplayName)",
+                accessibilityIdentifier: "agent-template-card-remove",
+                action: handleRemoveTap
+            )
+        }
+        .padding(.horizontal, DesignConstants.Spacing.step4x)
+        .padding(.top, DesignConstants.Spacing.step4x)
+    }
+
+    private var shareURL: URL? {
+        agentTemplateContact.publishedURL.flatMap { URL(string: $0) }
+    }
+
+    private var removeAlertTitle: String {
+        "Remove \(agentTemplateContact.resolvedDisplayName)?"
+    }
+
+    private var removeAlertMessage: String {
+        "This removes the agent from your contacts. It re-appears if you're still in a conversation that has it."
+    }
+
+    private func handleChat() {
+        NotificationCenter.default.post(
+            name: .contactsRequestedAgentTemplateConversation,
+            object: nil,
+            userInfo: ["templateId": agentTemplateContact.templateId]
+        )
+    }
+
+    private func handleRemoveTap() {
+        presentingRemoveConfirmation = true
+    }
+
+    private func handleRemoveConfirmed() {
+        guard !isRemoving else { return }
+        isRemoving = true
+        let templateId = agentTemplateContact.templateId
+        Task { @MainActor in
+            defer { isRemoving = false }
+            do {
+                try await agentTemplateContactsWriter.remove(templateId: templateId)
+                dismiss()
+            } catch {
+                Log.error("Failed to remove agent-template contact \(templateId): \(error.localizedDescription)")
+            }
+        }
+    }
+}
+
+#Preview("Agent template card") {
+    NavigationStack {
+        AgentTemplateContactCardView(
+            agentTemplateContact: .mock(
+                displayName: "Tifoso",
+                emoji: "🚴",
+                descriptionText: "Pro cycling expert and race-day strategist.",
+                publishedURL: "https://agents-dev.convos.org/tifoso.pnw1o"
+            ),
+            agentTemplateContactsWriter: MockAgentTemplateContactsWriter()
+        )
+    }
+}

--- a/Convos/Contacts/AgentTemplateContactCardView.swift
+++ b/Convos/Contacts/AgentTemplateContactCardView.swift
@@ -83,7 +83,7 @@ struct AgentTemplateContactCardView: View {
                 .font(.largeTitle.weight(.bold))
                 .foregroundStyle(.colorTextPrimary)
 
-            AgentBadge()
+            RoleLabelPill(label: "Agent")
 
             if let description = agentTemplateContact.descriptionText, !description.isEmpty {
                 Text(description)

--- a/Convos/Contacts/AgentTemplateContactRowView.swift
+++ b/Convos/Contacts/AgentTemplateContactRowView.swift
@@ -19,24 +19,10 @@ struct AgentTemplateContactRowView: View {
 
             Spacer()
 
-            AgentBadge()
+            RoleLabelPill(label: "Agent")
         }
         .padding(.vertical, 2.0)
         .accessibilityIdentifier("agent-template-row-\(agentTemplateContact.templateId)")
-    }
-}
-
-/// The "Agent" capsule tag shared by the agent-template list row and the
-/// standalone agent-template contact card. Matches the verified-agent
-/// role-label capsule styling `ContactRowView` already uses.
-struct AgentBadge: View {
-    var body: some View {
-        Text("Agent")
-            .font(.footnote)
-            .foregroundStyle(.colorTextSecondary)
-            .padding(.horizontal, DesignConstants.Spacing.step2x)
-            .padding(.vertical, DesignConstants.Spacing.stepX)
-            .background(.colorTextSecondary.opacity(0.1), in: .capsule)
     }
 }
 

--- a/Convos/Contacts/AgentTemplateContactRowView.swift
+++ b/Convos/Contacts/AgentTemplateContactRowView.swift
@@ -1,0 +1,85 @@
+import ConvosCore
+import SwiftUI
+
+/// Compact row for an agent-template contact in the alphabetical contacts
+/// list. Mirrors `ContactRowView`'s layout - avatar, name - and tags the
+/// row with an Agent badge so it reads distinctly from a human row.
+struct AgentTemplateContactRowView: View {
+    let agentTemplateContact: AgentTemplateContact
+
+    var body: some View {
+        HStack(spacing: DesignConstants.Spacing.step2x) {
+            AgentTemplateAvatarView(agentTemplateContact: agentTemplateContact)
+                .frame(width: 32, height: 32)
+
+            Text(agentTemplateContact.resolvedDisplayName)
+                .font(.body)
+                .foregroundStyle(.colorTextPrimary)
+                .lineLimit(1)
+
+            Spacer()
+
+            AgentBadge()
+        }
+        .padding(.vertical, 2.0)
+        .accessibilityIdentifier("agent-template-row-\(agentTemplateContact.templateId)")
+    }
+}
+
+/// The "Agent" capsule tag shared by the agent-template list row and the
+/// standalone agent-template contact card. Matches the verified-agent
+/// role-label capsule styling `ContactRowView` already uses.
+struct AgentBadge: View {
+    var body: some View {
+        Text("Agent")
+            .font(.footnote)
+            .foregroundStyle(.colorTextSecondary)
+            .padding(.horizontal, DesignConstants.Spacing.step2x)
+            .padding(.vertical, DesignConstants.Spacing.stepX)
+            .background(.colorTextSecondary.opacity(0.1), in: .capsule)
+    }
+}
+
+/// Avatar for an agent-template contact: the template emoji centered in a
+/// neutral circle. The emoji is the template's stable visual identity - a
+/// running instance's avatar is encrypted per-conversation and not
+/// available to a non-scoped browse row. Falls back to a name monogram
+/// when no emoji has been observed. `emojiPointSize` lets the caller scale
+/// from the 32pt list row up to the 140pt card header.
+struct AgentTemplateAvatarView: View {
+    let agentTemplateContact: AgentTemplateContact
+    var emojiPointSize: CGFloat = 18.0
+
+    var body: some View {
+        Circle()
+            .fill(.colorFillMinimal)
+            .overlay {
+                Text(symbol)
+                    .font(.system(size: emojiPointSize))
+            }
+    }
+
+    private var symbol: String {
+        if let emoji = agentTemplateContact.emoji, !emoji.isEmpty {
+            return emoji
+        }
+        let trimmed = agentTemplateContact.resolvedDisplayName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let first = trimmed.first else { return "🤖" }
+        return String(first).uppercased()
+    }
+}
+
+#Preview {
+    VStack(alignment: .leading) {
+        AgentTemplateContactRowView(
+            agentTemplateContact: .mock(displayName: "Tifoso", emoji: "🚴")
+        )
+        AgentTemplateContactRowView(
+            agentTemplateContact: .mock(displayName: "Trip Planner", emoji: "🗺️")
+        )
+        AgentTemplateContactRowView(
+            agentTemplateContact: .mock(displayName: nil, emoji: nil)
+        )
+    }
+    .padding()
+}

--- a/Convos/Contacts/ContactDetailView.swift
+++ b/Convos/Contacts/ContactDetailView.swift
@@ -1,5 +1,6 @@
 import ConvosCore
 import SwiftUI
+import UIKit
 
 // MARK: - Module overview
 //
@@ -62,6 +63,16 @@ struct ContactDetailView: View {
     @State private var sendMessageErrorMessage: String?
     @State private var presentingNewConvo: NewConversationViewModel?
 
+    // Agent-template share / publish state. `resolvedAgentTemplateShareURL`
+    // is seeded from `contact.agentTemplatePublishedURL` on appear and
+    // updated locally after a successful publish so the row flips from
+    // publish-and-share to plain share without waiting for the next
+    // contact-profile sync.
+    @State private var resolvedAgentTemplateShareURL: URL?
+    @State private var isPublishingAgentTemplate: Bool = false
+    @State private var isAgentTemplateShareSheetPresented: Bool = false
+    @State private var publishAgentTemplateErrorMessage: String?
+
     init(
         contact: Contact,
         mode: ContactDetailMode = .standalone,
@@ -103,6 +114,12 @@ struct ContactDetailView: View {
                 blockAlertActions: { blockAlertActions },
                 pickerSheet: { pickerSheet }
             ))
+            .modifier(ContactDetailShareModifier(
+                shareURL: resolvedAgentTemplateShareURL,
+                isShareSheetPresented: $isAgentTemplateShareSheetPresented,
+                publishErrorMessage: $publishAgentTemplateErrorMessage,
+                onAppearSeed: seedAgentTemplateShareURLIfNeeded
+            ))
             .sheet(item: $presentingNewConvo) { vm in
                 NewConversationView(
                     viewModel: vm,
@@ -111,6 +128,46 @@ struct ContactDetailView: View {
                 .background(.colorBackgroundSurfaceless)
             }
             .task(id: contact.inboxId) { await syncBlockedState() }
+    }
+
+    /// Seeds the in-memory share URL from the freshest source available.
+    /// Order:
+    ///   1. `contact.agentTemplatePublishedURL` - overlaid from the
+    ///      per-conversation member profile by `Contact.resolved(...)`. The
+    ///      authoritative source, but lags until the agent broadcasts its
+    ///      updated profile and the local membership sync runs.
+    ///   2. The cached `DBAgentTemplateContact.publishedURL` row, written
+    ///      by any prior publish-on-share flow (this view's own previous
+    ///      invocation or the standalone agent-template contact card).
+    ///      Lets the share row skip the POST until the member profile
+    ///      catches up.
+    /// If both miss, the share row stays in publish-and-share mode and the
+    /// next tap drives the POST.
+    private func seedAgentTemplateShareURLIfNeeded() {
+        guard resolvedAgentTemplateShareURL == nil else { return }
+
+        if let urlString = contact.agentTemplatePublishedURL,
+           let url = URL(string: urlString) {
+            resolvedAgentTemplateShareURL = url
+            return
+        }
+
+        guard let templateId = contact.agentTemplateId,
+              !templateId.isEmpty,
+              let session else {
+            return
+        }
+        do {
+            let cached = try session.messagingService()
+                .agentTemplateContactsRepository()
+                .fetchContact(templateId: templateId)
+            if let cachedURLString = cached?.publishedURL,
+               let url = URL(string: cachedURLString) {
+                resolvedAgentTemplateShareURL = url
+            }
+        } catch {
+            Log.error("Failed to read agent-template contact cache for templateId=\(templateId): \(String(describing: error))")
+        }
     }
 
     @ToolbarContentBuilder
@@ -166,11 +223,15 @@ struct ContactDetailView: View {
                     showBlock: !mode.isCurrentUser,
                     contactDisplayName: contact.resolvedDisplayName,
                     agentTemplateShareURL: agentTemplateShareURL,
+                    agentTemplateId: contact.agentTemplateId,
+                    isPublishingAgentTemplate: isPublishingAgentTemplate,
+                    canPublishAgentTemplate: session != nil,
                     agentInstanceId: contact.agentInstanceId,
                     showsInstanceIdRow: showsInstanceIdRow,
                     agentAttestation: contact.agentAttestation,
                     agentVerification: contact.agentVerification,
                     onSendMessage: isAgentTemplate ? handleChatWithAgentTemplate : handleSendMessage,
+                    onPublishAndShareAgentTemplate: handlePublishAndShareAgentTemplate,
                     onRemove: handleRemoveTap,
                     onToggleBlock: handleBlockTap
                 )
@@ -200,10 +261,14 @@ struct ContactDetailView: View {
     }
 
     /// The template share link for a template-backed agent, ready for the
-    /// Share row's `ShareLink`. `nil` for human contacts and for agents
-    /// without a published template, which hides the row.
+    /// Share row's `ShareLink`. Driven by `resolvedAgentTemplateShareURL`
+    /// (seeded from `contact.agentTemplatePublishedURL` on appear) so a
+    /// successful publish-on-tap flow flips the row in place. `nil` for
+    /// human contacts and for agent templates that have not been published
+    /// yet (in that case the share row falls back to a publish-and-share
+    /// action driven by `agentTemplateId`).
     private var agentTemplateShareURL: URL? {
-        contact.agentTemplatePublishedURL.flatMap { URL(string: $0) }
+        resolvedAgentTemplateShareURL
     }
 
     /// True on Dev/Local builds. Controls visibility of the instance id
@@ -437,6 +502,69 @@ struct ContactDetailView: View {
         )
     }
 
+    /// Tap handler for the publish-and-share row that fires when the
+    /// template-backed agent does not yet carry a `publishedUrl`. Calls
+    /// PATCH /api/v2/agent-templates/:id to flip the status to
+    /// `published`, then presents the system share sheet with the returned
+    /// URL. The URL is also persisted via the messaging service's
+    /// agent-template writer when one is reachable so a subsequent visit
+    /// (or the standalone agent-template contact card) gets the cached
+    /// `ContactDetailShareRow` path. Persistence failures are logged but
+    /// non-fatal - the in-memory `resolvedAgentTemplateShareURL` still
+    /// drives the share sheet.
+    private func handlePublishAndShareAgentTemplate() {
+        guard !isPublishingAgentTemplate,
+              let session,
+              let templateId = contact.agentTemplateId else {
+            return
+        }
+        isPublishingAgentTemplate = true
+        Task { @MainActor in
+            defer { isPublishingAgentTemplate = false }
+            do {
+                let template = try await session.publishAgentTemplate(id: templateId)
+                guard let urlString = template.publishedUrl,
+                      let url = URL(string: urlString) else {
+                    Log.error("publishAgentTemplate returned no publishedUrl for templateId=\(templateId), status=\(template.status), urlString=\(template.publishedUrl ?? "<nil>")")
+                    publishAgentTemplateErrorMessage = "Couldn't share right now, try again."
+                    return
+                }
+                await persistAgentTemplatePublishedURL(urlString, templateId: templateId, session: session)
+                resolvedAgentTemplateShareURL = url
+                isAgentTemplateShareSheetPresented = true
+            } catch {
+                Log.error("publishAgentTemplate failed for templateId=\(templateId): \(String(describing: error))")
+                publishAgentTemplateErrorMessage = "Couldn't share right now, try again."
+            }
+        }
+    }
+
+    private func persistAgentTemplatePublishedURL(
+        _ urlString: String,
+        templateId: String,
+        session: any SessionManagerProtocol
+    ) async {
+        let writer = session.messagingService().agentTemplateContactsWriter()
+        let snapshot = AgentTemplateContactSnapshot(
+            displayName: contact.displayName,
+            emoji: nil,
+            descriptionText: nil,
+            publishedURL: urlString,
+            avatarURL: contact.avatarURL,
+            agentVerification: contact.agentVerification,
+            profileUpdatedAt: Date()
+        )
+        do {
+            try await writer.upsert(
+                templateId: templateId,
+                addedViaConversationId: contact.addedViaConversationId ?? mode.conversationId,
+                profile: snapshot
+            )
+        } catch {
+            Log.error("Failed to persist publishedURL for templateId=\(templateId): \(error.localizedDescription)")
+        }
+    }
+
     private func syncBlockedState() async {
         do {
             guard let updated = try contactsRepository.fetchContact(inboxId: contact.inboxId) else {
@@ -532,8 +660,22 @@ private struct ContactDetailActions: View {
     let showRemove: Bool
     let showBlock: Bool
     let contactDisplayName: String
-    /// Non-nil only for template-backed agents; drives the Share row.
+    /// Non-nil when the template-backed agent has a `publishedUrl`. Drives
+    /// the plain `ContactDetailShareRow` (ShareLink) branch of the share
+    /// row. `nil` for human contacts, and for templated agents that
+    /// haven't been published yet (in which case `agentTemplateId` drives
+    /// the publish-and-share branch).
     let agentTemplateShareURL: URL?
+    /// Non-nil for template-backed agents. Enables the publish-and-share
+    /// branch of the share row when the template doesn't yet carry a
+    /// `publishedUrl`. `nil` for human contacts (no share row shown).
+    let agentTemplateId: String?
+    /// In-flight flag for the publish-and-share row. Drives the disabled
+    /// state and the "Sharing..." label while the PATCH is running.
+    let isPublishingAgentTemplate: Bool
+    /// Disables the publish-and-share row when the parent has no session
+    /// (no auth, no api client). Mirrors the existing Chat-row gate.
+    let canPublishAgentTemplate: Bool
     /// Always plumbed through when the contact has one. Display gate
     /// is `showsInstanceIdRow`, not nullability of this field.
     let agentInstanceId: String?
@@ -546,6 +688,7 @@ private struct ContactDetailActions: View {
     /// readout alongside the raw attestation value.
     let agentVerification: AgentVerification?
     let onSendMessage: () -> Void
+    let onPublishAndShareAgentTemplate: () -> Void
     let onRemove: () -> Void
     let onToggleBlock: () -> Void
 
@@ -556,12 +699,7 @@ private struct ContactDetailActions: View {
             if showChat {
                 chatButton
             }
-            if let agentTemplateShareURL {
-                ContactDetailShareRow(
-                    url: agentTemplateShareURL,
-                    contactDisplayName: contactDisplayName
-                )
-            }
+            agentTemplateShareRow
             if showAgentLinks {
                 agentLinkRows
             }
@@ -587,6 +725,42 @@ private struct ContactDetailActions: View {
             #endif
         }
         .padding(.horizontal, DesignConstants.Spacing.step4x)
+    }
+
+    /// Renders the agent-template share row in one of three shapes:
+    ///   - If the template already has a `publishedUrl`, a SwiftUI
+    ///     `ShareLink` (`ContactDetailShareRow`) wired straight to the URL.
+    ///   - If the agent is template-backed but has no published URL yet, a
+    ///     publish-and-share `ContactDetailActionRow` that drives the
+    ///     PATCH-then-share flow in the parent. Shows "Sharing..." while
+    ///     the PATCH is in flight.
+    ///   - Otherwise (human contact, or templated agent with no session
+    ///     access) renders nothing.
+    @ViewBuilder
+    private var agentTemplateShareRow: some View {
+        if let url = agentTemplateShareURL {
+            ContactDetailShareRow(
+                url: url,
+                contactDisplayName: contactDisplayName
+            )
+        } else if let agentTemplateId, !agentTemplateId.isEmpty {
+            // Two-state share button. Label stays "Share" to match the
+            // published-state row's affordance; the footer carries the
+            // differentiator and hints at the publish step (which needs
+            // network), so a user on a flaky connection sees the cause if
+            // it fails.
+            let publishLabel: String = isPublishingAgentTemplate ? "Sharing..." : "Share"
+            let publishFooter: String = "Publish to share a link adding \(contactDisplayName) to a convo"
+            ContactDetailActionRow(
+                label: publishLabel,
+                footer: publishFooter,
+                color: .colorTextPrimary,
+                isDisabled: isPublishingAgentTemplate || !canPublishAgentTemplate,
+                accessibilityLabel: "Publish and share \(contactDisplayName)",
+                accessibilityIdentifier: "contact-detail-publish-share",
+                action: onPublishAndShareAgentTemplate
+            )
+        }
     }
 
     @ViewBuilder
@@ -898,6 +1072,84 @@ private struct ContactDetailModalsModifier<
             .sheet(isPresented: $presentingPicker) {
                 pickerSheet()
             }
+    }
+}
+
+/// Modifier wrapping the agent-template share concerns: the activity-sheet
+/// presenter (driven by `shareURL` + `isShareSheetPresented`) and the
+/// "Couldn't share" alert. Split out from `ContactDetailModalsModifier` so
+/// the share concerns don't leak into the generic Block / Picker /
+/// SendMessage modifier shape.
+private struct ContactDetailShareModifier: ViewModifier {
+    let shareURL: URL?
+    @Binding var isShareSheetPresented: Bool
+    @Binding var publishErrorMessage: String?
+    let onAppearSeed: () -> Void
+
+    func body(content: Content) -> some View {
+        let isErrorPresented: Binding<Bool> = Binding(
+            get: { publishErrorMessage != nil },
+            set: { newValue in
+                if !newValue { publishErrorMessage = nil }
+            }
+        )
+        content
+            .background(shareSheetBackground)
+            .alert("Couldn't share", isPresented: isErrorPresented) {
+                Button("OK", role: .cancel) {}
+            } message: {
+                Text(publishErrorMessage ?? "")
+            }
+            .onAppear(perform: onAppearSeed)
+    }
+
+    @ViewBuilder
+    private var shareSheetBackground: some View {
+        if let shareURL {
+            ShareSheetPresenter(
+                activityItems: [shareURL],
+                isPresented: $isShareSheetPresented
+            )
+        }
+    }
+}
+
+/// Thin UIActivityViewController wrapper for presenting the system share
+/// sheet imperatively after the publish-and-share PATCH returns. Mirrors
+/// the same-named struct in `ConversationShareView.swift` and
+/// `AgentTemplateContactCardView.swift`; kept file-local here so this view
+/// doesn't depend on either of those.
+private struct ShareSheetPresenter: UIViewControllerRepresentable {
+    let activityItems: [Any]
+    @Binding var isPresented: Bool
+
+    func makeUIViewController(context: Context) -> UIViewController {
+        UIViewController()
+    }
+
+    func updateUIViewController(_ uiViewController: UIViewController, context: Context) {
+        guard isPresented, uiViewController.presentedViewController == nil else { return }
+        let activityVC = UIActivityViewController(
+            activityItems: activityItems,
+            applicationActivities: nil
+        )
+
+        if let popover = activityVC.popoverPresentationController {
+            popover.sourceView = uiViewController.view
+            popover.sourceRect = CGRect(
+                x: uiViewController.view.bounds.midX,
+                y: uiViewController.view.bounds.maxY,
+                width: 0,
+                height: 0
+            )
+            popover.permittedArrowDirections = .up
+        }
+
+        activityVC.completionWithItemsHandler = { _, _, _, _ in
+            isPresented = false
+        }
+
+        uiViewController.present(activityVC, animated: true)
     }
 }
 

--- a/Convos/Contacts/ContactDetailView.swift
+++ b/Convos/Contacts/ContactDetailView.swift
@@ -539,29 +539,65 @@ struct ContactDetailView: View {
         }
     }
 
+    /// Caches the freshly-published `publishedUrl` onto the local
+    /// `DBAgentTemplateContact` row so the next visit to this template
+    /// (here or in the standalone agent-template card) seeds the share
+    /// row without re-POSTing.
+    ///
+    /// Two safety properties this method has to preserve:
+    ///
+    /// 1. Do not nil out other profile fields. `Contact` doesn't carry the
+    ///    template's `emoji` or `descriptionText`, and a timestamped
+    ///    `AgentTemplateContactSnapshot` wholesale-replaces every field on
+    ///    the row (see `AgentTemplateContactsWriter.replacingProfile`). A
+    ///    naive `upsert` with `emoji: nil, descriptionText: nil` would
+    ///    wipe values written by the standalone card's prior upsert.
+    ///    Instead, read the existing row and re-pass every field through
+    ///    the snapshot unchanged, only swapping in `publishedURL`.
+    ///
+    /// 2. Do not auto-add a contact. If the agent has no row in
+    ///    `DBAgentTemplateContact`, the user has never opened the
+    ///    standalone agent-template card for this template, so we
+    ///    shouldn't promote them into the user's agent-template contacts
+    ///    as a side effect of tapping Share. Skip the write; the in-memory
+    ///    `resolvedAgentTemplateShareURL` covers this view session, and a
+    ///    future open of the standalone card (which has the full profile
+    ///    to hand) will populate the row properly. Repeat shares from a
+    ///    fresh `ContactDetailView` pay the POST cost again, which is
+    ///    idempotent and cheap.
     private func persistAgentTemplatePublishedURL(
         _ urlString: String,
         templateId: String,
         session: any SessionManagerProtocol
     ) async {
+        let repository = session.messagingService().agentTemplateContactsRepository()
+        let existing: AgentTemplateContact?
+        do {
+            existing = try repository.fetchContact(templateId: templateId)
+        } catch {
+            Log.error("Failed to read existing agent-template contact for templateId=\(templateId): \(String(describing: error))")
+            return
+        }
+        guard let existing else { return }
+
         let writer = session.messagingService().agentTemplateContactsWriter()
         let snapshot = AgentTemplateContactSnapshot(
-            displayName: contact.displayName,
-            emoji: nil,
-            descriptionText: nil,
+            displayName: existing.displayName,
+            emoji: existing.emoji,
+            descriptionText: existing.descriptionText,
             publishedURL: urlString,
-            avatarURL: contact.avatarURL,
-            agentVerification: contact.agentVerification,
+            avatarURL: existing.avatarURL,
+            agentVerification: existing.agentVerification,
             profileUpdatedAt: Date()
         )
         do {
             try await writer.upsert(
                 templateId: templateId,
-                addedViaConversationId: contact.addedViaConversationId ?? mode.conversationId,
+                addedViaConversationId: existing.addedViaConversationId,
                 profile: snapshot
             )
         } catch {
-            Log.error("Failed to persist publishedURL for templateId=\(templateId): \(error.localizedDescription)")
+            Log.error("Failed to persist publishedURL for templateId=\(templateId): \(String(describing: error))")
         }
     }
 

--- a/Convos/Contacts/ContactDetailView.swift
+++ b/Convos/Contacts/ContactDetailView.swift
@@ -215,17 +215,13 @@ struct ContactDetailView: View {
     @ViewBuilder
     private var headerBadge: some View {
         if mode.isCurrentUser {
-            ContactDetailBadge(
-                label: "You",
-                accessibilityIdentifier: "contact-detail-you-badge"
-            )
-            .padding(.top, DesignConstants.Spacing.step2x)
+            RoleLabelPill(label: "You")
+                .accessibilityIdentifier("contact-detail-you-badge")
+                .padding(.top, DesignConstants.Spacing.step2x)
         } else if let roleLabel = contact.agentVerification?.roleLabel {
-            ContactDetailBadge(
-                label: roleLabel,
-                accessibilityIdentifier: "contact-detail-role-label-\(contact.inboxId)"
-            )
-            .padding(.top, DesignConstants.Spacing.step2x)
+            RoleLabelPill(label: roleLabel)
+                .accessibilityIdentifier("contact-detail-role-label-\(contact.inboxId)")
+                .padding(.top, DesignConstants.Spacing.step2x)
         }
     }
 
@@ -462,26 +458,6 @@ private struct ContactDetailHeader: View {
                 .font(.largeTitle.weight(.bold))
                 .foregroundStyle(.colorTextPrimary)
         }
-    }
-}
-
-/// Small capsule pill rendered below the subtitle. Used for the
-/// verified-agent role label ("Agent", "Verified by ...") and for
-/// the "You" indicator on the current user's own card - same shape so
-/// the spacing around the pill mirrors the surrounding label spacing
-/// regardless of which one is showing.
-private struct ContactDetailBadge: View {
-    let label: String
-    let accessibilityIdentifier: String
-
-    var body: some View {
-        Text(label)
-            .font(.footnote)
-            .foregroundStyle(.colorTextSecondary)
-            .padding(.horizontal, DesignConstants.Spacing.step2x)
-            .padding(.vertical, DesignConstants.Spacing.stepX)
-            .background(.colorTextSecondary.opacity(0.1), in: .capsule)
-            .accessibilityIdentifier(accessibilityIdentifier)
     }
 }
 

--- a/Convos/Contacts/ContactDetailView.swift
+++ b/Convos/Contacts/ContactDetailView.swift
@@ -410,11 +410,16 @@ struct ContactDetailView: View {
     /// `ContactsView.handlePickerConfirm` and the invite-cell-tap pattern
     /// where the new-convo sheet is owned by the same view that hosted
     /// the picker.
-    private func handlePickerConfirm(_ inboxIds: Set<String>) {
-        guard !inboxIds.isEmpty, let session else { return }
+    private func handlePickerConfirm(_ selection: Set<ContactsPickerViewModel.Selection>) {
+        guard !selection.isEmpty, let session else { return }
+        let inboxIds: [String] = selection.compactMap(\.inboxId)
+        let templateIds: [String] = selection.compactMap(\.templateId)
         presentingNewConvo = NewConversationViewModel(
             session: session,
-            mode: .newConversationWithMembers(initialMemberInboxIds: Array(inboxIds))
+            mode: .newConversationWithMembers(
+                initialMemberInboxIds: inboxIds,
+                initialAgentTemplateIds: templateIds
+            )
         )
     }
 
@@ -679,7 +684,7 @@ private struct ContactDetailActions: View {
 /// rounded white pill on top with a small grey footer caption below - is
 /// the canonical card action style. The label color is the only knob: dark
 /// primary for affirmative actions, caution red for destructive.
-private struct ContactDetailActionRow: View {
+struct ContactDetailActionRow: View {
     let label: String
     let footer: String
     let color: Color
@@ -718,7 +723,7 @@ private struct ContactDetailActionRow: View {
 /// the system share sheet) rather than a plain action button, since the
 /// share intent is fully handled by the system. Rendered only when the
 /// agent carries a template `publishedUrl`.
-private struct ContactDetailShareRow: View {
+struct ContactDetailShareRow: View {
     let url: URL
     let contactDisplayName: String
 

--- a/Convos/Contacts/ContactDetailView.swift
+++ b/Convos/Contacts/ContactDetailView.swift
@@ -48,6 +48,7 @@ struct ContactDetailView: View {
     let showsCloseButton: Bool
     private let contactsWriter: any ContactsWriterProtocol
     private let contactsRepository: any ContactsRepositoryProtocol
+    private let agentTemplateContactsRepository: any AgentTemplateContactsRepositoryProtocol
     private let session: (any SessionManagerProtocol)?
     private let profileSettingsViewModel: ProfileSettingsViewModel
     private let onRemove: (() -> Void)?
@@ -66,6 +67,8 @@ struct ContactDetailView: View {
         mode: ContactDetailMode = .standalone,
         contactsWriter: any ContactsWriterProtocol,
         contactsRepository: any ContactsRepositoryProtocol,
+        agentTemplateContactsRepository: any AgentTemplateContactsRepositoryProtocol
+            = MockAgentTemplateContactsRepository(contacts: []),
         session: (any SessionManagerProtocol)? = nil,
         profileSettingsViewModel: ProfileSettingsViewModel = .shared,
         showsCloseButton: Bool = true,
@@ -75,6 +78,7 @@ struct ContactDetailView: View {
         self.mode = mode
         self.contactsWriter = contactsWriter
         self.contactsRepository = contactsRepository
+        self.agentTemplateContactsRepository = agentTemplateContactsRepository
         self.session = session
         self.profileSettingsViewModel = profileSettingsViewModel
         self.showsCloseButton = showsCloseButton
@@ -232,6 +236,7 @@ struct ContactDetailView: View {
         ContactsPickerView(
             mode: .newConversation,
             contactsRepository: contactsRepository,
+            agentTemplateContactsRepository: agentTemplateContactsRepository,
             preselectedInboxIds: [contact.inboxId],
             onConfirm: handlePickerConfirm
         )

--- a/Convos/Contacts/ContactsPickerRow.swift
+++ b/Convos/Contacts/ContactsPickerRow.swift
@@ -3,6 +3,8 @@ import SwiftUI
 
 /// Picker row showing avatar, name, and either a multi-select indicator or
 /// an "in chat" badge for members already in the destination conversation.
+/// Renders both human contacts and agent-template contacts; the kind
+/// discriminator on `Row` decides the avatar and the trailing badge.
 struct ContactsPickerRow: View {
     let row: ContactsPickerViewModel.Row
     let isSelected: Bool
@@ -12,12 +14,20 @@ struct ContactsPickerRow: View {
         let opacity: Double = row.isAlreadyInChat ? 0.45 : 1.0
         Button(action: onTap) {
             HStack(spacing: DesignConstants.Spacing.step3x) {
-                ContactAvatarView(contact: row.contact)
+                avatar
                     .frame(width: 56.0, height: 56.0)
 
-                ContactsPickerRowText(contact: row.contact, subtitle: row.subtitle)
+                ContactsPickerRowText(
+                    displayName: row.resolvedDisplayName,
+                    subtitle: row.subtitle
+                )
 
                 Spacer(minLength: 0.0)
+
+                if case .agentTemplate = row.kind {
+                    AgentBadge()
+                        .padding(.trailing, DesignConstants.Spacing.step2x)
+                }
 
                 ContactsPickerRowAccessory(
                     isAlreadyInChat: row.isAlreadyInChat,
@@ -30,19 +40,29 @@ struct ContactsPickerRow: View {
         .buttonStyle(.plain)
         .opacity(opacity)
         .disabled(row.isAlreadyInChat)
-        .accessibilityIdentifier("contacts-picker-row-\(row.contact.inboxId)")
+        .accessibilityIdentifier("contacts-picker-row-\(row.id)")
+    }
+
+    @ViewBuilder
+    private var avatar: some View {
+        switch row.kind {
+        case .human(let contact):
+            ContactAvatarView(contact: contact)
+        case .agentTemplate(let agent):
+            AgentTemplateAvatarView(agentTemplateContact: agent, emojiPointSize: 28.0)
+        }
     }
 }
 
 // MARK: - Row text
 
 private struct ContactsPickerRowText: View {
-    let contact: Contact
+    let displayName: String
     let subtitle: String
 
     var body: some View {
         VStack(alignment: .leading, spacing: DesignConstants.Spacing.stepHalf) {
-            Text(contact.resolvedDisplayName)
+            Text(displayName)
                 .font(.body)
                 .foregroundStyle(.colorTextPrimary)
                 .lineLimit(1)
@@ -108,25 +128,66 @@ private struct ContactsPickerRowAccessory: View {
         displayName: "Convo Agent",
         agentVerification: .verified(.convos)
     )
-    return VStack(alignment: .leading, spacing: 12.0) {
+    let tifoso = AgentTemplateContact.mock(displayName: "Tifoso", emoji: "🚴")
+    VStack(alignment: .leading, spacing: 12.0) {
         ContactsPickerRow(
-            row: .init(id: alice.inboxId, contact: alice, isAlreadyInChat: false, subtitle: "Bike Trip 2026"),
+            row: .init(
+                id: "human:\(alice.inboxId)",
+                kind: .human(alice),
+                isAlreadyInChat: false,
+                subtitle: "Bike Trip 2026"
+            ),
             isSelected: false,
             onTap: {}
         )
         ContactsPickerRow(
-            row: .init(id: bob.inboxId, contact: bob, isAlreadyInChat: false, subtitle: "DM"),
+            row: .init(
+                id: "human:\(bob.inboxId)",
+                kind: .human(bob),
+                isAlreadyInChat: false,
+                subtitle: "DM"
+            ),
             isSelected: true,
             onTap: {}
         )
         ContactsPickerRow(
-            row: .init(id: carol.inboxId, contact: carol, isAlreadyInChat: true, subtitle: "Game Night"),
+            row: .init(
+                id: "human:\(carol.inboxId)",
+                kind: .human(carol),
+                isAlreadyInChat: true,
+                subtitle: "Game Night"
+            ),
             isSelected: false,
             onTap: {}
         )
         ContactsPickerRow(
-            row: .init(id: agent.inboxId, contact: agent, isAlreadyInChat: false, subtitle: "Convos Agent"),
+            row: .init(
+                id: "human:\(agent.inboxId)",
+                kind: .human(agent),
+                isAlreadyInChat: false,
+                subtitle: "Convos Agent"
+            ),
             isSelected: false,
+            onTap: {}
+        )
+        ContactsPickerRow(
+            row: .init(
+                id: "agent:\(tifoso.templateId)",
+                kind: .agentTemplate(tifoso),
+                isAlreadyInChat: false,
+                subtitle: "Pro cycling expert"
+            ),
+            isSelected: false,
+            onTap: {}
+        )
+        ContactsPickerRow(
+            row: .init(
+                id: "agent:\(tifoso.templateId)",
+                kind: .agentTemplate(tifoso),
+                isAlreadyInChat: false,
+                subtitle: "Pro cycling expert"
+            ),
+            isSelected: true,
             onTap: {}
         )
     }

--- a/Convos/Contacts/ContactsPickerRow.swift
+++ b/Convos/Contacts/ContactsPickerRow.swift
@@ -25,7 +25,7 @@ struct ContactsPickerRow: View {
                 Spacer(minLength: 0.0)
 
                 if case .agentTemplate = row.kind {
-                    AgentBadge()
+                    RoleLabelPill(label: "Agent")
                         .padding(.trailing, DesignConstants.Spacing.step2x)
                 }
 

--- a/Convos/Contacts/ContactsPickerSelectedPills.swift
+++ b/Convos/Contacts/ContactsPickerSelectedPills.swift
@@ -18,20 +18,34 @@ import SwiftUI
 
 /// Wrapping row of selected-contact pills shown below the picker search bar.
 /// Tapping anywhere on a pill removes the contact from the selection.
+/// Renders human pills and agent-template pills in one flow row; both kinds
+/// share the same capsule shape with the kind-appropriate avatar inside.
 struct ContactsPickerSelectedPills: View {
-    let contacts: [Contact]
-    let onRemove: (String) -> Void
+    let humans: [Contact]
+    let agentTemplates: [AgentTemplateContact]
+    let onRemoveHuman: (String) -> Void
+    let onRemoveAgentTemplate: (String) -> Void
+
+    private var isEmpty: Bool {
+        humans.isEmpty && agentTemplates.isEmpty
+    }
 
     var body: some View {
-        if !contacts.isEmpty {
+        if !isEmpty {
             SelectedPillsFlowLayout(
                 horizontalSpacing: DesignConstants.Spacing.step2x,
                 verticalSpacing: DesignConstants.Spacing.step2x
             ) {
-                ForEach(contacts, id: \.inboxId) { contact in
+                ForEach(humans, id: \.inboxId) { contact in
                     SelectedContactPill(
                         contact: contact,
-                        onRemove: removeAction(for: contact.inboxId)
+                        onRemove: removeHumanAction(for: contact.inboxId)
+                    )
+                }
+                ForEach(agentTemplates, id: \.templateId) { agent in
+                    SelectedAgentTemplatePill(
+                        agentTemplateContact: agent,
+                        onRemove: removeAgentTemplateAction(for: agent.templateId)
                     )
                 }
             }
@@ -41,8 +55,12 @@ struct ContactsPickerSelectedPills: View {
         }
     }
 
-    private func removeAction(for inboxId: String) -> () -> Void {
-        { onRemove(inboxId) }
+    private func removeHumanAction(for inboxId: String) -> () -> Void {
+        { onRemoveHuman(inboxId) }
+    }
+
+    private func removeAgentTemplateAction(for templateId: String) -> () -> Void {
+        { onRemoveAgentTemplate(templateId) }
     }
 }
 
@@ -84,6 +102,55 @@ private struct SelectedContactPill: View {
     /// type sizes; tune `Constant.maxDisplayNameLength` to widen or tighten.
     private var truncatedDisplayName: String {
         let name = contact.resolvedDisplayName
+        let limit = Constant.maxDisplayNameLength
+        guard name.count > limit else { return name }
+        return String(name.prefix(limit - 1)) + "\u{2026}"
+    }
+
+    private enum Constant {
+        static let avatarSize: CGFloat = 24.0
+        static let removeIconOpacity: Double = 0.6
+        static let maxDisplayNameLength: Int = 20
+    }
+}
+
+// MARK: - Agent template pill
+
+private struct SelectedAgentTemplatePill: View {
+    let agentTemplateContact: AgentTemplateContact
+    let onRemove: () -> Void
+
+    var body: some View {
+        Button(action: onRemove) {
+            HStack(spacing: DesignConstants.Spacing.step2x) {
+                AgentTemplateAvatarView(
+                    agentTemplateContact: agentTemplateContact,
+                    emojiPointSize: 14.0
+                )
+                .frame(width: Constant.avatarSize, height: Constant.avatarSize)
+
+                Text(truncatedDisplayName)
+                    .font(.body)
+                    .foregroundStyle(.colorTextPrimaryInverted)
+                    .lineLimit(1)
+
+                Image(systemName: "xmark.circle.fill")
+                    .font(.body)
+                    .foregroundStyle(.colorTextPrimaryInverted.opacity(Constant.removeIconOpacity))
+            }
+            .padding(DesignConstants.Spacing.step3x)
+            .background(
+                Capsule().fill(.colorTextPrimary)
+            )
+            .contentShape(Capsule())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Remove \(agentTemplateContact.resolvedDisplayName)")
+        .accessibilityIdentifier("contacts-picker-agent-pill-\(agentTemplateContact.templateId)")
+    }
+
+    private var truncatedDisplayName: String {
+        let name = agentTemplateContact.resolvedDisplayName
         let limit = Constant.maxDisplayNameLength
         guard name.count > limit else { return name }
         return String(name.prefix(limit - 1)) + "\u{2026}"
@@ -180,11 +247,30 @@ private struct SelectedPillsFlowLayout: Layout {
 
 #Preview("Few pills") {
     ContactsPickerSelectedPills(
-        contacts: [
+        humans: [
             .mock(displayName: "Zed"),
             .mock(displayName: "Andy"),
         ],
-        onRemove: { _ in }
+        agentTemplates: [],
+        onRemoveHuman: { _ in },
+        onRemoveAgentTemplate: { _ in }
+    )
+    .padding()
+    .background(.colorBackgroundRaisedSecondary)
+}
+
+#Preview("Humans + agents") {
+    ContactsPickerSelectedPills(
+        humans: [
+            .mock(displayName: "Alice"),
+            .mock(displayName: "Bob"),
+        ],
+        agentTemplates: [
+            .mock(displayName: "Tifoso", emoji: "🚴"),
+            .mock(displayName: "Trip Planner", emoji: "🗺️"),
+        ],
+        onRemoveHuman: { _ in },
+        onRemoveAgentTemplate: { _ in }
     )
     .padding()
     .background(.colorBackgroundRaisedSecondary)
@@ -192,7 +278,7 @@ private struct SelectedPillsFlowLayout: Layout {
 
 #Preview("Many pills (wrap)") {
     ContactsPickerSelectedPills(
-        contacts: [
+        humans: [
             .mock(displayName: "Alice"),
             .mock(displayName: "Bob"),
             .mock(displayName: "Carol"),
@@ -202,7 +288,9 @@ private struct SelectedPillsFlowLayout: Layout {
             .mock(displayName: "Genevieve"),
             .mock(displayName: "Hieronymus"),
         ],
-        onRemove: { _ in }
+        agentTemplates: [],
+        onRemoveHuman: { _ in },
+        onRemoveAgentTemplate: { _ in }
     )
     .padding()
     .background(.colorBackgroundRaisedSecondary)
@@ -210,8 +298,10 @@ private struct SelectedPillsFlowLayout: Layout {
 
 #Preview("Empty (renders nothing)") {
     ContactsPickerSelectedPills(
-        contacts: [],
-        onRemove: { _ in }
+        humans: [],
+        agentTemplates: [],
+        onRemoveHuman: { _ in },
+        onRemoveAgentTemplate: { _ in }
     )
     .padding()
     .background(.colorBackgroundRaisedSecondary)
@@ -219,12 +309,16 @@ private struct SelectedPillsFlowLayout: Layout {
 
 #Preview("Long names truncate") {
     ContactsPickerSelectedPills(
-        contacts: [
+        humans: [
             .mock(displayName: "Alice"),
             .mock(displayName: "Fitzwilliam-Bartholomew Maximilian Featherington"),
             .mock(displayName: "Rumpelstiltskin"),
         ],
-        onRemove: { _ in }
+        agentTemplates: [
+            .mock(displayName: "Globe-Trotting Adventure Concierge", emoji: "🌍"),
+        ],
+        onRemoveHuman: { _ in },
+        onRemoveAgentTemplate: { _ in }
     )
     .padding()
     .background(.colorBackgroundRaisedSecondary)

--- a/Convos/Contacts/ContactsPickerView.swift
+++ b/Convos/Contacts/ContactsPickerView.swift
@@ -33,7 +33,10 @@ struct ContactsPickerView: View {
     @State private var viewModel: ContactsPickerViewModel
     @Environment(\.dismiss) private var dismiss: DismissAction
 
-    let onConfirm: (_ inboxIds: Set<String>) -> Void
+    /// Confirm callback receives the full heterogeneous selection. Call
+    /// sites split into humans (`.inboxId`) and agent templates
+    /// (`.templateId`) and route each to their dispatch path.
+    let onConfirm: (_ selection: Set<ContactsPickerViewModel.Selection>) -> Void
     /// Optional source conversation that informs the indicator pill's
     /// emoji avatar. For the new-convo flow callers can pass the current
     /// draft so the picker reflects whatever emoji the convo will inherit;
@@ -44,14 +47,17 @@ struct ContactsPickerView: View {
     init(
         mode: ContactsPickerMode,
         contactsRepository: any ContactsRepositoryProtocol,
+        agentTemplateContactsRepository: any AgentTemplateContactsRepositoryProtocol
+            = MockAgentTemplateContactsRepository(contacts: []),
         alreadyInChatInboxIds: Set<String> = [],
         preselectedInboxIds: Set<String> = [],
         pillConversation: Conversation? = nil,
-        onConfirm: @escaping (_ inboxIds: Set<String>) -> Void
+        onConfirm: @escaping (_ selection: Set<ContactsPickerViewModel.Selection>) -> Void
     ) {
         _viewModel = State(initialValue: ContactsPickerViewModel(
             mode: mode,
             contactsRepository: contactsRepository,
+            agentTemplateContactsRepository: agentTemplateContactsRepository,
             alreadyInChatInboxIds: alreadyInChatInboxIds,
             preselectedInboxIds: preselectedInboxIds
         ))
@@ -88,8 +94,10 @@ struct ContactsPickerView: View {
                     accessibilityIdentifier: "contacts-picker-search-field"
                 )
                 ContactsPickerSelectedPills(
-                    contacts: viewModel.selectedContacts,
-                    onRemove: handleRemove
+                    humans: viewModel.selectedContacts,
+                    agentTemplates: viewModel.selectedAgentContacts,
+                    onRemoveHuman: handleRemoveHuman,
+                    onRemoveAgentTemplate: handleRemoveAgentTemplate
                 )
             }
         }
@@ -118,18 +126,22 @@ struct ContactsPickerView: View {
 
     // MARK: - Actions
 
-    private func handleToggle(_ inboxId: String) {
-        viewModel.toggleSelection(for: inboxId)
+    private func handleToggle(_ selection: ContactsPickerViewModel.Selection) {
+        viewModel.toggleSelection(selection)
     }
 
-    private func handleRemove(_ inboxId: String) {
-        viewModel.deselect(inboxId: inboxId)
+    private func handleRemoveHuman(_ inboxId: String) {
+        viewModel.deselect(.human(inboxId: inboxId))
+    }
+
+    private func handleRemoveAgentTemplate(_ templateId: String) {
+        viewModel.deselect(.agentTemplate(templateId: templateId))
     }
 
     private func handleConfirm() {
-        let ids = viewModel.selectedInboxIds
-        guard !ids.isEmpty else { return }
-        onConfirm(ids)
+        let selection = viewModel.selected
+        guard !selection.isEmpty else { return }
+        onConfirm(selection)
         dismiss()
     }
 
@@ -220,7 +232,7 @@ private struct ContactsPickerIndicatorPill: View {
 
 private struct ContactsPickerList: View {
     @Bindable var viewModel: ContactsPickerViewModel
-    let onToggle: (String) -> Void
+    let onToggle: (ContactsPickerViewModel.Selection) -> Void
 
     var body: some View {
         if viewModel.sections.isEmpty {
@@ -237,7 +249,7 @@ private struct ContactsPickerList: View {
                 rowContent: { (row: ContactsPickerViewModel.Row) in
                     ContactsPickerRow(
                         row: row,
-                        isSelected: viewModel.isSelected(inboxId: row.id),
+                        isSelected: viewModel.isSelected(row.selection),
                         onTap: rowTapAction(for: row)
                     )
                 },
@@ -262,11 +274,11 @@ private struct ContactsPickerList: View {
     }
 
     private func rowTapAction(for row: ContactsPickerViewModel.Row) -> () -> Void {
-        let inboxId = row.id
+        let selection = row.selection
         let isAlreadyInChat = row.isAlreadyInChat
         return {
             guard !isAlreadyInChat else { return }
-            onToggle(inboxId)
+            onToggle(selection)
         }
     }
 }
@@ -341,6 +353,23 @@ private struct ContactsPickerConfirmButton: View {
         mode: .newConversation,
         contactsRepository: MockContactsRepository(contacts: contacts),
         preselectedInboxIds: preselected,
+        onConfirm: { _ in }
+    )
+}
+
+#Preview("Humans + agents") {
+    let humans: [Contact] = [
+        .mock(displayName: "Alice"),
+        .mock(displayName: "Bob"),
+    ]
+    let agents: [AgentTemplateContact] = [
+        .mock(displayName: "Tifoso", emoji: "🚴", descriptionText: "Pro cycling expert"),
+        .mock(displayName: "Trip Planner", emoji: "🗺️", descriptionText: "Plans your next adventure"),
+    ]
+    return ContactsPickerView(
+        mode: .newConversation,
+        contactsRepository: MockContactsRepository(contacts: humans),
+        agentTemplateContactsRepository: MockAgentTemplateContactsRepository(contacts: agents),
         onConfirm: { _ in }
     )
 }

--- a/Convos/Contacts/ContactsPickerViewModel.swift
+++ b/Convos/Contacts/ContactsPickerViewModel.swift
@@ -25,76 +25,155 @@ enum ContactsPickerMode: Hashable {
     }
 }
 
-/// View model backing the contact picker. Subscribes to the contacts
-/// repository, drops blocked contacts, applies search filtering, groups the
-/// result into alphabetical sections, and tracks the selected inboxIds.
+/// View model backing the contact picker. Subscribes to both the human and
+/// the agent-template contact repositories, drops blocked humans, applies
+/// search filtering, groups the merged result into alphabetical sections,
+/// and tracks a heterogeneous selection of inboxIds and templateIds.
 @Observable
 @MainActor
 final class ContactsPickerViewModel {
+    /// A single picked entity. Heterogeneous so a session can spawn agents
+    /// alongside inviting humans in one confirm.
+    enum Selection: Hashable {
+        case human(inboxId: String)
+        case agentTemplate(templateId: String)
+
+        var inboxId: String? {
+            if case .human(let id) = self { return id }
+            return nil
+        }
+
+        var templateId: String? {
+            if case .agentTemplate(let id) = self { return id }
+            return nil
+        }
+    }
+
     struct Section: Identifiable, Hashable {
         let id: String
         let title: String
         let rows: [Row]
     }
 
+    /// Row backing a picker cell. The kind discriminator carries the full
+    /// presentation model so cells can render human/agent affordances
+    /// without re-fetching from the repository.
     struct Row: Identifiable, Hashable {
         let id: String
-        let contact: Contact
+        let kind: Kind
         let isAlreadyInChat: Bool
-        /// Caption rendered under the contact name. Resolves to the name of
-        /// the conversation that promoted the inbox to a contact, falling
-        /// back to the agent role label (for verified agents) or "DM" (no
-        /// group convo name available).
+        /// Caption rendered under the contact name. For humans this is the
+        /// source conversation name / DM / agent role label resolver; for
+        /// agent templates it's the template description.
         let subtitle: String
+
+        enum Kind: Hashable {
+            case human(Contact)
+            case agentTemplate(AgentTemplateContact)
+        }
+
+        var selection: Selection {
+            switch kind {
+            case .human(let contact):
+                return .human(inboxId: contact.inboxId)
+            case .agentTemplate(let agent):
+                return .agentTemplate(templateId: agent.templateId)
+            }
+        }
+
+        var resolvedDisplayName: String {
+            switch kind {
+            case .human(let contact):
+                return contact.resolvedDisplayName
+            case .agentTemplate(let agent):
+                return agent.resolvedDisplayName
+            }
+        }
+
+        var alphabeticalSectionKey: String {
+            switch kind {
+            case .human(let contact):
+                return contact.alphabeticalSectionKey
+            case .agentTemplate(let agent):
+                return agent.alphabeticalSectionKey
+            }
+        }
     }
 
     let mode: ContactsPickerMode
     var sections: [Section] = []
-    var selectedInboxIds: Set<String> = []
+    var selected: Set<Selection> = []
     var searchQuery: String = "" {
         didSet { rebuildSections() }
     }
     var isLoading: Bool = true
 
     private let contactsRepository: any ContactsRepositoryProtocol
+    private let agentTemplateContactsRepository: any AgentTemplateContactsRepositoryProtocol
     private let alreadyInChatInboxIds: Set<String>
     private var allContacts: [Contact] = []
-    private var cancellable: AnyCancellable?
+    private var allAgentContacts: [AgentTemplateContact] = []
+    private var cancellables: Set<AnyCancellable> = []
 
     init(
         mode: ContactsPickerMode,
         contactsRepository: any ContactsRepositoryProtocol,
+        agentTemplateContactsRepository: any AgentTemplateContactsRepositoryProtocol
+            = MockAgentTemplateContactsRepository(contacts: []),
         alreadyInChatInboxIds: Set<String> = [],
         preselectedInboxIds: Set<String> = []
     ) {
         self.mode = mode
         self.contactsRepository = contactsRepository
+        self.agentTemplateContactsRepository = agentTemplateContactsRepository
         self.alreadyInChatInboxIds = alreadyInChatInboxIds
-        self.selectedInboxIds = preselectedInboxIds.subtracting(alreadyInChatInboxIds)
+        let preselected: Set<Selection> = preselectedInboxIds
+            .subtracting(alreadyInChatInboxIds)
+            .map { Selection.human(inboxId: $0) }
+            .reduce(into: Set<Selection>()) { $0.insert($1) }
+        self.selected = preselected
 
-        cancellable = contactsRepository.contactsPublisher
+        contactsRepository.contactsPublisher
             .receive(on: DispatchQueue.main)
             .sink { [weak self] contacts in
                 self?.applyContacts(contacts)
             }
+            .store(in: &cancellables)
 
-        if let initial = try? contactsRepository.fetchAll() {
-            applyContacts(initial)
+        agentTemplateContactsRepository.agentTemplateContactsPublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] agentContacts in
+                self?.applyAgentContacts(agentContacts)
+            }
+            .store(in: &cancellables)
+
+        if let initialContacts = try? contactsRepository.fetchAll() {
+            allContacts = initialContacts
         }
+        if let initialAgentContacts = try? agentTemplateContactsRepository.fetchAll() {
+            allAgentContacts = initialAgentContacts
+        }
+        rebuildSections()
     }
 
     // MARK: - Derived state
 
     var selectedContacts: [Contact] {
-        allContacts.filter { selectedInboxIds.contains($0.inboxId) }
+        let humanIds: Set<String> = selected.compactMap(\.inboxId).reduce(into: Set<String>()) { $0.insert($1) }
+        return allContacts.filter { humanIds.contains($0.inboxId) }
+    }
+
+    var selectedAgentContacts: [AgentTemplateContact] {
+        let templateIds: Set<String> = selected.compactMap(\.templateId).reduce(into: Set<String>()) { $0.insert($1) }
+        return allAgentContacts.filter { templateIds.contains($0.templateId) }
     }
 
     var selectionCount: Int {
-        selectedInboxIds.count
+        selected.count
     }
 
     var canConfirm: Bool {
-        !selectedInboxIds.isEmpty
+        !selected.isEmpty
     }
 
     var headerTitle: String {
@@ -126,7 +205,7 @@ final class ContactsPickerViewModel {
 
     /// Subtitle below the title in the indicator pill. Reads "Draft" when
     /// the user hasn't picked anyone yet, then transitions to "N selected"
-    /// once they start picking. Identical wording across both modes — the
+    /// once they start picking. Identical wording across both modes - the
     /// title already disambiguates the intent.
     var pillSubtitle: String {
         if selectionCount == 0 {
@@ -141,39 +220,41 @@ final class ContactsPickerViewModel {
 
     // MARK: - Mutations
 
-    func toggleSelection(for inboxId: String) {
-        guard !alreadyInChatInboxIds.contains(inboxId) else { return }
-        if selectedInboxIds.contains(inboxId) {
-            selectedInboxIds.remove(inboxId)
+    func toggleSelection(_ selection: Selection) {
+        if case .human(let inboxId) = selection, alreadyInChatInboxIds.contains(inboxId) {
+            return
+        }
+        if selected.contains(selection) {
+            selected.remove(selection)
         } else {
-            selectedInboxIds.insert(inboxId)
+            selected.insert(selection)
         }
     }
 
-    func deselect(inboxId: String) {
-        selectedInboxIds.remove(inboxId)
+    func deselect(_ selection: Selection) {
+        selected.remove(selection)
     }
 
     func clearSelection() {
-        selectedInboxIds.removeAll()
+        selected.removeAll()
     }
 
-    func isSelected(inboxId: String) -> Bool {
-        selectedInboxIds.contains(inboxId)
+    func isSelected(_ selection: Selection) -> Bool {
+        selected.contains(selection)
     }
 
     // MARK: - Section building
 
     private func applyContacts(_ contacts: [Contact]) {
         allContacts = contacts
-        // Prune selections to what's actually pickable. Pruning against the
-        // *visible* set (not just the known set) drops phantom selections --
-        // a preselected inboxId for a contact who's hidden because they're
-        // blocked / a verified agent / unnamed would otherwise stay in
-        // `selectedInboxIds`, counting toward `selectionCount` and passing
-        // `canConfirm` with no UI for the user to remove it.
-        let visibleInboxIds = Set(allContacts.filter(Self.isVisibleInPicker).map(\.inboxId))
-        selectedInboxIds = selectedInboxIds.intersection(visibleInboxIds)
+        pruneSelectionToKnownEntities()
+        rebuildSections()
+        isLoading = false
+    }
+
+    private func applyAgentContacts(_ agentContacts: [AgentTemplateContact]) {
+        allAgentContacts = agentContacts
+        pruneSelectionToKnownEntities()
         rebuildSections()
         isLoading = false
     }
@@ -194,40 +275,103 @@ final class ContactsPickerViewModel {
         return true
     }
 
-    private func rebuildSections() {
-        let visible = allContacts.filter(Self.isVisibleInPicker)
-        let filtered = filterByQuery(visible)
-        let grouped: [String: [Contact]] = Dictionary(
-            grouping: filtered,
-            by: { $0.alphabeticalSectionKey }
+    /// Drops selections whose underlying entity is either gone or no longer
+    /// visible in the picker. Pruning against the *visible* set (not just
+    /// the known set) drops phantom selections -- a preselected inboxId
+    /// for a contact who's hidden (blocked / verified / unnamed) would
+    /// otherwise stay in `selected`, counting toward `selectionCount` and
+    /// passing `canConfirm` with no UI for the user to remove it.
+    private func pruneSelectionToKnownEntities() {
+        let visibleInboxIds: Set<String> = Set(
+            allContacts.filter(Self.isVisibleInPicker).map(\.inboxId)
         )
+        let knownTemplateIds: Set<String> = Set(allAgentContacts.map(\.templateId))
+        selected = selected.filter { selection in
+            switch selection {
+            case .human(let inboxId):
+                return visibleInboxIds.contains(inboxId)
+            case .agentTemplate(let templateId):
+                return knownTemplateIds.contains(templateId)
+            }
+        }
+    }
+
+    private func rebuildSections() {
+        // Humans go through `isVisibleInPicker` (drops blocked, verified
+        // agents, and unnamed rows). Agent-template contacts live in
+        // their own table and are always shown.
+        let visibleHumans: [Contact] = allContacts.filter(Self.isVisibleInPicker)
+        let humanItems: [Row.Kind] = visibleHumans.map { .human($0) }
+        let agentItems: [Row.Kind] = allAgentContacts.map { .agentTemplate($0) }
+        let filtered: [Row.Kind] = filterByQuery(humanItems + agentItems)
+
+        let grouped: [String: [Row.Kind]] = Dictionary(grouping: filtered) { kind in
+            sectionKey(for: kind)
+        }
         let sortedKeys = grouped.keys.sorted(by: Self.sectionKeyOrder)
 
-        // Batched read of source-conversation metadata so each row's subtitle
-        // can show the convo the user met the contact in. Missing entries
-        // (deleted convo, never-recorded source) fall through to the agent
-        // label or empty in the subtitle resolver below.
-        let viaIds: Set<String> = Set(filtered.compactMap { $0.addedViaConversationId })
+        // Batched read of source-conversation metadata so each human row's
+        // subtitle can show the convo the user met the contact in. Agent
+        // rows skip this fetch (their subtitle is the template description).
+        let viaIds: Set<String> = Set(
+            filtered.compactMap { kind -> String? in
+                if case .human(let contact) = kind {
+                    return contact.addedViaConversationId
+                }
+                return nil
+            }
+        )
         let sources: [String: ContactSourceConversation] = (try? contactsRepository.sourceConversations(forIds: viaIds)) ?? [:]
 
         sections = sortedKeys.map { key in
-            let rows = (grouped[key] ?? []).map { contact in
-                Row(
-                    id: contact.inboxId,
-                    contact: contact,
-                    isAlreadyInChat: alreadyInChatInboxIds.contains(contact.inboxId),
-                    subtitle: contact.listSubtitle(sources: sources)
-                )
+            let rows = (grouped[key] ?? []).map { kind in
+                makeRow(kind: kind, sources: sources)
             }
             return Section(id: key, title: key, rows: rows)
         }
     }
 
-    private func filterByQuery(_ contacts: [Contact]) -> [Contact] {
+    private func makeRow(
+        kind: Row.Kind,
+        sources: [String: ContactSourceConversation]
+    ) -> Row {
+        switch kind {
+        case .human(let contact):
+            return Row(
+                id: "human:\(contact.inboxId)",
+                kind: kind,
+                isAlreadyInChat: alreadyInChatInboxIds.contains(contact.inboxId),
+                subtitle: contact.listSubtitle(sources: sources)
+            )
+        case .agentTemplate(let agent):
+            return Row(
+                id: "agent:\(agent.templateId)",
+                kind: kind,
+                isAlreadyInChat: false,
+                subtitle: agent.descriptionText ?? ""
+            )
+        }
+    }
+
+    private func sectionKey(for kind: Row.Kind) -> String {
+        switch kind {
+        case .human(let contact):
+            return contact.alphabeticalSectionKey
+        case .agentTemplate(let agent):
+            return agent.alphabeticalSectionKey
+        }
+    }
+
+    private func filterByQuery(_ items: [Row.Kind]) -> [Row.Kind] {
         let trimmed = searchQuery.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return contacts }
-        return contacts.filter { contact in
-            contact.resolvedDisplayName.localizedCaseInsensitiveContains(trimmed)
+        guard !trimmed.isEmpty else { return items }
+        return items.filter { kind in
+            switch kind {
+            case .human(let contact):
+                return contact.resolvedDisplayName.localizedCaseInsensitiveContains(trimmed)
+            case .agentTemplate(let agent):
+                return agent.resolvedDisplayName.localizedCaseInsensitiveContains(trimmed)
+            }
         }
     }
 

--- a/Convos/Contacts/ContactsPickerViewModel.swift
+++ b/Convos/Contacts/ContactsPickerViewModel.swift
@@ -153,6 +153,13 @@ final class ContactsPickerViewModel {
         if let initialAgentContacts = try? agentTemplateContactsRepository.fetchAll() {
             allAgentContacts = initialAgentContacts
         }
+        // Prune before `rebuildSections` so a preselected inboxId for a
+        // contact that's blocked, a verified agent, or unnamed (i.e. one
+        // `isVisibleInPicker` will drop) doesn't survive in `selected`
+        // until the async publisher fires. Without this, `selectionCount`
+        // is inflated, `canConfirm` passes with no visible UI to remove
+        // the phantom, and `pillSubtitle` shows the wrong count.
+        pruneSelectionToKnownEntities()
         rebuildSections()
         // A repository whose publisher doesn't emit synchronously on
         // subscription would otherwise leave `isLoading` stuck at `true`

--- a/Convos/Contacts/ContactsPickerViewModel.swift
+++ b/Convos/Contacts/ContactsPickerViewModel.swift
@@ -303,11 +303,21 @@ final class ContactsPickerViewModel {
     private func rebuildSections() {
         // Humans go through `isVisibleInPicker` (drops blocked, verified
         // agents, and unnamed rows). Agent-template contacts live in
-        // their own table and are always shown.
+        // their own table and are always shown. Sort the merged list by
+        // `resolvedDisplayName` (case-insensitive, matching each
+        // repository's sort) before grouping so humans and agents
+        // interleave alphabetically within each section -
+        // `Dictionary(grouping:)` preserves source order within each
+        // bucket, so without this sort all humans would render before
+        // any agent in every section.
         let visibleHumans: [Contact] = allContacts.filter(Self.isVisibleInPicker)
         let humanItems: [Row.Kind] = visibleHumans.map { .human($0) }
         let agentItems: [Row.Kind] = allAgentContacts.map { .agentTemplate($0) }
         let filtered: [Row.Kind] = filterByQuery(humanItems + agentItems)
+            .sorted { (lhs: Row.Kind, rhs: Row.Kind) -> Bool in
+                displayName(for: lhs)
+                    .localizedCaseInsensitiveCompare(displayName(for: rhs)) == .orderedAscending
+            }
 
         let grouped: [String: [Row.Kind]] = Dictionary(grouping: filtered) { kind in
             sectionKey(for: kind)
@@ -363,6 +373,15 @@ final class ContactsPickerViewModel {
             return contact.alphabeticalSectionKey
         case .agentTemplate(let agent):
             return agent.alphabeticalSectionKey
+        }
+    }
+
+    private func displayName(for kind: Row.Kind) -> String {
+        switch kind {
+        case .human(let contact):
+            return contact.resolvedDisplayName
+        case .agentTemplate(let agent):
+            return agent.resolvedDisplayName
         }
     }
 

--- a/Convos/Contacts/ContactsPickerViewModel.swift
+++ b/Convos/Contacts/ContactsPickerViewModel.swift
@@ -154,6 +154,10 @@ final class ContactsPickerViewModel {
             allAgentContacts = initialAgentContacts
         }
         rebuildSections()
+        // A repository whose publisher doesn't emit synchronously on
+        // subscription would otherwise leave `isLoading` stuck at `true`
+        // even though `sections` is populated from the fetch above.
+        isLoading = false
     }
 
     // MARK: - Derived state

--- a/Convos/Contacts/ContactsView.swift
+++ b/Convos/Contacts/ContactsView.swift
@@ -8,6 +8,7 @@ struct ContactsView: View {
 
     private let contactsRepository: any ContactsRepositoryProtocol
     private let contactsWriter: any ContactsWriterProtocol
+    private let agentTemplateContactsWriter: any AgentTemplateContactsWriterProtocol
     private let session: (any SessionManagerProtocol)?
     private let profileSettingsViewModel: ProfileSettingsViewModel
 
@@ -16,10 +17,16 @@ struct ContactsView: View {
         contactsWriter: any ContactsWriterProtocol = MockContactsWriter(),
         session: (any SessionManagerProtocol)? = nil,
         profileSettingsViewModel: ProfileSettingsViewModel = .shared
+        agentTemplateContactsRepository: any AgentTemplateContactsRepositoryProtocol = MockAgentTemplateContactsRepository(),
+        agentTemplateContactsWriter: any AgentTemplateContactsWriterProtocol = MockAgentTemplateContactsWriter()
     ) {
-        _viewModel = State(initialValue: ContactsViewModel(contactsRepository: contactsRepository))
+        _viewModel = State(initialValue: ContactsViewModel(
+            contactsRepository: contactsRepository,
+            agentTemplateContactsRepository: agentTemplateContactsRepository
+        ))
         self.contactsRepository = contactsRepository
         self.contactsWriter = contactsWriter
+        self.agentTemplateContactsWriter = agentTemplateContactsWriter
         self.session = session
         self.profileSettingsViewModel = profileSettingsViewModel
     }
@@ -123,6 +130,38 @@ struct ContactsView: View {
         )
     }
 
+    /// Renders one browse row. A human contact pushes `ContactCardView`; an
+    /// agent-template contact pushes the sibling `AgentTemplateContactCardView`.
+    @ViewBuilder
+    private func contactRow(for item: ContactsViewModel.ListItem) -> some View {
+        switch item {
+        case .human(let contact):
+            NavigationLink {
+                ContactCardView(
+                    contact: contact,
+                    contactsWriter: contactsWriter,
+                    contactsRepository: contactsRepository,
+                    session: session
+                )
+            } label: {
+                ContactRowView(contact: contact)
+            }
+            .listRowBackground(Color.clear)
+            .listRowSeparator(.hidden)
+        case .agentTemplate(let agentContact):
+            NavigationLink {
+                AgentTemplateContactCardView(
+                    agentTemplateContact: agentContact,
+                    agentTemplateContactsWriter: agentTemplateContactsWriter
+                )
+            } label: {
+                AgentTemplateContactRowView(agentTemplateContact: agentContact)
+            }
+            .listRowBackground(Color.clear)
+            .listRowSeparator(.hidden)
+        }
+    }
+
     private var emptyState: some View {
         VStack(spacing: DesignConstants.Spacing.step3x) {
             Image(systemName: "person.2.fill")
@@ -200,6 +239,9 @@ struct ContactsView: View {
 
 #Preview("Empty") {
     NavigationStack {
-        ContactsView(contactsRepository: MockContactsRepository(contacts: []))
+        ContactsView(
+            contactsRepository: MockContactsRepository(contacts: []),
+            agentTemplateContactsRepository: MockAgentTemplateContactsRepository(contacts: [])
+        )
     }
 }

--- a/Convos/Contacts/ContactsView.swift
+++ b/Convos/Contacts/ContactsView.swift
@@ -132,6 +132,7 @@ struct ContactsView: View {
                     contact: contact,
                     contactsWriter: contactsWriter,
                     contactsRepository: contactsRepository,
+                    agentTemplateContactsRepository: agentTemplateContactsRepository,
                     session: session,
                     profileSettingsViewModel: profileSettingsViewModel,
                     showsCloseButton: false

--- a/Convos/Contacts/ContactsView.swift
+++ b/Convos/Contacts/ContactsView.swift
@@ -8,6 +8,7 @@ struct ContactsView: View {
 
     private let contactsRepository: any ContactsRepositoryProtocol
     private let contactsWriter: any ContactsWriterProtocol
+    private let agentTemplateContactsRepository: any AgentTemplateContactsRepositoryProtocol
     private let agentTemplateContactsWriter: any AgentTemplateContactsWriterProtocol
     private let session: (any SessionManagerProtocol)?
     private let profileSettingsViewModel: ProfileSettingsViewModel
@@ -16,7 +17,7 @@ struct ContactsView: View {
         contactsRepository: any ContactsRepositoryProtocol,
         contactsWriter: any ContactsWriterProtocol = MockContactsWriter(),
         session: (any SessionManagerProtocol)? = nil,
-        profileSettingsViewModel: ProfileSettingsViewModel = .shared
+        profileSettingsViewModel: ProfileSettingsViewModel = .shared,
         agentTemplateContactsRepository: any AgentTemplateContactsRepositoryProtocol = MockAgentTemplateContactsRepository(),
         agentTemplateContactsWriter: any AgentTemplateContactsWriterProtocol = MockAgentTemplateContactsWriter()
     ) {
@@ -26,6 +27,7 @@ struct ContactsView: View {
         ))
         self.contactsRepository = contactsRepository
         self.contactsWriter = contactsWriter
+        self.agentTemplateContactsRepository = agentTemplateContactsRepository
         self.agentTemplateContactsWriter = agentTemplateContactsWriter
         self.session = session
         self.profileSettingsViewModel = profileSettingsViewModel
@@ -113,52 +115,41 @@ struct ContactsView: View {
                 )
             },
             rowContent: { (row: ContactsViewModel.Row) in
-                NavigationLink {
-                    ContactDetailView(
-                        contact: row.contact,
-                        contactsWriter: contactsWriter,
-                        contactsRepository: contactsRepository,
-                        session: session,
-                        profileSettingsViewModel: profileSettingsViewModel,
-                        showsCloseButton: false
-                    )
-                } label: {
-                    ContactRowView(contact: row.contact, subtitle: row.subtitle)
-                }
+                rowDestination(for: row)
             },
             listBackground: { Color.colorBackgroundRaisedSecondary }
         )
     }
 
-    /// Renders one browse row. A human contact pushes `ContactCardView`; an
-    /// agent-template contact pushes the sibling `AgentTemplateContactCardView`.
+    /// Renders one browse row. A human row pushes `ContactDetailView`; an
+    /// agent-template row pushes the sibling `AgentTemplateContactCardView`.
     @ViewBuilder
-    private func contactRow(for item: ContactsViewModel.ListItem) -> some View {
-        switch item {
+    private func rowDestination(for row: ContactsViewModel.Row) -> some View {
+        switch row.kind {
         case .human(let contact):
             NavigationLink {
-                ContactCardView(
+                ContactDetailView(
                     contact: contact,
                     contactsWriter: contactsWriter,
                     contactsRepository: contactsRepository,
-                    session: session
+                    session: session,
+                    profileSettingsViewModel: profileSettingsViewModel,
+                    showsCloseButton: false
                 )
             } label: {
-                ContactRowView(contact: contact)
+                ContactRowView(contact: contact, subtitle: row.subtitle)
             }
-            .listRowBackground(Color.clear)
-            .listRowSeparator(.hidden)
-        case .agentTemplate(let agentContact):
+        case .agentTemplate(let agent):
             NavigationLink {
                 AgentTemplateContactCardView(
-                    agentTemplateContact: agentContact,
-                    agentTemplateContactsWriter: agentTemplateContactsWriter
+                    agentTemplateContact: agent,
+                    agentTemplateContactsWriter: agentTemplateContactsWriter,
+                    session: session,
+                    profileSettingsViewModel: profileSettingsViewModel
                 )
             } label: {
-                AgentTemplateContactRowView(agentTemplateContact: agentContact)
+                AgentTemplateContactRowView(agentTemplateContact: agent)
             }
-            .listRowBackground(Color.clear)
-            .listRowSeparator(.hidden)
         }
     }
 
@@ -204,6 +195,7 @@ struct ContactsView: View {
         ContactsPickerView(
             mode: .newConversation,
             contactsRepository: contactsRepository,
+            agentTemplateContactsRepository: agentTemplateContactsRepository,
             onConfirm: handlePickerConfirm
         )
     }
@@ -217,16 +209,17 @@ struct ContactsView: View {
     /// Spins up a `NewConversationViewModel` locally and presents it as a
     /// sheet from this view, so the new conversation appears in place of
     /// the picker while the App Settings sheet stack stays alive
-    /// underneath. Dismissing the new-convo sheet lands the user back on
-    /// the contacts list, not at the root conversations list. Mirrors the
-    /// invite-cell-tap pattern (`presentingNewConversationForInvite` on
-    /// `ConversationViewModel`) where the sheet is owned by the same view
-    /// that hosted the picker.
-    private func handlePickerConfirm(_ inboxIds: Set<String>) {
-        guard !inboxIds.isEmpty, let session else { return }
+    /// underneath.
+    private func handlePickerConfirm(_ selection: Set<ContactsPickerViewModel.Selection>) {
+        guard !selection.isEmpty, let session else { return }
+        let inboxIds: [String] = selection.compactMap(\.inboxId)
+        let templateIds: [String] = selection.compactMap(\.templateId)
         presentingNewConvo = NewConversationViewModel(
             session: session,
-            mode: .newConversationWithMembers(initialMemberInboxIds: Array(inboxIds))
+            mode: .newConversationWithMembers(
+                initialMemberInboxIds: inboxIds,
+                initialAgentTemplateIds: templateIds
+            )
         )
     }
 }

--- a/Convos/Contacts/ContactsViewModel.swift
+++ b/Convos/Contacts/ContactsViewModel.swift
@@ -153,7 +153,11 @@ final class ContactsViewModel {
     /// displayName is missing/empty render as "Somebody" via
     /// `resolvedDisplayName`; a "Somebody" row carries no useful info
     /// for the browser, so we hide it until a profile name arrives.
-    private static func isVisibleInList(_ contact: Contact) -> Bool {
+    ///
+    /// Exposed (no `private`) so other surfaces in the Convos target can
+    /// match the same visibility rule when they compute their own badge
+    /// counts or filtered lists (e.g. the App Settings "Contacts" row).
+    static func isVisibleInList(_ contact: Contact) -> Bool {
         if contact.isVerifiedAgent { return false }
         guard let name = contact.displayName, !name.isEmpty else { return false }
         return true

--- a/Convos/Contacts/ContactsViewModel.swift
+++ b/Convos/Contacts/ContactsViewModel.swift
@@ -54,23 +54,27 @@ final class ContactsViewModel {
         }
     }
 
-    /// Dual-shape section so two consumers can read the same data the way
-    /// each expects: `rows` is humans-only (`Row` carries a `Contact`) for
-    /// callers that pre-date the agent-template merge, and `items` is the
-    /// merged list (`ListItem` sum) for agent-aware callers.
     struct Section: Identifiable, Hashable {
         let id: String
         let title: String
         let rows: [Row]
-        let items: [ListItem]
     }
 
+    /// One row in the alphabetical list. Carries the same `Kind`
+    /// discriminator as `ContactsPickerViewModel.Row` so the human vs
+    /// agent-template variants share the dispatch pattern.
     struct Row: Identifiable, Hashable {
         let id: String
-        let contact: Contact
-        /// Same resolver as the picker — convo name, then "DM" for 1:1
-        /// source, then agent role label, then empty (caller hides line).
+        let kind: Kind
+        /// Source-conversation name / DM / agent role label resolver
+        /// for the human variant; template description for the agent
+        /// variant; empty hides the line.
         let subtitle: String
+
+        enum Kind: Hashable {
+            case human(Contact)
+            case agentTemplate(AgentTemplateContact)
+        }
     }
 
     var sections: [Section] = []
@@ -176,18 +180,40 @@ final class ContactsViewModel {
             default: return lhs < rhs
             }
         }
-        let viaIds: Set<String> = Set(filtered.compactMap { $0.addedViaConversationId })
-        let sources: [String: ContactSourceConversation] = (try? contactsRepository.sourceConversations(forIds: viaIds)) ?? [:]
-        sections = sortedKeys.map { key in
-            let itemsInGroup: [ListItem] = grouped[key] ?? []
-            let humansInGroup: [Contact] = itemsInGroup.compactMap { item in
-                if case .human(let contact) = item { return contact }
+        let viaIds: Set<String> = Set(
+            filtered.compactMap { item -> String? in
+                if case .human(let contact) = item {
+                    return contact.addedViaConversationId
+                }
                 return nil
             }
-            let rowsInGroup: [Row] = humansInGroup.map { contact in
-                Row(id: contact.inboxId, contact: contact, subtitle: contact.listSubtitle(sources: sources))
+        )
+        let sources: [String: ContactSourceConversation] = (try? contactsRepository.sourceConversations(forIds: viaIds)) ?? [:]
+        sections = sortedKeys.map { key in
+            let rows = (grouped[key] ?? []).map { item in
+                makeRow(from: item, sources: sources)
             }
-            return Section(id: key, title: key, rows: rowsInGroup, items: itemsInGroup)
+            return Section(id: key, title: key, rows: rows)
+        }
+    }
+
+    private func makeRow(
+        from item: ListItem,
+        sources: [String: ContactSourceConversation]
+    ) -> Row {
+        switch item {
+        case .human(let contact):
+            return Row(
+                id: "human:\(contact.inboxId)",
+                kind: .human(contact),
+                subtitle: contact.listSubtitle(sources: sources)
+            )
+        case .agentTemplate(let agent):
+            return Row(
+                id: "agent:\(agent.templateId)",
+                kind: .agentTemplate(agent),
+                subtitle: agent.descriptionText ?? ""
+            )
         }
     }
 

--- a/Convos/Contacts/ContactsViewModel.swift
+++ b/Convos/Contacts/ContactsViewModel.swift
@@ -3,16 +3,66 @@ import ConvosCore
 import Foundation
 import Observation
 
-/// View model backing the Contacts list browse screen. Subscribes to the
-/// repository's reactive publisher and groups the contacts into alphabetical
-/// sections for rendering.
+/// View model backing the Contacts list browse screen. Subscribes to both
+/// the human-contacts repository and the agent-template-contacts repository
+/// and merges the two into shared alphabetical sections for rendering.
 @Observable
 @MainActor
 final class ContactsViewModel {
+    /// A single browsable row: either a human `Contact` or an
+    /// `AgentTemplateContact`. The two live in separate tables - one keyed
+    /// by `inboxId`, the other by `templateId` - and are merged here for
+    /// the unified alphabetical list.
+    enum ListItem: Identifiable, Hashable {
+        case human(Contact)
+        case agentTemplate(AgentTemplateContact)
+
+        var id: String {
+            switch self {
+            case .human(let contact):
+                return "human:\(contact.inboxId)"
+            case .agentTemplate(let agent):
+                return "agent:\(agent.templateId)"
+            }
+        }
+
+        var resolvedDisplayName: String {
+            switch self {
+            case .human(let contact):
+                return contact.resolvedDisplayName
+            case .agentTemplate(let agent):
+                return agent.resolvedDisplayName
+            }
+        }
+
+        var alphabeticalSectionKey: String {
+            switch self {
+            case .human(let contact):
+                return contact.alphabeticalSectionKey
+            case .agentTemplate(let agent):
+                return agent.alphabeticalSectionKey
+            }
+        }
+
+        var addedViaConversationId: String? {
+            switch self {
+            case .human(let contact):
+                return contact.addedViaConversationId
+            case .agentTemplate(let agent):
+                return agent.addedViaConversationId
+            }
+        }
+    }
+
+    /// Dual-shape section so two consumers can read the same data the way
+    /// each expects: `rows` is humans-only (`Row` carries a `Contact`) for
+    /// callers that pre-date the agent-template merge, and `items` is the
+    /// merged list (`ListItem` sum) for agent-aware callers.
     struct Section: Identifiable, Hashable {
         let id: String
         let title: String
         let rows: [Row]
+        let items: [ListItem]
     }
 
     struct Row: Identifiable, Hashable {
@@ -31,33 +81,62 @@ final class ContactsViewModel {
     }
 
     private let contactsRepository: any ContactsRepositoryProtocol
-    private var cancellable: AnyCancellable?
+    private let agentTemplateContactsRepository: any AgentTemplateContactsRepositoryProtocol
+    private var cancellables: Set<AnyCancellable> = []
     private var allContacts: [Contact] = []
+    private var allAgentContacts: [AgentTemplateContact] = []
 
-    init(contactsRepository: any ContactsRepositoryProtocol) {
+    init(
+        contactsRepository: any ContactsRepositoryProtocol,
+        agentTemplateContactsRepository: any AgentTemplateContactsRepositoryProtocol
+            = MockAgentTemplateContactsRepository(contacts: [])
+    ) {
         self.contactsRepository = contactsRepository
+        self.agentTemplateContactsRepository = agentTemplateContactsRepository
 
-        cancellable = contactsRepository.contactsPublisher
+        contactsRepository.contactsPublisher
             .receive(on: DispatchQueue.main)
             .sink { [weak self] contacts in
                 self?.applyContacts(contacts)
             }
+            .store(in: &cancellables)
 
-        // Best-effort initial fetch for the first paint while the publisher
-        // wires up its observation.
-        if let initial = try? contactsRepository.fetchAll() {
-            applyContacts(initial)
+        agentTemplateContactsRepository.agentTemplateContactsPublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] agentContacts in
+                self?.applyAgentContacts(agentContacts)
+            }
+            .store(in: &cancellables)
+
+        // Best-effort initial fetch for the first paint while the
+        // publishers wire up their observations.
+        if let initialContacts = try? contactsRepository.fetchAll() {
+            allContacts = initialContacts
         }
+        if let initialAgentContacts = try? agentTemplateContactsRepository.fetchAll() {
+            allAgentContacts = initialAgentContacts
+        }
+        recompute()
     }
 
     private func applyContacts(_ contacts: [Contact]) {
         allContacts = contacts
-        // `contactCount` drives the empty-state vs list-state branch and
-        // the compose button's enabled flag. Count what's actually visible
-        // in the list -- verified agents are hidden from this view, and
-        // unnamed contacts are filtered out below in `rebuildSections`,
-        // so include both predicates here too.
-        contactCount = contacts.filter(Self.isVisibleInList).count
+        recompute()
+    }
+
+    private func applyAgentContacts(_ agentContacts: [AgentTemplateContact]) {
+        allAgentContacts = agentContacts
+        recompute()
+    }
+
+    /// Shared recompute path triggered whenever either repository emits.
+    /// `contactCount` drives the empty-state vs list-state branch and the
+    /// compose button's enabled flag, so it counts everything the list
+    /// renders: humans that pass `isVisibleInList` (named, non-verified)
+    /// plus every agent-template contact.
+    private func recompute() {
+        let visibleHumanCount: Int = allContacts.filter(Self.isVisibleInList).count
+        contactCount = visibleHumanCount + allAgentContacts.count
         rebuildSections()
         isLoading = false
     }
@@ -76,14 +155,19 @@ final class ContactsViewModel {
         return true
     }
 
-    /// Recomputes `sections` from `allContacts` honoring the current
-    /// `searchQuery`. Mirrors the picker's filter/group pipeline so both
-    /// surfaces sort and bucket identically.
+    /// Recomputes `sections` from `allContacts` + `allAgentContacts`
+    /// honoring the current `searchQuery`. Humans (filtered through
+    /// `isVisibleInList`) and agent-template contacts are merged and
+    /// bucketed into shared alphabetical sections.
     private func rebuildSections() {
-        let visibleContacts = allContacts.filter(Self.isVisibleInList)
-        let filtered = filterByQuery(visibleContacts)
-        let grouped: [String: [Contact]] = Dictionary(grouping: filtered) { $0.alphabeticalSectionKey }
-        let sortedKeys = grouped.keys.sorted { lhs, rhs in
+        let humanItems: [ListItem] = allContacts
+            .filter(Self.isVisibleInList)
+            .map { ListItem.human($0) }
+        let agentItems: [ListItem] = allAgentContacts.map { ListItem.agentTemplate($0) }
+        let filtered: [ListItem] = filterByQuery(humanItems + agentItems)
+
+        let grouped: [String: [ListItem]] = Dictionary(grouping: filtered) { $0.alphabeticalSectionKey }
+        let sortedKeys: [String] = grouped.keys.sorted { lhs, rhs in
             // "#" sorts last so non-alpha names land after Z.
             switch (lhs, rhs) {
             case ("#", "#"): return false
@@ -95,18 +179,23 @@ final class ContactsViewModel {
         let viaIds: Set<String> = Set(filtered.compactMap { $0.addedViaConversationId })
         let sources: [String: ContactSourceConversation] = (try? contactsRepository.sourceConversations(forIds: viaIds)) ?? [:]
         sections = sortedKeys.map { key in
-            let rows = (grouped[key] ?? []).map { contact in
+            let itemsInGroup: [ListItem] = grouped[key] ?? []
+            let humansInGroup: [Contact] = itemsInGroup.compactMap { item in
+                if case .human(let contact) = item { return contact }
+                return nil
+            }
+            let rowsInGroup: [Row] = humansInGroup.map { contact in
                 Row(id: contact.inboxId, contact: contact, subtitle: contact.listSubtitle(sources: sources))
             }
-            return Section(id: key, title: key, rows: rows)
+            return Section(id: key, title: key, rows: rowsInGroup, items: itemsInGroup)
         }
     }
 
-    private func filterByQuery(_ contacts: [Contact]) -> [Contact] {
+    private func filterByQuery(_ items: [ListItem]) -> [ListItem] {
         let trimmed = searchQuery.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return contacts }
-        return contacts.filter { contact in
-            contact.resolvedDisplayName.localizedCaseInsensitiveContains(trimmed)
+        guard !trimmed.isEmpty else { return items }
+        return items.filter { item in
+            item.resolvedDisplayName.localizedCaseInsensitiveContains(trimmed)
         }
     }
 }

--- a/Convos/Contacts/ContactsViewModel.swift
+++ b/Convos/Contacts/ContactsViewModel.swift
@@ -161,14 +161,22 @@ final class ContactsViewModel {
 
     /// Recomputes `sections` from `allContacts` + `allAgentContacts`
     /// honoring the current `searchQuery`. Humans (filtered through
-    /// `isVisibleInList`) and agent-template contacts are merged and
-    /// bucketed into shared alphabetical sections.
+    /// `isVisibleInList`) and agent-template contacts are merged, sorted
+    /// alphabetically by `resolvedDisplayName` (case-insensitive, matching
+    /// each repository's own sort), and bucketed into shared sections.
+    /// The sort is applied before grouping because `Dictionary(grouping:)`
+    /// preserves source order within each bucket - without it, all humans
+    /// would render before any agent in every section.
     private func rebuildSections() {
         let humanItems: [ListItem] = allContacts
             .filter(Self.isVisibleInList)
             .map { ListItem.human($0) }
         let agentItems: [ListItem] = allAgentContacts.map { ListItem.agentTemplate($0) }
         let filtered: [ListItem] = filterByQuery(humanItems + agentItems)
+            .sorted { (lhs: ListItem, rhs: ListItem) -> Bool in
+                lhs.resolvedDisplayName
+                    .localizedCaseInsensitiveCompare(rhs.resolvedDisplayName) == .orderedAscending
+            }
 
         let grouped: [String: [ListItem]] = Dictionary(grouping: filtered) { $0.alphabeticalSectionKey }
         let sortedKeys: [String] = grouped.keys.sorted { lhs, rhs in

--- a/Convos/Conversation Creation/NewConversationViewModel.swift
+++ b/Convos/Conversation Creation/NewConversationViewModel.swift
@@ -903,12 +903,14 @@ extension NewConversationViewModel {
 
             // Agent-template spawn: the conversation now exists with a
             // shareable invite, so request a fresh instance for each
-            // pending templateId. One-shot - `.ready` may re-emit.
+            // pending templateId. Uses the batched fan-out method so all
+            // N joins fire in parallel -- the single-flight
+            // `requestAgentJoin(templateId:)` would cancel each prior
+            // call as the loop advances, leaving only the last to land.
+            // One-shot - `.ready` may re-emit.
             if !pendingAgentTemplateIds.isEmpty, !didTriggerAgentJoin {
                 didTriggerAgentJoin = true
-                for templateId in pendingAgentTemplateIds {
-                    conversationViewModel?.requestAgentJoin(templateId: templateId)
-                }
+                conversationViewModel?.requestAgentJoins(templateIds: pendingAgentTemplateIds)
             }
 
         case .joinFailed(_, let error):

--- a/Convos/Conversation Creation/NewConversationViewModel.swift
+++ b/Convos/Conversation Creation/NewConversationViewModel.swift
@@ -34,8 +34,13 @@ enum NewConversationMode {
     /// inbox IDs before emitting `.ready`. Used by the contacts picker
     /// "Start Conversation" path so navigation feels instant and the
     /// conversation arrives at `.ready` with the picked members already
-    /// in it.
-    case newConversationWithMembers(initialMemberInboxIds: [String])
+    /// in it. `initialAgentTemplateIds` (defaults to empty) requests one
+    /// fresh instance per id once the conversation reaches `.ready`,
+    /// mirroring the single-template `.newConversationWithTemplate` flow.
+    case newConversationWithMembers(
+        initialMemberInboxIds: [String],
+        initialAgentTemplateIds: [String] = []
+    )
     /// Opens an existing conversation in the same sheet presentation we
     /// use for the new-convo flows. Used when "Chat" on a contact card
     /// resolves to a 1:1 the user already has with that person, so the
@@ -169,11 +174,14 @@ class NewConversationViewModel: Identifiable {
 
     private var conversationStateManager: (any ConversationStateManagerProtocol)?
     private var acquiredMessagingService: AnyMessagingService?
-    /// Agent template id to provision into the conversation once it
-    /// reaches `.ready`. Set for the `.newConversationWithTemplate`
-    /// deeplink mode and when a `convos://template/<id>` QR is scanned.
+    /// Agent template ids to provision into the conversation once it
+    /// reaches `.ready`. Populated for the `.newConversationWithTemplate`
+    /// deeplink mode, the `convos://template/<id>` QR scan path, and the
+    /// contacts picker's mixed humans+templates new-conversation flow.
+    /// One entry per fresh instance to spawn; empty for the human-only
+    /// path.
     @ObservationIgnored
-    private var pendingAgentTemplateId: String?
+    private var pendingAgentTemplateIds: [String] = []
     /// Set when a template QR is scanned before the messaging service
     /// (and `conversationStateManager`) has been acquired; the create is
     /// kicked off once configuration completes. Mirrors `pendingInviteCode`.
@@ -215,8 +223,13 @@ class NewConversationViewModel: Identifiable {
         self.session = session
         self.qrScannerViewModel = QRScannerViewModel()
 
-        if case .newConversationWithTemplate(let templateId) = mode {
-            self.pendingAgentTemplateId = templateId
+        switch mode {
+        case .newConversationWithTemplate(let templateId):
+            self.pendingAgentTemplateIds = [templateId]
+        case .newConversationWithMembers(_, let templateIds):
+            self.pendingAgentTemplateIds = templateIds
+        default:
+            break
         }
 
         switch mode {
@@ -242,7 +255,7 @@ class NewConversationViewModel: Identifiable {
             self.allowsDismissingScanner = true
         }
 
-        if case .newConversationWithMembers(let ids) = mode {
+        if case .newConversationWithMembers(let ids, _) = mode {
             self.startedWithSeededMembers = true
             self.seededMemberInboxIds = ids
         } else {
@@ -339,7 +352,7 @@ class NewConversationViewModel: Identifiable {
                     existingConversationId: existingConversationId
                 )
 
-            case .newConversationWithMembers(let initialMemberInboxIds):
+            case .newConversationWithMembers(let initialMemberInboxIds, _):
                 let (messagingService, existingConversationId) = await session.prepareNewConversation()
                 guard !Task.isCancelled else { return }
                 let inboxElapsed = (CFAbsoluteTimeGetCurrent() - perfStartTime) * 1000
@@ -562,7 +575,7 @@ class NewConversationViewModel: Identifiable {
     /// conversation, then request an instance of the template into it
     /// once it reaches `.ready` (handled in `handleStateChange`).
     private func startAgentTemplateConversation(templateId: String) {
-        pendingAgentTemplateId = templateId
+        pendingAgentTemplateIds = [templateId]
         showingFullScreenScanner = false
         isCreatingConversation = true
 
@@ -888,12 +901,14 @@ extension NewConversationViewModel {
             Log.info("[PERF] NewConversation.ready: \(String(format: "%.0f", readyElapsed))ms (origin: \(result.origin))")
             Log.info("Conversation ready!")
 
-            // Agent-template deeplink: the conversation now exists with a
-            // shareable invite, so request a fresh instance of the
-            // template into it. One-shot - `.ready` may re-emit.
-            if let pendingAgentTemplateId, !didTriggerAgentJoin {
+            // Agent-template spawn: the conversation now exists with a
+            // shareable invite, so request a fresh instance for each
+            // pending templateId. One-shot - `.ready` may re-emit.
+            if !pendingAgentTemplateIds.isEmpty, !didTriggerAgentJoin {
                 didTriggerAgentJoin = true
-                conversationViewModel?.requestAgentJoin(templateId: pendingAgentTemplateId)
+                for templateId in pendingAgentTemplateIds {
+                    conversationViewModel?.requestAgentJoin(templateId: templateId)
+                }
             }
 
         case .joinFailed(_, let error):
@@ -918,9 +933,9 @@ extension NewConversationViewModel {
 
         // The include-info default applies to every conversation this VM
         // creates - the auto-create modes and the scanned-template path
-        // (which sets `pendingAgentTemplateId` but is not an auto-create
+        // (which seeds `pendingAgentTemplateIds` but is not an auto-create
         // mode). It does not apply when joining an existing invite.
-        guard autoCreateConversation || pendingAgentTemplateId != nil else { return }
+        guard autoCreateConversation || !pendingAgentTemplateIds.isEmpty else { return }
 
         do {
             try await stateManager.conversationMetadataWriter.updateIncludeInfoInPublicPreview(

--- a/Convos/Conversation Detail/ConversationMembersListView.swift
+++ b/Convos/Conversation Detail/ConversationMembersListView.swift
@@ -151,12 +151,7 @@ private struct MemberRow: View {
             Spacer()
 
             if let roleLabel = member.roleLabel {
-                Text(roleLabel)
-                    .font(.footnote)
-                    .foregroundStyle(.colorTextSecondary)
-                    .padding(.horizontal, DesignConstants.Spacing.step2x)
-                    .padding(.vertical, DesignConstants.Spacing.stepX)
-                    .background(.colorTextSecondary.opacity(0.1), in: .capsule)
+                RoleLabelPill(label: roleLabel)
             }
 
             Image(systemName: "chevron.right")

--- a/Convos/Conversation Detail/ConversationMembersListView.swift
+++ b/Convos/Conversation Detail/ConversationMembersListView.swift
@@ -99,6 +99,7 @@ struct ConversationMembersListView: View {
     private func memberContactDetailDestination(for member: ConversationMember) -> some View {
         let messagingService = viewModel.messagingService
         let contactsRepository = messagingService.contactsRepository()
+        let agentTemplateContactsRepository = messagingService.agentTemplateContactsRepository()
         let contactsWriter = messagingService.contactsWriter()
         let resolvedContact = Contact.resolved(
             member: member,
@@ -117,6 +118,7 @@ struct ConversationMembersListView: View {
             ),
             contactsWriter: contactsWriter,
             contactsRepository: contactsRepository,
+            agentTemplateContactsRepository: agentTemplateContactsRepository,
             session: viewModel.session,
             showsCloseButton: false,
             onRemove: onRemove

--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -506,6 +506,7 @@ struct MemberContactDetailSheetContent: View {
     var body: some View {
         let messagingService = viewModel.messagingService
         let contactsRepository = messagingService.contactsRepository()
+        let agentTemplateContactsRepository = messagingService.agentTemplateContactsRepository()
         let contactsWriter = messagingService.contactsWriter()
         let resolvedContact = Contact.resolved(
             member: member,
@@ -528,6 +529,7 @@ struct MemberContactDetailSheetContent: View {
                 ),
                 contactsWriter: contactsWriter,
                 contactsRepository: contactsRepository,
+                agentTemplateContactsRepository: agentTemplateContactsRepository,
                 session: viewModel.session,
                 profileSettingsViewModel: profileSettingsViewModel,
                 onRemove: onRemove

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -2676,6 +2676,12 @@ extension ConversationViewModel {
     /// is a bare join (the backend provisions its default agent); a
     /// non-nil id provisions a fresh instance of that template. The
     /// caller-facing `agents/join` body no longer accepts `instructions`.
+    ///
+    /// Single-flight: a new call cancels any prior in-flight join request
+    /// (retry-from-error semantics for the chat-header "+" menu). For
+    /// multi-template fan-out (picker confirms N templates at once) use
+    /// `requestAgentJoins(templateIds:)` instead -- it spawns a TaskGroup
+    /// so N calls run in parallel without cancelling each other.
     func requestAgentJoin(templateId: String?) {
         let slug = invite.urlSlug
         guard !slug.isEmpty else { return }
@@ -2686,51 +2692,21 @@ extension ConversationViewModel {
         let conversationId = conversation.id
         let requestId = UUID().uuidString
         let taskId = requestId
-        agentJoinTask = Task { [weak self, session] in
-            await Self.broadcastAgentJoinRequest(
-                status: .pending, requestId: requestId,
-                conversationId: conversationId, session: session
+        let session = self.session
+        agentJoinTask = Task { [weak self] in
+            let success = await Self.performAgentJoinCall(
+                templateId: templateId,
+                slug: slug,
+                conversationId: conversationId,
+                requestId: requestId,
+                forceErrorCode: forceErrorCode,
+                session: session
             )
-
-            do {
-                _ = try await session.requestAgentJoin(
-                    slug: slug,
-                    templateId: templateId,
-                    options: nil,
-                    forceErrorCode: forceErrorCode
-                )
-            } catch is CancellationError {
-                await MainActor.run { self?.clearAgentJoinTask(id: taskId) }
-                return
-            } catch let urlError as URLError where urlError.code == .cancelled {
-                await MainActor.run { self?.clearAgentJoinTask(id: taskId) }
-                return
-            } catch let error as APIError {
-                Log.error("requestAgentJoin: agents/join APIError: \(error) - \(error.localizedDescription)")
-                let status: AgentJoinStatus
-                if case .noAgentsAvailable = error { status = .noAgentsAvailable } else { status = .failed }
-                await Self.broadcastAgentJoinRequest(
-                    status: status, requestId: requestId,
-                    conversationId: conversationId, session: session
-                )
-                await MainActor.run {
-                    self?.clearAgentJoinTask(id: taskId)
-                    self?.onAgentJoinError()
-                }
-                return
-            } catch {
-                Log.error("requestAgentJoin: agents/join unknown error: \(error.localizedDescription)")
-                await Self.broadcastAgentJoinRequest(
-                    status: .failed, requestId: requestId,
-                    conversationId: conversationId, session: session
-                )
-                await MainActor.run {
-                    self?.clearAgentJoinTask(id: taskId)
-                    self?.onAgentJoinError()
-                }
-                return
+            await MainActor.run {
+                guard let self else { return }
+                if !success { self.onAgentJoinError() }
+                self.clearAgentJoinTask(id: taskId)
             }
-            await MainActor.run { self?.clearAgentJoinTask(id: taskId) }
         }
         agentJoinTaskId = taskId
     }
@@ -2739,6 +2715,113 @@ extension ConversationViewModel {
     /// affordances. Kept so their call sites don't change.
     func requestAgentJoin() {
         requestAgentJoin(templateId: nil)
+    }
+
+    /// Sequential batched variant of `requestAgentJoin(templateId:)`. Used
+    /// by the new-conversation flow when the picker confirmed multiple
+    /// agent templates at once. Awaits each call to completion before
+    /// firing the next, with a short inter-call delay so the previous
+    /// broadcast's libxmtp activity fully settles before the next API
+    /// call starts. Does not touch `agentJoinTask` / `agentJoinTaskId`
+    /// (those remain dedicated to the single-flight retry path).
+    ///
+    /// Band-aid for an unresolved issue where parallel `agents/join`
+    /// dispatch results in 2 of 3 URLSession data tasks being cancelled
+    /// (`URLError.cancelled`) — see "concurrent agents/join cancellation"
+    /// investigation notes. Manual one-at-a-time clicks work fine, so
+    /// serialization mirrors what the user can do by hand. Slow but
+    /// reliable: ~10 seconds per agent. Remove and restore TaskGroup
+    /// fan-out once the underlying cancellation is root-caused (likely
+    /// libxmtp + URLSession shared-connection-pool interaction or a
+    /// transient `SessionStateError.clientIdInboxInconsistency` in the
+    /// session state machine under concurrent waiters).
+    func requestAgentJoins(templateIds: [String]) {
+        guard !templateIds.isEmpty else { return }
+        let slug = invite.urlSlug
+        guard !slug.isEmpty else { return }
+        Log.info("requestAgentJoins called with \(templateIds.count) templates (sequential): \(templateIds)")
+
+        let forceErrorCode = agentJoinForceErrorCode
+        let conversationId = conversation.id
+        let session = self.session
+        Task { [weak self] in
+            var anyFailed = false
+            for (index, templateId) in templateIds.enumerated() {
+                if index > 0 {
+                    // Brief gap between calls so the previous broadcast's
+                    // libxmtp message-send fully settles before the next
+                    // call's broadcast / API races against it.
+                    try? await Task.sleep(nanoseconds: 500_000_000)
+                }
+                let requestId = UUID().uuidString
+                let success = await Self.performAgentJoinCall(
+                    templateId: templateId,
+                    slug: slug,
+                    conversationId: conversationId,
+                    requestId: requestId,
+                    forceErrorCode: forceErrorCode,
+                    session: session
+                )
+                if !success { anyFailed = true }
+            }
+            if anyFailed {
+                await MainActor.run { self?.onAgentJoinError() }
+            }
+        }
+    }
+
+    /// Performs a single `agents/join` call: broadcasts `.pending` before,
+    /// broadcasts the appropriate failure status (`.failed` or
+    /// `.noAgentsAvailable`) on error. Returns `true` on success or
+    /// cooperative cancellation, `false` only on an actual error response
+    /// from the backend. Static + parameterized so both the single-flight
+    /// and batched callers can share the same body without holding `self`.
+    private static func performAgentJoinCall(
+        templateId: String?,
+        slug: String,
+        conversationId: String,
+        requestId: String,
+        forceErrorCode: Int?,
+        session: any SessionManagerProtocol
+    ) async -> Bool {
+        Log.info("performAgentJoinCall starting templateId=\(templateId ?? "nil") requestId=\(requestId)")
+        await Self.broadcastAgentJoinRequest(
+            status: .pending, requestId: requestId,
+            conversationId: conversationId, session: session
+        )
+        Log.info("performAgentJoinCall about to POST agents/join templateId=\(templateId ?? "nil") requestId=\(requestId)")
+        do {
+            _ = try await session.requestAgentJoin(
+                slug: slug,
+                templateId: templateId,
+                options: nil,
+                forceErrorCode: forceErrorCode
+            )
+            Log.info("performAgentJoinCall succeeded templateId=\(templateId ?? "nil") requestId=\(requestId)")
+            return true
+        } catch is CancellationError {
+            Log.warning("performAgentJoinCall cancelled (CancellationError) templateId=\(templateId ?? "nil") requestId=\(requestId)")
+            return true
+        } catch let urlError as URLError where urlError.code == .cancelled {
+            Log.warning("performAgentJoinCall cancelled (URLError.cancelled) templateId=\(templateId ?? "nil") requestId=\(requestId)")
+            return true
+        } catch let error as APIError {
+            Log.error("requestAgentJoin: agents/join APIError: \(error) - \(error.localizedDescription)")
+            let status: AgentJoinStatus
+            if case .noAgentsAvailable = error { status = .noAgentsAvailable } else { status = .failed }
+            await Self.broadcastAgentJoinRequest(
+                status: status, requestId: requestId,
+                conversationId: conversationId, session: session
+            )
+            return false
+        } catch {
+            Log.error("requestAgentJoin: agents/join unknown error: \(error.localizedDescription)")
+            await Self.broadcastAgentJoinRequest(
+                status: .failed, requestId: requestId,
+                conversationId: conversationId, session: session
+            )
+            return false
+        }
     }
 
     private static func broadcastAgentJoinRequest(

--- a/Convos/Shared Views/RoleLabelPill.swift
+++ b/Convos/Shared Views/RoleLabelPill.swift
@@ -1,0 +1,31 @@
+import SwiftUI
+
+/// Compact role/label capsule used in member rows, contact cards, picker
+/// rows, and any other surface that needs to tag content with a short
+/// secondary-color label ("Agent", "Creator", "Admin", "You", etc.).
+///
+/// Callers that need an accessibility identifier apply it as a downstream
+/// modifier (e.g. `RoleLabelPill(label: "You").accessibilityIdentifier(...)`)
+/// rather than baking it into the type.
+struct RoleLabelPill: View {
+    let label: String
+
+    var body: some View {
+        Text(label)
+            .font(.footnote)
+            .foregroundStyle(.colorTextSecondary)
+            .padding(.horizontal, DesignConstants.Spacing.step2x)
+            .padding(.vertical, DesignConstants.Spacing.stepX)
+            .background(.colorTextSecondary.opacity(0.1), in: .capsule)
+    }
+}
+
+#Preview("Common labels") {
+    VStack(spacing: DesignConstants.Spacing.step3x) {
+        RoleLabelPill(label: "Agent")
+        RoleLabelPill(label: "Creator")
+        RoleLabelPill(label: "Admin")
+        RoleLabelPill(label: "You")
+    }
+    .padding()
+}

--- a/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient+Models.swift
+++ b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient+Models.swift
@@ -206,6 +206,25 @@ public enum ConvosAPI {
         }
     }
 
+    // MARK: - v2/agent-templates/:id
+    // Subset of the agent-template object the backend returns from the
+    // agent-template endpoints (POST /:id/publish, PATCH /:id, GET /:id).
+    // We only model the fields the share flow consumes today (id, status,
+    // publishedUrl); decoding is tolerant of extra keys via the default
+    // Codable behavior.
+
+    public struct AgentTemplate: Codable, Sendable {
+        public let id: String
+        public let status: String
+        public let publishedUrl: String?
+
+        public init(id: String, status: String, publishedUrl: String?) {
+            self.id = id
+            self.status = status
+            self.publishedUrl = publishedUrl
+        }
+    }
+
     // MARK: - Common Error Response
 
     public struct ErrorResponse: Codable {

--- a/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift
+++ b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift
@@ -90,6 +90,12 @@ public protocol ConvosAPIClientProtocol: AnyObject, Sendable {
         forceErrorCode: Int?
     ) async throws -> ConvosAPI.AgentJoinResponse
 
+    // Agent templates
+    /// PATCH /api/v2/agent-templates/:id flipping status to "published" so
+    /// the backend hands back a non-null `publishedUrl`. The share flow on
+    /// builder-created templates calls this lazily on first tap.
+    func publishAgentTemplate(id: String) async throws -> ConvosAPI.AgentTemplate
+
     // Connections
     func initiateCloudConnection(serviceId: String, redirectUri: String) async throws -> CloudConnectionsAPI.InitiateResponse
     func completeCloudConnection(connectionRequestId: String) async throws -> CloudConnectionsAPI.CompleteResponse
@@ -743,6 +749,76 @@ final class ConvosAPIClient: ConvosAPIClientProtocol, Sendable {
             throw APIError.templateArchived
         default:
             throw APIError.serverError(parseErrorMessage(from: data))
+        }
+    }
+
+    // MARK: - Agent templates
+
+    /// Publishes an agent template so the backend hands back a non-null
+    /// `publishedUrl`. Hits POST /:id/publish?status=published, which is
+    /// the documented first-publish path for a `draft` row and the
+    /// idempotent re-publish path for an already-first-published row
+    /// (`unlisted` / `published` / `archived`). Both branches return the
+    /// same serialized template shape with a populated `publishedUrl`, so
+    /// the caller doesn't care which branch the backend took.
+    ///
+    /// We don't PATCH the status here: PATCH is the only way to flip
+    /// `unlisted` -> `published`, but for the iOS share flow the share URL
+    /// works whether the row is `unlisted` or `published`. Promoting
+    /// unlisted to published is a directory-visibility change, not a
+    /// shareability change, and isn't part of the share button's intent.
+    func publishAgentTemplate(id: String) async throws -> ConvosAPI.AgentTemplate {
+        let path: String = "v2/agent-templates/\(id)/publish"
+        var request: URLRequest
+        do {
+            request = try authenticatedRequest(
+                for: path,
+                method: "POST",
+                queryParameters: ["status": "published"]
+            )
+        } catch {
+            Log.error("publishAgentTemplate failed to build POST request for path=\(path), baseURL=\(baseURL.absoluteString): \(String(describing: error))")
+            throw error
+        }
+        // POST /publish takes no body; the backend reads `status` from the
+        // query string when present.
+        Log.info("publishAgentTemplate POST \(request.url?.absoluteString ?? "<nil>")")
+
+        let (data, httpResponse) = try await performAuthenticatedRequest(request)
+        return try decodeAgentTemplateResponse(
+            data: data,
+            httpResponse: httpResponse,
+            id: id
+        )
+    }
+
+    private func decodeAgentTemplateResponse(
+        data: Data,
+        httpResponse: HTTPURLResponse,
+        id: String
+    ) throws -> ConvosAPI.AgentTemplate {
+        switch httpResponse.statusCode {
+        case 200...299:
+            do {
+                return try JSONDecoder().decode(ConvosAPI.AgentTemplate.self, from: data)
+            } catch {
+                Log.error("publishAgentTemplate decode failed: \(String(describing: error)) body=\(data.prettyPrintedJSONString ?? "<nil>")")
+                throw error
+            }
+        case 400:
+            let message = parseErrorMessage(from: data)
+            Log.error("publishAgentTemplate 400 for id=\(id): \(message ?? "<no message>")")
+            throw APIError.badRequest(message)
+        case 403:
+            Log.error("publishAgentTemplate 403 for id=\(id) - caller is not the template owner")
+            throw APIError.forbidden
+        case 404:
+            Log.error("publishAgentTemplate 404 for id=\(id)")
+            throw APIError.notFound
+        default:
+            let message = parseErrorMessage(from: data)
+            Log.error("publishAgentTemplate status=\(httpResponse.statusCode) for id=\(id): \(message ?? "<no message>")")
+            throw APIError.serverError(message)
         }
     }
 

--- a/ConvosCore/Sources/ConvosCore/API/MockAPIClient.swift
+++ b/ConvosCore/Sources/ConvosCore/API/MockAPIClient.swift
@@ -104,6 +104,14 @@ final class MockAPIClient: ConvosAPIClientProtocol, Sendable {
         .init(success: true, joined: true)
     }
 
+    func publishAgentTemplate(id: String) async throws -> ConvosAPI.AgentTemplate {
+        .init(
+            id: id,
+            status: "published",
+            publishedUrl: "https://agents.example.com/mock.\(id.prefix(5))"
+        )
+    }
+
     // MARK: - Connections
 
     func initiateCloudConnection(serviceId: String, redirectUri: String) async throws -> CloudConnectionsAPI.InitiateResponse {

--- a/ConvosCore/Sources/ConvosCore/Contacts/ContactSyncCoordinator.swift
+++ b/ConvosCore/Sources/ConvosCore/Contacts/ContactSyncCoordinator.swift
@@ -157,6 +157,12 @@ final class ContactSyncCoordinator: ContactSyncCoordinatorProtocol, @unchecked S
                     insertedIds.append(member.inboxId)
                 }
                 upsertedCount += 1
+
+                try Self.upsertAgentTemplateContactIfNeeded(
+                    db: db,
+                    profile: profile,
+                    conversationId: conversationId
+                )
             }
 
             // Only mark the conversation synced if we actually upserted at
@@ -189,6 +195,45 @@ final class ContactSyncCoordinator: ContactSyncCoordinatorProtocol, @unchecked S
         ContactsWriter.postContactsWereAdded(
             inboxIds: insertedInboxIds,
             notificationCenter: notificationCenter
+        )
+    }
+
+    /// A member that published a `templateId` in its per-conversation
+    /// profile metadata is a template-backed agent.
+    /// Captures the *template* as a contact (keyed by `templateId`),
+    /// alongside the inboxId-keyed `DBContact` upsert the caller does for
+    /// every member. The same template encountered in another conversation
+    /// - a different agent instance, a different `inboxId` - resolves to
+    /// this same row, so a user ends up with one contact per template
+    /// rather than one per instance.
+    ///
+    /// The snapshot is untimestamped, so it seeds a new row on first
+    /// encounter and no-ops on re-encounter - the same seed-only behavior
+    /// the coordinator uses for `DBContact`. Refreshing a template
+    /// contact's fields as fresher instance profiles arrive is a follow-up
+    /// (the parallel of `ContactsWriter.mirrorMemberProfileToContactInTransaction`).
+    private static func upsertAgentTemplateContactIfNeeded(
+        db: Database,
+        profile: DBMemberProfile?,
+        conversationId: String
+    ) throws {
+        guard profile?.isAgentTemplate == true,
+              let templateId = profile?.agentTemplateId else {
+            return
+        }
+        try AgentTemplateContactsWriter.upsertInTransaction(
+            db: db,
+            templateId: templateId,
+            addedViaConversationId: conversationId,
+            profile: AgentTemplateContactSnapshot(
+                displayName: profile?.name,
+                emoji: profile?.agentTemplateEmoji,
+                descriptionText: profile?.agentTemplateDescription,
+                publishedURL: profile?.agentTemplatePublishedURL,
+                avatarURL: profile?.avatar,
+                agentVerification: profile?.memberKind?.agentVerification,
+                profileUpdatedAt: nil
+            )
         )
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Inboxes/MockInboxesService.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/MockInboxesService.swift
@@ -106,6 +106,14 @@ public final class MockInboxesService: SessionManagerProtocol, @unchecked Sendab
         return .init(success: true, joined: true)
     }
 
+    public func publishAgentTemplate(id: String) async throws -> ConvosAPI.AgentTemplate {
+        ConvosAPI.AgentTemplate(
+            id: id,
+            status: "published",
+            publishedUrl: "https://agents.example.com/mock.\(id.prefix(5))"
+        )
+    }
+
     public func conversationRepository(for conversationId: String) -> any ConversationRepositoryProtocol {
         MockConversationRepository()
     }

--- a/ConvosCore/Sources/ConvosCore/Messaging/MessagingService.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/MessagingService.swift
@@ -243,6 +243,14 @@ final class MessagingService: MessagingServiceProtocol, @unchecked Sendable {
         )
     }
 
+    func agentTemplateContactsRepository() -> any AgentTemplateContactsRepositoryProtocol {
+        AgentTemplateContactsRepository(databaseReader: databaseReader)
+    }
+
+    func agentTemplateContactsWriter() -> any AgentTemplateContactsWriterProtocol {
+        AgentTemplateContactsWriter(databaseWriter: databaseWriter)
+    }
+
     func reactionWriter() -> any ReactionWriterProtocol {
         ReactionWriter(sessionStateManager: sessionStateManager,
                        databaseWriter: databaseWriter)

--- a/ConvosCore/Sources/ConvosCore/Messaging/MessagingServiceProtocol.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/MessagingServiceProtocol.swift
@@ -90,6 +90,8 @@ public protocol MessagingServiceProtocol: AnyObject, Sendable, PostPairBroadcast
     func contactsRepository() -> any ContactsRepositoryProtocol
     func contactsWriter() -> any ContactsWriterProtocol
     func contactSyncCoordinator() -> any ContactSyncCoordinatorProtocol
+    func agentTemplateContactsRepository() -> any AgentTemplateContactsRepositoryProtocol
+    func agentTemplateContactsWriter() -> any AgentTemplateContactsWriterProtocol
 
     func uploadImage(data: Data, filename: String) async throws -> String
     func uploadImageAndExecute(

--- a/ConvosCore/Sources/ConvosCore/Mocks/MockAgentTemplateContactsRepository.swift
+++ b/ConvosCore/Sources/ConvosCore/Mocks/MockAgentTemplateContactsRepository.swift
@@ -1,0 +1,49 @@
+import Combine
+import Foundation
+
+/// Mock agent-template contacts repository for previews and the mock
+/// messaging service. Mirrors `MockContactsRepository`.
+public final class MockAgentTemplateContactsRepository: AgentTemplateContactsRepositoryProtocol, @unchecked Sendable {
+    private let subject: CurrentValueSubject<[AgentTemplateContact], Never>
+
+    public var agentTemplateContactsPublisher: AnyPublisher<[AgentTemplateContact], Never> {
+        subject.eraseToAnyPublisher()
+    }
+
+    public init(contacts: [AgentTemplateContact] = MockAgentTemplateContactsRepository.defaultMockContacts) {
+        self.subject = .init(contacts)
+    }
+
+    public func fetchAll() throws -> [AgentTemplateContact] {
+        subject.value
+    }
+
+    public func fetchContact(templateId: String) throws -> AgentTemplateContact? {
+        subject.value.first { $0.templateId == templateId }
+    }
+
+    public func isContact(templateId: String) throws -> Bool {
+        subject.value.contains { $0.templateId == templateId }
+    }
+
+    public func setContacts(_ contacts: [AgentTemplateContact]) {
+        subject.send(contacts)
+    }
+
+    public static let defaultMockContacts: [AgentTemplateContact] = [
+        .mock(displayName: "Tifoso", emoji: "🚴"),
+        .mock(displayName: "Trip Planner", emoji: "🗺️"),
+    ]
+}
+
+public final class MockAgentTemplateContactsWriter: AgentTemplateContactsWriterProtocol, @unchecked Sendable {
+    public init() {}
+
+    public func upsert(
+        templateId: String,
+        addedViaConversationId: String?,
+        profile: AgentTemplateContactSnapshot
+    ) async throws {}
+
+    public func remove(templateId: String) async throws {}
+}

--- a/ConvosCore/Sources/ConvosCore/Mocks/MockMessagingService.swift
+++ b/ConvosCore/Sources/ConvosCore/Mocks/MockMessagingService.swift
@@ -155,6 +155,14 @@ public final class MockMessagingService: MessagingServiceProtocol, @unchecked Se
         MockContactSyncCoordinator()
     }
 
+    public func agentTemplateContactsRepository() -> any AgentTemplateContactsRepositoryProtocol {
+        MockAgentTemplateContactsRepository()
+    }
+
+    public func agentTemplateContactsWriter() -> any AgentTemplateContactsWriterProtocol {
+        MockAgentTemplateContactsWriter()
+    }
+
     public func uploadImage(data: Data, filename: String) async throws -> String {
         "https://example.com/uploads/\(filename)"
     }

--- a/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
@@ -597,6 +597,10 @@ public final class SessionManager: SessionManagerProtocol, @unchecked Sendable {
         )
     }
 
+    public func publishAgentTemplate(id: String) async throws -> ConvosAPI.AgentTemplate {
+        try await apiClient.publishAgentTemplate(id: id)
+    }
+
     public func conversationRepository(for conversationId: String) -> any ConversationRepositoryProtocol {
         ConversationRepository(
             conversationId: conversationId,

--- a/ConvosCore/Sources/ConvosCore/Sessions/SessionManagerProtocol.swift
+++ b/ConvosCore/Sources/ConvosCore/Sessions/SessionManagerProtocol.swift
@@ -99,6 +99,12 @@ public protocol SessionManagerProtocol: AnyObject, Sendable {
         forceErrorCode: Int?
     ) async throws -> ConvosAPI.AgentJoinResponse
 
+    /// PATCH /api/v2/agent-templates/:id flipping the template to
+    /// `published`. Used by the agent-template contact card's share action
+    /// for builder-created templates that don't yet carry a `publishedUrl`
+    /// in their profile data.
+    func publishAgentTemplate(id: String) async throws -> ConvosAPI.AgentTemplate
+
     func conversationRepository(for conversationId: String) -> any ConversationRepositoryProtocol
 
     func messagesRepository(for conversationId: String) -> any MessagesRepositoryProtocol

--- a/ConvosCore/Sources/ConvosCore/Storage/Database Models/DBAgentTemplateContact.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Database Models/DBAgentTemplateContact.swift
@@ -9,7 +9,7 @@ import GRDB
 /// profile fields observed from encountered instances.
 ///
 /// There is no `blockedAt` column - agent-template contacts support Remove
-/// only (see docs/plans/agent-templates-phase-2-prd.md).
+/// only; see the agent-templates PRD.
 struct DBAgentTemplateContact: Codable, FetchableRecord, PersistableRecord, Hashable, Identifiable {
     static let databaseTableName: String = "agentTemplateContact"
 

--- a/ConvosCore/Sources/ConvosCore/Storage/Database Models/DBAgentTemplateContact.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Database Models/DBAgentTemplateContact.swift
@@ -1,0 +1,95 @@
+import Foundation
+import GRDB
+
+/// Local agent-template contact record. Keyed by `templateId` (the backend
+/// `AgentTemplate.id`), distinct from `DBContact`'s `inboxId` key: a template
+/// instantiated into N conversations produces N separate agent inboxIds, so
+/// the stable identity of the contact is the template, not any running
+/// instance. Stores a denormalized, most-recent-wins snapshot of the template
+/// profile fields observed from encountered instances.
+///
+/// There is no `blockedAt` column - agent-template contacts support Remove
+/// only (see docs/plans/agent-templates-phase-2-prd.md).
+struct DBAgentTemplateContact: Codable, FetchableRecord, PersistableRecord, Hashable, Identifiable {
+    static let databaseTableName: String = "agentTemplateContact"
+
+    enum Columns {
+        static let templateId: Column = Column(CodingKeys.templateId)
+        static let addedAt: Column = Column(CodingKeys.addedAt)
+        static let addedViaConversationId: Column = Column(CodingKeys.addedViaConversationId)
+        static let displayName: Column = Column(CodingKeys.displayName)
+        static let emoji: Column = Column(CodingKeys.emoji)
+        static let descriptionText: Column = Column(CodingKeys.descriptionText)
+        static let publishedURL: Column = Column(CodingKeys.publishedURL)
+        static let avatarURL: Column = Column(CodingKeys.avatarURL)
+        static let agentVerification: Column = Column(CodingKeys.agentVerification)
+        static let profileUpdatedAt: Column = Column(CodingKeys.profileUpdatedAt)
+    }
+
+    var id: String { templateId }
+
+    let templateId: String
+    let addedAt: Date
+    let addedViaConversationId: String?
+
+    var displayName: String?
+    /// The template emoji. The stable visual for a non-conversation-scoped
+    /// row: running-instance avatars are encrypted per-conversation and do
+    /// not decode outside the conversation they belong to.
+    var emoji: String?
+    var descriptionText: String?
+    /// The backend `publishedUrl` for the template's web page.
+    var publishedURL: String?
+    var avatarURL: String?
+    /// Agent verification snapshot. `nil` means no agent signal observed yet.
+    var agentVerification: AgentVerification?
+    var profileUpdatedAt: Date?
+
+    init(
+        templateId: String,
+        addedAt: Date,
+        addedViaConversationId: String?,
+        displayName: String? = nil,
+        emoji: String? = nil,
+        descriptionText: String? = nil,
+        publishedURL: String? = nil,
+        avatarURL: String? = nil,
+        agentVerification: AgentVerification? = nil,
+        profileUpdatedAt: Date? = nil
+    ) {
+        self.templateId = templateId
+        self.addedAt = addedAt
+        self.addedViaConversationId = addedViaConversationId
+        self.displayName = displayName
+        self.emoji = emoji
+        self.descriptionText = descriptionText
+        self.publishedURL = publishedURL
+        self.avatarURL = avatarURL
+        self.agentVerification = agentVerification
+        self.profileUpdatedAt = profileUpdatedAt
+    }
+}
+
+extension DBAgentTemplateContact {
+    /// Returns a copy with every profile field replaced by the snapshot's
+    /// values (including `nil`s) and `profileUpdatedAt` set to `timestamp`.
+    /// Identity columns (`templateId`, `addedAt`, `addedViaConversationId`)
+    /// are preserved. Mirrors `DBContact.replacingProfileFields(with:at:)`.
+    func replacingProfileFields(
+        with snapshot: AgentTemplateContactSnapshot,
+        at timestamp: Date
+    ) -> DBAgentTemplateContact {
+        DBAgentTemplateContact(
+            templateId: templateId,
+            addedAt: addedAt,
+            addedViaConversationId: addedViaConversationId,
+            displayName: snapshot.displayName,
+            emoji: snapshot.emoji,
+            descriptionText: snapshot.descriptionText,
+            publishedURL: snapshot.publishedURL,
+            avatarURL: snapshot.avatarURL,
+            agentVerification: snapshot.agentVerification,
+            profileUpdatedAt: timestamp
+        )
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/AgentTemplateContact.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/AgentTemplateContact.swift
@@ -60,6 +60,18 @@ public struct AgentTemplateContact: Hashable, Identifiable, Sendable {
         guard templateId.count > 8 else { return templateId }
         return String(templateId.prefix(8))
     }
+
+    /// Alphabetical sectioning key for the contacts list. Returns "#" for
+    /// names that do not begin with a letter. Mirrors
+    /// `Contact.alphabeticalSectionKey` so humans and agent-template
+    /// contacts bucket into the same sections.
+    public var alphabeticalSectionKey: String {
+        guard let first = resolvedDisplayName.first else { return "#" }
+        guard let firstUpper = String(first).uppercased().first, firstUpper.isLetter else {
+            return "#"
+        }
+        return String(firstUpper)
+    }
 }
 
 extension AgentTemplateContact {

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/AgentTemplateContact.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/AgentTemplateContact.swift
@@ -1,0 +1,104 @@
+import Foundation
+
+/// Presentation-layer model for an agent-template contact, hydrated from
+/// `DBAgentTemplateContact`.
+///
+/// Keyed by `templateId` (the backend `AgentTemplate.id`) - the parallel of
+/// `Contact`, which is keyed by `inboxId`. A template instantiated into many
+/// conversations produces many agent inboxIds; the stable identity of the
+/// contact is the template itself, so the contact is keyed by the template.
+public struct AgentTemplateContact: Hashable, Identifiable, Sendable {
+    public var id: String { templateId }
+
+    public let templateId: String
+    public let displayName: String?
+    /// The template emoji. The stable visual for a non-conversation-scoped
+    /// row, since running-instance avatars are encrypted per-conversation.
+    public let emoji: String?
+    public let descriptionText: String?
+    /// The backend `publishedUrl`; drives the contact card's Share action.
+    public let publishedURL: String?
+    public let avatarURL: String?
+    public let addedAt: Date
+    public let addedViaConversationId: String?
+    /// Last-known agent verification for this template.
+    public let agentVerification: AgentVerification?
+
+    public init(
+        templateId: String,
+        displayName: String?,
+        emoji: String? = nil,
+        descriptionText: String? = nil,
+        publishedURL: String? = nil,
+        avatarURL: String? = nil,
+        addedAt: Date,
+        addedViaConversationId: String?,
+        agentVerification: AgentVerification? = nil
+    ) {
+        self.templateId = templateId
+        self.displayName = displayName
+        self.emoji = emoji
+        self.descriptionText = descriptionText
+        self.publishedURL = publishedURL
+        self.avatarURL = avatarURL
+        self.addedAt = addedAt
+        self.addedViaConversationId = addedViaConversationId
+        self.agentVerification = agentVerification
+    }
+
+    /// Display label that always returns something printable. Falls back to
+    /// a truncated `templateId` so a browse list never renders an empty
+    /// cell. Mirrors `Contact.resolvedDisplayName`.
+    public var resolvedDisplayName: String {
+        if let displayName, !displayName.isEmpty {
+            return displayName
+        }
+        return shortTemplateId
+    }
+
+    private var shortTemplateId: String {
+        guard templateId.count > 8 else { return templateId }
+        return String(templateId.prefix(8))
+    }
+}
+
+extension AgentTemplateContact {
+    init(dbAgentTemplateContact: DBAgentTemplateContact) {
+        self.init(
+            templateId: dbAgentTemplateContact.templateId,
+            displayName: dbAgentTemplateContact.displayName,
+            emoji: dbAgentTemplateContact.emoji,
+            descriptionText: dbAgentTemplateContact.descriptionText,
+            publishedURL: dbAgentTemplateContact.publishedURL,
+            avatarURL: dbAgentTemplateContact.avatarURL,
+            addedAt: dbAgentTemplateContact.addedAt,
+            addedViaConversationId: dbAgentTemplateContact.addedViaConversationId,
+            agentVerification: dbAgentTemplateContact.agentVerification
+        )
+    }
+}
+
+extension AgentTemplateContact {
+    public static func mock(
+        templateId: String = UUID().uuidString,
+        displayName: String? = "Sample Agent",
+        emoji: String? = "🤖",
+        descriptionText: String? = nil,
+        publishedURL: String? = nil,
+        avatarURL: String? = nil,
+        addedViaConversationId: String? = nil,
+        agentVerification: AgentVerification? = .verified(.convos)
+    ) -> AgentTemplateContact {
+        AgentTemplateContact(
+            templateId: templateId,
+            displayName: displayName,
+            emoji: emoji,
+            descriptionText: descriptionText,
+            publishedURL: publishedURL,
+            avatarURL: avatarURL,
+            addedAt: Date(),
+            addedViaConversationId: addedViaConversationId,
+            agentVerification: agentVerification
+        )
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/Profile.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/Profile.swift
@@ -222,8 +222,17 @@ extension Profile {
     /// legacy agents that do not carry a template. The metadata key must
     /// match the agent runtime's profile builder; see the matching
     /// accessor on `DBMemberProfile`.
+    ///
+    /// Empty / whitespace-only values are coerced to nil so downstream
+    /// guards like `contact.agentTemplateId != nil` cannot pass for a
+    /// value the API would reject. Mirrors `profileEmoji` and
+    /// `agentDescription` above; the runtime occasionally writes an
+    /// empty string when its template lookup hasn't resolved yet.
     public var agentTemplateId: String? {
-        metadata?[Constant.templateIdKey]?.stringValue
+        metadata?[Constant.templateIdKey]?.stringValue.flatMap { value in
+            let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimmed.isEmpty ? nil : trimmed
+        }
     }
 
     /// The shareable web URL for a template-backed agent (the backend's

--- a/ConvosCore/Sources/ConvosCore/Storage/Repositories/AgentTemplateContactsRepository.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Repositories/AgentTemplateContactsRepository.swift
@@ -1,0 +1,69 @@
+import Combine
+import Foundation
+import GRDB
+
+public protocol AgentTemplateContactsRepositoryProtocol: Sendable {
+    /// Reactive publisher of all agent-template contacts, ordered
+    /// alphabetically by resolved display name (case-insensitive).
+    var agentTemplateContactsPublisher: AnyPublisher<[AgentTemplateContact], Never> { get }
+
+    /// Synchronous fetch of the alphabetical agent-template-contact list.
+    func fetchAll() throws -> [AgentTemplateContact]
+
+    /// Fetches a single agent-template contact by `templateId`.
+    func fetchContact(templateId: String) throws -> AgentTemplateContact?
+
+    /// Indexed point read; true when `templateId` has a stored row.
+    func isContact(templateId: String) throws -> Bool
+}
+
+final class AgentTemplateContactsRepository: AgentTemplateContactsRepositoryProtocol, @unchecked Sendable {
+    private let databaseReader: any DatabaseReader
+
+    let agentTemplateContactsPublisher: AnyPublisher<[AgentTemplateContact], Never>
+
+    init(databaseReader: any DatabaseReader) {
+        self.databaseReader = databaseReader
+        self.agentTemplateContactsPublisher = ValueObservation
+            .tracking { db in
+                try AgentTemplateContactsRepository.fetchAllContacts(db)
+            }
+            .publisher(in: databaseReader)
+            .replaceError(with: [])
+            .eraseToAnyPublisher()
+    }
+
+    func fetchAll() throws -> [AgentTemplateContact] {
+        try databaseReader.read { db in
+            try AgentTemplateContactsRepository.fetchAllContacts(db)
+        }
+    }
+
+    func fetchContact(templateId: String) throws -> AgentTemplateContact? {
+        try databaseReader.read { db in
+            try DBAgentTemplateContact
+                .fetchOne(db, key: templateId)
+                .map(AgentTemplateContact.init(dbAgentTemplateContact:))
+        }
+    }
+
+    func isContact(templateId: String) throws -> Bool {
+        try databaseReader.read { db in
+            try DBAgentTemplateContact
+                .filter(DBAgentTemplateContact.Columns.templateId == templateId)
+                .fetchCount(db) > 0
+        }
+    }
+
+    private static func fetchAllContacts(_ db: Database) throws -> [AgentTemplateContact] {
+        // Case-insensitive sort done in Swift to keep behavior identical
+        // across SQLite collations, matching `ContactsRepository`.
+        try DBAgentTemplateContact
+            .fetchAll(db)
+            .map(AgentTemplateContact.init(dbAgentTemplateContact:))
+            .sorted { lhs, rhs in
+                lhs.resolvedDisplayName
+                    .localizedCaseInsensitiveCompare(rhs.resolvedDisplayName) == .orderedAscending
+            }
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Storage/SharedDatabaseMigrator.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/SharedDatabaseMigrator.swift
@@ -392,12 +392,12 @@ extension SharedDatabaseMigrator {
         }
     }
 
-    /// Agent Templates Phase 2: the templateId-keyed agent-template contact
-    /// table. Separate from the inboxId-keyed `contact` table because a
-    /// template instantiated into N conversations produces N distinct agent
-    /// inboxIds - the stable identity of the contact is the template.
-    /// Registered after the contacts-MVP migrations so the
-    /// `addedViaConversationId` foreign key against `conversation` resolves.
+    /// The templateId-keyed agent-template contact table. Separate from the
+    /// inboxId-keyed `contact` table because a template instantiated into N
+    /// conversations produces N distinct agent inboxIds - the stable
+    /// identity of the contact is the template. Registered after the
+    /// contacts-MVP migrations so the `addedViaConversationId` foreign key
+    /// against `conversation` resolves.
     private static func registerAgentTemplateContactMigrations(on migrator: inout DatabaseMigrator) {
         migrator.registerMigration("createAgentTemplateContactTable") { db in
             try SharedDatabaseMigrator.createAgentTemplateContactSchema(db)
@@ -806,8 +806,8 @@ extension SharedDatabaseMigrator {
     /// template profile fields observed from encountered instances.
     /// `addedViaConversationId` uses `setNull` so the contact survives its
     /// source conversation, matching the `contact` table. No `blockedAt`
-    /// column: agent-template contacts support Remove only (see
-    /// docs/plans/agent-templates-phase-2-prd.md).
+    /// column: agent-template contacts support Remove only - see the
+    /// agent-templates PRD.
     private static func createAgentTemplateContactSchema(_ db: Database) throws {
         try db.create(table: "agentTemplateContact") { t in
             t.column("templateId", .text)

--- a/ConvosCore/Sources/ConvosCore/Storage/SharedDatabaseMigrator.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/SharedDatabaseMigrator.swift
@@ -156,6 +156,7 @@ extension SharedDatabaseMigrator {
         migrator.registerMigration("replaceThinkingSessionWithThinkingMoment", migrate: Self.replaceThinkingSessionWithThinkingMoment)
 
         migrator.registerMigration("renameConversationHasHadVerifiedAssistantToAgent", migrate: Self.renameConversationHasHadVerifiedAssistantToAgent)
+        Self.registerAgentTemplateContactMigrations(on: &migrator)
 
         migrator.registerMigration("addAgentBuilderSummaryCloudConnectionIds", migrate: Self.addAgentBuilderSummaryCloudConnectionIds)
 
@@ -388,6 +389,18 @@ extension SharedDatabaseMigrator {
                 t.column("periodLabel", .text).notNull()
                 t.column("updatedAt", .datetime).notNull()
             }
+        }
+    }
+
+    /// Agent Templates Phase 2: the templateId-keyed agent-template contact
+    /// table. Separate from the inboxId-keyed `contact` table because a
+    /// template instantiated into N conversations produces N distinct agent
+    /// inboxIds - the stable identity of the contact is the template.
+    /// Registered after the contacts-MVP migrations so the
+    /// `addedViaConversationId` foreign key against `conversation` resolves.
+    private static func registerAgentTemplateContactMigrations(on migrator: inout DatabaseMigrator) {
+        migrator.registerMigration("createAgentTemplateContactTable") { db in
+            try SharedDatabaseMigrator.createAgentTemplateContactSchema(db)
         }
     }
 
@@ -786,5 +799,36 @@ extension SharedDatabaseMigrator {
                 .references("conversation", onDelete: .cascade)
             t.column("contactsSyncedAt", .datetime).notNull()
         }
+    }
+
+    /// Agent-template contact table. Keyed by `templateId` (the backend
+    /// `AgentTemplate.id`), storing a most-recent-wins snapshot of the
+    /// template profile fields observed from encountered instances.
+    /// `addedViaConversationId` uses `setNull` so the contact survives its
+    /// source conversation, matching the `contact` table. No `blockedAt`
+    /// column: agent-template contacts support Remove only (see
+    /// docs/plans/agent-templates-phase-2-prd.md).
+    private static func createAgentTemplateContactSchema(_ db: Database) throws {
+        try db.create(table: "agentTemplateContact") { t in
+            t.column("templateId", .text)
+                .notNull()
+                .primaryKey()
+            t.column("addedAt", .datetime).notNull()
+            t.column("addedViaConversationId", .text)
+                .references("conversation", onDelete: .setNull)
+            t.column("displayName", .text)
+            t.column("emoji", .text)
+            t.column("descriptionText", .text)
+            t.column("publishedURL", .text)
+            t.column("avatarURL", .text)
+            t.column("agentVerification", .jsonText)
+            t.column("profileUpdatedAt", .datetime)
+        }
+
+        try db.create(
+            index: "idx_agentTemplateContact_displayName",
+            on: "agentTemplateContact",
+            columns: ["displayName"]
+        )
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/AgentTemplateContactsWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/AgentTemplateContactsWriter.swift
@@ -1,0 +1,154 @@
+import Foundation
+import GRDB
+
+/// Snapshot of agent-template profile fields used when upserting an
+/// agent-template contact. Mirrors `ContactProfileSnapshot`: a timestamped
+/// snapshot (`profileUpdatedAt != nil`) is treated as one authoritative unit
+/// that wholesale-replaces every profile field on the stored row; an
+/// untimestamped snapshot is a fill-defaults payload that only seeds a new
+/// row and never updates an existing one.
+public struct AgentTemplateContactSnapshot: Sendable, Hashable {
+    public let displayName: String?
+    public let emoji: String?
+    public let descriptionText: String?
+    public let publishedURL: String?
+    public let avatarURL: String?
+    public let agentVerification: AgentVerification?
+    public let profileUpdatedAt: Date?
+
+    public init(
+        displayName: String? = nil,
+        emoji: String? = nil,
+        descriptionText: String? = nil,
+        publishedURL: String? = nil,
+        avatarURL: String? = nil,
+        agentVerification: AgentVerification? = nil,
+        profileUpdatedAt: Date? = nil
+    ) {
+        self.displayName = displayName
+        self.emoji = emoji
+        self.descriptionText = descriptionText
+        self.publishedURL = publishedURL
+        self.avatarURL = avatarURL
+        self.agentVerification = agentVerification
+        self.profileUpdatedAt = profileUpdatedAt
+    }
+}
+
+public protocol AgentTemplateContactsWriterProtocol: Sendable {
+    /// Idempotent upsert. If the contact already exists, the immutable
+    /// identity columns (`addedAt`, `addedViaConversationId`) are preserved
+    /// and the profile snapshot is applied subject to most-recent-wins.
+    func upsert(
+        templateId: String,
+        addedViaConversationId: String?,
+        profile: AgentTemplateContactSnapshot
+    ) async throws
+
+    /// Removes the agent-template contact. No-op when `templateId` has no
+    /// row. A still-shared conversation re-adds it on the next membership
+    /// sync - the same eventual-consistency story as human contacts.
+    func remove(templateId: String) async throws
+}
+
+final class AgentTemplateContactsWriter: AgentTemplateContactsWriterProtocol, @unchecked Sendable {
+    private let databaseWriter: any DatabaseWriter
+
+    init(databaseWriter: any DatabaseWriter) {
+        self.databaseWriter = databaseWriter
+    }
+
+    func upsert(
+        templateId: String,
+        addedViaConversationId: String?,
+        profile: AgentTemplateContactSnapshot
+    ) async throws {
+        try await databaseWriter.write { db in
+            try Self.upsert(
+                db: db,
+                templateId: templateId,
+                addedViaConversationId: addedViaConversationId,
+                profile: profile
+            )
+        }
+    }
+
+    func remove(templateId: String) async throws {
+        _ = try await databaseWriter.write { db in
+            try DBAgentTemplateContact.deleteOne(db, key: templateId)
+        }
+    }
+
+    fileprivate static func upsert(
+        db: Database,
+        templateId: String,
+        addedViaConversationId: String?,
+        profile: AgentTemplateContactSnapshot
+    ) throws {
+        if let existing = try DBAgentTemplateContact.fetchOne(db, key: templateId) {
+            // Identity columns (addedAt, addedViaConversationId) are
+            // preserved on re-upsert. The profile snapshot is applied only
+            // if it carries a `profileUpdatedAt` newer than the stored one;
+            // untimestamped re-upserts leave the existing row untouched.
+            guard let merged = replacingProfile(of: existing, with: profile) else {
+                return
+            }
+            try merged.save(db)
+            return
+        }
+
+        let now = Date()
+        let row = DBAgentTemplateContact(
+            templateId: templateId,
+            addedAt: now,
+            addedViaConversationId: addedViaConversationId,
+            displayName: profile.displayName,
+            emoji: profile.emoji,
+            descriptionText: profile.descriptionText,
+            publishedURL: profile.publishedURL,
+            avatarURL: profile.avatarURL,
+            agentVerification: profile.agentVerification,
+            profileUpdatedAt: profile.profileUpdatedAt ?? now
+        )
+        try row.save(db)
+        Log.debug("Inserted new agent-template contact for templateId=\(templateId)")
+    }
+
+    /// Returns `existing` with its profile fields replaced by `profile` if
+    /// the snapshot should apply; returns `nil` if the caller should leave
+    /// the stored row untouched. Mirrors `ContactsWriter.replacingProfile`:
+    /// untimestamped snapshots never update an existing row; timestamped
+    /// snapshots older than the stored `profileUpdatedAt` are dropped;
+    /// newer-or-equal snapshots wholesale-replace every profile field.
+    private static func replacingProfile(
+        of existing: DBAgentTemplateContact,
+        with profile: AgentTemplateContactSnapshot
+    ) -> DBAgentTemplateContact? {
+        guard let incomingTimestamp = profile.profileUpdatedAt else {
+            return nil
+        }
+        if let stored = existing.profileUpdatedAt, incomingTimestamp < stored {
+            return nil
+        }
+        return existing.replacingProfileFields(with: profile, at: incomingTimestamp)
+    }
+}
+
+/// In-transaction upsert helper for `ContactSyncCoordinator` (Phase 2.2),
+/// which captures agent-template contacts inside the membership-sync
+/// transaction. Mirrors `ContactsWriter.upsertContactInTransaction`.
+extension AgentTemplateContactsWriter {
+    static func upsertInTransaction(
+        db: Database,
+        templateId: String,
+        addedViaConversationId: String?,
+        profile: AgentTemplateContactSnapshot
+    ) throws {
+        try upsert(
+            db: db,
+            templateId: templateId,
+            addedViaConversationId: addedViaConversationId,
+            profile: profile
+        )
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/AgentTemplateContactsWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/AgentTemplateContactsWriter.swift
@@ -134,8 +134,8 @@ final class AgentTemplateContactsWriter: AgentTemplateContactsWriterProtocol, @u
     }
 }
 
-/// In-transaction upsert helper for `ContactSyncCoordinator` (Phase 2.2),
-/// which captures agent-template contacts inside the membership-sync
+/// In-transaction upsert helper for `ContactSyncCoordinator`, which
+/// captures agent-template contacts inside the membership-sync
 /// transaction. Mirrors `ContactsWriter.upsertContactInTransaction`.
 extension AgentTemplateContactsWriter {
     static func upsertInTransaction(

--- a/ConvosCore/Tests/ConvosCoreTests/AgentTemplateContactsRepositoryTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/AgentTemplateContactsRepositoryTests.swift
@@ -1,0 +1,87 @@
+@testable import ConvosCore
+import Foundation
+import GRDB
+import Testing
+
+@Suite("AgentTemplateContactsRepository Tests", .serialized)
+struct AgentTemplateContactsRepositoryTests {
+    @Test("fetchAll returns agent-template contacts sorted case-insensitively by name")
+    func testFetchAllSortsAlphabetically() async throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        let writer = AgentTemplateContactsWriter(databaseWriter: dbManager.dbWriter)
+        let repository = AgentTemplateContactsRepository(databaseReader: dbManager.dbReader)
+
+        try await writer.upsert(
+            templateId: "t-charlie",
+            addedViaConversationId: nil,
+            profile: AgentTemplateContactSnapshot(displayName: "Charlie")
+        )
+        try await writer.upsert(
+            templateId: "t-alice",
+            addedViaConversationId: nil,
+            profile: AgentTemplateContactSnapshot(displayName: "alice")
+        )
+        try await writer.upsert(
+            templateId: "t-bob",
+            addedViaConversationId: nil,
+            profile: AgentTemplateContactSnapshot(displayName: "Bob")
+        )
+
+        let all = try repository.fetchAll()
+        #expect(all.map(\.resolvedDisplayName) == ["alice", "Bob", "Charlie"])
+    }
+
+    @Test("fetchContact returns the matching contact and nil for an unknown templateId")
+    func testFetchContact() async throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        let writer = AgentTemplateContactsWriter(databaseWriter: dbManager.dbWriter)
+        let repository = AgentTemplateContactsRepository(databaseReader: dbManager.dbReader)
+
+        try await writer.upsert(
+            templateId: "t-1",
+            addedViaConversationId: nil,
+            profile: AgentTemplateContactSnapshot(displayName: "Tifoso", emoji: "🚴")
+        )
+
+        let found = try repository.fetchContact(templateId: "t-1")
+        #expect(found?.templateId == "t-1")
+        #expect(found?.displayName == "Tifoso")
+        #expect(found?.emoji == "🚴")
+
+        let missing = try repository.fetchContact(templateId: "t-unknown")
+        #expect(missing == nil)
+    }
+
+    @Test("isContact reflects whether a templateId has a stored row")
+    func testIsContact() async throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        let writer = AgentTemplateContactsWriter(databaseWriter: dbManager.dbWriter)
+        let repository = AgentTemplateContactsRepository(databaseReader: dbManager.dbReader)
+
+        try await writer.upsert(
+            templateId: "t-1",
+            addedViaConversationId: nil,
+            profile: AgentTemplateContactSnapshot(displayName: "Tifoso")
+        )
+
+        #expect(try repository.isContact(templateId: "t-1") == true)
+        #expect(try repository.isContact(templateId: "t-unknown") == false)
+    }
+
+    @Test("A contact with no name resolves to a truncated templateId")
+    func testResolvedDisplayNameFallsBackToShortTemplateId() async throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        let writer = AgentTemplateContactsWriter(databaseWriter: dbManager.dbWriter)
+        let repository = AgentTemplateContactsRepository(databaseReader: dbManager.dbReader)
+
+        let templateId = "200e27dc-badc-429f-a431-b01b0281ec95"
+        try await writer.upsert(
+            templateId: templateId,
+            addedViaConversationId: nil,
+            profile: AgentTemplateContactSnapshot(displayName: nil)
+        )
+
+        let found = try repository.fetchContact(templateId: templateId)
+        #expect(found?.resolvedDisplayName == "200e27dc")
+    }
+}

--- a/ConvosCore/Tests/ConvosCoreTests/AgentTemplateContactsWriterTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/AgentTemplateContactsWriterTests.swift
@@ -1,0 +1,267 @@
+@testable import ConvosCore
+import Foundation
+import GRDB
+import Testing
+
+@Suite("AgentTemplateContactsWriter Tests", .serialized)
+struct AgentTemplateContactsWriterTests {
+    /// Inserts a minimal `conversation` row so an agent-template contact can
+    /// FK against it. `agentTemplateContact.addedViaConversationId`
+    /// references `conversation(id)`; tests that exercise a non-nil
+    /// `addedViaConversationId` need the parent row to exist first.
+    private static func seedMinimalConversation(_ db: Database, id: String) throws {
+        let creatorInboxId = "creator-\(id)"
+        try DBMember(inboxId: creatorInboxId).save(db, onConflict: .ignore)
+        try DBConversation(
+            id: id,
+            clientConversationId: id,
+            inviteTag: "tag-\(id)",
+            creatorId: creatorInboxId,
+            kind: .group,
+            consent: .allowed,
+            createdAt: Date(),
+            name: nil,
+            description: nil,
+            imageURLString: nil,
+            publicImageURLString: nil,
+            includeInfoInPublicPreview: false,
+            expiresAt: nil,
+            debugInfo: .empty,
+            isLocked: false,
+            imageSalt: nil,
+            imageNonce: nil,
+            imageEncryptionKey: nil,
+            conversationEmoji: nil,
+            imageLastRenewed: nil,
+            isUnused: false,
+            hasHadVerifiedAssistant: false
+        ).insert(db)
+    }
+
+    @Test("upsert preserves addedAt and addedViaConversationId on subsequent calls")
+    func testIdempotentUpsertPreservesIdentityColumns() async throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        let writer = AgentTemplateContactsWriter(databaseWriter: dbManager.dbWriter)
+
+        let templateId = "template-1"
+        let originalConversation = "conv-original"
+        let later = "conv-later"
+
+        try await dbManager.dbWriter.write { db in
+            try Self.seedMinimalConversation(db, id: originalConversation)
+            try Self.seedMinimalConversation(db, id: later)
+        }
+
+        try await writer.upsert(
+            templateId: templateId,
+            addedViaConversationId: originalConversation,
+            profile: AgentTemplateContactSnapshot(
+                displayName: "First",
+                profileUpdatedAt: Date(timeIntervalSince1970: 100)
+            )
+        )
+
+        let firstAddedAt = try await dbManager.dbReader.read { db in
+            try DBAgentTemplateContact.fetchOne(db, key: templateId)?.addedAt
+        }
+
+        // Sleep briefly so the second call's "now" is meaningfully later if
+        // it ever leaked into addedAt.
+        try await Task.sleep(nanoseconds: 5_000_000)
+
+        try await writer.upsert(
+            templateId: templateId,
+            addedViaConversationId: later,
+            profile: AgentTemplateContactSnapshot(
+                displayName: "Second",
+                profileUpdatedAt: Date(timeIntervalSince1970: 200)
+            )
+        )
+
+        let after = try await dbManager.dbReader.read { db in
+            try DBAgentTemplateContact.fetchOne(db, key: templateId)
+        }
+
+        #expect(after?.addedAt == firstAddedAt)
+        #expect(after?.addedViaConversationId == originalConversation)
+        #expect(after?.displayName == "Second")
+    }
+
+    @Test("upsert drops older timestamped snapshots and applies newer ones")
+    func testUpsertMostRecentWins() async throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        let writer = AgentTemplateContactsWriter(databaseWriter: dbManager.dbWriter)
+        let templateId = "template-1"
+
+        try await writer.upsert(
+            templateId: templateId,
+            addedViaConversationId: nil,
+            profile: AgentTemplateContactSnapshot(
+                displayName: "Latest",
+                profileUpdatedAt: Date(timeIntervalSince1970: 200)
+            )
+        )
+
+        // Older event - must be dropped.
+        try await writer.upsert(
+            templateId: templateId,
+            addedViaConversationId: nil,
+            profile: AgentTemplateContactSnapshot(
+                displayName: "Older",
+                profileUpdatedAt: Date(timeIntervalSince1970: 100)
+            )
+        )
+
+        var stored = try await dbManager.dbReader.read { db in
+            try DBAgentTemplateContact.fetchOne(db, key: templateId)
+        }
+        #expect(stored?.displayName == "Latest")
+
+        // Newer event - must be applied.
+        try await writer.upsert(
+            templateId: templateId,
+            addedViaConversationId: nil,
+            profile: AgentTemplateContactSnapshot(
+                displayName: "Newest",
+                profileUpdatedAt: Date(timeIntervalSince1970: 300)
+            )
+        )
+
+        stored = try await dbManager.dbReader.read { db in
+            try DBAgentTemplateContact.fetchOne(db, key: templateId)
+        }
+        #expect(stored?.displayName == "Newest")
+    }
+
+    @Test("An untimestamped upsert leaves an existing row untouched")
+    func testUntimestampedUpsertNoOpsOnExistingRow() async throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        let writer = AgentTemplateContactsWriter(databaseWriter: dbManager.dbWriter)
+        let templateId = "template-1"
+
+        try await writer.upsert(
+            templateId: templateId,
+            addedViaConversationId: nil,
+            profile: AgentTemplateContactSnapshot(
+                displayName: "Original",
+                profileUpdatedAt: Date(timeIntervalSince1970: 100)
+            )
+        )
+
+        try await writer.upsert(
+            templateId: templateId,
+            addedViaConversationId: nil,
+            profile: AgentTemplateContactSnapshot(
+                displayName: "FromAnotherConvo",
+                emoji: "🚴",
+                profileUpdatedAt: nil
+            )
+        )
+
+        let stored = try await dbManager.dbReader.read { db in
+            try DBAgentTemplateContact.fetchOne(db, key: templateId)
+        }
+        #expect(stored?.displayName == "Original")
+        #expect(stored?.emoji == nil)
+        #expect(stored?.profileUpdatedAt == Date(timeIntervalSince1970: 100))
+    }
+
+    @Test("A newer snapshot wholesale-replaces every profile field")
+    func testNewerSnapshotWholesaleReplacesFields() async throws {
+        // The snapshot is one authoritative unit: a newer event carrying
+        // only a name clears the stored emoji, mirroring ContactsWriter.
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        let writer = AgentTemplateContactsWriter(databaseWriter: dbManager.dbWriter)
+        let templateId = "template-1"
+
+        try await writer.upsert(
+            templateId: templateId,
+            addedViaConversationId: nil,
+            profile: AgentTemplateContactSnapshot(
+                displayName: "Original",
+                emoji: "🚴",
+                publishedURL: "https://agents-dev.convos.org/tifoso.pnw1o",
+                profileUpdatedAt: Date(timeIntervalSince1970: 100)
+            )
+        )
+
+        try await writer.upsert(
+            templateId: templateId,
+            addedViaConversationId: nil,
+            profile: AgentTemplateContactSnapshot(
+                displayName: "Renamed",
+                profileUpdatedAt: Date(timeIntervalSince1970: 200)
+            )
+        )
+
+        let stored = try await dbManager.dbReader.read { db in
+            try DBAgentTemplateContact.fetchOne(db, key: templateId)
+        }
+        #expect(stored?.displayName == "Renamed")
+        #expect(stored?.emoji == nil)
+        #expect(stored?.publishedURL == nil)
+    }
+
+    @Test("upsert inserts a new row with the snapshot fields")
+    func testUpsertInsertsNewRow() async throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        let writer = AgentTemplateContactsWriter(databaseWriter: dbManager.dbWriter)
+        let templateId = "200e27dc-badc-429f-a431-b01b0281ec95"
+
+        try await writer.upsert(
+            templateId: templateId,
+            addedViaConversationId: nil,
+            profile: AgentTemplateContactSnapshot(
+                displayName: "Tifoso",
+                emoji: "🚴",
+                descriptionText: "Pro cycling expert",
+                publishedURL: "https://agents-dev.convos.org/tifoso.pnw1o",
+                agentVerification: .verified(.convos),
+                profileUpdatedAt: Date(timeIntervalSince1970: 100)
+            )
+        )
+
+        let stored = try await dbManager.dbReader.read { db in
+            try DBAgentTemplateContact.fetchOne(db, key: templateId)
+        }
+        #expect(stored?.templateId == templateId)
+        #expect(stored?.displayName == "Tifoso")
+        #expect(stored?.emoji == "🚴")
+        #expect(stored?.descriptionText == "Pro cycling expert")
+        #expect(stored?.publishedURL == "https://agents-dev.convos.org/tifoso.pnw1o")
+        #expect(stored?.agentVerification == .verified(.convos))
+    }
+
+    @Test("remove deletes the agent-template contact row")
+    func testRemoveDeletesRow() async throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        let writer = AgentTemplateContactsWriter(databaseWriter: dbManager.dbWriter)
+        let templateId = "template-1"
+
+        try await writer.upsert(
+            templateId: templateId,
+            addedViaConversationId: nil,
+            profile: AgentTemplateContactSnapshot(displayName: "Tifoso")
+        )
+
+        try await writer.remove(templateId: templateId)
+
+        let count = try await dbManager.dbReader.read { db in
+            try DBAgentTemplateContact.fetchCount(db)
+        }
+        #expect(count == 0)
+    }
+
+    @Test("remove no-ops when the templateId has no row")
+    func testRemoveUnknownTemplateNoOps() async throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        let writer = AgentTemplateContactsWriter(databaseWriter: dbManager.dbWriter)
+
+        try await writer.remove(templateId: "ghost")
+
+        let count = try await dbManager.dbReader.read { db in
+            try DBAgentTemplateContact.fetchCount(db)
+        }
+        #expect(count == 0)
+    }
+}

--- a/ConvosCore/Tests/ConvosCoreTests/AgentTemplateContactsWriterTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/AgentTemplateContactsWriterTests.swift
@@ -34,7 +34,7 @@ struct AgentTemplateContactsWriterTests {
             conversationEmoji: nil,
             imageLastRenewed: nil,
             isUnused: false,
-            hasHadVerifiedAssistant: false
+            hasHadVerifiedAgent: false
         ).insert(db)
     }
 

--- a/ConvosCore/Tests/ConvosCoreTests/ContactSyncCoordinatorTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ContactSyncCoordinatorTests.swift
@@ -510,6 +510,174 @@ struct ContactSyncCoordinatorTests {
 
         recorder.stop()
     }
+
+    // MARK: - Agent template capture
+
+    /// Saves a template-backed verified-agent member profile: `memberKind`
+    /// is `.verifiedConvos` and the metadata carries the `templateId` plus
+    /// the published-template fields the agent runtime stamps.
+    private static func saveAgentProfile(
+        db: Database,
+        conversationId: String,
+        inboxId: String,
+        templateId: String,
+        name: String = "Tifoso",
+        emoji: String = "🚴",
+        descriptionText: String = "Pro cycling expert",
+        publishedUrl: String = "https://agents-dev.convos.org/tifoso.pnw1o"
+    ) throws {
+        try DBMemberProfile(
+            conversationId: conversationId,
+            inboxId: inboxId,
+            name: name,
+            avatar: nil,
+            memberKind: .verifiedConvos,
+            metadata: [
+                "templateId": .string(templateId),
+                "emoji": .string(emoji),
+                "description": .string(descriptionText),
+                "publishedUrl": .string(publishedUrl)
+            ]
+        ).save(db)
+    }
+
+    @Test("A conversation with a template-backed agent captures the template as a contact")
+    func testTemplateBackedAgentCapturedAsContact() async throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        let selfInboxId = "self-inbox"
+        let conversationId = "conv-1"
+        let templateId = "200e27dc-badc-429f-a431-b01b0281ec95"
+
+        try await dbManager.dbWriter.write { db in
+            try DBInbox(inboxId: selfInboxId, clientId: "client").save(db)
+            try Self.seedConversation(
+                db: db,
+                conversationId: conversationId,
+                creatorInboxId: selfInboxId,
+                memberInboxIds: [selfInboxId, "agent-instance-a"]
+            )
+            try Self.saveAgentProfile(
+                db: db,
+                conversationId: conversationId,
+                inboxId: "agent-instance-a",
+                templateId: templateId
+            )
+        }
+
+        let coordinator = ContactSyncCoordinator(
+            databaseWriter: dbManager.dbWriter,
+            databaseReader: dbManager.dbReader
+        )
+        try await coordinator.syncContactsOnFirstMessage(for: conversationId)
+
+        let templateContacts = try await dbManager.dbReader.read { db in
+            try DBAgentTemplateContact.fetchAll(db)
+        }
+        #expect(templateContacts.count == 1)
+        let stored = templateContacts.first
+        #expect(stored?.templateId == templateId)
+        #expect(stored?.displayName == "Tifoso")
+        #expect(stored?.emoji == "🚴")
+        #expect(stored?.publishedURL == "https://agents-dev.convos.org/tifoso.pnw1o")
+        #expect(stored?.addedViaConversationId == conversationId)
+    }
+
+    @Test("The same template across two conversations yields exactly one contact row")
+    func testSameTemplateAcrossConversationsYieldsOneRow() async throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        let selfInboxId = "self-inbox"
+        let templateId = "200e27dc-badc-429f-a431-b01b0281ec95"
+
+        try await dbManager.dbWriter.write { db in
+            try DBInbox(inboxId: selfInboxId, clientId: "client").save(db)
+            // Two conversations, two different agent instances (distinct
+            // inboxIds), both provisioned from the same template.
+            try Self.seedConversation(
+                db: db,
+                conversationId: "conv-1",
+                creatorInboxId: selfInboxId,
+                memberInboxIds: [selfInboxId, "agent-a"]
+            )
+            try Self.saveAgentProfile(
+                db: db,
+                conversationId: "conv-1",
+                inboxId: "agent-a",
+                templateId: templateId
+            )
+            try Self.seedConversation(
+                db: db,
+                conversationId: "conv-2",
+                creatorInboxId: selfInboxId,
+                memberInboxIds: [selfInboxId, "agent-b"]
+            )
+            try Self.saveAgentProfile(
+                db: db,
+                conversationId: "conv-2",
+                inboxId: "agent-b",
+                templateId: templateId
+            )
+        }
+
+        let coordinator = ContactSyncCoordinator(
+            databaseWriter: dbManager.dbWriter,
+            databaseReader: dbManager.dbReader
+        )
+        try await coordinator.syncContactsOnFirstMessage(for: "conv-1")
+        try await coordinator.syncContactsOnFirstMessage(for: "conv-2")
+
+        let templateContacts = try await dbManager.dbReader.read { db in
+            try DBAgentTemplateContact.fetchAll(db)
+        }
+        #expect(templateContacts.count == 1)
+        #expect(templateContacts.first?.templateId == templateId)
+    }
+
+    @Test("A conversation with only humans and legacy verified agents yields no template contacts")
+    func testNoTemplateContactsForHumansAndLegacyAgents() async throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        let selfInboxId = "self-inbox"
+        let conversationId = "conv-1"
+
+        try await dbManager.dbWriter.write { db in
+            try DBInbox(inboxId: selfInboxId, clientId: "client").save(db)
+            try Self.seedConversation(
+                db: db,
+                conversationId: conversationId,
+                creatorInboxId: selfInboxId,
+                memberInboxIds: [selfInboxId, "alice", "legacy-agent"],
+                memberProfiles: ["alice": (name: "Alice", avatar: nil)]
+            )
+            // A legacy verified agent: verified, but carries no templateId
+            // in its profile metadata.
+            try DBMemberProfile(
+                conversationId: conversationId,
+                inboxId: "legacy-agent",
+                name: "Convos Assistant",
+                avatar: nil,
+                memberKind: .verifiedConvos,
+                metadata: nil
+            ).save(db)
+        }
+
+        let coordinator = ContactSyncCoordinator(
+            databaseWriter: dbManager.dbWriter,
+            databaseReader: dbManager.dbReader
+        )
+        try await coordinator.syncContactsOnFirstMessage(for: conversationId)
+
+        let templateCount = try await dbManager.dbReader.read { db in
+            try DBAgentTemplateContact.fetchCount(db)
+        }
+        #expect(templateCount == 0)
+
+        // The inboxId-keyed contact table is unaffected: both non-self
+        // members still land there (the legacy agent is hidden from the
+        // browse list separately, by the `!isVerifiedAgent` filter).
+        let contactIds: Set<String> = try await dbManager.dbReader.read { db in
+            Set(try DBContact.fetchAll(db).map(\.inboxId))
+        }
+        #expect(contactIds == Set(["alice", "legacy-agent"]))
+    }
 }
 
 /// Posts a sentinel notification on `center` and awaits its delivery on the

--- a/ConvosCore/Tests/ConvosCoreTests/ContactsWriterTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ContactsWriterTests.swift
@@ -376,10 +376,13 @@ struct ContactsWriterTests {
     @Test("upsertContact posts `contactsWereAdded` only on a brand-new contact row")
     func testUpsertPostsContactsWereAddedOnInsertOnly() async throws {
         let dbManager = MockDatabaseManager.makeTestDatabase()
-        let writer = ContactsWriter(databaseWriter: dbManager.dbWriter)
+        // Private center so sibling tests posting on `.default` cannot leak
+        // into the recorded set.
+        let center = NotificationCenter()
+        let writer = ContactsWriter(databaseWriter: dbManager.dbWriter, notificationCenter: center)
         let inboxId = "inbox-add-1"
 
-        let recorder = NotificationRecorder(name: .contactsWereAdded)
+        let recorder = NotificationRecorder(name: .contactsWereAdded, center: center)
 
         // First upsert on a fresh inboxId: real insert, post fires with the
         // singleton inboxId in the userInfo payload.
@@ -424,7 +427,10 @@ struct ContactsWriterTests {
     @Test("Block and unblock post `contactBlockingDidChange` on real state changes only")
     func testBlockingPostsNotificationOnRealChanges() async throws {
         let dbManager = MockDatabaseManager.makeTestDatabase()
-        let writer = ContactsWriter(databaseWriter: dbManager.dbWriter)
+        // Private center so sibling tests posting on `.default` cannot leak
+        // into the recorded set.
+        let center = NotificationCenter()
+        let writer = ContactsWriter(databaseWriter: dbManager.dbWriter, notificationCenter: center)
         let inboxId = "inbox-1"
 
         try await writer.upsertContact(
@@ -433,7 +439,7 @@ struct ContactsWriterTests {
             profile: ContactProfileSnapshot(displayName: "Test")
         )
 
-        let recorder = NotificationRecorder(name: .contactBlockingDidChange)
+        let recorder = NotificationRecorder(name: .contactBlockingDidChange, center: center)
 
         // First block: real change → post.
         try await writer.block(inboxId: inboxId)
@@ -756,13 +762,20 @@ struct ContactsWriterTests {
 
 /// Records every `Notification` posted on a given name so tests can assert
 /// what the writer fired. Removes its observer on `stop()`.
+///
+/// `center` lets a test bind the recorder to a private `NotificationCenter()`
+/// so a concurrently-running sibling test posting on `.default` can't leak
+/// into the recorded set. Pair with `ContactsWriter(databaseWriter:,
+/// notificationCenter:)` so the writer posts to the same private center.
 private final class NotificationRecorder: @unchecked Sendable {
+    private let center: NotificationCenter
     private(set) var notifications: [Notification] = []
     private var token: NSObjectProtocol?
     private let lock: NSLock = NSLock()
 
-    init(name: Notification.Name) {
-        token = NotificationCenter.default.addObserver(
+    init(name: Notification.Name, center: NotificationCenter = .default) {
+        self.center = center
+        token = center.addObserver(
             forName: name,
             object: nil,
             queue: nil
@@ -776,7 +789,7 @@ private final class NotificationRecorder: @unchecked Sendable {
 
     func stop() {
         if let token {
-            NotificationCenter.default.removeObserver(token)
+            center.removeObserver(token)
             self.token = nil
         }
     }

--- a/ConvosCore/Tests/ConvosCoreTests/TestStubAPIClientDefaults.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/TestStubAPIClientDefaults.swift
@@ -43,4 +43,16 @@ extension ConvosAPIClientProtocol {
     ) async throws -> ConvosAPI.AgentJoinResponse {
         ConvosAPI.AgentJoinResponse(success: true, joined: true)
     }
+
+    /// Default for the publish-on-share PATCH used by the agent-template
+    /// contact card. Returns a synthetic "published" template so fixtures
+    /// don't have to re-stub it. Tests that exercise this specifically
+    /// should override on their fixture.
+    func publishAgentTemplate(id: String) async throws -> ConvosAPI.AgentTemplate {
+        ConvosAPI.AgentTemplate(
+            id: id,
+            status: "published",
+            publishedUrl: "https://agents.example.com/test.\(id.prefix(5))"
+        )
+    }
 }

--- a/ConvosTests/ContactsPickerViewModelTests.swift
+++ b/ConvosTests/ContactsPickerViewModelTests.swift
@@ -15,6 +15,22 @@ final class ContactsPickerViewModelTests: XCTestCase {
         super.tearDown()
     }
 
+    // MARK: - Helpers
+
+    private func humanRowIds(_ viewModel: ContactsPickerViewModel) -> [String] {
+        viewModel.sections.flatMap { $0.rows }.compactMap { row in
+            if case .human(let contact) = row.kind { return contact.inboxId }
+            return nil
+        }
+    }
+
+    private func agentRowIds(_ viewModel: ContactsPickerViewModel) -> [String] {
+        viewModel.sections.flatMap { $0.rows }.compactMap { row in
+            if case .agentTemplate(let agent) = row.kind { return agent.templateId }
+            return nil
+        }
+    }
+
     // MARK: - Sectioning + sort
 
     func testAlphabeticalSectionsExcludeBlockedContactsByDefault() {
@@ -28,8 +44,7 @@ final class ContactsPickerViewModelTests: XCTestCase {
             contactsRepository: repo
         )
 
-        let allRowIds: [String] = viewModel.sections.flatMap { $0.rows.map(\.id) }
-        XCTAssertEqual(allRowIds.sorted(), [alice.inboxId, carl.inboxId].sorted())
+        XCTAssertEqual(humanRowIds(viewModel).sorted(), [alice.inboxId, carl.inboxId].sorted())
     }
 
     /// Verified-agent contacts (Convos / OAuth-attested assistants) live in
@@ -58,12 +73,10 @@ final class ContactsPickerViewModelTests: XCTestCase {
             contactsRepository: repo
         )
 
-        let allRowIds: [String] = viewModel.sections.flatMap { $0.rows.map(\.id) }
         // Alice and the unverified agent pass through; both verified agents
         // are filtered out. Unverified agents intentionally remain visible
-        // because they're not yet attested - the user may still want to act
-        // on them like any unknown contact.
-        XCTAssertEqual(allRowIds.sorted(), [alice.inboxId, unverifiedAgent.inboxId].sorted())
+        // because they're not yet attested.
+        XCTAssertEqual(humanRowIds(viewModel).sorted(), [alice.inboxId, unverifiedAgent.inboxId].sorted())
     }
 
     func testHashBucketSortsLastForNonAlphaNames() {
@@ -93,11 +106,11 @@ final class ContactsPickerViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.headerTitle, "New conversation")
 
         let firstId = MockContactsRepository.defaultMockContacts[0].inboxId
-        viewModel.toggleSelection(for: firstId)
+        viewModel.toggleSelection(.human(inboxId: firstId))
         XCTAssertEqual(viewModel.confirmButtonTitle, "Continue")
 
         let secondId = MockContactsRepository.defaultMockContacts[1].inboxId
-        viewModel.toggleSelection(for: secondId)
+        viewModel.toggleSelection(.human(inboxId: secondId))
         XCTAssertEqual(viewModel.confirmButtonTitle, "Continue")
     }
 
@@ -110,11 +123,11 @@ final class ContactsPickerViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.headerTitle, "Add to Dev Convosation")
 
         let firstId = MockContactsRepository.defaultMockContacts[0].inboxId
-        viewModel.toggleSelection(for: firstId)
+        viewModel.toggleSelection(.human(inboxId: firstId))
         XCTAssertEqual(viewModel.confirmButtonTitle, "Continue")
 
         let secondId = MockContactsRepository.defaultMockContacts[1].inboxId
-        viewModel.toggleSelection(for: secondId)
+        viewModel.toggleSelection(.human(inboxId: secondId))
         XCTAssertEqual(viewModel.confirmButtonTitle, "Continue")
     }
 
@@ -127,7 +140,7 @@ final class ContactsPickerViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.headerTitle, "Add to convo")
     }
 
-    // MARK: - Selection
+    // MARK: - Selection (humans)
 
     func testToggleSelectionTogglesAndCanConfirmReflectsCount() {
         let viewModel = ContactsPickerViewModel(
@@ -138,14 +151,15 @@ final class ContactsPickerViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.canConfirm)
 
         let target = MockContactsRepository.defaultMockContacts[0].inboxId
-        viewModel.toggleSelection(for: target)
+        let selection: ContactsPickerViewModel.Selection = .human(inboxId: target)
+        viewModel.toggleSelection(selection)
         XCTAssertTrue(viewModel.canConfirm)
         XCTAssertEqual(viewModel.selectionCount, 1)
-        XCTAssertTrue(viewModel.isSelected(inboxId: target))
+        XCTAssertTrue(viewModel.isSelected(selection))
 
-        viewModel.toggleSelection(for: target)
+        viewModel.toggleSelection(selection)
         XCTAssertFalse(viewModel.canConfirm)
-        XCTAssertFalse(viewModel.isSelected(inboxId: target))
+        XCTAssertFalse(viewModel.isSelected(selection))
     }
 
     func testToggleSelectionIgnoresAlreadyInChatContacts() {
@@ -156,8 +170,8 @@ final class ContactsPickerViewModelTests: XCTestCase {
             alreadyInChatInboxIds: [alreadyIn]
         )
 
-        viewModel.toggleSelection(for: alreadyIn)
-        XCTAssertFalse(viewModel.isSelected(inboxId: alreadyIn))
+        viewModel.toggleSelection(.human(inboxId: alreadyIn))
+        XCTAssertFalse(viewModel.isSelected(.human(inboxId: alreadyIn)))
         XCTAssertEqual(viewModel.selectionCount, 0)
     }
 
@@ -174,8 +188,66 @@ final class ContactsPickerViewModelTests: XCTestCase {
         )
 
         XCTAssertEqual(viewModel.selectionCount, 1)
-        XCTAssertFalse(viewModel.isSelected(inboxId: inChat))
-        XCTAssertTrue(viewModel.isSelected(inboxId: mocks[1].inboxId))
+        XCTAssertFalse(viewModel.isSelected(.human(inboxId: inChat)))
+        XCTAssertTrue(viewModel.isSelected(.human(inboxId: mocks[1].inboxId)))
+    }
+
+    // MARK: - Selection (agent templates)
+
+    func testAgentTemplatesAreSelectableAndMixWithHumans() {
+        let alice = Contact.mock(displayName: "Alice")
+        let bob = Contact.mock(displayName: "Bob")
+        let tifoso = AgentTemplateContact.mock(displayName: "Tifoso", emoji: "🚴")
+        let tripPlanner = AgentTemplateContact.mock(displayName: "Trip Planner", emoji: "🗺️")
+        let viewModel = ContactsPickerViewModel(
+            mode: .newConversation,
+            contactsRepository: MockContactsRepository(contacts: [alice, bob]),
+            agentTemplateContactsRepository: MockAgentTemplateContactsRepository(contacts: [tifoso, tripPlanner])
+        )
+
+        viewModel.toggleSelection(.human(inboxId: alice.inboxId))
+        viewModel.toggleSelection(.agentTemplate(templateId: tifoso.templateId))
+        viewModel.toggleSelection(.agentTemplate(templateId: tripPlanner.templateId))
+
+        XCTAssertEqual(viewModel.selectionCount, 3)
+        XCTAssertEqual(Set(viewModel.selectedContacts.map(\.inboxId)), [alice.inboxId])
+        XCTAssertEqual(
+            Set(viewModel.selectedAgentContacts.map(\.templateId)),
+            [tifoso.templateId, tripPlanner.templateId]
+        )
+    }
+
+    /// Agent-template rows are surfaced in the picker sections (unlike
+    /// verified humans, which are filtered out). Regression guard for the
+    /// 2.4 picker integration.
+    func testAgentTemplateRowsAppearInSections() {
+        let tifoso = AgentTemplateContact.mock(displayName: "Tifoso", emoji: "🚴")
+        let viewModel = ContactsPickerViewModel(
+            mode: .newConversation,
+            contactsRepository: MockContactsRepository(contacts: []),
+            agentTemplateContactsRepository: MockAgentTemplateContactsRepository(contacts: [tifoso])
+        )
+
+        XCTAssertEqual(agentRowIds(viewModel), [tifoso.templateId])
+    }
+
+    /// Selecting / deselecting an agent template via the explicit `Selection`
+    /// API round-trips cleanly. The `templateId` accessor exposes the same
+    /// id through both directions.
+    func testAgentTemplateSelectionRoundTrips() {
+        let tifoso = AgentTemplateContact.mock(displayName: "Tifoso", emoji: "🚴")
+        let viewModel = ContactsPickerViewModel(
+            mode: .newConversation,
+            contactsRepository: MockContactsRepository(contacts: []),
+            agentTemplateContactsRepository: MockAgentTemplateContactsRepository(contacts: [tifoso])
+        )
+        let selection: ContactsPickerViewModel.Selection = .agentTemplate(templateId: tifoso.templateId)
+
+        XCTAssertFalse(viewModel.isSelected(selection))
+        viewModel.toggleSelection(selection)
+        XCTAssertTrue(viewModel.isSelected(selection))
+        viewModel.deselect(selection)
+        XCTAssertFalse(viewModel.isSelected(selection))
     }
 
     // MARK: - Search
@@ -192,8 +264,22 @@ final class ContactsPickerViewModelTests: XCTestCase {
         )
 
         viewModel.searchQuery = "ALI"
-        let allRowIds: [String] = viewModel.sections.flatMap { $0.rows.map(\.id) }
-        XCTAssertEqual(allRowIds, [alice.inboxId])
+        XCTAssertEqual(humanRowIds(viewModel), [alice.inboxId])
+    }
+
+    func testSearchMatchesAgentTemplateNames() {
+        let alice = Contact.mock(displayName: "Alice")
+        let tifoso = AgentTemplateContact.mock(displayName: "Tifoso", emoji: "🚴")
+        let tripPlanner = AgentTemplateContact.mock(displayName: "Trip Planner", emoji: "🗺️")
+        let viewModel = ContactsPickerViewModel(
+            mode: .newConversation,
+            contactsRepository: MockContactsRepository(contacts: [alice]),
+            agentTemplateContactsRepository: MockAgentTemplateContactsRepository(contacts: [tifoso, tripPlanner])
+        )
+
+        viewModel.searchQuery = "trip"
+        XCTAssertEqual(humanRowIds(viewModel), [])
+        XCTAssertEqual(agentRowIds(viewModel), [tripPlanner.templateId])
     }
 
     func testEmptySearchQueryShowsEverything() {
@@ -218,10 +304,16 @@ final class ContactsPickerViewModelTests: XCTestCase {
             alreadyInChatInboxIds: [inChat]
         )
 
-        let inChatRow = viewModel.sections.flatMap(\.rows).first { $0.id == inChat }
+        let inChatRow = viewModel.sections.flatMap(\.rows).first { row in
+            if case .human(let contact) = row.kind { return contact.inboxId == inChat }
+            return false
+        }
         XCTAssertEqual(inChatRow?.isAlreadyInChat, true)
 
-        let otherRow = viewModel.sections.flatMap(\.rows).first { $0.id == mocks[1].inboxId }
+        let otherRow = viewModel.sections.flatMap(\.rows).first { row in
+            if case .human(let contact) = row.kind { return contact.inboxId == mocks[1].inboxId }
+            return false
+        }
         XCTAssertEqual(otherRow?.isAlreadyInChat, false)
     }
 
@@ -237,8 +329,8 @@ final class ContactsPickerViewModelTests: XCTestCase {
 
         let removed = mocks[0].inboxId
         let kept = mocks[1].inboxId
-        viewModel.toggleSelection(for: removed)
-        viewModel.toggleSelection(for: kept)
+        viewModel.toggleSelection(.human(inboxId: removed))
+        viewModel.toggleSelection(.human(inboxId: kept))
 
         repo.setContacts(mocks.filter { $0.inboxId != removed })
 
@@ -246,7 +338,31 @@ final class ContactsPickerViewModelTests: XCTestCase {
         // operator on the publisher subscription has a chance to deliver.
         try await Task.sleep(nanoseconds: 50_000_000)
 
-        XCTAssertFalse(viewModel.isSelected(inboxId: removed))
-        XCTAssertTrue(viewModel.isSelected(inboxId: kept))
+        XCTAssertFalse(viewModel.isSelected(.human(inboxId: removed)))
+        XCTAssertTrue(viewModel.isSelected(.human(inboxId: kept)))
+    }
+
+    /// Agent-template pruning mirrors the human path: if the agent-template
+    /// repo drops a row from underneath us (e.g. user removed the contact
+    /// from another surface mid-picker), the selection drops too.
+    func testAgentTemplateSelectionPrunedWhenContactRemoved() async throws {
+        let tifoso = AgentTemplateContact.mock(displayName: "Tifoso", emoji: "🚴")
+        let tripPlanner = AgentTemplateContact.mock(displayName: "Trip Planner", emoji: "🗺️")
+        let repo = MockAgentTemplateContactsRepository(contacts: [tifoso, tripPlanner])
+        let viewModel = ContactsPickerViewModel(
+            mode: .newConversation,
+            contactsRepository: MockContactsRepository(contacts: []),
+            agentTemplateContactsRepository: repo
+        )
+
+        viewModel.toggleSelection(.agentTemplate(templateId: tifoso.templateId))
+        viewModel.toggleSelection(.agentTemplate(templateId: tripPlanner.templateId))
+
+        repo.setContacts([tripPlanner])
+
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        XCTAssertFalse(viewModel.isSelected(.agentTemplate(templateId: tifoso.templateId)))
+        XCTAssertTrue(viewModel.isSelected(.agentTemplate(templateId: tripPlanner.templateId)))
     }
 }

--- a/ConvosTests/ContactsViewModelTests.swift
+++ b/ConvosTests/ContactsViewModelTests.swift
@@ -8,6 +8,23 @@ import XCTest
 /// The picker view model has its own suite in `ContactsPickerViewModelTests`.
 @MainActor
 final class ContactsViewModelTests: XCTestCase {
+    /// Human `inboxId`s across every section, in render order.
+    private func humanInboxIds(_ viewModel: ContactsViewModel) -> [String] {
+        viewModel.sections.flatMap { section in
+            section.items.compactMap { item -> String? in
+                guard case .human(let contact) = item else { return nil }
+                return contact.inboxId
+            }
+        }
+    }
+
+    /// Resolved display names across every section, in render order.
+    private func displayNames(_ viewModel: ContactsViewModel) -> [String] {
+        viewModel.sections.flatMap { section in
+            section.items.map(\.resolvedDisplayName)
+        }
+    }
+
     // MARK: - Verified-agent filter
 
     /// Verified-agent contacts stay in `DBContact` so chat-side surfaces
@@ -34,18 +51,21 @@ final class ContactsViewModelTests: XCTestCase {
 
         let viewModel = ContactsViewModel(contactsRepository: repo)
 
+<<<<<<< HEAD
         let allIds: [String] = viewModel.sections.flatMap { $0.rows.map(\.contact.inboxId) }
+=======
+>>>>>>> 2d0d2b7d (feat(agent-templates): capture and browse agent-template contacts)
         // Alice and the unverified agent pass through; both verified agents
         // are filtered out. Unverified agents intentionally remain visible
         // because they're not yet attested.
-        XCTAssertEqual(allIds.sorted(), [alice.inboxId, unverifiedAgent.inboxId].sorted())
+        XCTAssertEqual(humanInboxIds(viewModel).sorted(), [alice.inboxId, unverifiedAgent.inboxId].sorted())
     }
 
     /// `contactCount` drives the empty-state vs list-state branch in the
     /// `ContactsView` body and the compose button's enabled flag. It must
-    /// reflect the human-visible count, not the raw count - otherwise a
-    /// user whose contacts are all agents would see an empty list with a
-    /// non-empty count (no empty-state CTA, enabled compose button).
+    /// reflect the visible count, not the raw `DBContact` count - otherwise
+    /// a user whose only `DBContact` rows are verified agents would see an
+    /// empty list with a non-empty count.
     func testContactCountReflectsVisibleContactsNotRawCount() {
         let assistant = Contact.mock(
             displayName: "Convos Assistant",
@@ -56,7 +76,7 @@ final class ContactsViewModelTests: XCTestCase {
         let viewModel = ContactsViewModel(contactsRepository: repo)
 
         XCTAssertEqual(viewModel.contactCount, 0,
-                       "Agent-only contacts should not count toward the visible total")
+                       "Verified-agent DBContact rows should not count toward the visible total")
         XCTAssertTrue(viewModel.sections.isEmpty)
     }
 

--- a/ConvosTests/ContactsViewModelTests.swift
+++ b/ConvosTests/ContactsViewModelTests.swift
@@ -11,17 +11,20 @@ final class ContactsViewModelTests: XCTestCase {
     /// Human `inboxId`s across every section, in render order.
     private func humanInboxIds(_ viewModel: ContactsViewModel) -> [String] {
         viewModel.sections.flatMap { section in
-            section.items.compactMap { item -> String? in
-                guard case .human(let contact) = item else { return nil }
+            section.rows.compactMap { row -> String? in
+                guard case .human(let contact) = row.kind else { return nil }
                 return contact.inboxId
             }
         }
     }
 
-    /// Resolved display names across every section, in render order.
-    private func displayNames(_ viewModel: ContactsViewModel) -> [String] {
+    /// Agent-template `templateId`s across every section, in render order.
+    private func agentTemplateIds(_ viewModel: ContactsViewModel) -> [String] {
         viewModel.sections.flatMap { section in
-            section.items.map(\.resolvedDisplayName)
+            section.rows.compactMap { row -> String? in
+                guard case .agentTemplate(let agent) = row.kind else { return nil }
+                return agent.templateId
+            }
         }
     }
 
@@ -51,10 +54,6 @@ final class ContactsViewModelTests: XCTestCase {
 
         let viewModel = ContactsViewModel(contactsRepository: repo)
 
-<<<<<<< HEAD
-        let allIds: [String] = viewModel.sections.flatMap { $0.rows.map(\.contact.inboxId) }
-=======
->>>>>>> 2d0d2b7d (feat(agent-templates): capture and browse agent-template contacts)
         // Alice and the unverified agent pass through; both verified agents
         // are filtered out. Unverified agents intentionally remain visible
         // because they're not yet attested.
@@ -91,8 +90,7 @@ final class ContactsViewModelTests: XCTestCase {
         let viewModel = ContactsViewModel(contactsRepository: repo)
 
         viewModel.searchQuery = "ALI"
-        let allIds: [String] = viewModel.sections.flatMap { $0.rows.map(\.contact.inboxId) }
-        XCTAssertEqual(allIds, [alice.inboxId])
+        XCTAssertEqual(humanInboxIds(viewModel), [alice.inboxId])
     }
 
     func testSearchAndVerifiedAgentFilterComposeCorrectly() {
@@ -109,7 +107,24 @@ final class ContactsViewModelTests: XCTestCase {
         // Searching "alice" must not surface the verified Alice Assistant -
         // the agent filter precedes the search filter in the pipeline.
         viewModel.searchQuery = "alice"
-        let allIds: [String] = viewModel.sections.flatMap { $0.rows.map(\.contact.inboxId) }
-        XCTAssertEqual(allIds, [alice.inboxId])
+        XCTAssertEqual(humanInboxIds(viewModel), [alice.inboxId])
+    }
+
+    // MARK: - Agent-template merging
+
+    /// Agent-template contacts surface in the same alphabetical sections as
+    /// humans, distinguished by the `Row.kind` discriminator. Regression
+    /// guard for the 2.3 capture-and-browse path.
+    func testAgentTemplateContactsAppearAlongsideHumans() {
+        let alice = Contact.mock(displayName: "Alice")
+        let tifoso = AgentTemplateContact.mock(displayName: "Tifoso", emoji: "🚴")
+        let viewModel = ContactsViewModel(
+            contactsRepository: MockContactsRepository(contacts: [alice]),
+            agentTemplateContactsRepository: MockAgentTemplateContactsRepository(contacts: [tifoso])
+        )
+
+        XCTAssertEqual(humanInboxIds(viewModel), [alice.inboxId])
+        XCTAssertEqual(agentTemplateIds(viewModel), [tifoso.templateId])
+        XCTAssertEqual(viewModel.contactCount, 2)
     }
 }

--- a/ConvosTests/ConversationViewModelGlobalDefaultsTests.swift
+++ b/ConvosTests/ConversationViewModelGlobalDefaultsTests.swift
@@ -239,6 +239,10 @@ private final class TestSessionManager: SessionManagerProtocol, @unchecked Senda
         )
     }
 
+    func publishAgentTemplate(id: String) async throws -> ConvosAPI.AgentTemplate {
+        try await base.publishAgentTemplate(id: id)
+    }
+
     func voiceMemoTranscriptRepository() -> any VoiceMemoTranscriptRepositoryProtocol {
         base.voiceMemoTranscriptRepository()
     }

--- a/ConvosTests/ConversationsViewModelDeleteTests.swift
+++ b/ConvosTests/ConversationsViewModelDeleteTests.swift
@@ -307,6 +307,10 @@ private final class TestSessionManager: SessionManagerProtocol, @unchecked Senda
         )
     }
 
+    func publishAgentTemplate(id: String) async throws -> ConvosAPI.AgentTemplate {
+        try await base.publishAgentTemplate(id: id)
+    }
+
     func voiceMemoTranscriptRepository() -> any VoiceMemoTranscriptRepositoryProtocol {
         base.voiceMemoTranscriptRepository()
     }

--- a/docs/plans/agent-templates-phase-2-prd.md
+++ b/docs/plans/agent-templates-phase-2-prd.md
@@ -1,0 +1,335 @@
+# Feature: Agent Templates — Phase 2
+
+> **Status**: Draft
+> **Author**: Cameron Voell
+> **Created**: 2026-05-20
+> **Updated**: 2026-05-20
+> **Companion 1-pager**: [agent-templates.md](./agent-templates.md)
+> **Phase 1 PRD**: [agent-templates-phase-1-prd.md](./agent-templates-phase-1-prd.md)
+> **Related**: [contact-list-prd.md](./contact-list-prd.md), `convos-backend` PR #199 (`feat/agent-templates-crud`)
+
+## Overview
+
+Phase 1 shipped the share-and-instantiate loop: a user in a chat with a template-backed agent can open its contact card, Share its `publishedUrl`, spawn a fresh instance via "Pop up a convo", and route into a new conversation from a `convos://template/<id>` deeplink or QR scan. Discovery in Phase 1 is entirely chat-mediated - there is no contacts surface for agents.
+
+Phase 2 integrates agent templates into the contacts system established by the contacts PRD. A template the user has encountered - by scanning its QR, tapping its deeplink, or simply being in a conversation that contains an instance of it - is saved as a contact. That contact appears in the main contacts list alongside human contacts, opens the same contact card the chat-side entry already uses, and is selectable in the contacts picker so the user can drop a fresh instance into a new or existing conversation without needing the original share link again.
+
+The defining architectural decision of Phase 2: **an agent-template contact is keyed by its `templateId`, not by an `inboxId`.** A human contact is one inbox = one person (ADR-011). A template, once instantiated, produces a distinct agent `inboxId` in every conversation it joins - so the stable identity of the *contact* is the template, not any individual running instance. This requires a contact table separate from `DBContact`, keyed by `templateId`. This supersedes the data-model assumption in the 1-pager (FAQ #7c) and the Phase 1 PRD's Technical Design, both of which predate this decision and assumed agent contacts would live on `DBContact` keyed by `inboxId`.
+
+## Problem Statement
+
+After Phase 1, an agent template is only reachable if the user still has the share link or is still inside a conversation that contains an instance of it. There is no durable, browsable record of "agents I have access to." A user who was in a group with someone else's useful agent last week has no way to start their own conversation with that template today - the 1-pager's "cross-conversation discoverer" persona (Jarod) is entirely unserved by Phase 1.
+
+The contacts PRD already built the browse list, the contact card, the picker, and a passive auto-add hook (`ContactSyncCoordinator`) for human contacts. Phase 2's job is to make agent templates first-class citizens of that same system - so an agent is, as the 1-pager's counterintuitive angle puts it, "a contact, not a tool": it lives in the same list, opens from the same card, and is picked from the same picker as a human.
+
+## Goals
+
+- [ ] **Durable template contacts.** A template the user has encountered is persisted locally as a contact keyed by `templateId`, surviving app restarts and independent of whether the user still holds the share link.
+- [ ] **Automatic, mechanism-unified capture.** Scanning an agent QR, tapping a template deeplink, and organically being in a conversation with a template-backed agent all converge on a single capture mechanism - the membership-sync hook - so there is exactly one code path to reason about.
+- [ ] **Agent templates in the contacts list.** Agent-template contacts render in the main `ContactsView` browse list, mixed alphabetically with human contacts and tagged with an `AGENT` badge.
+- [ ] **One contact card, consistent behavior.** Opening an agent-template contact from the contacts list shows the same `ContactCardView` the chat-side member tap already opens, with the same Share and "Pop up a convo" actions.
+- [ ] **Agent templates in the picker.** The contacts picker surfaces agent-template contacts as a selectable row type alongside humans, in both the new-conversation and add-to-conversation modes.
+- [ ] **Spawn from the picker.** Selecting an agent-template contact for a new conversation spawns a fresh instance into it on creation; selecting one in add-to-conversation mode spawns a fresh instance into the existing conversation.
+- [ ] **Filter by people or agents.** The contacts list and the contacts picker both expose an All / Humans / Agents filter, so either surface can be scoped to just people or just agents.
+- [ ] **(Stretch) Shared-conversations section.** Both human and agent-template contact cards gain a section listing the conversations the user shares with that contact, each row rendered like a conversation-list row.
+- [ ] **No regressions.** Human contacts, the existing contacts list, picker, and contact card behave exactly as before. Phase 1's chat-side agent surfaces are unchanged.
+
+## Non-Goals
+
+Phase 2 explicitly does NOT:
+
+- **Build the agent builder / editor.** No create, edit, duplicate, fork, avatar upload, prompt editor, or publish surfaces. That is the separate Builder workstream, out of scope across both phases.
+- **Implement the existing-1:1 short-circuit (1-pager P2.5).** Tapping "Pop up a convo" / picking an agent always spawns a fresh instance, as in Phase 1. The "if you already have a 1:1 with this agent, navigate there instead" behavior remains a tracked fast-follow and is intentionally not in this PRD's scope - flagged so reviewers comparing against the 1-pager see the deliberate choice.
+- **Add a Block action for agent-template contacts.** Agent-template contacts support **Remove only** (see User Stories). Block - which for a human gates inbound conversation invites by `inboxId` - has no clean meaning for a template, every instance of which is a different inbox. Not in scope.
+- **Implement shared agent context / instance lineage.** Every spawned instance is independent (instance-per-conversation), as in Phase 1. See the 1-pager's shared-agent-context UAQ.
+- **Build a template marketplace, search, or directory.** Discovery is still capture-on-encounter plus the picker; no global browse.
+- **Prevent multi-instance-per-conversation.** Picking the same template twice, or adding a template already present in a conversation, is permitted in V2 (see Open Questions).
+
+## User Stories
+
+### As a user who scanned an agent's QR code, I want that agent saved so I can find it again.
+
+Acceptance criteria:
+
+- [ ] After the scanned-template flow creates a conversation and the agent joins, the template is present as a contact in the contacts list.
+- [ ] The same is true for the `convos://template/<id>` deeplink-tap flow and for organically being added to a group that already contains a template-backed agent.
+- [ ] Encountering the *same* template across multiple conversations results in exactly **one** contact row (keyed by `templateId`), not one per conversation.
+- [ ] Capture is best-effort and idempotent: re-encountering a template the user already has does not duplicate or error.
+
+### As a user, I want agent templates to appear in my contacts list and behave like any other contact.
+
+Acceptance criteria:
+
+- [ ] Agent-template contacts render in `ContactsView`, mixed alphabetically with human contacts, each tagged with an `AGENT` badge.
+- [ ] Tapping an agent-template row opens `ContactCardView` in standalone mode, showing the same Share and "Pop up a convo" actions the chat-side card already shows for a template-backed agent.
+- [ ] "Pop up a convo" from the standalone card spawns a fresh instance into a new conversation, identical to the chat-side behavior.
+- [ ] Share offers the iOS share sheet with the template's `publishedUrl`.
+- [ ] Legacy verified assistants (verified agents with no `templateId`) do **not** appear in the contacts list - the existing hidden-assistant behavior is preserved.
+
+### As a user, I want to remove an agent-template contact I no longer want.
+
+Acceptance criteria:
+
+- [ ] The agent-template contact card and/or list row exposes a Remove action.
+- [ ] Removing deletes the local contact row.
+- [ ] If the user is still in a conversation containing an instance of that template, the next membership sync re-adds it - the same eventual-consistency story as human contacts (1-pager FAQ #5). This is acceptable and expected; the PRD does not add guardrails against it.
+- [ ] There is no Block action for agent-template contacts.
+
+### As a user creating a new conversation, I want to pick an agent template the same way I pick a friend.
+
+Acceptance criteria:
+
+- [ ] The contacts picker shows agent-template contacts as selectable rows alongside human contacts, with the `AGENT` badge and the same selected-pill treatment.
+- [ ] The user can select any mix of human contacts and agent-template contacts in a single picker session.
+- [ ] On confirm, the new conversation is created with the selected humans as members and one freshly spawned instance per selected template joined into it.
+- [ ] `.ready` remains a strong guarantee that the conversation exists and all selected humans and agents are in it.
+
+### As a user in an existing conversation, I want to add an agent template to it.
+
+Acceptance criteria:
+
+- [ ] The chat plus-menu's "Add from Contacts" entry (contacts picker in `.addToConversation` mode) shows agent-template contacts as selectable.
+- [ ] Selecting one and confirming spawns a fresh instance of that template and joins it into the existing conversation.
+- [ ] On failure (agent-pool exhaustion, archived template), the user sees the same error UX as the new-conversation spawn path.
+
+### As a user with many contacts, I want to filter my list and the picker to just people or just agents.
+
+Acceptance criteria:
+
+- [ ] The contacts list (`ContactsView`) exposes an All / Humans / Agents filter. Selecting Humans hides agent-template contacts; selecting Agents hides human contacts; All shows both.
+- [ ] The contacts picker exposes the same filter, in both the new-conversation and add-to-conversation modes.
+- [ ] The filter is presentation-only - it does not mutate selection state. Switching the filter in the picker while contacts are selected preserves the selection.
+- [ ] The filter composes with search: searching within a filtered scope narrows further.
+- [ ] The list and picker use the same filter control so the two surfaces behave identically (the 1-pager's "shared filter row" intent).
+
+### (Stretch) As a user, I want to see every conversation I share with a contact, on the contact card.
+
+Acceptance criteria:
+
+- [ ] Both human and agent-template contact cards include a "Convos with you" section listing every conversation the user shares with that contact.
+- [ ] Each row renders like a conversation-list row - title, last-message timestamp, last-message preview.
+- [ ] For a human contact, "shared" means the contact's `inboxId` is a member; for an agent-template contact, it means a member's profile carries that `templateId`.
+- [ ] Tapping a row navigates into that conversation.
+
+## Technical Design
+
+### Architecture
+
+Phase 2 is almost entirely `ConvosCore` (a new contact table, repository, writer, an extension to `ContactSyncCoordinator`) plus the main `Convos` app (contacts-list rendering, the standalone contact card, the picker extension). No new `ConvosCoreiOS` bridge is needed.
+
+The central modeling question - **how an agent-template contact relates to the existing `Contact` / `DBContact` type** - is left to a `swift-architect` pass. Two stored-row identity spaces (`inboxId` for humans, `templateId` for templates) cannot share one table cleanly, so the storage layer is two tables. At the presentation layer the options are: (a) a distinct `AgentTemplateContact` type with `ContactCardView`, the list, and the picker generalized to accept either; (b) a sum-typed `Contact` carrying an identity-kind discriminator; (c) synthesizing a `Contact`-shaped value for the template case. The PRD's recommendation is (a) - an explicit second type - but the choice is a Technical Design deliverable, not a PRD mandate.
+
+**Dependencies (existing code Phase 2 extends):**
+
+- `ConvosCore/.../Contacts/ContactSyncCoordinator.swift` - the membership-sync hook that today upserts `DBContact` rows. Extended to also emit agent-template-contact rows for members whose `DBMemberProfile` metadata carries a `templateId`.
+- `ConvosCore/.../Storage/SharedDatabaseMigrator.swift` - a new migration for the `agentTemplateContact` table.
+- `Convos/Contacts/ContactsViewModel.swift` - `rebuildSections` extended to merge agent-template contacts into the alphabetical list.
+- `Convos/Contacts/ContactsPickerViewModel.swift` - the selection model (today `selectedInboxIds: Set<String>`) generalized to a heterogeneous selection of humans and templates.
+- `Convos/Contacts/ContactCardView.swift` / `ContactCardMode.swift` - standalone mode rendering for an agent-template contact (the card already renders Share + "Pop up a convo" for template-backed agents from Phase 1).
+- `Convos/Conversations List/ConversationsViewModel.swift` - the `.contactsRequestedNewConversation` / `.contactsRequestedAgentTemplateConversation` notification handlers, extended for mixed picker selections.
+
+### Data Model
+
+A new GRDB table, keyed by `templateId`. Profile fields are a most-recent-wins snapshot, mirroring `DBContact`'s pattern - updated as fresh instance profiles are observed.
+
+```swift
+struct DBAgentTemplateContact: Codable, FetchableRecord, PersistableRecord, Hashable, Identifiable {
+    static let databaseTableName = "agentTemplateContact"
+
+    var id: String { templateId }
+
+    let templateId: String          // Primary key - backend AgentTemplate.id (UUID)
+    let addedAt: Date
+    let addedViaConversationId: String?   // Conversation the template was first observed in
+
+    var displayName: String?        // Agent name, most-recent-wins from instance profiles
+    var emoji: String?              // Template emoji - the stable visual for a non-scoped row
+    var descriptionText: String?    // Template description
+    var publishedURL: String?       // Backend publishedUrl - drives the Share action
+    var avatarURL: String?          // Best-effort; see note below
+    var agentVerification: AgentVerification?
+    var profileUpdatedAt: Date?     // Most-recent-wins timestamp
+}
+```
+
+Migration (Phase 2.1):
+
+```swift
+migrator.registerMigration("createAgentTemplateContactTable") { db in
+    try db.create(table: "agentTemplateContact") { t in
+        t.column("templateId", .text).notNull().primaryKey()
+        t.column("addedAt", .datetime).notNull()
+        t.column("addedViaConversationId", .text)
+        t.column("displayName", .text)
+        t.column("emoji", .text)
+        t.column("descriptionText", .text)
+        t.column("publishedURL", .text)
+        t.column("avatarURL", .text)
+        t.column("agentVerification", .text)
+        t.column("profileUpdatedAt", .datetime)
+    }
+}
+```
+
+Notes:
+
+- **No `blockedAt` column.** Agent-template contacts support Remove (row delete) only - see Non-Goals. Remove is a `DELETE`, not a soft-delete flag.
+- **Emoji is the primary visual.** A running instance's avatar is encrypted per-conversation and does not decrypt outside the conversation it belongs to, so it is not a reliable visual for a non-scoped contacts-list row. The template `emoji` (already published in profile metadata, read in Phase 1 via `Profile.agentTemplateEmoji`) is the stable identity; `avatarURL` is stored best-effort and renderers fall back emoji -> monogram.
+- **Source of the snapshot fields.** `displayName`, `emoji`, `descriptionText`, `publishedURL`, `agentVerification` are all read from the per-conversation `DBMemberProfile` of an encountered instance - the same metadata Phase 1 already surfaces (`agentTemplateId`, `agentTemplatePublishedURL`, `agentTemplateEmoji`, `agentTemplateDescription`). Phase 2 adds no new profile-codec dependency.
+
+The `DBContact` table is unchanged. The contacts list and picker become a **union** of `DBContact` rows (humans, still filtered `!isVerifiedAgent`) and `DBAgentTemplateContact` rows (all shown).
+
+### API Changes
+
+Phase 2 introduces **no new read endpoints** - all template display data comes from profile metadata already flowing in Phase 1.
+
+The one external dependency is **instantiating a template into an existing conversation** (Phase 2.5). The 1-pager flagged this as a brand-new backend endpoint (`templateId` + existing `conversationId` -> instance joins) that "does not exist yet" and called it "the single largest external dependency for Phase 2." However, Phase 1's PR 2 extended `POST /v2/agents/join` to accept `slug + templateId`, and an existing conversation already has an invite slug. So the open question (see Risks and Open Questions) is whether `requestAgentJoin(slug: <existing conversation's invite slug>, templateId:)` already joins the existing conversation, removing the dependency entirely - or whether a distinct endpoint is genuinely required. **This must be confirmed with the backend lead before Phase 2.6 is committed**; per the scoping decision, add-to-existing is core Phase 2 scope and Phase 2 is not "done" without it, so a hard backend dependency here would block that sub-phase.
+
+### UI/UX
+
+Phase 2 introduces no new top-level navigation. Surfaces affected:
+
+| Surface | Today | Phase 2 |
+|---|---|---|
+| `ContactsView` browse list | Human contacts only (`!isVerifiedAgent` filter) | Humans + agent-template contacts, mixed alphabetically, agent rows tagged `AGENT`, plus an All / Humans / Agents filter |
+| Tap an agent-template row | n/a (agents not listed) | Opens `ContactCardView` in standalone mode |
+| `ContactsPickerView` (new conversation) | Human candidates only | Humans + agent-template contacts both selectable, plus the All / Humans / Agents filter |
+| `ContactsPickerView` (add to conversation) | Human candidates only | Humans + agent-template contacts both selectable, plus the All / Humans / Agents filter |
+| Agent-template contact card | Chat-scoped entry only (Phase 1) | Also reachable standalone from the contacts list |
+| Contact card (both kinds, stretch) | No shared-conversations section | "Convos with you" section listing shared conversations |
+
+**List treatment.** Agent rows sit inline in the alphabetical sections with an `AGENT` badge - not a separate section. On top of that inline mixing, an All / Humans / Agents filter scopes the list to one kind. The filter is a shared control reused by the picker, so browse-and-pick feel consistent (the 1-pager's "shared filter row" note). The exact control style - chip row, segmented control, menu - and the badge placement are designer calls (see Open Questions).
+
+**Picker selection.** Selected agent-template contacts get the same selected-pill treatment in the "To" header as selected humans; the `AGENT` badge persists on the row when selected so the user can tell which selections will spawn fresh instances on confirm. The All / Humans / Agents filter is presentation-only and never alters what is selected.
+
+**Wireframes:** see [agent-templates.md](./agent-templates.md), surfaces 4 (contacts list with agents) and 5 (picker with agents) - both of which draw the filter row.
+
+## Implementation Plan
+
+Stacked PRs via Graphite, one logical chunk per PR, mirroring the contacts PRD and Phase 1 PRD cadence.
+
+### Phase 2.1: Data layer
+
+- [ ] `DBAgentTemplateContact` GRDB record + `createAgentTemplateContactTable` migration.
+- [ ] `AgentTemplateContact` presentation model (resolve the human-vs-template type relationship - see Technical Design - with `swift-architect`).
+- [ ] `AgentTemplateContactsRepository` / `…Protocol` with a reactive publisher and fetch-by-templateId, mirroring `ContactsRepository`.
+- [ ] `AgentTemplateContactsWriter` with an idempotent most-recent-wins `upsert` and a `remove`, mirroring `ContactsWriter`.
+- [ ] Unit tests: upsert idempotency, most-recent-wins field merge, remove.
+
+Ship-readiness: data layer fully tested; no UI yet.
+
+### Phase 2.2: Passive auto-add
+
+- [ ] Extend `ContactSyncCoordinator` so that, alongside the existing per-member `DBContact` upsert, members whose `DBMemberProfile` metadata carries a `templateId` also upsert a `DBAgentTemplateContact` row.
+- [ ] Confirm the scanned-QR and `convos://template/<id>` deeplink flows both land their spawned agent in a conversation whose membership sync runs the new emit - so all three capture paths (scan, deeplink, organic group membership) are covered by the one hook.
+- [ ] Unit tests: a conversation with a template-backed agent yields an agent-template-contact row; the same template across two conversations yields one row; a conversation with only human / legacy-verified-agent members yields no agent-template-contact rows.
+
+Ship-readiness: template contacts are being captured into the new table; no UI exposure yet.
+
+### Phase 2.3: Contacts list + standalone contact card
+
+- [ ] `ContactsViewModel.rebuildSections` merges agent-template contacts into the alphabetical sections; agent rows carry an `AGENT` badge. The `!isVerifiedAgent` filter on `DBContact` rows stays.
+- [ ] Tapping an agent-template row opens `ContactCardView` in standalone mode, hydrated from `DBAgentTemplateContact`.
+- [ ] The standalone agent-template card renders Share + "Pop up a convo" (already implemented for template-backed agents in Phase 1) plus a Remove action that deletes the contact row.
+- [ ] SwiftUI Previews; manual check against [agent-templates.md](./agent-templates.md) surface 4.
+
+Ship-readiness: agent templates are browsable and openable from the contacts list; Share and spawn work standalone.
+
+### Phase 2.4: Picker accepts agent-template contacts (new conversation)
+
+- [ ] Generalize the picker selection model from `selectedInboxIds: Set<String>` to a heterogeneous selection of human inboxIds and agent templateIds.
+- [ ] `ContactsPickerViewModel.rebuildSections` includes agent-template contacts as selectable rows.
+- [ ] Extend the new-conversation create path so a confirmed mixed selection adds the human members and spawns one fresh instance per selected template. This touches the `.contactsRequestedNewConversation` payload (today inboxIds-only) and the `ConversationStateMachine` create sequence; reuse the Phase 1 `.newConversationWithTemplate` spawn-at-`.ready` mechanism, generalized to N templates.
+- [ ] Unit tests: mixed selection produces the right member set + spawn count; multiple templates each spawn once.
+
+Ship-readiness: a user can start a new conversation with any mix of humans and agents from the picker.
+
+### Phase 2.5: Humans / Agents filter (contacts list + picker)
+
+A shared All / Humans / Agents filter for both browse surfaces. Sequenced before Phase 2.6 deliberately: it depends only on agents being present in the list (2.3) and the picker (2.4), not on the backend-dependent add-to-existing work, so it should not be stacked behind that dependency.
+
+- [ ] A shared filter state / control (All / Humans / Agents) usable by both `ContactsViewModel` and `ContactsPickerViewModel`.
+- [ ] `ContactsView` renders the filter; selecting a scope hides the other contact kind. Composes with the existing alphabetical sectioning.
+- [ ] `ContactsPickerView` renders the same filter in both `.newConversation` and `.addToConversation` modes. The filter is presentation-only - it does not mutate the heterogeneous selection - and composes with the picker's existing search.
+- [ ] Unit tests: each filter scope yields the expected row set on both surfaces; filter + search compose; switching the filter preserves picker selection.
+
+Ship-readiness: both browse surfaces can be scoped to people or agents.
+
+### Phase 2.6: Add an agent instance to an existing conversation
+
+- [ ] Confirm the backend contract (see API Changes / Risks) before committing this sub-phase.
+- [ ] The picker in `.addToConversation` mode surfaces agent-template contacts; confirming a selected template spawns a fresh instance and joins it into the existing conversation.
+- [ ] Error UX matches the new-conversation spawn path.
+- [ ] Integration test against a local backend: add a template to an existing conversation -> the agent member appears with the expected `templateId` on its profile snapshot.
+
+Ship-readiness: the chat plus-menu's "Add from Contacts" entry can add agents; Phase 2's contacts integration is feature-complete.
+
+### Phase 2.7 (stretch): Shared-conversations section
+
+Explicitly optional - cut if the Phase 2.1-2.6 stack runs long.
+
+- [ ] A "Convos with you" section on both the human and agent-template contact cards, listing every conversation shared with that contact.
+- [ ] Each row renders like a conversation-list row (title, last-message timestamp, last-message preview) and navigates into the conversation on tap.
+- [ ] For an agent-template contact the "shared" query is "conversations containing a member whose profile carries `templateId` T." `templateId` is not a column on `conversation_members` today - it lives in `memberProfile.metadata` - so this sub-phase needs either a denormalized `templateId` column / index or an accepted metadata scan. Flagged as a Technical Design item for `swift-architect`.
+- [ ] Unit tests for both the inboxId-based and templateId-based shared-conversation queries.
+
+Ship-readiness: contact cards show shared history; ready to flip the Phase 2 feature flag.
+
+## Testing Strategy
+
+**Unit tests** (`ConvosCoreTests`, no Docker needed):
+
+- `AgentTemplateContactsWriter` - upsert idempotency, most-recent-wins merge, remove.
+- `ContactSyncCoordinator` - a template-backed agent member yields an agent-template-contact row; same template across conversations yields one row; human-only / legacy-verified-agent-only conversations yield none.
+- Picker selection model - heterogeneous selection round-trips; pruning a removed contact drops it from the selection.
+- Humans / Agents filter - each scope yields the expected row set on the list and the picker; filter composes with search; switching the filter preserves picker selection.
+- (Stretch) shared-conversation queries for both the inboxId and templateId paths.
+
+**Integration tests** (require Docker via `./dev/up`, plus a fixture template):
+
+- Scan / deeplink / organic-membership all land a row in `agentTemplateContact`.
+- New conversation from a mixed picker selection: members + spawned agents all present at `.ready`.
+- Add-to-existing: a confirmed template selection joins a fresh instance into the existing conversation.
+
+**Manual / QA test plan** (`qa/tests/<NN>-agent-templates-phase-2.md`):
+
+- Scan an agent QR, confirm it appears in the contacts list afterward.
+- Open an agent-template contact from the list; verify Share + "Pop up a convo" + Remove.
+- Remove a template contact; confirm it re-appears after the next sync if a shared conversation still contains an instance.
+- Create a new conversation with 2 humans + 1 agent from the picker.
+- Add an agent to an existing group via "Add from Contacts".
+- Confirm legacy verified assistants stay hidden from the list and picker.
+
+**Architecture review:** hand the human-vs-template type relationship and the picker selection-model refactor to `swift-architect` before Phase 2.1 and Phase 2.4 respectively.
+
+## Risks & Mitigations
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| The add-to-existing-conversation backend contract is genuinely a new endpoint, not covered by `agents/join` + an existing slug | High | Confirm with the backend lead before committing Phase 2.6. Phase 2.1-2.5 are independent of it and ship first; per the scoping decision Phase 2 is not "done" without 2.6, so surface the dependency early. |
+| The picker selection-model refactor (inboxIds-only -> heterogeneous) ripples into `.contactsRequestedNewConversation`, the state machine, and existing picker tests | Medium | Land it as its own PR (2.4) with the human-only path regression-tested first; `swift-architect` review before implementation. |
+| The human-vs-template presentation-type decision is made ad hoc and fragments the contact card / list / picker | Medium | Resolve it explicitly in Phase 2.1 with `swift-architect`; every later sub-phase depends on a settled type. |
+| A captured template is later archived / deleted on the backend (returns 410) | Low | The contact row persists; Share opens a dead link and "Pop up a convo" surfaces the existing `APIError.templateArchived` (410) error from Phase 1. Acceptable degradation; no special handling. |
+| Auto-add races the profile-snapshot sync, capturing a template before its name / emoji metadata has arrived | Low | Most-recent-wins upsert - a later snapshot fills in the fields; the row is usable (templateId-keyed) even with a sparse first capture. |
+| Removed templates re-appear and confuse users | Low | Documented eventual-consistency behavior (1-pager FAQ #5); the re-add only happens while the user is still in a shared conversation. Accepted, not mitigated. |
+
+## Open Questions
+
+- [ ] **Add-to-existing-conversation backend contract.** Does `POST /v2/agents/join` with an existing conversation's invite slug + `templateId` already join that conversation, or is a distinct `templateId` + `conversationId` endpoint required? Blocks Phase 2.6. (See API Changes.)
+- [ ] **Filter control style and default state.** Is the All / Humans / Agents filter a chip row, a segmented control, or a menu? And does it default to All, to Humans (preserving today's people-only list), or remember the user's last selection? Designer / product call (1-pager Phase 2 UAQ).
+- [ ] **`AGENT` badge placement.** Inline on each row vs. a section divider between humans and agents - designer call (1-pager Phase 2 UAQ).
+- [ ] **The "Assistants" Convos-menu entry.** With the contacts list now the agent browse surface, does the existing top-left-menu "Assistants" entry get retired, rebranded to "Agents", or kept pointing at the legacy hardcoded join flow? Needs a product call (1-pager FAQ #4).
+- [ ] **Multi-instance-per-conversation.** Should the picker prevent selecting the same template twice for one conversation, or hide a template already present when in `.addToConversation` mode? Nice-to-have guard, not a correctness bug (1-pager Phase 2 UAQ).
+- [ ] **Existing-1:1 short-circuit (1-pager P2.5).** Deferred out of this PRD's scope. Decide whether it becomes a Phase 2 fast-follow PR or its own small plan.
+- [ ] **(Stretch) shared-conversation query for templates.** Denormalize `templateId` onto `conversation_members`, or accept a `memberProfile.metadata` scan? Technical Design call in Phase 2.7.
+
+## References
+
+- [Agent Templates 1-pager](./agent-templates.md) - surfaces 4 and 5, Phase 2 items P2.1-P2.5, personas, UAQ.
+- [Agent Templates Phase 1 PRD](./agent-templates-phase-1-prd.md) - the chat-side agent surfaces, the spawn-and-join flow, the profile-metadata read path Phase 2 reuses.
+- [Contacts PRD](./contact-list-prd.md) - the contact-card mode pattern, the contacts list / picker, the `ContactSyncCoordinator` auto-add hook Phase 2 extends.
+- `ConvosCore/.../Contacts/ContactSyncCoordinator.swift` - the membership-sync hook extended in Phase 2.2.
+- `ConvosCore/.../Storage/Database Models/DBContact.swift` - the human-contact table whose shape `DBAgentTemplateContact` mirrors.
+- `Convos/Contacts/ContactsPickerViewModel.swift` - the picker selection model refactored in Phase 2.4.
+- `Convos/Contacts/ContactCardView.swift` - the contact card already rendering Share + "Pop up a convo" for template-backed agents (Phase 1).
+- `convos-backend` PR #199 (`feat/agent-templates-crud`) - the template CRUD; the add-to-existing endpoint question is downstream of this.

--- a/docs/plans/agent-templates-publish-on-share.md
+++ b/docs/plans/agent-templates-publish-on-share.md
@@ -122,9 +122,29 @@ and isn't part of the share button's intent.
         repeat visit skip the POST until the member profile catches
         up. Sync `throws` call; treat misses and errors as a no-op
         and fall through to the publish-and-share row.
-   - On success, persist locally via the writer obtained from
-     `session.messagingService().agentTemplateContactsWriter()`. Best
-     effort - persistence failures are logged but don't block the share.
+   - On success, persist locally - but only when an existing
+     `DBAgentTemplateContact` row is present. Read the row via
+     `session.messagingService().agentTemplateContactsRepository()
+     .fetchContact(templateId:)`, then upsert via
+     `session.messagingService().agentTemplateContactsWriter()` with a
+     snapshot that re-passes every existing field unchanged and swaps in
+     only the new `publishedURL`. Two reasons:
+     - `Contact` doesn't carry the template's `emoji` /
+       `descriptionText`, and a timestamped
+       `AgentTemplateContactSnapshot` wholesale-replaces every field on
+       the row (see `AgentTemplateContactsWriter.replacingProfile`). A
+       naive upsert with `emoji: nil, descriptionText: nil` would wipe
+       values written by the standalone card's prior upsert.
+     - If the row doesn't exist, the user has never opened the
+       standalone agent-template card for this template, so the view
+       must not promote them into the user's agent-template contacts as
+       a side effect of tapping Share. Skip the write in that case;
+       in-memory `resolvedAgentTemplateShareURL` covers this view
+       session, and a future open of the standalone card (which has the
+       full profile to hand) will populate the row properly. Repeat
+       shares from a fresh `ContactDetailView` re-POST, which is
+       idempotent and cheap.
+     Persistence failures are logged but don't block the share.
    - Bundle the new share concerns into a `ContactDetailShareModifier`
      view modifier (sheet-presenter background + "Couldn't share" alert
      + the `onAppear` seed) so the body's modifier chain stays under the

--- a/docs/plans/agent-templates-publish-on-share.md
+++ b/docs/plans/agent-templates-publish-on-share.md
@@ -1,0 +1,191 @@
+# iOS brief: publish-on-share for builder-flow agent templates
+
+## Context
+
+Two surfaces show agent-template contacts and need a Share button:
+
+- The standalone agent-template contact card
+  (`Convos/Contacts/AgentTemplateContactCardView.swift`), opened from the
+  Contacts tab.
+- The unified `ContactDetailView`
+  (`Convos/Contacts/ContactDetailView.swift`), opened by tapping an agent
+  in a conversation's member list or a chat-bubble avatar.
+
+Templates created via deep-link land with a `publishedUrl` already set on
+profile data, so the share sheet renders immediately. Templates created
+via the in-app builder flow land in `draft` and carry no `publishedUrl`,
+so the Share row has nothing to seed.
+
+For those builder-flow rows we tap a single backend endpoint that returns
+the canonical `publishedUrl`, hand it to the iOS share sheet, and persist
+it back so the next visit short-circuits to the cached path.
+
+## Backend endpoint
+
+`POST /api/v2/agent-templates/:id/publish?status=published`
+
+- Same JWT auth as the rest of the v2 API
+  (`X-Convos-AuthToken: <jwt>`).
+- No request body. The `?status=published` query handles both branches
+  the backend takes internally:
+  - First-publish (`firstPublishedAt: null` -> a `draft` row): sets
+    `firstPublishedAt = now`, sets status to `published`, returns the
+    serialized template.
+  - Re-publish (`firstPublishedAt` already set -> `unlisted` /
+    `published` / `archived`): bumps version, preserves the existing
+    status, returns the serialized template. The `?status=` query is
+    honored only when the row is currently `draft` (the
+    PATCHed-back-to-draft case), by design.
+- Response 200: serialized agent template. Fields the iOS client reads:
+  - `id: String`
+  - `status: String`
+  - `publishedUrl: String?` (non-null whenever status is not `"draft"`)
+- Error responses we surface to the user as a generic share failure:
+  - 403 - caller is not the template owner.
+  - 404 - template id unknown.
+  - 400 / 5xx - anything else.
+
+We deliberately do not PATCH the status. PATCH is the only way to flip
+`unlisted` -> `published`, but for the iOS share button the URL works the
+same either way - the recipient can open it. Promoting `unlisted` to
+`published` is a directory-visibility change, not a shareability change,
+and isn't part of the share button's intent.
+
+## iOS implementation requirements
+
+1. Add a `ConvosAPI.AgentTemplate` decodable carrying just the fields we
+   consume today (`id`, `status`, `publishedUrl`). Define it next to the
+   other `ConvosAPI` request/response types so a future detail fetch can
+   share the shape. No request body model needed.
+
+2. Add a method on `ConvosAPIClient`
+   (`ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift`, near the
+   `// MARK: - Agents` block that hosts `requestAgentJoin`):
+
+   ```swift
+   func publishAgentTemplate(id: String) async throws -> ConvosAPI.AgentTemplate
+   ```
+
+   Builds a single POST request via
+   `authenticatedRequest(for: "v2/agent-templates/\(id)/publish",
+   method: "POST", queryParameters: ["status": "published"])` with no
+   body. A private `decodeAgentTemplateResponse(...)` helper handles
+   status-code mapping: 2xx -> decode into `ConvosAPI.AgentTemplate`,
+   400/403/404 -> the corresponding `APIError` case, anything else ->
+   `APIError.serverError`. All branches log structured detail
+   (`PATCH /POST` style isn't needed - there's one call).
+
+3. Plumb the new method through `ConvosAPIClientProtocol`, `MockAPIClient`,
+   `MockInboxesService`, `SessionManagerProtocol`, `SessionManager`, the
+   `TestStubAPIClientDefaults` default-impl extension, and the two
+   `TestSessionManager` proxies in `ConvosTests`. Same forwarding pattern
+   as `requestAgentJoin`.
+
+4. Update `AgentTemplateContactCardView`:
+
+   - Always render a share row. If `agentTemplateContact.publishedURL` is
+     set, use the existing `ContactDetailShareRow` (SwiftUI `ShareLink`).
+     Otherwise render a `ContactDetailActionRow` labelled "Share" that
+     drives the publish-then-share flow. Disable it while the request is
+     in flight (label flips to "Sharing...") and when `session == nil`.
+   - On success, persist the returned URL via
+     `AgentTemplateContactsWriterProtocol.upsert(templateId:
+     addedViaConversationId: profile:)`. Re-pass the contact's current
+     `displayName`, `emoji`, `descriptionText`, `avatarURL`, and
+     `agentVerification` in the snapshot - the writer's
+     most-recent-wins rule wholesale-replaces the row's profile fields
+     from the snapshot, so missing fields would blank out existing data.
+   - Auto-present the iOS share sheet with the returned URL via a thin
+     `ShareSheetPresenter` (UIActivityViewController wrapper, mirroring
+     the one in `ConversationShareView.swift`).
+   - On failure, log via `Log.error(String(describing: error))` and
+     surface a "Couldn't share right now, try again." alert. No retry.
+
+5. Update `ContactDetailView` for the same UX from member-list and
+   chat-bubble entry points:
+
+   - Add `@State` for the in-memory `resolvedAgentTemplateShareURL`,
+     `isPublishingAgentTemplate`, `isAgentTemplateShareSheetPresented`,
+     `publishAgentTemplateErrorMessage`.
+   - Render the share row whenever `contact.agentTemplateId != nil`,
+     branching on `publishedURL` the same way as the standalone card.
+   - Seed `resolvedAgentTemplateShareURL` on appear from the freshest
+     source available, in this order:
+     1. `contact.agentTemplatePublishedURL` (overlaid by
+        `Contact.resolved(...)` from the per-conversation member
+        profile - the authoritative source, but lags until the agent's
+        profile broadcast and the local membership sync land).
+     2. `session.messagingService().agentTemplateContactsRepository()
+        .fetchContact(templateId:)` against `DBAgentTemplateContact` -
+        the cached URL written by any prior publish-on-share flow on
+        this template (this view or the standalone card). Lets a
+        repeat visit skip the POST until the member profile catches
+        up. Sync `throws` call; treat misses and errors as a no-op
+        and fall through to the publish-and-share row.
+   - On success, persist locally via the writer obtained from
+     `session.messagingService().agentTemplateContactsWriter()`. Best
+     effort - persistence failures are logged but don't block the share.
+   - Bundle the new share concerns into a `ContactDetailShareModifier`
+     view modifier (sheet-presenter background + "Couldn't share" alert
+     + the `onAppear` seed) so the body's modifier chain stays under the
+     CLAUDE.md type-check budget.
+
+6. Auth wiring: no new flow. `ConvosAPIClient.authenticatedRequest`
+   already attaches the `X-Convos-AuthToken` header from the SIWE-bound
+   or device JWT slot, which the agent-templates routes accept (same
+   `authOrAgentApiKeyAuth` middleware as the other v2 endpoints).
+
+## UX notes
+
+- The POST is fast (single DB write + revalidation), so a brief inline
+  "Sharing..." label is sufficient. No 30s budget like `requestAgentJoin`.
+- After a successful publish, the row should switch to the cached
+  `ContactDetailShareRow` on the next render so a repeat tap is instant.
+  For the standalone agent-template card, this falls out of writing
+  `publishedURL` back via the writer (the card reads
+  `AgentTemplateContact.publishedURL` directly from
+  `DBAgentTemplateContact`). For `ContactDetailView`, the seed step
+  consults `DBAgentTemplateContact` as a fallback so a fresh view
+  construction on a different conversation still gets the cached URL
+  without re-POSTing.
+- The agent-template's own profile data will eventually carry the
+  `publishedUrl` once the server-side flow propagates it; our local
+  write is a UX optimization, not the source of truth. Once member
+  profile sync surfaces the URL, the `contact.agentTemplatePublishedURL`
+  branch takes over and the `DBAgentTemplateContact` fallback becomes
+  unused.
+
+## Out of scope
+
+- PATCH `/api/v2/agent-templates/:id` for any reason. The share button is
+  POST-only.
+- Status downgrades, archiving, slug edits, or any other agent-template
+  mutations from the iOS share path.
+- Promoting `unlisted` to `published` as a side effect of tapping Share.
+  See the Context section - the share URL works either way.
+- Reusing the new `ConvosAPI.AgentTemplate` model for list / detail
+  fetches - we'll grow it when we wire those endpoints up.
+
+## Verification
+
+- Unit-test the new client method against the existing mock URLSession
+  pattern in `ConvosCoreTests` (model the test on the `requestAgentJoin`
+  coverage):
+  - 200 returns the decoded template (with `publishedUrl` populated).
+  - 403 maps to `APIError.forbidden`.
+  - 404 maps to `APIError.notFound`.
+  - 400 with a structured backend body maps to
+    `APIError.badRequest(_:)` carrying the raw JSON / message.
+- Manual: trigger the builder flow on the Dev env. Logger lines in
+  `publishAgentTemplate` will print:
+  - `publishAgentTemplate POST <url>` then a 2xx and the share sheet
+    rendering the returned URL.
+  - On second presentation, the row should already be the cached
+    `ContactDetailShareRow` (no POST).
+- Repeat the manual test from the member-list and chat-bubble entry
+  points on a builder-flow agent that does not yet carry a `publishedUrl`.
+  Expect the same single-POST behavior.
+- Run `swift test --package-path ConvosCore` (Docker up) before pushing
+  per the `CLAUDE.md` testing gate.
+- Run `/lint` and `/format` before commit; pre-commit hook will block on
+  remaining violations.


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/854"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1781913496&installation_id=128169237&pr_number=854&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F854&signature=383654a06f93932859a47fdc10ae65d01881b24884b1dc639a4df1c53bbaeae9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add agent template contacts to the contacts list, picker, and conversation creation flows
> - Introduces a new `DBAgentTemplateContact` database table, `AgentTemplateContactsRepository`, and `AgentTemplateContactsWriter` to persist and observe agent-template contacts seeded during member profile sync via `ContactSyncCoordinator`.
> - Updates `ContactsViewModel` and `ContactsPickerViewModel` to merge human contacts and agent-template contacts into a single alphabetically-sorted, sectioned list, supporting heterogeneous selection via a new `Selection` enum.
> - Adds `AgentTemplateContactCardView` and `AgentTemplateContactRowView` for dedicated agent-template UI, and a `RoleLabelPill` badge used in both the contacts list and conversation member rows.
> - Extends `NewConversationViewModel` and `ConversationViewModel` to accept multiple `initialAgentTemplateIds` and batch-request agent joins sequentially when a new conversation becomes ready.
> - Adds a publish-on-share flow in `ContactDetailView` that calls the new `POST v2/agent-templates/:id/publish` API, caches the resulting URL locally, and presents a system share sheet.
> - Risk: `newConversationWithMembers` mode gains a new `initialAgentTemplateIds` parameter — call sites that pattern-match this enum case must be updated.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 26fd622.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->