### PR TITLE
feat(agent-templates): capture and browse agent-template contacts

### DIFF
--- a/Convos/App Settings/AppSettingsView.swift
+++ b/Convos/App Settings/AppSettingsView.swift
@@ -131,6 +131,8 @@ struct AppSettingsView: View {
             contactsWriter: messagingService.contactsWriter(),
             session: session,
             profileSettingsViewModel: profileSettingsViewModel
+            agentTemplateContactsRepository: messagingService.agentTemplateContactsRepository(),
+            agentTemplateContactsWriter: messagingService.agentTemplateContactsWriter()
         )
     }
 

--- a/Convos/Contacts/AgentTemplateContactCardView.swift
+++ b/Convos/Contacts/AgentTemplateContactCardView.swift
@@ -1,0 +1,168 @@
+import ConvosCore
+import SwiftUI
+
+/// Standalone contact card for a template-backed agent, opened by tapping
+/// an agent row in the contacts list.
+///
+/// A deliberate sibling of `ContactCardView` (which is built around the
+/// human `Contact` type) rather than a generalization of it - the two
+/// share the `ContactCardActionRow` / `ContactCardShareRow` building
+/// blocks but keep their type models separate.
+///
+/// Actions:
+///   - Share - the iOS share sheet seeded with the template `publishedUrl`.
+///   - Pop up a convo - spawns a fresh instance by posting
+///     `.contactsRequestedAgentTemplateConversation`, the same spawn-and-join
+///     path the `convos://template/<id>` deeplink and the chat-side card use.
+///   - Remove - deletes the local agent-template contact row. If a shared
+///     conversation still contains an instance, the next membership sync
+///     re-adds it (the eventual-consistency story from the agent-templates PRD).
+struct AgentTemplateContactCardView: View {
+    let agentTemplateContact: AgentTemplateContact
+    private let agentTemplateContactsWriter: any AgentTemplateContactsWriterProtocol
+
+    @State private var presentingRemoveConfirmation: Bool = false
+    @State private var isRemoving: Bool = false
+    @Environment(\.dismiss) private var dismiss: DismissAction
+
+    init(
+        agentTemplateContact: AgentTemplateContact,
+        agentTemplateContactsWriter: any AgentTemplateContactsWriterProtocol
+    ) {
+        self.agentTemplateContact = agentTemplateContact
+        self.agentTemplateContactsWriter = agentTemplateContactsWriter
+    }
+
+    var body: some View {
+        bodyContent
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(.colorBackgroundRaisedSecondary)
+            .navigationTitle("")
+            .navigationBarTitleDisplayMode(.inline)
+            .alert(removeAlertTitle, isPresented: $presentingRemoveConfirmation) {
+                Button("Cancel", role: .cancel) {}
+                Button("Remove", role: .destructive, action: handleRemoveConfirmed)
+            } message: {
+                Text(removeAlertMessage)
+            }
+    }
+
+    @ViewBuilder
+    private var bodyContent: some View {
+        VStack(spacing: DesignConstants.Spacing.step3x) {
+            header
+            actions
+            Spacer()
+        }
+    }
+
+    private var header: some View {
+        VStack(spacing: DesignConstants.Spacing.step2x) {
+            AgentTemplateAvatarView(
+                agentTemplateContact: agentTemplateContact,
+                emojiPointSize: 64.0
+            )
+            .frame(width: 140.0, height: 140.0)
+            .padding(.top, DesignConstants.Spacing.step6x)
+
+            Text(agentTemplateContact.resolvedDisplayName)
+                .font(.largeTitle.weight(.bold))
+                .foregroundStyle(.colorTextPrimary)
+
+            AgentBadge()
+
+            if let description = agentTemplateContact.descriptionText, !description.isEmpty {
+                Text(description)
+                    .font(.subheadline)
+                    .foregroundStyle(.colorTextSecondary)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, DesignConstants.Spacing.step6x)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var actions: some View {
+        VStack(spacing: DesignConstants.Spacing.step4x) {
+            if let shareURL {
+                ContactCardShareRow(
+                    url: shareURL,
+                    contactDisplayName: agentTemplateContact.resolvedDisplayName
+                )
+            }
+            ContactCardActionRow(
+                label: "Pop up a convo",
+                footer: "Start a new convo with \(agentTemplateContact.resolvedDisplayName)",
+                color: .colorTextPrimary,
+                isDisabled: false,
+                accessibilityLabel: "Pop up a convo with \(agentTemplateContact.resolvedDisplayName)",
+                accessibilityIdentifier: "agent-template-card-chat",
+                action: handleChat
+            )
+            ContactCardActionRow(
+                label: "Remove",
+                footer: "Remove \(agentTemplateContact.resolvedDisplayName) from your contacts",
+                color: .colorCaution,
+                isDisabled: isRemoving,
+                accessibilityLabel: "Remove \(agentTemplateContact.resolvedDisplayName)",
+                accessibilityIdentifier: "agent-template-card-remove",
+                action: handleRemoveTap
+            )
+        }
+        .padding(.horizontal, DesignConstants.Spacing.step4x)
+        .padding(.top, DesignConstants.Spacing.step4x)
+    }
+
+    private var shareURL: URL? {
+        agentTemplateContact.publishedURL.flatMap { URL(string: $0) }
+    }
+
+    private var removeAlertTitle: String {
+        "Remove \(agentTemplateContact.resolvedDisplayName)?"
+    }
+
+    private var removeAlertMessage: String {
+        "This removes the agent from your contacts. It re-appears if you're still in a conversation that has it."
+    }
+
+    private func handleChat() {
+        NotificationCenter.default.post(
+            name: .contactsRequestedAgentTemplateConversation,
+            object: nil,
+            userInfo: ["templateId": agentTemplateContact.templateId]
+        )
+    }
+
+    private func handleRemoveTap() {
+        presentingRemoveConfirmation = true
+    }
+
+    private func handleRemoveConfirmed() {
+        guard !isRemoving else { return }
+        isRemoving = true
+        let templateId = agentTemplateContact.templateId
+        Task { @MainActor in
+            defer { isRemoving = false }
+            do {
+                try await agentTemplateContactsWriter.remove(templateId: templateId)
+                dismiss()
+            } catch {
+                Log.error("Failed to remove agent-template contact \(templateId): \(error.localizedDescription)")
+            }
+        }
+    }
+}
+
+#Preview("Agent template card") {
+    NavigationStack {
+        AgentTemplateContactCardView(
+            agentTemplateContact: .mock(
+                displayName: "Tifoso",
+                emoji: "🚴",
+                descriptionText: "Pro cycling expert and race-day strategist.",
+                publishedURL: "https://agents-dev.convos.org/tifoso.pnw1o"
+            ),
+            agentTemplateContactsWriter: MockAgentTemplateContactsWriter()
+        )
+    }
+}

--- a/Convos/Contacts/AgentTemplateContactRowView.swift
+++ b/Convos/Contacts/AgentTemplateContactRowView.swift
@@ -1,0 +1,85 @@
+import ConvosCore
+import SwiftUI
+
+/// Compact row for an agent-template contact in the alphabetical contacts
+/// list. Mirrors `ContactRowView`'s layout - avatar, name - and tags the
+/// row with an Agent badge so it reads distinctly from a human row.
+struct AgentTemplateContactRowView: View {
+    let agentTemplateContact: AgentTemplateContact
+
+    var body: some View {
+        HStack(spacing: DesignConstants.Spacing.step2x) {
+            AgentTemplateAvatarView(agentTemplateContact: agentTemplateContact)
+                .frame(width: 32, height: 32)
+
+            Text(agentTemplateContact.resolvedDisplayName)
+                .font(.body)
+                .foregroundStyle(.colorTextPrimary)
+                .lineLimit(1)
+
+            Spacer()
+
+            AgentBadge()
+        }
+        .padding(.vertical, 2.0)
+        .accessibilityIdentifier("agent-template-row-\(agentTemplateContact.templateId)")
+    }
+}
+
+/// The "Agent" capsule tag shared by the agent-template list row and the
+/// standalone agent-template contact card. Matches the verified-agent
+/// role-label capsule styling `ContactRowView` already uses.
+struct AgentBadge: View {
+    var body: some View {
+        Text("Agent")
+            .font(.footnote)
+            .foregroundStyle(.colorTextSecondary)
+            .padding(.horizontal, DesignConstants.Spacing.step2x)
+            .padding(.vertical, DesignConstants.Spacing.stepX)
+            .background(.colorTextSecondary.opacity(0.1), in: .capsule)
+    }
+}
+
+/// Avatar for an agent-template contact: the template emoji centered in a
+/// neutral circle. The emoji is the template's stable visual identity - a
+/// running instance's avatar is encrypted per-conversation and not
+/// available to a non-scoped browse row. Falls back to a name monogram
+/// when no emoji has been observed. `emojiPointSize` lets the caller scale
+/// from the 32pt list row up to the 140pt card header.
+struct AgentTemplateAvatarView: View {
+    let agentTemplateContact: AgentTemplateContact
+    var emojiPointSize: CGFloat = 18.0
+
+    var body: some View {
+        Circle()
+            .fill(.colorFillMinimal)
+            .overlay {
+                Text(symbol)
+                    .font(.system(size: emojiPointSize))
+            }
+    }
+
+    private var symbol: String {
+        if let emoji = agentTemplateContact.emoji, !emoji.isEmpty {
+            return emoji
+        }
+        let trimmed = agentTemplateContact.resolvedDisplayName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let first = trimmed.first else { return "🤖" }
+        return String(first).uppercased()
+    }
+}
+
+#Preview {
+    VStack(alignment: .leading) {
+        AgentTemplateContactRowView(
+            agentTemplateContact: .mock(displayName: "Tifoso", emoji: "🚴")
+        )
+        AgentTemplateContactRowView(
+            agentTemplateContact: .mock(displayName: "Trip Planner", emoji: "🗺️")
+        )
+        AgentTemplateContactRowView(
+            agentTemplateContact: .mock(displayName: nil, emoji: nil)
+        )
+    }
+    .padding()
+}

