### PR TITLE
fix(ci): skip beta review for internal-only Prod TestFlight groups

### DIFF
--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -67,6 +67,13 @@ platform :ios do
       groups: ["Convos iOS Team", "Convos Team", "Friends and Family", "XMTP Labs Team"],
       changelog: testflight_release_notes,
       distribute_external: false,
+      # All four groups are internal testers, which never go through Apple Beta
+      # App Review. pilot's submit_beta_review defaults to true and fires
+      # whenever groups: is set (independent of distribute_external), so without
+      # this it calls post_beta_app_review_submission and fails with "Another
+      # build in the same train is already in beta review". Internal groups are
+      # still attached to the build regardless of this flag.
+      submit_beta_review: false,
       skip_waiting_for_build_processing: false,
       notify_external_testers: false,
     )


### PR DESCRIPTION
## Problem

The Prod TestFlight pipeline (run [26736754188](https://github.com/xmtplabs/convos-ios/actions/runs/26736754188)) now **archives, signs, uploads, and processes a build successfully** (build `2.0.0 - 843` reached App Store Connect). It fails only at the final distribute step:

```
[!] Another build is in review. - Another build in the same train is already in beta review.
    Please submit it again once it gets completed.
(Spaceship::UnexpectedResponse) — upload_to_testflight, exit 233
```

## Root cause

All four prod TestFlight groups (`Convos iOS Team`, `Convos Team`, `Friends and Family`, `XMTP Labs Team`) are **internal** (confirmed in App Store Connect → Internal Testing). Internal groups never require Apple Beta App Review.

But `pilot`'s `submit_beta_review` option **defaults to `true`**, and `distribute_build` (pilot/build_manager.rb) gates the review submission on `submit_beta_review && groups` — **not** on `distribute_external`:

```ruby
if options[:submit_beta_review] && (options[:groups] || options[:distribute_external])
  uploaded_build.post_beta_app_review_submission   # <- fires even for internal groups
```

So even with `distribute_external: false`, because `groups:` is set and `submit_beta_review` was left at its `true` default, pilot called `post_beta_app_review_submission` and Apple rejected it (a prior 2.0.0 build is still in review).

## Fix

Add `submit_beta_review: false` to `upload_to_testflight`. The build is still attached to all four internal groups (the `groups:` handling in `distribute_build` runs regardless of this flag); only the unnecessary — and currently blocking — beta-review submission is skipped. Internal-only distribution is instant and needs no review.

## Verification

- `ruby -c fastlane/lanes/release.rb` → Syntax OK.
- `bundle exec fastlane lanes` parses; `testflight_prod` + `firebase_pr` present.
- Confirmed against pilot source that `submit_beta_review` default is `true` and is the only flag gating `post_beta_app_review_submission` for the internal path.
- Real verification on merge (auto-trigger on push to `dev`) or `gh workflow run testflight-prod.yml`.

## Context

Third in the prod-TestFlight bring-up sequence: #879 (migration) → #919 (match-resolved signing names) → this (internal-only distribution). Signing and upload are fully working as of #919 + dev's `skip_profile_detection` follow-up; this is the last blocker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/931"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782920032&installation_id=128169237&pr_number=931&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F931&signature=8929e08866afe7367a6b47abfd3aea610550059adba24513ce537fc36421d835"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Skip beta review for internal-only Prod TestFlight groups
> Passes `submit_beta_review: false` to `upload_to_testflight` in the `testflight_prod` lane in [release.rb](https://github.com/xmtplabs/convos-ios/pull/931/files#diff-4f4ec77529cea8e5a9f3f871c7e8e4d94bce0e51abff5634400b16b916973e15). This skips the beta review step, which is only required for external TestFlight groups.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cbea43a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->