### PR TITLE
Render pending agent-builder drafts as "New Agent"

### DIFF
--- a/Convos/Shared Views/AvatarView.swift
+++ b/Convos/Shared Views/AvatarView.swift
@@ -133,6 +133,8 @@ struct ConversationAvatarView: View {
             EmojiAvatarView(emoji: emoji)
         case .monogram(let name):
             MonogramView(name: name)
+        case .pendingAgent:
+            PendingAgentAvatarView()
         }
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Mocks/ModelMocks.swift
+++ b/ConvosCore/Sources/ConvosCore/Mocks/ModelMocks.swift
@@ -12,7 +12,8 @@ public extension Conversation {
         isPinned: Bool = false,
         isMuted: Bool = false,
         invite: Invite? = nil,
-        lastMessageText: String = "This is a preview of the last message"
+        lastMessageText: String = "This is a preview of the last message",
+        wasCreatedFromAgentBuilder: Bool = false
     ) -> Conversation {
         let mockMembers = members ?? [
             .mock(isCurrentUser: true),
@@ -53,7 +54,8 @@ public extension Conversation {
             debugInfo: ConversationDebugInfo.empty,
             isLocked: false,
             agentJoinStatus: nil,
-            hasHadVerifiedAgent: mockMembers.contains(where: \.agentVerification.isConvosAgent)
+            hasHadVerifiedAgent: mockMembers.contains(where: \.agentVerification.isConvosAgent),
+            wasCreatedFromAgentBuilder: wasCreatedFromAgentBuilder
         )
     }
 
@@ -99,7 +101,8 @@ public extension Conversation {
             debugInfo: .empty,
             isLocked: false,
             agentJoinStatus: nil,
-            hasHadVerifiedAgent: false
+            hasHadVerifiedAgent: false,
+            wasCreatedFromAgentBuilder: false
         )
     }
 
@@ -144,7 +147,8 @@ public extension Conversation {
             debugInfo: .empty,
             isLocked: false,
             agentJoinStatus: nil,
-            hasHadVerifiedAgent: false
+            hasHadVerifiedAgent: false,
+            wasCreatedFromAgentBuilder: false
         )
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Storage/Database Models/DBConversation.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Database Models/DBConversation.swift
@@ -274,6 +274,17 @@ struct DBConversation: Codable, FetchableRecord, PersistableRecord, Identifiable
         key: "conversationLocalState",
         using: localStateForeignKey
     )
+
+    /// The agent-builder summary row, present iff this conversation was
+    /// created through the Agent Builder (written at "Make"). Its presence
+    /// is the persisted marker that drives the pending-agent display
+    /// (placeholder "New Agent" name + add-agent avatar) until a verified
+    /// agent actually joins.
+    static let agentBuilderSummary: HasOneAssociation<DBConversation, DBAgentBuilderSummary> = hasOne(
+        DBAgentBuilderSummary.self,
+        key: "conversationAgentBuilderSummary",
+        using: ForeignKey([DBAgentBuilderSummary.Columns.conversationId], to: [Columns.id])
+    )
 }
 
 // MARK: - DBConversation Extensions

--- a/ConvosCore/Sources/ConvosCore/Storage/Database Models/DBConversationDetails.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Database Models/DBConversationDetails.swift
@@ -15,6 +15,10 @@ struct DBConversationDetails: Codable, FetchableRecord, PersistableRecord, Hasha
     /// `DBConversation.invites` — see the custom `init(from:)` below.
     let conversationInvites: [DBInvite]
     let conversationAgentJoinRequest: DBAgentJoinRequest?
