### PR TITLE
Voice-memo entry: no stray keyboard, no layout jump

### DIFF
--- a/Convos/Agent Builder/AgentBuilderView.swift
+++ b/Convos/Agent Builder/AgentBuilderView.swift
@@ -141,43 +141,20 @@ struct AgentBuilderView: View {
 
     /// On first appear, if the user opened the builder via the
     /// `AgentBuilderBar`'s waveform button, resolve mic permission and
-    /// then start the recording. Two timing rules:
-    ///
-    /// 1. `AVAudioApplication.requestRecordPermission` must resolve
-    ///    before we call `record()`; without it, AVFoundation succeeds
-    ///    the initial call but then fires
-    ///    `audioRecorderDidFinishRecording(successfully: false)` and the
-    ///    recording UI flashes on and off.
-    /// 2. `NewConversationViewModel` seats a placeholder `ConversationViewModel`
-    ///    synchronously in init and swaps it for the real one once
-    ///    `prepareNewConversation()` returns. Starting recording on the
-    ///    placeholder's `voiceMemoRecorder` works, but the swap then
-    ///    discards that recorder and the UI sees the new VM's idle one,
-    ///    making it look like recording stopped instantly. Wait for the
-    ///    swap (real conversation id, no `draft-` prefix) before kicking
-    ///    off the recording.
+    /// then start the recording. The recorder lives directly on
+    /// `AgentBuilderViewModel` (not proxied through the inner conversation
+    /// VM), so it's stable across the placeholder-to-real inner-VM swap
+    /// and the only timing constraint is the permission prompt: a
+    /// `record()` call before
+    /// `AVAudioApplication.requestRecordPermission` resolves fires
+    /// `audioRecorderDidFinishRecording(successfully: false)` and the
+    /// recording UI flashes.
     private func startVoiceMemoIfNeeded() {
         guard viewModel.entryMode == .voiceMemo else { return }
         Task { @MainActor in
             let granted = await VoiceMemoRecorder.ensureRecordPermission()
             guard granted else { return }
-            await waitForRealConversationViewModel()
             viewModel.startVoiceMemoRecording(restoreComposerFocusAfter: true)
-        }
-    }
-
-    /// Polls every 50ms for up to 3s until the inner conversation VM
-    /// has a non-draft conversation id (i.e. `configureWithMessagingService`
-    /// has run and the real VM has replaced the placeholder). Bails
-    /// silently after the deadline so a slow `prepareNewConversation`
-    /// doesn't pin the recording task open forever.
-    private func waitForRealConversationViewModel() async {
-        for _ in 0..<60 {
-            if let convoVM = viewModel.newConversationViewModel.conversationViewModel,
-               !convoVM.conversation.id.hasPrefix("draft-") {
-                return
-            }
-            try? await Task.sleep(for: .milliseconds(50))
         }
     }
 

--- a/Convos/Agent Builder/AgentBuilderView.swift
+++ b/Convos/Agent Builder/AgentBuilderView.swift
@@ -276,6 +276,11 @@ struct AgentBuilderView: View {
                 }
                 .toolbarTitleDisplayMode(.inline)
                 .onAppear {
+                    // Voice-memo entry skips the composer focus so the
+                    // keyboard doesn't pop up alongside the mic-permission
+                    // prompt; the body's main `.onAppear` kicks off the
+                    // recording itself.
+                    guard viewModel.entryMode != .voiceMemo else { return }
                     coordinator.moveFocus(to: .agentBuilder)
                 }
         }

--- a/Convos/Agent Builder/AgentBuilderView.swift
+++ b/Convos/Agent Builder/AgentBuilderView.swift
@@ -1,4 +1,5 @@
 import ConvosCore
+import ConvosCoreiOS
 import SwiftUI
 
 /// Where the [[AgentBuilderView]] is being rendered. Drives whether it
