### PR TITLE
Agent builder composer fills space above the iPad keyboard

### DIFF
--- a/Convos/Agent Builder/AgentBuilderView.swift
+++ b/Convos/Agent Builder/AgentBuilderView.swift
@@ -313,23 +313,23 @@ struct AgentBuilderView: View {
                     }
                 }
             )
-            // Fill the available height so the card grows to occupy the
-            // space between the top and the top of the keyboard, rather
-            // than a fixed height that floats on the large iPad canvas
-            // and lets the keyboard cover its lower content. SwiftUI's
-            // keyboard safe-area inset caps `maxHeight` at the keyboard's
-            // top edge. Because the card fills in *both* the standard and
-            // recording layouts, switching between them no longer changes
-            // the card's height (the old fixed `height:` existed only to
-            // prevent that shrink) -- the recording controls just appear
-            // below it.
-            .frame(maxHeight: .infinity)
+            // Cap the card at its original height but let it shrink below
+            // that when the keyboard constrains the available space. With a
+            // fixed `height:` the card stayed 375 even when the keyboard
+            // covered its lower content (media row + Make button); with a
+            // plain `maxHeight: .infinity` it ballooned to fill the whole
+            // iPad canvas. `maxHeight: composerHeight` gives both: 375 when
+            // there's room, less when the keyboard pushes up (SwiftUI's
+            // keyboard safe-area inset shrinks the proposed height and the
+            // card follows).
+            .frame(maxHeight: Constant.composerHeight)
             .padding(.horizontal, DesignConstants.Spacing.step4x)
             .padding(.top, DesignConstants.Spacing.step4x)
 
-            // Hidden (not removed) when recording so the row below keeps
-            // its slot and the recording controls don't reflow upward when
-            // the user taps the voice-memo button.
+            // Hidden (not removed) when recording, so the layout below the
+            // composer doesn't reflow when the user taps the voice-memo
+            // button. Without this, the recording-controls' Spacer-centered
+            // position would jump on entry.
             Text(composerHintText)
                 .font(.caption)
                 .foregroundStyle(.colorTextSecondary)
@@ -341,8 +341,8 @@ struct AgentBuilderView: View {
                 .opacity(viewModel.isRecordingVoiceMemo ? 0 : 1)
 
             if viewModel.isRecordingVoiceMemo {
+                Spacer(minLength: 0)
                 recordingControls(focusState: focusState)
-                    .padding(.bottom, DesignConstants.Spacing.step4x)
                     // Delay the appearance by `keyboardDismissDelay` so the
                     // keyboard dismissal animation triggered by the
                     // voice-memo tap (`focusState = nil`) finishes before
@@ -351,6 +351,9 @@ struct AgentBuilderView: View {
                         .easeInOut(duration: Constant.recordingControlsFadeDuration)
                             .delay(Constant.keyboardDismissDelay)
                     ))
+                Spacer(minLength: 0)
+            } else {
+                Spacer(minLength: 0)
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -435,6 +438,10 @@ struct AgentBuilderView: View {
     }
 
     private enum Constant {
+        /// Cap for the composer card height. The card grows up to this
+        /// (its original fixed size) and shrinks below it when the keyboard
+        /// constrains the available space.
+        static let composerHeight: CGFloat = 375.0
         /// iOS keyboard dismissal animation duration. Recording controls
         /// hold for this long before fading in so their position settles
         /// after the keyboard collapses rather than sliding through the

--- a/Convos/Agent Builder/AgentBuilderView.swift
+++ b/Convos/Agent Builder/AgentBuilderView.swift
@@ -313,20 +313,23 @@ struct AgentBuilderView: View {
                     }
                 }
             )
-            // Lock the composer card to its full height so switching
-            // into the recording layout (and hiding the hint row below)
-            // doesn't visibly shrink the card. `maxHeight` would let
-            // the recording layout's smaller intrinsic size collapse the
-            // card; explicit `height:` pins it at the standard-layout
-            // size for both states.
-            .frame(height: Constant.composerHeight)
+            // Fill the available height so the card grows to occupy the
+            // space between the top and the top of the keyboard, rather
+            // than a fixed height that floats on the large iPad canvas
+            // and lets the keyboard cover its lower content. SwiftUI's
+            // keyboard safe-area inset caps `maxHeight` at the keyboard's
+            // top edge. Because the card fills in *both* the standard and
+            // recording layouts, switching between them no longer changes
+            // the card's height (the old fixed `height:` existed only to
+            // prevent that shrink) -- the recording controls just appear
+            // below it.
+            .frame(maxHeight: .infinity)
             .padding(.horizontal, DesignConstants.Spacing.step4x)
             .padding(.top, DesignConstants.Spacing.step4x)
 