+    /// Present iff the conversation was created through the Agent Builder.
+    /// Decoded as nil when the caller's query doesn't include
+    /// `DBConversation.agentBuilderSummary`.
+    let conversationAgentBuilderSummary: DBAgentBuilderSummary?
 
     init(
         conversation: DBConversation,
@@ -23,7 +27,8 @@ struct DBConversationDetails: Codable, FetchableRecord, PersistableRecord, Hasha
         conversationLastMessageWithSource: DBLastMessageWithSource?,
         conversationLocalState: ConversationLocalState,
         conversationInvites: [DBInvite] = [],
-        conversationAgentJoinRequest: DBAgentJoinRequest?
+        conversationAgentJoinRequest: DBAgentJoinRequest?,
+        conversationAgentBuilderSummary: DBAgentBuilderSummary? = nil
     ) {
         self.conversation = conversation
         self.conversationCreator = conversationCreator
@@ -32,6 +37,7 @@ struct DBConversationDetails: Codable, FetchableRecord, PersistableRecord, Hasha
         self.conversationLocalState = conversationLocalState
         self.conversationInvites = conversationInvites
         self.conversationAgentJoinRequest = conversationAgentJoinRequest
+        self.conversationAgentBuilderSummary = conversationAgentBuilderSummary
     }
 
     init(from decoder: any Decoder) throws {
@@ -43,6 +49,7 @@ struct DBConversationDetails: Codable, FetchableRecord, PersistableRecord, Hasha
         self.conversationLocalState = try container.decode(ConversationLocalState.self, forKey: .conversationLocalState)
         self.conversationInvites = try container.decodeIfPresent([DBInvite].self, forKey: .conversationInvites) ?? []
         self.conversationAgentJoinRequest = try container.decodeIfPresent(DBAgentJoinRequest.self, forKey: .conversationAgentJoinRequest)
+        self.conversationAgentBuilderSummary = try container.decodeIfPresent(DBAgentBuilderSummary.self, forKey: .conversationAgentBuilderSummary)
     }
 }
 

