### PR TITLE
Render HTML thumbnails via WKWebView.takeSnapshot (no PDF detour)

### DIFF
--- a/Convos/Conversation Detail/AttachmentPreviewSheet.swift
+++ b/Convos/Conversation Detail/AttachmentPreviewSheet.swift
@@ -13,6 +13,7 @@ struct AttachmentPreviewSheet: View {
     var profileSheetContent: ((ConversationMember) -> AnyView)?
 
     @Environment(\.dismiss) private var dismiss: DismissAction
+    @Environment(\.colorScheme) private var colorScheme: ColorScheme
     @State private var resolvedHTMLTitle: String?
     @State private var htmlBodyBackgroundColor: Color?
     @State private var presentingProfileForMember: ConversationMember?
@@ -126,10 +127,15 @@ struct AttachmentPreviewSheet: View {
     }
 
     private func resolveHTMLShareImage() async -> UIImage? {
-        if let cached = HTMLThumbnailRenderer.shared.cachedThumbnail(for: attachment.key) {
+        let appearance = colorScheme.uiUserInterfaceStyle
+        if let cached = HTMLThumbnailRenderer.shared.cachedThumbnail(for: attachment.key, appearance: appearance) {
             return cached
         }
-        return await HTMLThumbnailRenderer.shared.thumbnail(for: attachment.key, fileURL: fileURL)
+        return await HTMLThumbnailRenderer.shared.thumbnail(
+            for: attachment.key,
+            fileURL: fileURL,
+            appearance: appearance
+        )
     }
 
     private func resolveMarkdownShareImage() async -> UIImage? {

--- a/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/HTMLThumbnailRenderer.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/HTMLThumbnailRenderer.swift
@@ -33,7 +33,18 @@ final class HTMLThumbnailRenderer {
     /// because the scene held onto each window across the lifetime of
     /// the app; reusing one window means the scene sees the single
     /// reservation forever and never accumulates new ones.
-    private lazy var offscreenWindow: UIWindow? = Self.makeOffscreenWindow()
+    ///
+    /// Not `lazy` - a first access during early launch or a background
+    /// context would resolve to `nil` and that `nil` would get cached
+    /// permanently, sinking every subsequent render. Retry on each
+    /// access until a `UIWindowScene` is actually available, then cache.
+    private var offscreenWindow: UIWindow? {
+        if let existing = _offscreenWindow { return existing }
+        let created = Self.makeOffscreenWindow()
+        _offscreenWindow = created
+        return created
+    }
+    private var _offscreenWindow: UIWindow?
 
     private static func makeOffscreenWindow() -> UIWindow? {
         let scene = UIApplication.shared.connectedScenes

--- a/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/HTMLThumbnailRenderer.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/HTMLThumbnailRenderer.swift
@@ -1,6 +1,5 @@
 import ConvosCore
 import ConvosLogging
-import PDFKit
 import UIKit
 import WebKit
 
@@ -11,7 +10,9 @@ final class HTMLThumbnailRenderer {
     private static let renderSize: CGSize = CGSize(width: 720, height: 1200)
     fileprivate static let paintDelay: TimeInterval = 0.5
     private static let loadTimeout: TimeInterval = 15.0
-    private static let cacheKeyPrefix: String = "html-thumb-v3-"
+    // v4: direct WKWebView.takeSnapshot via a shared off-screen window.
+    // v3 thumbnails (PDF -> PDFKit raster) get re-rendered when seen.
+    private static let cacheKeyPrefix: String = "html-thumb-v4-"
     private static let injectionScript: String = """
     (function() {
         var css = 'html, body { margin-top: 0 !important; padding-top: 0 !important; } ' +
@@ -23,6 +24,37 @@ final class HTMLThumbnailRenderer {
     """
 
     private var inflight: [String: Task<UIImage?, Never>] = [:]
+
+    /// Single off-screen `UIWindow` used as the host for every render
+    /// pass. We need *a* window so `WKWebView.takeSnapshot` actually
+    /// captures painted content (an unattached `WKWebView` snapshots to
+    /// blank). Allocating a fresh window per render historically leaked
+    /// a `UIWindowScene.keyboardLayoutGuide` reservation on each render
+    /// because the scene held onto each window across the lifetime of
+    /// the app; reusing one window means the scene sees the single
+    /// reservation forever and never accumulates new ones.
+    private lazy var offscreenWindow: UIWindow? = Self.makeOffscreenWindow()
+
+    private static func makeOffscreenWindow() -> UIWindow? {
+        let scene = UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .first { $0.activationState != .unattached }
+        guard let scene else { return nil }
+        let window = UIWindow(windowScene: scene)
+        // Park well off-screen rather than `isHidden = true` or
+        // `alpha = 0` - UIKit can skip rendering for the latter two,
+        // which would defeat the point of having a host window at all.
+        window.frame = CGRect(
+            x: -100_000.0,
+            y: -100_000.0,
+            width: renderSize.width,
+            height: renderSize.height
+        )
+        window.windowLevel = .normal - 1
+        window.isUserInteractionEnabled = false
+        window.isHidden = false
+        return window
+    }
 
     static func cacheKey(for attachmentKey: String, appearance: UIUserInterfaceStyle) -> String {
         cacheKeyPrefix + attachmentKey + "-" + appearanceSuffix(for: appearance)
@@ -67,12 +99,20 @@ final class HTMLThumbnailRenderer {
         return result
     }
 
-    /// Renders the file at `fileURL` to a `UIImage` without ever attaching a
-    /// `WKWebView` to a `UIWindow`. The WebView lives only as an in-memory
-    /// object: it loads the HTML, hands a vector PDF to PDFKit on
-    /// `didFinish`, and is deallocated. There is no scene attachment and no
-    /// `UIWindowScene.keyboardLayoutGuide` reservation to leak.
+    /// Renders the file at `fileURL` directly into a `UIImage` via
+    /// `WKWebView.takeSnapshot`. The WebView is briefly attached to the
+    /// shared off-screen `offscreenWindow` so the snapshot actually
+    /// captures painted content (an unattached WebView snapshots blank),
+    /// and removed once we have the image. Reusing one host window
+    /// across renders avoids the `UIWindowScene.keyboardLayoutGuide`
+    /// reservation leak that bit the original one-window-per-render
+    /// implementation.
     private func renderSnapshot(fileURL: URL, appearance: UIUserInterfaceStyle) async -> UIImage? {
+        guard let window = offscreenWindow else {
+            Log.error("HTMLThumbnailRenderer: no offscreen window available; skipping render")
+            return nil
+        }
+
         let config = WKWebViewConfiguration()
         let userScript = WKUserScript(
             source: Self.injectionScript,
@@ -90,12 +130,15 @@ final class HTMLThumbnailRenderer {
         webView.isOpaque = true
         webView.isUserInteractionEnabled = false
         // Drives `@media (prefers-color-scheme: ...)` resolution inside the
-        // loaded HTML — the WebView's traitCollection determines what
+        // loaded HTML - the WebView's traitCollection determines what
         // matchMedia returns regardless of view-hierarchy attachment.
         webView.overrideUserInterfaceStyle = appearance
 
+        window.addSubview(webView)
+
         return await withCheckedContinuation { (continuation: CheckedContinuation<UIImage?, Never>) in
-            let coordinator = LoadCoordinator(renderSize: Self.renderSize) { result in
+            let coordinator = LoadCoordinator(renderSize: Self.renderSize) { [weak webView] result in
+                webView?.removeFromSuperview()
                 continuation.resume(returning: result)
             }
             // Retain coordinator for the duration of the load via objc association.
@@ -134,17 +177,14 @@ private final class LoadCoordinator: NSObject, WKNavigationDelegate {
                 self?.resume(image: nil)
                 return
             }
-            let pdfConfig = WKPDFConfiguration()
-            pdfConfig.rect = CGRect(origin: .zero, size: renderSize)
-            webView.createPDF(configuration: pdfConfig) { result in
-                switch result {
-                case .success(let data):
-                    let image = Self.rasterize(pdfData: data, at: renderSize)
-                    self.resume(image: image)
-                case .failure(let error):
-                    Log.error("HTMLThumbnailRenderer createPDF failed: \(error)")
-                    self.resume(image: nil)
+            let snapshotConfig = WKSnapshotConfiguration()
+            snapshotConfig.rect = CGRect(origin: .zero, size: renderSize)
+            snapshotConfig.afterScreenUpdates = true
+            webView.takeSnapshot(with: snapshotConfig) { image, error in
+                if let error {
+                    Log.error("HTMLThumbnailRenderer takeSnapshot failed: \(error)")
                 }
+                self.resume(image: image)
             }
         }
     }
@@ -161,18 +201,6 @@ private final class LoadCoordinator: NSObject, WKNavigationDelegate {
     ) {
         Log.error("HTMLThumbnailRenderer provisional load failed: \(error)")
         resume(image: nil)
-    }
-
-    private static func rasterize(pdfData: Data, at size: CGSize) -> UIImage? {
-        guard let document = PDFDocument(data: pdfData), let page = document.page(at: 0) else {
-            Log.error("HTMLThumbnailRenderer PDF had no first page")
-            return nil
-        }
-        // page.thumbnail draws onto an opaque white background, which matches
-        // the prior takeSnapshot behavior for HTML that doesn't set its own
-        // body background.
-        let image = page.thumbnail(of: size, for: .mediaBox)
-        return image
     }
 
     private func resume(image: UIImage?) {


### PR DESCRIPTION
## Summary
- Drop the PDFKit round-trip in `HTMLThumbnailRenderer`. The PR that introduced it (#825) attached the WebView to a fresh `UIWindow` per render to dodge blank PDFs, which leaked a `UIWindowScene.keyboardLayoutGuide` reservation each pass; switching to PDF avoided the leak at the cost of an extra encode/decode.
- Replace it with a direct `WKWebView.takeSnapshot` into a `UIImage`. The WebView attaches briefly to a **single shared** off-screen `UIWindow` parked at `(-100_000, -100_000)`, so the snapshot captures painted content but the scene only ever sees one reservation for the app lifetime.
- Bump `cacheKeyPrefix` from `html-thumb-v3-` to `html-thumb-v4-`; v3 thumbnails get re-rendered on demand.
- Drive-by: `AttachmentPreviewSheet` was calling `cachedThumbnail(for:)` / `thumbnail(for:fileURL:)` without the `appearance:` arg that #825 added to the renderer. The main app target hasn't compiled on `dev` since then. Fix the two call sites and pull `@Environment(\.colorScheme)` into the view.

## Test plan
- [x] `xcodebuild build -scheme "Convos (Dev)"` succeeds (was failing on `dev` before the drive-by fix)
- [x] Fresh install + launch on `convos-html-thumbnail-direct-snapshot` sim
- [ ] Manual: receive an HTML attachment in a conversation, confirm the thumbnail in Stuff / list previews renders crisp (not blank, no PDF-y artifacts) in both light and dark
- [ ] Manual: render many HTML attachments in one session and confirm no `UIWindowScene.keyboardLayoutGuide` warnings accumulate in console

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/861"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1781981497&installation_id=128169237&pr_number=861&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F861&signature=f3eb3f457f1a907071f4241a1c42eb4c042a6a44178266393b6f0840789f937b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Render HTML thumbnails via `WKWebView.takeSnapshot` instead of PDF rasterization
> - Replaces the PDF-based rendering pipeline in [`HTMLThumbnailRenderer`](https://github.com/xmtplabs/convos-ios/pull/861/files#diff-96e548fad1e9c41e89533dcd4ed532c527bb892ad625efe13c7d6396461e4bd8) with `WKWebView.takeSnapshot`, attaching the web view to a hidden off-screen `UIWindow` to prevent blank snapshots.
> - [`AttachmentPreviewSheet`](https://github.com/xmtplabs/convos-ios/pull/861/files#diff-0448cf2ffc644b0aaa7199e5c1754dcf61efab4b8e972061e46cc816d49d94ce) now passes the current `UIUserInterfaceStyle` to cache lookups and render calls, producing appearance-specific thumbnails for light and dark mode.
> - Bumps the cache key prefix from `html-thumb-v3-` to `html-thumb-v4-`, invalidating all previously cached thumbnails.
> - Risk: rendering returns `nil` with an error log if no suitable `UIWindowScene` is available at snapshot time.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 58a47cc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->