### PR TITLE
Persist backlog thinking messages via the thinking-session writer

### DIFF
--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationWriter.swift
@@ -387,7 +387,8 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
     /// connection time forward, it does not replay historical backlog.
     func applyBacklogSupplementals(
         _ messages: [XMTPiOS.DecodedMessage],
-        for conversation: DBConversation
+        for conversation: DBConversation,
+        currentInboxId: String
     ) async {
         for message in messages {
             guard !message.isProfileMessage, !message.isTypingIndicator else {
@@ -395,6 +396,10 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
             }
             if message.isReadReceipt {
                 await storeReadReceipt(message, conversationId: conversation.id)
+                continue
+            }
+            if message.isThinking {
+                await storeThinking(message, conversationId: conversation.id, currentInboxId: currentInboxId)
                 continue
             }
             do {

--- a/ConvosCore/Sources/ConvosCore/Syncing/BatchCatchUp.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/BatchCatchUp.swift
@@ -176,7 +176,8 @@ struct BatchCatchUp {
             supplementalCount += entry.supplementalMessages.count
             await conversationWriter.applyBacklogSupplementals(
                 entry.supplementalMessages,
-                for: entry.conversation.dbConversation
+                for: entry.conversation.dbConversation,
+                currentInboxId: inboxId
             )
         }
 
@@ -337,9 +338,9 @@ struct BatchCatchUp {
         /// Goes through `IncomingMessageWriter.persist` in the batched transaction.
         case regular
         /// Handled post-transaction via `ConversationWriter.applyBacklogSupplementals`
-        /// (reactions, read receipts). These have per-type handlers that
-        /// the stream-driven path also uses; we apply them here because
-        /// the libxmtp stream doesn't replay historical backlog.
+        /// (reactions, read receipts, thinking moments). These have per-type
+        /// handlers that the stream-driven path also uses; we apply them here
+        /// because the libxmtp stream doesn't replay historical backlog.
         case supplemental
         /// Drop entirely (typing indicators, profile messages, undecodable).
         /// Typing indicators are inherently live-only; profile messages
@@ -351,7 +352,11 @@ struct BatchCatchUp {
         if message.isProfileMessage || message.isTypingIndicator {
             return .skip
         }
-        if message.isReadReceipt {
+        // Thinking messages back the thinking-detail view but must never be
+        // persisted as normal chat messages -- the stream path routes them
+        // through `ThinkingSessionWriter` (see `storeThinking`). Treat them
+        // as a supplemental so the batch applies them the same way.
+        if message.isReadReceipt || message.isThinking {
             return .supplemental
         }
         guard let contentType = try? message.encodedContent.type else {

--- a/ConvosCore/Tests/ConvosCoreTests/Integration/BatchCatchUpIntegrationTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/Integration/BatchCatchUpIntegrationTests.swift
@@ -195,6 +195,70 @@ struct BatchCatchUpIntegrationTests {
         try? await fixtures.cleanup()
     }
 
+    @Test("Batch routes thinking messages to the thinking-session store, not normal messages")
+    func batchStoresThinkingViaSessionWriter() async throws {
+        let fixtures = TestFixtures()
+        try await fixtures.createTestClients()
+
+        guard let clientA = fixtures.clientA as? Client,
+              let clientB = fixtures.clientB as? Client,
+              let clientIdB = fixtures.clientIdB else {
+            throw TestError.missingClients
+        }
+        let inboxIdB = clientB.inboxID
+
+        try await fixtures.databaseManager.dbWriter.write { db in
+            try DBInbox(inboxId: inboxIdB, clientId: clientIdB, createdAt: Date()).insert(db)
+        }
+
+        let group = try await clientA.conversations.newGroup(
+            with: [clientB.inboxID],
+            name: "Thinking Group"
+        )
+        try await clientB.conversations.sync()
+
+        // A sends one regular message and one thinking message.
+        _ = try await group.send(content: "hello")
+        let thinking = ThinkingContent(
+            state: .start,
+            targetMessageId: "target-message-1",
+            content: "Thinking about hello"
+        )
+        let thinkingMessageId = try await group.send(
+            encodedContent: try ThinkingCodec().encode(content: thinking)
+        )
+
+        let messageWriter = IncomingMessageWriter(databaseWriter: fixtures.databaseManager.dbWriter)
+        let conversationWriter = ConversationWriter(
+            identityStore: fixtures.identityStore,
+            databaseWriter: fixtures.databaseManager.dbWriter,
+            messageWriter: messageWriter
+        )
+        let batch = BatchCatchUp(
+            conversationWriter: conversationWriter,
+            messageWriter: messageWriter,
+            databaseWriter: fixtures.databaseManager.dbWriter
+        )
+
+        _ = try await batch.run(client: clientB, inboxId: inboxIdB, since: nil, activeConversationId: nil)
+
+        // The backlog thinking message lands in the thinking-session store...
+        let thinkingMomentCount = try await fixtures.databaseManager.dbReader.read { db in
+            try DBThinkingMoment
+                .filter(DBThinkingMoment.Columns.conversationId == group.id)
+                .fetchCount(db)
+        }
+        #expect(thinkingMomentCount == 1, "Expected the backlog thinking message to create one thinking moment, got \(thinkingMomentCount)")
+
+        // ...and is not persisted as a normal chat message.
+        let thinkingAsMessage = try await fixtures.databaseManager.dbReader.read { db in
+            try DBMessage.filter(DBMessage.Columns.id == thinkingMessageId).fetchOne(db)
+        }
+        #expect(thinkingAsMessage == nil, "Thinking message must not be stored as a normal DBMessage")
+
+        try? await fixtures.cleanup()
+    }
+
     @Test("Batch with no missed activity is a near no-op")
     func batchWithEmptyBacklogIsNoOp() async throws {
         let fixtures = TestFixtures()


### PR DESCRIPTION
BatchCatchUp.classify routed thinking messages to .regular, so catch-up
stored them as normal DBMessages -- they would surface as junk chat
messages and never populate the thinking-session store the thinking
detail view reads. The stream paths route thinking through
ThinkingSessionWriter (StreamProcessor.processThinking /
ConversationWriter.storeThinking) and never persist them as messages.

Classify thinking as .supplemental and add a thinking branch to
applyBacklogSupplementals (threading the local inboxId through) so the
batch mirrors the stream: thinking moments land in the thinking-session
store, not the chat history. Adds an integration test asserting a backlog
thinking message creates one thinking moment and no DBMessage.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/900"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782589075&installation_id=128169237&pr_number=900&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F900&signature=52edf62f4a6132b7cbfd99d1d9c8d59f308fac82968d63e8480843f2598c91cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Persist backlog thinking messages via the thinking-session writer instead of as regular messages
> - `BatchCatchUp.classify` now treats thinking messages (`message.isThinking`) as supplementals, routing them away from the normal batched message path.
> - `ConversationWriter.applyBacklogSupplementals` detects thinking messages and stores them via `storeThinking` rather than the regular chat message store. The method now requires a `currentInboxId` parameter.
> - An integration test verifies that thinking messages land in `DBThinkingMoment` and are absent from `DBMessage` after `BatchCatchUp.run`.
> - Behavioral Change: callers of `applyBacklogSupplementals` must now pass `currentInboxId`; thinking messages previously persisted as regular messages will now be stored as thinking moments.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 171309a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->