### PR TITLE
fix: switch to Chats tab when tapping a message notification

### DIFF
--- a/Convos/MainTabView.swift
+++ b/Convos/MainTabView.swift
@@ -208,6 +208,17 @@ struct MainTabView: View {
         }
     }
 
+    /// Tapping a message notification selects the conversation in
+    /// `ConversationsViewModel`, but that conversation only lives under the
+    /// Chats tab. Switch to Chats and dismiss any shell-level modal first so
+    /// the user isn't left on the Stuff tab or behind the App Settings sheet
+    /// looking at a corrupted hierarchy.
+    private func handleConversationNotificationTapped() {
+        activeTab = .chats
+        presentingAppSettings = false
+        presentingCommittedConversation = nil
+    }
+
     var body: some View {
         ZStack {
             tabView
@@ -224,6 +235,9 @@ struct MainTabView: View {
             }
             .onReceive(CreditsServices.shared.balancePublisher) { newBalance in
                 creditBalance = newBalance
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .conversationNotificationTapped)) { _ in
+                handleConversationNotificationTapped()
             }
             .sheet(item: $presentingCommittedConversation) { convoVM in
                 committedConversationSheetContent(viewModel: convoVM)


### PR DESCRIPTION
## Problem

Tapping a message notification takes the user to that conversation, but the navigation only selects the conversation in `ConversationsViewModel` — it doesn't switch tabs or dismiss shell-level modals. The selected conversation lives exclusively under the **Chats** tab, so if the user taps a notification while:

- on the **Stuff** tab, or
- with the **App Settings** sheet (or another shell-level sheet) presented,

the conversation becomes active behind the wrong tab / behind a modal, leaving the user stuck in a corrupted view hierarchy.

## Fix

`MainTabView` already owns `activeTab` and the shell-level modal state, so it's the right place to coordinate. Added an `.onReceive` for `.conversationNotificationTapped` (the same notification `ConversationsViewModel` uses to select the conversation) that:

- switches `activeTab` to `.chats`
- dismisses the App Settings sheet (`presentingAppSettings = false`)
- dismisses the committed-conversation sheet (`presentingCommittedConversation = nil`) — the other shell-level blocking modal

This keeps tab/modal state in the view that owns it (rather than threading bindings into the view model) and follows the existing `.onReceive(NotificationCenter.default.publisher(for:))` pattern used elsewhere in the app.

## Testing

- SwiftLint: clean (strict)
- `xcodebuild` for "Convos (Dev)": build succeeds with 0 warnings/errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Switch to Chats tab when tapping a message notification
> Adds a `.onReceive` handler in [MainTabView.swift](https://github.com/xmtplabs/convos-ios/pull/933/files#diff-2b02f95e9fabdce514b1dd6d74d930ca17fcc2380c7504789454c035484e9d67) that listens for `.conversationNotificationTapped` from `NotificationCenter`. When received, it switches the active tab to `.chats` and dismisses any open App Settings or committed conversation sheets.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 724149c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->