### PR TITLE
local-stack: auto-provision the in-app agent-builder

### DIFF
--- a/dev/local-stack/Makefile
+++ b/dev/local-stack/Makefile
@@ -11,7 +11,7 @@ export CONVOS_REPOS_DIR
 
 .DEFAULT_GOAL := help
 
-.PHONY: help init bootstrap up up-core down restart status logs hermes-build ios-config doctor clean nuke
+.PHONY: help init bootstrap up up-core down restart status logs hermes-build ios-config seed-credits doctor clean nuke
 
 help: ## Show this help
 	@grep -hE '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN{FS=":.*?## "}{printf "  \033[36m%-14s\033[0m %s\n", $$1, $$2}'
@@ -45,6 +45,9 @@ hermes-build: ## Pre-build the Hermes container image (capped)
 
 ios-config: ## Configure a convos-ios checkout as a Local thin client (IOS=/path; default: this repo)
 	@$(STACK) ios-config "$(IOS)"
+
+seed-credits: ## Grant local-dev credits to any unfunded account (run after first sign-in)
+	@$(STACK) seed-credits
 
 doctor: ## Check prereqs + Docker CPU cap (no changes)
 	@$(STACK) doctor

--- a/dev/local-stack/README.md
+++ b/dev/local-stack/README.md
@@ -42,6 +42,7 @@ or `make -C dev/local-stack ios-config IOS=$(pwd)` then build the **Convos (Loca
 | `make -C dev/local-stack status` | health of every service + Docker cap + load |
 | `make -C dev/local-stack logs SVC=worker` | tail a host service's log |
 | `make -C dev/local-stack down` | stop everything (keeps Postgres/MinIO data) |
+| `make -C dev/local-stack seed-credits` | grant local-dev credits to any unfunded account (run after first sign-in) |
 | `/run local` | (Claude) bring stack up + build/launch Local on the branch sim |
 | `/local-stack [up\|down\|status\|logs]` | (Claude) manage the shared stack |
 
@@ -52,6 +53,9 @@ The stack is **shared** — don't start a second one per worktree (ports collide
 - Backend JWT / nonce / notification / `DEV_API_TOKEN` secrets are **generated locally**.
 - **Firebase App Check**: one **shared Local debug token** (Firebase project `convos-otr`, app `org.convos.ios-local`) lives in 1Password; `ios-config` bakes it into each Local checkout's `.env`.
 - Set the `op://` refs (`OP_DEV_VARS_REF`, `OP_FIREBASE_LOCAL_TOKEN_REF`) in `<workspace>/stack.env` once for the team.
+
+### Agent-builder provisioning (auto)
+The in-chat agent-builder ("Make an agent") calls convos-backend directly from its Hermes container. `bootstrap` + `up` provision this automatically: they point the worker's **`CONVOS_API_BASE_URL`** at *this* backend via the host's LAN IP (reachable from both the worker process and the container — `localhost`/`host.docker.internal` each only work from one side), and align the backend's **`AGENT_ASSETS_API_KEY`** with the worker's `CONVOS_API_KEY` (or the builder's calls 401). The one manual step: accounts are created on first iOS sign-in, so **after signing in run `make … seed-credits`** to fund the account (else the builder shows "lost power"). `make … up` also seeds on each run.
 
 ### Shared iOS `.env` (Dev vs Local)
 The workspace also holds **`<workspace>/convos-ios.env`** — the shared **Dev** env (Firebase Dev App Check token, `GATEWAY_URL`, `AGENT_DEBUG_JWKS`). `make init` creates it; **`/firebase-token`**, **`/setup`**, and **`convos-task`** symlink each Dev checkout's `.env → <workspace>/convos-ios.env` (one token, every worktree shares it). They fall back to the legacy `<parent>/.env` when no workspace is configured.
@@ -68,6 +72,8 @@ A **`Convos (Local)`** checkout instead gets a **standalone `.env`** (written by
 | `herald` won't start: `spawn flock ENOENT` | `brew install flock`. |
 | `bootstrap` warns it can't read secrets (`op` not found / not signed in) | `brew install 1password-cli`, then `op signin` — re-run `bootstrap`. |
 | Agent stays "Joining…" | worker/herald down or auth incomplete → `make … status`, ensure auth works. |
+| Agent-builder: **"Asserted ownerAccountId does not exist"** | worker's `CONVOS_API_BASE_URL` points at the wrong backend (default is the hosted dev one, or the host IP drifted) → `make … up` re-syncs it to this backend; `make … doctor` flags drift. |
+| Agent-builder: **"lost power" / Upgrade** | the account has no local credits → after signing in, `make … seed-credits`. |
 
 ## Fixes to upstream (so this needs no workarounds)
 - ✅ **convos-ios** `Scripts/build-phases/copy-env-config-main-app.sh:106` `sed` bug (double-escaped backslashes that broke Local `Secrets.swift`) — **fixed in this branch** (committed in-repo; `ios-config` no longer needs to patch it).

--- a/dev/local-stack/stack.sh
+++ b/dev/local-stack/stack.sh
@@ -61,6 +61,12 @@ disable_app_check() { local tok; tok="$(grep -E '^DEV_API_TOKEN=' "${BACKEND_DIR
 # *:PORT). Empty when offline (no default route).
 host_ip() { local ifc; ifc="$(route -n get default 2>/dev/null | awk '/interface:/{print $2}')"; [[ -n "$ifc" ]] && ipconfig getifaddr "$ifc" 2>/dev/null || true; }
 
+# Write KEY=VALUE into a dotenv file WITHOUT sed replacement-string
+# interpretation — values like API keys can contain &, |, \ which corrupt a
+# `sed s|..|..|` replacement. Drops any existing KEY line, appends the new one
+# (callers pre-check the file exists).
+set_env_kv() { local file="$1" k="$2" v="$3" tmp; tmp="$(mktemp)"; grep -v "^${k}=" "$file" 2>/dev/null >"$tmp" || true; printf '%s=%s\n' "$k" "$v" >>"$tmp"; mv "$tmp" "$file"; }
+
 # Point the worker's CONVOS_API_BASE_URL at THIS backend via the host LAN IP.
 # The in-chat agent-builder calls convos-backend directly from its container;
 # .dev.vars ships the hosted dev backend by default, so the builder would
@@ -72,8 +78,7 @@ sync_backend_url() {
   want="http://${ip}:${BACKEND_PORT}/api"
   cur="$(grep -E '^CONVOS_API_BASE_URL=' "$dv" | cut -d= -f2-)"
   [[ "$cur" == "$want" ]] && { ok "worker CONVOS_API_BASE_URL = ${want} (current)"; return; }
-  if grep -q '^CONVOS_API_BASE_URL=' "$dv"; then sed -i '' "s|^CONVOS_API_BASE_URL=.*|CONVOS_API_BASE_URL=${want}|" "$dv"
-  else printf 'CONVOS_API_BASE_URL=%s\n' "$want" >>"$dv"; fi
+  set_env_kv "$dv" CONVOS_API_BASE_URL "$want"
   ok "worker CONVOS_API_BASE_URL -> ${want}"
 }
 
@@ -82,11 +87,12 @@ sync_backend_url() {
 # Keep them equal or those calls 401 once the worker points at the local backend.
 align_agent_key() {
   local dv="${WORKER_DIR}/.dev.vars" be="${BACKEND_DIR}/.env" key
+  [[ -f "$be" ]] || { warn "backend/.env missing — can't align AGENT_ASSETS_API_KEY"; return; }
   key="$(grep -E '^CONVOS_API_KEY=' "$dv" 2>/dev/null | cut -d= -f2-)"
-  [[ -f "$be" && -n "$key" && ${#key} -ge 32 ]] || { warn "can't align AGENT_ASSETS_API_KEY (need .dev.vars CONVOS_API_KEY + backend/.env)"; return; }
+  [[ -n "$key" ]] || { warn ".dev.vars CONVOS_API_KEY missing — can't align AGENT_ASSETS_API_KEY"; return; }
+  [[ ${#key} -ge 32 ]] || { warn ".dev.vars CONVOS_API_KEY too short (${#key} < 32) — can't align"; return; }
   [[ "$(grep -E '^AGENT_ASSETS_API_KEY=' "$be" | cut -d= -f2-)" == "$key" ]] && { ok "backend AGENT_ASSETS_API_KEY aligned (current)"; return; }
-  if grep -q '^AGENT_ASSETS_API_KEY=' "$be"; then sed -i '' "s|^AGENT_ASSETS_API_KEY=.*|AGENT_ASSETS_API_KEY=${key}|" "$be"
-  else printf 'AGENT_ASSETS_API_KEY=%s\n' "$key" >>"$be"; fi
+  set_env_kv "$be" AGENT_ASSETS_API_KEY "$key"
   ok "backend AGENT_ASSETS_API_KEY <- worker CONVOS_API_KEY"
 }
 
@@ -98,14 +104,17 @@ seed_credits() {
   local key floor=1000000 grant=100000000 accts n=0 a bal
   key="$(grep -E '^CONVOS_API_KEY=' "${WORKER_DIR}/.dev.vars" 2>/dev/null | cut -d= -f2-)"
   [[ -n "$key" ]] || { warn "no CONVOS_API_KEY; can't seed credits"; return; }
-  accts="$(docker exec "${COMPOSE_PROJECT}-convos_db-1" psql -U postgres -d postgres -tAc 'SELECT id FROM "Account";' 2>/dev/null | tr -d ' ')"
+  accts="$(dc exec -T convos_db psql -U postgres -d postgres -tAc 'SELECT id FROM "Account";' 2>/dev/null | tr -d ' ')"
   [[ -z "$accts" ]] && { ok "no accounts yet — sign in via the app, then: make seed-credits"; return; }
   for a in $accts; do
     [[ -z "$a" ]] && continue
-    bal="$(curl -s --max-time 6 -H "X-Agent-API-Key: $key" "http://localhost:${BACKEND_PORT}/api/v2/accounts/$a/credits" 2>/dev/null | grep -oE '"balance":"[0-9]+"' | grep -oE '[0-9]+')"
+    # tolerate balance as JSON string ("balance":"123") or number ("balance":123)
+    bal="$(curl -s --max-time 6 -H "X-Agent-API-Key: $key" "http://localhost:${BACKEND_PORT}/api/v2/accounts/$a/credits" 2>/dev/null | grep -oE '"balance":"?[0-9]+"?' | grep -oE '[0-9]+' || true)"
     { [[ -n "$bal" ]] && (( bal >= floor )); } 2>/dev/null && continue
+    # stable per-account idempotency key: the backend dedupes replays, so this
+    # can never over-grant even if a run repeats before the balance updates.
     curl -s -o /dev/null -X POST "http://localhost:${BACKEND_PORT}/api/v2/accounts/$a/credits/grants" \
-      -H "X-Agent-API-Key: $key" -H 'Content-Type: application/json' -H "Idempotency-Key: $(uuidgen)" \
+      -H "X-Agent-API-Key: $key" -H 'Content-Type: application/json' -H "Idempotency-Key: seed-${a}" \
       -d "{\"grantKind\":\"manual\",\"creditsDelta\":${grant},\"reason\":\"local dev seed\"}" --max-time 8 && n=$((n+1))
   done
   ok "seeded credits for ${n} account(s)"

--- a/dev/local-stack/stack.sh
+++ b/dev/local-stack/stack.sh
@@ -55,6 +55,62 @@ svc_running() { local n="$1"; [[ -f "$RUN_DIR/$n.pid" ]] && kill -0 "$(cat "$RUN
 stop_svc() { local name="$1" pat="${2:-}"; [[ -f "$RUN_DIR/$name.pid" ]] && kill "$(cat "$RUN_DIR/$name.pid")" 2>/dev/null || true; [[ -n "$pat" ]] && pkill -f "$pat" 2>/dev/null || true; rm -f "$RUN_DIR/$name.pid"; }
 disable_app_check() { local tok; tok="$(grep -E '^DEV_API_TOKEN=' "${BACKEND_DIR}/.env" 2>/dev/null | cut -d= -f2-)"; [[ -z "$tok" ]] && { warn "no DEV_API_TOKEN; can't disable App Check"; return; }; curl -s -X POST -H "Authorization: Bearer $tok" -H 'Content-Type: application/json' -d '{"enabled":false}' "http://localhost:${BACKEND_PORT}/api/v2/dev/app-attest" >/dev/null 2>&1 && ok "App Check disabled" || warn "couldn't disable App Check"; }
 
+# Host IP reachable from BOTH the worker (a host process) and the Hermes
+# container. `localhost` only works from the host, `host.docker.internal`
+# only from the container; the host's LAN IP works from both (backend binds
+# *:PORT). Empty when offline (no default route).
+host_ip() { local ifc; ifc="$(route -n get default 2>/dev/null | awk '/interface:/{print $2}')"; [[ -n "$ifc" ]] && ipconfig getifaddr "$ifc" 2>/dev/null || true; }
+
+# Point the worker's CONVOS_API_BASE_URL at THIS backend via the host LAN IP.
+# The in-chat agent-builder calls convos-backend directly from its container;
+# .dev.vars ships the hosted dev backend by default, so the builder would
+# assert the local account against a backend that's never seen it
+# ("Asserted ownerAccountId does not exist"). Idempotent / self-healing on IP change.
+sync_backend_url() {
+  local dv="${WORKER_DIR}/.dev.vars" ip want cur; [[ -f "$dv" ]] || return 0
+  ip="$(host_ip)"; [[ -z "$ip" ]] && { warn "no host IP (offline?) — leaving CONVOS_API_BASE_URL as-is"; return; }
+  want="http://${ip}:${BACKEND_PORT}/api"
+  cur="$(grep -E '^CONVOS_API_BASE_URL=' "$dv" | cut -d= -f2-)"
+  [[ "$cur" == "$want" ]] && { ok "worker CONVOS_API_BASE_URL = ${want} (current)"; return; }
+  if grep -q '^CONVOS_API_BASE_URL=' "$dv"; then sed -i '' "s|^CONVOS_API_BASE_URL=.*|CONVOS_API_BASE_URL=${want}|" "$dv"
+  else printf 'CONVOS_API_BASE_URL=%s\n' "$want" >>"$dv"; fi
+  ok "worker CONVOS_API_BASE_URL -> ${want}"
+}
+
+# The backend authenticates agent-key calls (generate, credits) against
+# AGENT_ASSETS_API_KEY; the worker/container present .dev.vars' CONVOS_API_KEY.
+# Keep them equal or those calls 401 once the worker points at the local backend.
+align_agent_key() {
+  local dv="${WORKER_DIR}/.dev.vars" be="${BACKEND_DIR}/.env" key
+  key="$(grep -E '^CONVOS_API_KEY=' "$dv" 2>/dev/null | cut -d= -f2-)"
+  [[ -f "$be" && -n "$key" && ${#key} -ge 32 ]] || { warn "can't align AGENT_ASSETS_API_KEY (need .dev.vars CONVOS_API_KEY + backend/.env)"; return; }
+  [[ "$(grep -E '^AGENT_ASSETS_API_KEY=' "$be" | cut -d= -f2-)" == "$key" ]] && { ok "backend AGENT_ASSETS_API_KEY aligned (current)"; return; }
+  if grep -q '^AGENT_ASSETS_API_KEY=' "$be"; then sed -i '' "s|^AGENT_ASSETS_API_KEY=.*|AGENT_ASSETS_API_KEY=${key}|" "$be"
+  else printf 'AGENT_ASSETS_API_KEY=%s\n' "$key" >>"$be"; fi
+  ok "backend AGENT_ASSETS_API_KEY <- worker CONVOS_API_KEY"
+}
+
+# Grant local-dev credits to any account below a floor (else the builder shows
+# "lost power"). Accounts are created on first iOS sign-in (after `up`), so this
+# is a no-op until then — re-run via `make up` or `make seed-credits` after
+# signing in. Idempotent: skips accounts already funded.
+seed_credits() {
+  local key floor=1000000 grant=100000000 accts n=0 a bal
+  key="$(grep -E '^CONVOS_API_KEY=' "${WORKER_DIR}/.dev.vars" 2>/dev/null | cut -d= -f2-)"
+  [[ -n "$key" ]] || { warn "no CONVOS_API_KEY; can't seed credits"; return; }
+  accts="$(docker exec "${COMPOSE_PROJECT}-convos_db-1" psql -U postgres -d postgres -tAc 'SELECT id FROM "Account";' 2>/dev/null | tr -d ' ')"
+  [[ -z "$accts" ]] && { ok "no accounts yet — sign in via the app, then: make seed-credits"; return; }
+  for a in $accts; do
+    [[ -z "$a" ]] && continue
+    bal="$(curl -s --max-time 6 -H "X-Agent-API-Key: $key" "http://localhost:${BACKEND_PORT}/api/v2/accounts/$a/credits" 2>/dev/null | grep -oE '"balance":"[0-9]+"' | grep -oE '[0-9]+')"
+    { [[ -n "$bal" ]] && (( bal >= floor )); } 2>/dev/null && continue
+    curl -s -o /dev/null -X POST "http://localhost:${BACKEND_PORT}/api/v2/accounts/$a/credits/grants" \
+      -H "X-Agent-API-Key: $key" -H 'Content-Type: application/json' -H "Idempotency-Key: $(uuidgen)" \
+      -d "{\"grantKind\":\"manual\",\"creditsDelta\":${grant},\"reason\":\"local dev seed\"}" --max-time 8 && n=$((n+1))
+  done
+  ok "seeded credits for ${n} account(s)"
+}
+
 # ============================ init (clone wizard) ============================
 cmd_init() {
   local default_ws; default_ws="$(dirname "$REPO_ROOT")/convos-stack"   # sibling of the convos-ios checkout
@@ -99,6 +155,19 @@ cmd_doctor() {
       warn "Docker has ${ncpu} CPUs — cap to ${DOCKER_MAX_CPUS:-6} (Docker Desktop > Settings > Resources) so the Hermes build can't starve the host"
     else ok "Docker running, ${ncpu} CPUs"; fi
   else die "Docker not running"; fi
+  # Agent-builder reachability: the worker's backend URL must track the host
+  # IP (it's reachable from both the worker and the Hermes container). doctor
+  # runs without load_env, so derive the path/port with the same defaults.
+  if [[ -n "$WORKSPACE" ]]; then
+    local dv="${WORKSPACE}/convos-assistants/workers/assistant/.dev.vars" ip cur
+    ip="$(host_ip)"
+    if [[ -f "$dv" && -n "$ip" ]]; then
+      cur="$(grep -E '^CONVOS_API_BASE_URL=' "$dv" | cut -d= -f2-)"
+      [[ "$cur" == "http://${ip}:${BACKEND_PORT:-4000}/api" ]] \
+        && ok "worker backend URL matches host IP ($ip)" \
+        || warn "worker CONVOS_API_BASE_URL='${cur:-<unset>}' != host http://${ip}:${BACKEND_PORT:-4000}/api — run 'make up' to re-sync (else the agent-builder calls the wrong backend)"
+    fi
+  fi
 }
 
 # ============================ bootstrap ============================
@@ -108,6 +177,8 @@ cmd_bootstrap() {
   have flock || brew install flock || warn "brew install flock failed"
   have uv    || brew install uv    || warn "brew install uv failed"
   bootstrap_backend; bootstrap_herald; bootstrap_assistants; bootstrap_cli
+  sync_backend_url   # worker -> this backend (host LAN IP), reachable from the Hermes container
+  align_agent_key    # backend AGENT_ASSETS_API_KEY == worker CONVOS_API_KEY
   ok "bootstrap complete — now: make up   (then in a convos-ios checkout: /run local)"
 }
 bootstrap_backend() {
@@ -153,11 +224,14 @@ bootstrap_cli() { log "convos-cli: deps + build"; pushd "$CLI_DIR" >/dev/null; p
 # ============================ up / down ============================
 cmd_up() {
   load_env; local tier="${1:-full}"; docker info >/dev/null 2>&1 || die "Docker not running"
+  sync_backend_url   # self-heal worker -> backend URL to the current host IP (before the worker starts)
+  align_agent_key    # keep backend AGENT_ASSETS_API_KEY == worker CONVOS_API_KEY
   log "infra ($([[ $tier == full ]] && echo 'Postgres + MinIO' || echo 'Postgres'))"
   if [[ "$tier" == full ]]; then dc up -d --wait || dc up -d; else dc up -d convos_db --wait || dc up -d convos_db; fi
   start_svc backend "$BACKEND_DIR" "pnpm dev"
   wait_http "http://localhost:${BACKEND_PORT}/healthcheck" 60 && ok "backend up" || warn "backend not healthy (make logs SVC=backend)"
   disable_app_check
+  seed_credits   # fund any unfunded accounts so the agent-builder isn't credit-gated ("lost power")
   if [[ "$tier" == full ]]; then
     start_svc herald "$HERALD_DIR" "pnpm start"
     wait_http "http://localhost:${HERALD_PORT}/livez" 30 && ok "herald up" || warn "herald not healthy (make logs SVC=herald)"
@@ -220,8 +294,9 @@ case "${1:-}" in
   logs)         cmd_logs "${2:-}";;
   hermes-build) cmd_hermes_build;;
   ios-config)   cmd_ios_config "${2:-}";;
+  seed-credits) load_env; seed_credits;;
   doctor)       cmd_doctor;;
   clean)        cmd_clean;;
   nuke)         cmd_nuke;;
-  *) die "usage: stack.sh <init|bootstrap|up [full|core]|down|status|logs [svc]|hermes-build|ios-config [path]|doctor|clean|nuke>";;
+  *) die "usage: stack.sh <init|bootstrap|up [full|core]|down|status|logs [svc]|hermes-build|ios-config [path]|seed-credits|doctor|clean|nuke>";;
 esac


### PR DESCRIPTION
Follow-up to #921 (merged). Makes the in-app agent-builder ("Make an agent") work against the local stack out of the box.

## Problem
The in-chat builder calls convos-backend **directly from its Hermes container**. On the local stack that failed two ways, and both reset on every re-bootstrap / fresh-Postgres round-trip:
- **"Asserted ownerAccountId does not exist"** — the worker's `CONVOS_API_BASE_URL` defaults to the hosted dev backend, so the builder asserted the *local* account against a backend that's never seen it.
- **"lost power" / Upgrade** — the local account had no credits (and the backend's `AGENT_ASSETS_API_KEY` was empty, so once pointed local the agent-key calls would 401).

## Fix — fold provisioning into the lifecycle so it self-heals
- `host_ip` — detect the LAN IP (`route get default` -> `ipconfig getifaddr`); reachable from **both** the worker (host) and the container, unlike `localhost` / `host.docker.internal` which each only work from one side.
- `sync_backend_url` — point `.dev.vars` `CONVOS_API_BASE_URL` at this backend via the host IP (idempotent; self-heals on IP drift).
- `align_agent_key` — keep backend `.env` `AGENT_ASSETS_API_KEY` == worker `CONVOS_API_KEY`.
- `seed_credits` — grant local-dev credits to any account below a floor (idempotent). New `make seed-credits` for after first sign-in (accounts don't exist until then).

`bootstrap` runs sync+align; `up` runs sync+align before services start and seeds credits once the backend is healthy; `doctor` warns if the worker's backend URL has drifted from the current host IP. README + Makefile updated.

Verified: `bash -n` clean; `doctor` reports the URL matches the host IP; `seed-credits` correctly skips already-funded accounts; full builder flow reaches the local backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/927"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782837171&installation_id=128169237&pr_number=927&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F927&signature=3fd70688d908cb306b047621e1fe44de29d7476e6f0d1aec139de4d53053cace"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Auto-provision the in-app agent-builder in the local-stack setup
> - [`stack.sh`](https://github.com/xmtplabs/convos-ios/pull/927/files#diff-ac74f42213bfd94cd92c5951d64ae7013a7155b648d52d642d4c25b01dfb3bd5) gains `sync_backend_url` to keep the worker's `CONVOS_API_BASE_URL` in sync with the host's LAN IP, self-healing when the IP changes between sessions.
> - `align_agent_key` copies the worker's `CONVOS_API_KEY` to the backend's `AGENT_ASSETS_API_KEY`, preventing 401s on agent-authenticated calls.
> - `seed_credits` checks each Postgres account's credit balance and idempotently tops up any below the minimum floor; runs automatically during `make up` and is also available as `make seed-credits`.
> - `cmd_doctor` now warns when the worker's backend URL does not match the current host LAN IP.
> - [`README.md`](https://github.com/xmtplabs/convos-ios/pull/927/files#diff-7f88bfc4f66f8ed99a643e72e0748646373c390bdc1c64c5828e20bfd6ccba10) documents the new `seed-credits` command and adds a troubleshooting section for agent-builder issues.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 467fb8a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->