### PR TITLE
Agents as contacts: show verified agents in the contacts list

### DIFF
--- a/Convos/App Settings/AppSettingsView.swift
+++ b/Convos/App Settings/AppSettingsView.swift
@@ -82,7 +82,7 @@ struct AppSettingsView: View {
             .toolbar { topToolbar }
             .onReceive(CreditsServices.shared.balancePublisher) { creditBalance = $0 }
             .onReceive(SubscriptionServices.shared.subscriptionPublisher) { currentSubscription = $0 }
-            .onReceive(session.messagingService().contactsRepository().contactsPublisher) { contactsCount = $0.count }
+            .onReceive(session.messagingService().contactsRepository().contactsPublisher) { contactsCount = $0.filter(\.isVisibleInContactsList).count }
         }
     }
 

--- a/Convos/Contacts/AddFromContactsPickerModifier.swift
+++ b/Convos/Contacts/AddFromContactsPickerModifier.swift
@@ -68,7 +68,9 @@ private struct AddFromContactsPickerModifier: ViewModifier {
         )
     }
 
-    private func handleConfirm(_ inboxIds: Set<String>) {
+    private func handleConfirm(_ inboxIds: Set<String>, _ agentTemplateId: String?) {
+        // Add-to-conversation is human-only: the picker doesn't surface
+        // agents in this mode, so `agentTemplateId` is always nil here.
         let ids = Array(inboxIds)
         guard !ids.isEmpty else { return }
         Task {

--- a/Convos/Contacts/Contact+BrowseVisibility.swift
+++ b/Convos/Contacts/Contact+BrowseVisibility.swift
@@ -1,0 +1,20 @@
+import ConvosCore
+import Foundation
+
+extension Contact {
+    /// Whether this contact renders in the Contacts browse list - and thus
+    /// counts toward the App Settings "Contacts" badge, which must agree
+    /// with the list. Shown: humans with a display name, and template-backed
+    /// agents (tagged with the Agent pill). Hidden: legacy verified
+    /// assistants without a template, agents whose template metadata hasn't
+    /// mirrored yet, and unnamed humans (they'd render as "Somebody" with
+    /// nothing to distinguish them). All agents stay in `DBContact` so
+    /// chat-side surfaces can still resolve them.
+    var isVisibleInContactsList: Bool {
+        if agentVerification != nil {
+            return agentTemplateId != nil
+        }
+        guard let displayName, !displayName.isEmpty else { return false }
+        return true
+    }
+}

--- a/Convos/Contacts/Contact+ListSubtitle.swift
+++ b/Convos/Contacts/Contact+ListSubtitle.swift
@@ -8,9 +8,12 @@ extension Contact {
     /// 1. Source-conversation name when available (the convo the user met
     ///    them in, e.g. "Bike Trip 2026").
     /// 2. `"DM"` when the source is a 1:1 (no group name to show).
-    /// 3. Agent role label for verified agents.
-    /// 4. Empty string — caller hides the line entirely (unnamed group,
+    /// 3. Empty string — caller hides the line entirely (unnamed group,
     ///    deleted source convo, synthetic contact, etc.).
+    ///
+    /// Verified agents carry their "Agent" / "Verified by ..." label in the
+    /// trailing `RoleLabelPill` on the row, not the subtitle, so the
+    /// subtitle stays free for the source conversation.
     ///
     /// Pulled out of the picker view model so the contacts browser can
     /// share the same priority order without duplicating it.
@@ -22,9 +25,6 @@ extension Contact {
             if source.kind == .dm {
                 return "DM"
             }
-        }
-        if let roleLabel = agentVerification?.roleLabel {
-            return roleLabel
         }
         return ""
     }

--- a/Convos/Contacts/ContactDetailView.swift
+++ b/Convos/Contacts/ContactDetailView.swift
@@ -410,11 +410,14 @@ struct ContactDetailView: View {
     /// `ContactsView.handlePickerConfirm` and the invite-cell-tap pattern
     /// where the new-convo sheet is owned by the same view that hosted
     /// the picker.
-    private func handlePickerConfirm(_ inboxIds: Set<String>) {
-        guard !inboxIds.isEmpty, let session else { return }
+    private func handlePickerConfirm(_ memberInboxIds: Set<String>, _ agentTemplateId: String?) {
+        guard !memberInboxIds.isEmpty || agentTemplateId != nil, let session else { return }
         presentingNewConvo = NewConversationViewModel(
             session: session,
-            mode: .newConversationWithMembers(initialMemberInboxIds: Array(inboxIds))
+            mode: .newConversationWithMembers(
+                initialMemberInboxIds: Array(memberInboxIds),
+                agentTemplateId: agentTemplateId
+            )
         )
     }
 

--- a/Convos/Contacts/ContactDetailView.swift
+++ b/Convos/Contacts/ContactDetailView.swift
@@ -215,13 +215,13 @@ struct ContactDetailView: View {
     @ViewBuilder
     private var headerBadge: some View {
         if mode.isCurrentUser {
-            ContactDetailBadge(
+            RoleLabelPill(
                 label: "You",
                 accessibilityIdentifier: "contact-detail-you-badge"
             )
             .padding(.top, DesignConstants.Spacing.step2x)
         } else if let roleLabel = contact.agentVerification?.roleLabel {
-            ContactDetailBadge(
+            RoleLabelPill(
                 label: roleLabel,
                 accessibilityIdentifier: "contact-detail-role-label-\(contact.inboxId)"
             )
@@ -457,26 +457,6 @@ private struct ContactDetailHeader: View {
                 .font(.largeTitle.weight(.bold))
                 .foregroundStyle(.colorTextPrimary)
         }
-    }
-}
-
-/// Small capsule pill rendered below the subtitle. Used for the
-/// verified-agent role label ("Agent", "Verified by ...") and for
-/// the "You" indicator on the current user's own card - same shape so
-/// the spacing around the pill mirrors the surrounding label spacing
-/// regardless of which one is showing.
-private struct ContactDetailBadge: View {
-    let label: String
-    let accessibilityIdentifier: String
-
-    var body: some View {
-        Text(label)
-            .font(.footnote)
-            .foregroundStyle(.colorTextSecondary)
-            .padding(.horizontal, DesignConstants.Spacing.step2x)
-            .padding(.vertical, DesignConstants.Spacing.stepX)
-            .background(.colorTextSecondary.opacity(0.1), in: .capsule)
-            .accessibilityIdentifier(accessibilityIdentifier)
     }
 }
 

--- a/Convos/Contacts/ContactRowView.swift
+++ b/Convos/Contacts/ContactRowView.swift
@@ -30,6 +30,9 @@ struct ContactRowView: View {
                 }
             }
             Spacer(minLength: 0.0)
+            if contact.isVerifiedAgent {
+                RoleLabelPill(label: "Agent")
+            }
         }
         .padding(.vertical, DesignConstants.Spacing.stepX)
         .contentShape(Rectangle())

--- a/Convos/Contacts/ContactsPickerRow.swift
+++ b/Convos/Contacts/ContactsPickerRow.swift
@@ -6,10 +6,14 @@ import SwiftUI
 struct ContactsPickerRow: View {
     let row: ContactsPickerViewModel.Row
     let isSelected: Bool
+    /// True when this row is an agent that can't be selected because
+    /// another agent is already selected (one agent per conversation).
+    var isAgentSelectionBlocked: Bool = false
     let onTap: () -> Void
 
     var body: some View {
-        let opacity: Double = row.isAlreadyInChat ? 0.45 : 1.0
+        let isDisabled: Bool = row.isAlreadyInChat || isAgentSelectionBlocked
+        let opacity: Double = isDisabled ? 0.45 : 1.0
         Button(action: onTap) {
             HStack(spacing: DesignConstants.Spacing.step3x) {
                 ContactAvatarView(contact: row.contact)
@@ -18,6 +22,10 @@ struct ContactsPickerRow: View {
                 ContactsPickerRowText(contact: row.contact, subtitle: row.subtitle)
 
                 Spacer(minLength: 0.0)
+
+                if row.contact.isVerifiedAgent {
+                    RoleLabelPill(label: "Agent")
+                }
 
                 ContactsPickerRowAccessory(
                     isAlreadyInChat: row.isAlreadyInChat,
@@ -29,7 +37,7 @@ struct ContactsPickerRow: View {
         }
         .buttonStyle(.plain)
         .opacity(opacity)
-        .disabled(row.isAlreadyInChat)
+        .disabled(isDisabled)
         .accessibilityIdentifier("contacts-picker-row-\(row.contact.inboxId)")
     }
 }

--- a/Convos/Contacts/ContactsPickerView.swift
+++ b/Convos/Contacts/ContactsPickerView.swift
@@ -31,9 +31,13 @@ import SwiftUI
 /// entry-point mapping and the role each mode plays.
 struct ContactsPickerView: View {
     @State private var viewModel: ContactsPickerViewModel
+    @State private var presentingAgentInfo: Bool = false
     @Environment(\.dismiss) private var dismiss: DismissAction
 
-    let onConfirm: (_ inboxIds: Set<String>) -> Void
+    /// `memberInboxIds` are the selected humans; `agentTemplateId` is the
+    /// template of the single selected agent, if any (the picker allows at
+    /// most one, and only in new-conversation mode).
+    let onConfirm: (_ memberInboxIds: Set<String>, _ agentTemplateId: String?) -> Void
     /// Optional source conversation that informs the indicator pill's
     /// emoji avatar. For the new-convo flow callers can pass the current
     /// draft so the picker reflects whatever emoji the convo will inherit;
@@ -47,7 +51,7 @@ struct ContactsPickerView: View {
         alreadyInChatInboxIds: Set<String> = [],
         preselectedInboxIds: Set<String> = [],
         pillConversation: Conversation? = nil,
-        onConfirm: @escaping (_ inboxIds: Set<String>) -> Void
+        onConfirm: @escaping (_ memberInboxIds: Set<String>, _ agentTemplateId: String?) -> Void
     ) {
         _viewModel = State(initialValue: ContactsPickerViewModel(
             mode: mode,
@@ -66,6 +70,20 @@ struct ContactsPickerView: View {
                 .navigationBarTitleDisplayMode(.inline)
                 .toolbar { toolbarContent }
         }
+        .onChange(of: viewModel.didSelectAgent) { _, didSelect in
+            guard didSelect else { return }
+            viewModel.didSelectAgent = false
+            guard !UserDefaults.standard.bool(forKey: Constant.seenOneAgentManyConvosKey) else { return }
+            UserDefaults.standard.set(true, forKey: Constant.seenOneAgentManyConvosKey)
+            presentingAgentInfo = true
+        }
+        .selfSizingSheet(isPresented: $presentingAgentInfo) {
+            OneAgentManyConvosInfoSheet()
+        }
+    }
+
+    private enum Constant {
+        static let seenOneAgentManyConvosKey: String = "hasSeenOneAgentManyConvos"
     }
 
     /// The list takes the full sheet and scrolls behind the toolbar
@@ -127,9 +145,15 @@ struct ContactsPickerView: View {
     }
 
     private func handleConfirm() {
-        let ids = viewModel.selectedInboxIds
-        guard !ids.isEmpty else { return }
-        onConfirm(ids)
+        guard viewModel.canConfirm else { return }
+        // Split the selection: the agent (if any) is spawned by template,
+        // not added as a member, so it's excluded from the member ids.
+        let agentTemplateId = viewModel.selectedAgentTemplateId
+        var memberIds = viewModel.selectedInboxIds
+        if let agentInboxId = viewModel.selectedAgentInboxId {
+            memberIds.remove(agentInboxId)
+        }
+        onConfirm(memberIds, agentTemplateId)
         dismiss()
     }
 
@@ -238,6 +262,7 @@ private struct ContactsPickerList: View {
                     ContactsPickerRow(
                         row: row,
                         isSelected: viewModel.isSelected(inboxId: row.id),
+                        isAgentSelectionBlocked: viewModel.isAgentSelectionBlocked(for: row.id),
                         onTap: rowTapAction(for: row)
                     )
                 },
@@ -304,7 +329,7 @@ private struct ContactsPickerConfirmButton: View {
     ContactsPickerView(
         mode: .newConversation,
         contactsRepository: MockContactsRepository(),
-        onConfirm: { _ in }
+        onConfirm: { _, _ in }
     )
 }
 
@@ -313,7 +338,7 @@ private struct ContactsPickerConfirmButton: View {
         mode: .addToConversation(conversationId: "convo-1", conversationTitle: "The Dev Convosation"),
         contactsRepository: MockContactsRepository(),
         alreadyInChatInboxIds: [MockContactsRepository.defaultMockContacts[0].inboxId],
-        onConfirm: { _ in }
+        onConfirm: { _, _ in }
     )
 }
 
@@ -321,7 +346,7 @@ private struct ContactsPickerConfirmButton: View {
     ContactsPickerView(
         mode: .newConversation,
         contactsRepository: MockContactsRepository(contacts: []),
-        onConfirm: { _ in }
+        onConfirm: { _, _ in }
     )
 }
 
@@ -341,6 +366,6 @@ private struct ContactsPickerConfirmButton: View {
         mode: .newConversation,
         contactsRepository: MockContactsRepository(contacts: contacts),
         preselectedInboxIds: preselected,
-        onConfirm: { _ in }
+        onConfirm: { _, _ in }
     )
 }

--- a/Convos/Contacts/ContactsPickerViewModel.swift
+++ b/Convos/Contacts/ContactsPickerViewModel.swift
@@ -51,6 +51,10 @@ final class ContactsPickerViewModel {
     let mode: ContactsPickerMode
     var sections: [Section] = []
     var selectedInboxIds: Set<String> = []
+    /// Set true when the user just selected an agent, so the view can
+    /// present the "One agent, many convos" info sheet. The view resets
+    /// it after handling.
+    var didSelectAgent: Bool = false
     var searchQuery: String = "" {
         didSet { rebuildSections() }
     }
@@ -146,8 +150,27 @@ final class ContactsPickerViewModel {
         if selectedInboxIds.contains(inboxId) {
             selectedInboxIds.remove(inboxId)
         } else {
+            // At most one agent per conversation - agents are
+            // instance-per-conversation and can't share context. Once one
+            // is selected, other agent rows are disabled (see
+            // `isAgentSelectionBlocked`); selecting a second is a no-op.
+            // Humans are unrestricted.
+            if isAgent(inboxId), selectedAgentInboxId != nil {
+                return
+            }
             selectedInboxIds.insert(inboxId)
+            if isAgent(inboxId) {
+                didSelectAgent = true
+            }
         }
+    }
+
+    /// True when `inboxId` is an unselected agent that can't be selected
+    /// because a different agent is already selected. The picker disables
+    /// these rows; the user deselects the current agent to pick another.
+    func isAgentSelectionBlocked(for inboxId: String) -> Bool {
+        guard isAgent(inboxId), !selectedInboxIds.contains(inboxId) else { return false }
+        return selectedAgentInboxId != nil
     }
 
     func deselect(inboxId: String) {
@@ -162,6 +185,29 @@ final class ContactsPickerViewModel {
         selectedInboxIds.contains(inboxId)
     }
 
+    /// `inboxId` of the currently selected agent, if any. At most one
+    /// agent may be selected (see `toggleSelection`).
+    var selectedAgentInboxId: String? {
+        selectedInboxIds.first { isAgent($0) }
+    }
+
+    /// `agentTemplateId` of the currently selected agent, threaded into
+    /// conversation creation so a fresh instance of that template is
+    /// spawned into the new (or existing) conversation.
+    var selectedAgentTemplateId: String? {
+        guard let agentInboxId = selectedAgentInboxId else { return nil }
+        return allContacts.first { $0.inboxId == agentInboxId }?.agentTemplateId
+    }
+
+    private func isAgent(_ inboxId: String) -> Bool {
+        allContacts.first { $0.inboxId == inboxId }?.agentTemplateId != nil
+    }
+
+    private var isNewConversationMode: Bool {
+        if case .newConversation = mode { return true }
+        return false
+    }
+
     // MARK: - Section building
 
     private func applyContacts(_ contacts: [Contact]) {
@@ -172,7 +218,7 @@ final class ContactsPickerViewModel {
         // blocked / a verified agent / unnamed would otherwise stay in
         // `selectedInboxIds`, counting toward `selectionCount` and passing
         // `canConfirm` with no UI for the user to remove it.
-        let visibleInboxIds = Set(allContacts.filter(Self.isVisibleInPicker).map(\.inboxId))
+        let visibleInboxIds = Set(allContacts.filter(isVisibleInPicker).map(\.inboxId))
         selectedInboxIds = selectedInboxIds.intersection(visibleInboxIds)
         rebuildSections()
         isLoading = false
@@ -181,21 +227,25 @@ final class ContactsPickerViewModel {
     /// Single source of truth for "is this contact a valid picker row".
     /// Hidden from the picker:
     ///  - blocked contacts (the user explicitly opted out of contacting them)
-    ///  - verified agents (kept in `DBContact` so chat-side surfaces can
-    ///    resolve them, but not a valid picker target since they don't accept
-    ///    1:1 DMs; agent rows have their own dedicated entry point)
-    ///  - contacts whose displayName is missing/empty (would render as
+    ///  - template-less agents (legacy verified assistants), and all agents
+    ///    in add-to-conversation mode; template-backed agents are selectable
+    ///    only when starting a new conversation, where selecting one spawns
+    ///    a fresh instance into it
+    ///  - humans whose displayName is missing/empty (would render as
     ///    "Somebody" via `resolvedDisplayName`; a name-less row isn't a
     ///    useful picker target -- there's nothing to distinguish one
     ///    "Somebody" from another)
-    private static func isVisibleInPicker(_ contact: Contact) -> Bool {
-        if contact.isBlocked || contact.isVerifiedAgent { return false }
+    private func isVisibleInPicker(_ contact: Contact) -> Bool {
+        guard !contact.isBlocked else { return false }
+        if contact.agentVerification != nil {
+            return isNewConversationMode && contact.agentTemplateId != nil
+        }
         guard let name = contact.displayName, !name.isEmpty else { return false }
         return true
     }
 
     private func rebuildSections() {
-        let visible = allContacts.filter(Self.isVisibleInPicker)
+        let visible = allContacts.filter(isVisibleInPicker)
         let filtered = filterByQuery(visible)
         let grouped: [String: [Contact]] = Dictionary(
             grouping: filtered,

--- a/Convos/Contacts/ContactsView.swift
+++ b/Convos/Contacts/ContactsView.swift
@@ -183,11 +183,14 @@ struct ContactsView: View {
     /// invite-cell-tap pattern (`presentingNewConversationForInvite` on
     /// `ConversationViewModel`) where the sheet is owned by the same view
     /// that hosted the picker.
-    private func handlePickerConfirm(_ inboxIds: Set<String>) {
-        guard !inboxIds.isEmpty, let session else { return }
+    private func handlePickerConfirm(_ memberInboxIds: Set<String>, _ agentTemplateId: String?) {
+        guard !memberInboxIds.isEmpty || agentTemplateId != nil, let session else { return }
         presentingNewConvo = NewConversationViewModel(
             session: session,
-            mode: .newConversationWithMembers(initialMemberInboxIds: Array(inboxIds))
+            mode: .newConversationWithMembers(
+                initialMemberInboxIds: Array(memberInboxIds),
+                agentTemplateId: agentTemplateId
+            )
         )
     }
 }

--- a/Convos/Contacts/ContactsViewModel.swift
+++ b/Convos/Contacts/ContactsViewModel.swift
@@ -60,20 +60,11 @@ final class ContactsViewModel {
         isLoading = false
     }
 
-    /// Single source of truth for "is this contact rendered in the list".
-    /// Template-backed agents are shown (tagged with the trailing Agent
-    /// pill on their row) so the user can start a conversation with one;
-    /// legacy verified assistants without a template stay hidden. Humans
-    /// whose displayName is missing/empty render as "Somebody" via
-    /// `resolvedDisplayName` and carry no useful info for the browser, so
-    /// they're hidden until a profile name arrives. All agents remain in
-    /// `DBContact` so chat-side surfaces can still resolve them.
+    /// Single source of truth for "is this contact rendered in the list" -
+    /// `Contact.isVisibleInContactsList`, shared with the App Settings
+    /// "Contacts" badge so the count and the list always agree.
     private static func isVisibleInList(_ contact: Contact) -> Bool {
-        if contact.agentVerification != nil {
-            return contact.agentTemplateId != nil
-        }
-        guard let name = contact.displayName, !name.isEmpty else { return false }
-        return true
+        contact.isVisibleInContactsList
     }
 
     /// Recomputes `sections` from `allContacts` honoring the current

--- a/Convos/Contacts/ContactsViewModel.swift
+++ b/Convos/Contacts/ContactsViewModel.swift
@@ -54,24 +54,24 @@ final class ContactsViewModel {
         allContacts = contacts
         // `contactCount` drives the empty-state vs list-state branch and
         // the compose button's enabled flag. Count what's actually visible
-        // in the list -- verified agents are hidden from this view, and
-        // unnamed contacts are filtered out below in `rebuildSections`,
-        // so include both predicates here too.
+        // in the list (see `isVisibleInList`).
         contactCount = contacts.filter(Self.isVisibleInList).count
         rebuildSections()
         isLoading = false
     }
 
     /// Single source of truth for "is this contact rendered in the list".
-    /// Verified agents stay in `DBContact` so chat-side surfaces (member
-    /// rows, system messages, the contact card opened from a member tap)
-    /// can still resolve them, but they're excluded here so the human
-    /// contact browser stays focused on real people. Contacts whose
-    /// displayName is missing/empty render as "Somebody" via
-    /// `resolvedDisplayName`; a "Somebody" row carries no useful info
-    /// for the browser, so we hide it until a profile name arrives.
+    /// Template-backed agents are shown (tagged with the trailing Agent
+    /// pill on their row) so the user can start a conversation with one;
+    /// legacy verified assistants without a template stay hidden. Humans
+    /// whose displayName is missing/empty render as "Somebody" via
+    /// `resolvedDisplayName` and carry no useful info for the browser, so
+    /// they're hidden until a profile name arrives. All agents remain in
+    /// `DBContact` so chat-side surfaces can still resolve them.
     private static func isVisibleInList(_ contact: Contact) -> Bool {
-        if contact.isVerifiedAgent { return false }
+        if contact.agentVerification != nil {
+            return contact.agentTemplateId != nil
+        }
         guard let name = contact.displayName, !name.isEmpty else { return false }
         return true
     }

--- a/Convos/Contacts/OneAgentManyConvosInfoSheet.swift
+++ b/Convos/Contacts/OneAgentManyConvosInfoSheet.swift
@@ -1,0 +1,33 @@
+import SwiftUI
+
+/// Shown when the user selects an agent in the contacts picker while
+/// starting a conversation. Explains that agents are
+/// instance-per-conversation (no shared context) and that whoever adds an
+/// agent funds its usage.
+struct OneAgentManyConvosInfoSheet: View {
+    @Environment(\.dismiss) private var dismiss: DismissAction
+
+    var body: some View {
+        FeatureInfoSheet(
+            tagline: "Agent Contacts",
+            title: "One agent,\nmany convos",
+            paragraphs: [
+                .init("For privacy, agents cannot share memories, context or skills between conversations.", size: .body),
+                .init("Whoever adds an agent funds its usage.", size: .subheadline),
+            ],
+            primaryButtonAction: { dismiss() },
+            showDragIndicator: true
+        )
+    }
+}
+
+#Preview {
+    @Previewable @State var isPresented: Bool = true
+
+    VStack {
+        Button { isPresented.toggle() } label: { Text("Show") }
+    }
+    .selfSizingSheet(isPresented: $isPresented) {
+        OneAgentManyConvosInfoSheet()
+    }
+}

--- a/Convos/Conversation Creation/NewConversationViewModel.swift
+++ b/Convos/Conversation Creation/NewConversationViewModel.swift
@@ -34,8 +34,11 @@ enum NewConversationMode {
     /// inbox IDs before emitting `.ready`. Used by the contacts picker
     /// "Start Conversation" path so navigation feels instant and the
     /// conversation arrives at `.ready` with the picked members already
-    /// in it.
-    case newConversationWithMembers(initialMemberInboxIds: [String])
+    /// in it. When `agentTemplateId` is non-nil the picker also selected
+    /// an agent: a fresh instance of that template is spawned into the
+    /// conversation once it reaches `.ready` (at most one agent per
+    /// conversation, enforced in the picker).
+    case newConversationWithMembers(initialMemberInboxIds: [String], agentTemplateId: String?)
     /// Opens an existing conversation in the same sheet presentation we
     /// use for the new-convo flows. Used when "Chat" on a contact card
     /// resolves to a 1:1 the user already has with that person, so the
@@ -218,6 +221,9 @@ class NewConversationViewModel: Identifiable {
         if case .newConversationWithTemplate(let templateId) = mode {
             self.pendingAgentTemplateId = templateId
         }
+        if case .newConversationWithMembers(_, let agentTemplateId) = mode, let agentTemplateId {
+            self.pendingAgentTemplateId = agentTemplateId
+        }
 
         switch mode {
         case .newConversation, .newAgent, .newConversationWithMembers, .newConversationWithTemplate:
@@ -242,7 +248,7 @@ class NewConversationViewModel: Identifiable {
             self.allowsDismissingScanner = true
         }
 
-        if case .newConversationWithMembers(let ids) = mode {
+        if case .newConversationWithMembers(let ids, _) = mode {
             self.startedWithSeededMembers = true
             self.seededMemberInboxIds = ids
         } else {
@@ -339,7 +345,7 @@ class NewConversationViewModel: Identifiable {
                     existingConversationId: existingConversationId
                 )
 
-            case .newConversationWithMembers(let initialMemberInboxIds):
+            case .newConversationWithMembers(let initialMemberInboxIds, _):
                 let (messagingService, existingConversationId) = await session.prepareNewConversation()
                 guard !Task.isCancelled else { return }
                 let inboxElapsed = (CFAbsoluteTimeGetCurrent() - perfStartTime) * 1000

--- a/Convos/Conversation Detail/ConversationMembersListView.swift
+++ b/Convos/Conversation Detail/ConversationMembersListView.swift
@@ -151,12 +151,7 @@ private struct MemberRow: View {
             Spacer()
 
             if let roleLabel = member.roleLabel {
-                Text(roleLabel)
-                    .font(.footnote)
-                    .foregroundStyle(.colorTextSecondary)
-                    .padding(.horizontal, DesignConstants.Spacing.step2x)
-                    .padding(.vertical, DesignConstants.Spacing.stepX)
-                    .background(.colorTextSecondary.opacity(0.1), in: .capsule)
+                RoleLabelPill(label: roleLabel)
             }
 
             Image(systemName: "chevron.right")

--- a/Convos/Shared Views/RoleLabelPill.swift
+++ b/Convos/Shared Views/RoleLabelPill.swift
@@ -1,0 +1,31 @@
+import ConvosCore
+import SwiftUI
+
+/// Small capsule pill rendering a short role label - "Agent",
+/// "Verified by ...", "Creator", "Admin", or "You". Shared by the
+/// conversation members list, the contacts list row, and the contact
+/// card so every surface that tags an identity uses one styling.
+struct RoleLabelPill: View {
+    let label: String
+    var accessibilityIdentifier: String?
+
+    var body: some View {
+        Text(label)
+            .font(.footnote)
+            .foregroundStyle(.colorTextSecondary)
+            .padding(.horizontal, DesignConstants.Spacing.step2x)
+            .padding(.vertical, DesignConstants.Spacing.stepX)
+            .background(.colorTextSecondary.opacity(0.1), in: .capsule)
+            .accessibilityIdentifier(accessibilityIdentifier ?? "")
+    }
+}
+
+#Preview {
+    VStack(spacing: DesignConstants.Spacing.step2x) {
+        RoleLabelPill(label: "Agent")
+        RoleLabelPill(label: "Verified by Calendar")
+        RoleLabelPill(label: "Creator")
+        RoleLabelPill(label: "You")
+    }
+    .padding()
+}

--- a/ConvosCore/Sources/ConvosCore/Contacts/ContactSyncCoordinator.swift
+++ b/ConvosCore/Sources/ConvosCore/Contacts/ContactSyncCoordinator.swift
@@ -141,7 +141,13 @@ final class ContactSyncCoordinator: ContactSyncCoordinatorProtocol, @unchecked S
                     // signal (preserve existing); .agent / .verifiedConvos /
                     // .verifiedUserOAuth map to the corresponding
                     // AgentVerification.
-                    agentVerification: profile?.memberKind?.agentVerification
+                    agentVerification: profile?.memberKind?.agentVerification,
+                    // Template identity for template-backed agents, persisted
+                    // so the contact can spawn a fresh instance after the
+                    // user leaves every conversation with a running instance.
+                    agentTemplateId: profile?.agentTemplateId,
+                    agentTemplatePublishedURL: profile?.agentTemplatePublishedURL,
+                    agentTemplateEmoji: profile?.agentTemplateEmoji
                 )
                 try ContactsWriter.upsertContactInTransaction(
                     db: db,

--- a/ConvosCore/Sources/ConvosCore/Storage/Database Models/DBContact.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Database Models/DBContact.swift
@@ -24,6 +24,9 @@ struct DBContact: Codable, FetchableRecord, PersistableRecord, Hashable, Identif
         static let profileUpdatedAt: Column = Column(CodingKeys.profileUpdatedAt)
         static let blockedAt: Column = Column(CodingKeys.blockedAt)
         static let agentVerification: Column = Column(CodingKeys.agentVerification)
+        static let agentTemplateId: Column = Column(CodingKeys.agentTemplateId)
+        static let agentTemplatePublishedURL: Column = Column(CodingKeys.agentTemplatePublishedURL)
+        static let agentTemplateEmoji: Column = Column(CodingKeys.agentTemplateEmoji)
     }
 
     var id: String { inboxId }
@@ -53,6 +56,19 @@ struct DBContact: Codable, FetchableRecord, PersistableRecord, Hashable, Identif
     /// snapshot with `nil` `agentVerification` wholesale-clears the stored
     /// verification (see `ContactsWriter.replacingProfile(of:with:)`).
     var agentVerification: AgentVerification?
+    /// Backend `AgentTemplate.id` for a template-backed agent, mirrored
+    /// most-recent-wins from the per-conversation `DBMemberProfile`
+    /// metadata. Persisted (rather than overlaid live) so the template
+    /// stays resolvable after the user leaves every conversation with a
+    /// running instance - which is what lets the contact spawn a fresh
+    /// instance later. `nil` for humans and template-less agents.
+    var agentTemplateId: String?
+    /// Shareable `publishedUrl` for the agent's template. Drives the
+    /// contact card's Share action. Mirrored alongside `agentTemplateId`.
+    var agentTemplatePublishedURL: String?
+    /// Template emoji glyph, used as the browse-row avatar fallback when
+    /// no live per-conversation profile is available to supply an image.
+    var agentTemplateEmoji: String?
 
     init(
         inboxId: String,
@@ -65,7 +81,10 @@ struct DBContact: Codable, FetchableRecord, PersistableRecord, Hashable, Identif
         avatarKey: Data? = nil,
         profileUpdatedAt: Date? = nil,
         blockedAt: Date? = nil,
-        agentVerification: AgentVerification? = nil
+        agentVerification: AgentVerification? = nil,
+        agentTemplateId: String? = nil,
+        agentTemplatePublishedURL: String? = nil,
+        agentTemplateEmoji: String? = nil
     ) {
         self.inboxId = inboxId
         self.addedAt = addedAt
@@ -78,6 +97,9 @@ struct DBContact: Codable, FetchableRecord, PersistableRecord, Hashable, Identif
         self.profileUpdatedAt = profileUpdatedAt
         self.blockedAt = blockedAt
         self.agentVerification = agentVerification
+        self.agentTemplateId = agentTemplateId
+        self.agentTemplatePublishedURL = agentTemplatePublishedURL
+        self.agentTemplateEmoji = agentTemplateEmoji
     }
 }
 
@@ -102,7 +124,10 @@ extension DBContact {
             avatarKey: snapshot.avatarKey,
             profileUpdatedAt: timestamp,
             blockedAt: blockedAt,
-            agentVerification: snapshot.agentVerification
+            agentVerification: snapshot.agentVerification,
+            agentTemplateId: snapshot.agentTemplateId,
+            agentTemplatePublishedURL: snapshot.agentTemplatePublishedURL,
+            agentTemplateEmoji: snapshot.agentTemplateEmoji
         )
     }
 
@@ -118,7 +143,10 @@ extension DBContact {
             avatarKey: avatarKey,
             profileUpdatedAt: profileUpdatedAt,
             blockedAt: blockedAt,
-            agentVerification: agentVerification
+            agentVerification: agentVerification,
+            agentTemplateId: agentTemplateId,
+            agentTemplatePublishedURL: agentTemplatePublishedURL,
+            agentTemplateEmoji: agentTemplateEmoji
         )
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/Contact.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/Contact.swift
@@ -29,25 +29,23 @@ public struct Contact: Hashable, Identifiable, Sendable {
     public let agentVerification: AgentVerification?
     /// The backend `AgentTemplate.id` a template-backed agent was
     /// provisioned from. `nil` for human contacts and for agents that do
-    /// not carry a template. Not persisted on `DBContact`; it is overlaid
-    /// onto the contact at resolution time from the per-conversation
-    /// member profile metadata (see `Contact.resolved(member:...)`), which
-    /// is the freshest source. Drives the contact card's Chat action.
+    /// not carry a template. Persisted on `DBContact` (mirrored from the
+    /// per-conversation member profile metadata) so it survives leaving
+    /// every conversation with a running instance; `Contact.resolved(member:...)`
+    /// overlays the freshest value when a live member profile is on hand.
+    /// Drives the contact card's Chat action.
     public let agentTemplateId: String?
     /// The shareable web URL for a template-backed agent (the backend's
     /// `publishedUrl`). `nil` for human contacts and for agents that do
-    /// not carry a template. Not persisted on `DBContact`; it is overlaid
-    /// onto the contact at resolution time from the per-conversation
-    /// member profile metadata (see `Contact.resolved(member:...)`), which
-    /// is the freshest source. Drives the contact card's Share button.
+    /// not carry a template. Persisted on `DBContact` alongside
+    /// `agentTemplateId`; overlaid live by `Contact.resolved(member:...)`
+    /// when available. Drives the contact card's Share button.
     public let agentTemplatePublishedURL: String?
-    /// Emoji glyph the member set on their per-conversation profile.
-    /// Not persisted on `DBContact`; overlaid onto the contact at
-    /// resolution time from the per-conversation member profile metadata
-    /// (see `Contact.resolved(member:...)`) so avatars rendered from a
-    /// resolved `Contact` (e.g. the in-chat contact detail sheet) carry
-    /// the same emoji avatar that `MessageAvatarView` shows in the
-    /// messages list.
+    /// Emoji glyph for the contact's avatar fallback. For template-backed
+    /// agents this is persisted on `DBContact` (the template emoji) so the
+    /// browse row renders it without a live member profile;
+    /// `Contact.resolved(member:...)` overlays the freshest per-conversation
+    /// emoji when available, matching `MessageAvatarView` in the messages list.
     public let profileEmoji: String?
     /// The agent runtime's `instanceId` for a specific provisioned agent.
     /// Not persisted on `DBContact`; overlaid at resolution time from the
@@ -153,7 +151,10 @@ extension Contact {
             addedAt: dbContact.addedAt,
             addedViaConversationId: dbContact.addedViaConversationId,
             isBlocked: dbContact.blockedAt != nil,
-            agentVerification: dbContact.agentVerification
+            agentVerification: dbContact.agentVerification,
+            agentTemplateId: dbContact.agentTemplateId,
+            agentTemplatePublishedURL: dbContact.agentTemplatePublishedURL,
+            profileEmoji: dbContact.agentTemplateEmoji
         )
     }
 }
@@ -193,9 +194,9 @@ extension Contact {
     }
 
     /// Returns a copy with `agentTemplateId` overlaid. Used by
-    /// `Contact.resolved(member:...)` to carry the freshest template id
-    /// from the per-conversation member profile onto a stored contact,
-    /// which has no template column of its own.
+    /// `Contact.resolved(member:...)` to prefer the freshest template id
+    /// from a live per-conversation member profile over the value
+    /// persisted on the stored contact.
     public func with(agentTemplateId: String?) -> Contact {
         Contact(
             inboxId: inboxId,
@@ -216,9 +217,9 @@ extension Contact {
     }
 
     /// Returns a copy with `agentTemplatePublishedURL` overlaid. Used by
-    /// `Contact.resolved(member:...)` to carry the freshest template
-    /// `publishedUrl` from the per-conversation member profile onto a
-    /// stored contact, which has no template column of its own.
+    /// `Contact.resolved(member:...)` to prefer the freshest template
+    /// `publishedUrl` from a live per-conversation member profile over
+    /// the value persisted on the stored contact.
     public func with(agentTemplatePublishedURL: String?) -> Contact {
         Contact(
             inboxId: inboxId,
@@ -266,9 +267,9 @@ extension Contact {
     }
 
     /// Returns a copy with `profileEmoji` overlaid. Used by
-    /// `Contact.resolved(member:...)` to carry the freshest emoji glyph
-    /// from the per-conversation member profile metadata onto a stored
-    /// contact, which has no emoji column of its own.
+    /// `Contact.resolved(member:...)` to prefer the freshest emoji glyph
+    /// from a live per-conversation member profile over the value
+    /// persisted on the stored contact.
     public func with(profileEmoji: String?) -> Contact {
         Contact(
             inboxId: inboxId,

--- a/ConvosCore/Sources/ConvosCore/Storage/SharedDatabaseMigrator.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/SharedDatabaseMigrator.swift
@@ -168,6 +168,24 @@ extension SharedDatabaseMigrator {
             }
         }
 
+        // Template identity for template-backed agent contacts, mirrored
+        // from the per-conversation member profile so it survives leaving
+        // the conversation. The partial index keeps a future
+        // "group contacts by template" query index-backed without a schema
+        // change - only agent rows carry a non-null templateId.
+        migrator.registerMigration("addContactAgentTemplateFields") { db in
+            try db.alter(table: "contact") { t in
+                t.add(column: "agentTemplateId", .text)
+                t.add(column: "agentTemplatePublishedURL", .text)
+                t.add(column: "agentTemplateEmoji", .text)
+            }
+            try db.execute(sql: """
+                CREATE INDEX IF NOT EXISTS contact_on_agentTemplateId
+                ON contact(agentTemplateId)
+                WHERE agentTemplateId IS NOT NULL
+                """)
+        }
+
         return migrator
     }
 

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/ContactsWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/ContactsWriter.swift
@@ -28,6 +28,11 @@ public struct ContactProfileSnapshot: Sendable, Hashable {
     public let avatarKey: Data?
     public let profileUpdatedAt: Date?
     public let agentVerification: AgentVerification?
+    /// Template identity for a template-backed agent, mirrored onto the
+    /// contact so it survives leaving the conversation. `nil` for humans.
+    public let agentTemplateId: String?
+    public let agentTemplatePublishedURL: String?
+    public let agentTemplateEmoji: String?
 
     public init(
         displayName: String? = nil,
@@ -36,7 +41,10 @@ public struct ContactProfileSnapshot: Sendable, Hashable {
         avatarNonce: Data? = nil,
         avatarKey: Data? = nil,
         profileUpdatedAt: Date? = nil,
-        agentVerification: AgentVerification? = nil
+        agentVerification: AgentVerification? = nil,
+        agentTemplateId: String? = nil,
+        agentTemplatePublishedURL: String? = nil,
+        agentTemplateEmoji: String? = nil
     ) {
         self.displayName = displayName
         self.avatarURL = avatarURL
@@ -45,6 +53,9 @@ public struct ContactProfileSnapshot: Sendable, Hashable {
         self.avatarKey = avatarKey
         self.profileUpdatedAt = profileUpdatedAt
         self.agentVerification = agentVerification
+        self.agentTemplateId = agentTemplateId
+        self.agentTemplatePublishedURL = agentTemplatePublishedURL
+        self.agentTemplateEmoji = agentTemplateEmoji
     }
 }
 
@@ -179,7 +190,10 @@ final class ContactsWriter: ContactsWriterProtocol, @unchecked Sendable {
             avatarNonce: profile.avatarNonce,
             avatarKey: profile.avatarKey,
             profileUpdatedAt: profile.profileUpdatedAt ?? now,
-            agentVerification: profile.agentVerification
+            agentVerification: profile.agentVerification,
+            agentTemplateId: profile.agentTemplateId,
+            agentTemplatePublishedURL: profile.agentTemplatePublishedURL,
+            agentTemplateEmoji: profile.agentTemplateEmoji
         )
         try row.save(db)
         Log.debug("Inserted new contact for inboxId=\(inboxId) via=\(addedViaConversationId ?? "nil")")
@@ -257,7 +271,10 @@ extension ContactsWriter {
         avatarNonce: Data? = nil,
         avatarKey: Data? = nil,
         receivedAt: Date,
-        agentVerification: AgentVerification? = nil
+        agentVerification: AgentVerification? = nil,
+        agentTemplateId: String? = nil,
+        agentTemplatePublishedURL: String? = nil,
+        agentTemplateEmoji: String? = nil
     ) throws {
         guard let existing = try DBContact.fetchOne(db, key: inboxId) else {
             return
@@ -269,7 +286,10 @@ extension ContactsWriter {
             avatarNonce: avatarNonce,
             avatarKey: avatarKey,
             profileUpdatedAt: receivedAt,
-            agentVerification: agentVerification
+            agentVerification: agentVerification,
+            agentTemplateId: agentTemplateId,
+            agentTemplatePublishedURL: agentTemplatePublishedURL,
+            agentTemplateEmoji: agentTemplateEmoji
         )
         guard let merged = replacingProfile(of: existing, with: snapshot) else {
             return
@@ -296,7 +316,10 @@ extension ContactsWriter {
             avatarNonce: profile.avatarNonce,
             avatarKey: profile.avatarKey,
             receivedAt: receivedAt,
-            agentVerification: profile.memberKind?.agentVerification
+            agentVerification: profile.memberKind?.agentVerification,
+            agentTemplateId: profile.agentTemplateId,
+            agentTemplatePublishedURL: profile.agentTemplatePublishedURL,
+            agentTemplateEmoji: profile.agentTemplateEmoji
         )
     }
 }

--- a/ConvosCore/Tests/ConvosCoreTests/ContactSyncCoordinatorTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ContactSyncCoordinatorTests.swift
@@ -245,6 +245,60 @@ struct ContactSyncCoordinatorTests {
         #expect(contactIds == Set(["alice", "carol"]))
     }
 
+    @Test("a template-backed agent member persists its template identity onto the contact")
+    func testTemplateAgentPersistsTemplateFields() async throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        let selfInboxId = "self-inbox"
+        let conversationId = "conv-agent"
+        let agentInboxId = "americano"
+
+        try await dbManager.dbWriter.write { db in
+            try DBInbox(inboxId: selfInboxId, clientId: "client").save(db)
+            try Self.seedConversation(
+                db: db,
+                conversationId: conversationId,
+                creatorInboxId: selfInboxId,
+                memberInboxIds: [selfInboxId, agentInboxId]
+            )
+            // Overwrite the agent's per-conversation profile with one that
+            // carries template metadata and a verified-Convos member kind.
+            try DBMemberProfile(
+                conversationId: conversationId,
+                inboxId: agentInboxId,
+                name: "Americano",
+                avatar: nil,
+                memberKind: .verifiedConvos,
+                metadata: [
+                    "templateId": .string("tmpl-coffee"),
+                    "publishedUrl": .string("https://convos.org/t/coffee"),
+                    "emoji": .string("☕️")
+                ]
+            ).save(db)
+        }
+
+        let coordinator = ContactSyncCoordinator(
+            databaseWriter: dbManager.dbWriter,
+            databaseReader: dbManager.dbReader
+        )
+        try await coordinator.syncContactsOnFirstMessage(for: conversationId)
+
+        let agent = try await dbManager.dbReader.read { db in
+            try DBContact.fetchOne(db, key: agentInboxId)
+        }
+        #expect(agent?.agentTemplateId == "tmpl-coffee")
+        #expect(agent?.agentTemplatePublishedURL == "https://convos.org/t/coffee")
+        #expect(agent?.agentTemplateEmoji == "☕️")
+        #expect(agent?.agentVerification?.isVerified == true)
+
+        // The hydrated read-model surfaces the same identity and reads as a
+        // verified agent, which is what the browse-list Agent pill keys on.
+        let contact: Contact? = try await dbManager.dbReader.read { db in
+            try DBContact.fetchOne(db, key: agentInboxId).map(Contact.init(dbContact:))
+        }
+        #expect(contact?.isVerifiedAgent == true)
+        #expect(contact?.agentTemplateId == "tmpl-coffee")
+    }
+
     @Test("self inbox is excluded from contacts")
     func testSelfSkip() async throws {
         let dbManager = MockDatabaseManager.makeTestDatabase()

--- a/ConvosTests/ContactsPickerViewModelTests.swift
+++ b/ConvosTests/ContactsPickerViewModelTests.swift
@@ -32,38 +32,90 @@ final class ContactsPickerViewModelTests: XCTestCase {
         XCTAssertEqual(allRowIds.sorted(), [alice.inboxId, carl.inboxId].sorted())
     }
 
-    /// Verified-agent contacts (Convos / OAuth-attested assistants) live in
-    /// `DBContact` so chat-side surfaces can resolve them, but the picker
-    /// browses humans only. Regression guard: if the predicate ever stops
-    /// filtering them, agents would surface in every "Start a convo" /
-    /// "Add to convo" flow.
-    func testSectionsExcludeVerifiedAgents() {
+    /// New-conversation mode surfaces humans and template-backed agents
+    /// (you can spawn a fresh instance into the new convo). Template-less
+    /// agents - legacy verified assistants and unverified agents - stay
+    /// hidden.
+    func testNewConversationShowsTemplateBackedAgentsOnly() {
         let alice = Contact.mock(displayName: "Alice")
-        let assistant = Contact.mock(
-            displayName: "Convos Assistant",
-            agentVerification: .verified(.convos)
+        let coffeeAgent = Contact.mock(
+            displayName: "Americano",
+            agentVerification: .verified(.convos),
+            agentTemplateId: "tmpl-coffee"
         )
-        let oauthAgent = Contact.mock(
-            displayName: "OAuth Bot",
-            agentVerification: .verified(.userOAuth)
+        let legacyAssistant = Contact.mock(
+            displayName: "Legacy Assistant",
+            agentVerification: .verified(.convos)
         )
         let unverifiedAgent = Contact.mock(
             displayName: "Unverified Bot",
             agentVerification: .unverified
         )
-        let repo = MockContactsRepository(contacts: [alice, assistant, oauthAgent, unverifiedAgent])
+        let repo = MockContactsRepository(contacts: [alice, coffeeAgent, legacyAssistant, unverifiedAgent])
+
+        let viewModel = ContactsPickerViewModel(mode: .newConversation, contactsRepository: repo)
+
+        let allRowIds: [String] = viewModel.sections.flatMap { $0.rows.map(\.id) }
+        XCTAssertEqual(allRowIds.sorted(), [alice.inboxId, coffeeAgent.inboxId].sorted())
+    }
+
+    /// Add-to-conversation mode is human-only - agents aren't spawned into
+    /// an existing conversation from the picker.
+    func testAddToConversationHidesAgents() {
+        let alice = Contact.mock(displayName: "Alice")
+        let coffeeAgent = Contact.mock(
+            displayName: "Americano",
+            agentVerification: .verified(.convos),
+            agentTemplateId: "tmpl-coffee"
+        )
+        let repo = MockContactsRepository(contacts: [alice, coffeeAgent])
 
         let viewModel = ContactsPickerViewModel(
-            mode: .newConversation,
+            mode: .addToConversation(conversationId: "convo-1", conversationTitle: nil),
             contactsRepository: repo
         )
 
         let allRowIds: [String] = viewModel.sections.flatMap { $0.rows.map(\.id) }
-        // Alice and the unverified agent pass through; both verified agents
-        // are filtered out. Unverified agents intentionally remain visible
-        // because they're not yet attested - the user may still want to act
-        // on them like any unknown contact.
-        XCTAssertEqual(allRowIds.sorted(), [alice.inboxId, unverifiedAgent.inboxId].sorted())
+        XCTAssertEqual(allRowIds, [alice.inboxId])
+    }
+
+    /// At most one agent may be selected. Once an agent is selected, other
+    /// agents are blocked (selecting a second is a no-op and their rows are
+    /// disabled); the user must deselect the first to pick another. Humans
+    /// are unrestricted.
+    func testSecondAgentSelectionIsBlocked() {
+        let alice = Contact.mock(displayName: "Alice")
+        let coffee = Contact.mock(
+            displayName: "Americano",
+            agentVerification: .verified(.convos),
+            agentTemplateId: "tmpl-coffee"
+        )
+        let tea = Contact.mock(
+            displayName: "Earl Grey",
+            agentVerification: .verified(.convos),
+            agentTemplateId: "tmpl-tea"
+        )
+        let repo = MockContactsRepository(contacts: [alice, coffee, tea])
+        let viewModel = ContactsPickerViewModel(mode: .newConversation, contactsRepository: repo)
+
+        viewModel.toggleSelection(for: alice.inboxId)
+        viewModel.toggleSelection(for: coffee.inboxId)
+        XCTAssertEqual(viewModel.selectedAgentTemplateId, "tmpl-coffee")
+        XCTAssertFalse(viewModel.isAgentSelectionBlocked(for: coffee.inboxId), "the selected agent itself isn't blocked")
+        XCTAssertTrue(viewModel.isAgentSelectionBlocked(for: tea.inboxId), "other agents are blocked once one is selected")
+
+        // Tapping a second agent is a no-op: the first stays, the second is not added.
+        viewModel.toggleSelection(for: tea.inboxId)
+        XCTAssertEqual(viewModel.selectedAgentTemplateId, "tmpl-coffee")
+        XCTAssertFalse(viewModel.isSelected(inboxId: tea.inboxId))
+        XCTAssertTrue(viewModel.isSelected(inboxId: coffee.inboxId))
+        XCTAssertTrue(viewModel.isSelected(inboxId: alice.inboxId))
+        XCTAssertEqual(viewModel.selectionCount, 2)
+
+        // Deselecting the agent unblocks the others.
+        viewModel.toggleSelection(for: coffee.inboxId)
+        XCTAssertNil(viewModel.selectedAgentTemplateId)
+        XCTAssertFalse(viewModel.isAgentSelectionBlocked(for: tea.inboxId))
     }
 
     func testHashBucketSortsLastForNonAlphaNames() {

--- a/ConvosTests/ContactsViewModelTests.swift
+++ b/ConvosTests/ContactsViewModelTests.swift
@@ -8,15 +8,13 @@ import XCTest
 /// The picker view model has its own suite in `ContactsPickerViewModelTests`.
 @MainActor
 final class ContactsViewModelTests: XCTestCase {
-    // MARK: - Verified-agent filter
+    // MARK: - Agents in the browse list
 
-    /// Verified-agent contacts stay in `DBContact` so chat-side surfaces
-    /// (member rows, system messages, the contact card opened from a chat
-    /// member tap) can still resolve them. They are filtered out of the
-    /// human-facing contact browser. Regression guard: if the predicate is
-    /// removed, the contacts list would show every Convos / OAuth-attested
-    /// agent alongside real people.
-    func testSectionsExcludeVerifiedAgents() {
+    /// Verified agents appear in the browse list alongside humans (tagged
+    /// with the trailing Agent pill on their row). Regression guard: if the
+    /// browse list re-introduces an agent filter, agents the user shares a
+    /// conversation with would vanish from contacts.
+    func testSectionsIncludeVerifiedAgents() {
         let alice = Contact.mock(displayName: "Alice")
         let assistant = Contact.mock(
             displayName: "Convos Assistant",
@@ -35,18 +33,16 @@ final class ContactsViewModelTests: XCTestCase {
         let viewModel = ContactsViewModel(contactsRepository: repo)
 
         let allIds: [String] = viewModel.sections.flatMap { $0.rows.map(\.contact.inboxId) }
-        // Alice and the unverified agent pass through; both verified agents
-        // are filtered out. Unverified agents intentionally remain visible
-        // because they're not yet attested.
-        XCTAssertEqual(allIds.sorted(), [alice.inboxId, unverifiedAgent.inboxId].sorted())
+        XCTAssertEqual(
+            allIds.sorted(),
+            [alice.inboxId, assistant.inboxId, oauthAgent.inboxId, unverifiedAgent.inboxId].sorted()
+        )
     }
 
     /// `contactCount` drives the empty-state vs list-state branch in the
-    /// `ContactsView` body and the compose button's enabled flag. It must
-    /// reflect the human-visible count, not the raw count - otherwise a
-    /// user whose contacts are all agents would see an empty list with a
-    /// non-empty count (no empty-state CTA, enabled compose button).
-    func testContactCountReflectsVisibleContactsNotRawCount() {
+    /// `ContactsView` body and the compose button's enabled flag. It now
+    /// counts agents too, since they appear in the list.
+    func testContactCountIncludesAgents() {
         let assistant = Contact.mock(
             displayName: "Convos Assistant",
             agentVerification: .verified(.convos)
@@ -55,9 +51,8 @@ final class ContactsViewModelTests: XCTestCase {
 
         let viewModel = ContactsViewModel(contactsRepository: repo)
 
-        XCTAssertEqual(viewModel.contactCount, 0,
-                       "Agent-only contacts should not count toward the visible total")
-        XCTAssertTrue(viewModel.sections.isEmpty)
+        XCTAssertEqual(viewModel.contactCount, 1)
+        XCTAssertFalse(viewModel.sections.isEmpty)
     }
 
     // MARK: - Search
@@ -75,7 +70,7 @@ final class ContactsViewModelTests: XCTestCase {
         XCTAssertEqual(allIds, [alice.inboxId])
     }
 
-    func testSearchAndVerifiedAgentFilterComposeCorrectly() {
+    func testSearchMatchesHumansAndAgentsAlike() {
         let alice = Contact.mock(displayName: "Alice")
         let aliceAssistant = Contact.mock(
             displayName: "Alice Assistant",
@@ -86,10 +81,10 @@ final class ContactsViewModelTests: XCTestCase {
 
         let viewModel = ContactsViewModel(contactsRepository: repo)
 
-        // Searching "alice" must not surface the verified Alice Assistant -
-        // the agent filter precedes the search filter in the pipeline.
+        // Search now spans agents too: both Alice and the Alice Assistant
+        // match "alice"; Bob does not.
         viewModel.searchQuery = "alice"
         let allIds: [String] = viewModel.sections.flatMap { $0.rows.map(\.contact.inboxId) }
-        XCTAssertEqual(allIds, [alice.inboxId])
+        XCTAssertEqual(allIds.sorted(), [alice.inboxId, aliceAssistant.inboxId].sorted())
     }
 }

--- a/ConvosTests/ContactsViewModelTests.swift
+++ b/ConvosTests/ContactsViewModelTests.swift
@@ -10,49 +10,55 @@ import XCTest
 final class ContactsViewModelTests: XCTestCase {
     // MARK: - Agents in the browse list
 
-    /// Verified agents appear in the browse list alongside humans (tagged
-    /// with the trailing Agent pill on their row). Regression guard: if the
-    /// browse list re-introduces an agent filter, agents the user shares a
-    /// conversation with would vanish from contacts.
-    func testSectionsIncludeVerifiedAgents() {
+    /// Only template-backed agents appear in the browse list (tagged with
+    /// the trailing Agent pill). Humans always show; agents without a
+    /// template id - legacy verified assistants and unverified agents -
+    /// stay in `DBContact` for chat-side resolution but are hidden here.
+    func testSectionsShowOnlyTemplateBackedAgents() {
         let alice = Contact.mock(displayName: "Alice")
-        let assistant = Contact.mock(
-            displayName: "Convos Assistant",
-            agentVerification: .verified(.convos)
+        let coffeeAgent = Contact.mock(
+            displayName: "Americano",
+            agentVerification: .verified(.convos),
+            agentTemplateId: "tmpl-coffee"
         )
-        let oauthAgent = Contact.mock(
-            displayName: "OAuth Bot",
-            agentVerification: .verified(.userOAuth)
+        let legacyAssistant = Contact.mock(
+            displayName: "Legacy Assistant",
+            agentVerification: .verified(.convos)
         )
         let unverifiedAgent = Contact.mock(
             displayName: "Unverified Bot",
             agentVerification: .unverified
         )
-        let repo = MockContactsRepository(contacts: [alice, assistant, oauthAgent, unverifiedAgent])
+        let repo = MockContactsRepository(contacts: [alice, coffeeAgent, legacyAssistant, unverifiedAgent])
 
         let viewModel = ContactsViewModel(contactsRepository: repo)
 
         let allIds: [String] = viewModel.sections.flatMap { $0.rows.map(\.contact.inboxId) }
-        XCTAssertEqual(
-            allIds.sorted(),
-            [alice.inboxId, assistant.inboxId, oauthAgent.inboxId, unverifiedAgent.inboxId].sorted()
-        )
+        // Human + template-backed agent show; template-less agents hidden.
+        XCTAssertEqual(allIds.sorted(), [alice.inboxId, coffeeAgent.inboxId].sorted())
     }
 
     /// `contactCount` drives the empty-state vs list-state branch in the
-    /// `ContactsView` body and the compose button's enabled flag. It now
-    /// counts agents too, since they appear in the list.
-    func testContactCountIncludesAgents() {
-        let assistant = Contact.mock(
-            displayName: "Convos Assistant",
+    /// `ContactsView` body and the compose button's enabled flag. It counts
+    /// only browsable rows - humans and template-backed agents - so a
+    /// template-less agent does not inflate the total.
+    func testContactCountCountsBrowsableRowsOnly() {
+        let alice = Contact.mock(displayName: "Alice")
+        let coffeeAgent = Contact.mock(
+            displayName: "Americano",
+            agentVerification: .verified(.convos),
+            agentTemplateId: "tmpl-coffee"
+        )
+        let legacyAssistant = Contact.mock(
+            displayName: "Legacy Assistant",
             agentVerification: .verified(.convos)
         )
-        let repo = MockContactsRepository(contacts: [assistant])
+        let repo = MockContactsRepository(contacts: [alice, coffeeAgent, legacyAssistant])
 
         let viewModel = ContactsViewModel(contactsRepository: repo)
 
-        XCTAssertEqual(viewModel.contactCount, 1)
-        XCTAssertFalse(viewModel.sections.isEmpty)
+        XCTAssertEqual(viewModel.contactCount, 2)
+        XCTAssertEqual(viewModel.sections.flatMap { $0.rows }.count, 2)
     }
 
     // MARK: - Search
@@ -70,19 +76,20 @@ final class ContactsViewModelTests: XCTestCase {
         XCTAssertEqual(allIds, [alice.inboxId])
     }
 
-    func testSearchMatchesHumansAndAgentsAlike() {
+    func testSearchMatchesHumansAndTemplateAgentsAlike() {
         let alice = Contact.mock(displayName: "Alice")
         let aliceAssistant = Contact.mock(
             displayName: "Alice Assistant",
-            agentVerification: .verified(.convos)
+            agentVerification: .verified(.convos),
+            agentTemplateId: "tmpl-alice"
         )
         let bob = Contact.mock(displayName: "Bob")
         let repo = MockContactsRepository(contacts: [alice, aliceAssistant, bob])
 
         let viewModel = ContactsViewModel(contactsRepository: repo)
 
-        // Search now spans agents too: both Alice and the Alice Assistant
-        // match "alice"; Bob does not.
+        // Search spans template-backed agents too: both Alice and the
+        // (template-backed) Alice Assistant match "alice"; Bob does not.
         viewModel.searchQuery = "alice"
         let allIds: [String] = viewModel.sections.flatMap { $0.rows.map(\.contact.inboxId) }
         XCTAssertEqual(allIds.sorted(), [alice.inboxId, aliceAssistant.inboxId].sorted())


### PR DESCRIPTION
## Summary

Stacked on #892. A lean alternative to #854's parallel agent-template-contact subsystem: verified agents are **already** stored as `DBContact` rows, so this surfaces them in the contacts browse list alongside humans — tagged with an "Agent" pill — by reusing the existing `Contact` / `ContactRowView` / `ContactCardView` instead of building a second contact model + repository + writer + duplicated views.

Keyed by `inboxId` (one row per instance). Cross-instance dedup is intentionally deferred — a future change can `GROUP BY agentTemplateId` (the new partial index makes that index-backed with no schema change).

## Changes

- **Persist template identity on `DBContact`** — `agentTemplateId`, `agentTemplatePublishedURL`, `agentTemplateEmoji`, mirrored from the per-conversation `DBMemberProfile` metadata in `ContactSyncCoordinator` and the timestamped mirror path, read into `Contact` on hydration. Persisting (vs the prior live-overlay-only) is what lets a follow-up spawn a fresh instance from an agent contact after you've left every conversation with a running instance. Partial index `contact(agentTemplateId) WHERE agentTemplateId IS NOT NULL` for the future grouping.
- **Shared `RoleLabelPill`** — dedupes the capsule pill that was copied inline in `ConversationMembersListView` and as `ContactDetailBadge` in `ContactDetailView` (and would have been a 4th copy as #854's `AgentBadge`). Reused for the new contact-row Agent pill.
- **Browse list shows agents** — dropped the `!isVerifiedAgent` filter in `ContactsViewModel`; the picker stays human-only. Subtitle keeps the source conversation; the agent label moved to the trailing pill.

## Not in this PR (next in the stack)

- Unfiltering agents from the **picker**, the **"One agent, many convos"** info sheet (on the Chat button + picker selection), and **spawning a fresh instance by `agentTemplateId`**. The persisted templateId here is the foundation that PR depends on.

## Testing

- Full `ConvosCore` suite: **993 tests / 142 suites passed** (Docker integration suites + the new `addContactAgentTemplateFields` migration on a fresh DB).
- New `ContactSyncCoordinatorTests.testTemplateAgentPersistsTemplateFields`; updated `ContactsViewModelTests` to assert agents now appear in the list / count / search.
- App target builds clean; SwiftLint clean; app launches past the migration on an existing populated DB.

## Relationship to #854

This supersedes #854's approach. Closing #854 is the author's call — or it can stay open if we later decide we want the `templateId`-keyed grouping it models.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/901"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782596978&installation_id=128169237&pr_number=901&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F901&signature=29246443ec1f4c02f3fcde9cb12094b3dd7000f9f2b49782d6949138adb9a3a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show verified agents with template metadata in the contacts list and picker
> - Adds `Contact.isVisibleInContactsList` to gate contacts browse visibility: humans with a display name are shown, agents only if they have both `agentVerification` and `agentTemplateId`.
> - Persists `agentTemplateId`, `agentTemplatePublishedURL`, and `agentTemplateEmoji` in `DBContact` via a new migration (`addContactAgentTemplateFields`) and propagates these fields through `ContactSyncCoordinator`, `ContactsWriter`, and `Contact.init(dbContact:)`.
> - Updates `ContactsPickerViewModel` to show template-backed agents only in new-conversation mode, enforce single-agent selection, and disable other agent rows when one is already selected.
> - Shows a one-time `OneAgentManyConvosInfoSheet` when an agent is first selected in the picker, and passes the selected `agentTemplateId` separately from member inbox IDs through `onConfirm` into `NewConversationViewModel`.
> - Adds a `RoleLabelPill` component used in contact rows, picker rows, and the conversation members list to display the
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 75c62b1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->