--- a/Convos/Contacts/ContactsView.swift
+++ b/Convos/Contacts/ContactsView.swift
@@ -8,6 +8,7 @@ struct ContactsView: View {
 
     private let contactsRepository: any ContactsRepositoryProtocol
     private let contactsWriter: any ContactsWriterProtocol
+    private let agentTemplateContactsWriter: any AgentTemplateContactsWriterProtocol
     private let session: (any SessionManagerProtocol)?
     private let profileSettingsViewModel: ProfileSettingsViewModel
 
@@ -16,10 +17,16 @@ struct ContactsView: View {
         contactsWriter: any ContactsWriterProtocol = MockContactsWriter(),
         session: (any SessionManagerProtocol)? = nil,
         profileSettingsViewModel: ProfileSettingsViewModel = .shared
+        agentTemplateContactsRepository: any AgentTemplateContactsRepositoryProtocol = MockAgentTemplateContactsRepository(),
+        agentTemplateContactsWriter: any AgentTemplateContactsWriterProtocol = MockAgentTemplateContactsWriter()
     ) {
-        _viewModel = State(initialValue: ContactsViewModel(contactsRepository: contactsRepository))
+        _viewModel = State(initialValue: ContactsViewModel(
+            contactsRepository: contactsRepository,
+            agentTemplateContactsRepository: agentTemplateContactsRepository
+        ))
         self.contactsRepository = contactsRepository
         self.contactsWriter = contactsWriter
+        self.agentTemplateContactsWriter = agentTemplateContactsWriter
         self.session = session
         self.profileSettingsViewModel = profileSettingsViewModel
     }
@@ -123,6 +130,38 @@ struct ContactsView: View {
         )
     }
 
