### PR TITLE
Unify message-ingest routing across stream and batch catch-up

### DIFF
--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationWriter.swift
@@ -391,22 +391,38 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
         currentInboxId: String
     ) async {
         for message in messages {
-            guard !message.isProfileMessage, !message.isTypingIndicator else {
-                continue
-            }
-            if message.isReadReceipt {
-                await storeReadReceipt(message, conversationId: conversation.id)
-                continue
-            }
-            if message.isThinking {
-                await storeThinking(message, conversationId: conversation.id, currentInboxId: currentInboxId)
-                continue
-            }
             do {
-                _ = try await messageWriter.store(message: message, for: conversation)
+                _ = try await applyCaughtUpMessage(message, for: conversation, currentInboxId: currentInboxId)
             } catch {
                 Log.error("Failed to apply backlog supplemental message \(message.id) in \(conversation.id): \(error)")
             }
+        }
+    }
+
+    /// Applies one caught-up (backlog) message via the correct handler and
+    /// returns its content type when it was stored as a regular message (so
+    /// the caller can evaluate the unread gate), or `nil` for read receipts,
+    /// thinking, or ignored messages. Single routing shared by
+    /// `fetchAndStoreLatestMessages` and `applyBacklogSupplementals` so the
+    /// two catch-up paths can't drift. Reactions flow through `store`, which
+    /// routes them to the reaction handlers.
+    private func applyCaughtUpMessage(
+        _ message: DecodedMessage,
+        for conversation: DBConversation,
+        currentInboxId: String
+    ) async throws -> MessageContentType? {
+        switch CaughtUpMessageKind.of(message) {
+        case .ignore:
+            return nil
+        case .readReceipt:
+            await storeReadReceipt(message, conversationId: conversation.id)
+            return nil
+        case .thinking:
+            await storeThinking(message, conversationId: conversation.id, currentInboxId: currentInboxId)
+            return nil
+        case .reaction, .regular:
+            let result = try await messageWriter.store(message: message, for: conversation)
+            return result.contentType
         }
     }
 
@@ -855,23 +871,26 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
 
         Log.debug("Found \(messages.count) new messages, catching up...")
 
