### PR TITLE
fix(messages): HTML attachments render as square tiles, aligned, no dup reactions

### DIFF
--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -31,6 +31,17 @@ struct PendingFileAttachment: Identifiable, Equatable {
         self.fileSize = fileSize
     }
 
+    /// Mirrors `HydratedAttachment.isHTMLFile` so the composer's staged-file
+    /// preview can match the in-chat HTML tile (square thumbnail) instead of
+    /// the generic filename + type chip.
+    var isHTMLFile: Bool {
+        let ext = (filename as NSString).pathExtension.lowercased()
+        if ext == "html" || ext == "htm" {
+            return true
+        }
+        return mimeType.lowercased() == "text/html"
+    }
+
     static func == (lhs: PendingFileAttachment, rhs: PendingFileAttachment) -> Bool {
         lhs.id == rhs.id
     }

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesInputView.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesInputView.swift
@@ -176,7 +176,38 @@ struct MessagesInputView: View {
         case .video(let video):
             photoVideoPreview(image: video.thumbnail, isVideo: true, attachmentId: attachment.id)
         case .file(let file):
-            filePreview(file: file)
+            if file.isHTMLFile {
+                htmlFilePreview(file: file)
+            } else {
+                filePreview(file: file)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func htmlFilePreview(file: PendingFileAttachment) -> some View {
+        let isPoof: Bool = poofingAttachmentIds.contains(file.id)
+        let scale: CGFloat = isPoof ? 1.3 : 1.0
+        let blur: CGFloat = isPoof ? 12.0 : 0.0
+        let opacity: Double = isPoof ? 0.0 : 1.0
+        ZStack(alignment: .topTrailing) {
+            ComposerHTMLThumbnail(
+                fileURL: file.url,
+                cacheKey: "composer-html-\(file.id.uuidString)"
+            )
+            .frame(width: attachmentPreviewSize, height: attachmentPreviewSize)
+            .clipShape(.rect(cornerRadius: DesignConstants.Spacing.step4x))
+            .scaleEffect(scale)
+            .blur(radius: blur)
+            .opacity(opacity)
+            .accessibilityLabel("HTML attachment preview")
+            .accessibilityIdentifier("html-attachment-preview")
+
+            removeAttachmentButton(
+                attachmentId: file.id,
+                label: "Remove file attachment",
+                identifier: "remove-file-attachment-button"
+            )
         }
     }
 
@@ -681,5 +712,76 @@ struct ExplodeCountdownBadge: View {
         .padding(.horizontal, 6)
         .padding(.vertical, 3)
         .background(.colorCaution.opacity(0.15), in: Capsule())
+    }
+}
+
+/// Square HTML thumbnail for a staged (not-yet-sent) file attachment in the
+/// composer. Renders the same `HTMLThumbnailRenderer` preview the in-chat
+/// `HTMLAttachmentBubble` uses, loaded from the local file URL, so a staged
+/// HTML file reads as a small page tile instead of the generic filename +
+/// "HTML" file chip. Keyed on a composer-local key (the staged attachment id),
+/// distinct from the content-addressed key the sent attachment later uses.
+private struct ComposerHTMLThumbnail: View {
+    let fileURL: URL
+    let cacheKey: String
+
+    @Environment(\.colorScheme) private var colorScheme: ColorScheme
+    @State private var renderedImage: UIImage?
+    @State private var hasLoadFailed: Bool = false
+
+    var body: some View {
+        Group {
+            if let renderedImage {
+                Image(uiImage: renderedImage)
+                    .resizable()
+                    .aspectRatio(contentMode: .fill)
+            } else {
+                ZStack {
+                    Color.colorFillSubtle
+                    if hasLoadFailed {
+                        Image(systemName: "globe")
+                            .font(.title3)
+                            .foregroundStyle(.secondary)
+                    } else {
+                        ProgressView()
+                    }
+                }
+            }
+        }
+        .onAppear(perform: seedFromMemoryCache)
+        .task(id: AttachmentColorSchemeKey(key: cacheKey, scheme: colorScheme)) {
+            await loadThumbnail()
+        }
+    }
+
+    private func seedFromMemoryCache() {
+        guard renderedImage == nil else { return }
+        if let cached = HTMLThumbnailRenderer.shared.cachedThumbnail(
+            for: cacheKey,
+            appearance: colorScheme.uiUserInterfaceStyle
+        ) {
+            renderedImage = cached
+            hasLoadFailed = false
+        }
+    }
+
+    private func loadThumbnail() async {
+        let appearance = colorScheme.uiUserInterfaceStyle
+        if let cached = HTMLThumbnailRenderer.shared.cachedThumbnail(for: cacheKey, appearance: appearance) {
+            renderedImage = cached
+            hasLoadFailed = false
+            return
+        }
+        let image = await HTMLThumbnailRenderer.shared.thumbnail(
+            for: cacheKey,
+            fileURL: fileURL,
+            appearance: appearance
+        )
+        if let image {
+            renderedImage = image
+            hasLoadFailed = false
+        } else if renderedImage == nil {
+            hasLoadFailed = true
+        }
     }
 }

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessageContextMenu/MessageContextMenuOverlay.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessageContextMenu/MessageContextMenuOverlay.swift
@@ -619,7 +619,6 @@ struct MessageContextMenuOverlay: View {
             HTMLAttachmentBubble(
                 attachment: attachment,
                 profile: profile,
-                reactions: [],
                 agentVerification: message?.sender.agentVerification ?? .unverified,
                 cornerRadiusOverride: radius
             )

--- a/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/HTMLAttachmentBubble.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/HTMLAttachmentBubble.swift
@@ -11,10 +11,8 @@ import UIKit
 struct HTMLAttachmentBubble: View {
     let attachment: HydratedAttachment
     let profile: Profile
-    let reactions: [MessageReaction]
     var agentVerification: AgentVerification = .unverified
     var onTapAvatar: (() -> Void)?
-    var onTapReactions: (() -> Void)?
     var cornerRadiusOverride: CGFloat?
     /// Namespace owned by the SwiftUI host (`MessagesView`) and threaded
     /// down through `MessagesViewController`'s cell config so the bubble
@@ -40,18 +38,14 @@ struct HTMLAttachmentBubble: View {
 
     @ViewBuilder
     private var bubble: some View {
+        // No inline reaction overlay: HTML tiles render through the normal
+        // (non-full-bleed) bubble path, where `MessagesGroupView.reactionRow`
+        // shows reactions underneath the tile like text / file bubbles.
+        // Overlaying them here too would double them up.
         let base = preview
             .frame(width: Constant.size, height: Constant.size)
             .background(Color.colorFillMinimal)
             .clipShape(RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
-            .overlay(alignment: .bottomLeading) {
-                if !reactions.isEmpty {
-                    let tap: () -> Void = {
-                        onTapReactions?()
-                    }
-                    MediaContainerReax(reactions: reactions, onTap: tap)
-                }
-            }
         if let transitionNamespace {
             base.matchedTransitionSource(id: attachment.key, in: transitionNamespace)
         } else {

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
@@ -274,14 +274,17 @@ struct MessagesGroupItemView: View {
         } else if attachment.isHTMLFile {
             let htmlTapAction: () -> Void = { onOpenFile?(attachment, message) }
             let avatarTap: () -> Void = { onTapAvatar(message) }
-            let reactionsTap: () -> Void = { onTapReactions?(message) }
+            let isOutgoing: Bool = message.sender.isCurrentUser
+            // The HTML tile has its own chrome (no `MessageContainer`), so it
+            // doesn't inherit the outgoing right-alignment other bubbles get.
+            // Align the gestured tile to the sender's side; the frame only
+            // positions it, so the tap target stays on the 160pt tile.
+            // Reactions render underneath via `reactionRow`, not on the tile.
             HTMLAttachmentBubble(
                 attachment: attachment,
                 profile: message.sender.profile,
-                reactions: message.reactions,
                 agentVerification: message.sender.agentVerification,
                 onTapAvatar: avatarTap,
-                onTapReactions: reactionsTap,
                 transitionNamespace: htmlAttachmentTransitionNamespace
             )
             .messageGesture(
@@ -292,6 +295,8 @@ struct MessagesGroupItemView: View {
                 onToggleReaction: onToggleReaction
             )
             .id(message.messageId)
+            .frame(maxWidth: .infinity, alignment: isOutgoing ? .trailing : .leading)
+            .padding(.trailing, isOutgoing ? DesignConstants.Spacing.step4x : 0)
         } else if attachment.mediaType == .file {
             let fileTapAction: () -> Void = { onOpenFile?(attachment, message) }
             FileAttachmentBubble(


### PR DESCRIPTION
Three follow-up fixes to #878's HTML-attachment tile work.

1. Outgoing HTML tiles rendered on the wrong (incoming) side. #878 reworked
   HTML attachments into 160x160 tiles and dropped HTML from
   `HydratedAttachment.isFullBleed`, routing them through the normal bubble
   path -- but the HTML branch in `MessagesGroupItemView.attachmentView` never
   applied the outgoing right-alignment the other bubbles get (text/file/voice
   self-align via `MessageContainer`'s internal `if isOutgoing { Spacer() }`;
   the HTML tile has its own chrome and isn't wrapped in `MessageContainer`).
   Align the gestured tile to the sender's side with matching trailing
   padding. The alignment frame is applied after `messageGesture`, so it only
   positions the 160pt tile -- the tap target is unchanged.

2. Reactions doubled up on HTML tiles. As a non-full-bleed bubble, the HTML
   tile already gets its reactions rendered underneath by
   `MessagesGroupView.reactionRow` (like text / file bubbles), but
   `HTMLAttachmentBubble` still carried the inline `MediaContainerReax` overlay
   meant for full-bleed media -- so reactions showed twice. Remove the overlay
   (and the now-dead `reactions` / `onTapReactions` params); reactions show
   only underneath.

3. The composer's staged-attachment chip showed HTML files as the generic
   filename + "HTML" file row. Render them as a square thumbnail chip matching
   the photo/video previews (80pt square, X in the top-right) via the same
   `HTMLThumbnailRenderer` preview loaded from the staged local file. Adds
   `PendingFileAttachment.isHTMLFile` and a `ComposerHTMLThumbnail` view.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/915"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782670835&installation_id=128169237&pr_number=915&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F915&signature=dd9671c6c9c027b51b19c3ee9162a6b4ef88396d0cacbb8536e8747e55ff1b40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix HTML attachment rendering to show square tiles, aligned by sender, with no duplicate reactions
> - HTML file attachments in the message composer now render as square thumbnail tiles via a new `ComposerHTMLThumbnail` view, replacing the generic filename/type chip.
> - HTML attachment tiles in the message list are now aligned to the sender's side (leading for incoming, trailing with padding for outgoing).
> - Removes the inline reactions overlay from `HTMLAttachmentBubble`; reactions now render via the standard `MessagesGroupView` reaction row instead, eliminating duplicate reactions.
> - `PendingFileAttachment` gains an `isHTMLFile` computed property to distinguish HTML files by extension or MIME type.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 085c92b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->