### PR TITLE
iPad: lift effects on attachment buttons

### DIFF
--- a/Convos/Agent Builder/AgentDraftComposer.swift
+++ b/Convos/Agent Builder/AgentDraftComposer.swift
@@ -301,6 +301,7 @@ struct AgentDraftComposer: View {
             )
             .padding(.horizontal, fadeWidth)
         }
+        .scrollClipDisabled()
         .scrollBounceBehavior(.basedOnSize)
         .frame(maxWidth: .infinity, alignment: .leading)
         .mask(

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesMediaInputView.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesMediaInputView.swift
@@ -38,6 +38,8 @@ struct MessagesMediaButtonsView: View {
             }
             .buttonStyle(.plain)
             .disabled(isMediaCapacityFull)
+            .hoverEffect(.lift)
+            .hoverEffectDisabled(isMediaCapacityFull)
             .accessibilityLabel("Photo library")
             .accessibilityIdentifier("photo-picker-button")
 
@@ -52,6 +54,8 @@ struct MessagesMediaButtonsView: View {
             }
             .buttonStyle(.plain)
             .disabled(isMediaCapacityFull)
+            .hoverEffect(.lift)
+            .hoverEffectDisabled(isMediaCapacityFull)
             .accessibilityLabel("Camera")
             .accessibilityIdentifier("camera-button")
 
@@ -66,6 +70,8 @@ struct MessagesMediaButtonsView: View {
             }
             .buttonStyle(.plain)
             .disabled(isVoiceMemoDisabled)
+            .hoverEffect(.lift)
+            .hoverEffectDisabled(isVoiceMemoDisabled)
             .accessibilityLabel("Voice memo")
             .accessibilityIdentifier("voice-memo-button")
 
@@ -80,6 +86,8 @@ struct MessagesMediaButtonsView: View {
             }
             .buttonStyle(.plain)
             .disabled(isMediaCapacityFull)
+            .hoverEffect(.lift)
+            .hoverEffectDisabled(isMediaCapacityFull)
             .accessibilityLabel("Attach file")
             .accessibilityIdentifier("file-picker-button")
 
@@ -94,6 +102,7 @@ struct MessagesMediaButtonsView: View {
                         .contentShape(.circle)
                 }
                 .buttonStyle(.plain)
+                .hoverEffect(.lift)
                 .accessibilityLabel("Connections")
                 .accessibilityIdentifier("connections-button")
             }
@@ -113,6 +122,8 @@ struct MessagesMediaButtonsView: View {
                 }
                 .buttonStyle(.plain)
                 .disabled(isSideConvoDisabled)
+                .hoverEffect(.lift)
+                .hoverEffectDisabled(isSideConvoDisabled)
                 .accessibilityLabel("Side convo")
                 .accessibilityIdentifier("side-convo-button")
             }
@@ -128,6 +139,7 @@ struct MessagesMediaButtonsView: View {
                         .contentShape(.circle)
                 }
                 .buttonStyle(.plain)
+                .hoverEffect(.lift)
                 .accessibilityLabel("Debug test attachment")
                 .accessibilityIdentifier("debug-test-attachment-button")
             }

--- a/Convos/Conversations List/AgentBuilderBar.swift
+++ b/Convos/Conversations List/AgentBuilderBar.swift
@@ -136,6 +136,7 @@ struct AgentBuilderBar: View {
                 .contentShape(.rect)
         }
         .buttonStyle(.plain)
+        .hoverEffect(.lift)
         .accessibilityLabel(label)
     }
 


### PR DESCRIPTION
## Summary

iPad/Mac hover affordance for the per-button tap targets in:

1. The **agent builder composer + chat composer** media-button row (`MessagesMediaButtonsView`) — photo, camera, voice memo, file, connections, side-convo. The chat composer's avatar and send button already had `.hoverEffect(.lift)`; this closes the consistency gap with the media buttons sitting next to them.
2. The **agent builder bar** — photo / camera / voice memo trio inside the expanded capsule (`AgentBuilderBar.attachmentButton`).

Each button pairs the lift with `.hoverEffectDisabled(...)` mirroring its existing `.disabled(...)` state so the lift disappears when the button is dimmed (capacity full, voice memo already recorded, etc.).

Also added `.scrollClipDisabled()` to the agent builder's horizontal media-button strip so the lift shadow doesn't clip against the scroll-view bounds.

Intentionally NOT lifting:
- The outer capsule of `AgentBuilderBar` (looked busy alongside per-button lifts)
- The "Make an agent" placeholder text inside the bar (visually weird to lift a label)

## Test plan

- [x] iPad device — hover each attachment button in the agent builder composer; lift fires
- [x] iPad device — hover each attachment button in the chat composer; lift fires
- [x] iPad device — hover the photo/camera/voice memo trio in the agent builder bar; lift fires
- [x] iPad device — disabled buttons (e.g. when media capacity is full) don't lift
- [x] iPhone — no visual regression (hover effects are no-ops on touch-only devices)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/886"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782508012&installation_id=128169237&pr_number=886&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F886&signature=b0cee2b67e4508cae8dc6698cd8fc073344400867c7a6ddb2455fa47516e5947"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add lift hover effects to attachment buttons on iPad
> Adds `hoverEffect(.lift)` to media input buttons, agent builder bar attachment buttons, and related action buttons so they respond to pointer hover on iPad. The effect is suppressed when a button is disabled. Also disables scroll clipping in [AgentDraftComposer.swift](https://github.com/xmtplabs/convos-ios/pull/886/files#diff-a9efd932548b1a0786239eaaddd5f4e1cba9cc0ca3fbfb7253a70e3571480cfc) so content can render beyond the scroll view bounds during scrolling.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 90187e4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->