### PR TITLE
Queue pre-swap attachments on AgentBuilderViewModel

### DIFF
--- a/Convos/Agent Builder/AgentBuilderViewModel.swift
+++ b/Convos/Agent Builder/AgentBuilderViewModel.swift
@@ -192,6 +192,20 @@ final class AgentBuilderViewModel: Identifiable {
     @ObservationIgnored
     private var restoreComposerFocusAfterRecording: Bool = false
 
+    /// Attachments captured before the inner `ConversationViewModel`
+    /// finishes its placeholder-to-real swap. Drained into the real
+    /// inner VM from `onReachedReady`.
+    @ObservationIgnored
+    private var queuedInitialAttachments: [QueuedInitialAttachment] = []
+    @ObservationIgnored
+    private var hasDrainedInitialAttachments: Bool = false
+
+    private enum QueuedInitialAttachment {
+        case photo(UIImage)
+        case video(URL)
+        case file(url: URL, filename: String, mimeType: String, fileSize: Int)
+    }
+
     init(session: any SessionManagerProtocol, entryMode: AgentBuilderEntryMode = .composer) {
         self.session = session
         self.entryMode = entryMode
@@ -211,6 +225,7 @@ final class AgentBuilderViewModel: Identifiable {
         // both the placeholder VM and its real replacement stay suppressed.
         self.newConversationViewModel.suppressesContactCard = true
         self.newConversationViewModel.onReachedReady = { [weak self] in
+            self?.drainInitialAttachmentsIfNeeded()
             self?.requestAgentJoinIfNeeded()
         }
         cloudConnectionsCancellable = session.cloudConnectionRepository().connectionsPublisher()
@@ -226,25 +241,79 @@ final class AgentBuilderViewModel: Identifiable {
 
     // MARK: - Composer mutations
 
+    /// Bar-entry attachment paths (camera capture, photo picker, file
+    /// picker) call `addPhotoAttachment` etc. immediately after
+    /// `onStartAgent()` returns - i.e. while `NewConversationViewModel`
+    /// is still on its synchronously-created placeholder
+    /// `ConversationViewModel`. Forwarding straight to the inner VM at
+    /// that moment lands the attachment on the placeholder, which is
+    /// then discarded when `configureWithMessagingService` swaps in the
+    /// real VM. Queue any add that lands before the real-VM swap and
+    /// drain into the real VM at `onReachedReady`, so the eager-upload
+    /// pipeline fires on the real `cachedMessageWriter`.
     func addPhotoAttachment(_ image: UIImage) {
-        newConversationViewModel.conversationViewModel?.addPhotoAttachment(image)
+        if hasDrainedInitialAttachments,
+           let convoVM = newConversationViewModel.conversationViewModel {
+            convoVM.addPhotoAttachment(image)
+        } else {
+            queuedInitialAttachments.append(.photo(image))
+        }
     }
 
     func addVideoAttachment(url: URL) {
-        newConversationViewModel.conversationViewModel?.addVideoAttachment(url: url)
+        if hasDrainedInitialAttachments,
+           let convoVM = newConversationViewModel.conversationViewModel {
+            convoVM.addVideoAttachment(url: url)
+        } else {
+            queuedInitialAttachments.append(.video(url))
+        }
     }
 
     func addFileAttachment(url: URL, filename: String, mimeType: String, fileSize: Int) {
-        newConversationViewModel.conversationViewModel?.addFileAttachment(
-            url: url,
-            filename: filename,
-            mimeType: mimeType,
-            fileSize: fileSize
-        )
+        if hasDrainedInitialAttachments,
+           let convoVM = newConversationViewModel.conversationViewModel {
+            convoVM.addFileAttachment(
+                url: url,
+                filename: filename,
+                mimeType: mimeType,
+                fileSize: fileSize
+            )
+        } else {
+            queuedInitialAttachments.append(
+                .file(url: url, filename: filename, mimeType: mimeType, fileSize: fileSize)
+            )
+        }
     }
 
     func removeAttachment(id: UUID) {
         newConversationViewModel.conversationViewModel?.removeMediaAttachment(id: id)
+    }
+
+    /// Flush attachments queued during the placeholder window into the
+    /// real inner conversation VM. Called once from `onReachedReady`;
+    /// the `hasDrainedInitialAttachments` flag then lets subsequent
+    /// adds short-circuit straight through.
+    private func drainInitialAttachmentsIfNeeded() {
+        guard !hasDrainedInitialAttachments else { return }
+        hasDrainedInitialAttachments = true
+        guard let convoVM = newConversationViewModel.conversationViewModel else { return }
+        let queued = queuedInitialAttachments
+        queuedInitialAttachments = []
+        for item in queued {
+            switch item {
+            case let .photo(image):
+                convoVM.addPhotoAttachment(image)
+            case let .video(url):
+                convoVM.addVideoAttachment(url: url)
+            case let .file(url, filename, mimeType, fileSize):
+                convoVM.addFileAttachment(
+                    url: url,
+                    filename: filename,
+                    mimeType: mimeType,
+                    fileSize: fileSize
+                )
+            }
+        }
     }
 
     func startVoiceMemoRecording(restoreComposerFocusAfter: Bool) {

--- a/Convos/Agent Builder/AgentBuilderViewModel.swift
+++ b/Convos/Agent Builder/AgentBuilderViewModel.swift
@@ -295,8 +295,15 @@ final class AgentBuilderViewModel: Identifiable {
     /// adds short-circuit straight through.
     private func drainInitialAttachmentsIfNeeded() {
         guard !hasDrainedInitialAttachments else { return }
-        hasDrainedInitialAttachments = true
+        // Flip the flag only after confirming the inner VM is available.
+        // Setting it before the guard left the queue full + the flag latched
+        // true when `onReachedReady` ran without a VM ever resolving --
+        // subsequent `addPhotoAttachment`/etc. calls would then route to the
+        // queue (their `if hasDrained, let convoVM` short-circuit fails on
+        // nil VM), and the queue would never drain because the early
+        // `hasDrainedInitialAttachments` guard above returns immediately.
         guard let convoVM = newConversationViewModel.conversationViewModel else { return }
+        hasDrainedInitialAttachments = true
         let queued = queuedInitialAttachments
         queuedInitialAttachments = []
         for item in queued {

--- a/Convos/Agent Builder/AgentBuilderViewModel.swift
+++ b/Convos/Agent Builder/AgentBuilderViewModel.swift
@@ -293,6 +293,28 @@ final class AgentBuilderViewModel: Identifiable {
     /// real inner conversation VM. Called once from `onReachedReady`;
     /// the `hasDrainedInitialAttachments` flag then lets subsequent
     /// adds short-circuit straight through.
+    /// Delete temp files owned by attachments still sitting in
+    /// `queuedInitialAttachments`. Called from `discard()` when the user
+    /// bails before the inner VM resolves -- the queue items haven't been
+    /// forwarded to the VM yet, so `cleanupPendingMediaAttachments()` on
+    /// the VM doesn't see them and their `temporaryDirectory` copies would
+    /// otherwise leak. Photos are in-memory `UIImage`s so they have no
+    /// file to delete.
+    private func cleanupQueuedInitialAttachments() {
+        let queued = queuedInitialAttachments
+        queuedInitialAttachments = []
+        for item in queued {
+            switch item {
+            case .photo:
+                continue
+            case .video(let url):
+                try? FileManager.default.removeItem(at: url)
+            case .file(let url, _, _, _):
+                try? FileManager.default.removeItem(at: url)
+            }
+        }
+    }
+
     private func drainInitialAttachmentsIfNeeded() {
         guard !hasDrainedInitialAttachments else { return }
         // Flip the flag only after confirming the inner VM is available.
@@ -708,6 +730,12 @@ final class AgentBuilderViewModel: Identifiable {
             // those temp copies are otherwise orphaned because `dismissWithDeletion`
             // doesn't iterate `pendingMediaAttachments`. Clean them up explicitly.
             newConversationViewModel.conversationViewModel?.cleanupPendingMediaAttachments()
+            // Attachments staged before the inner VM resolved haven't been
+            // forwarded yet -- `cleanupPendingMediaAttachments()` only walks
+            // what's already inside that VM. Walk the local queue too so the
+            // file-picker / camera / photo-picker temp files don't leak when
+            // the user discards before the placeholder window closes.
+            cleanupQueuedInitialAttachments()
         }
 
         let conversation = newConversationViewModel.conversationViewModel?.conversation


### PR DESCRIPTION
## Summary

Capturing a photo / video or picking from the photo or file picker from the `AgentBuilderBar` was silently dropping the attachment: when the bar's tap handler called `onStartAgent()` and immediately invoked `builderViewModel.addPhotoAttachment(image)`, the call landed on `NewConversationViewModel`'s synchronously-seeded placeholder `ConversationViewModel`. `configureWithMessagingService` then swapped the placeholder for the real VM and the chip strip surfaced empty when the sheet settled.

Same root cause as PR #882's voice-memo fix - the inner-VM swap discards anything attached to the placeholder.

## Approach

Mirror the voice-memo recorder pattern: hold a small queue on `AgentBuilderViewModel` and forward the queued items into the real inner VM from the existing `onReachedReady` callback. Once the drain has happened, subsequent adds (e.g. from the in-builder photo picker) short-circuit straight through. Eager-upload tasks now spin up on the real `cachedMessageWriter` instead of the discarded placeholder's mock writer.

Covered entry points: camera still image, camera video, photo / video picker selection, file picker.

## Test plan

- [ ] Tap the camera icon on the `AgentBuilderBar`, capture a photo - photo appears in the agent builder chip strip when the sheet settles.
- [ ] Same for camera video.
- [ ] Tap the photo icon on the `AgentBuilderBar`, select an image and a video - both appear in the chip strip.
- [ ] Inside an already-open builder, the in-composer photo picker, file picker and connection-related affordances all still attach as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/888"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782511676&installation_id=128169237&pr_number=888&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F888&signature=3309e35254cdc84e830d787fd48a71dcfd259ebf5da107c3d9e0e92abe67c43a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Queue pre-swap attachments on `AgentBuilderViewModel` before inner `ConversationViewModel` is ready
> - Adds a `queuedInitialAttachments` buffer and `hasDrainedInitialAttachments` flag to `AgentBuilderViewModel` so photo, video, and file attachments added before the inner `ConversationViewModel` resolves are held locally.
> - When `NewConversationViewModel.onReachedReady` fires, a new `drainInitialAttachmentsIfNeeded` method forwards all queued items to the real VM before `requestAgentJoinIfNeeded`.
> - Adds `cleanupQueuedInitialAttachments` to delete temp files for queued video and file items when the builder is discarded before the inner VM resolves.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9af7e90.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->