-        // Store messages and track if conversation should be marked unread
+        // Store messages and track if conversation should be marked unread.
+        // `activeConversationId` is nil here: this path runs from conversation
+        // discovery and push handling, where there is no foreground
+        // conversation to exempt.
         var marksConversationAsUnread = false
         let myInboxId = currentInboxId
         for message in messages {
-            guard !message.isProfileMessage, !message.isTypingIndicator else { continue }
-            if message.isReadReceipt {
-                await storeReadReceipt(message, conversationId: conversation.id)
-                continue
-            }
-            if message.isThinking {
-                await storeThinking(message, conversationId: conversation.id, currentInboxId: myInboxId)
-                continue
-            }
             Log.debug("Catching up with message sent at: \(message.sentAt.nanosecondsSince1970)")
-            let result = try await messageWriter.store(message: message, for: dbConversation)
-            if result.contentType.marksConversationAsUnread,
-               message.senderInboxId != myInboxId {
+            guard let contentType = try await applyCaughtUpMessage(
+                message,
+                for: dbConversation,
+                currentInboxId: myInboxId
+            ) else { continue }
+            if marksConversationUnread(
+                contentType: contentType,
+                senderInboxId: message.senderInboxId,
+                currentInboxId: myInboxId,
+                conversationId: conversation.id,
+                activeConversationId: nil
+            ) {
                 marksConversationAsUnread = true
             }
             Log.debug("Saved caught up message sent at: \(message.sentAt.nanosecondsSince1970)")

--- a/ConvosCore/Sources/ConvosCore/Syncing/BatchCatchUp.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/BatchCatchUp.swift
@@ -263,16 +263,20 @@ struct BatchCatchUp {
                 if messageResult.wasRemovedFromConversation, !messageResult.messageAlreadyExists {
                     removals.append(entry.conversation.dbConversation)
                 }
-                if messageResult.contentType.marksConversationAsUnread,
-                   preparedMessage.source.senderInboxId != inboxId {
+                // Shared unread predicate: skips our own messages and the
+                // conversation the user is currently viewing, identically to
+                // the stream paths.
+                if marksConversationUnread(
+                    contentType: messageResult.contentType,
+                    senderInboxId: preparedMessage.source.senderInboxId,
+                    currentInboxId: inboxId,
+                    conversationId: entry.conversation.dbConversation.id,
+                    activeConversationId: activeConversationId
+                ) {
                     entryMarksUnread = true
                 }
             }
-            // Skip the conversation the user is currently viewing, so a
-            // foreground catch-up back into the open conversation doesn't
-            // mark it unread. Mirrors the stream path's gate in
-            // `StreamProcessor` (`conversation.id != activeConversationId`).
-            if entryMarksUnread, entry.conversation.dbConversation.id != activeConversationId {
+            if entryMarksUnread {
                 unreadIds.append(entry.conversation.dbConversation.id)
             }
         }
@@ -349,23 +353,18 @@ struct BatchCatchUp {
     }
 
     private static func classify(_ message: XMTPiOS.DecodedMessage) -> MessageClassification {
-        if message.isProfileMessage || message.isTypingIndicator {
+        switch CaughtUpMessageKind.of(message) {
+        case .ignore:
             return .skip
-        }
-        // Thinking messages back the thinking-detail view but must never be
-        // persisted as normal chat messages -- the stream path routes them
-        // through `ThinkingSessionWriter` (see `storeThinking`). Treat them
-        // as a supplemental so the batch applies them the same way.
-        if message.isReadReceipt || message.isThinking {
+        // Read receipts, thinking, and reactions all run through the
+        // per-message supplemental handlers (post-commit), never the batched
+        // regular-message transaction. Thinking in particular backs the
+        // thinking-detail view and must not be persisted as a chat row.
+        case .readReceipt, .thinking, .reaction:
             return .supplemental
+        case .regular:
+            return .regular
         }
-        guard let contentType = try? message.encodedContent.type else {
-            return .skip
-        }
-        if contentType == ContentTypeReaction || contentType == ContentTypeReactionV2 {
-            return .supplemental
-        }
-        return .regular
     }
 
     /// `MAX(dateNs)` for the conversation, or `0` when the local DB has no messages

--- a/ConvosCore/Sources/ConvosCore/Syncing/CaughtUpMessageRouting.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/CaughtUpMessageRouting.swift
@@ -1,0 +1,65 @@
+import Foundation
+@preconcurrency import XMTPiOS
+
+/// Single source of truth for how a backlog ("caught up") message is
+/// classified, shared by every ingest path so they cannot drift:
+///   - real-time stream (`StreamProcessor`)
+///   - stream catch-up (`ConversationWriter.fetchAndStoreLatestMessages`)
+///   - batch catch-up (`BatchCatchUp` + `ConversationWriter.applyBacklogSupplementals`)
+///
+/// Three separate copies of this routing previously diverged, which caused
+/// backlog messages to be marked unread in the conversation the user was
+/// viewing, to skip QA "received" events, and to persist thinking messages
+/// as normal chat rows. Each path maps a `CaughtUpMessageKind` onto its own
+/// handling, but the classification itself lives here once.
+enum CaughtUpMessageKind {
+    /// Profile updates/snapshots, typing indicators, or content with no
+    /// decodable type. None of these are stored as chat messages on the
+    /// catch-up paths (profiles are applied by the profile handlers, typing
+    /// is live-only, and a message with no resolvable content type can't be
+    /// rendered).
+    case ignore
+    case readReceipt
+    case thinking
+    case reaction
+    /// Text, attachments, link previews, group updates, etc. -> the regular
+    /// message writer (`IncomingMessageWriter.store` / `persist`).
+    case regular
+
+    static func of(_ message: XMTPiOS.DecodedMessage) -> CaughtUpMessageKind {
+        if message.isProfileMessage || message.isTypingIndicator {
+            return .ignore
+        }
+        if message.isReadReceipt {
+            return .readReceipt
+        }
+        if message.isThinking {
+            return .thinking
+        }
+        guard let contentType = try? message.encodedContent.type else {
+            return .ignore
+        }
+        if contentType == ContentTypeReaction || contentType == ContentTypeReactionV2 {
+            return .reaction
+        }
+        return .regular
+    }
+}
+
+/// Whether a newly-persisted message should mark its conversation unread,
+/// applied identically by every ingest path. A message marks unread when its
+/// content type is user-visible (`marksConversationAsUnread`), it came from
+/// someone other than us, and it isn't the conversation the user is currently
+/// viewing. Pass `activeConversationId: nil` from contexts with no active
+/// conversation (push, conversation discovery).
+func marksConversationUnread(
+    contentType: MessageContentType,
+    senderInboxId: String,
+    currentInboxId: String,
+    conversationId: String,
+    activeConversationId: String?
+) -> Bool {
+    contentType.marksConversationAsUnread
+        && senderInboxId != currentInboxId
+        && conversationId != activeConversationId
+}

--- a/ConvosCore/Sources/ConvosCore/Syncing/StreamProcessor.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/StreamProcessor.swift
@@ -314,10 +314,15 @@ actor StreamProcessor: StreamProcessorProtocol {
 
                     let result = try await messageWriter.store(message: message, for: dbConversation)
 
-                    // Mark unread if needed
-                    if result.contentType.marksConversationAsUnread,
-                       conversation.id != activeConversationId,
-                       message.senderInboxId != params.client.inboxId {
+                    // Mark unread if needed (shared predicate with the
+                    // catch-up paths so the gate can't drift).
+                    if marksConversationUnread(
+                        contentType: result.contentType,
+                        senderInboxId: message.senderInboxId,
+                        currentInboxId: params.client.inboxId,
+                        conversationId: conversation.id,
+                        activeConversationId: activeConversationId
+                    ) {
                         try await localStateWriter.setUnread(true, for: conversation.id)
                     }
 

--- a/ConvosCore/Tests/ConvosCoreTests/CaughtUpMessageRoutingTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/CaughtUpMessageRoutingTests.swift
@@ -1,0 +1,69 @@
+@testable import ConvosCore
+import Foundation
+import Testing
+
+@Suite("CaughtUpMessageRouting")
+struct CaughtUpMessageRoutingTests {
+    private let conversationId = "conv-1"
+    private let me = "inbox-me"
+    private let other = "inbox-other"
+
+    @Test("Marks unread for a user-visible message from another sender")
+    func marksUnreadForOtherSender() {
+        #expect(marksConversationUnread(
+            contentType: .text,
+            senderInboxId: other,
+            currentInboxId: me,
+            conversationId: conversationId,
+            activeConversationId: nil
+        ))
+    }
+
+    @Test("Does not mark unread for our own message")
+    func skipsOwnMessage() {
+        #expect(!marksConversationUnread(
+            contentType: .text,
+            senderInboxId: me,
+            currentInboxId: me,
+            conversationId: conversationId,
+            activeConversationId: nil
+        ))
+    }
+
+    @Test("Does not mark unread for the conversation the user is viewing")
+    func skipsActiveConversation() {
+        #expect(!marksConversationUnread(
+            contentType: .text,
+            senderInboxId: other,
+            currentInboxId: me,
+            conversationId: conversationId,
+            activeConversationId: conversationId
+        ))
+    }
+
+    @Test("Marks unread when a different conversation is active")
+    func marksWhenDifferentConversationActive() {
+        #expect(marksConversationUnread(
+            contentType: .text,
+            senderInboxId: other,
+            currentInboxId: me,
+            conversationId: conversationId,
+            activeConversationId: "some-other-conversation"
+        ))
+    }
+
+    @Test("Does not mark unread for content types that never mark unread")
+    func skipsNonUnreadContentTypes() {
+        // `.update` (group membership) and the connection/capability silent
+        // types never mark a conversation unread, even from another sender.
+        for contentType: MessageContentType in [.update, .connectionEvent, .capabilityRequest, .connectionInvocation] {
+            #expect(!marksConversationUnread(
+                contentType: contentType,
+                senderInboxId: other,
+                currentInboxId: me,
+                conversationId: conversationId,
+                activeConversationId: nil
+            ), "\(contentType) should not mark unread")
+        }
+    }
+}