+    /// Renders one browse row. A human contact pushes `ContactCardView`; an
+    /// agent-template contact pushes the sibling `AgentTemplateContactCardView`.
+    @ViewBuilder
+    private func contactRow(for item: ContactsViewModel.ListItem) -> some View {
+        switch item {
+        case .human(let contact):
+            NavigationLink {
+                ContactCardView(
+                    contact: contact,
+                    contactsWriter: contactsWriter,
+                    contactsRepository: contactsRepository,
+                    session: session
+                )
+            } label: {
+                ContactRowView(contact: contact)
+            }
+            .listRowBackground(Color.clear)
+            .listRowSeparator(.hidden)
+        case .agentTemplate(let agentContact):
+            NavigationLink {
+                AgentTemplateContactCardView(
+                    agentTemplateContact: agentContact,
+                    agentTemplateContactsWriter: agentTemplateContactsWriter
+                )
+            } label: {
+                AgentTemplateContactRowView(agentTemplateContact: agentContact)
+            }
+            .listRowBackground(Color.clear)
+            .listRowSeparator(.hidden)
+        }
+    }
+
     private var emptyState: some View {
         VStack(spacing: DesignConstants.Spacing.step3x) {
             Image(systemName: "person.2.fill")
@@ -200,6 +239,9 @@ struct ContactsView: View {
 
 #Preview("Empty") {
     NavigationStack {
-        ContactsView(contactsRepository: MockContactsRepository(contacts: []))
+        ContactsView(
+            contactsRepository: MockContactsRepository(contacts: []),
+            agentTemplateContactsRepository: MockAgentTemplateContactsRepository(contacts: [])
+        )
     }
 }

--- a/Convos/Contacts/ContactsViewModel.swift
+++ b/Convos/Contacts/ContactsViewModel.swift
@@ -3,12 +3,48 @@ import ConvosCore
 import Foundation
 import Observation
 
-/// View model backing the Contacts list browse screen. Subscribes to the
-/// repository's reactive publisher and groups the contacts into alphabetical
-/// sections for rendering.
+/// View model backing the Contacts list browse screen. Subscribes to both
+/// the human-contacts repository and the agent-template-contacts repository
+/// and merges the two into shared alphabetical sections for rendering.
 @Observable
 @MainActor
 final class ContactsViewModel {
+    /// A single browsable row: either a human `Contact` or an
+    /// `AgentTemplateContact`. The two live in separate tables - one keyed
+    /// by `inboxId`, the other by `templateId` - and are merged here for
+    /// the unified alphabetical list.
+    enum ListItem: Identifiable, Hashable {
+        case human(Contact)
+        case agentTemplate(AgentTemplateContact)
+
+        var id: String {
+            switch self {
+            case .human(let contact):
+                return "human:\(contact.inboxId)"
+            case .agentTemplate(let agent):
+                return "agent:\(agent.templateId)"
+            }
+        }
+
+        var resolvedDisplayName: String {
+            switch self {
+            case .human(let contact):
+                return contact.resolvedDisplayName
+            case .agentTemplate(let agent):
+                return agent.resolvedDisplayName
+            }
+        }
+
+        var alphabeticalSectionKey: String {
+            switch self {
+            case .human(let contact):
+                return contact.alphabeticalSectionKey
+            case .agentTemplate(let agent):
+                return agent.alphabeticalSectionKey
+            }
+        }
+    }
+
     struct Section: Identifiable, Hashable {
         let id: String
         let title: String
@@ -31,49 +67,77 @@ final class ContactsViewModel {
     }
 
     private let contactsRepository: any ContactsRepositoryProtocol
-    private var cancellable: AnyCancellable?
+    private let agentTemplateContactsRepository: any AgentTemplateContactsRepositoryProtocol
+    private var cancellables: Set<AnyCancellable> = []
     private var allContacts: [Contact] = []
+    private var allAgentContacts: [AgentTemplateContact] = []
 
-    init(contactsRepository: any ContactsRepositoryProtocol) {
+    init(
+        contactsRepository: any ContactsRepositoryProtocol,
+        agentTemplateContactsRepository: any AgentTemplateContactsRepositoryProtocol
+            = MockAgentTemplateContactsRepository(contacts: [])
+    ) {
         self.contactsRepository = contactsRepository
+        self.agentTemplateContactsRepository = agentTemplateContactsRepository
 
-        cancellable = contactsRepository.contactsPublisher
+        contactsRepository.contactsPublisher
             .receive(on: DispatchQueue.main)
             .sink { [weak self] contacts in
                 self?.applyContacts(contacts)
             }
+            .store(in: &cancellables)
 
-        // Best-effort initial fetch for the first paint while the publisher
-        // wires up its observation.
-        if let initial = try? contactsRepository.fetchAll() {
-            applyContacts(initial)
+        agentTemplateContactsRepository.agentTemplateContactsPublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] agentContacts in
+                self?.applyAgentContacts(agentContacts)
+            }
+            .store(in: &cancellables)
+
+        // Best-effort initial fetch for the first paint while the
+        // publishers wire up their observations.
+        if let initialContacts = try? contactsRepository.fetchAll() {
+            allContacts = initialContacts
         }
+        if let initialAgentContacts = try? agentTemplateContactsRepository.fetchAll() {
+            allAgentContacts = initialAgentContacts
+        }
+        recompute()
     }
 
     private func applyContacts(_ contacts: [Contact]) {
         allContacts = contacts
-        // `contactCount` drives the empty-state vs list-state branch and
-        // the compose button's enabled flag. Use the human-visible count
-        // (verified agents are hidden from this view) so a user whose
-        // contacts are all agents sees the empty state correctly.
-        contactCount = contacts.filter { !$0.isVerifiedAgent }.count
+        recompute()
+    }
+
+    private func applyAgentContacts(_ agentContacts: [AgentTemplateContact]) {
+        allAgentContacts = agentContacts
+        recompute()
+    }
+
+    private func recompute() {
+        // Verified human-agent rows stay hidden (chat-side surfaces still
+        // resolve them from `DBContact`); agent-template contacts live in a
+        // separate table and are always shown. `contactCount` drives the
+        // empty-state branch, so it counts everything the list renders.
+        let visibleHumanCount: Int = allContacts.filter { !$0.isVerifiedAgent }.count
+        contactCount = visibleHumanCount + allAgentContacts.count
         rebuildSections()
         isLoading = false
     }
 
-    /// Recomputes `sections` from `allContacts` honoring the current
-    /// `searchQuery`. Mirrors the picker's filter/group pipeline so both
-    /// surfaces sort and bucket identically.
-    ///
-    /// Verified agents are kept in `DBContact` so chat-side surfaces (member
-    /// rows, system messages, the contact card opened from a member tap) can
-    /// still resolve their profile; they are excluded here so the human
-    /// contact browser stays focused on real people.
+    /// Recomputes `sections` from `allContacts` + `allAgentContacts`
+    /// honoring the current `searchQuery`. Humans and agent-template
+    /// contacts are merged and bucketed into shared alphabetical sections.
     private func rebuildSections() {
-        let visibleContacts = allContacts.filter { !$0.isVerifiedAgent }
-        let filtered = filterByQuery(visibleContacts)
-        let grouped: [String: [Contact]] = Dictionary(grouping: filtered) { $0.alphabeticalSectionKey }
-        let sortedKeys = grouped.keys.sorted { lhs, rhs in
+        let humanItems: [ListItem] = allContacts
+            .filter { !$0.isVerifiedAgent }
+            .map { ListItem.human($0) }
+        let agentItems: [ListItem] = allAgentContacts.map { ListItem.agentTemplate($0) }
+        let filtered: [ListItem] = filterByQuery(humanItems + agentItems)
+
+        let grouped: [String: [ListItem]] = Dictionary(grouping: filtered) { $0.alphabeticalSectionKey }
+        let sortedKeys: [String] = grouped.keys.sorted { lhs, rhs in
             // "#" sorts last so non-alpha names land after Z.
             switch (lhs, rhs) {
             case ("#", "#"): return false
@@ -92,11 +156,11 @@ final class ContactsViewModel {
         }
     }
 
-    private func filterByQuery(_ contacts: [Contact]) -> [Contact] {
+    private func filterByQuery(_ items: [ListItem]) -> [ListItem] {
         let trimmed = searchQuery.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return contacts }
-        return contacts.filter { contact in
-            contact.resolvedDisplayName.localizedCaseInsensitiveContains(trimmed)
+        guard !trimmed.isEmpty else { return items }
+        return items.filter { item in
+            item.resolvedDisplayName.localizedCaseInsensitiveContains(trimmed)
         }
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Contacts/ContactSyncCoordinator.swift
+++ b/ConvosCore/Sources/ConvosCore/Contacts/ContactSyncCoordinator.swift
@@ -150,6 +150,12 @@ final class ContactSyncCoordinator: ContactSyncCoordinatorProtocol, @unchecked S
                     profile: snapshot
                 )
                 upsertedCount += 1
+
+                try Self.upsertAgentTemplateContactIfNeeded(
+                    db: db,
+                    profile: profile,
+                    conversationId: conversationId
+                )
             }
 
             // Only mark the conversation synced if we actually upserted at
@@ -173,5 +179,44 @@ final class ContactSyncCoordinator: ContactSyncCoordinatorProtocol, @unchecked S
 
             Log.debug("Synced \(upsertedCount) contacts for conversation \(conversationId) (force=\(force))")
         }
+    }
+
+    /// A member that published a `templateId` in its per-conversation
+    /// profile metadata is a template-backed agent.
+    /// Captures the *template* as a contact (keyed by `templateId`),
+    /// alongside the inboxId-keyed `DBContact` upsert the caller does for
+    /// every member. The same template encountered in another conversation
+    /// - a different agent instance, a different `inboxId` - resolves to
+    /// this same row, so a user ends up with one contact per template
+    /// rather than one per instance.
+    ///
+    /// The snapshot is untimestamped, so it seeds a new row on first
+    /// encounter and no-ops on re-encounter - the same seed-only behavior
+    /// the coordinator uses for `DBContact`. Refreshing a template
+    /// contact's fields as fresher instance profiles arrive is a follow-up
+    /// (the parallel of `ContactsWriter.mirrorMemberProfileToContactInTransaction`).
+    private static func upsertAgentTemplateContactIfNeeded(
+        db: Database,
+        profile: DBMemberProfile?,
+        conversationId: String
+    ) throws {
+        guard profile?.isAgentTemplate == true,
+              let templateId = profile?.agentTemplateId else {
+            return
+        }
+        try AgentTemplateContactsWriter.upsertInTransaction(
+            db: db,
+            templateId: templateId,
+            addedViaConversationId: conversationId,
+            profile: AgentTemplateContactSnapshot(
+                displayName: profile?.name,
+                emoji: profile?.agentTemplateEmoji,
+                descriptionText: profile?.agentTemplateDescription,
+                publishedURL: profile?.agentTemplatePublishedURL,
+                avatarURL: profile?.avatar,
+                agentVerification: profile?.memberKind?.agentVerification,
+                profileUpdatedAt: nil
+            )
+        )
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Messaging/MessagingService.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/MessagingService.swift
@@ -243,6 +243,14 @@ final class MessagingService: MessagingServiceProtocol, @unchecked Sendable {
         )
     }
 
+    func agentTemplateContactsRepository() -> any AgentTemplateContactsRepositoryProtocol {
+        AgentTemplateContactsRepository(databaseReader: databaseReader)
+    }
+
+    func agentTemplateContactsWriter() -> any AgentTemplateContactsWriterProtocol {
+        AgentTemplateContactsWriter(databaseWriter: databaseWriter)
+    }
+
     func reactionWriter() -> any ReactionWriterProtocol {
         ReactionWriter(sessionStateManager: sessionStateManager,
                        databaseWriter: databaseWriter)

--- a/ConvosCore/Sources/ConvosCore/Messaging/MessagingServiceProtocol.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/MessagingServiceProtocol.swift
@@ -90,6 +90,8 @@ public protocol MessagingServiceProtocol: AnyObject, Sendable {
     func contactsRepository() -> any ContactsRepositoryProtocol
     func contactsWriter() -> any ContactsWriterProtocol
     func contactSyncCoordinator() -> any ContactSyncCoordinatorProtocol
+    func agentTemplateContactsRepository() -> any AgentTemplateContactsRepositoryProtocol
+    func agentTemplateContactsWriter() -> any AgentTemplateContactsWriterProtocol
 
     func uploadImage(data: Data, filename: String) async throws -> String
     func uploadImageAndExecute(

--- a/ConvosCore/Sources/ConvosCore/Mocks/MockMessagingService.swift
+++ b/ConvosCore/Sources/ConvosCore/Mocks/MockMessagingService.swift
@@ -155,6 +155,14 @@ public final class MockMessagingService: MessagingServiceProtocol, @unchecked Se
         MockContactSyncCoordinator()
     }
 
+    public func agentTemplateContactsRepository() -> any AgentTemplateContactsRepositoryProtocol {
+        MockAgentTemplateContactsRepository()
+    }
+
+    public func agentTemplateContactsWriter() -> any AgentTemplateContactsWriterProtocol {
+        MockAgentTemplateContactsWriter()
+    }
+
     public func uploadImage(data: Data, filename: String) async throws -> String {
         "https://example.com/uploads/\(filename)"
     }

--- a/ConvosCore/Sources/ConvosCore/Storage/Database Models/DBAgentTemplateContact.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Database Models/DBAgentTemplateContact.swift
@@ -9,7 +9,7 @@ import GRDB
 /// profile fields observed from encountered instances.
 ///
 /// There is no `blockedAt` column - agent-template contacts support Remove
-/// only (see docs/plans/agent-templates-phase-2-prd.md).
+/// only; see the agent-templates PRD.
 struct DBAgentTemplateContact: Codable, FetchableRecord, PersistableRecord, Hashable, Identifiable {
     static let databaseTableName: String = "agentTemplateContact"
 

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/AgentTemplateContact.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/AgentTemplateContact.swift
@@ -60,6 +60,18 @@ public struct AgentTemplateContact: Hashable, Identifiable, Sendable {
         guard templateId.count > 8 else { return templateId }
         return String(templateId.prefix(8))
     }
+
+    /// Alphabetical sectioning key for the contacts list. Returns "#" for
+    /// names that do not begin with a letter. Mirrors
+    /// `Contact.alphabeticalSectionKey` so humans and agent-template
+    /// contacts bucket into the same sections.
+    public var alphabeticalSectionKey: String {
+        guard let first = resolvedDisplayName.first else { return "#" }
+        guard let firstUpper = String(first).uppercased().first, firstUpper.isLetter else {
+            return "#"
+        }
+        return String(firstUpper)
+    }
 }
 
 extension AgentTemplateContact {

--- a/ConvosCore/Sources/ConvosCore/Storage/SharedDatabaseMigrator.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/SharedDatabaseMigrator.swift
@@ -257,12 +257,12 @@ extension SharedDatabaseMigrator {
         }
     }
 
-    /// Agent Templates Phase 2: the templateId-keyed agent-template contact
-    /// table. Separate from the inboxId-keyed `contact` table because a
-    /// template instantiated into N conversations produces N distinct agent
-    /// inboxIds - the stable identity of the contact is the template.
-    /// Registered after the contacts-MVP migrations so the
-    /// `addedViaConversationId` foreign key against `conversation` resolves.
+    /// The templateId-keyed agent-template contact table. Separate from the
+    /// inboxId-keyed `contact` table because a template instantiated into N
+    /// conversations produces N distinct agent inboxIds - the stable
+    /// identity of the contact is the template. Registered after the
+    /// contacts-MVP migrations so the `addedViaConversationId` foreign key
+    /// against `conversation` resolves.
     private static func registerAgentTemplateContactMigrations(on migrator: inout DatabaseMigrator) {
         migrator.registerMigration("createAgentTemplateContactTable") { db in
             try SharedDatabaseMigrator.createAgentTemplateContactSchema(db)
@@ -671,8 +671,8 @@ extension SharedDatabaseMigrator {
     /// template profile fields observed from encountered instances.
     /// `addedViaConversationId` uses `setNull` so the contact survives its
     /// source conversation, matching the `contact` table. No `blockedAt`
-    /// column: agent-template contacts support Remove only (see
-    /// docs/plans/agent-templates-phase-2-prd.md).
+    /// column: agent-template contacts support Remove only - see the
+    /// agent-templates PRD.
     private static func createAgentTemplateContactSchema(_ db: Database) throws {
         try db.create(table: "agentTemplateContact") { t in
             t.column("templateId", .text)

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/AgentTemplateContactsWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/AgentTemplateContactsWriter.swift
@@ -134,8 +134,8 @@ final class AgentTemplateContactsWriter: AgentTemplateContactsWriterProtocol, @u
     }
 }
 
-/// In-transaction upsert helper for `ContactSyncCoordinator` (Phase 2.2),
-/// which captures agent-template contacts inside the membership-sync
+/// In-transaction upsert helper for `ContactSyncCoordinator`, which
+/// captures agent-template contacts inside the membership-sync
 /// transaction. Mirrors `ContactsWriter.upsertContactInTransaction`.
 extension AgentTemplateContactsWriter {
     static func upsertInTransaction(

--- a/ConvosCore/Tests/ConvosCoreTests/ContactSyncCoordinatorTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ContactSyncCoordinatorTests.swift
@@ -409,4 +409,172 @@ struct ContactSyncCoordinatorTests {
         }
         #expect(inboxIds == Set(["alice"]))
     }
+
+    // MARK: - Agent template capture
+
+    /// Saves a template-backed verified-agent member profile: `memberKind`
+    /// is `.verifiedConvos` and the metadata carries the `templateId` plus
+    /// the published-template fields the agent runtime stamps.
+    private static func saveAgentProfile(
+        db: Database,
+        conversationId: String,
+        inboxId: String,
+        templateId: String,
+        name: String = "Tifoso",
+        emoji: String = "🚴",
+        descriptionText: String = "Pro cycling expert",
+        publishedUrl: String = "https://agents-dev.convos.org/tifoso.pnw1o"
+    ) throws {
+        try DBMemberProfile(
+            conversationId: conversationId,
+            inboxId: inboxId,
+            name: name,
+            avatar: nil,
+            memberKind: .verifiedConvos,
+            metadata: [
+                "templateId": .string(templateId),
+                "emoji": .string(emoji),
+                "description": .string(descriptionText),
+                "publishedUrl": .string(publishedUrl)
+            ]
+        ).save(db)
+    }
+
+    @Test("A conversation with a template-backed agent captures the template as a contact")
+    func testTemplateBackedAgentCapturedAsContact() async throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        let selfInboxId = "self-inbox"
+        let conversationId = "conv-1"
+        let templateId = "200e27dc-badc-429f-a431-b01b0281ec95"
+
+        try await dbManager.dbWriter.write { db in
+            try DBInbox(inboxId: selfInboxId, clientId: "client").save(db)
+            try Self.seedConversation(
+                db: db,
+                conversationId: conversationId,
+                creatorInboxId: selfInboxId,
+                memberInboxIds: [selfInboxId, "agent-instance-a"]
+            )
+            try Self.saveAgentProfile(
+                db: db,
+                conversationId: conversationId,
+                inboxId: "agent-instance-a",
+                templateId: templateId
+            )
+        }
+
+        let coordinator = ContactSyncCoordinator(
+            databaseWriter: dbManager.dbWriter,
+            databaseReader: dbManager.dbReader
+        )
+        try await coordinator.syncContactsOnFirstMessage(for: conversationId)
+
+        let templateContacts = try await dbManager.dbReader.read { db in
+            try DBAgentTemplateContact.fetchAll(db)
+        }
+        #expect(templateContacts.count == 1)
+        let stored = templateContacts.first
+        #expect(stored?.templateId == templateId)
+        #expect(stored?.displayName == "Tifoso")
+        #expect(stored?.emoji == "🚴")
+        #expect(stored?.publishedURL == "https://agents-dev.convos.org/tifoso.pnw1o")
+        #expect(stored?.addedViaConversationId == conversationId)
+    }
+
+    @Test("The same template across two conversations yields exactly one contact row")
+    func testSameTemplateAcrossConversationsYieldsOneRow() async throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        let selfInboxId = "self-inbox"
+        let templateId = "200e27dc-badc-429f-a431-b01b0281ec95"
+
+        try await dbManager.dbWriter.write { db in
+            try DBInbox(inboxId: selfInboxId, clientId: "client").save(db)
+            // Two conversations, two different agent instances (distinct
+            // inboxIds), both provisioned from the same template.
+            try Self.seedConversation(
+                db: db,
+                conversationId: "conv-1",
+                creatorInboxId: selfInboxId,
+                memberInboxIds: [selfInboxId, "agent-a"]
+            )
+            try Self.saveAgentProfile(
+                db: db,
+                conversationId: "conv-1",
+                inboxId: "agent-a",
+                templateId: templateId
+            )
+            try Self.seedConversation(
+                db: db,
+                conversationId: "conv-2",
+                creatorInboxId: selfInboxId,
+                memberInboxIds: [selfInboxId, "agent-b"]
+            )
+            try Self.saveAgentProfile(
+                db: db,
+                conversationId: "conv-2",
+                inboxId: "agent-b",
+                templateId: templateId
+            )
+        }
+
+        let coordinator = ContactSyncCoordinator(
+            databaseWriter: dbManager.dbWriter,
+            databaseReader: dbManager.dbReader
+        )
+        try await coordinator.syncContactsOnFirstMessage(for: "conv-1")
+        try await coordinator.syncContactsOnFirstMessage(for: "conv-2")
+
+        let templateContacts = try await dbManager.dbReader.read { db in
+            try DBAgentTemplateContact.fetchAll(db)
+        }
+        #expect(templateContacts.count == 1)
+        #expect(templateContacts.first?.templateId == templateId)
+    }
+
+    @Test("A conversation with only humans and legacy verified agents yields no template contacts")
+    func testNoTemplateContactsForHumansAndLegacyAgents() async throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        let selfInboxId = "self-inbox"
+        let conversationId = "conv-1"
+
+        try await dbManager.dbWriter.write { db in
+            try DBInbox(inboxId: selfInboxId, clientId: "client").save(db)
+            try Self.seedConversation(
+                db: db,
+                conversationId: conversationId,
+                creatorInboxId: selfInboxId,
+                memberInboxIds: [selfInboxId, "alice", "legacy-agent"],
+                memberProfiles: ["alice": (name: "Alice", avatar: nil)]
+            )
+            // A legacy verified agent: verified, but carries no templateId
+            // in its profile metadata.
+            try DBMemberProfile(
+                conversationId: conversationId,
+                inboxId: "legacy-agent",
+                name: "Convos Assistant",
+                avatar: nil,
+                memberKind: .verifiedConvos,
+                metadata: nil
+            ).save(db)
+        }
+
+        let coordinator = ContactSyncCoordinator(
+            databaseWriter: dbManager.dbWriter,
+            databaseReader: dbManager.dbReader
+        )
+        try await coordinator.syncContactsOnFirstMessage(for: conversationId)
+
+        let templateCount = try await dbManager.dbReader.read { db in
+            try DBAgentTemplateContact.fetchCount(db)
+        }
+        #expect(templateCount == 0)
+
+        // The inboxId-keyed contact table is unaffected: both non-self
+        // members still land there (the legacy agent is hidden from the
+        // browse list separately, by the `!isVerifiedAgent` filter).
+        let contactIds: Set<String> = try await dbManager.dbReader.read { db in
+            Set(try DBContact.fetchAll(db).map(\.inboxId))
+        }
+        #expect(contactIds == Set(["alice", "legacy-agent"]))
+    }
 }

--- a/ConvosTests/ContactsViewModelTests.swift
+++ b/ConvosTests/ContactsViewModelTests.swift
@@ -8,6 +8,23 @@ import XCTest
 /// The picker view model has its own suite in `ContactsPickerViewModelTests`.
 @MainActor
 final class ContactsViewModelTests: XCTestCase {
+    /// Human `inboxId`s across every section, in render order.
+    private func humanInboxIds(_ viewModel: ContactsViewModel) -> [String] {
+        viewModel.sections.flatMap { section in
+            section.items.compactMap { item -> String? in
+                guard case .human(let contact) = item else { return nil }
+                return contact.inboxId
+            }
+        }
+    }
+
+    /// Resolved display names across every section, in render order.
+    private func displayNames(_ viewModel: ContactsViewModel) -> [String] {
+        viewModel.sections.flatMap { section in
+            section.items.map(\.resolvedDisplayName)
+        }
+    }
+
     // MARK: - Verified-agent filter
 
     /// Verified-agent contacts stay in `DBContact` so chat-side surfaces
@@ -34,18 +51,21 @@ final class ContactsViewModelTests: XCTestCase {
 
         let viewModel = ContactsViewModel(contactsRepository: repo)
 
+<<<<<<< HEAD
         let allIds: [String] = viewModel.sections.flatMap { $0.rows.map(\.contact.inboxId) }
+=======
+>>>>>>> 2d0d2b7d (feat(agent-templates): capture and browse agent-template contacts)
         // Alice and the unverified agent pass through; both verified agents
         // are filtered out. Unverified agents intentionally remain visible
         // because they're not yet attested.
-        XCTAssertEqual(allIds.sorted(), [alice.inboxId, unverifiedAgent.inboxId].sorted())
+        XCTAssertEqual(humanInboxIds(viewModel).sorted(), [alice.inboxId, unverifiedAgent.inboxId].sorted())
     }
 
     /// `contactCount` drives the empty-state vs list-state branch in the
     /// `ContactsView` body and the compose button's enabled flag. It must
-    /// reflect the human-visible count, not the raw count - otherwise a
-    /// user whose contacts are all agents would see an empty list with a
-    /// non-empty count (no empty-state CTA, enabled compose button).
+    /// reflect the visible count, not the raw `DBContact` count - otherwise
+    /// a user whose only `DBContact` rows are verified agents would see an
+    /// empty list with a non-empty count.
     func testContactCountReflectsVisibleContactsNotRawCount() {
         let assistant = Contact.mock(
             displayName: "Convos Assistant",
@@ -56,7 +76,7 @@ final class ContactsViewModelTests: XCTestCase {
         let viewModel = ContactsViewModel(contactsRepository: repo)
 
         XCTAssertEqual(viewModel.contactCount, 0,
-                       "Agent-only contacts should not count toward the visible total")
+                       "Verified-agent DBContact rows should not count toward the visible total")
         XCTAssertTrue(viewModel.sections.isEmpty)
     }
 


### PR DESCRIPTION
## Summary

Phase 2.2 + 2.3 of the agent-templates Phase 2 PRD. An agent template the
user has encountered is now automatically saved as a contact and shows up
in the contacts list alongside human contacts, with its own contact card.

Stacks on the Phase 2.1 data-layer PR (the `DBAgentTemplateContact` table,
repository, and writer).

## Phase 2.2 - passive auto-add

`ContactSyncCoordinator` already loops a conversation's members and upserts
a `DBContact` row for each. It now also calls `upsertAgentTemplateContactIfNeeded`:
any member whose `DBMemberProfile` metadata carries a `templateId` gets an
`agentTemplateContact` row upserted (keyed by `templateId`) alongside the
inboxId-keyed `DBContact` upsert.

Because the coordinator is already wired into the membership-sync and
first-message hooks, every capture path converges here automatically -
scanning a QR, tapping a `convos://template/<id>` deeplink, and organic
group membership all flow through it. The same template across N
conversations resolves to one row (each instance has a distinct inboxId
but the same templateId).

## Phase 2.3 - contacts list + standalone card

- `ContactsViewModel` subscribes to both the human and agent-template
  repositories and merges them into shared alphabetical sections via a
  `ListItem` enum. The `!isVerifiedAgent` filter on `DBContact` is
  unchanged - agent-template contacts come from a separate table, so
  legacy verified assistants stay hidden while template contacts show.
- New `AgentTemplateContactRowView` - emoji avatar, name, an "Agent" badge.
- New `AgentTemplateContactCardView` - a deliberate sibling of
  `ContactCardView` (not a generalization of it), sharing the
  `ContactCardActionRow` / `ContactCardShareRow` building blocks. Renders
  Share, "Pop up a convo" (spawns a fresh instance), and Remove.
- `MessagingService` exposes `agentTemplateContactsRepository()` /
  `agentTemplateContactsWriter()`; `AppSettingsView` threads them into
  `ContactsView`. `ConversationsView`'s settings-sheet-dismissal handler
  now also covers the agent-template spawn notification.

## Key decisions

- Agent-template contacts are keyed by `templateId`, in a table separate
  from `DBContact` - a template instantiated into N conversations spawns N
  agent inboxIds, so the stable identity of the contact is the template.
- A dedicated `AgentTemplateContactCardView` rather than generalizing
  `ContactCardView` - keeps each card's type model clean.
- Remove-only: agent-template contacts have no Block (Block is meaningless
  for a type whose every instance is a different inbox). Removal re-adds on
  the next sync if a shared conversation still contains an instance.

## Testing

- `ContactSyncCoordinatorTests` - template agent captured; same template
  across two conversations yields one row; humans / legacy verified agents
  yield none.
- `ContactsViewModelTests` - updated for the merged `ListItem` model, plus
  alphabetical merge, count, and search coverage.
- SwiftUI previews for the new row and card.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/856"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1781916383&installation_id=128169237&pr_number=856&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F856&signature=3754f8519656eda243a13521a4376710783e1d23df99313119b484df153d8bbc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add agent-template contacts capture and browsing to the Contacts list
> - During conversation member sync, [`ContactSyncCoordinator`](https://github.com/xmtplabs/convos-ios/pull/856/files#diff-ef050bb6541b93915f5212a6dd8260c2d48d22723a63c759554a6383b72167f9) now detects template-backed agent profiles and upserts them as `AgentTemplateContact` rows, keyed by `templateId` to avoid duplicates across conversations.
> - [`ContactsViewModel`](https://github.com/xmtplabs/convos-ios/pull/856/files#diff-99446eaf0688b94fb2ff5d2f31cb1ea04efe01b762662e82909a1dcb74683a8a) merges agent-template contacts with human contacts into shared alphabetical sections; search, count, and empty-state logic cover both types.
> - New [`AgentTemplateContactRowView`](https://github.com/xmtplabs/convos-ios/pull/856/files#diff-adf072fbc298b7b063385680f371afb924c1132ba7d8bae98a35456b74a04b9d) and [`AgentTemplateContactCardView`](https://github.com/xmtplabs/convos-ios/pull/856/files#diff-66752ebe8d75726d59648f2699d7207ea04f61e842a4ce4df3383b87ec2f8d00) display agent contacts in the list and on a detail card with Share, start conversation, and Remove actions.
> - Tapping 'Pop up a convo' on an agent-template card posts `.contactsRequestedAgentTemplateConversation`, which [`ConversationsView`](https://github.com/xmtplabs/convos-ios/pull/856/files#diff-cd5b2e3f80b21e9829602c0b2b1b3a6c7b92d949fdb060d2f5d609050ec275e3) merges with the existing human contact notification to dismiss the settings sheet.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 2d0d2b7. 13 files reviewed, 5 issues evaluated, 1 issue filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
> <details>
> <summary>Convos/App Settings/AppSettingsView.swift — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 128](https://github.com/xmtplabs/convos-ios/blob/2d0d2b7dce50a772115af22b8253283009ff507e/Convos/App Settings/AppSettingsView.swift#L128): Missing comma after `profileSettingsViewModel: profileSettingsViewModel` on line 128. The diff adds two new parameters (`agentTemplateContactsRepository` and `agentTemplateContactsWriter`) after this line, but the existing line lacks the trailing comma required to separate it from the new parameters. This is a syntax error that will fail compilation. <b>[ Out of scope ]</b>
> </details>
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->