### PR TITLE
Remove "Secured by XMTP" UI

### DIFF
--- a/Convos/Agent Builder/AgentBuilderView.swift
+++ b/Convos/Agent Builder/AgentBuilderView.swift
@@ -176,7 +176,7 @@ struct AgentBuilderView: View {
                 }
             }
             if !viewModel.hasCommitted {
-                inlineLegalFooter
+                inlineTermsFooter
             }
         }
         .onAppear {
@@ -194,34 +194,11 @@ struct AgentBuilderView: View {
         }
     }
 
-    /// "Secured by XMTP" + "Terms & Privacy Policy" links rendered under
-    /// the inline composer. Lifted from the deleted "Pop-up private
-    /// convos" CTA so first-run users still have entry points to the
-    /// XMTP and legal pages on the chats-list empty state.
-    private var inlineLegalFooter: some View {
+    /// "Terms & Privacy Policy" link rendered under the inline composer
+    /// so first-run users on the chats-list empty state still have an
+    /// entry point to the legal page.
+    private var inlineTermsFooter: some View {
         HStack(spacing: DesignConstants.Spacing.step4x) {
-            Button {
-                if let url = URL(string: "https://xmtp.org") {
-                    openURL(url, prefersInApp: true)
-                }
-            } label: {
-                HStack(alignment: .firstTextBaseline, spacing: 0.0) {
-                    Text("Secured by ")
-                    Image("xmtpIcon")
-                        .renderingMode(.template)
-                        .resizable()
-                        .frame(width: 10.0, height: 10.0)
-                        .padding(.leading, 2.0)
-                        .padding(.trailing, 1.0)
-                        .offset(y: 0.5)
-                    Text("XMTP")
-                    Image(systemName: "chevron.right")
-                        .foregroundStyle(.colorTextTertiary)
-                        .padding(.leading, DesignConstants.Spacing.stepX)
-                }
-                .font(.caption)
-                .foregroundStyle(.colorTextSecondary)
-            }
             Button {
                 if let url = URL(string: "https://convos.org/terms-and-privacy") {
                     openURL(url, prefersInApp: true)

--- a/Convos/App Settings/AppSettingsView.swift
+++ b/Convos/App Settings/AppSettingsView.swift
@@ -278,7 +278,6 @@ struct AppSettingsView: View {
     @ViewBuilder
     private var linksSection: some View {
         Section {
-            securedByXMTPRow
             privacyTermsRow
             sendFeedbackRow
             if !ConfigManager.shared.currentEnvironment.isProduction {
@@ -288,28 +287,6 @@ struct AppSettingsView: View {
             linksFooter
         }
         .listRowSeparatorTint(.colorBorderSubtle)
-    }
-
-    @ViewBuilder
-    private var securedByXMTPRow: some View {
-        Button {
-            openExternalURL("https://xmtp.org")
-        } label: {
-            NavigationLink {
-                EmptyView()
-            } label: {
-                HStack(alignment: .firstTextBaseline, spacing: 0.0) {
-                    Text("Secured by ")
-                    Image("xmtpIcon")
-                        .renderingMode(.template)
-                        .foregroundStyle(.colorTextPrimary)
-                        .padding(.trailing, 1.0)
-                    Text("XMTP")
-                }
-                .foregroundStyle(.colorTextPrimary)
-            }
-        }
-        .foregroundStyle(.colorTextPrimary)
     }
 
     @ViewBuilder


### PR DESCRIPTION
## Summary

Drops the "Secured by XMTP" entry from two surfaces:

- **App Settings → Links section**: removes the `securedByXMTPRow` row (kept `Privacy & Terms`, `Send feedback`, and the dev-only `Debug` row).
- **Chats-list inline composer footer** (`AgentBuilderView.inlineBody`): removes the leading "Secured by XMTP" button; renamed the helper to `inlineTermsFooter` since it now hosts the single `Terms & Privacy Policy` link.

No other entry points reference `xmtpIcon` or the marketing string.

## Test plan

- [ ] Open App Settings - "Secured by XMTP" row is gone; Privacy & Terms / Send feedback rows still navigate as before.
- [ ] Open the chats tab on a fresh account so the inline composer is visible - the row under the composer now shows only the "Terms & Privacy Policy" link.
- [ ] Tap Terms & Privacy Policy from each surface - still opens https://convos.org/terms-and-privacy in the in-app browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/889"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782512242&installation_id=128169237&pr_number=889&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F889&signature=584daf628bd89f2953018cb92fc8dcac0cdbde45368ff0e051f35c1e2c0613ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove "Secured by XMTP" UI from App Settings and inline composer footer
> - Removes the `securedByXMTPRow` button from the links section in [AppSettingsView.swift](https://github.com/xmtplabs/convos-ios/pull/889/files#diff-30e98d39613710cf0f912b477ed30a8638995959caa9cb2e9facdc10e1c3f8b9).
> - Replaces `inlineLegalFooter` in [AgentBuilderView.swift](https://github.com/xmtplabs/convos-ios/pull/889/files#diff-112eb571b37e845cdd6337280b52c1c6b1cf8b2b100bf314a6b17aa960d0215e) with `inlineTermsFooter`, which shows only a Terms & Privacy Policy link instead of both a Terms link and an XMTP link.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8357656.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->