-            // Hidden (not removed) when recording, so the layout below
-            // the composer doesn't have to reflow when the user taps
-            // the voice-memo button. Without this, the recording-
-            // controls' Spacer-centered position would jump on entry.
+            // Hidden (not removed) when recording so the row below keeps
+            // its slot and the recording controls don't reflow upward when
+            // the user taps the voice-memo button.
             Text(composerHintText)
                 .font(.caption)
                 .foregroundStyle(.colorTextSecondary)
@@ -338,23 +341,16 @@ struct AgentBuilderView: View {
                 .opacity(viewModel.isRecordingVoiceMemo ? 0 : 1)
 
             if viewModel.isRecordingVoiceMemo {
-                Spacer(minLength: 0)
                 recordingControls(focusState: focusState)
-                    // Delay the appearance by `keyboardDismissDelay` so
-                    // the keyboard dismissal animation triggered by the
-                    // voice-memo tap (`focusState = nil`) finishes
-                    // before the controls fade in. Without the delay,
-                    // the Spacer-centered controls appear at the
-                    // keyboard-up Y and visibly slide down as the
-                    // keyboard collapses; with it, the appearance
-                    // lands at the final (keyboard-down) position.
+                    .padding(.bottom, DesignConstants.Spacing.step4x)
+                    // Delay the appearance by `keyboardDismissDelay` so the
+                    // keyboard dismissal animation triggered by the
+                    // voice-memo tap (`focusState = nil`) finishes before
+                    // the controls fade in.
                     .transition(.blurReplace.animation(
                         .easeInOut(duration: Constant.recordingControlsFadeDuration)
                             .delay(Constant.keyboardDismissDelay)
                     ))
-                Spacer(minLength: 0)
-            } else {
-                Spacer(minLength: 0)
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -439,11 +435,10 @@ struct AgentBuilderView: View {
     }
 
     private enum Constant {
-        static let composerHeight: CGFloat = 375.0
         /// iOS keyboard dismissal animation duration. Recording controls
-        /// hold for this long before fading in so their Spacer-centered
-        /// Y position settles after the keyboard collapses rather than
-        /// sliding through the transition.
+        /// hold for this long before fading in so their position settles
+        /// after the keyboard collapses rather than sliding through the
+        /// transition.
         static let keyboardDismissDelay: TimeInterval = 0.25
         static let recordingControlsFadeDuration: TimeInterval = 0.25
     }


### PR DESCRIPTION
## Summary

The agent builder composer card used a fixed `composerHeight: 375` pinned at the top of a `maxHeight: .infinity` container. On the large iPad canvas the card floated at a fixed size and its lower content (media-button row + Make button) extended **behind** the docked keyboard.

Switch the card to `.frame(maxHeight: .infinity)` so it grows to fill the height between the top bar and the keyboard's top edge — SwiftUI's keyboard safe-area inset caps it there. Applies to **both** builder surfaces since they share `composerRect`:
- the inline builder (chats-list empty state)
- the builder sheet

## Verified on iPad sim (landscape, docked keyboard)

| Element | Before (fixed 375) | After (fill) |
|---|---|---|
| Composer media-button row | ~y=460 (behind keyboard) | ~y=350 (above) |
| Make button | (behind keyboard) | ~y=319 (above) |
| Keyboard top (≈ underlying message bar) | ~y=388 | ~y=388 |

## Note on the recording layout

The fixed height existed only to stop the card shrinking when toggling into the recording layout (per the old comment). Since the card now fills in both layouts, its height no longer changes between them, so that concern is moot. The recording controls — previously centered in the slack below the fixed card via `Spacer`s — now sit just below the filled card; during recording the keyboard is dismissed, so the card fills the full height and the controls land at the bottom.

## Test plan

- [x] iPad sim: open builder sheet, keyboard up — composer + media row + Make button all sit above the keyboard (confirmed via accessibility frames)
- [x] iPhone build clean (no regression — available height above keyboard ≈ the old fixed height there)
- [x] SwiftLint clean
- [ ] iPad: inline builder (delete all conversations to hit the empty state) — same fill behavior
- [ ] iPad: voice-memo recording layout still reads correctly with the controls below the filled card

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/891"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782529029&installation_id=128169237&pr_number=891&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F891&signature=d0ed4df05d10b77fa3dfe7f3afc50bc4857fe47fd70ca1757e0a5b96a51e8e1a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Agent Builder composer to fill space above the iPad keyboard
> Changes `.frame(height:)` to `.frame(maxHeight:)` in [AgentBuilderView.swift](https://github.com/xmtplabs/convos-ios/pull/891/files#diff-112eb571b37e845cdd6337280b52c1c6b1cf8b2b100bf314a6b17aa960d0215e) so the composer card shrinks when the keyboard reduces available space instead of being pinned to a fixed 375pt height.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8d23d26.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->