### PR TITLE
Make joiner-side pairing completion idempotent

### DIFF
--- a/Convos/Devices/JoinerPairingSheetViewModel.swift
+++ b/Convos/Devices/JoinerPairingSheetViewModel.swift
@@ -41,6 +41,11 @@ final class JoinerPairingSheetViewModel: Identifiable {
     private let checkHasExistingData: (@MainActor () async -> Bool)?
     private var adoptedDisplayName: String?
     private var adoptedImageAssetIdentifier: String?
+    /// Guards `onPairingCompleted` against re-entry. The identity-share
+    /// message that drives completion can be redelivered by the stream, and
+    /// the adopt-profile callbacks + completion notification must run at
+    /// most once.
+    private var didComplete: Bool = false
 
     init(
         pairingId: String,
@@ -218,6 +223,8 @@ final class JoinerPairingSheetViewModel: Identifiable {
     }
 
     func onPairingCompleted() {
+        guard !didComplete else { return }
+        didComplete = true
         countdownTask?.cancel()
         title = "Adopting identity"
         flowState = .syncing


### PR DESCRIPTION
JoinerPairingSheetViewModel.onPairingCompleted runs the adopt-profile
callbacks and posts .pairingDidCompleteSuccessfully, but had no re-entry
guard. The .pairingDidReceiveIdentityShare message that drives it can be
redelivered by the stream, so completion could run twice (double adopt +
double notification). Add a didComplete guard so it runs at most once.
The initiator side is already guarded by the coordinator state machine.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/898"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782584236&installation_id=128169237&pr_number=898&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F898&signature=2c83f96c1df70f7b76af3de39edfd857492a4c60981730e7bfdbb2b4225189a7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make `onPairingCompleted` in `JoinerPairingSheetViewModel` idempotent
> Adds a `didComplete` guard to `onPairingCompleted` in [JoinerPairingSheetViewModel.swift](https://github.com/xmtplabs/convos-ios/pull/898/files#diff-74444d6b7dcd773dbdd3d5d8ec9d4d61d45b9e3e293ac5cb90ebcb2579c4f7ba) so that adoption callbacks, state updates, and the success notification fire at most once, even if the method is called multiple times.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cf62298.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->