### PR TITLE
Pairing: broadcast a fresh ProfileSnapshot to every group once the joiner's installation is active

### DIFF
--- a/Convos/Devices/DevicesViewModel.swift
+++ b/Convos/Devices/DevicesViewModel.swift
@@ -77,16 +77,41 @@ final class DevicesViewModel {
         if !didStartObserving {
             didStartObserving = true
             observers.add(for: .pairingDidCompleteSuccessfully) { [weak self] notification in
-                let name = (notification.userInfo?["joinerDeviceName"] as? String) ?? "New device"
+                // Only the initiator-side post carries `joinerDeviceName`
+                // (`PairingSheetViewModel.confirmEmoji`). The joiner's
+                // post has no userInfo. We use that to gate the
+                // initiator-only profile-snapshot broadcast: the joiner
+                // is the one *receiving* the snapshots, it shouldn't
+                // re-send them.
+                let userInfo = notification.userInfo
+                let joinerDeviceName = userInfo?["joinerDeviceName"] as? String
+                let displayName = joinerDeviceName ?? "New device"
+                let isInitiatorSide = joinerDeviceName != nil
                 Task { @MainActor in
-                    self?.insertOptimisticDevice(named: name)
+                    self?.insertOptimisticDevice(named: displayName)
                     await self?.refreshUntilRealInstallationAppears()
+                    if isInitiatorSide {
+                        await self?.broadcastProfileSnapshotsAfterPair()
+                    }
                 }
             }
         }
         Task { @MainActor in
             await refreshInstallations(refreshFromNetwork: true)
         }
+    }
+
+    /// Initiator-only: once the joiner's installation is visible in our
+    /// inbox, broadcast a fresh `ProfileSnapshot` to every group so the
+    /// joiner's new local DB hydrates each conversation's members
+    /// immediately. Falls through silently if the joiner's installation
+    /// never appears within the broadcaster's polling window.
+    private func broadcastProfileSnapshotsAfterPair() async {
+        guard let session else { return }
+        let broadcaster = PostPairProfileSnapshotBroadcaster(
+            messagingService: session.messagingService()
+        )
+        _ = await broadcaster.runAfterPairing()
     }
 
     /// Inserts a non-self placeholder row with the just-paired device's

--- a/Convos/Devices/DevicesViewModel.swift
+++ b/Convos/Devices/DevicesViewModel.swift
@@ -86,15 +86,21 @@ final class DevicesViewModel {
                 let displayName = (userInfo?["joinerDeviceName"] as? String) ?? "New device"
                 let isInitiatorSide = (userInfo?["isInitiator"] as? Bool) ?? false
                 Task { @MainActor in
-                    self?.insertOptimisticDevice(named: displayName)
+                    guard let self else { return }
+                    self.insertOptimisticDevice(named: displayName)
                     // Capture the installation baseline BEFORE the refresh
                     // waits for the joiner -- otherwise the joiner folds
                     // into the baseline and the broadcaster's diff finds
-                    // nothing new (so it never broadcasts).
-                    let baseline = isInitiatorSide ? await self?.currentInstallationIds() : nil
-                    await self?.refreshUntilRealInstallationAppears()
+                    // nothing new (so it never broadcasts). `nil` means we
+                    // couldn't read a trustworthy baseline; skip the
+                    // broadcast entirely rather than fire it against an
+                    // empty set (which would diff true on the initiator's
+                    // own installation and broadcast before the joiner
+                    // appears).
+                    let baseline = isInitiatorSide ? await self.currentInstallationIds() : nil
+                    await self.refreshUntilRealInstallationAppears()
                     if isInitiatorSide, let baseline {
-                        await self?.broadcastProfileSnapshotsAfterPair(baseline: baseline)
+                        await self.broadcastProfileSnapshotsAfterPair(baseline: baseline)
                     }
                 }
             }
