### PR TITLE
Push Notifications: AppDelegate static, debug button fix, hash debounce, count-gated discovery, token-change trigger

### DIFF
--- a/Convos/ConvosApp.swift
+++ b/Convos/ConvosApp.swift
@@ -93,7 +93,9 @@ struct ConvosApp: App {
         }
         self.conversationsViewModel = .init(session: convos.session)
         appDelegate.session = convos.session
-        appDelegate.pushNotificationRegistrar = convos.platformProviders.pushNotificationRegistrar
+        // PushNotificationRegistrar.configure(...) ran inside `PlatformProviders.iOS`
+        // above, so AppDelegate's APNS callback uses the static accessor directly
+        // (see ConvosAppDelegate.didRegisterForRemoteNotificationsWithDeviceToken).
         profileSettingsViewModel.bind(session: convos.session)
     }
 

--- a/Convos/ConvosAppDelegate.swift
+++ b/Convos/ConvosAppDelegate.swift
@@ -9,7 +9,6 @@ import UserNotifications
 @MainActor
 class ConvosAppDelegate: NSObject, UIApplicationDelegate, @preconcurrency UNUserNotificationCenterDelegate {
     var session: (any SessionManagerProtocol)?
-    var pushNotificationRegistrar: (any PushNotificationRegistrarProtocol)?
     private var leftConversationObserver: Any?
     private var foregroundObserver: Any?
 
@@ -32,13 +31,40 @@ class ConvosAppDelegate: NSObject, UIApplicationDelegate, @preconcurrency UNUser
         return true
     }
 
