### PR TITLE
Sweep quarantined conversations when a new contact is added

### DIFF
--- a/ConvosCore/Sources/ConvosCore/Contacts/ContactSyncCoordinator.swift
+++ b/ConvosCore/Sources/ConvosCore/Contacts/ContactSyncCoordinator.swift
@@ -69,14 +69,14 @@ final class ContactSyncCoordinator: ContactSyncCoordinatorProtocol, @unchecked S
     }
 
     private func sync(conversationId: String, force: Bool) async throws {
-        try await databaseWriter.write { [selfInboxIdProvider] db in
+        let newlyInsertedInboxIds: [String] = try await databaseWriter.write { [selfInboxIdProvider] db in
             // Without the local inbox singleton we cannot identify "self" and
             // therefore cannot exclude the local user from the upsert loop.
             // No-op rather than risk adding self as a contact. The next hook
             // (after the singleton is written) retries.
             guard let selfInboxId = try selfInboxIdProvider(db) else {
                 Log.debug("Skipping contacts sync for \(conversationId): inbox singleton not written yet")
-                return
+                return []
             }
 
             // Two short-circuits:
@@ -104,13 +104,13 @@ final class ContactSyncCoordinator: ContactSyncCoordinatorProtocol, @unchecked S
                 }()
                 guard selfIsCreator else {
                     Log.debug("Skipping forced contacts sync for never-synced conversation \(conversationId) (local user is not the creator)")
-                    return
+                    return []
                 }
                 Log.debug("Forced contacts sync proceeding for never-synced conversation \(conversationId) (local user is the creator)")
             }
 
             if alreadySynced && force == false {
-                return
+                return []
             }
 
             let members = try DBConversationMember
@@ -125,6 +125,7 @@ final class ContactSyncCoordinator: ContactSyncCoordinatorProtocol, @unchecked S
             )
 
             var upsertedCount: Int = 0
