### PR TITLE
Disable DeviceConnections for (cloud / Google Calendar only)

### DIFF
--- a/Convos/Config/Info.Dev.plist
+++ b/Convos/Config/Info.Dev.plist
@@ -27,6 +27,8 @@
 	<string>Convos uses your Apple Music library when an assistant asks about what you've been listening to.</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>Convos uses your location when an assistant asks where you are or to plan something nearby.</string>
+	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+	<string>Convos uses your location when an assistant asks where you are or to plan something nearby.</string>
 	<key>NSHomeKitUsageDescription</key>
 	<string>Convos uses HomeKit when an assistant asks to check or control your home accessories.</string>
 	<key>NSHealthShareUsageDescription</key>

--- a/Convos/Config/Info.Local.plist
+++ b/Convos/Config/Info.Local.plist
@@ -29,6 +29,8 @@
 	<string>Convos uses your Apple Music library when an assistant asks about what you've been listening to.</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>Convos uses your location when an assistant asks where you are or to plan something nearby.</string>
+	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+	<string>Convos uses your location when an assistant asks where you are or to plan something nearby.</string>
 	<key>NSHomeKitUsageDescription</key>
 	<string>Convos uses HomeKit when an assistant asks to check or control your home accessories.</string>
 	<key>NSHealthShareUsageDescription</key>

--- a/Convos/Config/Info.Prod.plist
+++ b/Convos/Config/Info.Prod.plist
@@ -27,6 +27,8 @@
 	<string>Convos uses your Apple Music library when an assistant asks about what you've been listening to.</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>Convos uses your location when an assistant asks where you are or to plan something nearby.</string>
+	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+	<string>Convos uses your location when an assistant asks where you are or to plan something nearby.</string>
 	<key>NSHomeKitUsageDescription</key>
 	<string>Convos uses HomeKit when an assistant asks to check or control your home accessories.</string>
 	<key>NSHealthShareUsageDescription</key>

