### PR TITLE
feat(agent-card): tap an in-conversation agent's card opens its contact detail

### DIFF
--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -2824,14 +2824,15 @@ extension ConversationViewModel {
         session.inviteMembershipResolver()
     }
 
-    /// Tapping a shared agent's contact card opens a new conversation seeded
-    /// with that agent template (the same flow the `convos://template/<id>`
-    /// deep link uses). The custom-scheme form carries the template id
-    /// directly; a web-slug share is resolved to its id via the API resolver
-    /// first.
+    /// Tapping a shared agent's contact card opens that agent's contact
+    /// detail when an agent running the same template is already a member of
+    /// this conversation; otherwise it opens a new conversation seeded with
+    /// the template (the same flow the `convos://template/<id>` deep link
+    /// uses). The custom-scheme form carries the template id directly; a
+    /// web-slug share is resolved to its id via the API resolver first.
     func onTapAgentShare(_ agentShare: MessageAgentShare) {
         if isValidTemplateId(agentShare.identifier) {
-            openAgentTemplate(templateId: agentShare.identifier)
+            presentAgentMemberOrTemplate(templateId: agentShare.identifier)
             return
         }
         let resolver = agentShareResolver
@@ -2842,9 +2843,24 @@ extension ConversationViewModel {
                 guard let self, let templateId = info?.templateId else { return }
                 // The web-slug resolve already returned the agent's profile;
                 // pass it through so the new conversation paints it optimistically.
-                self.openAgentTemplate(templateId: templateId, optimisticIdentity: info)
+                self.presentAgentMemberOrTemplate(templateId: templateId, optimisticIdentity: info)
             }
         }
+    }
+
+    /// Routes a tapped agent template to the in-conversation member's contact
+    /// detail when present, falling back to the spawn-a-new-conversation
+    /// template flow otherwise. The post-builder contact card reaches the same
+    /// member detail directly via `onTapAvatar` (it already has the member).
+    private func presentAgentMemberOrTemplate(templateId: String, optimisticIdentity: AgentShareInfo? = nil) {
+        let member: ConversationMember? = conversation.members.first { member in
+            member.isAgent && member.profile.agentTemplateId == templateId
+        }
+        if let member {
+            presentingProfileForMember = member
+            return
+        }
+        openAgentTemplate(templateId: templateId, optimisticIdentity: optimisticIdentity)
     }
 
     private func openAgentTemplate(templateId: String, optimisticIdentity: AgentShareInfo? = nil) {

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupView.swift
@@ -275,7 +275,10 @@ struct MessagesGroupView: View {
                     .frame(width: avatarSize, height: avatarSize)
             }
 
+            let cardTap = { onTapSender(group.sender) }
             AgentContactCardView(profile: card.profile, agentDescription: card.agentDescription)
+                .contentShape(Rectangle())
+                .onTapGesture(perform: cardTap)
                 .overlay(alignment: .bottomLeading) {
                     if cardIsLast && !group.sender.isCurrentUser {
                         avatarOverlay { onTapSender(group.sender) }


### PR DESCRIPTION
When a user taps an agent contact-card message cell and an agent running
that template is already a member of the conversation, show that member's
scoped contact detail instead of the spawn-a-new-conversation template
flow / deep link. Applies to both the agent-share card and the
post-agent-builder contact card.

- ConversationViewModel.onTapAgentShare routes through
  presentAgentMemberOrTemplate(templateId:): if a conversation member is
  an agent with that agentTemplateId, present its scoped contact detail
  via presentingProfileForMember; otherwise fall back to openAgentTemplate.
- MessagesGroupView's post-builder AgentContactCardView gains a card-wide
  tap routing to onTapSender(group.sender), opening the same scoped
  contact detail (its agent is always a member there).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/938"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782934057&installation_id=128169237&pr_number=938&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F938&signature=060bae416a796fc7b6c2949b1ea48a8b59d2b9210cb02eaf5bae80e358bedbf5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Open in-conversation agent's contact detail when tapping its card
> - Makes the entire `AgentContactCardView` tappable via `contentShape(Rectangle())` and `onTapGesture` in [`MessagesGroupView`](https://github.com/xmtplabs/convos-ios/pull/938/files#diff-96fea19951f287381d9170a90ce9ac8ba6f9e59f9d477dd1c5be2bbc1b5cdbe2); previously only the avatar overlay was tappable.
> - Adds `presentAgentMemberOrTemplate` in [`ConversationViewModel`](https://github.com/xmtplabs/convos-ios/pull/938/files#diff-d056b0b131534648b6d13cddafd053be956f5d23d035ad2538db85a8cc370d8d) to check if an agent member in the current conversation uses the tapped template; if so, opens that member's contact detail instead of spawning a new conversation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c538785.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->