### PR TITLE
Make the ConvosTests target compile again

### DIFF
--- a/ConvosTests/ContactDetailModeTests.swift
+++ b/ConvosTests/ContactDetailModeTests.swift
@@ -2,9 +2,9 @@
 import ConvosCore
 import XCTest
 
-final class ContactCardModeTests: XCTestCase {
+final class ContactDetailModeTests: XCTestCase {
     func testStandaloneModeReportsNonScoped() {
-        let mode: ContactCardMode = .standalone
+        let mode: ContactDetailMode = .standalone
         XCTAssertFalse(mode.isScopedToConversation)
         XCTAssertNil(mode.conversationId)
         XCTAssertFalse(mode.canRemoveMembers)
@@ -12,10 +12,12 @@ final class ContactCardModeTests: XCTestCase {
     }
 
     func testScopedModeExposesPayload() {
-        let mode: ContactCardMode = .scopedToConversation(
+        let mode: ContactDetailMode = .scopedToConversation(
             conversationId: "convo-1",
             canRemoveMembers: true,
-            isCurrentUser: false
+            isCurrentUser: false,
+            invitedBy: nil,
+            joinedAt: nil
         )
         XCTAssertTrue(mode.isScopedToConversation)
         XCTAssertEqual(mode.conversationId, "convo-1")
@@ -24,10 +26,12 @@ final class ContactCardModeTests: XCTestCase {
     }
 
     func testScopedModeCurrentUserFlag() {
-        let mode: ContactCardMode = .scopedToConversation(
+        let mode: ContactDetailMode = .scopedToConversation(
             conversationId: "convo-1",
             canRemoveMembers: false,
-            isCurrentUser: true
+            isCurrentUser: true,
+            invitedBy: nil,
+            joinedAt: nil
         )
         XCTAssertTrue(mode.isCurrentUser)
         XCTAssertFalse(mode.canRemoveMembers)

--- a/ConvosTests/ContactsPickerViewModelTests.swift
+++ b/ConvosTests/ContactsPickerViewModelTests.swift
@@ -5,7 +5,10 @@ import XCTest
 
 @MainActor
 final class ContactsPickerViewModelTests: XCTestCase {
-    private var cancellables: Set<AnyCancellable> = []
+    // Test-only state, mutated only from main-thread test bodies and the
+    // nonisolated XCTest tearDown; nonisolated(unsafe) lets both reach it
+    // without an isolation hop.
+    nonisolated(unsafe) private var cancellables: Set<AnyCancellable> = []
 
     override func tearDown() {
         cancellables.removeAll()

--- a/ConvosTests/ConversationOnboardingCoordinatorTests.swift
+++ b/ConvosTests/ConversationOnboardingCoordinatorTests.swift
@@ -29,6 +29,12 @@ final class ConversationOnboardingCoordinatorTests: XCTestCase {
         )
 
         cleanUpUserDefaults()
+
+        // The coordinator reads `ProfileSettingsViewModel.shared` (a
+        // singleton); reset it so a non-default profile left by another
+        // test can't push `start()` down the auto-apply branch.
+        ProfileSettingsViewModel.shared.editingDisplayName = ""
+        ProfileSettingsViewModel.shared.profileImage = nil
     }
 
     override func tearDown() async throws {

--- a/ConvosTests/ConversationViewModelGlobalDefaultsTests.swift
+++ b/ConvosTests/ConversationViewModelGlobalDefaultsTests.swift
@@ -1,5 +1,6 @@
 import Combine
 @testable import Convos
+import ConvosConnections
 import ConvosCore
 import XCTest
 
@@ -224,16 +225,18 @@ private final class TestSessionManager: SessionManagerProtocol, @unchecked Senda
         await base.inboxId(for: conversationId)
     }
 
-    func requestAgentJoin(slug: String, templateId: String?, forceErrorCode: Int? = nil) async throws -> ConvosAPI.AgentJoinResponse {
-        try await base.requestAgentJoin(slug: slug, templateId: templateId, forceErrorCode: forceErrorCode)
-    }
-
-    func redeemInviteCode(_ code: String) async throws -> ConvosAPI.InviteCodeStatus {
-        try await base.redeemInviteCode(code)
-    }
-
-    func fetchInviteCodeStatus(_ code: String) async throws -> ConvosAPI.InviteCodeStatus {
-        try await base.fetchInviteCodeStatus(code)
+    func requestAgentJoin(
+        slug: String,
+        templateId: String?,
+        options: ConvosAPI.AgentJoinOptions?,
+        forceErrorCode: Int?
+    ) async throws -> ConvosAPI.AgentJoinResponse {
+        try await base.requestAgentJoin(
+            slug: slug,
+            templateId: templateId,
+            options: options,
+            forceErrorCode: forceErrorCode
+        )
     }
 
     func voiceMemoTranscriptRepository() -> any VoiceMemoTranscriptRepositoryProtocol {
@@ -248,8 +251,52 @@ private final class TestSessionManager: SessionManagerProtocol, @unchecked Senda
         base.voiceMemoTranscriptionService()
     }
 
-    func assistantFilesLinksRepository(for conversationId: String) -> AssistantFilesLinksRepository {
-        base.assistantFilesLinksRepository(for: conversationId)
+    func agentFilesLinksRepository(for conversationId: String) -> AgentFilesLinksRepository {
+        base.agentFilesLinksRepository(for: conversationId)
+    }
+
+    func agentBuilderSummaryWriter() -> any AgentBuilderSummaryWriterProtocol {
+        base.agentBuilderSummaryWriter()
+    }
+
+    func agentBuilderSummaryRepository() -> any AgentBuilderSummaryRepositoryProtocol {
+        base.agentBuilderSummaryRepository()
+    }
+
+    func thinkingSessionRepository() -> any ThinkingSessionRepositoryProtocol {
+        base.thinkingSessionRepository()
+    }
+
+    func connectionEnablementStore() -> any EnablementStore {
+        base.connectionEnablementStore()
+    }
+
+    func deviceDataSink(for kind: ConnectionKind) -> (any DataSink)? {
+        base.deviceDataSink(for: kind)
+    }
+
+    func joinerPairingService() -> any PairingServiceProtocol {
+        base.joinerPairingService()
+    }
+
+    func refreshAfterPairingCompleted() async {
+        await base.refreshAfterPairingCompleted()
+    }
+
+    func hasAnyUsedConversations() async -> Bool {
+        await base.hasAnyUsedConversations()
+    }
+
+    func commitClaimedConversation(id conversationId: String) async {
+        await base.commitClaimedConversation(id: conversationId)
+    }
+
+    func releaseClaimedConversation(id conversationId: String) async {
+        await base.releaseClaimedConversation(id: conversationId)
+    }
+
+    func discardClaimedConversation(id conversationId: String) async {
+        await base.discardClaimedConversation(id: conversationId)
     }
 
     func pendingInviteDetails() throws -> [PendingInviteDetail] {

--- a/ConvosTests/ConversationsViewModelDeleteTests.swift
+++ b/ConvosTests/ConversationsViewModelDeleteTests.swift
@@ -1,4 +1,5 @@
 @testable import Convos
+import ConvosConnections
 import ConvosCore
 import XCTest
 
@@ -292,16 +293,18 @@ private final class TestSessionManager: SessionManagerProtocol, @unchecked Senda
         await base.inboxId(for: conversationId)
     }
 
-    func requestAgentJoin(slug: String, templateId: String?, forceErrorCode: Int? = nil) async throws -> ConvosAPI.AgentJoinResponse {
-        try await base.requestAgentJoin(slug: slug, templateId: templateId, forceErrorCode: forceErrorCode)
-    }
-
-    func redeemInviteCode(_ code: String) async throws -> ConvosAPI.InviteCodeStatus {
-        try await base.redeemInviteCode(code)
-    }
-
-    func fetchInviteCodeStatus(_ code: String) async throws -> ConvosAPI.InviteCodeStatus {
-        try await base.fetchInviteCodeStatus(code)
+    func requestAgentJoin(
+        slug: String,
+        templateId: String?,
+        options: ConvosAPI.AgentJoinOptions?,
+        forceErrorCode: Int?
+    ) async throws -> ConvosAPI.AgentJoinResponse {
+        try await base.requestAgentJoin(
+            slug: slug,
+            templateId: templateId,
+            options: options,
+            forceErrorCode: forceErrorCode
+        )
     }
 
     func voiceMemoTranscriptRepository() -> any VoiceMemoTranscriptRepositoryProtocol {
@@ -316,8 +319,52 @@ private final class TestSessionManager: SessionManagerProtocol, @unchecked Senda
         base.voiceMemoTranscriptionService()
     }
 
-    func assistantFilesLinksRepository(for conversationId: String) -> AssistantFilesLinksRepository {
-        base.assistantFilesLinksRepository(for: conversationId)
+    func agentFilesLinksRepository(for conversationId: String) -> AgentFilesLinksRepository {
+        base.agentFilesLinksRepository(for: conversationId)
+    }
+
+    func agentBuilderSummaryWriter() -> any AgentBuilderSummaryWriterProtocol {
+        base.agentBuilderSummaryWriter()
+    }
+
+    func agentBuilderSummaryRepository() -> any AgentBuilderSummaryRepositoryProtocol {
+        base.agentBuilderSummaryRepository()
+    }
+
+    func thinkingSessionRepository() -> any ThinkingSessionRepositoryProtocol {
+        base.thinkingSessionRepository()
+    }
+
+    func connectionEnablementStore() -> any EnablementStore {
+        base.connectionEnablementStore()
+    }
+
+    func deviceDataSink(for kind: ConnectionKind) -> (any DataSink)? {
+        base.deviceDataSink(for: kind)
+    }
+
+    func joinerPairingService() -> any PairingServiceProtocol {
+        base.joinerPairingService()
+    }
+
+    func refreshAfterPairingCompleted() async {
+        await base.refreshAfterPairingCompleted()
+    }
+
+    func hasAnyUsedConversations() async -> Bool {
+        await base.hasAnyUsedConversations()
+    }
+
+    func commitClaimedConversation(id conversationId: String) async {
+        await base.commitClaimedConversation(id: conversationId)
+    }
+
+    func releaseClaimedConversation(id conversationId: String) async {
+        await base.releaseClaimedConversation(id: conversationId)
+    }
+
+    func discardClaimedConversation(id conversationId: String) async {
+        await base.discardClaimedConversation(id: conversationId)
     }
 
     func pendingInviteDetails() throws -> [PendingInviteDetail] {

--- a/ConvosTests/DeepLinkHandlerTests.swift
+++ b/ConvosTests/DeepLinkHandlerTests.swift
@@ -17,14 +17,14 @@ final class DeepLinkHandlerTests: XCTestCase {
     // MARK: - Connection Grant Deep Links (custom scheme)
 
     func testCustomSchemeConnectionGrant_ParsesServiceAndConversationId() throws {
-        let url = try XCTUnwrap(URL(string: "\(appUrlScheme)://connections/grant?service=google_calendar&conversationId=abc123"))
+        let url = try XCTUnwrap(URL(string: "\(appUrlScheme)://connections/grant?service=googlecalendar&conversationId=abc123"))
         let destination = DeepLinkHandler.destination(for: url)
 
         guard case let .connectionGrant(service, conversationId) = destination else {
             XCTFail("Expected .connectionGrant, got \(String(describing: destination))")
             return
         }
-        XCTAssertEqual(service, "google_calendar")
+        XCTAssertEqual(service, "googlecalendar")
         XCTAssertEqual(conversationId, "abc123")
     }
 
@@ -34,7 +34,7 @@ final class DeepLinkHandlerTests: XCTestCase {
     }
 
     func testCustomSchemeConnectionGrant_MissingConversationIdReturnsNil() throws {
-        let url = try XCTUnwrap(URL(string: "\(appUrlScheme)://connections/grant?service=google_calendar"))
+        let url = try XCTUnwrap(URL(string: "\(appUrlScheme)://connections/grant?service=googlecalendar"))
         XCTAssertNil(DeepLinkHandler.destination(for: url))
     }
 
@@ -49,7 +49,7 @@ final class DeepLinkHandlerTests: XCTestCase {
     }
 
     func testCustomScheme_WrongPathReturnsNil() throws {
-        let url = try XCTUnwrap(URL(string: "\(appUrlScheme)://connections/revoke?service=google_calendar&conversationId=abc123"))
+        let url = try XCTUnwrap(URL(string: "\(appUrlScheme)://connections/revoke?service=googlecalendar&conversationId=abc123"))
         let destination = DeepLinkHandler.destination(for: url)
         if case .connectionGrant = destination {
             XCTFail("Unknown path under connections host should not be parsed as connectionGrant")
@@ -59,19 +59,19 @@ final class DeepLinkHandlerTests: XCTestCase {
     // MARK: - Connection Grant Deep Links (https universal link)
 
     func testHttpsConnectionGrant_ParsesServiceAndConversationId() throws {
-        let url = try XCTUnwrap(URL(string: "https://\(primaryDomain)/connections/grant?service=google_calendar&conversationId=abc123"))
+        let url = try XCTUnwrap(URL(string: "https://\(primaryDomain)/connections/grant?service=googlecalendar&conversationId=abc123"))
         let destination = DeepLinkHandler.destination(for: url)
 
         guard case let .connectionGrant(service, conversationId) = destination else {
             XCTFail("Expected .connectionGrant, got \(String(describing: destination))")
             return
         }
-        XCTAssertEqual(service, "google_calendar")
+        XCTAssertEqual(service, "googlecalendar")
         XCTAssertEqual(conversationId, "abc123")
     }
 
     func testHttpsConnectionGrant_InvalidHostReturnsNil() throws {
-        let url = try XCTUnwrap(URL(string: "https://evil.example.com/connections/grant?service=google_calendar&conversationId=abc"))
+        let url = try XCTUnwrap(URL(string: "https://evil.example.com/connections/grant?service=googlecalendar&conversationId=abc"))
         XCTAssertNil(DeepLinkHandler.destination(for: url))
     }
 
@@ -95,35 +95,35 @@ final class DeepLinkHandlerTests: XCTestCase {
     }
 
     func testKnownServiceIsAccepted() throws {
-        let url = try XCTUnwrap(URL(string: "\(appUrlScheme)://connections/grant?service=google_drive&conversationId=abc123"))
+        let url = try XCTUnwrap(URL(string: "\(appUrlScheme)://connections/grant?service=googledrive&conversationId=abc123"))
         guard case let .connectionGrant(service, conversationId) = DeepLinkHandler.destination(for: url) else {
             XCTFail("Expected .connectionGrant for known service")
             return
         }
-        XCTAssertEqual(service, "google_drive")
+        XCTAssertEqual(service, "googledrive")
         XCTAssertEqual(conversationId, "abc123")
     }
 
     // MARK: - Malicious conversationId
 
     func testConversationIdWithQuotesIsRejected() throws {
-        let url = try XCTUnwrap(URL(string: "\(appUrlScheme)://connections/grant?service=google_calendar&conversationId=abc%27%20OR%201%3D1"))
+        let url = try XCTUnwrap(URL(string: "\(appUrlScheme)://connections/grant?service=googlecalendar&conversationId=abc%27%20OR%201%3D1"))
         XCTAssertNil(DeepLinkHandler.destination(for: url))
     }
 
     func testConversationIdWithPathTraversalIsRejected() throws {
-        let url = try XCTUnwrap(URL(string: "\(appUrlScheme)://connections/grant?service=google_calendar&conversationId=..%2Fetc%2Fpasswd"))
+        let url = try XCTUnwrap(URL(string: "\(appUrlScheme)://connections/grant?service=googlecalendar&conversationId=..%2Fetc%2Fpasswd"))
         XCTAssertNil(DeepLinkHandler.destination(for: url))
     }
 
     func testConversationIdWithSpacesIsRejected() throws {
-        let url = try XCTUnwrap(URL(string: "\(appUrlScheme)://connections/grant?service=google_calendar&conversationId=abc%20123"))
+        let url = try XCTUnwrap(URL(string: "\(appUrlScheme)://connections/grant?service=googlecalendar&conversationId=abc%20123"))
         XCTAssertNil(DeepLinkHandler.destination(for: url))
     }
 
     func testOverlyLongConversationIdIsRejected() throws {
         let longId = String(repeating: "a", count: 600)
-        let url = try XCTUnwrap(URL(string: "\(appUrlScheme)://connections/grant?service=google_calendar&conversationId=\(longId)"))
+        let url = try XCTUnwrap(URL(string: "\(appUrlScheme)://connections/grant?service=googlecalendar&conversationId=\(longId)"))
         XCTAssertNil(DeepLinkHandler.destination(for: url))
     }
 
@@ -199,7 +199,7 @@ final class DeepLinkHandlerTests: XCTestCase {
         // scanned conversation invite keeps routing through the invite
         // path unchanged.
         let url = try XCTUnwrap(
-            URL(string: "\(appUrlScheme)://connections/grant?service=google_calendar&conversationId=abc123")
+            URL(string: "\(appUrlScheme)://connections/grant?service=googlecalendar&conversationId=abc123")
         )
         XCTAssertNil(DeepLinkHandler.agentTemplateId(from: url))
     }
@@ -215,7 +215,7 @@ final class DeepLinkHandlerTests: XCTestCase {
     func testHandleURLDropsUnknownConversationId() throws {
         let knownConversation = Conversation.mock(id: "known-conv")
         let viewModel = ConversationsViewModel.preview(conversations: [knownConversation])
-        let url = try XCTUnwrap(URL(string: "\(appUrlScheme)://connections/grant?service=google_calendar&conversationId=unknown-conv"))
+        let url = try XCTUnwrap(URL(string: "\(appUrlScheme)://connections/grant?service=googlecalendar&conversationId=unknown-conv"))
 
         viewModel.handleURL(url)
 
@@ -227,12 +227,12 @@ final class DeepLinkHandlerTests: XCTestCase {
     func testHandleURLSetsPendingGrantForKnownConversation() throws {
         let knownConversation = Conversation.mock(id: "known-conv")
         let viewModel = ConversationsViewModel.preview(conversations: [knownConversation])
-        let url = try XCTUnwrap(URL(string: "\(appUrlScheme)://connections/grant?service=google_calendar&conversationId=known-conv"))
+        let url = try XCTUnwrap(URL(string: "\(appUrlScheme)://connections/grant?service=googlecalendar&conversationId=known-conv"))
 
         viewModel.handleURL(url)
 
         XCTAssertNotNil(viewModel.pendingGrantRequest)
-        XCTAssertEqual(viewModel.pendingGrantRequest?.serviceId, "google_calendar")
+        XCTAssertEqual(viewModel.pendingGrantRequest?.serviceId, "googlecalendar")
         XCTAssertEqual(viewModel.pendingGrantRequest?.conversationId, "known-conv")
         XCTAssertEqual(viewModel.selectedConversationId, "known-conv")
     }
@@ -252,7 +252,7 @@ final class DeepLinkHandlerTests: XCTestCase {
     func testHandleURLDropsMaliciousConversationId() throws {
         let knownConversation = Conversation.mock(id: "known-conv")
         let viewModel = ConversationsViewModel.preview(conversations: [knownConversation])
-        let url = try XCTUnwrap(URL(string: "\(appUrlScheme)://connections/grant?service=google_calendar&conversationId=abc%27%20OR%201%3D1"))
+        let url = try XCTUnwrap(URL(string: "\(appUrlScheme)://connections/grant?service=googlecalendar&conversationId=abc%27%20OR%201%3D1"))
 
         viewModel.handleURL(url)
 

--- a/ConvosTests/GlobalConvoDefaultsTests.swift
+++ b/ConvosTests/GlobalConvoDefaultsTests.swift
@@ -15,7 +15,7 @@ final class GlobalConvoDefaultsTests: XCTestCase {
 
     func testDefaultValuesWhenUnset() {
         XCTAssertTrue(GlobalConvoDefaults.shared.autoRevealPhotos)
-        XCTAssertFalse(GlobalConvoDefaults.shared.includeInfoWithInvites)
+        XCTAssertTrue(GlobalConvoDefaults.shared.includeInfoWithInvites)
     }
 
     func testPersistsUpdatedValues() {
@@ -27,12 +27,12 @@ final class GlobalConvoDefaultsTests: XCTestCase {
     }
 
     func testResetRestoresDefaults() {
-        GlobalConvoDefaults.shared.autoRevealPhotos = true
+        GlobalConvoDefaults.shared.autoRevealPhotos = false
         GlobalConvoDefaults.shared.includeInfoWithInvites = false
 
         GlobalConvoDefaults.shared.reset()
 
         XCTAssertTrue(GlobalConvoDefaults.shared.autoRevealPhotos)
-        XCTAssertFalse(GlobalConvoDefaults.shared.includeInfoWithInvites)
+        XCTAssertTrue(GlobalConvoDefaults.shared.includeInfoWithInvites)
     }
 }

--- a/ConvosTests/ProfileSettingsViewModelTests.swift
+++ b/ConvosTests/ProfileSettingsViewModelTests.swift
@@ -17,8 +17,10 @@ final class ProfileSettingsViewModelTests: XCTestCase {
 
     override func tearDown() {
         UserDefaults.standard.removeObject(forKey: "hasShownProfileEditor")
-        ProfileSettingsViewModel.shared.editingDisplayName = ""
-        ProfileSettingsViewModel.shared.profileImage = nil
+        MainActor.assumeIsolated {
+            ProfileSettingsViewModel.shared.editingDisplayName = ""
+            ProfileSettingsViewModel.shared.profileImage = nil
+        }
         super.tearDown()
     }
 


### PR DESCRIPTION
## Summary

The `ConvosTests` app-unit-test target had bit-rotted on `dev` — it referenced APIs that were renamed or moved and predated tighter concurrency checking, so the **whole target failed to build** and therefore never ran. (Gating CI runs the ConvosCore SPM suite, so this went unnoticed.) This repairs the target end-to-end.

Result: **`ConvosTests` 145 pass, 0 fail.**

## Compile fixes

- **`TestSessionManager`** (a forwarding wrapper duplicated in `ConversationViewModelGlobalDefaultsTests` and `ConversationsViewModelDeleteTests`): dropped the removed `redeemInviteCode` / `fetchInviteCodeStatus` wrappers; renamed `assistantFilesLinksRepository` → `agentFilesLinksRepository`; added the 11 forwarders `SessionManagerProtocol` gained (agent-builder, device-pairing, claimed-conversation); updated `requestAgentJoin` to its new `options:` parameter. Added the `ConvosConnections` import for `EnablementStore` / `ConnectionKind` / `DataSink`.
- **`ContactCardModeTests` → `ContactDetailModeTests`**: `ContactCardMode` was renamed to `ContactDetailMode`; repointed the test (preserving coverage) instead of deleting it.
- **`ContactsPickerViewModelTests` / `ProfileSettingsViewModelTests`**: resolved main-actor isolation errors in the nonisolated XCTest `tearDown`.

## Runtime-failure fixes

Once the target ran, 7 tests failed because they asserted behavior the app had moved past. None indicated a real regression; tests updated to current behavior:

- **`GlobalConvoDefaultsTests`**: `includeInfoWithInvites` now defaults to `true` (app reads `?? true`); updated the default-value assertions, and pre-set `autoRevealPhotos = false` in the reset test so reset is actually exercised.
- **`DeepLinkHandlerTests`** (4): the connection-grant allowlist (`CloudConnectionServiceCatalog`) canonicalized service ids to `googlecalendar` / `googledrive` (no underscores); replaced `google_calendar` / `google_drive` throughout — which also makes the malicious-conversationId cases exercise the id check instead of short-circuiting on an unknown service.
- **`ConversationOnboardingCoordinatorTests`**: the coordinator reads the `ProfileSettingsViewModel.shared` singleton; reset it in `setUp` so a non-default profile left by another test can't push `start()` down the auto-apply branch and trip the per-conversation-flag precondition (test pollution surfaced now that the suite runs).

## Testing

- `xcodebuild test -only-testing:ConvosTests`: **145 passed, 0 failed**.
- SwiftLint clean on all changed files.

All changes are test-target-only; no app/source code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix compilation of the ConvosTests target
> - Updates `ContactDetailModeTests` to use `ContactDetailMode` (renamed from `ContactCardMode`) and adds required `invitedBy` and `joinedAt` parameters to `scopedToConversation` test calls.
> - Updates `TestSessionManager` mocks in multiple test files to conform to the expanded `SessionManagerProtocol`, adding forwarding stubs for new methods and renaming `assistantFilesLinksRepository` to `agentFilesLinksRepository`.
> - Fixes Swift concurrency issues: marks `cancellables` as `nonisolated(unsafe)` in `ContactsPickerViewModelTests` and wraps `ProfileSettingsViewModel` teardown mutations in `MainActor.assumeIsolated`.
> - Updates `DeepLinkHandlerTests` to assert normalized (no-underscore) service IDs for connection grant deep links.
> - Updates `GlobalConvoDefaultsTests` to expect `includeInfoWithInvites` to default to `true`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4f2a108.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->