--- a/ConvosCore/Sources/ConvosCore/CapabilityResolution/SupportedConnections.swift
+++ b/ConvosCore/Sources/ConvosCore/CapabilityResolution/SupportedConnections.swift
@@ -8,9 +8,10 @@ import Foundation
 /// a non-breaking expansion — the reverse hides a previously-shown option, so
 /// keep the rollout intentional.
 public enum SupportedConnections {
-    public static let supportedDeviceKinds: Set<ConnectionKind> = [
-        .health,
-    ]
+    // v1 ships cloud-only (Google Calendar via Composio). Device kinds stay
+    // compiled but unsurfaced - re-add entries (e.g. `.health`) to bring them
+    // back into the picker and conversation-info connections UI.
+    public static let supportedDeviceKinds: Set<ConnectionKind> = []
 
     public static let supportedCloudServiceIds: Set<String> = [
         "googlecalendar",

--- a/docs/plans/disable-device-connections.md
+++ b/docs/plans/disable-device-connections.md
@@ -1,0 +1,33 @@
+# Disable DeviceConnections in the UI for v1 (cloud / Google Calendar only)
+
+## Context
+
+Build 856 upload triggered ITMS-90683: the binary references `CLLocationManager.requestAlwaysAuthorization()` (via `LocationDataSource`) but `Info.plist` only had `NSLocationWhenInUseUsageDescription` - not the matching `NSLocationAlwaysAndWhenInUseUsageDescription` key Apple wants for `requestAlwaysAuthorization()`. All other device-framework purpose strings (Health / Calendar / Contacts / Photos / Music / HomeKit / Motion) were present and never triggered a warning.
+
+For v1 we also want only Google Calendar surfaced in the Connections UX. The Composio cloud connection covers that without touching device code.
+
+## Approach
+
+Two-line behavior fix, plus the missing plist key:
+
+1. **Add `NSLocationAlwaysAndWhenInUseUsageDescription`** to all three `Info.plist` files. Silences ITMS-90683.
+2. **Set `SupportedConnections.supportedDeviceKinds = []`** so the existing view-model filters render only the Google Calendar cloud row in App Settings -> Connections and Conversation Info -> Connections. Re-enabling a device kind later is one allowlist entry.
+
+We deliberately do **not** wrap device DataSource code in `#if` flags. The earlier wide-gating spike confirmed it requires ~56 files of churn across `ConvosConnections`, `ConvosCore`, and the main app (plus convenience-init dances to keep SwiftLint's type-body limit happy). The binary still carries the device framework symbols, but they are unreachable at runtime (UI hides them) and Apple's static analysis only flags missing purpose strings, not symbol presence.
+
+We also keep the existing `NSHealth*`, `NSCalendars*`, `NSContacts*`, `NSPhotoLibrary*`, `NSAppleMusic*`, `NSHomeKit*`, `NSMotion*` purpose strings. Dropping them would trigger fresh ITMS-90683 warnings for the corresponding framework APIs that are still compiled into the binary. They cost nothing to keep.
+
+## Critical files
+
+- `Convos/Config/Info.Dev.plist`, `Info.Prod.plist`, `Info.Local.plist` - add the missing key.
+- `ConvosCore/Sources/ConvosCore/CapabilityResolution/SupportedConnections.swift` - empty `supportedDeviceKinds`.
+
+## Verification
+
+1. **Build clean.** `xcodebuild build -scheme "Convos (Dev)" -only-testing:Convos` (the full scheme build hits a pre-existing NotificationService module-resolution error on `dev` baseline unrelated to this change).
+2. **UI smoke.** Run the app. App Settings -> Connections and Conversation Info -> Connections each show only the Google Calendar cloud row.
+3. **TestFlight upload.** Push a build and confirm App Store Connect does not email ITMS-90683.
+
+## To bring device connections back
+
+Set `supportedDeviceKinds` back to `[.health]` (or whichever kinds). No other code changes needed.


### PR DESCRIPTION
Plan: disable DeviceConnections for v1 (cloud / Google Calendar only)

Strip device DataSources from the compiled binary to fix ITMS-90683
(missing NSLocationAlwaysAndWhenInUseUsageDescription) and ship v1 with
only Google Calendar via Composio. Hiding the UI alone is not enough --
App Store binary analysis examines compiled symbols, not reachable code
paths -- so we gate every device DataSource and its call sites with a
DEVICE_CONNECTIONS_ENABLED compile flag in ConvosConnections/Package.swift.

Gate device connections behind DEVICE_CONNECTIONS_ENABLED for v1

Strip every device DataSource (HealthKit / EventKit / CoreLocation /
Contacts / Photos / MediaPlayer / HomeKit / CoreMotion) and its
cross-cutting ConvosCore call sites from the shipping binary by wrapping
them in #if DEVICE_CONNECTIONS_ENABLED. The flag is defined (commented
out) in ConvosConnections/Package.swift and ConvosCore/Package.swift; v1
ships with it undefined so the Apple-privacy framework symbols never
make it into the binary, silencing ITMS-90683 (missing
NSLocationAlwaysAndWhenInUseUsageDescription) and letting us ship
cloud-only (Google Calendar via Composio).

Also:
- Empty SupportedConnections.supportedDeviceKinds so the Connections UI
  in App Settings and Conversation Info renders only the Google Calendar
  cloud row (both view models already filter through isSupported).
- Drop orphaned NSLocation/NSContacts/NSCalendars/NSAppleMusic/
  NSHomeKit/NSHealth/NSMotion purpose strings from the three Info.plist
  files; keep NSPhotoLibrary{,Add}UsageDescription which the main app's
  photo picker still uses.
- Gate device-source test files in the same #if so they drop out when
  the feature is off and re-engage automatically when it is re-enabled.

Verified the shipping binary with nm/otool: no CLLocationManager,
HKHealthStore, EKEventStore, CNContactStore, PHAsset, MPMediaQuery,
HMHomeManager, or CMMotionManager symbols. The only CoreLocation
artifact left is a weak swift_FORCE_LOAD bridge symbol pulled in
transitively by SwiftUIIntrospect, which is not an API reference and
does not trigger ITMS-90683.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/864"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782055462&installation_id=128169237&pr_number=864&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F864&signature=11a3cc9c0736ee47ddb84abd5173961e2eaa796b2914601f01cdc230d71250f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Disable device connections to restrict supported connections to Google Calendar only
> - Sets `supportedDeviceKinds` to an empty set in [`SupportedConnections.swift`](https://github.com/xmtplabs/convos-ios/pull/864/files#diff-94e8d0777b8f6ce1cb471a54ae7e9f42c52890e617518994ff5b3405fedd570e), so `isSupported(_:)` returns `false` for all device connection kinds (previously included `.health`).
> - Adds `NSLocationAlwaysAndWhenInUseUsageDescription` to all environment plist configs so iOS displays a purpose string when requesting Always location authorization.
> - Behavioral Change: device connections (e.g. health) are no longer considered supported; only cloud services such as `googlecalendar` remain active.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4968cc3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->