### PR DESCRIPTION
The real-time stream, stream catch-up (fetchAndStoreLatestMessages), and
batch catch-up (BatchCatchUp) each carried their own copy of message
classification and the unread-marking gate. Those copies drifted, which
was the root cause of three recently-fixed bugs: backlog messages marked
the active conversation unread, skipped QA received events, and persisted
thinking messages as normal chat rows.

Introduce a single source of truth in CaughtUpMessageRouting:
- CaughtUpMessageKind.of(message) classifies a message once (ignore /
  readReceipt / thinking / reaction / regular).
- marksConversationUnread(...) is the one unread predicate (content type
  marks unread, sender isn't us, conversation isn't the active one).

All three paths now consume these. The two near-identical catch-up loops
(fetchAndStoreLatestMessages and applyBacklogSupplementals) collapse into
one shared applyCaughtUpMessage routine on ConversationWriter, so the
batch and stream catch-up handling can't diverge again. The batch's
batched-transaction architecture is unchanged.

Behavior-preserving except one safe alignment: stream catch-up now ignores
messages with no decodable content type (matching the batch) instead of
attempting to store them. Adds CaughtUpMessageRoutingTests covering the
unread predicate.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/902"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782599272&installation_id=128169237&pr_number=902&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F902&signature=eba9ea879d7add7c8025ddc8853df7e55c49f29ce2fd8a339992043e0552cbf6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Unify message-ingest routing across stream and batch catch-up paths
> - Adds [`CaughtUpMessageKind`](https://github.com/xmtplabs/convos-ios/pull/902/files#diff-598b418d3a129d76c49f0e7edfca153983ff3b9bcadf2181dca4bfaa68e3d738) as a single classification source for caught-up messages, replacing duplicated inline routing in `ConversationWriter` and `BatchCatchUp`.
> - Adds `marksConversationUnread` as a shared predicate used by stream, batch catch-up, and backlog-supplemental paths, replacing three separate inline unread-marking checks.
> - Adds `ConversationWriter.applyCaughtUpMessage` as a private helper that dispatches to read-receipt, thinking, reaction, or regular storage based on the centralized classification.
> - Adds unit tests in [`CaughtUpMessageRoutingTests`](https://github.com/xmtplabs/convos-ios/pull/902/files#diff-ced70b8c91850cfa9bc3f76dce2adda5fed8dfa752604e41979798984a56ec01) covering the `marksConversationUnread` predicate across sender, ownership, and active-conversation scenarios.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4022a3c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->