### PR TITLE
Lock conversation pager + fade page dots while message context menu is presented

### DIFF
--- a/Convos/Conversation Detail/ConversationPager.swift
+++ b/Convos/Conversation Detail/ConversationPager.swift
@@ -11,7 +11,23 @@ enum ConversationPagerPage: Int, CaseIterable, Identifiable {
 
 struct ConversationPager<MessagesPage: View, StuffPage: View>: View {
     @Binding var selectedPage: ConversationPagerPage
+    /// Whether the dots are mounted at all. Drives the `safeAreaInset`
+    /// itself, so flipping this resizes the pager content — only set it
+    /// based on keyboard presence, which already animates via the
+    /// system. Don't piggyback context-menu-driven hiding on this flag
+    /// or the bottom bar's own fade-out animation has to compete with a
+    /// layout reflow inside MessagesView.
     let showsPageDots: Bool
+    /// Hides the dots in-place when true (opacity + scale only, layout
+    /// space preserved). Used while the long-press context menu is
+    /// presented so the dots fade out without resizing anything around
+    /// them.
+    var dotsHidden: Bool = false
+    /// When true, horizontal paging between `messages` and `stuff` is
+    /// blocked. Used while the message long-press context menu is
+    /// presented — without it the user can drag past the menu into the
+    /// stuff page mid-interaction.
+    var scrollingDisabled: Bool = false
     @ViewBuilder let messagesPage: () -> MessagesPage
     @ViewBuilder let stuffPage: () -> StuffPage
 
@@ -36,6 +52,7 @@ struct ConversationPager<MessagesPage: View, StuffPage: View>: View {
                     if let newValue { selectedPage = newValue }
                 }
             ))
+            .scrollDisabled(scrollingDisabled)
             .introspect(.scrollView, on: .iOS(.v26)) { (scrollView: UIScrollView) in
                 scrollView.bounces = false
             }
@@ -43,6 +60,10 @@ struct ConversationPager<MessagesPage: View, StuffPage: View>: View {
         .safeAreaInset(edge: .bottom, spacing: 0) {
             if showsPageDots {
                 ConversationPagerDots(selectedPage: $selectedPage)
+                    .opacity(dotsHidden ? 0 : 1)
+                    .scaleEffect(dotsHidden ? 0.85 : 1)
+                    .allowsHitTesting(!dotsHidden)
+                    .animation(.spring(response: 0.3, dampingFraction: 0.9), value: dotsHidden)
             }
         }
     }

--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -36,6 +36,10 @@ struct ConversationView<MessagesBottomBar: View>: View {
     @State private var didReleasePastThreshold: Bool = false
     @State private var pagerSelectedPage: ConversationPagerPage = .messages
     @State private var isKeyboardVisible: Bool = false
+    /// Lifted out of `MessagesView` so this view can gate the pager
+    /// against horizontal swipes while the long-press context menu is
+    /// presented.
+    @State private var contextMenuState: MessageContextMenuState = .init()
     @State private var showingDebugInjector: Bool = false
     @State private var presentingAddFromContactsPicker: Bool = false
     @Environment(\.dismiss) private var dismiss: DismissAction
@@ -58,6 +62,7 @@ struct ConversationView<MessagesBottomBar: View>: View {
     private var messagesView: some View {
         @Bindable var onboardingCoordinator = viewModel.onboardingCoordinator
         return MessagesView(
+            contextMenuState: contextMenuState,
             conversation: viewModel.conversation,
             messages: viewModel.messagesWithThinkingIndicators,
             invite: viewModel.invite,
@@ -335,9 +340,12 @@ struct ConversationView<MessagesBottomBar: View>: View {
     }
 
     var body: some View {
+        let contextMenuPresented: Bool = contextMenuState.isPresented
         ConversationPager(
             selectedPage: $pagerSelectedPage,
             showsPageDots: !isKeyboardVisible,
+            dotsHidden: contextMenuPresented,
+            scrollingDisabled: contextMenuPresented,
             messagesPage: { messagesView },
             stuffPage: { stuffPage }
         )

--- a/Convos/Conversation Detail/Messages/MessagesView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesView.swift
@@ -8,6 +8,11 @@ enum MessagesViewTopBarTrailingItem {
 }
 
 struct MessagesView<BottomBarContent: View>: View {
+    /// Owned by the parent (`ConversationView`) so it can react to the
+    /// long-press context menu being presented — currently used to lock
+    /// the conversation/stuff pager so a swipe mid-press doesn't drag the
+    /// user out of the conversation into the stuff page.
+    @Bindable var contextMenuState: MessageContextMenuState
     let conversation: Conversation
     let messages: [MessagesListItemType]
     let invite: Invite
@@ -93,7 +98,6 @@ struct MessagesView<BottomBarContent: View>: View {
     @ViewBuilder let bottomBarContent: () -> BottomBarContent
 
     @State private var bottomBarHeight: CGFloat = 0.0
-    @State private var contextMenuState: MessageContextMenuState = .init()
     @State private var isPhotoPickerPresented: Bool = false
     @State private var scrollToBottom: (() -> Void)?
     @State private var notifyMessageInputFocused: (() -> Void)?


### PR DESCRIPTION
## Summary

Two coupled fixes when the long-press context menu is up on a message:

- **Disable horizontal paging** so a swipe mid-press doesn't drag the user out of the conversation into the Stuff page. New `scrollingDisabled` parameter on `ConversationPager` applies `.scrollDisabled` to the inner `ScrollView`.
- **Fade the chat/stuff page dots in place** (opacity + scale, ~300ms spring) so the indicator visually defers to the context menu. New `dotsHidden` parameter keeps the `safeAreaInset` height reserved while the dots are faded — without that, the dots disappearing collapses the inset and the messages content reflows, fighting the bottom bar's own fade-out animation.

Both are driven by `MessageContextMenuState.isPresented`. The state itself is lifted from `MessagesView`'s local `@State` up to `ConversationView` so the pager can observe it; `MessagesView` now takes `contextMenuState` as a parameter (same observable instance, owned one level higher).

## Test plan

- [x] Long-press a message on the messages page → page dots fade out smoothly, swipe-to-Stuff is blocked, bottom bar fades exactly as before (no layout shift).
- [x] Dismiss the context menu → dots fade back in, swiping resumes.
- [x] Keyboard show/hide unaffected (dots still remove from layout entirely on keyboard show, same as before).
- [x] Verified on iPhone 17 + iPhone 17 Pro simulators.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/881"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782498559&installation_id=128169237&pr_number=881&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F881&signature=cb976103db8dd70a5c2f428b7b63e02cd88376586a384d3becc9277f28843ef8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Lock conversation pager and fade page dots while a message context menu is presented
> - When a long-press context menu is shown on a message, horizontal paging in `ConversationPager` is disabled and the bottom page dots fade out in place with a spring animation.
> - `ConversationView` now owns `contextMenuState` and passes it down to `MessagesView`, deriving `contextMenuPresented` to drive `dotsHidden` and `scrollingDisabled` on the pager.
> - `ConversationPager` gains two new props: `scrollingDisabled` (blocks horizontal scroll) and `dotsHidden` (hides dots via opacity/scale while preserving layout space and disabling hit testing).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 632cba4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->