### PR TITLE
Compose: contacts picker first, then push the new conversation

### DIFF
--- a/Convos/App Settings/AppSettingsView.swift
+++ b/Convos/App Settings/AppSettingsView.swift
@@ -82,7 +82,7 @@ struct AppSettingsView: View {
             .toolbar { topToolbar }
             .onReceive(CreditsServices.shared.balancePublisher) { creditBalance = $0 }
             .onReceive(SubscriptionServices.shared.subscriptionPublisher) { currentSubscription = $0 }
-            .onReceive(session.messagingService().contactsRepository().contactsPublisher) { contactsCount = $0.count }
+            .onReceive(session.messagingService().contactsRepository().contactsPublisher) { contactsCount = ContactsViewModel.visibleContacts($0).count }
         }
     }
 

--- a/Convos/Contacts/ContactsListView.swift
+++ b/Convos/Contacts/ContactsListView.swift
@@ -75,3 +75,26 @@ struct ContactsListSectionHeader: View {
             .listRowBackground(Color.colorBackgroundRaisedSecondary)
     }
 }
+
+/// Shared "no contacts" empty state for the contacts browser and the picker
+/// so both read the same. Callers supply their own background.
+struct ContactsEmptyStateView: View {
+    var body: some View {
+        VStack(spacing: DesignConstants.Spacing.step3x) {
+            Image(systemName: "person.2.fill")
+                .resizable()
+                .scaledToFit()
+                .frame(width: 56, height: 56)
+                .foregroundStyle(.colorTextTertiary)
+            Text("No contacts yet")
+                .font(.headline)
+                .foregroundStyle(.colorTextPrimary)
+            Text("People you message in groups will show up here.")
+                .font(.subheadline)
+                .multilineTextAlignment(.center)
+                .foregroundStyle(.colorTextSecondary)
+                .padding(.horizontal, DesignConstants.Spacing.step6x)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}

--- a/Convos/Contacts/ContactsPickerView.swift
+++ b/Convos/Contacts/ContactsPickerView.swift
@@ -40,6 +40,12 @@ struct ContactsPickerView: View {
     /// for the add-to-conversation flow callers can pass the destination
     /// conversation. Nil shows a stable default avatar.
     let pillConversation: Conversation?
+    /// When `true` (the default) the picker wraps its content in its own
+    /// `NavigationStack`, suitable for being presented standalone as a
+    /// sheet. The Compose flow sets this to `false` so the picker is the
+    /// root of the host's stack and can push the new-conversation view onto
+    /// it instead of dismissing.
+    let embedsNavigationStack: Bool
 
     init(
         mode: ContactsPickerMode,
@@ -47,6 +53,7 @@ struct ContactsPickerView: View {
         alreadyInChatInboxIds: Set<String> = [],
         preselectedInboxIds: Set<String> = [],
         pillConversation: Conversation? = nil,
+        embedsNavigationStack: Bool = true,
         onConfirm: @escaping (_ inboxIds: Set<String>) -> Void
     ) {
         _viewModel = State(initialValue: ContactsPickerViewModel(
@@ -56,16 +63,23 @@ struct ContactsPickerView: View {
             preselectedInboxIds: preselectedInboxIds
         ))
         self.pillConversation = pillConversation
+        self.embedsNavigationStack = embedsNavigationStack
         self.onConfirm = onConfirm
     }
 
     var body: some View {
-        NavigationStack {
-            content
-                .background(.colorBackgroundRaisedSecondary)
-                .navigationBarTitleDisplayMode(.inline)
-                .toolbar { toolbarContent }
+        if embedsNavigationStack {
+            NavigationStack { pickerContent }
+        } else {
+            pickerContent
         }
+    }
+
+    private var pickerContent: some View {
+        content
+            .background(.colorBackgroundRaisedSecondary)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar { toolbarContent }
     }
 
     /// The list takes the full sheet and scrolls behind the toolbar
@@ -128,6 +142,13 @@ struct ContactsPickerView: View {
 
     private func handleConfirm() {
         let ids = viewModel.selectedInboxIds
+        if case .compose = viewModel.mode {
+            // Compose: Skip/Continue proceeds even with no selection, and the
+            // host pushes the new-conversation view onto the stack, so the
+            // picker stays put as the root rather than dismissing itself.
+            onConfirm(ids)
+            return
+        }
         guard !ids.isEmpty else { return }
         onConfirm(ids)
         dismiss()
@@ -247,18 +268,7 @@ private struct ContactsPickerList: View {
     }
 
     private var emptyState: some View {
-        VStack(spacing: DesignConstants.Spacing.step2x) {
-            Image(systemName: "person.crop.circle.badge.questionmark")
-                .resizable()
-                .scaledToFit()
-                .frame(width: 48.0, height: 48.0)
-                .foregroundStyle(.colorTextTertiary)
-            Text("No contacts to show")
-                .font(.subheadline)
-                .foregroundStyle(.colorTextSecondary)
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .padding(DesignConstants.Spacing.step6x)
+        ContactsEmptyStateView()
     }
 
     private func rowTapAction(for row: ContactsPickerViewModel.Row) -> () -> Void {

--- a/Convos/Contacts/ContactsPickerViewModel.swift
+++ b/Convos/Contacts/ContactsPickerViewModel.swift
@@ -13,11 +13,17 @@ import Observation
 /// shape (mode enum + parameterized view) over duplicating the view.
 enum ContactsPickerMode: Hashable {
     case newConversation
+    /// Compose entry point: the picker is the first step of the Compose
+    /// flow and selecting contacts is optional. The bottom CTA reads
+    /// "Skip" with nothing selected and "Continue" once a contact is
+    /// picked, and is always enabled (Skip is a valid action). Proceeding
+    /// pushes the new-conversation view rather than dismissing.
+    case compose
     case addToConversation(conversationId: String, conversationTitle: String?)
 
     var isAddToConversation: Bool {
         switch self {
-        case .newConversation:
+        case .newConversation, .compose:
             return false
         case .addToConversation:
             return true
@@ -94,12 +100,19 @@ final class ContactsPickerViewModel {
     }
 
     var canConfirm: Bool {
-        !selectedInboxIds.isEmpty
+        // Compose allows skipping (no selection required); the other modes
+        // need at least one contact picked before the CTA enables.
+        switch mode {
+        case .compose:
+            return true
+        case .newConversation, .addToConversation:
+            return !selectedInboxIds.isEmpty
+        }
     }
 
     var headerTitle: String {
         switch mode {
-        case .newConversation:
+        case .newConversation, .compose:
             return "New conversation"
         case .addToConversation(_, let title):
             if let title, !title.isEmpty {
@@ -114,7 +127,7 @@ final class ContactsPickerViewModel {
     /// the picker is scoped to an existing chat.
     var pillTitle: String {
         switch mode {
-        case .newConversation:
+        case .newConversation, .compose:
             return "New Convo"
         case .addToConversation(_, let title):
             if let title, !title.isEmpty {
@@ -136,7 +149,10 @@ final class ContactsPickerViewModel {
     }
 
     var confirmButtonTitle: String {
-        "Continue"
+        if case .compose = mode, selectedInboxIds.isEmpty {
+            return "Skip"
+        }
+        return "Continue"
     }
 
     // MARK: - Mutations
@@ -176,6 +192,15 @@ final class ContactsPickerViewModel {
         selectedInboxIds = selectedInboxIds.intersection(visibleInboxIds)
         rebuildSections()
         isLoading = false
+    }
+
+    /// Contacts the picker would actually show. Shared with
+    /// `ConversationsViewModel` so Compose can decide whether the picker is
+    /// worth presenting (vs. opening the new-conversation view directly) --
+    /// the raw contact count includes agents / blocked / unnamed entries that
+    /// never appear here.
+    static func pickableContacts(_ contacts: [Contact]) -> [Contact] {
+        contacts.filter(isVisibleInPicker)
     }
 
     /// Single source of truth for "is this contact a valid picker row".

--- a/Convos/Contacts/ContactsView.swift
+++ b/Convos/Contacts/ContactsView.swift
@@ -124,23 +124,8 @@ struct ContactsView: View {
     }
 
     private var emptyState: some View {
-        VStack(spacing: DesignConstants.Spacing.step3x) {
-            Image(systemName: "person.2.fill")
-                .resizable()
-                .scaledToFit()
-                .frame(width: 56, height: 56)
-                .foregroundStyle(.colorTextTertiary)
-            Text("No contacts yet")
-                .font(.headline)
-                .foregroundStyle(.colorTextPrimary)
-            Text("People you message in groups will show up here.")
-                .font(.subheadline)
-                .multilineTextAlignment(.center)
-                .foregroundStyle(.colorTextSecondary)
-                .padding(.horizontal, DesignConstants.Spacing.step6x)
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .background(.colorBackgroundRaisedSecondary)
+        ContactsEmptyStateView()
+            .background(.colorBackgroundRaisedSecondary)
     }
 
     // MARK: - Toolbar

--- a/Convos/Contacts/ContactsViewModel.swift
+++ b/Convos/Contacts/ContactsViewModel.swift
@@ -62,6 +62,13 @@ final class ContactsViewModel {
         isLoading = false
     }
 
+    /// Contacts actually rendered in the browser list. Shared with App
+    /// Settings so its "Contacts" count matches what the list shows -- the
+    /// raw contact count includes hidden verified agents / unnamed entries.
+    static func visibleContacts(_ contacts: [Contact]) -> [Contact] {
+        contacts.filter(isVisibleInList)
+    }
+
     /// Single source of truth for "is this contact rendered in the list".
     /// Verified agents stay in `DBContact` so chat-side surfaces (member
     /// rows, system messages, the contact card opened from a member tap)

--- a/Convos/Conversation Creation/ComposeFlowView.swift
+++ b/Convos/Conversation Creation/ComposeFlowView.swift
@@ -1,0 +1,69 @@
+import ConvosCore
+import SwiftUI
+
+// MARK: - Module overview
+//
+// `ComposeFlowView` is the Compose entry flow. Single entry point:
+//
+//   1. MainTabView's Compose button -> `ConversationsViewModel.onStartConvo()`,
+//      which presents this sheet only when the user has pickable contacts
+//      (with none, it opens the new-conversation view directly and this view
+//      is never shown). The picker is hard-wired to `ContactsPickerMode.compose`
+//      -- the mode is owned here, not passed by the caller.
+//
+// Mirrors the entry-point-map convention used by `ContactsPickerView` /
+// `ContactCardMode` (see CLAUDE.md "View Modes for Multi-Entry-Point Surfaces").
+
+/// Root of the Compose flow, presented as a sheet when the user taps Compose
+/// *and has contacts to pick from* (with no contacts, `onStartConvo` skips
+/// this entirely and opens the new-conversation view directly).
+///
+/// A conversation is claimed from the warm cache upfront (by
+/// `ConversationsViewModel.onStartConvo`) and handed in as
+/// `composeConversationViewModel`.
+///
+/// Step 1 is the contacts picker in `.compose` mode -- selecting contacts is
+/// optional, so its bottom button reads "Skip" until a contact is picked and
+/// "Continue" after.
+///
+/// Step 2 pushes the *same* claimed conversation onto this stack: Skip opens
+/// it as-is, Continue first adds the picked contacts. The pushed view shows a
+/// close (X) that tears down the whole flow -- there is no back to the picker.
+struct ComposeFlowView: View {
+    @Bindable var conversationsViewModel: ConversationsViewModel
+    let composeConversationViewModel: NewConversationViewModel
+    @Bindable var profileSettingsViewModel: ProfileSettingsViewModel
+    let contactsRepository: any ContactsRepositoryProtocol
+    @State private var pushedConversation: NewConversationViewModel?
+
+    var body: some View {
+        NavigationStack {
+            ContactsPickerView(
+                mode: .compose,
+                contactsRepository: contactsRepository,
+                embedsNavigationStack: false,
+                onConfirm: handleProceed
+            )
+            .navigationDestination(item: $pushedConversation) { conversationViewModel in
+                NewConversationView(
+                    viewModel: conversationViewModel,
+                    profileSettingsViewModel: profileSettingsViewModel,
+                    embedsNavigationStack: false,
+                    onClose: { conversationsViewModel.presentingComposeFlow = false }
+                )
+            }
+        }
+    }
+
+    /// Skip (empty selection) opens the claimed conversation as-is; Continue
+    /// adds the picked contacts to it first. The push happens immediately
+    /// either way -- the members land in the open conversation a moment later.
+    private func handleProceed(with inboxIds: Set<String>) {
+        if !inboxIds.isEmpty, let conversationViewModel = composeConversationViewModel.conversationViewModel {
+            Task {
+                try? await conversationViewModel.addMembersFromContacts(Array(inboxIds))
+            }
+        }
+        pushedConversation = composeConversationViewModel
+    }
+}

--- a/Convos/Conversation Creation/NewConversationView.swift
+++ b/Convos/Conversation Creation/NewConversationView.swift
@@ -4,6 +4,17 @@ import SwiftUI
 struct NewConversationView: View {
     let viewModel: NewConversationViewModel
     @Bindable var profileSettingsViewModel: ProfileSettingsViewModel
+    /// When `true` (the default) the view wraps its content in its own
+    /// `NavigationStack` -- the standalone sheet presentation. The Compose
+    /// flow sets this `false` so the view is pushed onto the contacts
+    /// picker's stack (no nested `NavigationStack`). When pushed the back
+    /// button is hidden so the user can't return to the picker; the close
+    /// (X) button tears down the whole flow via `onClose` instead.
+    var embedsNavigationStack: Bool = true
+    /// Closes the entire Compose flow. Set when the view is pushed onto the
+    /// picker's stack; when `nil` (standalone sheet) the close button
+    /// dismisses via the environment `dismiss`.
+    var onClose: (() -> Void)? = nil
     @State private var hasShownScannerOnAppear: Bool = false
     @State private var sidebarWidth: CGFloat = 0.0
     @State private var focusCoordinator: FocusCoordinator = FocusCoordinator(horizontalSizeClass: nil)
@@ -18,7 +29,7 @@ struct NewConversationView: View {
             insetsTopSafeArea: false,
             sidebarColumnWidth: $sidebarWidth
         ) { focusState, coordinator in
-            NavigationStack {
+            ConditionalNavigationStack(embedsStack: embedsNavigationStack) {
                 @Bindable var viewModel = viewModel
                 Group {
                     if viewModel.showingFullScreenScanner {
@@ -48,15 +59,25 @@ struct NewConversationView: View {
                     }
                 }
                 .toolbar {
+                    // The close (X) is the only way out in both presentations:
+                    // standalone it dismisses the sheet; pushed (Compose flow)
+                    // `onClose` tears down the whole flow. Paired with the
+                    // hidden back button below so the pushed view can't return
+                    // to the picker.
                     if !viewModel.showingFullScreenScanner {
                         ToolbarItem(placement: .topBarLeading) {
                             Button(role: .close) {
-                                dismiss()
+                                if let onClose {
+                                    onClose()
+                                } else {
+                                    dismiss()
+                                }
                             }
                             .accessibilityIdentifier("close-new-conversation")
                         }
                     }
                 }
+                .navigationBarBackButtonHidden(!embedsNavigationStack)
                 .background(.colorBackgroundSurfaceless)
                 .sheet(isPresented: $viewModel.presentingJoinConversationSheet) {
                     JoinConversationView(viewModel: viewModel.qrScannerViewModel, allowsDismissal: true) { scannedCode in
@@ -88,6 +109,22 @@ struct NewConversationView: View {
         }
         .onChange(of: horizontalSizeClass) { _, newSizeClass in
             focusCoordinator.horizontalSizeClass = newSizeClass
+        }
+    }
+}
+
+/// Wraps content in a `NavigationStack` only when `embedsStack` is true.
+/// Lets a view be presented standalone (its own stack) or pushed onto a
+/// host's stack (no nested stack) from the same body.
+private struct ConditionalNavigationStack<Content: View>: View {
+    let embedsStack: Bool
+    @ViewBuilder let content: () -> Content
+
+    var body: some View {
+        if embedsStack {
+            NavigationStack { content() }
+        } else {
+            content()
         }
     }
 }

--- a/Convos/Conversation Creation/NewConversationViewModel.swift
+++ b/Convos/Conversation Creation/NewConversationViewModel.swift
@@ -54,7 +54,7 @@ enum NewConversationMode {
 
 @MainActor
 @Observable
-class NewConversationViewModel: Identifiable {
+class NewConversationViewModel: Identifiable, Hashable {
     // MARK: - Public
 
     let session: any SessionManagerProtocol
@@ -810,6 +810,19 @@ class NewConversationViewModel: Identifiable {
 /// `ConversationStateMachine` observation, the per-state UI handling, and
 /// the join / create error paths. Split into an extension purely to keep
 /// the type body within SwiftLint's `type_body_length` budget; every
+/// Identity-based `Hashable` so the model can drive a
+/// `navigationDestination(item:)` push (the Compose flow pushes the new
+/// conversation onto the picker's stack). Mirrors `ConversationViewModel`.
+extension NewConversationViewModel {
+    nonisolated static func == (lhs: NewConversationViewModel, rhs: NewConversationViewModel) -> Bool {
+        lhs === rhs
+    }
+
+    nonisolated func hash(into hasher: inout Hasher) {
+        hasher.combine(ObjectIdentifier(self))
+    }
+}
+
 /// member stays file-private and `@MainActor`-isolated (inherited from
 /// the type), so behavior is identical to when these lived inline.
 extension NewConversationViewModel {

--- a/Convos/Conversation Detail/ConversationShareView.swift
+++ b/Convos/Conversation Detail/ConversationShareView.swift
@@ -11,6 +11,11 @@ struct ConversationShareOverlay: View {
     @State private var showCard: Bool = false
     @State private var isShareSheetPresented: Bool = false
     @State private var conversationImage: Image = Image("convosOrangeIcon")
+    /// Whether a real conversation image loaded. Drives the QR center: a real
+    /// image renders as-is; otherwise the convos placeholder is tinted to
+    /// contrast the dark center chip (it was previously template-tinted to
+    /// match it, so it was invisible in both light and dark mode).
+    @State private var hasConversationImage: Bool = false
     @State private var qrCodeImage: UIImage?
     @Environment(\.displayScale) private var displayScale: CGFloat
 
@@ -78,6 +83,7 @@ struct ConversationShareOverlay: View {
         .cachedImage(for: conversation) { image in
             if let image {
                 conversationImage = Image(uiImage: image)
+                hasConversationImage = true
             }
         }
         .task {
@@ -115,6 +121,7 @@ struct ConversationShareOverlay: View {
                 Image("convosOrangeIcon")
                     .renderingMode(.template)
                     .resizable()
+                    .scaledToFit()
                     .frame(width: 14.0, height: 14.0)
                     .foregroundStyle(.colorFillTertiary)
 
@@ -142,9 +149,18 @@ struct ConversationShareOverlay: View {
                         ZStack {
                             Rectangle()
                                 .fill(.colorTextPrimary)
-                            conversationImage
-                                .resizable()
-                                .aspectRatio(contentMode: .fill)
+                            if hasConversationImage {
+                                conversationImage
+                                    .resizable()
+                                    .aspectRatio(contentMode: .fill)
+                            } else {
+                                Image("convosOrangeIcon")
+                                    .renderingMode(.template)
+                                    .resizable()
+                                    .scaledToFit()
+                                    .foregroundStyle(.colorTextPrimaryInverted)
+                                    .padding(centerImageSize * 0.2)
+                            }
                         }
                         .frame(width: centerImageSize, height: centerImageSize)
                         .clipShape(RoundedRectangle(cornerRadius: DesignConstants.CornerRadius.small))

--- a/Convos/Conversations List/ConversationsViewModel.swift
+++ b/Convos/Conversations List/ConversationsViewModel.swift
@@ -97,6 +97,17 @@ final class ConversationsViewModel {
             updateListVisibility()
         }
     }
+    /// The claimed conversation backing the Compose flow. Created upfront by
+    /// `onStartConvo()` (mode `.newConversation`, which claims a warm-cached
+    /// conversation that already has an invite) so the contacts picker can
+    /// show that conversation's convo code in its empty state, and reused as
+    /// the destination the picker pushes on Skip / Continue. Cleared (and
+    /// torn down if it stayed empty) by `endComposeFlow()`.
+    var composeConversationViewModel: NewConversationViewModel? {
+        didSet {
+            oldValue?.cleanUpIfNeeded()
+        }
+    }
     var agentBuilderViewModel: AgentBuilderViewModel? {
         didSet {
             // Mirrors `newConversationViewModel.didSet`'s cleanup: when
@@ -114,6 +125,11 @@ final class ConversationsViewModel {
             updateListVisibility()
         }
     }
+    /// Drives the Compose flow sheet: the contacts picker is the root and
+    /// the claimed `composeConversationViewModel` is pushed onto it on Skip /
+    /// Continue. Distinct from `newConversationViewModel` (scanner / join /
+    /// template), so the two never drive overlapping presentations.
+    var presentingComposeFlow: Bool = false
     var presentingExplodeInfo: Bool = false
     var presentingPinLimitInfo: Bool = false
 
@@ -389,11 +405,37 @@ final class ConversationsViewModel {
         }
     }
 
+    /// Compose opens the contacts picker first (optional selection), then
+    /// pushes the conversation on Skip / Continue (`ComposeFlowView`). With no
+    /// contacts to pick from, the picker would be pointless -- so we skip it
+    /// and open the new-conversation view directly, like the pre-picker flow.
     func onStartConvo() {
-        newConversationViewModel = NewConversationViewModel(
+        // Count the contacts the picker would actually show (excludes agents,
+        // blocked, and unnamed) -- the raw contact count includes those, so
+        // it can't decide whether the picker is worth showing.
+        let contacts = (try? session.messagingServiceSync().contactsRepository().fetchAll()) ?? []
+        let pickable = ContactsPickerViewModel.pickableContacts(contacts)
+        guard !pickable.isEmpty else {
+            newConversationViewModel = NewConversationViewModel(
+                session: session,
+                mode: .newConversation
+            )
+            return
+        }
+        composeConversationViewModel = NewConversationViewModel(
             session: session,
             mode: .newConversation
         )
+        presentingComposeFlow = true
+    }
+
+    /// Tears down the Compose flow when its sheet is dismissed. Clearing
+    /// `composeConversationViewModel` runs its `didSet` cleanup (which keeps a
+    /// conversation that already has content / members and discards an empty
+    /// claimed draft).
+    func endComposeFlow() {
+        presentingComposeFlow = false
+        composeConversationViewModel = nil
     }
 
     func onJoinConvo() {

--- a/Convos/MainTabView.swift
+++ b/Convos/MainTabView.swift
@@ -762,5 +762,22 @@ private struct MainTabSheetsModifier: ViewModifier {
                     .zoom(sourceID: "composer-transition-source", in: namespace)
                 )
             }
+            .sheet(isPresented: $conversationsViewModel.presentingComposeFlow, onDismiss: {
+                conversationsViewModel.endComposeFlow()
+            }) {
+                if let composeViewModel = conversationsViewModel.composeConversationViewModel {
+                    ComposeFlowView(
+                        conversationsViewModel: conversationsViewModel,
+                        composeConversationViewModel: composeViewModel,
+                        profileSettingsViewModel: profileSettingsViewModel,
+                        contactsRepository: conversationsViewModel.session.messagingServiceSync().contactsRepository()
+                    )
+                    .background(.colorBackgroundSurfaceless)
+                    .presentationSizing(.page)
+                    .navigationTransition(
+                        .zoom(sourceID: "composer-transition-source", in: namespace)
+                    )
+                }
+            }
     }
 }

--- a/ConvosTests/ContactsPickerViewModelTests.swift
+++ b/ConvosTests/ContactsPickerViewModelTests.swift
@@ -249,4 +249,49 @@ final class ContactsPickerViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.isSelected(inboxId: removed))
         XCTAssertTrue(viewModel.isSelected(inboxId: kept))
     }
+
+    // MARK: - pickableContacts (Compose skip decision)
+
+    /// `pickableContacts` is the shared filter the Compose flow uses to decide
+    /// whether the picker is worth showing. It must agree with what the picker
+    /// renders -- named humans only, not blocked, not verified agents.
+    func testPickableContactsKeepsNamedHumans() {
+        let alice = Contact.mock(displayName: "Alice")
+        let bob = Contact.mock(displayName: "Bob")
+        let result = ContactsPickerViewModel.pickableContacts([alice, bob])
+        XCTAssertEqual(result.map(\.inboxId).sorted(), [alice.inboxId, bob.inboxId].sorted())
+    }
+
+    func testPickableContactsExcludesBlocked() {
+        let alice = Contact.mock(displayName: "Alice")
+        let blocked = Contact.mock(displayName: "Blocked", isBlocked: true)
+        let result = ContactsPickerViewModel.pickableContacts([alice, blocked])
+        XCTAssertEqual(result.map(\.inboxId), [alice.inboxId])
+    }
+
+    func testPickableContactsExcludesVerifiedAgents() {
+        let alice = Contact.mock(displayName: "Alice")
+        let convosAgent = Contact.mock(displayName: "Convos Assistant", agentVerification: .verified(.convos))
+        let oauthAgent = Contact.mock(displayName: "OAuth Bot", agentVerification: .verified(.userOAuth))
+        let result = ContactsPickerViewModel.pickableContacts([alice, convosAgent, oauthAgent])
+        XCTAssertEqual(result.map(\.inboxId), [alice.inboxId])
+    }
+
+    func testPickableContactsExcludesUnnamed() {
+        let named = Contact.mock(displayName: "Named")
+        let nilName = Contact.mock(displayName: nil)
+        let emptyName = Contact.mock(displayName: "")
+        let result = ContactsPickerViewModel.pickableContacts([named, nilName, emptyName])
+        XCTAssertEqual(result.map(\.inboxId), [named.inboxId])
+    }
+
+    /// All agents / blocked / unnamed collapses to empty -- which is exactly
+    /// what makes Compose skip the picker and open the new-conversation view
+    /// directly (the bug behind the "13 contacts but empty picker" report).
+    func testPickableContactsEmptyWhenNonePickable() {
+        let agent = Contact.mock(displayName: "Agent", agentVerification: .verified(.convos))
+        let blocked = Contact.mock(displayName: "Blocked", isBlocked: true)
+        let unnamed = Contact.mock(displayName: nil)
+        XCTAssertTrue(ContactsPickerViewModel.pickableContacts([agent, blocked, unnamed]).isEmpty)
+    }
 }


### PR DESCRIPTION
Tapping Compose now claims a conversation from the warm cache and, if you
have pickable contacts, opens the contacts picker (.compose mode) before the
new-conversation view. Selecting contacts is optional: the bottom CTA reads
"Skip" with nothing selected and "Continue" once a contact is picked. Skip
opens the claimed conversation as-is; Continue adds the picked contacts to it
first. With no pickable contacts the picker is skipped entirely and the
new-conversation view opens directly (the pre-picker behavior).

- ContactsPickerView gains an `embedsNavigationStack` flag so the Compose
  flow can root it in its own stack; NewConversationView gains
  `embedsNavigationStack` + `onClose` so it can be pushed (no nested stack,
  back button hidden, an X that tears down the whole flow).
- The claimed conversation is owned explicitly by ConversationsViewModel
  (composeConversationViewModel), distinct from newConversationViewModel
  (scanner / join / template), with its own cleanup.
- Shared contact filters so the skip decision, the picker, and the App
  Settings count all agree: the App Settings "Contacts" count now matches
  what the browser shows (hidden verified agents / unnamed contacts no longer
  inflate it), and the picker reuses ContactsView's "No contacts yet" empty
  state via a shared ContactsEmptyStateView.
- ConversationShareOverlay (the "+" menu convo code) fixes: the header
  balloon keeps its aspect ratio (scaledToFit), and the center logo is tinted
  so it's visible on the dark chip in both light and dark mode.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/916"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782688967&installation_id=128169237&pr_number=916&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F916&signature=23a1f3cd542edf3533860d1e69dc44606ca93e24f1f70dda767d30be721cd80b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show contacts picker before pushing new conversation in compose flow
> - Adds a new `ComposeFlowView` that presents a contacts picker (in `.compose` mode) before pushing `NewConversationView` onto a shared `NavigationStack`, allowing users to skip contact selection or pick members before opening the conversation.
> - `ConversationsViewModel.onStartConvo` now checks for pickable contacts first; if any exist it opens the compose flow sheet, otherwise it falls back directly to the new conversation sheet.
> - `ContactsPickerView` and `NewConversationView` both gain an `embedsNavigationStack` flag so they can be pushed by a host stack without nesting their own.
> - Adds a `.compose` picker mode where the confirm button reads "Skip" with zero selections and never dismisses on confirm, letting the host handle navigation.
> - Fixes the contacts count in App Settings to exclude hidden entries (verified agents, unnamed contacts) by using the new `ContactsViewModel.visibleContacts` helper.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized edaa69f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->