### PR TITLE
fix(consent): close the block-visibility window; reconciler is a backstop

### DIFF
--- a/ConvosCore/Sources/ConvosCore/Messaging/MessagingService.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/MessagingService.swift
@@ -233,7 +233,7 @@ final class MessagingService: MessagingServiceProtocol, @unchecked Sendable {
     }
 
     func contactsWriter() -> any ContactsWriterProtocol {
-        ContactsWriter(databaseWriter: databaseWriter)
+        ContactsWriter(databaseWriter: databaseWriter, sessionStateManager: sessionStateManager)
     }
 
     func contactSyncCoordinator() -> any ContactSyncCoordinatorProtocol {

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/ContactsWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/ContactsWriter.swift
@@ -1,12 +1,19 @@
 import Foundation
 import GRDB
 
-// Block / unblock are pure contact-row writes here. Feed visibility is
-// keyed on conversation consent, and `ConversationConsentReconciler`
-// observes the `contact` table: a block flips the creator's conversations
-// to `.denied` (hidden) and an unblock restores them to `.allowed`
-// (visible). No notification or direct consent write is needed at this
-// layer.
+// `block` flips feed visibility synchronously: in one DB transaction it
+// sets the contact's `blockedAt` and demotes the creator's conversations
+// to `.denied`. The feed is a GRDB observation on the `consent` column, so
+// it hides on commit with no network in the path - the user never sees a
+// blocked contact's chats linger. The XMTP-side consent flip then runs
+// best-effort afterward purely for cross-device + re-sync durability;
+// failures are logged, not thrown, because the local feed is already
+// correct. `ConversationConsentReconciler` stays as a backstop that only
+// re-fires when re-sync rewrites the DB `consent` column back to `.allowed`.
+//
+// `unblock` remains a pure contact-row write. By policy a `.denied`
+// conversation is never auto-promoted (the user effectively deleted it),
+// so unblocking does not restore conversations hidden while blocked.
 
 /// Snapshot of profile fields used when upserting a contact. Callers pass
 /// the most recent snapshot they have for the inbox. A timestamped
@@ -77,9 +84,14 @@ public protocol ContactsWriterProtocol: Sendable {
         profile: ContactProfileSnapshot
     ) async throws
 
-    /// Marks the contact as blocked. No-op if the inboxId has no contact row
-    /// (blocking does not auto-create contacts) or is already blocked. Repeat
-    /// calls leave the original `blockedAt` timestamp in place.
+    /// Marks the contact as blocked and synchronously demotes the creator's
+    /// still-visible conversations to `.denied` in the same transaction, so
+    /// the feed hides them immediately (no network in the path). The
+    /// XMTP-side consent flip runs best-effort afterward for cross-device
+    /// durability. No-op if the inboxId has no contact row (blocking does
+    /// not auto-create contacts). Repeat calls leave the original
+    /// `blockedAt` timestamp in place but still re-demote any conversation
+    /// that drifted back to visible.
     func block(inboxId: String) async throws
 
     /// Clears the blocked flag on the contact. No-op if the inboxId has no
@@ -89,9 +101,18 @@ public protocol ContactsWriterProtocol: Sendable {
 
 final class ContactsWriter: ContactsWriterProtocol, @unchecked Sendable {
     private let databaseWriter: any DatabaseWriter
+    /// Used by `block` to flip XMTP consent after the synchronous DB demote.
+    /// Optional so pure-DB unit tests can construct the writer without a
+    /// live session; when nil the XMTP flip is skipped and the
+    /// `ConversationConsentReconciler` backstop covers durability.
+    private let sessionStateManager: (any SessionStateManagerProtocol)?
 
-    init(databaseWriter: any DatabaseWriter) {
+    init(
+        databaseWriter: any DatabaseWriter,
+        sessionStateManager: (any SessionStateManagerProtocol)? = nil
+    ) {
         self.databaseWriter = databaseWriter
+        self.sessionStateManager = sessionStateManager
     }
 
     func upsertContact(
@@ -128,21 +149,67 @@ final class ContactsWriter: ContactsWriterProtocol, @unchecked Sendable {
     }
 
     func block(inboxId: String) async throws {
-        try await databaseWriter.write { db in
+        let demotedConversationIds: [String] = try await databaseWriter.write { db in
             guard let existing = try DBContact.fetchOne(db, key: inboxId) else {
                 // Blocking is action-gated on an existing contact row. We
                 // never auto-create a contact just to flag it as blocked.
                 Log.debug("block(inboxId:) skipped, no contact row for \(inboxId)")
-                return
+                return []
             }
-            guard existing.blockedAt == nil else {
-                // Idempotent: leave the original blockedAt timestamp.
-                return
+            // Idempotent: only stamp blockedAt on the first block, but always
+            // demote any still-visible conversations (a repeat block heals a
+            // conversation that drifted back to visible via re-sync).
+            if existing.blockedAt == nil {
+                try existing.with(blockedAt: Date()).save(db)
             }
-            try existing.with(blockedAt: Date()).save(db)
+            return try Self.demoteVisibleConversations(db: db, creatorId: inboxId)
         }
-        // `ConversationConsentReconciler` observes the `contact` table and
-        // demotes this creator's conversations to `.denied`, hiding them.
+        // Feed is already hidden (window 0). Flip XMTP consent best-effort for
+        // cross-device + re-sync durability; the local DB is authoritative so
+        // a failure here is logged, not thrown, and the reconciler backstop
+        // re-converges if re-sync later reverts the DB column.
+        guard let sessionStateManager, !demotedConversationIds.isEmpty else {
+            return
+        }
+        do {
+            let client = try await sessionStateManager.waitForInboxReadyResult().client
+            for conversationId in demotedConversationIds {
+                do {
+                    // Retry transient failures (a momentary network blip). The
+                    // local feed is already correct, so an exhausted retry just
+                    // logs; re-sync drift is then caught by the reconciler
+                    // backstop, which itself re-runs on app foreground and on
+                    // network reconnect (SessionStateMachine -> resume).
+                    try await withExponentialBackoffRetry {
+                        try await client.update(consent: .denied, for: conversationId)
+                    }
+                } catch {
+                    Log.error("block(inboxId:) XMTP consent flip failed for \(conversationId): \(error.localizedDescription)")
+                }
+            }
+        } catch {
+            Log.error("block(inboxId:) could not obtain client for XMTP consent flip: \(error.localizedDescription)")
+        }
+    }
+
+    /// Demotes every still-visible conversation created by `creatorId` to
+    /// `.denied` and returns their ids. Mirrors the
+    /// `ConversationConsentReconciler` join (`conversation.creatorId =
+    /// contact.inboxId`), so shared groups the local user created stay
+    /// visible. Conversations already `.denied` are left untouched.
+    private static func demoteVisibleConversations(db: Database, creatorId: String) throws -> [String] {
+        let conversationIds: [String] = try DBConversation
+            .filter(DBConversation.Columns.creatorId == creatorId)
+            .filter(DBConversation.Columns.consent != Consent.denied)
+            .fetchAll(db)
+            .map(\.id)
+        guard !conversationIds.isEmpty else {
+            return []
+        }
+        try DBConversation
+            .filter(conversationIds.contains(DBConversation.Columns.id))
+            .updateAll(db, DBConversation.Columns.consent.set(to: Consent.denied))
+        return conversationIds
     }
 
     func unblock(inboxId: String) async throws {

--- a/ConvosCore/Sources/ConvosCore/Syncing/ConversationConsentReconciler.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/ConversationConsentReconciler.swift
@@ -14,9 +14,14 @@ import XMTPiOS
 /// local user joined stays `.allowed` (flipped at arrival by
 /// `StreamProcessor`). The reconciler covers two contact-state visibility
 /// transitions: promotion when a stranger becomes a contact
-/// (`.unknown` -> `.allowed`) and demotion on block (`.allowed` -> `.denied`),
-/// so `block` stays a pure contact-row write and this reconciler reacts to it
-/// via GRDB observation.
+/// (`.unknown` -> `.allowed`) and demotion on block (`.allowed` -> `.denied`).
+///
+/// Demotion is no longer driven primarily from here: `ContactsWriter.block`
+/// flips both the DB `consent` column and XMTP synchronously, so the feed
+/// hides with zero window. For the block direction this reconciler is a
+/// backstop - it only re-fires when re-sync rewrites the DB `consent` column
+/// back to `.allowed` while the contact is still blocked. Promotion is still
+/// driven from here via GRDB observation.
 ///
 /// Only `.unknown` is promoted - never `.denied`. A `.denied` conversation
 /// from a non-blocked contact is one the user explicitly deleted, so it is
@@ -71,23 +76,53 @@ final class ConversationConsentReconciler: @unchecked Sendable {
         }
     }
 
+    /// Upper bound on concurrent in-flight reconciles per batch. Each
+    /// reconcile is a network round-trip to XMTP, so we parallelize to
+    /// shrink the tail-of-batch window without hammering the service.
+    private static let maxConcurrentReconciles: Int = 6
+
     private func observe() async {
         let dbReader = databaseReader
         let stream = ValueObservation
             .tracking { db in
                 try Self.fetchMismatchedTargets(db: db)
             }
+            // An unrelated conversation/contact write re-emits the observation
+            // even when the mismatched set is unchanged; skip re-driving the
+            // (network-touching) reconcile loop when the targets are identical.
+            .removeDuplicates()
             .values(in: dbReader)
         do {
             for try await targets in stream {
                 if Task.isCancelled { return }
-                for target in targets {
-                    if Task.isCancelled { return }
-                    await reconcile(target)
-                }
+                await reconcileBatch(targets)
             }
         } catch {
             Log.error("ConversationConsentReconciler: stream failed: \(error.localizedDescription)")
+        }
+    }
+
+    /// Reconciles a batch with bounded concurrency. A large mismatch set
+    /// (block-all, or first launch after the backfill migration) would
+    /// otherwise serialize N network round-trips; a sliding window of at
+    /// most `maxConcurrentReconciles` keeps the tail short.
+    private func reconcileBatch(_ targets: [Target]) async {
+        await withTaskGroup(of: Void.self) { group in
+            var iterator = targets.makeIterator()
+            var inflight = 0
+            while inflight < Self.maxConcurrentReconciles, let target = iterator.next() {
+                group.addTask { [weak self] in await self?.reconcile(target) }
+                inflight += 1
+            }
+            while await group.next() != nil {
+                if Task.isCancelled {
+                    group.cancelAll()
+                    break
+                }
+                if let target = iterator.next() {
+                    group.addTask { [weak self] in await self?.reconcile(target) }
+                }
+            }
         }
     }
 
@@ -138,7 +173,13 @@ final class ConversationConsentReconciler: @unchecked Sendable {
             // which a concurrent save can observe a stale XMTP value.
             let targetState: ConsentState = target.consent.consentState
             if try conversation.consentState() != targetState {
-                try await conversation.updateConsentState(state: targetState)
+                // Retry transient failures in-session; a fully failed target
+                // stays mismatched and is re-driven on the next tracked-region
+                // change, app foreground, or network reconnect (all restart
+                // this observation).
+                try await withExponentialBackoffRetry {
+                    try await conversation.updateConsentState(state: targetState)
+                }
             }
             let consent: Consent = target.consent
             let conversationId: String = target.conversationId

--- a/ConvosCore/Sources/ConvosCore/Utilities/RetryWithBackoff.swift
+++ b/ConvosCore/Sources/ConvosCore/Utilities/RetryWithBackoff.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+/// Runs `operation`, retrying on a thrown error up to `maxAttempts` total
+/// with exponential backoff (via `TimeInterval.calculateExponentialBackoff`)
+/// between attempts. Returns as soon as an attempt succeeds; re-throws the
+/// last error once every attempt has failed.
+///
+/// Cancellation-aware: a cancelled task stops retrying and re-throws the
+/// most recent error rather than sleeping again.
+func withExponentialBackoffRetry<T>(
+    maxAttempts: Int = 3,
+    operation: () async throws -> T
+) async throws -> T {
+    var attempt: Int = 0
+    while true {
+        do {
+            return try await operation()
+        } catch {
+            attempt += 1
+            if attempt >= maxAttempts || Task.isCancelled {
+                throw error
+            }
+            let delay: TimeInterval = .calculateExponentialBackoff(for: attempt - 1)
+            try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+        }
+    }
+}

--- a/ConvosCore/Tests/ConvosCoreTests/ContactsWriterTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ContactsWriterTests.swift
@@ -38,6 +38,42 @@ struct ContactsWriterTests {
         ).insert(db)
     }
 
+    /// Inserts a `conversation` row created by `creatorId` with the given
+    /// consent, plus its creator `DBMember`. Used by block-demotion tests
+    /// that need conversations attributed to a specific (blockable) inbox.
+    private static func seedConversation(
+        _ db: Database,
+        id: String,
+        creatorId: String,
+        consent: Consent
+    ) throws {
+        try DBMember(inboxId: creatorId).save(db, onConflict: .ignore)
+        try DBConversation(
+            id: id,
+            clientConversationId: id,
+            inviteTag: "tag-\(id)",
+            creatorId: creatorId,
+            kind: .group,
+            consent: consent,
+            createdAt: Date(),
+            name: nil,
+            description: nil,
+            imageURLString: nil,
+            publicImageURLString: nil,
+            includeInfoInPublicPreview: false,
+            expiresAt: nil,
+            debugInfo: .empty,
+            isLocked: false,
+            imageSalt: nil,
+            imageNonce: nil,
+            imageEncryptionKey: nil,
+            conversationEmoji: nil,
+            imageLastRenewed: nil,
+            isUnused: false,
+            hasHadVerifiedAgent: false
+        ).insert(db)
+    }
+
     @Test("upsertContact preserves addedAt and addedViaConversationId on subsequent calls")
     func testIdempotentUpsertPreservesIdentityColumns() async throws {
         let dbManager = MockDatabaseManager.makeTestDatabase()
@@ -418,6 +454,43 @@ struct ContactsWriterTests {
         }
         #expect(contact?.displayName == "Renamed")
         #expect(contact?.blockedAt != nil)
+    }
+
+    @Test("block synchronously demotes the creator's visible conversations to denied (window 0)")
+    func testBlockDemotesCreatorConversationsSynchronously() async throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        let writer = ContactsWriter(databaseWriter: dbManager.dbWriter)
+        let blockedInboxId = "blocked-inbox"
+        let otherCreator = "other-creator"
+
+        try await dbManager.dbWriter.write { db in
+            try Self.seedConversation(db, id: "conv-allowed", creatorId: blockedInboxId, consent: .allowed)
+            try Self.seedConversation(db, id: "conv-unknown", creatorId: blockedInboxId, consent: .unknown)
+            try Self.seedConversation(db, id: "conv-mine", creatorId: otherCreator, consent: .allowed)
+        }
+        try await writer.upsertContact(
+            inboxId: blockedInboxId,
+            addedViaConversationId: nil,
+            profile: ContactProfileSnapshot(displayName: "Blocked")
+        )
+
+        try await writer.block(inboxId: blockedInboxId)
+
+        // No observation tick required: consent is demoted in the same write
+        // transaction as blockedAt, so the feed (a consent observation) hides
+        // these on commit.
+        let (allowedConsent, unknownConsent, mineConsent) = try await dbManager.dbReader.read { db in
+            try (
+                DBConversation.fetchOne(db, key: "conv-allowed")?.consent,
+                DBConversation.fetchOne(db, key: "conv-unknown")?.consent,
+                DBConversation.fetchOne(db, key: "conv-mine")?.consent
+            )
+        }
+        #expect(allowedConsent == .denied)
+        #expect(unknownConsent == .denied)
+        // A conversation created by someone else (e.g. a shared group the
+        // local user created) stays visible - mirrors the reconciler join.
+        #expect(mineConsent == .allowed)
     }
 
     @Test("agentVerification persists on a new contact via upsert")


### PR DESCRIPTION
PR #930 made ConversationConsentReconciler the primary path for consent
changes, leaving a user-visible window on block ("I blocked them, why is
their chat still here?") plus serial-batch and no-retry regressions.

- ContactsWriter.block now demotes the blocked creator's still-visible
  conversations to .denied in the same DB transaction as blockedAt, so the
  feed (a consent observation) hides them on commit -- zero window, no
  network in the path. The demotion mirrors the reconciler join
  (creatorId == inboxId), so shared groups the local user created stay
  visible. The XMTP-side flip then runs best-effort with bounded retry for
  cross-device / re-sync durability.
- ConversationConsentReconciler is now a backstop for the block direction:
  added removeDuplicates() and a bounded-concurrency batch reconcile (max 6
  in flight) so a large mismatch set (block-all / first launch after the
  backfill migration) no longer serializes N XMTP round-trips, plus bounded
  retry on updateConsentState. Reconnect/foreground re-scan was already
  wired (NetworkMonitor / handleEnterForeground -> resume()).

Adds a window-0 unit test; full ConvosCore suite (1069 tests) passes.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/937"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782933173&installation_id=128169237&pr_number=937&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F937&signature=2dd4bed5fada235e585b291b11798f34248747029b8fd1031c2b05b80439419d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix contact blocking to synchronously demote visible conversations and use reconciler as backstop
> - `ContactsWriter.block` now demotes all visible conversations created by a blocked contact to `.denied` within the same DB transaction, closing the visibility window that previously existed between a block action and the next reconciler pass.
> - After the DB commit, best-effort XMPP consent flips are attempted via `withExponentialBackoffRetry`; failures are logged and do not roll back the local demotion.
> - `ConversationConsentReconciler` is updated to act as a backstop: it retries with exponential backoff, deduplicates unchanged target sets, and caps concurrency at 6 parallel reconciles via the new `reconcileBatch` method.
> - A new `withExponentialBackoffRetry` utility in [`RetryWithBackoff.swift`](https://github.com/xmtplabs/convos-ios/pull/937/files#diff-d0ef4d7dc057e6b7475f514be445e59619a48f51f38f8f86f497d550ea5d5a9c) provides cancellation-aware retry logic (up to 3 attempts by default) shared by both `ContactsWriter` and the reconciler.
> - Behavioral Change: Blocking a contact now immediately affects conversation visibility in the DB rather than waiting for the next reconciler cycle.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c670a23.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->