### PR TITLE
fix: immediately show prior invites when new contact added

### DIFF
--- a/ConvosCore/Sources/ConvosCore/Contacts/ContactSyncCoordinator.swift
+++ b/ConvosCore/Sources/ConvosCore/Contacts/ContactSyncCoordinator.swift
@@ -69,14 +69,14 @@ final class ContactSyncCoordinator: ContactSyncCoordinatorProtocol, @unchecked S
     }
 
     private func sync(conversationId: String, force: Bool) async throws {
-        try await databaseWriter.write { [selfInboxIdProvider] db in
+        let insertedInboxIds: [String] = try await databaseWriter.write { [selfInboxIdProvider] db in
             // Without the local inbox singleton we cannot identify "self" and
             // therefore cannot exclude the local user from the upsert loop.
             // No-op rather than risk adding self as a contact. The next hook
             // (after the singleton is written) retries.
             guard let selfInboxId = try selfInboxIdProvider(db) else {
                 Log.debug("Skipping contacts sync for \(conversationId): inbox singleton not written yet")
-                return
+                return []
             }
 
             // Two short-circuits:
@@ -87,9 +87,9 @@ final class ContactSyncCoordinator: ContactSyncCoordinatorProtocol, @unchecked S
             //   - member-added hook on a never-synced conversation: skip,
             //     so we honor the action-gated rule and don't pull
             //     strangers from a group the local user has not acted in.
-            //     Exception: if the local user is the *creator* of the
+            //     Exception: if the local user is the creator of the
             //     conversation, creating the group is itself the explicit
-            //     action — no need to wait for a first message.
+            //     action - no need to wait for a first message.
             let alreadySynced = try DBConversationContactsSync
                 .filter(DBConversationContactsSync.Columns.conversationId == conversationId)
                 .fetchCount(db) > 0
@@ -104,13 +104,13 @@ final class ContactSyncCoordinator: ContactSyncCoordinatorProtocol, @unchecked S
                 }()
                 guard selfIsCreator else {
                     Log.debug("Skipping forced contacts sync for never-synced conversation \(conversationId) (local user is not the creator)")
-                    return
+                    return []
                 }
                 Log.debug("Forced contacts sync proceeding for never-synced conversation \(conversationId) (local user is the creator)")
             }
 
             if alreadySynced && force == false {
-                return
+                return []
             }
 
             let members = try DBConversationMember
@@ -125,6 +125,7 @@ final class ContactSyncCoordinator: ContactSyncCoordinatorProtocol, @unchecked S
             )
 
             var upsertedCount: Int = 0
