### PR TITLE
Pin builder indicator as pending agent + filter unsupported connections

### DIFF
--- a/Convos/Agent Builder/AgentBuilderConnectionsSheet.swift
+++ b/Convos/Agent Builder/AgentBuilderConnectionsSheet.swift
@@ -18,7 +18,7 @@ struct AgentBuilderConnectionsSheet: View {
                 .padding(.bottom, DesignConstants.Spacing.step2x)
 
             VStack(spacing: 0) {
-                ForEach(Array(AgentBuilderConnection.allCases.enumerated()), id: \.element.id) { index, connection in
+                ForEach(Array(AgentBuilderConnection.supportedCases.enumerated()), id: \.element.id) { index, connection in
                     if index > 0 {
                         Divider()
                             .padding(.leading, DesignConstants.Spacing.step10x + DesignConstants.Spacing.step4x)

--- a/Convos/Agent Builder/AgentBuilderViewModel.swift
+++ b/Convos/Agent Builder/AgentBuilderViewModel.swift
@@ -59,6 +59,35 @@ enum AgentBuilderConnection: String, CaseIterable, Identifiable {
         }
     }
 
+    /// `ConnectionKind` for device-backed kinds, `nil` for cloud kinds.
+    /// Used by `supportedCases` to gate device kinds behind the same
+    /// allowlist (`SupportedConnections`) that the chat-side picker and
+    /// `ConversationConnectionsViewModel` already respect.
+    var deviceKind: ConnectionKind? {
+        switch self {
+        case .appleHealth: return .health
+        case .googleCalendar: return nil
+        }
+    }
+
+    /// Cases currently surfaced to users. Mirrors the gating in
+    /// `ConversationConnectionsViewModel`: device kinds are filtered by
+    /// `SupportedConnections.supportedDeviceKinds` and cloud kinds by
+    /// `SupportedConnections.supportedCloudServiceIds`. v1 ships cloud-
+    /// only (Google Calendar) — Apple Health is hidden until the host
+    /// re-introduces it in `SupportedConnections`.
+    static var supportedCases: [AgentBuilderConnection] {
+        allCases.filter { connection in
+            if let kind = connection.deviceKind {
+                return SupportedConnections.isSupported(kind)
+            }
+            if let cloudServiceId = connection.cloudServiceId {
+                return SupportedConnections.isSupported(cloudServiceId: cloudServiceId)
+            }
+            return false
+        }
+    }
+
     static let googleCalendarServiceId: String = "googlecalendar"
 }
 

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -346,6 +346,14 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
     /// avatar / display name path takes over naturally.
     var shouldRenderAsPendingAgent: Bool {
         guard isInAgentBuilderFlow || agentBuilderSummary != nil else { return false }
+        // While the builder is on screen, always render as pending. The
+        // verified agent may have silently joined the draft conversation
+        // in the background, but the indicator should keep showing the
+        // generic agent icon + "New Agent" / "Draft" copy until the user
+        // taps Make. The post-commit branch (`agentBuilderSummary != nil`)
+        // still flips back to the real agent the moment the verified
+        // member appears.
+        if isInAgentBuilderFlow { return true }
         return !conversation.members.contains(where: \.isVerifiedConvosAgent)
     }
 


### PR DESCRIPTION
- `ConversationViewModel.shouldRenderAsPendingAgent` now returns true
  unconditionally while `isInAgentBuilderFlow` is set. The verified
  agent can silently join the draft conversation in the background,
  but the indicator should keep showing the generic agent icon +
  "New Agent" / "Draft" copy until the user taps Make. The post-
  commit branch (`agentBuilderSummary != nil`) still flips back to
  the real agent the moment the verified member appears.
- `AgentBuilderConnection` gains `deviceKind` and `supportedCases`
  helpers; `AgentBuilderConnectionsSheet` iterates `supportedCases`
  instead of `allCases`. Apple Health was still rendering even though
  `SupportedConnections.supportedDeviceKinds` is empty in v1 — the
  builder's sheet wasn't going through that allowlist. Now it
  mirrors the gating that `ConversationConnectionsViewModel`
  already respects, so re-introducing a kind in
  `SupportedConnections` is the single source of truth.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/876"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782427812&installation_id=128169237&pr_number=876&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F876&signature=6fd3b0d663239265f832b999fdcba7f273f47d3224ae49a29a40d9348aea0afa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pin agent builder indicator as pending and filter unsupported connections
> - `shouldRenderAsPendingAgent` in [ConversationViewModel.swift](https://github.com/xmtplabs/convos-ios/pull/876/files#diff-d056b0b131534648b6d13cddafd053be956f5d23d035ad2538db85a8cc370d8d) now returns `true` whenever the Agent Builder flow is active, even if a verified agent has already joined.
> - `AgentBuilderConnection` in [AgentBuilderViewModel.swift](https://github.com/xmtplabs/convos-ios/pull/876/files#diff-8b71893f1830eea03680a58b5237f2369242000afbb064e57463171dfe38db65) gains a `supportedCases` property that filters connections using `SupportedConnections`, excluding unsupported device and cloud service types.
> - The connections sheet in [AgentBuilderConnectionsSheet.swift](https://github.com/xmtplabs/convos-ios/pull/876/files#diff-4a5235406e3cdb581e13c49048231fd41e5e66719df6d789bf611e3a4929beda) now renders only `supportedCases` instead of all connection cases.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1ddbd02.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->