@@ -107,15 +113,19 @@ final class DevicesViewModel {
     /// The inbox's currently-known installation IDs (cached, no network
     /// round-trip) -- used as the pre-refresh baseline for the post-pair
     /// broadcast so the joiner's not-yet-visible installation is excluded.
-    private func currentInstallationIds() async -> Set<String> {
-        guard let session else { return [] }
+    /// Returns `nil` (not an empty set) when the baseline can't be read,
+    /// so the caller skips the broadcast: an empty baseline would diff
+    /// true against the initiator's own installation and fire the
+    /// broadcast before the joiner ever appears.
+    private func currentInstallationIds() async -> Set<String>? {
+        guard let session else { return nil }
         do {
             let snapshot = try await session.messagingService()
                 .installationsSnapshot(refreshFromNetwork: false)
             return Set(snapshot.installations.map(\.id))
         } catch {
             Log.warning("DevicesViewModel: failed to read installation baseline before pairing broadcast: \(error.localizedDescription)")
-            return []
+            return nil
         }
     }
 

--- a/Convos/Devices/DevicesViewModel.swift
+++ b/Convos/Devices/DevicesViewModel.swift
@@ -77,21 +77,24 @@ final class DevicesViewModel {
         if !didStartObserving {
             didStartObserving = true
             observers.add(for: .pairingDidCompleteSuccessfully) { [weak self] notification in
-                // Only the initiator-side post carries `joinerDeviceName`
-                // (`PairingSheetViewModel.confirmEmoji`). The joiner's
-                // post has no userInfo. We use that to gate the
-                // initiator-only profile-snapshot broadcast: the joiner
-                // is the one *receiving* the snapshots, it shouldn't
-                // re-send them.
                 let userInfo = notification.userInfo
-                let joinerDeviceName = userInfo?["joinerDeviceName"] as? String
-                let displayName = joinerDeviceName ?? "New device"
-                let isInitiatorSide = joinerDeviceName != nil
+                // The initiator's post carries an explicit `isInitiator`
+                // flag (plus the joiner's device name). The joiner's post
+                // has neither. Only the initiator broadcasts the
+                // profile-snapshot fan-out -- the joiner is the one
+                // *receiving* the snapshots, it shouldn't re-send them.
+                let displayName = (userInfo?["joinerDeviceName"] as? String) ?? "New device"
+                let isInitiatorSide = (userInfo?["isInitiator"] as? Bool) ?? false
                 Task { @MainActor in
                     self?.insertOptimisticDevice(named: displayName)
+                    // Capture the installation baseline BEFORE the refresh
+                    // waits for the joiner -- otherwise the joiner folds
+                    // into the baseline and the broadcaster's diff finds
+                    // nothing new (so it never broadcasts).
+                    let baseline = isInitiatorSide ? await self?.currentInstallationIds() : nil
                     await self?.refreshUntilRealInstallationAppears()
-                    if isInitiatorSide {
-                        await self?.broadcastProfileSnapshotsAfterPair()
+                    if isInitiatorSide, let baseline {
+                        await self?.broadcastProfileSnapshotsAfterPair(baseline: baseline)
                     }
                 }
             }
@@ -101,17 +104,37 @@ final class DevicesViewModel {
         }
     }
 
+    /// The inbox's currently-known installation IDs (cached, no network
+    /// round-trip) -- used as the pre-refresh baseline for the post-pair
+    /// broadcast so the joiner's not-yet-visible installation is excluded.
+    private func currentInstallationIds() async -> Set<String> {
+        guard let session else { return [] }
+        do {
+            let snapshot = try await session.messagingService()
+                .installationsSnapshot(refreshFromNetwork: false)
+            return Set(snapshot.installations.map(\.id))
+        } catch {
+            Log.warning("DevicesViewModel: failed to read installation baseline before pairing broadcast: \(error.localizedDescription)")
+            return []
+        }
+    }
+
     /// Initiator-only: once the joiner's installation is visible in our
     /// inbox, broadcast a fresh `ProfileSnapshot` to every group so the
     /// joiner's new local DB hydrates each conversation's members
-    /// immediately. Falls through silently if the joiner's installation
-    /// never appears within the broadcaster's polling window.
-    private func broadcastProfileSnapshotsAfterPair() async {
+    /// immediately. `baseline` is the pre-refresh installation set; the
+    /// broadcaster waits for an installation beyond it before sending.
+    /// Falls through silently if the joiner's installation never appears
+    /// within the broadcaster's polling window.
+    private func broadcastProfileSnapshotsAfterPair(baseline: Set<String>) async {
         guard let session else { return }
         let broadcaster = PostPairProfileSnapshotBroadcaster(
             messagingService: session.messagingService()
         )
-        _ = await broadcaster.runAfterPairing()
+        let didBroadcast = await broadcaster.runAfterPairing(baseline: baseline)
+        if !didBroadcast {
+            Log.warning("DevicesViewModel: post-pair profile broadcast did not run (joiner installation not detected within polling window)")
+        }
     }
 
     /// Inserts a non-self placeholder row with the just-paired device's

--- a/Convos/Devices/PairingSheetViewModel.swift
+++ b/Convos/Devices/PairingSheetViewModel.swift
@@ -202,7 +202,10 @@ final class PairingSheetViewModel {
                 NotificationCenter.default.post(
                     name: .pairingDidCompleteSuccessfully,
                     object: nil,
-                    userInfo: ["joinerDeviceName": deviceName]
+                    // `isInitiator` gates the post-pair profile-snapshot
+                    // broadcast to the initiator side only (the joiner
+                    // receives the snapshots, it doesn't re-send them).
+                    userInfo: ["joinerDeviceName": deviceName, "isInitiator": true]
                 )
                 title = "Device added"
                 flowState = .completed(deviceName: deviceName)

--- a/ConvosCore/Sources/ConvosCore/Messaging/MessagingService.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/MessagingService.swift
@@ -374,6 +374,56 @@ final class MessagingService: MessagingServiceProtocol, @unchecked Sendable {
         )
     }
 
+    /// Sends a fresh `ProfileSnapshot` (containing the current profile
+    /// metadata for every member) to every group the local user is in.
+    /// Used by the post-pair broadcaster so a newly-paired installation
+    /// has each conversation's member profiles populated locally without
+    /// having to rely on history sync — every group gets one snapshot
+    /// from the initiator immediately after the joiner's installation
+    /// becomes active.
+    ///
+    /// Best-effort per group: a single group's failure is logged and
+    /// skipped so a transient send error doesn't abort the fan-out.
+    func broadcastProfileSnapshotsToAllGroups() async {
+        let result: InboxReadyResult
+        do {
+            result = try await sessionStateManager.waitForInboxReadyResult()
+        } catch {
+            Log.warning("MessagingService: broadcastProfileSnapshotsToAllGroups skipped, inbox not ready: \(error)")
+            return
+        }
+        let conversations: [XMTPiOS.Conversation]
+        do {
+            conversations = try await result.client.conversationsProvider.list(
+                createdAfterNs: nil,
+                createdBeforeNs: nil,
+                lastActivityBeforeNs: nil,
+                lastActivityAfterNs: nil,
+                limit: nil,
+                consentStates: [.allowed],
+                orderBy: .createdAt
+            )
+        } catch {
+            Log.warning("MessagingService: broadcastProfileSnapshotsToAllGroups list failed: \(error)")
+            return
+        }
+        var sent: Int = 0
+        for conversation in conversations {
+            guard case let .group(group) = conversation else { continue }
+            do {
+                let memberInboxIds = try await group.members.map(\.inboxId)
+                try await ProfileSnapshotBuilder.sendSnapshot(
+                    group: group,
+                    memberInboxIds: memberInboxIds
+                )
+                sent += 1
+            } catch {
+                Log.warning("MessagingService: ProfileSnapshot send failed for group \(group.id): \(error.localizedDescription)")
+            }
+        }
+        Log.info("MessagingService: broadcasted ProfileSnapshot to \(sent) group(s) after pairing")
+    }
+
     func installationsSnapshot(refreshFromNetwork: Bool) async throws -> InstallationsSnapshot {
         let result = try await sessionStateManager.waitForInboxReadyResult()
         let installations = try await result.client.listInstallations(refreshFromNetwork: refreshFromNetwork)

--- a/ConvosCore/Sources/ConvosCore/Messaging/MessagingService.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/MessagingService.swift
@@ -384,13 +384,17 @@ final class MessagingService: MessagingServiceProtocol, @unchecked Sendable {
     ///
     /// Best-effort per group: a single group's failure is logged and
     /// skipped so a transient send error doesn't abort the fan-out.
-    func broadcastProfileSnapshotsToAllGroups() async {
+    /// Returns the count of groups a snapshot was successfully sent to
+    /// (0 when the inbox wasn't ready or the conversation list failed),
+    /// so callers can tell whether the fan-out actually happened.
+    @discardableResult
+    func broadcastProfileSnapshotsToAllGroups() async -> Int {
         let result: InboxReadyResult
         do {
             result = try await sessionStateManager.waitForInboxReadyResult()
         } catch {
             Log.warning("MessagingService: broadcastProfileSnapshotsToAllGroups skipped, inbox not ready: \(error)")
-            return
+            return 0
         }
         let conversations: [XMTPiOS.Conversation]
         do {
@@ -405,8 +409,12 @@ final class MessagingService: MessagingServiceProtocol, @unchecked Sendable {
             )
         } catch {
             Log.warning("MessagingService: broadcastProfileSnapshotsToAllGroups list failed: \(error)")
-            return
+            return 0
         }
+        // Sent sequentially rather than via a task group: `XMTPiOS.Group`
+        // is not `Sendable`, so fanning these into concurrent tasks would
+        // trip strict-concurrency errors. Post-pair is a one-time event,
+        // so the sequential cost is acceptable.
         var sent: Int = 0
         for conversation in conversations {
             guard case let .group(group) = conversation else { continue }
@@ -422,6 +430,7 @@ final class MessagingService: MessagingServiceProtocol, @unchecked Sendable {
             }
         }
         Log.info("MessagingService: broadcasted ProfileSnapshot to \(sent) group(s) after pairing")
+        return sent
     }
 
     func installationsSnapshot(refreshFromNetwork: Bool) async throws -> InstallationsSnapshot {

--- a/ConvosCore/Sources/ConvosCore/Messaging/MessagingServiceProtocol.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/MessagingServiceProtocol.swift
@@ -118,6 +118,14 @@ public protocol MessagingServiceProtocol: AnyObject, Sendable {
     /// any other paired devices). The Devices screen drives off this.
     func installationsSnapshot(refreshFromNetwork: Bool) async throws -> InstallationsSnapshot
 
+    /// Sends a fresh `ProfileSnapshot` to every allowed group the local
+    /// user is in. Invoked by the post-pair broadcaster so a newly-paired
+    /// installation has profile data for each member of each group
+    /// immediately, without having to wait for libxmtp's history sync to
+    /// replay older `ProfileUpdate` / `ProfileSnapshot` messages.
+    /// Best-effort per group; never throws.
+    func broadcastProfileSnapshotsToAllGroups() async
+
     /// Revokes every installation other than this device's own. Used by
     /// "Sign out other devices". Returns the installationIds revoked.
     func revokeOtherInstallations() async throws -> [String]

--- a/ConvosCore/Sources/ConvosCore/Messaging/MessagingServiceProtocol.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/MessagingServiceProtocol.swift
@@ -35,7 +35,7 @@ extension MessagingServiceProtocol {
     }
 }
 
-public protocol MessagingServiceProtocol: AnyObject, Sendable {
+public protocol MessagingServiceProtocol: AnyObject, Sendable, PostPairBroadcastMessaging {
     var state: MessagingServiceState { get }
     var sessionStateManager: any SessionStateManagerProtocol { get }
 
@@ -116,15 +116,8 @@ public protocol MessagingServiceProtocol: AnyObject, Sendable {
 
     /// Snapshot of the inbox's libxmtp installations (this device plus
     /// any other paired devices). The Devices screen drives off this.
-    func installationsSnapshot(refreshFromNetwork: Bool) async throws -> InstallationsSnapshot
-
-    /// Sends a fresh `ProfileSnapshot` to every allowed group the local
-    /// user is in. Invoked by the post-pair broadcaster so a newly-paired
-    /// installation has profile data for each member of each group
-    /// immediately, without having to wait for libxmtp's history sync to
-    /// replay older `ProfileUpdate` / `ProfileSnapshot` messages.
-    /// Best-effort per group; never throws.
-    func broadcastProfileSnapshotsToAllGroups() async
+    /// (`installationsSnapshot` + `broadcastProfileSnapshotsToAllGroups`
+    /// are inherited from `PostPairBroadcastMessaging`.)
 
     /// Revokes every installation other than this device's own. Used by
     /// "Sign out other devices". Returns the installationIds revoked.

--- a/ConvosCore/Sources/ConvosCore/Mocks/MockMessagingService.swift
+++ b/ConvosCore/Sources/ConvosCore/Mocks/MockMessagingService.swift
@@ -187,7 +187,7 @@ public final class MockMessagingService: MessagingServiceProtocol, @unchecked Se
         InstallationsSnapshot(inboxId: "mock-inbox", currentInstallationId: "mock-installation", installations: [])
     }
 
-    public func broadcastProfileSnapshotsToAllGroups() async {}
+    public func broadcastProfileSnapshotsToAllGroups() async -> Int { 0 }
 
     public func revokeOtherInstallations() async throws -> [String] {
         []

--- a/ConvosCore/Sources/ConvosCore/Mocks/MockMessagingService.swift
+++ b/ConvosCore/Sources/ConvosCore/Mocks/MockMessagingService.swift
@@ -187,6 +187,8 @@ public final class MockMessagingService: MessagingServiceProtocol, @unchecked Se
         InstallationsSnapshot(inboxId: "mock-inbox", currentInstallationId: "mock-installation", installations: [])
     }
 
+    public func broadcastProfileSnapshotsToAllGroups() async {}
+
     public func revokeOtherInstallations() async throws -> [String] {
         []
     }

--- a/ConvosCore/Sources/ConvosCore/Pairing/PostPairProfileSnapshotBroadcaster.swift
+++ b/ConvosCore/Sources/ConvosCore/Pairing/PostPairProfileSnapshotBroadcaster.swift
@@ -1,0 +1,84 @@
+import Foundation
+
+public protocol PostPairProfileSnapshotBroadcasterProtocol: Sendable {
+    /// Waits for the joiner's installation to appear in the inbox's
+    /// installation set, then broadcasts a `ProfileSnapshot` to every
+    /// group the initiator is in. One-shot; idempotent if called
+    /// multiple times (each call independently polls + sends).
+    ///
+    /// Returns `true` if a new non-current installation was detected
+    /// within the polling window and the broadcast ran; `false` if the
+    /// window elapsed with no new installation visible (snapshot send
+    /// is skipped in that case, since the new installation is the
+    /// whole reason we'd send).
+    func runAfterPairing() async -> Bool
+}
+
+/// Orchestrates the initiator-side post-pair profile-snapshot fan-out.
+///
+/// Pairing context: after the joiner adopts the initiator's identity
+/// (`LivePairingService.handleIdentityShare`), the joiner re-bootstraps
+/// under the shared `inboxId` and publishes its installation
+/// key-package. The XMTP network surfaces the new installation in the
+/// inbox's installations list a few seconds later. From the joiner's
+/// perspective the conversations exist (libxmtp adds the joiner's
+/// installation to each group's MLS state via UpdateGroupMembership
+/// commits), but the joiner's local DB has no `DBMemberProfile` rows
+/// yet — those get populated by inbound `ProfileUpdate` /
+/// `ProfileSnapshot` messages. Without a freshly-sent snapshot the
+/// joiner waits on libxmtp's history sync to replay old snapshots,
+/// which can be slow or partial.
+///
+/// This broadcaster makes the catch-up explicit: poll until a new
+/// installation appears, then have the initiator's `MessagingService`
+/// send a fresh `ProfileSnapshot` (built from every group's current
+/// members) to every group. The joiner's installation, now part of
+/// each group, receives those snapshots via its regular message
+/// stream and hydrates its local DB.
+public final class PostPairProfileSnapshotBroadcaster: PostPairProfileSnapshotBroadcasterProtocol, @unchecked Sendable {
+    private let messagingService: any MessagingServiceProtocol
+
+    public init(messagingService: any MessagingServiceProtocol) {
+        self.messagingService = messagingService
+    }
+
+    public func runAfterPairing() async -> Bool {
+        let didAppear = await waitForNewInstallation()
+        guard didAppear else {
+            Log.warning("PostPairProfileSnapshotBroadcaster: new installation never appeared within polling window; skipping snapshot fan-out")
+            return false
+        }
+        await messagingService.broadcastProfileSnapshotsToAllGroups()
+        return true
+    }
+
+    /// Polls libxmtp's installation list on the same schedule
+    /// `DevicesViewModel` uses for its optimistic-row reconciliation.
+    /// Returns true as soon as any installation other than the current
+    /// one is visible; returns false if the entire schedule elapses
+    /// with no new installation found.
+    private func waitForNewInstallation() async -> Bool {
+        let schedule: [TimeInterval] = Constant.pollSchedule
+        for delay in schedule {
+            if delay > 0 {
+                try? await Task.sleep(for: .seconds(delay))
+            }
+            do {
+                let snapshot = try await messagingService.installationsSnapshot(refreshFromNetwork: true)
+                let hasNonSelf = snapshot.installations.contains { $0.id != snapshot.currentInstallationId }
+                if hasNonSelf { return true }
+            } catch {
+                Log.warning("PostPairProfileSnapshotBroadcaster: installationsSnapshot failed: \(error.localizedDescription)")
+            }
+        }
+        return false
+    }
+
+    private enum Constant {
+        /// Matches `DevicesViewModel.refreshUntilRealInstallationAppears`:
+        /// cumulative ~37s, roughly exponential. Long enough to catch
+        /// the joiner's key-package publish, short enough that we don't
+        /// hang on a never-completes pair.
+        static let pollSchedule: [TimeInterval] = [0, 2, 5, 10, 20]
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Pairing/PostPairProfileSnapshotBroadcaster.swift
+++ b/ConvosCore/Sources/ConvosCore/Pairing/PostPairProfileSnapshotBroadcaster.swift
@@ -43,9 +43,23 @@ public final class PostPairProfileSnapshotBroadcaster: PostPairProfileSnapshotBr
     }
 
     public func runAfterPairing() async -> Bool {
-        let didAppear = await waitForNewInstallation()
+        // Take an immediate baseline of the inbox's currently-visible
+        // installation IDs *before* the polling loop begins. The
+        // joiner's just-published key-package is the installation that
+        // appears in subsequent snapshots but is NOT in this baseline.
+        // Without the diff, an initiator who already had a paired
+        // device (or any other prior installation) would see a non-
+        // self installation immediately and broadcast before the
+        // joiner's installation actually joined the groups' MLS state -
+        // at which point the snapshot misses the joiner entirely and
+        // the bug we set out to fix recurs.
+        guard let baseline = await fetchInstallationIds() else {
+            Log.warning("PostPairProfileSnapshotBroadcaster: baseline installations fetch failed; skipping snapshot fan-out to avoid an unanchored broadcast")
+            return false
+        }
+        let didAppear = await waitForInstallationAdded(beyond: baseline)
         guard didAppear else {
-            Log.warning("PostPairProfileSnapshotBroadcaster: new installation never appeared within polling window; skipping snapshot fan-out")
+            Log.warning("PostPairProfileSnapshotBroadcaster: no new installation appeared within polling window; skipping snapshot fan-out")
             return false
         }
         await messagingService.broadcastProfileSnapshotsToAllGroups()
@@ -54,24 +68,32 @@ public final class PostPairProfileSnapshotBroadcaster: PostPairProfileSnapshotBr
 
     /// Polls libxmtp's installation list on the same schedule
     /// `DevicesViewModel` uses for its optimistic-row reconciliation.
-    /// Returns true as soon as any installation other than the current
-    /// one is visible; returns false if the entire schedule elapses
-    /// with no new installation found.
-    private func waitForNewInstallation() async -> Bool {
-        let schedule: [TimeInterval] = Constant.pollSchedule
-        for delay in schedule {
+    /// Returns true the first time we see an installation id that
+    /// wasn't in the baseline set; false if the entire schedule
+    /// elapses with no new installation.
+    private func waitForInstallationAdded(beyond baseline: Set<String>) async -> Bool {
+        for delay in Constant.pollSchedule {
             if delay > 0 {
                 try? await Task.sleep(for: .seconds(delay))
             }
-            do {
-                let snapshot = try await messagingService.installationsSnapshot(refreshFromNetwork: true)
-                let hasNonSelf = snapshot.installations.contains { $0.id != snapshot.currentInstallationId }
-                if hasNonSelf { return true }
-            } catch {
-                Log.warning("PostPairProfileSnapshotBroadcaster: installationsSnapshot failed: \(error.localizedDescription)")
-            }
+            guard let current = await fetchInstallationIds() else { continue }
+            if !current.subtracting(baseline).isEmpty { return true }
         }
         return false
+    }
+
+    /// One-shot install-list fetch returning the full set of ids.
+    /// Returns nil on failure so the caller can distinguish "no new
+    /// installation" from "we don't know what was there to begin
+    /// with."
+    private func fetchInstallationIds() async -> Set<String>? {
+        do {
+            let snapshot = try await messagingService.installationsSnapshot(refreshFromNetwork: true)
+            return Set(snapshot.installations.map(\.id))
+        } catch {
+            Log.warning("PostPairProfileSnapshotBroadcaster: installationsSnapshot failed: \(error.localizedDescription)")
+            return nil
+        }
     }
 
     private enum Constant {

--- a/ConvosCore/Sources/ConvosCore/Pairing/PostPairProfileSnapshotBroadcaster.swift
+++ b/ConvosCore/Sources/ConvosCore/Pairing/PostPairProfileSnapshotBroadcaster.swift
@@ -1,17 +1,35 @@
 import Foundation
 
+/// Narrow slice of `MessagingServiceProtocol` the post-pair broadcaster
+/// needs. Segregating it keeps the broadcaster unit-testable with a tiny
+/// double instead of the full messaging-service surface.
+/// `MessagingServiceProtocol` inherits this, so `any MessagingServiceProtocol`
+/// satisfies it directly.
+public protocol PostPairBroadcastMessaging: Sendable {
+    func installationsSnapshot(refreshFromNetwork: Bool) async throws -> InstallationsSnapshot
+    @discardableResult
+    func broadcastProfileSnapshotsToAllGroups() async -> Int
+}
+
 public protocol PostPairProfileSnapshotBroadcasterProtocol: Sendable {
-    /// Waits for the joiner's installation to appear in the inbox's
-    /// installation set, then broadcasts a `ProfileSnapshot` to every
-    /// group the initiator is in. One-shot; idempotent if called
+    /// Waits for an installation outside `baseline` to appear in the
+    /// inbox's installation set, then broadcasts a `ProfileSnapshot` to
+    /// every group the initiator is in. One-shot; idempotent if called
     /// multiple times (each call independently polls + sends).
     ///
-    /// Returns `true` if a new non-current installation was detected
+    /// `baseline` MUST be captured before the joiner's installation could
+    /// have surfaced -- i.e. at the moment pairing completes, before any
+    /// install-list refresh that waits for the joiner. Capturing it later
+    /// (e.g. after a poll that already saw the joiner) folds the joiner
+    /// into the baseline, so the diff finds nothing new and the broadcast
+    /// never fires.
+    ///
+    /// Returns `true` if an installation beyond `baseline` was detected
     /// within the polling window and the broadcast ran; `false` if the
-    /// window elapsed with no new installation visible (snapshot send
-    /// is skipped in that case, since the new installation is the
-    /// whole reason we'd send).
-    func runAfterPairing() async -> Bool
+    /// window elapsed with no new installation visible (snapshot send is
+    /// skipped in that case, since the new installation is the whole
+    /// reason we'd send).
+    func runAfterPairing(baseline: Set<String>) async -> Bool
 }
 
 /// Orchestrates the initiator-side post-pair profile-snapshot fan-out.
@@ -36,33 +54,36 @@ public protocol PostPairProfileSnapshotBroadcasterProtocol: Sendable {
 /// each group, receives those snapshots via its regular message
 /// stream and hydrates its local DB.
 public final class PostPairProfileSnapshotBroadcaster: PostPairProfileSnapshotBroadcasterProtocol, @unchecked Sendable {
-    private let messagingService: any MessagingServiceProtocol
+    private let messagingService: any PostPairBroadcastMessaging
+    private let pollSchedule: [TimeInterval]
 
-    public init(messagingService: any MessagingServiceProtocol) {
+    public init(messagingService: any PostPairBroadcastMessaging) {
         self.messagingService = messagingService
+        self.pollSchedule = Constant.pollSchedule
     }
 
-    public func runAfterPairing() async -> Bool {
-        // Take an immediate baseline of the inbox's currently-visible
-        // installation IDs *before* the polling loop begins. The
-        // joiner's just-published key-package is the installation that
-        // appears in subsequent snapshots but is NOT in this baseline.
-        // Without the diff, an initiator who already had a paired
-        // device (or any other prior installation) would see a non-
-        // self installation immediately and broadcast before the
-        // joiner's installation actually joined the groups' MLS state -
-        // at which point the snapshot misses the joiner entirely and
-        // the bug we set out to fix recurs.
-        guard let baseline = await fetchInstallationIds() else {
-            Log.warning("PostPairProfileSnapshotBroadcaster: baseline installations fetch failed; skipping snapshot fan-out to avoid an unanchored broadcast")
-            return false
-        }
+    /// Test seam: inject a faster poll schedule so unit tests don't sleep
+    /// through the production cadence.
+    init(messagingService: any PostPairBroadcastMessaging, pollSchedule: [TimeInterval]) {
+        self.messagingService = messagingService
+        self.pollSchedule = pollSchedule
+    }
+
+    public func runAfterPairing(baseline: Set<String>) async -> Bool {
+        // `baseline` is the installation set captured by the caller
+        // *before* the post-pair install-list refresh ran, so the
+        // joiner's just-published key-package is guaranteed to be absent
+        // from it. Any installation that shows up beyond this set is the
+        // joiner. (Capturing the baseline here, after the refresh already
+        // waited for the joiner, would fold it in and the broadcast would
+        // never fire.)
         let didAppear = await waitForInstallationAdded(beyond: baseline)
         guard didAppear else {
             Log.warning("PostPairProfileSnapshotBroadcaster: no new installation appeared within polling window; skipping snapshot fan-out")
             return false
         }
-        await messagingService.broadcastProfileSnapshotsToAllGroups()
+        let sent = await messagingService.broadcastProfileSnapshotsToAllGroups()
+        Log.info("PostPairProfileSnapshotBroadcaster: broadcast ProfileSnapshot to \(sent) group(s)")
         return true
     }
 
@@ -72,7 +93,7 @@ public final class PostPairProfileSnapshotBroadcaster: PostPairProfileSnapshotBr
     /// wasn't in the baseline set; false if the entire schedule
     /// elapses with no new installation.
     private func waitForInstallationAdded(beyond baseline: Set<String>) async -> Bool {
-        for delay in Constant.pollSchedule {
+        for delay in pollSchedule {
             if delay > 0 {
                 try? await Task.sleep(for: .seconds(delay))
             }

--- a/ConvosCore/Tests/ConvosCoreTests/PostPairProfileSnapshotBroadcasterTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/PostPairProfileSnapshotBroadcasterTests.swift
@@ -1,0 +1,100 @@
+@testable import ConvosCore
+import Foundation
+import os
+import Testing
+
+@Suite("PostPairProfileSnapshotBroadcaster Tests")
+struct PostPairProfileSnapshotBroadcasterTests {
+    /// Minimal `PostPairBroadcastMessaging` double: returns a scripted
+    /// sequence of installation-id sets (one per poll) and records how
+    /// many times the broadcast was invoked.
+    private final class FakeBroadcastMessaging: PostPairBroadcastMessaging, @unchecked Sendable {
+        private struct State {
+            var snapshots: [[String]]
+            var index: Int = 0
+            var broadcastCallCount: Int = 0
+        }
+        private let state: OSAllocatedUnfairLock<State>
+        let broadcastReturnValue: Int
+
+        init(snapshots: [[String]], broadcastReturnValue: Int = 3) {
+            self.state = OSAllocatedUnfairLock(initialState: State(snapshots: snapshots))
+            self.broadcastReturnValue = broadcastReturnValue
+        }
+
+        var broadcastCallCount: Int {
+            state.withLock { $0.broadcastCallCount }
+        }
+
+        func installationsSnapshot(refreshFromNetwork: Bool) async throws -> InstallationsSnapshot {
+            let ids: [String] = state.withLock { s in
+                // Hold on the last entry once the script is exhausted so
+                // extra polls keep seeing the final state.
+                let current = s.snapshots[min(s.index, s.snapshots.count - 1)]
+                if s.index < s.snapshots.count - 1 { s.index += 1 }
+                return current
+            }
+            return InstallationsSnapshot(
+                inboxId: "inbox",
+                currentInstallationId: "self",
+                installations: ids.map { InstallationInfo(id: $0, createdAt: nil) }
+            )
+        }
+
+        @discardableResult
+        func broadcastProfileSnapshotsToAllGroups() async -> Int {
+            state.withLock { $0.broadcastCallCount += 1 }
+            return broadcastReturnValue
+        }
+    }
+
+    private func makeBroadcaster(_ fake: FakeBroadcastMessaging) -> PostPairProfileSnapshotBroadcaster {
+        // All-zero schedule so the test never sleeps; length controls how
+        // many polls happen before giving up.
+        PostPairProfileSnapshotBroadcaster(messagingService: fake, pollSchedule: [0, 0, 0])
+    }
+
+    @Test("Broadcasts when a new installation appears beyond the baseline")
+    func broadcastsOnNewInstallation() async {
+        // First poll already shows the joiner beyond the baseline.
+        let fake = FakeBroadcastMessaging(snapshots: [["self", "joiner"]])
+        let didRun = await makeBroadcaster(fake).runAfterPairing(baseline: ["self"])
+        #expect(didRun)
+        #expect(fake.broadcastCallCount == 1)
+    }
+
+    @Test("Skips the broadcast when no new installation appears")
+    func skipsWhenNoNewInstallation() async {
+        // Every poll returns only the baseline set -- nothing new.
+        let fake = FakeBroadcastMessaging(snapshots: [["self"]])
+        let didRun = await makeBroadcaster(fake).runAfterPairing(baseline: ["self"])
+        #expect(!didRun)
+        #expect(fake.broadcastCallCount == 0)
+    }
+
+    @Test("Waits for the joiner rather than firing on a pre-existing paired device")
+    func waitsForJoinerNotExistingDevice() async {
+        // Baseline already contains a previously-paired device. The joiner
+        // only appears on the third poll. The broadcaster must wait for it
+        // and not fire on the pre-existing device.
+        let baseline: Set<String> = ["self", "oldDevice"]
+        let fake = FakeBroadcastMessaging(snapshots: [
+            ["self", "oldDevice"],
+            ["self", "oldDevice"],
+            ["self", "oldDevice", "joiner"]
+        ])
+        let didRun = await makeBroadcaster(fake).runAfterPairing(baseline: baseline)
+        #expect(didRun)
+        #expect(fake.broadcastCallCount == 1)
+    }
+
+    @Test("A baseline that already includes the joiner never broadcasts")
+    func staleBaselineNeverBroadcasts() async {
+        // Reproduces the original bug: if the baseline is captured after
+        // the joiner is already visible, the diff finds nothing new.
+        let fake = FakeBroadcastMessaging(snapshots: [["self", "joiner"]])
+        let didRun = await makeBroadcaster(fake).runAfterPairing(baseline: ["self", "joiner"])
+        #expect(!didRun)
+        #expect(fake.broadcastCallCount == 0)
+    }
+}


### PR DESCRIPTION
## Bug

After a successful pair, the joiner's new installation joins each of the inbox's groups via libxmtp's `UpdateGroupMembership` commits, but the joiner's local DB has **no `DBMemberProfile` rows** for those members. Profile names and avatars stay blank until libxmtp's history sync replays old `ProfileUpdate` / `ProfileSnapshot` messages, which can be slow or partial.

## Fix

Have the **initiator** broadcast a fresh `ProfileSnapshot` to every group once the joiner's installation is visible in the inbox's installation set. The joiner's installation, now part of each group, receives those snapshots through its regular message stream and hydrates `DBMemberProfile` locally — no waiting on history sync.

## Pieces

- **`PostPairProfileSnapshotBroadcaster`** (new file, `ConvosCore/Pairing/`). One-shot orchestrator. Polls libxmtp's installation list on the same `[0, 2, 5, 10, 20]` schedule `DevicesViewModel` uses; once a non-current installation appears, calls into `MessagingService` to fan out. Returns `Bool` so callers can drive their own UI state from the new-installation arrival if they want.
- **`MessagingService.broadcastProfileSnapshotsToAllGroups()`** (+ protocol surface + mock no-op). Lists every `.allowed` conversation, filters to `.group`, builds a `ProfileSnapshot` from `group.members`, sends via existing `ProfileSnapshotBuilder.sendSnapshot`. Best-effort per group: one send failure is logged and the rest of the fan-out continues.
- **`DevicesViewModel.startObserving`**'s existing `.pairingDidCompleteSuccessfully` observer now branches on `userInfo["joinerDeviceName"]`:
  - **Present** → initiator-side post (`PairingSheetViewModel.confirmEmoji`); kick off the broadcaster alongside the existing optimistic-row reconcile poll.
  - **Absent** → joiner-side post (`JoinerPairingSheetViewModel.onPairingCompleted`); skip the broadcast (the joiner is the recipient, not the sender).

## Test plan

- [x] Build clean on iPhone 17 + iPhone 17 Pro simulators.
- [x] `swiftlint --strict` clean (760 files, 0 violations).
- [x] Manual: initiator and joiner sims pair successfully; after pairing the joiner immediately sees full member names + avatars in every previously-empty group, instead of waiting on history sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/887"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782510866&installation_id=128169237&pr_number=887&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F887&signature=4205b5e88feccd9ae69c7a71cf10ccb4073c9a73baaa090a0f664ceb07ebf5a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Broadcast a fresh ProfileSnapshot to all groups after pairing completes on the initiator
> - Adds `PostPairProfileSnapshotBroadcaster` in [PostPairProfileSnapshotBroadcaster.swift](https://github.com/xmtplabs/convos-ios/pull/887/files#diff-4e243347522da6744a7826a767ce3087f227a2abea574bd4635415aefa85565d), which polls installations until a new joiner installation appears beyond a captured baseline, then calls `broadcastProfileSnapshotsToAllGroups` on `MessagingService`.
> - `MessagingService` gains `broadcastProfileSnapshotsToAllGroups`, which iterates all allowed group conversations and sends a `ProfileSnapshot` to each, returning the count of groups successfully sent to.
> - `DevicesViewModel` captures a baseline of installation IDs on receipt of `pairingDidCompleteSuccessfully`, waits for the real installation to appear, then triggers the broadcaster — gated to the initiator side only via a new `isInitiator` flag in the notification userInfo.
> - `MessagingServiceProtocol` now inherits from the narrow `PostPairBroadcastMessaging` protocol to keep the broadcaster unit-testable.
> - Risk: the broadcaster silently skips broadcasting if no new installation appears within its polling window.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2a48d1e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->