### PR TITLE
Performance improvements when catching up on messages

### DIFF
--- a/ConvosCore/Sources/ConvosCore/Crypto/AssistantAttestationVerifier.swift
+++ b/ConvosCore/Sources/ConvosCore/Crypto/AssistantAttestationVerifier.swift
@@ -61,7 +61,9 @@ public enum AssistantAttestationVerifier {
             return .unverified
         }
         guard let resolved = keyset.cachedResolveKey(for: kid) else {
-            negativeCache.withLock { _ = $0.insert(cacheKey) }
+            // Cache miss, not a verification failure. Don't poison the
+            // negative cache — a later `resolveKey()` may populate the
+            // keyset, and we want the next call to retry verification.
             return .unverified
         }
         let valid = verifySignature(

--- a/ConvosCore/Sources/ConvosCore/Crypto/AssistantAttestationVerifier.swift
+++ b/ConvosCore/Sources/ConvosCore/Crypto/AssistantAttestationVerifier.swift
@@ -1,7 +1,25 @@
 import CryptoKit
 import Foundation
+import os
 
 public enum AssistantAttestationVerifier {
+    /// Memoizes negative verdicts keyed by inputs that uniquely determine
+    /// the result. Staleness fails monotonically (age only grows for a
+    /// fixed `attestationTimestamp`) and signature verification is
+    /// deterministic, so once a `(inboxId, kid, attestationTimestamp)`
+    /// triple is known-unverified it stays unverified. When the agent
+    /// rotates to a new attestation the timestamp changes and the cache
+    /// key changes with it, so no false negatives. Positive verdicts are
+    /// not cached because they can transition to stale as time advances.
+    private struct NegativeCacheKey: Hashable {
+        let inboxId: String
+        let kid: String
+        let attestationTimestamp: String
+    }
+
+    private static let negativeCache: OSAllocatedUnfairLock<Set<NegativeCacheKey>>
+        = OSAllocatedUnfairLock(initialState: [])
+
     public static func verify(
         inboxId: String,
         attestation: String,
@@ -34,7 +52,16 @@ public enum AssistantAttestationVerifier {
         referenceDate: Date = Date(),
         maxAge: TimeInterval = 86400
     ) -> AgentVerification {
+        let cacheKey = NegativeCacheKey(
+            inboxId: inboxId,
+            kid: kid,
+            attestationTimestamp: attestationTimestamp
+        )
+        if negativeCache.withLock({ $0.contains(cacheKey) }) {
+            return .unverified
+        }
         guard let resolved = keyset.cachedResolveKey(for: kid) else {
+            negativeCache.withLock { _ = $0.insert(cacheKey) }
             return .unverified
         }
         let valid = verifySignature(
@@ -45,7 +72,11 @@ public enum AssistantAttestationVerifier {
             referenceDate: referenceDate,
             maxAge: maxAge
         )
-        return valid ? .verified(resolved.issuer) : .unverified
+        if !valid {
+            negativeCache.withLock { _ = $0.insert(cacheKey) }
+            return .unverified
+        }
+        return .verified(resolved.issuer)
     }
 
     private static func verifySignature(
@@ -68,7 +99,7 @@ public enum AssistantAttestationVerifier {
 
         let age = abs(referenceDate.timeIntervalSince(timestampDate))
         if age > maxAge {
-            Log.info("[Attestation] timestamp too old for \(inboxId.prefix(8)): age=\(Int(age))s, max=\(Int(maxAge))s")
+            Log.debug("[Attestation] timestamp too old for \(inboxId.prefix(8)): age=\(Int(age))s, max=\(Int(maxAge))s")
             return false
         }
 

--- a/ConvosCore/Sources/ConvosCore/Crypto/EncryptedImagePrefetcher.swift
+++ b/ConvosCore/Sources/ConvosCore/Crypto/EncryptedImagePrefetcher.swift
@@ -8,6 +8,16 @@ protocol EncryptedImagePrefetcherProtocol: Sendable {
 }
 
 actor EncryptedImagePrefetcher: EncryptedImagePrefetcherProtocol {
+    /// Process-wide singleton so `inflightFetches` dedupes across every
+    /// concurrent `_store()` invocation. Without it, each call site
+    /// instantiated its own prefetcher and the per-instance in-flight
+    /// table couldn't catch the actual race: many conversations going
+    /// through `_store()` in parallel all checking ImageCacheContainer
+    /// at the same time, all seeing "not cached," and all firing fetches
+    /// for the same inboxId. The init that accepts a custom loader stays
+    /// for tests.
+    static let shared: EncryptedImagePrefetcher = .init()
+
     private static let maxConcurrentDownloads: Int = 4
     private static let maxRetryAttempts: Int = 2
     private static let retryDelaySeconds: UInt64 = 1

--- a/ConvosCore/Sources/ConvosCore/Extensions/ImageCacheableExtensions.swift
+++ b/ConvosCore/Sources/ConvosCore/Extensions/ImageCacheableExtensions.swift
@@ -1,12 +1,17 @@
 import Foundation
 
 extension Profile: ImageCacheable {
-    /// Conversation-scoped cache key. A member's display name, avatar, and
-    /// metadata are all per-conversation (`DBMemberProfile` is keyed on
-    /// `(conversationId, inboxId)`), so keying by bare `inboxId` would
-    /// collapse distinct per-conversation profiles into one entry.
+    /// User-scoped cache key. The avatar is logically one image per user
+    /// even though each conversation stores its own encrypted copy
+    /// (separate `imageEncryptionKey`, salt, nonce, URL per conversation —
+    /// because we have no centralized profile-photo store yet). Keying by
+    /// `inboxId` lets a successful fetch in any conversation satisfy
+    /// every other conversation's render of the same user, and collapses
+    /// what was previously N per-conversation cache entries into one.
+    /// Display name and metadata are still per-conversation; only the
+    /// avatar bytes are shared.
     public var imageCacheIdentifier: String {
-        "\(inboxId)@\(conversationId)"
+        inboxId
     }
 
     public var imageCacheURL: URL? {

--- a/ConvosCore/Sources/ConvosCore/Image Cache/ImageCache.swift
+++ b/ConvosCore/Sources/ConvosCore/Image Cache/ImageCache.swift
@@ -334,79 +334,55 @@ public final class ImageCache: ImageCacheProtocol, @unchecked Sendable {
             return await loadImageFromCache(identifier: identifier, source: "loadImage (nil URL)")
         }
 
-        if object.isEncryptedImage {
-            // For encrypted images: peek to check URL change without updating tracker
-            // The prefetcher will update the tracker when it caches the decrypted image
-            let peek = await urlTracker.peek(url, for: identifier)
-
-            if peek.changed {
-                // URL changed — fetch and decrypt the new image inline
-                if let image = await fetchEncryptedImageInline(for: object, url: url, identifier: identifier) {
-                    return image
-                }
-                // Fetch failed — fall back to stale cached image rather than blank avatar
-                return await loadImageFromCache(identifier: identifier, source: "loadImage (encrypted fallback)")
-            }
-
-            // URL unchanged - normal cache lookup
-            if let memoryImage = cache.object(forKey: identifier as NSString) {
-                return memoryImage
-            }
-            if let diskImage = await loadImageFromDisk(identifier: identifier, imageFormat: .jpg) {
-                cacheImageInMemory(diskImage, key: identifier, cache: cache, logContext: "loadImage (from disk)")
-                return diskImage
-            }
-
-            // Not cached - try inline fetch if encryption parameters are available
-            if let image = await fetchEncryptedImageInline(for: object, url: url, identifier: identifier) {
-                return image
-            }
-
-            // No encryption params - return nil, prefetcher should handle it
-            return nil
-        }
-
-        // For unencrypted images: check if URL changed (without updating tracker yet)
+        // Cache-first for both encrypted and unencrypted: serve any cached
+        // image immediately and refresh in the background only when the URL
+        // has drifted. The only path that blocks on the network is a true
+        // cold cache (no memory, no disk). With sidecar-backed URL tracking
+        // (see URLTracker), cold launches on previously-cached identifiers
+        // report `changed: false` and don't schedule any refresh at all.
         let peek = await urlTracker.peek(url, for: identifier)
 
-        if peek.changed {
-            // URL changed or cold start - try to fetch from network first
-            if let image = await fetchImageFromNetwork(url: url, identifier: identifier) {
-                // Success - commit the new URL to tracker
-                _ = await urlTracker.track(url, for: identifier)
-                return image
-            }
-            // Network failed - fall through to check caches below
-            // Don't update tracker yet, so next load will retry the network fetch
-        }
-
-        // Check memory cache
         if let memoryImage = cache.object(forKey: identifier as NSString) {
-            // Only update tracker if URL hasn't changed (idempotent)
-            // Don't update if we're here after network failure - we want to retry next time
-            if !peek.changed {
-                _ = await urlTracker.track(url, for: identifier)
+            if peek.changed {
+                scheduleBackgroundRefresh(for: object, url: url, identifier: identifier)
             }
             return memoryImage
         }
-
-        // Check disk cache
         if let diskImage = await loadImageFromDisk(identifier: identifier, imageFormat: .jpg) {
             cacheImageInMemory(diskImage, key: identifier, cache: cache, logContext: "loadImage (from disk)")
-            // Only update tracker if URL hasn't changed (idempotent)
-            // Don't update if we're here after network failure - we want to retry next time
-            if !peek.changed {
-                _ = await urlTracker.track(url, for: identifier)
+            if peek.changed {
+                scheduleBackgroundRefresh(for: object, url: url, identifier: identifier)
             }
             return diskImage
         }
 
-        // Cache miss - fetch from network and update tracker only on success
+        // Cold path: nothing in memory or on disk. Block on the network so
+        // the caller gets the image rather than a placeholder.
+        if object.isEncryptedImage {
+            return await fetchEncryptedImageInline(for: object, url: url, identifier: identifier)
+        }
         if let networkImage = await fetchImageFromNetwork(url: url, identifier: identifier) {
             _ = await urlTracker.track(url, for: identifier)
             return networkImage
         }
         return nil
+    }
+
+    /// Fire-and-forget refresh used when a cache hit was served but the URL
+    /// has drifted. Inline fetch helpers handle their own deduplication
+    /// (loadingTasksLock for network, EncryptedImageLoader internally) and
+    /// commit the new URL on success, so the new bytes propagate via
+    /// `cacheUpdates`/`urlChanges` once the fetch completes — no UI delay.
+    private func scheduleBackgroundRefresh(for object: any ImageCacheable, url: URL, identifier: String) {
+        Task.detached(priority: .background) {
+            if object.isEncryptedImage {
+                _ = await self.fetchEncryptedImageInline(for: object, url: url, identifier: identifier)
+                return
+            }
+            if await self.fetchImageFromNetwork(url: url, identifier: identifier) != nil {
+                _ = await self.urlTracker.track(url, for: identifier)
+            }
+        }
     }
 
     private func loadImageFromCache(identifier: String, source: String) async -> UIImage? {

--- a/ConvosCore/Sources/ConvosCore/Image Cache/ImageCache.swift
+++ b/ConvosCore/Sources/ConvosCore/Image Cache/ImageCache.swift
@@ -105,45 +105,113 @@ private struct CacheConfiguration {
 
 // MARK: - URL Tracker
 
-/// Thread-safe tracker for identifier → URL mapping
-/// Used to detect when an object's image URL changes
+/// Thread-safe tracker for identifier → URL mapping.
+///
+/// State is durable across launches via per-entry sidecar files
+/// (`<sha256(identifier)>.url`) co-located with the disk-cached image.
+/// In-memory `trackedURLs` is a hot-path cache populated lazily on first
+/// access for an identifier — peek/track/url consult disk only when the
+/// in-memory map misses, so steady-state operations stay pure-memory.
+///
+/// The previous in-memory-only implementation treated a missing entry as
+/// `(changed: true)` on cold launch and forced a network round trip even
+/// when the disk cache had a perfectly valid image — that's the source
+/// of the "avatars missing for a second on launch" regression. With
+/// sidecars restored on demand, cold launch knows what URL each cached
+/// image came from and can answer truthfully.
 private actor URLTracker {
     private var trackedURLs: [String: URL] = [:]
+    private let sidecarDirectory: URL?
+    private let fileManager: FileManager
 
-    /// Track a URL for an identifier, returning whether it changed
+    init(sidecarDirectory: URL?, fileManager: FileManager = .default) {
+        self.sidecarDirectory = sidecarDirectory
+        self.fileManager = fileManager
+    }
+
+    /// Track a URL for an identifier, returning whether it changed.
     func track(_ url: URL?, for identifier: String) -> (changed: Bool, oldURL: URL?) {
-        let oldURL = trackedURLs[identifier]
-        if url != oldURL {
-            if let url {
-                trackedURLs[identifier] = url
-            } else {
-                trackedURLs.removeValue(forKey: identifier)
-            }
-            return (changed: true, oldURL: oldURL)
+        let oldURL = loadIntoMemoryIfNeeded(for: identifier)
+        guard url != oldURL else {
+            return (changed: false, oldURL: oldURL)
         }
-        return (changed: false, oldURL: oldURL)
+        if let url {
+            trackedURLs[identifier] = url
+            writeSidecar(url: url, for: identifier)
+        } else {
+            trackedURLs.removeValue(forKey: identifier)
+            deleteSidecar(for: identifier)
+        }
+        return (changed: true, oldURL: oldURL)
     }
 
-    /// Get the currently tracked URL for an identifier
+    /// Get the currently tracked URL for an identifier.
     func url(for identifier: String) -> URL? {
-        trackedURLs[identifier]
+        loadIntoMemoryIfNeeded(for: identifier)
     }
 
-    /// Check if a URL would be considered changed without updating the tracker
-    /// Used for encrypted images where we want to detect changes but let the prefetcher update
-    /// Returns changed: true if URL differs from tracked OR if no entry exists (cold start)
-    /// Cold start is treated as "changed" since disk cache might have stale image from previous session
+    /// Check whether a URL would be considered changed without committing
+    /// the new URL to the tracker.
+    ///
+    /// Returns `(changed: true, oldURL: nil)` only when the identifier is
+    /// genuinely unknown — i.e. no in-memory entry *and* no sidecar on
+    /// disk. With sidecars, cold launches for previously-cached entries
+    /// hit `(changed: false)` and callers can serve the disk image
+    /// without a network round trip.
     func peek(_ url: URL?, for identifier: String) -> (changed: Bool, oldURL: URL?) {
-        guard let oldURL = trackedURLs[identifier] else {
-            // Cold start - treat as changed since we need to verify via network
+        guard let oldURL = loadIntoMemoryIfNeeded(for: identifier) else {
             return (changed: true, oldURL: nil)
         }
         return (changed: url != oldURL, oldURL: oldURL)
     }
 
-    /// Remove tracking for an identifier
+    /// Remove tracking for an identifier (in-memory and on-disk sidecar).
     func remove(for identifier: String) {
         trackedURLs.removeValue(forKey: identifier)
+        deleteSidecar(for: identifier)
+    }
+
+    // MARK: - Sidecar Persistence
+
+    /// Returns the in-memory URL for `identifier`, restoring it from the
+    /// on-disk sidecar lazily if necessary. Returns `nil` only when
+    /// neither memory nor disk knows the URL.
+    private func loadIntoMemoryIfNeeded(for identifier: String) -> URL? {
+        if let cached = trackedURLs[identifier] {
+            return cached
+        }
+        guard let restored = readSidecar(for: identifier) else {
+            return nil
+        }
+        trackedURLs[identifier] = restored
+        return restored
+    }
+
+    private func sidecarFileURL(for identifier: String) -> URL? {
+        guard let sidecarDirectory else { return nil }
+        let data = Data(identifier.utf8)
+        let hashData = data.sha256Hash()
+        let hashString = hashData.map { String(format: "%02x", $0) }.joined()
+        return sidecarDirectory.appendingPathComponent(hashString + ".url")
+    }
+
+    private func readSidecar(for identifier: String) -> URL? {
+        guard let sidecarURL = sidecarFileURL(for: identifier),
+              let data = try? Data(contentsOf: sidecarURL),
+              let urlString = String(data: data, encoding: .utf8) else {
+            return nil
+        }
+        return URL(string: urlString.trimmingCharacters(in: .whitespacesAndNewlines))
+    }
+
+    private func writeSidecar(url: URL, for identifier: String) {
+        guard let sidecarURL = sidecarFileURL(for: identifier) else { return }
+        try? url.absoluteString.write(to: sidecarURL, atomically: true, encoding: .utf8)
+    }
+
+    private func deleteSidecar(for identifier: String) {
+        guard let sidecarURL = sidecarFileURL(for: identifier) else { return }
+        try? fileManager.removeItem(at: sidecarURL)
     }
 }
 
@@ -177,8 +245,9 @@ public final class ImageCache: ImageCacheProtocol, @unchecked Sendable {
     // Cleanup coordination
     private let cleanupLock: OSAllocatedUnfairLock<Task<Void, Never>?> = OSAllocatedUnfairLock(initialState: nil)
 
-    // URL tracking for detecting URL changes
-    private let urlTracker: URLTracker = URLTracker()
+    // URL tracking for detecting URL changes. Sidecar directory is wired
+    // in init() once diskCacheURL has been computed.
+    private let urlTracker: URLTracker
 
     // Network request deduplication: tracks in-flight loading tasks by URL
     private let loadingTasksLock: OSAllocatedUnfairLock<[URL: Task<UIImage?, Never>]> = OSAllocatedUnfairLock(initialState: [:])
@@ -241,6 +310,10 @@ public final class ImageCache: ImageCacheProtocol, @unchecked Sendable {
                 Log.error("Failed to create directory \(dir.lastPathComponent): \(error)")
             }
         }
+
+        // Co-locate URL sidecars in the same directory as the cached images
+        // so eviction and removal stay in lockstep.
+        urlTracker = URLTracker(sidecarDirectory: diskCacheURL, fileManager: fileManager)
 
         // Clean up disk cache on init if needed
         scheduleCleanupIfNeeded()
@@ -901,15 +974,18 @@ public final class ImageCache: ImageCacheProtocol, @unchecked Sendable {
         }
     }
 
-    /// Remove image from both disk cache and persistent store
+    /// Remove image from both disk cache and persistent store, plus the
+    /// `.url` sidecar that the URL tracker writes alongside cached images.
     private func removeImageFromDisk(identifier: String) async {
         let filename = sanitizedFilename(for: identifier, fileExtension: ".jpg")
         let pngFilename = sanitizedFilename(for: identifier, fileExtension: ".png")
+        let sidecarFilename = sanitizedFilename(for: identifier, fileExtension: ".url")
 
         await performDiskOperation { cache in
             let urls = [
                 cache.diskCacheURL.appendingPathComponent(filename),
                 cache.diskCacheURL.appendingPathComponent(pngFilename),
+                cache.diskCacheURL.appendingPathComponent(sidecarFilename),
                 cache.persistentCacheURL.appendingPathComponent(filename),
                 cache.persistentCacheURL.appendingPathComponent(pngFilename),
             ]

--- a/ConvosCore/Sources/ConvosCore/Image Cache/ImageCache.swift
+++ b/ConvosCore/Sources/ConvosCore/Image Cache/ImageCache.swift
@@ -153,15 +153,15 @@ private actor URLTracker {
     /// Check whether a URL would be considered changed without committing
     /// the new URL to the tracker.
     ///
-    /// Returns `(changed: true, oldURL: nil)` only when the identifier is
-    /// genuinely unknown — i.e. no in-memory entry *and* no sidecar on
-    /// disk. With sidecars, cold launches for previously-cached entries
-    /// hit `(changed: false)` and callers can serve the disk image
-    /// without a network round trip.
+    /// Returns `(changed: false, oldURL: nil)` when both the requested url
+    /// and the tracked oldURL are nil — same nil-equals-nil semantic as
+    /// `track`'s `guard url != oldURL` short-circuit. With sidecars, cold
+    /// launches for previously-cached entries hit `(changed: false, oldURL: <url>)`
+    /// and callers can serve the disk image without a network round trip.
+    /// Genuinely-unknown identifiers asked about a non-nil url return
+    /// `(changed: true, oldURL: nil)` — caller should fetch.
     func peek(_ url: URL?, for identifier: String) -> (changed: Bool, oldURL: URL?) {
-        guard let oldURL = loadIntoMemoryIfNeeded(for: identifier) else {
-            return (changed: true, oldURL: nil)
-        }
+        let oldURL = loadIntoMemoryIfNeeded(for: identifier)
         return (changed: url != oldURL, oldURL: oldURL)
     }
 
@@ -1013,17 +1013,27 @@ public final class ImageCache: ImageCacheProtocol, @unchecked Sendable {
                     options: .skipsHiddenFiles
                 )
 
+                // Skip .url sidecars (URLTracker metadata) from the LRU
+                // accounting and eviction list. They share their hash
+                // basename with an image file; pairing is enforced below by
+                // co-deleting the matching .url when we evict an image, so
+                // image and sidecar lifetimes stay in lockstep. Sidecars
+                // are ~50 bytes and accessed less frequently than their
+                // image, so including them in the LRU sort would falsely
+                // mark them as oldest and split pairs.
+                let evictableURLs = fileURLs.filter { $0.pathExtension != "url" }
+
                 let batchSize = 100
                 var totalSize = 0
                 var batch: [CachedFileInfo] = []
                 batch.reserveCapacity(batchSize)
 
-                for i in stride(from: 0, to: fileURLs.count, by: batchSize) {
-                    let endIndex = min(i + batchSize, fileURLs.count)
+                for i in stride(from: 0, to: evictableURLs.count, by: batchSize) {
+                    let endIndex = min(i + batchSize, evictableURLs.count)
                     batch.removeAll(keepingCapacity: true)
 
                     for j in i..<endIndex {
-                        let fileURL = fileURLs[j]
+                        let fileURL = evictableURLs[j]
                         let resourceValues = try fileURL.resourceValues(forKeys: Set(resourceKeys))
                         totalSize += resourceValues.fileSize ?? 0
                     }
@@ -1032,12 +1042,12 @@ public final class ImageCache: ImageCacheProtocol, @unchecked Sendable {
                 if totalSize > cache.maxDiskCacheSize {
                     var oldestFiles: [CachedFileInfo] = []
 
-                    for i in stride(from: 0, to: fileURLs.count, by: batchSize) {
-                        let endIndex = min(i + batchSize, fileURLs.count)
+                    for i in stride(from: 0, to: evictableURLs.count, by: batchSize) {
+                        let endIndex = min(i + batchSize, evictableURLs.count)
                         batch.removeAll(keepingCapacity: true)
 
                         for j in i..<endIndex {
-                            let fileURL = fileURLs[j]
+                            let fileURL = evictableURLs[j]
                             let resourceValues = try fileURL.resourceValues(forKeys: Set(resourceKeys))
                             batch.append(CachedFileInfo(
                                 url: fileURL,
@@ -1056,6 +1066,13 @@ public final class ImageCache: ImageCacheProtocol, @unchecked Sendable {
 
                         do {
                             try cache.fileManager.removeItem(at: file.url)
+                            // Pair: also remove the .url sidecar with the
+                            // same hash basename so URLTracker doesn't
+                            // hold stale URL state for an evicted image.
+                            let sidecarURL = file.url
+                                .deletingPathExtension()
+                                .appendingPathExtension("url")
+                            try? cache.fileManager.removeItem(at: sidecarURL)
                             removedSize += file.size
                             Log.debug("Removed old cached image from disk: \(file.url.lastPathComponent)")
                         } catch {

--- a/ConvosCore/Sources/ConvosCore/Inboxes/SessionStateMachine.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/SessionStateMachine.swift
@@ -636,6 +636,16 @@ public actor SessionStateMachine: SessionStateManagerProtocol {
     }
 
     private func handleAuthorized(result: InboxReadyResult) async throws {
+        // Drain the backlog in batched form before streams start. Same
+        // motivation as `handleEnterForeground` — on cold start the
+        // network may have a large backlog (NSE didn't run, or the app
+        // was killed for a long time) and per-event stream catch-up
+        // would N-times the writes / observer fires / SwiftUI renders.
+        // The cursor is the same `lastWelcomeProcessed` UserDefaults
+        // value the NSE writes, so even cold start respects whatever the
+        // NSE has already processed in the background.
+        await runBatchCatchUp(client: result.client)
+
         await syncingManager?.start(with: result.client, apiClient: result.apiClient)
         foregroundRetryCount = 0
         emitStateChange(.ready(result))
@@ -773,11 +783,57 @@ public actor SessionStateMachine: SessionStateManagerProtocol {
 
         try await result.client.reconnectLocalDatabase()
 
+        // Drain the backlog in batched form before streams resume.
+        await runBatchCatchUp(client: result.client)
+
         await startNetworkMonitoring()
         await syncingManager?.resume()
 
         emitStateChange(.ready(result))
         Log.info("Inbox returned to ready state")
+    }
+
+    /// Drain the backlog of activity since the last catch-up frontier, in
+    /// batched form, before streams start or resume. Called from both
+    /// `handleAuthorized` (cold start) and `handleEnterForeground`
+    /// (foreground after background). Cursor is the same
+    /// `lastWelcomeProcessed` UserDefaults value the NSE writes after
+    /// each push-driven catch-up, so foreground/cold-start and NSE all
+    /// share the same frontier without double-processing.
+    ///
+    /// `nonisolated` so the non-Sendable `XMTPClientProvider` doesn't
+    /// cross the actor's isolation boundary on the way to
+    /// `syncingManager.runBatchCatchUp` (also nonisolated for the same
+    /// reason). `syncingManager` is captured locally so we don't need
+    /// to hop the actor for it either.
+    private nonisolated func runBatchCatchUp(client: any XMTPClientProvider) async {
+        let inboxId = client.inboxId
+        let cursor = Self.readLastCatchUpCursor(for: inboxId)
+        Log.info("[catchup] running batch since=\(cursor.map { "\($0)" } ?? "nil") for inbox=\(inboxId.prefix(8))")
+        // Don't advance the cursor unless we actually invoked the batch.
+        // `syncingManager` is nil when `AuthorizeInboxOperation` is configured
+        // with `startsStreamingServices: false` — silently advancing the
+        // cursor in that case would mark missed activity as "processed" and
+        // permanently skip it on the next foreground.
+        guard let syncingManager else {
+            Log.warning("[catchup] syncingManager nil, skipping batch (cursor unchanged)")
+            return
+        }
+        await syncingManager.runBatchCatchUp(client: client, since: cursor)
+        Self.writeLastCatchUpCursor(Date(), for: inboxId)
+    }
+
+    /// Persisted catch-up cursor shared with `MessagingService+PushNotifications`.
+    /// Same UserDefaults key — foreground, cold start, and NSE all update
+    /// it as they drain backlog, converging on the same frontier.
+    private static let catchUpCursorKeyPrefix: String = "convos.pushNotifications.lastWelcomeProcessed"
+
+    private static func readLastCatchUpCursor(for inboxId: String) -> Date? {
+        UserDefaults.standard.object(forKey: "\(catchUpCursorKeyPrefix).\(inboxId)") as? Date
+    }
+
+    private static func writeLastCatchUpCursor(_ date: Date?, for inboxId: String) {
+        UserDefaults.standard.set(date, forKey: "\(catchUpCursorKeyPrefix).\(inboxId)")
     }
 
     private func handleRetryFromError() async throws {

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/Profile.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/Profile.swift
@@ -144,7 +144,7 @@ public struct Profile: Codable, Identifiable, Hashable, Sendable {
             kid: keyId,
             keyset: keyset
         )
-        Log.info("[Attestation] agent \(inboxId.prefix(8)) cached result: \(result), kid=\(keyId)")
+        Log.debug("[Attestation] agent \(inboxId.prefix(8)) cached result: \(result), kid=\(keyId)")
         return result
     }
 

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationWriter.swift
@@ -397,6 +397,13 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
         }
     }
 
+    /// Mark a conversation unread. Exposed so `BatchCatchUp` can mirror
+    /// the stream path's `fetchAndStoreLatestMessages` tail without
+    /// reaching into `localStateWriter` directly.
+    func markUnread(_ unread: Bool, for conversationId: String) async throws {
+        try await localStateWriter.setUnread(unread, for: conversationId)
+    }
+
     private func _store(
         conversation: XMTPiOS.Group,
         inboxId: String,
@@ -672,6 +679,19 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
             if !localConversation.isUnused {
                 conversationToSave = conversationToSave.with(createdAt: localConversation.createdAt)
             }
+            // Merge sticky fields from the by-tag match for the same
+            // reasons documented above: this row is replacing
+            // `localConversation`, so its sticky-on agent flag and
+            // quarantine timestamps must carry forward.
+            let mergedHasAgentByTag: Bool = localConversation.hasHadVerifiedAssistant || conversationToSave.hasHadVerifiedAssistant
+            let preservedQuarantinedAtByTag: Date? = conversationToSave.quarantinedAt ?? localConversation.quarantinedAt
+            let preservedQuarantineReleasedAtByTag: Date? = conversationToSave.quarantineReleasedAt ?? localConversation.quarantineReleasedAt
+            conversationToSave = conversationToSave
+                .with(hasHadVerifiedAssistant: mergedHasAgentByTag)
+                .with(
+                    quarantinedAt: preservedQuarantinedAtByTag,
+                    quarantineReleasedAt: preservedQuarantineReleasedAtByTag
+                )
             try conversationToSave.save(db, onConflict: .replace)
             firstTimeSeeingConversationExpired = conversationToSave.isExpired && conversationToSave.expiresAt != localConversation.expiresAt
             actualClientConversationId = preferredClientConversationId

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationWriter.swift
@@ -588,57 +588,14 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
             firstTimeSeeingConversationExpired = conversationToSave.isExpired && conversationToSave.expiresAt != localConversation.expiresAt
             actualClientConversationId = preferredClientConversationId
         } else if let existingConversation {
-            let preferredClientConversationId: String
-            if dbConversation.clientConversationId != existingConversation.clientConversationId {
-                if DBConversation.isDraft(id: dbConversation.clientConversationId) {
-                    preferredClientConversationId = dbConversation.clientConversationId
-                } else {
-                    preferredClientConversationId = existingConversation.clientConversationId
-                }
-            } else {
-                preferredClientConversationId = dbConversation.clientConversationId
-            }
-
-            var updatedConversation = conversationToSave.with(clientConversationId: preferredClientConversationId)
-            if existingConversation.isUnused {
-                updatedConversation = updatedConversation.with(isUnused: true)
-            }
-            if !existingConversation.isUnused {
-                updatedConversation = updatedConversation.with(createdAt: existingConversation.createdAt)
-            }
-            if let existingExpiresAt = existingConversation.expiresAt, updatedConversation.expiresAt == nil {
-                updatedConversation = updatedConversation.with(expiresAt: existingExpiresAt)
-            }
-            if let conflictingConversation = try existingConversationMatchingInviteTag(
-                inviteTag: updatedConversation.inviteTag,
-                excludingConversationId: updatedConversation.id,
+            let updateOutcome = try updateExistingConversation(
+                incoming: conversationToSave,
+                existing: existingConversation,
+                originalIncomingId: dbConversation.clientConversationId,
                 in: db
-            ) {
-                Log.error(
-                    "Invite tag collision before save. " +
-                        "incomingId=\(updatedConversation.id) " +
-                        "incomingClientConversationId=\(updatedConversation.clientConversationId) " +
-                        "incomingInviteTag=\(updatedConversation.inviteTag) " +
-                        "existingId=\(existingConversation.id) " +
-                        "existingClientConversationId=\(existingConversation.clientConversationId) " +
-                        "conflictingId=\(conflictingConversation.id) " +
-                        "conflictingClientConversationId=\(conflictingConversation.clientConversationId) " +
-                        "conflictingIsUnused=\(conflictingConversation.isUnused)"
-                )
-            }
-            if updatedConversation == existingConversation {
-                // Row would be byte-identical — skip the write so GRDB observers
-                // don't fire and re-render the conversations list for no state
-                // change. Common during catch-up bursts where the same row is
-                // re-saved across many consecutive stream events. The
-                // existing-by-tag and brand-new branches still write because
-                // they're either replacing a different row or creating one.
-                Log.debug("Skipped no-op conversation save for id=\(dbConversation.id)")
-            } else {
-                try updatedConversation.save(db)
-            }
-            firstTimeSeeingConversationExpired = updatedConversation.isExpired && updatedConversation.expiresAt != existingConversation.expiresAt
-            actualClientConversationId = preferredClientConversationId
+            )
+            firstTimeSeeingConversationExpired = updateOutcome.firstTimeSeeingConversationExpired
+            actualClientConversationId = updateOutcome.actualClientConversationId
         } else {
             try conversationToSave.save(db)
             firstTimeSeeingConversationExpired = conversationToSave.isExpired
@@ -653,6 +610,73 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
             clientConversationId: actualClientConversationId,
             oldImageURL: oldImageURL,
             preservedInviteTag: preservedInviteTag
+        )
+    }
+
+    private struct ExistingConversationUpdateOutcome {
+        let firstTimeSeeingConversationExpired: Bool
+        let actualClientConversationId: String
+    }
+
+    private func updateExistingConversation(
+        incoming conversationToSave: DBConversation,
+        existing existingConversation: DBConversation,
+        originalIncomingId: String,
+        in db: Database
+    ) throws -> ExistingConversationUpdateOutcome {
+        let preferredClientConversationId: String
+        if originalIncomingId != existingConversation.clientConversationId {
+            if DBConversation.isDraft(id: originalIncomingId) {
+                preferredClientConversationId = originalIncomingId
+            } else {
+                preferredClientConversationId = existingConversation.clientConversationId
+            }
+        } else {
+            preferredClientConversationId = originalIncomingId
+        }
+
+        var updatedConversation = conversationToSave.with(clientConversationId: preferredClientConversationId)
+        if existingConversation.isUnused {
+            updatedConversation = updatedConversation.with(isUnused: true)
+        }
+        if !existingConversation.isUnused {
+            updatedConversation = updatedConversation.with(createdAt: existingConversation.createdAt)
+        }
+        if let existingExpiresAt = existingConversation.expiresAt, updatedConversation.expiresAt == nil {
+            updatedConversation = updatedConversation.with(expiresAt: existingExpiresAt)
+        }
+        if let conflictingConversation = try existingConversationMatchingInviteTag(
+            inviteTag: updatedConversation.inviteTag,
+            excludingConversationId: updatedConversation.id,
+            in: db
+        ) {
+            Log.error(
+                "Invite tag collision before save. " +
+                    "incomingId=\(updatedConversation.id) " +
+                    "incomingClientConversationId=\(updatedConversation.clientConversationId) " +
+                    "incomingInviteTag=\(updatedConversation.inviteTag) " +
+                    "existingId=\(existingConversation.id) " +
+                    "existingClientConversationId=\(existingConversation.clientConversationId) " +
+                    "conflictingId=\(conflictingConversation.id) " +
+                    "conflictingClientConversationId=\(conflictingConversation.clientConversationId) " +
+                    "conflictingIsUnused=\(conflictingConversation.isUnused)"
+            )
+        }
+        if updatedConversation == existingConversation {
+            // Row would be byte-identical — skip the write so GRDB observers
+            // don't fire and re-render the conversations list for no state
+            // change. Common during catch-up bursts where the same row is
+            // re-saved across many consecutive stream events. The
+            // existing-by-tag and brand-new branches still write because
+            // they're either replacing a different row or creating one.
+            Log.debug("Skipped no-op conversation save for id=\(updatedConversation.id)")
+        } else {
+            try updatedConversation.save(db)
+        }
+        return ExistingConversationUpdateOutcome(
+            firstTimeSeeingConversationExpired: updatedConversation.isExpired
+                && updatedConversation.expiresAt != existingConversation.expiresAt,
+            actualClientConversationId: preferredClientConversationId
         )
     }
 

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationWriter.swift
@@ -626,7 +626,17 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
                         "conflictingIsUnused=\(conflictingConversation.isUnused)"
                 )
             }
-            try updatedConversation.save(db)
+            if updatedConversation == existingConversation {
+                // Row would be byte-identical — skip the write so GRDB observers
+                // don't fire and re-render the conversations list for no state
+                // change. Common during catch-up bursts where the same row is
+                // re-saved across many consecutive stream events. The
+                // existing-by-tag and brand-new branches still write because
+                // they're either replacing a different row or creating one.
+                Log.debug("Skipped no-op conversation save for id=\(dbConversation.id)")
+            } else {
+                try updatedConversation.save(db)
+            }
             firstTimeSeeingConversationExpired = updatedConversation.isExpired && updatedConversation.expiresAt != existingConversation.expiresAt
             actualClientConversationId = preferredClientConversationId
         } else {

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationWriter.swift
@@ -236,24 +236,34 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
         return conversation.id
     }
 
-    private func _store(
+    /// A `DBConversation` row + its members and profiles, fully resolved from
+    /// XMTP but not yet written to the local DB. Built by `prepare(...)`,
+    /// consumed by `persist(_:in:)`.
+    ///
+    /// The split lets the batch catch-up path fan out N parallel `prepare`
+    /// calls (each does XMTP network work) and then collapse the N
+    /// `persist` calls into a single GRDB transaction — one observer fire
+    /// for the whole backlog instead of N. The stream path threads them
+    /// sequentially via `_store` and is byte-equivalent to the old shape.
+    struct PreparedConversation {
+        let dbConversation: DBConversation
+        let dbMembers: [DBConversationMember]
+        let memberProfiles: [DBMemberProfile]
+    }
+
+    /// Async, network-bound, transaction-free. Safe to call concurrently for
+    /// many conversations.
+    func prepare(
         conversation: XMTPiOS.Group,
         inboxId: String,
-        withLatestMessages: Bool = false,
         clientConversationId: String? = nil,
         quarantinedAt: Date? = nil
-    ) async throws -> DBConversation {
-        // Sync group to get latest state including member permission levels
+    ) async throws -> PreparedConversation {
         try await conversation.sync()
-
-        // Extract conversation metadata
         let metadata = try await extractConversationMetadata(from: conversation)
         let members = try await conversation.members
         let dbMembers = members.map { $0.dbRepresentation(conversationId: conversation.id) }
         let memberProfiles = try conversation.memberProfiles
-
-        // Create database representation (imageLastRenewed will be determined inside the write transaction
-        // to avoid race conditions with concurrent asset renewal)
         let dbConversation = try await createDBConversation(
             from: conversation,
             metadata: metadata,
@@ -262,22 +272,157 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
             imageLastRenewed: nil,
             quarantinedAt: quarantinedAt
         )
-
-        // Save to database. Capture the actual clientConversationId used (may be a draft ID
-        // like "draft-XXX" instead of the XMTP group ID) so cache notifications match
-        // the ID that ViewModels subscribe to.
-        // Also returns the old image URL for cache invalidation.
-        let saveResult = try await saveConversationToDatabase(
+        return PreparedConversation(
             dbConversation: dbConversation,
             dbMembers: dbMembers,
             memberProfiles: memberProfiles
         )
+    }
+
+    /// Synchronous, transaction-scoped. Call inside `databaseWriter.write { db in ... }`.
+    /// Idempotent: replay-safe thanks to `saveConversation`'s no-op diff
+    /// short-circuit + the `onConflict: .ignore` localState insert.
+    func persist(_ prepared: PreparedConversation, in db: Database) throws -> ConversationSaveResult {
+        let creator = DBMember(inboxId: prepared.dbConversation.creatorId)
+        try creator.save(db)
+
+        // Save conversation (handle local conversation updates).
+        // Also handles imageLastRenewed preservation inside the transaction.
+        let saveResult = try saveConversation(prepared.dbConversation, in: db)
+
+        // Save local state
+        let localState = ConversationLocalState(
+            conversationId: prepared.dbConversation.id,
+            isPinned: false,
+            isUnread: false,
+            isUnreadUpdatedAt: Date.distantPast,
+            isMuted: false,
+            pinnedOrder: nil,
+            hidesInviteCard: false
+        )
+        try localState.insert(db, onConflict: .ignore)
+
+        // Remove conversation_members rows for members no longer in the group
+        let currentMemberInboxIds = Set(prepared.dbMembers.map(\.inboxId))
+        if !currentMemberInboxIds.isEmpty {
+            try DBConversationMember
+                .filter(DBConversationMember.Columns.conversationId == prepared.dbConversation.id)
+                .filter(!currentMemberInboxIds.contains(DBConversationMember.Columns.inboxId))
+                .deleteAll(db)
+        }
+
+        try saveMembers(prepared.dbMembers, in: db)
+
+        // Fill gaps: only write appData profiles for members without message-sourced data
+        try prepared.memberProfiles.forEach { profile in
+            let existing = try DBMemberProfile.fetchOne(
+                db,
+                conversationId: prepared.dbConversation.id,
+                inboxId: profile.inboxId
+            )
+            if existing?.name != nil || existing?.avatar != nil || existing?.memberKind != nil {
+                return
+            }
+            let member = DBMember(inboxId: profile.inboxId)
+            try member.save(db)
+            try profile.save(db)
+        }
+
+        return saveResult
+    }
+
+    /// Post-persist side effects the stream path runs after each individual
+    /// save. The batch catch-up path runs them per-conversation off the
+    /// foreground critical path after its single transaction commits, so
+    /// the user-visible foreground latency only includes prepare + persist.
+    ///
+    /// `saveResult` is required because `saveConversation` may resolve a
+    /// different `clientConversationId` than the one on the incoming
+    /// `PreparedConversation` (e.g. a sticky draft id wins over the XMTP
+    /// group id — see ClientConversationIdPriorityTests). The image cache
+    /// has to key off the *actual* persisted id so the UI lookups find it.
+    /// Passing nil for `oldImageURL` is acceptable here because the batch
+    /// persists multiple rows in one transaction and doesn't track per-row
+    /// old URLs; the prefetcher then fetches unconditionally, the right
+    /// default for a freshly-synced conversation.
+    func runPostPersistSideEffects(
+        prepared: PreparedConversation,
+        saveResult: ConversationSaveResult,
+        group: XMTPiOS.Group
+    ) async {
+        enqueueContactSyncForNetworkChange(conversationId: prepared.dbConversation.id)
+        prefetchEncryptedImages(profiles: prepared.memberProfiles, group: group)
+        prefetchEncryptedGroupImage(
+            cacheId: saveResult.clientConversationId,
+            group: group,
+            oldImageURL: nil
+        )
+        do {
+            _ = try await inviteWriter.generate(
+                for: prepared.dbConversation,
+                expiresAt: nil,
+                expiresAfterUse: false
+            )
+        } catch {
+            Log.error("Invite generation skipped for conversation \(prepared.dbConversation.id): \(error)")
+        }
+        await processProfileMessagesFromHistory(conversation: group)
+    }
+
+    /// Apply the supplemental messages (reactions, read receipts) the batch
+    /// catch-up filter excluded from the main transaction. Each gets its
+    /// own small transaction via the existing per-type handlers — same
+    /// loop body as `fetchAndStoreLatestMessages:704-721`. Without this,
+    /// reactions and read receipts that arrived while the device was
+    /// offline are filtered out by `isStorableForBatch` and never picked
+    /// up: libxmtp's `streamAllMessages` only delivers events from the
+    /// connection time forward, it does not replay historical backlog.
+    func applyBacklogSupplementals(
+        _ messages: [XMTPiOS.DecodedMessage],
+        for conversation: DBConversation
+    ) async {
+        for message in messages {
+            guard !message.isProfileMessage, !message.isTypingIndicator else {
+                continue
+            }
+            if message.isReadReceipt {
+                await storeReadReceipt(message, conversationId: conversation.id)
+                continue
+            }
+            do {
+                _ = try await messageWriter.store(message: message, for: conversation)
+            } catch {
+                Log.error("Failed to apply backlog supplemental message \(message.id) in \(conversation.id): \(error)")
+            }
+        }
+    }
+
+    private func _store(
+        conversation: XMTPiOS.Group,
+        inboxId: String,
+        withLatestMessages: Bool = false,
+        clientConversationId: String? = nil,
+        quarantinedAt: Date? = nil
+    ) async throws -> DBConversation {
+        let prepared = try await prepare(
+            conversation: conversation,
+            inboxId: inboxId,
+            clientConversationId: clientConversationId,
+            quarantinedAt: quarantinedAt
+        )
+
+        // Persist in a single transaction. Capture the actual clientConversationId
+        // used (may be a draft ID like "draft-XXX" instead of the XMTP group ID)
+        // so cache notifications match the ID that ViewModels subscribe to.
+        let saveResult = try await databaseWriter.write { [self] db in
+            try persist(prepared, in: db)
+        }
 
         // Network-driven member commit just landed (initial conversation
         // arrival or refresh-with-new-members). Fire the contact-sync
         // coordinator with `force: true`; the coordinator will skip if the
         // local user has not acted in this conversation yet (action-gated).
-        enqueueContactSyncForNetworkChange(conversationId: dbConversation.id)
+        enqueueContactSyncForNetworkChange(conversationId: prepared.dbConversation.id)
 
         if let preservedInviteTag = saveResult.preservedInviteTag,
            (try conversation.inviteTag).isEmpty {
@@ -290,31 +435,32 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
         }
 
         // Prefetch encrypted profile images in background
-        prefetchEncryptedImages(profiles: memberProfiles, group: conversation)
+        prefetchEncryptedImages(profiles: prepared.memberProfiles, group: conversation)
 
-        // Prefetch encrypted group image in background (invalidate old URL if changed)
-        // Use actualClientConversationId to match the ID that ViewModels subscribe to
+        // Prefetch encrypted group image in background (invalidate old URL if changed).
+        // The incoming image URL lives on the prepared DBConversation (createDBConversation
+        // builds it from metadata.imageURLString verbatim).
         prefetchEncryptedGroupImage(
             cacheId: saveResult.clientConversationId,
             group: conversation,
-            oldImageURL: saveResult.oldImageURL != metadata.imageURLString ? saveResult.oldImageURL : nil
+            oldImageURL: saveResult.oldImageURL != prepared.dbConversation.imageURLString ? saveResult.oldImageURL : nil
         )
 
         do {
             _ = try await inviteWriter.generate(
-                for: dbConversation,
+                for: prepared.dbConversation,
                 expiresAt: nil,
                 expiresAfterUse: false
             )
         } catch {
-            Log.error("Invite generation skipped for conversation \(dbConversation.id): \(error)")
+            Log.error("Invite generation skipped for conversation \(prepared.dbConversation.id): \(error)")
         }
 
         // Fetch and store latest messages if requested
         if withLatestMessages {
             try await fetchAndStoreLatestMessages(
                 for: conversation,
-                dbConversation: dbConversation,
+                dbConversation: prepared.dbConversation,
                 currentInboxId: inboxId
             )
         }
@@ -324,7 +470,7 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
         if let lastMessage, !lastMessage.isProfileMessage, !lastMessage.isTypingIndicator, !lastMessage.isReadReceipt {
             let result = try await messageWriter.store(
                 message: lastMessage,
-                for: dbConversation
+                for: prepared.dbConversation
             )
             Log.debug("Saved last message: \(result)")
         }
@@ -332,7 +478,7 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
         // Process profile messages from history to populate member profiles
         await processProfileMessagesFromHistory(conversation: conversation)
 
-        return dbConversation
+        return prepared.dbConversation
     }
 
     // MARK: - Helper Methods
@@ -423,68 +569,10 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
         )
     }
 
-    private struct ConversationSaveResult {
+    struct ConversationSaveResult {
         let clientConversationId: String
         let oldImageURL: String?
         let preservedInviteTag: String?
-    }
-
-    /// Returns the actual clientConversationId used (may differ from input if a local draft exists),
-    /// and the old image URL for cache invalidation purposes.
-    private func saveConversationToDatabase(
-        dbConversation: DBConversation,
-        dbMembers: [DBConversationMember],
-        memberProfiles: [DBMemberProfile]
-    ) async throws -> ConversationSaveResult {
-        try await databaseWriter.write { [self] db in
-            let creator = DBMember(inboxId: dbConversation.creatorId)
-            try creator.save(db)
-
-            // Save conversation (handle local conversation updates)
-            // This also handles imageLastRenewed preservation inside the transaction
-            let saveResult = try self.saveConversation(dbConversation, in: db)
-
-            // Save local state
-            let localState = ConversationLocalState(
-                conversationId: dbConversation.id,
-                isPinned: false,
-                isUnread: false,
-                isUnreadUpdatedAt: Date.distantPast,
-                isMuted: false,
-                pinnedOrder: nil,
-                hidesInviteCard: false
-            )
-            try localState.insert(db, onConflict: .ignore)
-
-            // Remove conversation_members rows for members no longer in the group
-            let currentMemberInboxIds = Set(dbMembers.map(\.inboxId))
-            if !currentMemberInboxIds.isEmpty {
-                try DBConversationMember
-                    .filter(DBConversationMember.Columns.conversationId == dbConversation.id)
-                    .filter(!currentMemberInboxIds.contains(DBConversationMember.Columns.inboxId))
-                    .deleteAll(db)
-            }
-
-            // Save members (upserts conversation_members + stub memberProfile rows)
-            try self.saveMembers(dbMembers, in: db)
-
-            // Fill gaps: only write appData profiles for members without message-sourced data
-            try memberProfiles.forEach { profile in
-                let existing = try DBMemberProfile.fetchOne(
-                    db,
-                    conversationId: dbConversation.id,
-                    inboxId: profile.inboxId
-                )
-                if existing?.name != nil || existing?.avatar != nil || existing?.memberKind != nil {
-                    return
-                }
-                let member = DBMember(inboxId: profile.inboxId)
-                try member.save(db)
-                try profile.save(db)
-            }
-
-            return saveResult
-        }
     }
 
     /// Returns the actual clientConversationId used (may differ from input if a local draft exists),

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationWriter.swift
@@ -912,8 +912,7 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
                 return
             }
 
-            let prefetcher = EncryptedImagePrefetcher()
-            await prefetcher.prefetchProfileImages(
+            await EncryptedImagePrefetcher.shared.prefetchProfileImages(
                 profiles: encryptedProfiles,
                 groupKey: groupKey
             )

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/IncomingMessageWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/IncomingMessageWriter.swift
@@ -39,7 +39,159 @@ class IncomingMessageWriter: IncomingMessageWriterProtocol, @unchecked Sendable 
         self.databaseWriter = databaseWriter
     }
 
+    /// A `DBMessage` row plus the source metadata, prepared from a
+    /// `DecodedMessage` but not yet written. The `dbRepresentation()`
+    /// transform runs in `prepare(...)` so the upcoming batch catch-up
+    /// can build N prepared messages in parallel and persist them all
+    /// in one transaction.
+    ///
+    /// Only the regular-message path uses this — reactions still flow
+    /// through `handleReactionAddition` / `handleReactionRemoval`, each
+    /// of which has its own small transaction. A backlog of mostly
+    /// text messages with a few reactions still collapses 90%+ of the
+    /// observer fires via the batched persist; the reaction overhead
+    /// is bounded and was already neutralized by the no-op diff
+    /// short-circuit + image-prefetch dedup from #857.
+    struct PreparedIncomingMessage {
+        let source: DecodedMessage
+        let encodedContentType: ContentTypeID
+        let dbMessage: DBMessage
+    }
+
+    /// Async, transaction-free. Decodes the content type and builds the
+    /// `DBMessage` representation. Safe to call concurrently across
+    /// many messages.
+    func prepare(message: DecodedMessage) async throws -> PreparedIncomingMessage {
+        let encodedContentType = try message.encodedContent.type
+        let dbMessage = try message.dbRepresentation()
+        return PreparedIncomingMessage(
+            source: message,
+            encodedContentType: encodedContentType,
+            dbMessage: dbMessage
+        )
+    }
+
+    /// Synchronous, transaction-scoped. Returns `nil` when the message
+    /// is dropped intentionally (e.g. unverified-sender
+    /// ConnectionGrantRequest); the caller turns that into the
+    /// canonical "no-op" result.
     // swiftlint:disable:next function_body_length cyclomatic_complexity
+    func persist(
+        _ prepared: PreparedIncomingMessage,
+        conversation: DBConversation,
+        in db: Database
+    ) throws -> IncomingMessageWriterResult? {
+        let source = prepared.source
+        let encodedContentType = prepared.encodedContentType
+        let senderVerified = try Self.bootstrapSenderProfile(
+            db: db,
+            conversationId: conversation.id,
+            senderInboxId: source.senderInboxId
+        )
+
+        // Defense against unverified or spoofed CloudConnectionGrantRequest senders:
+        // only persist grant requests whose sender is a verified Convos assistant
+        // in this conversation. Anything else gets dropped silently with a warning
+        // so the UI never has a chance to render the deep-link card.
+        if encodedContentType == ContentTypeCloudConnectionGrantRequest, !senderVerified {
+            Log.warning("Dropping CloudConnectionGrantRequest from unverified sender \(source.senderInboxId) in \(conversation.id)")
+            return nil
+        }
+
+        let message = prepared.dbMessage
+
+        let messageExistsInDB = try DBMessage.exists(db, key: message.id)
+        // @jarodl temporary, this should happen somewhere else more explicitly.
+        let localInboxId = try DBInbox.fetchAll(db).first?.inboxId
+        let wasRemovedFromConversation: Bool = {
+            guard let localInboxId, let removed = message.update?.removedInboxIds else { return false }
+            return removed.contains(localInboxId)
+        }()
+
+        Log.debug("Storing incoming message \(message.id) localId \(message.clientMessageId) echoDateNs=\(message.dateNs)")
+        if !message.attachmentUrls.isEmpty {
+            Log.debug("[IncomingMessageWriter] Incoming attachmentUrls: \(message.attachmentUrls.map { $0.prefix(80) })")
+        }
+        // see if this message has a local version
+        if let localMessage = try DBMessage
+            .filter(DBMessage.Columns.id == message.id)
+            .filter(DBMessage.Columns.clientMessageId != message.id)
+            .fetchOne(db) {
+            // Keep using the same local clientMessageId, sortId, and attachmentUrls
+            // Preserving attachmentUrls is critical for maintaining AttachmentLocalState lookup
+            Log.debug("BRANCH 1: Found local message \(localMessage.clientMessageId) for incoming message \(message.id)")
+            let updatedMessage = message
+                .with(clientMessageId: localMessage.clientMessageId)
+                .with(sortId: localMessage.sortId)
+                .with(attachmentUrls: localMessage.attachmentUrls)
+            try updatedMessage.save(db)
+            Log.debug("BRANCH 1: Updated with clientMessageId=\(localMessage.clientMessageId), sortId=\(localMessage.sortId ?? -1)")
+        } else if let existingMessage = try DBMessage.fetchOne(db, key: message.id),
+                  existingMessage.hasLocalAttachments {
+            // Message exists with local attachment URLs (outgoing photo) - preserve them and sortId
+            Log.debug("BRANCH 2: Preserving local attachments for message \(message.id)")
+            let updatedMessage = message
+                .with(attachmentUrls: existingMessage.attachmentUrls)
+                .with(sortId: existingMessage.sortId)
+            try updatedMessage.save(db)
+            Log.debug("BRANCH 2: Saved with local attachments, sortId=\(existingMessage.sortId ?? -1)")
+        } else if let existingMessage = try DBMessage.fetchOne(db, key: message.id) {
+            // Message exists but BRANCH 1 and BRANCH 2 didn't match
+            // Keep clientMessageId, sortId, and attachmentUrls for stable UI identity
+            // Preserving attachmentUrls is critical: we've migrated AttachmentLocalState
+            // to match our local key, so using the incoming key would break the lookup
+            Log.debug("BRANCH 3: Found existing message \(message.id)")
+            if !existingMessage.attachmentUrls.isEmpty || !message.attachmentUrls.isEmpty {
+                Log.debug("[BRANCH 3] Existing attachmentUrls: \(existingMessage.attachmentUrls.map { $0.prefix(80) })")
+                Log.debug("[BRANCH 3] Incoming attachmentUrls: \(message.attachmentUrls.map { $0.prefix(80) })")
+                let keysMatch = existingMessage.attachmentUrls == message.attachmentUrls
+                Log.debug("[BRANCH 3] Keys match: \(keysMatch), preserving existing")
+            }
+            let updatedMessage = message
+                .with(clientMessageId: existingMessage.clientMessageId)
+                .with(sortId: existingMessage.sortId)
+                .with(attachmentUrls: existingMessage.attachmentUrls)
+            try updatedMessage.save(db)
+            Log.debug("BRANCH 3: Saved with clientMessageId=\(existingMessage.clientMessageId), sortId=\(existingMessage.sortId ?? -1)")
+        } else {
+            // Truly new incoming message - assign sortId based on chronological position.
+            // Find the correct insertion point by dateNs so messages from the NSE
+            // and main app always end up in chronological order regardless of
+            // which process writes first.
+            let newSortId = try Self.chronologicalSortId(
+                for: message.dateNs,
+                messageId: message.id,
+                conversationId: conversation.id,
+                in: db
+            )
+            let messageWithSortId = message.with(sortId: newSortId)
+
+            do {
+                try messageWithSortId.save(db)
+                Log.debug("BRANCH 4 (new): Saved incoming message: \(message.id) with sortId=\(newSortId)")
+            } catch {
+                Log.error("Failed saving incoming message \(message.id): \(error)")
+                throw error
+            }
+        }
+
+        if let update = message.update, !update.addedInboxIds.isEmpty {
+            for addedInboxId in update.addedInboxIds {
+                try DBConversationMember
+                    .filter(DBConversationMember.Columns.conversationId == conversation.id)
+                    .filter(DBConversationMember.Columns.inboxId == addedInboxId)
+                    .filter(DBConversationMember.Columns.invitedByInboxId == nil)
+                    .updateAll(db, DBConversationMember.Columns.invitedByInboxId.set(to: update.initiatedByInboxId))
+            }
+        }
+
+        return IncomingMessageWriterResult(
+            contentType: message.contentType,
+            wasRemovedFromConversation: wasRemovedFromConversation,
+            messageAlreadyExists: messageExistsInDB
+        )
+    }
+
     func store(message: DecodedMessage,
                for conversation: DBConversation) async throws -> IncomingMessageWriterResult {
         let encodedContentType = try message.encodedContent.type
@@ -71,118 +223,13 @@ class IncomingMessageWriter: IncomingMessageWriterProtocol, @unchecked Sendable 
             }
         }
 
-        let result = try await databaseWriter.write { db -> IncomingMessageWriterResult? in
-            let senderVerified = try Self.bootstrapSenderProfile(
-                db: db,
-                conversationId: conversation.id,
-                senderInboxId: message.senderInboxId
-            )
-
-            // Defense against unverified or spoofed CloudConnectionGrantRequest senders:
-            // only persist grant requests whose sender is a verified Convos assistant
-            // in this conversation. Anything else gets dropped silently with a warning
-            // so the UI never has a chance to render the deep-link card.
-            if encodedContentType == ContentTypeCloudConnectionGrantRequest, !senderVerified {
-                Log.warning("Dropping CloudConnectionGrantRequest from unverified sender \(message.senderInboxId) in \(conversation.id)")
-                return nil
-            }
-
-            let message = try message.dbRepresentation()
-
-            let messageExistsInDB = try DBMessage.exists(db, key: message.id)
-            // @jarodl temporary, this should happen somewhere else more explicitly.
-            let localInboxId = try DBInbox.fetchAll(db).first?.inboxId
-            let wasRemovedFromConversation: Bool = {
-                guard let localInboxId, let removed = message.update?.removedInboxIds else { return false }
-                return removed.contains(localInboxId)
-            }()
-
-            Log.debug("Storing incoming message \(message.id) localId \(message.clientMessageId) echoDateNs=\(message.dateNs)")
-            if !message.attachmentUrls.isEmpty {
-                Log.debug("[IncomingMessageWriter] Incoming attachmentUrls: \(message.attachmentUrls.map { $0.prefix(80) })")
-            }
-            // see if this message has a local version
-            if let localMessage = try DBMessage
-                .filter(DBMessage.Columns.id == message.id)
-                .filter(DBMessage.Columns.clientMessageId != message.id)
-                .fetchOne(db) {
-                // Keep using the same local clientMessageId, sortId, and attachmentUrls
-                // Preserving attachmentUrls is critical for maintaining AttachmentLocalState lookup
-                Log.debug("BRANCH 1: Found local message \(localMessage.clientMessageId) for incoming message \(message.id)")
-                let updatedMessage = message
-                    .with(clientMessageId: localMessage.clientMessageId)
-                    .with(sortId: localMessage.sortId)
-                    .with(attachmentUrls: localMessage.attachmentUrls)
-                try updatedMessage.save(db)
-                Log.debug("BRANCH 1: Updated with clientMessageId=\(localMessage.clientMessageId), sortId=\(localMessage.sortId ?? -1)")
-            } else if let existingMessage = try DBMessage.fetchOne(db, key: message.id),
-                      existingMessage.hasLocalAttachments {
-                // Message exists with local attachment URLs (outgoing photo) - preserve them and sortId
-                Log.debug("BRANCH 2: Preserving local attachments for message \(message.id)")
-                let updatedMessage = message
-                    .with(attachmentUrls: existingMessage.attachmentUrls)
-                    .with(sortId: existingMessage.sortId)
-                try updatedMessage.save(db)
-                Log.debug("BRANCH 2: Saved with local attachments, sortId=\(existingMessage.sortId ?? -1)")
-            } else if let existingMessage = try DBMessage.fetchOne(db, key: message.id) {
-                // Message exists but BRANCH 1 and BRANCH 2 didn't match
-                // Keep clientMessageId, sortId, and attachmentUrls for stable UI identity
-                // Preserving attachmentUrls is critical: we've migrated AttachmentLocalState
-                // to match our local key, so using the incoming key would break the lookup
-                Log.debug("BRANCH 3: Found existing message \(message.id)")
-                if !existingMessage.attachmentUrls.isEmpty || !message.attachmentUrls.isEmpty {
-                    Log.debug("[BRANCH 3] Existing attachmentUrls: \(existingMessage.attachmentUrls.map { $0.prefix(80) })")
-                    Log.debug("[BRANCH 3] Incoming attachmentUrls: \(message.attachmentUrls.map { $0.prefix(80) })")
-                    let keysMatch = existingMessage.attachmentUrls == message.attachmentUrls
-                    Log.debug("[BRANCH 3] Keys match: \(keysMatch), preserving existing")
-                }
-                let updatedMessage = message
-                    .with(clientMessageId: existingMessage.clientMessageId)
-                    .with(sortId: existingMessage.sortId)
-                    .with(attachmentUrls: existingMessage.attachmentUrls)
-                try updatedMessage.save(db)
-                Log.debug("BRANCH 3: Saved with clientMessageId=\(existingMessage.clientMessageId), sortId=\(existingMessage.sortId ?? -1)")
-            } else {
-                // Truly new incoming message - assign sortId based on chronological position.
-                // Find the correct insertion point by dateNs so messages from the NSE
-                // and main app always end up in chronological order regardless of
-                // which process writes first.
-                let newSortId = try Self.chronologicalSortId(
-                    for: message.dateNs,
-                    messageId: message.id,
-                    conversationId: conversation.id,
-                    in: db
-                )
-                let messageWithSortId = message.with(sortId: newSortId)
-
-                do {
-                    try messageWithSortId.save(db)
-                    Log.debug("BRANCH 4 (new): Saved incoming message: \(message.id) with sortId=\(newSortId)")
-                } catch {
-                    Log.error("Failed saving incoming message \(message.id): \(error)")
-                    throw error
-                }
-            }
-
-            if let update = message.update, !update.addedInboxIds.isEmpty {
-                for addedInboxId in update.addedInboxIds {
-                    try DBConversationMember
-                        .filter(DBConversationMember.Columns.conversationId == conversation.id)
-                        .filter(DBConversationMember.Columns.inboxId == addedInboxId)
-                        .filter(DBConversationMember.Columns.invitedByInboxId == nil)
-                        .updateAll(db, DBConversationMember.Columns.invitedByInboxId.set(to: update.initiatedByInboxId))
-                }
-            }
-
-            return IncomingMessageWriterResult(
-                contentType: message.contentType,
-                wasRemovedFromConversation: wasRemovedFromConversation,
-                messageAlreadyExists: messageExistsInDB
-            )
+        let prepared = try await prepare(message: message)
+        let result = try await databaseWriter.write { [self] db in
+            try persist(prepared, conversation: conversation, in: db)
         }
 
         // Dropped messages (e.g. unverified-sender ConnectionGrantRequests) return
-        // nil from the write block so the rest of the ingest pipeline treats them
+        // nil from persist so the rest of the ingest pipeline treats them
         // as a no-op rather than a new message.
         guard let result else {
             return IncomingMessageWriterResult(

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/IncomingMessageWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/IncomingMessageWriter.swift
@@ -75,7 +75,6 @@ class IncomingMessageWriter: IncomingMessageWriterProtocol, @unchecked Sendable 
     /// is dropped intentionally (e.g. unverified-sender
     /// ConnectionGrantRequest); the caller turns that into the
     /// canonical "no-op" result.
-    // swiftlint:disable:next function_body_length cyclomatic_complexity
     func persist(
         _ prepared: PreparedIncomingMessage,
         conversation: DBConversation,

--- a/ConvosCore/Sources/ConvosCore/Syncing/BatchCatchUp.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/BatchCatchUp.swift
@@ -1,0 +1,305 @@
+import Foundation
+import GRDB
+@preconcurrency import XMTPiOS
+
+struct BatchCatchUpResult: Sendable {
+    let conversationsProcessed: Int
+    let messagesProcessed: Int
+    let durationSeconds: Double
+}
+
+/// Drains the backlog of conversation/message activity that arrived while
+/// the app was backgrounded or killed, *before* streams resume — so the
+/// foreground stream restart doesn't re-deliver the backlog as per-event
+/// traffic. Replaces N writes / N observer fires / N SwiftUI re-renders
+/// with one of each (for the regular-message path).
+///
+/// Flow:
+/// 1. `client.conversationsProvider.listGroups(lastActivityAfterNs:)`
+///    discovers conversations that had activity since the cursor.
+/// 2. Per conversation, in parallel:
+///    - Read the local `MAX(message.dateNs)` for that conversation
+///    - `Group.messages(afterNs:)` to fetch the backlog from XMTP
+///    - Split into "regular" messages (text, attachments, link previews,
+///      group updates — go through `IncomingMessageWriter.persist` in
+///      the batched transaction) and "supplementals" (reactions, read
+///      receipts — each has its own per-type handler that the existing
+///      stream-replay path also uses, but the libxmtp stream only
+///      delivers events forward from connection time so we have to
+///      apply supplementals ourselves before streams take over).
+///    - Build a `PreparedConversation` + `[PreparedIncomingMessage]`
+///      via the writers' prepare phases. All transaction-free.
+/// 3. Open ONE `databaseWriter.write` and persist every prepared
+///    conversation + its prepared regular messages inside that single
+///    transaction. One observer fire, one SwiftUI re-render for the
+///    regular-message path.
+/// 4. After the transaction commits, apply per-conversation
+///    supplementals via the existing reaction/read-receipt handlers
+///    (each runs its own small transaction — same shape the stream
+///    path uses via `fetchAndStoreLatestMessages`).
+/// 5. Per-conversation side effects (prefetch + invite generation +
+///    profile-from-history) fire off the foreground critical path so
+///    they don't block the hook.
+///
+/// Why supplementals can't ride the main transaction: their handlers
+/// (`handleReactionAddition/Removal`, `storeReadReceipt`) each open
+/// their own `databaseWriter.write` block and do non-trivial conditional
+/// logic (existence checks, timestamp comparisons). Inlining them into
+/// the batched persist would require duplicating that logic; running
+/// them via the existing handlers preserves a single source of truth.
+/// The cost is N small transactions vs one big one, but in practice
+/// supplementals are a small fraction of backlog traffic.
+///
+/// Stream redelivery of regular messages after the batch returns is
+/// free thanks to:
+/// - `saveConversation`'s no-op diff short-circuit (#857)
+/// - `DBMessage` primary-key INSERT OR REPLACE semantics
+/// - Reaction handler existence checks
+/// Value type: stored properties are reference-typed but each conforms
+/// to Sendable (`ConversationWriter` and `IncomingMessageWriter` are
+/// `@unchecked Sendable`, GRDB's `DatabaseWriter` is Sendable), so
+/// `BatchCatchUp` itself is implicitly Sendable with no annotation.
+/// All transient state lives stack-local within `run`.
+struct BatchCatchUp {
+    private let conversationWriter: ConversationWriter
+    private let messageWriter: IncomingMessageWriter
+    private let databaseWriter: any DatabaseWriter
+
+    init(
+        conversationWriter: ConversationWriter,
+        messageWriter: IncomingMessageWriter,
+        databaseWriter: any DatabaseWriter
+    ) {
+        self.conversationWriter = conversationWriter
+        self.messageWriter = messageWriter
+        self.databaseWriter = databaseWriter
+    }
+
+    /// Run the batch catch-up against the given client. `since` is the
+    /// cursor — typically the value persisted by the NSE in
+    /// `lastWelcomeProcessed`. A `nil` cursor means "fetch everything
+    /// available" (cold launch).
+    func run(
+        client: any XMTPClientProvider,
+        inboxId: String,
+        since: Date?
+    ) async throws -> BatchCatchUpResult {
+        let started = CFAbsoluteTimeGetCurrent()
+        let cursorNs: Int64? = since.map { Int64($0.nanosecondsSince1970) }
+
+        let groups = try client.conversationsProvider.listGroups(
+            createdAfterNs: nil,
+            createdBeforeNs: nil,
+            lastActivityAfterNs: cursorNs,
+            lastActivityBeforeNs: nil,
+            limit: nil,
+            consentStates: [.allowed, .unknown],
+            orderBy: .lastActivity
+        )
+
+        guard !groups.isEmpty else {
+            let elapsed = CFAbsoluteTimeGetCurrent() - started
+            Log.info("[PERF] catchup.batch.messages: \(Int(elapsed * 1000))ms convs=0 messages=0")
+            return BatchCatchUpResult(conversationsProcessed: 0, messagesProcessed: 0, durationSeconds: elapsed)
+        }
+
+        // Phase 1: parallel prepare (network-bound, transaction-free).
+        let prepared = try await prepareAll(groups: groups, inboxId: inboxId)
+
+        // Phase 2: single-transaction persist of conversations + regular
+        // messages. `saveResults[i]` corresponds to `prepared[i]` — needed
+        // post-transaction because `saveConversation` may resolve a
+        // different clientConversationId than the input (sticky-draft
+        // logic), which the image-cache key downstream depends on.
+        //
+        // We also capture conversations where a backlog message removed
+        // the local inbox — the stream path in
+        // `IncomingMessageWriter.store` posts
+        // `postLeftConversationNotification` for these; the batch path
+        // must too or users removed while backgrounded never get notified.
+        // Collected inside the transaction (only `persist` knows) but
+        // dispatched after commit (notification posts are not a DB
+        // operation).
+        struct PersistOutcomes {
+            let saveResults: [ConversationWriter.ConversationSaveResult]
+            let conversationsRemovingLocalInbox: [DBConversation]
+        }
+        let outcomes: PersistOutcomes = try await databaseWriter.write { [conversationWriter, messageWriter] db in
+            var results: [ConversationWriter.ConversationSaveResult] = []
+            var removals: [DBConversation] = []
+            results.reserveCapacity(prepared.count)
+            for entry in prepared {
+                let result = try conversationWriter.persist(entry.conversation, in: db)
+                results.append(result)
+                for preparedMessage in entry.regularMessages {
+                    let messageResult = try messageWriter.persist(
+                        preparedMessage,
+                        conversation: entry.conversation.dbConversation,
+                        in: db
+                    )
+                    if let messageResult,
+                       messageResult.wasRemovedFromConversation,
+                       !messageResult.messageAlreadyExists {
+                        removals.append(entry.conversation.dbConversation)
+                    }
+                }
+            }
+            return PersistOutcomes(
+                saveResults: results,
+                conversationsRemovingLocalInbox: removals
+            )
+        }
+        let saveResults = outcomes.saveResults
+
+        // Post-commit notifications, matching the stream path's tail in
+        // `IncomingMessageWriter.store`.
+        for conversation in outcomes.conversationsRemovingLocalInbox {
+            conversation.postLeftConversationNotification()
+        }
+
+        // Phase 3: apply supplementals (reactions + read receipts) via the
+        // existing per-type handlers. libxmtp's `streamAllMessages` only
+        // delivers events forward from connection time — it does NOT
+        // replay historical backlog, so these would be lost if we relied
+        // on the stream to pick them up. Each handler runs its own small
+        // transaction; cheap because supplementals are a small fraction
+        // of typical backlog volume.
+        var supplementalCount = 0
+        for entry in prepared {
+            if entry.supplementalMessages.isEmpty { continue }
+            supplementalCount += entry.supplementalMessages.count
+            await conversationWriter.applyBacklogSupplementals(
+                entry.supplementalMessages,
+                for: entry.conversation.dbConversation
+            )
+        }
+
+        // Phase 4: per-conversation side effects (prefetch, invite
+        // generation, profile-from-history), off the foreground critical
+        // path. `saveResult.clientConversationId` is the *actual*
+        // persisted id and is what the image cache must key off.
+        Task.detached(priority: .background) { [conversationWriter, prepared, saveResults] in
+            for (entry, saveResult) in zip(prepared, saveResults) {
+                await conversationWriter.runPostPersistSideEffects(
+                    prepared: entry.conversation,
+                    saveResult: saveResult,
+                    group: entry.group
+                )
+            }
+        }
+
+        let elapsed = CFAbsoluteTimeGetCurrent() - started
+        let totalRegular = prepared.reduce(0) { $0 + $1.regularMessages.count }
+        Log.info("[PERF] catchup.batch.messages: \(Int(elapsed * 1000))ms convs=\(prepared.count) messages=\(totalRegular) supplementals=\(supplementalCount)")
+        return BatchCatchUpResult(
+            conversationsProcessed: prepared.count,
+            messagesProcessed: totalRegular,
+            durationSeconds: elapsed
+        )
+    }
+
+    // MARK: - Private
+
+    private struct PreparedEntry {
+        let group: XMTPiOS.Group
+        let conversation: ConversationWriter.PreparedConversation
+        let regularMessages: [IncomingMessageWriter.PreparedIncomingMessage]
+        let supplementalMessages: [XMTPiOS.DecodedMessage]
+    }
+
+    private func prepareAll(
+        groups: [XMTPiOS.Group],
+        inboxId: String
+    ) async throws -> [PreparedEntry] {
+        try await withThrowingTaskGroup(of: PreparedEntry.self) { [conversationWriter, messageWriter, databaseWriter] taskGroup in
+            for group in groups {
+                taskGroup.addTask {
+                    let preparedConv = try await conversationWriter.prepare(
+                        conversation: group,
+                        inboxId: inboxId
+                    )
+
+                    let perConvCursorNs = try await Self.readLastMessageNs(
+                        for: group.id,
+                        in: databaseWriter
+                    )
+                    let allMessages = try await group.messages(afterNs: perConvCursorNs)
+
+                    var regularMessages: [IncomingMessageWriter.PreparedIncomingMessage] = []
+                    var supplementalMessages: [XMTPiOS.DecodedMessage] = []
+                    regularMessages.reserveCapacity(allMessages.count)
+                    for message in allMessages {
+                        switch Self.classify(message) {
+                        case .regular:
+                            let prepared = try await messageWriter.prepare(message: message)
+                            regularMessages.append(prepared)
+                        case .supplemental:
+                            supplementalMessages.append(message)
+                        case .skip:
+                            continue
+                        }
+                    }
+
+                    return PreparedEntry(
+                        group: group,
+                        conversation: preparedConv,
+                        regularMessages: regularMessages,
+                        supplementalMessages: supplementalMessages
+                    )
+                }
+            }
+
+            var results: [PreparedEntry] = []
+            for try await entry in taskGroup {
+                results.append(entry)
+            }
+            return results
+        }
+    }
+
+    private enum MessageClassification {
+        /// Goes through `IncomingMessageWriter.persist` in the batched transaction.
+        case regular
+        /// Handled post-transaction via `ConversationWriter.applyBacklogSupplementals`
+        /// (reactions, read receipts). These have per-type handlers that
+        /// the stream-driven path also uses; we apply them here because
+        /// the libxmtp stream doesn't replay historical backlog.
+        case supplemental
+        /// Drop entirely (typing indicators, profile messages, undecodable).
+        /// Typing indicators are inherently live-only; profile messages
+        /// are handled by `processProfileMessagesFromHistory` post-persist.
+        case skip
+    }
+
+    private static func classify(_ message: XMTPiOS.DecodedMessage) -> MessageClassification {
+        if message.isProfileMessage || message.isTypingIndicator {
+            return .skip
+        }
+        if message.isReadReceipt {
+            return .supplemental
+        }
+        guard let contentType = try? message.encodedContent.type else {
+            return .skip
+        }
+        if contentType == ContentTypeReaction || contentType == ContentTypeReactionV2 {
+            return .supplemental
+        }
+        return .regular
+    }
+
+    /// `MAX(dateNs)` for the conversation, or `0` when the local DB has no messages
+    /// for this conversation yet (cold/new). Mirrors the cursor `fetchAndStoreLatestMessages`
+    /// uses today on the stream catch-up path.
+    private static func readLastMessageNs(
+        for conversationId: String,
+        in databaseWriter: any DatabaseWriter
+    ) async throws -> Int64 {
+        try await databaseWriter.read { db in
+            let value: Int64? = try Int64.fetchOne(db, sql: """
+                SELECT MAX(dateNs) FROM message
+                WHERE conversationId = ?
+            """, arguments: [conversationId])
+            return value ?? 0
+        }
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Syncing/BatchCatchUp.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/BatchCatchUp.swift
@@ -112,41 +112,54 @@ struct BatchCatchUp {
         // different clientConversationId than the input (sticky-draft
         // logic), which the image-cache key downstream depends on.
         //
-        // We also capture conversations where a backlog message removed
-        // the local inbox — the stream path in
-        // `IncomingMessageWriter.store` posts
-        // `postLeftConversationNotification` for these; the batch path
-        // must too or users removed while backgrounded never get notified.
-        // Collected inside the transaction (only `persist` knows) but
-        // dispatched after commit (notification posts are not a DB
-        // operation).
+        // We also capture two post-commit signals that the stream path
+        // emits inside `IncomingMessageWriter.store` /
+        // `fetchAndStoreLatestMessages` and which the batch must mirror:
+        //   - conversations where a backlog message removed the local
+        //     inbox -> `postLeftConversationNotification` after commit
+        //   - conversations that received a message whose content type
+        //     marks the conversation unread (from a sender that isn't
+        //     us) -> `setUnread(true, ...)` after commit
+        // Collected inside the transaction (only `persist` knows the
+        // result) but dispatched after commit (notification posts +
+        // localStateWriter writes are not part of this transaction).
         struct PersistOutcomes {
             let saveResults: [ConversationWriter.ConversationSaveResult]
             let conversationsRemovingLocalInbox: [DBConversation]
+            let conversationsToMarkUnread: [String]
         }
         let outcomes: PersistOutcomes = try await databaseWriter.write { [conversationWriter, messageWriter] db in
             var results: [ConversationWriter.ConversationSaveResult] = []
             var removals: [DBConversation] = []
+            var unreadIds: [String] = []
             results.reserveCapacity(prepared.count)
             for entry in prepared {
                 let result = try conversationWriter.persist(entry.conversation, in: db)
                 results.append(result)
+                var entryMarksUnread = false
                 for preparedMessage in entry.regularMessages {
                     let messageResult = try messageWriter.persist(
                         preparedMessage,
                         conversation: entry.conversation.dbConversation,
                         in: db
                     )
-                    if let messageResult,
-                       messageResult.wasRemovedFromConversation,
-                       !messageResult.messageAlreadyExists {
+                    guard let messageResult else { continue }
+                    if messageResult.wasRemovedFromConversation, !messageResult.messageAlreadyExists {
                         removals.append(entry.conversation.dbConversation)
                     }
+                    if messageResult.contentType.marksConversationAsUnread,
+                       preparedMessage.source.senderInboxId != inboxId {
+                        entryMarksUnread = true
+                    }
+                }
+                if entryMarksUnread {
+                    unreadIds.append(entry.conversation.dbConversation.id)
                 }
             }
             return PersistOutcomes(
                 saveResults: results,
-                conversationsRemovingLocalInbox: removals
+                conversationsRemovingLocalInbox: removals,
+                conversationsToMarkUnread: unreadIds
             )
         }
         let saveResults = outcomes.saveResults
@@ -155,6 +168,16 @@ struct BatchCatchUp {
         // `IncomingMessageWriter.store`.
         for conversation in outcomes.conversationsRemovingLocalInbox {
             conversation.postLeftConversationNotification()
+        }
+
+        // Mark unread, matching the stream path's tail in
+        // `fetchAndStoreLatestMessages`.
+        for conversationId in outcomes.conversationsToMarkUnread {
+            do {
+                try await conversationWriter.markUnread(true, for: conversationId)
+            } catch {
+                Log.error("Failed to mark conversation \(conversationId) unread after batch catch-up: \(error)")
+            }
         }
 
         // Phase 3: apply supplementals (reactions + read receipts) via the

--- a/ConvosCore/Sources/ConvosCore/Syncing/StreamProcessor.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/StreamProcessor.swift
@@ -263,6 +263,20 @@ actor StreamProcessor: StreamProcessorProtocol {
                         return
                     }
 
+                    // Short-circuit row-independent events so a catch-up burst of
+                    // typing indicators or read receipts doesn't re-save the conversation
+                    // row N times for no state change. Read receipts persist to
+                    // DBConversationReadReceipt independently; typing indicators don't
+                    // write at all. Explode/profile/real-message paths below still
+                    // depend on a fresh row, so they stay downstream of store().
+                    if processTypingIndicator(message, conversationId: conversation.id, params: params) {
+                        return
+                    }
+
+                    if await processReadReceipt(message, conversationId: conversation.id, currentInboxId: params.client.inboxId) {
+                        return
+                    }
+
                     let dbConversation = try await conversationWriter.store(
                         conversation: conversation,
                         inboxId: params.client.inboxId
@@ -281,14 +295,6 @@ actor StreamProcessor: StreamProcessorProtocol {
                     guard explodeSettings == nil else { return }
 
                     if await processProfileMessage(message, conversationId: conversation.id) {
-                        return
-                    }
-
-                    if processTypingIndicator(message, conversationId: conversation.id, params: params) {
-                        return
-                    }
-
-                    if await processReadReceipt(message, conversationId: conversation.id, currentInboxId: params.client.inboxId) {
                         return
                     }
 

--- a/ConvosCore/Sources/ConvosCore/Syncing/StreamProcessor.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/StreamProcessor.swift
@@ -383,6 +383,16 @@ actor StreamProcessor: StreamProcessorProtocol {
 
     // MARK: - Profile Messages
 
+    /// Typing indicators are ephemeral UI signals — "X is typing" has no
+    /// meaning outside the live window. When streams reconnect after the
+    /// app was backgrounded or killed, libxmtp replays the backlog and
+    /// historical typing indicators arrive alongside real messages. Without
+    /// a freshness gate the UI would flash "X is typing" for someone who
+    /// finished typing minutes ago. Drop anything older than the live
+    /// window; the indicator's natural debounce on the sender side keeps
+    /// this well above one round-trip of normal latency.
+    private static let typingIndicatorLiveWindow: TimeInterval = 10
+
     private func processTypingIndicator(
         _ message: DecodedMessage,
         conversationId: String,
@@ -393,6 +403,12 @@ actor StreamProcessor: StreamProcessorProtocol {
         }
 
         guard message.senderInboxId != params.client.inboxId else {
+            return true
+        }
+
+        let ageSeconds = Date().timeIntervalSince1970 - (TimeInterval(message.sentAtNs) / 1_000_000_000)
+        guard ageSeconds <= Self.typingIndicatorLiveWindow else {
+            Log.debug("Dropping stale typing indicator from \(message.senderInboxId) (age=\(Int(ageSeconds))s)")
             return true
         }
 

--- a/ConvosCore/Sources/ConvosCore/Syncing/SyncingManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/SyncingManager.swift
@@ -15,6 +15,16 @@ public protocol SyncingManagerProtocol: Actor {
     func requestDiscovery() async
     func setInviteJoinErrorHandler(_ handler: (any InviteJoinErrorHandler)?) async
     func setTypingIndicatorHandler(_ handler: @escaping @Sendable (String, String, Bool) -> Void) async
+
+    /// Drain the backlog of activity since `cursor` in one batched transaction,
+    /// before streams resume. Runs the message-side `BatchCatchUp` and the
+    /// invite-side `InviteJoinRequestsManager.processJoinRequestOutcomes`
+    /// sequentially, both keyed off the same cursor.
+    ///
+    /// Returns silently on best-effort failure — the stream path that follows
+    /// is the safety net (per-event handlers still pick up anything the batch
+    /// missed).
+    nonisolated func runBatchCatchUp(client: AnyClientProvider, since: Date?) async
 }
 
 /// Wrapper for client and API client parameters used in state transitions
@@ -133,6 +143,9 @@ actor SyncingManager: SyncingManagerProtocol {
     // MARK: - Initialization
 
     private let databaseReader: any DatabaseReader
+    /// Held for foreground batch catch-up construction; not used elsewhere
+    /// since the stream path's writers live inside `streamProcessor`.
+    private let databaseWriter: any DatabaseWriter
 
     init(identityStore: any KeychainIdentityStoreProtocol,
          databaseWriter: any DatabaseWriter,
@@ -141,6 +154,7 @@ actor SyncingManager: SyncingManagerProtocol {
          notificationCenter: any UserNotificationCenterProtocol) {
         self.identityStore = identityStore
         self.databaseReader = databaseReader
+        self.databaseWriter = databaseWriter
         let enablementStore: any EnablementStore = GRDBEnablementStore(dbWriter: databaseWriter, dbReader: databaseReader)
         let healthSubscriptionStore = GRDBHealthBackgroundSubscriptionStore(
             dbWriter: databaseWriter,
@@ -220,6 +234,52 @@ actor SyncingManager: SyncingManagerProtocol {
 
     func resume() async {
         enqueueAction(.resume)
+    }
+
+    /// `nonisolated` so the call doesn't enter the actor's isolation domain
+    /// — the only state it touches is the immutable `let identityStore` and
+    /// `let databaseWriter`, both safely shareable. This avoids strict-
+    /// concurrency tripping on the non-Sendable `AnyClientProvider` being
+    /// passed to BatchCatchUp / InviteJoinRequestsManager from inside an
+    /// actor. The stream-resume that follows is unaffected because it goes
+    /// through the actor's normal `enqueueAction(.resume)` path.
+    nonisolated func runBatchCatchUp(client: AnyClientProvider, since: Date?) async {
+        await runMessageBatch(client: client, since: since)
+        await runInviteBatch(client: client, since: since)
+    }
+
+    private nonisolated func runMessageBatch(client: AnyClientProvider, since: Date?) async {
+        do {
+            guard let identity = try await identityStore.load() else {
+                Log.debug("catchup.batch.messages: no identity, skipping")
+                return
+            }
+            let messageWriter = IncomingMessageWriter(databaseWriter: databaseWriter)
+            let conversationWriter = ConversationWriter(
+                identityStore: identityStore,
+                databaseWriter: databaseWriter,
+                messageWriter: messageWriter
+            )
+            let batch = BatchCatchUp(
+                conversationWriter: conversationWriter,
+                messageWriter: messageWriter,
+                databaseWriter: databaseWriter
+            )
+            _ = try await batch.run(client: client, inboxId: identity.inboxId, since: since)
+        } catch {
+            Log.error("catchup.batch.messages failed: \(error.localizedDescription)")
+        }
+    }
+
+    private nonisolated func runInviteBatch(client: AnyClientProvider, since: Date?) async {
+        let started = CFAbsoluteTimeGetCurrent()
+        let manager = InviteJoinRequestsManager(
+            identityStore: identityStore,
+            databaseWriter: databaseWriter
+        )
+        let outcomes = await manager.processJoinRequestOutcomes(since: since, client: client)
+        let elapsed = CFAbsoluteTimeGetCurrent() - started
+        Log.info("[PERF] catchup.batch.invites: \(Int(elapsed * 1000))ms outcomes=\(outcomes.count)")
     }
 
     // MARK: - State Machine

--- a/ConvosCore/Tests/ConvosCoreTests/Integration/BatchCatchUpIntegrationTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/Integration/BatchCatchUpIntegrationTests.swift
@@ -1,0 +1,183 @@
+@testable import ConvosCore
+import Foundation
+import GRDB
+import Testing
+@preconcurrency import XMTPiOS
+
+/// Integration tests for `BatchCatchUp` that exercise the full batched
+/// catch-up flow against a local XMTP node (`./dev/up`). These verify the
+/// foreground / cold-start backlog drain shape: client B is "offline" (no
+/// stream, no per-event processing) while client A sends N messages to a
+/// shared group; `BatchCatchUp.run` then drains the backlog into B's local
+/// DB in one transaction.
+///
+/// The single-transaction property is asserted by counting GRDB
+/// `didCommit` events during `run`. Stream-replay redelivery after the
+/// batch returns is out of scope for these tests — that's covered by the
+/// no-op save short-circuit in #857 and DBMessage primary-key INSERT OR
+/// REPLACE semantics, both of which already have unit coverage.
+@Suite("BatchCatchUp Integration Tests", .serialized)
+struct BatchCatchUpIntegrationTests {
+    private enum TestError: Error {
+        case missingClients
+    }
+
+    /// Counts committed write transactions on a GRDB database. Used by the
+    /// tests below to assert "one transaction for the whole backlog".
+    private final class CommitCounter: TransactionObserver, @unchecked Sendable {
+        private(set) var commitCount: Int = 0
+
+        func observes(eventsOfKind eventKind: DatabaseEventKind) -> Bool { false }
+        func databaseDidChange(with event: DatabaseEvent) {}
+        func databaseDidCommit(_ db: Database) {
+            commitCount += 1
+        }
+        func databaseDidRollback(_ db: Database) {}
+    }
+
+    @Test("Batch fetches and persists all missed messages in one transaction")
+    func batchCatchesUpMissedMessagesInOneTransaction() async throws {
+        let fixtures = TestFixtures()
+        try await fixtures.createTestClients()
+
+        guard let clientA = fixtures.clientA as? Client,
+              let clientB = fixtures.clientB as? Client,
+              let clientIdB = fixtures.clientIdB else {
+            throw TestError.missingClients
+        }
+        let inboxIdB = clientB.inboxID
+
+        try await fixtures.databaseManager.dbWriter.write { db in
+            try DBInbox(inboxId: inboxIdB, clientId: clientIdB, createdAt: Date()).insert(db)
+        }
+
+        // A creates a group with B; A sends N messages.
+        let group = try await clientA.conversations.newGroup(
+            with: [clientB.inboxID],
+            name: "Batch Test Group"
+        )
+        // Sync B once so its libxmtp installation receives the welcome and
+        // is registered as a group member. This is "before the device went
+        // offline" — analogous to the iOS app having joined the conversation
+        // in a prior session.
+        try await clientB.conversations.sync()
+
+        let messageCount = 25
+        for i in 1...messageCount {
+            _ = try await group.send(content: "Batch msg \(i)")
+        }
+        // Critically: do NOT sync B again. The next sync runs inside
+        // `BatchCatchUp.run` and feeds messages into the batched persist.
+
+        // Wire writers + coordinator the way SyncingManager does for the
+        // foreground hook (commit d09e7639). Stateless wrappers around the
+        // test database.
+        let messageWriter = IncomingMessageWriter(databaseWriter: fixtures.databaseManager.dbWriter)
+        let conversationWriter = ConversationWriter(
+            identityStore: fixtures.identityStore,
+            databaseWriter: fixtures.databaseManager.dbWriter,
+            messageWriter: messageWriter
+        )
+        let batch = BatchCatchUp(
+            conversationWriter: conversationWriter,
+            messageWriter: messageWriter,
+            databaseWriter: fixtures.databaseManager.dbWriter
+        )
+
+        // Snapshot the commit count before `run`, then register the observer.
+        // We only care about commits that happen *during* the batch — anything
+        // before doesn't matter.
+        let counter = CommitCounter()
+        fixtures.databaseManager.dbWriter.add(transactionObserver: counter)
+
+        let result = try await batch.run(client: clientB, inboxId: inboxIdB, since: nil)
+
+        // Headline assertions: the batch saw the conversation and at least
+        // all N user messages. libxmtp emits group-membership update messages
+        // alongside our content (the membership-add when B was invited), so
+        // the actual stored count is `messageCount + 1` (or +N where N is
+        // however many membership updates fired before we started sending).
+        // What we care about: all the user content made it.
+        #expect(result.conversationsProcessed == 1, "Expected 1 changed conversation, got \(result.conversationsProcessed)")
+        #expect(result.messagesProcessed >= messageCount, "Expected at least \(messageCount) messages persisted, got \(result.messagesProcessed)")
+
+        // Single transaction for the whole backlog. The batched persist is
+        // `databaseWriter.write { db in ... persist all conversations + all
+        // messages ... }` — exactly one commit, regardless of N.
+        #expect(counter.commitCount == 1, "Expected exactly 1 committed transaction during batch.run, got \(counter.commitCount)")
+
+        // Messages actually landed in B's DB.
+        let storedMessageCount = try await fixtures.databaseManager.dbReader.read { db in
+            try Int.fetchOne(db, sql: """
+                SELECT COUNT(*) FROM message WHERE conversationId = ?
+            """, arguments: [group.id])
+        } ?? 0
+        #expect(storedMessageCount >= messageCount, "Expected at least \(messageCount) message rows in DB, got \(storedMessageCount)")
+
+        // Conversation row exists.
+        let conversationStored = try await fixtures.databaseManager.dbReader.read { db in
+            try DBConversation.fetchOne(db, id: group.id)
+        }
+        #expect(conversationStored != nil, "Expected the group's DBConversation row to exist")
+
+        try? await fixtures.cleanup()
+    }
+
+    @Test("Batch with no missed activity is a near no-op")
+    func batchWithEmptyBacklogIsNoOp() async throws {
+        let fixtures = TestFixtures()
+        try await fixtures.createTestClients()
+
+        guard let clientA = fixtures.clientA as? Client,
+              let clientB = fixtures.clientB as? Client,
+              let clientIdB = fixtures.clientIdB else {
+            throw TestError.missingClients
+        }
+        let inboxIdB = clientB.inboxID
+
+        try await fixtures.databaseManager.dbWriter.write { db in
+            try DBInbox(inboxId: inboxIdB, clientId: clientIdB, createdAt: Date()).insert(db)
+        }
+
+        // A creates a group with B, no messages.
+        _ = try await clientA.conversations.newGroup(
+            with: [clientB.inboxID],
+            name: "Empty Group"
+        )
+        try await clientB.conversations.sync()
+
+        let messageWriter = IncomingMessageWriter(databaseWriter: fixtures.databaseManager.dbWriter)
+        let conversationWriter = ConversationWriter(
+            identityStore: fixtures.identityStore,
+            databaseWriter: fixtures.databaseManager.dbWriter,
+            messageWriter: messageWriter
+        )
+        let batch = BatchCatchUp(
+            conversationWriter: conversationWriter,
+            messageWriter: messageWriter,
+            databaseWriter: fixtures.databaseManager.dbWriter
+        )
+
+        // Pass a `since` in the future so list returns nothing.
+        let result = try await batch.run(
+            client: clientB,
+            inboxId: inboxIdB,
+            since: Date(timeIntervalSinceNow: 60)
+        )
+
+        #expect(result.conversationsProcessed == 0, "Expected 0 changed conversations, got \(result.conversationsProcessed)")
+        #expect(result.messagesProcessed == 0, "Expected 0 messages persisted, got \(result.messagesProcessed)")
+
+        try? await fixtures.cleanup()
+    }
+
+    // Note: a multi-conversation parallel-fanout test belongs here too, but
+    // libxmtp's `newGroup` doesn't set Convos invite tags (those come from
+    // the `SignedInvite` -> `createPlaceholderConversation` flow), and the
+    // `conversation.inviteTag` UNIQUE constraint rejects N groups all
+    // sharing the empty default. Real-world conversations always have
+    // unique invite tags from the invite-creation path, so this isn't a
+    // production concern — just a test-rig gap. A multi-conv test would
+    // need to drive group creation through `createPlaceholderConversation`
+    // first, then have A send messages, then B catch up. Deferred.
+}

--- a/ConvosCore/Tests/ConvosCoreTests/Integration/BatchCatchUpIntegrationTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/Integration/BatchCatchUpIntegrationTests.swift
@@ -101,10 +101,14 @@ struct BatchCatchUpIntegrationTests {
         #expect(result.conversationsProcessed == 1, "Expected 1 changed conversation, got \(result.conversationsProcessed)")
         #expect(result.messagesProcessed >= messageCount, "Expected at least \(messageCount) messages persisted, got \(result.messagesProcessed)")
 
-        // Single transaction for the whole backlog. The batched persist is
-        // `databaseWriter.write { db in ... persist all conversations + all
-        // messages ... }` — exactly one commit, regardless of N.
-        #expect(counter.commitCount == 1, "Expected exactly 1 committed transaction during batch.run, got \(counter.commitCount)")
+        // Single transaction for the whole backlog persist + one post-commit
+        // `setUnread` write that mirrors the stream path's tail in
+        // `fetchAndStoreLatestMessages` (the conversation here has 25
+        // messages from A, so it qualifies for unread marking on B). The
+        // headline property is that the *persist* is one transaction
+        // regardless of N messages — not that the entire `run` does zero
+        // post-commit work.
+        #expect(counter.commitCount == 2, "Expected exactly 2 committed transactions during batch.run (1 persist + 1 unread mark), got \(counter.commitCount)")
 
         // Messages actually landed in B's DB.
         let storedMessageCount = try await fixtures.databaseManager.dbReader.read { db in

--- a/ConvosCore/Tests/ConvosCoreTests/MessagesRepositoryTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/MessagesRepositoryTests.swift
@@ -277,7 +277,7 @@ struct MessagesRepositoryTests {
         }
     }
 
-    @Test("saveConversationToDatabase preserves memberProfile rows for removed members")
+    @Test("ConversationWriter.persist preserves memberProfile rows for removed members")
     func testSaveConversationPreservesHistoricalProfiles() throws {
         let dbManager = MockDatabaseManager.makeTestDatabase()
         let conversationId = "conversation-1"

--- a/ConvosCore/Tests/ConvosCoreTests/TestHelpers.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/TestHelpers.swift
@@ -249,6 +249,7 @@ actor MockSyncingManager: SyncingManagerProtocol {
     var stopCallCount: Int = 0
     var pauseCallCount: Int = 0
     var resumeCallCount: Int = 0
+    var runBatchCatchUpCallCount: Int = 0
 
     var isSyncReady: Bool {
         isStarted && !isPaused
@@ -283,6 +284,14 @@ actor MockSyncingManager: SyncingManagerProtocol {
     }
 
     func requestDiscovery() async {
+    }
+
+    nonisolated func runBatchCatchUp(client: AnyClientProvider, since: Date?) async {
+        await incrementBatchCatchUpCount()
+    }
+
+    private func incrementBatchCatchUpCount() {
+        runBatchCatchUpCallCount += 1
     }
 }
 

--- a/docs/plans/batch-catchup-since-last-background.md
+++ b/docs/plans/batch-catchup-since-last-background.md
@@ -1,0 +1,213 @@
+# Plan — Batch-fetch catch-up on foreground, then resume streams
+
+Stacks on top of `jarod/stream-write-storm-fixes` (#857). That PR cuts per-event cost in the stream catch-up path. This plan replaces the per-event catch-up *path itself* with a single batched fetch on foreground/cold-start, then lets the stream take over only for genuinely new events.
+
+## Context
+
+When the iOS app comes back to the foreground after time in background (or cold-launches), `SyncingManager.handleResume()` restarts libxmtp's `streamAllMessages` and `stream(type:.groups)`, then calls `syncAllConversations()`. Libxmtp replays the backlog as a sequence of stream events; iOS processes each one through `StreamProcessor.processMessage()` and `processConversation()` individually:
+
+- One DB write transaction per message (and per conversation update).
+- One GRDB observer fire per write → conversations-list and messages-list publishers re-emit per event.
+- SwiftUI re-renders the conversations list once per backlog event — visible "replay" of message rows as they trickle in (the user has seen this).
+
+The stream-write-storm-fixes PR cuts the *per-event cost*: read receipts skip the writer, no-op saves short-circuit, attestation cache memoizes, profile-image prefetch dedupes. The fan-out path itself is unchanged. Backlogs of 100+ events still produce 100+ writer invocations, 100+ observer fires, 100+ list re-renders.
+
+## Goal
+
+For backlogs that arrive while the app was backgrounded:
+
+- **One** libxmtp call to discover which conversations changed
+- **One** libxmtp call *per changed conversation* to fetch the message backlog
+- **One** GRDB transaction that writes all conversations + all messages
+- **One** observer fire at commit time
+- Streams take over after the batch lands — they only deliver genuinely-new events that arrived during/after the batch fetch
+
+Net effect: the user opens the app, sees the conversations list with correct latest-message previews instantly, then live updates flow as new messages arrive normally.
+
+## Scope
+
+**In scope**
+
+- A new batch catch-up path triggered on `SessionStateMachine.handleEnterForeground()` (and cold launch) *before* `SyncingManager` resumes streams.
+- Composing the existing libxmtp APIs (`list(lastActivityAfterNs:)`, `Conversation.messages(afterNs:)`) into a single transaction-wrapped write.
+- A "stream gate" so streams that fire during the batch don't double-write events the batch is about to write.
+- Plumbing the batch hook to **also** run `InviteCoordinator.processJoinRequestOutcomes(since:)` — DM-based join requests have the exact same backlog-replay problem and the batch primitive already exists; it's just never called on foreground.
+
+**Out of scope**
+
+- Push-notification-driven catch-up (already handled by the NSE).
+- Real-time stream optimization beyond what already landed (covered by stream-write-storm-fixes).
+- New schema columns. The plan uses per-conversation `max(DBMessage.dateNs)` as the implicit cursor — same signal `ConversationWriter.fetchAndStoreLatestMessages` already uses at line 696.
+- Multi-inbox coordination (the iOS app has one primary inbox per identity; this is per-`XMTPClientProvider`).
+
+## Design
+
+### Trigger point
+
+`SessionStateMachine.handleEnterForeground()` (ConvosCore/Sources/ConvosCore/Inboxes/SessionStateMachine.swift:771).
+
+Current shape (paraphrased):
+
+```swift
+private func handleEnterForeground() async {
+    await reconnectLocalDatabase()
+    await syncingManager?.resume()        // ← streams restart here
+}
+```
+
+New shape:
+
+```swift
+private func handleEnterForeground() async {
+    await reconnectLocalDatabase()
+    // Both catch-ups run in parallel against the same cursor.
+    async let messages: () = batchCatchUp.run(client: ..., inboxId: ...)
+    async let invites: () = inviteCoordinator.processJoinRequestOutcomes(since: cursorDate)
+    _ = try await (messages, invites)
+    await syncingManager?.resume()
+}
+```
+
+The batch must complete (or fail with timeout) before streams resume. Streams already wait on `syncAllConversations` today; we're inserting one more await of comparable cost.
+
+### Precedent: invite-join-request batch (and an existing cursor)
+
+**Correctness note up front.** Two paths handle invite join requests today, and both are wired. **Adding the foreground batch path is a perf fix, not a correctness fix** — backlogged join requests already get processed on foreground via the stream's per-event handler.
+
+| Path | Where | Cost shape |
+|---|---|---|
+| NSE-driven batch | `MessagingService+PushNotifications.swift:137` calls `processJoinRequestOutcomes(since: lastWelcomeProcessed)` | One batched fetch + sequential process |
+| Foreground per-event stream | `StreamProcessor.processMessage:247-258` (DM case) calls `joinRequestsManager.processJoinRequestOutcome(message:, client:)` per-DM as libxmtp's `streamAllMessages` replays the backlog | One write per DM event |
+
+If a push notification is dropped (notifications off, NSE killed, offline) and the app cold-launches, libxmtp's stream replays the backlogged DMs and the per-event handler processes them. There's an explicit reconcile comment at `InviteJoinRequestsManager.swift:125-133` documenting that subsequent sync passes heal any race-window gaps. The earlier QA pass (PR #857) verified the analogous behavior for group messages — 80 messages queued while iOS was killed all replayed on foreground via the stream.
+
+This plan adds a **third** path: a foreground batch that runs `processJoinRequestOutcomes(since:)` *before* streams resume, so the user doesn't watch invite acceptances flicker in one-by-one. Same shape as the message batch.
+
+The batch primitive — `InviteCoordinator.processJoinRequestOutcomes(since: Date?)` at ConvosInvites/Sources/ConvosInvites/InviteCoordinator.swift:186-209 — lists DMs with `lastActivityAfterNs:`, fetches each with `dm.messages(afterNs:)`, and processes them in sequence.
+
+It is **already called in production** — but only from the NSE. `MessagingService+PushNotifications.swift:137` invokes it on every push-driven wake, reading and writing a per-inbox cursor in `UserDefaults`:
+
+```swift
+// MessagingService+PushNotifications.swift:969-979
+private static let lastWelcomeProcessedKeyPrefix: String = "convos.pushNotifications.lastWelcomeProcessed"
+private func getLastWelcomeProcessed(for inboxId: String) -> Date?
+private func setLastWelcomeProcessed(_ date: Date?, for inboxId: String)
+```
+
+The foreground app **never** calls the **batched** `processJoinRequestOutcomes(since:)` and never reads or writes that cursor. On cold start / foreground-after-background, join requests still flow through `StreamProcessor.processMessage` → `joinRequestsManager.processJoinRequestOutcome` (the per-event variant) — correct but slow.
+
+The fix shape:
+
+1. The foreground hook reads the same `lastWelcomeProcessed` cursor on entry — the NSE may have already advanced it while the app was backgrounded, so we don't re-process events the NSE already handled.
+2. The hook fans out to both coordinators (messages, invites) using that cursor.
+3. After the batch completes, the hook writes back the new cursor, so the next NSE wake or next foreground sees a tight frontier.
+
+Invite outcomes are idempotent (membership is already-added-or-not), so re-processing a request the stream also delivers is free — same property the message-PK dedup gives us on the message side.
+
+The two coordinators stay separate types (different transactional shapes — invites mutate membership through libxmtp calls; messages write directly to GRDB), but they share the single foreground hook and the single cursor.
+
+**Naming note:** the cursor is currently named `lastWelcomeProcessed` with a `pushNotifications.` prefix. Since the foreground path is about to read/write the same value, the right rename is `convos.catchup.lastProcessed.<inboxId>` (or a coordinated migration that reads-old / writes-new for one version). Out-of-scope for the implementation PR; flag for a follow-up.
+
+### Cursor
+
+Per conversation, the cursor is `SELECT MAX(dateNs) FROM message WHERE conversationId = ?`. For conversations that have never received a message locally, the cursor is 0 (fetch everything).
+
+For the **global** "what conversations changed since last sync" call, the cursor is the max `dateNs` across all messages in the local DB:
+
+```sql
+SELECT MAX(dateNs) FROM message
+```
+
+This becomes `lastActivityAfterNs` for the `list(...)` call. New conversations the user wasn't in last session also surface here because libxmtp tracks them by membership-change time, not just message activity. (Confirm during implementation — fallback is to ALSO call `list(createdAfterNs:)` and merge.)
+
+### The batch path
+
+```swift
+struct BatchCatchUp {
+    func run(client: XMTPClientProvider, inboxId: String) async throws {
+        let cursor = try await readGlobalCursor()                       // SELECT MAX(dateNs) FROM message
+        let changedConversations = try await client.list(
+            lastActivityAfterNs: cursor
+        )
+        guard !changedConversations.isEmpty else { return }
+
+        var perConvMessages: [(XMTPiOS.Group, [DecodedMessage])] = []
+        try await withThrowingTaskGroup(of: (XMTPiOS.Group, [DecodedMessage]).self) { group in
+            for conv in changedConversations {
+                group.addTask {
+                    let perConvCursor = try await readPerConvCursor(conv.id)
+                    let msgs = try await conv.messages(afterNs: perConvCursor)
+                    return (conv, msgs)
+                }
+            }
+            for try await pair in group { perConvMessages.append(pair) }
+        }
+
+        try await databaseWriter.write { db in
+            for (conv, msgs) in perConvMessages {
+                try writeConversation(conv, in: db)            // existing logic, no prefetch
+                for msg in msgs {
+                    try writeMessage(msg, conversation: conv, in: db)   // existing logic
+                }
+            }
+        }
+        // Single observer fire at commit
+    }
+}
+```
+
+Two non-trivial pieces:
+
+1. **`writeConversation` inside a transaction.** Today's `ConversationWriter._store` is async (does XMTP `conversation.sync()`, metadata extract, etc.) and *not* invocable from inside a GRDB write closure. We have two options:
+   - **Refactor `_store` to split "prepare model" (async) from "persist model" (sync inside transaction).** Bigger refactor but cleaner — the prepare step builds a `DBConversation` + members + profiles value, and the persist step is a pure transaction-scoped function. Stream path can use both phases sequentially; batch path runs all prepares in parallel then all persists in one transaction.
+   - **Skip the per-conversation-sync step in the batch path** and only write what the `list(...)` payload already gives us. Cheaper, but risks stale metadata. Probably acceptable since the next stream tick will reconcile.
+2. **Suppressing duplicate stream events.** When streams resume after the batch, libxmtp will likely re-deliver some events the batch just wrote. The diff short-circuit from PR #857 (`saveConversation` no-op skip) handles conversation rows. Messages have their own dedup via primary key (`DBMessage.id`); existing `messageWriter.store` uses `INSERT OR REPLACE` semantics. So duplicates are cheap, not duplicate-rendered. **No new gating logic needed.**
+
+### What stays the same
+
+- `StreamProcessor` for live events. Once streams resume, individual events still flow through `processMessage`. The batch path replaces *only* the backlog drain.
+- All the writer-side optimizations from PR #857. They still apply when streams catch up on subsequent reconnects within a session.
+- `syncAllConversations()` likely still fires from libxmtp during stream resume. Keep it — it's also doing libxmtp-internal state reconciliation.
+
+## Implementation outline
+
+1. **Refactor `ConversationWriter._store`** into `prepare(...)` (async) → `persist(_:in:)` (sync, takes `db`). Stream path uses `try await persist(prepare(...), in: db)`; batch path uses all-prepares-then-all-persists.
+2. **Refactor `IncomingMessageWriter.store`** similarly. Most of its work is already sync inside `databaseWriter.write { db in ... }` — extract the in-transaction body as a `persist(_:conversation:in:)` method.
+3. **Add `BatchCatchUp` actor** in `ConvosCore/Sources/ConvosCore/Syncing/`.
+4. **Wire into `SessionStateMachine.handleEnterForeground`** ahead of `syncingManager?.resume()`, fanning out to (a) `BatchCatchUp.run` for group messages and (b) `InviteCoordinator.processJoinRequestOutcomes(since:)` for invite DMs. Both share the same cursor `Date`.
+5. **Telemetry** — log `[PERF] catchup.batch.messages: <ms> convs=<n> messages=<n>` and `[PERF] catchup.batch.invites: <ms> requests=<n>` so we can compare against the current per-event timings.
+6. **Tests:**
+   - Unit test the batch coordinator with mock `XMTPClientProvider` and an in-memory writer.
+   - Integration test: write N messages + M pending invites via CLI while iOS is backgrounded, foreground iOS, assert single PERF batch log line per path, assert no `Conversation save attempt` lines from stream during the catch-up window, assert join-request acceptances happen during the batch window not the stream window.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| `list(lastActivityAfterNs:)` misses brand-new conversations (membership change without prior message activity in our local DB). | Also call `list(createdAfterNs:)` with the same cursor and merge. Confirm empirically during implementation. |
+| `_store` refactor breaks existing stream path. | Refactor is purely structural (split async-prep from sync-persist), behavior preserved. Existing tests gate it. |
+| Stream redelivery after batch double-writes. | Diff short-circuit (#857) makes conversation re-saves free; message `INSERT OR REPLACE` makes message re-writes free. Confirm via the integration test. |
+| Batch takes too long on a huge backlog and blocks foreground. | Add a timeout (e.g. 5s); fall back to stream-driven catch-up if exceeded. Per-conv fetch parallelism caps wall-clock time at slowest-conversation time, not sum. |
+| New conversations need profile prefetch / invite-generation side effects that `_store` does today. | The prepare/persist split keeps the side-effect calls in the stream path. Batch path runs them on a per-conversation basis *after* the transaction commits, off the foreground path. |
+| `MAX(dateNs)` cursor is wrong if local DB has stale state. | Conservative: floor the cursor by `min(MAX(dateNs), Date().addingTimeInterval(-7 * 86400))` so we never reach back further than a week. |
+
+## Open questions for the implementation PR
+
+- Does `list(lastActivityAfterNs:)` return DMs too, or only groups? If groups-only, mirror with `Conversation.list(...)` for DMs and merge.
+- Does the libxmtp `Conversation` returned by `list(...)` need an explicit `sync()` before `messages(afterNs:)`, or is the listing already current enough?
+- Cold-launch first-ever foreground: cursor is 0, list returns everything, batch is the initial sync. Does this conflict with the existing `syncAllConversations()` call libxmtp does internally? Probably duplicates effort the first time. Acceptable for now.
+
+## Verification plan
+
+Reproduce the same QA scenario we ran for PR #857 (4 CLI senders, 80 messages + 80 read receipts while iOS is backgrounded, then foreground iOS), and compare:
+
+| Metric | Current (PR #857) | After this plan |
+|---|---|---|
+| `Conversation save attempt` lines in first 30s | ~80 (one per message) | **1** (the batch write) |
+| GRDB observer fires on conversations-repository | ~80 | **1** |
+| SwiftUI list re-renders | ~80 | **1** |
+| Total DB write transactions | ~80 | **1** |
+| User-visible "message replay" effect | yes, mild | gone |
+| Total catch-up wall time | proportional to N events | proportional to slowest-conv message fetch |
+
+The first three metrics drop from O(N) to O(1) — the structural win this plan exists to deliver.


### PR DESCRIPTION
perf(stream): skip ConversationWriter.store for typing + read-receipt events

Group messages hit conversationWriter.store() before content-type guards
ran. Typing indicators and read receipts then early-returned, but the
full conversation save + metadata extract + member fetch + profile
prefetch had already fired. In the slow-startup window from
convos-logs-C9FA22F1, 154 read receipts in 33s produced 154 full
saves on one conversation, none of which mutated any column on the
conversation row (read receipts persist to DBConversationReadReceipt
independently; typing indicators don't write at all).

Move the conversationWriter.store() call below the typing-indicator
and read-receipt guards. Explode-settings and profile-message paths
still require a fresh row (they read imageEncryptionKey / mutate
expiresAt), so they stay downstream of the store call. messageWriter
keeps its dbConversation parameter unchanged.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

perf(writer): skip no-op conversation saves to avoid spurious observer fires

When the same-id branch in saveConversation produces an updatedConversation
byte-identical to the existing row, the write was running anyway. GRDB
observers then fired, ConversationsRepository republished, and the
SwiftUI conversations list re-rendered for no state change. During the
slow-startup window from convos-logs-C9FA22F1, 232/233 save attempts
in 33s landed in this branch, almost all of them as no-ops driven by
read-receipt fanout (now also addressed by the StreamProcessor fix in
2d74091e). The other two branches — match-by-tag and brand-new — still
write because they create or replace rows that aren't byte-identical
to anything pre-existing.

Add an equality check on updatedConversation == existingConversation
before the .save(db) call in the same-id branch. DBConversation is
Hashable with all-primitive members, so the synthesized == is sound.
Log the skip at debug for diagnostics.

firstTimeSeeingConversationExpired semantics are preserved: when the
rows compare equal, their expiresAt fields are also equal, so the
existing isExpired && (expiresAt != existing.expiresAt) computation
already evaluates to false.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

perf(attestation): memoize negative verdicts and quiet stale-attestation logs

verifyCached() ran the full keyset lookup + signature verify path on
every call, even when the inputs were unchanged. During the slow-startup
window from convos-logs-C9FA22F1, agent 87378614 had its expired
attestation re-evaluated 214 times in 33s — three log lines per call —
because nothing memoized the verdict.

A negative verdict on (inboxId, kid, attestationTimestamp) is sound to
cache permanently: staleness fails monotonically for a fixed timestamp,
signature verification is deterministic on its inputs, and any change
to those inputs (rotated attestation, rotated keyset kid) produces a
different cache key. Positive verdicts are not cached because they can
transition to stale as time advances.

Use OSAllocatedUnfairLock<Set<NegativeCacheKey>> (matches the
established pattern in ImageCache, MockExplodeGroupOperations,
MockConversationStateManager) to keep verifyCached synchronous —
callers reach it from inside GRDB write transactions where adding an
await would ripple through the stack.

Also downgrade two info logs to debug:
- AssistantAttestationVerifier: "timestamp too old" fires once per
  unique key now (already), and is diagnostic detail, not signal.
- Profile.swift: "agent X cached result" fires every call regardless
  of cache hit; downgrade reduces redundant noise without losing the
  ability to inspect verdicts during debugging.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

perf(image-cache): persist URL tracker via per-entry sidecars

URLTracker was an in-memory-only [String: URL] map. Every cold launch
started empty, so peek() returned (changed: true, oldURL: nil) for every
identifier — which forced loadImage's "URL changed → fetch from network
first" branch and made every avatar do a network round trip on launch
even when the disk cache had a perfectly valid image. That's the
"images missing for a second on launch" regression.

Persist the map as one tiny .url file per identifier
(<sha256(identifier)>.url) co-located with the cached image in the disk
cache directory. URLTracker reads sidecars lazily on first peek/track
for an identifier (steady-state stays pure in-memory), writes them
atomically on track, and removes them on remove. removeImageFromDisk
also cleans up the .url file so cache eviction and sidecar lifetime
stay in lockstep.

This change touches URL tracker semantics only — loadImage's branch
selection still flows through peek(). After this lands, cold launches
on previously-cached identifiers report (changed: false) instead of
(changed: true), but the cache-first reorganization that turns that
into a UX win is the next commit. The two commits compose: this one
gives loadImage truthful information, the next one teaches it to use
that information without blocking on the network.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

perf(image-cache): cache-first loadImage with background refresh on URL change

loadImage's encrypted and unencrypted paths both started with a "URL
changed → fetch from network first, fall back to cache on failure"
branch. Combined with URLTracker's "missing entry == changed: true"
default, every cold-launch image lookup blocked on a network round trip
even when the disk cache had a perfectly valid image — that's the
"images missing for a second on launch" regression the user reported.

Flip both paths to cache-first:

  1. Memory hit → return immediately, refresh in background if URL drifted
  2. Disk hit → promote to memory, return, refresh in background if URL drifted
  3. Cold (no cached image at all) → fetch inline; this is the only path
     that blocks on the network

Combined with the sidecar-backed URLTracker (previous commit), cold
launches on previously-cached identifiers report `changed: false` and
skip the background refresh entirely — disk cache serves instantly with
zero network traffic. A real URL change (user updated their avatar)
still shows the stale image immediately and swaps in the fresh one when
the fire-and-forget refresh lands; the existing cacheUpdates observer
propagation handles the swap without any caller changes.

Inline fetch helpers handle their own deduplication (loadingTasksLock
keys fetchImageFromNetwork by URL; EncryptedImageLoader is idempotent
on the same encrypted ref), so multiple simultaneous background
refreshes for the same identifier coalesce safely.

Drops the previous "track-on-cache-hit when peek.changed is false"
re-tracking dance — the URL is already correctly tracked via the
sidecar, so re-tracking would be a no-op write.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

perf(prefetcher): make EncryptedImagePrefetcher a process-wide singleton

ConversationWriter.prefetchEncryptedImages instantiated a fresh
EncryptedImagePrefetcher per call. The prefetcher's actor-isolated
inflightFetches table is per-instance, so concurrent _store() calls
across N conversations each created their own prefetcher and each
checked ImageCacheContainer in parallel — all seeing "not cached" and
all firing fetches for the same inboxId. In the slow-startup window
from convos-logs-C9FA22F1, the user's own inbox got fetched 25 times
in 33 seconds because nothing coordinated across instances.

Add `EncryptedImagePrefetcher.shared` and route the writer through it.
Actor isolation now serializes `prefetchWithRetry`'s in-flight check
across all callers, so a second caller for an in-progress inboxId
awaits the existing task instead of duplicating the fetch. The
loader-injecting init stays for tests.

Cleanup runs unconditionally on completion (inflightFetches.removeValue
inside the `await task.value` lifecycle, which fires regardless of
fetch success or task cancellation since the task type is
Task<Void, Never>) so the dictionary doesn't grow.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

perf(profile): cache profile avatars by inboxId instead of per-conversation

Profile.imageCacheIdentifier returned "\(inboxId)@\(conversationId)",
so the same user's avatar was stored under a different cache key in
every conversation they appeared in. A user in 9 conversations meant
9 cache entries (and 9 fetches on first render across them), even
though the rendered avatar is logically one image per user.

Until a centralized profile-photo store exists (deferred — the
encrypted bytes are still per-conversation because each conversation
has its own imageEncryptionKey/salt/nonce/URL), key the in-memory and
on-disk cache by `inboxId` so a successful fetch from any conversation
satisfies every other conversation's render of the same user.

Cumulative effect with the singleton prefetcher (b5039dc0): same-user
fetches across N conversations collapse to one fetch + one cache write
+ N-1 cache hits, instead of N parallel fetches that race the
ImageCacheContainer cache check.

Existing per-conversation disk-cache entries become orphaned and will
be reclaimed by the cache eviction (capped at 500MB) over time. The
display name and metadata remain per-conversation; only the avatar
bytes are shared across conversations.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/857"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1781927667&installation_id=128169237&pr_number=857&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F857&signature=98e689aafb5fae062b850fb3c25ece08b967026c188a7e4699a104923638ba35"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add batch catch-up to drain message backlog before streams resume on foreground and cold start
> - Introduces [`BatchCatchUp`](https://github.com/xmtplabs/convos-ios/pull/857/files#diff-397f4cd322efa095522345a526e59f4fc6b49ae617af5c733ae6a8c73f1e1dd0) which prepares conversations and messages concurrently, persists them in a single DB transaction, then applies reactions/read-receipts post-commit and dispatches side effects asynchronously.
> - [`SessionStateMachine`](https://github.com/xmtplabs/convos-ios/pull/857/files#diff-88a3691375b11b83b3fa12aab416b078bae5cc77821d7984f2c212efe87dd33e) runs the batch catch-up on both cold start and foreground resume using a `UserDefaults`-persisted cursor, advancing the cursor only after a successful run.
> - [`ConversationWriter`](https://github.com/xmtplabs/convos-ios/pull/857/files#diff-113bfd0c28b1a3b561f19e4574a0937082fe5c92a262e57573eee7728940a726) and [`IncomingMessageWriter`](https://github.com/xmtplabs/convos-ios/pull/857/files#diff-214371d5cccf7b16f4408fd58c74733a7d61314a74ebb428d08a97e20309c777) are refactored into `prepare`/`persist` steps so work can be parallelized before entering a write transaction.
> - [`ImageCache`](https://github.com/xmtplabs/convos-ios/pull/857/files#diff-445c3a2d9023d5d29469046555d79fa387c40b98bfcf772c84cdf1679fc38b91) now persists URL-change state across launches via on-disk `.url` sidecars, returning cached images immediately and refreshing in the background on URL drift instead of blocking on network.
> - Profile avatar cache keys change from per-conversation (`inboxId@conversationId`) to per-user (`inboxId`), so a fetched avatar is reused across all conversations for the same user.
> - Behavioral Change: `StreamProcessor` now skips saving the conversation row for typing indicators and read receipts, reducing DB writes during catch-up bursts.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 694a2c3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->