### PR TITLE
Connections picker: permission bundles plan

### DIFF
--- a/docs/plans/connections-picker-bundles-draft.md
+++ b/docs/plans/connections-picker-bundles-draft.md
@@ -1,6 +1,6 @@
 # Connections Picker — Bundles + Backend Config (draft)
 
-**status:** sharing for vibes-check
+**status:** draft
 **owner:** louis
 **date:** 2026-05-19
 
@@ -92,7 +92,6 @@ Earlier draft had `rationale`. New name: `description`. Reason: the Figma label 
 ## Stuff I'm punting on
 
 - Localization. English-only copy for now; structure supports `{ "en": "...", "fr": "..." }` later but I'd rather not bake it in until we actually localize.
-- Granting from inside a convo vs from the global connections screen — same schema, two entry points. UX of the global screen is unblocked by this.
 
 ## Asks
 

--- a/docs/plans/connections-picker-bundles-draft.md
+++ b/docs/plans/connections-picker-bundles-draft.md
@@ -34,11 +34,11 @@ Backend-served, cached on device. App icon embedded as base64 so we don't need a
 
 ```json
 {
-  "version": 1,
   "services": [
     {
       "id": "googlecalendar",
       "composio_slug": "googlecalendar",
+      "version": 1,
       "display_name": { "en": "Google Calendar" },
       "icon": {
         "format": "png",
@@ -47,7 +47,6 @@ Backend-served, cached on device. App icon embedded as base64 so we don't need a
       "bundles": [
         {
           "id": "calendar.events",
-          "version": 1,
           "title": { "en": "Events" },
           "description": { "en": "View and edit events on all calendars" },
           "default_enabled": false,
@@ -64,13 +63,13 @@ Backend-served, cached on device. App icon embedded as base64 so we don't need a
 }
 ```
 
