### PR TITLE
Don't mark the active conversation unread during batch catch-up

### DIFF
--- a/ConvosCore/Sources/ConvosCore/Syncing/BatchCatchUp.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/BatchCatchUp.swift
@@ -82,7 +82,8 @@ struct BatchCatchUp {
     func run(
         client: any XMTPClientProvider,
         inboxId: String,
-        since: Date?
+        since: Date?,
+        activeConversationId: String?
     ) async throws -> BatchCatchUpResult {
         let started = CFAbsoluteTimeGetCurrent()
         let cursorNs: Int64? = since.map { Int64($0.nanosecondsSince1970) }
@@ -119,7 +120,8 @@ struct BatchCatchUp {
         //     inbox -> `postLeftConversationNotification` after commit
         //   - conversations that received a message whose content type
         //     marks the conversation unread (from a sender that isn't
-        //     us) -> `setUnread(true, ...)` after commit
+        //     us, and that isn't the conversation the user is currently
+        //     viewing) -> `setUnread(true, ...)` after commit
         // Collected inside the transaction (only `persist` knows the
         // result) but dispatched after commit (notification posts +
         // localStateWriter writes are not part of this transaction).
@@ -152,7 +154,11 @@ struct BatchCatchUp {
                         entryMarksUnread = true
                     }
                 }
-                if entryMarksUnread {
+                // Skip the conversation the user is currently viewing, so a
+                // foreground catch-up back into the open conversation doesn't
+                // mark it unread. Mirrors the stream path's gate in
+                // `StreamProcessor` (`conversation.id != activeConversationId`).
+                if entryMarksUnread, entry.conversation.dbConversation.id != activeConversationId {
                     unreadIds.append(entry.conversation.dbConversation.id)
                 }
             }

--- a/ConvosCore/Sources/ConvosCore/Syncing/SyncingManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/SyncingManager.swift
@@ -253,7 +253,13 @@ actor SyncingManager: SyncingManagerProtocol {
                 messageWriter: messageWriter,
                 databaseWriter: databaseWriter
             )
-            _ = try await batch.run(client: client, inboxId: identity.inboxId, since: since)
+            let activeId = await activeConversationId
+            _ = try await batch.run(
+                client: client,
+                inboxId: identity.inboxId,
+                since: since,
+                activeConversationId: activeId
+            )
         } catch {
             Log.error("catchup.batch.messages failed: \(error.localizedDescription)")
         }

--- a/ConvosCore/Tests/ConvosCoreTests/Integration/BatchCatchUpIntegrationTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/Integration/BatchCatchUpIntegrationTests.swift
@@ -90,7 +90,7 @@ struct BatchCatchUpIntegrationTests {
         let counter = CommitCounter()
         fixtures.databaseManager.dbWriter.add(transactionObserver: counter)
 
-        let result = try await batch.run(client: clientB, inboxId: inboxIdB, since: nil)
+        let result = try await batch.run(client: clientB, inboxId: inboxIdB, since: nil, activeConversationId: nil)
 
         // Headline assertions: the batch saw the conversation and at least
         // all N user messages. libxmtp emits group-membership update messages
@@ -123,6 +123,74 @@ struct BatchCatchUpIntegrationTests {
             try DBConversation.fetchOne(db, id: group.id)
         }
         #expect(conversationStored != nil, "Expected the group's DBConversation row to exist")
+
+        try? await fixtures.cleanup()
+    }
+
+    @Test("Batch does not mark the conversation the user is viewing as unread")
+    func batchSkipsUnreadForActiveConversation() async throws {
+        let fixtures = TestFixtures()
+        try await fixtures.createTestClients()
+
+        guard let clientA = fixtures.clientA as? Client,
+              let clientB = fixtures.clientB as? Client,
+              let clientIdB = fixtures.clientIdB else {
+            throw TestError.missingClients
+        }
+        let inboxIdB = clientB.inboxID
+
+        try await fixtures.databaseManager.dbWriter.write { db in
+            try DBInbox(inboxId: inboxIdB, clientId: clientIdB, createdAt: Date()).insert(db)
+        }
+
+        let group = try await clientA.conversations.newGroup(
+            with: [clientB.inboxID],
+            name: "Active Conversation Group"
+        )
+        try await clientB.conversations.sync()
+
+        let messageCount = 5
+        for i in 1...messageCount {
+            _ = try await group.send(content: "Active msg \(i)")
+        }
+
+        let messageWriter = IncomingMessageWriter(databaseWriter: fixtures.databaseManager.dbWriter)
+        let conversationWriter = ConversationWriter(
+            identityStore: fixtures.identityStore,
+            databaseWriter: fixtures.databaseManager.dbWriter,
+            messageWriter: messageWriter
+        )
+        let batch = BatchCatchUp(
+            conversationWriter: conversationWriter,
+            messageWriter: messageWriter,
+            databaseWriter: fixtures.databaseManager.dbWriter
+        )
+
+        let counter = CommitCounter()
+        fixtures.databaseManager.dbWriter.add(transactionObserver: counter)
+
+        // The user is currently viewing this conversation, so the backlog
+        // drain must persist the messages but skip the unread mark -- the
+        // same gate the stream path applies in `StreamProcessor`.
+        let result = try await batch.run(
+            client: clientB,
+            inboxId: inboxIdB,
+            since: nil,
+            activeConversationId: group.id
+        )
+
+        #expect(result.messagesProcessed >= messageCount, "Expected at least \(messageCount) messages persisted, got \(result.messagesProcessed)")
+        // One transaction for the persist, and crucially no second
+        // transaction for an unread mark -- the conversation is active.
+        #expect(counter.commitCount == 1, "Expected exactly 1 committed transaction (persist only, no unread mark) for the active conversation, got \(counter.commitCount)")
+
+        let isUnread = try await fixtures.databaseManager.dbReader.read { db in
+            try ConversationLocalState
+                .filter(ConversationLocalState.Columns.conversationId == group.id)
+                .fetchOne(db)?
+                .isUnread ?? false
+        }
+        #expect(isUnread == false, "Active conversation should not be marked unread after batch catch-up")
 
         try? await fixtures.cleanup()
     }
@@ -166,7 +234,8 @@ struct BatchCatchUpIntegrationTests {
         let result = try await batch.run(
             client: clientB,
             inboxId: inboxIdB,
-            since: Date(timeIntervalSinceNow: 60)
+            since: Date(timeIntervalSinceNow: 60),
+            activeConversationId: nil
         )
 
         #expect(result.conversationsProcessed == 0, "Expected 0 changed conversations, got \(result.conversationsProcessed)")


### PR DESCRIPTION
BatchCatchUp's unread-marking tail gated only on content type and sender,
omitting the active-conversation check the stream path applies in
StreamProcessor (conversation.id != activeConversationId). A foreground
catch-up back into the conversation the user was already viewing would
mark it unread. Thread SyncingManager's activeConversationId into
BatchCatchUp.run and skip the unread mark for that conversation. Adds an
integration test covering the active-conversation case.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/896"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782584062&installation_id=128169237&pr_number=896&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F896&signature=5a1c8874a1c0a1166ae6a156e0f288720c47b1883d2db9b19059590c9c134696"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Skip marking the active conversation unread during batch catch-up
> When `BatchCatchUp.run` processes backlog messages, it now skips adding the currently viewed conversation to the unread list. `SyncingManager` reads `activeConversationId` from actor state before invoking batch catch-up and passes it through. A new integration test in [BatchCatchUpIntegrationTests.swift](https://github.com/xmtplabs/convos-ios/pull/896/files#diff-7b3900527e8abe270e3ff10bb1ad356888781904194e47e27cd5be977e93ce35) verifies that messages are persisted, no extra unread-mark transaction is committed, and the conversation's local unread state stays false.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b562786.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->