### PR TITLE
feat(agent-share): contact card + composer chip for agent-share links

### DIFF
--- a/Convos/Agent Builder/AgentContactCardChip.swift
+++ b/Convos/Agent Builder/AgentContactCardChip.swift
@@ -1,0 +1,121 @@
+import ConvosCore
+import SwiftUI
+
+/// A compact, display-only contact-card chip for a shared agent. Renders a
+/// scaled-down rendering of the hero contact-card layout (emoji avatar above a
+/// bold name above a tail-truncated summary) inside an attachment-style chip
+/// container, with an X to remove.
+///
+/// Used as the composer attachment chip when an agent-share link is pasted
+/// into the message input (the parallel of the invite chip). It is hand-built
+/// rather than reusing `AgentContactCardView` because nesting a `glassEffect`
+/// inside the composer's outer glass surface renders the inner one blank --
+/// the backdrop-sampling pipeline can't resolve a stable material when the
+/// parent is already a glass surface. Lifted from PR #868's private
+/// `remixAgentBadge` and promoted to a real, data-driven component.
+struct AgentContactCardChip: View {
+    let displayName: String
+    let emoji: String?
+    let summary: String?
+    let onRemove: () -> Void
+
+    var body: some View {
+        ZStack(alignment: .topTrailing) {
+            card
+            removeButton
+        }
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("agent-share-chip")
+    }
+
+    private var card: some View {
+        VStack(alignment: .leading, spacing: Metric.avatarToTextSpacing) {
+            avatar
+            VStack(alignment: .leading, spacing: Metric.nameToSummarySpacing) {
+                Text(displayName)
+                    .font(.system(size: Metric.nameFontSize, weight: .bold))
+                    .tracking(Metric.nameTracking)
+                    .foregroundStyle(.colorTextPrimary)
+                Text(summary ?? AgentContactCardView.placeholderSubtitle)
+                    .font(.system(size: Metric.summaryFontSize))
+                    .foregroundStyle(.colorTextSecondary)
+                    .lineLimit(2, reservesSpace: true)
+                    .truncationMode(.tail)
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .padding(Metric.innerPadding)
+        .frame(width: Metric.badgeWidth, height: Metric.badgeHeight)
+        .background(.colorBackgroundRaised, in: .rect(cornerRadius: Metric.cornerRadius))
+        .overlay(
+            RoundedRectangle(cornerRadius: Metric.cornerRadius)
+                .stroke(.colorFillMinimal, lineWidth: 0.5)
+        )
+    }
+
+    @ViewBuilder
+    private var avatar: some View {
+        if let emoji, !emoji.isEmpty {
+            EmojiAvatarView(emoji: emoji, agentVerification: .verified(.convos))
+                .frame(width: Metric.avatarSize, height: Metric.avatarSize)
+        } else {
+            MonogramView(text: displayName, agentVerification: .verified(.convos))
+                .frame(width: Metric.avatarSize, height: Metric.avatarSize)
+                .clipShape(Circle())
+        }
+    }
+
+    private var removeButton: some View {
+        Button(action: onRemove) {
+            Image(systemName: "xmark")
+                .font(.system(size: 10, weight: .bold))
+                .foregroundStyle(.white)
+                .frame(width: 20, height: 20)
+                .background(.black)
+                .clipShape(.circle)
+                .overlay(Circle().stroke(.white.opacity(0.6), lineWidth: 1))
+        }
+        .padding(.top, -DesignConstants.Spacing.stepX)
+        .padding(.trailing, -DesignConstants.Spacing.stepX)
+        .accessibilityLabel("Remove shared agent")
+        .accessibilityIdentifier("agent-share-chip-remove-button")
+    }
+
+    /// Outer dimensions roughly match a 30%-scale hero contact card (a hero
+    /// card is ~354x232, so ~30% ~= 106x70). Avatar shrinks 74pt -> ~22pt to
+    /// match.
+    private enum Metric {
+        static let badgeWidth: CGFloat = 110
+        static let badgeHeight: CGFloat = 72
+        static let cornerRadius: CGFloat = 12
+        static let innerPadding: CGFloat = 8
+        static let avatarSize: CGFloat = 22
+        static let avatarToTextSpacing: CGFloat = 4
+        static let nameToSummarySpacing: CGFloat = 1
+        static let nameFontSize: CGFloat = 11
+        static let nameTracking: CGFloat = -0.3
+        static let summaryFontSize: CGFloat = 7
+    }
+}
+
+#Preview("Resolved") {
+    AgentContactCardChip(
+        displayName: "Tifoso",
+        emoji: "🚴",
+        summary: "I'll help you plan your next ride, log mileage, and remember your favorite routes.",
+        onRemove: {}
+    )
+    .padding()
+    .background(Color.colorBackgroundSurfaceless)
+}
+
+#Preview("Resolving (no summary)") {
+    AgentContactCardChip(
+        displayName: "Agent",
+        emoji: nil,
+        summary: nil,
+        onRemove: {}
+    )
+    .padding()
+    .background(Color.colorBackgroundSurfaceless)
+}

--- a/Convos/Agent Builder/AgentContactCardChip.swift
+++ b/Convos/Agent Builder/AgentContactCardChip.swift
@@ -59,7 +59,7 @@ struct AgentContactCardChip: View {
             EmojiAvatarView(emoji: emoji, agentVerification: .verified(.convos))
                 .frame(width: Metric.avatarSize, height: Metric.avatarSize)
         } else {
-            MonogramView(text: displayName, agentVerification: .verified(.convos))
+            MonogramView(name: displayName, agentVerification: .verified(.convos))
                 .frame(width: Metric.avatarSize, height: Metric.avatarSize)
                 .clipShape(Circle())
         }

--- a/Convos/Agent Builder/AgentContactCardChip.swift
+++ b/Convos/Agent Builder/AgentContactCardChip.swift
@@ -81,20 +81,21 @@ struct AgentContactCardChip: View {
         .accessibilityIdentifier("agent-share-chip-remove-button")
     }
 
-    /// Outer dimensions roughly match a 30%-scale hero contact card (a hero
-    /// card is ~354x232, so ~30% ~= 106x70). Avatar shrinks 74pt -> ~22pt to
-    /// match.
+    /// A 2x scaling of a ~30%-scale hero contact card (a hero card is
+    /// ~354x232, so ~30% ~= 106x70, doubled ~= 220x144). Every metric is
+    /// scaled uniformly so the chip keeps the hero card's aspect ratio and
+    /// internal proportions.
     private enum Metric {
-        static let badgeWidth: CGFloat = 110
-        static let badgeHeight: CGFloat = 72
-        static let cornerRadius: CGFloat = 12
-        static let innerPadding: CGFloat = 8
-        static let avatarSize: CGFloat = 22
-        static let avatarToTextSpacing: CGFloat = 4
-        static let nameToSummarySpacing: CGFloat = 1
-        static let nameFontSize: CGFloat = 11
-        static let nameTracking: CGFloat = -0.3
-        static let summaryFontSize: CGFloat = 7
+        static let badgeWidth: CGFloat = 220
+        static let badgeHeight: CGFloat = 144
+        static let cornerRadius: CGFloat = 24
+        static let innerPadding: CGFloat = 16
+        static let avatarSize: CGFloat = 44
+        static let avatarToTextSpacing: CGFloat = 8
+        static let nameToSummarySpacing: CGFloat = 2
+        static let nameFontSize: CGFloat = 22
+        static let nameTracking: CGFloat = -0.6
+        static let summaryFontSize: CGFloat = 14
     }
 }
 

--- a/Convos/Agent Builder/AgentContactCardView.swift
+++ b/Convos/Agent Builder/AgentContactCardView.swift
@@ -10,9 +10,26 @@ import SwiftUI
 /// "Learning more about my job" with a pulse highlight matching
 /// `AgentJoinStatusView`. Once the value arrives, the subtitle
 /// blur-replaces to the real text.
