### PR TITLE
Pick subscription product IDs by bundle ID

### DIFF
--- a/Convos.storekit
+++ b/Convos.storekit
@@ -84,7 +84,7 @@
               "locale" : "en_US"
             }
           ],
-          "productID" : "app.convos.subs.builder.annual",
+          "productID" : "app.convos.subs.annual",
           "recurringSubscriptionPeriod" : "P1Y",
           "referenceName" : "Plus Annual",
           "subscriptionGroupID" : "21F0AAB1-7B9D-4C3E-8F92-A0E1B2C3D401",
@@ -105,7 +105,7 @@
               "locale" : "en_US"
             }
           ],
-          "productID" : "app.convos.subs.builder.monthly",
+          "productID" : "app.convos.subs.monthly",
           "recurringSubscriptionPeriod" : "P1M",
           "referenceName" : "Plus Monthly",
           "subscriptionGroupID" : "21F0AAB1-7B9D-4C3E-8F92-A0E1B2C3D401",

--- a/ConvosCore/Sources/ConvosCore/Services/Subscription/SubscriptionProductIDs.swift
+++ b/ConvosCore/Sources/ConvosCore/Services/Subscription/SubscriptionProductIDs.swift
@@ -1,31 +1,37 @@
 import Foundation
 
 public enum SubscriptionProductIDs {
-    public static let plusMonthly: String = "app.convos.subs.builder.monthly"
-    public static let plusAnnual: String = "app.convos.subs.builder.annual"
+    /// Bundle ID is the literal key StoreKit uses to look up products in
+    /// App Store Connect. The prod ASC app owns the `plus.*` product IDs
+    /// (registered to `org.convos.ios`); every other bundle (Dev preview,
+    /// Local, App Clip, PR) talks to the Dev ASC app, which owns the
+    /// unprefixed `subs.monthly` / `subs.annual` IDs.
+    ///
+    /// We read the bundle ID directly rather than routing through
+    /// `AppEnvironment.isProduction` because the bundle ID is the literal
+    /// thing StoreKit checks; routing through ConfigManager + config.json
+    /// + AppEnvironment adds three layers of indirection where a build
+    /// misconfiguration could put the env in an inconsistent state.
+    private static let isProductionBundle: Bool =
+        Bundle.main.bundleIdentifier == "org.convos.ios"
 
-    public static let all: Set<String> = [
-        plusMonthly,
-        plusAnnual,
-    ]
+    public static let plusMonthly: String = isProductionBundle
+        ? "app.convos.subs.plus.monthly"
+        : "app.convos.subs.monthly"
 
-    /// Legacy product ID from the pre-Plus era. Never returned by
-    /// `availableProducts()` (removed from `all`) but still recognized so
-    /// any existing entitlement migrates cleanly to Plus instead of being
-    /// silently dropped. Same intent as `SubscriptionTier.init(from:)`
-    /// mapping the backend "pro" string to `.plus`.
-    private static let legacyProMonthly: String = "app.convos.subs.pro.monthly"
+    public static let plusAnnual: String = isProductionBundle
+        ? "app.convos.subs.plus.annual"
+        : "app.convos.subs.annual"
+
+    public static let all: Set<String> = [plusMonthly, plusAnnual]
 
     public static func tier(for productID: String) -> SubscriptionTier? {
-        switch productID {
-        case plusMonthly, plusAnnual, legacyProMonthly: return .plus
-        default: return nil
-        }
+        all.contains(productID) ? .plus : nil
     }
 
     public static func period(for productID: String) -> SubscriptionPeriod? {
         switch productID {
-        case plusMonthly, legacyProMonthly: return .monthly
+        case plusMonthly: return .monthly
         case plusAnnual: return .annual
         default: return nil
         }


### PR DESCRIPTION
App Store Connect product IDs are globally unique across all apps in a
developer account, so dev and prod can't share IDs. Prod ASC owns the
`app.convos.subs.plus.{monthly,annual}` namespace; every other bundle
(Dev preview, Local, App Clip, PR) hits Dev ASC where the unprefixed
`app.convos.subs.{monthly,annual}` products live.

Read the bundle ID directly instead of routing through
`AppEnvironment.isProduction`. The bundle ID is the literal key StoreKit
uses to look up products; routing through ConfigManager + config.json +
AppEnvironment adds layers where a build misconfiguration could put the
env in an inconsistent state with what StoreKit actually sees.

Dropped the legacy product ID fallback list. The only thing it protected
was a single Dev sandbox subscriber on `app.convos.subs.builder.*`, who
can re-subscribe to the new product in one tap via Apple's Manage
Subscriptions sheet (free in sandbox).

Updates `Convos.storekit` to match the Dev ASC product IDs so local
simulator builds see the same products as a Dev TestFlight build.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/913"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782665711&installation_id=128169237&pr_number=913&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F913&signature=98312a95dcb9f494a026c175f0b4cf80e41d233e649d9e687a29a69664dace1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pick subscription product IDs by bundle ID in `SubscriptionProductIDs`
> - `plusMonthly` and `plusAnnual` now return environment-specific IDs: `app.convos.subs.plus.*` for the production bundle (`org.convos.ios`) and `app.convos.subs.*` for all other bundles.
> - The local [Convos.storekit](https://github.com/xmtplabs/convos-ios/pull/913/files#diff-6378be264a46d37b43d130e694b01b18534d6f67f9d5432718a116a7108513e8) config is updated to match the non-production IDs.
> - Removes the legacy `legacyProMonthly` constant (`app.convos.subs.pro.monthly`) and its mappings from `tier(for:)` and `period(for:)`.
> - Behavioral Change: any code relying on the old hardcoded `app.convos.subs.builder.*` or legacy `app.convos.subs.pro.monthly` IDs will no longer match recognized products.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized df5cd93.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->