@@ -86,6 +87,7 @@ struct AgentBuilderView: View {
             // or X cancel) so ordinary post-Make agent chatter anchors
             // inline like a normal agent convo.
             viewModel.newConversationViewModel.isInAgentBuilderFlow = true
+            startVoiceMemoIfNeeded()
         }
         .onDisappear {
             viewModel.newConversationViewModel.isInAgentBuilderFlow = false
@@ -116,12 +118,66 @@ struct AgentBuilderView: View {
                 indicatorPlaceholderOverride: indicatorPlaceholder,
                 indicatorSubtitleOverride: indicatorSubtitle,
                 allowsIndicatorEditing: viewModel.hasCommitted,
-                defaultFocusOverride: viewModel.hasCommitted ? nil : .agentBuilder
+                defaultFocusOverride: initialFocusOverride
             ) { focusState, coordinator in
                 content(focusState: focusState, coordinator: coordinator)
             }
         case .inline:
             inlineBody
+        }
+    }
+
+    /// Initial focus the sheet path requests from `ConversationPresenter`.
+    /// `nil` for post-commit (no input focus needed) and for voice-memo
+    /// entry (keep the keyboard down while we kick off the recording -
+    /// `stopVoiceMemoRecording`'s `restoreComposerFocusAfter: true` path
+    /// brings the keyboard back up when the user finishes the take).
+    /// `.agentBuilder` for the default composer entry.
+    private var initialFocusOverride: MessagesViewInputFocus? {
+        if viewModel.hasCommitted { return nil }
+        if viewModel.entryMode == .voiceMemo { return nil }
+        return .agentBuilder
+    }
+
+    /// On first appear, if the user opened the builder via the
+    /// `AgentBuilderBar`'s waveform button, resolve mic permission and
+    /// then start the recording. Two timing rules:
+    ///
+    /// 1. `AVAudioApplication.requestRecordPermission` must resolve
+    ///    before we call `record()`; without it, AVFoundation succeeds
+    ///    the initial call but then fires
+    ///    `audioRecorderDidFinishRecording(successfully: false)` and the
+    ///    recording UI flashes on and off.
+    /// 2. `NewConversationViewModel` seats a placeholder `ConversationViewModel`
+    ///    synchronously in init and swaps it for the real one once
+    ///    `prepareNewConversation()` returns. Starting recording on the
+    ///    placeholder's `voiceMemoRecorder` works, but the swap then
+    ///    discards that recorder and the UI sees the new VM's idle one,
+    ///    making it look like recording stopped instantly. Wait for the
+    ///    swap (real conversation id, no `draft-` prefix) before kicking
+    ///    off the recording.
+    private func startVoiceMemoIfNeeded() {
+        guard viewModel.entryMode == .voiceMemo else { return }
+        Task { @MainActor in
+            let granted = await VoiceMemoRecorder.ensureRecordPermission()
+            guard granted else { return }
+            await waitForRealConversationViewModel()
+            viewModel.startVoiceMemoRecording(restoreComposerFocusAfter: true)
+        }
+    }
+
+    /// Polls every 50ms for up to 3s until the inner conversation VM
+    /// has a non-draft conversation id (i.e. `configureWithMessagingService`
+    /// has run and the real VM has replaced the placeholder). Bails
+    /// silently after the deadline so a slow `prepareNewConversation`
+    /// doesn't pin the recording task open forever.
+    private func waitForRealConversationViewModel() async {
+        for _ in 0..<60 {
+            if let convoVM = viewModel.newConversationViewModel.conversationViewModel,
+               !convoVM.conversation.id.hasPrefix("draft-") {
+                return
+            }
+            try? await Task.sleep(for: .milliseconds(50))
         }
     }
 
@@ -147,6 +203,10 @@ struct AgentBuilderView: View {
             }
         }
         .onAppear {
+            // Voice-memo entry skips the composer focus so the keyboard
+            // doesn't pop up alongside the mic-permission prompt; the
+            // body's main `.onAppear` kicks off the recording itself.
+            guard viewModel.entryMode != .voiceMemo else { return }
             focusCoordinator.moveFocus(to: .agentBuilder)
         }
         .onChange(of: focusCoordinator.currentFocus) { _, newFocus in
@@ -294,25 +354,45 @@ struct AgentBuilderView: View {
                     }
                 }
             )
-            .frame(maxHeight: Constant.composerHeight)
+            // Lock the composer card to its full height so switching
+            // into the recording layout (and hiding the hint row below)
+            // doesn't visibly shrink the card. `maxHeight` would let
+            // the recording layout's smaller intrinsic size collapse the
+            // card; explicit `height:` pins it at the standard-layout
+            // size for both states.
+            .frame(height: Constant.composerHeight)
             .padding(.horizontal, DesignConstants.Spacing.step4x)
             .padding(.top, DesignConstants.Spacing.step4x)
 