-Key fields on a bundle:
-- `id` — stable identifier we persist on the grant
-- `version` — bumped whenever `composio_actions` (or other semantically meaningful fields) change; sent in connection messages so the assistant can detect stale clients (see Versioning below)
-- `title` — localized map; bold line in the card
-- `description` — localized map; rationale line under the title (renamed from `rationale` to match Figma copy)
-- `default_enabled` — figma shows toggles off; flip per-bundle if we want one on by default
-- `composio_actions` — what we actually send to Composio when granted
+Key fields:
+- `services[].version` — service-level version; bumped whenever *anything* about that service changes (icon, copy, any bundle's actions). Sent in connection messages so the assistant can detect stale clients (see Versioning below).
+- `bundles[].id` — stable identifier we persist on the grant
+- `bundles[].title` — localized map; bold line in the card
+- `bundles[].description` — localized map; rationale line under the title (renamed from `rationale` to match Figma copy)
+- `bundles[].default_enabled` — figma shows toggles off; flip per-bundle if we want one on by default
+- `bundles[].composio_actions` — what we actually send to Composio when granted
 
 Localized strings always carry at minimum an `en` key. Renderer is:
 
@@ -84,27 +83,30 @@ Open question: do we also want `read_only` / `write` hints per bundle so we can 
 
 ## Versioning + self-healing clients
 
-We query the bundle config out of band (separate from the conversation). That means a device can be on `version: 1` of "Events" while the assistant has been upgraded to expect `version: 3`. To handle this without baking the config into every conversation, every connection message carries the bundle id **and** the version the device knows about:
+We query the service config out of band (separate from the conversation). That means a device can be on `googlecalendar` version `1` while the assistant has been upgraded to expect version `3`. To handle this without baking the config into every conversation, every connection message carries the service id, the bundle id, **and** the service version the device knows about:
 
 ```json
 {
-  "bundle_id": "calendar.events",
-  "bundle_version": 1
+  "service_id": "googlecalendar",
+  "service_version": 1,
+  "bundle_id": "calendar.events"
 }
 ```
 
-If the assistant sees a stale version, it returns a `stale_resource` status on the existing `CapabilityRequestResult` codec (inline — no side-channel event), telling the device which bundles to refresh:
+Versioning is **per-service**, not per-bundle. Connection messages always reference a single service, so the wire cost is the same as per-bundle versioning, but the backend only has to bump one number when anything about that service changes (icon, copy, any bundle's actions). Coarser than per-bundle, but avoids the storm-of-invalidations problem of a top-level config version. Trade-off chosen: small extra refresh churn for any change inside a service, in exchange for much simpler backend bookkeeping.
+
+If the assistant sees a stale version, it returns a `stale_resource` status on the existing `CapabilityRequestResult` codec (inline — no side-channel event), telling the device which services to refresh:
 
 ```json
 {
   "status": "stale_resource",
-  "stale_bundles": [
-    { "id": "calendar.events", "expected_version": 3 }
+  "stale_services": [
+    { "id": "googlecalendar", "expected_version": 3 }
   ]
 }
 ```
 
-Device refetches the config, retries the capability call. Self-healing, one extra round-trip in the worst case. Reuses the codec we just stabilized in #771 — no new top-level event type.
+Device refetches that service's config, retries the capability call. Self-healing, one extra round-trip in the worst case. Reuses the codec we just stabilized in #771 — no new top-level event type.
 
 ## Renames vs earlier scribbles
 

--- a/docs/plans/connections-picker-bundles-draft.md
+++ b/docs/plans/connections-picker-bundles-draft.md
@@ -1,8 +1,8 @@
 # Connections Picker — Bundles + Backend Config (draft)
 
-**status:** draft
+**status:** approved
 **owner:** louis
-**date:** 2026-05-19
+**date:** 2026-05-26
 **related:** [capability-resolution-flows.md](capability-resolution-flows.md) (how the picker gets triggered — agent sends a capability request, device opens the sheet)
 
 ## The thing

--- a/docs/plans/connections-picker-bundles-draft.md
+++ b/docs/plans/connections-picker-bundles-draft.md
@@ -3,8 +3,7 @@
 **status:** draft
 **owner:** louis
 **date:** 2026-05-19
-
-Heads up: this is a notepad, not a real PRD.
+**related:** [capability-resolution-flows.md](capability-resolution-flows.md) (how the picker gets triggered — agent sends a capability request, device opens the sheet)
 
 ## The thing
 

--- a/docs/plans/connections-picker-bundles-draft.md
+++ b/docs/plans/connections-picker-bundles-draft.md
@@ -30,7 +30,7 @@ A few reasons piling up:
 
 ## Schema (draft)
 
-Backend-served, cached on device. App icon embedded as base64 so we don't need a CDN round-trip in the picker.
+Backend-served, cached on device. App icon embedded as base64 so we don't need a CDN round-trip in the picker. All user-facing strings (`display_name`, `title`, `description`) are localized maps with `en` as the guaranteed fallback — single code path, no migration when we add more locales later.
 
 ```json
 {
@@ -39,7 +39,7 @@ Backend-served, cached on device. App icon embedded as base64 so we don't need a
     {
       "id": "google_calendar",
       "composio_slug": "googlecalendar",
-      "display_name": "Google Calendar",
+      "display_name": { "en": "Google Calendar" },
       "icon": {
         "format": "png",
         "base64": "iVBORw0KGgoAAAANSUhEUgA..."
@@ -47,8 +47,9 @@ Backend-served, cached on device. App icon embedded as base64 so we don't need a
       "bundles": [
         {
           "id": "calendar.events",
-          "title": "Events",
-          "description": "View and edit events on all calendars",
+          "version": 1,
+          "title": { "en": "Events" },
+          "description": { "en": "View and edit events on all calendars" },
           "default_enabled": false,
           "composio_actions": [
             "GOOGLECALENDAR_LIST_EVENTS",
@@ -65,12 +66,45 @@ Backend-served, cached on device. App icon embedded as base64 so we don't need a
 
 Key fields on a bundle:
 - `id` — stable identifier we persist on the grant
-- `title` — what the user reads (bold line in the card)
-- `description` — the rationale line under the title; renamed from `rationale` in earlier sketches to match Figma copy
+- `version` — bumped whenever `composio_actions` (or other semantically meaningful fields) change; sent in connection messages so the assistant can detect stale clients (see Versioning below)
+- `title` — localized map; bold line in the card
+- `description` — localized map; rationale line under the title (renamed from `rationale` to match Figma copy)
 - `default_enabled` — figma shows toggles off; flip per-bundle if we want one on by default
 - `composio_actions` — what we actually send to Composio when granted
 
+Localized strings always carry at minimum an `en` key. Renderer is:
+
+```swift
+func localized(_ map: [String: String], locale: Locale) -> String {
+    map[locale.languageCode] ?? map["en"] ?? ""
+}
+```
+
 Open question: do we also want `read_only` / `write` hints per bundle so we can show a small "writes" badge on cards that mutate? Probably v2.
+
+## Versioning + self-healing clients
+
+We query the bundle config out of band (separate from the conversation). That means a device can be on `version: 1` of "Events" while the assistant has been upgraded to expect `version: 3`. To handle this without baking the config into every conversation, every connection message carries the bundle id **and** the version the device knows about:
+
+```json
+{
+  "bundle_id": "calendar.events",
+  "bundle_version": 1
+}
+```
+
+If the assistant sees a stale version, it returns a `stale_resource` status on the existing `CapabilityRequestResult` codec (inline — no side-channel event), telling the device which bundles to refresh:
+
+```json
+{
+  "status": "stale_resource",
+  "stale_bundles": [
+    { "id": "calendar.events", "expected_version": 3 }
+  ]
+}
+```
+
+Device refetches the config, retries the capability call. Self-healing, one extra round-trip in the worst case. Reuses the codec we just stabilized in #771 — no new top-level event type.
 
 ## Renames vs earlier scribbles
 
@@ -91,7 +125,8 @@ Earlier draft had `rationale`. New name: `description`. Reason: the Figma label 
 
 ## Stuff I'm punting on
 
-- Localization. English-only copy for now; structure supports `{ "en": "...", "fr": "..." }` later but I'd rather not bake it in until we actually localize.
+- Per-bundle `read_only` / `write` hints surfaced as badges. v2.
+- Multi-locale launch. Structure supports it day one (`{ "en": "...", "fr": "..." }`), but copy is en-only until we actually localize.
 
 ## Asks
 

--- a/docs/plans/connections-picker-bundles-draft.md
+++ b/docs/plans/connections-picker-bundles-draft.md
@@ -37,7 +37,7 @@ Backend-served, cached on device. App icon embedded as base64 so we don't need a
   "version": 1,
   "services": [
     {
-      "id": "google_calendar",
+      "id": "googlecalendar",
       "composio_slug": "googlecalendar",
       "display_name": { "en": "Google Calendar" },
       "icon": {

--- a/docs/plans/connections-picker-bundles-draft.md
+++ b/docs/plans/connections-picker-bundles-draft.md
@@ -1,0 +1,102 @@
+# Connections Picker — Bundles + Backend Config (draft)
+
+**status:** sharing for vibes-check
+**owner:** louis
+**date:** 2026-05-19
+
+Heads up: this is a notepad, not a real PRD.
+
+## The thing
+
+Today the connections sheet shows raw capability verbs (read / write / etc) per Composio action. That's fine for engineers, not great for humans. We want one card per *intent* the user actually has — "Events", "Files", "Drafts" — and behind the scenes that one card flips a bundle of Composio actions on/off.
+
+Figma: <https://www.figma.com/design/m2Te49zs8hriZdzmtLVTEu/Convos-26?node-id=1846-18062>
+
+The card has:
+- a **title** (e.g. "Events")
+- a **description / rationale** under it (e.g. "View and edit events on all calendars")
+- a toggle per row — the sheet is scoped to one service, but a service typically exposes several permission rows, and each row's toggle could fan out to multiple Composio actions under the hood
+
+That's it. No separate read/write switches in the basic view, unless we want to surface it to the user.
+
+## Why bundles
+
+A few reasons piling up:
+
+1. **Users don't think in CRUD.** "Events" is a thing. "GOOGLECALENDAR_CREATE_EVENT + GOOGLECALENDAR_UPDATE_EVENT + GOOGLECALENDAR_DELETE_EVENT + GOOGLECALENDAR_LIST_EVENTS" is not a thing.
+2. **Composio churn.** Composio adds/renames actions. If the UI hard-codes action lists, every change is an app release. Bundles let backend re-map without shipping iOS.
+3. **One toggle UX.** The Figma is intentionally simple — one toggle per row. Bundles are the only way to keep it that simple while still granting multi-action access.
+4. **Future scopes / federation.** Same bundle id ("calendar.events") survives even if we move off Composio later.
+
+## Schema (draft)
+
+Backend-served, cached on device. App icon embedded as base64 so we don't need a CDN round-trip in the picker.
+
+```json
+{
+  "version": 1,
+  "services": [
+    {
+      "id": "google_calendar",
+      "composio_slug": "googlecalendar",
+      "display_name": "Google Calendar",
+      "icon": {
+        "format": "png",
+        "base64": "iVBORw0KGgoAAAANSUhEUgA..."
+      },
+      "bundles": [
+        {
+          "id": "calendar.events",
+          "title": "Events",
+          "description": "View and edit events on all calendars",
+          "default_enabled": false,
+          "composio_actions": [
+            "GOOGLECALENDAR_LIST_EVENTS",
+            "GOOGLECALENDAR_CREATE_EVENT",
+            "GOOGLECALENDAR_UPDATE_EVENT",
+            "GOOGLECALENDAR_DELETE_EVENT"
+          ]
+        }
+      ]
+    }
+  ]
+}
+```
+
+Key fields on a bundle:
+- `id` — stable identifier we persist on the grant
+- `title` — what the user reads (bold line in the card)
+- `description` — the rationale line under the title; renamed from `rationale` in earlier sketches to match Figma copy
+- `default_enabled` — figma shows toggles off; flip per-bundle if we want one on by default
+- `composio_actions` — what we actually send to Composio when granted
+
+Open question: do we also want `read_only` / `write` hints per bundle so we can show a small "writes" badge on cards that mutate? Probably v2.
+
+## Renames vs earlier scribbles
+
+Earlier draft had `rationale`. New name: `description`. Reason: the Figma label is plainer ("View and edit events on all calendars") and `description` reads more naturally for designers writing copy. We can alias `rationale` if anyone's already coding against it.
+
+## What the app does
+
+- Fetch the service config JSON when the picker opens (cache it; respect cache headers).
+- Render one card per bundle. Title + description + toggle.
+- On Done, send a single grant containing the *bundle ids* the user toggled on. Translate to Composio action slugs at the publish boundary (same pattern as the slug-vs-canonical fix we just shipped in #771).
+- Store grants keyed by `(service_id, bundle_id)`. Revoke flips them all back off.
+
+## What the backend does
+
+- Owns the config JSON. Versioned.
+- Resolves bundle → action list when actually executing on behalf of the agent (so the device never has to know exactly which Composio actions a bundle holds — we only persist the bundle id).
+- Can ship new actions inside an existing bundle without a client update.
+
+## Stuff I'm punting on
+
+- Localization. English-only copy for now; structure supports `{ "en": "...", "fr": "..." }` later but I'd rather not bake it in until we actually localize.
+- Granting from inside a convo vs from the global connections screen — same schema, two entry points. UX of the global screen is unblocked by this.
+
+## Asks
+
+- Naming sanity: `description` vs `rationale` — anyone strongly prefer one? I'll go with `description`.
+- Design: how many bundles per service is realistic? If it's >5 we'll want to think about scroll vs collapsing.
+
+Comments / hot takes welcome.

--- a/docs/plans/connections-picker-bundles-draft.md
+++ b/docs/plans/connections-picker-bundles-draft.md
@@ -29,32 +29,30 @@ A few reasons piling up:
 
 ## Schema (draft)
 
-Backend-served, cached on device. App icon embedded as base64 so we don't need a CDN round-trip in the picker. All user-facing strings (`display_name`, `title`, `description`) are localized maps with `en` as the guaranteed fallback — single code path, no migration when we add more locales later.
+Backend-served, cached on device (`GET /v2/connections/services`, served with `Cache-Control: private, max-age=300`). All wire JSON is camelCase. An `icon` (base64-embedded, so no CDN round-trip in the picker) is optional in the schema and omitted in v1 — format TBD. All user-facing strings (`displayName`, `title`, `description`) are localized maps with `en` as the guaranteed fallback — single code path, no migration when we add more locales later.
+
+Contract source of truth: convos-backend `docs/schemas/connections-services.schema.json` + `docs/schemas/connection-grant.schema.json`.
 
 ```json
 {
   "services": [
     {
       "id": "googlecalendar",
-      "composio_slug": "googlecalendar",
-      "version": 1,
-      "display_name": { "en": "Google Calendar" },
-      "icon": {
-        "format": "png",
-        "base64": "iVBORw0KGgoAAAANSUhEUgA..."
-      },
+      "composioSlug": "googlecalendar",
+      "version": 2,
+      "displayName": { "en": "Google Calendar" },
       "bundles": [
         {
           "id": "calendar.events",
           "title": { "en": "Events" },
           "description": { "en": "View and edit events on all calendars" },
-          "default_enabled": false,
-          "composio_actions": [
-            "GOOGLECALENDAR_LIST_EVENTS",
-            "GOOGLECALENDAR_CREATE_EVENT",
-            "GOOGLECALENDAR_UPDATE_EVENT",
-            "GOOGLECALENDAR_DELETE_EVENT"
-          ]
+          "defaultEnabled": false
+        },
+        {
+          "id": "calendar.events.read",
+          "title": { "en": "View events" },
+          "description": { "en": "View events on all calendars" },
+          "defaultEnabled": false
         }
       ]
     }
@@ -67,8 +65,9 @@ Key fields:
 - `bundles[].id` — stable identifier we persist on the grant
 - `bundles[].title` — localized map; bold line in the card
 - `bundles[].description` — localized map; rationale line under the title (renamed from `rationale` to match Figma copy)
-- `bundles[].default_enabled` — figma shows toggles off; flip per-bundle if we want one on by default
-- `bundles[].composio_actions` — what we actually send to Composio when granted
+- `bundles[].defaultEnabled` — figma shows toggles off; flip per-bundle if we want one on by default
+
+Composio action slugs are **not** in the response — the backend strips them from the served config and resolves bundle → actions itself at exec time. Slugs never reach a client.
 
 Localized strings always carry at minimum an `en` key. Renderer is:
 
@@ -82,15 +81,17 @@ Open question: do we also want `read_only` / `write` hints per bundle so we can 
 
 ## Versioning + self-healing clients
 
-We query the service config out of band (separate from the conversation). That means a device can be on `googlecalendar` version `1` while the assistant has been upgraded to expect version `3`. To handle this without baking the config into every conversation, every connection message carries the service id, the bundle id, **and** the service version the device knows about:
+We query the service config out of band (separate from the conversation). That means a device can be on `googlecalendar` version `1` while the assistant has been upgraded to expect version `3`. To handle this without baking the config into every conversation, every connection message carries the service id (as `toolkit`), the granted bundle ids, **and** the service version the device knows about — matching the shipped `POST /v2/connections/grants` body:
 
 ```json
 {
-  "service_id": "googlecalendar",
-  "service_version": 1,
-  "bundle_id": "calendar.events"
+  "toolkit": "googlecalendar",
+  "serviceVersion": 2,
+  "bundleIds": ["calendar.events"]
 }
 ```
+
+On the HTTP path, staleness is caught at grant time: an unknown/stale bundle id is rejected with **400 `{"code": "unknown_bundle", "bundleId": "<the bad id>"}`** — the client refetches `/services` and re-presents the picker against the fresh catalog.
 
 Versioning is **per-service**, not per-bundle. Connection messages always reference a single service, so the wire cost is the same as per-bundle versioning, but the backend only has to bump one number when anything about that service changes (icon, copy, any bundle's actions). Coarser than per-bundle, but avoids the storm-of-invalidations problem of a top-level config version. Trade-off chosen: small extra refresh churn for any change inside a service, in exchange for much simpler backend bookkeeping.
 
@@ -99,11 +100,13 @@ If the assistant sees a stale version, it returns a `stale_resource` status on t
 ```json
 {
   "status": "stale_resource",
-  "stale_services": [
-    { "id": "googlecalendar", "expected_version": 3 }
+  "staleServices": [
+    { "id": "googlecalendar", "expectedVersion": 3 }
   ]
 }
 ```
+
+Payload keys are camelCase to match the existing `CapabilityRequestResult` codec's CodingKeys — agent team to confirm the worker side emits camelCase too.
 
 Device refetches that service's config, retries the capability call. Self-healing, one extra round-trip in the worst case. Reuses the codec we just stabilized in #771 — no new top-level event type.
 
@@ -113,10 +116,11 @@ Earlier draft had `rationale`. New name: `description`. Reason: the Figma label 
 
 ## What the app does
 
-- Fetch the service config JSON when the picker opens (cache it; respect cache headers).
+- Fetch the service config JSON when the picker opens (`GET /v2/connections/services`; cache it — the backend serves `Cache-Control: private, max-age=300`).
 - Render one card per bundle. Title + description + toggle.
-- On Done, send a single grant containing the *bundle ids* the user toggled on. Translate to Composio action slugs at the publish boundary (same pattern as the slug-vs-canonical fix we just shipped in #771).
-- Store grants keyed by `(service_id, bundle_id)`. Revoke flips them all back off.
+- On Done, send a single grant containing the *bundle ids* the user toggled on (`bundleIds` + `serviceVersion`). No slug translation on device — the backend resolves bundles to Composio actions at exec.
+- On 400 `unknown_bundle`: refetch `/services`, re-present the picker, retry once.
+- Store grants keyed by `(serviceId, bundleId)`. Revoke flips them all back off.
 
 ## What the backend does
 


### PR DESCRIPTION
## Summary
- Adds approved planning doc for the new connections picker UI — backend-driven permission bundles that group multiple Composio actions behind a single user-facing toggle
- Covers the JSON schema (localized strings, base64 icons, per-service versioning), app/backend responsibilities, and inline stale-resource self-healing via the existing CapabilityRequestResult codec

## Test plan
- [ ] Doc review — schema shape, open questions
- [ ] No code changes, doc only

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/869"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782394650&installation_id=128169237&pr_number=869&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F869&signature=3882df6ea4da826f04bc171e7385e137fdc1f6bc8b18b7d7831b89427b09f1f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add planning document for Connections Picker permission bundles model
> Adds [connections-picker-bundles-draft.md](https://github.com/xmtplabs/convos-ios/pull/869/files#diff-136643f3e5ac0a94c4587789fa903b71df33f18c0862d14892c064c76027b881), a design plan for a backend-served configuration model for the Connections Picker. The document covers the service/bundle schema, localization, versioning, device vs. backend responsibilities, error handling for unknown bundles, and self-healing client behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 750a41f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->