+            var insertedIds: [String] = []
             for member in members {
                 if member.inboxId == selfInboxId {
                     continue
@@ -143,12 +144,15 @@ final class ContactSyncCoordinator: ContactSyncCoordinatorProtocol, @unchecked S
                     // AgentVerification.
                     agentVerification: profile?.memberKind?.agentVerification
                 )
-                try ContactsWriter.upsertContactInTransaction(
+                let didInsert = try ContactsWriter.upsertContactInTransaction(
                     db: db,
                     inboxId: member.inboxId,
                     addedViaConversationId: conversationId,
                     profile: snapshot
                 )
+                if didInsert {
+                    insertedIds.append(member.inboxId)
+                }
                 upsertedCount += 1
             }
 
@@ -159,10 +163,10 @@ final class ContactSyncCoordinator: ContactSyncCoordinatorProtocol, @unchecked S
             // empty roster we leave the marker absent so the next outbound
             // message retries the sync once the peer rows have streamed in.
             // Tradeoff: a legitimate one-person group (only self) will retry
-            // on every send. Acceptable — it's a few indexed reads.
+            // on every send. Acceptable - it's a few indexed reads.
             guard upsertedCount > 0 else {
                 Log.debug("Contacts sync for \(conversationId) saw no non-self members; skipping marker so next message retries")
-                return
+                return []
             }
 
             let marker = DBConversationContactsSync(
@@ -172,6 +176,13 @@ final class ContactSyncCoordinator: ContactSyncCoordinatorProtocol, @unchecked S
             try marker.save(db)
 
             Log.debug("Synced \(upsertedCount) contacts for conversation \(conversationId) (force=\(force))")
+            return insertedIds
         }
+
+        // Post after the transaction commits so the `QuarantineSweeper`
+        // observer in `SessionManager` runs against committed contact rows.
+        // A single notification per batch coalesces the whole group sync
+        // into one sweep, no debounce timer required.
+        ContactsWriter.postContactsWereAdded(inboxIds: insertedInboxIds)
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Contacts/ContactSyncCoordinator.swift
+++ b/ConvosCore/Sources/ConvosCore/Contacts/ContactSyncCoordinator.swift
@@ -30,6 +30,7 @@ public protocol ContactSyncCoordinatorProtocol: Sendable {
 final class ContactSyncCoordinator: ContactSyncCoordinatorProtocol, @unchecked Sendable {
     private let databaseWriter: any DatabaseWriter
     private let databaseReader: any DatabaseReader
+    private let notificationCenter: NotificationCenter
 
     /// Closure that returns the local user's `inboxId`. Called within the
     /// sync transaction so the lookup hits the same snapshot as the member
@@ -41,10 +42,12 @@ final class ContactSyncCoordinator: ContactSyncCoordinatorProtocol, @unchecked S
     init(
         databaseWriter: any DatabaseWriter,
         databaseReader: any DatabaseReader,
+        notificationCenter: NotificationCenter = .default,
         selfInboxIdProvider: @escaping @Sendable (Database) throws -> String? = ContactSyncCoordinator.defaultSelfInboxIdProvider
     ) {
         self.databaseWriter = databaseWriter
         self.databaseReader = databaseReader
+        self.notificationCenter = notificationCenter
         self.selfInboxIdProvider = selfInboxIdProvider
     }
 
@@ -183,6 +186,9 @@ final class ContactSyncCoordinator: ContactSyncCoordinatorProtocol, @unchecked S
         // observer in `SessionManager` runs against committed contact rows.
         // A single notification per batch coalesces the whole group sync
         // into one sweep, no debounce timer required.
-        ContactsWriter.postContactsWereAdded(inboxIds: insertedInboxIds)
+        ContactsWriter.postContactsWereAdded(
+            inboxIds: insertedInboxIds,
+            notificationCenter: notificationCenter
+        )
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
@@ -31,6 +31,7 @@ public final class SessionManager: SessionManagerProtocol, @unchecked Sendable {
     private var cloudConnectionsCancellable: AnyCancellable?
     private var activeConversationObserver: NSObjectProtocol?
     private var contactBlockingObserver: NSObjectProtocol?
+    private var contactsWereAddedObserver: NSObjectProtocol?
     private var quarantineSweeperTask: Task<Void, Never>?
     private var cachedQuarantineSweeper: (any QuarantineSweeperProtocol)?
 
@@ -176,6 +177,9 @@ public final class SessionManager: SessionManagerProtocol, @unchecked Sendable {
         if let contactBlockingObserver {
             NotificationCenter.default.removeObserver(contactBlockingObserver)
         }
+        if let contactsWereAddedObserver {
+            NotificationCenter.default.removeObserver(contactsWereAddedObserver)
+        }
     }
 
     // MARK: - Private Methods
@@ -203,7 +207,7 @@ public final class SessionManager: SessionManagerProtocol, @unchecked Sendable {
         }
 
         // Trigger an immediate quarantine sweep when a contact gets
-        // unblocked (or blocked — though only unblocking has a UX-visible
+        // unblocked (or blocked - though only unblocking has a UX-visible
         // effect on existing held conversations). Without this, the user
         // would have to wait for the next hourly sweep or app-foreground
         // entry before quarantined-by-block conversations reappear in
@@ -214,6 +218,22 @@ public final class SessionManager: SessionManagerProtocol, @unchecked Sendable {
             queue: .main
         ) { [weak self] _ in
             self?.runQuarantineSweep(reason: "contactBlockingDidChange")
+        }
+
+        // Trigger an immediate quarantine sweep when one or more new
+        // contact rows are committed. Batch callers (e.g.
+        // `ContactSyncCoordinator` syncing a whole group on first send)
+        // accumulate inserted inboxIds inside their transaction and post
+        // a single notification post-commit, so one sweep covers the
+        // entire batch. Without this, a conversation held in quarantine
+        // because its creator was a stranger only reappears on the next
+        // hourly or foreground sweep.
+        contactsWereAddedObserver = NotificationCenter.default.addObserver(
+            forName: .contactsWereAdded,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            self?.runQuarantineSweep(reason: "contactsWereAdded")
         }
 
         scheduleQuarantineSweeper()
@@ -228,7 +248,22 @@ public final class SessionManager: SessionManagerProtocol, @unchecked Sendable {
         let sweeper = QuarantineSweeper(
             databaseWriter: databaseWriter,
             databaseReader: databaseReader,
-            contactsRepository: ContactsRepository(databaseReader: databaseReader)
+            contactsRepository: ContactsRepository(databaseReader: databaseReader),
+            // Bump XMTP-side consent to `.allowed` before the sweeper
+            // commits the DB promotion. Routed through the messaging
+            // service's `XMTPClientProvider`, the same path
+            // `ConversationConsentWriter.join` uses. Throws if the inbox
+            // isn't ready yet (first-launch race), if the XMTP client
+            // can't find the conversation in its local cache, or on any
+            // network error - the sweeper handles those by deferring the
+            // affected row to the next sweep cycle.
+            consentBumper: { [weak self] conversationId in
+                guard let self else { return }
+                let inboxReady = try await self.loadOrCreateService()
+                    .sessionStateManager
+                    .waitForInboxReadyResult()
+                try await inboxReady.client.update(consent: .allowed, for: conversationId)
+            }
         )
         cachedQuarantineSweeper = sweeper
 

--- a/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
@@ -239,67 +239,6 @@ public final class SessionManager: SessionManagerProtocol, @unchecked Sendable {
         scheduleQuarantineSweeper()
     }
 
-    /// Periodic sweeper that promotes quarantined conversations whose
-    /// senders have become contacts and deletes those past the TTL. Runs
-    /// once at session-observe time and once per `Constant.foregroundSweepInterval`
-    /// while the process is alive. The foreground observer above also
-    /// triggers an extra sweep on every foreground entry.
-    private func scheduleQuarantineSweeper() {
-        let sweeper = QuarantineSweeper(
-            databaseWriter: databaseWriter,
-            databaseReader: databaseReader,
-            contactsRepository: ContactsRepository(databaseReader: databaseReader),
-            // Bump XMTP-side consent to `.allowed` before the sweeper
-            // commits the DB promotion. Routed through the messaging
-            // service's `XMTPClientProvider`, the same path
-            // `ConversationConsentWriter.join` uses. Throws if the inbox
-            // isn't ready yet (first-launch race), if the XMTP client
-            // can't find the conversation in its local cache, or on any
-            // network error - the sweeper handles those by deferring the
-            // affected row to the next sweep cycle.
-            consentBumper: { [weak self] conversationId in
-                guard let self else { return }
-                let inboxReady = try await self.loadOrCreateService()
-                    .sessionStateManager
-                    .waitForInboxReadyResult()
-                try await inboxReady.client.update(consent: .allowed, for: conversationId)
-            }
-        )
-        cachedQuarantineSweeper = sweeper
-
-        quarantineSweeperTask?.cancel()
-        quarantineSweeperTask = Task { [weak self] in
-            // Initial sweep at launch.
-            await Self.invokeSweep(sweeper, reason: "launch")
-            // Hourly sweep while the process lives. Foreground entries also
-            // trigger an extra sweep via the foreground observer.
-            while !Task.isCancelled {
-                let interval: UInt64 = UInt64(QuarantineSweeper.Constant.foregroundSweepInterval * 1_000_000_000)
-                try? await Task.sleep(nanoseconds: interval)
-                guard self != nil, !Task.isCancelled else { return }
-                await Self.invokeSweep(sweeper, reason: "interval")
-            }
-        }
-    }
-
-    private func runQuarantineSweep(reason: String) {
-        guard let sweeper = cachedQuarantineSweeper else { return }
-        Task.detached {
-            await Self.invokeSweep(sweeper, reason: reason)
-        }
-    }
-
-    private static func invokeSweep(
-        _ sweeper: any QuarantineSweeperProtocol,
-        reason: String
-    ) async {
-        do {
-            try await sweeper.sweep()
-        } catch {
-            Log.error("QuarantineSweeper sweep (reason=\(reason)) failed: \(error.localizedDescription)")
-        }
-    }
-
     private func updateActiveConversation(_ conversationId: String?) {
         screenStateLock.withLock { state in
             state.activeConversationId = (conversationId?.isEmpty == false) ? conversationId : nil
@@ -957,6 +896,71 @@ public final class SessionManager: SessionManagerProtocol, @unchecked Sendable {
                     )
                 }
             }
+        }
+    }
+}
+
+// MARK: - Quarantine Sweeping
+
+extension SessionManager {
+    /// Periodic sweeper that promotes quarantined conversations whose
+    /// senders have become contacts and deletes those past the TTL. Runs
+    /// once at session-observe time and once per `Constant.foregroundSweepInterval`
+    /// while the process is alive. The foreground observer also triggers
+    /// an extra sweep on every foreground entry.
+    private func scheduleQuarantineSweeper() {
+        let sweeper = QuarantineSweeper(
+            databaseWriter: databaseWriter,
+            databaseReader: databaseReader,
+            contactsRepository: ContactsRepository(databaseReader: databaseReader),
+            // Bump XMTP-side consent to `.allowed` before the sweeper
+            // commits the DB promotion. Routed through the messaging
+            // service's `XMTPClientProvider`, the same path
+            // `ConversationConsentWriter.join` uses. Throws if the inbox
+            // isn't ready yet (first-launch race), if the XMTP client
+            // can't find the conversation in its local cache, or on any
+            // network error - the sweeper handles those by deferring the
+            // affected row to the next sweep cycle.
+            consentBumper: { [weak self] conversationId in
+                guard let self else { return }
+                let inboxReady = try await self.loadOrCreateService()
+                    .sessionStateManager
+                    .waitForInboxReadyResult()
+                try await inboxReady.client.update(consent: .allowed, for: conversationId)
+            }
+        )
+        cachedQuarantineSweeper = sweeper
+
+        quarantineSweeperTask?.cancel()
+        quarantineSweeperTask = Task { [weak self] in
+            // Initial sweep at launch.
+            await Self.invokeSweep(sweeper, reason: "launch")
+            // Hourly sweep while the process lives. Foreground entries also
+            // trigger an extra sweep via the foreground observer.
+            while !Task.isCancelled {
+                let interval: UInt64 = UInt64(QuarantineSweeper.Constant.foregroundSweepInterval * 1_000_000_000)
+                try? await Task.sleep(nanoseconds: interval)
+                guard self != nil, !Task.isCancelled else { return }
+                await Self.invokeSweep(sweeper, reason: "interval")
+            }
+        }
+    }
+
+    private func runQuarantineSweep(reason: String) {
+        guard let sweeper = cachedQuarantineSweeper else { return }
+        Task.detached {
+            await Self.invokeSweep(sweeper, reason: reason)
+        }
+    }
+
+    private static func invokeSweep(
+        _ sweeper: any QuarantineSweeperProtocol,
+        reason: String
+    ) async {
+        do {
+            try await sweeper.sweep()
+        } catch {
+            Log.error("QuarantineSweeper sweep (reason=\(reason)) failed: \(error.localizedDescription)")
         }
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
@@ -903,6 +903,13 @@ public final class SessionManager: SessionManagerProtocol, @unchecked Sendable {
 // MARK: - Quarantine Sweeping
 
 extension SessionManager {
+    /// Thrown when the consent-bump closure outlives its owning
+    /// `SessionManager` (the `Task.detached` fan-out in
+    /// `runQuarantineSweep` can do this). Forces the sweeper to defer
+    /// the row instead of committing a DB promotion whose XMTP-side
+    /// bump never happened.
+    private struct ConsentBumpSessionDeinitError: Error {}
+
     /// Periodic sweeper that promotes quarantined conversations whose
     /// senders have become contacts and deletes those past the TTL. Runs
     /// once at session-observe time and once per `Constant.foregroundSweepInterval`
@@ -913,16 +920,14 @@ extension SessionManager {
             databaseWriter: databaseWriter,
             databaseReader: databaseReader,
             contactsRepository: ContactsRepository(databaseReader: databaseReader),
-            // Bump XMTP-side consent to `.allowed` before the sweeper
-            // commits the DB promotion. Routed through the messaging
-            // service's `XMTPClientProvider`, the same path
-            // `ConversationConsentWriter.join` uses. Throws if the inbox
-            // isn't ready yet (first-launch race), if the XMTP client
-            // can't find the conversation in its local cache, or on any
-            // network error - the sweeper handles those by deferring the
-            // affected row to the next sweep cycle.
+            // Bump XMTP-side consent via the same path
+            // `ConversationConsentWriter.join` uses. Any throw (inbox
+            // not ready, conversation missing from local cache, network
+            // error, session deinit) defers the row to the next sweep.
             consentBumper: { [weak self] conversationId in
-                guard let self else { return }
+                guard let self else {
+                    throw ConsentBumpSessionDeinitError()
+                }
                 let inboxReady = try await self.loadOrCreateService()
                     .sessionStateManager
                     .waitForInboxReadyResult()

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/ContactsWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/ContactsWriter.swift
@@ -12,6 +12,23 @@ public extension Notification.Name {
     static let contactBlockingDidChange: Notification.Name = Notification.Name(
         "ContactBlockingDidChange"
     )
+
+    /// Posted on the main queue after one or more brand-new `DBContact`
+    /// rows are committed. Idempotent re-upserts and profile-only updates
+    /// do not fire. `SessionManager` observes this to trigger an
+    /// immediate `QuarantineSweeper.sweep()` so a conversation that was
+    /// held in quarantine because its creator was a stranger is promoted
+    /// to the main feed as soon as the creator is added as a contact,
+    /// without waiting for the next hourly or foreground-entry sweep.
+    ///
+    /// Batch callers (e.g. `ContactSyncCoordinator` syncing every
+    /// non-self member of a group when the local user first acts there)
+    /// collect inserted inboxIds inside their transaction and emit a
+    /// single notification after the write commits. UserInfo:
+    /// `inboxIds: [String]`.
+    static let contactsWereAdded: Notification.Name = Notification.Name(
+        "ContactsWereAdded"
+    )
 }
 
 /// Snapshot of profile fields used when upserting a contact. Callers pass
@@ -94,13 +111,16 @@ final class ContactsWriter: ContactsWriterProtocol, @unchecked Sendable {
         addedViaConversationId: String?,
         profile: ContactProfileSnapshot
     ) async throws {
-        try await databaseWriter.write { db in
+        let didInsert: Bool = try await databaseWriter.write { db in
             try Self.upsert(
                 db: db,
                 inboxId: inboxId,
                 addedViaConversationId: addedViaConversationId,
                 profile: profile
             )
+        }
+        if didInsert {
+            ContactsWriter.postContactsWereAdded(inboxIds: [inboxId])
         }
     }
 
@@ -183,12 +203,45 @@ final class ContactsWriter: ContactsWriterProtocol, @unchecked Sendable {
         }
     }
 
+    /// Posted on the main queue after one or more brand-new contact rows
+    /// are committed. Callers in a batch context (e.g.
+    /// `ContactSyncCoordinator`) accumulate inserted inboxIds inside
+    /// their `databaseWriter.write` closure and call this once after the
+    /// write returns, so the eventual `QuarantineSweeper.sweep()` sees
+    /// committed contact rows.
+    ///
+    /// No-op on an empty array so batch callers can call unconditionally
+    /// after their transaction.
+    static func postContactsWereAdded(inboxIds: [String]) {
+        guard !inboxIds.isEmpty else { return }
+        let userInfo: [String: Any] = ["inboxIds": inboxIds]
+        if Thread.isMainThread {
+            NotificationCenter.default.post(
+                name: .contactsWereAdded,
+                object: nil,
+                userInfo: userInfo
+            )
+        } else {
+            DispatchQueue.main.async {
+                NotificationCenter.default.post(
+                    name: .contactsWereAdded,
+                    object: nil,
+                    userInfo: userInfo
+                )
+            }
+        }
+    }
+
+    /// Returns `true` when this call inserted a brand-new `DBContact` row
+    /// for `inboxId`, `false` when an existing row was merged-into (or
+    /// left untouched). Callers use the return value to decide whether
+    /// to post `contactsWereAdded` after the transaction commits.
     fileprivate static func upsert(
         db: Database,
         inboxId: String,
         addedViaConversationId: String?,
         profile: ContactProfileSnapshot
-    ) throws {
+    ) throws -> Bool {
         if let existing = try DBContact.fetchOne(db, key: inboxId) {
             // Identity columns (addedAt, addedViaConversationId) are
             // intentionally preserved on re-upsert. The profile snapshot is
@@ -196,10 +249,10 @@ final class ContactsWriter: ContactsWriterProtocol, @unchecked Sendable {
             // the stored one (see `replacingProfile`); untimestamped
             // re-upserts leave the existing row untouched.
             guard let merged = replacingProfile(of: existing, with: profile) else {
-                return
+                return false
             }
             try merged.save(db)
-            return
+            return false
         }
 
         let now = Date()
@@ -217,6 +270,7 @@ final class ContactsWriter: ContactsWriterProtocol, @unchecked Sendable {
         )
         try row.save(db)
         Log.debug("Inserted new contact for inboxId=\(inboxId) via=\(addedViaConversationId ?? "nil")")
+        return true
     }
 
     /// Returns `existing` with its profile fields replaced by `profile` if
@@ -257,12 +311,18 @@ final class ContactsWriter: ContactsWriterProtocol, @unchecked Sendable {
 /// saves onto `DBContact` (`mirrorMemberProfileToContactInTransaction`,
 /// `saveMemberProfileAndMirrorToContactInTransaction`).
 extension ContactsWriter {
+    /// In-transaction upsert that returns `true` when a brand-new contact
+    /// row was inserted. Batch callers (e.g. `ContactSyncCoordinator`)
+    /// accumulate the inserted inboxIds inside their `databaseWriter.write`
+    /// closure and call `postContactsWereAdded(inboxIds:)` once after the
+    /// transaction commits, so a single sweep covers the whole batch.
+    @discardableResult
     static func upsertContactInTransaction(
         db: Database,
         inboxId: String,
         addedViaConversationId: String?,
         profile: ContactProfileSnapshot
-    ) throws {
+    ) throws -> Bool {
         try upsert(
             db: db,
             inboxId: inboxId,

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/ContactsWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/ContactsWriter.swift
@@ -101,9 +101,14 @@ public protocol ContactsWriterProtocol: Sendable {
 
 final class ContactsWriter: ContactsWriterProtocol, @unchecked Sendable {
     private let databaseWriter: any DatabaseWriter
+    private let notificationCenter: NotificationCenter
 
-    init(databaseWriter: any DatabaseWriter) {
+    init(
+        databaseWriter: any DatabaseWriter,
+        notificationCenter: NotificationCenter = .default
+    ) {
         self.databaseWriter = databaseWriter
+        self.notificationCenter = notificationCenter
     }
 
     func upsertContact(
@@ -120,7 +125,10 @@ final class ContactsWriter: ContactsWriterProtocol, @unchecked Sendable {
             )
         }
         if didInsert {
-            ContactsWriter.postContactsWereAdded(inboxIds: [inboxId])
+            ContactsWriter.postContactsWereAdded(
+                inboxIds: [inboxId],
+                notificationCenter: notificationCenter
+            )
         }
     }
 
@@ -158,7 +166,11 @@ final class ContactsWriter: ContactsWriterProtocol, @unchecked Sendable {
             return true
         }
         if didChange {
-            ContactsWriter.postBlockingDidChange(inboxId: inboxId, blocked: true)
+            ContactsWriter.postBlockingDidChange(
+                inboxId: inboxId,
+                blocked: true,
+                notificationCenter: notificationCenter
+            )
         }
     }
 
@@ -175,7 +187,11 @@ final class ContactsWriter: ContactsWriterProtocol, @unchecked Sendable {
             return true
         }
         if didChange {
-            ContactsWriter.postBlockingDidChange(inboxId: inboxId, blocked: false)
+            ContactsWriter.postBlockingDidChange(
+                inboxId: inboxId,
+                blocked: false,
+                notificationCenter: notificationCenter
+            )
         }
     }
 
@@ -184,17 +200,25 @@ final class ContactsWriter: ContactsWriterProtocol, @unchecked Sendable {
     /// observes this to trigger an immediate `QuarantineSweeper.sweep()`
     /// so unblocking restores held-by-block conversations to the main
     /// feed without waiting for the next hourly/foreground sweep.
-    private static func postBlockingDidChange(inboxId: String, blocked: Bool) {
+    ///
+    /// The `notificationCenter` parameter exists so tests can scope
+    /// observers to a private center and avoid cross-suite leakage
+    /// through `.default`.
+    private static func postBlockingDidChange(
+        inboxId: String,
+        blocked: Bool,
+        notificationCenter: NotificationCenter
+    ) {
         let userInfo: [String: Any] = ["inboxId": inboxId, "blocked": blocked]
         if Thread.isMainThread {
-            NotificationCenter.default.post(
+            notificationCenter.post(
                 name: .contactBlockingDidChange,
                 object: nil,
                 userInfo: userInfo
             )
         } else {
             DispatchQueue.main.async {
-                NotificationCenter.default.post(
+                notificationCenter.post(
                     name: .contactBlockingDidChange,
                     object: nil,
                     userInfo: userInfo
@@ -212,18 +236,25 @@ final class ContactsWriter: ContactsWriterProtocol, @unchecked Sendable {
     ///
     /// No-op on an empty array so batch callers can call unconditionally
     /// after their transaction.
-    static func postContactsWereAdded(inboxIds: [String]) {
+    ///
+    /// The `notificationCenter` parameter exists so tests can scope
+    /// observers to a private center and avoid cross-suite leakage
+    /// through `.default`. Production callers omit it and get `.default`.
+    static func postContactsWereAdded(
+        inboxIds: [String],
+        notificationCenter: NotificationCenter = .default
+    ) {
         guard !inboxIds.isEmpty else { return }
         let userInfo: [String: Any] = ["inboxIds": inboxIds]
         if Thread.isMainThread {
-            NotificationCenter.default.post(
+            notificationCenter.post(
                 name: .contactsWereAdded,
                 object: nil,
                 userInfo: userInfo
             )
         } else {
             DispatchQueue.main.async {
-                NotificationCenter.default.post(
+                notificationCenter.post(
                     name: .contactsWereAdded,
                     object: nil,
                     userInfo: userInfo

--- a/ConvosCore/Sources/ConvosCore/Syncing/QuarantineSweeper.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/QuarantineSweeper.swift
@@ -5,7 +5,18 @@ import GRDB
 ///
 /// - Promotes a quarantined conversation to the main feed when its sender
 ///   has since become a contact (and is not blocked) by setting
-///   `quarantineReleasedAt = now`.
+///   `quarantineReleasedAt = now` AND bumping `consent` to `.allowed`
+///   (mirrors the side-effect parity that `StreamProcessor.decideInboundConversation`
+///   applies on the `.deliver` path: the main feed query is scoped to
+///   `consent IN (.allowed)`, so promotion has to flip the column or the
+///   row stays hidden). Before applying the DB write, the sweeper also
+///   asks the injected `consentBumper` closure to bump XMTP-side consent
+///   for the conversation; if that throws (client not ready, conversation
+///   missing from local XMTP cache, network error), the per-row promotion
+///   is skipped and retried on the next sweep so we never end up with a
+///   row that's visible in the feed but whose XMTP consent is still
+///   `.unknown` (which would cause `StreamProcessor.shouldProcessConversation`
+///   to silently drop future inbound messages).
 /// - Deletes a quarantined conversation whose hold window has expired
 ///   (default 7 days, configurable via `Constant.ttl`). Deletion cascades
 ///   to messages and member rows via existing foreign-key onDelete rules.
@@ -21,17 +32,26 @@ final class QuarantineSweeper: QuarantineSweeperProtocol, @unchecked Sendable {
     private let databaseWriter: any DatabaseWriter
     private let databaseReader: any DatabaseReader
     private let contactsRepository: any ContactsRepositoryProtocol
+    private let consentBumper: @Sendable (String) async throws -> Void
     private let now: @Sendable () -> Date
 
+    /// - Parameter consentBumper: Bumps XMTP-side consent to `.allowed` for
+    ///   the given conversationId. Production wiring in
+    ///   `SessionManager.scheduleQuarantineSweeper` routes through the
+    ///   messaging service's `XMTPClientProvider.update(consent:for:)`.
+    ///   Throw to skip this row's promotion on the current sweep; the row
+    ///   stays quarantined and the next sweep retries.
     init(
         databaseWriter: any DatabaseWriter,
         databaseReader: any DatabaseReader,
         contactsRepository: any ContactsRepositoryProtocol,
+        consentBumper: @escaping @Sendable (String) async throws -> Void,
         now: @escaping @Sendable () -> Date = { Date() }
     ) {
         self.databaseWriter = databaseWriter
         self.databaseReader = databaseReader
         self.contactsRepository = contactsRepository
+        self.consentBumper = consentBumper
         self.now = now
     }
 
@@ -51,7 +71,19 @@ final class QuarantineSweeper: QuarantineSweeperProtocol, @unchecked Sendable {
             let isBlocked = (try? contactsRepository.isBlocked(inboxId: snapshot.creatorId)) ?? false
 
             if isContact && !isBlocked {
-                promotionIds.append(snapshot.conversationId)
+                // Bump XMTP consent before committing the DB promotion so a
+                // failure here defers the promotion to the next sweep cycle
+                // rather than leaving the row visible in the feed with
+                // `.unknown` XMTP consent (which silently gates future
+                // inbound messages in `shouldProcessConversation`).
+                do {
+                    try await consentBumper(snapshot.conversationId)
+                    promotionIds.append(snapshot.conversationId)
+                } catch {
+                    Log.warning(
+                        "QuarantineSweeper: XMTP consent bump failed for \(snapshot.conversationId), deferring promotion: \(error.localizedDescription)"
+                    )
+                }
             } else if currentTime.timeIntervalSince(snapshot.quarantinedAt) > Constant.ttl {
                 deletionIds.append(snapshot.conversationId)
             }
@@ -69,10 +101,12 @@ final class QuarantineSweeper: QuarantineSweeperProtocol, @unchecked Sendable {
         try await databaseWriter.write { db in
             for id in promotionsToApply {
                 guard let existing = try DBConversation.fetchOne(db, key: id) else { continue }
-                let updated = existing.with(
-                    quarantinedAt: existing.quarantinedAt,
-                    quarantineReleasedAt: appliedAt
-                )
+                let updated = existing
+                    .with(
+                        quarantinedAt: existing.quarantinedAt,
+                        quarantineReleasedAt: appliedAt
+                    )
+                    .with(consent: .allowed)
                 try updated.save(db)
             }
             for id in deletionsToApply {

--- a/ConvosCore/Tests/ConvosCoreTests/ContactSyncCoordinatorTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ContactSyncCoordinatorTests.swift
@@ -409,4 +409,118 @@ struct ContactSyncCoordinatorTests {
         }
         #expect(inboxIds == Set(["alice"]))
     }
+
+    @Test("syncContacts posts a single `contactsWereAdded` notification covering the whole batch")
+    func testSyncContactsPostsSingleBatchNotification() async throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        let selfInboxId = "self-inbox"
+        let conversationId = "conv-batch"
+
+        try await dbManager.dbWriter.write { db in
+            try DBInbox(inboxId: selfInboxId, clientId: "client").save(db)
+            try Self.seedConversation(
+                db: db,
+                conversationId: conversationId,
+                creatorInboxId: selfInboxId,
+                memberInboxIds: [selfInboxId, "alice", "bob", "carol"]
+            )
+        }
+
+        let recorder = SyncNotificationRecorder(name: .contactsWereAdded)
+
+        let coordinator = ContactSyncCoordinator(
+            databaseWriter: dbManager.dbWriter,
+            databaseReader: dbManager.dbReader
+        )
+        try await coordinator.syncContactsOnFirstMessage(for: conversationId)
+
+        // Allow the main-queue dispatch from `postContactsWereAdded` to drain.
+        try await Task.sleep(nanoseconds: 30_000_000)
+
+        #expect(recorder.notifications.count == 1, "Batch sync must coalesce N inserts into one notification")
+        let payload = recorder.notifications.first?.userInfo?["inboxIds"] as? [String] ?? []
+        #expect(Set(payload) == Set(["alice", "bob", "carol"]))
+
+        // Second sync is a no-op (already-synced) and must not re-fire.
+        try await coordinator.syncContactsOnFirstMessage(for: conversationId)
+        try await Task.sleep(nanoseconds: 30_000_000)
+        #expect(recorder.notifications.count == 1)
+
+        recorder.stop()
+    }
+
+    @Test("syncContacts does not post `contactsWereAdded` when no new contact rows are inserted")
+    func testSyncContactsDoesNotPostWhenNothingInserted() async throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        let selfInboxId = "self-inbox"
+        let conversationId = "conv-noop"
+
+        // Pre-seed the conversation members as contacts so the coordinator's
+        // upserts merge into existing rows rather than inserting new ones.
+        try await dbManager.dbWriter.write { db in
+            try DBInbox(inboxId: selfInboxId, clientId: "client").save(db)
+            try Self.seedConversation(
+                db: db,
+                conversationId: conversationId,
+                creatorInboxId: selfInboxId,
+                memberInboxIds: [selfInboxId, "alice"]
+            )
+            try DBContact(
+                inboxId: "alice",
+                addedAt: Date(timeIntervalSince1970: 1),
+                addedViaConversationId: nil,
+                displayName: "Alice",
+                avatarURL: nil,
+                avatarSalt: nil,
+                avatarNonce: nil,
+                avatarKey: nil,
+                profileUpdatedAt: Date(timeIntervalSince1970: 1),
+                agentVerification: nil
+            ).save(db)
+        }
+
+        let recorder = SyncNotificationRecorder(name: .contactsWereAdded)
+
+        let coordinator = ContactSyncCoordinator(
+            databaseWriter: dbManager.dbWriter,
+            databaseReader: dbManager.dbReader
+        )
+        try await coordinator.syncContactsOnFirstMessage(for: conversationId)
+        try await Task.sleep(nanoseconds: 30_000_000)
+
+        #expect(recorder.notifications.isEmpty, "No new contact rows, so no sweep-trigger should fire")
+
+        recorder.stop()
+    }
+}
+
+/// Local copy of the recorder used by `ContactsWriterTests`. Kept private
+/// to this file so each test file can opt into the helper without coupling
+/// suites to a shared scaffolding module.
+private final class SyncNotificationRecorder: @unchecked Sendable {
+    private(set) var notifications: [Notification] = []
+    private var token: NSObjectProtocol?
+    private let lock: NSLock = NSLock()
+
+    init(name: Notification.Name) {
+        token = NotificationCenter.default.addObserver(
+            forName: name,
+            object: nil,
+            queue: nil
+        ) { [weak self] notification in
+            guard let self else { return }
+            self.lock.lock()
+            self.notifications.append(notification)
+            self.lock.unlock()
+        }
+    }
+
+    func stop() {
+        if let token {
+            NotificationCenter.default.removeObserver(token)
+            self.token = nil
+        }
+    }
+
+    deinit { stop() }
 }

--- a/ConvosCore/Tests/ConvosCoreTests/ContactSyncCoordinatorTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ContactSyncCoordinatorTests.swift
@@ -426,24 +426,35 @@ struct ContactSyncCoordinatorTests {
             )
         }
 
-        let recorder = SyncNotificationRecorder(name: .contactsWereAdded)
+        // Private center so other suites posting on `.default` cannot leak in.
+        let center = NotificationCenter()
+        let recorder = SyncNotificationRecorder(name: .contactsWereAdded, center: center)
 
         let coordinator = ContactSyncCoordinator(
             databaseWriter: dbManager.dbWriter,
-            databaseReader: dbManager.dbReader
+            databaseReader: dbManager.dbReader,
+            notificationCenter: center
         )
         try await coordinator.syncContactsOnFirstMessage(for: conversationId)
 
-        // Allow the main-queue dispatch from `postContactsWereAdded` to drain.
-        try await Task.sleep(nanoseconds: 30_000_000)
+        // Wait for the main-queue dispatch from `postContactsWereAdded` to
+        // land. Polling beats a fixed sleep because the dispatch latency
+        // varies under CI load.
+        try await waitUntil(timeout: .seconds(2)) {
+            recorder.notifications.count >= 1
+        }
 
         #expect(recorder.notifications.count == 1, "Batch sync must coalesce N inserts into one notification")
         let payload = recorder.notifications.first?.userInfo?["inboxIds"] as? [String] ?? []
         #expect(Set(payload) == Set(["alice", "bob", "carol"]))
 
-        // Second sync is a no-op (already-synced) and must not re-fire.
+        // Second sync is a no-op (already-synced) and must not re-fire. Use
+        // a happens-after sentinel: post a marker on the same center after
+        // the no-op call, wait for the sentinel, then assert no second
+        // `contactsWereAdded` arrived. Polling for the absence of a
+        // notification would be a race; the sentinel pattern is not.
         try await coordinator.syncContactsOnFirstMessage(for: conversationId)
-        try await Task.sleep(nanoseconds: 30_000_000)
+        try await flush(center: center)
         #expect(recorder.notifications.count == 1)
 
         recorder.stop()
@@ -479,14 +490,21 @@ struct ContactSyncCoordinatorTests {
             ).save(db)
         }
 
-        let recorder = SyncNotificationRecorder(name: .contactsWereAdded)
+        let center = NotificationCenter()
+        let recorder = SyncNotificationRecorder(name: .contactsWereAdded, center: center)
 
         let coordinator = ContactSyncCoordinator(
             databaseWriter: dbManager.dbWriter,
-            databaseReader: dbManager.dbReader
+            databaseReader: dbManager.dbReader,
+            notificationCenter: center
         )
         try await coordinator.syncContactsOnFirstMessage(for: conversationId)
-        try await Task.sleep(nanoseconds: 30_000_000)
+
+        // Happens-after sentinel: any real `contactsWereAdded` post from the
+        // sync above would have been dispatched to the main queue before
+        // the sentinel post we make here, so once the sentinel arrives the
+        // recorder has seen everything the sync could have produced.
+        try await flush(center: center)
 
         #expect(recorder.notifications.isEmpty, "No new contact rows, so no sweep-trigger should fire")
 
@@ -494,30 +512,78 @@ struct ContactSyncCoordinatorTests {
     }
 }
 
+/// Posts a sentinel notification on `center` and awaits its delivery on the
+/// main queue. Use this in tests that need to assert "nothing happened":
+/// because `postContactsWereAdded` dispatches to the main queue, any real
+/// post made before this call lands on the queue before the sentinel.
+private func flush(center: NotificationCenter) async throws {
+    let sentinelName = Notification.Name("ContactSyncCoordinatorTests.Sentinel.\(UUID().uuidString)")
+    let arrived = SentinelLatch()
+    let token = center.addObserver(forName: sentinelName, object: nil, queue: nil) { _ in
+        arrived.fire()
+    }
+    defer { center.removeObserver(token) }
+
+    await MainActor.run {
+        center.post(name: sentinelName, object: nil)
+    }
+    try await waitUntil(timeout: .seconds(2)) { arrived.didFire }
+}
+
+private final class SentinelLatch: @unchecked Sendable {
+    private let lock: NSLock = NSLock()
+    private var _didFire: Bool = false
+
+    var didFire: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return _didFire
+    }
+
+    func fire() {
+        lock.lock()
+        _didFire = true
+        lock.unlock()
+    }
+}
+
 /// Local copy of the recorder used by `ContactsWriterTests`. Kept private
 /// to this file so each test file can opt into the helper without coupling
 /// suites to a shared scaffolding module.
+///
+/// The recorder is bound to a specific `NotificationCenter` so callers can
+/// scope it to a private center and avoid cross-suite leakage through
+/// `.default`. The `lock`-guarded array makes concurrent appends safe when
+/// the center delivers to its own queue.
 private final class SyncNotificationRecorder: @unchecked Sendable {
-    private(set) var notifications: [Notification] = []
+    private let center: NotificationCenter
+    private var _notifications: [Notification] = []
     private var token: NSObjectProtocol?
     private let lock: NSLock = NSLock()
 
-    init(name: Notification.Name) {
-        token = NotificationCenter.default.addObserver(
+    var notifications: [Notification] {
+        lock.lock()
+        defer { lock.unlock() }
+        return _notifications
+    }
+
+    init(name: Notification.Name, center: NotificationCenter = .default) {
+        self.center = center
+        token = center.addObserver(
             forName: name,
             object: nil,
             queue: nil
         ) { [weak self] notification in
             guard let self else { return }
             self.lock.lock()
-            self.notifications.append(notification)
+            self._notifications.append(notification)
             self.lock.unlock()
         }
     }
 
     func stop() {
         if let token {
-            NotificationCenter.default.removeObserver(token)
+            center.removeObserver(token)
             self.token = nil
         }
     }

--- a/ConvosCore/Tests/ConvosCoreTests/ContactsWriterTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ContactsWriterTests.swift
@@ -373,6 +373,54 @@ struct ContactsWriterTests {
         #expect(count == 0)
     }
 
+    @Test("upsertContact posts `contactsWereAdded` only on a brand-new contact row")
+    func testUpsertPostsContactsWereAddedOnInsertOnly() async throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        let writer = ContactsWriter(databaseWriter: dbManager.dbWriter)
+        let inboxId = "inbox-add-1"
+
+        let recorder = NotificationRecorder(name: .contactsWereAdded)
+
+        // First upsert on a fresh inboxId: real insert, post fires with the
+        // singleton inboxId in the userInfo payload.
+        try await writer.upsertContact(
+            inboxId: inboxId,
+            addedViaConversationId: nil,
+            profile: ContactProfileSnapshot(
+                displayName: "Original",
+                profileUpdatedAt: Date(timeIntervalSince1970: 100)
+            )
+        )
+        try await Task.sleep(nanoseconds: 20_000_000)
+        #expect(recorder.notifications.count == 1)
+        #expect(recorder.notifications.first?.userInfo?["inboxIds"] as? [String] == [inboxId])
+
+        // Idempotent re-upsert with an older timestamp: no row change, no post.
+        try await writer.upsertContact(
+            inboxId: inboxId,
+            addedViaConversationId: nil,
+            profile: ContactProfileSnapshot(
+                displayName: "Stale",
+                profileUpdatedAt: Date(timeIntervalSince1970: 50)
+            )
+        )
+        try await Task.sleep(nanoseconds: 20_000_000)
+        #expect(recorder.notifications.count == 1)
+
+        // Profile-only update on an existing row: still no insert, no post.
+        try await writer.updateProfileIfNewer(
+            inboxId: inboxId,
+            profile: ContactProfileSnapshot(
+                displayName: "Renamed",
+                profileUpdatedAt: Date(timeIntervalSince1970: 200)
+            )
+        )
+        try await Task.sleep(nanoseconds: 20_000_000)
+        #expect(recorder.notifications.count == 1)
+
+        recorder.stop()
+    }
+
     @Test("Block and unblock post `contactBlockingDidChange` on real state changes only")
     func testBlockingPostsNotificationOnRealChanges() async throws {
         let dbManager = MockDatabaseManager.makeTestDatabase()

--- a/ConvosCore/Tests/ConvosCoreTests/QuarantineSweeperTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/QuarantineSweeperTests.swift
@@ -52,15 +52,26 @@ struct QuarantineSweeperTests {
         ).save(db)
     }
 
+    /// Builds a sweeper with sensible defaults. Tests that care about the
+    /// XMTP-consent-bump path pass an explicit closure; tests that do not
+    /// get a no-op bumper that always succeeds.
+    private static func makeSweeper(
+        dbManager: MockDatabaseManager,
+        consentBumper: @escaping @Sendable (String) async throws -> Void = { _ in }
+    ) -> QuarantineSweeper {
+        QuarantineSweeper(
+            databaseWriter: dbManager.dbWriter,
+            databaseReader: dbManager.dbReader,
+            contactsRepository: ContactsRepository(databaseReader: dbManager.dbReader),
+            consentBumper: consentBumper
+        )
+    }
+
     @Test("Sweep no-ops when there are no quarantined conversations")
     func testNoOpWhenNothingQuarantined() async throws {
         let dbManager = MockDatabaseManager.makeTestDatabase()
 
-        let sweeper = QuarantineSweeper(
-            databaseWriter: dbManager.dbWriter,
-            databaseReader: dbManager.dbReader,
-            contactsRepository: ContactsRepository(databaseReader: dbManager.dbReader)
-        )
+        let sweeper = Self.makeSweeper(dbManager: dbManager)
 
         try await sweeper.sweep()
 
@@ -82,11 +93,7 @@ struct QuarantineSweeperTests {
             try Self.seedContact(db, inboxId: creator)
         }
 
-        let sweeper = QuarantineSweeper(
-            databaseWriter: dbManager.dbWriter,
-            databaseReader: dbManager.dbReader,
-            contactsRepository: ContactsRepository(databaseReader: dbManager.dbReader)
-        )
+        let sweeper = Self.makeSweeper(dbManager: dbManager)
 
         try await sweeper.sweep()
 
@@ -109,11 +116,7 @@ struct QuarantineSweeperTests {
             try Self.seedContact(db, inboxId: creator, blocked: true)
         }
 
-        let sweeper = QuarantineSweeper(
-            databaseWriter: dbManager.dbWriter,
-            databaseReader: dbManager.dbReader,
-            contactsRepository: ContactsRepository(databaseReader: dbManager.dbReader)
-        )
+        let sweeper = Self.makeSweeper(dbManager: dbManager)
 
         try await sweeper.sweep()
 
@@ -134,11 +137,7 @@ struct QuarantineSweeperTests {
             try Self.seedConversation(db, id: convId, creatorId: creator, quarantinedAt: stale)
         }
 
-        let sweeper = QuarantineSweeper(
-            databaseWriter: dbManager.dbWriter,
-            databaseReader: dbManager.dbReader,
-            contactsRepository: ContactsRepository(databaseReader: dbManager.dbReader)
-        )
+        let sweeper = Self.makeSweeper(dbManager: dbManager)
 
         try await sweeper.sweep()
 
@@ -159,11 +158,7 @@ struct QuarantineSweeperTests {
             try Self.seedConversation(db, id: convId, creatorId: creator, quarantinedAt: recent)
         }
 
-        let sweeper = QuarantineSweeper(
-            databaseWriter: dbManager.dbWriter,
-            databaseReader: dbManager.dbReader,
-            contactsRepository: ContactsRepository(databaseReader: dbManager.dbReader)
-        )
+        let sweeper = Self.makeSweeper(dbManager: dbManager)
 
         try await sweeper.sweep()
 
@@ -189,11 +184,7 @@ struct QuarantineSweeperTests {
         }
 
         // First sweep with sender still blocked: no promotion.
-        let firstSweeper = QuarantineSweeper(
-            databaseWriter: dbManager.dbWriter,
-            databaseReader: dbManager.dbReader,
-            contactsRepository: ContactsRepository(databaseReader: dbManager.dbReader)
-        )
+        let firstSweeper = Self.makeSweeper(dbManager: dbManager)
         try await firstSweeper.sweep()
 
         let stillHeld = try await dbManager.dbReader.read { db in
@@ -211,12 +202,8 @@ struct QuarantineSweeperTests {
             try contact.with(blockedAt: nil).save(db)
         }
 
-        // Second sweep: now isContact && !isBlocked → promote.
-        let secondSweeper = QuarantineSweeper(
-            databaseWriter: dbManager.dbWriter,
-            databaseReader: dbManager.dbReader,
-            contactsRepository: ContactsRepository(databaseReader: dbManager.dbReader)
-        )
+        // Second sweep: now isContact && !isBlocked -> promote.
+        let secondSweeper = Self.makeSweeper(dbManager: dbManager)
         try await secondSweeper.sweep()
 
         let promoted = try await dbManager.dbReader.read { db in
@@ -242,19 +229,136 @@ struct QuarantineSweeperTests {
             )
         }
 
-        let sweeper = QuarantineSweeper(
-            databaseWriter: dbManager.dbWriter,
-            databaseReader: dbManager.dbReader,
-            contactsRepository: ContactsRepository(databaseReader: dbManager.dbReader)
-        )
+        let sweeper = Self.makeSweeper(dbManager: dbManager)
 
         try await sweeper.sweep()
 
-        // The row had an old quarantinedAt but was already released — it
+        // The row had an old quarantinedAt but was already released - it
         // should not be deleted.
         let row = try await dbManager.dbReader.read { db in
             try DBConversation.fetchOne(db, key: convId)
         }
         #expect(row != nil)
+    }
+
+    @Test("Promotion sets consent = .allowed so the main feed query surfaces the row")
+    func testPromotionFlipsConsentToAllowed() async throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        let creator = "creator-1"
+        let convId = "conv-1"
+        let quarantinedAt = Date(timeIntervalSinceNow: -60)
+
+        // Seed with the consent state a real quarantined inbound row carries:
+        // `.unknown`, since `StreamProcessor.decideInboundConversation` only
+        // bumps XMTP consent on the `.deliver` branch.
+        try await dbManager.dbWriter.write { db in
+            try DBMember(inboxId: creator).save(db, onConflict: .ignore)
+            try DBConversation(
+                id: convId,
+                clientConversationId: convId,
+                inviteTag: "tag-\(convId)",
+                creatorId: creator,
+                kind: .group,
+                consent: .unknown,
+                createdAt: Date(),
+                name: nil,
+                description: nil,
+                imageURLString: nil,
+                publicImageURLString: nil,
+                includeInfoInPublicPreview: false,
+                expiresAt: nil,
+                debugInfo: .empty,
+                isLocked: false,
+                imageSalt: nil,
+                imageNonce: nil,
+                imageEncryptionKey: nil,
+                conversationEmoji: nil,
+                imageLastRenewed: nil,
+                isUnused: false,
+                hasHadVerifiedAgent: false,
+                quarantinedAt: quarantinedAt,
+                quarantineReleasedAt: nil
+            ).insert(db)
+            try Self.seedContact(db, inboxId: creator)
+        }
+
+        let sweeper = Self.makeSweeper(dbManager: dbManager)
+        try await sweeper.sweep()
+
+        let row = try await dbManager.dbReader.read { db in
+            try DBConversation.fetchOne(db, key: convId)
+        }
+        #expect(row?.quarantineReleasedAt != nil)
+        #expect(row?.consent == .allowed, "Promotion must flip consent to .allowed so the main feed query surfaces the row")
+    }
+
+    @Test("XMTP consent bump failure defers the promotion to the next sweep")
+    func testConsentBumpFailureDefersPromotion() async throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        let creator = "creator-1"
+        let convId = "conv-1"
+        let quarantinedAt = Date(timeIntervalSinceNow: -60)
+
+        try await dbManager.dbWriter.write { db in
+            try Self.seedConversation(db, id: convId, creatorId: creator, quarantinedAt: quarantinedAt)
+            try Self.seedContact(db, inboxId: creator)
+        }
+
+        struct StubError: Error {}
+        let failingSweeper = Self.makeSweeper(
+            dbManager: dbManager,
+            consentBumper: { _ in throw StubError() }
+        )
+        try await failingSweeper.sweep()
+
+        let stillHeld = try await dbManager.dbReader.read { db in
+            try DBConversation.fetchOne(db, key: convId)
+        }
+        #expect(stillHeld?.quarantineReleasedAt == nil, "Failed XMTP bump must leave the row quarantined for next sweep")
+
+        // Next sweep with a working bumper retries successfully.
+        let recoveringSweeper = Self.makeSweeper(dbManager: dbManager)
+        try await recoveringSweeper.sweep()
+
+        let promoted = try await dbManager.dbReader.read { db in
+            try DBConversation.fetchOne(db, key: convId)
+        }
+        #expect(promoted?.quarantineReleasedAt != nil)
+        #expect(promoted?.consent == .allowed)
+    }
+
+    @Test("Sweeper invokes the consentBumper exactly once per promoted conversation")
+    func testConsentBumperInvokedOncePerPromotion() async throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        let quarantinedAt = Date(timeIntervalSinceNow: -60)
+
+        try await dbManager.dbWriter.write { db in
+            try Self.seedConversation(db, id: "conv-a", creatorId: "alice", quarantinedAt: quarantinedAt)
+            try Self.seedConversation(db, id: "conv-b", creatorId: "bob", quarantinedAt: quarantinedAt)
+            try Self.seedContact(db, inboxId: "alice")
+            try Self.seedContact(db, inboxId: "bob")
+        }
+
+        let recorder = ConversationIdRecorder()
+        let sweeper = Self.makeSweeper(
+            dbManager: dbManager,
+            consentBumper: { conversationId in
+                await recorder.record(conversationId)
+            }
+        )
+        try await sweeper.sweep()
+
+        let seen = await recorder.values
+        #expect(Set(seen) == Set(["conv-a", "conv-b"]))
+        #expect(seen.count == 2, "Bumper must not be called twice per promotion")
+    }
+}
+
+/// Records the conversationIds passed to a stubbed consentBumper closure
+/// in a Sendable-safe way for the assertion at the end of the test.
+private actor ConversationIdRecorder {
+    private(set) var values: [String] = []
+    func record(_ conversationId: String) {
+        values.append(conversationId)
     }
 }


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/893"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782570266&installation_id=128169237&pr_number=893&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F893&signature=1c5dc384be9ece59f20efbe54154bbd8baa368ee281781c92909ed3d43da722f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show prior invites immediately when a new contact is added by triggering a quarantine sweep
> - `ContactsWriter` now returns a `Bool` from `upsertContactInTransaction` indicating whether a new `DBContact` row was inserted, and posts a `.contactsWereAdded` notification (with `inboxIds` in `userInfo`) only on true inserts — not on idempotent re-upserts.
> - `ContactSyncCoordinator` collects inserted `inboxIds` during a sync transaction and emits a single batch `.contactsWereAdded` notification after the write commits.
> - `SessionManager` observes `.contactsWereAdded` and immediately triggers `runQuarantineSweep` so quarantined conversations from the newly added contact are promoted without waiting for the next scheduled sweep.
> - `QuarantineSweeper` now bumps XMTP-side consent to `.allowed` before promoting a conversation; if the consent bump fails, promotion is deferred to the next sweep.
> - Behavioral Change: quarantine promotion now requires a successful XMTP consent bump and sets `consent` to `.allowed` in the DB; previously it only set `quarantineReleasedAt`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e4baa8d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->