### PR TITLE
Local backend + agents stack tooling (/run local) + getting-started README

### DIFF
--- a/.claude/commands/firebase-token.md
+++ b/.claude/commands/firebase-token.md
@@ -1,159 +1,105 @@
 ---
-description: Fetch the Firebase App Check debug token from simulator logs and pin it in the shared parent .env so every worktree reuses one token.
+description: Fetch the Firebase App Check debug token from simulator logs and pin it in the shared workspace convos-ios.env so every worktree reuses one token.
 ---
 
 # /firebase-token
 
-Retrieve a Firebase App Check debug token from the running app, pin it in the **shared parent `.env`**, and make sure the current repo/worktree's `.env` is symlinked to that shared file. One token, one place to rotate it, every worktree picks it up.
+Retrieve a Firebase App Check debug token from the running app, pin it in the **shared `convos-ios.env`** (in the local-stack workspace), and make sure this checkout's `.env` symlinks to that shared file. One token, one place to rotate it, every worktree picks it up.
 
 ## When to use
-
 - You've launched the app on a fresh simulator and are seeing App Check rejections.
 - You want to set up the shared-token pattern for the first time.
-- The token rotated (e.g. token expired / Firebase removed it) and you need a new one.
+- The token rotated (expired / Firebase removed it) and you need a new one.
 
 ## Instructions
 
-### Step 1: Resolve paths for the shared `.env`
+### Step 1: Resolve the shared `.env`
 
 ```bash
 REPO_ROOT=$(git rev-parse --show-toplevel)
-PARENT_DIR=$(dirname "$REPO_ROOT")
-PARENT_ENV="$PARENT_DIR/.env"
+# Shared convos-ios DEV .env: prefer the local-stack workspace (CONVOS_REPOS_DIR env, or the
+# .convos-stack pointer at the repo root) -> <workspace>/convos-ios.env. Fall back to the legacy
+# parent (<dirname repo>/.env) when no workspace is configured.
+WS="${CONVOS_REPOS_DIR:-}"
+[ -z "$WS" ] && [ -f "$REPO_ROOT/.convos-stack" ] && WS="$(tr -d '\n' < "$REPO_ROOT/.convos-stack")"
+if [ -n "$WS" ] && [ -d "$WS" ]; then SHARED_ENV="$WS/convos-ios.env"; else SHARED_ENV="$(dirname "$REPO_ROOT")/.env"; fi
 LOCAL_ENV="$REPO_ROOT/.env"
 ```
-
-For the standard layout (`~/Code/xmtplabs/convos-ios/`, `~/Code/xmtplabs/convos-ios-task-*/`), `$PARENT_DIR` is `~/Code/xmtplabs/` and the shared file is `~/Code/xmtplabs/.env`. Both the main clone and every worktree's `.env` symlinks to it via `../.env`.
+With the local stack set up (`make -C dev/local-stack init`), `$SHARED_ENV` is `<workspace>/convos-ios.env`. Without it, it's the legacy `<parent>/.env`. Every checkout's `.env` symlinks to `$SHARED_ENV`.
 
 ### Step 2: Ensure the symlink exists
+
+Ensure `$SHARED_ENV` exists first — if missing, `touch "$SHARED_ENV"`.
 
 Four cases for `$LOCAL_ENV`:
 
 | State | Action |
 |-------|--------|
-| Missing | `ln -s ../.env "$LOCAL_ENV"` and report "Linked .env → ../.env" |
-| Symlink → `../.env` (resolves to `$PARENT_ENV`) | No-op |
-| Symlink pointing elsewhere | Warn, stop. Don't clobber. |
-| Regular file | Warn, stop. Don't destroy local env vars. Print the migration recipe: `mv .env ../.env && ln -s ../.env .env` (after verifying the user actually wants the contents moved to the shared file). |
-
-Ensure `$PARENT_ENV` exists — if missing, `touch "$PARENT_ENV"`.
+| Missing | `ln -s "$SHARED_ENV" "$LOCAL_ENV"` and report "Linked .env → $SHARED_ENV" |
+| Symlink → `$SHARED_ENV` | No-op |
+| Symlink pointing elsewhere | Warn, stop. Don't clobber. (A `Convos (Local)` checkout intentionally has a *standalone* `.env` written by `ios-config` — leave it.) |
+| Regular file | Warn, stop. Print the migration recipe: `cat .env >> "$SHARED_ENV" && rm .env && ln -s "$SHARED_ENV" .env` (after confirming the user wants the contents moved). |
 
 ### Step 3: Verify the app is running
 
-Take a screenshot or call `xcrun simctl listapps $UDID | grep -q org.convos.ios-preview`. If the app isn't running, tell the user to run `/run` first and stop — we can't extract a token without a live app.
+Take a screenshot or `xcrun simctl listapps $UDID | grep -q org.convos.ios-preview`. If the app isn't running, tell the user to `/run` first and stop — no live app, no token.
 
 ### Step 4: Capture logs and extract the token
 
-Preferred path (MCP available in the main session):
-
+Preferred (MCP):
 ```
 mcp__XcodeBuildMCP__start_sim_log_cap with bundleId and captureConsole: true
 wait 3-5 seconds
 mcp__XcodeBuildMCP__stop_sim_log_cap with logSessionId
 ```
-
-Bash fallback when MCP isn't available:
-
+Bash fallback:
 ```bash
 UDID=$(cat .claude/.simulator_id)
 xcrun simctl spawn "$UDID" log show \
   --predicate 'eventMessage CONTAINS "App Check debug token"' \
   --last 5m --style compact 2>/dev/null | tail -50
 ```
-
-Search the output for:
-
-```
-[AppCheckCore][I-GAC004001] App Check debug token: 'XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX'
-```
-
-The token is a UUID inside single quotes.
+Find: `[AppCheckCore][I-GAC004001] App Check debug token: 'XXXXXXXX-...'` — a UUID in single quotes.
 
 ### Step 5: Write the token to the shared `.env`
 
-Update `$PARENT_ENV` in place. Replace any existing line, otherwise append:
-
 ```bash
 TOKEN="<extracted-uuid>"
-if grep -q '^FIREBASE_APP_CHECK_DEBUG_TOKEN=' "$PARENT_ENV"; then
-  # macOS sed requires '' after -i
-  sed -i '' "s|^FIREBASE_APP_CHECK_DEBUG_TOKEN=.*|FIREBASE_APP_CHECK_DEBUG_TOKEN=${TOKEN}|" "$PARENT_ENV"
+if grep -q '^FIREBASE_APP_CHECK_DEBUG_TOKEN=' "$SHARED_ENV"; then
+  sed -i '' "s|^FIREBASE_APP_CHECK_DEBUG_TOKEN=.*|FIREBASE_APP_CHECK_DEBUG_TOKEN=${TOKEN}|" "$SHARED_ENV"
 else
-  echo "FIREBASE_APP_CHECK_DEBUG_TOKEN=${TOKEN}" >> "$PARENT_ENV"
+  echo "FIREBASE_APP_CHECK_DEBUG_TOKEN=${TOKEN}" >> "$SHARED_ENV"
 fi
 ```
 
 ### Step 6: Report
-
-**If token extracted and pinned:**
 
 ```
 🔥 Firebase App Check Debug Token
 
 Token: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
 
-✓ Pinned in <PARENT_ENV>
-✓ .env → ../.env symlink in place at <LOCAL_ENV>
-  (all convos-ios worktrees under <PARENT_DIR> share this token)
+✓ Pinned in <SHARED_ENV>
+✓ .env → <SHARED_ENV> symlink in place at <LOCAL_ENV>
+  (every convos-ios checkout/worktree sharing this workspace reuses this token)
 
 Register it in Firebase Console if you haven't already:
 https://console.firebase.google.com/u/1/project/convos-otr/appcheck/apps
+  → pick the app for your scheme (Dev: org.convos.ios-preview, Local: org.convos.ios-local,
+    Prod: org.convos.ios) → ⋮ → Manage debug tokens → Add debug token → paste the UUID.
+  (Register in BOTH the Dev and Local apps if you build both schemes against this token.)
 
-1. Click the link
-2. Pick the iOS app for your scheme:
-   - Dev:   org.convos.ios-preview
-   - Local: org.convos.ios-local
-   - Prod:  org.convos.ios
-3. Overflow menu (⋮) → Manage debug tokens → Add debug token
-4. Paste the UUID above
-
-Relaunch the app (/run) to pick up the new token.
+Relaunch the app (/run) to pick it up.
 ```
 
-**If no token found in logs:**
-
-```
-No Firebase App Check debug token found in logs.
-
-Could mean:
-- The simulator is already registered with this token (check <PARENT_ENV>)
-- The app hasn't initialized Firebase yet (try interacting with the app, then rerun)
-- Logs were captured too early (rerun /firebase-token)
-```
-
-Still report the symlink status from step 2 so the user knows `.env` plumbing is in place.
-
-**If local `.env` blocked the symlink (step 2 warning case):**
-
-Stop before step 3 and print clear instructions:
-
-```
-⚠️  <LOCAL_ENV> is a regular file, not a symlink.
-
-The shared-token pattern requires each worktree's .env to be a symlink to
-../.env so one token rotation updates every workspace.
-
-To migrate (preserves your existing contents):
-  cat .env >> ../.env     # merge into shared
-  rm .env                 # remove the local
-  ln -s ../.env .env      # symlink it
-
-Review ../.env afterwards to dedupe any keys.
-```
+If no token found, or the local `.env` blocked the symlink, report that and the migration recipe (Step 2), and still report the symlink status.
 
 ## Bundle IDs per scheme
-
 | Scheme | Bundle id |
 |--------|-----------|
 | Convos (Dev) | `org.convos.ios-preview` |
 | Convos (Local) | `org.convos.ios-local` |
 | Convos (Prod) | `org.convos.ios` |
 
-## Why the shared-parent pattern
-
-Engineers working across multiple convos-ios worktrees want one Firebase debug token:
-- One place to rotate when the token expires or gets removed from the Firebase Console
-- No per-worktree duplication or drift
-- New worktrees created via `convos-task new` pick it up automatically (the script symlinks `.env` → `../.env` when the parent exists)
-
-`/setup`'s `.env` warning also leads with the symlink recipe to keep every worktree on the same token.
+## Why the shared-workspace pattern
+One Firebase debug token across all your convos-ios worktrees: one place to rotate it, no per-worktree drift. It lives in the **local-stack workspace** (`<workspace>/convos-ios.env`) alongside the rest of the shared local-dev state, resolved via the `.convos-stack` pointer. `/setup` and `convos-task` create the same symlink for new checkouts/worktrees. (Falls back to the legacy `<parent>/.env` when no workspace is configured.) A `Convos (Local)` checkout keeps a *standalone* `.env` (written by `ios-config` / `/run local`) instead of the symlink, since Local needs a localhost backend URL.

