### PR TITLE
Type the pairing-completion payload and share the install poll schedule

### DIFF
--- a/Convos/Devices/DevicesViewModel.swift
+++ b/Convos/Devices/DevicesViewModel.swift
@@ -77,17 +77,14 @@ final class DevicesViewModel {
         if !didStartObserving {
             didStartObserving = true
             observers.add(for: .pairingDidCompleteSuccessfully) { [weak self] notification in
-                let userInfo = notification.userInfo
-                // The initiator's post carries an explicit `isInitiator`
-                // flag (plus the joiner's device name). The joiner's post
-                // has neither. Only the initiator broadcasts the
-                // profile-snapshot fan-out -- the joiner is the one
-                // *receiving* the snapshots, it shouldn't re-send them.
-                let displayName = (userInfo?["joinerDeviceName"] as? String) ?? "New device"
-                let isInitiatorSide = (userInfo?["isInitiator"] as? Bool) ?? false
+                // Default to `.joiner` if the payload is somehow absent: the
+                // joiner side does no broadcast, which is the safe fallback.
+                // Only the initiator broadcasts the profile-snapshot fan-out
+                // (the joiner is the one *receiving* the snapshots).
+                let role = notification.pairingCompletion?.role ?? .joiner
                 Task { @MainActor in
                     guard let self else { return }
-                    self.insertOptimisticDevice(named: displayName)
+                    self.insertOptimisticDevice(named: role.optimisticDeviceName)
                     // Capture the installation baseline BEFORE the refresh
                     // waits for the joiner -- otherwise the joiner folds
                     // into the baseline and the broadcaster's diff finds
@@ -97,9 +94,9 @@ final class DevicesViewModel {
                     // empty set (which would diff true on the initiator's
                     // own installation and broadcast before the joiner
                     // appears).
-                    let baseline = isInitiatorSide ? await self.currentInstallationIds() : nil
+                    let baseline = role.isInitiator ? await self.currentInstallationIds() : nil
                     await self.refreshUntilRealInstallationAppears()
-                    if isInitiatorSide, let baseline {
+                    if role.isInitiator, let baseline {
                         await self.broadcastProfileSnapshotsAfterPair(baseline: baseline)
                     }
                 }
@@ -176,7 +173,7 @@ final class DevicesViewModel {
     /// a few seconds. Poll until a real non-self installation shows or
     /// we hit the cap.
     private func refreshUntilRealInstallationAppears() async {
-        let schedule: [TimeInterval] = [0, 2, 5, 10, 20]
+        let schedule = PairingInstallationPoll.schedule
         for (index, delay) in schedule.enumerated() {
             if delay > 0 {
                 try? await Task.sleep(for: .seconds(delay))

--- a/Convos/Devices/JoinerPairingSheetViewModel.swift
+++ b/Convos/Devices/JoinerPairingSheetViewModel.swift
@@ -234,7 +234,7 @@ final class JoinerPairingSheetViewModel: Identifiable {
         Task { @MainActor in
             await onPairingAdopted?()
             await onApplyAdoptedProfile?(capturedDisplayName, capturedImage)
-            NotificationCenter.default.post(name: .pairingDidCompleteSuccessfully, object: nil)
+            NotificationCenter.default.postPairingCompleted(PairingCompletion(role: .joiner))
             title = "Device paired"
             flowState = .completed
             canDismiss = true

--- a/Convos/Devices/PairingSheetViewModel.swift
+++ b/Convos/Devices/PairingSheetViewModel.swift
@@ -199,13 +199,11 @@ final class PairingSheetViewModel {
                 if let appGroupIdentifier {
                     PairedDeviceNameStore.setPending(deviceName, appGroup: appGroupIdentifier)
                 }
-                NotificationCenter.default.post(
-                    name: .pairingDidCompleteSuccessfully,
-                    object: nil,
-                    // `isInitiator` gates the post-pair profile-snapshot
-                    // broadcast to the initiator side only (the joiner
-                    // receives the snapshots, it doesn't re-send them).
-                    userInfo: ["joinerDeviceName": deviceName, "isInitiator": true]
+                // `.initiator` gates the post-pair profile-snapshot broadcast
+                // to the initiator side only (the joiner receives the
+                // snapshots, it doesn't re-send them).
+                NotificationCenter.default.postPairingCompleted(
+                    PairingCompletion(role: .initiator(joinerDeviceName: deviceName))
                 )
                 title = "Device added"
                 flowState = .completed(deviceName: deviceName)

--- a/ConvosCore/Sources/ConvosCore/Pairing/PairedDeviceNameStore.swift
+++ b/ConvosCore/Sources/ConvosCore/Pairing/PairedDeviceNameStore.swift
@@ -52,10 +52,3 @@ public enum PairedDeviceNameStore {
         return value
     }
 }
-
-public extension Notification.Name {
-    /// Posted by the pairing flow after a successful pair completes on
-    /// either side, so observers like `DevicesViewModel` can refresh
-    /// installations (and claim any pending name).
-    static let pairingDidCompleteSuccessfully: Notification.Name = Notification.Name("convos.pairing.didCompleteSuccessfully")
-}

--- a/ConvosCore/Sources/ConvosCore/Pairing/PairingCompletion.swift
+++ b/ConvosCore/Sources/ConvosCore/Pairing/PairingCompletion.swift
@@ -1,0 +1,70 @@
+import Foundation
+
+public extension Notification.Name {
+    /// Posted by the pairing flow after a successful pair completes on
+    /// either side, so observers like `DevicesViewModel` can refresh
+    /// installations (and claim any pending name). Carries a typed
+    /// `PairingCompletion` payload -- read it via `Notification.pairingCompletion`.
+    static let pairingDidCompleteSuccessfully: Notification.Name = Notification.Name("convos.pairing.didCompleteSuccessfully")
+}
+
+/// Which side of the pairing handshake posted the completion.
+///
+/// The initiator is the device that displayed the QR/PIN and adopted the
+/// joiner; it carries the joiner's device name and is the only side that
+/// broadcasts the post-pair profile snapshots (the joiner is the one
+/// receiving them, so it must not re-send). The joiner is the device that
+/// scanned in and adopted the initiator's identity.
+public enum PairingRole: Sendable, Equatable {
+    case initiator(joinerDeviceName: String)
+    case joiner
+
+    public var isInitiator: Bool {
+        if case .initiator = self { return true }
+        return false
+    }
+
+    /// The paired device's name to show optimistically in the device list.
+    /// The initiator knows the joiner's name; the joiner side falls back to
+    /// a generic label until the real installation row surfaces.
+    public var optimisticDeviceName: String {
+        switch self {
+        case let .initiator(joinerDeviceName):
+            return joinerDeviceName
+        case .joiner:
+            return "New device"
+        }
+    }
+}
+
+/// Typed payload for `.pairingDidCompleteSuccessfully`, replacing the prior
+/// stringly-typed `userInfo` dictionary whose role was inferred from the
+/// presence of an `"isInitiator"` key.
+public struct PairingCompletion: Sendable, Equatable {
+    public let role: PairingRole
+
+    public init(role: PairingRole) {
+        self.role = role
+    }
+
+    fileprivate static let userInfoKey: String = "convos.pairing.completion"
+}
+
+public extension NotificationCenter {
+    /// Post `.pairingDidCompleteSuccessfully` carrying a typed payload.
+    func postPairingCompleted(_ completion: PairingCompletion) {
+        post(
+            name: .pairingDidCompleteSuccessfully,
+            object: nil,
+            userInfo: [PairingCompletion.userInfoKey: completion]
+        )
+    }
+}
+
+public extension Notification {
+    /// The typed pairing-completion payload, or `nil` if the notification
+    /// wasn't posted with one.
+    var pairingCompletion: PairingCompletion? {
+        userInfo?[PairingCompletion.userInfoKey] as? PairingCompletion
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Pairing/PairingInstallationPoll.swift
+++ b/ConvosCore/Sources/ConvosCore/Pairing/PairingInstallationPoll.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+/// Shared cadence for waiting on a just-paired joiner's installation to
+/// surface in the inbox's installation list. libxmtp's
+/// `listInstallations(refreshFromNetwork:)` reflects network-side state that
+/// lags the joiner's key-package publish by a few seconds, so both the
+/// initiator's optimistic-row reconciliation (`DevicesViewModel`) and the
+/// post-pair profile broadcaster (`PostPairProfileSnapshotBroadcaster`) poll
+/// on this schedule.
+public enum PairingInstallationPoll {
+    /// Seconds to wait before each poll attempt. Cumulative ~37s, roughly
+    /// exponential: long enough to catch the key-package publish, short
+    /// enough not to hang on a pair that never completes.
+    public static let schedule: [TimeInterval] = [0, 2, 5, 10, 20]
+}

--- a/ConvosCore/Sources/ConvosCore/Pairing/PostPairProfileSnapshotBroadcaster.swift
+++ b/ConvosCore/Sources/ConvosCore/Pairing/PostPairProfileSnapshotBroadcaster.swift
@@ -59,7 +59,7 @@ public final class PostPairProfileSnapshotBroadcaster: PostPairProfileSnapshotBr
 
     public init(messagingService: any PostPairBroadcastMessaging) {
         self.messagingService = messagingService
-        self.pollSchedule = Constant.pollSchedule
+        self.pollSchedule = PairingInstallationPoll.schedule
     }
 
     /// Test seam: inject a faster poll schedule so unit tests don't sleep
@@ -87,11 +87,11 @@ public final class PostPairProfileSnapshotBroadcaster: PostPairProfileSnapshotBr
         return true
     }
 
-    /// Polls libxmtp's installation list on the same schedule
-    /// `DevicesViewModel` uses for its optimistic-row reconciliation.
-    /// Returns true the first time we see an installation id that
-    /// wasn't in the baseline set; false if the entire schedule
-    /// elapses with no new installation.
+    /// Polls libxmtp's installation list on `PairingInstallationPoll.schedule`
+    /// (the same cadence `DevicesViewModel` uses for its optimistic-row
+    /// reconciliation). Returns true the first time we see an installation id
+    /// that wasn't in the baseline set; false if the entire schedule elapses
+    /// with no new installation.
     private func waitForInstallationAdded(beyond baseline: Set<String>) async -> Bool {
         for delay in pollSchedule {
             if delay > 0 {
@@ -115,13 +115,5 @@ public final class PostPairProfileSnapshotBroadcaster: PostPairProfileSnapshotBr
             Log.warning("PostPairProfileSnapshotBroadcaster: installationsSnapshot failed: \(error.localizedDescription)")
             return nil
         }
-    }
-
-    private enum Constant {
-        /// Matches `DevicesViewModel.refreshUntilRealInstallationAppears`:
-        /// cumulative ~37s, roughly exponential. Long enough to catch
-        /// the joiner's key-package publish, short enough that we don't
-        /// hang on a never-completes pair.
-        static let pollSchedule: [TimeInterval] = [0, 2, 5, 10, 20]
     }
 }

--- a/ConvosCore/Tests/ConvosCoreTests/PairingCompletionTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/PairingCompletionTests.swift
@@ -1,0 +1,45 @@
+@testable import ConvosCore
+import Foundation
+import Testing
+
+@Suite("PairingCompletion")
+struct PairingCompletionTests {
+    @Test("Initiator role reports isInitiator and carries the joiner name")
+    func initiatorRole() {
+        let role: PairingRole = .initiator(joinerDeviceName: "Jarod's iPad")
+        #expect(role.isInitiator)
+        #expect(role.optimisticDeviceName == "Jarod's iPad")
+    }
+
+    @Test("Joiner role is not the initiator and uses the generic name")
+    func joinerRole() {
+        let role: PairingRole = .joiner
+        #expect(!role.isInitiator)
+        #expect(role.optimisticDeviceName == "New device")
+    }
+
+    @Test("Posting carries the typed payload through to the observer")
+    func postAndReadPayload() {
+        let center = NotificationCenter()
+        var received: PairingCompletion?
+        let token = center.addObserver(
+            forName: .pairingDidCompleteSuccessfully,
+            object: nil,
+            queue: nil
+        ) { notification in
+            received = notification.pairingCompletion
+        }
+        defer { center.removeObserver(token) }
+
+        center.postPairingCompleted(PairingCompletion(role: .initiator(joinerDeviceName: "Pixel")))
+
+        #expect(received == PairingCompletion(role: .initiator(joinerDeviceName: "Pixel")))
+        #expect(received?.role.isInitiator == true)
+    }
+
+    @Test("A notification without a payload yields nil")
+    func missingPayload() {
+        let notification = Notification(name: .pairingDidCompleteSuccessfully)
+        #expect(notification.pairingCompletion == nil)
+    }
+}


### PR DESCRIPTION
The .pairingDidCompleteSuccessfully notification carried a stringly-typed
userInfo dictionary whose initiator-vs-joiner role was inferred from the
presence of an "isInitiator" key. A typo in either the post or the read
would silently downgrade the initiator to the joiner path (no profile
broadcast, "New device" fallback name).

Replace it with a typed PairingCompletion payload carrying an explicit
PairingRole (.initiator(joinerDeviceName:) / .joiner), posted via
NotificationCenter.postPairingCompleted(_:) and read via
Notification.pairingCompletion. The optimistic device name and the
broadcast gate now derive from the role enum instead of dictionary keys.
Relocate the Notification.Name to live beside the payload type.

Also dedupe the [0, 2, 5, 10, 20] post-pair install-poll cadence, which
was hand-maintained in two places (DevicesViewModel and
PostPairProfileSnapshotBroadcaster), into one PairingInstallationPoll.schedule.

Adds PairingCompletionTests for the role helpers and the notification
round-trip.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/903"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782599693&installation_id=128169237&pr_number=903&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F903&signature=f8fce06b6dbb4581a737e17309a4d21b0380516fdd2a90896f46d7736088d922"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Type the pairing-completion notification payload and centralize the install poll schedule
> - Introduces `PairingRole` (`.initiator(joinerDeviceName:)` / `.joiner`) and `PairingCompletion` in [PairingCompletion.swift](https://github.com/xmtplabs/convos-ios/pull/903/files#diff-e8520cad53f7c8a07b4a0e306718abef42a59c8254fc9a82f727e46dc1d57ac0), replacing raw `userInfo` string keys with a strongly-typed struct posted via a new `NotificationCenter.postPairingCompleted` helper.
> - Updates `DevicesViewModel.startObserving` to decode the typed payload; defaults to `.joiner` semantics when the payload is absent.
> - Adds `PairingInstallationPoll.schedule` (`[0, 2, 5, 10, 20]` seconds) in [PairingInstallationPoll.swift](https://github.com/xmtplabs/convos-ios/pull/903/files#diff-732c86d4f79945c8a714929bc4488654814320cc6c12cc978bdcb3c1cb435128) and replaces hardcoded arrays in both `DevicesViewModel` and `PostPairProfileSnapshotBroadcaster`.
> - Adds `PairingCompletionTests` covering role behavior, round-trip notification posting/reading, and missing-payload fallback.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1f678e1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->