-            if !viewModel.isRecordingVoiceMemo {
-                Text(composerHintText)
-                    .font(.caption)
-                    .foregroundStyle(.colorTextSecondary)
-                    .multilineTextAlignment(.center)
-                    .frame(maxWidth: .infinity)
-                    .padding(.horizontal, DesignConstants.Spacing.step4x)
-                    .padding(.top, DesignConstants.Spacing.step2x)
-                    .padding(.bottom, DesignConstants.Spacing.step3x)
-            }
+            // Hidden (not removed) when recording, so the layout below
+            // the composer doesn't have to reflow when the user taps
+            // the voice-memo button. Without this, the recording-
+            // controls' Spacer-centered position would jump on entry.
+            Text(composerHintText)
+                .font(.caption)
+                .foregroundStyle(.colorTextSecondary)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: .infinity)
+                .padding(.horizontal, DesignConstants.Spacing.step4x)
+                .padding(.top, DesignConstants.Spacing.step2x)
+                .padding(.bottom, DesignConstants.Spacing.step3x)
+                .opacity(viewModel.isRecordingVoiceMemo ? 0 : 1)
 
             if viewModel.isRecordingVoiceMemo {
                 Spacer(minLength: 0)
                 recordingControls(focusState: focusState)
-                    .transition(.blurReplace)
+                    // Delay the appearance by `keyboardDismissDelay` so
+                    // the keyboard dismissal animation triggered by the
+                    // voice-memo tap (`focusState = nil`) finishes
+                    // before the controls fade in. Without the delay,
+                    // the Spacer-centered controls appear at the
+                    // keyboard-up Y and visibly slide down as the
+                    // keyboard collapses; with it, the appearance
+                    // lands at the final (keyboard-down) position.
+                    .transition(.blurReplace.animation(
+                        .easeInOut(duration: Constant.recordingControlsFadeDuration)
+                            .delay(Constant.keyboardDismissDelay)
+                    ))
                 Spacer(minLength: 0)
             } else {
                 Spacer(minLength: 0)
@@ -401,6 +481,12 @@ struct AgentBuilderView: View {
 
     private enum Constant {
         static let composerHeight: CGFloat = 375.0
+        /// iOS keyboard dismissal animation duration. Recording controls
+        /// hold for this long before fading in so their Spacer-centered
+        /// Y position settles after the keyboard collapses rather than
+        /// sliding through the transition.
+        static let keyboardDismissDelay: TimeInterval = 0.25
+        static let recordingControlsFadeDuration: TimeInterval = 0.25
     }
 }
 

--- a/Convos/Agent Builder/AgentBuilderViewModel.swift
+++ b/Convos/Agent Builder/AgentBuilderViewModel.swift
@@ -124,27 +124,29 @@ final class AgentBuilderViewModel: Identifiable {
         newConversationViewModel.conversationViewModel?.pendingMediaAttachments ?? []
     }
 
-    /// Shares the inner conversation VM's voice-memo recorder so the same
-    /// audio file flows through to `sendVoiceMemo()` on commit. The
-    /// builder's UI reacts to recorder state changes via Observation.
-    var voiceMemoRecorder: VoiceMemoRecorder? {
-        newConversationViewModel.conversationViewModel?.voiceMemoRecorder
-    }
+    /// Builder-owned voice-memo recorder. Lives directly on the
+    /// AgentBuilderViewModel (rather than proxying through the inner
+    /// `ConversationViewModel`) because `NewConversationViewModel` seats
+    /// a placeholder inner VM synchronously and swaps it for the real
+    /// one once `prepareNewConversation()` returns. A proxy would lose
+    /// any recording in flight at the moment of the swap; owning the
+    /// recorder here keeps it stable for the entire builder lifetime.
+    /// The recorded audio file (URL) is what flows through to
+    /// `sendBuilderBundle()` at commit, so post-Make path is unaffected.
+    let voiceMemoRecorder: VoiceMemoRecorder = VoiceMemoRecorder()
 
     var isRecordingVoiceMemo: Bool {
-        guard let recorder = voiceMemoRecorder else { return false }
-        if case .recording = recorder.state { return true }
+        if case .recording = voiceMemoRecorder.state { return true }
         return false
     }
 
     var recordedVoiceMemo: (url: URL, duration: TimeInterval)? {
-        guard let recorder = voiceMemoRecorder else { return nil }
-        if case let .recorded(url, duration) = recorder.state { return (url, duration) }
+        if case let .recorded(url, duration) = voiceMemoRecorder.state { return (url, duration) }
         return nil
     }
 
     var voiceMemoAudioLevels: [Float] {
-        voiceMemoRecorder?.audioLevels ?? []
+        voiceMemoRecorder.audioLevels
     }
 
     /// Connection toggles set in the connections sheet. Drives chip rendering
@@ -246,9 +248,8 @@ final class AgentBuilderViewModel: Identifiable {
     }
 
     func startVoiceMemoRecording(restoreComposerFocusAfter: Bool) {
-        guard let recorder = voiceMemoRecorder else { return }
         do {
-            try recorder.startRecording()
+            try voiceMemoRecorder.startRecording()
             restoreComposerFocusAfterRecording = restoreComposerFocusAfter
         } catch {
             Log.error("AgentBuilder: failed to start voice memo recording: \(error.localizedDescription)")
@@ -260,14 +261,14 @@ final class AgentBuilderViewModel: Identifiable {
     /// kicked off the recording.
     @discardableResult
     func stopVoiceMemoRecording() -> Bool {
-        voiceMemoRecorder?.stopRecording()
+        voiceMemoRecorder.stopRecording()
         let shouldRestore = restoreComposerFocusAfterRecording
         restoreComposerFocusAfterRecording = false
         return shouldRestore
     }
 
     func cancelRecordedVoiceMemo() {
-        voiceMemoRecorder?.cancelRecording()
+        voiceMemoRecorder.cancelRecording()
     }
 
     /// Toggle a connection. Device kinds (Apple Health) are local-only —
@@ -626,7 +627,7 @@ final class AgentBuilderViewModel: Identifiable {
         // until `hasCommitted` flips. Cleaning them here would race the
         // in-flight upload and leave the bundle pointing at deleted paths.
         if !isCommitting {
-            voiceMemoRecorder?.cancelRecording()
+            voiceMemoRecorder.cancelRecording()
             // File picker stages copies into `FileManager.default.temporaryDirectory`;
             // those temp copies are otherwise orphaned because `dismissWithDeletion`
             // doesn't iterate `pendingMediaAttachments`. Clean them up explicitly.

--- a/Convos/Agent Builder/AgentBuilderViewModel.swift
+++ b/Convos/Agent Builder/AgentBuilderViewModel.swift
@@ -90,11 +90,28 @@ enum AgentBuilderConnection: String, CaseIterable, Identifiable {
     static let googleCalendarServiceId: String = "googlecalendar"
 }
 
+/// How the builder was entered. Drives which surface (composer text
+/// field vs. voice-memo recorder) gets attention on first appear.
+/// `composer` is the default - the builder appears with its text field
+/// focused and the keyboard up. `voiceMemo` is the
+/// `AgentBuilderBar`'s waveform-button path: the builder appears
+/// without focusing the text field (so the keyboard stays down while
+/// the system mic-permission prompt resolves) and the view kicks off
+/// `startVoiceMemoRecording` on appear.
+enum AgentBuilderEntryMode {
+    case composer
+    case voiceMemo
+}
+
 @MainActor
 @Observable
 final class AgentBuilderViewModel: Identifiable {
     let id: UUID = UUID()
     let session: any SessionManagerProtocol
+    /// How the builder was entered. Read by `AgentBuilderView` on appear
+    /// to decide whether to focus the composer (and raise the keyboard)
+    /// or skip focus and start a voice-memo recording instead.
+    let entryMode: AgentBuilderEntryMode
 
     let newConversationViewModel: NewConversationViewModel
 
@@ -173,8 +190,9 @@ final class AgentBuilderViewModel: Identifiable {
     @ObservationIgnored
     private var restoreComposerFocusAfterRecording: Bool = false
 
-    init(session: any SessionManagerProtocol) {
+    init(session: any SessionManagerProtocol, entryMode: AgentBuilderEntryMode = .composer) {
         self.session = session
+        self.entryMode = entryMode
         self.newConversationViewModel = NewConversationViewModel(
             session: session,
             mode: .newAgent

--- a/Convos/Agent Builder/AgentDraftComposer.swift
+++ b/Convos/Agent Builder/AgentDraftComposer.swift
@@ -45,8 +45,8 @@ struct AgentDraftComposer: View {
 
     var body: some View {
         Group {
-            if viewModel.isRecordingVoiceMemo, let recorder = viewModel.voiceMemoRecorder {
-                recordingLayout(recorder: recorder)
+            if viewModel.isRecordingVoiceMemo {
+                recordingLayout(recorder: viewModel.voiceMemoRecorder)
             } else {
                 standardLayout
             }

--- a/Convos/Agent Builder/AgentDraftComposer.swift
+++ b/Convos/Agent Builder/AgentDraftComposer.swift
@@ -215,7 +215,7 @@ struct AgentDraftComposer: View {
     }
 
     private var textFieldPlaceholder: String {
-        viewModel.isRecordingVoiceMemo ? "Speaking an agent into existance" : "Make a new agent"
+        viewModel.isRecordingVoiceMemo ? "Speaking an agent into existence" : "Make a new agent"
     }
 
     private var textField: some View {

--- a/Convos/Conversations List/ConversationsViewModel.swift
+++ b/Convos/Conversations List/ConversationsViewModel.swift
@@ -334,8 +334,8 @@ final class ConversationsViewModel {
         )
     }
 
-    func onStartAgent() {
-        agentBuilderViewModel = AgentBuilderViewModel(session: session)
+    func onStartAgent(entryMode: AgentBuilderEntryMode = .composer) {
+        agentBuilderViewModel = AgentBuilderViewModel(session: session, entryMode: entryMode)
     }
 
     private func join(from inviteCode: String) {

--- a/Convos/MainTabView.swift
+++ b/Convos/MainTabView.swift
@@ -592,17 +592,15 @@ struct MainTabView: View {
         conversationsViewModel.onStartAgent()
     }
 
-    /// Open the builder and immediately start voice-memo recording. The
-    /// builder's voice-memo recorder is created lazily inside its init
-    /// path, so we schedule the start call on the next runloop tick to
-    /// give the VM a moment to wire up before we call `startRecording`.
+    /// Open the builder pre-configured to start a voice-memo recording.
+    /// `AgentBuilderView` reads `viewModel.entryMode` on appear and skips
+    /// the initial composer-focus (so the keyboard doesn't pop up
+    /// alongside the mic-permission prompt) before calling
+    /// `startVoiceMemoRecording`. The view also owns the timing of the
+    /// `record()` call, so we don't need the previous racy 50ms sleep
+    /// to wait for the inner conversation VM's recorder to materialize.
     private func openBuilderInVoiceMemoMode() {
-        conversationsViewModel.onStartAgent()
-        guard let builderViewModel = conversationsViewModel.agentBuilderViewModel else { return }
-        Task { @MainActor in
-            try? await Task.sleep(for: .milliseconds(50))
-            builderViewModel.startVoiceMemoRecording(restoreComposerFocusAfter: true)
-        }
+        conversationsViewModel.onStartAgent(entryMode: .voiceMemo)
     }
 
     /// Camera capture (still image): open the builder and load the image

--- a/ConvosCore/Sources/ConvosCoreiOS/VoiceMemoRecorder.swift
+++ b/ConvosCore/Sources/ConvosCoreiOS/VoiceMemoRecorder.swift
@@ -26,6 +26,33 @@ public final class VoiceMemoRecorder: NSObject {
         super.init()
     }
 
+    /// Resolve mic permission ahead of `startRecording()`. Returns `true`
+    /// when the user has already granted (or just granted via the system
+    /// prompt) access; `false` when they've denied. Callers must await
+    /// this before invoking `startRecording()` - if `record()` is called
+    /// while permission is `.undetermined`, AVFoundation succeeds the
+    /// initial call but immediately fires
+    /// `audioRecorderDidFinishRecording(_:successfully: false)`, which
+    /// flips the recorder back to `.idle` without ever capturing audio.
+    @MainActor
+    public static func ensureRecordPermission() async -> Bool {
+        let application = AVAudioApplication.shared
+        switch application.recordPermission {
+        case .granted:
+            return true
+        case .denied:
+            return false
+        case .undetermined:
+            return await withCheckedContinuation { continuation in
+                AVAudioApplication.requestRecordPermission { granted in
+                    continuation.resume(returning: granted)
+                }
+            }
+        @unknown default:
+            return false
+        }
+    }
+
     public func startRecording() throws {
         guard case .idle = state else { return }
 


### PR DESCRIPTION
## Summary

Fixes four interlocking bugs when opening the agent builder from the `AgentBuilderBar`'s waveform button:

1. **Keyboard pops up alongside the mic-permission prompt.** The composer text field was grabbing focus on appear.
2. **Stop button flashes on then off.** `AVAudioRecorder.record()` ran before `AVAudioApplication.requestRecordPermission` resolved, so AVFoundation fired `audioRecorderDidFinishRecording(successfully: false)` and the recording UI flashed.
3. **"Starts then stops."** `NewConversationViewModel` seats a placeholder `ConversationViewModel` synchronously and swaps it for the real one when `prepareNewConversation()` returns. Starting the recording before the swap meant the UI ended up watching the new VM's idle recorder instead of the placeholder's active one.
4. **Recording controls slide / composer collapses.** The Spacer-centered controls rode the keyboard dismissal animation, and removing the hint row let the smaller intrinsic recording layout collapse the composer card.

## Approach

- Thread an `AgentBuilderEntryMode { .composer, .voiceMemo }` from `MainTabView.openBuilderInVoiceMemoMode` through `ConversationsViewModel.onStartAgent` into `AgentBuilderViewModel.init`. Replaces the racy 50ms `Task` that used to kick off the recording.
- `AgentBuilderView` reads the entry mode on appear:
  - **Sheet mode** — `defaultFocusOverride` returns `nil` so `ConversationPresenter` doesn't raise the keyboard.
  - **Inline mode** — `.onAppear` early-returns before `focusCoordinator.moveFocus(to: .agentBuilder)`.
  - **Body** — awaits `VoiceMemoRecorder.ensureRecordPermission()` (new helper using `AVAudioApplication.requestRecordPermission`) and polls for the real (non-`draft-`) inner conversation id before calling `startVoiceMemoRecording`.
- `composerRect` layout tweaks:
  - Composer height locked at `Constant.composerHeight` with explicit `.frame(height:)` instead of `.frame(maxHeight:)`.
  - Hint text rendered at `.opacity(isRecording ? 0 : 1)` instead of conditionally so the row keeps its layout slot.
  - Recording controls' `.blurReplace` transition delayed by `Constant.keyboardDismissDelay` (250ms) so the keyboard dismissal completes before they fade in; controls land at their final Y instead of sliding through it.

## Test plan

- [ ] On a fresh simulator (no saved mic permission), tap the `AgentBuilderBar`'s waveform button. Mic prompt fires; granting starts the recording cleanly. No keyboard pops up.
- [ ] Repeat the tap with mic already granted. Recording starts on second tap without the stop button flashing on/off.
- [ ] Open the composer, type a few words to bring the keyboard up, then tap the waveform button inside the composer's media-buttons strip. Keyboard dismisses, stop button appears at its final position (no slide), composer card stays the same size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/882"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782498739&installation_id=128169237&pr_number=882&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F882&signature=02bf72a3daca16f81896bf9b131d828e53ad5b14a2eef84f0b106930a49a9b55"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix stray keyboard focus and layout jump when entering Agent Builder in voice-memo mode
> - When the Agent Builder is opened in voice-memo mode, keyboard focus is suppressed and voice memo recording starts automatically after mic permission is granted via a new `VoiceMemoRecorder.ensureRecordPermission()` static method.
> - `AgentBuilderViewModel` now owns its `VoiceMemoRecorder` directly, so the recorder persists across inner conversation view-model swaps.
> - The composer card uses a fixed height (`.frame(height:)`) instead of `maxHeight`, preventing layout shifts when switching to recording mode; the hint row fades out rather than being removed, and recording controls fade in after a short delay to avoid visible repositioning during keyboard dismissal.
> - Entry mode (`composer` or `voiceMemo`) is now a first-class concept passed from `ConversationsViewModel.onStartAgent` through to `AgentBuilderViewModel`, replacing the previous ad-hoc delayed `startRecording` task in `MainTabView`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 96f53c5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->