+    // Lifecycle ordering invariant for the singleton-based token handoff:
+    //
+    //   ConvosApp.init
+    //     |
+    //     +--> PlatformProviders.iOS
+    //     |       |
+    //     |       +--> PushNotificationRegistrar.configure(IOSPushNotificationRegistrar())
+    //     |                            (singleton _shared is set HERE)
+    //     v
+    //   UIKit lifecycle starts
+    //     |
+    //     +--> application(_:didFinishLaunchingWithOptions:)
+    //     |       |
+    //     |       +--> UIApplication.registerForRemoteNotifications()
+    //     v
+    //   APNS callback
+    //     |
+    //     +--> didRegisterForRemoteNotificationsWithDeviceToken
+    //             |
+    //             +--> PushNotificationRegistrar.save(token:)
+    //                     |
+    //                     +-- _shared != nil (normal lifecycle) -> save + post notification
+    //                     +-- _shared == nil (test / extension)  -> Log.error + no-op (D10)
+    //
+    // The singleton is configured before UIKit fires didFinishLaunching, so the
+    // happy path is race-free by construction. The graceful no-op covers UI tests
+    // and any future lifecycle change without crashing the process.
     func application(_ application: UIApplication,
                      didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
         let tokenParts = deviceToken.map { data in String(format: "%02.2hhx", data) }
         let token = tokenParts.joined()
 
         Log.info("Received device token from APNS")
-        pushNotificationRegistrar?.save(token: token)
+        PushNotificationRegistrar.save(token: token)
     }
 
     func application(_ application: UIApplication,

--- a/Convos/Debug View/DebugView.swift
+++ b/Convos/Debug View/DebugView.swift
@@ -399,12 +399,29 @@ extension DebugViewSection {
         let apnsEnv = ConfigManager.shared.currentEnvironment.apnsEnvironment.rawValue
         Log.info("Debug: Force re-registering device (APNS env: \(apnsEnv))")
 
-        let platformProviders = PlatformProviders.iOS
-        DeviceRegistrationManager.clearRegistrationState(deviceInfo: platformProviders.deviceInfo)
+        // The original implementation called `PlatformProviders.iOS` here, which
+        // constructs a fresh `IOSPushNotificationRegistrar` whose in-memory token
+        // is nil. That made the debug button race against the real app's state
+        // and could register the device with `pushToken: nil` even when the
+        // device had a valid token. Reuse the already-configured singletons so
+        // the debug action sees the SAME APNS token, deviceId, and registrar
+        // state the app uses everywhere else.
+        //
+        // `ConvosCore.DeviceInfo` is fully qualified because the main app has
+        // its own `DeviceInfo` struct in Utilities & Extensions that shadows
+        // the ConvosCore enum at this call site.
+        let deviceInfo = ConvosCore.DeviceInfo.shared
+        let providersForDebug = PlatformProviders(
+            appLifecycle: MockAppLifecycleProvider(),
+            deviceInfo: deviceInfo,
+            pushNotificationRegistrar: PushNotificationRegistrar.shared,
+            notificationCenter: UNUserNotificationCenter.current()
+        )
+        DeviceRegistrationManager.clearRegistrationState(deviceInfo: deviceInfo)
 
         let manager = DeviceRegistrationManager(
             environment: ConfigManager.shared.currentEnvironment,
-            platformProviders: platformProviders
+            platformProviders: providersForDebug
         )
         await manager.registerDeviceIfNeeded()
     }

--- a/ConvosCore/Sources/ConvosCore/Inboxes/PushNotificationRegistrarProtocol.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/PushNotificationRegistrarProtocol.swift
@@ -73,9 +73,24 @@ public enum PushNotificationRegistrar {
     }
 
     /// Saves the push token and notifies observers of the change.
-    /// Convenience accessor for `PushNotificationRegistrar.shared.save(token:)`
+    ///
+    /// Unlike `shared`, this convenience does not fatalError when the singleton
+    /// hasn't been configured. The intended hot path (`AppDelegate.didRegister
+    /// ForRemoteNotificationsWithDeviceToken`) lands after `configure()` runs
+    /// under the normal SwiftUI lifecycle, but UI tests that exercise the
+    /// AppDelegate directly, the `.iOSExtension` provider path, and any
+    /// future lifecycle change still need to degrade safely. A crash on the
+    /// APNS callback is higher blast radius than a logged drop, which can be
+    /// detected by the absence of a registered token in the backend.
     public static func save(token: String) {
-        shared.save(token: token)
+        lock.lock()
+        let registrar = _shared
+        lock.unlock()
+        guard let registrar = registrar else {
+            Log.error("PushNotificationRegistrar.save(token:) called before configure() — token dropped")
+            return
+        }
+        registrar.save(token: token)
     }
 
     /// Requests notification authorization if not already granted, then registers for remote notifications.

--- a/ConvosCore/Sources/ConvosCore/Syncing/PushTopicSubscriptionCache.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/PushTopicSubscriptionCache.swift
@@ -1,0 +1,111 @@
+import CryptoKit
+import Foundation
+
+/// Hash debounce cache for `PushTopicSubscriptionManager.reconcilePushTopics`.
+/// Lives in UserDefaults so the cache survives app launches without holding
+/// the actor (which would burn an extra memory copy of the topic set on every
+/// process).
+///
+/// Cache key partitions by `(inboxId, clientId, deviceId, pushTokenSha256)`
+/// so the four invalidation paths the plan calls out fall out naturally:
+///
+/// - APNS token rotation: `pushTokenSha256` changes -> different key -> miss.
+/// - Identity rotation (sign-out/in as a new account): `inboxId` / `clientId`
+///   change -> different key -> miss. Stale entries for the previous identity
+///   stay in UserDefaults but are functionally inert (no key in any future
+///   lookup will match them) and get reaped by ``clearAll()`` when the caller
+///   explicitly wants a clean slate.
+/// - Device-id rotation: `deviceId` changes -> different key -> miss.
+/// - Topic set change: the value (topic-set hash) differs from the cached one
+///   -> miss.
+///
+/// Writes only happen inside `subscribe`'s success branch in
+/// `PushTopicSubscriptionManager`. A thrown API call leaves the cache
+/// un-mutated so the next reconcile retries the wire. The "HTTP 200 but
+/// remote-apply skipped" state that Stack 2's response shape will surface
+/// (D16: `remoteApplied: false`) is not handled yet. Until that field
+/// ships, iOS trusts a successful URLSession round trip.
+final class PushTopicSubscriptionCache: @unchecked Sendable {
+    private static let storeKey: String = "convos.pushTopicSubscriptionCache.v1"
+
+    private let userDefaults: UserDefaults
+    private let lock: NSLock = .init()
+
+    init(userDefaults: UserDefaults = .standard) {
+        self.userDefaults = userDefaults
+    }
+
+    /// Looks up the cached topic-set hash for the supplied key.
+    /// Returns nil on first call, after a successful failure that left no
+    /// cache write, or whenever the caller passes a fresh `(identity, token,
+    /// device)` tuple.
+    func lookupHash(forKey key: String) -> String? {
+        lock.lock()
+        defer { lock.unlock() }
+        return readDict()[key]
+    }
+
+    /// Stores the topic-set hash. Callers MUST only invoke this from inside
+    /// `subscribe`'s success branch; writing pessimistically (before the API
+    /// call returns) would leave iOS thinking it's synced after a transient
+    /// failure, silently breaking the retry loop the plan exists to enable.
+    func storeHash(_ hash: String, forKey key: String) {
+        lock.lock()
+        defer { lock.unlock() }
+        var dict = readDict()
+        dict[key] = hash
+        userDefaults.set(dict, forKey: Self.storeKey)
+    }
+
+    /// Clears every cached hash. Intended for explicit "wipe my state"
+    /// operations like sign-out, "Delete all data", or test setup. Day-to-day
+    /// identity rotation is handled by key partitioning above and does NOT
+    /// need to call this.
+    func clearAll() {
+        lock.lock()
+        defer { lock.unlock() }
+        userDefaults.removeObject(forKey: Self.storeKey)
+    }
+
+    private func readDict() -> [String: String] {
+        userDefaults.dictionary(forKey: Self.storeKey) as? [String: String] ?? [:]
+    }
+}
+
+/// Components of the cache key, kept here so the same canonicalization is
+/// used at write-time (inside subscribe's success branch) and lookup-time
+/// (top of reconcile).
+struct PushTopicCacheKey: Sendable {
+    let inboxId: String
+    let clientId: String
+    let deviceId: String
+    let pushTokenSha256: String
+
+    var keyString: String {
+        "\(inboxId)|\(clientId)|\(deviceId)|\(pushTokenSha256)"
+    }
+}
+
+/// Canonical hashing routine shared by the iOS cache and the eventual Stack 2
+/// backend snapshot. Topics are sorted lexicographically as UTF-8 strings,
+/// joined with a single LF separator, and run through SHA-256 with lowercase
+/// hex output. Match this byte-for-byte on the Node side when the snapshot
+/// table needs to compare hashes across the wire.
+enum PushTopicHash {
+    static func of(_ topics: [String]) -> String {
+        let canonical = topics.sorted().joined(separator: "\n")
+        let digest = SHA256.hash(data: Data(canonical.utf8))
+        return digest.map { String(format: "%02x", $0) }.joined()
+    }
+
+    /// SHA-256 of the APNS token bytes, lowercase hex. Returns the literal
+    /// sentinel `"none"` when no token is available yet so cache keys still
+    /// partition cleanly between the pre-token and post-token states (and so
+    /// the first real token after cold launch always produces a cache miss
+    /// and a fresh reconcile).
+    static func ofToken(_ token: String?) -> String {
+        guard let token = token, !token.isEmpty else { return "none" }
+        let digest = SHA256.hash(data: Data(token.utf8))
+        return digest.map { String(format: "%02x", $0) }.joined()
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Syncing/PushTopicSubscriptionManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/PushTopicSubscriptionManager.swift
@@ -40,6 +40,11 @@ protocol PushTopicSubscriptionManaging: Actor {
         params: SyncClientParams,
         context: String
     ) async
+
+    /// Drops every cached push-topic-set hash. Production callers invoke
+    /// this on sign-out / "Delete all data" paths; tests use it to force
+    /// a deterministic cache miss.
+    func clearCache() async
 }
 
 protocol PushTopicConversationListing: Sendable {
@@ -109,17 +114,29 @@ actor PushTopicSubscriptionManager: PushTopicSubscriptionManaging {
     private let deviceRegistrationManager: (any DeviceRegistrationManagerProtocol)?
     private let deviceInfoProvider: (any DeviceInfoProviding)?
     private let conversationLister: any PushTopicConversationListing
+    /// Hash debounce cache. When nil, every reconcile hits the wire (used by
+    /// tests that want to assert delivery without thinking about caching, and
+    /// by NSE one-shot constructions where reconcile is never called).
+    private let cache: PushTopicSubscriptionCache?
+    /// Returns the current APNS token, hashed into the cache key so token
+    /// rotation forces a miss. Closure-based so tests can drive both nil and
+    /// non-nil paths without touching the global singleton.
+    private let pushTokenProvider: (@Sendable () -> String?)?
 
     init(
         identityStore: any KeychainIdentityStoreProtocol,
         deviceRegistrationManager: (any DeviceRegistrationManagerProtocol)? = nil,
         deviceInfoProvider: (any DeviceInfoProviding)? = nil,
-        conversationLister: any PushTopicConversationListing = XMTPPushTopicConversationLister()
+        conversationLister: any PushTopicConversationListing = XMTPPushTopicConversationLister(),
+        cache: PushTopicSubscriptionCache? = nil,
+        pushTokenProvider: (@Sendable () -> String?)? = nil
     ) {
         self.identityStore = identityStore
         self.deviceRegistrationManager = deviceRegistrationManager
         self.deviceInfoProvider = deviceInfoProvider
         self.conversationLister = conversationLister
+        self.cache = cache
+        self.pushTokenProvider = pushTokenProvider
     }
 
     func subscribeToGroupAndWelcome(
@@ -201,10 +218,98 @@ actor PushTopicSubscriptionManager: PushTopicSubscriptionManaging {
         )
     }
 
+    // Reconcile pipeline (D8 hash debounce + D14 token-change trigger compatible):
+    //
+    //     reconcilePushTopics(params, context)
+    //       |
+    //       +-- computeReconcileDesiredSubscriptions  (welcome + groups + DMs)
+    //       |
+    //       +-- dedupe                                (per-topic uniqueness)
+    //       |
+    //       +-- if cache + token + identity available:
+    //       |     |
+    //       |     +-- cacheKey = (inboxId, clientId, deviceId, pushTokenSha256)
+    //       |     +-- hash     = SHA256 of sorted-joined topic set
+    //       |     +-- if cache.lookup(cacheKey) == hash -> SKIP (no wire call)
+    //       |     +-- else                               -> subscribe(cacheKey)
+    //       |
+    //       +-- else (no cache wired, or no token/identity yet):
+    //             +-- subscribe(cacheKey: nil)            (legacy "always send")
+    //
+    //     subscribe(to:params:context:cacheKey:)
+    //       |
+    //       +-- POST /v2/notifications/subscribe
+    //       |     |
+    //       |     +-- success -> log + if cacheKey != nil { cache.store(hash) }
+    //       |     +-- throw   -> Log.warning + QAEvent + NO cache write
+    //       |                    (next reconcile retries the wire)
     func reconcilePushTopics(
         params: SyncClientParams,
         context: String
     ) async {
+        let subscriptions = await computeReconcileDesiredSubscriptions(
+            params: params,
+            context: context
+        )
+        let deduped = dedupe(subscriptions)
+        guard !deduped.isEmpty else { return }
+
+        guard let cache = cache,
+              let cacheKey = await currentCacheKey(params: params, context: context) else {
+            await subscribe(to: deduped, params: params, context: context, cacheKey: nil)
+            return
+        }
+        let currentHash = PushTopicHash.of(deduped.map(\.topic))
+        if let cached = cache.lookupHash(forKey: cacheKey.keyString), cached == currentHash {
+            Log.debug("Reconcile no-op \(context): topic hash matches cached state")
+            return
+        }
+        // Pass currentHash through so subscribe doesn't recompute SHA-256 over
+        // the same topic set on success.
+        await subscribe(
+            to: deduped,
+            params: params,
+            context: context,
+            cacheKey: cacheKey.keyString,
+            precomputedHash: currentHash
+        )
+    }
+
+    /// Clears the hash debounce cache. Call on "Delete all data" / sign-out
+    /// paths when the caller wants to drop every previously-recorded state,
+    /// not just rely on partitioning by identity. Day-to-day identity rotation
+    /// is already handled by the cache key including `inboxId` and `clientId`
+    /// (a new identity reads through a fresh key automatically).
+    func clearCache() {
+        cache?.clearAll()
+    }
+
+    private func currentCacheKey(
+        params: SyncClientParams,
+        context: String
+    ) async -> PushTopicCacheKey? {
+        guard let identity = await identity(matching: params) else { return nil }
+        guard let deviceId = await deviceIdentifier(context: context) else { return nil }
+        let token = pushTokenProvider?()
+        return PushTopicCacheKey(
+            inboxId: identity.inboxId,
+            clientId: identity.clientId,
+            deviceId: deviceId,
+            pushTokenSha256: PushTopicHash.ofToken(token)
+        )
+    }
+
+    /// Computes the full desired topic set for a reconcile pass without sending
+    /// anything to the backend. Pulling this out of `reconcilePushTopics` lets
+    /// the debounce path (D8) compute a hash and decide whether to send, and
+    /// gives Stack 2's diagnostics surface the same source-of-truth iOS uses
+    /// to derive desired state. The per-conversation `subscribeToGroup...` /
+    /// `subscribeToInviteDMTopics` paths keep their own narrow builders since
+    /// they're firing one-shot deltas, not a full sweep.
+    private func computeReconcileDesiredSubscriptions(
+        params: SyncClientParams,
+        context: String
+    ) async -> [TopicSubscription] {
         var subscriptions: [TopicSubscription] = [welcomeSubscription(params: params)]
         var degradedSources: [String] = []
 
@@ -242,7 +347,7 @@ actor PushTopicSubscriptionManager: PushTopicSubscriptionManaging {
             ])
         }
 
-        await subscribe(to: subscriptions, params: params, context: context)
+        return subscriptions
     }
 
     // MARK: - Private
@@ -250,7 +355,9 @@ actor PushTopicSubscriptionManager: PushTopicSubscriptionManaging {
     private func subscribe(
         to subscriptions: [TopicSubscription],
         params: SyncClientParams,
-        context: String
+        context: String,
+        cacheKey: String? = nil,
+        precomputedHash: String? = nil
     ) async {
         let subscriptions = dedupe(subscriptions)
         guard !subscriptions.isEmpty else { return }
@@ -269,6 +376,18 @@ actor PushTopicSubscriptionManager: PushTopicSubscriptionManaging {
             )
             Log.info("Subscribed to push topics \(context): \(topicSummary(subscriptions))")
             Log.debug("Subscribed push topic values \(context): \(subscriptions.map(\.topic).joined(separator: ", "))")
+            // Success-only cache write. A failure path falls through to the
+            // catch arm below and leaves the cache untouched so the next
+            // reconcile retries. The cacheKey is nil for per-conversation
+            // subscribe paths (group join / invite DM) since they're deltas,
+            // not full sweeps and don't participate in reconcile debounce.
+            if let cacheKey = cacheKey, let cache = cache {
+                // Reuse the hash reconcile already computed when checking the
+                // cache miss. Falls back to computing it here only when the
+                // per-conversation path opts into caching (it doesn't today).
+                let hash = precomputedHash ?? PushTopicHash.of(subscriptions.map(\.topic))
+                cache.storeHash(hash, forKey: cacheKey)
+            }
         } catch {
             Log.warning("Failed subscribing to push topics \(context): \(error)")
             QAEvent.emit(.sync, "push_topic_subscribe_failed", [

--- a/ConvosCore/Sources/ConvosCore/Syncing/StreamProcessor.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/StreamProcessor.swift
@@ -29,6 +29,14 @@ protocol StreamProcessorProtocol: Actor {
 
     func reconcilePushSubscriptions(params: SyncClientParams, context: String) async
 
+    /// Drops every cached push-topic-set hash. Intended for the explicit
+    /// "Delete all data" / sign-out path where the caller wants to force the
+    /// next reconcile to hit the wire instead of debouncing. Day-to-day
+    /// identity rotation is already handled by partitioning the cache key
+    /// on inboxId / clientId, so callers should NOT invoke this on every
+    /// resume / foreground.
+    func clearPushSubscriptionCache() async
+
     func setInviteJoinErrorHandler(_ handler: (any InviteJoinErrorHandler)?)
     func setTypingIndicatorHandler(_ handler: @escaping @Sendable (String, String, Bool) -> Void)
 }
@@ -96,7 +104,13 @@ actor StreamProcessor: StreamProcessorProtocol {
         self.databaseReader = databaseReader
         self.pushTopicSubscriptionManager = PushTopicSubscriptionManager(
             identityStore: identityStore,
-            deviceRegistrationManager: deviceRegistrationManager
+            deviceRegistrationManager: deviceRegistrationManager,
+            cache: PushTopicSubscriptionCache(),
+            // Closure captures the configured singleton so cache keys partition
+            // by the live APNS token. Token rotation forces a miss; the new
+            // `.convosPushTokenDidChange` listener (D14) then drives a fresh
+            // reconcile through the wire.
+            pushTokenProvider: { PushNotificationRegistrar.token }
         )
         self.notificationCenter = notificationCenter
         self.inviteJoinErrorHandler = nil
@@ -843,6 +857,8 @@ actor StreamProcessor: StreamProcessorProtocol {
     func reconcilePushSubscriptions(params: SyncClientParams, context: String) async {
         await pushTopicSubscriptionManager.reconcilePushTopics(params: params, context: context)
     }
+
+    func clearPushSubscriptionCache() async { await pushTopicSubscriptionManager.clearCache() }
 
     private func handleJoinRequestOutcome(
         _ outcome: InviteJoinRequestOutcome,

--- a/ConvosCore/Sources/ConvosCore/Syncing/SyncingManager+PushTokenObserver.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/SyncingManager+PushTokenObserver.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+/// D14 wiring: bring an APNS token rotation through to push topic reconcile
+/// even when the conversation set is unchanged.
+///
+/// Without this, the iOS-side hash cache (D8) keeps happily debouncing because
+/// everything except the token hashes the same; the XMTP notifications server
+/// keeps the old deliveryMechanism and stops delivering pushes. The cache key
+/// includes the token sha so this dispatch produces a miss naturally and the
+/// reconcile actually hits the wire.
+///
+/// Lives in its own extension file so it can grow with documentation without
+/// pushing the primary `SyncingManager` body past the SwiftLint type-body cap.
+extension SyncingManager {
+    func installPushTokenObserver() {
+        let pushTokenObserver = NotificationCenter.default.addObserver(
+            forName: .convosPushTokenDidChange,
+            object: nil,
+            queue: nil
+        ) { [weak self] _ in
+            Task { [weak self] in
+                await self?.reconcileAfterTokenChange()
+            }
+        }
+        notificationObservers.append(pushTokenObserver)
+    }
+
+    func reconcileAfterTokenChange() async {
+        let activeParams: SyncClientParams?
+        switch _state {
+        case .idle, .stopping, .error: activeParams = nil
+        case .starting(let params, _), .ready(let params), .paused(let params): activeParams = params
+        }
+        guard let params = activeParams else {
+            Log.debug("convosPushTokenDidChange ignored - no active SyncClientParams")
+            return
+        }
+        await streamProcessor.reconcilePushSubscriptions(params: params, context: "after token change")
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Syncing/SyncingManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/SyncingManager.swift
@@ -108,7 +108,7 @@ actor SyncingManager: SyncingManagerProtocol {
     // MARK: - Properties
 
     private let identityStore: any KeychainIdentityStoreProtocol
-    private let streamProcessor: any StreamProcessorProtocol
+    let streamProcessor: any StreamProcessorProtocol
     // Maximum consecutive stream failures before giving up. Prevents FD exhaustion when
     // XMTP service is unavailable (each failed connection attempt can leak file descriptors).
     private let maxStreamRetries: Int = 10
@@ -124,7 +124,7 @@ actor SyncingManager: SyncingManagerProtocol {
     private var conversationStreamReadyContinuation: AsyncStream<Void>.Continuation?
 
     // State machine
-    private var _state: State = .idle
+    var _state: State = .idle
     private var actionQueue: [Action] = []
 
     var isSyncReady: Bool {
@@ -137,7 +137,7 @@ actor SyncingManager: SyncingManagerProtocol {
     // Notification handling
     // Safe to use nonisolated(unsafe) because the array is only mutated during actor-isolated
     // setup, and deinit only runs after all actor tasks complete (no concurrent access possible).
-    nonisolated(unsafe) private var notificationObservers: [NSObjectProtocol] = []
+    nonisolated(unsafe) var notificationObservers: [NSObjectProtocol] = []
     private var notificationTask: Task<Void, Never>?
 
     // MARK: - Initialization
@@ -491,7 +491,15 @@ actor SyncingManager: SyncingManagerProtocol {
     /// missing groups that the conversation stream failed to deliver (e.g., stream timeout,
     /// inbox paused during approval, app backgrounded). This method provides a fallback
     /// by listing all groups and storing any that aren't already in the DB.
-    private func discoverNewConversations(params: SyncClientParams) async {
+    ///
+    /// Returns the count of conversations actually processed and written. The count is
+    /// load-bearing for `requestDiscovery`'s D3 gate: when the join-poll fires every 3
+    /// seconds while waiting for a welcome that hasn't arrived yet, count==0 short-circuits
+    /// the downstream push reconcile so the device stops flooding `/v2/notifications/subscribe`.
+    /// A best-effort listing failure returns 0 (treat "I couldn't tell" as "nothing new"
+    /// so we don't reconcile on a partial signal).
+    @discardableResult
+    private func discoverNewConversations(params: SyncClientParams) async -> Int {
         do {
             let groups = try params.client.conversationsProvider.listGroups(
                 createdAfterNs: nil,
@@ -530,8 +538,10 @@ actor SyncingManager: SyncingManagerProtocol {
             if discoveredCount > 0 {
                 Log.info("Discovered \(discoveredCount) new conversations after sync")
             }
+            return discoveredCount
         } catch {
             Log.error("Failed to discover new conversations: \(error)")
+            return 0
         }
     }
 
@@ -693,6 +703,23 @@ actor SyncingManager: SyncingManagerProtocol {
         )
     }
 
+    // D3: ConversationStateMachine.joinFlow polls requestDiscovery every 3s
+    // while waiting for the joined group. Before this gate, every tick fired
+    // a full /v2/notifications/subscribe (topicCount: 50 in Datadog). Now we
+    // only reconcile when discoverNewConversations actually wrote a new row.
+    // Token rotation is brought through by the .convosPushTokenDidChange
+    // listener (D14), not through here.
+    /// Force-drop the iOS-side push topic hash cache. Exposed for sign-out /
+    /// "Delete all data" paths AND for tests that need a deterministic
+    /// cache-miss without going through the global PushNotificationRegistrar
+    /// singleton (which other test suites mutate via resetForTesting and
+    /// would race against). Production callers should NOT invoke this on
+    /// every resume — the cache key partitioning handles routine state
+    /// changes naturally.
+    func clearPushSubscriptionCache() async {
+        await streamProcessor.clearPushSubscriptionCache()
+    }
+
     func requestDiscovery() async {
         guard case .ready(let params) = _state else {
             Log.debug("requestDiscovery ignored - not in ready state (\(_state))")
@@ -703,7 +730,11 @@ actor SyncingManager: SyncingManagerProtocol {
             _ = try await params.client.conversationsProvider.syncAllConversations(consentStates: params.consentStates)
             let syncElapsed = String(format: "%.0f", (CFAbsoluteTimeGetCurrent() - syncStart) * 1000)
             Log.info("[PERF] sync.requestDiscovery: \(syncElapsed)ms")
-            await discoverNewConversations(params: params)
+            let discoveredCount = await discoverNewConversations(params: params)
+            guard discoveredCount > 0 else {
+                Log.debug("requestDiscovery: no new conversations, skipping push topic reconcile")
+                return
+            }
             await streamProcessor.reconcilePushSubscriptions(
                 params: params,
                 context: "after requested discovery"
@@ -915,6 +946,7 @@ actor SyncingManager: SyncingManagerProtocol {
             }
         }
         notificationObservers.append(activeConversationObserver)
+        installPushTokenObserver()
     }
 }
 

--- a/ConvosCore/Tests/ConvosCoreTests/PushNotificationRegistrarStaticTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/PushNotificationRegistrarStaticTests.swift
@@ -1,0 +1,46 @@
+@testable import ConvosCore
+import Foundation
+import Testing
+
+/// Stack 1 / D10 regression: `PushNotificationRegistrar.save(token:)` is the
+/// hot path AppDelegate calls when APNS delivers the device token. The
+/// previous implementation routed through `shared`, which fatalError'd when
+/// `configure()` had not been called — fine under the normal SwiftUI cold
+/// launch (PlatformProviders.iOS configures before UIKit fires
+/// didFinishLaunching) but a crash for the `.iOSExtension` path, UI tests
+/// that exercise AppDelegate directly, and any future lifecycle change.
+///
+/// The graceful no-op trades a crash for a logged drop: missing pushes are
+/// recoverable (no DeviceRegistration row in backend), a SIGABRT on a hot
+/// callback isn't.
+///
+/// Serialized so the brief unconfigured window doesn't race with other
+/// suites that touch the singleton.
+@Suite("PushNotificationRegistrar static convenience", .serialized)
+struct PushNotificationRegistrarStaticTests {
+    @Test("save(token:) does not crash before configure() — graceful no-op")
+    func saveBeforeConfigureDoesNotCrash() {
+        PushNotificationRegistrar.resetForTesting()
+
+        // No configure() call here on purpose. The old implementation would
+        // fatalError on the next line; the new graceful path logs an error
+        // and returns without touching anything.
+        PushNotificationRegistrar.save(token: "would-have-crashed-before-fix")
+        #expect(PushNotificationRegistrar.token == nil)
+
+        // Reconfigure with the mock so any test in this suite that follows
+        // (or runs concurrently against the shared singleton) sees a known
+        // configured state instead of the empty post-reset state.
+        PushNotificationRegistrar.configure(MockPushNotificationRegistrarProvider())
+    }
+
+    @Test("save(token:) forwards to the configured registrar after configure()")
+    func saveAfterConfigureForwards() {
+        PushNotificationRegistrar.resetForTesting()
+        let registrar = MockPushNotificationRegistrarProvider()
+        PushNotificationRegistrar.configure(registrar)
+
+        PushNotificationRegistrar.save(token: "real-token")
+        #expect(PushNotificationRegistrar.token == "real-token")
+    }
+}

--- a/ConvosCore/Tests/ConvosCoreTests/PushTopicSubscriptionManagerTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/PushTopicSubscriptionManagerTests.swift
@@ -185,6 +185,195 @@ struct PushTopicSubscriptionManagerTests {
         #expect(apiClient.subscribeCallCount == 1)
     }
 
+    @Test("Reconcile cache hit skips the wire on identical topic set")
+    func reconcileCacheHitSkipsTheWire() async throws {
+        let identityStore = MockKeychainIdentityStore()
+        let keys = try await identityStore.generateKeys()
+        _ = try await identityStore.save(inboxId: "test-inbox-id", clientId: "client-1", keys: keys)
+
+        let client = TestableMockClient()
+        client.inboxId = "test-inbox-id"
+        let apiClient = RecordingPushAPIClient()
+        let conversationLister = RecordingPushConversationLister(
+            groupIds: ["group-1"],
+            dmIds: ["dm-1"]
+        )
+        let cache = isolatedCache()
+        let manager = PushTopicSubscriptionManager(
+            identityStore: identityStore,
+            deviceInfoProvider: MockDeviceInfoProvider(deviceIdentifier: "device-1"),
+            conversationLister: conversationLister,
+            cache: cache,
+            pushTokenProvider: { "fake-apns-token" }
+        )
+
+        await manager.reconcilePushTopics(
+            params: SyncClientParams(client: client, apiClient: apiClient),
+            context: "first"
+        )
+        await manager.reconcilePushTopics(
+            params: SyncClientParams(client: client, apiClient: apiClient),
+            context: "second"
+        )
+
+        // First reconcile hits the wire and primes the cache; the second sees
+        // an identical hash and short-circuits before the API call.
+        #expect(apiClient.subscribeCalls.count == 1)
+    }
+
+    @Test("Reconcile cache miss sends when topic set changes between calls")
+    func reconcileCacheMissSends() async throws {
+        let identityStore = MockKeychainIdentityStore()
+        let keys = try await identityStore.generateKeys()
+        _ = try await identityStore.save(inboxId: "test-inbox-id", clientId: "client-1", keys: keys)
+
+        let client = TestableMockClient()
+        client.inboxId = "test-inbox-id"
+        let apiClient = RecordingPushAPIClient()
+        let conversationLister = RecordingPushConversationLister(
+            groupIds: ["group-1"],
+            dmIds: []
+        )
+        let cache = isolatedCache()
+        let manager = PushTopicSubscriptionManager(
+            identityStore: identityStore,
+            deviceInfoProvider: MockDeviceInfoProvider(deviceIdentifier: "device-1"),
+            conversationLister: conversationLister,
+            cache: cache,
+            pushTokenProvider: { "fake-apns-token" }
+        )
+
+        await manager.reconcilePushTopics(
+            params: SyncClientParams(client: client, apiClient: apiClient),
+            context: "first"
+        )
+        conversationLister.setGroupIds(["group-1", "group-2"])
+        await manager.reconcilePushTopics(
+            params: SyncClientParams(client: client, apiClient: apiClient),
+            context: "second"
+        )
+
+        // Set grew between reconciles -> hash differs -> the second call must
+        // hit the wire so the new topic actually gets subscribed.
+        #expect(apiClient.subscribeCalls.count == 2)
+        #expect(apiClient.subscribeCalls.last?.topics.contains("group-2".xmtpGroupTopicFormat) == true)
+    }
+
+    @Test("Reconcile failure does not write to cache so the next reconcile retries")
+    func reconcileFailureSkipsCacheWrite() async throws {
+        let identityStore = MockKeychainIdentityStore()
+        let keys = try await identityStore.generateKeys()
+        _ = try await identityStore.save(inboxId: "test-inbox-id", clientId: "client-1", keys: keys)
+
+        let client = TestableMockClient()
+        client.inboxId = "test-inbox-id"
+        let failingAPI = ThrowingPushAPIClient()
+        let recoveryAPI = RecordingPushAPIClient()
+        let conversationLister = RecordingPushConversationLister(
+            groupIds: ["group-1"],
+            dmIds: []
+        )
+        let cache = isolatedCache()
+        let manager = PushTopicSubscriptionManager(
+            identityStore: identityStore,
+            deviceInfoProvider: MockDeviceInfoProvider(deviceIdentifier: "device-1"),
+            conversationLister: conversationLister,
+            cache: cache,
+            pushTokenProvider: { "fake-apns-token" }
+        )
+
+        await manager.reconcilePushTopics(
+            params: SyncClientParams(client: client, apiClient: failingAPI),
+            context: "fail"
+        )
+        await manager.reconcilePushTopics(
+            params: SyncClientParams(client: client, apiClient: recoveryAPI),
+            context: "retry"
+        )
+
+        // Iron-rule regression: a failure on the first call must leave the
+        // cache untouched so the second call re-attempts the wire even
+        // though the desired topic set is unchanged.
+        #expect(failingAPI.subscribeCallCount == 1)
+        #expect(recoveryAPI.subscribeCalls.count == 1)
+    }
+
+    @Test("Reconcile sends when APNS token changes even if topic set is identical")
+    func reconcileSendsWhenTokenChanges() async throws {
+        let identityStore = MockKeychainIdentityStore()
+        let keys = try await identityStore.generateKeys()
+        _ = try await identityStore.save(inboxId: "test-inbox-id", clientId: "client-1", keys: keys)
+
+        let client = TestableMockClient()
+        client.inboxId = "test-inbox-id"
+        let apiClient = RecordingPushAPIClient()
+        let conversationLister = RecordingPushConversationLister(
+            groupIds: ["group-1"],
+            dmIds: []
+        )
+        let cache = isolatedCache()
+        let tokenBox = TokenBox(value: "token-A")
+        let manager = PushTopicSubscriptionManager(
+            identityStore: identityStore,
+            deviceInfoProvider: MockDeviceInfoProvider(deviceIdentifier: "device-1"),
+            conversationLister: conversationLister,
+            cache: cache,
+            pushTokenProvider: { tokenBox.read() }
+        )
+
+        await manager.reconcilePushTopics(
+            params: SyncClientParams(client: client, apiClient: apiClient),
+            context: "token-A"
+        )
+        tokenBox.set("token-B")
+        await manager.reconcilePushTopics(
+            params: SyncClientParams(client: client, apiClient: apiClient),
+            context: "token-B"
+        )
+
+        // Cache key includes the token hash, so rotating the token produces a
+        // miss and a fresh wire call - which is exactly what we need to keep
+        // XMTP server's deliveryMechanism aligned with the device's APNS state.
+        #expect(apiClient.subscribeCalls.count == 2)
+    }
+
+    @Test("clearCache forces the next reconcile to hit the wire")
+    func clearCacheForcesWire() async throws {
+        let identityStore = MockKeychainIdentityStore()
+        let keys = try await identityStore.generateKeys()
+        _ = try await identityStore.save(inboxId: "test-inbox-id", clientId: "client-1", keys: keys)
+
+        let client = TestableMockClient()
+        client.inboxId = "test-inbox-id"
+        let apiClient = RecordingPushAPIClient()
+        let conversationLister = RecordingPushConversationLister(
+            groupIds: ["group-1"],
+            dmIds: []
+        )
+        let cache = isolatedCache()
+        let manager = PushTopicSubscriptionManager(
+            identityStore: identityStore,
+            deviceInfoProvider: MockDeviceInfoProvider(deviceIdentifier: "device-1"),
+            conversationLister: conversationLister,
+            cache: cache,
+            pushTokenProvider: { "fake-apns-token" }
+        )
+
+        await manager.reconcilePushTopics(
+            params: SyncClientParams(client: client, apiClient: apiClient),
+            context: "first"
+        )
+        await manager.clearCache()
+        await manager.reconcilePushTopics(
+            params: SyncClientParams(client: client, apiClient: apiClient),
+            context: "after-clear"
+        )
+
+        // Explicit clear is the escape hatch for "Delete all data" / sign-out.
+        // Without it the second call would short-circuit on the cache hit.
+        #expect(apiClient.subscribeCalls.count == 2)
+    }
+
     @Test("Reconcile still subscribes available topics when one listing fails")
     func reconcileSubscribesAvailableTopicsWhenListingFails() async throws {
         let identityStore = MockKeychainIdentityStore()
@@ -438,6 +627,10 @@ private final class RecordingPushConversationLister: PushTopicConversationListin
         state.withLock { $0.dmCalls }
     }
 
+    func setGroupIds(_ ids: [String]) {
+        state.withLock { $0.groupIds = ids }
+    }
+
     func listGroupConversationIds(
         params _: SyncClientParams,
         consentStates: [ConsentState]?,
@@ -477,5 +670,39 @@ private final class RecordingPushConversationLister: PushTopicConversationListin
     private func usesLastActivityOrder(_ orderBy: ConversationsOrderBy) -> Bool {
         guard case .lastActivity = orderBy else { return false }
         return true
+    }
+}
+
+/// Returns a cache backed by a freshly-named UserDefaults suite so tests can
+/// run concurrently without bleeding state into each other (or into the
+/// host process's standard UserDefaults).
+private func isolatedCache() -> PushTopicSubscriptionCache {
+    let suiteName = "PushTopicSubscriptionCacheTests.\(UUID().uuidString)"
+    // Force-unwrap is intentional: a UserDefaults suite for a unique UUID
+    // cannot collide with another suite or fail allocation in practice. If
+    // this ever returns nil the cache tests would silently corrupt
+    // `.standard`; abort instead.
+    guard let defaults = UserDefaults(suiteName: suiteName) else {
+        fatalError("Failed to allocate UserDefaults suite \(suiteName) for test")
+    }
+    return PushTopicSubscriptionCache(userDefaults: defaults)
+}
+
+/// Thread-safe mutable string container for swapping the APNS token between
+/// reconcile calls. Closure-captured by the test, mutated by `.set(...)`,
+/// read by the manager's `pushTokenProvider`.
+private final class TokenBox: @unchecked Sendable {
+    private let state: OSAllocatedUnfairLock<String?>
+
+    init(value: String?) {
+        state = OSAllocatedUnfairLock(initialState: value)
+    }
+
+    func read() -> String? {
+        state.withLock { $0 }
+    }
+
+    func set(_ value: String?) {
+        state.withLock { $0 = value }
     }
 }

--- a/ConvosCore/Tests/ConvosCoreTests/SyncingManagerPushReconciliationTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/SyncingManagerPushReconciliationTests.swift
@@ -49,7 +49,15 @@ struct SyncingManagerPushReconciliationTests {
         try? await fixtures.cleanup()
     }
 
-    @Test("Reconciles push subscriptions after resume")
+    /// After D8 the resume path's reconcile no longer unconditionally hits
+    /// the wire -- if the cache says the desired topic set hasn't changed,
+    /// the reconcile correctly no-ops. To still prove resume DRIVES a
+    /// reconcile we clear the cache before resume, which forces a miss
+    /// regardless of what state the global PushNotificationRegistrar
+    /// singleton is in. Routing through the global singleton (token
+    /// rotation) flaked because PushNotificationRegistrarStaticTests
+    /// resets that singleton in parallel.
+    @Test("Resume triggers a reconcile that reaches the wire after cache is cleared")
     func reconcilesAfterResume() async throws {
         let fixtures = TestFixtures()
         let mockClient = TestableMockClient()
@@ -70,6 +78,9 @@ struct SyncingManagerPushReconciliationTests {
         let countAfterStart = recordingAPI.subscribeCount
 
         await syncingManager.pause()
+        // Force a cache miss without touching the global singleton.
+        // Equivalent to the "Delete all data" production escape hatch.
+        await syncingManager.clearPushSubscriptionCache()
         await syncingManager.resume()
 
         try await waitUntil(timeout: .seconds(15)) {
@@ -78,15 +89,22 @@ struct SyncingManagerPushReconciliationTests {
 
         #expect(
             recordingAPI.subscribeCount > countAfterStart,
-            "Resume must trigger a fresh push topic reconcile"
+            "Resume after clearPushSubscriptionCache must hit the wire to re-apply the topic set"
         )
 
         await syncingManager.stop()
         try? await fixtures.cleanup()
     }
 
-    @Test("Reconciles push subscriptions after requestDiscovery")
-    func reconcilesAfterRequestDiscovery() async throws {
+    /// Regression test for the D3 / iron-rule scenario: when ConversationStateMachine
+    /// polls requestDiscovery every 3 seconds waiting for a slow-arriving welcome,
+    /// the previous behavior was to call `reconcilePushSubscriptions` on every poll
+    /// even though no conversation had been discovered. That floods
+    /// `/v2/notifications/subscribe` with full topic-set posts (the "topicCount: 50
+    /// per poll" Datadog signal). After D3, requestDiscovery only reconciles when
+    /// `discoverNewConversations()` returns > 0, so a stuck join no longer floods.
+    @Test("requestDiscovery with no new conversations does not trigger a push reconcile")
+    func requestDiscoveryWithoutNewConversationsSkipsReconcile() async throws {
         let fixtures = TestFixtures()
         let mockClient = TestableMockClient()
         mockClient.streamBehavior = .neverClose
@@ -105,7 +123,61 @@ struct SyncingManagerPushReconciliationTests {
         try await waitUntil(timeout: .seconds(15)) { recordingAPI.subscribeCount >= 1 }
         let countAfterStart = recordingAPI.subscribeCount
 
-        await syncingManager.requestDiscovery()
+        // Simulate the 3s join-poll loop: hammer requestDiscovery ten times with
+        // an empty conversation set. None of these should reach the wire because
+        // discoverNewConversations() returns 0 each pass.
+        for _ in 0..<10 {
+            await syncingManager.requestDiscovery()
+        }
+        // Give any latent reconcile task a beat to fire before we assert the
+        // gate held. Real wire calls would arrive well within this window.
+        try await Task.sleep(for: .milliseconds(250))
+
+        #expect(
+            recordingAPI.subscribeCount == countAfterStart,
+            "Ten requestDiscovery polls with zero discovered conversations must not trigger any new push topic reconciles (was: each poll posted the full topic set)"
+        )
+
+        await syncingManager.stop()
+        try? await fixtures.cleanup()
+    }
+
+    /// D14: an APNS token rotation must drive a reconcile even when the
+    /// conversation set hasn't changed. This test proves the
+    /// .convosPushTokenDidChange listener is wired through to a reconcile
+    /// that reaches the wire. We force a cache miss via
+    /// `clearPushSubscriptionCache` rather than via the global
+    /// MockPushNotificationRegistrarProvider's token, because that
+    /// singleton is reset in parallel by PushNotificationRegistrarStaticTests
+    /// and the cross-suite race made this test flaky. The
+    /// "token sha changes -> cache key changes -> miss" property is
+    /// covered separately by the unit tests on PushTopicSubscriptionManager.
+    @Test("Posting .convosPushTokenDidChange triggers a push topic reconcile")
+    func tokenChangeTriggersReconcile() async throws {
+        let fixtures = TestFixtures()
+        let mockClient = TestableMockClient()
+        mockClient.streamBehavior = .neverClose
+        try await seedIdentity(matching: mockClient, into: fixtures)
+        let recordingAPI = RecordingPushAPIClientForReconciliationTests()
+
+        let syncingManager = SyncingManager(
+            identityStore: fixtures.identityStore,
+            databaseWriter: fixtures.databaseManager.dbWriter,
+            databaseReader: fixtures.databaseManager.dbReader,
+            deviceRegistrationManager: NoopDeviceRegistrationManager(),
+            notificationCenter: MockUserNotificationCenter()
+        )
+
+        await syncingManager.start(with: mockClient, apiClient: recordingAPI)
+        try await waitUntil(timeout: .seconds(15)) { recordingAPI.subscribeCount >= 1 }
+        let countAfterStart = recordingAPI.subscribeCount
+
+        // Force a deterministic cache miss for the upcoming reconcile.
+        // In production this would be driven by the token's sha changing
+        // inside the cache key; we shortcut to the same effect without
+        // depending on the global singleton.
+        await syncingManager.clearPushSubscriptionCache()
+        NotificationCenter.default.post(name: .convosPushTokenDidChange, object: nil)
 
         try await waitUntil(timeout: .seconds(15)) {
             recordingAPI.subscribeCount > countAfterStart
@@ -113,7 +185,7 @@ struct SyncingManagerPushReconciliationTests {
 
         #expect(
             recordingAPI.subscribeCount > countAfterStart,
-            "requestDiscovery must trigger a fresh push topic reconcile"
+            "convosPushTokenDidChange must drive a reconcile that reaches the wire"
         )
 
         await syncingManager.stop()

--- a/NotificationService/NotificationService.swift
+++ b/NotificationService/NotificationService.swift
@@ -13,20 +13,24 @@ private let globalPushHandler: CachedPushNotificationHandler? = {
 
         Log.info("Initializing global push handler for environment: \(environment.name)")
 
+        // LibXMTP logging is intentionally disabled in the Notification Service
+        // Extension. Enabling it triggered a Rust panic in `tracing-oslog`:
+        //     thread '<unnamed>' panicked at .../tracing-oslog-0.3.0/src/logger.rs:166:
+        //     invalid span, this shouldn't happen
+        // The panic fires deep in the os_log integration when libxmtp emits
+        // tracing spans inside the NSE process, killing the extension before
+        // it can decode the payload. To the user this presents as "push
+        // arrived in APNS but no banner shown" (verified on real device,
+        // 2026-05-29). Main app is unaffected; only the NSE process crosses
+        // the tracing-oslog boundary that triggers it.
+        //
+        // Mitigation: drop NSE-side logging entirely on non-production builds.
+        // We lose NSE debug visibility but recover push delivery. File the
+        // libxmtp / tracing-oslog issue and revisit once the panic is fixed
+        // upstream. Production already skipped this block, so production
+        // users were never affected.
         if !environment.isProduction {
-            Log.info("Activating LibXMTP file log writer (NSE) at \(environment.defaultXMTPLogsDirectoryURL.path) (level=.debug, rotation=hourly, maxFiles=10)…")
-            Client.activatePersistentLibXMTPLogWriter(
-                logLevel: .debug,
-                rotationSchedule: .hourly,
-                maxFiles: 10,
-                customLogDirectory: environment.defaultXMTPLogsDirectoryURL,
-                processType: .notificationExtension
-            )
-            Log.info("LibXMTP file log writer activated (NSE)")
-            // NSE memory/time limits — quieter than main app.
-            Log.info("Setting LibXMTP native log level to .info (NSE)…")
-            Client.setLibXMTPNativeLogLevel(.info)
-            Log.info("LibXMTP native log level set to .info (NSE)")
+            Log.info("Skipping LibXMTP logging in NSE (tracing-oslog panic workaround). Main app still logs.")
         }
 
         let nseVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "unknown"


### PR DESCRIPTION
Implements Stack 1 of docs/plans/ios-notifications-subscription-debugging.md (#907). iOS-only; no backend changes.

## What this does

- **T1+T2 (D2, D10)**: ConvosAppDelegate uses `PushNotificationRegistrar.save(token:)` static, dropping the injected `pushNotificationRegistrar` property. The static is now graceful — logs an error and no-ops if `configure()` didn't run, so test environments and the `.iOSExtension` provider path degrade safely instead of fatalError.
- **T3**: `DebugView.registerDeviceAgain` no longer constructs a fresh `PlatformProviders.iOS`. The fresh providers shipped with a brand-new `IOSPushNotificationRegistrar` whose `_token` was nil, so the debug button could re-register with a stale token while the rest of the app still held the real one. Wrap the configured singletons instead.
- **T4 (D7)**: Pull the listing logic out of `PushTopicSubscriptionManager.reconcilePushTopics` into a private `computeReconcileDesiredSubscriptions` helper so the debounce path and (future) diagnostics surface read the same source of truth.
- **T5 (D8)**: Add `PushTopicSubscriptionCache` backed by UserDefaults. Cache key partitions by `inboxId + clientId + deviceId + pushTokenSha256`; hash is sorted-utf8 + LF separator + SHA-256 hex lowercase. Writes only inside `subscribe()`'s success branch so a thrown API call leaves the cache untouched and the next reconcile retries. `clearCache()` exposes the explicit drop path for sign-out and "Delete all data".
- **T6 (D3)**: `SyncingManager.discoverNewConversations` returns Int. `requestDiscovery` only calls `reconcilePushSubscriptions` when count > 0. Stops the 3s join-poll flood (Datadog `topicCount: 50` per tick).
- **T7 (D14)**: `SyncingManager` observes `.convosPushTokenDidChange` and drives a reconcile with context "after token change" so a rotated APNS token always re-applies upstream even when the conversation set is unchanged. Cache key changes naturally produce the cache miss.
- **T7.5 (added during testing)**: Mitigate a libxmtp `tracing-oslog` panic in the Notification Service Extension by disabling LibXMTP logging in the NSE on non-prod builds. See "Production validation findings" below.

## Tests

7 new unit tests covering cache hit/miss/failure/token-rotation/explicit-clear, plus a regression test asserting 10 `requestDiscovery` polls with no new conversations produce zero subscribe calls. 2 new unit tests for the graceful save path. Resume test rewritten to use the new `clearPushSubscriptionCache` escape hatch instead of mutating the global `PushNotificationRegistrar` singleton (which made it flake under cross-suite parallel runs).

1051 ConvosCore tests pass; swift build clean; swiftlint --strict clean.

## Production validation findings

Tested against a real broken phone (production-symptom: no push delivery for any conversation). Findings:

1. **24 stale `ClientIdentifier` rows** accumulated for one device over 4 months, oldest from 2026-02-03. Confirms codex's D15 prediction in production: same-account identity rotation creates orphan rows that webhook delivery still resolves to the current device. The NSE-unregister middleware (Stack 2's T14) is what stops this from regenerating.
2. **The real wedge was a libxmtp `tracing-oslog` panic in the NSE**, not the orphans. The NSE crashed processing the message backlog, dropping the push silently:
   ```
   thread '<unnamed>' panicked at tracing-oslog-0.3.0/src/logger.rs:166:
   invalid span, this shouldn't happen
   ```
   Fires reliably on physical iOS device when the NSE has 5+ envelopes to catch up on. Does NOT fire on simulator with single-envelope payloads (probabilistic with span emission volume). Filed upstream with libxmtp. Stack 1 ships the workaround (disable NSE-side LibXMTP logging on non-prod); production was already skipping it so no production users are affected.
3. **iOS's `welcome:75f19f4b...` topic source != backend's `ClientIdentifier.id`**. iOS prints the 64-char hex XMTP `installationId` in the topic; backend stores a Convos-issued UUID (`9A430A09-...`) as the clientId. These are different identifiers. Worth documenting for future Stack 2 work and for anyone debugging push delivery by hand.

## What's still needed (Stack 2)

- T11.5: backend logs `accountId` on `Subscribing to topics` (already a gap that bit us during this validation — Datadog only filters by `deviceId` which the iOS debug menu doesn't expose).
- T20: one-time migration to clean up the accumulated orphan `ClientIdentifier` rows. Without this, every existing wedged device stays wedged (Stack 1 doesn't auto-heal them; only deletion + reinstall + NSE workaround does).
- T14 (NSE unregister middleware) + T15 (webhook accountId check): forward-going prevention of new orphan accumulation.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add hash-based debounce, token-change trigger, and count-gated discovery for push topic reconciliation
> - Adds `PushTopicSubscriptionCache` to persist a SHA-256 hash of the desired push topic set, keyed by identity, device, and APNS token; reconciliation skips the network call on a cache hit.
> - `SyncingManager` now observes `.convosPushTokenDidChange` and triggers a push topic reconcile when syncing is active, ensuring token rotations propagate immediately.
> - `requestDiscovery` no longer triggers push reconcile when zero new conversations are discovered, reducing unnecessary network calls.
> - Routes APNS token registration in `ConvosAppDelegate` through `PushNotificationRegistrar.save(token:)` static accessor; calling it before `configure()` now logs and no-ops instead of crashing.
> - Fixes the debug re-register action in `DebugView` to reuse live singletons so registration is not sent with a nil push token.
> - Removes LibXMTP log initialization from the Notification Service Extension in non-production builds to prevent a tracing-oslog panic that killed the extension during push handling.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a3c4362.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->