### PR TITLE
Contact detail: shared row framework for human + agent + self

### DIFF
--- a/Convos/Contacts/ContactDetailView.swift
+++ b/Convos/Contacts/ContactDetailView.swift
@@ -11,20 +11,27 @@ import SwiftUI
 //   2. Member-avatar tap inside a chat (`ConversationView` presents
 //      `presentingProfileForMember`) -> `mode: .scopedToConversation(...)`.
 //
-// Section visibility is driven by the mode plus the contact's stored state:
+// One row framework for everyone: header / subtitle / optional pill / a
+// stack of secondary rows that all share `ContactDetailActionRow`. Human,
+// verified-agent, and the current user's own card differ only in *which*
+// rows render, in this fixed order:
 //
 //   - Close (X) button - always, top-leading overlay
-//   - Header (avatar / name / optional role-label capsule) - always
+//   - Header (avatar + name) - always
 //   - Subtitle - "Invited X ago by Y" in scoped mode when the member has a
 //     `joinedAt`; otherwise "Added X ago" from `contact.addedAt`
-//   - Agent rows (Get skills / Learn about assistants) - both modes, when
-//     `contact.agentVerification?.isVerified == true`
-//   - Chat - both modes; calls `contactsWriter.upsertContact(...)`
-//     before opening the picker so a synthetic / non-yet-stored contact is
-//     promoted to a real one. Disabled for verified agents (no DMs yet).
+//   - Pill below the subtitle - "You" for the current user's own card,
+//     the agent role label ("Assistant", "Verified by ...") for verified
+//     agents, otherwise nothing
+//   - Chat - hidden for the current user; disabled for verified agents
+//     (no DMs yet); calls `contactsWriter.upsertContact(...)` before
+//     opening the picker so a synthetic / non-yet-stored contact is
+//     promoted to a real one
+//   - Get skills / Learn about assistants - verified agents only, inline
+//     in the action stack after Chat
 //   - Remove - scoped mode only, when the viewer is an admin
 //     (`canRemoveMembers`) and the tapped member is not the current user
-//   - Block / Unblock - both modes (hidden for the current user)
+//   - Block / Unblock - hidden for the current user; both modes otherwise
 //
 // Mirrors `ContactsPickerMode`'s "one component, two entry points" pattern.
 
