### PR TITLE
Contacts: "Somebody" fallback, hide unnamed from list/picker

### DIFF
--- a/Convos/Contacts/ContactsPickerViewModel.swift
+++ b/Convos/Contacts/ContactsPickerViewModel.swift
@@ -174,10 +174,20 @@ final class ContactsPickerViewModel {
     }
 
     private func rebuildSections() {
-        // Verified agents are kept in `DBContact` so chat-side surfaces can
-        // resolve them, but are hidden from the picker so users only see
-        // human candidates when starting / adding to a conversation.
-        let visible = allContacts.filter { !$0.isBlocked && !$0.isVerifiedAgent }
+        // Hidden from the picker:
+        //  - blocked contacts (the user explicitly opted out of contacting them)
+        //  - verified agents (kept in `DBContact` so chat-side surfaces can
+        //    resolve them, but not a valid picker target since they don't
+        //    accept 1:1 DMs; agent rows have their own dedicated entry point)
+        //  - contacts whose displayName is missing/empty (would render as
+        //    "Somebody" via `resolvedDisplayName`; a name-less row isn't a
+        //    useful picker target -- there's nothing to distinguish it from
+        //    every other unnamed contact)
+        let visible = allContacts.filter { contact in
+            guard !contact.isBlocked, !contact.isVerifiedAgent else { return false }
+            guard let name = contact.displayName, !name.isEmpty else { return false }
+            return true
+        }
         let filtered = filterByQuery(visible)
         let grouped: [String: [Contact]] = Dictionary(
             grouping: filtered,

--- a/Convos/Contacts/ContactsPickerViewModel.swift
+++ b/Convos/Contacts/ContactsPickerViewModel.swift
@@ -166,28 +166,36 @@ final class ContactsPickerViewModel {
 
     private func applyContacts(_ contacts: [Contact]) {
         allContacts = contacts
-        // Prune selections that no longer exist in the contact list.
-        let known = Set(contacts.map(\.inboxId))
-        selectedInboxIds = selectedInboxIds.intersection(known)
+        // Prune selections to what's actually pickable. Pruning against the
+        // *visible* set (not just the known set) drops phantom selections --
+        // a preselected inboxId for a contact who's hidden because they're
+        // blocked / a verified agent / unnamed would otherwise stay in
+        // `selectedInboxIds`, counting toward `selectionCount` and passing
+        // `canConfirm` with no UI for the user to remove it.
+        let visibleInboxIds = Set(allContacts.filter(Self.isVisibleInPicker).map(\.inboxId))
+        selectedInboxIds = selectedInboxIds.intersection(visibleInboxIds)
         rebuildSections()
         isLoading = false
     }
 
+    /// Single source of truth for "is this contact a valid picker row".
+    /// Hidden from the picker:
+    ///  - blocked contacts (the user explicitly opted out of contacting them)
+    ///  - verified agents (kept in `DBContact` so chat-side surfaces can
+    ///    resolve them, but not a valid picker target since they don't accept
+    ///    1:1 DMs; agent rows have their own dedicated entry point)
+    ///  - contacts whose displayName is missing/empty (would render as
+    ///    "Somebody" via `resolvedDisplayName`; a name-less row isn't a
+    ///    useful picker target -- there's nothing to distinguish one
+    ///    "Somebody" from another)
+    private static func isVisibleInPicker(_ contact: Contact) -> Bool {
+        if contact.isBlocked || contact.isVerifiedAgent { return false }
+        guard let name = contact.displayName, !name.isEmpty else { return false }
+        return true
+    }
+
     private func rebuildSections() {
-        // Hidden from the picker:
-        //  - blocked contacts (the user explicitly opted out of contacting them)
-        //  - verified agents (kept in `DBContact` so chat-side surfaces can
-        //    resolve them, but not a valid picker target since they don't
-        //    accept 1:1 DMs; agent rows have their own dedicated entry point)
-        //  - contacts whose displayName is missing/empty (would render as
-        //    "Somebody" via `resolvedDisplayName`; a name-less row isn't a
-        //    useful picker target -- there's nothing to distinguish it from
-        //    every other unnamed contact)
-        let visible = allContacts.filter { contact in
-            guard !contact.isBlocked, !contact.isVerifiedAgent else { return false }
-            guard let name = contact.displayName, !name.isEmpty else { return false }
-            return true
-        }
+        let visible = allContacts.filter(Self.isVisibleInPicker)
         let filtered = filterByQuery(visible)
         let grouped: [String: [Contact]] = Dictionary(
             grouping: filtered,

--- a/Convos/Contacts/ContactsViewModel.swift
+++ b/Convos/Contacts/ContactsViewModel.swift
@@ -53,24 +53,34 @@ final class ContactsViewModel {
     private func applyContacts(_ contacts: [Contact]) {
         allContacts = contacts
         // `contactCount` drives the empty-state vs list-state branch and
-        // the compose button's enabled flag. Use the human-visible count
-        // (verified agents are hidden from this view) so a user whose
-        // contacts are all agents sees the empty state correctly.
-        contactCount = contacts.filter { !$0.isVerifiedAgent }.count
+        // the compose button's enabled flag. Count what's actually visible
+        // in the list -- verified agents are hidden from this view, and
+        // unnamed contacts are filtered out below in `rebuildSections`,
+        // so include both predicates here too.
+        contactCount = contacts.filter(Self.isVisibleInList).count
         rebuildSections()
         isLoading = false
+    }
+
+    /// Single source of truth for "is this contact rendered in the list".
+    /// Verified agents stay in `DBContact` so chat-side surfaces (member
+    /// rows, system messages, the contact card opened from a member tap)
+    /// can still resolve them, but they're excluded here so the human
+    /// contact browser stays focused on real people. Contacts whose
+    /// displayName is missing/empty render as "Somebody" via
+    /// `resolvedDisplayName`; a "Somebody" row carries no useful info
+    /// for the browser, so we hide it until a profile name arrives.
+    private static func isVisibleInList(_ contact: Contact) -> Bool {
+        if contact.isVerifiedAgent { return false }
+        guard let name = contact.displayName, !name.isEmpty else { return false }
+        return true
     }
 
     /// Recomputes `sections` from `allContacts` honoring the current
     /// `searchQuery`. Mirrors the picker's filter/group pipeline so both
     /// surfaces sort and bucket identically.
-    ///
-    /// Verified agents are kept in `DBContact` so chat-side surfaces (member
-    /// rows, system messages, the contact card opened from a member tap) can
-    /// still resolve their profile; they are excluded here so the human
-    /// contact browser stays focused on real people.
     private func rebuildSections() {
-        let visibleContacts = allContacts.filter { !$0.isVerifiedAgent }
+        let visibleContacts = allContacts.filter(Self.isVisibleInList)
         let filtered = filterByQuery(visibleContacts)
         let grouped: [String: [Contact]] = Dictionary(grouping: filtered) { $0.alphabeticalSectionKey }
         let sortedKeys = grouped.keys.sorted { lhs, rhs in

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/Contact.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/Contact.swift
@@ -106,14 +106,16 @@ public struct Contact: Hashable, Identifiable, Sendable {
         agentVerification?.isVerified == true
     }
 
-    /// Display label that always returns something printable. Falls back to a
-    /// truncated inboxId so the alphabetical browse list never renders an
-    /// empty cell.
+    /// Display label that always returns something printable. Falls back
+    /// to "Somebody" rather than a truncated inboxId -- exposing a hex
+    /// prefix in any user-facing surface reads as a bug. Same placeholder
+    /// the message-input and profile-settings surfaces use for unnamed
+    /// participants.
     public var resolvedDisplayName: String {
         if let name = displayName, !name.isEmpty {
             return name
         }
-        return shortInboxId
+        return "Somebody"
     }
 
     /// Used for alphabetical sectioning. Returns "#" for contacts whose
@@ -127,11 +129,6 @@ public struct Contact: Hashable, Identifiable, Sendable {
             return "#"
         }
         return String(firstUpper)
-    }
-
-    private var shortInboxId: String {
-        guard inboxId.count > 8 else { return inboxId }
-        return String(inboxId.prefix(8))
     }
 }
 

--- a/ConvosCore/Sources/ConvosCore/Storage/Repositories/ContactsRepository.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Repositories/ContactsRepository.swift
@@ -146,7 +146,7 @@ final class ContactsRepository: ContactsRepositoryProtocol, @unchecked Sendable 
         // Case-insensitive sort done in Swift to keep behavior identical
         // across SQLite collations (idx_contact_displayName supports first
         // paint; the in-memory sort handles nil names by deferring to the
-        // shortened inboxId fallback).
+        // "Somebody" fallback in resolvedDisplayName).
         return rows
             .map(Contact.init(dbContact:))
             .sorted { lhs, rhs in

--- a/ConvosCore/Tests/ConvosCoreTests/ContactsRepositoryTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ContactsRepositoryTests.swift
@@ -110,7 +110,7 @@ struct ContactsRepositoryTests {
         #expect(alice?.isBlocked == false)
     }
 
-    @Test("Contacts with nil displayName fall back to truncated inboxId in the sort key")
+    @Test("Contacts with nil displayName fall back to \"Somebody\" in the sort key")
     func testNilDisplayNameFallback() throws {
         let dbManager = MockDatabaseManager.makeTestDatabase()
 
@@ -131,8 +131,9 @@ struct ContactsRepositoryTests {
 
         let repo = ContactsRepository(databaseReader: dbManager.dbReader)
         let names = try repo.fetchAll().map(\.resolvedDisplayName)
-        // "Mid" sorts before "zzzzzzzz" by case-insensitive compare
-        #expect(names == ["Mid", "zzzzzzzz"])
+        // The nil-name contact resolves to "Somebody", not its inboxId, so
+        // it sorts by "Somebody" - after "Mid" by case-insensitive compare.
+        #expect(names == ["Mid", "Somebody"])
     }
 
     @Test("sourceConversations returns the convo name + kind for each id, drops missing ids")


### PR DESCRIPTION
## Summary

- `Contact.resolvedDisplayName` falls back to **"Somebody"** instead of an 8-char inbox-id prefix. The hex prefix was showing up as the person's name in chat headers, contact detail, and other person-facing surfaces — reads as a bug. Matches the placeholder the message-input bar and profile settings already use for unnamed participants. Dropped the now-unused `shortInboxId` helper.
- In the **Contacts list** and the **Contacts picker**, hide contacts that would render as "Somebody". A name-less row carries no useful information for the browser/picker and there's nothing distinguishing one "Somebody" from another. Verified agents and blocked contacts stay hidden via the existing filters; the new predicate joins them.
- `contactCount` in the list (drives the empty-state branch + compose-button enabled flag) now uses the same predicate as the rendered rows so both stay in sync.

`Contact.resolvedDisplayName` still flows through to chat-side surfaces (member rows, system messages, contact detail opened from a member tap) — those legitimately need to render *something* for unnamed members, and "Somebody" is consistent with the rest of the app.

## Test plan

- [x] Build clean
- [ ] Contacts list: a contact with no profile name doesn't appear
- [ ] Contacts list: empty state shows when only unnamed contacts exist
- [ ] Contacts picker: a contact with no profile name isn't pickable
- [ ] Chat: a member with no profile name renders as "Somebody" everywhere (system messages, header, etc.) rather than a hex inbox prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Hide unnamed contacts from list and picker, falling back to "Somebody" as display name
> - Contacts with a missing or empty `displayName` are now excluded from both the contacts list ([ContactsViewModel](https://github.com/xmtplabs/convos-ios/pull/883/files#diff-99446eaf0688b94fb2ff5d2f31cb1ea04efe01b762662e82909a1dcb74683a8a)) and the contacts picker ([ContactsPickerViewModel](https://github.com/xmtplabs/convos-ios/pull/883/files#diff-7a4aa100f6c78f226bd8d1f4ba794c6f31df8ec0139bebb7d3e0163a97cc6a24)).
> - `Contact.resolvedDisplayName` in [Contact.swift](https://github.com/xmtplabs/convos-ios/pull/883/files#diff-3f9bbc09935e65f0c7385b79374f81ee59a5ae752504ecc93ab159db797fcfc6) now returns `"Somebody"` instead of a truncated inbox ID when `displayName` is missing or empty, affecting any display or sort that uses this property.
> - Each view model introduces a static visibility predicate (`isVisibleInList`/`isVisibleInPicker`) as a single source of truth for filtering, replacing previously scattered inline checks.
> - Behavioral Change: unnamed contacts now group under section 'S' wherever they appear (e.g. search results), and preselected inbox IDs for unnamed contacts are cleared in the picker.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4fe18f9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->