### PR TITLE
feat: adds agent instanceId to profile screen on internal builds

### DIFF
--- a/Convos/Contacts/ContactDetailView.swift
+++ b/Convos/Contacts/ContactDetailView.swift
@@ -162,6 +162,8 @@ struct ContactDetailView: View {
                     showBlock: !mode.isCurrentUser,
                     contactDisplayName: contact.resolvedDisplayName,
                     agentTemplateShareURL: agentTemplateShareURL,
+                    agentInstanceId: contact.agentInstanceId,
+                    showsInstanceIdRow: showsInstanceIdRow,
                     onSendMessage: isAgentTemplate ? handleChatWithAgentTemplate : handleSendMessage,
                     onRemove: handleRemoveTap,
                     onToggleBlock: handleBlockTap
@@ -196,6 +198,12 @@ struct ContactDetailView: View {
     /// without a published template, which hides the row.
     private var agentTemplateShareURL: URL? {
         contact.agentTemplatePublishedURL.flatMap { URL(string: $0) }
+    }
+
+    /// True on Dev/Local builds. Controls visibility of the instance id
+    /// row only - the id itself is always plumbed through.
+    private var showsInstanceIdRow: Bool {
+        ConfigManager.shared.currentEnvironment.isInternalBuild
     }
 
     /// Pill rendered below the subtitle. "You" for the current user's
@@ -538,6 +546,11 @@ private struct ContactDetailActions: View {
     let contactDisplayName: String
     /// Non-nil only for template-backed agents; drives the Share row.
     let agentTemplateShareURL: URL?
+    /// Always plumbed through when the contact has one. Display gate
+    /// is `showsInstanceIdRow`, not nullability of this field.
+    let agentInstanceId: String?
+    /// True on Dev/Local builds. Hides the row on production.
+    let showsInstanceIdRow: Bool
     let onSendMessage: () -> Void
     let onRemove: () -> Void
     let onToggleBlock: () -> Void
@@ -563,6 +576,9 @@ private struct ContactDetailActions: View {
             }
             if showBlock {
                 blockRow
+            }
+            if showsInstanceIdRow, let agentInstanceId {
+                ContactDetailDebugInstanceIdRow(instanceId: agentInstanceId)
             }
         }
         .padding(.horizontal, DesignConstants.Spacing.step4x)
@@ -711,6 +727,59 @@ private struct ContactDetailShareRow: View {
     }
 }
 
+// MARK: - Debug instance id row (internal builds only)
+
+/// Internal-build-only row surfacing the agent runtime's `instanceId`
+/// for log correlation. Tap to copy. Gated by the call site in
+/// `ContactDetailView` via `AppEnvironment.isInternalBuild`.
+private struct ContactDetailDebugInstanceIdRow: View {
+    let instanceId: String
+
+    @State private var didCopy: Bool = false
+
+    var body: some View {
+        let labelText: String = didCopy ? "Copied" : "Tap to copy"
+        VStack(alignment: .leading, spacing: DesignConstants.Spacing.stepX) {
+            Button(action: copyToClipboard) {
+                VStack(alignment: .leading, spacing: DesignConstants.Spacing.stepX) {
+                    Text("Instance ID (dev)")
+                        .font(.caption.weight(.medium))
+                        .foregroundStyle(.colorTextSecondary)
+                    Text(instanceId)
+                        .font(.system(.footnote, design: .monospaced))
+                        .foregroundStyle(.colorTextPrimary)
+                        .multilineTextAlignment(.leading)
+                        .lineLimit(2)
+                        .truncationMode(.middle)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.vertical, DesignConstants.Spacing.step3x)
+                .padding(.horizontal, DesignConstants.Spacing.step3x)
+                .background(
+                    RoundedRectangle(cornerRadius: 12.0).fill(.colorFillMinimal)
+                )
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Instance ID, \(instanceId)")
+            .accessibilityHint("Double tap to copy")
+            .accessibilityIdentifier("contact-detail-debug-instance-id")
+            Text(labelText)
+                .font(.caption)
+                .foregroundStyle(.colorTextSecondary)
+                .padding(.horizontal, DesignConstants.Spacing.step3x)
+        }
+    }
+
+    private func copyToClipboard() {
+        UIPasteboard.general.string = instanceId
+        didCopy = true
+        Task {
+            try? await Task.sleep(nanoseconds: 1_500_000_000)
+            didCopy = false
+        }
+    }
+}
+
 // MARK: - Modals modifier
 
 private struct ContactDetailModalsModifier<
@@ -765,7 +834,8 @@ extension Contact {
         addedViaConversationId: String?,
         agentVerification: AgentVerification?,
         agentTemplateId: String? = nil,
-        agentTemplatePublishedURL: String? = nil
+        agentTemplatePublishedURL: String? = nil,
+        agentInstanceId: String? = nil
     ) -> Contact {
         Contact(
             inboxId: inboxId,
@@ -779,7 +849,8 @@ extension Contact {
             isBlocked: false,
             agentVerification: agentVerification,
             agentTemplateId: agentTemplateId,
-            agentTemplatePublishedURL: agentTemplatePublishedURL
+            agentTemplatePublishedURL: agentTemplatePublishedURL,
+            agentInstanceId: agentInstanceId
         )
     }
 
@@ -792,12 +863,11 @@ extension Contact {
     /// and non-contact members. The synthetic fallback is promoted to a
     /// real contact when the user taps "Chat".
     ///
-    /// The agent-template `templateId` and `publishedUrl` live only in the
-    /// per-conversation member profile metadata (`DBContact` has no
-    /// template columns), so they are overlaid here onto whichever contact
-    /// is returned - stored or synthetic - from the freshest source. The
-    /// `templateId` is what enables the Chat button to spawn a fresh
-    /// instance; without this overlay `isAgentTemplate` is always false.
+    /// The agent-template `templateId`, `publishedUrl`, and `instanceId`
+    /// live only in the per-conversation member profile metadata
+    /// (`DBContact` has no template column), so they are overlaid here
+    /// onto whichever contact is returned. Without the `templateId`
+    /// overlay `isAgentTemplate` is always false.
     public static func resolved(
         member: ConversationMember,
         in conversationId: String,
@@ -805,10 +875,12 @@ extension Contact {
     ) -> Contact {
         let templateId: String? = member.profile.agentTemplateId
         let templatePublishedURL: String? = member.profile.agentTemplatePublishedURL
+        let instanceId: String? = member.profile.agentInstanceId
         if let stored = try? contactsRepository.fetchContact(inboxId: member.profile.inboxId) {
             return stored
                 .with(agentTemplateId: templateId)
                 .with(agentTemplatePublishedURL: templatePublishedURL)
+                .with(agentInstanceId: instanceId)
         }
         return .synthetic(
             inboxId: member.profile.inboxId,
@@ -820,7 +892,8 @@ extension Contact {
             addedViaConversationId: conversationId,
             agentVerification: member.agentVerification,
             agentTemplateId: templateId,
-            agentTemplatePublishedURL: templatePublishedURL
+            agentTemplatePublishedURL: templatePublishedURL,
+            agentInstanceId: instanceId
         )
     }
 }
@@ -865,6 +938,21 @@ extension Contact {
                 displayName: "Tifoso",
                 agentVerification: .verified(.convos),
                 agentTemplatePublishedURL: "https://agents-dev.convos.org/tifoso.pnw1o"
+            ),
+            contactsWriter: MockContactsWriter(),
+            contactsRepository: MockContactsRepository()
+        )
+    }
+}
+
+#Preview("Agent template with instance id (dev)") {
+    NavigationStack {
+        ContactDetailView(
+            contact: .mock(
+                displayName: "Tifoso",
+                agentVerification: .verified(.convos),
+                agentTemplatePublishedURL: "https://agents-dev.convos.org/tifoso.pnw1o",
+                agentInstanceId: "inst_01HZQX0K7AYB5R8N3W2J6FQGCD"
             ),
             contactsWriter: MockContactsWriter(),
             contactsRepository: MockContactsRepository()

--- a/ConvosCore/Sources/ConvosCore/AppEnvironment.swift
+++ b/ConvosCore/Sources/ConvosCore/AppEnvironment.swift
@@ -226,6 +226,17 @@ public extension AppEnvironment {
         }
     }
 
+    /// True for Dev and Local builds. Gate debug-only UI on this so it
+    /// never reaches the App Store build.
+    var isInternalBuild: Bool {
+        switch self {
+        case .dev, .local:
+            true
+        case .production, .tests:
+            false
+        }
+    }
+
     var defaultXMTPLogsDirectoryURL: URL {
         guard !isTestingEnvironment else {
             return FileManager.default.temporaryDirectory

--- a/ConvosCore/Sources/ConvosCore/Storage/Database Models/DBMemberProfile.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Database Models/DBMemberProfile.swift
@@ -268,6 +268,12 @@ extension DBMemberProfile {
         metadata?[Constant.publishedURLKey]?.stringValue
     }
 
+    /// The agent runtime's `instanceId` for this provisioned agent.
+    /// Surfaced on the contact card behind an internal-build gate.
+    var agentInstanceId: String? {
+        metadata?[Constant.instanceIdKey]?.stringValue
+    }
+
     /// The agent template's emoji, when published.
     var agentTemplateEmoji: String? {
         metadata?[Constant.emojiKey]?.stringValue
@@ -293,5 +299,6 @@ extension DBMemberProfile {
         static let publishedURLKey: String = "publishedUrl"
         static let emojiKey: String = "emoji"
         static let descriptionKey: String = "description"
+        static let instanceIdKey: String = "instanceId"
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/Contact.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/Contact.swift
@@ -41,6 +41,10 @@ public struct Contact: Hashable, Identifiable, Sendable {
     /// member profile metadata (see `Contact.resolved(member:...)`), which
     /// is the freshest source. Drives the contact card's Share button.
     public let agentTemplatePublishedURL: String?
+    /// The agent runtime's `instanceId` for a specific provisioned agent.
+    /// Not persisted on `DBContact`; overlaid at resolution time from the
+    /// per-conversation member profile (see `Contact.resolved(member:...)`).
+    public let agentInstanceId: String?
 
     public init(
         inboxId: String,
@@ -54,7 +58,8 @@ public struct Contact: Hashable, Identifiable, Sendable {
         isBlocked: Bool = false,
         agentVerification: AgentVerification? = nil,
         agentTemplateId: String? = nil,
-        agentTemplatePublishedURL: String? = nil
+        agentTemplatePublishedURL: String? = nil,
+        agentInstanceId: String? = nil
     ) {
         self.inboxId = inboxId
         self.displayName = displayName
@@ -68,6 +73,7 @@ public struct Contact: Hashable, Identifiable, Sendable {
         self.agentVerification = agentVerification
         self.agentTemplateId = agentTemplateId
         self.agentTemplatePublishedURL = agentTemplatePublishedURL
+        self.agentInstanceId = agentInstanceId
     }
 
     /// True when this contact has the full set of AES-256-GCM material
@@ -148,7 +154,8 @@ extension Contact {
         isBlocked: Bool = false,
         agentVerification: AgentVerification? = nil,
         agentTemplateId: String? = nil,
-        agentTemplatePublishedURL: String? = nil
+        agentTemplatePublishedURL: String? = nil,
+        agentInstanceId: String? = nil
     ) -> Contact {
         Contact(
             inboxId: inboxId,
@@ -162,7 +169,8 @@ extension Contact {
             isBlocked: isBlocked,
             agentVerification: agentVerification,
             agentTemplateId: agentTemplateId,
-            agentTemplatePublishedURL: agentTemplatePublishedURL
+            agentTemplatePublishedURL: agentTemplatePublishedURL,
+            agentInstanceId: agentInstanceId
         )
     }
 
@@ -183,7 +191,8 @@ extension Contact {
             isBlocked: isBlocked,
             agentVerification: agentVerification,
             agentTemplateId: agentTemplateId,
-            agentTemplatePublishedURL: agentTemplatePublishedURL
+            agentTemplatePublishedURL: agentTemplatePublishedURL,
+            agentInstanceId: agentInstanceId
         )
     }
 
@@ -204,7 +213,27 @@ extension Contact {
             isBlocked: isBlocked,
             agentVerification: agentVerification,
             agentTemplateId: agentTemplateId,
-            agentTemplatePublishedURL: agentTemplatePublishedURL
+            agentTemplatePublishedURL: agentTemplatePublishedURL,
+            agentInstanceId: agentInstanceId
+        )
+    }
+
+    /// Returns a copy with `agentInstanceId` overlaid.
+    public func with(agentInstanceId: String?) -> Contact {
+        Contact(
+            inboxId: inboxId,
+            displayName: displayName,
+            avatarURL: avatarURL,
+            avatarSalt: avatarSalt,
+            avatarNonce: avatarNonce,
+            avatarKey: avatarKey,
+            addedAt: addedAt,
+            addedViaConversationId: addedViaConversationId,
+            isBlocked: isBlocked,
+            agentVerification: agentVerification,
+            agentTemplateId: agentTemplateId,
+            agentTemplatePublishedURL: agentTemplatePublishedURL,
+            agentInstanceId: agentInstanceId
         )
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/Profile.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/Profile.swift
@@ -209,6 +209,7 @@ public struct Profile: Codable, Identifiable, Hashable, Sendable {
         static let emojiMetadataKey: String = "emoji"
         static let templateIdKey: String = "templateId"
         static let publishedURLKey: String = "publishedUrl"
+        static let instanceIdKey: String = "instanceId"
     }
 }
 
@@ -234,6 +235,14 @@ extension Profile {
     /// the matching accessor on `DBMemberProfile`.
     public var agentTemplatePublishedURL: String? {
         metadata?[Constant.publishedURLKey]?.stringValue
+    }
+
+    /// The agent runtime's `instanceId` for this provisioned agent
+    /// (one templateId spawns N instances, each with its own inboxId).
+    /// Surfaced on the contact card behind an internal-build gate for
+    /// log correlation.
+    public var agentInstanceId: String? {
+        metadata?[Constant.instanceIdKey]?.stringValue
     }
 }
 

--- a/ConvosCore/Tests/ConvosCoreTests/AgentTemplateMetadataTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/AgentTemplateMetadataTests.swift
@@ -72,6 +72,33 @@ struct AgentTemplateMetadataTests {
         #expect(profile.agentTemplateId == nil)
         #expect(profile.isAgentTemplate == false)
     }
+
+    @Test("A template-backed agent exposes the instanceId when published")
+    func templateBackedAgentExposesInstanceId() {
+        let profile = makeProfile(
+            memberKind: .verifiedConvos,
+            metadata: [
+                "templateId": .string("200e27dc-badc-429f-a431-b01b0281ec95"),
+                "instanceId": .string("inst_01HZQX0K7AYB5R8N3W2J6FQGCD")
+            ]
+        )
+        #expect(profile.agentInstanceId == "inst_01HZQX0K7AYB5R8N3W2J6FQGCD")
+    }
+
+    @Test("A human member exposes no instanceId")
+    func humanMemberHasNoInstanceId() {
+        let profile = makeProfile(memberKind: nil, metadata: nil)
+        #expect(profile.agentInstanceId == nil)
+    }
+
+    @Test("A non-string instanceId metadata value does not resolve")
+    func nonStringInstanceIdIgnored() {
+        let profile = makeProfile(
+            memberKind: .agent,
+            metadata: ["instanceId": .number(42)]
+        )
+        #expect(profile.agentInstanceId == nil)
+    }
 }
 
 struct ProfileAgentTemplateMetadataTests {
@@ -117,6 +144,21 @@ struct ProfileAgentTemplateMetadataTests {
         )
         #expect(profile.agentTemplateId == nil)
         #expect(profile.agentTemplatePublishedURL == nil)
+    }
+
+    @Test("A template-backed agent profile exposes the instanceId when published")
+    func templateBackedAgentExposesInstanceId() {
+        let profile = makeProfile(
+            isAgent: true,
+            metadata: ["instanceId": .string("inst_01HZQX0K7AYB5R8N3W2J6FQGCD")]
+        )
+        #expect(profile.agentInstanceId == "inst_01HZQX0K7AYB5R8N3W2J6FQGCD")
+    }
+
+    @Test("A human profile exposes no instanceId")
+    func humanProfileHasNoInstanceId() {
+        let profile = makeProfile(isAgent: false, metadata: nil)
+        #expect(profile.agentInstanceId == nil)
     }
 }
 
@@ -166,5 +208,38 @@ struct ContactAgentTemplateTests {
         )
         let cleared = base.with(agentTemplatePublishedURL: nil)
         #expect(cleared.agentTemplatePublishedURL == nil)
+    }
+
+    @Test("with(agentInstanceId:) overlays the id onto a copy")
+    func withOverlaysInstanceId() {
+        let base = Contact.mock(displayName: "Tifoso")
+        #expect(base.agentInstanceId == nil)
+
+        let overlaid = base.with(agentInstanceId: "inst_01HZQX0K7AYB5R8N3W2J6FQGCD")
+        #expect(overlaid.agentInstanceId == "inst_01HZQX0K7AYB5R8N3W2J6FQGCD")
+        #expect(overlaid.inboxId == base.inboxId)
+        #expect(overlaid.displayName == base.displayName)
+        #expect(overlaid.isBlocked == base.isBlocked)
+    }
+
+    @Test("with(agentInstanceId:) preserves an existing templateId")
+    func withInstanceIdPreservesTemplateId() {
+        let base = Contact.mock(
+            displayName: "Tifoso",
+            agentTemplateId: "200e27dc-badc-429f-a431-b01b0281ec95"
+        )
+        let overlaid = base.with(agentInstanceId: "inst_01HZQX0K7AYB5R8N3W2J6FQGCD")
+        #expect(overlaid.agentTemplateId == "200e27dc-badc-429f-a431-b01b0281ec95")
+        #expect(overlaid.agentInstanceId == "inst_01HZQX0K7AYB5R8N3W2J6FQGCD")
+    }
+
+    @Test("with(agentInstanceId:) can clear the id")
+    func withCanClearInstanceId() {
+        let base = Contact.mock(
+            displayName: "Tifoso",
+            agentInstanceId: "inst_01HZQX0K7AYB5R8N3W2J6FQGCD"
+        )
+        let cleared = base.with(agentInstanceId: nil)
+        #expect(cleared.agentInstanceId == nil)
     }
 }


### PR DESCRIPTION

<img width="300" alt="image" src="https://github.com/user-attachments/assets/e4a9f3b4-311c-4858-8011-769c98848ccc" />


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/870"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782411120&installation_id=128169237&pr_number=870&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F870&signature=5a589c83f468f2aa1d3360f0b82dcc14c1f7df7ef2b69104bbe874ff7bae7f8c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Display agent instance ID on the profile screen in internal builds
> - Adds `agentInstanceId` to the `Contact` model, populated at resolution time from `member.profile.agentInstanceId` (via metadata key `"instanceId"`).
> - Adds `AppEnvironment.isInternalBuild` to gate debug UI on `.dev` and `.local` environments.
> - Renders a new `ContactDetailDebugInstanceIdRow` in `ContactDetailActions` when `isInternalBuild` is true and `agentInstanceId` is non-nil; tapping the row copies the value to the clipboard.
> - Extends `DBMemberProfile` and `Profile` with `agentInstanceId` computed properties reading from metadata.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 017f483.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->