### PR TITLE
Clear credit balance on account teardown

### DIFF
--- a/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
@@ -563,6 +563,7 @@ public final class SessionManager: SessionManagerProtocol, @unchecked Sendable {
             try DBCloudConnectionGrant.deleteAll(db)
             try DBCloudConnection.deleteAll(db)
             try DBCapabilityResolution.deleteAll(db)
+            try DBCreditBalance.deleteAll(db)
             try DBConversationReadReceipt.deleteAll(db)
             try DBPendingPhotoUpload.deleteAll(db)
             try DBVoiceMemoTranscript.deleteAll(db)

--- a/ConvosCore/Tests/ConvosCoreTests/SessionManagerDeleteAllDataTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/SessionManagerDeleteAllDataTests.swift
@@ -28,6 +28,16 @@ struct SessionManagerDeleteAllDataTests {
                 inboxId: "self",
                 name: "Me"
             ).save(db)
+
+            try DBCreditBalance(
+                id: DBCreditBalance.currentRowID,
+                balance: 1_000,
+                monthlyGrant: 1_000,
+                monthlyGrantUsed: 0,
+                nextRefreshAt: Date(),
+                periodLabel: "month",
+                updatedAt: Date()
+            ).save(db)
         }
 
         for try await _ in session.deleteAllInboxesWithProgress() {}
@@ -44,9 +54,13 @@ struct SessionManagerDeleteAllDataTests {
         let inboxCount = try await databaseManager.dbReader.read { db in
             try DBInbox.fetchCount(db)
         }
+        let creditBalanceCount = try await databaseManager.dbReader.read { db in
+            try DBCreditBalance.fetchCount(db)
+        }
         #expect(contactCount == 0)
         #expect(myProfileCount == 0)
         #expect(conversationCount == 0)
         #expect(inboxCount == 0)
+        #expect(creditBalanceCount == 0)
     }
 }


### PR DESCRIPTION
DBCreditBalance is account-scoped (a single "current" row) but was never
deleted by deleteAllInboxes, so after logout/account-switch a new account
on the same install saw the previous account's balance until the first
network refresh landed. Reads flow through GRDB, so deleting the row
propagates to observers automatically. Add it to wipeResidualInboxRows
and extend the delete-all-data test.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/895"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782583583&installation_id=128169237&pr_number=895&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F895&signature=0b13568e3d42728b1a16454456b654743974fc70a7dc3ca1a3ed2a37d2b9d1f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Clear credit balance on account teardown
> Adds `DBCreditBalance` to the tables purged during the delete-all-inboxes account reset in [SessionManager.swift](https://github.com/xmtplabs/convos-ios/pull/895/files#diff-047bb043999d66a7809a8ab86918296f5f449652df54267763f6ec8da0a71ca7). A corresponding test in [SessionManagerDeleteAllDataTests.swift](https://github.com/xmtplabs/convos-ios/pull/895/files#diff-35c539ac30bd71bb2ade0c207dab68f4dda25b4bc031f611783741690194ab2d) seeds a credit balance row and asserts it is removed after teardown.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 87f3293.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->