### PR TITLE
local-stack: ios-config stops hard-coding a backend URL (un-poisons Dev builds)

### DIFF
--- a/.claude/commands/run.md
+++ b/.claude/commands/run.md
@@ -33,7 +33,7 @@ Skip this whole step for Dev/Prod schemes. The orchestration is committed in thi
 1. `LS="$(git rev-parse --show-toplevel)/dev/local-stack"`.
 2. **First-run:** `make -C "$LS" status` (30s). If it errors *"no workspace configured — run: make init"*, the machine isn't set up: run `make -C "$LS" init` (defaults the workspace to a sibling of this repo and clones the service repos; ~600000ms timeout), then **pause** and tell the user to set the `OP_*` 1Password refs in `<workspace>/stack.env` and run `make -C "$LS" bootstrap` once.
 3. **Bring it up if needed:** if `status` shows backend/worker down, run `make -C "$LS" up` with a **1200000ms (20 min)** timeout (first run builds the Hermes image — capped; later runs are fast). Relay any Docker-cap warning from `make -C "$LS" doctor`.
-4. **Configure this checkout as a thin client:** `make -C "$LS" ios-config IOS="$(pwd)"` — sets `config.local.json` `xmtpNetwork→dev` and writes `./.env` (localhost backend + shared Firebase Local token).
+4. **Configure this checkout as a thin client:** `make -C "$LS" ios-config IOS="$(pwd)"` — sets `config.local.json` `xmtpNetwork→dev` and writes `./.env` (shared Firebase Local token; `CONVOS_API_BASE_URL` left empty so Local auto-detects the Mac LAN IP and a Dev build on the same checkout isn't redirected to localhost).
 
 ### Step 1: Resolve the simulator
 

--- a/dev/local-stack/README.md
+++ b/dev/local-stack/README.md
@@ -60,7 +60,7 @@ The in-chat agent-builder ("Make an agent") calls convos-backend directly from i
 ### Shared iOS `.env` (Dev vs Local)
 The workspace also holds **`<workspace>/convos-ios.env`** — the shared **Dev** env (Firebase Dev App Check token, `GATEWAY_URL`, `AGENT_DEBUG_JWKS`). `make init` creates it; **`/firebase-token`**, **`/setup`**, and **`convos-task`** symlink each Dev checkout's `.env → <workspace>/convos-ios.env` (one token, every worktree shares it). They fall back to the legacy `<parent>/.env` when no workspace is configured.
 
-A **`Convos (Local)`** checkout instead gets a **standalone `.env`** (written by `ios-config` / `/run local`: localhost backend + Firebase *Local* token) — `ios-config` `rm`s any Dev symlink first so it won't clobber the shared file. So a given checkout is configured for Dev *or* Local at a time.
+A **`Convos (Local)`** checkout instead gets a **standalone `.env`** (written by `ios-config` / `/run local`: Firebase *Local* token, and `CONVOS_API_BASE_URL` left **empty**) — `ios-config` `rm`s any Dev symlink first so it won't clobber the shared file. The backend URL is intentionally left empty: the build phase bakes `.env` into `Secrets.swift` for **both** schemes and a non-empty value overrides the per-scheme config default, so a hard-coded `localhost` would silently redirect a **Dev** build on the same checkout to localhost (fine on the simulator, "connection refused" on a device). Empty means the **Local** build auto-detects this Mac's LAN IP (reachable from sim and device) while a **Dev** build falls back to `config.dev.json`'s real backend. The Firebase debug token still differs per scheme, so a checkout is still effectively Dev *or* Local at a time on the simulator (a device uses real App Attest, not the debug token).
 
 ## Troubleshooting
 | Symptom | Fix |
@@ -74,6 +74,7 @@ A **`Convos (Local)`** checkout instead gets a **standalone `.env`** (written by
 | Agent stays "Joining…" | worker/herald down or auth incomplete → `make … status`, ensure auth works. |
 | Agent-builder: **"Asserted ownerAccountId does not exist"** | worker's `CONVOS_API_BASE_URL` points at the wrong backend (default is the hosted dev one, or the host IP drifted) → `make … up` re-syncs it to this backend; `make … doctor` flags drift. |
 | Agent-builder: **"lost power" / Upgrade** | the account has no local credits → after signing in, `make … seed-credits`. |
+| **Dev** build hits `localhost` / "connection refused" on a device | the checkout's `.env` has a leftover `CONVOS_API_BASE_URL=localhost` from an old Local config → re-run `make … ios-config` (now writes it empty), or clear that line. Newer `ios-config` no longer hard-codes it. |
 
 ## Fixes to upstream (so this needs no workarounds)
 - ✅ **convos-ios** `Scripts/build-phases/copy-env-config-main-app.sh:106` `sed` bug (double-escaped backslashes that broke Local `Secrets.swift`) — **fixed in this branch** (committed in-repo; `ios-config` no longer needs to patch it).

--- a/dev/local-stack/stack.sh
+++ b/dev/local-stack/stack.sh
@@ -287,8 +287,16 @@ cmd_ios_config() {
   local fb=""; { have op && [[ -n "${OP_FIREBASE_LOCAL_TOKEN_REF:-}" ]] && fb="$(op read "$OP_FIREBASE_LOCAL_TOKEN_REF" 2>/dev/null||true)"; } || true
   [[ -z "$fb" ]] && warn "no Firebase Local token from 1Password — set FIREBASE_APP_CHECK_DEBUG_TOKEN in $ios/.env (shared Local token)"
   rm -f "$ios/.env"   # break any Dev-shared symlink; the Local scheme uses a standalone .env
-  { printf 'CONVOS_API_BASE_URL=http://localhost:%s/api\nGATEWAY_URL=\nSENTRY_DSN=\nFIREBASE_APP_CHECK_DEBUG_TOKEN=%s\nAGENT_DEBUG_JWKS=\n' "$BACKEND_PORT" "$fb"; } > "$ios/.env"
-  ok "wrote standalone Local $ios/.env (localhost backend + Firebase Local token; any Dev symlink replaced)"
+  # Leave CONVOS_API_BASE_URL EMPTY on purpose. The build phase reads this same
+  # .env for BOTH schemes (copy-env-config-main-app.sh): a non-empty value here
+  # is baked into Secrets and, per ConfigManager, overrides the per-scheme
+  # config default — so a hard-coded localhost would silently redirect a Dev
+  # build on this checkout to localhost (broken on a device). Empty means:
+  #   - Local build  -> auto-detects this Mac's LAN IP (reachable from sim AND
+  #     device; ATS-allowed via Info.Local.plist NSAllowsLocalNetworking),
+  #   - Dev build     -> falls back to config.dev.json's real dev backend.
+  { printf 'CONVOS_API_BASE_URL=\nGATEWAY_URL=\nSENTRY_DSN=\nFIREBASE_APP_CHECK_DEBUG_TOKEN=%s\nAGENT_DEBUG_JWKS=\n' "$fb"; } > "$ios/.env"
+  ok "wrote standalone Local $ios/.env (Local Firebase token; backend auto-resolved, no Dev-poisoning override)"
 }
 
 cmd_clean() { load_env; cmd_down; rm -rf "$RUN_DIR"; ok "cleaned run state"; }


### PR DESCRIPTION
Follow-up to #927. Fixes a footgun where building the **Dev** scheme on a checkout that was configured for the local stack silently used `localhost` as the backend — fine on the simulator, "connection refused" on a device.

## Root cause
The build phase (`Scripts/build-phases/copy-env-config-main-app.sh`) bakes the checkout's `.env` into `Secrets.swift` for **both** the Local *and* Dev schemes (Local block + the `CONFIGURATION = "Dev"` block at `:119`). `ConvosApp.swift` feeds `Secrets.CONVOS_API_BASE_URL` in as the override, and `ConfigManager.swift:102` lets a **non-empty** Secrets value win over the per-scheme `config.*.json` default.

`ios-config` wrote `CONVOS_API_BASE_URL=http://localhost:4000/api` to point the **Local** scheme at the Mac — but that same `.env` then overrode `config.dev.json`'s real backend (`https://api.dev.convos.xyz/api`) for a **Dev** build on the same checkout.

## Fix
`ios-config` now leaves `CONVOS_API_BASE_URL` **empty**:
- **Local** build → the build phase auto-detects the Mac's LAN IP (reachable from simulator *and* device; ATS-allowed via `Info.Local.plist`'s `NSAllowsLocalNetworking`).
- **Dev** build → empty override → falls back to `config.dev.json`'s real dev backend.

The shared Dev `.env` already omits this key, so Dev was always meant to use the config default — this just stops the Local config from clobbering it. Existing checkouts pick it up by re-running `make … ios-config` (or clearing the stale line); a README troubleshooting row documents that.

Docs: updated the Dev-vs-Local `.env` section, the `/run local` step, and added a troubleshooting row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/929"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782881335&installation_id=128169237&pr_number=929&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F929&signature=45db4c6870c077c3c79bc2e3062ee7bce89196f28f754d2ceb4bb37fba4e15b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `ios-config` to write an empty `CONVOS_API_BASE_URL` instead of hardcoding localhost
> Previously, `ios-config` wrote `CONVOS_API_BASE_URL=http://localhost:<PORT>/api` to the iOS checkout `.env`, which caused Dev scheme builds on a device to redirect to localhost instead of the intended backend. Now [`stack.sh`](https://github.com/xmtplabs/convos-ios/pull/929/files#diff-ac74f42213bfd94cd92c5951d64ae7013a7155b648d52d642d4c25b01dfb3bd5) writes an empty `CONVOS_API_BASE_URL`, letting Local builds auto-detect the Mac's LAN IP and leaving Dev builds unaffected. The README and run command docs are updated to explain the intentional empty value and add a troubleshooting note.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e5f58a7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->