### PR TITLE
Optimistic pending-agent identity for template chats

### DIFF
--- a/Convos/Contacts/Contact+SyntheticAgentMember.swift
+++ b/Convos/Contacts/Contact+SyntheticAgentMember.swift
@@ -1,0 +1,63 @@
+import ConvosCore
+import Foundation
+
+extension AgentShareInfo {
+    /// Sentinel inbox id for the optimistic agent card member. Built from the
+    /// template id so it never collides with a real member's inbox id, and so
+    /// the "real verified agent joined" checks can recognize and ignore it.
+    func optimisticAgentInboxId() -> String {
+        "optimistic-agent-\(templateId ?? "pending")"
+    }
+
+    /// Builds a presentation-only `ConversationMember` from this agent-share
+    /// profile, scoped to the supplied draft `conversationId`. Used by
+    /// `ConversationViewModel` to feed the messages-list repository's
+    /// `verifiedAgent` so the existing processor synthesizes the agent
+    /// contact card before the real agent has joined `conversation.members`.
+    ///
+    /// This member is a card vehicle only -- it is handed to the repository,
+    /// never inserted into `conversation.members`, and it carries the
+    /// `optimisticAgentInboxId()` sentinel so it is easy to tell apart from a
+    /// real member. The emoji and description live in `Profile.metadata`
+    /// (matching how a real agent profile carries them), and the verification
+    /// is forced to `.verified(.convos)` so the card renders with the verified
+    /// styling for the duration of the optimistic window.
+    func optimisticCardMember(conversationId: String) -> ConversationMember {
+        var metadata: ProfileMetadata = [:]
+        if let emoji, !emoji.isEmpty {
+            metadata["emoji"] = .string(emoji)
+        }
+        if let descriptionText, !descriptionText.isEmpty {
+            metadata["description"] = .string(descriptionText)
+        }
+        let profile = Profile(
+            inboxId: optimisticAgentInboxId(),
+            conversationId: conversationId,
+            name: displayName,
+            avatar: avatarURL,
+            isAgent: true,
+            metadata: metadata.isEmpty ? nil : metadata
+        )
+        return ConversationMember(
+            profile: profile,
+            role: .member,
+            isCurrentUser: false,
+            isAgent: true,
+            agentVerification: .verified(.convos)
+        )
+    }
+
+    /// Neutral placeholder identity for the agent-template deep link, where
+    /// only the template id is known at creation time. Paints a generic
+    /// "Joining..." agent (no name or emoji) until the async resolve returns
+    /// the real profile and upgrades it in place.
+    static func neutralPendingAgent(templateId: String) -> AgentShareInfo {
+        AgentShareInfo(
+            templateId: templateId,
+            displayName: nil,
+            emoji: nil,
+            descriptionText: nil,
+            avatarURL: nil
+        )
+    }
+}