+///
+/// Visual styling of an `AgentContactCardView`. `.standard` is the in-chat /
+/// post-Make appearance (40pt avatar, `.title2` name, `.body` summary).
+/// `.hero` is the larger "browse" variant -- bigger avatar, larger bolded
+/// name with tight letter-spacing, smaller footnote-style summary, and almost
+/// no gap between the two text lines.
+enum AgentContactCardStyle {
+    case standard
+    case hero
+}
+
 struct AgentContactCardView: View {
     let profile: Profile
     let agentDescription: String?
+    var style: AgentContactCardStyle = .standard
+    /// Optional explicit size. When set, the card sizes itself to this width
+    /// instead of relying on its intrinsic size or an outer `.frame` from the
+    /// caller -- required where every card must be exactly the same width (e.g.
+    /// a paged carousel that snaps centers).
+    var cardSize: CGSize?
 
     @State private var isAppearing: Bool = true
     @State private var hasAnimated: Bool = false
@@ -28,6 +45,52 @@ struct AgentContactCardView: View {
         agentDescription?.isEmpty == false
     }
 
+    private var avatarSize: CGFloat {
+        switch style {
+        case .standard: return Constant.standardAvatarSize
+        case .hero: return Constant.heroAvatarSize
+        }
+    }
+
+    private var displayNameFont: Font {
+        switch style {
+        case .standard: return .title2
+        case .hero: return Constant.heroDisplayNameFont
+        }
+    }
+
+    private var displayNameTracking: CGFloat {
+        switch style {
+        case .standard: return 0
+        case .hero: return Constant.heroDisplayNameTracking
+        }
+    }
+
+    private var subtitleFont: Font {
+        switch style {
+        case .standard: return .body
+        case .hero: return .footnote
+        }
+    }
+
+    private var titleSubtitleSpacing: CGFloat {
+        switch style {
+        case .standard: return DesignConstants.Spacing.stepX
+        case .hero: return Constant.heroTitleSubtitleSpacing
+        }
+    }
+
+    /// `nil` lets the subtitle expand to whatever its content needs; the
+    /// `.hero` variant pins it at a fixed line count with `reservesSpace: true`
+    /// so every card has the same intrinsic height regardless of summary
+    /// length (and longer summaries tail-truncate cleanly).
+    private var subtitleLineLimit: Int? {
+        switch style {
+        case .standard: return nil
+        case .hero: return Constant.heroSubtitleLineLimit
+        }
+    }
+
     var body: some View {
         // Wrapping the glass surface in a `GlassEffectContainer` gives iOS a
         // stable scope to coordinate the material's backdrop-sampling
@@ -41,6 +104,10 @@ struct AgentContactCardView: View {
         GlassEffectContainer {
             glassCard
         }
+        // Only constrain width -- height stays intrinsic. With the subtitle
+        // pinned to a fixed line count in `.hero`, every card has identical
+        // intrinsic height.
+        .frame(width: cardSize?.width)
         .opacity(isAppearing ? 0 : 1)
         .onAppear {
             guard isAppearing, !hasAnimated else { return }
@@ -55,16 +122,19 @@ struct AgentContactCardView: View {
         VStack(alignment: .leading, spacing: DesignConstants.Spacing.step4x) {
             MessageAvatarView(
                 profile: profile,
-                size: Constant.avatarSize,
+                size: avatarSize,
                 agentVerification: .verified(.convos)
             )
-            VStack(alignment: .leading, spacing: DesignConstants.Spacing.stepX) {
+            VStack(alignment: .leading, spacing: titleSubtitleSpacing) {
                 Text(profile.displayName)
-                    .font(.title2)
+                    .font(displayNameFont)
+                    .tracking(displayNameTracking)
+                    .lineSpacing(0)
                     .foregroundStyle(.colorTextPrimary)
                 subtitleText
             }
         }
+        .frame(maxWidth: .infinity, alignment: .topLeading)
         .padding(DesignConstants.Spacing.step8x)
         .background(.colorBackgroundRaised, in: .rect(cornerRadius: Constant.cornerRadius))
         .glassEffect(.regular.interactive(), in: .rect(cornerRadius: Constant.cornerRadius))
@@ -74,23 +144,56 @@ struct AgentContactCardView: View {
     private var subtitleText: some View {
         if hasAgentDescription {
             Text(displayedSubtitle)
-                .font(.body)
+                .font(subtitleFont)
                 .foregroundStyle(.colorTextSecondary)
+                .modifier(SubtitleLineLimitModifier(lineLimit: subtitleLineLimit))
                 .transition(.blurReplace)
                 .id("subtitle-loaded")
         } else {
-            PulsingSubtitle(text: displayedSubtitle)
+            PulsingSubtitle(text: displayedSubtitle, font: subtitleFont)
+                .modifier(SubtitleLineLimitModifier(lineLimit: subtitleLineLimit))
                 .transition(.blurReplace)
                 .id("subtitle-placeholder")
         }
     }
 
     private enum Constant {
-        static let avatarSize: CGFloat = 40
+        static let standardAvatarSize: CGFloat = 40
+        /// 74pt "hero" avatar -- reads as a browse-target rather than a
+        /// chat-row thumbnail.
+        static let heroAvatarSize: CGFloat = 74
         static let cornerRadius: CGFloat = 24
+        /// Hero display-name typography: SF Pro Bold 40pt with -1pt letter
+        /// spacing.
+        static let heroDisplayNameFont: Font = .system(size: 40, weight: .bold)
+        static let heroDisplayNameTracking: CGFloat = -1
+        /// Hero variant collapses the gap between name and summary to 2pt --
+        /// the two lines should read as one unit.
+        static let heroTitleSubtitleSpacing: CGFloat = 2
+        /// Hero variant reserves space for a 2-line summary so every card has
+        /// the same intrinsic height regardless of summary length.
+        static let heroSubtitleLineLimit: Int = 2
     }
 
     static let placeholderSubtitle: String = "Learning more about my job"
+}
+
+/// Applies `.lineLimit(_:Int, reservesSpace: true).truncationMode(.tail)` when
+/// a line count is provided. The `reservesSpace` overload doesn't accept
+/// `Int?`, so we branch via a `ViewModifier` rather than passing the optional
+/// directly.
+private struct SubtitleLineLimitModifier: ViewModifier {
+    let lineLimit: Int?
+
+    func body(content: Content) -> some View {
+        if let lineLimit {
+            content
+                .lineLimit(lineLimit, reservesSpace: true)
+                .truncationMode(.tail)
+        } else {
+            content
+        }
+    }
 }
 
 /// Opacity pulse that matches `AgentJoinStatusView`'s "Agent is
@@ -101,11 +204,12 @@ struct AgentContactCardView: View {
 /// repeat-forever transaction so it doesn't leak into siblings.
 private struct PulsingSubtitle: View {
     let text: String
+    var font: Font = .body
     @State private var isPulsed: Bool = false
 
     var body: some View {
         Text(text)
-            .font(.body)
+            .font(font)
             .foregroundStyle(.colorTextSecondary)
             .opacity(isPulsed ? 0.5 : 1.0)
             .animation(.easeInOut(duration: 1.2).repeatForever(autoreverses: true), value: isPulsed)

--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -80,6 +80,11 @@ struct ConversationView<MessagesBottomBar: View>: View {
                 viewModel.updateLinkedConversationName(name)
                 focusCoordinator.endEditing(for: .sideConvoName, context: .quickEditor)
             },
+            pendingAgentShareName: viewModel.pendingAgentShare?.resolved?.displayName,
+            pendingAgentShareEmoji: viewModel.pendingAgentShare?.resolved?.emoji,
+            pendingAgentShareSummary: viewModel.pendingAgentShare?.resolved?.descriptionText,
+            isShowingAgentShareChip: viewModel.pendingAgentShare != nil,
+            onClearAgentShare: viewModel.clearPendingAgentShare,
             sendButtonEnabled: viewModel.sendButtonEnabled,
             profileImage: $viewModel.myProfileViewModel.profileImage,
             onboardingCoordinator: onboardingCoordinator,
@@ -332,6 +337,7 @@ struct ConversationView<MessagesBottomBar: View>: View {
         }
         .onChange(of: viewModel.messageText) { _, _ in
             viewModel.checkForInviteURL()
+            viewModel.checkForAgentShareURL()
             viewModel.checkForPastedLink()
         }
         .animation(.easeOut, value: viewModel.explodeState)

--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -103,6 +103,8 @@ struct ConversationView<MessagesBottomBar: View>: View {
             onClearMediaAttachment: viewModel.removeMediaAttachment(id:),
             onTapAvatar: viewModel.onTapAvatar(_:),
             onTapInvite: viewModel.onTapInvite(_:),
+            onTapAgentShare: viewModel.onTapAgentShare(_:),
+            agentShareResolver: viewModel.agentShareResolver,
             onReaction: viewModel.onReaction(emoji:messageId:),
             onToggleReaction: viewModel.onReaction(emoji:messageId:),
             onTapReactions: viewModel.onTapReactions(_:),
@@ -378,6 +380,13 @@ struct ConversationView<MessagesBottomBar: View>: View {
             isPresented: $presentingAddFromContactsPicker
         )
         .sheet(item: $viewModel.presentingNewConversationForInvite) { viewModel in
+            NewConversationView(
+                viewModel: viewModel,
+                profileSettingsViewModel: profileSettingsViewModel
+            )
+            .background(.colorBackgroundSurfaceless)
+        }
+        .sheet(item: $viewModel.presentingNewConversationForAgentShare) { viewModel in
             NewConversationView(
                 viewModel: viewModel,
                 profileSettingsViewModel: profileSettingsViewModel

--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -310,6 +310,18 @@ struct ConversationView<MessagesBottomBar: View>: View {
         AnyView(MemberContactDetailSheetContent(viewModel: viewModel, member: member, profileSettingsViewModel: profileSettingsViewModel))
     }
 
+    /// Shared content for the invite- and agent-share-driven new-conversation
+    /// sheets. Extracted so neither `.sheet(item:)` closure inflates `body`'s
+    /// type-check past the 300ms budget.
+    @ViewBuilder
+    private func newConversationSheet(_ viewModel: NewConversationViewModel) -> some View {
+        NewConversationView(
+            viewModel: viewModel,
+            profileSettingsViewModel: profileSettingsViewModel
+        )
+        .background(.colorBackgroundSurfaceless)
+    }
+
     private var pagerDotsInset: CGFloat {
         isKeyboardVisible ? 0.0 : 24.0
     }
@@ -386,18 +398,10 @@ struct ConversationView<MessagesBottomBar: View>: View {
             isPresented: $presentingAddFromContactsPicker
         )
         .sheet(item: $viewModel.presentingNewConversationForInvite) { viewModel in
-            NewConversationView(
-                viewModel: viewModel,
-                profileSettingsViewModel: profileSettingsViewModel
-            )
-            .background(.colorBackgroundSurfaceless)
+            newConversationSheet(viewModel)
         }
         .sheet(item: $viewModel.presentingNewConversationForAgentShare) { viewModel in
-            NewConversationView(
-                viewModel: viewModel,
-                profileSettingsViewModel: profileSettingsViewModel
-            )
-            .background(.colorBackgroundSurfaceless)
+            newConversationSheet(viewModel)
         }
         .selfSizingSheet(isPresented: $viewModel.presentingExplodedInviteInfo) {
             ExplodeInfoView()

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -16,6 +16,14 @@ struct PendingInvite {
     var explodeDuration: ExplodeDuration?
 }
 
+/// A pasted agent-share link staged as a composer chip. `share` is the parsed
+/// link (sent verbatim on send); `resolved` is the agent's public profile once
+/// the resolver returns (nil while resolving -> chip shows its placeholder).
+struct PendingAgentShare {
+    let share: MessageAgentShare
+    var resolved: AgentShareInfo?
+}
+
 struct PendingFileAttachment: Identifiable, Equatable {
     let id: UUID
     let url: URL
@@ -594,10 +602,17 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
     var pendingInviteConvoName: String = ""
     var pendingInviteImage: UIImage?
 
+    /// A pasted agent-share link staged as a composer chip. Display-only: the
+    /// agent's name / emoji come from the resolver, not the sender, so unlike
+    /// `pendingInvite` there are no editable fields. The URL is sent verbatim
+    /// on send (and auto-classifies as an agent-share message).
+    var pendingAgentShare: PendingAgentShare?
+
     var sendButtonEnabled: Bool {
         !messageText.isEmpty
             || !pendingMediaAttachments.isEmpty
             || pendingInvite != nil
+            || pendingAgentShare != nil
             || pastedLinkPreview != nil
     }
 
@@ -2247,9 +2262,10 @@ extension ConversationViewModel {
         let hasText = !messageText.isEmpty
         let hasMedia = !pendingMediaAttachments.isEmpty
         let hasInvite = pendingInvite != nil
+        let hasAgentShare = pendingAgentShare != nil
         let hasLinkPreview = pastedLinkPreview != nil
 
-        guard hasText || hasMedia || hasInvite || hasLinkPreview else { return }
+        guard hasText || hasMedia || hasInvite || hasAgentShare || hasLinkPreview else { return }
 
         let prevMessageText = messageText
         let replyTarget = replyingToMessage
@@ -2259,6 +2275,7 @@ extension ConversationViewModel {
         let sideConvoLinkedId = pendingInvite?.linkedConversationId
         let sideConvoExplodeDuration = pendingInvite?.explodeDuration
         let sideConvoImage = pendingInviteImage
+        let prevAgentShareURL = pendingAgentShare?.share.url
         let prevLinkURL = pastedLinkPreview?.url
 
         stopTyping()
@@ -2270,6 +2287,7 @@ extension ConversationViewModel {
         pendingInvite = nil
         pendingInviteConvoName = ""
         pendingInviteImage = nil
+        pendingAgentShare = nil
         pastedLinkPreview = nil
         focusCoordinator.endEditing(for: .message, context: .conversation)
 
@@ -2304,6 +2322,7 @@ extension ConversationViewModel {
                 try await sendTextAndLinksIfNeeded(
                     text: hasText ? prevMessageText : nil,
                     inviteURL: finalInviteURL,
+                    agentShareURL: prevAgentShareURL,
                     linkURL: prevLinkURL,
                     photoTrackingKey: nil,
                     replyTarget: trailingReplyTarget,
@@ -2517,6 +2536,7 @@ extension ConversationViewModel {
     private func sendTextAndLinksIfNeeded(
         text: String?,
         inviteURL: String?,
+        agentShareURL: String? = nil,
         linkURL: String?,
         photoTrackingKey: String?,
         replyTarget: AnyMessage?,
@@ -2532,8 +2552,18 @@ extension ConversationViewModel {
             }
         }
 
-        if let linkURL {
+        if let agentShareURL {
+            // The URL auto-classifies as an agent-share message on save, so
+            // this is a plain send -- no dedicated writer entry point needed.
             if replyTarget != nil && !hasAttachment && text == nil && inviteURL == nil, let replyTarget {
+                try await messageWriter.sendReply(text: agentShareURL, afterPhoto: photoTrackingKey, toMessageWithClientId: replyTarget.messageId)
+            } else {
+                try await messageWriter.send(text: agentShareURL, afterPhoto: photoTrackingKey)
+            }
+        }
+
+        if let linkURL {
+            if replyTarget != nil && !hasAttachment && text == nil && inviteURL == nil && agentShareURL == nil, let replyTarget {
                 try await messageWriter.sendReply(text: linkURL, afterPhoto: photoTrackingKey, toMessageWithClientId: replyTarget.messageId)
             } else {
                 try await messageWriter.send(text: linkURL, afterPhoto: photoTrackingKey)
@@ -3473,6 +3503,33 @@ extension ConversationViewModel {
             pendingInvite = PendingInvite(code: result.code, fullURL: result.fullURL, range: result.range)
             messageText = InviteURLDetector.removeInviteURL(from: messageText, range: result.range)
         }
+    }
+
+    /// Detects a pasted agent-share link, lifts it out of the text into a
+    /// composer chip, and kicks off an async resolve to populate the chip's
+    /// name / emoji. Mirrors `checkForInviteURL`; runs from the same
+    /// `messageText` onChange.
+    func checkForAgentShareURL() {
+        guard pendingAgentShare == nil,
+              let share = MessageAgentShare.from(text: messageText) else {
+            return
+        }
+        convosButtonTask?.cancel()
+        convosButtonCancellable?.cancel()
+        pendingAgentShare = PendingAgentShare(share: share, resolved: nil)
+        messageText = ""
+        let resolver = agentShareResolver
+        Task { [weak self] in
+            let info = await resolver.resolve(identifier: share.identifier)
+            await MainActor.run {
+                guard let self, self.pendingAgentShare?.share == share else { return }
+                self.pendingAgentShare?.resolved = info
+            }
+        }
+    }
+
+    func clearPendingAgentShare() {
+        pendingAgentShare = nil
     }
 
     func clearPendingInvite() {

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -630,6 +630,11 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
     var presentingNewConversationForInvite: NewConversationViewModel? {
         didSet { oldValue?.cleanUpIfNeeded() }
     }
+    /// Drives the new-conversation flow opened by tapping a shared agent's
+    /// contact card. Mirrors `presentingNewConversationForInvite`.
+    var presentingNewConversationForAgentShare: NewConversationViewModel? {
+        didSet { oldValue?.cleanUpIfNeeded() }
+    }
     var presentingConversationForked: Bool = false
     var presentingReactionsForMessage: AnyMessage?
     var presentingReadByForGroup: MessagesGroup?
@@ -2645,6 +2650,42 @@ extension ConversationViewModel {
             mode: .joinInvite(code: invite.inviteSlug)
         )
     }
+
+    /// Resolves a shared agent's link to its public profile for the message
+    /// card. Vended by the session so the real API-backed resolver swaps in
+    /// transparently once it lands.
+    var agentShareResolver: any AgentShareResolving {
+        session.agentShareResolver()
+    }
+
+    /// Tapping a shared agent's contact card opens a new conversation seeded
+    /// with that agent template (the same flow the `convos://template/<id>`
+    /// deep link uses). Only the custom-scheme form carries a template id
+    /// directly; a web-slug share resolves to an id via the API resolver,
+    /// which isn't wired yet, so those are a no-op for now.
+    func onTapAgentShare(_ agentShare: MessageAgentShare) {
+        guard isValidTemplateId(agentShare.identifier) else {
+            Log.debug("Agent-share tap with non-template-id identifier (web slug); resolve-to-id not wired yet")
+            return
+        }
+        presentingNewConversationForAgentShare = NewConversationViewModel(
+            session: session,
+            mode: .newConversationWithTemplate(templateId: agentShare.identifier)
+        )
+    }
+
+    private func isValidTemplateId(_ value: String) -> Bool {
+        guard let pattern = ConversationViewModel.uuidPattern else { return false }
+        let range = NSRange(value.startIndex..., in: value)
+        return pattern.firstMatch(in: value, options: [], range: range) != nil
+    }
+
+    private static let uuidPattern: NSRegularExpression? = {
+        try? NSRegularExpression(
+            pattern: "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+            options: [.caseInsensitive]
+        )
+    }()
 
     func onDisplayNameEndedEditing(focusCoordinator: FocusCoordinator, context: FocusTransitionContext) {
         isEditingDisplayName = false

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -2690,17 +2690,29 @@ extension ConversationViewModel {
 
     /// Tapping a shared agent's contact card opens a new conversation seeded
     /// with that agent template (the same flow the `convos://template/<id>`
-    /// deep link uses). Only the custom-scheme form carries a template id
-    /// directly; a web-slug share resolves to an id via the API resolver,
-    /// which isn't wired yet, so those are a no-op for now.
+    /// deep link uses). The custom-scheme form carries the template id
+    /// directly; a web-slug share is resolved to its id via the API resolver
+    /// first.
     func onTapAgentShare(_ agentShare: MessageAgentShare) {
-        guard isValidTemplateId(agentShare.identifier) else {
-            Log.debug("Agent-share tap with non-template-id identifier (web slug); resolve-to-id not wired yet")
+        if isValidTemplateId(agentShare.identifier) {
+            openAgentTemplate(templateId: agentShare.identifier)
             return
         }
+        let resolver = agentShareResolver
+        let identifier = agentShare.identifier
+        Task { [weak self] in
+            let info = await resolver.resolve(identifier: identifier)
+            await MainActor.run {
+                guard let self, let templateId = info?.templateId else { return }
+                self.openAgentTemplate(templateId: templateId)
+            }
+        }
+    }
+
+    private func openAgentTemplate(templateId: String) {
         presentingNewConversationForAgentShare = NewConversationViewModel(
             session: session,
-            mode: .newConversationWithTemplate(templateId: agentShare.identifier)
+            mode: .newConversationWithTemplate(templateId: templateId)
         )
     }
 

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Cells/MessagesListItemTypeCell.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Cells/MessagesListItemTypeCell.swift
@@ -160,6 +160,8 @@ class MessagesListItemTypeCell: UICollectionViewCell {
             .frame(maxWidth: .infinity, alignment: item.alignment == .center ? .center : .leading)
             .id("message-cell-\(item.differenceIdentifier)")
             .environment(\.messageContextMenuState, config.contextMenuState)
+            .environment(\.agentShareResolver, config.agentShareResolver)
+            .environment(\.onTapAgentShare, config.onTapAgentShare)
         }
         .margins(.horizontal, 0.0)
         .margins(.vertical, 0.0)

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Data Source/CellFactory.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Data Source/CellFactory.swift
@@ -7,6 +7,12 @@ struct CellConfig {
     let conversationId: String
     let shouldBlurPhotos: Bool
     let onTapInvite: (MessageInvite) -> Void
+    /// Resolves a received/sent agent-share link to the shared agent's public
+    /// profile so its message card can render name / emoji / description.
+    let agentShareResolver: any AgentShareResolving
+    /// Fired when an agent-share message card is tapped -- opens the shared
+    /// agent's template flow.
+    let onTapAgentShare: @MainActor @Sendable (MessageAgentShare) -> Void
     let onTapAvatar: (AnyMessage) -> Void
     /// Fired when an avatar / sender label is tapped on a group that has no
     /// concrete `AnyMessage` to attach (e.g. the synthesized agent

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Data Source/DefaultMessagesLayoutDelegate.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Data Source/DefaultMessagesLayoutDelegate.swift
@@ -172,6 +172,8 @@ final class DefaultMessagesLayoutDelegate: MessagesLayoutDelegate {
             height = 40.0
         case .invite:
             height = 240.0
+        case .agentShare:
+            height = 160.0
         case .linkPreview:
             height = 210.0
         case .update, .assistantJoinRequest:

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Data Source/MessagesCollectionDataSource.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Data Source/MessagesCollectionDataSource.swift
@@ -7,6 +7,8 @@ protocol MessagesCollectionDataSource: UICollectionViewDataSource, MessagesLayou
     var sections: [MessagesCollectionSection] { get set }
     func prepare(with collectionView: UICollectionView)
     var onTapInvite: ((MessageInvite) -> Void)? { get set }
+    var agentShareResolver: any AgentShareResolving { get set }
+    var onTapAgentShare: ((MessageAgentShare) -> Void)? { get set }
     var onTapAvatar: ((ConversationMember) -> Void)? { get set }
     var onTapReactions: ((AnyMessage) -> Void)? { get set }
     var onTapReadReceipts: ((MessagesGroup) -> Void)? { get set }

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Data Source/MessagesCollectionViewDataSource.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Data Source/MessagesCollectionViewDataSource.swift
@@ -17,6 +17,8 @@ final class MessagesCollectionViewDataSource: NSObject {
     var shouldBlurPhotos: Bool = true
     var onTapAvatar: ((ConversationMember) -> Void)?
     var onTapInvite: ((MessageInvite) -> Void)?
+    var agentShareResolver: any AgentShareResolving = MockAgentShareResolver()
+    var onTapAgentShare: ((MessageAgentShare) -> Void)?
     var onTapReactions: ((AnyMessage) -> Void)?
     var onTapReadReceipts: ((MessagesGroup) -> Void)?
     var onTapThinkingIndicator: ((ThinkingSessionDescriptor) -> Void)?
@@ -89,6 +91,10 @@ extension MessagesCollectionViewDataSource: UICollectionViewDataSource {
             onTapInvite: { [weak self] invite in
                 Log.debug("Tapped invite: \(invite)")
                 self?.onTapInvite?(invite)
+            },
+            agentShareResolver: agentShareResolver,
+            onTapAgentShare: { [weak self] agentShare in
+                self?.onTapAgentShare?(agentShare)
             },
             onTapAvatar: { [weak self] message in
                 self?.onTapAvatar?(message.sender)

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/MessagesViewController.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/MessagesViewController.swift
@@ -244,6 +244,10 @@ final class MessagesViewController: UIViewController {
     }
 
     var onTapInvite: ((MessageInvite) -> Void)?
+    var onTapAgentShare: ((MessageAgentShare) -> Void)?
+    var agentShareResolver: any AgentShareResolving = MockAgentShareResolver() {
+        didSet { dataSource.agentShareResolver = agentShareResolver }
+    }
     var onTapAvatar: ((ConversationMember) -> Void)?
     var onLoadPreviousMessages: (() -> Void)?
     var onReaction: ((String, String) -> Void)?
@@ -453,6 +457,11 @@ final class MessagesViewController: UIViewController {
         dataSource.onTapInvite = { [weak self] invite in
             guard let self = self else { return }
             self.onTapInvite?(invite)
+        }
+        dataSource.agentShareResolver = agentShareResolver
+        dataSource.onTapAgentShare = { [weak self] agentShare in
+            guard let self = self else { return }
+            self.onTapAgentShare?(agentShare)
         }
         dataSource.onTapReactions = { [weak self] message in
             guard let self = self else { return }

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesBottomBar.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesBottomBar.swift
@@ -51,6 +51,11 @@ struct MessagesBottomBar<BottomBarContent: View>: View {
     var pendingInviteExplodeDuration: ExplodeDuration?
     var onSetInviteExplodeDuration: ((ExplodeDuration?) -> Void)?
     var onInviteConvoNameEditingEnded: ((String) -> Void)?
+    var pendingAgentShareName: String?
+    var pendingAgentShareEmoji: String?
+    var pendingAgentShareSummary: String?
+    var isShowingAgentShareChip: Bool = false
+    var onClearAgentShare: (() -> Void)?
     let sendButtonEnabled: Bool
     @Binding var profileImage: UIImage?
     @Binding var isPhotoPickerPresented: Bool
@@ -432,6 +437,10 @@ struct MessagesBottomBar<BottomBarContent: View>: View {
                 pendingInviteExplodeDuration: pendingInviteExplodeDuration,
                 onSetInviteExplodeDuration: onSetInviteExplodeDuration,
                 onInviteConvoNameEditingEnded: onInviteConvoNameEditingEnded,
+                pendingAgentShareName: pendingAgentShareName,
+                pendingAgentShareEmoji: pendingAgentShareEmoji,
+                pendingAgentShareSummary: pendingAgentShareSummary,
+                isShowingAgentShareChip: isShowingAgentShareChip,
                 sendButtonEnabled: sendButtonEnabled,
                 focusState: $focusState,
                 animateAvatarForProfileSetup: onboardingCoordinator.shouldAnimateAvatarForProfileSetup,
@@ -441,6 +450,7 @@ struct MessagesBottomBar<BottomBarContent: View>: View {
                 onProfilePhotoTap: onProfilePhotoTap,
                 onSendMessage: onSendMessage,
                 onClearInvite: onClearInvite,
+                onClearAgentShare: onClearAgentShare,
                 onClearLinkPreview: onClearLinkPreview,
                 onClearMediaAttachment: onClearMediaAttachment
             )

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesInputView.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesInputView.swift
@@ -18,6 +18,12 @@ struct MessagesInputView: View {
     var pendingInviteExplodeDuration: ExplodeDuration?
     var onSetInviteExplodeDuration: ((ExplodeDuration?) -> Void)?
     var onInviteConvoNameEditingEnded: ((String) -> Void)?
+    /// Set when a pasted agent-share link is staged as a composer chip. Name /
+    /// emoji are nil until the resolver returns (chip shows its placeholder).
+    var pendingAgentShareName: String?
+    var pendingAgentShareEmoji: String?
+    var pendingAgentShareSummary: String?
+    var isShowingAgentShareChip: Bool = false
     let sendButtonEnabled: Bool
     @FocusState.Binding var focusState: MessagesViewInputFocus?
     let animateAvatarForProfileSetup: Bool
@@ -28,6 +34,7 @@ struct MessagesInputView: View {
     let onProfilePhotoTap: () -> Void
     let onSendMessage: () -> Void
     let onClearInvite: () -> Void
+    var onClearAgentShare: (() -> Void)?
     var onClearLinkPreview: (() -> Void)?
     var onClearMediaAttachment: ((UUID) -> Void)?
 
@@ -60,6 +67,7 @@ struct MessagesInputView: View {
     private var hasAttachments: Bool {
         !pendingMediaAttachments.isEmpty
             || pendingInviteURL != nil
+            || isShowingAgentShareChip
             || composerLinkPreview != nil
     }
 
@@ -156,6 +164,14 @@ struct MessagesInputView: View {
                 }
                 if let pendingInviteURL {
                     inviteAttachmentPreview(url: pendingInviteURL)
+                }
+                if isShowingAgentShareChip {
+                    AgentContactCardChip(
+                        displayName: pendingAgentShareName ?? "Agent",
+                        emoji: pendingAgentShareEmoji,
+                        summary: pendingAgentShareSummary,
+                        onRemove: { onClearAgentShare?() }
+                    )
                 }
                 if let composerLinkPreview {
                     linkPreviewAttachment(preview: composerLinkPreview)

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessageContextMenu/MessageContextMenuOverlay.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessageContextMenu/MessageContextMenuOverlay.swift
@@ -390,6 +390,9 @@ struct MessageContextMenuOverlay: View {
                     onTapAvatar: nil
                 )
 
+            case .agentShare(let agentShare):
+                AgentShareBubble(agentShare: agentShare)
+
             case .linkPreview(let preview):
                 LinkPreviewBubbleView(
                     preview: preview,

--- a/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/AgentShareBubble.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/AgentShareBubble.swift
@@ -1,0 +1,58 @@
+import ConvosCore
+import SwiftUI
+
+/// Renders a received/sent agent-share message as a contact card. The message
+/// body carries only the share link; the agent's name / emoji / description
+/// are resolved on appear via the `AgentShareResolving` injected through the
+/// environment (mocked today, API-backed later). While resolving, the card's
+/// own pulsing "Learning more about my job" placeholder stands in. Tapping the
+/// card opens the shared agent's template flow.
+///
+/// The resolver and tap handler are injected via the environment rather than
+/// threaded through the (deep) messages-view hierarchy, matching how
+/// `messageContextMenuState` is delivered to cells.
+struct AgentShareBubble: View {
+    let agentShare: MessageAgentShare
+
+    @Environment(\.agentShareResolver) private var resolver: any AgentShareResolving
+    @Environment(\.onTapAgentShare) private var onTapAgentShare: @MainActor @Sendable (MessageAgentShare) -> Void
+
+    @State private var resolved: AgentShareInfo?
+    @State private var didResolve: Bool = false
+
+    var body: some View {
+        let action = { onTapAgentShare(agentShare) }
+        Button(action: action) {
+            AgentContactCardView(
+                profile: cardProfile,
+                agentDescription: resolved?.descriptionText
+            )
+        }
+        .buttonStyle(.plain)
+        .task(id: agentShare.identifier) {
+            guard !didResolve else { return }
+            let info = await resolver.resolve(identifier: agentShare.identifier)
+            await MainActor.run {
+                resolved = info
+                didResolve = true
+            }
+        }
+        .accessibilityIdentifier("agent-share-card")
+    }
+
+    /// Synthesizes a `Profile` from the resolved info so the existing
+    /// `AgentContactCardView` renders unchanged (the emoji rides in profile
+    /// metadata exactly as a real agent profile carries it). Before the
+    /// resolve completes, the profile is name-less so the card shows its
+    /// pulsing placeholder.
+    private var cardProfile: Profile {
+        Profile(
+            inboxId: "agent-share-\(agentShare.identifier)",
+            conversationId: "agent-share",
+            name: resolved?.displayName,
+            avatar: resolved?.avatarURL,
+            isAgent: true,
+            metadata: resolved?.emoji.map { ["emoji": .string($0)] }
+        )
+    }
+}

--- a/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/AgentShareBubble.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/AgentShareBubble.swift
@@ -4,31 +4,28 @@ import SwiftUI
 /// Renders a received/sent agent-share message as a contact card. The message
 /// body carries only the share link; the agent's name / emoji / description
 /// are resolved on appear via the `AgentShareResolving` injected through the
-/// environment (mocked today, API-backed later). While resolving, the card's
-/// own pulsing "Learning more about my job" placeholder stands in. Tapping the
-/// card opens the shared agent's template flow.
+/// environment (matching how `messageContextMenuState` is delivered to cells).
+/// While resolving, the card's own pulsing "Learning more about my job"
+/// placeholder stands in.
 ///
-/// The resolver and tap handler are injected via the environment rather than
-/// threaded through the (deep) messages-view hierarchy, matching how
-/// `messageContextMenuState` is delivered to cells.
+/// This view is display-only: the tap that opens the shared agent's template
+/// flow is owned by the enclosing `messageGesture` (`onSingleTap`), so the
+/// same gesture pipeline as other message bubbles handles it -- and the
+/// context-menu preview, which renders this view without that gesture, stays
+/// correctly non-interactive.
 struct AgentShareBubble: View {
     let agentShare: MessageAgentShare
 
     @Environment(\.agentShareResolver) private var resolver: any AgentShareResolving
-    @Environment(\.onTapAgentShare) private var onTapAgentShare: @MainActor @Sendable (MessageAgentShare) -> Void
 
     @State private var resolved: AgentShareInfo?
     @State private var didResolve: Bool = false
 
     var body: some View {
-        let action = { onTapAgentShare(agentShare) }
-        Button(action: action) {
-            AgentContactCardView(
-                profile: cardProfile,
-                agentDescription: resolved?.descriptionText
-            )
-        }
-        .buttonStyle(.plain)
+        AgentContactCardView(
+            profile: cardProfile,
+            agentDescription: resolved?.descriptionText
+        )
         .task(id: agentShare.identifier) {
             guard !didResolve else { return }
             let info = await resolver.resolve(identifier: agentShare.identifier)

--- a/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/AgentShareEnvironment.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/AgentShareEnvironment.swift
@@ -1,0 +1,28 @@
+import ConvosCore
+import SwiftUI
+
+/// Environment delivery for the agent-share message card's two cross-cutting
+/// dependencies -- the resolver that turns a share link into displayable agent
+/// info, and the tap handler that opens the shared agent's template flow.
+/// Injected once at the cell (like `messageContextMenuState`) so they don't
+/// have to thread through the deep messages-view hierarchy.
+
+private struct AgentShareResolverKey: EnvironmentKey {
+    static let defaultValue: any AgentShareResolving = MockAgentShareResolver()
+}
+
+private struct OnTapAgentShareKey: EnvironmentKey {
+    static let defaultValue: @MainActor @Sendable (MessageAgentShare) -> Void = { _ in }
+}
+
+extension EnvironmentValues {
+    var agentShareResolver: any AgentShareResolving {
+        get { self[AgentShareResolverKey.self] }
+        set { self[AgentShareResolverKey.self] = newValue }
+    }
+
+    var onTapAgentShare: @MainActor @Sendable (MessageAgentShare) -> Void {
+        get { self[OnTapAgentShareKey.self] }
+        set { self[OnTapAgentShareKey.self] = newValue }
+    }
+}

--- a/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/ReplyReferenceView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/ReplyReferenceView.swift
@@ -29,6 +29,8 @@ struct ReplyReferenceView: View {
             return "photo"
         case .invite:
             return "invite"
+        case .agentShare:
+            return "agent"
         case .linkPreview(let preview):
             return preview.title ?? preview.displayHost
         case .update, .assistantJoinRequest, .connectionGrantRequest:

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
@@ -201,16 +201,34 @@ struct MessagesGroupItemView: View {
 
     @ViewBuilder
     private func agentShareBubble(agentShare: MessageAgentShare) -> some View {
-        AgentShareBubble(agentShare: agentShare)
-            .messageGesture(
-                message: message,
-                bubbleStyle: bubbleType,
-                onReply: onReply,
-                onToggleReaction: onToggleReaction
-            )
-            .id("agent-share-\(message.messageId)")
-            .modifier(MessageAppearanceModifier(isAppearing: isAppearing, source: message.source))
-            .padding(.trailing, trailingPadding)
+        let isOutgoing = message.sender.isCurrentUser
+        // The card sizes to its content but is capped at the same max width as
+        // text bubbles via a low-priority 50pt spacer (mirrors the in-convo
+        // `MessagesGroupView.contactCardRow`). The spacer sits opposite the
+        // sender so the card hugs the leading edge for incoming and the
+        // trailing edge for outgoing.
+        HStack(alignment: .bottom, spacing: 0.0) {
+            if isOutgoing {
+                Spacer()
+                    .frame(minWidth: 50.0)
+                    .layoutPriority(-1)
+            }
+            AgentShareBubble(agentShare: agentShare)
+                .messageGesture(
+                    message: message,
+                    bubbleStyle: bubbleType,
+                    onReply: onReply,
+                    onToggleReaction: onToggleReaction
+                )
+                .id("agent-share-\(message.messageId)")
+                .modifier(MessageAppearanceModifier(isAppearing: isAppearing, source: message.source))
+            if !isOutgoing {
+                Spacer()
+                    .frame(minWidth: 50.0)
+                    .layoutPriority(-1)
+            }
+        }
+        .padding(.trailing, trailingPadding)
     }
 
     @ViewBuilder

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
@@ -30,6 +30,11 @@ struct MessagesGroupItemView: View {
     var parentAudioTranscriptText: String?
     var omitTrailingPadding: Bool = false
 
+    /// Tap handler for an agent-share card, delivered via the environment from
+    /// the cell (like `agentShareResolver`) rather than threaded through the
+    /// messages-view hierarchy. Opens the shared agent's template flow.
+    @Environment(\.onTapAgentShare) private var onTapAgentShare: @MainActor @Sendable (MessageAgentShare) -> Void
+
     @State private var isAppearing: Bool = true
     @State private var hasAnimated: Bool = false
 
@@ -217,6 +222,7 @@ struct MessagesGroupItemView: View {
                 .messageGesture(
                     message: message,
                     bubbleStyle: bubbleType,
+                    onSingleTap: { onTapAgentShare(agentShare) },
                     onReply: onReply,
                     onToggleReaction: onToggleReaction
                 )

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
@@ -114,6 +114,8 @@ struct MessagesGroupItemView: View {
             emojiBubble(text: text)
         case .invite(let invite):
             inviteBubble(invite: invite)
+        case .agentShare(let agentShare):
+            agentShareBubble(agentShare: agentShare)
         case .linkPreview(let preview):
             linkPreviewBubble(preview: preview)
         case .attachment(let attachment):
@@ -195,6 +197,20 @@ struct MessagesGroupItemView: View {
         .id("message-invite-\(message.messageId)")
         .modifier(MessageAppearanceModifier(isAppearing: isAppearing, source: message.source))
         .padding(.trailing, trailingPadding)
+    }
+
+    @ViewBuilder
+    private func agentShareBubble(agentShare: MessageAgentShare) -> some View {
+        AgentShareBubble(agentShare: agentShare)
+            .messageGesture(
+                message: message,
+                bubbleStyle: bubbleType,
+                onReply: onReply,
+                onToggleReaction: onToggleReaction
+            )
+            .id("agent-share-\(message.messageId)")
+            .modifier(MessageAppearanceModifier(isAppearing: isAppearing, source: message.source))
+            .padding(.trailing, trailingPadding)
     }
 
     @ViewBuilder

--- a/Convos/Conversation Detail/Messages/MessagesView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesView.swift
@@ -259,6 +259,11 @@ struct MessagesView<BottomBarContent: View>: View {
                 onPhotoRevealed: onPhotoRevealed,
                 onPhotoHidden: onPhotoHidden
             )
+            // The overlay renders in a separate tree from the message cells,
+            // so it doesn't inherit the cell's resolver injection. Provide it
+            // here so an agent-share card preview resolves real data, not the
+            // env-default mock.
+            .environment(\.agentShareResolver, agentShareResolver)
         }
         .sheet(item: $htmlAttachmentPreview) { item in
             AttachmentPreviewSheet(

--- a/Convos/Conversation Detail/Messages/MessagesView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesView.swift
@@ -48,6 +48,8 @@ struct MessagesView<BottomBarContent: View>: View {
     let onClearMediaAttachment: (UUID) -> Void
     let onTapAvatar: (ConversationMember) -> Void
     let onTapInvite: (MessageInvite) -> Void
+    var onTapAgentShare: (MessageAgentShare) -> Void = { _ in }
+    var agentShareResolver: any AgentShareResolving = MockAgentShareResolver()
     let onReaction: (String, String) -> Void
     let onToggleReaction: (String, String) -> Void
     let onTapReactions: (AnyMessage) -> Void
@@ -119,6 +121,8 @@ struct MessagesView<BottomBarContent: View>: View {
             onTapAvatar: onTapAvatar,
             onLoadPreviousMessages: onLoadPreviousMessages,
             onTapInvite: onTapInvite,
+            onTapAgentShare: onTapAgentShare,
+            agentShareResolver: agentShareResolver,
             onReaction: onReaction,
             onToggleReaction: onToggleReaction,
             onTapReactions: onTapReactions,

--- a/Convos/Conversation Detail/Messages/MessagesView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesView.swift
@@ -33,6 +33,11 @@ struct MessagesView<BottomBarContent: View>: View {
     var pendingInviteExplodeDuration: ExplodeDuration?
     var onSetInviteExplodeDuration: ((ExplodeDuration?) -> Void)?
     var onInviteConvoNameEditingEnded: ((String) -> Void)?
+    var pendingAgentShareName: String?
+    var pendingAgentShareEmoji: String?
+    var pendingAgentShareSummary: String?
+    var isShowingAgentShareChip: Bool = false
+    var onClearAgentShare: (() -> Void)?
     let sendButtonEnabled: Bool
     @Binding var profileImage: UIImage?
     let onboardingCoordinator: ConversationOnboardingCoordinator
@@ -189,6 +194,11 @@ struct MessagesView<BottomBarContent: View>: View {
                     pendingInviteExplodeDuration: pendingInviteExplodeDuration,
                     onSetInviteExplodeDuration: onSetInviteExplodeDuration,
                     onInviteConvoNameEditingEnded: onInviteConvoNameEditingEnded,
+                    pendingAgentShareName: pendingAgentShareName,
+                    pendingAgentShareEmoji: pendingAgentShareEmoji,
+                    pendingAgentShareSummary: pendingAgentShareSummary,
+                    isShowingAgentShareChip: isShowingAgentShareChip,
+                    onClearAgentShare: onClearAgentShare,
                     sendButtonEnabled: sendButtonEnabled,
                     profileImage: $profileImage,
                     isPhotoPickerPresented: $isPhotoPickerPresented,

--- a/Convos/Conversation Detail/Messages/MessagesViewRepresentable.swift
+++ b/Convos/Conversation Detail/Messages/MessagesViewRepresentable.swift
@@ -13,6 +13,8 @@ struct MessagesViewRepresentable: UIViewControllerRepresentable {
     let onTapAvatar: (ConversationMember) -> Void
     let onLoadPreviousMessages: () -> Void
     let onTapInvite: (MessageInvite) -> Void
+    var onTapAgentShare: (MessageAgentShare) -> Void = { _ in }
+    var agentShareResolver: any AgentShareResolving = MockAgentShareResolver()
     let onReaction: (String, String) -> Void
     let onToggleReaction: (String, String) -> Void
     let onTapReactions: (AnyMessage) -> Void
@@ -89,6 +91,8 @@ struct MessagesViewRepresentable: UIViewControllerRepresentable {
         messagesViewController.onTapAvatar = onTapAvatar
         messagesViewController.onLoadPreviousMessages = onLoadPreviousMessages
         messagesViewController.onTapInvite = onTapInvite
+        messagesViewController.onTapAgentShare = onTapAgentShare
+        messagesViewController.agentShareResolver = agentShareResolver
         messagesViewController.onReaction = onReaction
         messagesViewController.onToggleReaction = onToggleReaction
         messagesViewController.onTapReactions = onTapReactions

--- a/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient+Models.swift
+++ b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient+Models.swift
@@ -217,11 +217,33 @@ public enum ConvosAPI {
         public let id: String
         public let status: String
         public let publishedUrl: String?
+        /// Public profile fields, populated by the detail endpoint
+        /// (`GET /v2/agent-templates/:idOrUrlSlug`). Optional because the
+        /// publish response historically only carried id/status/publishedUrl.
+        public let slug: String?
+        public let agentName: String?
+        public let description: String?
+        public let emoji: String?
+        public let avatarUrl: String?
 
-        public init(id: String, status: String, publishedUrl: String?) {
+        public init(
+            id: String,
+            status: String,
+            publishedUrl: String?,
+            slug: String? = nil,
+            agentName: String? = nil,
+            description: String? = nil,
+            emoji: String? = nil,
+            avatarUrl: String? = nil
+        ) {
             self.id = id
             self.status = status
             self.publishedUrl = publishedUrl
+            self.slug = slug
+            self.agentName = agentName
+            self.description = description
+            self.emoji = emoji
+            self.avatarUrl = avatarUrl
         }
     }
 

--- a/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift
+++ b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift
@@ -96,6 +96,12 @@ public protocol ConvosAPIClientProtocol: AnyObject, Sendable {
     /// builder-created templates calls this lazily on first tap.
     func publishAgentTemplate(id: String) async throws -> ConvosAPI.AgentTemplate
 
+    /// Public detail fetch for a published agent template, keyed by its
+    /// template id (UUID) or hashed url slug (e.g. `gandalf.felpl`). Backs the
+    /// agent-share card/chip resolver. Unauthenticated: the backend serves
+    /// published templates to anonymous callers.
+    func getAgentTemplate(idOrUrlSlug: String) async throws -> ConvosAPI.AgentTemplate
+
     // Connections
     func initiateCloudConnection(serviceId: String, redirectUri: String) async throws -> CloudConnectionsAPI.InitiateResponse
     func completeCloudConnection(connectionRequestId: String) async throws -> CloudConnectionsAPI.CompleteResponse
@@ -820,6 +826,15 @@ final class ConvosAPIClient: ConvosAPIClientProtocol, Sendable {
             Log.error("publishAgentTemplate status=\(httpResponse.statusCode) for id=\(id): \(message ?? "<no message>")")
             throw APIError.serverError(message)
         }
+    }
+
+    func getAgentTemplate(idOrUrlSlug: String) async throws -> ConvosAPI.AgentTemplate {
+        // Public, unauthenticated GET -- the detail endpoint serves published
+        // templates to anonymous callers. `request(for:)` builds a bare GET
+        // (no auth header) and `performRequest` maps 404 -> APIError.notFound.
+        let encoded = idOrUrlSlug.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? idOrUrlSlug
+        let request = try request(for: "v2/agent-templates/\(encoded)")
+        return try await performRequest(request)
     }
 
     // MARK: - Connections

--- a/ConvosCore/Sources/ConvosCore/API/MockAPIClient.swift
+++ b/ConvosCore/Sources/ConvosCore/API/MockAPIClient.swift
@@ -112,6 +112,19 @@ final class MockAPIClient: ConvosAPIClientProtocol, Sendable {
         )
     }
 
+    func getAgentTemplate(idOrUrlSlug: String) async throws -> ConvosAPI.AgentTemplate {
+        .init(
+            id: UUID().uuidString,
+            status: "published",
+            publishedUrl: "https://agents.example.com/a/\(idOrUrlSlug)",
+            slug: idOrUrlSlug,
+            agentName: "Mock Agent",
+            description: "A mock agent template for previews and tests.",
+            emoji: "🤖",
+            avatarUrl: nil
+        )
+    }
+
     // MARK: - Connections
 
     func initiateCloudConnection(serviceId: String, redirectUri: String) async throws -> CloudConnectionsAPI.InitiateResponse {

--- a/ConvosCore/Sources/ConvosCore/AgentShare/AgentShareResolving.swift
+++ b/ConvosCore/Sources/ConvosCore/AgentShare/AgentShareResolving.swift
@@ -1,0 +1,70 @@
+import Foundation
+
+/// The public profile of a shared agent template, resolved from an
+/// agent-share link's identifier. Just enough to render a contact card --
+/// the same fields `AgentTemplateContact` exposes.
+public struct AgentShareInfo: Sendable, Hashable {
+    public let displayName: String?
+    public let emoji: String?
+    public let descriptionText: String?
+    public let avatarURL: String?
+
+    public init(
+        displayName: String?,
+        emoji: String?,
+        descriptionText: String?,
+        avatarURL: String?
+    ) {
+        self.displayName = displayName
+        self.emoji = emoji
+        self.descriptionText = descriptionText
+        self.avatarURL = avatarURL
+    }
+}
+
+/// Resolves an agent-share link identifier (a template id or hashed url slug)
+/// to the template's public profile. The backend exposes
+/// `GET /api/v2/agent-templates/:idOrHashedSlug` for this; the real
+/// `ConvosAPIClient`-backed implementation is a follow-up. Until then
+/// `MockAgentShareResolver` stands in so the full UI pipeline (composer chip +
+/// message card) works end to end.
+public protocol AgentShareResolving: Sendable {
+    func resolve(identifier: String) async -> AgentShareInfo?
+}
+
+/// Deterministic stand-in resolver. Maps an identifier to one of a few sample
+/// personas (stable per identifier so the same link always renders the same
+/// card), with a short delay so the card's "resolving" placeholder is
+/// exercised. Swap for the API-backed resolver once the iOS client method
+/// lands.
+public struct MockAgentShareResolver: AgentShareResolving {
+    public init() {}
+
+    public func resolve(identifier: String) async -> AgentShareInfo? {
+        try? await Task.sleep(nanoseconds: 400_000_000)
+        let personas = MockAgentShareResolver.personas
+        let index = abs(identifier.hashValue) % personas.count
+        return personas[index]
+    }
+
+    private static let personas: [AgentShareInfo] = [
+        AgentShareInfo(
+            displayName: "Tifoso",
+            emoji: "🚴",
+            descriptionText: "I'll help you plan your next ride, log mileage, and remember your favorite routes.",
+            avatarURL: nil
+        ),
+        AgentShareInfo(
+            displayName: "Sous",
+            emoji: "🍳",
+            descriptionText: "Your kitchen sidekick -- recipes, substitutions, and timing for everything on the stove.",
+            avatarURL: nil
+        ),
+        AgentShareInfo(
+            displayName: "Ledger",
+            emoji: "📒",
+            descriptionText: "I keep a running tab of shared expenses and tell you who owes what.",
+            avatarURL: nil
+        ),
+    ]
+}

--- a/ConvosCore/Sources/ConvosCore/AgentShare/AgentShareResolving.swift
+++ b/ConvosCore/Sources/ConvosCore/AgentShare/AgentShareResolving.swift
@@ -4,17 +4,23 @@ import Foundation
 /// agent-share link's identifier. Just enough to render a contact card --
 /// the same fields `AgentTemplateContact` exposes.
 public struct AgentShareInfo: Sendable, Hashable {
+    /// The resolved template id (UUID). Drives opening the agent's template
+    /// flow when its card is tapped -- a web-slug share only yields an id once
+    /// resolved, so this is `nil` until then.
+    public let templateId: String?
     public let displayName: String?
     public let emoji: String?
     public let descriptionText: String?
     public let avatarURL: String?
 
     public init(
+        templateId: String?,
         displayName: String?,
         emoji: String?,
         descriptionText: String?,
         avatarURL: String?
     ) {
+        self.templateId = templateId
         self.displayName = displayName
         self.emoji = emoji
         self.descriptionText = descriptionText
@@ -51,22 +57,52 @@ public struct MockAgentShareResolver: AgentShareResolving {
 
     private static let personas: [AgentShareInfo] = [
         AgentShareInfo(
+            templateId: nil,
             displayName: "Tifoso",
             emoji: "🚴",
             descriptionText: "I'll help you plan your next ride, log mileage, and remember your favorite routes.",
             avatarURL: nil
         ),
         AgentShareInfo(
+            templateId: nil,
             displayName: "Sous",
             emoji: "🍳",
             descriptionText: "Your kitchen sidekick -- recipes, substitutions, and timing for everything on the stove.",
             avatarURL: nil
         ),
         AgentShareInfo(
+            templateId: nil,
             displayName: "Ledger",
             emoji: "📒",
             descriptionText: "I keep a running tab of shared expenses and tell you who owes what.",
             avatarURL: nil
         ),
     ]
+}
+
+/// Resolves agent-share links against the backend's public template detail
+/// endpoint (`GET /v2/agent-templates/:idOrUrlSlug`) via `ConvosAPIClient`.
+/// The real resolver `SessionManager` vends in place of `MockAgentShareResolver`.
+public struct ApiAgentShareResolver: AgentShareResolving {
+    private let apiClient: any ConvosAPIClientProtocol
+
+    public init(apiClient: any ConvosAPIClientProtocol) {
+        self.apiClient = apiClient
+    }
+
+    public func resolve(identifier: String) async -> AgentShareInfo? {
+        do {
+            let template = try await apiClient.getAgentTemplate(idOrUrlSlug: identifier)
+            return AgentShareInfo(
+                templateId: template.id,
+                displayName: template.agentName,
+                emoji: template.emoji,
+                descriptionText: template.description,
+                avatarURL: template.avatarUrl
+            )
+        } catch {
+            Log.error("ApiAgentShareResolver failed to resolve \(identifier): \(error.localizedDescription)")
+            return nil
+        }
+    }
 }

--- a/ConvosCore/Sources/ConvosCore/AgentShare/AgentShareResolving.swift
+++ b/ConvosCore/Sources/ConvosCore/AgentShare/AgentShareResolving.swift
@@ -43,7 +43,9 @@ public struct MockAgentShareResolver: AgentShareResolving {
     public func resolve(identifier: String) async -> AgentShareInfo? {
         try? await Task.sleep(nanoseconds: 400_000_000)
         let personas = MockAgentShareResolver.personas
-        let index = abs(identifier.hashValue) % personas.count
+        // Unsigned arithmetic avoids `abs(Int.min)` trapping -- `hashValue`
+        // can be any `Int`, including `Int.min`.
+        let index = Int(UInt(bitPattern: identifier.hashValue) % UInt(personas.count))
         return personas[index]
     }
 

--- a/ConvosCore/Sources/ConvosCore/AgentShare/AgentShareURL.swift
+++ b/ConvosCore/Sources/ConvosCore/AgentShare/AgentShareURL.swift
@@ -69,40 +69,29 @@ public struct AgentShareURL: Hashable, Sendable {
         return scheme == Constant.schemeBase || scheme.hasPrefix(Constant.schemeBase + "-")
     }
 
-    /// `https://agents[-env].convos.org/a/<slug>` -- the published web link the
-    /// backend hands out (e.g. `agents-dev.convos.org/a/gandalf.felpl`). The
-    /// host varies by environment (`agents-dev.convos.org` in dev; the prod
-    /// host is not finalized), so match any `agents`-prefixed `convos.org`
-    /// subdomain rather than pinning a single host. The path is `/a/<slug>`; a
-    /// bare `/<slug>` is also accepted for resilience.
+    /// The published web link the backend hands out, of the form
+    /// `https://<convos.org host>/a/<slug>`. The host varies by environment --
+    /// `agents-dev.convos.org/a/...` in dev, `convos.org/a/...` in prod -- so
+    /// match any `convos.org` host (apex or subdomain) and key on the reserved
+    /// `/a/` path segment as the agent-page signal. The path must be exactly
+    /// `/a/<slug>`; a bare `/<slug>` is intentionally not matched (it would
+    /// swallow ordinary marketing pages like `convos.org/about`).
     private static func webSlug(from url: URL) -> String? {
-        guard url.scheme == "https", isAgentsHost(url.host) else { return nil }
+        guard url.scheme == "https", isConvosHost(url.host) else { return nil }
         let components = url.pathComponents.filter { $0 != "/" }
-        let slug: String?
-        switch components.count {
-        case 1 where components[0] != Constant.webPathPrefix:
-            // Bare `/<slug>`. Exclude a lone `a` so a trailing-slash `/a/`
-            // (which collapses to `["a"]`) isn't misread as the slug "a".
-            slug = components[0]
-        case 2 where components[0] == Constant.webPathPrefix:
-            slug = components[1]
-        default:
-            slug = nil
+        guard components.count == 2, components[0] == Constant.webPathPrefix else {
+            return nil
         }
-        guard let slug, !slug.isEmpty else { return nil }
+        let slug = components[1]
+        guard !slug.isEmpty else { return nil }
         return slug
     }
 
-    /// Matches `agents.convos.org` and any env-suffixed sibling
-    /// (`agents-dev.convos.org`, `agents-local.convos.org`, ...). The leading
-    /// DNS label must be `agents` or `agents-<env>`, and the remainder must be
-    /// exactly `convos.org`.
-    private static func isAgentsHost(_ host: String?) -> Bool {
-        guard let host, let dotIndex = host.firstIndex(of: ".") else { return false }
-        let label = String(host[host.startIndex..<dotIndex])
-        let remainder = String(host[host.index(after: dotIndex)...])
-        guard remainder == Constant.convosDomainSuffix else { return false }
-        return label == Constant.agentsHostPrefix || label.hasPrefix(Constant.agentsHostPrefix + "-")
+    /// Matches `convos.org` (apex) and any subdomain of it
+    /// (`agents-dev.convos.org`, `app.convos.org`, ...).
+    private static func isConvosHost(_ host: String?) -> Bool {
+        guard let host else { return false }
+        return host == Constant.convosDomainSuffix || host.hasSuffix("." + Constant.convosDomainSuffix)
     }
 
     private static func isValidTemplateId(_ value: String) -> Bool {
@@ -121,7 +110,6 @@ public struct AgentShareURL: Hashable, Sendable {
     private enum Constant {
         static let schemeBase: String = "convos"
         static let templateHost: String = "template"
-        static let agentsHostPrefix: String = "agents"
         static let convosDomainSuffix: String = "convos.org"
         static let webPathPrefix: String = "a"
     }

--- a/ConvosCore/Sources/ConvosCore/AgentShare/AgentShareURL.swift
+++ b/ConvosCore/Sources/ConvosCore/AgentShare/AgentShareURL.swift
@@ -69,16 +69,27 @@ public struct AgentShareURL: Hashable, Sendable {
         return scheme == Constant.schemeBase || scheme.hasPrefix(Constant.schemeBase + "-")
     }
 
-    /// `https://agents[-env].convos.org/<slug>` -- the published web link. The
+    /// `https://agents[-env].convos.org/a/<slug>` -- the published web link the
+    /// backend hands out (e.g. `agents-dev.convos.org/a/gandalf.felpl`). The
     /// host varies by environment (`agents-dev.convos.org` in dev; the prod
     /// host is not finalized), so match any `agents`-prefixed `convos.org`
-    /// subdomain rather than pinning a single host.
+    /// subdomain rather than pinning a single host. The path is `/a/<slug>`; a
+    /// bare `/<slug>` is also accepted for resilience.
     private static func webSlug(from url: URL) -> String? {
         guard url.scheme == "https", isAgentsHost(url.host) else { return nil }
         let components = url.pathComponents.filter { $0 != "/" }
-        guard components.count == 1 else { return nil }
-        let slug = components[0]
-        guard !slug.isEmpty else { return nil }
+        let slug: String?
+        switch components.count {
+        case 1 where components[0] != Constant.webPathPrefix:
+            // Bare `/<slug>`. Exclude a lone `a` so a trailing-slash `/a/`
+            // (which collapses to `["a"]`) isn't misread as the slug "a".
+            slug = components[0]
+        case 2 where components[0] == Constant.webPathPrefix:
+            slug = components[1]
+        default:
+            slug = nil
+        }
+        guard let slug, !slug.isEmpty else { return nil }
         return slug
     }
 
@@ -112,5 +123,6 @@ public struct AgentShareURL: Hashable, Sendable {
         static let templateHost: String = "template"
         static let agentsHostPrefix: String = "agents"
         static let convosDomainSuffix: String = "convos.org"
+        static let webPathPrefix: String = "a"
     }
 }

--- a/ConvosCore/Sources/ConvosCore/AgentShare/AgentShareURL.swift
+++ b/ConvosCore/Sources/ConvosCore/AgentShare/AgentShareURL.swift
@@ -1,0 +1,116 @@
+import Foundation
+
+/// A parsed agent-share link. Shares a published agent template so a
+/// recipient can render a contact card for it and pop open a conversation
+/// seeded with that agent. The parallel of `ConvosInvites`' invite-URL
+/// parsing, but far lighter: an agent-share link carries no signed payload,
+/// only an identifier the backend resolves to the template's public profile.
+///
+/// Two link shapes are recognized:
+///  - custom scheme `convos[-env]://template/<templateId>` (a UUID), the same
+///    form `DeepLinkHandler` already routes for in-app template deep links;
+///  - web `https://agents[-env].convos.org/<slug>`, where `<slug>` is the
+///    backend's hashed url slug (`<base>.<hash>`).
+///
+/// In both shapes `identifier` is whatever the backend's resolver accepts
+/// (`:idOrHashedSlug`) -- the UUID for the scheme form, the slug for the web
+/// form -- and `url` is the original absolute string, preserved so the sent
+/// message body is the link the user pasted.
+public struct AgentShareURL: Hashable, Sendable {
+    public let identifier: String
+    public let url: String
+
+    public init(identifier: String, url: String) {
+        self.identifier = identifier
+        self.url = url
+    }
+
+    /// Parses `text` (trimmed) as a single agent-share link, returning `nil`
+    /// when it isn't one. Mirrors `MessageInvite.from(text:)`'s contract so
+    /// the message classifier can call both the same way.
+    public static func from(text: String) -> AgentShareURL? {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let url = URL(string: trimmed) else { return nil }
+        return from(url: url)
+    }
+
+    public static func from(url: URL) -> AgentShareURL? {
+        if let identifier = customSchemeTemplateId(from: url) {
+            return AgentShareURL(identifier: identifier, url: url.absoluteString)
+        }
+        if let slug = webSlug(from: url) {
+            return AgentShareURL(identifier: slug, url: url.absoluteString)
+        }
+        return nil
+    }
+
+    /// `convos[-env]://template/<uuid>` -- host is `template`, the single path
+    /// component is the template id. Matches `DeepLinkHandler`'s scheme form.
+    ///
+    /// The scheme is matched by prefix (`convos`, `convos-dev`,
+    /// `convos-local`, `convos-pr`) rather than against
+    /// `ConfigManager.shared.appUrlScheme`. This keeps the classifier free of a
+    /// process-wide config dependency (ConfigManager isn't installed in
+    /// `ConvosCore`'s test environment) and lets it recognize a link authored
+    /// in any environment.
+    private static func customSchemeTemplateId(from url: URL) -> String? {
+        guard isConvosScheme(url.scheme), url.host == Constant.templateHost else {
+            return nil
+        }
+        let components = url.pathComponents.filter { $0 != "/" }
+        guard components.count == 1, isValidTemplateId(components[0]) else {
+            return nil
+        }
+        return components[0]
+    }
+
+    private static func isConvosScheme(_ scheme: String?) -> Bool {
+        guard let scheme else { return false }
+        return scheme == Constant.schemeBase || scheme.hasPrefix(Constant.schemeBase + "-")
+    }
+
+    /// `https://agents[-env].convos.org/<slug>` -- the published web link. The
+    /// host varies by environment (`agents-dev.convos.org` in dev; the prod
+    /// host is not finalized), so match any `agents`-prefixed `convos.org`
+    /// subdomain rather than pinning a single host.
+    private static func webSlug(from url: URL) -> String? {
+        guard url.scheme == "https", isAgentsHost(url.host) else { return nil }
+        let components = url.pathComponents.filter { $0 != "/" }
+        guard components.count == 1 else { return nil }
+        let slug = components[0]
+        guard !slug.isEmpty else { return nil }
+        return slug
+    }
+
+    /// Matches `agents.convos.org` and any env-suffixed sibling
+    /// (`agents-dev.convos.org`, `agents-local.convos.org`, ...). The leading
+    /// DNS label must be `agents` or `agents-<env>`, and the remainder must be
+    /// exactly `convos.org`.
+    private static func isAgentsHost(_ host: String?) -> Bool {
+        guard let host, let dotIndex = host.firstIndex(of: ".") else { return false }
+        let label = String(host[host.startIndex..<dotIndex])
+        let remainder = String(host[host.index(after: dotIndex)...])
+        guard remainder == Constant.convosDomainSuffix else { return false }
+        return label == Constant.agentsHostPrefix || label.hasPrefix(Constant.agentsHostPrefix + "-")
+    }
+
+    private static func isValidTemplateId(_ value: String) -> Bool {
+        guard let pattern = uuidPattern else { return false }
+        let range = NSRange(value.startIndex..., in: value)
+        return pattern.firstMatch(in: value, options: [], range: range) != nil
+    }
+
+    private static let uuidPattern: NSRegularExpression? = {
+        try? NSRegularExpression(
+            pattern: "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+            options: [.caseInsensitive]
+        )
+    }()
+
+    private enum Constant {
+        static let schemeBase: String = "convos"
+        static let templateHost: String = "template"
+        static let agentsHostPrefix: String = "agents"
+        static let convosDomainSuffix: String = "convos.org"
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/AgentShare/MessageAgentShare.swift
+++ b/ConvosCore/Sources/ConvosCore/AgentShare/MessageAgentShare.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+/// A message whose body is an agent-share link. The parallel of
+/// `MessageInvite`, but it stores only what the link itself carries -- an
+/// `identifier` the backend resolves and the original `url` -- because, unlike
+/// an invite, an agent-share link has no embedded signed metadata. The
+/// agent's display name / emoji / description are fetched on demand by an
+/// `AgentShareResolving` at render time.
+public struct MessageAgentShare: Sendable, Hashable, Codable {
+    public let identifier: String
+    public let url: String
+
+    public init(identifier: String, url: String) {
+        self.identifier = identifier
+        self.url = url
+    }
+
+    /// Attempts to parse a `MessageAgentShare` from text content. Returns
+    /// `nil` if the text is not a recognized agent-share link. Mirrors
+    /// `MessageInvite.from(text:)` so message classification can call both
+    /// the same way.
+    public static func from(text: String) -> MessageAgentShare? {
+        guard let parsed = AgentShareURL.from(text: text) else { return nil }
+        return MessageAgentShare(identifier: parsed.identifier, url: parsed.url)
+    }
+
+    public static var mock: MessageAgentShare {
+        .init(identifier: "11111111-1111-4111-8111-111111111111", url: "convos://template/11111111-1111-4111-8111-111111111111")
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
@@ -602,6 +602,10 @@ public final class SessionManager: SessionManagerProtocol, @unchecked Sendable {
         try await apiClient.publishAgentTemplate(id: id)
     }
 
+    public func agentShareResolver() -> any AgentShareResolving {
+        ApiAgentShareResolver(apiClient: apiClient)
+    }
+
     public func conversationRepository(for conversationId: String) -> any ConversationRepositoryProtocol {
         ConversationRepository(
             conversationId: conversationId,

--- a/ConvosCore/Sources/ConvosCore/Sessions/SessionManagerProtocol.swift
+++ b/ConvosCore/Sources/ConvosCore/Sessions/SessionManagerProtocol.swift
@@ -122,6 +122,13 @@ public protocol SessionManagerProtocol: AnyObject, Sendable {
     func builderBundleHiddenMessagesRepository() -> any BuilderBundleHiddenMessagesRepositoryProtocol
     func thinkingSessionRepository() -> any ThinkingSessionRepositoryProtocol
 
+    /// Resolves a pasted/received agent-share link to the shared template's
+    /// public profile (name / emoji / description) for rendering its contact
+    /// card. A default returns `MockAgentShareResolver`; the real
+    /// `ConvosAPIClient`-backed resolver is wired in `SessionManager` once the
+    /// iOS client method for the backend's template-resolve endpoint lands.
+    func agentShareResolver() -> any AgentShareResolving
+
     func conversationsRepository(for consent: [Consent]) -> any ConversationsRepositoryProtocol
     func conversationsCountRepo(
         for consent: [Consent],
@@ -200,6 +207,13 @@ public protocol SessionManagerProtocol: AnyObject, Sendable {
 }
 
 extension SessionManagerProtocol {
+    /// Default agent-share resolver. Returns the mock until the API-backed
+    /// resolver is wired into `SessionManager`, so every conformer (including
+    /// test mocks) gets a working resolver without bespoke wiring.
+    public func agentShareResolver() -> any AgentShareResolving {
+        MockAgentShareResolver()
+    }
+
     public func requestAgentJoin(slug: String) async throws -> ConvosAPI.AgentJoinResponse {
         try await requestAgentJoin(slug: slug, templateId: nil, options: nil, forceErrorCode: nil)
     }

--- a/ConvosCore/Sources/ConvosCore/Storage/Hydration/DBMessage+MessagePreview.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Hydration/DBMessage+MessagePreview.swift
@@ -59,6 +59,12 @@ extension DBLastMessageWithSource {
                 } else {
                     text = "sent an invite"
                 }
+            case .agentShare:
+                if shouldShowSenderName {
+                    text = "\(senderName) shared an agent"
+                } else {
+                    text = "shared an agent"
+                }
             case .linkPreview:
                 if shouldShowSenderName {
                     text = "\(senderName) sent a link"
@@ -96,6 +102,12 @@ extension DBLastMessageWithSource {
                     text = "\(senderName) replied with an invite"
                 } else {
                     text = "replied with an invite"
+                }
+            case .agentShare:
+                if shouldShowSenderName {
+                    text = "\(senderName) replied with an agent"
+                } else {
+                    text = "replied with an agent"
                 }
             case .linkPreview:
                 if shouldShowSenderName {

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/MessageContent.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/MessageContent.swift
@@ -62,6 +62,7 @@ public struct ConnectionEventSummary: Hashable, Codable, Sendable {
 public enum MessageContent: Hashable, Codable, Sendable {
     case text(String),
          invite(MessageInvite),
+         agentShare(MessageAgentShare),
          emoji(String), // all emoji, not a reaction
          attachment(HydratedAttachment),
          attachments([HydratedAttachment]),

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/MessageContentType.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/MessageContentType.swift
@@ -4,6 +4,7 @@ import Foundation
 
 public enum MessageContentType: String, Codable, Sendable {
     case text, emoji, attachments, update, invite
+    case agentShare // swiftlint:disable:this raw_value_for_camel_cased_codable_enum
     case linkPreview // swiftlint:disable:this raw_value_for_camel_cased_codable_enum
     case assistantJoinRequest // swiftlint:disable:this raw_value_for_camel_cased_codable_enum
     case connectionGrantRequest // swiftlint:disable:this raw_value_for_camel_cased_codable_enum

--- a/ConvosCore/Sources/ConvosCore/Storage/Repositories/MessagesRepository.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Repositories/MessagesRepository.swift
@@ -499,6 +499,11 @@ extension Array where Element == DBMessage {
                 return nil
             }
             return .invite(invite)
+        case .agentShare:
+            guard let text = dbMessage.text, let agentShare = MessageAgentShare.from(text: text) else {
+                return .text(dbMessage.text ?? "")
+            }
+            return .agentShare(agentShare)
         case .linkPreview:
             guard let preview = dbMessage.linkPreview else {
                 return .text(dbMessage.text ?? "")
@@ -624,6 +629,12 @@ extension Array where Element == DBMessage {
             } else {
                 replyContent = .text(dbMessage.text ?? "")
             }
+        case .agentShare:
+            if let text = dbMessage.text, let agentShare = MessageAgentShare.from(text: text) {
+                replyContent = .agentShare(agentShare)
+            } else {
+                replyContent = .text(dbMessage.text ?? "")
+            }
         case .linkPreview:
             if let preview = dbMessage.linkPreview {
                 replyContent = .linkPreview(preview)
@@ -667,6 +678,12 @@ extension Array where Element == DBMessage {
                 parentContent = .invite(invite)
             } else {
                 parentContent = .text("[Invite]")
+            }
+        case .agentShare:
+            if let text = sourceDBMessage.text, let agentShare = MessageAgentShare.from(text: text) {
+                parentContent = .agentShare(agentShare)
+            } else {
+                parentContent = .text(sourceDBMessage.text ?? "")
             }
         case .linkPreview:
             if let preview = sourceDBMessage.linkPreview {

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/OutgoingMessageWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/OutgoingMessageWriter.swift
@@ -2025,13 +2025,16 @@ actor OutgoingMessageWriter: OutgoingMessageWriterProtocol {
         let isContentEmoji = text.allCharactersEmoji
         let trimmedText = text.trimmingCharacters(in: .whitespacesAndNewlines)
         let invite = MessageInvite.from(text: text)
-        let linkPreview = invite == nil && !isContentEmoji ? LinkPreview.from(text: text) : nil
+        let isAgentShare = invite == nil && !isContentEmoji && MessageAgentShare.from(text: text) != nil
+        let linkPreview = invite == nil && !isAgentShare && !isContentEmoji ? LinkPreview.from(text: text) : nil
 
         let contentType: MessageContentType
         if isContentEmoji {
             contentType = .emoji
         } else if invite != nil {
             contentType = .invite
+        } else if isAgentShare {
+            contentType = .agentShare
         } else if linkPreview != nil {
             contentType = .linkPreview
         } else {

--- a/ConvosCore/Sources/ConvosCore/Storage/XMTP DB Representations/DecodedMessage+DBRepresentation.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/XMTP DB Representations/DecodedMessage+DBRepresentation.swift
@@ -128,6 +128,17 @@ extension XMTPiOS.DecodedMessage {
                 text: contentString,
                 update: nil
             )
+        } else if !isContentEmoji, MessageAgentShare.from(text: contentString) != nil {
+            return DBMessageComponents(
+                messageType: .original,
+                contentType: .agentShare,
+                sourceMessageId: nil,
+                emoji: nil,
+                invite: nil,
+                attachmentUrls: [],
+                text: contentString,
+                update: nil
+            )
         } else if !isContentEmoji, let preview = LinkPreview.from(text: contentString) {
             return DBMessageComponents(
                 messageType: .original,

--- a/ConvosCore/Tests/ConvosCoreTests/AgentShareURLTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/AgentShareURLTests.swift
@@ -1,0 +1,84 @@
+@testable import ConvosCore
+import Foundation
+import Testing
+
+@Suite("AgentShareURL parsing")
+struct AgentShareURLTests {
+    private let templateId: String = "11111111-1111-4111-8111-111111111111"
+
+    @Test("parses the prod custom scheme template link")
+    func parsesProdScheme() throws {
+        let url = "convos://template/\(templateId)"
+        let parsed = try #require(AgentShareURL.from(text: url))
+        #expect(parsed.identifier == templateId)
+        #expect(parsed.url == url)
+    }
+
+    @Test("parses the env-suffixed custom scheme template link")
+    func parsesEnvScheme() throws {
+        let parsed = try #require(AgentShareURL.from(text: "convos-dev://template/\(templateId)"))
+        #expect(parsed.identifier == templateId)
+    }
+
+    @Test("parses the dev web share link")
+    func parsesWebLink() throws {
+        let parsed = try #require(AgentShareURL.from(text: "https://agents-dev.convos.org/tifoso.pnw1o"))
+        #expect(parsed.identifier == "tifoso.pnw1o")
+    }
+
+    @Test("parses a bare agents.convos.org host")
+    func parsesBareAgentsHost() throws {
+        let parsed = try #require(AgentShareURL.from(text: "https://agents.convos.org/sous.ab12c"))
+        #expect(parsed.identifier == "sous.ab12c")
+    }
+
+    @Test("rejects a non-template custom-scheme link")
+    func rejectsOtherSchemeHost() {
+        #expect(AgentShareURL.from(text: "convos://pair/\(templateId)") == nil)
+    }
+
+    @Test("rejects a custom-scheme template link with a non-UUID id")
+    func rejectsNonUUIDTemplateId() {
+        #expect(AgentShareURL.from(text: "convos://template/not-a-uuid") == nil)
+    }
+
+    @Test("rejects an unrelated https host")
+    func rejectsUnrelatedHost() {
+        #expect(AgentShareURL.from(text: "https://example.com/tifoso.pnw1o") == nil)
+        #expect(AgentShareURL.from(text: "https://dev.convos.org/i/somecode") == nil)
+    }
+
+    @Test("rejects a web link with no slug or extra path segments")
+    func rejectsBadWebPath() {
+        #expect(AgentShareURL.from(text: "https://agents-dev.convos.org/") == nil)
+        #expect(AgentShareURL.from(text: "https://agents-dev.convos.org/a/b") == nil)
+    }
+
+    @Test("rejects plain text")
+    func rejectsPlainText() {
+        #expect(AgentShareURL.from(text: "hey check this out") == nil)
+        #expect(AgentShareURL.from(text: "") == nil)
+    }
+
+    @Test("MessageAgentShare.from mirrors AgentShareURL parsing")
+    func messageAgentShareFrom() throws {
+        let url = "convos://template/\(templateId)"
+        let share = try #require(MessageAgentShare.from(text: url))
+        #expect(share.identifier == templateId)
+        #expect(share.url == url)
+        #expect(MessageAgentShare.from(text: "not a link") == nil)
+    }
+}
+
+@Suite("MockAgentShareResolver")
+struct MockAgentShareResolverTests {
+    @Test("resolves to a stable persona per identifier")
+    func stablePerIdentifier() async {
+        let resolver = MockAgentShareResolver()
+        let first = await resolver.resolve(identifier: "abc")
+        let again = await resolver.resolve(identifier: "abc")
+        #expect(first != nil)
+        #expect(first == again)
+        #expect(first?.displayName?.isEmpty == false)
+    }
+}

--- a/ConvosCore/Tests/ConvosCoreTests/AgentShareURLTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/AgentShareURLTests.swift
@@ -89,3 +89,48 @@ struct MockAgentShareResolverTests {
         #expect(first?.displayName?.isEmpty == false)
     }
 }
+
+@Suite("ApiAgentShareResolver")
+struct ApiAgentShareResolverTests {
+    @Test("maps the template detail response into AgentShareInfo")
+    func mapsTemplateResponse() async {
+        let api = AgentShareStubAPIClient(
+            template: ConvosAPI.AgentTemplate(
+                id: "17555bf3-f66c-4706-8c35-f2fe6fbe0ef7",
+                status: "published",
+                publishedUrl: "https://agents-dev.convos.org/a/gandalf.felpl",
+                slug: "gandalf",
+                agentName: "Gandalf",
+                description: "The Grey Wizard.",
+                emoji: "🧙",
+                avatarUrl: nil
+            )
+        )
+        let resolver = ApiAgentShareResolver(apiClient: api)
+        let info = await resolver.resolve(identifier: "gandalf.felpl")
+        #expect(info?.templateId == "17555bf3-f66c-4706-8c35-f2fe6fbe0ef7")
+        #expect(info?.displayName == "Gandalf")
+        #expect(info?.emoji == "🧙")
+        #expect(info?.descriptionText == "The Grey Wizard.")
+    }
+
+    @Test("returns nil when the fetch throws")
+    func nilOnError() async {
+        let resolver = ApiAgentShareResolver(apiClient: AgentShareStubAPIClient(template: nil))
+        let info = await resolver.resolve(identifier: "missing.slug")
+        #expect(info == nil)
+    }
+}
+
+/// Returns a fixed template (or throws `notFound` when nil) for the
+/// agent-share detail fetch. Every other `ConvosAPIClientProtocol` requirement
+/// is satisfied by the shared `TestStubAPIClientDefaults` no-op extension.
+private final class AgentShareStubAPIClient: TestStubAPIClient, @unchecked Sendable {
+    private let template: ConvosAPI.AgentTemplate?
+    init(template: ConvosAPI.AgentTemplate?) { self.template = template }
+
+    override func getAgentTemplate(idOrUrlSlug: String) async throws -> ConvosAPI.AgentTemplate {
+        guard let template else { throw APIError.notFound }
+        return template
+    }
+}

--- a/ConvosCore/Tests/ConvosCoreTests/AgentShareURLTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/AgentShareURLTests.swift
@@ -20,16 +20,22 @@ struct AgentShareURLTests {
         #expect(parsed.identifier == templateId)
     }
 
-    @Test("parses the dev web share link")
+    @Test("parses the dev web share link with the /a/ path prefix")
     func parsesWebLink() throws {
-        let parsed = try #require(AgentShareURL.from(text: "https://agents-dev.convos.org/tifoso.pnw1o"))
-        #expect(parsed.identifier == "tifoso.pnw1o")
+        let parsed = try #require(AgentShareURL.from(text: "https://agents-dev.convos.org/a/gandalf.felpl"))
+        #expect(parsed.identifier == "gandalf.felpl")
     }
 
-    @Test("parses a bare agents.convos.org host")
-    func parsesBareAgentsHost() throws {
+    @Test("parses a bare-slug agents.convos.org host (no /a/ prefix)")
+    func parsesBareSlug() throws {
         let parsed = try #require(AgentShareURL.from(text: "https://agents.convos.org/sous.ab12c"))
         #expect(parsed.identifier == "sous.ab12c")
+    }
+
+    @Test("parses the prod-style /a/ web link")
+    func parsesProdWebLink() throws {
+        let parsed = try #require(AgentShareURL.from(text: "https://agents.convos.org/a/tifoso.pnw1o"))
+        #expect(parsed.identifier == "tifoso.pnw1o")
     }
 
     @Test("rejects a non-template custom-scheme link")
@@ -48,10 +54,11 @@ struct AgentShareURLTests {
         #expect(AgentShareURL.from(text: "https://dev.convos.org/i/somecode") == nil)
     }
 
-    @Test("rejects a web link with no slug or extra path segments")
+    @Test("rejects a web link with no slug or too many path segments")
     func rejectsBadWebPath() {
         #expect(AgentShareURL.from(text: "https://agents-dev.convos.org/") == nil)
-        #expect(AgentShareURL.from(text: "https://agents-dev.convos.org/a/b") == nil)
+        #expect(AgentShareURL.from(text: "https://agents-dev.convos.org/a/slug/extra") == nil)
+        #expect(AgentShareURL.from(text: "https://agents-dev.convos.org/a/") == nil)
     }
 
     @Test("rejects plain text")

--- a/ConvosCore/Tests/ConvosCoreTests/AgentShareURLTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/AgentShareURLTests.swift
@@ -20,21 +20,15 @@ struct AgentShareURLTests {
         #expect(parsed.identifier == templateId)
     }
 
-    @Test("parses the dev web share link with the /a/ path prefix")
-    func parsesWebLink() throws {
+    @Test("parses the dev web share link (agents-dev.convos.org/a/<slug>)")
+    func parsesDevWebLink() throws {
         let parsed = try #require(AgentShareURL.from(text: "https://agents-dev.convos.org/a/gandalf.felpl"))
         #expect(parsed.identifier == "gandalf.felpl")
     }
 
-    @Test("parses a bare-slug agents.convos.org host (no /a/ prefix)")
-    func parsesBareSlug() throws {
-        let parsed = try #require(AgentShareURL.from(text: "https://agents.convos.org/sous.ab12c"))
-        #expect(parsed.identifier == "sous.ab12c")
-    }
-
-    @Test("parses the prod-style /a/ web link")
+    @Test("parses the prod web share link (convos.org/a/<slug>)")
     func parsesProdWebLink() throws {
-        let parsed = try #require(AgentShareURL.from(text: "https://agents.convos.org/a/tifoso.pnw1o"))
+        let parsed = try #require(AgentShareURL.from(text: "https://convos.org/a/tifoso.pnw1o"))
         #expect(parsed.identifier == "tifoso.pnw1o")
     }
 
@@ -48,17 +42,26 @@ struct AgentShareURLTests {
         #expect(AgentShareURL.from(text: "convos://template/not-a-uuid") == nil)
     }
 
-    @Test("rejects an unrelated https host")
+    @Test("rejects a non-convos.org https host even with an /a/ path")
     func rejectsUnrelatedHost() {
-        #expect(AgentShareURL.from(text: "https://example.com/tifoso.pnw1o") == nil)
+        #expect(AgentShareURL.from(text: "https://example.com/a/tifoso.pnw1o") == nil)
+        // A look-alike suffix must not match (notconvos.org is not convos.org).
+        #expect(AgentShareURL.from(text: "https://notconvos.org/a/tifoso.pnw1o") == nil)
+    }
+
+    @Test("rejects convos.org paths that aren't /a/<slug>")
+    func rejectsNonAgentPaths() {
+        // Bare slug / marketing pages must not be swallowed.
+        #expect(AgentShareURL.from(text: "https://convos.org/about") == nil)
+        #expect(AgentShareURL.from(text: "https://convos.org/tifoso.pnw1o") == nil)
         #expect(AgentShareURL.from(text: "https://dev.convos.org/i/somecode") == nil)
     }
 
     @Test("rejects a web link with no slug or too many path segments")
     func rejectsBadWebPath() {
         #expect(AgentShareURL.from(text: "https://agents-dev.convos.org/") == nil)
-        #expect(AgentShareURL.from(text: "https://agents-dev.convos.org/a/slug/extra") == nil)
-        #expect(AgentShareURL.from(text: "https://agents-dev.convos.org/a/") == nil)
+        #expect(AgentShareURL.from(text: "https://convos.org/a/slug/extra") == nil)
+        #expect(AgentShareURL.from(text: "https://convos.org/a/") == nil)
     }
 
     @Test("rejects plain text")

--- a/ConvosCore/Tests/ConvosCoreTests/TestStubAPIClientDefaults.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/TestStubAPIClientDefaults.swift
@@ -55,4 +55,62 @@ extension ConvosAPIClientProtocol {
             publishedUrl: "https://agents.example.com/test.\(id.prefix(5))"
         )
     }
+
+    /// Default for the public agent-template detail fetch used by the
+    /// agent-share card/chip resolver. Tests that exercise it specifically
+    /// should override on their fixture.
+    func getAgentTemplate(idOrUrlSlug: String) async throws -> ConvosAPI.AgentTemplate {
+        ConvosAPI.AgentTemplate(
+            id: UUID().uuidString,
+            status: "published",
+            publishedUrl: "https://agents.example.com/a/\(idOrUrlSlug)",
+            slug: idOrUrlSlug,
+            agentName: "Test Agent",
+            description: "A test agent template.",
+            emoji: "🤖",
+            avatarUrl: nil
+        )
+    }
+}
+
+/// Open, fully-conforming `ConvosAPIClientProtocol` base for test fixtures that
+/// only care about one or two methods. Every requirement throws / returns a
+/// trivial value; subclasses override just what they exercise. Spares each new
+/// stub from re-declaring the whole (large) protocol surface.
+class TestStubAPIClient: ConvosAPIClientProtocol, @unchecked Sendable {
+    func request(for path: String, method: String, queryParameters: [String: String]?) throws -> URLRequest {
+        URLRequest(url: URL(string: "https://example.com/\(path)") ?? URL(string: "https://example.com")!)
+    }
+    func registerDevice(deviceId: String, pushToken: String?) async throws {}
+    func authenticate(appCheckToken: String, retryCount: Int) async throws -> String { "" }
+    func authenticateWithSIWE(appCheckToken: String, signing: BackendAuthSigningContext) async throws -> String { "" }
+    func updateSIWESigningContext(_ context: BackendAuthSigningContext?) {}
+    func accountAuthCheck(jwt: String?) async throws -> ConvosAPI.AuthCheckResponse {
+        throw CancellationError()
+    }
+    func uploadAttachment(data: Data, filename: String, contentType: String, acl: String) async throws -> String { "" }
+    func uploadAttachmentAndExecute(data: Data, filename: String, afterUpload: @escaping (String) async throws -> Void) async throws -> String { "" }
+    func getPresignedUploadURL(filename: String, contentType: String) async throws -> (uploadURL: String, assetURL: String) {
+        ("", "")
+    }
+    func subscribeToTopics(deviceId: String, clientId: String, topics: [String]) async throws {}
+    func unsubscribeFromTopics(clientId: String, topics: [String]) async throws {}
+    func unregisterInstallation(clientId: String) async throws {}
+    func renewAssetsBatch(assetKeys: [String]) async throws -> AssetRenewalResult {
+        AssetRenewalResult(renewed: 0, failed: 0, expiredKeys: [])
+    }
+    func initiateCloudConnection(serviceId: String, redirectUri: String) async throws -> CloudConnectionsAPI.InitiateResponse {
+        throw CancellationError()
+    }
+    func completeCloudConnection(connectionRequestId: String) async throws -> CloudConnectionsAPI.CompleteResponse {
+        throw CancellationError()
+    }
+    func listCloudConnections() async throws -> [CloudConnectionsAPI.ConnectionResponse] { [] }
+    func revokeCloudConnection(connectionId: String) async throws {}
+
+    /// Declared on the base (not just the protocol-extension default) so
+    /// subclasses can `override` it.
+    func getAgentTemplate(idOrUrlSlug: String) async throws -> ConvosAPI.AgentTemplate {
+        ConvosAPI.AgentTemplate(id: UUID().uuidString, status: "published", publishedUrl: nil)
+    }
 }


### PR DESCRIPTION
## Summary

Adds an **agent-share contact card** to conversations, reusing UI introduced in
the still-unmerged #868 (Agent Builder remix). Two surfaces, mirroring how
invite URLs already work:

- **Message cell** — a received/sent agent-share link renders as an agent
  **contact card** (avatar + name + description), tapping it opens the shared
  agent's template flow.
- **Composer chip** — pasting an agent-share link into the message input lifts
  it out of the text into a display-only **contact-card chip** above the
  composer, then sends the link on send.

### Agent-share URL formats recognized
- custom scheme `convos[-env]://template/<uuid>` (the form `DeepLinkHandler`
  already routes)
- web `https://agents[-env].convos.org/<slug>`

### Mocked agent data (resolver seam)
An agent-share link only carries an identifier, so the agent's name / emoji /
description are fetched via an `AgentShareResolving` injected through the
session. This PR ships `MockAgentShareResolver` (deterministic personas); the
real `ConvosAPIClient.getAgentTemplate(idOrHashedSlug:)`-backed resolver is a
**follow-up** (the iOS client method for the backend's public template-resolve
endpoint doesn't exist yet, and the prod web-URL host is still TBD). The
card/chip show the existing pulsing "learning…" placeholder while resolving.

## Implementation notes

- **ConvosCore data layer** — `AgentShareURL` parser (scheme matched by prefix,
  no `ConfigManager` dependency so it's test-safe and env-agnostic),
  `MessageAgentShare` + `MessageContent.agentShare` + `MessageContentType
  .agentShare`. The URL lives in the existing `text` column and is recomputed
  on hydration (no DB migration). Classified alongside `MessageInvite.from` in
  `OutgoingMessageWriter.saveTextToDatabase`, `DecodedMessage` hydration,
  `MessagesRepository`, and conversation-list preview text.
- **Reusable UI** — `AgentContactCardView` gains `.standard`/`.hero` styles +
  `cardSize` (lifted from #868); new display-only `AgentContactCardChip`
  (promoted from #868's private `remixAgentBadge`).
- **Cell wiring** — the resolver + tap handler reach the message card via the
  **environment** (like `messageContextMenuState`), sourced from `CellConfig`,
  rather than threading through the deep messages-view hierarchy.
- **Composer chip** — `pendingAgentShare` state + `checkForAgentShareURL`
  (same `messageText` onChange as invites) threaded
  ConversationView -> MessagesView -> MessagesBottomBar -> MessagesInputView.

Tap on a **web-slug** share is a no-op until the resolve-to-id API lands; only
the custom-scheme (UUID) form opens the template flow today.

## Test plan

- `swift test --package-path ConvosCore` -> **1084 tests pass** (incl. 11 new
  `AgentShareURL` / `MockAgentShareResolver` tests)
- App target builds clean (`Convos (Dev)`)
- SwiftLint clean on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/928"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782870881&installation_id=128169237&pr_number=928&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F928&signature=6395423c3c8a1c0446db9db00906536da2db91da17dd34a0f74007b83d5d56f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add agent-share contact card chip in the message composer and agent-share bubble in the message list
> - Detects agent-share URLs typed or pasted into the composer, strips them from the text field, and replaces them with a dismissible `AgentContactCardChip` that asynchronously resolves the agent's display name and emoji via a new `AgentShareResolving` protocol.
> - Sends the agent-share URL as a classified `agentShare` content type, persisted and decoded through the storage layer so the message list renders an `AgentShareBubble` (an `AgentContactCardView` populated at runtime by resolving the link).
> - Tapping an agent-share card opens the new-conversation flow pre-seeded with the agent template; slugs are resolved to a UUID template ID before opening.
> - Adds `AgentContactCardView` `.hero` style with larger avatar, bold tracking, and fixed 2-line subtitle alongside the existing `.standard` style.
> - Conversation list previews, reply references, and context-menu overlays all handle the new `agentShare` content type.
> - `SessionManager` provides an `ApiAgentShareResolver` backed by a new `GET /v2/agent-templates/:idOrUrlSlug` endpoint; mock and test-stub implementations are included.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6e26416.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->