@@ -123,6 +130,10 @@ struct ContactDetailView: View {
         // overlap with the close button. A ScrollView keeps the header
         // pinned below the toolbar and lets the rest scroll.
         ScrollView {
+            // Spacing 0 here is load-bearing: `headerBadge` returns an
+            // `EmptyView` when there's no pill to show, and a non-zero
+            // VStack spacing would still reserve space around that empty
+            // view, inflating the gap between subtitle and actions.
             VStack(spacing: 0.0) {
                 ContactDetailHeader(contact: contact)
                 ContactDetailSubtitle(
@@ -157,7 +168,12 @@ struct ContactDetailView: View {
                 .padding(.bottom, 80.0)
             }
         }
-        .scrollContentBackground(.hidden)
+        // ScrollView on short content (human card with just Chat + Block)
+        // would otherwise rubber-band on touch even though the content
+        // already fits. `.basedOnSize` disables bounce when the content
+        // fits the viewport and re-enables it when it doesn't (agent or
+        // self card on smaller phones).
+        .scrollBounceBehavior(.basedOnSize)
     }
 
     // MARK: - Derived

--- a/Convos/Contacts/ContactDetailView.swift
+++ b/Convos/Contacts/ContactDetailView.swift
@@ -115,47 +115,76 @@ struct ContactDetailView: View {
 
     @ViewBuilder
     private var bodyContent: some View {
-        VStack(spacing: 0.0) {
-            ContactDetailHeader(contact: contact)
-            ContactDetailSubtitle(
-                contact: contact,
-                invitedBy: mode.invitedBy,
-                joinedAt: mode.joinedAt,
-                isBlocked: isBlocked
-            )
-            .padding(.top, DesignConstants.Spacing.step2x)
-            if isVerifiedAgent {
-                ContactDetailAgentLinks()
-                    .padding(.top, DesignConstants.Spacing.step8x)
+        // ScrollView (not a plain VStack with a Spacer) because verified
+        // agents render two extra link rows + a Remove row above Block,
+        // and on smaller phones that content can exceed the sheet's
+        // height. The previous VStack+Spacer layout pushed long content
+        // *up* behind the transparent toolbar - the avatar would visually
+        // overlap with the close button. A ScrollView keeps the header
+        // pinned below the toolbar and lets the rest scroll.
+        ScrollView {
+            VStack(spacing: 0.0) {
+                ContactDetailHeader(contact: contact)
+                ContactDetailSubtitle(
+                    contact: contact,
+                    invitedBy: mode.invitedBy,
+                    joinedAt: mode.joinedAt,
+                    isBlocked: isBlocked
+                )
+                .padding(.top, DesignConstants.Spacing.step2x)
+                headerBadge
+                ContactDetailActions(
+                    isBlocked: isBlocked,
+                    isApplyingBlockChange: isApplyingBlockChange,
+                    // Verified agents (Convos / OAuth-verified) don't accept
+                    // 1:1 DMs today, so the Chat CTA would open a conversation
+                    // that goes nowhere. Disable until DM support for agents
+                    // lands; the agent rows that follow the Chat button
+                    // remain the right way to interact.
+                    canSendMessage: session != nil && !isVerifiedAgent,
+                    showChat: !mode.isCurrentUser,
+                    showAgentLinks: isVerifiedAgent,
+                    showRemove: mode.isScopedToConversation
+                        && !mode.isCurrentUser
+                        && mode.canRemoveMembers,
+                    showBlock: !mode.isCurrentUser,
+                    contactDisplayName: contact.resolvedDisplayName,
+                    onSendMessage: handleSendMessage,
+                    onRemove: handleRemoveTap,
+                    onToggleBlock: handleBlockTap
+                )
+                .padding(.top, DesignConstants.Spacing.step8x)
+                .padding(.bottom, 80.0)
             }
-            ContactDetailActions(
-                isBlocked: isBlocked,
-                isApplyingBlockChange: isApplyingBlockChange,
-                // Verified agents (Convos / OAuth-verified) don't accept
-                // 1:1 DMs today, so the Chat CTA would open a conversation
-                // that goes nowhere. Disable until DM support for agents
-                // lands; the "Get skills" / "Learn about assistants" rows
-                // above remain the right way to interact.
-                canSendMessage: session != nil && !isVerifiedAgent,
-                showRemove: mode.isScopedToConversation
-                    && !mode.isCurrentUser
-                    && mode.canRemoveMembers,
-                showBlock: !mode.isCurrentUser,
-                contactDisplayName: contact.resolvedDisplayName,
-                onSendMessage: handleSendMessage,
-                onRemove: handleRemoveTap,
-                onToggleBlock: handleBlockTap
-            )
-            .padding(.top, DesignConstants.Spacing.step8x)
-            .padding(.bottom, 80.0)
-            Spacer(minLength: 0.0)
         }
+        .scrollContentBackground(.hidden)
     }
 
     // MARK: - Derived
 
     private var isVerifiedAgent: Bool {
         contact.isVerifiedAgent
+    }
+
+    /// Pill rendered below the subtitle. "You" for the current user's
+    /// own card, the agent role label for verified agents, otherwise
+    /// nothing. The top padding is inside the builder so it doesn't
+    /// inflate the gap above the actions row when no badge is showing.
+    @ViewBuilder
+    private var headerBadge: some View {
+        if mode.isCurrentUser {
+            ContactDetailBadge(
+                label: "You",
+                accessibilityIdentifier: "contact-detail-you-badge"
+            )
+            .padding(.top, DesignConstants.Spacing.step2x)
+        } else if let roleLabel = contact.agentVerification?.roleLabel {
+            ContactDetailBadge(
+                label: roleLabel,
+                accessibilityIdentifier: "contact-detail-role-label-\(contact.inboxId)"
+            )
+            .padding(.top, DesignConstants.Spacing.step2x)
+        }
     }
 
     // MARK: - Picker sheet
@@ -372,17 +401,27 @@ private struct ContactDetailHeader: View {
             Text(contact.resolvedDisplayName)
                 .font(.largeTitle.weight(.bold))
                 .foregroundStyle(.colorTextPrimary)
-
-            if let roleLabel = contact.agentVerification?.roleLabel {
-                Text(roleLabel)
-                    .font(.footnote)
-                    .foregroundStyle(.colorTextSecondary)
-                    .padding(.horizontal, DesignConstants.Spacing.step2x)
-                    .padding(.vertical, DesignConstants.Spacing.stepX)
-                    .background(.colorTextSecondary.opacity(0.1), in: .capsule)
-                    .accessibilityIdentifier("contact-detail-role-label-\(contact.inboxId)")
-            }
         }
+    }
+}
+
+/// Small capsule pill rendered below the subtitle. Used for the
+/// verified-agent role label ("Assistant", "Verified by ...") and for
+/// the "You" indicator on the current user's own card - same shape so
+/// the spacing around the pill mirrors the surrounding label spacing
+/// regardless of which one is showing.
+private struct ContactDetailBadge: View {
+    let label: String
+    let accessibilityIdentifier: String
+
+    var body: some View {
+        Text(label)
+            .font(.footnote)
+            .foregroundStyle(.colorTextSecondary)
+            .padding(.horizontal, DesignConstants.Spacing.step2x)
+            .padding(.vertical, DesignConstants.Spacing.stepX)
+            .background(.colorTextSecondary.opacity(0.1), in: .capsule)
+            .accessibilityIdentifier(accessibilityIdentifier)
     }
 }
 
@@ -436,69 +475,19 @@ private struct ContactDetailSubtitle: View {
     }
 }
 
-// MARK: - Agent links
-
-private struct ContactDetailAgentLinks: View {
-    @Environment(\.openURL) private var openURL: OpenURLAction
-
-    var body: some View {
-        VStack(spacing: DesignConstants.Spacing.step2x) {
-            agentLinkRow(
-                title: "Get skills",
-                subtitle: "Browse 100+ curated capabilities",
-                url: AgentLinks.getSkillsURL,
-                accessibilityIdentifier: "contact-detail-get-skills"
-            )
-            agentLinkRow(
-                title: "Learn about assistants",
-                subtitle: "Capabilities, privacy and security",
-                url: AgentLinks.learnAboutAssistantsURL,
-                accessibilityIdentifier: "contact-detail-learn-about-assistants"
-            )
-        }
-        .padding(.horizontal, DesignConstants.Spacing.step3x)
-    }
-
-    private func agentLinkRow(
-        title: String,
-        subtitle: String,
-        url: URL,
-        accessibilityIdentifier: String
-    ) -> some View {
-        let action = { openURL(url) }
-        return Button(action: action) {
-            HStack {
-                VStack(alignment: .leading, spacing: 2.0) {
-                    Text(title)
-                        .font(.body)
-                        .foregroundStyle(.colorTextPrimary)
-                    Text(subtitle)
-                        .font(.caption)
-                        .foregroundStyle(.colorTextSecondary)
-                }
-                Spacer()
-                Image(systemName: "chevron.right")
-                    .font(.system(size: 13, weight: .medium))
-                    .foregroundStyle(.colorTextTertiary)
-            }
-            .padding(DesignConstants.Spacing.step3x)
-            .background(
-                RoundedRectangle(cornerRadius: 12.0).fill(.colorFillMinimal)
-            )
-        }
-        .accessibilityIdentifier(accessibilityIdentifier)
-    }
-}
-
 // MARK: - Action stack
 
-/// Renders Chat + (optional) Remove + (optional) Block in the order shown
-/// in the design. Chat is the primary CTA (filled dark pill); Remove and
-/// Block use the secondary action-row style (white pill + caption).
+/// Renders Chat (always first) plus any combination of the verified-
+/// agent links, Remove, and Block - in that order. Chat is the primary
+/// CTA (filled dark pill); the rest use the secondary action-row style
+/// (capsule label + caption below) so an agent and human card share
+/// one row framework and only differ in which rows render.
 private struct ContactDetailActions: View {
     let isBlocked: Bool
     let isApplyingBlockChange: Bool
     let canSendMessage: Bool
+    let showChat: Bool
+    let showAgentLinks: Bool
     let showRemove: Bool
     let showBlock: Bool
     let contactDisplayName: String
@@ -506,9 +495,16 @@ private struct ContactDetailActions: View {
     let onRemove: () -> Void
     let onToggleBlock: () -> Void
 
+    @Environment(\.openURL) private var openURL: OpenURLAction
+
     var body: some View {
         VStack(spacing: DesignConstants.Spacing.step6x) {
-            chatButton
+            if showChat {
+                chatButton
+            }
+            if showAgentLinks {
+                agentLinkRows
+            }
             if showRemove {
                 removeRow
             }
@@ -517,6 +513,28 @@ private struct ContactDetailActions: View {
             }
         }
         .padding(.horizontal, DesignConstants.Spacing.step4x)
+    }
+
+    @ViewBuilder
+    private var agentLinkRows: some View {
+        ContactDetailActionRow(
+            label: "Get skills",
+            footer: "Browse 100+ curated capabilities",
+            color: .colorTextPrimary,
+            isDisabled: false,
+            accessibilityLabel: "Get skills",
+            accessibilityIdentifier: "contact-detail-get-skills",
+            action: { openURL(AgentLinks.getSkillsURL) }
+        )
+        ContactDetailActionRow(
+            label: "Learn about assistants",
+            footer: "Capabilities, privacy and security",
+            color: .colorTextPrimary,
+            isDisabled: false,
+            accessibilityLabel: "Learn about assistants",
+            accessibilityIdentifier: "contact-detail-learn-about-assistants",
+            action: { openURL(AgentLinks.learnAboutAssistantsURL) }
+        )
     }
 
     private var chatButton: some View {


### PR DESCRIPTION
## Summary

Audit of the contact-detail card across human contacts, verified agents, and the current user's own card. Three concrete issues + a structural unification.

- **Rows now share one framework.** Agent rows (Get skills / Learn about assistants) used a rounded-rect-12pt shape with chevron + stacked title/subtitle. Block/Remove used the capsule + caption-below shape. Everything now uses the latter, identical paddings + spacing.
- **Chat is always first.** The agent links were rendering *above* Chat — they're now folded into the action stack between Chat and Remove.
- **"Assistant" pill moved below the subtitle.** Previously inside `ContactDetailHeader`, crowding the name. Now in its own slot below "Invited X ago" so the spacing mirrors the surrounding labels.
- **Current user gets a "You" pill** in the same slot using the same design as the "Assistant" pill. Generalized `ContactDetailRoleBadge` into a parameterized `ContactDetailBadge` so both reuse one component.
- **Chat is hidden on the current user's own card.** Added `showChat: !mode.isCurrentUser` alongside the existing `showBlock` / `showRemove` gates so you don't see a "Chat with yourself" affordance.
- **Avatar/toolbar overlap fixed.** Wrapped `bodyContent` in a `ScrollView`. The old `VStack + Spacer(minLength: 0)` layout collapsed the spacer when content exceeded the sheet height (agent card with all sections), pushing the avatar up behind the transparent toolbar.

Row order (each gated independently): Chat → Get skills → Learn about assistants → Remove → Block.

## Test plan
- [ ] Open a normal human contact card from inside a chat (member tap): avatar sits below the close button, Chat + Block render, no other rows. Block hides the role-label pill since none applies.
- [ ] Open a verified-agent contact card (Convos Assistant): avatar below toolbar, "Assistant" pill below "Invited X ago", rows in order Chat (disabled) → Get skills → Learn about → Remove (if admin) → Block.
- [ ] Open the current user's own card: "You" pill in the same slot, Chat / Remove / Block all hidden.
- [ ] Scroll behavior: agent card on a smaller phone should scroll naturally rather than push content behind the toolbar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/855"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1781916020&installation_id=128169237&pr_number=855&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F855&signature=1d6c0a426e2c87ed16daac5a96b5cb426438155c170b331418402267c79fabc0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Unify contact detail layout for human, agent, and self into a shared row framework
> - Wraps `ContactDetailView` body in a `ScrollView` so long content no longer overlaps the close button.
> - Adds a `headerBadge` below the subtitle: a 'You' pill for the current user, or the agent role label pill for verified agents.
> - Moves agent link rows ('Get skills', 'Learn about assistants') into `ContactDetailActions`, ordering them as: Chat, agent links, Remove, Block.
> - Hides the Chat button when viewing the current user's own card via a new `showChat` flag on `ContactDetailActions`.
> - Removes the standalone `ContactDetailAgentLinks` component and the inline agent role label from `ContactDetailHeader`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a327af0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->