### PR TITLE
fix(ci): internal-only TestFlight distribution, drop group assignment

### DIFF
--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -61,21 +61,20 @@ platform :ios do
       },
     )
 
+    # Internal-only distribution. All prod TestFlight groups (Convos iOS Team,
+    # Convos Team, Friends and Family, XMTP Labs Team) are internal, and Apple
+    # makes a build available to internal testers automatically once it finishes
+    # processing - you cannot (and need not) explicitly attach a build to an
+    # internal group. pilot's groups: option is for external distribution, so
+    # passing internal groups makes it call add_beta_groups and Apple rejects it
+    # ("Cannot add internal group to a build"). skip_submission uploads, waits
+    # for processing, and sets the changelog, but returns before the distribute
+    # step, so no group assignment or beta-review submission is attempted.
     upload_to_testflight(
       ipa: File.join(OUTPUT_DIR, "Convos-Prod-TestFlight.ipa"),
       app_identifier: PROD_BUNDLE_ID,
-      groups: ["Convos iOS Team", "Convos Team", "Friends and Family", "XMTP Labs Team"],
       changelog: testflight_release_notes,
-      distribute_external: false,
-      # All four groups are internal testers, which never go through Apple Beta
-      # App Review. pilot's submit_beta_review defaults to true and fires
-      # whenever groups: is set (independent of distribute_external), so without
-      # this it calls post_beta_app_review_submission and fails with "Another
-      # build in the same train is already in beta review". Internal groups are
-      # still attached to the build regardless of this flag.
-      submit_beta_review: false,
-      skip_waiting_for_build_processing: false,
-      notify_external_testers: false,
+      skip_submission: true,
     )
   end
 


### PR DESCRIPTION
## Problem

Run [26766055881](https://github.com/xmtplabs/convos-ios/actions/runs/26766055881) uploaded and processed build `2.0.0 - 848` successfully, then failed at the final action:

```
[16:07:07]: Distributing new build to testers: 2.0.0 - 848
[16:07:14]: Builds cannot be assigned to this internal group. - Cannot add internal group to a build.
(Spaceship::UnexpectedResponse) — upload_to_testflight, exit 1
```

Stack: `pilot/build_manager.rb:466 distribute_build` → `add_beta_groups_to_build`.

## Root cause

All four prod TestFlight groups (`Convos iOS Team`, `Convos Team`, `Friends and Family`, `XMTP Labs Team`) are **internal**. Two facts about App Store Connect:

1. A build is made available to **internal** testers **automatically** once Apple finishes processing.
2. The ASC API **rejects** any attempt to explicitly attach a build to an internal group — that's the exact error above.

pilot's `groups:` option is designed for **external** distribution (fastlane docs: `groups` is "required when `distribute_external` is set to true"). With `groups:` set, pilot's `distribute_build` calls `add_beta_groups` regardless of `distribute_external: false`, and Apple errors on the internal groups.

This is the third distinct distribute-stage failure in this train, each one line further than the last:
- #931 fixed `submit_beta_review` (beta-review submission for internal groups) →
- this fixes `add_beta_groups` (group assignment for internal groups).

## Fix

For internal-only distribution, don't assign groups at all. Drop `groups:` / `distribute_external:` / `submit_beta_review:` and set **`skip_submission: true`**. pilot then:

- uploads the IPA,
- waits for full processing,
- sets the changelog,
- and **returns before the distribute step** (`distribute` line 193: `return if config[:skip_submission]`), so neither `add_beta_groups` nor `post_beta_app_review_submission` is called.

Internal testers receive the build automatically after processing — no API assignment needed.

## Verification

- `ruby -c fastlane/lanes/release.rb` → Syntax OK.
- `bundle exec fastlane lanes` parses; `testflight_prod` + `firebase_pr` present.
- Confirmed in pilot source (`build_manager.rb`) that `skip_submission: true` returns before `distribute_build`, and that the changelog is set during the processing wait (which the failing log corroborates: "Successfully set the changelog for build" prints *before* "Distributing new build to testers").
- Real verification on merge (auto-trigger on push to `dev`).

## Note on "which group"

Apple's batch `add_beta_groups` call fails if any group in the set is non-attachable, and the API doesn't report which — so the exact offender isn't named in logs. It doesn't matter for the fix: explicit assignment is wrong for *all* internal groups. If you later add an **external** group, it'll need `groups:` + `distribute_external: true` + `submit_beta_review: true` again (and Beta App Review), which can be a separate lane/flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/932"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782925942&installation_id=128169237&pr_number=932&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F932&signature=25418cdf976986134dea537397975ef65552f663742c7dc45baac34dbe6561b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Upload to TestFlight for internal distribution only in `testflight_prod` lane
> Removes group assignment, external distribution, and beta review submission from the `testflight_prod` lane in [release.rb](https://github.com/xmtplabs/convos-ios/pull/932/files#diff-4f4ec77529cea8e5a9f3f871c7e8e4d94bce0e51abff5634400b16b916973e15). Adds `skip_submission: true` so the lane only uploads the IPA and sets the changelog without triggering any distribution flow.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 26b9148.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->