### PR TITLE
fix(ci): manual AppStore signing for the Prod TestFlight archive

### DIFF
--- a/Convos.xcodeproj/project.pbxproj
+++ b/Convos.xcodeproj/project.pbxproj
@@ -2048,10 +2048,10 @@
 			baseConfigurationReferenceRelativePath = Config/Prod.xcconfig;
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = NotificationService/NotificationService.entitlements;
-				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_IDENTITY = "Apple Distribution";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = FY4NZR34Z3;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = NotificationService/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = NotificationService;
@@ -2065,7 +2065,7 @@
 				MARKETING_VERSION = 1.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "$(NOTIFICATION_SERVICE_BUNDLE_ID)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "";
+				PROVISIONING_PROFILE_SPECIFIER = "match AppStore org.convos.ios.ConvosNSE";
 				SKIP_INSTALL = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_STRICT_CONCURRENCY = complete;
@@ -2136,7 +2136,8 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = "$(ASSETCATALOG_COMPILER_APPICON_NAME)";
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = Convos/Convos.entitlements;
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_IDENTITY = "Apple Distribution";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = FY4NZR34Z3;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -2160,6 +2161,7 @@
 				MARKETING_VERSION = 1.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "$(CONVOS_BUNDLE_ID)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "match AppStore org.convos.ios";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;


### PR DESCRIPTION
## Problem
The **Prod TestFlight Release** workflow fails on every `dev` push (e.g. runs for #913 and #879 merges) at the archive step:

```
** ARCHIVE FAILED **
error: No profiles for 'org.convos.ios' were found ... Automatic signing is disabled and unable to generate a profile.
error: Signing for "NotificationService" requires a development team.
```

This is **not** caused by those PRs (#913 only changed `Convos.storekit` + a Swift file) — the lane has never successfully run; its signing was never wired up.

## Root cause
`fastlane/lanes/release.rb` installs the AppStore distribution profiles via `match(type: "appstore")` and maps them in `build_app`'s `export_options.provisioningProfiles`. But that mapping only applies at **export** time. The **archive** (`xcodebuild archive`) uses the project's `Release` build settings, where:

- `Convos` → `CODE_SIGN_STYLE = Automatic`, no profile specifier
- `NotificationService` → `CODE_SIGN_STYLE = Automatic`, **empty** `DEVELOPMENT_TEAM`, `CODE_SIGN_IDENTITY = "Apple Development"`

On CI, automatic signing can't reach Apple to generate a profile (would need `-allowProvisioningUpdates`), so the archive fails *before* export — the `match` profiles are never used.

## Fix
Set the `Release` config of both prod-distributed targets to **manual** signing with the exact profiles `match` installs (matching the lane's `export_options`):

| Target | CODE_SIGN_STYLE | CODE_SIGN_IDENTITY | DEVELOPMENT_TEAM | PROVISIONING_PROFILE_SPECIFIER |
|---|---|---|---|---|
| Convos | Manual | Apple Distribution | FY4NZR34Z3 | `match AppStore org.convos.ios` |
| NotificationService | Manual | Apple Distribution | FY4NZR34Z3 | `match AppStore org.convos.ios.ConvosNSE` |

Diff is **7 insertions / 5 deletions** — only those signing keys.

## Scope / safety
- `Release` is the **Prod-only** config (Dev/Local schemes use Dev/Local configs — unchanged).
- Simulator builds skip provisioning, so local dev is unaffected.
- Verified the project still parses (`xcodebuild -list`) and the settings read back correctly via `xcodeproj`.

The release owner should sanity-check the match profile names against the App Store Connect setup before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/917"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782691520&installation_id=128169237&pr_number=917&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F917&signature=7ea2a5e40d149e68091a6652583990700156e4fe64db9b4625e811aef2906541"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Switch Prod TestFlight archive to manual App Store code signing
> Updates [project.pbxproj](https://github.com/xmtplabs/convos-ios/pull/917/files#diff-d58364582ce5ff189bf9f87c20898db7df50a681e6e9df35dca291d7b9373da7) to use manual signing with the `Apple Distribution` identity and explicit App Store provisioning profiles (`match AppStore org.convos.ios` and `match AppStore org.convos.ios.ConvosNSE`) for team `FY4NZR34Z3`. Previously, automatic signing with `Apple Development` was used, which is incompatible with App Store/TestFlight distribution builds.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 38a4651.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->