### PR TITLE
fix(agents): hide share button when template has no published URL

### DIFF
--- a/Convos/Contacts/ContactDetailView.swift
+++ b/Convos/Contacts/ContactDetailView.swift
@@ -147,7 +147,7 @@ struct ContactDetailView: View {
                 Button(action: action) {
                     Image(systemName: "square.and.arrow.up")
                 }
-                .accessibilityLabel("Share agent")
+                .accessibilityLabel("Share \(contact.resolvedDisplayName)")
                 .accessibilityIdentifier("contact-detail-share-agent")
             }
         }

--- a/Convos/Contacts/ContactDetailView.swift
+++ b/Convos/Contacts/ContactDetailView.swift
@@ -60,14 +60,7 @@ struct ContactDetailView: View {
     @State private var presentingSendMessageError: Bool = false
     @State private var sendMessageErrorMessage: String?
     @State private var presentingNewConvo: NewConversationViewModel?
-    /// Resolved share link for a template-backed agent, lazily populated by
-    /// the top-bar share action (seeded from the persisted published URL, or
-    /// fetched via the publish endpoint on first tap).
-    @State private var resolvedAgentShareURL: URL?
-    @State private var isPublishingAgentTemplate: Bool = false
     @State private var presentingAgentShareSheet: Bool = false
-    @State private var presentingPublishError: Bool = false
-    @State private var publishErrorMessage: String?
     /// Gates the "One agent, many convos" confirmation before the "Chat"
     /// button spawns a new conversation with this agent. `agentInfoConfirmed`
     /// distinguishes a "Got it" tap from a drag-to-cancel in the sheet's
@@ -112,10 +105,7 @@ struct ContactDetailView: View {
                 blockAlertTitle: blockAlertTitle,
                 blockAlertMessage: blockAlertMessage,
                 presentingAgentShareSheet: $presentingAgentShareSheet,
-                agentShareURL: resolvedAgentShareURL,
-                onAgentSharePresented: { isPublishingAgentTemplate = false },
-                presentingPublishError: $presentingPublishError,
-                publishErrorMessage: publishErrorMessage,
+                agentShareURL: agentTemplateShareURL,
                 presentingAgentInfo: $presentingAgentInfo,
                 onAgentInfoConfirm: { agentInfoConfirmed = true },
                 onAgentInfoDismiss: handleAgentInfoDismiss,
@@ -143,23 +133,20 @@ struct ContactDetailView: View {
         }
     }
 
-    /// Share affordance for a template-backed agent: publishes the template
-    /// (if not already published) and presents the system share sheet with
-    /// the resulting link. Only shown for agent contacts when a session is
-    /// available to drive the publish call.
+    /// Share affordance for a template-backed agent. Shown only once the agent
+    /// carries a published share link (`agentTemplateShareURL`, from its
+    /// profile metadata or the persisted contact); tapping it presents the
+    /// system share sheet. An agent with no `publishedUrl` can't be shared, so
+    /// the button is hidden rather than offering an action that would fail -
+    /// the backend is expected to populate the link for every template.
     @ToolbarContentBuilder
     private var agentShareToolbarItem: some ToolbarContent {
-        if isAgentTemplate, session != nil {
+        if agentTemplateShareURL != nil {
             ToolbarItem(placement: .topBarTrailing) {
-                let action = { handlePublishAndShareAgentTemplate() }
+                let action = { presentingAgentShareSheet = true }
                 Button(action: action) {
-                    if isPublishingAgentTemplate {
-                        ProgressView()
-                    } else {
-                        Image(systemName: "square.and.arrow.up")
-                    }
+                    Image(systemName: "square.and.arrow.up")
                 }
-                .disabled(isPublishingAgentTemplate)
                 .accessibilityLabel("Share agent")
                 .accessibilityIdentifier("contact-detail-share-agent")
             }
@@ -501,47 +488,6 @@ struct ContactDetailView: View {
         guard agentInfoConfirmed else { return }
         agentInfoConfirmed = false
         confirmChatWithAgentTemplate()
-    }
-
-    /// Resolves a shareable template link and presents the share sheet. Uses
-    /// the already-published URL when present, otherwise publishes the
-    /// template via the backend on first tap. A publish failure (e.g. the
-    /// caller isn't the template owner) surfaces an alert.
-    private func handlePublishAndShareAgentTemplate() {
-        // Show the button's spinner from the moment of tap until the share sheet
-        // has finished presenting (cleared in the `.shareSheet` onPresented). This
-        // covers both the already-published path and the publish round-trip, plus
-        // the gap while the share sheet is preparing.
-        isPublishingAgentTemplate = true
-        if let url = resolvedAgentShareURL ?? agentTemplateShareURL {
-            resolvedAgentShareURL = url
-            presentingAgentShareSheet = true
-            return
-        }
-        guard let session, let templateId = contact.agentTemplateId else {
-            isPublishingAgentTemplate = false
-            return
-        }
-        Task {
-            do {
-                let template = try await session.publishAgentTemplate(id: templateId)
-                guard let urlString = template.publishedUrl, let url = URL(string: urlString) else {
-                    publishErrorMessage = "This agent can't be shared yet."
-                    presentingPublishError = true
-                    isPublishingAgentTemplate = false
-                    return
-                }
-                resolvedAgentShareURL = url
-                presentingAgentShareSheet = true
-            } catch {
-                // Surface the friendly DisplayError copy (e.g. APIError's
-                // "The requested resource was not found.") rather than the raw
-                // bridged NSError ("...ConvosCore.APIError error 6.").
-                publishErrorMessage = (error as? DisplayError)?.description ?? error.localizedDescription
-                presentingPublishError = true
-                isPublishingAgentTemplate = false
-            }
-        }
     }
 
     private func syncBlockedState() async {
@@ -946,9 +892,6 @@ private struct ContactDetailModalsModifier<
     let blockAlertMessage: String
     @Binding var presentingAgentShareSheet: Bool
     let agentShareURL: URL?
-    let onAgentSharePresented: () -> Void
-    @Binding var presentingPublishError: Bool
-    let publishErrorMessage: String?
     @Binding var presentingAgentInfo: Bool
     let onAgentInfoConfirm: () -> Void
     let onAgentInfoDismiss: () -> Void
@@ -971,22 +914,12 @@ private struct ContactDetailModalsModifier<
             } message: { message in
                 Text(message)
             }
-            .alert(
-                "Couldn't share agent",
-                isPresented: $presentingPublishError,
-                presenting: publishErrorMessage
-            ) { _ in
-                Button("OK", role: .cancel) {}
-            } message: { message in
-                Text(message)
-            }
             .sheet(isPresented: $presentingPicker) {
                 pickerSheet()
             }
             .shareSheet(
                 isPresented: $presentingAgentShareSheet,
-                items: agentShareItems,
-                onPresented: onAgentSharePresented
+                items: agentShareItems
             )
             .selfSizingSheet(isPresented: $presentingAgentInfo, onDismiss: onAgentInfoDismiss) {
                 OneAgentManyConvosInfoSheet(onConfirm: onAgentInfoConfirm)
@@ -1046,11 +979,13 @@ extension Contact {
     /// and non-contact members. The synthetic fallback is promoted to a
     /// real contact when the user taps "Chat".
     ///
-    /// The agent-template `templateId`, `publishedUrl`, and `instanceId`
-    /// live only in the per-conversation member profile metadata
-    /// (`DBContact` has no template column), so they are overlaid here
-    /// onto whichever contact is returned. Without the `templateId`
-    /// overlay `isAgentTemplate` is always false.
+    /// The agent-template `templateId`, `publishedUrl`, and `instanceId` are
+    /// overlaid here from the freshest per-conversation member profile
+    /// metadata onto whichever contact is returned. Without the `templateId`
+    /// overlay `isAgentTemplate` is always false. `publishedUrl` falls back to
+    /// the persisted contact value when the live metadata omits it - the agent
+    /// runtime doesn't always carry the link, and overwriting a known URL with
+    /// a nil would hide the Share button for an agent we already have a link for.
     public static func resolved(
         member: ConversationMember,
         in conversationId: String,
@@ -1062,9 +997,10 @@ extension Contact {
         let instanceId: String? = member.profile.agentInstanceId
         let attestation: String? = member.profile.agentAttestation
         if let stored = try? contactsRepository.fetchContact(inboxId: member.profile.inboxId) {
+            let resolvedPublishedURL: String? = templatePublishedURL ?? stored.agentTemplatePublishedURL
             return stored
                 .with(agentTemplateId: templateId)
-                .with(agentTemplatePublishedURL: templatePublishedURL)
+                .with(agentTemplatePublishedURL: resolvedPublishedURL)
                 .with(profileEmoji: emoji)
                 .with(agentInstanceId: instanceId)
                 .with(agentVerification: member.agentVerification)

--- a/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift
+++ b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift
@@ -91,11 +91,6 @@ public protocol ConvosAPIClientProtocol: AnyObject, Sendable {
     ) async throws -> ConvosAPI.AgentJoinResponse
 
     // Agent templates
-    /// PATCH /api/v2/agent-templates/:id flipping status to "published" so
-    /// the backend hands back a non-null `publishedUrl`. The share flow on
-    /// builder-created templates calls this lazily on first tap.
-    func publishAgentTemplate(id: String) async throws -> ConvosAPI.AgentTemplate
-
     /// Public detail fetch for a published agent template, keyed by its
     /// template id (UUID) or hashed url slug (e.g. `gandalf.felpl`). Backs the
     /// agent-share card/chip resolver. Unauthenticated: the backend serves
@@ -759,74 +754,6 @@ final class ConvosAPIClient: ConvosAPIClientProtocol, Sendable {
     }
 
     // MARK: - Agent templates
-
-    /// Publishes an agent template so the backend hands back a non-null
-    /// `publishedUrl`. Hits POST /:id/publish?status=published, which is
-    /// the documented first-publish path for a `draft` row and the
-    /// idempotent re-publish path for an already-first-published row
-    /// (`unlisted` / `published` / `archived`). Both branches return the
-    /// same serialized template shape with a populated `publishedUrl`, so
-    /// the caller doesn't care which branch the backend took.
-    ///
-    /// We don't PATCH the status here: PATCH is the only way to flip
-    /// `unlisted` -> `published`, but for the iOS share flow the share URL
-    /// works whether the row is `unlisted` or `published`. Promoting
-    /// unlisted to published is a directory-visibility change, not a
-    /// shareability change, and isn't part of the share button's intent.
-    func publishAgentTemplate(id: String) async throws -> ConvosAPI.AgentTemplate {
-        let path: String = "v2/agent-templates/\(id)/publish"
-        var request: URLRequest
-        do {
-            request = try authenticatedRequest(
-                for: path,
-                method: "POST",
-                queryParameters: ["status": "published"]
-            )
-        } catch {
-            Log.error("publishAgentTemplate failed to build POST request for path=\(path), baseURL=\(baseURL.absoluteString): \(String(describing: error))")
-            throw error
-        }
-        // POST /publish takes no body; the backend reads `status` from the
-        // query string when present.
-        Log.info("publishAgentTemplate POST \(request.url?.absoluteString ?? "<nil>")")
-
-        let (data, httpResponse) = try await performAuthenticatedRequest(request)
-        return try decodeAgentTemplateResponse(
-            data: data,
-            httpResponse: httpResponse,
-            id: id
-        )
-    }
-
-    private func decodeAgentTemplateResponse(
-        data: Data,
-        httpResponse: HTTPURLResponse,
-        id: String
-    ) throws -> ConvosAPI.AgentTemplate {
-        switch httpResponse.statusCode {
-        case 200...299:
-            do {
-                return try JSONDecoder().decode(ConvosAPI.AgentTemplate.self, from: data)
-            } catch {
-                Log.error("publishAgentTemplate decode failed: \(String(describing: error)) body=\(data.prettyPrintedJSONString ?? "<nil>")")
-                throw error
-            }
-        case 400:
-            let message = parseErrorMessage(from: data)
-            Log.error("publishAgentTemplate 400 for id=\(id): \(message ?? "<no message>")")
-            throw APIError.badRequest(message)
-        case 403:
-            Log.error("publishAgentTemplate 403 for id=\(id) - caller is not the template owner")
-            throw APIError.forbidden
-        case 404:
-            Log.error("publishAgentTemplate 404 for id=\(id)")
-            throw APIError.notFound
-        default:
-            let message = parseErrorMessage(from: data)
-            Log.error("publishAgentTemplate status=\(httpResponse.statusCode) for id=\(id): \(message ?? "<no message>")")
-            throw APIError.serverError(message)
-        }
-    }
 
     func getAgentTemplate(idOrUrlSlug: String) async throws -> ConvosAPI.AgentTemplate {
         // Public, unauthenticated GET -- the detail endpoint serves published

--- a/ConvosCore/Sources/ConvosCore/API/MockAPIClient.swift
+++ b/ConvosCore/Sources/ConvosCore/API/MockAPIClient.swift
@@ -104,14 +104,6 @@ final class MockAPIClient: ConvosAPIClientProtocol, Sendable {
         .init(success: true, joined: true)
     }
 
-    func publishAgentTemplate(id: String) async throws -> ConvosAPI.AgentTemplate {
-        .init(
-            id: id,
-            status: "published",
-            publishedUrl: "https://agents.example.com/mock.\(id.prefix(5))"
-        )
-    }
-
     func getAgentTemplate(idOrUrlSlug: String) async throws -> ConvosAPI.AgentTemplate {
         .init(
             id: UUID().uuidString,

--- a/ConvosCore/Sources/ConvosCore/Inboxes/MockInboxesService.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/MockInboxesService.swift
@@ -106,14 +106,6 @@ public final class MockInboxesService: SessionManagerProtocol, @unchecked Sendab
         return .init(success: true, joined: true)
     }
 
-    public func publishAgentTemplate(id: String) async throws -> ConvosAPI.AgentTemplate {
-        ConvosAPI.AgentTemplate(
-            id: id,
-            status: "published",
-            publishedUrl: "https://agents.example.com/mock.\(id.prefix(5))"
-        )
-    }
-
     public func conversationRepository(for conversationId: String) -> any ConversationRepositoryProtocol {
         MockConversationRepository()
     }

--- a/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
@@ -593,10 +593,6 @@ public final class SessionManager: SessionManagerProtocol, @unchecked Sendable {
         )
     }
 
-    public func publishAgentTemplate(id: String) async throws -> ConvosAPI.AgentTemplate {
-        try await apiClient.publishAgentTemplate(id: id)
-    }
-
     public func agentShareResolver() -> any AgentShareResolving {
         ApiAgentShareResolver(
             apiClient: apiClient,

--- a/ConvosCore/Sources/ConvosCore/Sessions/SessionManagerProtocol.swift
+++ b/ConvosCore/Sources/ConvosCore/Sessions/SessionManagerProtocol.swift
@@ -99,12 +99,6 @@ public protocol SessionManagerProtocol: AnyObject, Sendable {
         forceErrorCode: Int?
     ) async throws -> ConvosAPI.AgentJoinResponse
 
-    /// PATCH /api/v2/agent-templates/:id flipping the template to
-    /// `published`. Used by the agent-template contact card's share action
-    /// for builder-created templates that don't yet carry a `publishedUrl`
-    /// in their profile data.
-    func publishAgentTemplate(id: String) async throws -> ConvosAPI.AgentTemplate
-
     func conversationRepository(for conversationId: String) -> any ConversationRepositoryProtocol
 
     func messagesRepository(for conversationId: String) -> any MessagesRepositoryProtocol

--- a/ConvosCore/Tests/ConvosCoreTests/TestStubAPIClientDefaults.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/TestStubAPIClientDefaults.swift
@@ -44,18 +44,6 @@ extension ConvosAPIClientProtocol {
         ConvosAPI.AgentJoinResponse(success: true, joined: true)
     }
 
-    /// Default for the publish-on-share PATCH used by the agent-template
-    /// contact card. Returns a synthetic "published" template so fixtures
-    /// don't have to re-stub it. Tests that exercise this specifically
-    /// should override on their fixture.
-    func publishAgentTemplate(id: String) async throws -> ConvosAPI.AgentTemplate {
-        ConvosAPI.AgentTemplate(
-            id: id,
-            status: "published",
-            publishedUrl: "https://agents.example.com/test.\(id.prefix(5))"
-        )
-    }
-
     /// Default for the public agent-template detail fetch used by the
     /// agent-share card/chip resolver. Tests that exercise it specifically
     /// should override on their fixture.


### PR DESCRIPTION
## What

The agent contact card's **Share** button now renders only when the template already carries a `publishedUrl`, instead of attempting an owner-only publish that 403s for non-owners ("Couldn't share agent / You don't have permission to access this.").

## Why

The agent runtime doesn't always propagate `publishedUrl` into the agent's per-conversation profile metadata, so the share flow fell through to the publish (mint) endpoint — which 403s anyone who isn't the template owner. The backend is being changed so every finished template carries a URL; this is the client half.

While tracing it I also found `Contact.resolved(member:)` would *clobber* a stored `publishedUrl` with a nil from the live metadata, hiding the button even for agents we already had a link for.

## Changes

- Gate `agentShareToolbarItem` on `agentTemplateShareURL != nil`; tap opens the system share sheet directly (no per-tap network call, no error alert).
- `Contact.resolved(member:)` coalesces the live-metadata `publishedUrl` with the persisted value (`?? stored.agentTemplatePublishedURL`) instead of overwriting a known URL with nil.
- Removed the now-unused publish/mint path end to end: `SessionManagerProtocol`/`SessionManager`/`MockInboxesService`, `ConvosAPIClient.publishAgentTemplate` + the orphaned `decodeAgentTemplateResponse` helper, and the mock/test stubs.

Net: **20 insertions, 195 deletions** across 7 files.

## Testing

- `ConvosCore` full suite: **1072 tests / 156 suites passed**.
- App (Dev scheme) builds; ConvosCore + test target build; SwiftLint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/939"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782952270&installation_id=128169237&pr_number=939&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F939&signature=69125b894f8d79aa75ef57786e9849e2057e96c94afcd26aec62c944572401e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Hide share button in contact detail view when agent template has no published URL
> - The share button in `ContactDetailView` now only appears when `agentTemplateShareURL` is non-nil, replacing the previous behavior where tapping the button would trigger a publish network request on first use.
> - Removes the publish-on-share flow entirely: `handlePublishAndShareAgentTemplate`, `publishAgentTemplate(id:)` from `SessionManager`, `ConvosAPIClient`, and related protocols and mocks are all deleted.
> - Fixes URL resolution in `Contact.resolved(member:in:contactsRepository:)` to prefer the live member profile URL but fall back to the stored contact's known URL when the live value is nil, preventing the share button from disappearing unexpectedly.
> - Behavioral Change: Users can no longer publish an agent template by tapping the share button; the button is hidden until the template already has a published URL.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 22ab699.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->