### PR TITLE
Back ConversationViewModel.isInAgentBuilderFlow with the messages repo

### DIFF
--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -508,15 +508,18 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
     /// when the agent actually joins). Used by
     /// `ConversationViewModel+ThinkingIndicators` to route agent
     /// thinking sessions under the contact card instead of the inline
-    /// footer, and forwarded to the messages-list repo so the processor
-    /// can suppress the legacy "Agent joined" update row for the
-    /// duration of the builder UX. Independent of whether the conversation
-    /// was created via the builder — the same flow will run when adding
-    /// an agent to an existing conversation.
-    var isInAgentBuilderFlow: Bool = false {
-        didSet {
-            messagesListRepository.isInAgentBuilderFlow = isInAgentBuilderFlow
-        }
+    /// footer, and read by the messages-list processor so it can suppress
+    /// the legacy "Agent joined" update row for the duration of the builder
+    /// UX. Independent of whether the conversation was created via the
+    /// builder — the same flow will run when adding an agent to an existing
+    /// conversation.
+    ///
+    /// Backed by `messagesListRepository` (its single owner, which feeds the
+    /// processor) rather than a mirrored stored copy, so there's one value to
+    /// keep in sync across the placeholder-to-real VM swap instead of two.
+    var isInAgentBuilderFlow: Bool {
+        get { messagesListRepository.isInAgentBuilderFlow }
+        set { messagesListRepository.isInAgentBuilderFlow = newValue }
     }
     @ObservationIgnored
     private var videoThumbnailTasks: [UUID: Task<Void, Never>] = [:]


### PR DESCRIPTION
Stacked on #899.

`isInAgentBuilderFlow` was stored and hand-forwarded through four layers (`NewConversationViewModel` -> `ConversationViewModel` -> `MessagesListRepository` -> `MessagesListProcessor`) via `didSet` chains, with a mirrored copy on `ConversationViewModel` that had to be re-synced on every placeholder-to-real VM swap.

This makes `ConversationViewModel.isInAgentBuilderFlow` a computed pass-through to `messagesListRepository` (its single owner, which feeds the processor), removing the redundant stored copy and its `didSet`-forward. The `ConversationViewModel+ThinkingIndicators` read and the "Joining" gate are unchanged at their call sites; `NewConversationViewModel` keeps the one canonical copy it needs to survive the VM swap.

**No behavior change.** Scoped deliberately narrow: the other builder signals (`suppressesContactCard`, `isAwaitingBuilderBundleSend`, `forcedAgentVerification`) have distinct lifetimes and are intentionally left as separate concepts rather than merged into one context object.

App build succeeds; SwiftLint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/904"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782600696&installation_id=128169237&pr_number=904&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F904&signature=c7f4d80fbe71dcfd1d48fecbab729608897e7076284a60a73af93f39dde88048"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Back `ConversationViewModel.isInAgentBuilderFlow` with `messagesListRepository`
> Converts `isInAgentBuilderFlow` in [ConversationViewModel.swift](https://github.com/xmtplabs/convos-ios/pull/904/files#diff-d056b0b131534648b6d13cddafd053be956f5d23d035ad2538db85a8cc370d8d) from a stored `Bool` to a computed property that proxies reads and writes directly to `messagesListRepository.isInAgentBuilderFlow`. Previously, the stored value was independent of the repository, so reads would not reflect repository state.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1938eb1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->