### PR TITLE
Render HTML attachments as 160x160 in-group tiles with zoom transition

### DIFF
--- a/Convos/Conversation Detail/AttachmentPreviewSheet.swift
+++ b/Convos/Conversation Detail/AttachmentPreviewSheet.swift
@@ -192,6 +192,7 @@ struct AttachmentPreviewSheet: View {
         if attachment.isHTMLFile {
             AttachmentHTMLContent(
                 fileURL: fileURL,
+                attachmentKey: attachment.key,
                 onBodyBackgroundColor: { color in
                     htmlBodyBackgroundColor = color
                 }
@@ -289,33 +290,26 @@ private struct SentDateFormatter {
 
 struct AttachmentHTMLContent: UIViewRepresentable {
     let fileURL: URL
+    /// Optional attachment key. When provided, `makeUIView` first asks the
+    /// `HTMLContentPrewarmer` for a live WebView that's already loaded and
+    /// painted - the matched-geometry zoom transition then lands on real
+    /// content instead of waiting on a fresh `WKWebView.loadFileURL`.
+    var attachmentKey: String?
     var onBodyBackgroundColor: ((Color?) -> Void)?
 
-    private static let bgScript: String = """
-    (function() {
-        function postBg() {
-            var bg = getComputedStyle(document.body).backgroundColor;
-            if (!bg || bg === 'rgba(0, 0, 0, 0)' || bg === 'transparent') {
-                bg = getComputedStyle(document.documentElement).backgroundColor;
-            }
-            if (window.webkit && window.webkit.messageHandlers && window.webkit.messageHandlers.convosBg) {
-                window.webkit.messageHandlers.convosBg.postMessage(bg || '');
-            }
-        }
-        postBg();
-        window.addEventListener('load', postBg);
-    })();
-    """
-
     func makeUIView(context: Context) -> WKWebView {
+        if let key = attachmentKey,
+           let prewarmed = HTMLContentPrewarmer.shared.borrowContent(for: key) {
+            context.coordinator.usingPrewarmedWebView = true
+            context.coordinator.loadedFileURL = fileURL
+            DispatchQueue.main.async {
+                self.onBodyBackgroundColor?(prewarmed.bodyBackgroundColor)
+            }
+            return prewarmed.webView
+        }
         let config = WKWebViewConfiguration()
-        config.userContentController.add(context.coordinator, name: "convosBg")
-        let userScript = WKUserScript(
-            source: Self.bgScript,
-            injectionTime: .atDocumentEnd,
-            forMainFrameOnly: true
-        )
-        config.userContentController.addUserScript(userScript)
+        config.userContentController.add(context.coordinator, name: HTMLBodyBackgroundBridge.messageHandlerName)
+        config.userContentController.addUserScript(HTMLBodyBackgroundBridge.makeUserScript())
         let webView = WKWebView(frame: .zero, configuration: config)
         webView.isOpaque = false
         webView.backgroundColor = .clear
@@ -326,6 +320,10 @@ struct AttachmentHTMLContent: UIViewRepresentable {
 
     func updateUIView(_ webView: WKWebView, context: Context) {
         context.coordinator.onBodyBackgroundColor = onBodyBackgroundColor
+        // Prewarmed WebViews already loaded the same file during their
+        // off-screen warm-up; calling `loadFileURL` here would discard
+        // the painted DOM and trigger a fresh load, defeating the prewarm.
+        if context.coordinator.usingPrewarmedWebView { return }
         guard context.coordinator.loadedFileURL != fileURL else { return }
         context.coordinator.loadedFileURL = fileURL
         let readAccessURL = fileURL.deletingLastPathComponent()
@@ -339,6 +337,11 @@ struct AttachmentHTMLContent: UIViewRepresentable {
     final class Coordinator: NSObject, WKNavigationDelegate, WKScriptMessageHandler {
         var loadedFileURL: URL?
         var onBodyBackgroundColor: ((Color?) -> Void)?
+        /// True when `makeUIView` returned a `WKWebView` borrowed from
+        /// the prewarmer. The pre-load has already happened, so
+        /// `updateUIView` skips its `loadFileURL` path to avoid kicking
+        /// off a redundant second load that would blank out the view.
+        var usingPrewarmedWebView: Bool = false
 
         init(onBodyBackgroundColor: ((Color?) -> Void)?) {
             self.onBodyBackgroundColor = onBodyBackgroundColor
@@ -364,30 +367,12 @@ struct AttachmentHTMLContent: UIViewRepresentable {
             _ userContentController: WKUserContentController,
             didReceive message: WKScriptMessage
         ) {
-            guard message.name == "convosBg",
+            guard message.name == HTMLBodyBackgroundBridge.messageHandlerName,
                   let raw = message.body as? String else { return }
-            let parsed = Self.parseCSSColor(raw)
+            let parsed = HTMLBodyBackgroundBridge.parseCSSColor(raw)
             DispatchQueue.main.async { [weak self] in
                 self?.onBodyBackgroundColor?(parsed)
             }
-        }
-
-        private static func parseCSSColor(_ raw: String) -> Color? {
-            let trimmed = raw.trimmingCharacters(in: .whitespaces).lowercased()
-            let isRGBA = trimmed.hasPrefix("rgba(")
-            let prefix = isRGBA ? "rgba(" : "rgb("
-            guard trimmed.hasPrefix(prefix), trimmed.hasSuffix(")") else { return nil }
-            let inner = trimmed.dropFirst(prefix.count).dropLast()
-            let parts = inner
-                .split(separator: ",")
-                .map { $0.trimmingCharacters(in: .whitespaces) }
-            guard parts.count >= 3,
-                  let r = Double(parts[0]),
-                  let g = Double(parts[1]),
-                  let b = Double(parts[2]) else { return nil }
-            let alpha: Double = parts.count >= 4 ? (Double(parts[3]) ?? 1.0) : 1.0
-            if alpha < 0.05 { return nil }
-            return Color(.sRGB, red: r / 255.0, green: g / 255.0, blue: b / 255.0, opacity: alpha)
         }
     }
 }

--- a/Convos/Conversation Detail/AttachmentPreviewSheet.swift
+++ b/Convos/Conversation Detail/AttachmentPreviewSheet.swift
@@ -300,6 +300,17 @@ struct AttachmentHTMLContent: UIViewRepresentable {
     func makeUIView(context: Context) -> WKWebView {
         if let key = attachmentKey,
            let prewarmed = HTMLContentPrewarmer.shared.borrowContent(for: key) {
+            // Prewarmed WebView still has the `PrewarmCoordinator`
+            // wired as its navigation delegate and as the listener on
+            // the `convosBg` script handler. Re-point both at the
+            // sheet's coordinator so link taps now route through
+            // `InAppBrowser.open(...)` and any subsequent bg-color
+            // posts land on `onBodyBackgroundColor` instead of the
+            // stale prewarm coordinator.
+            let controller = prewarmed.webView.configuration.userContentController
+            controller.removeScriptMessageHandler(forName: HTMLBodyBackgroundBridge.messageHandlerName)
+            controller.add(context.coordinator, name: HTMLBodyBackgroundBridge.messageHandlerName)
+            prewarmed.webView.navigationDelegate = context.coordinator
             context.coordinator.usingPrewarmedWebView = true
             context.coordinator.loadedFileURL = fileURL
             DispatchQueue.main.async {

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Cells/MessagesListItemTypeCell.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Cells/MessagesListItemTypeCell.swift
@@ -89,6 +89,7 @@ class MessagesListItemTypeCell: UICollectionViewCell {
                         onDeleteMessage: config.onDeleteMessage,
                         onRetryTranscript: config.onRetryTranscript,
                         allVoiceMemoTranscripts: config.allVoiceMemoTranscripts,
+                        htmlAttachmentTransitionNamespace: config.htmlAttachmentTransitionNamespace,
                         creditsDepleted: config.creditsDepleted
                     )
 

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Data Source/CellFactory.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Data Source/CellFactory.swift
@@ -47,6 +47,10 @@ struct CellConfig {
     /// glassEffectTransition(.matchedGeometry)`. Nil when the messages list
     /// isn't part of a builder commit (regular chats).
     let agentBuilderTransitionNamespace: Namespace.ID?
+    /// Shared SwiftUI namespace used to zoom-transition an
+    /// `HTMLAttachmentBubble` into the post-tap `AttachmentPreviewSheet`.
+    /// `MessagesView` owns the namespace and the matching `.sheet(item:)`.
+    let htmlAttachmentTransitionNamespace: Namespace.ID?
     /// Maps an inbox to the user's full `Contact` when the inbox is a
     /// known contact. Cells use it for both the display-name override
     /// (via `?.displayName`) and avatar substitution (so a system-

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Data Source/DefaultMessagesLayoutDelegate.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Data Source/DefaultMessagesLayoutDelegate.swift
@@ -102,10 +102,11 @@ final class DefaultMessagesLayoutDelegate: MessagesLayoutDelegate {
     }
 
     private func estimatedAttachmentHeight(for attachment: HydratedAttachment, width: CGFloat) -> CGFloat {
-        // HTML attachments render via HTMLAttachmentBubble at a fixed 500pt cellHeight
-        // regardless of mediaType, so check before falling into the .file branch.
+        // HTML attachments render via HTMLAttachmentBubble as a 160×160 tile
+        // inside the message group, regardless of mediaType, so check before
+        // falling into the .file branch.
         if attachment.isHTMLFile {
-            return 500.0
+            return 160.0
         }
         switch attachment.mediaType {
         case .audio:

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Data Source/MessagesCollectionDataSource.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Data Source/MessagesCollectionDataSource.swift
@@ -36,5 +36,6 @@ protocol MessagesCollectionDataSource: UICollectionViewDataSource, MessagesLayou
     var isAgentJoinPending: Bool { get set }
     var headerMode: MessagesHeaderMode { get set }
     var agentBuilderTransitionNamespace: Namespace.ID? { get set }
+    var htmlAttachmentTransitionNamespace: Namespace.ID? { get set }
     var hidesInviteCard: Bool { get set }
 }

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Data Source/MessagesCollectionViewDataSource.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Data Source/MessagesCollectionViewDataSource.swift
@@ -43,6 +43,7 @@ final class MessagesCollectionViewDataSource: NSObject {
     var isAgentJoinPending: Bool = false
     var headerMode: MessagesHeaderMode = .standard
     var agentBuilderTransitionNamespace: Namespace.ID?
+    var htmlAttachmentTransitionNamespace: Namespace.ID?
     var hidesInviteCard: Bool = false
 
     var allVoiceMemoTranscripts: [String: VoiceMemoTranscriptListItem] {
@@ -162,6 +163,7 @@ extension MessagesCollectionViewDataSource: UICollectionViewDataSource {
             headerMode: headerMode,
             hidesInviteCard: hidesInviteCard,
             agentBuilderTransitionNamespace: agentBuilderTransitionNamespace,
+            htmlAttachmentTransitionNamespace: htmlAttachmentTransitionNamespace,
             memberContactOverride: { [weak self] inboxId in
                 self?.memberContactOverride?(inboxId)
             }

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/MessagesViewController.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/MessagesViewController.swift
@@ -42,6 +42,7 @@ final class MessagesViewController: UIViewController {
         /// prepends an `.agentBuilderSummary` cell.
         let agentBuilderSummary: AgentBuilderSummary?
         let agentBuilderTransitionNamespace: Namespace.ID?
+        let htmlAttachmentTransitionNamespace: Namespace.ID?
 
         init(
             conversation: Conversation,
@@ -50,7 +51,8 @@ final class MessagesViewController: UIViewController {
             hasLoadedAllMessages: Bool,
             headerMode: MessagesHeaderMode = .standard,
             agentBuilderSummary: AgentBuilderSummary? = nil,
-            agentBuilderTransitionNamespace: Namespace.ID? = nil
+            agentBuilderTransitionNamespace: Namespace.ID? = nil,
+            htmlAttachmentTransitionNamespace: Namespace.ID? = nil
         ) {
             self.conversation = conversation
             self.messages = messages
@@ -59,6 +61,7 @@ final class MessagesViewController: UIViewController {
             self.headerMode = headerMode
             self.agentBuilderSummary = agentBuilderSummary
             self.agentBuilderTransitionNamespace = agentBuilderTransitionNamespace
+            self.htmlAttachmentTransitionNamespace = htmlAttachmentTransitionNamespace
         }
     }
 
@@ -135,6 +138,7 @@ final class MessagesViewController: UIViewController {
             headerMode = state.headerMode
             agentBuilderSummary = state.agentBuilderSummary
             agentBuilderTransitionNamespace = state.agentBuilderTransitionNamespace
+            htmlAttachmentTransitionNamespace = state.htmlAttachmentTransitionNamespace
             processUpdates(
                 for: state.conversation,
                 with: state.messages,
@@ -291,6 +295,15 @@ final class MessagesViewController: UIViewController {
     var agentBuilderTransitionNamespace: Namespace.ID? {
         didSet { dataSource.agentBuilderTransitionNamespace = agentBuilderTransitionNamespace }
     }
+    var htmlAttachmentTransitionNamespace: Namespace.ID? {
+        didSet { dataSource.htmlAttachmentTransitionNamespace = htmlAttachmentTransitionNamespace }
+    }
+    /// Called with the loaded HTML file URL when the user taps an HTML
+    /// bubble. SwiftUI subscribes (via `MessagesViewRepresentable`) so it
+    /// can drive the post-tap `AttachmentPreviewSheet` presentation with
+    /// a matched-geometry zoom transition. When `nil`, falls back to the
+    /// in-class UIKit `presentAttachmentPreview` path.
+    var onPresentHTMLAttachmentPreview: ((HydratedAttachment, URL, ConversationMember, Date) -> Void)?
 
     var hasAgent: Bool = false {
         didSet { dataSource.hasAgent = hasAgent }
@@ -1042,12 +1055,21 @@ extension MessagesViewController {
             do {
                 let fileURL = try await loadFileForPreview(attachment)
                 await MainActor.run {
-                    presentAttachmentPreview(
-                        attachment: attachment,
-                        fileURL: fileURL,
-                        sender: message.sender,
-                        sentAt: message.date
-                    )
+                    if attachment.isHTMLFile, let onPresentHTMLAttachmentPreview {
+                        onPresentHTMLAttachmentPreview(
+                            attachment,
+                            fileURL,
+                            message.sender,
+                            message.date
+                        )
+                    } else {
+                        presentAttachmentPreview(
+                            attachment: attachment,
+                            fileURL: fileURL,
+                            sender: message.sender,
+                            sentAt: message.date
+                        )
+                    }
                 }
             } catch {
                 Log.error("Failed to open file attachment: \(error)")

--- a/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/HTMLAttachmentBubble.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/HTMLAttachmentBubble.swift
@@ -3,6 +3,11 @@ import ConvosLogging
 import SwiftUI
 import UIKit
 
+/// Inline thumbnail used inside a message group for an agent-sent HTML
+/// page. Renders as a 160x160 square with a 20pt corner radius and
+/// leaves the sender avatar to the surrounding `MessagesGroupView` (no
+/// header / no view affordance - the whole tile is tappable to open
+/// the file via the standard message gesture).
 struct HTMLAttachmentBubble: View {
     let attachment: HydratedAttachment
     let profile: Profile
@@ -11,148 +16,84 @@ struct HTMLAttachmentBubble: View {
     var onTapAvatar: (() -> Void)?
     var onTapReactions: (() -> Void)?
     var cornerRadiusOverride: CGFloat?
+    /// Namespace owned by the SwiftUI host (`MessagesView`) and threaded
+    /// down through `MessagesViewController`'s cell config so the bubble
+    /// can pair with the post-tap `AttachmentPreviewSheet`'s
+    /// `.navigationTransition(.zoom(sourceID:in:))` for a matched-geometry
+    /// transition. `nil` in contexts that don't present the sheet (e.g.
+    /// reply parent thumbnails, context-menu snapshots).
+    var transitionNamespace: Namespace.ID?
 
-    @Environment(\.horizontalSizeClass) private var horizontalSizeClass: UserInterfaceSizeClass?
     @Environment(\.colorScheme) private var colorScheme: ColorScheme
     @State private var renderedImage: UIImage?
     @State private var hasLoadFailed: Bool = false
-    @State private var bottomEdgeColor: Color?
 
     var body: some View {
-        VStack(spacing: 0) {
-            header
-            preview
-        }
-        .frame(maxWidth: .infinity)
-        .frame(height: Constant.cellHeight)
-        .background(Color.colorBackgroundSurfaceless)
-        .overlay(alignment: .bottom) {
-            bottomFade
-        }
-        .clipShape(RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
-        .overlay(alignment: .bottomLeading) {
-            if !reactions.isEmpty {
-                let tap: () -> Void = {
-                    onTapReactions?()
+        bubble
+            .accessibilityIdentifier("html-attachment-bubble")
+            .accessibilityLabel("HTML page from \(profile.displayName)")
+            .task(id: AttachmentColorSchemeKey(key: attachment.key, scheme: colorScheme)) {
+                await loadThumbnail()
+            }
+    }
+
+    @ViewBuilder
+    private var bubble: some View {
+        let base = preview
+            .frame(width: Constant.size, height: Constant.size)
+            .background(Color.colorFillMinimal)
+            .clipShape(RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
+            .overlay(alignment: .bottomLeading) {
+                if !reactions.isEmpty {
+                    let tap: () -> Void = {
+                        onTapReactions?()
+                    }
+                    MediaContainerReax(reactions: reactions, onTap: tap)
                 }
-                MediaContainerReax(reactions: reactions, onTap: tap)
             }
+        if let transitionNamespace {
+            base.matchedTransitionSource(id: attachment.key, in: transitionNamespace)
+        } else {
+            base
         }
-        .accessibilityIdentifier("html-attachment-bubble")
-        .accessibilityLabel("HTML page from \(profile.displayName)")
-        .task(id: AttachmentColorSchemeKey(key: attachment.key, scheme: colorScheme)) {
-            await loadThumbnail()
-        }
-    }
-
-    @ViewBuilder
-    private var header: some View {
-        HStack(spacing: DesignConstants.Spacing.step2x) {
-            senderTapTarget
-            Spacer()
-            viewAffordance
-        }
-        .padding(.horizontal, DesignConstants.Spacing.step4x)
-        .frame(height: Constant.headerHeight)
-        .frame(maxWidth: .infinity)
-        .overlay(alignment: .bottom) {
-            Color.colorBorderSubtle
-                .frame(height: Constant.borderHeight)
-                .padding(.horizontal, DesignConstants.Spacing.step4x)
-        }
-    }
-
-    @ViewBuilder
-    private var senderTapTarget: some View {
-        let tap: () -> Void = {
-            onTapAvatar?()
-        }
-        Button(action: tap) {
-            HStack(spacing: DesignConstants.Spacing.step2x) {
-                ProfileAvatarView(
-                    profile: profile,
-                    profileImage: nil,
-                    useSystemPlaceholder: false,
-                    agentVerification: agentVerification
-                )
-                .frame(width: DesignConstants.ImageSizes.smallAvatar, height: DesignConstants.ImageSizes.smallAvatar)
-                Text(profile.displayName)
-                    .font(.footnote)
-                    .foregroundStyle(.colorTextPrimary)
-                    .lineLimit(1)
-                    .accessibilityIdentifier("html-attachment-bubble-sender")
-            }
-        }
-        .buttonStyle(.plain)
-        .background(GesturePassthroughBackground())
-        .accessibilityLabel("View \(profile.displayName)'s profile")
-    }
-
-    @ViewBuilder
-    private var viewAffordance: some View {
-        HStack(spacing: 4) {
-            Text("View")
-                .font(.footnote)
-            Image(systemName: "chevron.right")
-                .font(.footnote)
-        }
-        .foregroundStyle(.secondary)
-        .accessibilityHidden(true)
     }
 
     @ViewBuilder
     private var preview: some View {
-        GeometryReader { proxy in
-            if let renderedImage {
-                Image(uiImage: renderedImage)
-                    .resizable()
-                    .aspectRatio(contentMode: .fill)
-                    .frame(width: proxy.size.width, height: proxy.size.height, alignment: .top)
-                    .clipped()
-            } else {
-                ZStack {
-                    Rectangle().fill(Color.colorFillMinimal)
-                    if hasLoadFailed {
-                        Image(systemName: "exclamationmark.triangle")
-                            .font(.title2)
-                            .foregroundStyle(.secondary)
-                    } else {
-                        ProgressView()
-                    }
+        if let renderedImage {
+            Image(uiImage: renderedImage)
+                .resizable()
+                .aspectRatio(contentMode: .fill)
+                .frame(width: Constant.size, height: Constant.size, alignment: .top)
+                .clipped()
+        } else {
+            ZStack {
+                Color.clear
+                if hasLoadFailed {
+                    Image(systemName: "exclamationmark.triangle")
+                        .font(.title3)
+                        .foregroundStyle(.secondary)
+                } else {
+                    ProgressView()
                 }
-                .frame(width: proxy.size.width, height: proxy.size.height)
             }
         }
     }
 
-    @ViewBuilder
-    private var bottomFade: some View {
-        let endColor: Color = bottomEdgeColor ?? .clear
-        LinearGradient(
-            colors: [endColor.opacity(0), endColor],
-            startPoint: .top,
-            endPoint: .bottom
-        )
-        .frame(height: Constant.fadeHeight)
-        .allowsHitTesting(false)
-    }
-
     private var cornerRadius: CGFloat {
-        if let cornerRadiusOverride { return cornerRadiusOverride }
-        return horizontalSizeClass == .regular ? DesignConstants.CornerRadius.medium : 0
+        cornerRadiusOverride ?? Constant.cornerRadius
     }
 
     private func loadThumbnail() async {
         let appearance = colorScheme.uiUserInterfaceStyle
         renderedImage = nil
-        bottomEdgeColor = nil
         hasLoadFailed = false
         if let cached = HTMLThumbnailRenderer.shared.cachedThumbnail(
             for: attachment.key,
             appearance: appearance
         ) {
             renderedImage = cached
-            bottomEdgeColor = cached.convos_bottomCenterColor()
+            await prewarmLiveContentIfPossible()
             return
         }
         do {
@@ -163,19 +104,30 @@ struct HTMLAttachmentBubble: View {
                 appearance: appearance
             )
             renderedImage = image
-            bottomEdgeColor = image?.convos_bottomCenterColor()
             hasLoadFailed = image == nil
+            HTMLContentPrewarmer.shared.prewarm(attachmentKey: attachment.key, fileURL: fileURL)
         } catch {
             Log.error("Failed to load HTML attachment thumbnail: \(error)")
             hasLoadFailed = true
         }
     }
 
+    /// Cached-thumbnail path doesn't go through `FileAttachmentLoader`, so
+    /// resolve the file URL here so the prewarmer can load the same file
+    /// into a live WebView. Cheap when the file is already on disk; the
+    /// loader caches its result.
+    private func prewarmLiveContentIfPossible() async {
+        do {
+            let fileURL = try await FileAttachmentLoader.loadFile(for: attachment)
+            HTMLContentPrewarmer.shared.prewarm(attachmentKey: attachment.key, fileURL: fileURL)
+        } catch {
+            Log.error("Failed to resolve fileURL for HTML prewarm: \(error.localizedDescription)")
+        }
+    }
+
     private enum Constant {
-        static let headerHeight: CGFloat = 56.0
-        static let cellHeight: CGFloat = 500.0
-        static let fadeHeight: CGFloat = 68.0
-        static let borderHeight: CGFloat = 1.0
+        static let size: CGFloat = 160.0
+        static let cornerRadius: CGFloat = 20.0
     }
 }
 
@@ -194,42 +146,5 @@ extension ColorScheme {
         case .light: return .light
         @unknown default: return .light
         }
-    }
-}
-
-private extension UIImage {
-    /// Returns the color of a single pixel sampled near the bottom-center of the image.
-    /// Used to derive a fade-out gradient end color that matches the rendered HTML body bg.
-    func convos_bottomCenterColor() -> Color? {
-        guard let cgImage,
-              cgImage.width > 0,
-              cgImage.height > 0 else { return nil }
-        let x = cgImage.width / 2
-        let imageRowFromTop = max(cgImage.height - 4, 0)
-        // CGContext.draw flips the CGImage along y, so to land `imageRowFromTop` at
-        // context y=0 we offset by `height - 1 - row`. Without this flip we'd sample
-        // 4 rows from the top instead of the bottom.
-        let yOffset = cgImage.height - 1 - imageRowFromTop
-        let colorSpace = CGColorSpaceCreateDeviceRGB()
-        var pixel: [UInt8] = [0, 0, 0, 0]
-        let bitmapInfo = CGImageAlphaInfo.premultipliedLast.rawValue | CGBitmapInfo.byteOrder32Big.rawValue
-        guard let context = CGContext(
-            data: &pixel,
-            width: 1,
-            height: 1,
-            bitsPerComponent: 8,
-            bytesPerRow: 4,
-            space: colorSpace,
-            bitmapInfo: bitmapInfo
-        ) else { return nil }
-        context.draw(cgImage, in: CGRect(x: -x, y: -yOffset, width: cgImage.width, height: cgImage.height))
-        let alpha = CGFloat(pixel[3]) / 255.0
-        if alpha < 0.05 { return nil }
-        // Pixel buffer is premultipliedLast; SwiftUI's Color expects straight RGB,
-        // so divide by alpha to recover the source channel values.
-        let red = CGFloat(pixel[0]) / 255.0 / alpha
-        let green = CGFloat(pixel[1]) / 255.0 / alpha
-        let blue = CGFloat(pixel[2]) / 255.0 / alpha
-        return Color(.sRGB, red: red, green: green, blue: blue, opacity: alpha)
     }
 }

--- a/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/HTMLAttachmentBubble.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/HTMLAttachmentBubble.swift
@@ -32,6 +32,7 @@ struct HTMLAttachmentBubble: View {
         bubble
             .accessibilityIdentifier("html-attachment-bubble")
             .accessibilityLabel("HTML page from \(profile.displayName)")
+            .onAppear(perform: seedFromMemoryCache)
             .task(id: AttachmentColorSchemeKey(key: attachment.key, scheme: colorScheme)) {
                 await loadThumbnail()
             }
@@ -84,18 +85,38 @@ struct HTMLAttachmentBubble: View {
         cornerRadiusOverride ?? Constant.cornerRadius
     }
 
+    /// Synchronous memory-cache read so an already-rendered tile shows its
+    /// thumbnail on the first frame after the cell is reconfigured, rather
+    /// than flashing the spinner until `loadThumbnail`'s async path runs.
+    /// The hosting cell rebuilds this view (and resets `@State`) on every
+    /// reuse, so without this seed every scroll back into view flickers.
+    /// Mirrors the no-flicker pattern in `View.cachedImage(for:into:)`.
+    private func seedFromMemoryCache() {
+        guard renderedImage == nil else { return }
+        if let cached = HTMLThumbnailRenderer.shared.cachedThumbnail(
+            for: attachment.key,
+            appearance: colorScheme.uiUserInterfaceStyle
+        ) {
+            renderedImage = cached
+            hasLoadFailed = false
+        }
+    }
+
     private func loadThumbnail() async {
         let appearance = colorScheme.uiUserInterfaceStyle
-        renderedImage = nil
-        hasLoadFailed = false
         if let cached = HTMLThumbnailRenderer.shared.cachedThumbnail(
             for: attachment.key,
             appearance: appearance
         ) {
             renderedImage = cached
+            hasLoadFailed = false
             await prewarmLiveContentIfPossible()
             return
         }
+        // No in-memory thumbnail. Keep showing whatever we already have - a
+        // thumbnail seeded on appear, or the other-appearance image during a
+        // color-scheme swap - while we resolve the file and read disk or
+        // re-render, so a shown tile never blanks back to a spinner.
         do {
             let fileURL = try await FileAttachmentLoader.loadFile(for: attachment)
             let image = await HTMLThumbnailRenderer.shared.thumbnail(
@@ -103,12 +124,21 @@ struct HTMLAttachmentBubble: View {
                 fileURL: fileURL,
                 appearance: appearance
             )
-            renderedImage = image
-            hasLoadFailed = image == nil
+            if let image {
+                renderedImage = image
+                hasLoadFailed = false
+            } else if renderedImage == nil {
+                // Only surface the warning when there's nothing to show; a
+                // transient render miss shouldn't replace a good thumbnail
+                // (the bytes are usually still on disk for the next pass).
+                hasLoadFailed = true
+            }
             HTMLContentPrewarmer.shared.prewarm(attachmentKey: attachment.key, fileURL: fileURL)
         } catch {
             Log.error("Failed to load HTML attachment thumbnail: \(error)")
-            hasLoadFailed = true
+            if renderedImage == nil {
+                hasLoadFailed = true
+            }
         }
     }
 

--- a/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/HTMLBodyBackgroundBridge.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/HTMLBodyBackgroundBridge.swift
@@ -1,0 +1,71 @@
+import SwiftUI
+import WebKit
+
+/// Shared JS + CSS-color plumbing used by both `AttachmentHTMLContent`
+/// (live sheet) and `HTMLContentPrewarmer` (off-screen warm-up). The
+/// renderer for an agent's HTML page injects this script to report its
+/// computed body background back to native, so the surrounding sheet
+/// can tint its chrome to match the page tone. Keeping one source of
+/// truth here means a future tweak to the JS or the parser only has
+/// to land in one place.
+enum HTMLBodyBackgroundBridge {
+    /// Name of the message handler the JS script posts to. Both sides
+    /// register a `WKScriptMessageHandler` under this name on the
+    /// `WKUserContentController`.
+    static let messageHandlerName: String = "convosBg"
+
+    /// JS injected at `.atDocumentEnd` that reports the computed body
+    /// background back to native via `window.webkit.messageHandlers`.
+    /// Reports once at end-of-document and again on `load` so layouts
+    /// that paint a background only after stylesheets resolve still
+    /// land their final colour.
+    static let userScriptSource: String = """
+    (function() {
+        function postBg() {
+            var bg = getComputedStyle(document.body).backgroundColor;
+            if (!bg || bg === 'rgba(0, 0, 0, 0)' || bg === 'transparent') {
+                bg = getComputedStyle(document.documentElement).backgroundColor;
+            }
+            if (window.webkit && window.webkit.messageHandlers && window.webkit.messageHandlers.convosBg) {
+                window.webkit.messageHandlers.convosBg.postMessage(bg || '');
+            }
+        }
+        postBg();
+        window.addEventListener('load', postBg);
+    })();
+    """
+
+    /// Build a `WKUserScript` that injects `userScriptSource` at document end.
+    /// `WKUserScript.init` is main-actor isolated in iOS 26, so the helper
+    /// is too; the only callers (the live sheet's `makeUIView` and the
+    /// prewarmer) already run on the main actor.
+    @MainActor
+    static func makeUserScript() -> WKUserScript {
+        WKUserScript(
+            source: userScriptSource,
+            injectionTime: .atDocumentEnd,
+            forMainFrameOnly: true
+        )
+    }
+
+    /// Parses the `rgb(...)` / `rgba(...)` payload posted by the JS
+    /// script. Returns nil for fully-transparent or unrecognised
+    /// formats so the caller can fall back to its default tint.
+    static func parseCSSColor(_ raw: String) -> Color? {
+        let trimmed = raw.trimmingCharacters(in: .whitespaces).lowercased()
+        let isRGBA = trimmed.hasPrefix("rgba(")
+        let prefix = isRGBA ? "rgba(" : "rgb("
+        guard trimmed.hasPrefix(prefix), trimmed.hasSuffix(")") else { return nil }
+        let inner = trimmed.dropFirst(prefix.count).dropLast()
+        let parts = inner
+            .split(separator: ",")
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+        guard parts.count >= 3,
+              let red = Double(parts[0]),
+              let green = Double(parts[1]),
+              let blue = Double(parts[2]) else { return nil }
+        let alpha: Double = parts.count >= 4 ? (Double(parts[3]) ?? 1.0) : 1.0
+        if alpha < 0.05 { return nil }
+        return Color(.sRGB, red: red / 255.0, green: green / 255.0, blue: blue / 255.0, opacity: alpha)
+    }
+}

--- a/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/HTMLContentPrewarmer.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/HTMLContentPrewarmer.swift
@@ -43,11 +43,11 @@ final class HTMLContentPrewarmer {
     /// borrowed WebView would still flash blank for the first frame
     /// after being attached to the sheet's hierarchy.
     private static let paintDelay: TimeInterval = 0.3
-    /// Off-screen render size: matches a typical iPhone canvas so the
-    /// loaded layout already approximates the sheet's frame. Resizing
-    /// after handoff is cheap (WKWebView reflows), but starting at the
-    /// right ballpark avoids a visible layout pop.
-    private static let prewarmSize: CGSize = CGSize(width: 430, height: 932)
+    /// Fallback render size used only when the active window scene's
+    /// screen bounds aren't available (no foreground-active scene yet).
+    /// Picked to match a typical iPhone 17 canvas so the rare fallback
+    /// path still produces a useful layout.
+    private static let fallbackPrewarmSize: CGSize = CGSize(width: 430, height: 932)
 
     /// Insertion-ordered LRU: most recently used appended to the end.
     private var cache: [(key: String, content: PrewarmedContent)] = []
@@ -78,16 +78,34 @@ final class HTMLContentPrewarmer {
             .first { $0.activationState != .unattached }
         guard let scene else { return nil }
         let window = UIWindow(windowScene: scene)
+        let size: CGSize = currentPrewarmSize(scene: scene)
         window.frame = CGRect(
             x: -100_000.0,
             y: -100_000.0,
-            width: prewarmSize.width,
-            height: prewarmSize.height
+            width: size.width,
+            height: size.height
         )
         window.windowLevel = .normal - 1
         window.isUserInteractionEnabled = false
         window.isHidden = false
         return window
+    }
+
+    /// Resolve the prewarm size from the current scene's screen bounds.
+    /// Matches the eventual sheet's content area on the user's device
+    /// (iPhone / iPad, portrait / landscape, Stage Manager window)
+    /// so the off-screen layout doesn't have to reflow on handoff.
+    /// Falls back to a fixed iPhone canvas only when there's no scene
+    /// to ask (early-launch edge case the offscreen window already
+    /// guards against).
+    private static func currentPrewarmSize(scene: UIWindowScene? = nil) -> CGSize {
+        let resolvedScene: UIWindowScene? = scene ?? UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .first { $0.activationState != .unattached }
+        guard let resolvedScene else { return fallbackPrewarmSize }
+        let bounds: CGRect = resolvedScene.screen.bounds
+        guard bounds.width > 0, bounds.height > 0 else { return fallbackPrewarmSize }
+        return bounds.size
     }
 
     /// Enqueues a background load for `(attachmentKey, fileURL)`. The
@@ -142,8 +160,9 @@ final class HTMLContentPrewarmer {
         let config = WKWebViewConfiguration()
         config.userContentController.add(coordinator, name: HTMLBodyBackgroundBridge.messageHandlerName)
         config.userContentController.addUserScript(HTMLBodyBackgroundBridge.makeUserScript())
+        let size: CGSize = Self.currentPrewarmSize()
         let webView = WKWebView(
-            frame: CGRect(origin: .zero, size: Self.prewarmSize),
+            frame: CGRect(origin: .zero, size: size),
             configuration: config
         )
         webView.isOpaque = false

--- a/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/HTMLContentPrewarmer.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/HTMLContentPrewarmer.swift
@@ -1,0 +1,230 @@
+import ConvosCore
+import ConvosLogging
+import SwiftUI
+import UIKit
+import WebKit
+
+/// Process-wide LRU cache of fully-loaded `WKWebView`s for HTML
+/// attachments the user has seen recently. Sits between the thumbnail
+/// renderer (which produces the 160 x 160 cell tile) and the
+/// `AttachmentPreviewSheet` (which would otherwise spin up a fresh
+/// WebView on tap and wait for `didFinish` before content paints). A
+/// live borrowed WebView eliminates the visible "thumbnail -> blank web
+/// view -> content fade-in" beat on the matched-geometry zoom transition
+/// for the most recent few HTML files.
+///
+/// Memory ceiling is `cacheLimit` WebViews - typically 5 - with strict
+/// LRU eviction. When a cell scrolls into view we kick off a prewarm;
+/// when an older cell rolls off the front of the cache, its WebView is
+/// torn down. The cache never holds more than `cacheLimit` regardless
+/// of how many HTML attachments are in the conversation.
+///
+/// Prewarms are serialised: at most one off-screen `WKWebView` is loading
+/// at any time. Spinning up several `WKWebView` instances in parallel
+/// during a fast scroll has noticeable CPU + memory cost; queuing keeps
+/// us at one concurrent renderer without sacrificing the cache hit rate
+/// (the queue still respects the LRU policy on the way in).
+@MainActor
+final class HTMLContentPrewarmer {
+    static let shared: HTMLContentPrewarmer = HTMLContentPrewarmer()
+
+    /// Borrowed handoff payload. The caller owns lifetime of the
+    /// returned WebView once they take it from the cache - the cache
+    /// itself drops its reference.
+    struct PrewarmedContent {
+        let webView: WKWebView
+        let bodyBackgroundColor: Color?
+    }
+
+    private static let cacheLimit: Int = 5
+    private static let loadTimeout: TimeInterval = 15.0
+    /// Mirrors `HTMLThumbnailRenderer.paintDelay` - the WebView paints a
+    /// frame after `didFinish` rather than during. Without this the
+    /// borrowed WebView would still flash blank for the first frame
+    /// after being attached to the sheet's hierarchy.
+    private static let paintDelay: TimeInterval = 0.3
+    /// Off-screen render size: matches a typical iPhone canvas so the
+    /// loaded layout already approximates the sheet's frame. Resizing
+    /// after handoff is cheap (WKWebView reflows), but starting at the
+    /// right ballpark avoids a visible layout pop.
+    private static let prewarmSize: CGSize = CGSize(width: 430, height: 932)
+
+    /// Insertion-ordered LRU: most recently used appended to the end.
+    private var cache: [(key: String, content: PrewarmedContent)] = []
+    /// FIFO of pending `(attachmentKey, fileURL)` requests. We pop one
+    /// at a time; appended duplicates are coalesced before they enter
+    /// the queue.
+    private var pendingQueue: [(key: String, fileURL: URL)] = []
+    /// Set of keys for entries currently queued or being processed.
+    /// Used to coalesce repeat calls so a single attachment never
+    /// occupies more than one slot end-to-end.
+    private var queuedKeys: Set<String> = []
+    private var isProcessing: Bool = false
+    /// Reused off-screen host window - same pattern as
+    /// `HTMLThumbnailRenderer`. Allocating a fresh window per prewarm
+    /// leaks a `UIWindowScene.keyboardLayoutGuide` reservation, so the
+    /// renderer reuses one. Mirroring that here.
+    private var offscreenWindow: UIWindow? {
+        if let existing = _offscreenWindow { return existing }
+        let created = Self.makeOffscreenWindow()
+        _offscreenWindow = created
+        return created
+    }
+    private var _offscreenWindow: UIWindow?
+
+    private static func makeOffscreenWindow() -> UIWindow? {
+        let scene = UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .first { $0.activationState != .unattached }
+        guard let scene else { return nil }
+        let window = UIWindow(windowScene: scene)
+        window.frame = CGRect(
+            x: -100_000.0,
+            y: -100_000.0,
+            width: prewarmSize.width,
+            height: prewarmSize.height
+        )
+        window.windowLevel = .normal - 1
+        window.isUserInteractionEnabled = false
+        window.isHidden = false
+        return window
+    }
+
+    /// Enqueues a background load for `(attachmentKey, fileURL)`. The
+    /// queue processes one entry at a time; repeat calls for an already-
+    /// cached or already-queued attachment are no-ops.
+    func prewarm(attachmentKey: String, fileURL: URL) {
+        if cache.contains(where: { $0.key == attachmentKey }) {
+            promote(attachmentKey: attachmentKey)
+            return
+        }
+        if queuedKeys.contains(attachmentKey) { return }
+        queuedKeys.insert(attachmentKey)
+        pendingQueue.append((key: attachmentKey, fileURL: fileURL))
+        processQueueIfIdle()
+    }
+
+    /// Removes and returns the cached `PrewarmedContent` if one exists.
+    /// The caller takes full ownership of the WebView; nothing in the
+    /// cache references it after this call.
+    func borrowContent(for attachmentKey: String) -> PrewarmedContent? {
+        guard let index = cache.firstIndex(where: { $0.key == attachmentKey }) else { return nil }
+        let entry = cache.remove(at: index)
+        entry.content.webView.removeFromSuperview()
+        return entry.content
+    }
+
+    private func promote(attachmentKey: String) {
+        guard let index = cache.firstIndex(where: { $0.key == attachmentKey }) else { return }
+        let entry = cache.remove(at: index)
+        cache.append(entry)
+    }
+
+    private func processQueueIfIdle() {
+        guard !isProcessing else { return }
+        guard !pendingQueue.isEmpty else { return }
+        let next = pendingQueue.removeFirst()
+        isProcessing = true
+        Task { @MainActor [weak self] in
+            await self?.performPrewarm(attachmentKey: next.key, fileURL: next.fileURL)
+            self?.queuedKeys.remove(next.key)
+            self?.isProcessing = false
+            self?.processQueueIfIdle()
+        }
+    }
+
+    private func performPrewarm(attachmentKey: String, fileURL: URL) async {
+        guard let window = offscreenWindow else {
+            Log.error("HTMLContentPrewarmer: no offscreen window available; skipping prewarm of \(attachmentKey)")
+            return
+        }
+        let coordinator = PrewarmCoordinator()
+        let config = WKWebViewConfiguration()
+        config.userContentController.add(coordinator, name: HTMLBodyBackgroundBridge.messageHandlerName)
+        config.userContentController.addUserScript(HTMLBodyBackgroundBridge.makeUserScript())
+        let webView = WKWebView(
+            frame: CGRect(origin: .zero, size: Self.prewarmSize),
+            configuration: config
+        )
+        webView.isOpaque = false
+        webView.backgroundColor = .clear
+        webView.scrollView.backgroundColor = .clear
+        webView.navigationDelegate = coordinator
+        window.addSubview(webView)
+        let readAccessURL = fileURL.deletingLastPathComponent()
+        webView.loadFileURL(fileURL, allowingReadAccessTo: readAccessURL)
+        let success: Bool = await coordinator.waitForLoad(timeout: Self.loadTimeout, paintDelay: Self.paintDelay)
+        guard success else {
+            webView.stopLoading()
+            webView.removeFromSuperview()
+            return
+        }
+        let entry: PrewarmedContent = PrewarmedContent(
+            webView: webView,
+            bodyBackgroundColor: coordinator.bodyBackgroundColor
+        )
+        insert(attachmentKey: attachmentKey, content: entry)
+    }
+
+    private func insert(attachmentKey: String, content: PrewarmedContent) {
+        cache.removeAll { $0.key == attachmentKey }
+        cache.append((key: attachmentKey, content: content))
+        while cache.count > Self.cacheLimit {
+            let dropped = cache.removeFirst()
+            dropped.content.webView.stopLoading()
+            dropped.content.webView.removeFromSuperview()
+        }
+    }
+}
+
+private final class PrewarmCoordinator: NSObject, WKNavigationDelegate, WKScriptMessageHandler {
+    private(set) var bodyBackgroundColor: Color?
+    private var didFinishContinuation: CheckedContinuation<Bool, Never>?
+    private var finished: Bool = false
+
+    func waitForLoad(timeout: TimeInterval, paintDelay: TimeInterval) async -> Bool {
+        let success: Bool = await withCheckedContinuation { continuation in
+            self.didFinishContinuation = continuation
+            DispatchQueue.main.asyncAfter(deadline: .now() + timeout) { [weak self] in
+                self?.complete(success: false)
+            }
+        }
+        guard success else { return false }
+        try? await Task.sleep(for: .seconds(paintDelay))
+        return true
+    }
+
+    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation?) {
+        complete(success: true)
+    }
+
+    func webView(_ webView: WKWebView, didFail navigation: WKNavigation?, withError error: Error) {
+        Log.error("HTMLContentPrewarmer load failed: \(error.localizedDescription)")
+        complete(success: false)
+    }
+
+    func webView(
+        _ webView: WKWebView,
+        didFailProvisionalNavigation navigation: WKNavigation?,
+        withError error: Error
+    ) {
+        Log.error("HTMLContentPrewarmer provisional load failed: \(error.localizedDescription)")
+        complete(success: false)
+    }
+
+    func userContentController(
+        _ userContentController: WKUserContentController,
+        didReceive message: WKScriptMessage
+    ) {
+        guard message.name == HTMLBodyBackgroundBridge.messageHandlerName,
+              let raw = message.body as? String else { return }
+        bodyBackgroundColor = HTMLBodyBackgroundBridge.parseCSSColor(raw)
+    }
+
+    private func complete(success: Bool) {
+        guard !finished else { return }
+        finished = true
+        didFinishContinuation?.resume(returning: success)
+        didFinishContinuation = nil
+    }
+}

--- a/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/HTMLThumbnailRenderer.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/HTMLThumbnailRenderer.swift
@@ -28,12 +28,19 @@ final class HTMLThumbnailRenderer {
     })();
     """
 
-    /// Pinned at .atDocumentStart so the artifact's CSS lays out for a
-    /// 160pt-wide tile regardless of whatever <meta viewport> the page
-    /// shipped with. Inserting before the existing tag wins because the
-    /// last meta viewport in the head is what UIKit honors.
+    /// Runs at .atDocumentEnd so the parser has populated <head> with
+    /// the artifact's own <meta viewport>. We strip every existing
+    /// viewport tag and append ours - last-in-head wins, and removing
+    /// first guarantees we are last regardless of how many the artifact
+    /// shipped. Injecting at .atDocumentStart would not see the
+    /// artifact's tag (parser has not run yet), so the artifact's
+    /// static viewport would end up after ours and win.
     private static let viewportScript: String = """
     (function() {
+        var existing = document.querySelectorAll('meta[name="viewport"]');
+        for (var i = 0; i < existing.length; i++) {
+            existing[i].remove();
+        }
         var m = document.createElement('meta');
         m.name = 'viewport';
         m.content = 'width=160, initial-scale=1, viewport-fit=cover';
@@ -162,7 +169,7 @@ final class HTMLThumbnailRenderer {
         config.userContentController.addUserScript(surfaceUserScript)
         let viewportUserScript = WKUserScript(
             source: Self.viewportScript,
-            injectionTime: .atDocumentStart,
+            injectionTime: .atDocumentEnd,
             forMainFrameOnly: true
         )
         config.userContentController.addUserScript(viewportUserScript)

--- a/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/HTMLThumbnailRenderer.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/HTMLThumbnailRenderer.swift
@@ -18,15 +18,6 @@ final class HTMLThumbnailRenderer {
     // thumbnails (720x1200, no viewport / surface hints) get re-
     // rendered on demand.
     private static let cacheKeyPrefix: String = "html-thumb-v5-"
-    private static let injectionScript: String = """
-    (function() {
-        var css = 'html, body { margin-top: 0 !important; padding-top: 0 !important; } ' +
-                  '.note, .table, .note-hero, main, article { padding-top: 0 !important; margin-top: 0 !important; }';
-        var style = document.createElement('style');
-        style.textContent = css;
-        (document.head || document.documentElement).appendChild(style);
-    })();
-    """
 
     /// Runs at .atDocumentEnd so the parser has populated <head> with
     /// the artifact's own <meta viewport>. We strip every existing
@@ -173,12 +164,6 @@ final class HTMLThumbnailRenderer {
             forMainFrameOnly: true
         )
         config.userContentController.addUserScript(viewportUserScript)
-        let paddingUserScript = WKUserScript(
-            source: Self.injectionScript,
-            injectionTime: .atDocumentEnd,
-            forMainFrameOnly: true
-        )
-        config.userContentController.addUserScript(paddingUserScript)
 
         let webView = WKWebView(
             frame: CGRect(origin: .zero, size: Self.renderSize),

--- a/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/HTMLThumbnailRenderer.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/HTMLThumbnailRenderer.swift
@@ -7,17 +7,23 @@ import WebKit
 final class HTMLThumbnailRenderer {
     static let shared: HTMLThumbnailRenderer = HTMLThumbnailRenderer()
 
-    // 480x480 = the 160pt in-group tile rendered at @3x. @2x devices
-    // downscale the resulting image cleanly. Larger than necessary
-    // wastes work for every thumbnail; smaller would blur on @3x.
-    private static let renderSize: CGSize = CGSize(width: 480, height: 480)
+    // The on-screen HTML tile is 160pt. We lay the WebView out at exactly
+    // that size so the artifact's responsive layout matches the live tile
+    // (paired with `width=160` in viewportScript). Output crispness comes
+    // from snapshotOutputWidth, not from an oversized frame.
+    private static let tileSize: CGSize = CGSize(width: 160, height: 160)
+    // WKWebView.takeSnapshot re-rasterizes the render tree to this width
+    // (points), producing a 480px @3x image of the 160pt layout. This is a
+    // true re-raster - vector text / CSS stay crisp - not a bitmap upscale.
+    // @2x devices downscale 480 cleanly; smaller would blur on @3x.
+    private static let snapshotOutputWidth: CGFloat = 480.0
     fileprivate static let paintDelay: TimeInterval = 0.5
     private static let loadTimeout: TimeInterval = 15.0
-    // v5: render size dropped to 480x480 + viewport pinned to width=160
-    // + small-surface attrs stamped before any artifact JS runs. v4
-    // thumbnails (720x1200, no viewport / surface hints) get re-
-    // rendered on demand.
-    private static let cacheKeyPrefix: String = "html-thumb-v5-"
+    // v6: WebView frame matches the 160pt tile and takeSnapshot upsamples
+    // to 480px via snapshotWidth. v5 laid out at 160 inside a 480 frame, so
+    // content only filled the top-left 160x160 of the capture; those
+    // thumbnails get re-rendered on demand.
+    private static let cacheKeyPrefix: String = "html-thumb-v6-"
 
     /// Runs at .atDocumentEnd so the parser has populated <head> with
     /// the artifact's own <meta viewport>. We strip every existing
@@ -85,8 +91,8 @@ final class HTMLThumbnailRenderer {
         window.frame = CGRect(
             x: -100_000.0,
             y: -100_000.0,
-            width: renderSize.width,
-            height: renderSize.height
+            width: tileSize.width,
+            height: tileSize.height
         )
         window.windowLevel = .normal - 1
         window.isUserInteractionEnabled = false
@@ -166,7 +172,7 @@ final class HTMLThumbnailRenderer {
         config.userContentController.addUserScript(viewportUserScript)
 
         let webView = WKWebView(
-            frame: CGRect(origin: .zero, size: Self.renderSize),
+            frame: CGRect(origin: .zero, size: Self.tileSize),
             configuration: config
         )
         webView.scrollView.isScrollEnabled = false
@@ -181,7 +187,10 @@ final class HTMLThumbnailRenderer {
         window.addSubview(webView)
 
         return await withCheckedContinuation { (continuation: CheckedContinuation<UIImage?, Never>) in
-            let coordinator = LoadCoordinator(renderSize: Self.renderSize) { [weak webView] result in
+            let coordinator = LoadCoordinator(
+                captureRect: CGRect(origin: .zero, size: Self.tileSize),
+                snapshotWidth: Self.snapshotOutputWidth
+            ) { [weak webView] result in
                 webView?.removeFromSuperview()
                 continuation.resume(returning: result)
             }
@@ -206,23 +215,29 @@ final class HTMLThumbnailRenderer {
 
 private final class LoadCoordinator: NSObject, WKNavigationDelegate {
     private let completion: (UIImage?) -> Void
-    private let renderSize: CGSize
+    private let captureRect: CGRect
+    private let snapshotWidth: CGFloat
     private var hasResumed: Bool = false
 
-    init(renderSize: CGSize, completion: @escaping (UIImage?) -> Void) {
-        self.renderSize = renderSize
+    init(captureRect: CGRect, snapshotWidth: CGFloat, completion: @escaping (UIImage?) -> Void) {
+        self.captureRect = captureRect
+        self.snapshotWidth = snapshotWidth
         self.completion = completion
     }
 
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation?) {
-        let renderSize = renderSize
+        let captureRect = captureRect
+        let snapshotWidth = snapshotWidth
         DispatchQueue.main.asyncAfter(deadline: .now() + HTMLThumbnailRenderer.paintDelay) { [weak self, weak webView] in
             guard let self, !self.hasResumed, let webView else {
                 self?.resume(image: nil)
                 return
             }
             let snapshotConfig = WKSnapshotConfiguration()
-            snapshotConfig.rect = CGRect(origin: .zero, size: renderSize)
+            snapshotConfig.rect = captureRect
+            // Re-rasterize the 160pt render tree to a 480px image - crisp,
+            // not a bitmap upscale - so the tile fills the full capture.
+            snapshotConfig.snapshotWidth = NSNumber(value: Double(snapshotWidth))
             snapshotConfig.afterScreenUpdates = true
             webView.takeSnapshot(with: snapshotConfig) { image, error in
                 if let error {

--- a/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/HTMLThumbnailRenderer.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/HTMLThumbnailRenderer.swift
@@ -7,12 +7,17 @@ import WebKit
 final class HTMLThumbnailRenderer {
     static let shared: HTMLThumbnailRenderer = HTMLThumbnailRenderer()
 
-    private static let renderSize: CGSize = CGSize(width: 720, height: 1200)
+    // 480x480 = the 160pt in-group tile rendered at @3x. @2x devices
+    // downscale the resulting image cleanly. Larger than necessary
+    // wastes work for every thumbnail; smaller would blur on @3x.
+    private static let renderSize: CGSize = CGSize(width: 480, height: 480)
     fileprivate static let paintDelay: TimeInterval = 0.5
     private static let loadTimeout: TimeInterval = 15.0
-    // v4: direct WKWebView.takeSnapshot via a shared off-screen window.
-    // v3 thumbnails (PDF -> PDFKit raster) get re-rendered when seen.
-    private static let cacheKeyPrefix: String = "html-thumb-v4-"
+    // v5: render size dropped to 480x480 + viewport pinned to width=160
+    // + small-surface attrs stamped before any artifact JS runs. v4
+    // thumbnails (720x1200, no viewport / surface hints) get re-
+    // rendered on demand.
+    private static let cacheKeyPrefix: String = "html-thumb-v5-"
     private static let injectionScript: String = """
     (function() {
         var css = 'html, body { margin-top: 0 !important; padding-top: 0 !important; } ' +
@@ -20,6 +25,30 @@ final class HTMLThumbnailRenderer {
         var style = document.createElement('style');
         style.textContent = css;
         (document.head || document.documentElement).appendChild(style);
+    })();
+    """
+
+    /// Pinned at .atDocumentStart so the artifact's CSS lays out for a
+    /// 160pt-wide tile regardless of whatever <meta viewport> the page
+    /// shipped with. Inserting before the existing tag wins because the
+    /// last meta viewport in the head is what UIKit honors.
+    private static let viewportScript: String = """
+    (function() {
+        var m = document.createElement('meta');
+        m.name = 'viewport';
+        m.content = 'width=160, initial-scale=1, viewport-fit=cover';
+        (document.head || document.documentElement).appendChild(m);
+    })();
+    """
+
+    /// Pinned at .atDocumentStart so the runtime's surface-detection JS
+    /// reads these attributes on first run rather than falling back to
+    /// its `innerHeight >= 900` heuristic - which would resolve to
+    /// "large" at our 480pt height and re-strip the attrs.
+    private static let surfaceScript: String = """
+    (function() {
+        document.documentElement.setAttribute('data-convos-thumbnail', 'true');
+        document.documentElement.setAttribute('data-convos-surface', 'small');
     })();
     """
 
@@ -125,12 +154,24 @@ final class HTMLThumbnailRenderer {
         }
 
         let config = WKWebViewConfiguration()
-        let userScript = WKUserScript(
+        let surfaceUserScript = WKUserScript(
+            source: Self.surfaceScript,
+            injectionTime: .atDocumentStart,
+            forMainFrameOnly: true
+        )
+        config.userContentController.addUserScript(surfaceUserScript)
+        let viewportUserScript = WKUserScript(
+            source: Self.viewportScript,
+            injectionTime: .atDocumentStart,
+            forMainFrameOnly: true
+        )
+        config.userContentController.addUserScript(viewportUserScript)
+        let paddingUserScript = WKUserScript(
             source: Self.injectionScript,
             injectionTime: .atDocumentEnd,
             forMainFrameOnly: true
         )
-        config.userContentController.addUserScript(userScript)
+        config.userContentController.addUserScript(paddingUserScript)
 
         let webView = WKWebView(
             frame: CGRect(origin: .zero, size: Self.renderSize),

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
@@ -16,6 +16,11 @@ struct MessagesGroupItemView: View {
     let onPhotoHidden: (String) -> Void
     let onPhotoDimensionsLoaded: (String, Int, Int) -> Void
     var onOpenFile: ((HydratedAttachment, AnyMessage) -> Void)?
+    /// Namespace owned by `MessagesView` and threaded down via the cell
+    /// config; pairs the HTML bubble with the matched-geometry zoom on
+    /// the post-tap `AttachmentPreviewSheet`. nil outside the main
+    /// messages list path (reply parents, etc.).
+    var htmlAttachmentTransitionNamespace: Namespace.ID?
     var onTapReactions: ((AnyMessage) -> Void)?
     var onReaction: ((String, String) -> Void)?
     let onToggleReaction: (String, String) -> Void
@@ -276,7 +281,8 @@ struct MessagesGroupItemView: View {
                 reactions: message.reactions,
                 agentVerification: message.sender.agentVerification,
                 onTapAvatar: avatarTap,
-                onTapReactions: reactionsTap
+                onTapReactions: reactionsTap,
+                transitionNamespace: htmlAttachmentTransitionNamespace
             )
             .messageGesture(
                 message: message,

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupView.swift
@@ -28,6 +28,11 @@ struct MessagesGroupView: View {
     var onDeleteMessage: ((AnyMessage) -> Void)?
     var onRetryTranscript: ((VoiceMemoTranscriptListItem) -> Void)?
     var allVoiceMemoTranscripts: [String: VoiceMemoTranscriptListItem] = [:]
+    /// Threaded through to `HTMLAttachmentBubble`'s
+    /// `.matchedTransitionSource(...)` so the bubble pairs with the
+    /// `AttachmentPreviewSheet` zoom transition. nil outside the main
+    /// messages list path.
+    var htmlAttachmentTransitionNamespace: Namespace.ID?
     /// Mirrors `ConversationViewModel.creditsDepleted`. Drives the inline
     /// `bolt.fill` glyph next to an agent sender's display name when
     /// the global credit balance is depleted.
@@ -342,6 +347,7 @@ struct MessagesGroupView: View {
                     onPhotoHidden: onPhotoHidden,
                     onPhotoDimensionsLoaded: onPhotoDimensionsLoaded,
                     onOpenFile: onOpenFile,
+                    htmlAttachmentTransitionNamespace: htmlAttachmentTransitionNamespace,
                     onTapReactions: onTapReactions,
                     onReaction: onReaction,
                     onToggleReaction: onToggleReaction,

--- a/Convos/Conversation Detail/Messages/MessagesView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesView.swift
@@ -101,6 +101,13 @@ struct MessagesView<BottomBarContent: View>: View {
     @State private var isPhotoPickerPresented: Bool = false
     @State private var scrollToBottom: (() -> Void)?
     @State private var notifyMessageInputFocused: (() -> Void)?
+    /// Drives the SwiftUI sheet presentation of `AttachmentPreviewSheet`
+    /// for HTML attachments. Non-HTML previews still go through the
+    /// UIKit path in `MessagesViewController.presentAttachmentPreview`.
+    @State private var htmlAttachmentPreview: HTMLAttachmentPreviewItem?
+    /// Shared namespace between the `HTMLAttachmentBubble` source and
+    /// the sheet's `.navigationTransition(.zoom(...))` destination.
+    @Namespace private var htmlAttachmentTransitionNamespace: Namespace.ID
 
     var body: some View {
         MessagesViewRepresentable(
@@ -141,6 +148,15 @@ struct MessagesView<BottomBarContent: View>: View {
             headerMode: headerMode,
             agentBuilderSummary: agentBuilderSummary,
             agentBuilderTransitionNamespace: agentBuilderTransitionNamespace,
+            htmlAttachmentTransitionNamespace: htmlAttachmentTransitionNamespace,
+            onPresentHTMLAttachmentPreview: { attachment, fileURL, sender, sentAt in
+                htmlAttachmentPreview = HTMLAttachmentPreviewItem(
+                    attachment: attachment,
+                    fileURL: fileURL,
+                    sender: sender,
+                    sentAt: sentAt
+                )
+            },
             bottomBarHeight: bottomBarHeight + extraBottomInset,
             onBottomOverscrollChanged: onBottomOverscrollChanged,
             onBottomOverscrollReleased: onBottomOverscrollReleased,
@@ -234,5 +250,28 @@ struct MessagesView<BottomBarContent: View>: View {
                 onPhotoHidden: onPhotoHidden
             )
         }
+        .sheet(item: $htmlAttachmentPreview) { item in
+            AttachmentPreviewSheet(
+                attachment: item.attachment,
+                fileURL: item.fileURL,
+                sender: item.sender,
+                sentAt: item.sentAt,
+                profileSheetContent: profileSheetForMember
+            )
+            .navigationTransition(.zoom(sourceID: item.attachment.key, in: htmlAttachmentTransitionNamespace))
+        }
     }
+}
+
+/// Identifiable payload carried into the SwiftUI `.sheet(item:)` that
+/// presents an HTML attachment. Wraps the fields the UIKit
+/// `MessagesViewController.openFileAttachment` already loads - the
+/// representable bridges the call into SwiftUI state when an HTML
+/// attachment is tapped, so the matched-geometry zoom transition can fire.
+struct HTMLAttachmentPreviewItem: Identifiable, Equatable {
+    let id: UUID = UUID()
+    let attachment: HydratedAttachment
+    let fileURL: URL
+    let sender: ConversationMember
+    let sentAt: Date
 }

--- a/Convos/Conversation Detail/Messages/MessagesViewRepresentable.swift
+++ b/Convos/Conversation Detail/Messages/MessagesViewRepresentable.swift
@@ -40,6 +40,8 @@ struct MessagesViewRepresentable: UIViewControllerRepresentable {
     var headerMode: MessagesHeaderMode = .standard
     var agentBuilderSummary: AgentBuilderSummary?
     var agentBuilderTransitionNamespace: Namespace.ID?
+    var htmlAttachmentTransitionNamespace: Namespace.ID?
+    var onPresentHTMLAttachmentPreview: ((HydratedAttachment, URL, ConversationMember, Date) -> Void)?
     let bottomBarHeight: CGFloat
     /// Hosts that intentionally have no composer (the thinking detail sheet)
     /// pass `false` so the controller doesn't wait for a non-existent bottom
@@ -139,6 +141,7 @@ let menuPresented = contextMenuState.isPresented
         if wasMenuPresented, !menuPresented {
             messagesViewController.applyDeferredBottomInset()
         }
+        messagesViewController.onPresentHTMLAttachmentPreview = onPresentHTMLAttachmentPreview
         messagesViewController.state = .init(
             conversation: conversation,
             messages: messages,
@@ -146,7 +149,8 @@ let menuPresented = contextMenuState.isPresented
             hasLoadedAllMessages: hasLoadedAllMessages,
             headerMode: headerMode,
             agentBuilderSummary: agentBuilderSummary,
-            agentBuilderTransitionNamespace: agentBuilderTransitionNamespace
+            agentBuilderTransitionNamespace: agentBuilderTransitionNamespace,
+            htmlAttachmentTransitionNamespace: htmlAttachmentTransitionNamespace
         )
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/HydratedAttachment.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/HydratedAttachment.swift
@@ -73,7 +73,7 @@ public struct HydratedAttachment: Hashable, Codable, Sendable {
     }
 
     public var isFullBleed: Bool {
-        mediaType.isFullBleed || isHTMLFile
+        mediaType.isFullBleed
     }
 
     public var mediaType: MediaType {


### PR DESCRIPTION
Replaces the 500pt full-bleed HTML attachment cell with a 160x160
thumbnail rendered inside the regular `MessagesGroupView` flow, so an
HTML page reads as a peer to photo, voice memo and file bubbles
rather than commandeering the whole row. Tapping the tile presents
the existing `AttachmentPreviewSheet` with a SwiftUI matched-geometry
zoom transition from the tile's frame, and the live `WKWebView` is
pre-loaded off-screen so the sheet opens on real content instead of
a blank fade.

- `HTMLAttachmentBubble` slimmed to a 160x160 tile (20pt corner
  radius, reactions chip overlay, no header / sender row / view
  affordance - the surrounding group owns those). Applies
  `.matchedTransitionSource(id: attachment.key, in: ns)` so the
  bubble pairs with the sheet's `.navigationTransition(.zoom(...))`
  on the same namespace.
- `HydratedAttachment.isFullBleed` no longer treats HTML files as
  full-bleed, which is what makes the bubble flow through the normal
  group path (avatar gutter, sender label, reactions row).
- New `htmlAttachmentTransitionNamespace` + `onPresentHTMLAttachmentPreview`
  threaded `MessagesView -> MessagesViewRepresentable -> MessagesViewController
  -> MessagesCollectionDataSource -> CellFactory.CellConfig -> MessagesListItemTypeCell
  -> MessagesGroupView -> MessagesGroupItemView -> HTMLAttachmentBubble`.
  The view controller routes the existing `openFileAttachment` flow
  through the SwiftUI host for HTML files only (other attachment
  types stay on the UIKit `presentAttachmentPreview` path), and
  `MessagesView` owns the namespace + the `.sheet(item:)` that drives
  the zoom transition.
- `HTMLContentPrewarmer` is a session-wide MainActor singleton that
  holds an LRU of up to 5 fully-loaded off-screen `WKWebView`s keyed
  by attachment key. `HTMLAttachmentBubble.loadThumbnail` enqueues a
  prewarm after the thumbnail renders. Prewarms are serialised
  through a single-flight FIFO queue so fast scrolling can't stack
  parallel off-screen loads. `AttachmentHTMLContent.makeUIView`
  borrows the prewarmed WebView when one is available (and reuses
  the captured `body { background }` colour), skipping the fresh
  `loadFileURL` that would otherwise blank the view.
- `HTMLBodyBackgroundBridge` extracts the JS bg-color reporter and
  the rgb()/rgba() parser into one shared source used by both the
  live sheet and the prewarmer.
- Layout delegate's HTML cell estimate goes from 500pt to 160pt.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/878"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782448779&installation_id=128169237&pr_number=878&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F878&signature=222a83e44d26861da62e463a0b1cfee8006ebce27231aff3322305a8aba427be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Render HTML attachments as 160×160 in-group tiles with zoom transition on tap
> - HTML attachment bubbles are redesigned as 160×160 square tiles (no header or full-bleed treatment); thumbnails are rendered at 480pt for crisp @3x display.
> - Tapping a tile presents `AttachmentPreviewSheet` via a SwiftUI sheet with a matched-geometry zoom transition, driven by a shared `@Namespace` threaded from `MessagesView` through the UIKit data source stack.
> - `HTMLContentPrewarmer` off-screen loads a `WKWebView` for cached attachments so the preview sheet can borrow a fully-painted view, reducing load latency.
> - `HTMLBodyBackgroundBridge` centralizes JS injection and CSS color parsing used by both the prewarmer and the preview sheet.
> - Behavioral Change: HTML attachments are no longer full-bleed and their estimated cell height drops from 500pt to 160pt, which will affect existing layout calculations.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5149429.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->