### PR TITLE
fix(agent-builder): trim whitespace; keep agent join alive; clear "Joining" when verified

### DIFF
--- a/Convos/Agent Builder/AgentBuilderViewModel.swift
+++ b/Convos/Agent Builder/AgentBuilderViewModel.swift
@@ -426,6 +426,13 @@ final class AgentBuilderViewModel: Identifiable {
 
     // MARK: - Derived state
 
+    /// Whitespace-/newline-only composer text isn't a prompt — the commit
+    /// planner trims it away and never sends it, so Make must not treat it
+    /// as content either.
+    private var hasPromptText: Bool {
+        !composerText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
     /// Make button is enabled as soon as the composer has any content.
     /// Tapping Make before the state machine reaches `.ready` is fine —
     /// the morph animates the user into `ConversationView`, which surfaces
@@ -433,7 +440,7 @@ final class AgentBuilderViewModel: Identifiable {
     /// via `ConversationStateMachine.sendMessage` (which already
     /// serializes against `.ready`).
     var isMakeEnabled: Bool {
-        !composerText.isEmpty
+        hasPromptText
             || !pendingMediaAttachments.isEmpty
             || recordedVoiceMemo != nil
             || !enabledConnections.isEmpty
@@ -487,12 +494,6 @@ final class AgentBuilderViewModel: Identifiable {
         composerText = ""
 
         if let innerVM = newConversationViewModel.conversationViewModel {
-            // Allocate the bundle's `clientMessageId`s synchronously so they
-            // can land in `AgentBuilderSummary.bundledMessageIds` BEFORE
-            // the writer ever touches the DB. `MessagesListProcessor` then
-            // filters by id, not by timestamp — a slow multi-remote upload
-            // can no longer leak a bare bundle bubble past the summary card.
-            let textMessageId: String? = textToSend.isEmpty ? nil : UUID().uuidString
             let voiceMemoSnapshot: BuilderVoiceMemoSnapshot?
             if let recorded = recordedVoiceMemo {
                 voiceMemoSnapshot = BuilderVoiceMemoSnapshot(
@@ -503,25 +504,30 @@ final class AgentBuilderViewModel: Identifiable {
             } else {
                 voiceMemoSnapshot = nil
             }
-            let willSendBundle: Bool = voiceMemoSnapshot != nil || !innerVM.pendingMediaAttachments.isEmpty
-            let bundleMessageId: String? = willSendBundle ? UUID().uuidString : nil
-            var bundledMessageIds: Set<String> = []
-            if let textMessageId { bundledMessageIds.insert(textMessageId) }
-            if let bundleMessageId { bundledMessageIds.insert(bundleMessageId) }
 
             var cloudConnectionIdsByRawValue: [String: String] = [:]
             for (connection, cloudConnectionId) in capturedCloudConnectionIds {
                 cloudConnectionIdsByRawValue[connection.rawValue] = cloudConnectionId
             }
-            let summary: AgentBuilderSummary = buildSummary(
-                prompt: textToSend,
+            // `AgentBuilderCommitPlanner` allocates the bundle's
+            // `clientMessageId`s and assembles the summary so they land in
+            // `AgentBuilderSummary.bundledMessageIds` before the writer ever
+            // touches the DB. `MessagesListProcessor` then filters by id, not
+            // by timestamp — a slow multi-remote upload can no longer leak a
+            // bare bundle bubble past the summary card.
+            let attachments: [AgentBuilderSummaryAttachment] = buildSummaryAttachments(
                 voiceMemo: voiceMemoSnapshot,
                 mediaAttachments: innerVM.pendingMediaAttachments,
-                connections: enabledConnections,
-                cloudConnectionIds: cloudConnectionIdsByRawValue,
-                bundledMessageIds: bundledMessageIds
+                connections: enabledConnections
             )
-            innerVM.agentBuilderSummary = summary
+            let plan: AgentBuilderCommitPlan = AgentBuilderCommitPlanner.makePlan(
+                prompt: textToSend,
+                attachments: attachments,
+                cloudConnectionIds: cloudConnectionIdsByRawValue
+            )
+            let textMessageId: String? = plan.textMessageId
+            let bundleMessageId: String? = plan.bundleMessageId
+            innerVM.agentBuilderSummary = plan.summary
             // Hide the staged-chip strip on the chat composer for the
             // duration of the post-commit upload + publish window. Without
             // this the chat view emerges (under the fading-out builder)
@@ -548,12 +554,12 @@ final class AgentBuilderViewModel: Identifiable {
             // conversation send path stays per-attachment so per-item
             // reactions / replies keep working there; the bundle path is
             // builder-only.
-            let summaryToPersist: AgentBuilderSummary = summary
+            let summaryToPersist: AgentBuilderSummary = plan.summary
             let conversationIdForPersist: String = innerVM.conversation.id
             let sessionForPersist = session
-            Task { @MainActor [weak innerVM, textToSend, voiceMemoSnapshot, textMessageId, bundleMessageId, summaryToPersist, conversationIdForPersist, sessionForPersist] in
+            Task { @MainActor [weak innerVM, voiceMemoSnapshot, textMessageId, bundleMessageId, summaryToPersist, conversationIdForPersist, sessionForPersist] in
                 guard let innerVM else { return }
-                // Persist the summary (with its `bundledMessageIds`) BEFORE
+                // Persist the summary (with its `bundledMessageIds`) before
                 // any writer call. If the app dies between Make and the
                 // bundle landing, the filter set is already on disk — the
                 // next launch's `summaryPublisher` rehydrates the summary
@@ -577,7 +583,7 @@ final class AgentBuilderViewModel: Identifiable {
                     // stuck pulsing card.
                 }
                 await innerVM.sendBuilderBundle(
-                    text: textToSend,
+                    text: summaryToPersist.prompt,
                     voiceMemo: voiceMemoSnapshot,
                     textMessageId: textMessageId,
                     bundleMessageId: bundleMessageId
@@ -623,19 +629,18 @@ final class AgentBuilderViewModel: Identifiable {
         // path it replaced did not.
     }
 
-    /// Build the AgentBuilderSummary that renders as the first cell of the
-    /// post-Make conversation. Captures chip-ready data (thumbnails encoded as
-    /// PNG, file metadata, voice memo levels, connection identifiers) so the
-    /// summary view can render the same chips the composer just had — minus
-    /// the X buttons.
-    private func buildSummary(
-        prompt: String,
+    /// Map the composer's staged inputs into the `AgentBuilderSummaryAttachment`
+    /// list the summary card renders — thumbnails encoded as JPEG `Data`, file
+    /// metadata, voice memo levels, connection identifiers — so the summary view
+    /// can show the same chips the composer just had, minus the X buttons. The
+    /// id allocation, bundle detection, and summary assembly happen in
+    /// `AgentBuilderCommitPlanner`; this method owns only the iOS-side
+    /// (`UIImage`) encoding that can't live in ConvosCore.
+    private func buildSummaryAttachments(
         voiceMemo: BuilderVoiceMemoSnapshot?,
         mediaAttachments: [PendingMediaAttachment],
-        connections: Set<AgentBuilderConnection>,
-        cloudConnectionIds: [String: String],
-        bundledMessageIds: Set<String>
-    ) -> AgentBuilderSummary {
+        connections: Set<AgentBuilderConnection>
+    ) -> [AgentBuilderSummaryAttachment] {
         var attachments: [AgentBuilderSummaryAttachment] = []
         if let voiceMemo {
             attachments.append(.voiceMemo(id: UUID(), duration: voiceMemo.duration, levels: voiceMemo.levels))
@@ -658,18 +663,7 @@ final class AgentBuilderViewModel: Identifiable {
         for connection in connections.sorted(by: { $0.id < $1.id }) {
             attachments.append(.connection(id: UUID(), identifier: connection.rawValue))
         }
-        // `cutoffDate` still gates agent-side groups (pre-Make hello
-        // messages from the agent) — we don't control the agent's send
-        // timing so timestamps are the only signal there. User-side filtering
-        // is by-id via `bundledMessageIds`, which doesn't suffer the
-        // upload-stretch race that the old user-side cutoff pad did.
-        return AgentBuilderSummary(
-            prompt: prompt,
-            attachments: attachments,
-            cutoffDate: Date(),
-            bundledMessageIds: bundledMessageIds,
-            cloudConnectionIds: cloudConnectionIds
-        )
+        return attachments
     }
 
     private enum Constant {
@@ -777,6 +771,13 @@ final class AgentBuilderViewModel: Identifiable {
         didRequestAgentJoin = true
 
         agentJoinTask?.cancel()
+        // Capture `session` only, not `self`: the join needs nothing back from
+        // the VM, and not capturing `self` avoids a cycle through the stored
+        // `agentJoinTask`. `deinit` and `discard()` cancel the task on teardown,
+        // which is intentional here (and the opposite of the committed-
+        // conversation join in `ConversationViewModel`, which must survive the
+        // view closing): closing the builder discards the draft conversation --
+        // leaving / deleting the group -- so there's nothing left to join.
         agentJoinTask = Task { [session] in
             do {
                 _ = try await session.requestAgentJoin(slug: slug, options: .agentBuilder)

--- a/Convos/Contacts/ContactDetailView.swift
+++ b/Convos/Contacts/ContactDetailView.swift
@@ -164,6 +164,8 @@ struct ContactDetailView: View {
                     agentTemplateShareURL: agentTemplateShareURL,
                     agentInstanceId: contact.agentInstanceId,
                     showsInstanceIdRow: showsInstanceIdRow,
+                    agentAttestation: contact.agentAttestation,
+                    agentVerification: contact.agentVerification,
                     onSendMessage: isAgentTemplate ? handleChatWithAgentTemplate : handleSendMessage,
                     onRemove: handleRemoveTap,
                     onToggleBlock: handleBlockTap
@@ -551,6 +553,12 @@ private struct ContactDetailActions: View {
     let agentInstanceId: String?
     /// True on Dev/Local builds. Hides the row on production.
     let showsInstanceIdRow: Bool
+    /// Agent's published attestation signature (`nil` when it joined without
+    /// attaching one). Surfaced in the debug-only attestation row.
+    let agentAttestation: String?
+    /// Last-known agent verification, drives the debug row's valid/invalid
+    /// readout alongside the raw attestation value.
+    let agentVerification: AgentVerification?
     let onSendMessage: () -> Void
     let onRemove: () -> Void
     let onToggleBlock: () -> Void
@@ -580,6 +588,17 @@ private struct ContactDetailActions: View {
             if showsInstanceIdRow, let agentInstanceId {
                 ContactDetailDebugInstanceIdRow(instanceId: agentInstanceId)
             }
+            #if DEBUG
+            // Agents only (provisioned, attested, or verified) -- skip human
+            // contacts, which carry no attestation. Shows even for unverified
+            // agents on purpose: the whole point is to see why one isn't valid.
+            if agentInstanceId != nil || agentAttestation != nil || agentVerification?.isVerified == true {
+                ContactDetailDebugAttestationRow(
+                    attestation: agentAttestation,
+                    verification: agentVerification
+                )
+            }
+            #endif
         }
         .padding(.horizontal, DesignConstants.Spacing.step4x)
     }
@@ -779,6 +798,86 @@ private struct ContactDetailDebugInstanceIdRow: View {
     }
 }
 
+#if DEBUG
+// MARK: - Debug attestation row (debug builds only)
+
+/// Debug-build-only row surfacing an agent's published attestation signature
+/// and whether it currently verifies, so engineers can diagnose in-app why an
+/// agent reads as verified or unverified (e.g. an agent that joined without
+/// publishing attestation shows "(none)" + "Not verified"). Sits directly
+/// below the instance-id row and mirrors its capsule + footer shape. Tap to
+/// copy the raw attestation value.
+private struct ContactDetailDebugAttestationRow: View {
+    let attestation: String?
+    let verification: AgentVerification?
+
+    @State private var didCopy: Bool = false
+
+    private var displayValue: String {
+        guard let attestation, !attestation.isEmpty else { return "(none)" }
+        return attestation
+    }
+
+    private var validityText: String {
+        switch verification {
+        case .verified(let issuer):
+            return "Valid - \(issuer.rawValue)"
+        case .unverified, .none:
+            return attestation == nil ? "No attestation" : "Invalid (not verified)"
+        }
+    }
+
+    private var isValid: Bool {
+        verification?.isVerified == true
+    }
+
+    var body: some View {
+        let validityColor: Color = isValid ? .colorTextPrimary : .colorTextSecondary
+        let footerText: String = didCopy ? "Copied" : validityText
+        VStack(alignment: .leading, spacing: DesignConstants.Spacing.stepX) {
+            Button(action: copyToClipboard) {
+                HStack(spacing: DesignConstants.Spacing.step2x) {
+                    Text("Attestation")
+                        .font(.body)
+                        .foregroundStyle(.colorTextPrimary)
+                    Spacer(minLength: DesignConstants.Spacing.step2x)
+                    Image(systemName: isValid ? "checkmark.seal.fill" : "xmark.seal")
+                        .foregroundStyle(validityColor)
+                    Text(displayValue)
+                        .font(.system(.footnote, design: .monospaced))
+                        .foregroundStyle(.colorTextSecondary)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                }
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, DesignConstants.Spacing.step4x)
+                .padding(.horizontal, DesignConstants.Spacing.step4x)
+                .background(Capsule().fill(.colorFillMinimal))
+            }
+            .buttonStyle(.plain)
+            .disabled(attestation == nil)
+            .accessibilityLabel("Attestation, \(validityText)")
+            .accessibilityHint("Double tap to copy")
+            .accessibilityIdentifier("contact-detail-debug-attestation")
+            Text(footerText)
+                .font(.caption)
+                .foregroundStyle(.colorTextSecondary)
+                .padding(.horizontal, DesignConstants.Spacing.step4x)
+        }
+    }
+
+    private func copyToClipboard() {
+        guard let attestation else { return }
+        UIPasteboard.general.string = attestation
+        didCopy = true
+        Task {
+            try? await Task.sleep(nanoseconds: 1_500_000_000)
+            didCopy = false
+        }
+    }
+}
+#endif
+
 // MARK: - Modals modifier
 
 private struct ContactDetailModalsModifier<
@@ -878,6 +977,7 @@ extension Contact {
         let templatePublishedURL: String? = member.profile.agentTemplatePublishedURL
         let emoji: String? = member.profile.profileEmoji
         let instanceId: String? = member.profile.agentInstanceId
+        let attestation: String? = member.profile.agentAttestation
         if let stored = try? contactsRepository.fetchContact(inboxId: member.profile.inboxId) {
             return stored
                 .with(agentTemplateId: templateId)
@@ -885,6 +985,7 @@ extension Contact {
                 .with(profileEmoji: emoji)
                 .with(agentInstanceId: instanceId)
                 .with(agentVerification: member.agentVerification)
+                .with(agentAttestation: attestation)
         }
         return .synthetic(
             inboxId: member.profile.inboxId,
@@ -900,6 +1001,7 @@ extension Contact {
             profileEmoji: emoji,
             agentInstanceId: instanceId
         )
+        .with(agentAttestation: attestation)
     }
 }
 

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -165,8 +165,17 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
     var agentBuilderSummary: AgentBuilderSummary? {
         didSet {
             messagesListRepository.agentBuilderSummary = agentBuilderSummary
+            scheduleAgentBuilderPlaceholderExpiry()
         }
     }
+
+    /// Flips true once the post-commit agent-builder placeholder window
+    /// (`AgentBuilderPlaceholder.displayDuration` past the summary's
+    /// `cutoffDate`) elapses without a verified agent joining. Stops the
+    /// optimistic Convos-verified placeholder from lingering forever on an
+    /// agent that joined but never published attestation -- see
+    /// `shouldRenderAsPendingAgent`.
+    private var agentBuilderPlaceholderExpired: Bool = false
 
     // MARK: - Private
 
@@ -247,6 +256,8 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
     private var agentBuilderSummaryCancellable: AnyCancellable?
     @ObservationIgnored
     private var observedAgentBuilderSummaryConversationId: String?
+    @ObservationIgnored
+    private var agentBuilderPlaceholderExpiryTask: Task<Void, Never>?
     @ObservationIgnored
     private var latestObservedCapabilityRequest: CapabilityRequest?
     @ObservationIgnored
@@ -346,15 +357,49 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
     /// avatar / display name path takes over naturally.
     var shouldRenderAsPendingAgent: Bool {
         guard isInAgentBuilderFlow || agentBuilderSummary != nil else { return false }
-        // While the builder is on screen, always render as pending. The
-        // verified agent may have silently joined the draft conversation
-        // in the background, but the indicator should keep showing the
-        // generic agent icon + "New Agent" / "Draft" copy until the user
-        // taps Make. The post-commit branch (`agentBuilderSummary != nil`)
-        // still flips back to the real agent the moment the verified
-        // member appears.
-        if isInAgentBuilderFlow { return true }
-        return !conversation.members.contains(where: \.isVerifiedConvosAgent)
+        // Pre-commit: while drafting in the builder (no summary yet), always
+        // show the generic agent placeholder -- even if a verified agent has
+        // silently joined the draft in the background. The user hasn't tapped
+        // Make, so the indicator stays generic ("New Agent" / "Draft").
+        if isInAgentBuilderFlow, agentBuilderSummary == nil {
+            return true
+        }
+        // A real verified Convos agent joined -> drop the placeholder
+        // immediately, even while the builder view is still mounted. The
+        // builder view stays on screen through the post-Make morph, so gating
+        // on `isInAgentBuilderFlow` alone pinned "Joining..." on forever even
+        // after the agent verified.
+        guard !conversation.members.contains(where: \.isVerifiedConvosAgent) else { return false }
+        // No verified agent yet -> keep the optimistic verified placeholder
+        // only within the time-box past the commit. If the agent never
+        // verifies (e.g. it joins without publishing attestation), this stops
+        // the placeholder lingering forever and reading an unverified agent as
+        // a verified Convos one.
+        return !agentBuilderPlaceholderExpired
+    }
+
+    /// (Re)arm the post-commit placeholder time-box whenever the summary
+    /// changes. Anchored on the summary's `cutoffDate` so the window is correct
+    /// across relaunches: a summary rehydrated after its window has already
+    /// elapsed expires immediately rather than restarting the clock. Cleared
+    /// (no summary) resets to not-expired so a fresh draft starts clean.
+    private func scheduleAgentBuilderPlaceholderExpiry() {
+        agentBuilderPlaceholderExpiryTask?.cancel()
+        guard let summary = agentBuilderSummary else {
+            agentBuilderPlaceholderExpired = false
+            return
+        }
+        let remaining: TimeInterval = AgentBuilderPlaceholder.remainingDisplayTime(since: summary.cutoffDate)
+        guard remaining > 0 else {
+            agentBuilderPlaceholderExpired = true
+            return
+        }
+        agentBuilderPlaceholderExpired = false
+        agentBuilderPlaceholderExpiryTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .seconds(remaining))
+            guard !Task.isCancelled else { return }
+            self?.agentBuilderPlaceholderExpired = true
+        }
     }
 
     /// Inbox-to-contact-name lookup used for auto-generated unnamed-group
@@ -689,9 +734,15 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
         pendingTypingIndicatorTask?.cancel()
         loadConversationImageTask?.cancel()
         explodeTask?.cancel()
-        agentJoinTask?.cancel()
+        // Intentionally not cancelled here. A requested agent join is a
+        // durable backend trigger that should complete even after the user
+        // closes the conversation view (which deallocates this VM). The
+        // in-flight request holds `session` strongly and finishes on its own;
+        // tying it to the view lifecycle was cancelling joins mid-request, so
+        // the backend never provisioned the agent.
         convosButtonTask?.cancel()
         explodeDurationTask?.cancel()
+        agentBuilderPlaceholderExpiryTask?.cancel()
     }
 
     // MARK: - Init
@@ -927,6 +978,12 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
             .sink { [weak self] summary in
                 self?.agentBuilderSummary = summary
             }
+        // The summary set during `init` doesn't fire `agentBuilderSummary`'s
+        // `didSet`, so arm the placeholder time-box explicitly here (this runs
+        // from both init paths). Without it, a cold launch of an already-expired
+        // builder convo would briefly render the verified placeholder until the
+        // publisher's first emission rescheduled it.
+        scheduleAgentBuilderPlaceholderExpiry()
     }
 
     /// Subscribe to the GRDB-backed thinking session feed for this
@@ -2640,6 +2697,9 @@ extension ConversationViewModel {
                     forceErrorCode: forceErrorCode
                 )
             } catch is CancellationError {
+                await MainActor.run { self?.clearAgentJoinTask(id: taskId) }
+                return
+            } catch let urlError as URLError where urlError.code == .cancelled {
                 await MainActor.run { self?.clearAgentJoinTask(id: taskId) }
                 return
             } catch let error as APIError {

--- a/ConvosCore/Sources/ConvosCore/AgentBuilder/AgentBuilderCommitPlanner.swift
+++ b/ConvosCore/Sources/ConvosCore/AgentBuilder/AgentBuilderCommitPlanner.swift
@@ -1,0 +1,87 @@
+import Foundation
+
+/// The deterministic outcome of tapping "Make" in the Agent Builder: the
+/// `AgentBuilderSummary` to persist + render, and the `clientMessageId`s the
+/// builder will issue on the user's behalf. Computing this in one place keeps
+/// the id-allocation / bundle-detection logic out of the view model and lets
+/// the crash-safety contract (`bundledMessageIds` must exactly match the sends
+/// the builder issues) be unit-tested without a SwiftUI host.
+public struct AgentBuilderCommitPlan: Sendable, Equatable {
+    public let summary: AgentBuilderSummary
+    /// `clientMessageId` for the prompt-text send, or `nil` when the prompt is
+    /// empty (connections / media only).
+    public let textMessageId: String?
+    /// `clientMessageId` for the multi-remote attachment bundle send, or `nil`
+    /// when there is nothing to bundle (no voice memo, photos, videos, files).
+    public let bundleMessageId: String?
+
+    public init(summary: AgentBuilderSummary, textMessageId: String?, bundleMessageId: String?) {
+        self.summary = summary
+        self.textMessageId = textMessageId
+        self.bundleMessageId = bundleMessageId
+    }
+}
+
+public enum AgentBuilderCommitPlanner {
+    /// Build the commit plan from the summary attachments the view model has
+    /// already assembled (thumbnails encoded iOS-side) plus the prompt and any
+    /// captured cloud-connection ids.
+    ///
+    /// The prompt is trimmed of whitespace and newlines; a blank prompt is
+    /// treated as no prompt (no text id, empty summary prompt) so the builder
+    /// never issues a whitespace-only text send. The trimmed value is the
+    /// canonical prompt — callers should send `plan.summary.prompt`, not the
+    /// raw composer text, so the sent message matches the rendered summary.
+    ///
+    /// `generateMessageId` and `now` are injectable so the id-allocation and
+    /// `cutoffDate` behavior can be asserted deterministically in tests.
+    /// `bundleMessageId` is allocated when any non-connection attachment is
+    /// present. Note this gate keys off attachment *presence*, while the actual
+    /// send (`sendBuilderBundle`) drops photos/videos that never got an eager
+    /// upload key — so a `bundleMessageId` can occasionally be allocated for a
+    /// bundle that sends nothing. That over-allocation is benign: a
+    /// `bundledMessageIds` entry with no matching send just filters nothing.
+    public static func makePlan(
+        prompt: String,
+        attachments: [AgentBuilderSummaryAttachment],
+        cloudConnectionIds: [String: String],
+        now: Date = Date(),
+        generateMessageId: () -> String = { UUID().uuidString }
+    ) -> AgentBuilderCommitPlan {
+        let trimmedPrompt: String = prompt.trimmingCharacters(in: .whitespacesAndNewlines)
+        let textMessageId: String? = trimmedPrompt.isEmpty ? nil : generateMessageId()
+        let willSendBundle: Bool = attachments.contains { attachment in
+            switch attachment {
+            case .connection:
+                return false
+            case .photo, .video, .file, .voiceMemo:
+                return true
+            }
+        }
+        let bundleMessageId: String? = willSendBundle ? generateMessageId() : nil
+
+        var bundledMessageIds: Set<String> = []
+        if let textMessageId {
+            bundledMessageIds.insert(textMessageId)
+        }
+        if let bundleMessageId {
+            bundledMessageIds.insert(bundleMessageId)
+        }
+
+        // `cutoffDate` gates agent-side pre-Make chatter by timestamp (we don't
+        // control the agent's send timing). User-side sends are filtered by id
+        // via `bundledMessageIds`, which doesn't suffer the upload-stretch race.
+        let summary = AgentBuilderSummary(
+            prompt: trimmedPrompt,
+            attachments: attachments,
+            cutoffDate: now,
+            bundledMessageIds: bundledMessageIds,
+            cloudConnectionIds: cloudConnectionIds
+        )
+        return AgentBuilderCommitPlan(
+            summary: summary,
+            textMessageId: textMessageId,
+            bundleMessageId: bundleMessageId
+        )
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/AgentBuilder/AgentBuilderPlaceholder.swift
+++ b/ConvosCore/Sources/ConvosCore/AgentBuilder/AgentBuilderPlaceholder.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+/// Time-box for the optimistic "verified Convos agent is joining" placeholder
+/// the chat header shows after an Agent Builder commit.
+///
+/// While a builder draft is committing, the UI paints the Convos-verified
+/// identity (avatar + "Agent" name + "Joining..." subtitle) as a stand-in
+/// before the real agent member actually arrives -- see
+/// `ConversationViewModel.shouldRenderAsPendingAgent`. If the agent never
+/// verifies (e.g. it joins without publishing attestation), that placeholder
+/// must not linger forever and mislead the user into reading an unverified
+/// agent as a verified Convos one. So it expires `displayDuration` after the
+/// commit (`AgentBuilderSummary.cutoffDate`), after which the conversation
+/// renders with its real, unverified identity.
+///
+/// Anchoring on `cutoffDate` (the Make moment) rather than a wall-clock timer
+/// start means the window is correct across app relaunches: a summary
+/// rehydrated long after its commit is already expired and never shows the
+/// placeholder.
+public enum AgentBuilderPlaceholder {
+    /// How long past the commit the optimistic verified placeholder may show
+    /// before falling back to the real (unverified) rendering. Generous enough
+    /// to cover a healthy provision -> join -> attestation-publish round trip;
+    /// a genuinely verified agent flips the rendering the moment it joins
+    /// regardless of this window, so this only bounds the broken case.
+    public static let displayDuration: TimeInterval = 60
+
+    /// Seconds remaining before the placeholder should stop showing, measured
+    /// from the commit moment. A value <= 0 means the window has already
+    /// elapsed and the placeholder should no longer show.
+    public static func remainingDisplayTime(since cutoffDate: Date, now: Date = Date()) -> TimeInterval {
+        displayDuration - now.timeIntervalSince(cutoffDate)
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/AgentBuilderSummary.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/AgentBuilderSummary.swift
@@ -1,14 +1,17 @@
 import Foundation
 
-/// In-memory, session-scoped summary of an Agent Builder draft, captured
-/// at the moment the user taps "Make". Rendered as the first cell of the
-/// post-commit `MessagesListView` in place of the user's prompt messages and
-/// any pre-Make agent chatter — see `MessagesListItemType.agentBuilderSummary`.
+/// Summary of an Agent Builder draft, captured at the moment the user taps
+/// "Make". Rendered as the first cell of the post-commit `MessagesListView`
+/// in place of the user's prompt messages and any pre-Make agent chatter —
+/// see `MessagesListItemType.agentBuilderSummary`.
 ///
-/// Not persisted: if the user navigates away and comes back, the conversation
-/// shows the natural message history. This struct intentionally avoids
-/// iOS-only types (no `UIImage`) so it can live in ConvosCore and be embedded
-/// in `MessagesListItemType` without a circular import.
+/// Persisted via `DBAgentBuilderSummary` (written by `AgentBuilderSummaryWriter`
+/// before any send), so a force-quit between Make and the bundle landing still
+/// rehydrates the summary + its `bundledMessageIds` filter on next launch, and
+/// the `AgentBuilderConnectionGrantReplayer` can fire missing grants after the
+/// agent joins. This struct intentionally avoids iOS-only types (no `UIImage`)
+/// so it can live in ConvosCore and be embedded in `MessagesListItemType`
+/// without a circular import.
 public struct AgentBuilderSummary: Sendable, Equatable, Codable, Identifiable, Hashable {
     public let id: UUID
     public let prompt: String

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/Contact.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/Contact.swift
@@ -53,6 +53,13 @@ public struct Contact: Hashable, Identifiable, Sendable {
     /// Not persisted on `DBContact`; overlaid at resolution time from the
     /// per-conversation member profile (see `Contact.resolved(member:...)`).
     public let agentInstanceId: String?
+    /// The agent's published attestation signature, read from the
+    /// per-conversation member profile metadata at resolution time. Not
+    /// persisted on `DBContact`. Surfaced on the contact card behind a
+    /// debug-build gate alongside `agentVerification` for diagnosing why an
+    /// agent reads as verified or unverified. Overlaid via
+    /// `with(agentAttestation:)`, applied last in `resolved(member:...)`.
+    public let agentAttestation: String?
 
     public init(
         inboxId: String,
@@ -68,7 +75,8 @@ public struct Contact: Hashable, Identifiable, Sendable {
         agentTemplateId: String? = nil,
         agentTemplatePublishedURL: String? = nil,
         profileEmoji: String? = nil,
-        agentInstanceId: String? = nil
+        agentInstanceId: String? = nil,
+        agentAttestation: String? = nil
     ) {
         self.inboxId = inboxId
         self.displayName = displayName
@@ -84,6 +92,7 @@ public struct Contact: Hashable, Identifiable, Sendable {
         self.agentTemplatePublishedURL = agentTemplatePublishedURL
         self.profileEmoji = profileEmoji
         self.agentInstanceId = agentInstanceId
+        self.agentAttestation = agentAttestation
     }
 
     /// True when this contact has the full set of AES-256-GCM material
@@ -295,7 +304,32 @@ extension Contact {
             agentTemplateId: agentTemplateId,
             agentTemplatePublishedURL: agentTemplatePublishedURL,
             profileEmoji: profileEmoji,
-            agentInstanceId: agentInstanceId
+            agentInstanceId: agentInstanceId,
+            agentAttestation: agentAttestation
+        )
+    }
+
+    /// Returns a copy with `agentAttestation` overlaid. The other `with(...)`
+    /// overlays don't carry this field, so apply this one last in
+    /// `resolved(member:...)` -- it copies every current field, so any prior
+    /// overlay in the chain is preserved.
+    public func with(agentAttestation: String?) -> Contact {
+        Contact(
+            inboxId: inboxId,
+            displayName: displayName,
+            avatarURL: avatarURL,
+            avatarSalt: avatarSalt,
+            avatarNonce: avatarNonce,
+            avatarKey: avatarKey,
+            addedAt: addedAt,
+            addedViaConversationId: addedViaConversationId,
+            isBlocked: isBlocked,
+            agentVerification: agentVerification,
+            agentTemplateId: agentTemplateId,
+            agentTemplatePublishedURL: agentTemplatePublishedURL,
+            profileEmoji: profileEmoji,
+            agentInstanceId: agentInstanceId,
+            agentAttestation: agentAttestation
         )
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/Profile.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/Profile.swift
@@ -243,6 +243,22 @@ extension Profile {
     public var agentInstanceId: String? {
         metadata?[Constant.instanceIdKey]?.stringValue
     }
+
+    /// The Ed25519 attestation signature this agent published in its
+    /// per-conversation profile metadata. `nil` when the agent joined
+    /// without attaching attestation (it then reads as unverified). The
+    /// metadata key matches the verification guard in
+    /// `verifyCachedAgentAttestation`. Surfaced on the contact card behind a
+    /// debug-build gate for diagnosing agent verification.
+    public var agentAttestation: String? {
+        metadata?["attestation"]?.stringValue
+    }
+
+    /// The key id (`kid`) the attestation was signed with, matched against
+    /// the published agent keyset. `nil` when no attestation is present.
+    public var agentAttestationKid: String? {
+        metadata?["attestation_kid"]?.stringValue
+    }
 }
 
 // MARK: - Array Extensions

--- a/ConvosCore/Tests/ConvosCoreTests/AgentBuilderCommitPlannerTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/AgentBuilderCommitPlannerTests.swift
@@ -1,0 +1,197 @@
+@testable import ConvosCore
+import Foundation
+import Testing
+
+/// Coverage for `AgentBuilderCommitPlanner.makePlan` - the pure id-allocation
+/// and summary-assembly step extracted out of `AgentBuilderViewModel.commit`.
+/// The crash-safety contract is that `bundledMessageIds` exactly matches the
+/// sends the builder issues (prompt text + media bundle), so the post-commit
+/// list filters those bubbles by id rather than by a race-prone timestamp.
+@Suite("AgentBuilderCommitPlanner Tests")
+struct AgentBuilderCommitPlannerTests {
+    /// Deterministic id source so message-id allocation can be asserted
+    /// exactly. Records every id handed out so tests can also assert *how
+    /// many* were allocated.
+    private final class IdSequence {
+        private(set) var issued: [String] = []
+        func next() -> String {
+            let id = "id-\(issued.count + 1)"
+            issued.append(id)
+            return id
+        }
+    }
+
+    @Test("Text-only commit allocates a text id, no bundle id")
+    func textOnlyAllocatesTextId() {
+        let ids = IdSequence()
+        let plan = AgentBuilderCommitPlanner.makePlan(
+            prompt: "hello agent",
+            attachments: [],
+            cloudConnectionIds: [:],
+            generateMessageId: ids.next
+        )
+
+        #expect(plan.textMessageId == "id-1")
+        #expect(plan.bundleMessageId == nil)
+        #expect(plan.summary.bundledMessageIds == ["id-1"])
+        #expect(plan.summary.prompt == "hello agent")
+        #expect(ids.issued == ["id-1"])
+    }
+
+    @Test("Voice-memo-only commit allocates a bundle id, no text id")
+    func voiceMemoOnlyAllocatesBundleId() {
+        let ids = IdSequence()
+        let plan = AgentBuilderCommitPlanner.makePlan(
+            prompt: "",
+            attachments: [.voiceMemo(id: UUID(), duration: 3, levels: [0.1, 0.2])],
+            cloudConnectionIds: [:],
+            generateMessageId: ids.next
+        )
+
+        #expect(plan.textMessageId == nil)
+        #expect(plan.bundleMessageId == "id-1")
+        #expect(plan.summary.bundledMessageIds == ["id-1"])
+        #expect(ids.issued == ["id-1"])
+    }
+
+    @Test("Text plus media bundles both ids, text allocated before bundle")
+    func textPlusMediaAllocatesBothIds() {
+        let ids = IdSequence()
+        let plan = AgentBuilderCommitPlanner.makePlan(
+            prompt: "make me a thing",
+            attachments: [.photo(id: UUID(), thumbnailData: nil)],
+            cloudConnectionIds: [:],
+            generateMessageId: ids.next
+        )
+
+        #expect(plan.textMessageId == "id-1")
+        #expect(plan.bundleMessageId == "id-2")
+        #expect(plan.summary.bundledMessageIds == ["id-1", "id-2"])
+        #expect(ids.issued == ["id-1", "id-2"])
+    }
+
+    @Test("Connections-only commit allocates no message ids and bundles nothing")
+    func connectionsOnlyAllocatesNoIds() {
+        let ids = IdSequence()
+        let plan = AgentBuilderCommitPlanner.makePlan(
+            prompt: "",
+            attachments: [.connection(id: UUID(), identifier: "googleCalendar")],
+            cloudConnectionIds: ["googleCalendar": "cloud-1"],
+            generateMessageId: ids.next
+        )
+
+        #expect(plan.textMessageId == nil)
+        #expect(plan.bundleMessageId == nil)
+        #expect(plan.summary.bundledMessageIds.isEmpty)
+        #expect(ids.issued.isEmpty)
+        #expect(plan.summary.attachments.count == 1)
+        #expect(plan.summary.cloudConnectionIds == ["googleCalendar": "cloud-1"])
+    }
+
+    @Test("A connection alongside media still allocates only the bundle id")
+    func connectionDoesNotCountAsBundleable() {
+        let ids = IdSequence()
+        let plan = AgentBuilderCommitPlanner.makePlan(
+            prompt: "",
+            attachments: [
+                .file(id: UUID(), filename: "a.pdf", mimeType: "application/pdf", fileSize: 10),
+                .connection(id: UUID(), identifier: "appleHealth"),
+            ],
+            cloudConnectionIds: [:],
+            generateMessageId: ids.next
+        )
+
+        // The file makes this bundleable; the connection alone never would.
+        #expect(plan.bundleMessageId == "id-1")
+        #expect(plan.summary.bundledMessageIds == ["id-1"])
+    }
+
+    @Test("Summary preserves attachment order, cutoffDate, and cloud ids")
+    func summaryCarriesInputsThrough() {
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let voiceId = UUID()
+        let photoId = UUID()
+        let plan = AgentBuilderCommitPlanner.makePlan(
+            prompt: "hi",
+            attachments: [
+                .voiceMemo(id: voiceId, duration: 1, levels: []),
+                .photo(id: photoId, thumbnailData: nil),
+            ],
+            cloudConnectionIds: ["googleCalendar": "cloud-9"],
+            now: now,
+            generateMessageId: { UUID().uuidString }
+        )
+
+        #expect(plan.summary.cutoffDate == now)
+        #expect(plan.summary.attachments.map(\.id) == [voiceId, photoId])
+        #expect(plan.summary.cloudConnectionIds == ["googleCalendar": "cloud-9"])
+    }
+
+    @Test("Empty prompt with no attachments allocates nothing")
+    func emptyEverythingAllocatesNothing() {
+        let ids = IdSequence()
+        let plan = AgentBuilderCommitPlanner.makePlan(
+            prompt: "",
+            attachments: [],
+            cloudConnectionIds: [:],
+            generateMessageId: ids.next
+        )
+
+        #expect(plan.textMessageId == nil)
+        #expect(plan.bundleMessageId == nil)
+        #expect(plan.summary.bundledMessageIds.isEmpty)
+        #expect(plan.summary.prompt.isEmpty)
+        #expect(ids.issued.isEmpty)
+    }
+
+    @Test("Whitespace-only prompt is trimmed away: no text id, empty summary prompt")
+    func whitespaceOnlyPromptAllocatesNoTextId() {
+        let ids = IdSequence()
+        let plan = AgentBuilderCommitPlanner.makePlan(
+            prompt: "   \n\t  ",
+            attachments: [],
+            cloudConnectionIds: [:],
+            generateMessageId: ids.next
+        )
+
+        #expect(plan.textMessageId == nil)
+        #expect(plan.bundleMessageId == nil)
+        #expect(plan.summary.bundledMessageIds.isEmpty)
+        #expect(plan.summary.prompt.isEmpty)
+        #expect(ids.issued.isEmpty)
+    }
+
+    @Test("Surrounding whitespace is trimmed from the canonical summary prompt")
+    func promptIsTrimmedInSummary() {
+        let plan = AgentBuilderCommitPlanner.makePlan(
+            prompt: "  hello agent\n",
+            attachments: [],
+            cloudConnectionIds: [:],
+            generateMessageId: { UUID().uuidString }
+        )
+
+        #expect(plan.summary.prompt == "hello agent")
+        #expect(plan.textMessageId != nil)
+    }
+
+    @Test("Multiple media items still allocate exactly one bundle id")
+    func multipleMediaAllocatesSingleBundleId() {
+        let ids = IdSequence()
+        let plan = AgentBuilderCommitPlanner.makePlan(
+            prompt: "",
+            attachments: [
+                .photo(id: UUID(), thumbnailData: nil),
+                .video(id: UUID(), thumbnailData: nil),
+                .file(id: UUID(), filename: "a.pdf", mimeType: "application/pdf", fileSize: 10),
+                .voiceMemo(id: UUID(), duration: 2, levels: []),
+            ],
+            cloudConnectionIds: [:],
+            generateMessageId: ids.next
+        )
+
+        #expect(plan.textMessageId == nil)
+        #expect(plan.bundleMessageId == "id-1")
+        #expect(plan.summary.bundledMessageIds == ["id-1"])
+        #expect(ids.issued == ["id-1"])
+    }
+}

--- a/ConvosCore/Tests/ConvosCoreTests/AgentBuilderPlaceholderTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/AgentBuilderPlaceholderTests.swift
@@ -1,0 +1,45 @@
+@testable import ConvosCore
+import Foundation
+import Testing
+
+/// Coverage for `AgentBuilderPlaceholder` - the time-box that stops the
+/// optimistic "verified agent joining" placeholder from lingering forever
+/// when an agent joins but never publishes attestation.
+@Suite("AgentBuilderPlaceholder Tests")
+struct AgentBuilderPlaceholderTests {
+    @Test("Freshly committed summary has ~full window remaining")
+    func freshCommitHasFullWindow() {
+        let cutoff = Date(timeIntervalSince1970: 1_800_000_000)
+        let now = cutoff
+        let remaining = AgentBuilderPlaceholder.remainingDisplayTime(since: cutoff, now: now)
+        #expect(remaining == AgentBuilderPlaceholder.displayDuration)
+    }
+
+    @Test("Partway through the window leaves the expected remainder")
+    func partwayLeavesRemainder() {
+        let cutoff = Date(timeIntervalSince1970: 1_800_000_000)
+        let now = cutoff.addingTimeInterval(20)
+        let remaining = AgentBuilderPlaceholder.remainingDisplayTime(since: cutoff, now: now)
+        #expect(remaining == AgentBuilderPlaceholder.displayDuration - 20)
+        #expect(remaining > 0)
+    }
+
+    @Test("A commit older than the window has already expired")
+    func oldCommitIsExpired() {
+        let cutoff = Date(timeIntervalSince1970: 1_800_000_000)
+        let now = cutoff.addingTimeInterval(AgentBuilderPlaceholder.displayDuration + 1)
+        let remaining = AgentBuilderPlaceholder.remainingDisplayTime(since: cutoff, now: now)
+        #expect(remaining < 0)
+    }
+
+    @Test("Exactly at the boundary is treated as elapsed")
+    func boundaryIsElapsed() {
+        let cutoff = Date(timeIntervalSince1970: 1_800_000_000)
+        let now = cutoff.addingTimeInterval(AgentBuilderPlaceholder.displayDuration)
+        let remaining = AgentBuilderPlaceholder.remainingDisplayTime(since: cutoff, now: now)
+        // remaining == 0 -> the scheduler treats `> 0` as "still showing", so
+        // zero means expire now.
+        #expect(remaining == 0)
+        #expect(!(remaining > 0))
+    }
+}


### PR DESCRIPTION
Resumes the Agent Builder commit-planner review work and fixes a
separately-discovered agent-join cancellation.

Agent Builder:
- Extract Make's id-allocation + summary assembly into a pure, testable
  ConvosCore AgentBuilderCommitPlanner (10 unit tests).
- Treat whitespace-/newline-only prompts as empty: the planner trims the
  canonical summary prompt, the commit sends that trimmed value, and the
  Make button no longer enables on whitespace-only text.
- Correct the stale "Not persisted" doc on AgentBuilderSummary.

Agent join:
- ConversationViewModel.deinit no longer cancels the in-flight
  agents/join request, so closing the new-conversation view no longer
  aborts the join before the backend provisions the agent.
- Handle URLError.cancelled so a genuine cancel doesn't broadcast a false
  .failed or fire the error haptic.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/899"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782586447&installation_id=128169237&pr_number=899&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F899&signature=caa35548add3ae2879b87ccc2e7a5c866b3ea2a8fdc9afd61db495ef10e7e398"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix agent join persistence, trim whitespace in agent builder, and time-box verified placeholder
> - Trims whitespace from composer text before evaluating commit eligibility; whitespace-only prompts produce no text send and disable the Make button.
> - Extracts commit planning into `AgentBuilderCommitPlanner.makePlan`, which allocates message IDs and assembles `AgentBuilderSummary` deterministically, covered by new unit tests.
> - Time-boxes the optimistic verified placeholder to 60 seconds post-commit via `AgentBuilderPlaceholder` and `ConversationViewModel.scheduleAgentBuilderPlaceholderExpiry`; the placeholder hides immediately when a verified agent joins.
> - Keeps the agent join task alive across conversation view deallocation by capturing `[session]` instead of `[self]`, and treats `URLError.cancelled` as a benign cancellation.
> - Adds `agentAttestation` to `Contact` and `Profile`, surfacing it in a debug-only attestation row in `ContactDetailView`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ee3a70f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->