--- a/Convos/Contacts/ContactDetailView.swift
+++ b/Convos/Contacts/ContactDetailView.swift
@@ -481,9 +481,19 @@ struct ContactDetailView: View {
 
     private func confirmChatWithAgentTemplate() {
         guard let session, let templateId = contact.agentTemplateId else { return }
+        // The contact card already has the agent's identity in hand, so paint
+        // it optimistically while the conversation provisions and the agent
+        // joins -- no async resolve needed.
+        let optimisticIdentity = AgentShareInfo(
+            templateId: templateId,
+            displayName: contact.displayName,
+            emoji: contact.profileEmoji,
+            descriptionText: nil,
+            avatarURL: contact.avatarURL
+        )
         presentingNewConvo = NewConversationViewModel(
             session: session,
-            mode: .newConversationWithTemplate(templateId: templateId)
+            mode: .newConversationWithTemplate(templateId: templateId, optimisticIdentity: optimisticIdentity)
         )
     }
 

--- a/Convos/Conversation Creation/NewConversationViewModel.swift
+++ b/Convos/Conversation Creation/NewConversationViewModel.swift
@@ -49,8 +49,15 @@ enum NewConversationMode {
     /// Same instant-placeholder flow as `.newConversation`; once the
     /// conversation reaches `.ready`, a fresh instance of the given
     /// agent template is requested into it. Used by the agent-template
-    /// deeplink (`convos://template/<id>`).
-    case newConversationWithTemplate(templateId: String)
+    /// deeplink (`convos://template/<id>`) and the "Chat" action on an
+    /// agent contact card.
+    ///
+    /// `optimisticIdentity` paints the upcoming agent (name + emoji/photo,
+    /// verified styling, "Joining..." subtitle, contact card) from the moment
+    /// the sheet opens. The contact-card path passes the in-hand identity; the
+    /// deep link passes `nil` (only the template id is known) and the identity
+    /// is resolved asynchronously and upgraded in place.
+    case newConversationWithTemplate(templateId: String, optimisticIdentity: AgentShareInfo?)
     case scanner
     case joinInvite(code: String)
 }
@@ -65,6 +72,12 @@ class NewConversationViewModel: Identifiable, Hashable {
         didSet {
             conversationViewModel?.allowsContactCard = !suppressesContactCard
             conversationViewModel?.isInAgentBuilderFlow = isInAgentBuilderFlow
+            // Re-arm the optimistic agent overlay on every VM we vend so it
+            // survives the placeholder -> real-conversation swap (mirrors
+            // `suppressesContactCard` / `isInAgentBuilderFlow` above).
+            if isOptimisticAgentMode {
+                conversationViewModel?.activateOptimisticAgent(identity: optimisticAgentIdentity)
+            }
         }
     }
     /// When `true`, every `conversationViewModel` we vend (the initial
@@ -186,6 +199,22 @@ class NewConversationViewModel: Identifiable, Hashable {
     /// agent join twice.
     @ObservationIgnored
     private var didTriggerAgentJoin: Bool = false
+    /// Set for `.newConversationWithTemplate`. Drives the optimistic
+    /// pending-agent identity painted on every inner `conversationViewModel`
+    /// (indicator + contact card) before the real agent joins.
+    @ObservationIgnored
+    private var isOptimisticAgentMode: Bool = false
+    /// The optimistic agent identity forwarded to each inner VM. Starts as the
+    /// caller-supplied identity (contact-card path) or a neutral placeholder
+    /// (deep link); upgraded by `resolveOptimisticAgentIdentityIfNeeded`.
+    @ObservationIgnored
+    private var optimisticAgentIdentity: AgentShareInfo?
+    /// `true` when this VM must resolve the optimistic identity itself (the
+    /// deep-link path supplied only a template id).
+    @ObservationIgnored
+    private var resolvesOptimisticAgentIdentity: Bool = false
+    @ObservationIgnored
+    private var optimisticAgentResolveTask: Task<Void, Never>?
     @ObservationIgnored
     nonisolated(unsafe) private var _reachedReadyState: Bool = false
     @ObservationIgnored
@@ -218,8 +247,11 @@ class NewConversationViewModel: Identifiable, Hashable {
         self.session = session
         self.qrScannerViewModel = QRScannerViewModel()
 
-        if case .newConversationWithTemplate(let templateId) = mode {
+        if case .newConversationWithTemplate(let templateId, let optimisticIdentity) = mode {
             self.pendingAgentTemplateId = templateId
+            self.isOptimisticAgentMode = true
+            self.optimisticAgentIdentity = optimisticIdentity ?? .neutralPendingAgent(templateId: templateId)
+            self.resolvesOptimisticAgentIdentity = (optimisticIdentity == nil)
         }
         if case .newConversationWithMembers(_, let agentTemplateId) = mode, let agentTemplateId {
             self.pendingAgentTemplateId = agentTemplateId
@@ -261,6 +293,22 @@ class NewConversationViewModel: Identifiable, Hashable {
         self.isCreatingConversation = mode.isNewConversation
         createPlaceholderConversationViewModel()
         acquireInbox(mode: mode)
+        resolveOptimisticAgentIdentityIfNeeded()
+    }
+
+    /// Resolve the optimistic agent identity for the deep-link path, where
+    /// only a template id is known at creation time. The neutral placeholder
+    /// is already painted; this upgrades it in place once the resolver
+    /// returns the real name + emoji/photo.
+    private func resolveOptimisticAgentIdentityIfNeeded() {
+        guard resolvesOptimisticAgentIdentity, let templateId = pendingAgentTemplateId else { return }
+        let resolver = session.agentShareResolver()
+        optimisticAgentResolveTask = Task { [weak self] in
+            let info = await resolver.resolve(identifier: templateId)
+            guard let self, let info else { return }
+            self.optimisticAgentIdentity = info
+            self.conversationViewModel?.applyOptimisticAgentIdentity(info)
+        }
     }
 
     internal init(
@@ -296,6 +344,7 @@ class NewConversationViewModel: Identifiable, Hashable {
         joinConversationTask?.cancel()
         resetTask?.cancel()
         stateObservationTask?.cancel()
+        optimisticAgentResolveTask?.cancel()
     }
 
     func cleanUpIfNeeded() {

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -193,8 +193,32 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
     /// `cutoffDate`) elapses without a verified agent joining. Stops the
     /// optimistic Convos-verified placeholder from lingering forever on an
     /// agent that joined but never published attestation -- see
-    /// `shouldRenderAsPendingAgent`.
+    /// `shouldRenderAsPendingAgentBuilder`.
     private var agentBuilderPlaceholderExpired: Bool = false
+
+    /// The agent identity an agent-template flow asked us to paint
+    /// optimistically before the real verified agent joins -- the template
+    /// name + emoji/photo for the "Chat on a contact" path, or a neutral
+    /// placeholder (upgraded in place once the resolve returns) for the
+    /// `convos://template/<id>` deep link. Lives on the view model (not the
+    /// `Conversation` value) so it survives the draft -> real conversation
+    /// swap. Drives the "with identity" case of `pendingAgentPresentation`.
+    private(set) var optimisticAgentIdentity: AgentShareInfo?
+
+    /// `true` once an agent-template flow activates the optimistic overlay.
+    /// Mirrors the agent-builder placeholder machinery: time-boxed via
+    /// `optimisticAgentExpired` so a join that never lands doesn't leave a
+    /// permanent fake-verified agent.
+    private var optimisticAgentActive: Bool = false
+
+    /// Flips `true` when the optimistic-agent window
+    /// (`AgentBuilderPlaceholder.displayDuration` after activation) elapses
+    /// without a real verified agent joining, dropping the optimistic
+    /// presentation so the conversation falls back to its real identity.
+    private var optimisticAgentExpired: Bool = false
+
+    @ObservationIgnored
+    private var optimisticAgentExpiryTask: Task<Void, Never>?
 
     // MARK: - Private
 
@@ -328,9 +352,63 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
     /// Forwards the verified Convos agent from the conversation members
     /// to the messages-list repository — gated by `allowsContactCard` so the
     /// caller can defer the card without changing the underlying conversation.
+    ///
+    /// When no real verified agent has joined yet but an agent-template flow
+    /// is painting an optimistic identity (and that identity has enough to
+    /// render a card), feed a presentation-only synthetic agent member so the
+    /// processor synthesizes the contact card immediately. The synthetic
+    /// member is only ever handed to the repository here -- it is never
+    /// inserted into `conversation.members`.
     private func syncVerifiedAgentToRepo() {
-        let agent: ConversationMember? = conversation.members.first(where: \.isVerifiedConvosAgent)
+        let realAgent: ConversationMember? = conversation.members.first(where: \.isVerifiedConvosAgent)
+        let agent: ConversationMember?
+        if let realAgent {
+            agent = realAgent
+        } else if let presentation = pendingAgentPresentation,
+                  presentation.showsContactCard,
+                  let identity = optimisticAgentIdentity {
+            agent = identity.optimisticCardMember(conversationId: conversation.id)
+        } else {
+            agent = nil
+        }
         messagesListRepository.verifiedAgent = allowsContactCard ? agent : nil
+    }
+
+    /// Activate the optimistic agent overlay for an agent-template flow.
+    /// Idempotent: calling again only refreshes the identity (so a deep-link
+    /// resolve can upgrade the placeholder in place) without restarting the
+    /// time-box. The window mirrors the agent-builder placeholder so a join
+    /// that never lands eventually drops the optimistic styling rather than
+    /// reading an unverified (or absent) agent as a verified Convos one.
+    func activateOptimisticAgent(identity: AgentShareInfo?) {
+        optimisticAgentIdentity = identity
+        guard !optimisticAgentActive else {
+            syncVerifiedAgentToRepo()
+            return
+        }
+        optimisticAgentActive = true
+        optimisticAgentExpired = false
+        syncVerifiedAgentToRepo()
+        optimisticAgentExpiryTask?.cancel()
+        optimisticAgentExpiryTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .seconds(AgentBuilderPlaceholder.displayDuration))
+            guard !Task.isCancelled else { return }
+            self?.optimisticAgentExpired = true
+            self?.syncVerifiedAgentToRepo()
+        }
+    }
+
+    /// Upgrade the optimistic identity in place once the agent-template deep
+    /// link's async resolve returns the real profile. Keeps the running
+    /// time-box; the computed `pendingAgentPresentation` and the repo card
+    /// refresh from the new identity.
+    func applyOptimisticAgentIdentity(_ info: AgentShareInfo) {
+        guard optimisticAgentActive else {
+            activateOptimisticAgent(identity: info)
+            return
+        }
+        optimisticAgentIdentity = info
+        syncVerifiedAgentToRepo()
     }
 
     private func applyPendingDraftEdits() {
@@ -359,22 +437,66 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
         }
     }
     var untitledConversationPlaceholder: String {
-        if shouldRenderAsPendingAgent {
-            return "Agent"
+        if let presentation = pendingAgentPresentation {
+            return presentation.name ?? "Agent"
         }
         return conversation.computedDisplayName(memberNameOverride: contactNameLookup)
     }
 
-    /// `true` while the conversation is in (or was created via) the agent
-    /// builder UX and no verified agent has joined yet. Surfaces a
-    /// stand-in identity for the indicator — "Agent" placeholder name
-    /// and the Convos-verified monogram avatar via `forcedAgentVerification`
-    /// — so the chat header doesn't fall back to the generic "New Convo"
-    /// label + emoji circle while the agent is still provisioning. Flips
-    /// false the moment the verified agent actually appears in
-    /// `conversation.members`, at which point the regular member-driven
-    /// avatar / display name path takes over naturally.
+    /// Unified optimistic pending-agent rendering for the indicator and the
+    /// contact card. `nil` when the conversation should render normally.
+    ///
+    /// The agent-template flows ("Chat on a contact" + the
+    /// `convos://template/<id>` deep link) take priority and supply the real
+    /// identity (`showsContactCard == true`). The Agent Builder is the
+    /// generic "no identity" case (`name`/`emoji` nil, `showsContactCard
+    /// == false`) -- it keeps its own gating in
+    /// `shouldRenderAsPendingAgentBuilder` and its own summary card. Both
+    /// drop the moment a real verified Convos agent joins
+    /// `conversation.members`, and both are time-boxed as a backstop.
+    var pendingAgentPresentation: PendingAgentPresentation? {
+        let hasRealVerifiedAgent: Bool = conversation.members.contains(where: \.isVerifiedConvosAgent)
+        if optimisticAgentActive, !optimisticAgentExpired, !hasRealVerifiedAgent {
+            let identity = optimisticAgentIdentity
+            let hasIdentity: Bool = (identity?.displayName?.isEmpty == false) || (identity?.emoji?.isEmpty == false)
+            return PendingAgentPresentation(
+                name: identity?.displayName,
+                emoji: identity?.emoji,
+                avatarURL: identity?.avatarURL,
+                agentDescription: identity?.descriptionText,
+                showsContactCard: hasIdentity
+            )
+        }
+        if shouldRenderAsPendingAgentBuilder {
+            return PendingAgentPresentation(
+                name: nil,
+                emoji: nil,
+                avatarURL: nil,
+                agentDescription: nil,
+                showsContactCard: false
+            )
+        }
+        return nil
+    }
+
+    /// `true` while the conversation should show any optimistic pending-agent
+    /// rendering (builder or template). Kept as the indicator's
+    /// `forcedAgentVerification` gate (see `MainTabView` /
+    /// `ConversationPresenter`).
     var shouldRenderAsPendingAgent: Bool {
+        pendingAgentPresentation != nil
+    }
+
+    /// `true` while the conversation is in (or was created via) the agent
+    /// builder UX and no verified agent has joined yet. The generic "no
+    /// identity" input to `pendingAgentPresentation` — surfaces the "New
+    /// Agent" / "Agent" placeholder name and the add-agent glyph via
+    /// `forcedAgentVerification` so the chat header doesn't fall back to the
+    /// generic "New Convo" label + emoji circle while the agent is still
+    /// provisioning. Flips false the moment the verified agent actually
+    /// appears in `conversation.members`, at which point the regular
+    /// member-driven avatar / display name path takes over naturally.
+    var shouldRenderAsPendingAgentBuilder: Bool {
         guard isInAgentBuilderFlow || agentBuilderSummary != nil else { return false }
         // Pre-commit: while drafting in the builder (no summary yet), always
         // show the generic agent placeholder -- even if a verified agent has
@@ -465,7 +587,13 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
     }
 
     var conversationName: String {
-        isEditingConversationName ? editingConversationName : conversation.computedDisplayName(memberNameOverride: contactNameLookup)
+        if isEditingConversationName {
+            return editingConversationName
+        }
+        if let presentation = pendingAgentPresentation {
+            return presentation.name ?? "New Agent"
+        }
+        return conversation.computedDisplayName(memberNameOverride: contactNameLookup)
     }
 
     var conversationDescription: String {
@@ -2704,15 +2832,17 @@ extension ConversationViewModel {
             let info = await resolver.resolve(identifier: identifier)
             await MainActor.run {
                 guard let self, let templateId = info?.templateId else { return }
-                self.openAgentTemplate(templateId: templateId)
+                // The web-slug resolve already returned the agent's profile;
+                // pass it through so the new conversation paints it optimistically.
+                self.openAgentTemplate(templateId: templateId, optimisticIdentity: info)
             }
         }
     }
 
-    private func openAgentTemplate(templateId: String) {
+    private func openAgentTemplate(templateId: String, optimisticIdentity: AgentShareInfo? = nil) {
         presentingNewConversationForAgentShare = NewConversationViewModel(
             session: session,
-            mode: .newConversationWithTemplate(templateId: templateId)
+            mode: .newConversationWithTemplate(templateId: templateId, optimisticIdentity: optimisticIdentity)
         )
     }
 

--- a/Convos/Conversation Detail/PendingAgentPresentation.swift
+++ b/Convos/Conversation Detail/PendingAgentPresentation.swift
@@ -1,0 +1,63 @@
+import ConvosCore
+import SwiftUI
+
+/// Identity-aware description of the optimistic "pending agent" rendering a
+/// conversation should show before its verified agent has actually joined.
+///
+/// Two flows produce one of these and every indicator render site consumes
+/// it (see `ConversationViewModel.pendingAgentPresentation`):
+///
+/// - Agent Builder: the "no identity" case. The builder has no real agent
+///   identity at Make time, so it emits a generic presentation (`name` /
+///   `emoji` nil -> "New Agent" + the add-agent glyph) and shows its own
+///   summary card rather than a contact card (`showsContactCard == false`).
+/// - Agent template (chat-on-a-contact or `convos://template/<id>` deep
+///   link): the "with identity" case. The template name + emoji/photo are
+///   painted immediately with verified styling, and the agent contact card is
+///   shown in the messages list (`showsContactCard == true`).
+struct PendingAgentPresentation: Equatable {
+    /// `nil` falls back to the generic "New Agent" / "Agent" placeholder.
+    var name: String?
+    /// `nil` falls back to the add-agent glyph (`PendingAgentAvatarView`).
+    var emoji: String?
+    var avatarURL: String?
+    var agentDescription: String?
+    /// The builder uses its own summary card, so it sets this `false`; the
+    /// template paths show the agent contact card once an identity exists.
+    var showsContactCard: Bool
+}
+
+/// Avatar-only slice of a `PendingAgentPresentation`, injected into the
+/// SwiftUI environment so `ConversationAvatarView` can paint the upcoming
+/// agent's emoji/photo (with verified styling) before any real member data
+/// exists. `nil` (or a content-less value) means fall back to the add-agent
+/// glyph driven by `forcedAgentVerification`.
+struct PendingAgentAvatarIdentity: Equatable {
+    let emoji: String?
+    let avatarURL: String?
+
+    var hasContent: Bool {
+        (emoji?.isEmpty == false) || (avatarURL?.isEmpty == false)
+    }
+}
+
+private struct PendingAgentAvatarIdentityKey: EnvironmentKey {
+    static let defaultValue: PendingAgentAvatarIdentity? = nil
+}
+
+extension EnvironmentValues {
+    var pendingAgentIdentity: PendingAgentAvatarIdentity? {
+        get { self[PendingAgentAvatarIdentityKey.self] }
+        set { self[PendingAgentAvatarIdentityKey.self] = newValue }
+    }
+}
+
+extension PendingAgentPresentation {
+    /// The avatar-environment value for this presentation, or `nil` when the
+    /// presentation carries no emoji/photo (builder generic case + neutral
+    /// deep-link placeholder) so the add-agent glyph shows instead.
+    var avatarIdentity: PendingAgentAvatarIdentity? {
+        let identity = PendingAgentAvatarIdentity(emoji: emoji, avatarURL: avatarURL)
+        return identity.hasContent ? identity : nil
+    }
+}

--- a/Convos/Conversations List/ConversationsViewModel.swift
+++ b/Convos/Conversations List/ConversationsViewModel.swift
@@ -462,7 +462,9 @@ final class ConversationsViewModel {
     private func startConversation(withAgentTemplateId templateId: String) {
         newConversationViewModel = NewConversationViewModel(
             session: session,
-            mode: .newConversationWithTemplate(templateId: templateId)
+            // Deep link knows only the template id; the optimistic identity is
+            // resolved asynchronously inside NewConversationViewModel.
+            mode: .newConversationWithTemplate(templateId: templateId, optimisticIdentity: nil)
         )
     }
 

--- a/Convos/MainTabView.swift
+++ b/Convos/MainTabView.swift
@@ -504,6 +504,7 @@ struct MainTabView: View {
         let pendingAgentOverride: AgentVerification? = convoVM.shouldRenderAsPendingAgent
             ? .verified(.convos)
             : nil
+        let pendingAgentIdentity: PendingAgentAvatarIdentity? = convoVM.pendingAgentPresentation?.avatarIdentity
         let isReadOnly: Bool = conversationsViewModel.staleDeviceObserver.isDeviceRemoved
         HStack {
             ConversationIndicatorWrapper(
@@ -515,6 +516,7 @@ struct MainTabView: View {
                 focusCoordinator: liftedIndicatorFocusCoordinator
             )
             .environment(\.forcedAgentVerification, pendingAgentOverride)
+            .environment(\.pendingAgentIdentity, pendingAgentIdentity)
             .hoverEffect(.lift)
             .disabled(isReadOnly)
             .matchedGeometryEffect(

--- a/Convos/Shared Views/AvatarView.swift
+++ b/Convos/Shared Views/AvatarView.swift
@@ -81,6 +81,7 @@ struct ConversationAvatarView: View {
     let conversationImage: UIImage?
 
     @Environment(\.forcedAgentVerification) private var forcedVerification: AgentVerification?
+    @Environment(\.pendingAgentIdentity) private var pendingAgentIdentity: PendingAgentAvatarIdentity?
     @State private var cachedImage: UIImage?
     @Environment(\.memberNameOverride) private var memberNameOverride: @Sendable (String) -> String?
 
@@ -90,7 +91,14 @@ struct ConversationAvatarView: View {
 
     var body: some View {
         Group {
-            if hasForcedAgentStyle {
+            if let pendingAgentIdentity, pendingAgentIdentity.hasContent {
+                // An agent-template flow painted an upcoming identity before
+                // the real verified agent joined (see
+                // `ConversationViewModel.pendingAgentPresentation`). Render its
+                // emoji/photo with verified styling so the indicator advertises
+                // the agent the conversation is about to have.
+                pendingAgentIdentityAvatar(pendingAgentIdentity)
+            } else if hasForcedAgentStyle {
                 // The forced-agent style is set by the Agent Builder's
                 // conversation indicator before the user taps Make
                 // (see `MainTabView.centeredConversationIndicator`). The
@@ -112,6 +120,25 @@ struct ConversationAvatarView: View {
         .aspectRatio(1.0, contentMode: .fit)
         .clipShape(Circle())
         .cachedImage(for: conversation, into: $cachedImage)
+    }
+
+    @ViewBuilder
+    private func pendingAgentIdentityAvatar(_ identity: PendingAgentAvatarIdentity) -> some View {
+        if let emoji = identity.emoji, !emoji.isEmpty {
+            EmojiAvatarView(emoji: emoji, agentVerification: .verified(.convos))
+        } else if let urlString = identity.avatarURL, let url = URL(string: urlString) {
+            AsyncImage(url: url) { phase in
+                if case .success(let image) = phase {
+                    image
+                        .resizable()
+                        .scaledToFill()
+                } else {
+                    PendingAgentAvatarView()
+                }
+            }
+        } else {
+            PendingAgentAvatarView()
+        }
     }
 
     @ViewBuilder

--- a/Convos/Shared Views/ConversationPresenter.swift
+++ b/Convos/Shared Views/ConversationPresenter.swift
@@ -146,6 +146,7 @@ struct ConversationPresenter<Content: View>: View {
         let pendingAgentOverride: AgentVerification? = viewModel.shouldRenderAsPendingAgent
             ? .verified(.convos)
             : nil
+        let pendingAgentIdentity: PendingAgentAvatarIdentity? = viewModel.pendingAgentPresentation?.avatarIdentity
         ConversationIndicatorWrapper(
             viewModel: viewModel,
             placeholderOverride: indicatorPlaceholderOverride,
@@ -155,6 +156,7 @@ struct ConversationPresenter<Content: View>: View {
             focusCoordinator: focusCoordinator
         )
         .environment(\.forcedAgentVerification, pendingAgentOverride)
+        .environment(\.pendingAgentIdentity, pendingAgentIdentity)
         .hoverEffect(.lift)
         .disabled(isReadOnly)
         .matchedGeometryEffect(

--- a/ConvosTests/PendingAgentPresentationTests.swift
+++ b/ConvosTests/PendingAgentPresentationTests.swift
@@ -1,0 +1,140 @@
+@testable import Convos
+import ConvosCore
+import XCTest
+
+/// Coverage for the unified optimistic pending-agent identity: the
+/// `AgentShareInfo.optimisticCardMember` card vehicle and
+/// `ConversationViewModel.pendingAgentPresentation` (generic builder case vs
+/// identity-aware template case, plus the deep-link upgrade and the
+/// real-agent teardown).
+@MainActor
+final class PendingAgentPresentationTests: XCTestCase {
+    // MARK: - optimisticCardMember
+
+    func testOptimisticCardMemberCarriesIdentityAndVerification() {
+        let info = AgentShareInfo(
+            templateId: "tid-123",
+            displayName: "Tifoso",
+            emoji: "🚴",
+            descriptionText: "Plans your rides",
+            avatarURL: "https://example.com/a.png"
+        )
+
+        let member = info.optimisticCardMember(conversationId: "conv-1")
+
+        XCTAssertEqual(member.profile.inboxId, "optimistic-agent-tid-123",
+                       "Sentinel inbox id should be derived from the template id")
+        XCTAssertEqual(member.profile.conversationId, "conv-1")
+        XCTAssertTrue(member.isAgent)
+        XCTAssertTrue(member.isVerifiedConvosAgent,
+                      "Optimistic card member should render with verified Convos styling")
+        XCTAssertEqual(member.profile.name, "Tifoso")
+        XCTAssertEqual(member.profile.profileEmoji, "🚴")
+        XCTAssertEqual(member.profile.agentDescription, "Plans your rides")
+    }
+
+    func testNeutralPendingAgentHasNoIdentity() {
+        let member = AgentShareInfo.neutralPendingAgent(templateId: "tid-9").optimisticCardMember(conversationId: "c")
+
+        XCTAssertEqual(member.profile.inboxId, "optimistic-agent-tid-9")
+        XCTAssertNil(member.profile.name)
+        XCTAssertNil(member.profile.profileEmoji)
+        XCTAssertNil(member.profile.agentDescription)
+        XCTAssertTrue(member.isVerifiedConvosAgent)
+    }
+
+    // MARK: - pendingAgentPresentation
+
+    func testNoPresentationWhenNotPending() {
+        let viewModel = makeViewModel()
+
+        XCTAssertNil(viewModel.pendingAgentPresentation)
+        XCTAssertFalse(viewModel.shouldRenderAsPendingAgent)
+    }
+
+    func testTemplateIdentityPresentation() {
+        let viewModel = makeViewModel()
+        viewModel.activateOptimisticAgent(identity: AgentShareInfo(
+            templateId: "tid",
+            displayName: "Tifoso",
+            emoji: "🚴",
+            descriptionText: "Plans your rides",
+            avatarURL: nil
+        ))
+
+        let presentation = viewModel.pendingAgentPresentation
+        XCTAssertEqual(presentation?.name, "Tifoso")
+        XCTAssertEqual(presentation?.emoji, "🚴")
+        XCTAssertEqual(presentation?.showsContactCard, true)
+        XCTAssertEqual(presentation?.avatarIdentity?.emoji, "🚴")
+
+        XCTAssertEqual(viewModel.conversationName, "Tifoso")
+        XCTAssertEqual(viewModel.untitledConversationPlaceholder, "Tifoso")
+        XCTAssertEqual(viewModel.conversationInfoSubtitle, "Joining...")
+    }
+
+    func testNeutralPresentationHidesContactCard() {
+        let viewModel = makeViewModel()
+        viewModel.activateOptimisticAgent(identity: .neutralPendingAgent(templateId: "tid"))
+
+        let presentation = viewModel.pendingAgentPresentation
+        XCTAssertNotNil(presentation, "Neutral deep-link placeholder still renders as pending")
+        XCTAssertNil(presentation?.name)
+        XCTAssertEqual(presentation?.showsContactCard, false,
+                       "No contact card until an identity (name/emoji) exists")
+        XCTAssertNil(presentation?.avatarIdentity,
+                     "No avatar identity -> falls back to the add-agent glyph")
+        XCTAssertEqual(viewModel.untitledConversationPlaceholder, "Agent")
+        XCTAssertEqual(viewModel.conversationInfoSubtitle, "Joining...")
+    }
+
+    func testDeepLinkIdentityUpgradesInPlace() {
+        let viewModel = makeViewModel()
+        viewModel.activateOptimisticAgent(identity: .neutralPendingAgent(templateId: "tid"))
+        XCTAssertEqual(viewModel.pendingAgentPresentation?.showsContactCard, false)
+
+        viewModel.applyOptimisticAgentIdentity(AgentShareInfo(
+            templateId: "tid",
+            displayName: "Sous",
+            emoji: "🍳",
+            descriptionText: nil,
+            avatarURL: nil
+        ))
+
+        XCTAssertEqual(viewModel.pendingAgentPresentation?.name, "Sous")
+        XCTAssertEqual(viewModel.pendingAgentPresentation?.emoji, "🍳")
+        XCTAssertEqual(viewModel.pendingAgentPresentation?.showsContactCard, true)
+    }
+
+    func testRealVerifiedAgentDropsOptimisticPresentation() {
+        let members: [ConversationMember] = [
+            .mock(isCurrentUser: true),
+            .mock(isAgent: true, agentVerification: .verified(.convos))
+        ]
+        let viewModel = makeViewModel(conversation: .mock(id: "test-convo", name: nil, members: members))
+        viewModel.activateOptimisticAgent(identity: AgentShareInfo(
+            templateId: "tid",
+            displayName: "Tifoso",
+            emoji: "🚴",
+            descriptionText: nil,
+            avatarURL: nil
+        ))
+
+        XCTAssertNil(viewModel.pendingAgentPresentation,
+                     "A real verified Convos agent in members wins over the optimistic identity")
+        XCTAssertFalse(viewModel.shouldRenderAsPendingAgent)
+    }
+
+    // MARK: - Helpers
+
+    private func makeViewModel(
+        conversation: Conversation = .mock(id: "test-convo", name: nil, members: [.mock(isCurrentUser: true)])
+    ) -> ConversationViewModel {
+        ConversationViewModel(
+            conversation: conversation,
+            session: MockInboxesService(),
+            messagingService: MockMessagingService(),
+            applyGlobalDefaultsForNewConversation: false
+        )
+    }
+}


### PR DESCRIPTION
Paint the upcoming agent identity (name + emoji/photo, verified styling,
"Joining..." subtitle, contact card) in the chat indicator and messages
list the moment a template-backed agent conversation is created, instead
of showing the generic "New Convo" placeholder until the agent joins.

Generalizes the agent-builder pending-agent path into a reusable,
identity-aware PendingAgentPresentation that both flows produce and every
render site consumes. The builder is the generic "no identity" case; the
template paths (Chat on an agent contact, and the convos://template/<id>
deep link) carry the real identity. No ConvosCore changes: the indicator
is driven by the presentation, and the contact card reuses the existing
member-based synthesis by feeding the repo a presentation-only synthetic
agent member (never added to conversation.members). Optimistic styling is
time-boxed and drops when a real verified agent joins.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/935"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782931872&installation_id=128169237&pr_number=935&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F935&signature=4d2210e6abaf74bc7fc1ddd46b627c6aff0ce094e7fd4bb85bfcb3edde8e614d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add optimistic pending-agent identity display for template-initiated chats
> - Introduces `PendingAgentPresentation`, a new model that centralizes pending-agent rendering state (name, emoji, avatar URL, description, contact card visibility) across conversation UI.
> - When starting a chat from an agent contact card, the agent's name, emoji, and photo are shown immediately via a synthetic `ConversationMember` before the real agent joins.
> - Deep-link initiated flows start with a neutral placeholder identity and asynchronously resolve the real agent identity via `agentShareResolver()`, upgrading the display in place.
> - The optimistic overlay is time-boxed using `AgentBuilderPlaceholder.displayDuration` and automatically clears if a real agent doesn't join in time.
> - Avatar views read `pendingAgentIdentity` from the SwiftUI environment to render emoji or URL-based avatars with verified styling during the optimistic window.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fb5b1e7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->