### PR TITLE
fix(agent-share): resolve share cards read-through the template cache

### DIFF
--- a/ConvosCore/Sources/ConvosCore/AgentShare/AgentShareResolving.swift
+++ b/ConvosCore/Sources/ConvosCore/AgentShare/AgentShareResolving.swift
@@ -1,4 +1,5 @@
 import Foundation
+import GRDB
 
 /// The public profile of a shared agent template, resolved from an
 /// agent-share link's identifier. Just enough to render a contact card --
@@ -81,18 +82,43 @@ public struct MockAgentShareResolver: AgentShareResolving {
 }
 
 /// Resolves agent-share links against the backend's public template detail
-/// endpoint (`GET /v2/agent-templates/:idOrUrlSlug`) via `ConvosAPIClient`.
+/// endpoint (`GET /v2/agent-templates/:idOrUrlSlug`) via `ConvosAPIClient`,
+/// read-through the `DBAgentTemplate` cache so a card that's already been
+/// seen (here or by the contacts `AgentTemplateCacheCoordinator`) renders
+/// from disk without a network round-trip. Without the cache the message
+/// list re-fetched on every scroll-into-view -- the cell's resolve state is
+/// per-instance and cells recycle -- so the card flashed its "Somebody" /
+/// pulsing-placeholder state each time and stuck there on any fetch failure.
+///
 /// The real resolver `SessionManager` vends in place of `MockAgentShareResolver`.
 public struct ApiAgentShareResolver: AgentShareResolving {
     private let apiClient: any ConvosAPIClientProtocol
+    private let databaseReader: any DatabaseReader
+    private let cacheWriter: any AgentTemplateCacheWriterProtocol
 
-    public init(apiClient: any ConvosAPIClientProtocol) {
+    public init(
+        apiClient: any ConvosAPIClientProtocol,
+        databaseReader: any DatabaseReader,
+        cacheWriter: any AgentTemplateCacheWriterProtocol
+    ) {
         self.apiClient = apiClient
+        self.databaseReader = databaseReader
+        self.cacheWriter = cacheWriter
     }
 
     public func resolve(identifier: String) async -> AgentShareInfo? {
+        if let cached = await cachedInfo(for: identifier) {
+            return cached
+        }
         do {
             let template = try await apiClient.getAgentTemplate(idOrUrlSlug: identifier)
+            do {
+                try await cacheWriter.upsert(template, fetchedAt: Date())
+            } catch {
+                // Non-fatal: the resolve still returns the fetched data, but a
+                // failed write means the next resolve hits the network again.
+                Log.warning("ApiAgentShareResolver failed to cache \(identifier): \(error.localizedDescription)")
+            }
             return AgentShareInfo(
                 templateId: template.id,
                 displayName: template.agentName,
@@ -104,5 +130,31 @@ public struct ApiAgentShareResolver: AgentShareResolving {
             Log.error("ApiAgentShareResolver failed to resolve \(identifier): \(error.localizedDescription)")
             return nil
         }
+    }
+
+    /// The share link's identifier is a template id or a url slug, so the
+    /// cache is matched on either. A hit requires a usable identity (name or
+    /// description present) so a sparse row -- e.g. one written from a publish
+    /// response that carried only id/status -- still falls through to the
+    /// detail fetch rather than rendering an empty card.
+    private func cachedInfo(for identifier: String) async -> AgentShareInfo? {
+        let row: DBAgentTemplate? = try? await databaseReader.read { db in
+            try DBAgentTemplate
+                .filter(
+                    DBAgentTemplate.Columns.templateId == identifier
+                        || DBAgentTemplate.Columns.slug == identifier
+                )
+                .fetchOne(db)
+        }
+        guard let row, row.agentName != nil || row.templateDescription != nil else {
+            return nil
+        }
+        return AgentShareInfo(
+            templateId: row.templateId,
+            displayName: row.agentName,
+            emoji: row.emoji,
+            descriptionText: row.templateDescription,
+            avatarURL: row.avatarURL
+        )
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
@@ -598,7 +598,11 @@ public final class SessionManager: SessionManagerProtocol, @unchecked Sendable {
     }
 
     public func agentShareResolver() -> any AgentShareResolving {
-        ApiAgentShareResolver(apiClient: apiClient)
+        ApiAgentShareResolver(
+            apiClient: apiClient,
+            databaseReader: databaseReader,
+            cacheWriter: AgentTemplateCacheWriter(databaseWriter: databaseWriter)
+        )
     }
 
     public func conversationRepository(for conversationId: String) -> any ConversationRepositoryProtocol {

--- a/ConvosCore/Sources/ConvosCore/Storage/Database Models/DBAgentTemplate.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Database Models/DBAgentTemplate.swift
@@ -21,6 +21,8 @@ struct DBAgentTemplate: Codable, FetchableRecord, PersistableRecord, Hashable, I
         static let emoji: Column = Column(CodingKeys.emoji)
         static let avatarURL: Column = Column(CodingKeys.avatarURL)
         static let publishedURL: Column = Column(CodingKeys.publishedURL)
+        static let templateDescription: Column = Column(CodingKeys.templateDescription)
+        static let slug: Column = Column(CodingKeys.slug)
         static let fetchedAt: Column = Column(CodingKeys.fetchedAt)
     }
 
@@ -31,7 +33,17 @@ struct DBAgentTemplate: Codable, FetchableRecord, PersistableRecord, Hashable, I
     var emoji: String?
     var avatarURL: String?
     var publishedURL: String?
+    var templateDescription: String?
+    var slug: String?
     var fetchedAt: Date
+
+    enum CodingKeys: String, CodingKey {
+        case templateId, agentName, emoji, avatarURL, publishedURL
+        // The cache column is named `description`; the Swift property avoids
+        // that name (it shadows `CustomStringConvertible.description`).
+        case templateDescription = "description"
+        case slug, fetchedAt
+    }
 
     init(
         templateId: String,
@@ -39,6 +51,8 @@ struct DBAgentTemplate: Codable, FetchableRecord, PersistableRecord, Hashable, I
         emoji: String?,
         avatarURL: String?,
         publishedURL: String?,
+        templateDescription: String?,
+        slug: String?,
         fetchedAt: Date
     ) {
         self.templateId = templateId
@@ -46,6 +60,8 @@ struct DBAgentTemplate: Codable, FetchableRecord, PersistableRecord, Hashable, I
         self.emoji = emoji
         self.avatarURL = avatarURL
         self.publishedURL = publishedURL
+        self.templateDescription = templateDescription
+        self.slug = slug
         self.fetchedAt = fetchedAt
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Storage/SharedDatabaseMigrator.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/SharedDatabaseMigrator.swift
@@ -201,6 +201,8 @@ extension SharedDatabaseMigrator {
             migrate: Self.backfillContactAgentTemplateFieldsFromMemberProfiles
         )
 
+        migrator.registerMigration("addAgentTemplateDescriptionAndSlug", migrate: Self.addAgentTemplateDescriptionAndSlug)
+
         return migrator
     }
 
@@ -386,6 +388,25 @@ extension SharedDatabaseMigrator {
             t.column("publishedURL", .text)
             t.column("fetchedAt", .datetime).notNull()
         }
+    }
+
+    /// Adds the `description` and `slug` columns to the agent-template cache.
+    /// The detail endpoint (`GET /v2/agent-templates/:idOrUrlSlug`) returns
+    /// both; storing them lets the agent-share resolver render a card's
+    /// subtitle from cache and look the cache up by slug, not just by template
+    /// id (share links are often slug-keyed). The slug index keeps that
+    /// lookup cheap; it's partial so null slugs (rows cached before this
+    /// migration, until they're refreshed) don't bloat it.
+    private static func addAgentTemplateDescriptionAndSlug(_ db: Database) throws {
+        try db.alter(table: "agentTemplate") { t in
+            t.add(column: "description", .text)
+            t.add(column: "slug", .text)
+        }
+        try db.execute(sql: """
+            CREATE INDEX IF NOT EXISTS agentTemplate_on_slug
+            ON agentTemplate(slug)
+            WHERE slug IS NOT NULL
+            """)
     }
 
     /// Rename `conversation.hasHadVerifiedAssistant` -> `hasHadVerifiedAgent`

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/AgentTemplateCacheWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/AgentTemplateCacheWriter.swift
@@ -22,6 +22,8 @@ final class AgentTemplateCacheWriter: AgentTemplateCacheWriterProtocol {
             emoji: template.emoji,
             avatarURL: template.avatarUrl,
             publishedURL: template.publishedUrl,
+            templateDescription: template.description,
+            slug: template.slug,
             fetchedAt: fetchedAt
         )
         try await databaseWriter.write { db in

--- a/ConvosCore/Tests/ConvosCoreTests/AgentShareURLTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/AgentShareURLTests.swift
@@ -1,5 +1,6 @@
 @testable import ConvosCore
 import Foundation
+import GRDB
 import Testing
 
 @Suite("AgentShareURL parsing")
@@ -95,44 +96,130 @@ struct MockAgentShareResolverTests {
 
 @Suite("ApiAgentShareResolver")
 struct ApiAgentShareResolverTests {
-    @Test("maps the template detail response into AgentShareInfo")
-    func mapsTemplateResponse() async {
-        let api = AgentShareStubAPIClient(
-            template: ConvosAPI.AgentTemplate(
-                id: "17555bf3-f66c-4706-8c35-f2fe6fbe0ef7",
-                status: "published",
-                publishedUrl: "https://agents-dev.convos.org/a/gandalf.felpl",
-                slug: "gandalf",
-                agentName: "Gandalf",
-                description: "The Grey Wizard.",
-                emoji: "🧙",
-                avatarUrl: nil
-            )
+    private let templateId: String = "17555bf3-f66c-4706-8c35-f2fe6fbe0ef7"
+
+    private func makeDatabase() throws -> DatabaseQueue {
+        let dbQueue = try DatabaseQueue()
+        try SharedDatabaseMigrator.shared.migrate(database: dbQueue)
+        return dbQueue
+    }
+
+    private func gandalf(slug: String?) -> ConvosAPI.AgentTemplate {
+        ConvosAPI.AgentTemplate(
+            id: templateId,
+            status: "published",
+            publishedUrl: "https://agents-dev.convos.org/a/gandalf.felpl",
+            slug: slug,
+            agentName: "Gandalf",
+            description: "The Grey Wizard.",
+            emoji: "🧙",
+            avatarUrl: nil
         )
-        let resolver = ApiAgentShareResolver(apiClient: api)
-        let info = await resolver.resolve(identifier: "gandalf.felpl")
-        #expect(info?.templateId == "17555bf3-f66c-4706-8c35-f2fe6fbe0ef7")
+    }
+
+    private func resolver(api: AgentShareStubAPIClient, db: DatabaseQueue) -> ApiAgentShareResolver {
+        ApiAgentShareResolver(
+            apiClient: api,
+            databaseReader: db,
+            cacheWriter: AgentTemplateCacheWriter(databaseWriter: db)
+        )
+    }
+
+    @Test("maps the template detail response into AgentShareInfo")
+    func mapsTemplateResponse() async throws {
+        let db = try makeDatabase()
+        let api = AgentShareStubAPIClient(template: gandalf(slug: "gandalf"))
+        let info = await resolver(api: api, db: db).resolve(identifier: "gandalf.felpl")
+        #expect(info?.templateId == templateId)
         #expect(info?.displayName == "Gandalf")
         #expect(info?.emoji == "🧙")
         #expect(info?.descriptionText == "The Grey Wizard.")
     }
 
     @Test("returns nil when the fetch throws")
-    func nilOnError() async {
-        let resolver = ApiAgentShareResolver(apiClient: AgentShareStubAPIClient(template: nil))
+    func nilOnError() async throws {
+        let db = try makeDatabase()
+        let resolver = resolver(api: AgentShareStubAPIClient(template: nil), db: db)
         let info = await resolver.resolve(identifier: "missing.slug")
         #expect(info == nil)
+    }
+
+    @Test("caches the fetched template so a second resolve skips the network")
+    func cachesAfterFetch() async throws {
+        let db = try makeDatabase()
+        let api = AgentShareStubAPIClient(template: gandalf(slug: "gandalf"))
+        let resolver = resolver(api: api, db: db)
+
+        let first = await resolver.resolve(identifier: templateId)
+        #expect(first?.displayName == "Gandalf")
+        #expect(api.fetchCount == 1)
+
+        let second = await resolver.resolve(identifier: templateId)
+        #expect(second?.displayName == "Gandalf")
+        #expect(second?.descriptionText == "The Grey Wizard.")
+        // Served from the DBAgentTemplate cache, not a second round-trip.
+        #expect(api.fetchCount == 1)
+    }
+
+    @Test("resolves from cache by slug, not just by template id")
+    func cacheHitBySlug() async throws {
+        let db = try makeDatabase()
+        let api = AgentShareStubAPIClient(template: gandalf(slug: "gandalf.felpl"))
+        let resolver = resolver(api: api, db: db)
+
+        // First resolve by slug populates the cache (keyed by the resolved id,
+        // with the slug column stored).
+        _ = await resolver.resolve(identifier: "gandalf.felpl")
+        #expect(api.fetchCount == 1)
+
+        let again = await resolver.resolve(identifier: "gandalf.felpl")
+        #expect(again?.displayName == "Gandalf")
+        #expect(api.fetchCount == 1)
+    }
+
+    @Test("a sparse cached row falls through to the detail fetch")
+    func sparseRowFallsThrough() async throws {
+        let db = try makeDatabase()
+        // Seed a row with no name/description (e.g. from a publish response).
+        try await db.write { database in
+            try DBAgentTemplate(
+                templateId: self.templateId,
+                agentName: nil,
+                emoji: nil,
+                avatarURL: nil,
+                publishedURL: "https://agents-dev.convos.org/a/gandalf.felpl",
+                templateDescription: nil,
+                slug: nil,
+                fetchedAt: Date()
+            ).save(database)
+        }
+        let api = AgentShareStubAPIClient(template: gandalf(slug: "gandalf"))
+        let resolver = resolver(api: api, db: db)
+
+        let info = await resolver.resolve(identifier: templateId)
+        #expect(info?.displayName == "Gandalf")
+        // The sparse row didn't satisfy the read, so the detail endpoint ran.
+        #expect(api.fetchCount == 1)
     }
 }
 
 /// Returns a fixed template (or throws `notFound` when nil) for the
-/// agent-share detail fetch. Every other `ConvosAPIClientProtocol` requirement
-/// is satisfied by the shared `TestStubAPIClientDefaults` no-op extension.
+/// agent-share detail fetch, counting calls so cache hits can be asserted.
+/// Every other `ConvosAPIClientProtocol` requirement is satisfied by the
+/// shared `TestStubAPIClientDefaults` no-op extension.
 private final class AgentShareStubAPIClient: TestStubAPIClient, @unchecked Sendable {
     private let template: ConvosAPI.AgentTemplate?
+    private let fetchCountLock: NSLock = NSLock()
+    private var _fetchCount: Int = 0
+
+    var fetchCount: Int {
+        fetchCountLock.withLock { _fetchCount }
+    }
+
     init(template: ConvosAPI.AgentTemplate?) { self.template = template }
 
     override func getAgentTemplate(idOrUrlSlug: String) async throws -> ConvosAPI.AgentTemplate {
+        fetchCountLock.withLock { _fetchCount += 1 }
         guard let template else { throw APIError.notFound }
         return template
     }

--- a/ConvosCore/Tests/ConvosCoreTests/ContactsRepositoryTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ContactsRepositoryTests.swift
@@ -253,6 +253,8 @@ struct ContactsRepositoryTests {
                 emoji: "✈️",
                 avatarURL: nil,
                 publishedURL: "https://convos.org/a/travel",
+                templateDescription: nil,
+                slug: nil,
                 fetchedAt: Date()
             ).save(db)
         }


### PR DESCRIPTION
Agent contact-card cells in the message list resolved via
ApiAgentShareResolver, which hit GET /v2/agent-templates/:id directly on
every resolve and never touched the DBAgentTemplate read-through cache
from PR 930. The cell's resolve state is per-instance and cells recycle,
so each scroll-into-view spawned a fresh network round-trip and rendered
the placeholder state ("Somebody" + the pulsing "Learning more about my
job" subtitle) until it returned -- sticking there permanently on any
fetch failure. That placeholder is the agent-builder resolving state and
should never be the resting state of a share card.

Route resolution through the cache:
- Add `description` and `slug` columns to the agentTemplate cache (the
  detail endpoint returns both; the cache stored neither, so it couldn't
  back a card subtitle or a slug-keyed lookup). Partial slug index.
- AgentTemplateCacheWriter persists them, so the contacts
  AgentTemplateCacheCoordinator fills them too -- one shared cache.
- ApiAgentShareResolver reads the cache first (matched on template id or
  slug; a sparse row falls through to the fetch), and upserts on a miss.
  A previously-seen card, or any agent already in contacts, renders from
  disk with no round-trip.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/934"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782930856&installation_id=128169237&pr_number=934&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F934&signature=537098bbf5acb8c25f128580991076a002cdc5dd57fa9ad15529cc123fa901bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add read-through caching to `ApiAgentShareResolver` for agent share cards
> - `ApiAgentShareResolver` now checks the local `DBAgentTemplate` cache before making a network request, returning cached `AgentShareInfo` when a matching row with a name or description exists.
> - On a cache miss, the API result is written back to the cache via `AgentTemplateCacheWriter`; a write failure logs a warning but does not block the response.
> - Adds `description` and `slug` columns to the `agentTemplate` table via a new GRDB migration, with a partial index on `slug` for efficient lookups.
> - `SessionManager.agentShareResolver()` is updated to wire the database reader and writer into the resolver.
> - Behavioral Change: agent share resolution now performs a DB read on every call before any network fetch.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2bac253.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->