### PR TITLE
Emit received QA events for backlog messages in batch catch-up

### DIFF
--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationWriter.swift
@@ -387,7 +387,8 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
     /// connection time forward, it does not replay historical backlog.
     func applyBacklogSupplementals(
         _ messages: [XMTPiOS.DecodedMessage],
-        for conversation: DBConversation
+        for conversation: DBConversation,
+        currentInboxId: String
     ) async {
         for message in messages {
             guard !message.isProfileMessage, !message.isTypingIndicator else {
@@ -395,6 +396,10 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
             }
             if message.isReadReceipt {
                 await storeReadReceipt(message, conversationId: conversation.id)
+                continue
+            }
+            if message.isThinking {
+                await storeThinking(message, conversationId: conversation.id, currentInboxId: currentInboxId)
                 continue
             }
             do {

--- a/ConvosCore/Sources/ConvosCore/Syncing/BatchCatchUp.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/BatchCatchUp.swift
@@ -176,7 +176,8 @@ struct BatchCatchUp {
             supplementalCount += entry.supplementalMessages.count
             await conversationWriter.applyBacklogSupplementals(
                 entry.supplementalMessages,
-                for: entry.conversation.dbConversation
+                for: entry.conversation.dbConversation,
+                currentInboxId: inboxId
             )
         }
 
@@ -337,9 +338,9 @@ struct BatchCatchUp {
         /// Goes through `IncomingMessageWriter.persist` in the batched transaction.
         case regular
         /// Handled post-transaction via `ConversationWriter.applyBacklogSupplementals`
-        /// (reactions, read receipts). These have per-type handlers that
-        /// the stream-driven path also uses; we apply them here because
-        /// the libxmtp stream doesn't replay historical backlog.
+        /// (reactions, read receipts, thinking moments). These have per-type
+        /// handlers that the stream-driven path also uses; we apply them here
+        /// because the libxmtp stream doesn't replay historical backlog.
         case supplemental
         /// Drop entirely (typing indicators, profile messages, undecodable).
         /// Typing indicators are inherently live-only; profile messages
@@ -351,7 +352,11 @@ struct BatchCatchUp {
         if message.isProfileMessage || message.isTypingIndicator {
             return .skip
         }
-        if message.isReadReceipt {
+        // Thinking messages back the thinking-detail view but must never be
+        // persisted as normal chat messages -- the stream path routes them
+        // through `ThinkingSessionWriter` (see `storeThinking`). Treat them
+        // as a supplemental so the batch applies them the same way.
+        if message.isReadReceipt || message.isThinking {
             return .supplemental
         }
         guard let contentType = try? message.encodedContent.type else {

--- a/ConvosCore/Sources/ConvosCore/Syncing/BatchCatchUp.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/BatchCatchUp.swift
@@ -113,7 +113,7 @@ struct BatchCatchUp {
         // different clientConversationId than the input (sticky-draft
         // logic), which the image-cache key downstream depends on.
         //
-        // We also capture two post-commit signals that the stream path
+        // We also capture three post-commit signals that the stream path
         // emits inside `IncomingMessageWriter.store` /
         // `fetchAndStoreLatestMessages` and which the batch must mirror:
         //   - conversations where a backlog message removed the local
@@ -122,53 +122,30 @@ struct BatchCatchUp {
         //     marks the conversation unread (from a sender that isn't
         //     us, and that isn't the conversation the user is currently
         //     viewing) -> `setUnread(true, ...)` after commit
+        //   - a "received" QA event per newly-persisted message ->
+        //     `QAEvent.emit(.message, "received", ...)` after commit
         // Collected inside the transaction (only `persist` knows the
         // result) but dispatched after commit (notification posts +
         // localStateWriter writes are not part of this transaction).
-        struct PersistOutcomes {
-            let saveResults: [ConversationWriter.ConversationSaveResult]
-            let conversationsRemovingLocalInbox: [DBConversation]
-            let conversationsToMarkUnread: [String]
-        }
         let outcomes: PersistOutcomes = try await databaseWriter.write { [conversationWriter, messageWriter] db in
-            var results: [ConversationWriter.ConversationSaveResult] = []
-            var removals: [DBConversation] = []
-            var unreadIds: [String] = []
-            results.reserveCapacity(prepared.count)
-            for entry in prepared {
-                let result = try conversationWriter.persist(entry.conversation, in: db)
-                results.append(result)
-                var entryMarksUnread = false
-                for preparedMessage in entry.regularMessages {
-                    let messageResult = try messageWriter.persist(
-                        preparedMessage,
-                        conversation: entry.conversation.dbConversation,
-                        in: db
-                    )
-                    guard let messageResult else { continue }
-                    if messageResult.wasRemovedFromConversation, !messageResult.messageAlreadyExists {
-                        removals.append(entry.conversation.dbConversation)
-                    }
-                    if messageResult.contentType.marksConversationAsUnread,
-                       preparedMessage.source.senderInboxId != inboxId {
-                        entryMarksUnread = true
-                    }
-                }
-                // Skip the conversation the user is currently viewing, so a
-                // foreground catch-up back into the open conversation doesn't
-                // mark it unread. Mirrors the stream path's gate in
-                // `StreamProcessor` (`conversation.id != activeConversationId`).
-                if entryMarksUnread, entry.conversation.dbConversation.id != activeConversationId {
-                    unreadIds.append(entry.conversation.dbConversation.id)
-                }
-            }
-            return PersistOutcomes(
-                saveResults: results,
-                conversationsRemovingLocalInbox: removals,
-                conversationsToMarkUnread: unreadIds
+            try Self.persistPreparedEntries(
+                prepared,
+                inboxId: inboxId,
+                activeConversationId: activeConversationId,
+                conversationWriter: conversationWriter,
+                messageWriter: messageWriter,
+                in: db
             )
         }
         let saveResults = outcomes.saveResults
+
+        // Emit the per-message "received" QA events the stream path emits
+        // in `IncomingMessageWriter.store`. Collected inside the
+        // transaction (only `persist` knows whether the row was new) and
+        // emitted here after commit, matching the stream path's ordering.
+        for params in outcomes.qaReceivedEvents {
+            QAEvent.emit(.message, "received", params)
+        }
 
         // Post-commit notifications, matching the stream path's tail in
         // `IncomingMessageWriter.store`.
@@ -234,6 +211,76 @@ struct BatchCatchUp {
         let conversation: ConversationWriter.PreparedConversation
         let regularMessages: [IncomingMessageWriter.PreparedIncomingMessage]
         let supplementalMessages: [XMTPiOS.DecodedMessage]
+    }
+
+    /// Signals collected inside the persist transaction but dispatched
+    /// after commit. `saveResults[i]` corresponds to `prepared[i]`.
+    private struct PersistOutcomes {
+        let saveResults: [ConversationWriter.ConversationSaveResult]
+        let conversationsRemovingLocalInbox: [DBConversation]
+        let conversationsToMarkUnread: [String]
+        let qaReceivedEvents: [[String: String]]
+    }
+
+    /// Persists every prepared conversation + its regular messages inside
+    /// the caller's single transaction and returns the post-commit signals
+    /// the batch must mirror from the stream path. Pure transaction work;
+    /// the caller fires the notifications / unread marks / QA events after
+    /// the transaction commits.
+    private static func persistPreparedEntries(
+        _ prepared: [PreparedEntry],
+        inboxId: String,
+        activeConversationId: String?,
+        conversationWriter: ConversationWriter,
+        messageWriter: IncomingMessageWriter,
+        in db: Database
+    ) throws -> PersistOutcomes {
+        var results: [ConversationWriter.ConversationSaveResult] = []
+        var removals: [DBConversation] = []
+        var unreadIds: [String] = []
+        var qaReceivedEvents: [[String: String]] = []
+        results.reserveCapacity(prepared.count)
+        for entry in prepared {
+            let result = try conversationWriter.persist(entry.conversation, in: db)
+            results.append(result)
+            var entryMarksUnread = false
+            for preparedMessage in entry.regularMessages {
+                let messageResult = try messageWriter.persist(
+                    preparedMessage,
+                    conversation: entry.conversation.dbConversation,
+                    in: db
+                )
+                guard let messageResult else { continue }
+                if !messageResult.messageAlreadyExists {
+                    qaReceivedEvents.append([
+                        "id": preparedMessage.source.id,
+                        "conversation": entry.conversation.dbConversation.id,
+                        "sender": preparedMessage.source.senderInboxId,
+                        "type": messageResult.contentType.rawValue
+                    ])
+                }
+                if messageResult.wasRemovedFromConversation, !messageResult.messageAlreadyExists {
+                    removals.append(entry.conversation.dbConversation)
+                }
+                if messageResult.contentType.marksConversationAsUnread,
+                   preparedMessage.source.senderInboxId != inboxId {
+                    entryMarksUnread = true
+                }
+            }
+            // Skip the conversation the user is currently viewing, so a
+            // foreground catch-up back into the open conversation doesn't
+            // mark it unread. Mirrors the stream path's gate in
+            // `StreamProcessor` (`conversation.id != activeConversationId`).
+            if entryMarksUnread, entry.conversation.dbConversation.id != activeConversationId {
+                unreadIds.append(entry.conversation.dbConversation.id)
+            }
+        }
+        return PersistOutcomes(
+            saveResults: results,
+            conversationsRemovingLocalInbox: removals,
+            conversationsToMarkUnread: unreadIds,
+            qaReceivedEvents: qaReceivedEvents
+        )
     }
 
     private func prepareAll(

--- a/ConvosCore/Tests/ConvosCoreTests/Integration/BatchCatchUpIntegrationTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/Integration/BatchCatchUpIntegrationTests.swift
@@ -195,6 +195,70 @@ struct BatchCatchUpIntegrationTests {
         try? await fixtures.cleanup()
     }
 
+    @Test("Batch routes thinking messages to the thinking-session store, not normal messages")
+    func batchStoresThinkingViaSessionWriter() async throws {
+        let fixtures = TestFixtures()
+        try await fixtures.createTestClients()
+
+        guard let clientA = fixtures.clientA as? Client,
+              let clientB = fixtures.clientB as? Client,
+              let clientIdB = fixtures.clientIdB else {
+            throw TestError.missingClients
+        }
+        let inboxIdB = clientB.inboxID
+
+        try await fixtures.databaseManager.dbWriter.write { db in
+            try DBInbox(inboxId: inboxIdB, clientId: clientIdB, createdAt: Date()).insert(db)
+        }
+
+        let group = try await clientA.conversations.newGroup(
+            with: [clientB.inboxID],
+            name: "Thinking Group"
+        )
+        try await clientB.conversations.sync()
+
+        // A sends one regular message and one thinking message.
+        _ = try await group.send(content: "hello")
+        let thinking = ThinkingContent(
+            state: .start,
+            targetMessageId: "target-message-1",
+            content: "Thinking about hello"
+        )
+        let thinkingMessageId = try await group.send(
+            encodedContent: try ThinkingCodec().encode(content: thinking)
+        )
+
+        let messageWriter = IncomingMessageWriter(databaseWriter: fixtures.databaseManager.dbWriter)
+        let conversationWriter = ConversationWriter(
+            identityStore: fixtures.identityStore,
+            databaseWriter: fixtures.databaseManager.dbWriter,
+            messageWriter: messageWriter
+        )
+        let batch = BatchCatchUp(
+            conversationWriter: conversationWriter,
+            messageWriter: messageWriter,
+            databaseWriter: fixtures.databaseManager.dbWriter
+        )
+
+        _ = try await batch.run(client: clientB, inboxId: inboxIdB, since: nil, activeConversationId: nil)
+
+        // The backlog thinking message lands in the thinking-session store...
+        let thinkingMomentCount = try await fixtures.databaseManager.dbReader.read { db in
+            try DBThinkingMoment
+                .filter(DBThinkingMoment.Columns.conversationId == group.id)
+                .fetchCount(db)
+        }
+        #expect(thinkingMomentCount == 1, "Expected the backlog thinking message to create one thinking moment, got \(thinkingMomentCount)")
+
+        // ...and is not persisted as a normal chat message.
+        let thinkingAsMessage = try await fixtures.databaseManager.dbReader.read { db in
+            try DBMessage.filter(DBMessage.Columns.id == thinkingMessageId).fetchOne(db)
+        }
+        #expect(thinkingAsMessage == nil, "Thinking message must not be stored as a normal DBMessage")
+
+        try? await fixtures.cleanup()
+    }
+
     @Test("Batch with no missed activity is a near no-op")
     func batchWithEmptyBacklogIsNoOp() async throws {
         let fixtures = TestFixtures()


### PR DESCRIPTION
IncomingMessageWriter.store emits a QAEvent.message "received" for each
newly-persisted message, but BatchCatchUp called persist directly and
skipped it, so backlog-delivered messages produced no QA event and the
harness under-counted messages received during catch-up. Collect the
"received" payloads inside the persist transaction and emit them after
commit, mirroring the stream path's ordering. Extracts the persist loop
into persistPreparedEntries to keep run() under the cyclomatic-complexity
limit.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/897"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782584064&installation_id=128169237&pr_number=897&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F897&signature=5d58fd433711c767cb0780d44d7e2cb1a4107f0e7d872d83040667d564473144"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Emit QA 'received' events for messages persisted during batch catch-up
> - [`BatchCatchUp`](https://github.com/xmtplabs/convos-ios/pull/897/files#diff-397f4cd322efa095522345a526e59f4fc6b49ae617af5c733ae6a8c73f1e1dd0) now emits a `QAEvent.emit(.message, "received", ...)` for each newly persisted message after the write transaction commits, mirroring the behavior of the stream path.
> - Thinking messages are now classified as supplemental in `BatchCatchUp.classify` and routed to the thinking-session writer via `ConversationWriter.applyBacklogSupplementals`, keeping them out of the normal `DBMessage` store.
> - A new private helper `persistPreparedEntries` extracts the transaction-scoped persist loop and collects QA event metadata (message id, conversation id, sender inbox id, content type) for post-commit emission.
> - An integration test in [`BatchCatchUpIntegrationTests`](https://github.com/xmtplabs/convos-ios/pull/897/files#diff-7b3900527e8abe270e3ff10bb1ad356888781904194e47e27cd5be977e93ce35) verifies that thinking messages land in `DBThinkingMoment` and not in `DBMessage` after catch-up.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c3cbbe2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->