### PR TITLE
fix(writer): mark builder-bundle messages failed on prepare error paths

### DIFF
--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/OutgoingMessageWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/OutgoingMessageWriter.swift
@@ -801,9 +801,18 @@ actor OutgoingMessageWriter: OutgoingMessageWriterProtocol {
         let prepared: PreparedAttachmentBundle? = bundleItems.isEmpty
             ? nil
             : try await prepareBuilderBundleAttachments(items: bundleItems, clientMessageId: bundleClientMessageId, inboxReady: inboxReady)
-        let textMessageId: String? = text.isEmpty
-            ? nil
-            : try await prepareBuilderBundleText(text, clientMessageId: textClientMessageId, inboxReady: inboxReady)
+        let textMessageId: String?
+        do {
+            textMessageId = text.isEmpty
+                ? nil
+                : try await prepareBuilderBundleText(text, clientMessageId: textClientMessageId, inboxReady: inboxReady)
+        } catch {
+            // The attachment bundle is already prepared and persisted "sending";
+            // a text-prepare failure aborts the send before publishing, so mark
+            // the bundle failed too rather than stranding it.
+            if let prepared { try? await markMessageFailed(messageId: prepared.messageId) }
+            throw error
+        }
 
         let bundledMessageIds: [String] = [prepared?.messageId, textMessageId].compactMap { $0 }
         guard !bundledMessageIds.isEmpty else { return }
@@ -933,10 +942,23 @@ actor OutgoingMessageWriter: OutgoingMessageWriterProtocol {
         inboxReady: InboxReadyResult
     ) async throws {
         let conversationIdLocal = self.conversationId
-        guard let sender = try await inboxReady.client.messageSender(for: conversationIdLocal) else {
-            throw OutgoingMessageWriterError.conversationNotFound(conversationId: conversationIdLocal)
+        let sender: any MessageSender
+        let manifestMessageId: String
+        do {
+            guard let resolvedSender = try await inboxReady.client.messageSender(for: conversationIdLocal) else {
+                throw OutgoingMessageWriterError.conversationNotFound(conversationId: conversationIdLocal)
+            }
+            sender = resolvedSender
+            manifestMessageId = try await resolvedSender.prepare(builderBundleManifest: BuilderBundleManifest(messageIds: manifestIds))
+        } catch {
+            // Sender resolution and the manifest prepare run before anything
+            // publishes, but the bundle and text are already persisted
+            // "sending". A failure here aborts the send, so mark them failed --
+            // otherwise they'd be stuck "sending" with no retry affordance.
+            if let prepared { try? await markMessageFailed(messageId: prepared.messageId) }
+            if let textMessageId { try? await markMessageFailed(messageId: textMessageId) }
+            throw error
         }
-        let manifestMessageId = try await sender.prepare(builderBundleManifest: BuilderBundleManifest(messageIds: manifestIds))
         do {
             try await sender.publishMessage(messageId: manifestMessageId)
         } catch {


### PR DESCRIPTION
## Summary

Follow-up to #922. That PR hardened the **three publish** catches in the
builder-bundle send, but a closer pass found **two earlier throw paths** in the
same function family that still left already-persisted "sending" messages
stranded forever (the exact bug #922 set out to kill). This PR closes them.

`sendBuilderBundle` persists the bundle and text as "sending" before publishing.
Now every throw path marks the not-yet-published prepared messages failed before
rethrowing:

- **sender resolution + `prepare(builderBundleManifest:)`** (in
  `publishPreparedBuilderBundle`) - both run before anything publishes, so a
  failure stranded the prepared bundle and text. Wrapping the resolution also
  covers `messageSender(for:)` *throwing* (not just returning nil), which a bare
  `guard-else` missed.
- **the text prepare** (in `sendBuilderBundle`) - runs after the attachment
  bundle is already prepared, so a failure there stranded the bundle.

## Why a separate PR

These two edits were described in #922 but never actually committed - the
`Edit` calls silently failed during a tool-output degradation and weren't
re-verified before that PR was finalized/merged. A reviewer caught the gap on
the merged code; this PR applies the fixes for real.

## Test plan

- `swift test --package-path ConvosCore` -> **1073 tests pass**
- SwiftLint clean (pre-push hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/924"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782768591&installation_id=128169237&pr_number=924&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F924&signature=1ccb67aea84ab6e60d5ad2e89c5dcac30932389213c6c1bf40581606fa485c55"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Mark builder-bundle messages as failed on prepare error paths in `OutgoingMessageWriter`
> - When `prepareBuilderBundleText` throws, the already-prepared attachment bundle message is now marked failed via `markMessageFailed` before the error is rethrown, preventing it from being stuck in a sending state.
> - When sender resolution or manifest preparation fails inside `publishPreparedBuilderBundle`, both the bundle and text message records (when present) are now marked failed before rethrowing.
> - Behavioral Change: messages that previously remained indefinitely in a sending state after these error paths will now transition to a failed state.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 162816a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->