### PR TITLE
feat: share button makes templates publicly accessible and enables sharing publishedUrls on agents built in app

### DIFF
--- a/Convos/Contacts/AgentTemplateContactCardView.swift
+++ b/Convos/Contacts/AgentTemplateContactCardView.swift
@@ -1,5 +1,6 @@
 import ConvosCore
 import SwiftUI
+import UIKit
 
 /// Standalone contact card for a template-backed agent, opened by tapping
 /// an agent row in the contacts list.
@@ -11,6 +12,11 @@ import SwiftUI
 ///
 /// Actions:
 ///   - Share - the iOS share sheet seeded with the template `publishedUrl`.
+///     If the contact does not yet carry a `publishedURL` (builder-flow
+///     templates land on the device without one), the row instead drives a
+///     PATCH /api/v2/agent-templates/:id flipping the template to
+///     `published`, persists the returned URL onto the contact, and
+///     auto-presents the share sheet.
 ///   - Pop up a convo - spawns a fresh instance via a local
 ///     `NewConversationViewModel` presentation, same path the chat-side
 ///     agent card uses (`ContactDetailView.handleChatWithAgentTemplate`).
@@ -26,6 +32,16 @@ struct AgentTemplateContactCardView: View {
     @State private var presentingRemoveConfirmation: Bool = false
     @State private var isRemoving: Bool = false
     @State private var presentingNewConvo: NewConversationViewModel?
+
+    // Share / publish state. `resolvedShareURL` is seeded from the contact's
+    // published URL on appear and updated locally after a successful publish
+    // so the row flips from publish-and-share to plain share without
+    // waiting for the next contact sync.
+    @State private var resolvedShareURL: URL?
+    @State private var isPublishing: Bool = false
+    @State private var isShareSheetPresented: Bool = false
+    @State private var publishErrorMessage: String?
+
     @Environment(\.dismiss) private var dismiss: DismissAction
 
     init(
@@ -41,16 +57,28 @@ struct AgentTemplateContactCardView: View {
     }
 
     var body: some View {
+        let isPublishErrorPresented: Binding<Bool> = Binding(
+            get: { publishErrorMessage != nil },
+            set: { newValue in
+                if !newValue { publishErrorMessage = nil }
+            }
+        )
         bodyContent
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .background(.colorBackgroundRaisedSecondary)
             .navigationTitle("")
             .navigationBarTitleDisplayMode(.inline)
+            .onAppear(perform: seedShareURLIfNeeded)
             .alert(removeAlertTitle, isPresented: $presentingRemoveConfirmation) {
                 Button("Cancel", role: .cancel) {}
                 Button("Remove", role: .destructive, action: handleRemoveConfirmed)
             } message: {
                 Text(removeAlertMessage)
+            }
+            .alert("Couldn't share", isPresented: isPublishErrorPresented) {
+                Button("OK", role: .cancel) {}
+            } message: {
+                Text(publishErrorMessage ?? "")
             }
             .sheet(item: $presentingNewConvo) { vm in
                 NewConversationView(
@@ -59,6 +87,17 @@ struct AgentTemplateContactCardView: View {
                 )
                 .background(.colorBackgroundSurfaceless)
             }
+            .background(shareSheetPresenter)
+    }
+
+    @ViewBuilder
+    private var shareSheetPresenter: some View {
+        if let url = resolvedShareURL {
+            ShareSheetPresenter(
+                activityItems: [url],
+                isPresented: $isShareSheetPresented
+            )
+        }
     }
 
     @ViewBuilder
@@ -98,12 +137,7 @@ struct AgentTemplateContactCardView: View {
     @ViewBuilder
     private var actions: some View {
         VStack(spacing: DesignConstants.Spacing.step4x) {
-            if let shareURL {
-                ContactDetailShareRow(
-                    url: shareURL,
-                    contactDisplayName: agentTemplateContact.resolvedDisplayName
-                )
-            }
+            shareRow
             ContactDetailActionRow(
                 label: "Pop up a convo",
                 footer: "Start a new convo with \(agentTemplateContact.resolvedDisplayName)",
@@ -127,8 +161,36 @@ struct AgentTemplateContactCardView: View {
         .padding(.top, DesignConstants.Spacing.step4x)
     }
 
-    private var shareURL: URL? {
-        agentTemplateContact.publishedURL.flatMap { URL(string: $0) }
+    @ViewBuilder
+    private var shareRow: some View {
+        if let url = resolvedShareURL {
+            ContactDetailShareRow(
+                url: url,
+                contactDisplayName: agentTemplateContact.resolvedDisplayName
+            )
+        } else {
+            // Two-state share button: the "Share" label stays the same so a
+            // user who has seen the published-state row recognises this row
+            // as the share affordance. The footer carries the differentiator
+            // - it hints at the publish step (which needs network), so a
+            // user on a flaky connection sees the cause if it fails.
+            let publishLabel: String = isPublishing ? "Sharing..." : "Share"
+            let publishFooter: String = "Publish to share a link adding \(agentTemplateContact.resolvedDisplayName) to a convo"
+            ContactDetailActionRow(
+                label: publishLabel,
+                footer: publishFooter,
+                color: .colorTextPrimary,
+                isDisabled: isPublishing || session == nil,
+                accessibilityLabel: "Publish and share \(agentTemplateContact.resolvedDisplayName)",
+                accessibilityIdentifier: "agent-template-card-publish-share",
+                action: handlePublishAndShare
+            )
+        }
+    }
+
+    private func seedShareURLIfNeeded() {
+        guard resolvedShareURL == nil else { return }
+        resolvedShareURL = agentTemplateContact.publishedURL.flatMap { URL(string: $0) }
     }
 
     private var removeAlertTitle: String {
@@ -152,6 +214,53 @@ struct AgentTemplateContactCardView: View {
         )
     }
 
+    private func handlePublishAndShare() {
+        guard !isPublishing, let session else { return }
+        let templateId = agentTemplateContact.templateId
+        isPublishing = true
+        Task { @MainActor in
+            defer { isPublishing = false }
+            do {
+                let template = try await session.publishAgentTemplate(id: templateId)
+                guard let urlString = template.publishedUrl,
+                      let url = URL(string: urlString) else {
+                    Log.error("publishAgentTemplate returned no publishedUrl for templateId=\(templateId), status=\(template.status), urlString=\(template.publishedUrl ?? "<nil>")")
+                    publishErrorMessage = "Couldn't share right now, try again."
+                    return
+                }
+                await persistPublishedURL(urlString)
+                resolvedShareURL = url
+                isShareSheetPresented = true
+            } catch {
+                Log.error("publishAgentTemplate failed for templateId=\(templateId): \(String(describing: error))")
+                publishErrorMessage = "Couldn't share right now, try again."
+            }
+        }
+    }
+
+    private func persistPublishedURL(_ urlString: String) async {
+        let snapshot = AgentTemplateContactSnapshot(
+            displayName: agentTemplateContact.displayName,
+            emoji: agentTemplateContact.emoji,
+            descriptionText: agentTemplateContact.descriptionText,
+            publishedURL: urlString,
+            avatarURL: agentTemplateContact.avatarURL,
+            agentVerification: agentTemplateContact.agentVerification,
+            profileUpdatedAt: Date()
+        )
+        do {
+            try await agentTemplateContactsWriter.upsert(
+                templateId: agentTemplateContact.templateId,
+                addedViaConversationId: agentTemplateContact.addedViaConversationId,
+                profile: snapshot
+            )
+        } catch {
+            // Persistence is a UX optimization; the in-memory
+            // `resolvedShareURL` still drives the rest of this session.
+            Log.error("Failed to persist publishedURL for templateId=\(agentTemplateContact.templateId): \(error.localizedDescription)")
+        }
+    }
+
     private func handleRemoveTap() {
         presentingRemoveConfirmation = true
     }
@@ -172,7 +281,46 @@ struct AgentTemplateContactCardView: View {
     }
 }
 
-#Preview("Agent template card") {
+/// Thin UIActivityViewController wrapper for presenting the system share
+/// sheet imperatively after the publish API call returns. Mirrors the
+/// `ShareSheetPresenter` in `ConversationShareView.swift`; kept file-local
+/// here so the agent-template card doesn't depend on the conversation
+/// share overlay's other state.
+private struct ShareSheetPresenter: UIViewControllerRepresentable {
+    let activityItems: [Any]
+    @Binding var isPresented: Bool
+
+    func makeUIViewController(context: Context) -> UIViewController {
+        UIViewController()
+    }
+
+    func updateUIViewController(_ uiViewController: UIViewController, context: Context) {
+        guard isPresented, uiViewController.presentedViewController == nil else { return }
+        let activityVC = UIActivityViewController(
+            activityItems: activityItems,
+            applicationActivities: nil
+        )
+
+        if let popover = activityVC.popoverPresentationController {
+            popover.sourceView = uiViewController.view
+            popover.sourceRect = CGRect(
+                x: uiViewController.view.bounds.midX,
+                y: uiViewController.view.bounds.maxY,
+                width: 0,
+                height: 0
+            )
+            popover.permittedArrowDirections = .up
+        }
+
+        activityVC.completionWithItemsHandler = { _, _, _, _ in
+            isPresented = false
+        }
+
+        uiViewController.present(activityVC, animated: true)
+    }
+}
+
+#Preview("Agent template card - published") {
     NavigationStack {
         AgentTemplateContactCardView(
             agentTemplateContact: .mock(
@@ -180,6 +328,20 @@ struct AgentTemplateContactCardView: View {
                 emoji: "🚴",
                 descriptionText: "Pro cycling expert and race-day strategist.",
                 publishedURL: "https://agents-dev.convos.org/tifoso.pnw1o"
+            ),
+            agentTemplateContactsWriter: MockAgentTemplateContactsWriter()
+        )
+    }
+}
+
+#Preview("Agent template card - unpublished") {
+    NavigationStack {
+        AgentTemplateContactCardView(
+            agentTemplateContact: .mock(
+                displayName: "Tifoso",
+                emoji: "🚴",
+                descriptionText: "Pro cycling expert and race-day strategist.",
+                publishedURL: nil
             ),
             agentTemplateContactsWriter: MockAgentTemplateContactsWriter()
         )

--- a/Convos/Contacts/ContactDetailView.swift
+++ b/Convos/Contacts/ContactDetailView.swift
@@ -1,5 +1,6 @@
 import ConvosCore
 import SwiftUI
+import UIKit
 
 // MARK: - Module overview
 //
@@ -62,6 +63,16 @@ struct ContactDetailView: View {
     @State private var sendMessageErrorMessage: String?
     @State private var presentingNewConvo: NewConversationViewModel?
 
+    // Agent-template share / publish state. `resolvedAgentTemplateShareURL`
+    // is seeded from `contact.agentTemplatePublishedURL` on appear and
+    // updated locally after a successful publish so the row flips from
+    // publish-and-share to plain share without waiting for the next
+    // contact-profile sync.
+    @State private var resolvedAgentTemplateShareURL: URL?
+    @State private var isPublishingAgentTemplate: Bool = false
+    @State private var isAgentTemplateShareSheetPresented: Bool = false
+    @State private var publishAgentTemplateErrorMessage: String?
+
     init(
         contact: Contact,
         mode: ContactDetailMode = .standalone,
@@ -103,6 +114,12 @@ struct ContactDetailView: View {
                 blockAlertActions: { blockAlertActions },
                 pickerSheet: { pickerSheet }
             ))
+            .modifier(ContactDetailShareModifier(
+                shareURL: resolvedAgentTemplateShareURL,
+                isShareSheetPresented: $isAgentTemplateShareSheetPresented,
+                publishErrorMessage: $publishAgentTemplateErrorMessage,
+                onAppearSeed: seedAgentTemplateShareURLIfNeeded
+            ))
             .sheet(item: $presentingNewConvo) { vm in
                 NewConversationView(
                     viewModel: vm,
@@ -111,6 +128,46 @@ struct ContactDetailView: View {
                 .background(.colorBackgroundSurfaceless)
             }
             .task(id: contact.inboxId) { await syncBlockedState() }
+    }
+
+    /// Seeds the in-memory share URL from the freshest source available.
+    /// Order:
+    ///   1. `contact.agentTemplatePublishedURL` - overlaid from the
+    ///      per-conversation member profile by `Contact.resolved(...)`. The
+    ///      authoritative source, but lags until the agent broadcasts its
+    ///      updated profile and the local membership sync runs.
+    ///   2. The cached `DBAgentTemplateContact.publishedURL` row, written
+    ///      by any prior publish-on-share flow (this view's own previous
+    ///      invocation or the standalone agent-template contact card).
+    ///      Lets the share row skip the POST until the member profile
+    ///      catches up.
+    /// If both miss, the share row stays in publish-and-share mode and the
+    /// next tap drives the POST.
+    private func seedAgentTemplateShareURLIfNeeded() {
+        guard resolvedAgentTemplateShareURL == nil else { return }
+
+        if let urlString = contact.agentTemplatePublishedURL,
+           let url = URL(string: urlString) {
+            resolvedAgentTemplateShareURL = url
+            return
+        }
+
+        guard let templateId = contact.agentTemplateId,
+              !templateId.isEmpty,
+              let session else {
+            return
+        }
+        do {
+            let cached = try session.messagingService()
+                .agentTemplateContactsRepository()
+                .fetchContact(templateId: templateId)
+            if let cachedURLString = cached?.publishedURL,
+               let url = URL(string: cachedURLString) {
+                resolvedAgentTemplateShareURL = url
+            }
+        } catch {
+            Log.error("Failed to read agent-template contact cache for templateId=\(templateId): \(String(describing: error))")
+        }
     }
 
     @ToolbarContentBuilder
@@ -166,11 +223,15 @@ struct ContactDetailView: View {
                     showBlock: !mode.isCurrentUser,
                     contactDisplayName: contact.resolvedDisplayName,
                     agentTemplateShareURL: agentTemplateShareURL,
+                    agentTemplateId: contact.agentTemplateId,
+                    isPublishingAgentTemplate: isPublishingAgentTemplate,
+                    canPublishAgentTemplate: session != nil,
                     agentInstanceId: contact.agentInstanceId,
                     showsInstanceIdRow: showsInstanceIdRow,
                     agentAttestation: contact.agentAttestation,
                     agentVerification: contact.agentVerification,
                     onSendMessage: isAgentTemplate ? handleChatWithAgentTemplate : handleSendMessage,
+                    onPublishAndShareAgentTemplate: handlePublishAndShareAgentTemplate,
                     onRemove: handleRemoveTap,
                     onToggleBlock: handleBlockTap
                 )
@@ -200,10 +261,14 @@ struct ContactDetailView: View {
     }
 
     /// The template share link for a template-backed agent, ready for the
-    /// Share row's `ShareLink`. `nil` for human contacts and for agents
-    /// without a published template, which hides the row.
+    /// Share row's `ShareLink`. Driven by `resolvedAgentTemplateShareURL`
+    /// (seeded from `contact.agentTemplatePublishedURL` on appear) so a
+    /// successful publish-on-tap flow flips the row in place. `nil` for
+    /// human contacts and for agent templates that have not been published
+    /// yet (in that case the share row falls back to a publish-and-share
+    /// action driven by `agentTemplateId`).
     private var agentTemplateShareURL: URL? {
-        contact.agentTemplatePublishedURL.flatMap { URL(string: $0) }
+        resolvedAgentTemplateShareURL
     }
 
     /// True on Dev/Local builds. Controls visibility of the instance id
@@ -437,6 +502,69 @@ struct ContactDetailView: View {
         )
     }
 
+    /// Tap handler for the publish-and-share row that fires when the
+    /// template-backed agent does not yet carry a `publishedUrl`. Calls
+    /// PATCH /api/v2/agent-templates/:id to flip the status to
+    /// `published`, then presents the system share sheet with the returned
+    /// URL. The URL is also persisted via the messaging service's
+    /// agent-template writer when one is reachable so a subsequent visit
+    /// (or the standalone agent-template contact card) gets the cached
+    /// `ContactDetailShareRow` path. Persistence failures are logged but
+    /// non-fatal - the in-memory `resolvedAgentTemplateShareURL` still
+    /// drives the share sheet.
+    private func handlePublishAndShareAgentTemplate() {
+        guard !isPublishingAgentTemplate,
+              let session,
+              let templateId = contact.agentTemplateId else {
+            return
+        }
+        isPublishingAgentTemplate = true
+        Task { @MainActor in
+            defer { isPublishingAgentTemplate = false }
+            do {
+                let template = try await session.publishAgentTemplate(id: templateId)
+                guard let urlString = template.publishedUrl,
+                      let url = URL(string: urlString) else {
+                    Log.error("publishAgentTemplate returned no publishedUrl for templateId=\(templateId), status=\(template.status), urlString=\(template.publishedUrl ?? "<nil>")")
+                    publishAgentTemplateErrorMessage = "Couldn't share right now, try again."
+                    return
+                }
+                await persistAgentTemplatePublishedURL(urlString, templateId: templateId, session: session)
+                resolvedAgentTemplateShareURL = url
+                isAgentTemplateShareSheetPresented = true
+            } catch {
+                Log.error("publishAgentTemplate failed for templateId=\(templateId): \(String(describing: error))")
+                publishAgentTemplateErrorMessage = "Couldn't share right now, try again."
+            }
+        }
+    }
+
+    private func persistAgentTemplatePublishedURL(
+        _ urlString: String,
+        templateId: String,
+        session: any SessionManagerProtocol
+    ) async {
+        let writer = session.messagingService().agentTemplateContactsWriter()
+        let snapshot = AgentTemplateContactSnapshot(
+            displayName: contact.displayName,
+            emoji: nil,
+            descriptionText: nil,
+            publishedURL: urlString,
+            avatarURL: contact.avatarURL,
+            agentVerification: contact.agentVerification,
+            profileUpdatedAt: Date()
+        )
+        do {
+            try await writer.upsert(
+                templateId: templateId,
+                addedViaConversationId: contact.addedViaConversationId ?? mode.conversationId,
+                profile: snapshot
+            )
+        } catch {
+            Log.error("Failed to persist publishedURL for templateId=\(templateId): \(error.localizedDescription)")
+        }
+    }
+
     private func syncBlockedState() async {
         do {
             guard let updated = try contactsRepository.fetchContact(inboxId: contact.inboxId) else {
@@ -532,8 +660,22 @@ private struct ContactDetailActions: View {
     let showRemove: Bool
     let showBlock: Bool
     let contactDisplayName: String
-    /// Non-nil only for template-backed agents; drives the Share row.
+    /// Non-nil when the template-backed agent has a `publishedUrl`. Drives
+    /// the plain `ContactDetailShareRow` (ShareLink) branch of the share
+    /// row. `nil` for human contacts, and for templated agents that
+    /// haven't been published yet (in which case `agentTemplateId` drives
+    /// the publish-and-share branch).
     let agentTemplateShareURL: URL?
+    /// Non-nil for template-backed agents. Enables the publish-and-share
+    /// branch of the share row when the template doesn't yet carry a
+    /// `publishedUrl`. `nil` for human contacts (no share row shown).
+    let agentTemplateId: String?
+    /// In-flight flag for the publish-and-share row. Drives the disabled
+    /// state and the "Sharing..." label while the PATCH is running.
+    let isPublishingAgentTemplate: Bool
+    /// Disables the publish-and-share row when the parent has no session
+    /// (no auth, no api client). Mirrors the existing Chat-row gate.
+    let canPublishAgentTemplate: Bool
     /// Always plumbed through when the contact has one. Display gate
     /// is `showsInstanceIdRow`, not nullability of this field.
     let agentInstanceId: String?
@@ -546,6 +688,7 @@ private struct ContactDetailActions: View {
     /// readout alongside the raw attestation value.
     let agentVerification: AgentVerification?
     let onSendMessage: () -> Void
+    let onPublishAndShareAgentTemplate: () -> Void
     let onRemove: () -> Void
     let onToggleBlock: () -> Void
 
@@ -556,12 +699,7 @@ private struct ContactDetailActions: View {
             if showChat {
                 chatButton
             }
-            if let agentTemplateShareURL {
-                ContactDetailShareRow(
-                    url: agentTemplateShareURL,
-                    contactDisplayName: contactDisplayName
-                )
-            }
+            agentTemplateShareRow
             if showAgentLinks {
                 agentLinkRows
             }
@@ -587,6 +725,42 @@ private struct ContactDetailActions: View {
             #endif
         }
         .padding(.horizontal, DesignConstants.Spacing.step4x)
+    }
+
+    /// Renders the agent-template share row in one of three shapes:
+    ///   - If the template already has a `publishedUrl`, a SwiftUI
+    ///     `ShareLink` (`ContactDetailShareRow`) wired straight to the URL.
+    ///   - If the agent is template-backed but has no published URL yet, a
+    ///     publish-and-share `ContactDetailActionRow` that drives the
+    ///     PATCH-then-share flow in the parent. Shows "Sharing..." while
+    ///     the PATCH is in flight.
+    ///   - Otherwise (human contact, or templated agent with no session
+    ///     access) renders nothing.
+    @ViewBuilder
+    private var agentTemplateShareRow: some View {
+        if let url = agentTemplateShareURL {
+            ContactDetailShareRow(
+                url: url,
+                contactDisplayName: contactDisplayName
+            )
+        } else if let agentTemplateId, !agentTemplateId.isEmpty {
+            // Two-state share button. Label stays "Share" to match the
+            // published-state row's affordance; the footer carries the
+            // differentiator and hints at the publish step (which needs
+            // network), so a user on a flaky connection sees the cause if
+            // it fails.
+            let publishLabel: String = isPublishingAgentTemplate ? "Sharing..." : "Share"
+            let publishFooter: String = "Publish to share a link adding \(contactDisplayName) to a convo"
+            ContactDetailActionRow(
+                label: publishLabel,
+                footer: publishFooter,
+                color: .colorTextPrimary,
+                isDisabled: isPublishingAgentTemplate || !canPublishAgentTemplate,
+                accessibilityLabel: "Publish and share \(contactDisplayName)",
+                accessibilityIdentifier: "contact-detail-publish-share",
+                action: onPublishAndShareAgentTemplate
+            )
+        }
     }
 
     @ViewBuilder
@@ -898,6 +1072,84 @@ private struct ContactDetailModalsModifier<
             .sheet(isPresented: $presentingPicker) {
                 pickerSheet()
             }
+    }
+}
+
+/// Modifier wrapping the agent-template share concerns: the activity-sheet
+/// presenter (driven by `shareURL` + `isShareSheetPresented`) and the
+/// "Couldn't share" alert. Split out from `ContactDetailModalsModifier` so
+/// the share concerns don't leak into the generic Block / Picker /
+/// SendMessage modifier shape.
+private struct ContactDetailShareModifier: ViewModifier {
+    let shareURL: URL?
+    @Binding var isShareSheetPresented: Bool
+    @Binding var publishErrorMessage: String?
+    let onAppearSeed: () -> Void
+
+    func body(content: Content) -> some View {
+        let isErrorPresented: Binding<Bool> = Binding(
+            get: { publishErrorMessage != nil },
+            set: { newValue in
+                if !newValue { publishErrorMessage = nil }
+            }
+        )
+        content
+            .background(shareSheetBackground)
+            .alert("Couldn't share", isPresented: isErrorPresented) {
+                Button("OK", role: .cancel) {}
+            } message: {
+                Text(publishErrorMessage ?? "")
+            }
+            .onAppear(perform: onAppearSeed)
+    }
+
+    @ViewBuilder
+    private var shareSheetBackground: some View {
+        if let shareURL {
+            ShareSheetPresenter(
+                activityItems: [shareURL],
+                isPresented: $isShareSheetPresented
+            )
+        }
+    }
+}
+
+/// Thin UIActivityViewController wrapper for presenting the system share
+/// sheet imperatively after the publish-and-share PATCH returns. Mirrors
+/// the same-named struct in `ConversationShareView.swift` and
+/// `AgentTemplateContactCardView.swift`; kept file-local here so this view
+/// doesn't depend on either of those.
+private struct ShareSheetPresenter: UIViewControllerRepresentable {
+    let activityItems: [Any]
+    @Binding var isPresented: Bool
+
+    func makeUIViewController(context: Context) -> UIViewController {
+        UIViewController()
+    }
+
+    func updateUIViewController(_ uiViewController: UIViewController, context: Context) {
+        guard isPresented, uiViewController.presentedViewController == nil else { return }
+        let activityVC = UIActivityViewController(
+            activityItems: activityItems,
+            applicationActivities: nil
+        )
+
+        if let popover = activityVC.popoverPresentationController {
+            popover.sourceView = uiViewController.view
+            popover.sourceRect = CGRect(
+                x: uiViewController.view.bounds.midX,
+                y: uiViewController.view.bounds.maxY,
+                width: 0,
+                height: 0
+            )
+            popover.permittedArrowDirections = .up
+        }
+
+        activityVC.completionWithItemsHandler = { _, _, _, _ in
+            isPresented = false
+        }
+
+        uiViewController.present(activityVC, animated: true)
     }
 }
 

--- a/Convos/Contacts/ContactDetailView.swift
+++ b/Convos/Contacts/ContactDetailView.swift
@@ -539,29 +539,65 @@ struct ContactDetailView: View {
         }
     }
 
+    /// Caches the freshly-published `publishedUrl` onto the local
+    /// `DBAgentTemplateContact` row so the next visit to this template
+    /// (here or in the standalone agent-template card) seeds the share
+    /// row without re-POSTing.
+    ///
+    /// Two safety properties this method has to preserve:
+    ///
+    /// 1. Do not nil out other profile fields. `Contact` doesn't carry the
+    ///    template's `emoji` or `descriptionText`, and a timestamped
+    ///    `AgentTemplateContactSnapshot` wholesale-replaces every field on
+    ///    the row (see `AgentTemplateContactsWriter.replacingProfile`). A
+    ///    naive `upsert` with `emoji: nil, descriptionText: nil` would
+    ///    wipe values written by the standalone card's prior upsert.
+    ///    Instead, read the existing row and re-pass every field through
+    ///    the snapshot unchanged, only swapping in `publishedURL`.
+    ///
+    /// 2. Do not auto-add a contact. If the agent has no row in
+    ///    `DBAgentTemplateContact`, the user has never opened the
+    ///    standalone agent-template card for this template, so we
+    ///    shouldn't promote them into the user's agent-template contacts
+    ///    as a side effect of tapping Share. Skip the write; the in-memory
+    ///    `resolvedAgentTemplateShareURL` covers this view session, and a
+    ///    future open of the standalone card (which has the full profile
+    ///    to hand) will populate the row properly. Repeat shares from a
+    ///    fresh `ContactDetailView` pay the POST cost again, which is
+    ///    idempotent and cheap.
     private func persistAgentTemplatePublishedURL(
         _ urlString: String,
         templateId: String,
         session: any SessionManagerProtocol
     ) async {
+        let repository = session.messagingService().agentTemplateContactsRepository()
+        let existing: AgentTemplateContact?
+        do {
+            existing = try repository.fetchContact(templateId: templateId)
+        } catch {
+            Log.error("Failed to read existing agent-template contact for templateId=\(templateId): \(String(describing: error))")
+            return
+        }
+        guard let existing else { return }
+
         let writer = session.messagingService().agentTemplateContactsWriter()
         let snapshot = AgentTemplateContactSnapshot(
-            displayName: contact.displayName,
-            emoji: nil,
-            descriptionText: nil,
+            displayName: existing.displayName,
+            emoji: existing.emoji,
+            descriptionText: existing.descriptionText,
             publishedURL: urlString,
-            avatarURL: contact.avatarURL,
-            agentVerification: contact.agentVerification,
+            avatarURL: existing.avatarURL,
+            agentVerification: existing.agentVerification,
             profileUpdatedAt: Date()
         )
         do {
             try await writer.upsert(
                 templateId: templateId,
-                addedViaConversationId: contact.addedViaConversationId ?? mode.conversationId,
+                addedViaConversationId: existing.addedViaConversationId,
                 profile: snapshot
             )
         } catch {
-            Log.error("Failed to persist publishedURL for templateId=\(templateId): \(error.localizedDescription)")
+            Log.error("Failed to persist publishedURL for templateId=\(templateId): \(String(describing: error))")
         }
     }
 

--- a/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient+Models.swift
+++ b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient+Models.swift
@@ -206,6 +206,25 @@ public enum ConvosAPI {
         }
     }
 
+    // MARK: - v2/agent-templates/:id
+    // Subset of the agent-template object the backend returns from the
+    // agent-template endpoints (POST /:id/publish, PATCH /:id, GET /:id).
+    // We only model the fields the share flow consumes today (id, status,
+    // publishedUrl); decoding is tolerant of extra keys via the default
+    // Codable behavior.
+
+    public struct AgentTemplate: Codable, Sendable {
+        public let id: String
+        public let status: String
+        public let publishedUrl: String?
+
+        public init(id: String, status: String, publishedUrl: String?) {
+            self.id = id
+            self.status = status
+            self.publishedUrl = publishedUrl
+        }
+    }
+
     // MARK: - Common Error Response
 
     public struct ErrorResponse: Codable {

--- a/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift
+++ b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift
@@ -90,6 +90,12 @@ public protocol ConvosAPIClientProtocol: AnyObject, Sendable {
         forceErrorCode: Int?
     ) async throws -> ConvosAPI.AgentJoinResponse
 
+    // Agent templates
+    /// PATCH /api/v2/agent-templates/:id flipping status to "published" so
+    /// the backend hands back a non-null `publishedUrl`. The share flow on
+    /// builder-created templates calls this lazily on first tap.
+    func publishAgentTemplate(id: String) async throws -> ConvosAPI.AgentTemplate
+
     // Connections
     func initiateCloudConnection(serviceId: String, redirectUri: String) async throws -> CloudConnectionsAPI.InitiateResponse
     func completeCloudConnection(connectionRequestId: String) async throws -> CloudConnectionsAPI.CompleteResponse
@@ -743,6 +749,76 @@ final class ConvosAPIClient: ConvosAPIClientProtocol, Sendable {
             throw APIError.templateArchived
         default:
             throw APIError.serverError(parseErrorMessage(from: data))
+        }
+    }
+
+    // MARK: - Agent templates
+
+    /// Publishes an agent template so the backend hands back a non-null
+    /// `publishedUrl`. Hits POST /:id/publish?status=published, which is
+    /// the documented first-publish path for a `draft` row and the
+    /// idempotent re-publish path for an already-first-published row
+    /// (`unlisted` / `published` / `archived`). Both branches return the
+    /// same serialized template shape with a populated `publishedUrl`, so
+    /// the caller doesn't care which branch the backend took.
+    ///
+    /// We don't PATCH the status here: PATCH is the only way to flip
+    /// `unlisted` -> `published`, but for the iOS share flow the share URL
+    /// works whether the row is `unlisted` or `published`. Promoting
+    /// unlisted to published is a directory-visibility change, not a
+    /// shareability change, and isn't part of the share button's intent.
+    func publishAgentTemplate(id: String) async throws -> ConvosAPI.AgentTemplate {
+        let path: String = "v2/agent-templates/\(id)/publish"
+        var request: URLRequest
+        do {
+            request = try authenticatedRequest(
+                for: path,
+                method: "POST",
+                queryParameters: ["status": "published"]
+            )
+        } catch {
+            Log.error("publishAgentTemplate failed to build POST request for path=\(path), baseURL=\(baseURL.absoluteString): \(String(describing: error))")
+            throw error
+        }
+        // POST /publish takes no body; the backend reads `status` from the
+        // query string when present.
+        Log.info("publishAgentTemplate POST \(request.url?.absoluteString ?? "<nil>")")
+
+        let (data, httpResponse) = try await performAuthenticatedRequest(request)
+        return try decodeAgentTemplateResponse(
+            data: data,
+            httpResponse: httpResponse,
+            id: id
+        )
+    }
+
+    private func decodeAgentTemplateResponse(
+        data: Data,
+        httpResponse: HTTPURLResponse,
+        id: String
+    ) throws -> ConvosAPI.AgentTemplate {
+        switch httpResponse.statusCode {
+        case 200...299:
+            do {
+                return try JSONDecoder().decode(ConvosAPI.AgentTemplate.self, from: data)
+            } catch {
+                Log.error("publishAgentTemplate decode failed: \(String(describing: error)) body=\(data.prettyPrintedJSONString ?? "<nil>")")
+                throw error
+            }
+        case 400:
+            let message = parseErrorMessage(from: data)
+            Log.error("publishAgentTemplate 400 for id=\(id): \(message ?? "<no message>")")
+            throw APIError.badRequest(message)
+        case 403:
+            Log.error("publishAgentTemplate 403 for id=\(id) - caller is not the template owner")
+            throw APIError.forbidden
+        case 404:
+            Log.error("publishAgentTemplate 404 for id=\(id)")
+            throw APIError.notFound
+        default:
+            let message = parseErrorMessage(from: data)
+            Log.error("publishAgentTemplate status=\(httpResponse.statusCode) for id=\(id): \(message ?? "<no message>")")
+            throw APIError.serverError(message)
         }
     }
 

--- a/ConvosCore/Sources/ConvosCore/API/MockAPIClient.swift
+++ b/ConvosCore/Sources/ConvosCore/API/MockAPIClient.swift
@@ -104,6 +104,14 @@ final class MockAPIClient: ConvosAPIClientProtocol, Sendable {
         .init(success: true, joined: true)
     }
 
+    func publishAgentTemplate(id: String) async throws -> ConvosAPI.AgentTemplate {
+        .init(
+            id: id,
+            status: "published",
+            publishedUrl: "https://agents.example.com/mock.\(id.prefix(5))"
+        )
+    }
+
     // MARK: - Connections
 
     func initiateCloudConnection(serviceId: String, redirectUri: String) async throws -> CloudConnectionsAPI.InitiateResponse {

--- a/ConvosCore/Sources/ConvosCore/Inboxes/MockInboxesService.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/MockInboxesService.swift
@@ -106,6 +106,14 @@ public final class MockInboxesService: SessionManagerProtocol, @unchecked Sendab
         return .init(success: true, joined: true)
     }
 
+    public func publishAgentTemplate(id: String) async throws -> ConvosAPI.AgentTemplate {
+        ConvosAPI.AgentTemplate(
+            id: id,
+            status: "published",
+            publishedUrl: "https://agents.example.com/mock.\(id.prefix(5))"
+        )
+    }
+
     public func conversationRepository(for conversationId: String) -> any ConversationRepositoryProtocol {
         MockConversationRepository()
     }

--- a/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
@@ -597,6 +597,10 @@ public final class SessionManager: SessionManagerProtocol, @unchecked Sendable {
         )
     }
 
+    public func publishAgentTemplate(id: String) async throws -> ConvosAPI.AgentTemplate {
+        try await apiClient.publishAgentTemplate(id: id)
+    }
+
     public func conversationRepository(for conversationId: String) -> any ConversationRepositoryProtocol {
         ConversationRepository(
             conversationId: conversationId,

--- a/ConvosCore/Sources/ConvosCore/Sessions/SessionManagerProtocol.swift
+++ b/ConvosCore/Sources/ConvosCore/Sessions/SessionManagerProtocol.swift
@@ -99,6 +99,12 @@ public protocol SessionManagerProtocol: AnyObject, Sendable {
         forceErrorCode: Int?
     ) async throws -> ConvosAPI.AgentJoinResponse
 
+    /// PATCH /api/v2/agent-templates/:id flipping the template to
+    /// `published`. Used by the agent-template contact card's share action
+    /// for builder-created templates that don't yet carry a `publishedUrl`
+    /// in their profile data.
+    func publishAgentTemplate(id: String) async throws -> ConvosAPI.AgentTemplate
+
     func conversationRepository(for conversationId: String) -> any ConversationRepositoryProtocol
 
     func messagesRepository(for conversationId: String) -> any MessagesRepositoryProtocol

--- a/ConvosCore/Tests/ConvosCoreTests/TestStubAPIClientDefaults.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/TestStubAPIClientDefaults.swift
@@ -43,4 +43,16 @@ extension ConvosAPIClientProtocol {
     ) async throws -> ConvosAPI.AgentJoinResponse {
         ConvosAPI.AgentJoinResponse(success: true, joined: true)
     }
+
+    /// Default for the publish-on-share PATCH used by the agent-template
+    /// contact card. Returns a synthetic "published" template so fixtures
+    /// don't have to re-stub it. Tests that exercise this specifically
+    /// should override on their fixture.
+    func publishAgentTemplate(id: String) async throws -> ConvosAPI.AgentTemplate {
+        ConvosAPI.AgentTemplate(
+            id: id,
+            status: "published",
+            publishedUrl: "https://agents.example.com/test.\(id.prefix(5))"
+        )
+    }
 }

--- a/ConvosTests/ConversationViewModelGlobalDefaultsTests.swift
+++ b/ConvosTests/ConversationViewModelGlobalDefaultsTests.swift
@@ -239,6 +239,10 @@ private final class TestSessionManager: SessionManagerProtocol, @unchecked Senda
         )
     }
 
+    func publishAgentTemplate(id: String) async throws -> ConvosAPI.AgentTemplate {
+        try await base.publishAgentTemplate(id: id)
+    }
+
     func voiceMemoTranscriptRepository() -> any VoiceMemoTranscriptRepositoryProtocol {
         base.voiceMemoTranscriptRepository()
     }

--- a/ConvosTests/ConversationsViewModelDeleteTests.swift
+++ b/ConvosTests/ConversationsViewModelDeleteTests.swift
@@ -307,6 +307,10 @@ private final class TestSessionManager: SessionManagerProtocol, @unchecked Senda
         )
     }
 
+    func publishAgentTemplate(id: String) async throws -> ConvosAPI.AgentTemplate {
+        try await base.publishAgentTemplate(id: id)
+    }
+
     func voiceMemoTranscriptRepository() -> any VoiceMemoTranscriptRepositoryProtocol {
         base.voiceMemoTranscriptRepository()
     }

--- a/docs/plans/agent-templates-publish-on-share.md
+++ b/docs/plans/agent-templates-publish-on-share.md
@@ -122,9 +122,29 @@ and isn't part of the share button's intent.
         repeat visit skip the POST until the member profile catches
         up. Sync `throws` call; treat misses and errors as a no-op
         and fall through to the publish-and-share row.
-   - On success, persist locally via the writer obtained from
-     `session.messagingService().agentTemplateContactsWriter()`. Best
-     effort - persistence failures are logged but don't block the share.
+   - On success, persist locally - but only when an existing
+     `DBAgentTemplateContact` row is present. Read the row via
+     `session.messagingService().agentTemplateContactsRepository()
+     .fetchContact(templateId:)`, then upsert via
+     `session.messagingService().agentTemplateContactsWriter()` with a
+     snapshot that re-passes every existing field unchanged and swaps in
+     only the new `publishedURL`. Two reasons:
+     - `Contact` doesn't carry the template's `emoji` /
+       `descriptionText`, and a timestamped
+       `AgentTemplateContactSnapshot` wholesale-replaces every field on
+       the row (see `AgentTemplateContactsWriter.replacingProfile`). A
+       naive upsert with `emoji: nil, descriptionText: nil` would wipe
+       values written by the standalone card's prior upsert.
+     - If the row doesn't exist, the user has never opened the
+       standalone agent-template card for this template, so the view
+       must not promote them into the user's agent-template contacts as
+       a side effect of tapping Share. Skip the write in that case;
+       in-memory `resolvedAgentTemplateShareURL` covers this view
+       session, and a future open of the standalone card (which has the
+       full profile to hand) will populate the row properly. Repeat
+       shares from a fresh `ContactDetailView` re-POST, which is
+       idempotent and cheap.
+     Persistence failures are logged but don't block the share.
    - Bundle the new share concerns into a `ContactDetailShareModifier`
      view modifier (sheet-presenter background + "Couldn't share" alert
      + the `onAppear` seed) so the body's modifier chain stays under the

--- a/docs/plans/agent-templates-publish-on-share.md
+++ b/docs/plans/agent-templates-publish-on-share.md
@@ -1,0 +1,191 @@
+# iOS brief: publish-on-share for builder-flow agent templates
+
+## Context
+
+Two surfaces show agent-template contacts and need a Share button:
+
+- The standalone agent-template contact card
+  (`Convos/Contacts/AgentTemplateContactCardView.swift`), opened from the
+  Contacts tab.
+- The unified `ContactDetailView`
+  (`Convos/Contacts/ContactDetailView.swift`), opened by tapping an agent
+  in a conversation's member list or a chat-bubble avatar.
+
+Templates created via deep-link land with a `publishedUrl` already set on
+profile data, so the share sheet renders immediately. Templates created
+via the in-app builder flow land in `draft` and carry no `publishedUrl`,
+so the Share row has nothing to seed.
+
+For those builder-flow rows we tap a single backend endpoint that returns
+the canonical `publishedUrl`, hand it to the iOS share sheet, and persist
+it back so the next visit short-circuits to the cached path.
+
+## Backend endpoint
+
+`POST /api/v2/agent-templates/:id/publish?status=published`
+
+- Same JWT auth as the rest of the v2 API
+  (`X-Convos-AuthToken: <jwt>`).
+- No request body. The `?status=published` query handles both branches
+  the backend takes internally:
+  - First-publish (`firstPublishedAt: null` -> a `draft` row): sets
+    `firstPublishedAt = now`, sets status to `published`, returns the
+    serialized template.
+  - Re-publish (`firstPublishedAt` already set -> `unlisted` /
+    `published` / `archived`): bumps version, preserves the existing
+    status, returns the serialized template. The `?status=` query is
+    honored only when the row is currently `draft` (the
+    PATCHed-back-to-draft case), by design.
+- Response 200: serialized agent template. Fields the iOS client reads:
+  - `id: String`
+  - `status: String`
+  - `publishedUrl: String?` (non-null whenever status is not `"draft"`)
+- Error responses we surface to the user as a generic share failure:
+  - 403 - caller is not the template owner.
+  - 404 - template id unknown.
+  - 400 / 5xx - anything else.
+
+We deliberately do not PATCH the status. PATCH is the only way to flip
+`unlisted` -> `published`, but for the iOS share button the URL works the
+same either way - the recipient can open it. Promoting `unlisted` to
+`published` is a directory-visibility change, not a shareability change,
+and isn't part of the share button's intent.
+
+## iOS implementation requirements
+
+1. Add a `ConvosAPI.AgentTemplate` decodable carrying just the fields we
+   consume today (`id`, `status`, `publishedUrl`). Define it next to the
+   other `ConvosAPI` request/response types so a future detail fetch can
+   share the shape. No request body model needed.
+
+2. Add a method on `ConvosAPIClient`
+   (`ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift`, near the
+   `// MARK: - Agents` block that hosts `requestAgentJoin`):
+
+   ```swift
+   func publishAgentTemplate(id: String) async throws -> ConvosAPI.AgentTemplate
+   ```
+
+   Builds a single POST request via
+   `authenticatedRequest(for: "v2/agent-templates/\(id)/publish",
+   method: "POST", queryParameters: ["status": "published"])` with no
+   body. A private `decodeAgentTemplateResponse(...)` helper handles
+   status-code mapping: 2xx -> decode into `ConvosAPI.AgentTemplate`,
+   400/403/404 -> the corresponding `APIError` case, anything else ->
+   `APIError.serverError`. All branches log structured detail
+   (`PATCH /POST` style isn't needed - there's one call).
+
+3. Plumb the new method through `ConvosAPIClientProtocol`, `MockAPIClient`,
+   `MockInboxesService`, `SessionManagerProtocol`, `SessionManager`, the
+   `TestStubAPIClientDefaults` default-impl extension, and the two
+   `TestSessionManager` proxies in `ConvosTests`. Same forwarding pattern
+   as `requestAgentJoin`.
+
+4. Update `AgentTemplateContactCardView`:
+
+   - Always render a share row. If `agentTemplateContact.publishedURL` is
+     set, use the existing `ContactDetailShareRow` (SwiftUI `ShareLink`).
+     Otherwise render a `ContactDetailActionRow` labelled "Share" that
+     drives the publish-then-share flow. Disable it while the request is
+     in flight (label flips to "Sharing...") and when `session == nil`.
+   - On success, persist the returned URL via
+     `AgentTemplateContactsWriterProtocol.upsert(templateId:
+     addedViaConversationId: profile:)`. Re-pass the contact's current
+     `displayName`, `emoji`, `descriptionText`, `avatarURL`, and
+     `agentVerification` in the snapshot - the writer's
+     most-recent-wins rule wholesale-replaces the row's profile fields
+     from the snapshot, so missing fields would blank out existing data.
+   - Auto-present the iOS share sheet with the returned URL via a thin
+     `ShareSheetPresenter` (UIActivityViewController wrapper, mirroring
+     the one in `ConversationShareView.swift`).
+   - On failure, log via `Log.error(String(describing: error))` and
+     surface a "Couldn't share right now, try again." alert. No retry.
+
+5. Update `ContactDetailView` for the same UX from member-list and
+   chat-bubble entry points:
+
+   - Add `@State` for the in-memory `resolvedAgentTemplateShareURL`,
+     `isPublishingAgentTemplate`, `isAgentTemplateShareSheetPresented`,
+     `publishAgentTemplateErrorMessage`.
+   - Render the share row whenever `contact.agentTemplateId != nil`,
+     branching on `publishedURL` the same way as the standalone card.
+   - Seed `resolvedAgentTemplateShareURL` on appear from the freshest
+     source available, in this order:
+     1. `contact.agentTemplatePublishedURL` (overlaid by
+        `Contact.resolved(...)` from the per-conversation member
+        profile - the authoritative source, but lags until the agent's
+        profile broadcast and the local membership sync land).
+     2. `session.messagingService().agentTemplateContactsRepository()
+        .fetchContact(templateId:)` against `DBAgentTemplateContact` -
+        the cached URL written by any prior publish-on-share flow on
+        this template (this view or the standalone card). Lets a
+        repeat visit skip the POST until the member profile catches
+        up. Sync `throws` call; treat misses and errors as a no-op
+        and fall through to the publish-and-share row.
+   - On success, persist locally via the writer obtained from
+     `session.messagingService().agentTemplateContactsWriter()`. Best
+     effort - persistence failures are logged but don't block the share.
+   - Bundle the new share concerns into a `ContactDetailShareModifier`
+     view modifier (sheet-presenter background + "Couldn't share" alert
+     + the `onAppear` seed) so the body's modifier chain stays under the
+     CLAUDE.md type-check budget.
+
+6. Auth wiring: no new flow. `ConvosAPIClient.authenticatedRequest`
+   already attaches the `X-Convos-AuthToken` header from the SIWE-bound
+   or device JWT slot, which the agent-templates routes accept (same
+   `authOrAgentApiKeyAuth` middleware as the other v2 endpoints).
+
+## UX notes
+
+- The POST is fast (single DB write + revalidation), so a brief inline
+  "Sharing..." label is sufficient. No 30s budget like `requestAgentJoin`.
+- After a successful publish, the row should switch to the cached
+  `ContactDetailShareRow` on the next render so a repeat tap is instant.
+  For the standalone agent-template card, this falls out of writing
+  `publishedURL` back via the writer (the card reads
+  `AgentTemplateContact.publishedURL` directly from
+  `DBAgentTemplateContact`). For `ContactDetailView`, the seed step
+  consults `DBAgentTemplateContact` as a fallback so a fresh view
+  construction on a different conversation still gets the cached URL
+  without re-POSTing.
+- The agent-template's own profile data will eventually carry the
+  `publishedUrl` once the server-side flow propagates it; our local
+  write is a UX optimization, not the source of truth. Once member
+  profile sync surfaces the URL, the `contact.agentTemplatePublishedURL`
+  branch takes over and the `DBAgentTemplateContact` fallback becomes
+  unused.
+
+## Out of scope
+
+- PATCH `/api/v2/agent-templates/:id` for any reason. The share button is
+  POST-only.
+- Status downgrades, archiving, slug edits, or any other agent-template
+  mutations from the iOS share path.
+- Promoting `unlisted` to `published` as a side effect of tapping Share.
+  See the Context section - the share URL works either way.
+- Reusing the new `ConvosAPI.AgentTemplate` model for list / detail
+  fetches - we'll grow it when we wire those endpoints up.
+
+## Verification
+
+- Unit-test the new client method against the existing mock URLSession
+  pattern in `ConvosCoreTests` (model the test on the `requestAgentJoin`
+  coverage):
+  - 200 returns the decoded template (with `publishedUrl` populated).
+  - 403 maps to `APIError.forbidden`.
+  - 404 maps to `APIError.notFound`.
+  - 400 with a structured backend body maps to
+    `APIError.badRequest(_:)` carrying the raw JSON / message.
+- Manual: trigger the builder flow on the Dev env. Logger lines in
+  `publishAgentTemplate` will print:
+  - `publishAgentTemplate POST <url>` then a 2xx and the share sheet
+    rendering the returned URL.
+  - On second presentation, the row should already be the cached
+    `ContactDetailShareRow` (no POST).
+- Repeat the manual test from the member-list and chat-bubble entry
+  points on a builder-flow agent that does not yet carry a `publishedUrl`.
+  Expect the same single-POST behavior.
+- Run `swift test --package-path ConvosCore` (Docker up) before pushing
+  per the `CLAUDE.md` testing gate.
+- Run `/lint` and `/format` before commit; pre-commit hook will block on
+  remaining violations.


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/906"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782634279&installation_id=128169237&pr_number=906&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F906&signature=517442797dc7e4d5c3f7277fd863cc27198efbc6660846efa554cfb194eeb26d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add publish-on-share flow for agent templates in contact detail and card views
> - Adds a Share button to `ContactDetailView` and `AgentTemplateContactCardView` for template-backed agents; on first tap, calls `POST v2/agent-templates/:id/publish` to publish the template and retrieve a `publishedUrl`.
> - Persists the returned URL to the local contact store so subsequent visits show a direct `ShareLink` without re-publishing.
> - Presents the system share sheet (`UIActivityViewController`) on success via a new `ShareSheetPresenter` wrapper; shows a 'Couldn't share' alert on failure.
> - Adds `publishAgentTemplate(id:)` to `ConvosAPIClientProtocol`, `SessionManagerProtocol`, and their mock/test implementations.
> - Behavioral Change: agent-template contacts that previously had no share action now trigger a network request on the first share tap.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5b5b5e0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->