+            var insertedInboxIds: [String] = []
             for member in members {
                 if member.inboxId == selfInboxId {
                     continue
@@ -143,12 +144,15 @@ final class ContactSyncCoordinator: ContactSyncCoordinatorProtocol, @unchecked S
                     // AgentVerification.
                     agentVerification: profile?.memberKind?.agentVerification
                 )
-                try ContactsWriter.upsertContactInTransaction(
+                let didInsert = try ContactsWriter.upsertContactInTransaction(
                     db: db,
                     inboxId: member.inboxId,
                     addedViaConversationId: conversationId,
                     profile: snapshot
                 )
+                if didInsert {
+                    insertedInboxIds.append(member.inboxId)
+                }
                 upsertedCount += 1
             }
 
@@ -162,7 +166,7 @@ final class ContactSyncCoordinator: ContactSyncCoordinatorProtocol, @unchecked S
             // on every send. Acceptable — it's a few indexed reads.
             guard upsertedCount > 0 else {
                 Log.debug("Contacts sync for \(conversationId) saw no non-self members; skipping marker so next message retries")
-                return
+                return insertedInboxIds
             }
 
             let marker = DBConversationContactsSync(
@@ -172,6 +176,14 @@ final class ContactSyncCoordinator: ContactSyncCoordinatorProtocol, @unchecked S
             try marker.save(db)
 
             Log.debug("Synced \(upsertedCount) contacts for conversation \(conversationId) (force=\(force))")
+            return insertedInboxIds
+        }
+        // Fire `.contactDidUpsert` post-commit so observers (e.g.
+        // `QuarantineSweeper` via `SessionManager`) read a consistent
+        // post-write DB. One notification per newly-inserted contact;
+        // observers can coalesce if they want.
+        for inboxId in newlyInsertedInboxIds {
+            ContactsWriter.postContactDidUpsert(inboxId: inboxId)
         }
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
@@ -31,6 +31,7 @@ public final class SessionManager: SessionManagerProtocol, @unchecked Sendable {
     private var cloudConnectionsCancellable: AnyCancellable?
     private var activeConversationObserver: NSObjectProtocol?
     private var contactBlockingObserver: NSObjectProtocol?
+    private var contactDidUpsertObserver: NSObjectProtocol?
     private var quarantineSweeperTask: Task<Void, Never>?
     private var cachedQuarantineSweeper: (any QuarantineSweeperProtocol)?
 
@@ -176,6 +177,9 @@ public final class SessionManager: SessionManagerProtocol, @unchecked Sendable {
         if let contactBlockingObserver {
             NotificationCenter.default.removeObserver(contactBlockingObserver)
         }
+        if let contactDidUpsertObserver {
+            NotificationCenter.default.removeObserver(contactDidUpsertObserver)
+        }
     }
 
     // MARK: - Private Methods
@@ -216,53 +220,22 @@ public final class SessionManager: SessionManagerProtocol, @unchecked Sendable {
             self?.runQuarantineSweep(reason: "contactBlockingDidChange")
         }
 
+        // Same idea, but for fresh contact insertions: when a stranger
+        // becomes a contact (typically via `ContactSyncCoordinator`
+        // running on the user's first message in a shared group),
+        // promote any DMs from that peer that were quarantined back
+        // when they were still a stranger. Without this hook the user
+        // would have to wait for the next hourly tick or foreground
+        // entry to see the queued DM appear in the main feed.
+        contactDidUpsertObserver = NotificationCenter.default.addObserver(
+            forName: .contactDidUpsert,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            self?.runQuarantineSweep(reason: "contactDidUpsert")
+        }
+
         scheduleQuarantineSweeper()
-    }
-
-    /// Periodic sweeper that promotes quarantined conversations whose
-    /// senders have become contacts and deletes those past the TTL. Runs
-    /// once at session-observe time and once per `Constant.foregroundSweepInterval`
-    /// while the process is alive. The foreground observer above also
-    /// triggers an extra sweep on every foreground entry.
-    private func scheduleQuarantineSweeper() {
-        let sweeper = QuarantineSweeper(
-            databaseWriter: databaseWriter,
-            databaseReader: databaseReader,
-            contactsRepository: ContactsRepository(databaseReader: databaseReader)
-        )
-        cachedQuarantineSweeper = sweeper
-
-        quarantineSweeperTask?.cancel()
-        quarantineSweeperTask = Task { [weak self] in
-            // Initial sweep at launch.
-            await Self.invokeSweep(sweeper, reason: "launch")
-            // Hourly sweep while the process lives. Foreground entries also
-            // trigger an extra sweep via the foreground observer.
-            while !Task.isCancelled {
-                let interval: UInt64 = UInt64(QuarantineSweeper.Constant.foregroundSweepInterval * 1_000_000_000)
-                try? await Task.sleep(nanoseconds: interval)
-                guard self != nil, !Task.isCancelled else { return }
-                await Self.invokeSweep(sweeper, reason: "interval")
-            }
-        }
-    }
-
-    private func runQuarantineSweep(reason: String) {
-        guard let sweeper = cachedQuarantineSweeper else { return }
-        Task.detached {
-            await Self.invokeSweep(sweeper, reason: reason)
-        }
-    }
-
-    private static func invokeSweep(
-        _ sweeper: any QuarantineSweeperProtocol,
-        reason: String
-    ) async {
-        do {
-            try await sweeper.sweep()
-        } catch {
-            Log.error("QuarantineSweeper sweep (reason=\(reason)) failed: \(error.localizedDescription)")
-        }
     }
 
     private func updateActiveConversation(_ conversationId: String?) {
@@ -1061,5 +1034,56 @@ public extension SessionManager {
             }
         }
         Log.info("SessionManager: removed \(deletedCount) stale libxmtp file(s) for adopted inboxId after pairing adoption")
+    }
+}
+
+// MARK: - Quarantine Sweeper
+
+extension SessionManager {
+    /// Periodic sweeper that promotes quarantined conversations whose
+    /// senders have become contacts and deletes those past the TTL. Runs
+    /// once at session-observe time and once per `Constant.foregroundSweepInterval`
+    /// while the process is alive. The foreground observer and the
+    /// `.contactDidUpsert` / `.contactBlockingDidChange` observers also
+    /// trigger extra sweeps.
+    func scheduleQuarantineSweeper() {
+        let sweeper = QuarantineSweeper(
+            databaseWriter: databaseWriter,
+            databaseReader: databaseReader,
+            contactsRepository: ContactsRepository(databaseReader: databaseReader)
+        )
+        cachedQuarantineSweeper = sweeper
+
+        quarantineSweeperTask?.cancel()
+        quarantineSweeperTask = Task { [weak self] in
+            // Initial sweep at launch.
+            await Self.invokeSweep(sweeper, reason: "launch")
+            // Hourly sweep while the process lives. Foreground entries also
+            // trigger an extra sweep via the foreground observer.
+            while !Task.isCancelled {
+                let interval: UInt64 = UInt64(QuarantineSweeper.Constant.foregroundSweepInterval * 1_000_000_000)
+                try? await Task.sleep(nanoseconds: interval)
+                guard self != nil, !Task.isCancelled else { return }
+                await Self.invokeSweep(sweeper, reason: "interval")
+            }
+        }
+    }
+
+    func runQuarantineSweep(reason: String) {
+        guard let sweeper = cachedQuarantineSweeper else { return }
+        Task.detached {
+            await Self.invokeSweep(sweeper, reason: reason)
+        }
+    }
+
+    private static func invokeSweep(
+        _ sweeper: any QuarantineSweeperProtocol,
+        reason: String
+    ) async {
+        do {
+            try await sweeper.sweep()
+        } catch {
+            Log.error("QuarantineSweeper sweep (reason=\(reason)) failed: \(error.localizedDescription)")
+        }
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/ContactsWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/ContactsWriter.swift
@@ -12,6 +12,18 @@ public extension Notification.Name {
     static let contactBlockingDidChange: Notification.Name = Notification.Name(
         "ContactBlockingDidChange"
     )
+
+    /// Posted on the main queue by `ContactsWriter` when a brand-new
+    /// `DBContact` row is inserted (re-upserts and profile-only updates
+    /// of existing contacts do not fire). `SessionManager` observes
+    /// this to run an immediate `QuarantineSweeper.sweep()` so a
+    /// conversation that was quarantined because its creator wasn't yet
+    /// a contact flows into the main feed as soon as the user adds them
+    /// — without waiting for the next hourly or foreground-entry sweep.
+    /// UserInfo: `inboxId: String`.
+    static let contactDidUpsert: Notification.Name = Notification.Name(
+        "ContactDidUpsert"
+    )
 }
 
 /// Snapshot of profile fields used when upserting a contact. Callers pass
@@ -94,13 +106,16 @@ final class ContactsWriter: ContactsWriterProtocol, @unchecked Sendable {
         addedViaConversationId: String?,
         profile: ContactProfileSnapshot
     ) async throws {
-        try await databaseWriter.write { db in
+        let didInsert: Bool = try await databaseWriter.write { db in
             try Self.upsert(
                 db: db,
                 inboxId: inboxId,
                 addedViaConversationId: addedViaConversationId,
                 profile: profile
             )
+        }
+        if didInsert {
+            ContactsWriter.postContactDidUpsert(inboxId: inboxId)
         }
     }
 
@@ -183,12 +198,44 @@ final class ContactsWriter: ContactsWriterProtocol, @unchecked Sendable {
         }
     }
 
+    /// Posted on the main queue after a brand-new contact row is
+    /// inserted by `upsertContact` or `upsertContactInTransaction`
+    /// (re-upserts on an existing row do not fire). `SessionManager`
+    /// observes this to run an immediate `QuarantineSweeper.sweep()`
+    /// so any conversation quarantined because its creator wasn't a
+    /// contact flows into the main feed as soon as the user adds them.
+    static func postContactDidUpsert(inboxId: String) {
+        let userInfo: [String: Any] = ["inboxId": inboxId]
+        if Thread.isMainThread {
+            NotificationCenter.default.post(
+                name: .contactDidUpsert,
+                object: nil,
+                userInfo: userInfo
+            )
+        } else {
+            DispatchQueue.main.async {
+                NotificationCenter.default.post(
+                    name: .contactDidUpsert,
+                    object: nil,
+                    userInfo: userInfo
+                )
+            }
+        }
+    }
+
+    /// Returns `true` when a brand-new contact row was inserted, `false`
+    /// when the call hit an existing row (regardless of whether the
+    /// profile snapshot replaced any fields). Callers that need to react
+    /// to "a contact was added" (e.g. release quarantined conversations
+    /// from this peer) use the boolean to decide whether to fire
+    /// `.contactDidUpsert`.
+    @discardableResult
     fileprivate static func upsert(
         db: Database,
         inboxId: String,
         addedViaConversationId: String?,
         profile: ContactProfileSnapshot
-    ) throws {
+    ) throws -> Bool {
         if let existing = try DBContact.fetchOne(db, key: inboxId) {
             // Identity columns (addedAt, addedViaConversationId) are
             // intentionally preserved on re-upsert. The profile snapshot is
@@ -196,10 +243,10 @@ final class ContactsWriter: ContactsWriterProtocol, @unchecked Sendable {
             // the stored one (see `replacingProfile`); untimestamped
             // re-upserts leave the existing row untouched.
             guard let merged = replacingProfile(of: existing, with: profile) else {
-                return
+                return false
             }
             try merged.save(db)
-            return
+            return false
         }
 
         let now = Date()
@@ -217,6 +264,7 @@ final class ContactsWriter: ContactsWriterProtocol, @unchecked Sendable {
         )
         try row.save(db)
         Log.debug("Inserted new contact for inboxId=\(inboxId) via=\(addedViaConversationId ?? "nil")")
+        return true
     }
 
     /// Returns `existing` with its profile fields replaced by `profile` if
@@ -257,12 +305,18 @@ final class ContactsWriter: ContactsWriterProtocol, @unchecked Sendable {
 /// saves onto `DBContact` (`mirrorMemberProfileToContactInTransaction`,
 /// `saveMemberProfileAndMirrorToContactInTransaction`).
 extension ContactsWriter {
+    /// Returns `true` when a brand-new contact row was inserted, so the
+    /// caller can fire `.contactDidUpsert` (via
+    /// `ContactsWriter.postContactDidUpsert(inboxId:)`) once the
+    /// surrounding transaction commits. The transaction-local path
+    /// can't post directly because the write hasn't been visible yet.
+    @discardableResult
     static func upsertContactInTransaction(
         db: Database,
         inboxId: String,
         addedViaConversationId: String?,
         profile: ContactProfileSnapshot
-    ) throws {
+    ) throws -> Bool {
         try upsert(
             db: db,
             inboxId: inboxId,


### PR DESCRIPTION
## Bug

A is in a group with B and C. B DMs A before A has B as a contact, so the DM lands as a **quarantined** conversation (`DBConversation.quarantinedAt != nil, quarantineReleasedAt == nil` — filtered out of the main feed by `ConversationsRepository`).

A later sends the first message in the A/B/C group, which triggers `ContactSyncCoordinator` and upserts B + C as contacts. But the `QuarantineSweeper` isn't kicked, so the queued DM from B doesn't appear in A's main feed until the next hourly tick or foreground entry.

## Cause

Only `block` / `unblock` posted a notification (`.contactBlockingDidChange`) to wake the sweeper. Regular contact insertions — by far the most common path to promote quarantined DMs from a stranger — had no immediate hook. The sweeper would still pick them up on the next 60-minute tick or `applicationDidBecomeActive`, just with up to an hour of delay.

## Fix

Post a new `.contactDidUpsert` notification when a brand-new `DBContact` row is inserted (re-upserts and profile-only updates do not fire). `SessionManager` observes it and runs an immediate sweep, same shape as the existing `.contactBlockingDidChange` path.

### Wiring details

- `ContactsWriter.upsert(db:…)` now returns `Bool` (`true` = brand-new insert). Both entry points — `upsertContact` (async) and `upsertContactInTransaction` (sync, in-transaction helper used by `ContactSyncCoordinator`) — thread the boolean back to their callers.
- `upsertContact` fires `.contactDidUpsert` directly after the write commits.
- `ContactSyncCoordinator` collects the inboxIds of newly inserted contacts inside its `databaseWriter.write { … }` closure, returns them, and posts one `.contactDidUpsert` per id after the closure returns. Notifications fire against a consistent post-commit DB so observers see the new contact when they read.
- `SessionManager.observe()` registers a second observer mirroring `contactBlockingObserver`; teardown also removes it.
- Moved `scheduleQuarantineSweeper` / `runQuarantineSweep` / `invokeSweep` into a same-file `extension SessionManager` (the new observer pushed the class body over the 635-line `type_body_length` cap; behavior unchanged).

## Test plan

- [x] All 7 existing `QuarantineSweeperTests` pass.
- [x] `swiftlint --strict` clean (759 files, 0 violations).
- [x] Build clean on iPhone 17 + iPhone 17 Pro simulators.
- [ ] Manual: A in group with B, C; B sends DM to A; A sends first message in group; DM from B appears in A's main feed within seconds (not 60 min).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/884"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782502741&installation_id=128169237&pr_number=884&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F884&signature=3d9db2a9161831933d1a3341eeda98715733e0e113cbfc8a8b3f750fe827660e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Sweep quarantined conversations immediately when a new contact is added
> - Adds a `contactDidUpsert` notification fired (post-commit) only when a brand-new `DBContact` row is inserted, via a new `ContactsWriter.postContactDidUpsert` helper.
> - `ContactSyncCoordinator.sync` now returns newly inserted `inboxId`s from the write transaction and posts one `contactDidUpsert` notification per new contact after commit.
> - `SessionManager` observes `contactDidUpsert` and calls `runQuarantineSweep` immediately, so quarantined conversations are swept when a contact is added rather than waiting for the hourly or foreground-entry sweep.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ac9c8d3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->