### PR TITLE
Replace in-memory connection-grant polling with persisted replayer

### DIFF
--- a/Convos/Agent Builder/AgentBuilderViewModel.swift
+++ b/Convos/Agent Builder/AgentBuilderViewModel.swift
@@ -4,7 +4,6 @@ import ConvosCore
 import ConvosCoreiOS
 import Foundation
 import Observation
-import Sentry
 import SwiftUI
 import UIKit
 
@@ -168,8 +167,6 @@ final class AgentBuilderViewModel: Identifiable {
     private var didRequestAgentJoin: Bool = false
     @ObservationIgnored
     private(set) var didDiscard: Bool = false
-    @ObservationIgnored
-    private var pendingConnectionGrantTask: Task<Void, Never>?
     /// Whether the composer text field was focused at the moment the user
     /// kicked off a voice memo. Read by the stop-recording action so we can
     /// return the keyboard to the composer where the user left off.
@@ -205,7 +202,6 @@ final class AgentBuilderViewModel: Identifiable {
 
     deinit {
         agentJoinTask?.cancel()
-        pendingConnectionGrantTask?.cancel()
     }
 
     // MARK: - Composer mutations
@@ -396,12 +392,16 @@ final class AgentBuilderViewModel: Identifiable {
             if let textMessageId { bundledMessageIds.insert(textMessageId) }
             if let bundleMessageId { bundledMessageIds.insert(bundleMessageId) }
 
+            var cloudConnectionIdsByRawValue: [String: String] = [:]
+            for (connection, cloudConnectionId) in capturedCloudConnectionIds {
+                cloudConnectionIdsByRawValue[connection.rawValue] = cloudConnectionId
+            }
             let summary: AgentBuilderSummary = buildSummary(
                 prompt: textToSend,
-                voiceMemo: recordedVoiceMemo,
-                voiceMemoLevels: voiceMemoAudioLevels,
+                voiceMemo: voiceMemoSnapshot,
                 mediaAttachments: innerVM.pendingMediaAttachments,
                 connections: enabledConnections,
+                cloudConnectionIds: cloudConnectionIdsByRawValue,
                 bundledMessageIds: bundledMessageIds
             )
             innerVM.agentBuilderSummary = summary
@@ -498,8 +498,12 @@ final class AgentBuilderViewModel: Identifiable {
             self.newConversationViewModel.suppressesContactCard = false
             self.newConversationViewModel.conversationViewModel?.allowsContactCard = true
         }
-
-        scheduleConnectionGrants()
+        // Connection grants are now driven by
+        // `AgentBuilderConnectionGrantReplayer`, which observes the
+        // persisted summary + member rows and fires grants once the
+        // verified agent appears. The replayer survives app death
+        // between Make and agent-join — the in-memory poll-and-timeout
+        // path it replaced did not.
     }
 
     /// Build the AgentBuilderSummary that renders as the first cell of the
@@ -509,15 +513,15 @@ final class AgentBuilderViewModel: Identifiable {
     /// the X buttons.
     private func buildSummary(
         prompt: String,
-        voiceMemo: (url: URL, duration: TimeInterval)?,
-        voiceMemoLevels: [Float],
+        voiceMemo: BuilderVoiceMemoSnapshot?,
         mediaAttachments: [PendingMediaAttachment],
         connections: Set<AgentBuilderConnection>,
+        cloudConnectionIds: [String: String],
         bundledMessageIds: Set<String>
     ) -> AgentBuilderSummary {
         var attachments: [AgentBuilderSummaryAttachment] = []
         if let voiceMemo {
-            attachments.append(.voiceMemo(id: UUID(), duration: voiceMemo.duration, levels: voiceMemoLevels))
+            attachments.append(.voiceMemo(id: UUID(), duration: voiceMemo.duration, levels: voiceMemo.levels))
         }
         for attachment in mediaAttachments {
             switch attachment {
@@ -546,110 +550,13 @@ final class AgentBuilderViewModel: Identifiable {
             prompt: prompt,
             attachments: attachments,
             cutoffDate: Date(),
-            bundledMessageIds: bundledMessageIds
+            bundledMessageIds: bundledMessageIds,
+            cloudConnectionIds: cloudConnectionIds
         )
-    }
-
-    private func scheduleConnectionGrants() {
-        guard !enabledConnections.isEmpty else { return }
-        let connections = enabledConnections
-        let capturedIds = capturedCloudConnectionIds
-        pendingConnectionGrantTask?.cancel()
-        pendingConnectionGrantTask = Task { @MainActor [weak self] in
-            let deadline: Date = Date().addingTimeInterval(Constant.agentJoinTimeoutS)
-            while !Task.isCancelled, Date() < deadline {
-                if let convoVM = self?.newConversationViewModel.conversationViewModel,
-                   convoVM.conversation.hasAgent {
-                    self?.fireConnectionGrants(connections, capturedIds: capturedIds, in: convoVM)
-                    return
-                }
-                try? await Task.sleep(for: .milliseconds(Constant.agentPollIntervalMs))
-            }
-            guard !Task.isCancelled else { return }
-            let message: String = "AgentBuilder: timed out after \(Int(Constant.agentJoinTimeoutS))s waiting for agent to join — \(connections.count) connection grant(s) skipped"
-            Log.error(message)
-            SentrySDK.capture(message: message) { scope in
-                scope.setLevel(.warning)
-                scope.setTag(value: "agent_join_timeout", key: "agent_builder")
-                scope.setExtra(value: connections.count, key: "skipped_connection_count")
-                scope.setExtra(value: connections.map(\.id).sorted().joined(separator: ","), key: "skipped_connections")
-            }
-            UINotificationFeedbackGenerator().notificationOccurred(.error)
-        }
-    }
-
-    /// Fires the user-enabled connection grants against the now-real conversation.
-    /// Device kinds go through `ConversationConnectionsViewModel.toggleDeviceConnection`
-    /// (it owns the `EnablementStore` write + per-agent fanout + connection event).
-    /// Cloud kinds bypass that VM's `cloudRows` lookup — the freshly-constructed VM's
-    /// `.receive(on:.main)` subscription leaves rows empty for one runloop tick, racy
-    /// when we tap Make right after OAuth completes. We use the
-    /// `CloudConnection.id` we captured at toggle-on time and fan out the grant
-    /// directly via the messaging service's writers, mirroring what
-    /// `ConversationConnectionsViewModel.grant(connectionId:providerId:)` does.
-    private func fireConnectionGrants(
-        _ connections: Set<AgentBuilderConnection>,
-        capturedIds: [AgentBuilderConnection: String],
-        in convoVM: ConversationViewModel
-    ) {
-        let connectionsVM = convoVM.makeConversationConnectionsViewModel()
-        for connection in connections {
-            switch connection {
-            case .appleHealth:
-                connectionsVM.toggleDeviceConnection(.health)
-            case .googleCalendar:
-                guard let connectionId = capturedIds[connection] else {
-                    Log.warning("AgentBuilder: no captured CloudConnection.id for \(connection.id) — grant skipped")
-                    continue
-                }
-                fireCloudGrant(
-                    connectionId: connectionId,
-                    serviceId: AgentBuilderConnection.googleCalendarServiceId,
-                    in: convoVM
-                )
-            }
-        }
-    }
-
-    private func fireCloudGrant(
-        connectionId: String,
-        serviceId: String,
-        in convoVM: ConversationViewModel
-    ) {
-        let agentInboxIds: [String] = convoVM.conversation.members
-            .filter(\.isAgent)
-            .map(\.profile.inboxId)
-        guard !agentInboxIds.isEmpty else { return }
-        let messagingService = session.messagingService()
-        let grantWriter = messagingService.connectionGrantWriter()
-        let connectionEventWriter = messagingService.connectionEventWriter()
-        let conversationId: String = convoVM.conversation.id
-        let providerId: String = "composio.\(serviceId)"
-        Task {
-            var grantedAgents: [String] = []
-            for agent in agentInboxIds {
-                do {
-                    try await grantWriter.grantConnection(connectionId, to: conversationId, grantedToInboxId: agent)
-                    grantedAgents.append(agent)
-                } catch {
-                    Log.error("AgentBuilder: grantConnection failed for \(serviceId) agent \(agent): \(error.localizedDescription)")
-                }
-            }
-            if let representative = grantedAgents.first {
-                try? await connectionEventWriter.sendGranted(
-                    providerId: providerId,
-                    capability: nil,
-                    grantedToInboxId: representative,
-                    in: conversationId
-                )
-            }
-        }
     }
 
     private enum Constant {
         static let contentFadeMs: Int = 180
-        static let agentPollIntervalMs: Int = 250
-        static let agentJoinTimeoutS: TimeInterval = 30
         /// Wall-clock delay from Make tap until the contact card is allowed
         /// to render. ~180ms covers the content fade, ~350ms the overlay
         /// spring; the rest (~970ms) is dwell time so the chat reveals
@@ -695,7 +602,6 @@ final class AgentBuilderViewModel: Identifiable {
         guard !didDiscard else { return }
         didDiscard = true
         agentJoinTask?.cancel()
-        pendingConnectionGrantTask?.cancel()
         didRequestAgentJoin = true // suppress any late retries
         // Skip recording/attachment cleanup while a commit is mid-flight —
         // `sendBuilderBundle` still holds references to those temp files

--- a/ConvosCore/Sources/ConvosCore/AgentBuilder/AgentBuilderConnectionGrantReplayer.swift
+++ b/ConvosCore/Sources/ConvosCore/AgentBuilder/AgentBuilderConnectionGrantReplayer.swift
@@ -1,0 +1,325 @@
+import Combine
+import ConvosConnections
+import Foundation
+import GRDB
+import os
+
+/// Session-wide service that fires `AgentBuilder` connection grants once
+/// the verified agent has joined a conversation, replaying any grants
+/// the in-memory `AgentBuilderViewModel.commit` flow would have lost on
+/// app death between Make and agent-join.
+///
+/// State of the world:
+/// - `AgentBuilderViewModel.commit` writes an `AgentBuilderSummary` that
+///   carries `.connection` chip attachments (rawValue identifier) plus a
+///   `cloudConnectionIds` dictionary mapping the iOS `AgentBuilderConnection`
+///   rawValue to the captured `CloudConnection.id` (cloud kinds only —
+///   device kinds need no id).
+/// - The replayer observes summaries + conversation members. When a
+///   summary's conversation gains a verified Convos agent, it walks the
+///   connection chips and fires any grant that isn't already applied
+///   (idempotency comes from `cloudConnectionRepository.grants(for:)` for
+///   cloud kinds and `enablementStore.isEnabled(...)` for device kinds —
+///   no separate "did I fire it?" flag is needed).
+///
+/// Survives app launches because the inputs (summary, members, grant
+/// store) all live in the DB.
+public final class AgentBuilderConnectionGrantReplayer: Sendable {
+    /// `AgentBuilderConnection.appleHealth.rawValue`. Mirrored as a string
+    /// constant so the replayer doesn't have to depend on the iOS-side
+    /// enum (which only exists in the Convos target).
+    private static let appleHealthRawValue: String = "appleHealth"
+    /// `AgentBuilderConnection.googleCalendar.rawValue`.
+    private static let googleCalendarRawValue: String = "googleCalendar"
+    /// Composio service id encoded into the cloud `ProviderID` (i.e.
+    /// `composio.googlecalendar`). Mirrors
+    /// `AgentBuilderConnection.googleCalendarServiceId`.
+    private static let googleCalendarServiceId: String = "googlecalendar"
+
+    private let databaseReader: any DatabaseReader
+    private let grantWriter: any CloudConnectionGrantWriterProtocol
+    private let cloudConnectionRepository: any CloudConnectionRepositoryProtocol
+    private let connectionEventWriter: any ConnectionEventWriterProtocol
+    private let enablementStore: any EnablementStore
+    private let summaryWriter: any AgentBuilderSummaryWriterProtocol
+
+    private let observationTask: OSAllocatedUnfairLock<Task<Void, Never>?> = .init(initialState: nil)
+    /// Conversations the replayer has already attempted in this process
+    /// run. Lets the loop short-circuit redundant work when a stream emit
+    /// is identical to the last one (which happens for every unrelated
+    /// member edit). Persistent idempotency comes from the summary's
+    /// `connectionsAppliedAt` stamp.
+    private let inflightConversations: OSAllocatedUnfairLock<Set<String>> = .init(initialState: [])
+
+    public init(
+        databaseReader: any DatabaseReader,
+        grantWriter: any CloudConnectionGrantWriterProtocol,
+        cloudConnectionRepository: any CloudConnectionRepositoryProtocol,
+        connectionEventWriter: any ConnectionEventWriterProtocol,
+        enablementStore: any EnablementStore,
+        summaryWriter: any AgentBuilderSummaryWriterProtocol
+    ) {
+        self.databaseReader = databaseReader
+        self.grantWriter = grantWriter
+        self.cloudConnectionRepository = cloudConnectionRepository
+        self.connectionEventWriter = connectionEventWriter
+        self.enablementStore = enablementStore
+        self.summaryWriter = summaryWriter
+    }
+
+    /// Begin observing. Safe to call repeatedly — the previous task is
+    /// cancelled and replaced.
+    public func start() {
+        let new: Task<Void, Never> = Task { [weak self] in
+            await self?.observe()
+        }
+        observationTask.withLock { existing in
+            existing?.cancel()
+            existing = new
+        }
+    }
+
+    public func stop() {
+        observationTask.withLock { existing in
+            existing?.cancel()
+            existing = nil
+        }
+    }
+
+    private func observe() async {
+        let dbReader = databaseReader
+        let stream = ValueObservation
+            .tracking { db in
+                try Self.fetchReadyTargets(db: db)
+            }
+            .values(in: dbReader)
+        do {
+            for try await targets in stream {
+                if Task.isCancelled { return }
+                for target in targets {
+                    await tryFireGrants(for: target)
+                }
+            }
+        } catch {
+            Log.error("AgentBuilderConnectionGrantReplayer: stream failed: \(error.localizedDescription)")
+        }
+    }
+
+    private func tryFireGrants(for target: ReplayTarget) async {
+        let conversationId: String = target.conversationId
+        let claimed: Bool = inflightConversations.withLock { active in
+            if active.contains(conversationId) { return false }
+            active.insert(conversationId)
+            return true
+        }
+        guard claimed else { return }
+        defer {
+            inflightConversations.withLock { active in
+                active.remove(conversationId)
+            }
+        }
+
+        let summary: AgentBuilderSummary = target.summary
+        let agentInboxIds: [String] = target.agentInboxIds
+        guard !agentInboxIds.isEmpty else { return }
+
+        var anyFailed: Bool = false
+        for attachment in summary.attachments {
+            guard case let .connection(_, identifier) = attachment else { continue }
+            switch identifier {
+            case Self.appleHealthRawValue:
+                let success: Bool = await fireDeviceGrant(
+                    kind: .health,
+                    conversationId: conversationId,
+                    agentInboxIds: agentInboxIds
+                )
+                if !success { anyFailed = true }
+            case Self.googleCalendarRawValue:
+                guard let cloudConnectionId = summary.cloudConnectionIds[identifier] else {
+                    Log.warning("AgentBuilderConnectionGrantReplayer: missing cloudConnectionId for \(identifier) in \(conversationId) — grant skipped")
+                    anyFailed = true
+                    continue
+                }
+                let success: Bool = await fireCloudGrant(
+                    connectionId: cloudConnectionId,
+                    serviceId: Self.googleCalendarServiceId,
+                    conversationId: conversationId,
+                    agentInboxIds: agentInboxIds
+                )
+                if !success { anyFailed = true }
+            default:
+                Log.warning("AgentBuilderConnectionGrantReplayer: unknown connection identifier \(identifier) in \(conversationId)")
+            }
+        }
+
+        guard !anyFailed else { return }
+        do {
+            try await summaryWriter.markConnectionsApplied(for: conversationId, at: Date())
+        } catch {
+            Log.error("AgentBuilderConnectionGrantReplayer: markConnectionsApplied failed for \(conversationId): \(error.localizedDescription)")
+        }
+    }
+
+    /// Returns `true` if the connection's grant state matches what the
+    /// summary requested (either freshly applied or already on disk).
+    /// Failures return `false` so the caller leaves the summary
+    /// unstamped and a subsequent launch retries.
+    private func fireDeviceGrant(
+        kind: ConnectionKind,
+        conversationId: String,
+        agentInboxIds: [String]
+    ) async -> Bool {
+        let alreadyEnabled: Bool = await isAnyCapabilityEnabled(
+            kind: kind,
+            conversationId: conversationId,
+            agentInboxIds: agentInboxIds
+        )
+        if alreadyEnabled { return true }
+        var written: [String] = []
+        for agent in agentInboxIds {
+            for capability in ConnectionCapability.allCases {
+                await enablementStore.setEnabled(
+                    true,
+                    kind: kind,
+                    capability: capability,
+                    conversationId: conversationId,
+                    grantedToInboxId: agent
+                )
+            }
+            written.append(agent)
+        }
+        guard let representative = written.first else { return false }
+        do {
+            try await connectionEventWriter.sendGranted(
+                providerId: "device.\(kind.rawValue)",
+                capability: nil,
+                grantedToInboxId: representative,
+                in: conversationId
+            )
+            return true
+        } catch {
+            Log.error("AgentBuilderConnectionGrantReplayer: sendGranted (device \(kind.rawValue)) failed: \(error.localizedDescription)")
+            return false
+        }
+    }
+
+    private func fireCloudGrant(
+        connectionId: String,
+        serviceId: String,
+        conversationId: String,
+        agentInboxIds: [String]
+    ) async -> Bool {
+        let alreadyGranted: Bool = await isCloudGrantApplied(
+            connectionId: connectionId,
+            conversationId: conversationId
+        )
+        if alreadyGranted { return true }
+        let providerId: String = "composio.\(serviceId)"
+        var granted: [String] = []
+        for agent in agentInboxIds {
+            do {
+                try await grantWriter.grantConnection(
+                    connectionId,
+                    to: conversationId,
+                    grantedToInboxId: agent
+                )
+                granted.append(agent)
+            } catch {
+                Log.error("AgentBuilderConnectionGrantReplayer: grantConnection failed for \(serviceId) agent \(agent): \(error.localizedDescription)")
+            }
+        }
+        guard granted.count == agentInboxIds.count, let representative = granted.first else {
+            return false
+        }
+        do {
+            try await connectionEventWriter.sendGranted(
+                providerId: providerId,
+                capability: nil,
+                grantedToInboxId: representative,
+                in: conversationId
+            )
+            return true
+        } catch {
+            Log.error("AgentBuilderConnectionGrantReplayer: sendGranted (\(providerId)) failed: \(error.localizedDescription)")
+            return false
+        }
+    }
+
+    private func isAnyCapabilityEnabled(
+        kind: ConnectionKind,
+        conversationId: String,
+        agentInboxIds: [String]
+    ) async -> Bool {
+        for agent in agentInboxIds {
+            for capability in ConnectionCapability.allCases {
+                let enabled: Bool = await enablementStore.isEnabled(
+                    kind: kind,
+                    capability: capability,
+                    conversationId: conversationId,
+                    grantedToInboxId: agent
+                )
+                if enabled { return true }
+            }
+        }
+        return false
+    }
+
+    private func isCloudGrantApplied(connectionId: String, conversationId: String) async -> Bool {
+        do {
+            let grants: [CloudConnectionGrant] = try await cloudConnectionRepository.grants(for: conversationId)
+            return grants.contains(where: { $0.connectionId == connectionId })
+        } catch {
+            Log.error("AgentBuilderConnectionGrantReplayer: grants(for:) failed for \(conversationId): \(error.localizedDescription)")
+            return false
+        }
+    }
+
+    /// Pull summaries that have at least one `.connection` attachment
+    /// joined to conversations that have a verified Convos agent in their
+    /// member list. Returned as a flat list of `ReplayTarget`s so the
+    /// observation stream is cheap to evaluate (single query, no
+    /// per-conversation round-trips).
+    private static func fetchReadyTargets(db: Database) throws -> [ReplayTarget] {
+        let summaryRows: [DBAgentBuilderSummary] = try DBAgentBuilderSummary.fetchAll(db)
+        guard !summaryRows.isEmpty else { return [] }
+        var targets: [ReplayTarget] = []
+        for row in summaryRows {
+            guard row.connectionsAppliedAt == nil else { continue }
+            guard let summary = try? row.toAgentBuilderSummary() else { continue }
+            guard Self.hasConnectionAttachment(summary) else { continue }
+            let agentInboxIds: [String] = try Self.verifiedAgentInboxIds(
+                db: db,
+                conversationId: row.conversationId
+            )
+            guard !agentInboxIds.isEmpty else { continue }
+            targets.append(ReplayTarget(
+                conversationId: row.conversationId,
+                summary: summary,
+                agentInboxIds: agentInboxIds
+            ))
+        }
+        return targets
+    }
+
+    private static func hasConnectionAttachment(_ summary: AgentBuilderSummary) -> Bool {
+        summary.attachments.contains { attachment in
+            if case .connection = attachment { return true }
+            return false
+        }
+    }
+
+    private static func verifiedAgentInboxIds(db: Database, conversationId: String) throws -> [String] {
+        let profileRows: [DBMemberProfile] = try DBMemberProfile
+            .filter(DBMemberProfile.Columns.conversationId == conversationId)
+            .fetchAll(db)
+        return profileRows
+            .filter { $0.isAgent && $0.agentVerification.isVerified }
+            .map(\.inboxId)
+    }
+}
+
+private struct ReplayTarget: Sendable {
+    let conversationId: String
+    let summary: AgentBuilderSummary
+    let agentInboxIds: [String]
+}

--- a/ConvosCore/Sources/ConvosCore/AgentBuilder/AgentBuilderConnectionGrantReplayer.swift
+++ b/ConvosCore/Sources/ConvosCore/AgentBuilder/AgentBuilderConnectionGrantReplayer.swift
@@ -148,7 +148,12 @@ public final class AgentBuilderConnectionGrantReplayer: Sendable {
                 )
                 if !success { anyFailed = true }
             default:
+                // Unknown identifier — newer summaries written by a
+                // future build may carry connection kinds this build
+                // doesn't recognise. Don't stamp `connectionsAppliedAt`;
+                // leave the row eligible for a later build to retry.
                 Log.warning("AgentBuilderConnectionGrantReplayer: unknown connection identifier \(identifier) in \(conversationId)")
+                anyFailed = true
             }
         }
 
@@ -160,23 +165,29 @@ public final class AgentBuilderConnectionGrantReplayer: Sendable {
         }
     }
 
-    /// Returns `true` if the connection's grant state matches what the
-    /// summary requested (either freshly applied or already on disk).
-    /// Failures return `false` so the caller leaves the summary
-    /// unstamped and a subsequent launch retries.
+    /// Returns `true` if every agent in `agentInboxIds` ends the call
+    /// with the device kind enabled (either already on disk before we
+    /// started, or written successfully now). Per-agent checks make
+    /// partial pre-existing state safe: an agent that's missing
+    /// enablement still gets written even if a sibling agent already
+    /// had it.
     private func fireDeviceGrant(
         kind: ConnectionKind,
         conversationId: String,
         agentInboxIds: [String]
     ) async -> Bool {
-        let alreadyEnabled: Bool = await isAnyCapabilityEnabled(
-            kind: kind,
-            conversationId: conversationId,
-            agentInboxIds: agentInboxIds
-        )
-        if alreadyEnabled { return true }
-        var written: [String] = []
+        var agentsNeedingWrite: [String] = []
         for agent in agentInboxIds {
+            let enabled: Bool = await isAgentCapabilityEnabled(
+                kind: kind,
+                conversationId: conversationId,
+                agent: agent
+            )
+            if !enabled { agentsNeedingWrite.append(agent) }
+        }
+        if agentsNeedingWrite.isEmpty { return true }
+        var newlyWritten: [String] = []
+        for agent in agentsNeedingWrite {
             for capability in ConnectionCapability.allCases {
                 await enablementStore.setEnabled(
                     true,
@@ -186,21 +197,23 @@ public final class AgentBuilderConnectionGrantReplayer: Sendable {
                     grantedToInboxId: agent
                 )
             }
-            written.append(agent)
+            newlyWritten.append(agent)
         }
-        guard let representative = written.first else { return false }
-        do {
-            try await connectionEventWriter.sendGranted(
-                providerId: "device.\(kind.rawValue)",
-                capability: nil,
-                grantedToInboxId: representative,
-                in: conversationId
-            )
-            return true
-        } catch {
-            Log.error("AgentBuilderConnectionGrantReplayer: sendGranted (device \(kind.rawValue)) failed: \(error.localizedDescription)")
-            return false
+        let allEnabled: Bool = newlyWritten.count == agentsNeedingWrite.count
+        if let representative = newlyWritten.first {
+            do {
+                try await connectionEventWriter.sendGranted(
+                    providerId: "device.\(kind.rawValue)",
+                    capability: nil,
+                    grantedToInboxId: representative,
+                    in: conversationId
+                )
+            } catch {
+                Log.error("AgentBuilderConnectionGrantReplayer: sendGranted (device \(kind.rawValue)) failed: \(error.localizedDescription)")
+                return false
+            }
         }
+        return allEnabled
     }
 
     private func fireCloudGrant(
@@ -209,69 +222,66 @@ public final class AgentBuilderConnectionGrantReplayer: Sendable {
         conversationId: String,
         agentInboxIds: [String]
     ) async -> Bool {
-        let alreadyGranted: Bool = await isCloudGrantApplied(
-            connectionId: connectionId,
-            conversationId: conversationId
-        )
-        if alreadyGranted { return true }
+        let alreadyGrantedAgents: Set<String>
+        do {
+            let grants: [CloudConnectionGrant] = try await cloudConnectionRepository.grants(for: conversationId)
+            alreadyGrantedAgents = Set(
+                grants
+                    .filter { $0.connectionId == connectionId }
+                    .map(\.grantedToInboxId)
+            )
+        } catch {
+            Log.error("AgentBuilderConnectionGrantReplayer: grants(for:) failed for \(conversationId): \(error.localizedDescription)")
+            return false
+        }
+        let agentsToGrant: [String] = agentInboxIds.filter { !alreadyGrantedAgents.contains($0) }
+        if agentsToGrant.isEmpty { return true }
         let providerId: String = "composio.\(serviceId)"
-        var granted: [String] = []
-        for agent in agentInboxIds {
+        var newlyGranted: [String] = []
+        for agent in agentsToGrant {
             do {
                 try await grantWriter.grantConnection(
                     connectionId,
                     to: conversationId,
                     grantedToInboxId: agent
                 )
-                granted.append(agent)
+                newlyGranted.append(agent)
             } catch {
                 Log.error("AgentBuilderConnectionGrantReplayer: grantConnection failed for \(serviceId) agent \(agent): \(error.localizedDescription)")
             }
         }
-        guard granted.count == agentInboxIds.count, let representative = granted.first else {
-            return false
-        }
-        do {
-            try await connectionEventWriter.sendGranted(
-                providerId: providerId,
-                capability: nil,
-                grantedToInboxId: representative,
-                in: conversationId
-            )
-            return true
-        } catch {
-            Log.error("AgentBuilderConnectionGrantReplayer: sendGranted (\(providerId)) failed: \(error.localizedDescription)")
-            return false
-        }
-    }
-
-    private func isAnyCapabilityEnabled(
-        kind: ConnectionKind,
-        conversationId: String,
-        agentInboxIds: [String]
-    ) async -> Bool {
-        for agent in agentInboxIds {
-            for capability in ConnectionCapability.allCases {
-                let enabled: Bool = await enablementStore.isEnabled(
-                    kind: kind,
-                    capability: capability,
-                    conversationId: conversationId,
-                    grantedToInboxId: agent
+        let allGranted: Bool = newlyGranted.count == agentsToGrant.count
+        if let representative = newlyGranted.first {
+            do {
+                try await connectionEventWriter.sendGranted(
+                    providerId: providerId,
+                    capability: nil,
+                    grantedToInboxId: representative,
+                    in: conversationId
                 )
-                if enabled { return true }
+            } catch {
+                Log.error("AgentBuilderConnectionGrantReplayer: sendGranted (\(providerId)) failed: \(error.localizedDescription)")
+                return false
             }
         }
-        return false
+        return allGranted
     }
 
-    private func isCloudGrantApplied(connectionId: String, conversationId: String) async -> Bool {
-        do {
-            let grants: [CloudConnectionGrant] = try await cloudConnectionRepository.grants(for: conversationId)
-            return grants.contains(where: { $0.connectionId == connectionId })
-        } catch {
-            Log.error("AgentBuilderConnectionGrantReplayer: grants(for:) failed for \(conversationId): \(error.localizedDescription)")
-            return false
+    private func isAgentCapabilityEnabled(
+        kind: ConnectionKind,
+        conversationId: String,
+        agent: String
+    ) async -> Bool {
+        for capability in ConnectionCapability.allCases {
+            let enabled: Bool = await enablementStore.isEnabled(
+                kind: kind,
+                capability: capability,
+                conversationId: conversationId,
+                grantedToInboxId: agent
+            )
+            if enabled { return true }
         }
+        return false
     }
 
     /// Pull summaries that have at least one `.connection` attachment

--- a/ConvosCore/Sources/ConvosCore/Sessions/SessionManager+AgentBuilderGrantReplayer.swift
+++ b/ConvosCore/Sources/ConvosCore/Sessions/SessionManager+AgentBuilderGrantReplayer.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+extension SessionManager {
+    /// Returns the session-wide AgentBuilder grant replayer, instantiating
+    /// and starting it on first access. Idempotent — `start()` cancels the
+    /// previous observation task before kicking off a new one, but normal
+    /// callers only hit this once during session bootstrap.
+    public func agentBuilderConnectionGrantReplayer() -> AgentBuilderConnectionGrantReplayer {
+        agentBuilderGrantReplayerLock.withLock { replayer in
+            if let replayer { return replayer }
+            let new = AgentBuilderConnectionGrantReplayer(
+                databaseReader: databaseReader,
+                grantWriter: messagingService().connectionGrantWriter(),
+                cloudConnectionRepository: cloudConnectionRepository(),
+                connectionEventWriter: messagingService().connectionEventWriter(),
+                enablementStore: connectionEnablementStore(),
+                summaryWriter: agentBuilderSummaryWriter()
+            )
+            new.start()
+            replayer = new
+            return new
+        }
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
@@ -146,6 +146,11 @@ public final class SessionManager: SessionManagerProtocol, @unchecked Sendable {
             await self.bootstrapCapabilityProviders()
             guard !Task.isCancelled else { return }
 
+            // Kick off the AgentBuilder grant replayer after the capability
+            // providers have bootstrapped — it relies on the cloud-connection
+            // and enablement stores being ready to query.
+            _ = self.agentBuilderConnectionGrantReplayer()
+
             self.assetRenewalTask = Task(priority: .utility) { [weak self] in
                 guard let self, !Task.isCancelled else { return }
                 let recoveryHandler = ExpiredAssetRecoveryHandler(databaseWriter: self.databaseWriter)
@@ -833,6 +838,11 @@ public final class SessionManager: SessionManagerProtocol, @unchecked Sendable {
     /// shared registry per session instead of per-callsite copies.
     private let capabilityRegistryLock: OSAllocatedUnfairLock<(any CapabilityProviderRegistry)?> = .init(initialState: nil)
     private let connectionEnablementStoreLock: OSAllocatedUnfairLock<(any EnablementStore)?> = .init(initialState: nil)
+    /// Lazily-constructed singleton replayer. Lives for the lifetime of
+    /// the session because it owns a long-running `ValueObservation`
+    /// stream over `agentBuilderSummary` + member rows. Constructed by
+    /// the accessor in `SessionManager+AgentBuilderGrantReplayer.swift`.
+    let agentBuilderGrantReplayerLock: OSAllocatedUnfairLock<AgentBuilderConnectionGrantReplayer?> = .init(initialState: nil)
 
     public func capabilityProviderRegistry() -> any CapabilityProviderRegistry {
         capabilityRegistryLock.withLock { registry in

--- a/ConvosCore/Sources/ConvosCore/Storage/Database Models/DBAgentBuilderSummary.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Database Models/DBAgentBuilderSummary.swift
@@ -17,6 +17,8 @@ public struct DBAgentBuilderSummary: Codable, FetchableRecord, PersistableRecord
         public static let createdAt: Column = Column(CodingKeys.createdAt)
         public static let cutoffDate: Column = Column(CodingKeys.cutoffDate)
         public static let bundledMessageIdsJSON: Column = Column(CodingKeys.bundledMessageIdsJSON)
+        public static let cloudConnectionIdsJSON: Column = Column(CodingKeys.cloudConnectionIdsJSON)
+        public static let connectionsAppliedAt: Column = Column(CodingKeys.connectionsAppliedAt)
     }
 
     public let conversationId: String
@@ -36,6 +38,17 @@ public struct DBAgentBuilderSummary: Codable, FetchableRecord, PersistableRecord
     /// JSON array (not a Set) for portability; the model layer rehydrates
     /// into a Set for O(1) lookups.
     public let bundledMessageIdsJSON: String
+    /// JSON-encoded `[String: String]` mapping `AgentBuilderConnection`
+    /// rawValue → captured `CloudConnection.id`. Drives the post-Make grant
+    /// replayer so a force-quit between Make and agent-join doesn't lose the
+    /// user's selection. Defaults to `"{}"` on summaries written before this
+    /// column existed.
+    public let cloudConnectionIdsJSON: String
+    /// Set the first time the replayer has fully processed this summary's
+    /// connections. Once non-null, the replayer skips this row. `nil` for
+    /// summaries written before the replayer existed, or that haven't yet
+    /// reached the replayer.
+    public let connectionsAppliedAt: Date?
 
     public init(
         conversationId: String,
@@ -44,7 +57,9 @@ public struct DBAgentBuilderSummary: Codable, FetchableRecord, PersistableRecord
         attachmentsJSON: String,
         createdAt: Date,
         cutoffDate: Date,
-        bundledMessageIdsJSON: String
+        bundledMessageIdsJSON: String,
+        cloudConnectionIdsJSON: String,
+        connectionsAppliedAt: Date? = nil
     ) {
         self.conversationId = conversationId
         self.summaryId = summaryId
@@ -53,5 +68,7 @@ public struct DBAgentBuilderSummary: Codable, FetchableRecord, PersistableRecord
         self.createdAt = createdAt
         self.cutoffDate = cutoffDate
         self.bundledMessageIdsJSON = bundledMessageIdsJSON
+        self.cloudConnectionIdsJSON = cloudConnectionIdsJSON
+        self.connectionsAppliedAt = connectionsAppliedAt
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Storage/Hydration/DBAgentBuilderSummary+Conversion.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Hydration/DBAgentBuilderSummary+Conversion.swift
@@ -21,13 +21,22 @@ extension DBAgentBuilderSummary {
             }
             return Set(array)
         }()
+        let cloudConnectionIds: [String: String] = {
+            guard let data = cloudConnectionIdsJSON.data(using: .utf8),
+                  let dict = try? JSONDecoder().decode([String: String].self, from: data) else {
+                return [:]
+            }
+            return dict
+        }()
         return AgentBuilderSummary(
             id: UUID(uuidString: summaryId) ?? UUID(),
             prompt: prompt,
             attachments: attachments,
             createdAt: createdAt,
             cutoffDate: cutoffDate,
-            bundledMessageIds: bundledIds
+            bundledMessageIds: bundledIds,
+            cloudConnectionIds: cloudConnectionIds,
+            connectionsAppliedAt: connectionsAppliedAt
         )
     }
 }
@@ -36,13 +45,16 @@ extension AgentBuilderSummary {
     /// Encode for storage. Attachments serialize to JSON (base64 inside for
     /// any `Data` thumbnails). `bundledMessageIds` serializes as a JSON array
     /// (Sets aren't directly JSON-encodable; the conversion back is in
-    /// `toAgentBuilderSummary`).
+    /// `toAgentBuilderSummary`). `cloudConnectionIds` serialize as a JSON
+    /// object keyed by connection `rawValue`.
     public func toDBAgentBuilderSummary(conversationId: String) throws -> DBAgentBuilderSummary {
         let attachmentsData: Data = try JSONEncoder().encode(attachments)
         let attachmentsJSON: String = String(data: attachmentsData, encoding: .utf8) ?? "[]"
         let bundledIdsArray: [String] = Array(bundledMessageIds)
         let bundledIdsData: Data = try JSONEncoder().encode(bundledIdsArray)
         let bundledMessageIdsJSON: String = String(data: bundledIdsData, encoding: .utf8) ?? "[]"
+        let cloudConnectionIdsData: Data = try JSONEncoder().encode(cloudConnectionIds)
+        let cloudConnectionIdsJSON: String = String(data: cloudConnectionIdsData, encoding: .utf8) ?? "{}"
         return DBAgentBuilderSummary(
             conversationId: conversationId,
             summaryId: id.uuidString,
@@ -50,7 +62,9 @@ extension AgentBuilderSummary {
             attachmentsJSON: attachmentsJSON,
             createdAt: createdAt,
             cutoffDate: cutoffDate,
-            bundledMessageIdsJSON: bundledMessageIdsJSON
+            bundledMessageIdsJSON: bundledMessageIdsJSON,
+            cloudConnectionIdsJSON: cloudConnectionIdsJSON,
+            connectionsAppliedAt: connectionsAppliedAt
         )
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/AgentBuilderSummary.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/AgentBuilderSummary.swift
@@ -29,6 +29,24 @@ public struct AgentBuilderSummary: Sendable, Equatable, Codable, Identifiable, H
     /// any writer call returns, so the messages are filtered the moment they
     /// land in the DB — no `sentAt` race.
     public let bundledMessageIds: Set<String>
+    /// Captured `CloudConnection.id`s keyed by the iOS-side
+    /// `AgentBuilderConnection` rawValue (e.g. "googleCalendar"). Snapshotted
+    /// at the moment the user toggled the connection on (or completed the
+    /// OAuth flow). Device-only connections like `appleHealth` are not present
+    /// in this dictionary — they don't need an id, the enablement-store
+    /// write is enough. Persisted alongside the summary so the
+    /// `AgentBuilderConnectionGrantReplayer` can fire missing grants after
+    /// an app death between Make and agent-join. Empty for summaries written
+    /// without any cloud connections enabled.
+    public let cloudConnectionIds: [String: String]
+    /// Set the first time the `AgentBuilderConnectionGrantReplayer` has
+    /// fully processed this summary's connections (every connection
+    /// either fired successfully or was already applied). Once non-nil,
+    /// the replayer skips this summary so it can't re-fire grants the
+    /// user later revoked from the chat UI. `nil` for summaries that
+    /// haven't reached the replayer yet (e.g. the agent hasn't joined,
+    /// or this summary was written before the replayer existed).
+    public let connectionsAppliedAt: Date?
 
     public init(
         id: UUID = UUID(),
@@ -36,7 +54,9 @@ public struct AgentBuilderSummary: Sendable, Equatable, Codable, Identifiable, H
         attachments: [AgentBuilderSummaryAttachment],
         createdAt: Date = Date(),
         cutoffDate: Date,
-        bundledMessageIds: Set<String> = []
+        bundledMessageIds: Set<String> = [],
+        cloudConnectionIds: [String: String] = [:],
+        connectionsAppliedAt: Date? = nil
     ) {
         self.id = id
         self.prompt = prompt
@@ -44,6 +64,8 @@ public struct AgentBuilderSummary: Sendable, Equatable, Codable, Identifiable, H
         self.createdAt = createdAt
         self.cutoffDate = cutoffDate
         self.bundledMessageIds = bundledMessageIds
+        self.cloudConnectionIds = cloudConnectionIds
+        self.connectionsAppliedAt = connectionsAppliedAt
     }
 }
 

--- a/ConvosCore/Sources/ConvosCore/Storage/SharedDatabaseMigrator.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/SharedDatabaseMigrator.swift
@@ -157,6 +157,10 @@ extension SharedDatabaseMigrator {
 
         migrator.registerMigration("renameConversationHasHadVerifiedAssistantToAgent", migrate: Self.renameConversationHasHadVerifiedAssistantToAgent)
 
+        migrator.registerMigration("addAgentBuilderSummaryCloudConnectionIds", migrate: Self.addAgentBuilderSummaryCloudConnectionIds)
+
+        migrator.registerMigration("addAgentBuilderSummaryConnectionsAppliedAt", migrate: Self.addAgentBuilderSummaryConnectionsAppliedAt)
+
         return migrator
     }
 
@@ -216,6 +220,33 @@ extension SharedDatabaseMigrator {
     private static func addAgentBuilderSummaryBundledMessageIds(_ db: Database) throws {
         try db.alter(table: "agentBuilderSummary") { t in
             t.add(column: "bundledMessageIdsJSON", .text).notNull().defaults(to: "[]")
+        }
+    }
+
+    /// JSON-encoded `[String: String]` mapping AgentBuilderConnection
+    /// rawValue → captured CloudConnection.id. Drives the post-Make grant
+    /// replayer: a force-quit between Make and agent-join no longer loses
+    /// the user's selected cloud connections — the replayer reads the
+    /// summary on next launch and fires the grants once the agent appears.
+    /// Defaults to `"{}"` on older summaries.
+    private static func addAgentBuilderSummaryCloudConnectionIds(_ db: Database) throws {
+        try db.alter(table: "agentBuilderSummary") { t in
+            t.add(column: "cloudConnectionIdsJSON", .text).notNull().defaults(to: "{}")
+        }
+    }
+
+    /// Timestamp set the first time the `AgentBuilderConnectionGrantReplayer`
+    /// finishes a successful pass over a summary's connections. Once set,
+    /// the replayer skips the row so a manual revoke from the chat UI
+    /// doesn't get silently undone by the next launch's replay scan. Nullable
+    /// — `nil` for summaries written before this column existed (those are
+    /// still safe to replay because the original commit's in-memory poll
+    /// would have either landed before the upgrade or been lost to app
+    /// death; the replayer's grant-store idempotency check keeps duplicate
+    /// firings from doing damage even in the worst case).
+    private static func addAgentBuilderSummaryConnectionsAppliedAt(_ db: Database) throws {
+        try db.alter(table: "agentBuilderSummary") { t in
+            t.add(column: "connectionsAppliedAt", .datetime)
         }
     }
 

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/AgentBuilderSummaryWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/AgentBuilderSummaryWriter.swift
@@ -4,6 +4,11 @@ import GRDB
 public protocol AgentBuilderSummaryWriterProtocol: Sendable {
     func save(_ summary: AgentBuilderSummary, for conversationId: String) async throws
     func delete(for conversationId: String) async throws
+    /// Stamp the row's `connectionsAppliedAt` with the given timestamp.
+    /// Idempotent — overwrites any existing value. Used by the replayer
+    /// after a successful pass so subsequent launches don't re-fire grants
+    /// the user may have manually revoked.
+    func markConnectionsApplied(for conversationId: String, at date: Date) async throws
 }
 
 public final class AgentBuilderSummaryWriter: AgentBuilderSummaryWriterProtocol, Sendable {
@@ -23,6 +28,15 @@ public final class AgentBuilderSummaryWriter: AgentBuilderSummaryWriterProtocol,
     public func delete(for conversationId: String) async throws {
         try await databaseWriter.write { db in
             try DBAgentBuilderSummary.deleteOne(db, key: conversationId)
+        }
+    }
+
+    public func markConnectionsApplied(for conversationId: String, at date: Date) async throws {
+        try await databaseWriter.write { db in
+            try db.execute(
+                sql: "UPDATE agentBuilderSummary SET connectionsAppliedAt = ? WHERE conversationId = ?",
+                arguments: [date, conversationId]
+            )
         }
     }
 }


### PR DESCRIPTION
Before: AgentBuilderViewModel.commit kicked off an in-memory task that
polled convoVM.conversation.hasAgent for 30s, then fired the user's
selected connection grants. If the app died (force-quit, OOM, crash)
between Make and agent-join, the captured CloudConnection.id and the
enabledConnections set were gone forever - the user's grants were
silently dropped, surviving only as decorative chips on the summary
card. The 30s timeout would also silently miss real agent-join delays.

After: persist the captured cloud connection ids on the summary itself
(AgentBuilderSummary.cloudConnectionIds) and let a session-wide
AgentBuilderConnectionGrantReplayer fire the grants whenever the
matching conversation gains a verified Convos agent. The replayer
observes the summary + member tables with a ValueObservation, so it
naturally survives app launches and waits as long as the agent takes
to join.

- New AgentBuilderSummary.cloudConnectionIds: [String: String] (rawValue
  -> captured CloudConnection.id) + DB column / migration.
- New AgentBuilderSummary.connectionsAppliedAt: Date? + DB column /
  migration. Once the replayer finishes a fully successful pass it
  stamps this so subsequent launches don't re-fire grants the user
  may have manually revoked from the chat UI.
- New AgentBuilderConnectionGrantReplayer in ConvosCore. Single
  owner of the grant-firing logic; mirrors the chat-side
  ConversationConnectionsViewModel.grant path but doesn't depend on
  any view model. Idempotent per-grant against the cloud-grant store
  and the enablement store, and idempotent across launches via the
  connectionsAppliedAt stamp.
- SessionManager constructs and starts the replayer after capability
  providers bootstrap; the accessor lives in a separate extension file
  to keep the SessionManager type body under the lint cap.
- AgentBuilderViewModel.buildSummary populates cloudConnectionIds;
  the old scheduleConnectionGrants / fireConnectionGrants /
  fireCloudGrant helpers, the pendingConnectionGrantTask, and the
  30s timeout constants + Sentry/haptic timeout signal are removed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/877"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782431601&installation_id=128169237&pr_number=877&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F877&signature=4967f111907da1a0d06084d6c764ea8e67795f8a9e4dcdaac35974ff470331dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace in-memory connection-grant polling with persisted `AgentBuilderConnectionGrantReplayer`
> - Removes `scheduleConnectionGrants()` and related polling/timeout logic from `AgentBuilderViewModel`, which previously waited in-memory for an agent to join and then fired connection grants directly.
> - Adds `AgentBuilderConnectionGrantReplayer`, a session-wide service that observes the database for summaries with pending connection attachments and a verified agent member, then replays grants idempotently.
> - `AgentBuilderSummary` gains `cloudConnectionIds` and `connectionsAppliedAt` fields; two new DB migrations add the corresponding columns to `agentBuilderSummary`.
> - The replayer is started during session bootstrap in `SessionManager` and survives app restarts by tracking grant completion via `connectionsAppliedAt`.
> - Behavioral Change: connection grants are no longer fired immediately in the commit flow; they are applied asynchronously by the replayer after a verified agent appears in the conversation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b02423d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->