--- a/ConvosCore/Sources/ConvosCore/Storage/Hydration/DBConversationDetails+Conversation.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Hydration/DBConversationDetails+Conversation.swift
@@ -72,7 +72,8 @@ extension DBConversationDetails {
             debugInfo: conversation.debugInfo,
             isLocked: conversation.isLocked,
             agentJoinStatus: agentJoinStatus,
-            hasHadVerifiedAgent: conversation.hasHadVerifiedAgent
+            hasHadVerifiedAgent: conversation.hasHadVerifiedAgent,
+            wasCreatedFromAgentBuilder: conversationAgentBuilderSummary != nil
         )
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/Conversation.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/Conversation.swift
@@ -38,6 +38,13 @@ public struct Conversation: Codable, Hashable, Identifiable, Sendable {
     public let isLocked: Bool
     public let agentJoinStatus: AgentJoinStatus?
     public let hasHadVerifiedAgent: Bool
+    /// True when this conversation was created through the Agent Builder
+    /// (an `AgentBuilderSummary` row exists for it). Drives the
+    /// pending-agent presentation -- "New Agent" placeholder name + the
+    /// add-agent avatar instead of the generic "New Convo" + emoji circle
+    /// -- until a verified agent actually joins. See
+    /// `isPendingAgentBuilderDraft`.
+    public let wasCreatedFromAgentBuilder: Bool
 }
 
 public extension Conversation {
@@ -69,9 +76,26 @@ public extension Conversation {
     /// `Profile`/`ConversationMember`'s override semantics). When the
     /// conversation already has an explicit `name`, it's returned verbatim
     /// — the override only affects auto-generated titles.
+    /// True while an Agent-Builder-created conversation is still waiting on
+    /// its verified agent to join. In this window the conversation has only
+    /// the local user as a member, so it would otherwise render as the
+    /// generic "New Convo" + emoji circle; instead we surface the
+    /// pending-agent identity ("New Agent" + add-agent avatar) to match the
+    /// builder indicator. Gated on the sticky `hasHadVerifiedAgent` flag
+    /// (set once any Convos-verified agent has joined) rather than the
+    /// current member list, so the hand-off to normal member-driven
+    /// rendering is permanent -- a builder agent that later leaves doesn't
+    /// flip the conversation back to the "New Agent" placeholder.
+    var isPendingAgentBuilderDraft: Bool {
+        wasCreatedFromAgentBuilder && !hasHadVerifiedAgent
+    }
+
     func computedDisplayName(memberNameOverride: (String) -> String?) -> String {
         if let name, !name.isEmpty {
             return name
+        }
+        if isPendingAgentBuilderDraft {
+            return "New Agent"
         }
         if kind == .dm {
             if let other = otherMember {
@@ -100,6 +124,14 @@ public extension Conversation {
     }
 
     var avatarType: ConversationAvatarType {
+        // A pending agent-builder draft shows the add-agent glyph (matching
+        // the builder bar / indicator) rather than the conversation emoji,
+        // even before the verified agent joins. Checked before the
+        // image/member branches so a user-only draft doesn't fall through
+        // to the emoji circle.
+        if isPendingAgentBuilderDraft {
+            return .pendingAgent
+        }
         if imageURL != nil {
             return .customImage
         }

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/ConversationAvatarType.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/ConversationAvatarType.swift
@@ -6,4 +6,8 @@ public enum ConversationAvatarType: Sendable, Equatable {
     case clustered([Profile])
     case emoji(String)
     case monogram(String)
+    /// An Agent-Builder conversation whose verified agent hasn't joined
+    /// yet. Rendered as the add-agent glyph (see `PendingAgentAvatarView`),
+    /// mirroring the builder bar / indicator.
+    case pendingAgent
 }

--- a/ConvosCore/Sources/ConvosCore/Storage/Repositories/ConversationsRepository.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Repositories/ConversationsRepository.swift
@@ -189,6 +189,7 @@ extension QueryInterfaceRequest where RowDecoder == DBConversation {
                     .including(optional: DBConversationMember.inviterProfile)
             )
             .including(required: DBConversation.localState)
+            .including(optional: DBConversation.agentBuilderSummary)
             .with(DBConversation.lastMessageWithSourceCTE)
             .including(optional: lastMessageWithSource)
             .with(DBConversation.latestAgentJoinRequestCTE)

--- a/ConvosCore/Sources/ConvosCore/Storage/Repositories/MessagesRepository.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Repositories/MessagesRepository.swift
@@ -796,6 +796,7 @@ fileprivate extension Database {
                     .including(optional: DBConversationMember.memberProfile)
             )
             .including(required: DBConversation.localState)
+            .including(optional: DBConversation.agentBuilderSummary)
             .including(
                 all: DBConversation._members
                     .forKey("conversationMembers")
@@ -822,6 +823,7 @@ private struct LightweightConversationDetails: Codable, FetchableRecord, Hashabl
     let conversationCreator: LightweightCreatorDetails?
     let conversationMembers: [DBConversationMemberProfileWithRole]
     let conversationLocalState: ConversationLocalState
+    let conversationAgentBuilderSummary: DBAgentBuilderSummary?
 }
 
 private extension LightweightConversationDetails {
@@ -890,7 +892,8 @@ private extension LightweightConversationDetails {
             debugInfo: conversation.debugInfo,
             isLocked: conversation.isLocked,
             agentJoinStatus: nil,
-            hasHadVerifiedAgent: conversation.hasHadVerifiedAgent
+            hasHadVerifiedAgent: conversation.hasHadVerifiedAgent,
+            wasCreatedFromAgentBuilder: conversationAgentBuilderSummary != nil
         )
     }
 }

--- a/ConvosCore/Tests/ConvosCoreTests/DefaultConversationDisplayTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/DefaultConversationDisplayTests.swift
@@ -289,7 +289,8 @@ struct DefaultConversationDisplayTests {
             debugInfo: .empty,
             isLocked: false,
             agentJoinStatus: nil,
-            hasHadVerifiedAgent: false
+            hasHadVerifiedAgent: false,
+            wasCreatedFromAgentBuilder: false
         )
         #expect(conversation.avatarType == .customImage)
     }
@@ -331,7 +332,8 @@ struct DefaultConversationDisplayTests {
             debugInfo: .empty,
             isLocked: false,
             agentJoinStatus: nil,
-            hasHadVerifiedAgent: false
+            hasHadVerifiedAgent: false,
+            wasCreatedFromAgentBuilder: false
         )
 
         if case .profile(let profile, _) = conversation.avatarType {
@@ -531,5 +533,111 @@ struct DefaultConversationDisplayTests {
             Profile.empty(inboxId: "anon2")
         ]
         #expect(profiles.formattedNamesString == "Alice, Bob, Charlie and 2 others")
+    }
+
+    // MARK: - Pending Agent Builder Draft Tests
+
+    @Test("Builder draft with no agent yet shows New Agent")
+    func builderDraftShowsNewAgent() {
+        let members = [ConversationMember.mock(isCurrentUser: true, name: "You")]
+        let conversation = Conversation.mock(
+            name: nil,
+            members: members,
+            wasCreatedFromAgentBuilder: true
+        )
+        #expect(conversation.isPendingAgentBuilderDraft == true)
+        #expect(conversation.computedDisplayName == "New Agent")
+    }
+
+    @Test("Builder draft with no agent yet uses pendingAgent avatar")
+    func builderDraftUsesPendingAgentAvatar() {
+        let members = [ConversationMember.mock(isCurrentUser: true, name: "You")]
+        let conversation = Conversation.mock(
+            name: nil,
+            members: members,
+            wasCreatedFromAgentBuilder: true
+        )
+        #expect(conversation.avatarType == .pendingAgent)
+    }
+
+    @Test("Builder draft with explicit name keeps the name")
+    func builderDraftWithNameKeepsName() {
+        let conversation = Conversation.mock(
+            name: "Tifoso",
+            members: [ConversationMember.mock(isCurrentUser: true, name: "You")],
+            wasCreatedFromAgentBuilder: true
+        )
+        #expect(conversation.computedDisplayName == "Tifoso")
+    }
+
+    @Test("Non-builder empty conversation still shows New Convo")
+    func nonBuilderEmptyShowsNewConvo() {
+        let members = [ConversationMember.mock(isCurrentUser: true, name: "You")]
+        let conversation = Conversation.mock(name: nil, members: members)
+        #expect(conversation.isPendingAgentBuilderDraft == false)
+        #expect(conversation.computedDisplayName == "New Convo")
+    }
+
+    @Test("Builder conversation that has had a verified agent is no longer pending")
+    func builderWithVerifiedAgentNotPending() {
+        let members = [
+            ConversationMember.mock(isCurrentUser: true, name: "You"),
+            ConversationMember.mock(isCurrentUser: false, name: "Tifoso")
+        ]
+        let conversation = Conversation.makePendingAgentTestConversation(
+            members: members,
+            wasCreatedFromAgentBuilder: true,
+            hasHadVerifiedAgent: true
+        )
+        #expect(conversation.isPendingAgentBuilderDraft == false)
+        // Falls through to the normal member-driven name.
+        #expect(conversation.computedDisplayName == "Tifoso")
+    }
+}
+
+private extension Conversation {
+    /// Builds a group conversation with explicit control over the two
+    /// flags the pending-agent-builder logic depends on. `Conversation.mock`
+    /// derives `hasHadVerifiedAgent` from member verification, so this
+    /// helper is needed to exercise the "had an agent, it left" case
+    /// independently of the member list.
+    static func makePendingAgentTestConversation(
+        members: [ConversationMember],
+        wasCreatedFromAgentBuilder: Bool,
+        hasHadVerifiedAgent: Bool
+    ) -> Conversation {
+        Conversation(
+            id: "test",
+            clientConversationId: "client-test",
+            creator: members.first ?? .mock(isCurrentUser: true),
+            createdAt: Date(),
+            consent: .allowed,
+            kind: .group,
+            name: nil,
+            description: nil,
+            members: members,
+            otherMember: nil,
+            messages: [],
+            isPinned: false,
+            isUnread: false,
+            isMuted: false,
+            pinnedOrder: nil,
+            hidesInviteCard: false,
+            lastMessage: nil,
+            imageURL: nil,
+            imageSalt: nil,
+            imageNonce: nil,
+            imageEncryptionKey: nil,
+            conversationEmoji: nil,
+            includeInfoInPublicPreview: false,
+            isDraft: false,
+            invite: nil,
+            expiresAt: nil,
+            debugInfo: .empty,
+            isLocked: false,
+            agentJoinStatus: nil,
+            hasHadVerifiedAgent: hasHadVerifiedAgent,
+            wasCreatedFromAgentBuilder: wasCreatedFromAgentBuilder
+        )
     }
 }


### PR DESCRIPTION
## Summary

A conversation created through the Agent Builder shows the builder indicator's **"New Agent" + add-agent icon** while the agent provisions. But once the user leaves the builder and the draft surfaces in the conversations list — or anywhere outside the builder's own `forcedAgentVerification` environment — it fell back to the generic **"New Convo" + emoji circle** until the verified agent actually joined.

This carries the signal on the hydrated `Conversation` itself, so every renderer (conversations list, pinned cell, chat header, stuff preview, …) gets it for free through the existing hydration path.

## How

- `DBConversation` gains a `hasOne(DBAgentBuilderSummary)` association. The summary row (written at "Make", PK = `conversationId`) is the existing persisted marker for "created via the builder" — **no new column, no migration**.
- `DBConversationDetails` decodes the optional summary; the shared `detailedConversationQuery()` and the messages-repo lightweight query both `.including(optional:)` it.
- Hydration sets `Conversation.wasCreatedFromAgentBuilder`.
- `Conversation.isPendingAgentBuilderDraft` = `wasCreatedFromAgentBuilder && !hasHadVerifiedAgent`. Gating on the sticky `hasHadVerifiedAgent` flag (not the current member list) means an agent that later leaves doesn't flip the conversation back to the placeholder.
- `computedDisplayName` returns `"New Agent"` and `avatarType` returns a new `.pendingAgent` case while pending; `AvatarView` renders `PendingAgentAvatarView` (the add-agent glyph) for it.

## Why this approach

The first instinct — a reactive publisher of "builder conversation IDs" plumbed through a SwiftUI environment to the row cells — was rejected as the wrong layer. The right fix is to make the hydrated `Conversation` self-describing: the flag lands on the model via the one shared query funnel, and all display sites (`computedDisplayName`, `avatarType`) already run off the model. No per-surface plumbing.

Reused the existing `DBAgentBuilderSummary` marker instead of adding a `DBConversation` column (which has 19 `.with(...)` copy methods + 3 constructors to thread a new field through).

## Test plan

- [x] `swift test --package-path ConvosCore` — **1009/1009 pass**, including 5 new cases in `DefaultConversationDisplayTests` (pending name + avatar, explicit-name passthrough, non-builder "New Convo" control, had-an-agent-then-not-pending)
- [x] ConvosCore + iOS app build clean
- [ ] Manual: create an agent via the builder, leave before the agent joins, confirm the conversations-list row shows "New Agent" + add-agent icon, then flips to the real agent once it joins

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/890"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782527655&installation_id=128169237&pr_number=890&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F890&signature=b5fe2158150b5b5961e129d938b360c7e2c8b27b8330c593c9afe7501da500fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Render pending agent-builder draft conversations as "New Agent" with a distinct avatar
> - Adds `wasCreatedFromAgentBuilder` to the `Conversation` model, populated by joining a `DBAgentBuilderSummary` row in both detailed and lightweight conversation queries.
> - Introduces `isPendingAgentBuilderDraft` computed property (true when `wasCreatedFromAgentBuilder && !hasHadVerifiedAgent`) to drive display logic.
> - Sets `computedDisplayName` to `"New Agent"` for pending drafts (unless an explicit name is set) and `avatarType` to the new `.pendingAgent` case, which renders `PendingAgentAvatarView` in the avatar UI.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1b5fff4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->