--- a/.claude/commands/local-stack.md
+++ b/.claude/commands/local-stack.md
@@ -1,0 +1,39 @@
+---
+description: Manage the shared local Convos stack (backend + Postgres + herald + assistants/Hermes + MinIO).
+---
+
+# /local-stack
+
+Control the **shared** local backend+agents stack that the "Convos (Local)" scheme runs against. The orchestration is committed here in `dev/local-stack/`; it operates on an external workspace (the dir holding the cloned service repos + runtime state). One stack serves every convos-ios checkout/worktree. (To also build+launch the app, use `/run local`.)
+
+## Usage
+```
+/local-stack            # status (default)
+/local-stack init       # first-time: pick a workspace dir + clone the service repos
+/local-stack bootstrap  # one-time per machine: deps, secrets (1Password), migrations
+/local-stack up         # start the full stack (backend, pg, herald, worker+Hermes, minio)
+/local-stack down       # stop host services + infra (keeps data volumes)
+/local-stack logs       # tail logs  (add: backend|herald|worker)
+/local-stack doctor     # check prereqs + Docker CPU cap
+```
+
+## Instructions
+
+1. **Resolve the make dir** (always in THIS repo): `LS="$(git rev-parse --show-toplevel)/dev/local-stack"`.
+2. **Run the target** from there: `make -C "$LS" <target>` (map `logs <svc>` → `make -C "$LS" logs SVC=<svc>`).
+   | arg | target | timeout |
+   |-----|--------|---------|
+   | (none)/`status` | `status` | 30s |
+   | `init` | `init` | 600000ms (clones 4 repos) |
+   | `bootstrap` | `bootstrap` | 1200000ms |
+   | `up` | `up` | **1200000ms** (first run builds the Hermes image) |
+   | `down` | `down` | 60s |
+   | `logs [svc]` | `logs SVC=<svc>` | stream / background |
+   | `doctor` | `doctor` | 60s |
+3. **First-run handling:** if a command fails with *"no workspace configured — run: make init"*, the dev hasn't set up the workspace. Run `make -C "$LS" init` — it defaults the workspace to a **sibling of this repo** (`<repo-parent>/convos-stack`) and clones the service repos there. Confirm the path with the user first if you can. Then they edit `<workspace>/stack.env` (the `OP_*` 1Password refs) and run `bootstrap`.
+4. **Relay results** concisely; surface any `doctor` warnings — especially the **Docker-CPU-cap** one (it's what keeps the Hermes build from overloading the machine).
+
+## Notes
+- First `up` ever builds the Hermes container image — minutes, but capped to Docker's CPU limit. Later `up`s are seconds.
+- The stack is **shared** — one instance, many thin iOS checkouts (don't start a second; ports collide). It uses the hosted **DEV** xmtp network.
+- One-time per machine: `init` → set `OP_*` refs in `<workspace>/stack.env` → `bootstrap`, and cap Docker Desktop CPUs per `doctor`.

--- a/.claude/commands/run.md
+++ b/.claude/commands/run.md
@@ -1,5 +1,5 @@
 ---
-description: Build and launch the Convos iOS app in this worktree's dedicated simulator.
+description: Build and launch the Convos iOS app in this worktree's dedicated simulator. `/run local` also brings up the shared local backend+agents stack.
 ---
 
 # /run
@@ -9,8 +9,9 @@ Build and launch the app on the worktree's dedicated simulator. Idempotent — r
 ## Usage
 
 ```
-/run                      # default scheme "Convos (Dev)"
-/run "Convos (Local)"     # different scheme
+/run                      # default scheme "Convos (Dev)" — talks to the Dev cloud
+/run local                # FULL LOCAL: bring up the shared stack + run "Convos (Local)" against it
+/run "Convos (Local)"     # same as `/run local`
 /run "Convos (Prod)"
 ```
 
@@ -21,7 +22,18 @@ Bundle IDs by scheme:
 | `Convos (Local)` | `org.convos.ios-local` |
 | `Convos (Prod)` | `org.convos.ios` |
 
+**Local mode** (`local` / `Convos (Local)`) runs the app entirely against services on this machine (backend :4000, herald :5050, assistants worker :8787 + Hermes, MinIO, Postgres) over the hosted DEV xmtp network. That stack runs **once** and is shared by every convos-ios checkout/worktree.
+
 ## Instructions
+
+### Step 0: (LOCAL MODE ONLY) ensure the shared stack is up + configure this checkout
+
+Skip this whole step for Dev/Prod schemes. The orchestration is committed in this repo at `dev/local-stack/` and resolves its external workspace itself (via the gitignored `.convos-stack` pointer or `$CONVOS_REPOS_DIR`).
+
+1. `LS="$(git rev-parse --show-toplevel)/dev/local-stack"`.
+2. **First-run:** `make -C "$LS" status` (30s). If it errors *"no workspace configured — run: make init"*, the machine isn't set up: run `make -C "$LS" init` (defaults the workspace to a sibling of this repo and clones the service repos; ~600000ms timeout), then **pause** and tell the user to set the `OP_*` 1Password refs in `<workspace>/stack.env` and run `make -C "$LS" bootstrap` once.
+3. **Bring it up if needed:** if `status` shows backend/worker down, run `make -C "$LS" up` with a **1200000ms (20 min)** timeout (first run builds the Hermes image — capped; later runs are fast). Relay any Docker-cap warning from `make -C "$LS" doctor`.
+4. **Configure this checkout as a thin client:** `make -C "$LS" ios-config IOS="$(pwd)"` — sets `config.local.json` `xmtpNetwork→dev`, applies the build-phase `sed` fix, writes `./.env` (localhost backend + shared Firebase Local token).
 
 ### Step 1: Resolve the simulator
 
@@ -54,6 +66,7 @@ xcrun simctl boot "$SIM_UUID" 2>/dev/null || true
 
 Use `xcodebuild` via Bash. Do **not** use `mcp__XcodeBuildMCP__build_sim` — it mis-sequences SPM extension dependencies (`ConvosCore`, `ConvosCoreiOS`, `XMTPiOS`) on fresh worktrees. See `CLAUDE.md`.
 
+**Dev / Prod schemes** (team signing):
 ```bash
 xcodebuild build \
   -project Convos.xcodeproj \
@@ -62,9 +75,18 @@ xcodebuild build \
   -derivedDataPath .derivedData 2>&1 | tail -100
 ```
 
-Replace the scheme string if the user passed one. Set a 300s timeout on the command.
+**Local scheme** — `org.convos.ios-local` is **not** in convos-certificates, so CLI automatic signing drops the app-group entitlement and the app crashes at launch (`Failed getting container URL for group identifier`). Build **ad-hoc** so the simulated entitlements are applied:
+```bash
+xcodebuild build \
+  -project Convos.xcodeproj \
+  -scheme "Convos (Local)" -configuration Local \
+  -destination "platform=iOS Simulator,id=$SIM_UUID" \
+  -derivedDataPath .derivedData -skipMacroValidation \
+  CODE_SIGN_STYLE=Manual CODE_SIGN_IDENTITY="-" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=YES \
+  PROVISIONING_PROFILE_SPECIFIER="" DEVELOPMENT_TEAM="" 2>&1 | tail -100
+```
 
-If the build fails:
+Set a 600s timeout. If the build fails:
 - Surface the compilation errors from the tail.
 - For `module not found` errors, `rm -rf .derivedData` and rebuild once.
 - Stop if it still fails.
@@ -80,13 +102,17 @@ open -a Simulator
 
 ### Step 4: Report
 
-One line:
-
 ```
 ✅ App running on <SIMULATOR_NAME>
 ```
+For **local mode**, also one line on stack health (from `make -C "$LS" status`) and note: auth + "Make an agent" now run against the local backend/agents.
 
 **Do not** capture screenshots, probe the UI, tail logs, or test anything after launch — the user will ask explicitly if they want that.
+
+## Local-mode failure notes
+- Crash on app-group container at launch → you built Local without the ad-hoc flags (Step 2). Rebuild with them.
+- Firebase 403 / auth never completes → `./.env` is missing the shared `FIREBASE_APP_CHECK_DEBUG_TOKEN`; re-run `make -C "$LS" ios-config IOS="$(pwd)"`.
+- Backend 500 on `/auth/*` → backend lost Postgres (Docker bounced); `make -C "$LS" up` re-brings infra and re-disables App Check.
 
 ## DerivedData isolation
 

--- a/.claude/commands/run.md
+++ b/.claude/commands/run.md
@@ -33,7 +33,7 @@ Skip this whole step for Dev/Prod schemes. The orchestration is committed in thi
 1. `LS="$(git rev-parse --show-toplevel)/dev/local-stack"`.
 2. **First-run:** `make -C "$LS" status` (30s). If it errors *"no workspace configured — run: make init"*, the machine isn't set up: run `make -C "$LS" init` (defaults the workspace to a sibling of this repo and clones the service repos; ~600000ms timeout), then **pause** and tell the user to set the `OP_*` 1Password refs in `<workspace>/stack.env` and run `make -C "$LS" bootstrap` once.
 3. **Bring it up if needed:** if `status` shows backend/worker down, run `make -C "$LS" up` with a **1200000ms (20 min)** timeout (first run builds the Hermes image — capped; later runs are fast). Relay any Docker-cap warning from `make -C "$LS" doctor`.
-4. **Configure this checkout as a thin client:** `make -C "$LS" ios-config IOS="$(pwd)"` — sets `config.local.json` `xmtpNetwork→dev`, applies the build-phase `sed` fix, writes `./.env` (localhost backend + shared Firebase Local token).
+4. **Configure this checkout as a thin client:** `make -C "$LS" ios-config IOS="$(pwd)"` — sets `config.local.json` `xmtpNetwork→dev` and writes `./.env` (localhost backend + shared Firebase Local token).
 
 ### Step 1: Resolve the simulator
 

--- a/.claude/scripts/convos-task
+++ b/.claude/scripts/convos-task
@@ -298,13 +298,25 @@ cmd_new() {
     echo -e "${BLUE}📁 Location: $WORKTREE_DIR${NC}"
     echo -e "${BLUE}🌿 Branch: $BRANCH_NAME${NC}"
 
-    # Link the parent's .env into the worktree so Firebase App Check debug token
-    # (and any other shared secrets) are picked up without per-worktree duplication.
-    if [ -f "$BASE_DIR/.env" ] && [ ! -e "$WORKTREE_DIR/.env" ]; then
-        ln -s ../.env "$WORKTREE_DIR/.env"
-        echo -e "${BLUE}🔗 Linked .env → ../.env${NC}"
-    elif [ ! -f "$BASE_DIR/.env" ]; then
-        echo -e "${YELLOW}⚠️  No .env at $BASE_DIR/.env — create one and worktrees will link to it on next 'new'${NC}"
+    # Share the convos-ios DEV .env (Firebase App Check token + other shared secrets) without
+    # per-worktree duplication. Prefer the local-stack workspace (CONVOS_REPOS_DIR env, or the
+    # main repo's .convos-stack pointer) -> <workspace>/convos-ios.env; else legacy $BASE_DIR/.env.
+    SHARED_ENV=""
+    WS_DIR="${CONVOS_REPOS_DIR:-}"
+    [ -z "$WS_DIR" ] && [ -f "$MAIN_REPO/.convos-stack" ] && WS_DIR="$(tr -d '\n' < "$MAIN_REPO/.convos-stack")"
+    if [ -n "$WS_DIR" ] && [ -d "$WS_DIR" ]; then
+        SHARED_ENV="$WS_DIR/convos-ios.env"
+        # propagate the workspace pointer so /run local, /local-stack, /firebase-token resolve it in the worktree
+        [ -f "$MAIN_REPO/.convos-stack" ] && cp "$MAIN_REPO/.convos-stack" "$WORKTREE_DIR/.convos-stack" 2>/dev/null || true
+    elif [ -f "$BASE_DIR/.env" ]; then
+        SHARED_ENV="$BASE_DIR/.env"
+    fi
+    if [ -n "$SHARED_ENV" ] && [ ! -e "$WORKTREE_DIR/.env" ]; then
+        [ -f "$SHARED_ENV" ] || touch "$SHARED_ENV"
+        ln -s "$SHARED_ENV" "$WORKTREE_DIR/.env"
+        echo -e "${BLUE}🔗 Linked .env → $SHARED_ENV${NC}"
+    elif [ -z "$SHARED_ENV" ]; then
+        echo -e "${YELLOW}⚠️  No shared .env found (no workspace pointer, no $BASE_DIR/.env) — run 'make -C dev/local-stack init' or /firebase-token${NC}"
     fi
 
     # Write task config file (includes simulator name for later use)

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 ## Claude Code local settings
 .claude/settings.local.json
 .convos-task
+.convos-stack
 
 ## User settings
 xcuserdata/

--- a/Convos/Config/config.local.json
+++ b/Convos/Config/config.local.json
@@ -1,7 +1,7 @@
 {
   "environment": "local",
   "backendUrl": "http://localhost:4000/api",
-  "xmtpNetwork": "local",
+  "xmtpNetwork": "dev",
   "bundleId": "org.convos.ios-local",
   "appGroupIdentifier": "group.org.convos.ios-local",
   "relyingPartyIdentifier": "local.convos.org",

--- a/README.md
+++ b/README.md
@@ -17,58 +17,93 @@ Convos is a privacy-first messenger that offers:
 
 Learn more at [convos.org](https://convos.org).
 
-## Project Setup
+## Getting started
 
 ### Prerequisites
 
-- macOS with Xcode 16+
-- Homebrew
-- Docker (required for running the test suite via `./dev/up`)
+- **macOS** with **Xcode 16+** (the app targets iOS 26)
+- **[Homebrew](https://brew.sh)**
+- **Docker Desktop** — needed for the ConvosCore test suite (local XMTP node) and to run the local backend/agents stack
+- **[1Password CLI](https://developer.1password.com/docs/cli/) (`op`)** — for team secrets (code-signing match password, local-stack secrets)
+- Access to the team **1Password** vault and the Firebase project `convos-otr`
 
-### Quick Start
+### First-time setup
 
 ```bash
-# 1. Install dependencies and configure your environment
+git clone https://github.com/xmtplabs/convos-ios.git
+cd convos-ios
 ./Scripts/setup.sh        # or: make setup
-
-# 2. Create your local .env from the template
-cp .env.example .env
-
-# 3. (Optional) Add a Firebase App Check debug token to .env
-#    See .env comments, or generate one at:
-#    https://console.firebase.google.com/project/convos-otr/appcheck
 ```
 
-The setup script will:
-- Configure the repo's Git hooks (`core.hooksPath` → `Scripts/hooks/`), which works for both regular clones and `git worktree`s
-- Configure Xcode defaults for consistent development
-- Install required dependencies:
-  - SwiftLint (code linting, pinned version for compatibility)
-  - SwiftFormat (code formatting)
-  - swift-protobuf (Protocol Buffer support)
-  - GitHub CLI (for release automation)
+`Scripts/setup.sh` is idempotent and:
 
-### Manual Setup
+- Configures Git hooks (`core.hooksPath` → `Scripts/hooks/`) so SwiftFormat + SwiftLint run on commit/push — works in clones **and** `git worktree`s
+- Applies Xcode defaults (trim whitespace, 120-col guide, build durations, …)
+- Installs tooling via Homebrew: **SwiftLint** (pinned), **SwiftFormat**, **swift-protobuf**, **GitHub CLI**, **tmux**, **fastlane**
+- Adds **`convos-task`** to your shell `PATH` (alias **`ct`**) for the parallel-worktree workflow
+- Sets up a **shared Firebase App Check debug token** and symlinks this checkout's `.env` to it (one token across all your worktrees — see `/firebase-token`)
+- Runs **`fastlane bootstrap`** to install the team's code-signing certificates/profiles. It prompts for `MATCH_PASSWORD` — grab it from the team 1Password vault. `export MATCH_PASSWORD=…` in your shell rc to skip the prompt next time.
 
-If you prefer to install dependencies individually, run:
+When it finishes, open a new terminal (or `source` your shell rc) so `convos-task` / `ct` are on `PATH`.
+
+> Signing assets live in the encrypted [convos-certificates](https://github.com/xmtplabs/convos-certificates) fastlane *match* repo. If `fastlane bootstrap` is skipped, re-run it later once Xcode is signed in.
+
+### Build & run
+
+The app has three build environments — pick the matching **scheme** in Xcode (or use the commands below). Endpoints, bundle IDs, and secrets handling are documented in **[ENVIRONMENTS.md](ENVIRONMENTS.md)**:
+
+| Scheme | Bundle id | Talks to |
+|--------|-----------|----------|
+| **Convos (Dev)** | `org.convos.ios-preview` | the hosted **Dev** backend + xmtp (default for day-to-day work) |
+| **Convos (Local)** | `org.convos.ios-local` | a **local** backend + agents stack on your machine (see below) |
+| **Convos (Prod)** | `org.convos.ios` | production |
+
+**In Xcode:** select a scheme and Run on an iOS 26 simulator.
+
+**With Claude Code** (recommended — handles the simulator-per-branch workflow):
+
+| Command | What it does |
+|---------|--------------|
+| `/setup` | Create/clone this branch's dedicated simulator, install deps, set build defaults |
+| `/run` | Build + launch **Convos (Dev)** on the branch simulator |
+| `/run local` | Bring up the local stack (if needed) + build + launch **Convos (Local)** against it |
+| `/build`, `/build --run` | Compile (and optionally launch) |
+| `/firebase-token` | Capture + pin a Firebase App Check debug token (shared across worktrees) |
+| `/test`, `/lint`, `/format` | Run tests / lint / format |
+
+### Running against a local backend + agents (local stack)
+
+The **"Convos (Local)"** scheme can run against the full Convos backend + agents stack on your machine — backend, Postgres, herald, the assistants worker + Hermes containers, and MinIO — over the hosted DEV xmtp network. Auth, messaging, and "Make an agent" all run locally. One **shared** stack serves every checkout/worktree (it lives in a workspace dir you choose; these committed scripts just point at it).
 
 ```bash
-brew install swiftformat swift-protobuf gh
+# one-time per machine (cap Docker Desktop to ~6 CPUs first — Settings → Resources)
+make -C dev/local-stack doctor      # check prereqs + Docker CPU cap
+make -C dev/local-stack init        # pick a workspace dir + clone the service repos into it
+make -C dev/local-stack bootstrap   # deps, secrets (1Password), migrations
+
+# everyday
+make -C dev/local-stack up          # start the full stack (first run builds the Hermes image)
+make -C dev/local-stack status      # health of every service
+make -C dev/local-stack down        # stop it (keeps data)
 ```
 
-Then run `./Scripts/setup.sh` once to install the pinned SwiftLint version, configure git hooks, and apply Xcode defaults.
+Then build + launch Local with the Claude command **`/run local`** (or `make -C dev/local-stack ios-config IOS=$(pwd)`, then build the Local scheme). Manage the stack from any checkout with **`/local-stack`**.
 
-### Configuration
+> Distinct from `./dev/up` (below), which starts a local **xmtp node** for the ConvosCore **test suite** — not the backend/agents stack.
 
-The setup script configures Xcode with:
-- Automatic trailing whitespace trimming
-- 120-character page guide
-- Build operation duration display
-- Disabled plugin fingerprint validation for development
+Full runbook (architecture, secrets/1Password, troubleshooting, Dev-vs-Local `.env` rules): **[dev/local-stack/README.md](dev/local-stack/README.md)**.
 
-For build environments (Local, Dev, Production), bundle IDs, and secrets handling, see [ENVIRONMENTS.md](ENVIRONMENTS.md).
+### Parallel work (git worktrees)
 
-### Useful Make Targets
+`convos-task` (alias `ct`) spins up isolated worktrees so you can work on several features at once — each gets its own Graphite branch, a dedicated simulator, and an independent Claude Code session, all sharing one Firebase token and the one local stack:
+
+```bash
+ct new my-feature       # new worktree + branch + simulator + Claude session
+ct list                 # show active tasks
+ct cleanup my-feature   # remove when done
+```
+
+### Useful make targets
 
 ```bash
 make setup           # Run Scripts/setup.sh
@@ -78,34 +113,23 @@ make protobuf        # Regenerate Swift code from .proto files
 make clean           # Remove generated secrets and build artifacts
 ```
 
-## Project Structure
+## Project structure
 
 ```
 convos-ios/
-├── Convos/              # Main iOS application
-├── ConvosCore/          # Shared business logic Swift Package
+├── Convos/              # Main iOS application (SwiftUI views + view models)
+├── ConvosCore/          # Shared business logic Swift Package (XMTP, GRDB, auth, messaging)
+├── ConvosAppData/       # Shared protobuf types + serialization
+├── ConvosInvites/       # Invite system (tokens, join requests)
 ├── NotificationService/ # Push notification extension
-└── Scripts/             # Build and development scripts
+├── dev/local-stack/     # One-command local backend + agents stack (see its README)
+├── Scripts/             # Setup, build phases, hooks, secrets generation
+└── .claude/             # Claude Code commands (/run, /build, /setup, /local-stack, …) + convos-task
 ```
 
-### ConvosCore Package
+`ConvosCore` holds all shared business logic — XMTP client management and messaging, GRDB database, authentication/identity, conversation and message handling, and push-notification support. It is built to compile on macOS for fast test execution (no UIKit). See the source files and `CLAUDE.md` for conventions.
 
-`ConvosCore` is a Swift Package containing all shared business logic, including:
-- XMTP client management and messaging
-- Database management with GRDB
-- Authentication and identity management
-- Conversation and message handling
-- Push notification support
-
-See [ConvosCore documentation](#convoscore-documentation) below for details.
-
-## Development
-
-### Building
-
-Open `Convos.xcodeproj` in Xcode and build normally. The project uses Swift Package Manager for dependencies.
-
-### Testing
+## Testing
 
 Most ConvosCore tests require Docker to run a local XMTP node.
 
@@ -114,23 +138,19 @@ Most ConvosCore tests require Docker to run a local XMTP node.
 ./dev/test
 
 # Or manage Docker manually:
-./dev/up                                             # start local XMTP node
-swift test --package-path ConvosCore                 # run ConvosCore tests
-./dev/down                                           # stop when finished
+./dev/up                                # start local XMTP node
+swift test --package-path ConvosCore    # run ConvosCore tests
+./dev/down                              # stop when finished
 
-# iOS app tests via xcodebuild (use a scheme that includes the environment)
+# iOS app tests via xcodebuild
 xcodebuild test \
   -project Convos.xcodeproj \
   -scheme "Convos (Local)" \
   -destination "platform=iOS Simulator,name=iPhone 17"
 ```
 
-### Code Quality
+## Code quality
 
-Pre-commit hooks automatically run:
-- SwiftLint for code style
-- SwiftFormat for formatting
+Pre-commit and pre-push hooks (installed by `Scripts/setup.sh`) run **SwiftFormat** and **SwiftLint** automatically; violations block the commit/push. Run them manually with `/lint` and `/format`, or `swiftlint` / `swiftformat .`.
 
-## ConvosCore Documentation
-
-ConvosCore is the core Swift Package containing shared logic between the main app and notification extension. See individual component documentation in the source files for details.
+See `CLAUDE.md` for architecture conventions, SwiftUI/type-checker rules, and the Graphite-based PR workflow.

--- a/Scripts/build-phases/copy-env-config-main-app.sh
+++ b/Scripts/build-phases/copy-env-config-main-app.sh
@@ -103,7 +103,7 @@ HEADER_EOF
         echo "📋 Adding additional secrets from .env file..."
 
         # Process .env file: skip comments, empty lines, and IP-related keys (since we handled them above), then format as Swift
-        sed -n '/^[^#]/p' "${SRCROOT}/.env" | grep '=' | grep -v '^CONVOS_API_BASE_URL' | grep -v '^XMTP_CUSTOM_HOST' | grep -v '^GIT_COMMIT_SHA' | sed 's/^\\([^=]*\\)=\\(.*\\)$/    static let \\1 = "\\2"/' | sed 's/""\\(.*\\)""/"\\1"/' >> "$SECRETS_FILE"
+        sed -n '/^[^#]/p' "${SRCROOT}/.env" | grep '=' | grep -v '^CONVOS_API_BASE_URL' | grep -v '^XMTP_CUSTOM_HOST' | grep -v '^GIT_COMMIT_SHA' | sed 's/^\([^=]*\)=\(.*\)$/    static let \1 = "\2"/' | sed 's/""\(.*\)""/"\1"/' >> "$SECRETS_FILE"
     fi
     
     # Close the enum

--- a/Scripts/setup.sh
+++ b/Scripts/setup.sh
@@ -222,8 +222,14 @@ fi
 
 if [ ! "${CI}" = true ] || [ "${CLAUDE_SETUP}" = "1" ]; then
     REPO_ROOT="$(cd "${DIRNAME}/.." && pwd)"
-    PARENT_DIR="$(dirname "${REPO_ROOT}")"
-    PARENT_ENV="${PARENT_DIR}/.env"
+    # Shared convos-ios DEV .env location: prefer the local-stack workspace
+    # (CONVOS_REPOS_DIR env, or the .convos-stack pointer at the repo root) ->
+    # <workspace>/convos-ios.env. Fall back to the legacy parent (<dirname repo>/.env)
+    # when no workspace is configured. One token, shared across all checkouts/worktrees.
+    _ws=""
+    if [ -n "${CONVOS_REPOS_DIR:-}" ]; then _ws="${CONVOS_REPOS_DIR}"
+    elif [ -f "${REPO_ROOT}/.convos-stack" ]; then _ws="$(tr -d '\n' < "${REPO_ROOT}/.convos-stack")"; fi
+    if [ -n "${_ws}" ] && [ -d "${_ws}" ]; then PARENT_ENV="${_ws}/convos-ios.env"; else PARENT_ENV="$(dirname "${REPO_ROOT}")/.env"; fi
     LOCAL_ENV="${REPO_ROOT}/.env"
     FIREBASE_CONSOLE_URL="https://console.firebase.google.com/u/1/project/convos-otr/appcheck/apps"
 
@@ -284,13 +290,13 @@ if [ ! "${CI}" = true ] || [ "${CLAUDE_SETUP}" = "1" ]; then
 
         SYMLINK_NOTE=""
         if [ ! -e "${LOCAL_ENV}" ] && [ ! -L "${LOCAL_ENV}" ]; then
-            ln -s ../.env "${LOCAL_ENV}"
-            SYMLINK_NOTE="✓ Linked .env → ../.env at ${LOCAL_ENV}"
+            ln -s "${PARENT_ENV}" "${LOCAL_ENV}"
+            SYMLINK_NOTE="✓ Linked .env → ${PARENT_ENV} at ${LOCAL_ENV}"
         elif [ -L "${LOCAL_ENV}" ]; then
             link_target="$(readlink "${LOCAL_ENV}")"
             SYMLINK_NOTE="✓ .env → ${link_target} symlink already in place at ${LOCAL_ENV}"
         elif [ -f "${LOCAL_ENV}" ]; then
-            SYMLINK_NOTE=$'⚠️  '"${LOCAL_ENV}"$' is a regular file, not a symlink.\n   To share one token across worktrees:\n     cat .env >> ../.env && rm .env && ln -s ../.env .env'
+            SYMLINK_NOTE="⚠️  ${LOCAL_ENV} is a regular file, not a symlink. To share one token: cat .env >> ${PARENT_ENV} && rm .env && ln -s ${PARENT_ENV} .env"
         fi
 
         print_firebase_report "${NEW_TOKEN}" "${PARENT_ENV}" "${SYMLINK_NOTE}"

--- a/dev/local-stack/Makefile
+++ b/dev/local-stack/Makefile
@@ -1,0 +1,56 @@
+# Convos local stack — committed in convos-ios, runs an EXTERNAL shared workspace.
+# Usage from a convos-ios checkout:  make -C dev/local-stack <target>
+# (or the Claude commands /run local and /local-stack). See README.md.
+#
+# `make up` is the FULL stack (backend + Postgres + herald + assistants/Hermes + MinIO) —
+# what most iOS devs need, since the agents backend is core to the app.
+
+SHELL := /bin/bash
+STACK := bash ./stack.sh
+export CONVOS_REPOS_DIR
+
+.DEFAULT_GOAL := help
+
+.PHONY: help init bootstrap up up-core down restart status logs hermes-build ios-config doctor clean nuke
+
+help: ## Show this help
+	@grep -hE '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN{FS=":.*?## "}{printf "  \033[36m%-14s\033[0m %s\n", $$1, $$2}'
+
+init: ## First-time: choose a workspace dir + clone the service repos into it (WS=/path optional)
+	@$(STACK) init "$(WS)"
+
+bootstrap: ## One-time per machine: deps, secrets (1Password), env files, migrations
+	@$(STACK) bootstrap
+
+up: ## Start the FULL stack — the default
+	@$(STACK) up full
+
+up-core: ## Start only backend + Postgres (no agents) — escape hatch
+	@$(STACK) up core
+
+down: ## Stop host services + infra (keeps data volumes)
+	@$(STACK) down
+
+restart: ## down + up (full)
+	@$(STACK) down && $(STACK) up full
+
+status: ## Health of every service + Docker cap + load
+	@$(STACK) status
+
+logs: ## Tail host-service logs (SVC=backend|herald|worker to scope)
+	@$(STACK) logs $(SVC)
+
+hermes-build: ## Pre-build the Hermes container image (capped)
+	@$(STACK) hermes-build
+
+ios-config: ## Configure a convos-ios checkout as a Local thin client (IOS=/path; default: this repo)
+	@$(STACK) ios-config "$(IOS)"
+
+doctor: ## Check prereqs + Docker CPU cap (no changes)
+	@$(STACK) doctor
+
+clean: ## Stop + remove host-service run state
+	@$(STACK) clean
+
+nuke: ## clean + drop docker volumes (Postgres + MinIO data) — destructive
+	@$(STACK) nuke

--- a/dev/local-stack/README.md
+++ b/dev/local-stack/README.md
@@ -66,10 +66,11 @@ A **`Convos (Local)`** checkout instead gets a **standalone `.env`** (written by
 | iOS auth never completes; Firebase **403 "App attestation failed"** | Shared Local debug token missing → re-run `ios-config`; confirm `.env` has `FIREBASE_APP_CHECK_DEBUG_TOKEN`. |
 | Backend `500` on `/auth/*` after Docker restarted | `make … up` re-brings Postgres + re-disables App Check. |
 | `herald` won't start: `spawn flock ENOENT` | `brew install flock`. |
+| `bootstrap` warns it can't read secrets (`op` not found / not signed in) | `brew install 1password-cli`, then `op signin` — re-run `bootstrap`. |
 | Agent stays "Joining…" | worker/herald down or auth incomplete → `make … status`, ensure auth works. |
 
 ## Fixes to upstream (so this needs no workarounds)
-- ✅ **convos-ios** `Scripts/build-phases/copy-env-config-main-app.sh:106` `sed` bug (double-escaped backslashes that broke Local `Secrets.swift`) — **fixed in this branch**. (`ios-config` still re-patches it idempotently for older checkouts.)
+- ✅ **convos-ios** `Scripts/build-phases/copy-env-config-main-app.sh:106` `sed` bug (double-escaped backslashes that broke Local `Secrets.swift`) — **fixed in this branch** (committed in-repo; `ios-config` no longer needs to patch it).
 - **convos-assistants** `docker-compose.yaml` — MinIO `network_mode: host` doesn't publish ports on macOS; use port mapping (this stack does).
 - **convos-assistants** — default `R2_PARENT_*` to local MinIO creds when `IS_LOCAL_DEV=true`.
 - **herald-lite** — detect/degrade when `flock` is missing on macOS.

--- a/dev/local-stack/README.md
+++ b/dev/local-stack/README.md
@@ -69,8 +69,8 @@ A **`Convos (Local)`** checkout instead gets a **standalone `.env`** (written by
 | Agent stays "Joining…" | worker/herald down or auth incomplete → `make … status`, ensure auth works. |
 
 ## Fixes to upstream (so this needs no workarounds)
-1. **convos-ios** `Scripts/build-phases/copy-env-config-main-app.sh:106` — `sed` double-escaped backslashes break Local `Secrets.swift`. (`ios-config` patches it; commit the one-liner.)
-2. **convos-assistants** `docker-compose.yaml` — MinIO `network_mode: host` doesn't publish ports on macOS; use port mapping (this stack does).
-3. **convos-assistants** — default `R2_PARENT_*` to local MinIO creds when `IS_LOCAL_DEV=true`.
-4. **herald-lite** — detect/degrade when `flock` is missing on macOS.
-5. **convos-ios** (biggest win) — let the **Local** scheme skip Firebase App Check so local dev needs no Firebase token at all.
+- ✅ **convos-ios** `Scripts/build-phases/copy-env-config-main-app.sh:106` `sed` bug (double-escaped backslashes that broke Local `Secrets.swift`) — **fixed in this branch**. (`ios-config` still re-patches it idempotently for older checkouts.)
+- **convos-assistants** `docker-compose.yaml` — MinIO `network_mode: host` doesn't publish ports on macOS; use port mapping (this stack does).
+- **convos-assistants** — default `R2_PARENT_*` to local MinIO creds when `IS_LOCAL_DEV=true`.
+- **herald-lite** — detect/degrade when `flock` is missing on macOS.
+- **convos-ios** (biggest win) — let the **Local** scheme skip Firebase App Check so local dev needs no Firebase token at all.

--- a/dev/local-stack/README.md
+++ b/dev/local-stack/README.md
@@ -1,0 +1,76 @@
+# Convos local stack (for convos-ios devs)
+
+Run the **whole Convos backend + agents stack on your machine** and point the iOS **"Convos (Local)"** scheme at it — so the app's auth, messaging, and the agent-builder ("Make an agent") all run locally.
+
+These scripts are **committed in convos-ios** and operate on an **external workspace** you choose (which holds the cloned service repos + runtime state). **One shared stack** serves every convos-ios checkout/worktree.
+
+```
+convos-ios/ (this repo — every checkout/worktree has these scripts)
+  dev/local-stack/   Makefile  stack.sh  stack.compose.yml  stack.env.example  README.md
+  .convos-stack      → points at your workspace (gitignored, machine-local)
+
+<workspace>/ (you pick this; default: sibling of convos-ios, e.g. ~/Code/xmtplabs/convos-stack)
+  convos-backend/  herald-lite/  convos-assistants/  convos-cli/   ← cloned by `make init`
+  stack.env   .run/                                                ← machine-local, shared by all worktrees
+```
+
+Services (all on `localhost`, shared): backend `:4000` + Postgres `:5432`, assistants worker `:8787` + Hermes containers + MinIO `:9000`, herald `:5050`. **XMTP = hosted DEV network** (no local node — local users and agents interoperate there).
+
+## Quick start
+```bash
+cd <a convos-ios checkout>
+
+make -C dev/local-stack doctor       # check prereqs (node, pnpm, bun, docker, op, ...) + Docker CPU cap
+make -C dev/local-stack init         # pick a workspace dir + clone the 4 service repos into it
+# -> then edit <workspace>/stack.env and set the OP_* 1Password references (one-time, team-wide)
+make -C dev/local-stack bootstrap    # deps, generated backend secrets, .dev.vars (1Password), migrations
+make -C dev/local-stack up           # start the FULL stack (first run builds the Hermes image; capped)
+```
+Then run the app:
+```
+/run local        # Claude command: stack up (if needed) + configure this checkout + build/launch Local
+```
+or `make -C dev/local-stack ios-config IOS=$(pwd)` then build the **Convos (Local)** scheme.
+
+## Prerequisites
+- macOS + **Xcode**, **Docker Desktop** (cap CPUs to ~6 in Settings → Resources — important so the Hermes build can't pin your machine; `make … doctor` warns), **Node 24+**, **pnpm**, **bun**, **1Password CLI** (`op`). `doctor` installs/flags `flock` + `uv`.
+
+## Everyday commands (run from any convos-ios checkout)
+| Command | What |
+|---|---|
+| `make -C dev/local-stack up` | start full stack (most devs) — `up-core` for backend+pg only |
+| `make -C dev/local-stack status` | health of every service + Docker cap + load |
+| `make -C dev/local-stack logs SVC=worker` | tail a host service's log |
+| `make -C dev/local-stack down` | stop everything (keeps Postgres/MinIO data) |
+| `/run local` | (Claude) bring stack up + build/launch Local on the branch sim |
+| `/local-stack [up\|down\|status\|logs]` | (Claude) manage the shared stack |
+
+The stack is **shared** — don't start a second one per worktree (ports collide). All checkouts point at the same `localhost`; the workspace state lives outside any checkout.
+
+## Secrets (1Password)
+- `bootstrap` pulls the assistants **`.dev.vars`** from the `Assistants Local .dev.vars` 1Password item (`op read`), then forces `R2_PARENT_*` to the local MinIO creds.
+- Backend JWT / nonce / notification / `DEV_API_TOKEN` secrets are **generated locally**.
+- **Firebase App Check**: one **shared Local debug token** (Firebase project `convos-otr`, app `org.convos.ios-local`) lives in 1Password; `ios-config` bakes it into each Local checkout's `.env`.
+- Set the `op://` refs (`OP_DEV_VARS_REF`, `OP_FIREBASE_LOCAL_TOKEN_REF`) in `<workspace>/stack.env` once for the team.
+
+### Shared iOS `.env` (Dev vs Local)
+The workspace also holds **`<workspace>/convos-ios.env`** — the shared **Dev** env (Firebase Dev App Check token, `GATEWAY_URL`, `AGENT_DEBUG_JWKS`). `make init` creates it; **`/firebase-token`**, **`/setup`**, and **`convos-task`** symlink each Dev checkout's `.env → <workspace>/convos-ios.env` (one token, every worktree shares it). They fall back to the legacy `<parent>/.env` when no workspace is configured.
+
+A **`Convos (Local)`** checkout instead gets a **standalone `.env`** (written by `ios-config` / `/run local`: localhost backend + Firebase *Local* token) — `ios-config` `rm`s any Dev symlink first so it won't clobber the shared file. So a given checkout is configured for Dev *or* Local at a time.
+
+## Troubleshooting
+| Symptom | Fix |
+|---|---|
+| Machine grinds during first `up` | Docker not CPU-capped → Docker Desktop → Resources → CPUs ≈ 6 (`doctor` warns). |
+| iOS app crashes at launch (`…container URL for group identifier`) | Local built without ad-hoc signing → use `/run local` (it passes the flags). |
+| iOS auth never completes; Firebase **403 "App attestation failed"** | Shared Local debug token missing → re-run `ios-config`; confirm `.env` has `FIREBASE_APP_CHECK_DEBUG_TOKEN`. |
+| Backend `500` on `/auth/*` after Docker restarted | `make … up` re-brings Postgres + re-disables App Check. |
+| `herald` won't start: `spawn flock ENOENT` | `brew install flock`. |
+| Agent stays "Joining…" | worker/herald down or auth incomplete → `make … status`, ensure auth works. |
+
+## Fixes to upstream (so this needs no workarounds)
+1. **convos-ios** `Scripts/build-phases/copy-env-config-main-app.sh:106` — `sed` double-escaped backslashes break Local `Secrets.swift`. (`ios-config` patches it; commit the one-liner.)
+2. **convos-assistants** `docker-compose.yaml` — MinIO `network_mode: host` doesn't publish ports on macOS; use port mapping (this stack does).
+3. **convos-assistants** — default `R2_PARENT_*` to local MinIO creds when `IS_LOCAL_DEV=true`.
+4. **herald-lite** — detect/degrade when `flock` is missing on macOS.
+5. **convos-ios** (biggest win) — let the **Local** scheme skip Firebase App Check so local dev needs no Firebase token at all.

--- a/dev/local-stack/stack.compose.yml
+++ b/dev/local-stack/stack.compose.yml
@@ -1,0 +1,44 @@
+# Shared local infra for the convos stack: Postgres (backend DB) + MinIO (assistants R2 stand-in).
+# Deliberately minimal — we do NOT use the repos' own compose files:
+#   - convos-backend/dev/compose.yml also runs a local xmtp node + notification server
+#     (this stack uses the hosted DEV xmtp network, so they aren't needed).
+#   - convos-assistants/docker-compose.yaml runs herald as a prebuilt image with
+#     network_mode: host (doesn't publish ports on Docker Desktop/macOS) — we run herald
+#     from source and port-map MinIO here.
+# Vars come from the workspace stack.env (exported by stack.sh). Project name: convos-stack.
+services:
+  convos_db:
+    image: postgres:16
+    environment:
+      POSTGRES_PASSWORD: convos
+    ports:
+      - "${PG_PORT:-5432}:5432"
+    volumes:
+      - convos_pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  minio:
+    image: bitnamilegacy/minio:2025.7.23-debian-12-r5
+    ports:
+      - "${MINIO_PORT:-9000}:9000"
+      - "${MINIO_CONSOLE_PORT:-9001}:9001"
+    environment:
+      MINIO_ROOT_USER: "${MINIO_USER:-convos}"
+      MINIO_ROOT_PASSWORD: "${MINIO_PASSWORD:-assistants}"
+      MINIO_DEFAULT_BUCKETS: "${MINIO_BUCKET:-assistants-private-dev}"
+    volumes:
+      - convos_miniodata:/bitnami/minio/data
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 10s
+      timeout: 5s
+      retries: 6
+      start_period: 10s
+
+volumes:
+  convos_pgdata:
+  convos_miniodata:

--- a/dev/local-stack/stack.env.example
+++ b/dev/local-stack/stack.env.example
@@ -29,6 +29,7 @@ SIWE_DOMAIN=dev.convos.org
 SIWE_URI=https://dev.convos.org
 
 # Local MinIO / R2-parent creds (the worker reuses R2_PARENT_* as static MinIO creds locally).
+# Local-only placeholder credentials — never reuse these anywhere real.
 MINIO_USER=convos
 MINIO_PASSWORD=assistants
 MINIO_BUCKET=assistants-private-dev

--- a/dev/local-stack/stack.env.example
+++ b/dev/local-stack/stack.env.example
@@ -1,0 +1,50 @@
+# Workspace config for the convos local stack. `make init` writes a copy of this to
+# <workspace>/stack.env with CONVOS_REPOS_DIR filled in. Plain KEY=VALUE only (this file is
+# also consumed by docker compose), no shell expansion.
+
+# Absolute path to the workspace that holds the cloned service repos + runtime state.
+# `make init` sets this; you normally don't edit it by hand.
+CONVOS_REPOS_DIR=
+
+# Per-repo overrides (optional). Default to $CONVOS_REPOS_DIR/<repo> when blank.
+# BACKEND_DIR=
+# HERALD_DIR=
+# ASSISTANTS_DIR=
+# CLI_DIR=
+# WORKER_DIR=
+
+# Ports (must match the iOS Local scheme + service defaults).
+BACKEND_PORT=4000
+HERALD_PORT=5050
+WORKER_PORT=8787
+PG_PORT=5432
+MINIO_PORT=9000
+MINIO_CONSOLE_PORT=9001
+
+# XMTP: this stack uses the hosted DEV network (no local xmtp node).
+XMTP_ENV=dev
+
+# SIWE domain the iOS Local scheme signs with (must match backend).
+SIWE_DOMAIN=dev.convos.org
+SIWE_URI=https://dev.convos.org
+
+# Local MinIO / R2-parent creds (the worker reuses R2_PARENT_* as static MinIO creds locally).
+MINIO_USER=convos
+MINIO_PASSWORD=assistants
+MINIO_BUCKET=assistants-private-dev
+
+# 1Password (op CLI) references — set these once for your team.
+#   Find them: op item get "Assistants Local .dev.vars" --format json
+# NOTE: values with spaces MUST be quoted (stack.env is sourced by bash).
+OP_VAULT=Engineering
+OP_DEV_VARS_REF="op://Engineering/Assistants Local .dev.vars/notesPlain"
+# Shared Local Firebase App Check debug token (registered in Firebase project convos-otr
+# for app 1:226420087156:ios:036b488464bec3c5c77421 / org.convos.ios-local):
+OP_FIREBASE_LOCAL_TOKEN_REF="op://Engineering/Convos iOS Local AppCheck/credential"
+
+# Cap Docker Desktop CPUs to <= this (Settings > Resources) so the Hermes build can't
+# starve the host. `make doctor` only warns if your cap is higher.
+DOCKER_MAX_CPUS=6
+
+# Override the GitHub org base for `make init` cloning if needed.
+# GH_BASE=https://github.com/xmtplabs

--- a/dev/local-stack/stack.sh
+++ b/dev/local-stack/stack.sh
@@ -48,7 +48,7 @@ load_env() {
 # stack.env is already sourced+exported, so compose reads the vars from the environment.
 dc() { docker compose -p "$COMPOSE_PROJECT" -f "$COMPOSE_FILE" "$@"; }
 
-wait_http() { local url="$1" t="${2:-60}" i=0; while (( i < t )); do local c; c="$(curl -s -o /dev/null -w '%{http_code}' --max-time 8 "$url" 2>/dev/null || true)"; [[ -n "$c" && "$c" != "000" ]] && return 0; sleep 1; ((i++)); done; return 1; }
+wait_http() { local url="$1" t="${2:-60}" i=0; while (( i < t )); do local c; c="$(curl -s -o /dev/null -w '%{http_code}' --max-time 8 "$url" 2>/dev/null || true)"; [[ "$c" =~ ^2[0-9][0-9]$ ]] && return 0; sleep 1; ((i++)); done; return 1; }
 
 start_svc() { local name="$1" dir="$2"; shift 2; if svc_running "$name"; then ok "$name already running"; return 0; fi; [[ -d "$dir" ]] || die "$name dir missing: $dir"; log "starting $name ${c_dim}($dir)${c_rst}"; ( cd "$dir" && nohup bash -lc "$*" >"$RUN_DIR/$name.log" 2>&1 & echo $! >"$RUN_DIR/$name.pid" ); }
 svc_running() { local n="$1"; [[ -f "$RUN_DIR/$n.pid" ]] && kill -0 "$(cat "$RUN_DIR/$n.pid")" 2>/dev/null; }
@@ -182,7 +182,7 @@ cmd_down() {
 # ============================ status / logs ============================
 cmd_status() {
   load_env; log "service health"
-  chk() { local n="$1" u="$2" c; c="$(curl -s -o /dev/null -w '%{http_code}' --max-time 3 "$u" 2>/dev/null || echo 000)"; [[ "$c" != 000 ]] && ok "$(printf '%-8s %s' "$n" "$u") -> $c" || warn "$(printf '%-8s %s' "$n" "$u") -> down"; }
+  chk() { local n="$1" u="$2" c; c="$(curl -s -o /dev/null -w '%{http_code}' --max-time 5 "$u" 2>/dev/null || echo 000)"; [[ "$c" =~ ^2[0-9][0-9]$ ]] && ok "$(printf '%-8s %s' "$n" "$u") -> $c" || warn "$(printf '%-8s %s' "$n" "$u") -> ${c/000/down}"; }
   chk backend "http://localhost:${BACKEND_PORT}/healthcheck"
   chk herald  "http://localhost:${HERALD_PORT}/livez"
   chk worker  "http://localhost:${WORKER_PORT}/openapi.json"
@@ -199,10 +199,8 @@ cmd_ios_config() {
   load_env; local ios="${1:-$REPO_ROOT}"
   [[ -f "$ios/Convos/Config/config.local.json" ]] || die "not a convos-ios checkout: $ios"
   log "configuring Local thin client: $ios"
-  sed -i '' 's/"xmtpNetwork": "local"/"xmtpNetwork": "dev"/' "$ios/Convos/Config/config.local.json" 2>/dev/null || true
-  ok "config.local.json xmtpNetwork -> dev"
-  local bp="$ios/Scripts/build-phases/copy-env-config-main-app.sh"
-  if [[ -f "$bp" ]] && grep -q 'static let \\\\1' "$bp"; then sed -i '' '106 s/\\\\/\\/g' "$bp" && ok "patched build-phase sed bug"; else ok "build-phase fix already applied/upstreamed"; fi
+  if grep -q '"xmtpNetwork": "dev"' "$ios/Convos/Config/config.local.json"; then ok "config.local.json xmtpNetwork already 'dev'"
+  else sed -i '' 's/"xmtpNetwork": "local"/"xmtpNetwork": "dev"/' "$ios/Convos/Config/config.local.json" 2>/dev/null && ok "config.local.json xmtpNetwork -> dev"; fi
   local fb=""; { have op && [[ -n "${OP_FIREBASE_LOCAL_TOKEN_REF:-}" ]] && fb="$(op read "$OP_FIREBASE_LOCAL_TOKEN_REF" 2>/dev/null||true)"; } || true
   [[ -z "$fb" ]] && warn "no Firebase Local token from 1Password — set FIREBASE_APP_CHECK_DEBUG_TOKEN in $ios/.env (shared Local token)"
   rm -f "$ios/.env"   # break any Dev-shared symlink; the Local scheme uses a standalone .env

--- a/dev/local-stack/stack.sh
+++ b/dev/local-stack/stack.sh
@@ -1,0 +1,229 @@
+#!/usr/bin/env bash
+# convos local stack — committed in convos-ios, operates on an EXTERNAL workspace dir
+# (CONVOS_REPOS_DIR) that holds the cloned service repos + machine-local state. One shared
+# stack serves every convos-ios checkout/worktree. See README.md.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"        # convos-ios/dev/local-stack
+COMPOSE_FILE="${SCRIPT_DIR}/stack.compose.yml"
+COMPOSE_PROJECT="convos-stack"
+REPO_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel 2>/dev/null || (cd "$SCRIPT_DIR/../.." && pwd))"
+POINTER="${REPO_ROOT}/.convos-stack"                              # gitignored: points at the workspace
+
+SERVICE_REPOS=(convos-backend herald-lite convos-assistants convos-cli)
+GH_BASE="${GH_BASE:-https://github.com/xmtplabs}"
+
+c_red=$'\e[31m'; c_grn=$'\e[32m'; c_yel=$'\e[33m'; c_cyn=$'\e[36m'; c_dim=$'\e[2m'; c_rst=$'\e[0m'
+log()  { printf '%s==>%s %s\n' "$c_cyn" "$c_rst" "$*"; }
+ok()   { printf '%s ok %s %s\n' "$c_grn" "$c_rst" "$*"; }
+warn() { printf '%s warn%s %s\n' "$c_yel" "$c_rst" "$*" >&2; }
+die()  { printf '%sfail%s %s\n' "$c_red" "$c_rst" "$*" >&2; exit 1; }
+have() { command -v "$1" >/dev/null 2>&1; }
+
+resolve_workspace() {
+  if   [[ -n "${CONVOS_REPOS_DIR:-}" ]]; then WORKSPACE="$CONVOS_REPOS_DIR"
+  elif [[ -f "$POINTER" ]];            then WORKSPACE="$(tr -d '\n' < "$POINTER")"
+  else WORKSPACE=""; fi
+}
+
+load_env() {
+  resolve_workspace
+  [[ -n "$WORKSPACE" ]] || die "no workspace configured — run: make init"
+  [[ -f "${WORKSPACE}/stack.env" ]] || die "no ${WORKSPACE}/stack.env — run: make init"
+  set -a; . "${WORKSPACE}/stack.env"; set +a
+  CONVOS_REPOS_DIR="$WORKSPACE"
+  BACKEND_DIR="${BACKEND_DIR:-${WORKSPACE}/convos-backend}"
+  HERALD_DIR="${HERALD_DIR:-${WORKSPACE}/herald-lite}"
+  ASSISTANTS_DIR="${ASSISTANTS_DIR:-${WORKSPACE}/convos-assistants}"
+  CLI_DIR="${CLI_DIR:-${WORKSPACE}/convos-cli}"
+  WORKER_DIR="${WORKER_DIR:-${ASSISTANTS_DIR}/workers/assistant}"
+  : "${BACKEND_PORT:=4000}" "${HERALD_PORT:=5050}" "${WORKER_PORT:=8787}" "${MINIO_PORT:=9000}"
+  : "${XMTP_ENV:=dev}" "${SIWE_DOMAIN:=dev.convos.org}" "${SIWE_URI:=https://dev.convos.org}"
+  : "${MINIO_USER:=convos}" "${MINIO_PASSWORD:=assistants}" "${MINIO_BUCKET:=assistants-private-dev}"
+  : "${DOCKER_MAX_CPUS:=6}"
+  export BACKEND_PORT HERALD_PORT WORKER_PORT MINIO_PORT MINIO_CONSOLE_PORT MINIO_USER MINIO_PASSWORD MINIO_BUCKET PG_PORT
+  RUN_DIR="${WORKSPACE}/.run"; mkdir -p "$RUN_DIR"
+}
+
+# stack.env is already sourced+exported, so compose reads the vars from the environment.
+dc() { docker compose -p "$COMPOSE_PROJECT" -f "$COMPOSE_FILE" "$@"; }
+
+wait_http() { local url="$1" t="${2:-60}" i=0; while (( i < t )); do local c; c="$(curl -s -o /dev/null -w '%{http_code}' --max-time 8 "$url" 2>/dev/null || true)"; [[ -n "$c" && "$c" != "000" ]] && return 0; sleep 1; ((i++)); done; return 1; }
+
+start_svc() { local name="$1" dir="$2"; shift 2; if svc_running "$name"; then ok "$name already running"; return 0; fi; [[ -d "$dir" ]] || die "$name dir missing: $dir"; log "starting $name ${c_dim}($dir)${c_rst}"; ( cd "$dir" && nohup bash -lc "$*" >"$RUN_DIR/$name.log" 2>&1 & echo $! >"$RUN_DIR/$name.pid" ); }
+svc_running() { local n="$1"; [[ -f "$RUN_DIR/$n.pid" ]] && kill -0 "$(cat "$RUN_DIR/$n.pid")" 2>/dev/null; }
+stop_svc() { local name="$1" pat="${2:-}"; [[ -f "$RUN_DIR/$name.pid" ]] && kill "$(cat "$RUN_DIR/$name.pid")" 2>/dev/null || true; [[ -n "$pat" ]] && pkill -f "$pat" 2>/dev/null || true; rm -f "$RUN_DIR/$name.pid"; }
+disable_app_check() { local tok; tok="$(grep -E '^DEV_API_TOKEN=' "${BACKEND_DIR}/.env" 2>/dev/null | cut -d= -f2-)"; [[ -z "$tok" ]] && { warn "no DEV_API_TOKEN; can't disable App Check"; return; }; curl -s -X POST -H "Authorization: Bearer $tok" -H 'Content-Type: application/json' -d '{"enabled":false}' "http://localhost:${BACKEND_PORT}/api/v2/dev/app-attest" >/dev/null 2>&1 && ok "App Check disabled" || warn "couldn't disable App Check"; }
+
+# ============================ init (clone wizard) ============================
+cmd_init() {
+  local default_ws; default_ws="$(dirname "$REPO_ROOT")/convos-stack"   # sibling of the convos-ios checkout
+  local ws="${1:-${CONVOS_REPOS_DIR:-}}"
+  if [[ -z "$ws" ]]; then
+    if [[ -t 0 ]]; then read -r -p "Workspace dir for the local stack [${default_ws}]: " ws || true; fi
+    ws="${ws:-$default_ws}"
+  fi
+  mkdir -p "$ws"; ws="$(cd "$ws" && pwd)"
+  printf '%s\n' "$ws" > "$POINTER"; ok "pointer written: ${POINTER} -> ${ws}"
+
+  log "cloning service repos into ${ws} (skips any already present)"
+  for r in "${SERVICE_REPOS[@]}"; do
+    if [[ -d "${ws}/${r}/.git" ]]; then ok "${r} already cloned"
+    else log "git clone ${r}"; git clone "${GH_BASE}/${r}.git" "${ws}/${r}" || warn "clone ${r} failed — clone it manually into ${ws}/${r}"; fi
+  done
+
+  if [[ ! -f "${ws}/stack.env" ]]; then
+    sed "s|^CONVOS_REPOS_DIR=.*|CONVOS_REPOS_DIR=${ws}|" "${SCRIPT_DIR}/stack.env.example" > "${ws}/stack.env"
+    ok "wrote ${ws}/stack.env — set OP_* 1Password refs in it before `make bootstrap`"
+  else ok "${ws}/stack.env exists (left as-is)"; fi
+  if [[ ! -f "${ws}/convos-ios.env" ]]; then
+    printf '# Shared convos-ios DEV .env (Firebase App Check debug token, GATEWAY_URL, AGENT_DEBUG_JWKS, ...).\n# Dev convos-ios checkouts symlink their .env to this file; run /firebase-token to pin the token.\nFIREBASE_APP_CHECK_DEBUG_TOKEN=\nAGENT_DEBUG_JWKS=\nGATEWAY_URL=\nSENTRY_DSN=\n' > "${ws}/convos-ios.env"
+    ok "created ${ws}/convos-ios.env (shared Dev env — convos-ios checkouts symlink their .env here)"
+  fi
+  ok "init done. Next: edit ${ws}/stack.env (OP_* refs), then: make bootstrap && make up"
+}
+
+# ============================ doctor ============================
+cmd_doctor() {
+  resolve_workspace
+  [[ -n "$WORKSPACE" ]] && ok "workspace: ${WORKSPACE}" || warn "no workspace yet (run: make init)"
+  log "prerequisites"
+  for t in node pnpm bun docker openssl curl git; do have "$t" && ok "$t $($t --version 2>/dev/null | head -1)" || warn "$t MISSING"; done
+  have uv && ok "uv $(uv --version)" || warn "uv MISSING (brew install uv) — assistants repo-setup"
+  have flock && ok "flock present" || warn "flock MISSING (brew install flock) — herald on macOS"
+  have op && ok "1Password CLI present" || warn "op MISSING (brew install 1password-cli) — secrets"
+  have xcodebuild && ok "Xcode $(xcodebuild -version 2>/dev/null | head -1)" || warn "xcodebuild MISSING"
+  if docker info >/dev/null 2>&1; then
+    local ncpu; ncpu="$(docker info --format '{{.NCPU}}' 2>/dev/null || echo '?')"
+    if [[ "$ncpu" =~ ^[0-9]+$ ]] && (( ncpu > ${DOCKER_MAX_CPUS:-6} )); then
+      warn "Docker has ${ncpu} CPUs — cap to ${DOCKER_MAX_CPUS:-6} (Docker Desktop > Settings > Resources) so the Hermes build can't starve the host"
+    else ok "Docker running, ${ncpu} CPUs"; fi
+  else die "Docker not running"; fi
+}
+
+# ============================ bootstrap ============================
+cmd_bootstrap() {
+  load_env
+  cmd_doctor || true
+  have flock || brew install flock || warn "brew install flock failed"
+  have uv    || brew install uv    || warn "brew install uv failed"
+  bootstrap_backend; bootstrap_herald; bootstrap_assistants; bootstrap_cli
+  ok "bootstrap complete — now: make up   (then in a convos-ios checkout: /run local)"
+}
+bootstrap_backend() {
+  log "convos-backend: env + deps + codegen + migrations"; pushd "$BACKEND_DIR" >/dev/null
+  pnpm install
+  if [[ ! -f .env ]]; then
+    local keys; keys="$(pnpm tsx dev/scripts/generateEcdsaKeys.ts 2>/dev/null)"
+    grep -vE '^(JWT_PRIVATE_KEY|JWT_PUBLIC_KEY|XMTP_NOTIFICATION_SECRET|NONCE_HMAC_SECRET|SIWE_DOMAIN|SIWE_URI|WEBSITE_URL|DEV_API_TOKEN|XMTP_ENV)=' .env.example > .env
+    { printf '\n# --- convos local stack ---\n'
+      printf '%s\n' "$keys" | grep '^JWT_PRIVATE_KEY='; printf '%s\n' "$keys" | grep '^JWT_PUBLIC_KEY='
+      printf 'XMTP_NOTIFICATION_SECRET=%s\n' "$(openssl rand -hex 32)"
+      printf 'NONCE_HMAC_SECRET=%s\n' "$(openssl rand -hex 32)"
+      printf 'WEBSITE_URL=%s\nSIWE_DOMAIN=%s\nSIWE_URI=%s\n' "$SIWE_URI" "$SIWE_DOMAIN" "$SIWE_URI"
+      printf 'DEV_API_TOKEN=%s\nXMTP_ENV=%s\n' "$(openssl rand -hex 24)" "$XMTP_ENV"
+    } >> .env; ok "wrote convos-backend/.env"
+  else ok "convos-backend/.env exists"; fi
+  pnpm prisma:generate >/dev/null && pnpm buf:generate >/dev/null && ok "codegen done"
+  dc up -d convos_db --wait >/dev/null 2>&1 || dc up -d convos_db
+  pnpm migrate:deploy >/dev/null && ok "migrations applied"; popd >/dev/null
+}
+bootstrap_herald() {
+  log "herald-lite: env + deps"; pushd "$HERALD_DIR" >/dev/null; pnpm install
+  [[ -f .env ]] || printf 'DATA_DIR=./data\nPORT=%s\nENV=dev\nXMTP_ENV=%s\nLOG_LEVEL=info\n' "$HERALD_PORT" "$XMTP_ENV" > .env
+  ok "herald-lite/.env ready"; popd >/dev/null
+}
+bootstrap_assistants() {
+  log "convos-assistants: deps + .dev.vars + repo-setup"; pushd "$ASSISTANTS_DIR" >/dev/null; pnpm install
+  local dv="${WORKER_DIR}/.dev.vars"
+  if [[ ! -f "$dv" ]]; then
+    if have op && [[ -n "${OP_DEV_VARS_REF:-}" ]] && op read "$OP_DEV_VARS_REF" >"$dv" 2>/dev/null; then ok "fetched .dev.vars from 1Password"
+    else warn "populate ${dv} from 1Password item 'Assistants Local .dev.vars' (op not set up / OP_DEV_VARS_REF unset)"; fi
+  fi
+  if [[ -f "$dv" ]]; then
+    sed -i '' -E "s|^R2_PARENT_ACCESS_KEY_ID=.*|R2_PARENT_ACCESS_KEY_ID=${MINIO_USER}|; s|^R2_PARENT_SECRET_ACCESS_KEY=.*|R2_PARENT_SECRET_ACCESS_KEY=${MINIO_PASSWORD}|" "$dv" 2>/dev/null || true
+    grep -q '^R2_PARENT_ACCESS_KEY_ID=' "$dv" || printf 'R2_PARENT_ACCESS_KEY_ID=%s\nR2_PARENT_SECRET_ACCESS_KEY=%s\n' "$MINIO_USER" "$MINIO_PASSWORD" >>"$dv"
+    ok ".dev.vars R2_PARENT_* set to local MinIO creds"
+  fi
+  if have uv; then pnpm run repo-setup >/dev/null 2>&1 && ok "repo-setup done" || warn "repo-setup failed (check uv)"; fi
+  popd >/dev/null
+}
+bootstrap_cli() { log "convos-cli: deps + build"; pushd "$CLI_DIR" >/dev/null; pnpm install && pnpm build >/dev/null 2>&1 && ok "cli built" || warn "cli build failed"; popd >/dev/null; }
+
+# ============================ up / down ============================
+cmd_up() {
+  load_env; local tier="${1:-full}"; docker info >/dev/null 2>&1 || die "Docker not running"
+  log "infra ($([[ $tier == full ]] && echo 'Postgres + MinIO' || echo 'Postgres'))"
+  if [[ "$tier" == full ]]; then dc up -d --wait || dc up -d; else dc up -d convos_db --wait || dc up -d convos_db; fi
+  start_svc backend "$BACKEND_DIR" "pnpm dev"
+  wait_http "http://localhost:${BACKEND_PORT}/healthcheck" 60 && ok "backend up" || warn "backend not healthy (make logs SVC=backend)"
+  disable_app_check
+  if [[ "$tier" == full ]]; then
+    start_svc herald "$HERALD_DIR" "pnpm start"
+    wait_http "http://localhost:${HERALD_PORT}/livez" 30 && ok "herald up" || warn "herald not healthy (make logs SVC=herald)"
+    start_svc worker "$WORKER_DIR" "pnpm dev"
+    log "waiting for worker :${WORKER_PORT} (first run builds Hermes image — minutes, capped)"
+    wait_http "http://localhost:${WORKER_PORT}/openapi.json" 1200 && ok "worker up (Hermes ready)" || warn "worker still starting (make logs SVC=worker)"
+  fi
+  echo; cmd_status
+}
+cmd_down() {
+  load_env; log "stopping host services"
+  stop_svc worker  "with-wrangler-docker-fuse-proxy|run-wrangler.sh|workerd|miniflare"
+  stop_svc herald  "${HERALD_DIR}.*src/index.ts"
+  # herald holds a single-writer flock via a child `flock ... herald.lock` process that
+  # survives the node process; kill it too, or the next herald start hangs 600s on the lock.
+  pkill -f "herald.lock" 2>/dev/null || true
+  pkill -f "sleep 2147483647" 2>/dev/null || true
+  stop_svc backend "${BACKEND_DIR}.*src/index.ts"
+  log "stopping infra (data kept)"; dc stop >/dev/null 2>&1 || true; ok "stopped"
+}
+
+# ============================ status / logs ============================
+cmd_status() {
+  load_env; log "service health"
+  chk() { local n="$1" u="$2" c; c="$(curl -s -o /dev/null -w '%{http_code}' --max-time 3 "$u" 2>/dev/null || echo 000)"; [[ "$c" != 000 ]] && ok "$(printf '%-8s %s' "$n" "$u") -> $c" || warn "$(printf '%-8s %s' "$n" "$u") -> down"; }
+  chk backend "http://localhost:${BACKEND_PORT}/healthcheck"
+  chk herald  "http://localhost:${HERALD_PORT}/livez"
+  chk worker  "http://localhost:${WORKER_PORT}/openapi.json"
+  chk minio   "http://localhost:${MINIO_PORT}/minio/health/live"
+  docker ps --format '  {{.Names}}: {{.Status}}' 2>/dev/null | grep -iE "convos-stack" || true
+  printf '  %sworkspace=%s · docker CPUs=%s · load=%s%s\n' "$c_dim" "$WORKSPACE" "$(docker info --format '{{.NCPU}}' 2>/dev/null||echo '?')" "$(uptime|sed -E 's/.*load average[s]*: *([0-9.]+).*/\1/')" "$c_rst"
+}
+cmd_logs() { load_env; local svc="${1:-}"; if [[ -n "$svc" ]]; then tail -f "$RUN_DIR/${svc}.log"; else [[ -n "$(ls "$RUN_DIR"/*.log 2>/dev/null||true)" ]] || die "no logs yet (make up)"; tail -f "$RUN_DIR"/*.log; fi; }
+
+cmd_hermes_build() { load_env; docker info >/dev/null 2>&1 || die "Docker not running"; log "building Hermes image (capped)"; pushd "$WORKER_DIR" >/dev/null; pnpm exec wrangler containers build ./../../runtime/hermes/Dockerfile || pnpm run prebuild; popd >/dev/null; ok "Hermes image cached"; }
+
+# ============================ ios-config ============================
+cmd_ios_config() {
+  load_env; local ios="${1:-$REPO_ROOT}"
+  [[ -f "$ios/Convos/Config/config.local.json" ]] || die "not a convos-ios checkout: $ios"
+  log "configuring Local thin client: $ios"
+  sed -i '' 's/"xmtpNetwork": "local"/"xmtpNetwork": "dev"/' "$ios/Convos/Config/config.local.json" 2>/dev/null || true
+  ok "config.local.json xmtpNetwork -> dev"
+  local bp="$ios/Scripts/build-phases/copy-env-config-main-app.sh"
+  if [[ -f "$bp" ]] && grep -q 'static let \\\\1' "$bp"; then sed -i '' '106 s/\\\\/\\/g' "$bp" && ok "patched build-phase sed bug"; else ok "build-phase fix already applied/upstreamed"; fi
+  local fb=""; { have op && [[ -n "${OP_FIREBASE_LOCAL_TOKEN_REF:-}" ]] && fb="$(op read "$OP_FIREBASE_LOCAL_TOKEN_REF" 2>/dev/null||true)"; } || true
+  [[ -z "$fb" ]] && warn "no Firebase Local token from 1Password — set FIREBASE_APP_CHECK_DEBUG_TOKEN in $ios/.env (shared Local token)"
+  rm -f "$ios/.env"   # break any Dev-shared symlink; the Local scheme uses a standalone .env
+  { printf 'CONVOS_API_BASE_URL=http://localhost:%s/api\nGATEWAY_URL=\nSENTRY_DSN=\nFIREBASE_APP_CHECK_DEBUG_TOKEN=%s\nAGENT_DEBUG_JWKS=\n' "$BACKEND_PORT" "$fb"; } > "$ios/.env"
+  ok "wrote standalone Local $ios/.env (localhost backend + Firebase Local token; any Dev symlink replaced)"
+}
+
+cmd_clean() { load_env; cmd_down; rm -rf "$RUN_DIR"; ok "cleaned run state"; }
+cmd_nuke()  { load_env; cmd_down; rm -rf "$RUN_DIR"; dc down -v >/dev/null 2>&1 || true; warn "dropped docker volumes (Postgres + MinIO data wiped)"; }
+
+case "${1:-}" in
+  init)         shift; cmd_init "${1:-}";;
+  bootstrap)    cmd_bootstrap;;
+  up)           cmd_up "${2:-full}";;
+  down)         cmd_down;;
+  status)       cmd_status;;
+  logs)         cmd_logs "${2:-}";;
+  hermes-build) cmd_hermes_build;;
+  ios-config)   cmd_ios_config "${2:-}";;
+  doctor)       cmd_doctor;;
+  clean)        cmd_clean;;
+  nuke)         cmd_nuke;;
+  *) die "usage: stack.sh <init|bootstrap|up [full|core]|down|status|logs [svc]|hermes-build|ios-config [path]|doctor|clean|nuke>";;
+esac


### PR DESCRIPTION
## What

Adds `dev/local-stack/` — a one-command, **shared** local stack the **Convos (Local)** scheme runs against (backend + Postgres + herald + assistants worker + Hermes containers + MinIO) over the hosted **DEV** xmtp network. Auth, messaging, and "Make an agent" all run on your machine. One stack serves every checkout/worktree.

## What's in it

- **`dev/local-stack/`** — `stack.sh` + `Makefile` + `stack.compose.yml` + `stack.env.example` + runbook `README.md`. Committed scripts operate on an **external workspace** you choose; `make init` is a clone-wizard that pulls the service repos into it. State (`stack.env`, logs) lives in the workspace, shared by all worktrees.
- **Claude commands**: `/run local` (stack up → configure this checkout → build+launch Local) and `/local-stack` (init/bootstrap/up/down/status/logs/doctor).
- **Shared iOS Dev `.env` moved to the workspace** (`convos-ios.env`): `Scripts/setup.sh`, `/firebase-token`, and `convos-task` resolve it via a `.convos-stack` pointer (`$CONVOS_REPOS_DIR` → pointer → legacy `<parent>/.env` fallback) and propagate the pointer into new worktrees.
- **`Convos (Local)` now defaults to `xmtpNetwork: dev`** — the Local scheme runs against a local backend + the hosted DEV xmtp network (not a local xmtp node). The local xmtp node via `./dev/up` remains for the ConvosCore **test suite**, which is separate.
- **Fixes a real `sed` bug** in `Scripts/build-phases/copy-env-config-main-app.sh:106` (double-escaped backslashes) that made extra `.env` keys land in Local `Secrets.swift` as raw `KEY=value` lines — invalid Swift. Local builds aren't in CI, so it went unnoticed.
- **README** rewritten into a proper getting-started guide (setup + signing, schemes, Claude commands, worktrees, local stack, testing).

## Usage

```bash
make -C dev/local-stack doctor      # prereqs + Docker cap
make -C dev/local-stack init        # pick a workspace + clone the service repos
make -C dev/local-stack bootstrap   # deps, secrets (1Password), migrations
make -C dev/local-stack up          # start the full stack
/run local                          # build + launch Local against it
```

## Validation

Proven by a full clean-slate round-trip (`make down → bootstrap → up` rebuilt all services healthy from a fresh DB), then a clean iOS reinstall confirmed SIWE auth (`/auth/token` + `/device/register` 200) and agent provisioning (`/v2/agents/join` 200) against the freshly-reproduced stack. The Hermes image build is capped to Docker's CPU limit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add local backend stack tooling and getting-started README for convos-ios
> - Adds [dev/local-stack/stack.sh](https://github.com/xmtplabs/convos-ios/pull/921/files#diff-ac74f42213bfd94cd92c5951d64ae7013a7155b648d52d642d4c25b01dfb3bd5) and [dev/local-stack/Makefile](https://github.com/xmtplabs/convos-ios/pull/921/files#diff-e5ae5314721d0c6f8e2526ad85320890b5747bbcd3f494b9b50ab71e86063f7e) to initialize, bootstrap, start/stop, and monitor a shared local backend+agents stack (Postgres, MinIO, backend, herald, assistants worker) via `make -C dev/local-stack`.
> - Adds [dev/local-stack/stack.compose.yml](https://github.com/xmtplabs/convos-ios/pull/921/files#diff-e6a5680663ada8f3a09ad2093134297c615bfd6b690f2144616842deee1672cf) with Docker Compose services for Postgres 16 and MinIO, and [dev/local-stack/stack.env.example](https://github.com/xmtplabs/convos-ios/pull/921/files#diff-8570a7059fe0075aba9a614bbb02ba8ac1295d3ad296832dc285709eb0184a83) as a configuration template.
> - Updates [Scripts/setup.sh](https://github.com/xmtplabs/convos-ios/pull/921/files#diff-490f2d9bc338440322d4b7d5bcb8c209ee7633cdb9f4245ceb2cb78bc6486314) and the `convos-task` script to resolve a workspace-scoped `convos-ios.env` (via `CONVOS_REPOS_DIR` or `.convos-stack`) instead of linking `.env` to the parent directory.
> - Fixes a `sed` escaping bug in [Scripts/build-phases/copy-env-config-main-app.sh](https://github.com/xmtplabs/convos-ios/pull/921/files#diff-70ff2e26adae8d6f9ca7352b29379af3ec6c31c345fb891598d331e529c05c4f) that was emitting malformed Swift constants in `Secrets.swift`.
> - Changes the local config `xmtpNetwork` from `"local"` to `"dev"` in [Convos/Config/config.local.json](https://github.com/xmtplabs/convos-ios/pull/921/files#diff-db4dbc6782158cc2fc4a3b78316f01264f05189713072208c437431fa11fd65b) and rewrites [README.md](https://github.com/xmtplabs/convos-ios/pull/921/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) with first-time setup, environment/scheme docs, and local stack workflow.
> - Behavioral Change: `.env` symlinks in new worktrees now point to `<workspace>/convos-ios.env` when a workspace is configured, replacing the previous `../.env` fallback.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8be55bf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->