### PR TITLE
feat(agents): share prominence, convo sections, reusable QR agent code

### DIFF
--- a/.claude/commands/debug-assistant.md
+++ b/.claude/commands/debug-assistant.md
@@ -238,7 +238,7 @@ FIFO=/tmp/agent-stdin-$SLUG
 rm -f "$FIFO"; mkfifo "$FIFO"
 ( exec 3>"$FIFO"; sleep 99999 ) &  # writer keeps fifo open
 cat "$FIFO" | CONVOS_HOME="$AGENT_HOME" convos agent serve … &
-# once serve logs the `ready` event, push the emoji + description + templateId:
+# once serve logs the `ready` event, push emoji + description + templateId + publishedUrl:
 jq -nc --arg n "$PERSONA_NAME" --arg e "$EMOJI" --arg d "$DESCRIPTION" --arg t "$TEMPLATE_ID" --arg u "$PUBLISHED_URL" \
   '{type:"update-profile",name:$n,metadata:{emoji:$e,description:$d,templateId:$t,publishedUrl:$u}}' > "$FIFO"
 ```
@@ -294,7 +294,7 @@ Subjects: `calendar`, `contacts`, `tasks`, `mail`, `photos`, `fitness`, `music`,
 - **iOS log shows "[Attestation] timestamp too old".** The agent's `attestation_ts` is older than 24 h. Just re-run `agent serve` — `--attestation-private-key` re-signs on each start.
 - **iOS log shows "[Attestation] cached result: unverified".** Either the JWKS pubkey doesn't match the private key (re-derive JWKS in step 2 and re-pin in step 3), or the kid in `Secrets.swift` differs from the kid used to sign — make sure both ends use the same `--kid`.
 - **Two agents joined; only one is verified.** Each XMTP identity has its own inboxId; each agent needs its own `CONVOS_HOME` so the CLI signs against the correct inboxId.
-- **Agent shows initials (e.g. "FT") instead of its emoji, or the contact card has no description.** The metadata you passed at join time (`emoji` / `description` / `templateId`) was overwritten by the serve loop's metadata-less startup `ProfileUpdate`. Push the whole set again through the running loop's stdin: `jq -nc --arg n "<persona>" --arg e "🏋️" --arg d "<one-liner>" --arg t "debug-<slug>" '{type:"update-profile",name:$n,metadata:{emoji:$e,description:$d,templateId:$t}}' > "$FIFO"`. iOS re-renders the avatar and card subtitle within a few seconds. (`agent serve` has no `--metadata` flag, so there's no way to carry it through startup — the post-serve push is the reliable path.)
+- **Agent shows initials (e.g. "FT") instead of its emoji, or the contact card has no description.** The metadata you passed at join time (`emoji` / `description` / `templateId` / `publishedUrl`) was overwritten by the serve loop's metadata-less startup `ProfileUpdate`. Push the whole set again through the running loop's stdin: `jq -nc --arg n "<persona>" --arg e "🏋️" --arg d "<one-liner>" --arg t "debug-<slug>" --arg u "<published-url>" '{type:"update-profile",name:$n,metadata:{emoji:$e,description:$d,templateId:$t,publishedUrl:$u}}' > "$FIFO"`. iOS re-renders the avatar and card subtitle within a few seconds. (`agent serve` has no `--metadata` flag, so there's no way to carry it through startup — the post-serve push is the reliable path.)
 - **Agent is verified in chat but never appears in Contacts.** Its profile is missing `templateId` in `metadata` — `Contact.isVisibleInContactsList` only surfaces agents that carry one. Re-push the profile with both `emoji` and `templateId` (see above), then have the local user send a message in the conversation so `ContactSyncCoordinator` mirrors the templateId onto the contact. (If you only ever set `emoji`, the agent stays chat-only.)
 - **Contact card has no Share button.** The profile is missing `publishedUrl` in `metadata` — `ContactDetailView` only shows the Share action / agent-share QR when `Profile.agentTemplatePublishedURL` is non-empty. Re-push the profile including `publishedUrl` (see Step 6). Any plausible string works for a debug agent; the QR just encodes it.
 

--- a/.claude/commands/debug-assistant.md
+++ b/.claude/commands/debug-assistant.md
@@ -142,6 +142,31 @@ TEMPLATE_ID="${TEMPLATE_ID:-debug-$SLUG}"
 echo "🪪 templateId: $TEMPLATE_ID"
 ```
 
+### Step 4d: Write a one-line description for the contact card
+
+iOS reads `metadata.description` (-> `Profile.agentDescription`) and renders it on the `AgentContactCard` under the agent's name. A real agent writes this itself once it decides what it's set up to do; a debug agent has to set it explicitly or the card shows no subtitle. Map the persona to a short line, generic fallback otherwise:
+
+```bash
+case "$(echo "$PERSONA" | tr '[:upper:]' '[:lower:]')" in
+    *fitness*|*trainer*|*workout*)  DESCRIPTION="Your personal fitness coach - workout plans, form cues, and accountability." ;;
+    *travel*|*trip*)                DESCRIPTION="Plans trips end to end - flights, stays, and a day-by-day itinerary." ;;
+    *calendar*|*schedul*)           DESCRIPTION="Keeps your week in order - scheduling, reminders, and conflict-spotting." ;;
+    *meal*|*chef*|*food*|*recipe*)  DESCRIPTION="Plans meals and recipes around your goals and what is in the fridge." ;;
+    *finance*|*money*|*budget*)     DESCRIPTION="Tracks spending and helps you stick to a budget." ;;
+    *) DESCRIPTION="A $PERSONA assistant (local debug agent)." ;;
+esac
+echo "📝 description: $DESCRIPTION"
+```
+
+### Step 4e: Set a `publishedUrl` so the contact card's Share button shows
+
+iOS only renders the Share button / agent-share QR overlay on the contact detail view when the agent's profile carries a non-empty `publishedUrl` in `metadata` (`Profile.agentTemplatePublishedURL`, which `ContactDetailView` gates the share action on). Real template agents get a backend-minted link shaped like `https://agents-dev.convos.org/<slug>.<shortid>`; a debug agent fakes one. The host doesn't have to resolve — the QR just encodes whatever string you set:
+
+```bash
+PUBLISHED_URL="${PUBLISHED_URL:-https://agents-dev.convos.org/$SLUG.dbg01}"
+echo "🔗 publishedUrl: $PUBLISHED_URL"
+```
+
 ### Step 5: Join (or attach), with one command
 
 Two paths, both single-shot now that the CLI signs internally with `--attestation-private-key`:
@@ -155,7 +180,9 @@ PERSONA_NAME="$PERSONA"
 JOIN=$(CONVOS_HOME="$AGENT_HOME" convos conversations join "$INVITE" \
     --profile-name "$PERSONA_NAME" \
     --metadata "emoji=$EMOJI" \
+    --metadata "description=$DESCRIPTION" \
     --metadata "templateId=$TEMPLATE_ID" \
+    --metadata "publishedUrl=$PUBLISHED_URL" \
     --attestation-private-key "$KEY_PATH" \
     --attestation-kid "$KID" \
     --timeout 120 \
@@ -166,7 +193,7 @@ echo "🤝 Joined conversation $CONV_ID"
 
 The CLI mints the attestation itself, signing `sha256(inboxId || now)` once the XMTP client materializes the inboxId. No re-mint needed.
 
-Caveat about join `--metadata`: emoji and templateId are written into the join's profile, but `convos agent serve` (Step 6) publishes its own `ProfileUpdate` at startup built only from `--name` / `--profile-name` — with no metadata — which **overwrites** the join metadata with an empty set. So neither the emoji nor the templateId set here survives the serve loop. You must re-push both after serve is up (Step 6 below). Verified on the simulator: without the re-push the agent renders as "FT"-style initials and never appears as a contact.
+Caveat about join `--metadata`: emoji, description, templateId, and publishedUrl are written into the join's profile, but `convos agent serve` (Step 6) publishes its own `ProfileUpdate` at startup built only from `--name` / `--profile-name` — with no metadata — which **overwrites** the join metadata with an empty set. So none of the emoji, description, templateId, or publishedUrl set here survives the serve loop. You must re-push all four after serve is up (Step 6 below). Verified on the simulator: without the re-push the agent renders as "FT"-style initials and never appears as a contact.
 
 **b. Attaching to an existing conversation:**
 
@@ -175,7 +202,9 @@ CONV_ID="<existing-id>"
 CONVOS_HOME="$AGENT_HOME" convos conversation update-profile "$CONV_ID" \
     --name "$PERSONA_NAME" \
     --metadata "emoji=$EMOJI" \
-    --metadata "templateId=$TEMPLATE_ID"
+    --metadata "description=$DESCRIPTION" \
+    --metadata "templateId=$TEMPLATE_ID" \
+    --metadata "publishedUrl=$PUBLISHED_URL"
 ```
 
 (Skip the join — go straight to step 6. As with path (a), the serve loop's startup `ProfileUpdate` carries no metadata, so the emoji and templateId have to be pushed *after* serve is up via the stdin `update-profile` command in Step 6, not here.)
@@ -193,13 +222,14 @@ CONVOS_HOME="$AGENT_HOME" convos agent serve "$CONV_ID" \
 
 Keep this in the foreground — the user interacts via stdin (`{"type":"send","text":"…"}`, `{"type":"react",…}`, etc.). Ctrl-C to stop. Nothing persists beyond `~/.convos-debug-attest.pem`, the `.env` entry, and the agent's identity dir.
 
-`agent serve` has no `--metadata` flag, so the emoji and templateId set at join time are gone after the startup `ProfileUpdate`. Re-publish both through the running loop's stdin once serve is up (a single `update-profile` carries the whole metadata set):
+`agent serve` has no `--metadata` flag, so the emoji, description, templateId, and publishedUrl set at join time are gone after the startup `ProfileUpdate`. Re-publish all four through the running loop's stdin once serve is up (a single `update-profile` carries the whole metadata set). Build it with `jq` so the free-text description can't break the JSON:
 
 ```bash
-echo '{"type":"update-profile","name":"'"$PERSONA_NAME"'","metadata":{"emoji":"'"$EMOJI"'","templateId":"'"$TEMPLATE_ID"'"}}' > "$FIFO"
+jq -nc --arg n "$PERSONA_NAME" --arg e "$EMOJI" --arg d "$DESCRIPTION" --arg t "$TEMPLATE_ID" --arg u "$PUBLISHED_URL" \
+  '{type:"update-profile",name:$n,metadata:{emoji:$e,description:$d,templateId:$t,publishedUrl:$u}}' > "$FIFO"
 ```
 
-The loop logs `{"event":"sent","type":"update-profile",...,"metadata":{"emoji":"…","templateId":"…"}}`; iOS re-renders the avatar with the emoji within a few seconds, and the agent shows up as a contact once the local user next acts in the conversation (`ContactSyncCoordinator` mirrors the templateId onto the contact on the first outbound message / member sync).
+The loop logs `{"event":"sent","type":"update-profile",...,"metadata":{"emoji":"…","description":"…","templateId":"…","publishedUrl":"…"}}`; iOS re-renders the avatar with the emoji within a few seconds, shows the description and the Share button on the contact card, and the agent shows up as a contact once the local user next acts in the conversation (`ContactSyncCoordinator` mirrors the templateId onto the contact on the first outbound message / member sync).
 
 When backgrounding via Claude Code (e.g. for QA), pipe a fifo into stdin so the process doesn't see EOF — and keep the fifo path so you can send the `update-profile` (and later commands) into it:
 
@@ -208,8 +238,9 @@ FIFO=/tmp/agent-stdin-$SLUG
 rm -f "$FIFO"; mkfifo "$FIFO"
 ( exec 3>"$FIFO"; sleep 99999 ) &  # writer keeps fifo open
 cat "$FIFO" | CONVOS_HOME="$AGENT_HOME" convos agent serve … &
-# once serve logs the `ready` event, push the emoji + templateId:
-echo '{"type":"update-profile","name":"'"$PERSONA_NAME"'","metadata":{"emoji":"'"$EMOJI"'","templateId":"'"$TEMPLATE_ID"'"}}' > "$FIFO"
+# once serve logs the `ready` event, push the emoji + description + templateId:
+jq -nc --arg n "$PERSONA_NAME" --arg e "$EMOJI" --arg d "$DESCRIPTION" --arg t "$TEMPLATE_ID" --arg u "$PUBLISHED_URL" \
+  '{type:"update-profile",name:$n,metadata:{emoji:$e,description:$d,templateId:$t,publishedUrl:$u}}' > "$FIFO"
 ```
 
 ### Step 7: Report
@@ -219,6 +250,9 @@ echo '{"type":"update-profile","name":"'"$PERSONA_NAME"'","metadata":{"emoji":"'
 📌 Pinned in:    <SHARED_ENV>
 📂 Agent home:   ~/.convos-debug-agent-<slug>
 🤖 Agent:         <PERSONA_NAME>
+🪪 templateId:    <TEMPLATE_ID>
+📝 Description:   <DESCRIPTION>
+🔗 publishedUrl:  <PUBLISHED_URL>
 💬 Conversation:  <CONV_ID>
 
 Agent is running. iOS marks it as verified(.convos) once it sees the
@@ -260,8 +294,9 @@ Subjects: `calendar`, `contacts`, `tasks`, `mail`, `photos`, `fitness`, `music`,
 - **iOS log shows "[Attestation] timestamp too old".** The agent's `attestation_ts` is older than 24 h. Just re-run `agent serve` — `--attestation-private-key` re-signs on each start.
 - **iOS log shows "[Attestation] cached result: unverified".** Either the JWKS pubkey doesn't match the private key (re-derive JWKS in step 2 and re-pin in step 3), or the kid in `Secrets.swift` differs from the kid used to sign — make sure both ends use the same `--kid`.
 - **Two agents joined; only one is verified.** Each XMTP identity has its own inboxId; each agent needs its own `CONVOS_HOME` so the CLI signs against the correct inboxId.
-- **Agent shows initials (e.g. "FT") instead of its emoji.** The `--metadata emoji=…` you passed at join time was overwritten by the serve loop's metadata-less startup `ProfileUpdate`. Push it again through the running loop's stdin: `echo '{"type":"update-profile","name":"<persona>","metadata":{"emoji":"🏋️","templateId":"debug-<slug>"}}' > "$FIFO"`. iOS re-renders the avatar within a few seconds. (`agent serve` has no `--metadata` flag, so there's no way to carry it through startup — the post-serve push is the reliable path.)
+- **Agent shows initials (e.g. "FT") instead of its emoji, or the contact card has no description.** The metadata you passed at join time (`emoji` / `description` / `templateId`) was overwritten by the serve loop's metadata-less startup `ProfileUpdate`. Push the whole set again through the running loop's stdin: `jq -nc --arg n "<persona>" --arg e "🏋️" --arg d "<one-liner>" --arg t "debug-<slug>" '{type:"update-profile",name:$n,metadata:{emoji:$e,description:$d,templateId:$t}}' > "$FIFO"`. iOS re-renders the avatar and card subtitle within a few seconds. (`agent serve` has no `--metadata` flag, so there's no way to carry it through startup — the post-serve push is the reliable path.)
 - **Agent is verified in chat but never appears in Contacts.** Its profile is missing `templateId` in `metadata` — `Contact.isVisibleInContactsList` only surfaces agents that carry one. Re-push the profile with both `emoji` and `templateId` (see above), then have the local user send a message in the conversation so `ContactSyncCoordinator` mirrors the templateId onto the contact. (If you only ever set `emoji`, the agent stays chat-only.)
+- **Contact card has no Share button.** The profile is missing `publishedUrl` in `metadata` — `ContactDetailView` only shows the Share action / agent-share QR when `Profile.agentTemplatePublishedURL` is non-empty. Re-push the profile including `publishedUrl` (see Step 6). Any plausible string works for a debug agent; the QR just encodes it.
 
 ## Cleanup
 

--- a/Convos/Contacts/AgentShareOverlay.swift
+++ b/Convos/Contacts/AgentShareOverlay.swift
@@ -1,0 +1,45 @@
+import ConvosCore
+import SwiftUI
+
+/// The agent contact card's share flow: a QR "agent code" encoding the agent
+/// template's published URL, with the template emoji over a `.colorLava`
+/// circle in the center and the template name as the header. A thin wrapper
+/// over the reusable `QRCodeCardOverlay`, mirroring the conversation
+/// "Convos code" flow.
+struct AgentShareOverlay: View {
+    let displayName: String
+    let emoji: String?
+    let publishedURLString: String
+    @Binding var isPresented: Bool
+    let topSafeAreaInset: CGFloat
+
+    var body: some View {
+        QRCodeCardOverlay(
+            encodedURLString: publishedURLString,
+            isPresented: $isPresented,
+            topSafeAreaInset: topSafeAreaInset,
+            header: {
+                Text(displayName)
+                    .kerning(1.0)
+            },
+            center: {
+                centerChip
+            }
+        )
+    }
+
+    private var centerChip: some View {
+        ZStack {
+            Circle()
+                .fill(.colorLava)
+            if let emoji {
+                GeometryReader { proxy in
+                    let side: CGFloat = min(proxy.size.width, proxy.size.height)
+                    Text(emoji)
+                        .font(.system(size: side * 0.5, weight: .semibold, design: .rounded))
+                        .frame(width: side, height: side)
+                }
+            }
+        }
+    }
+}

--- a/Convos/Contacts/AgentTemplateConversationsSections.swift
+++ b/Convos/Contacts/AgentTemplateConversationsSections.swift
@@ -1,0 +1,88 @@
+import ConvosCore
+import SwiftUI
+
+/// The "Convos with you" / "someone else added them" sections on the agent
+/// contact card. Lists conversations that already contain this agent
+/// template, split by who added the agent, reusing `ConversationsListItem`
+/// for each row. Render only when there is content (see `isEmpty`).
+struct AgentTemplateConversationsSections: View {
+    let conversations: AgentTemplateConversations
+
+    var body: some View {
+        VStack(spacing: DesignConstants.Spacing.step6x) {
+            if !conversations.addedByCurrentUser.isEmpty {
+                AgentTemplateConversationsSection(
+                    header: "Convos with you",
+                    conversations: conversations.addedByCurrentUser,
+                    footer: "You added them · Using your credits",
+                    showsPrivacyNote: true
+                )
+            }
+            if !conversations.addedByOthers.isEmpty {
+                AgentTemplateConversationsSection(
+                    header: nil,
+                    conversations: conversations.addedByOthers,
+                    footer: "Someone else added them",
+                    showsPrivacyNote: false
+                )
+            }
+        }
+    }
+}
+
+/// One grouped section: an optional header label, a rounded card of
+/// conversation rows separated by dividers (plus an optional privacy note),
+/// and a footer caption.
+private struct AgentTemplateConversationsSection: View {
+    let header: String?
+    let conversations: [Conversation]
+    let footer: String
+    let showsPrivacyNote: Bool
+
+    private static var privacyNote: String {
+        "For privacy, agents cannot share memories, context or skills between conversations."
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: DesignConstants.Spacing.step2x) {
+            if let header {
+                Text(header)
+                    .font(.callout)
+                    .foregroundStyle(.colorTextSecondary)
+                    .padding(.horizontal, DesignConstants.Spacing.step2x)
+            }
+
+            VStack(spacing: 0.0) {
+                ForEach(Array(conversations.enumerated()), id: \.element.id) { index, conversation in
+                    if index > 0 {
+                        Divider()
+                            .padding(.leading, DesignConstants.Spacing.step4x)
+                    }
+                    ConversationsListItem(conversation: conversation)
+                }
+
+                if showsPrivacyNote {
+                    Text(Self.privacyNote)
+                        .font(.callout)
+                        .foregroundStyle(.colorTextSecondary)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(DesignConstants.Spacing.step4x)
+                        .background(
+                            RoundedRectangle(cornerRadius: DesignConstants.CornerRadius.medium)
+                                .fill(.colorFillMinimal)
+                        )
+                        .padding(DesignConstants.Spacing.step4x)
+                }
+            }
+            .background(
+                RoundedRectangle(cornerRadius: DesignConstants.CornerRadius.large)
+                    .fill(.colorBackgroundRaised)
+            )
+
+            Text(footer)
+                .font(.caption)
+                .foregroundStyle(.colorTextTertiary)
+                .padding(.horizontal, DesignConstants.Spacing.step2x)
+        }
+    }
+}

--- a/Convos/Contacts/AgentTemplateConversationsSections.swift
+++ b/Convos/Contacts/AgentTemplateConversationsSections.swift
@@ -49,9 +49,9 @@ private struct AgentTemplateConversationsSection: View {
         VStack(alignment: .leading, spacing: DesignConstants.Spacing.step2x) {
             if let header {
                 Text(header)
-                    .font(.callout)
+                    .font(.footnote)
                     .foregroundStyle(.colorTextSecondary)
-                    .padding(.horizontal, DesignConstants.Spacing.step2x)
+                    .padding(.leading, DesignConstants.Spacing.step2x)
             }
 
             VStack(spacing: 0.0) {
@@ -65,12 +65,12 @@ private struct AgentTemplateConversationsSection: View {
 
                 if showsPrivacyNote {
                     Text(Self.privacyNote)
-                        .font(.callout)
+                        .font(.footnote)
                         .foregroundStyle(.colorTextSecondary)
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .padding(DesignConstants.Spacing.step4x)
                         .background(
-                            RoundedRectangle(cornerRadius: DesignConstants.CornerRadius.medium)
+                            RoundedRectangle(cornerRadius: DesignConstants.CornerRadius.regular)
                                 .fill(.colorFillMinimal)
                         )
                         .padding(DesignConstants.Spacing.step4x)
@@ -82,9 +82,9 @@ private struct AgentTemplateConversationsSection: View {
             )
 
             Text(footer)
-                .font(.caption)
+                .font(.caption2)
                 .foregroundStyle(.colorTextTertiary)
-                .padding(.horizontal, DesignConstants.Spacing.step2x)
+                .padding(.leading, DesignConstants.Spacing.step2x)
         }
     }
 }

--- a/Convos/Contacts/AgentTemplateConversationsSections.swift
+++ b/Convos/Contacts/AgentTemplateConversationsSections.swift
@@ -9,22 +9,24 @@ struct AgentTemplateConversationsSections: View {
     let conversations: AgentTemplateConversations
 
     var body: some View {
-        VStack(spacing: DesignConstants.Spacing.step6x) {
-            if !conversations.addedByCurrentUser.isEmpty {
-                AgentTemplateConversationsSection(
-                    header: "Convos with you",
-                    conversations: conversations.addedByCurrentUser,
-                    footer: "You added them · Using your credits",
-                    showsPrivacyNote: true
-                )
-            }
-            if !conversations.addedByOthers.isEmpty {
-                AgentTemplateConversationsSection(
-                    header: nil,
-                    conversations: conversations.addedByOthers,
-                    footer: "Someone else added them",
-                    showsPrivacyNote: false
-                )
+        if !conversations.isEmpty {
+            VStack(spacing: DesignConstants.Spacing.step6x) {
+                if !conversations.addedByCurrentUser.isEmpty {
+                    AgentTemplateConversationsSection(
+                        header: "Convos with you",
+                        conversations: conversations.addedByCurrentUser,
+                        footer: "You added them · Using your credits",
+                        showsPrivacyNote: true
+                    )
+                }
+                if !conversations.addedByOthers.isEmpty {
+                    AgentTemplateConversationsSection(
+                        header: nil,
+                        conversations: conversations.addedByOthers,
+                        footer: "Someone else added them",
+                        showsPrivacyNote: false
+                    )
+                }
             }
         }
     }

--- a/Convos/Contacts/ContactDetailView.swift
+++ b/Convos/Contacts/ContactDetailView.swift
@@ -142,7 +142,12 @@ struct ContactDetailView: View {
             return
         }
         let repository = session.conversationsRepository(for: [.allowed])
-        agentTemplateConversations = (try? repository.conversations(withAgentTemplateId: templateId)) ?? .empty
+        do {
+            agentTemplateConversations = try repository.conversations(withAgentTemplateId: templateId)
+        } catch {
+            Log.error("Failed to load agent template conversations for \(templateId): \(error.localizedDescription)")
+            agentTemplateConversations = .empty
+        }
     }
 
     /// Agent "code card" share flow: a QR encoding the template's published
@@ -176,17 +181,24 @@ struct ContactDetailView: View {
     /// Share affordance for a template-backed agent. Shown only once the agent
     /// carries a published share link (`agentTemplateShareURL`, from its
     /// profile metadata or the persisted contact); tapping it presents the
-    /// system share sheet. An agent with no `publishedUrl` can't be shared, so
-    /// the button is hidden rather than offering an action that would fail -
-    /// the backend is expected to populate the link for every template.
+    /// agent-share QR overlay. An agent with no `publishedUrl` can't be shared,
+    /// so the button is hidden rather than offering an action that would fail -
+    /// the backend is expected to populate the link for every template. It is
+    /// also hidden while the overlay is up so it doesn't sit on top of the
+    /// presented card.
+    ///
+    /// Styled with `.glassProminent` tinted to the primary color so it reads as
+    /// a prominent black button with an inverse icon, matching the close
+    /// button's glass treatment without a hand-rolled background.
     @ToolbarContentBuilder
     private var agentShareToolbarItem: some ToolbarContent {
-        if agentTemplateShareURL != nil {
+        if agentTemplateShareURL != nil, !presentingAgentShareSheet {
             ToolbarItem(placement: .topBarTrailing) {
                 let action = { presentingAgentShareSheet = true }
                 Button(action: action) {
                     Image(systemName: "square.and.arrow.up")
                 }
+                .buttonStyle(.glassProminent)
                 .tint(.colorFillPrimary)
                 .accessibilityLabel("Share \(contact.resolvedDisplayName)")
                 .accessibilityIdentifier("contact-detail-share-agent")

--- a/Convos/Contacts/ContactDetailView.swift
+++ b/Convos/Contacts/ContactDetailView.swift
@@ -240,17 +240,13 @@ struct ContactDetailView: View {
                     showsInstanceIdRow: showsInstanceIdRow,
                     agentAttestation: contact.agentAttestation,
                     agentVerification: contact.agentVerification,
+                    agentTemplateConversations: agentTemplateConversations,
                     onSendMessage: isAgentTemplate ? handleChatWithAgentTemplate : handleSendMessage,
                     onShare: { presentingAgentShareSheet = true },
                     onRemove: handleRemoveTap,
                     onToggleBlock: handleBlockTap
                 )
                 .padding(.top, DesignConstants.Spacing.step8x)
-                if !agentTemplateConversations.isEmpty {
-                    AgentTemplateConversationsSections(conversations: agentTemplateConversations)
-                        .padding(.horizontal, DesignConstants.Spacing.step4x)
-                        .padding(.top, DesignConstants.Spacing.step8x)
-                }
             }
             .padding(.bottom, 80.0)
         }
@@ -645,6 +641,10 @@ private struct ContactDetailActions: View {
     /// Last-known agent verification, drives the debug row's valid/invalid
     /// readout alongside the raw attestation value.
     let agentVerification: AgentVerification?
+    /// Conversations already containing this agent template, rendered as the
+    /// "Convos with you" / "someone else added" sections directly under the
+    /// Share row (or Chat when there's no Share row).
+    let agentTemplateConversations: AgentTemplateConversations
     let onSendMessage: () -> Void
     let onShare: () -> Void
     let onRemove: () -> Void
@@ -659,6 +659,9 @@ private struct ContactDetailActions: View {
             }
             if showShare {
                 shareRow
+            }
+            if !agentTemplateConversations.isEmpty {
+                AgentTemplateConversationsSections(conversations: agentTemplateConversations)
             }
             if showAgentLinks {
                 agentLinkRows

--- a/Convos/Contacts/ContactDetailView.swift
+++ b/Convos/Contacts/ContactDetailView.swift
@@ -61,6 +61,10 @@ struct ContactDetailView: View {
     @State private var sendMessageErrorMessage: String?
     @State private var presentingNewConvo: NewConversationViewModel?
     @State private var presentingAgentShareSheet: Bool = false
+    /// Conversations already containing this agent template, split by who
+    /// added the agent. Loaded on appear for template-backed agents; drives
+    /// the "Convos with you" / "someone else added them" sections.
+    @State private var agentTemplateConversations: AgentTemplateConversations = .empty
     /// Gates the "One agent, many convos" confirmation before the "Chat"
     /// button spawns a new conversation with this agent. `agentInfoConfirmed`
     /// distinguishes a "Got it" tap from a drag-to-cancel in the sheet's
@@ -104,8 +108,6 @@ struct ContactDetailView: View {
                 sendMessageErrorMessage: sendMessageErrorMessage,
                 blockAlertTitle: blockAlertTitle,
                 blockAlertMessage: blockAlertMessage,
-                presentingAgentShareSheet: $presentingAgentShareSheet,
-                agentShareURL: agentTemplateShareURL,
                 presentingAgentInfo: $presentingAgentInfo,
                 onAgentInfoConfirm: { agentInfoConfirmed = true },
                 onAgentInfoDismiss: handleAgentInfoDismiss,
@@ -119,7 +121,37 @@ struct ContactDetailView: View {
                 )
                 .background(.colorBackgroundSurfaceless)
             }
+            .overlay { agentShareOverlay }
             .task(id: contact.inboxId) { await syncBlockedState() }
+            .task(id: contact.agentTemplateId) { await loadAgentTemplateConversations() }
+    }
+
+    /// Loads conversations already containing this agent template, partitioned
+    /// by who added the agent. No-op for non-template contacts.
+    private func loadAgentTemplateConversations() async {
+        guard let session, let templateId = contact.agentTemplateId else {
+            agentTemplateConversations = .empty
+            return
+        }
+        let repository = session.conversationsRepository(for: [.allowed])
+        agentTemplateConversations = (try? repository.conversations(withAgentTemplateId: templateId)) ?? .empty
+    }
+
+    /// Agent "code card" share flow: a QR encoding the template's published
+    /// URL with the system share sheet behind it (mirrors the conversation
+    /// "Convos code"). Replaces the plain share sheet so the toolbar button
+    /// and the "Share" row both open the richer card.
+    @ViewBuilder
+    private var agentShareOverlay: some View {
+        if presentingAgentShareSheet, let publishedURL = contact.agentTemplatePublishedURL {
+            AgentShareOverlay(
+                displayName: contact.resolvedDisplayName,
+                emoji: contact.profileEmoji,
+                publishedURLString: publishedURL,
+                isPresented: $presentingAgentShareSheet,
+                topSafeAreaInset: 0.0
+            )
+        }
     }
 
     @ToolbarContentBuilder
@@ -147,6 +179,7 @@ struct ContactDetailView: View {
                 Button(action: action) {
                     Image(systemName: "square.and.arrow.up")
                 }
+                .tint(.colorFillPrimary)
                 .accessibilityLabel("Share \(contact.resolvedDisplayName)")
                 .accessibilityIdentifier("contact-detail-share-agent")
             }
@@ -188,6 +221,7 @@ struct ContactDetailView: View {
                     // `handleChatWithAgentTemplate`).
                     canSendMessage: session != nil && (!isVerifiedAgent || isAgentTemplate),
                     showChat: !mode.isCurrentUser,
+                    showShare: agentTemplateShareURL != nil,
                     showAgentLinks: isVerifiedAgent,
                     showRemove: mode.isScopedToConversation
                         && !mode.isCurrentUser
@@ -199,12 +233,18 @@ struct ContactDetailView: View {
                     agentAttestation: contact.agentAttestation,
                     agentVerification: contact.agentVerification,
                     onSendMessage: isAgentTemplate ? handleChatWithAgentTemplate : handleSendMessage,
+                    onShare: { presentingAgentShareSheet = true },
                     onRemove: handleRemoveTap,
                     onToggleBlock: handleBlockTap
                 )
                 .padding(.top, DesignConstants.Spacing.step8x)
-                .padding(.bottom, 80.0)
+                if !agentTemplateConversations.isEmpty {
+                    AgentTemplateConversationsSections(conversations: agentTemplateConversations)
+                        .padding(.horizontal, DesignConstants.Spacing.step4x)
+                        .padding(.top, DesignConstants.Spacing.step8x)
+                }
             }
+            .padding(.bottom, 80.0)
         }
         // ScrollView on short content (human card with just Chat + Block)
         // would otherwise rubber-band on touch even though the content
@@ -581,6 +621,7 @@ private struct ContactDetailActions: View {
     let isApplyingBlockChange: Bool
     let canSendMessage: Bool
     let showChat: Bool
+    let showShare: Bool
     let showAgentLinks: Bool
     let showRemove: Bool
     let showBlock: Bool
@@ -597,6 +638,7 @@ private struct ContactDetailActions: View {
     /// readout alongside the raw attestation value.
     let agentVerification: AgentVerification?
     let onSendMessage: () -> Void
+    let onShare: () -> Void
     let onRemove: () -> Void
     let onToggleBlock: () -> Void
 
@@ -606,6 +648,9 @@ private struct ContactDetailActions: View {
         VStack(spacing: DesignConstants.Spacing.step6x) {
             if showChat {
                 chatButton
+            }
+            if showShare {
+                shareRow
             }
             if showAgentLinks {
                 agentLinkRows
@@ -672,6 +717,18 @@ private struct ContactDetailActions: View {
         .disabled(!canSendMessage)
         .accessibilityLabel("Chat with \(contactDisplayName)")
         .accessibilityIdentifier("contact-detail-chat")
+    }
+
+    private var shareRow: some View {
+        ContactDetailActionRow(
+            label: "Share \(contactDisplayName)",
+            footer: "Show a code or send a link to add this agent",
+            color: .colorTextPrimary,
+            isDisabled: false,
+            accessibilityLabel: "Share \(contactDisplayName)",
+            accessibilityIdentifier: "contact-detail-share-agent-row",
+            action: onShare
+        )
     }
 
     private var removeRow: some View {
@@ -890,8 +947,6 @@ private struct ContactDetailModalsModifier<
     let sendMessageErrorMessage: String?
     let blockAlertTitle: String
     let blockAlertMessage: String
-    @Binding var presentingAgentShareSheet: Bool
-    let agentShareURL: URL?
     @Binding var presentingAgentInfo: Bool
     let onAgentInfoConfirm: () -> Void
     let onAgentInfoDismiss: () -> Void
@@ -917,17 +972,9 @@ private struct ContactDetailModalsModifier<
             .sheet(isPresented: $presentingPicker) {
                 pickerSheet()
             }
-            .shareSheet(
-                isPresented: $presentingAgentShareSheet,
-                items: agentShareItems
-            )
             .selfSizingSheet(isPresented: $presentingAgentInfo, onDismiss: onAgentInfoDismiss) {
                 OneAgentManyConvosInfoSheet(onConfirm: onAgentInfoConfirm)
             }
-    }
-
-    private var agentShareItems: [Any] {
-        agentShareURL.map { [$0] } ?? []
     }
 }
 

--- a/Convos/Contacts/ContactDetailView.swift
+++ b/Convos/Contacts/ContactDetailView.swift
@@ -693,15 +693,6 @@ private struct ContactDetailActions: View {
     @ViewBuilder
     private var agentLinkRows: some View {
         ContactDetailActionRow(
-            label: "Get skills",
-            footer: "Browse 100+ curated capabilities",
-            color: .colorTextPrimary,
-            isDisabled: false,
-            accessibilityLabel: "Get skills",
-            accessibilityIdentifier: "contact-detail-get-skills",
-            action: { openURL(AgentLinks.getSkillsURL) }
-        )
-        ContactDetailActionRow(
             label: "Learn about agents",
             footer: "Capabilities, privacy and security",
             color: .colorTextPrimary,

--- a/Convos/Contacts/ContactDetailView.swift
+++ b/Convos/Contacts/ContactDetailView.swift
@@ -94,13 +94,23 @@ struct ContactDetailView: View {
     }
 
     var body: some View {
-        bodyContent
+        contentWithModals
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .background(.colorBackgroundRaisedSecondary)
             .navigationBarTitleDisplayMode(.inline)
             .toolbarBackground(.hidden, for: .navigationBar)
             .toolbar { closeToolbarItem }
             .toolbar { agentShareToolbarItem }
+            .task(id: contact.inboxId) { await syncBlockedState() }
+            .task(id: contact.agentTemplateId) { await loadAgentTemplateConversations() }
+    }
+
+    /// `bodyContent` plus the modal / sheet / overlay presentation layer.
+    /// Split out of `body` so each modifier chain stays short enough for the
+    /// type-checker (see the CLAUDE.md build-performance notes) as this view
+    /// keeps accruing presentation surfaces.
+    private var contentWithModals: some View {
+        bodyContent
             .modifier(ContactDetailModalsModifier(
                 presentingBlockConfirmation: $presentingBlockConfirmation,
                 presentingPicker: $presentingPicker,
@@ -122,8 +132,6 @@ struct ContactDetailView: View {
                 .background(.colorBackgroundSurfaceless)
             }
             .overlay { agentShareOverlay }
-            .task(id: contact.inboxId) { await syncBlockedState() }
-            .task(id: contact.agentTemplateId) { await loadAgentTemplateConversations() }
     }
 
     /// Loads conversations already containing this agent template, partitioned

--- a/Convos/Conversation Detail/ConversationShareView.swift
+++ b/Convos/Conversation Detail/ConversationShareView.swift
@@ -66,6 +66,7 @@ struct ConversationShareOverlay: View {
                         .scaledToFit()
                         .foregroundStyle(.colorTextPrimaryInverted)
                         .padding(inset)
+                        .frame(width: proxy.size.width, height: proxy.size.height)
                 }
             }
         }

--- a/Convos/Conversation Detail/ConversationShareView.swift
+++ b/Convos/Conversation Detail/ConversationShareView.swift
@@ -2,224 +2,74 @@ import ConvosCore
 import ConvosCoreiOS
 import SwiftUI
 
+/// The conversation "Convos code" share flow: a QR card encoding the invite
+/// URL with the conversation image in the center, presented over
+/// `ConversationInfoView` with the native share sheet behind it. A thin
+/// wrapper over the reusable `QRCodeCardOverlay`.
 struct ConversationShareOverlay: View {
     let conversation: Conversation
     let invite: Invite
     @Binding var isPresented: Bool
     let topSafeAreaInset: CGFloat
 
-    @State private var showCard: Bool = false
-    @State private var isShareSheetPresented: Bool = false
     @State private var conversationImage: Image = Image("convosOrangeIcon")
     /// Whether a real conversation image loaded. Drives the QR center: a real
     /// image renders as-is; otherwise the convos placeholder is tinted to
-    /// contrast the dark center chip (it was previously template-tinted to
-    /// match it, so it was invisible in both light and dark mode).
+    /// contrast the dark center chip.
     @State private var hasConversationImage: Bool = false
-    @State private var qrCodeImage: UIImage?
-    @Environment(\.displayScale) private var displayScale: CGFloat
-
-    private static let headerHeight: CGFloat = 40.0
-    private static let cardPadding: CGFloat = 40.0
-    private static let maxQRSize: CGFloat = 220.0
-    private static let shareSheetFraction: CGFloat = 0.55
-
-    @State private var containerSize: CGSize = .zero
-
-    private func qrDisplaySize(in size: CGSize) -> CGFloat {
-        let availableHeight = size.height * (1.0 - Self.shareSheetFraction)
-            - topSafeAreaInset
-            - DesignConstants.Spacing.step4x
-            - Self.headerHeight
-            - Self.cardPadding
-            - DesignConstants.Spacing.step10x
-        let availableWidth = size.width
-            - DesignConstants.Spacing.step10x * 2
-            - Self.cardPadding * 2
-        let maxFit = min(availableHeight, availableWidth)
-        return min(max(maxFit, 120.0), Self.maxQRSize)
-    }
 
     var body: some View {
-        GeometryReader { geometry in
-        ZStack {
-            if showCard {
-                Color.black.opacity(0.5)
-                    .background(.ultraThinMaterial)
-                    .ignoresSafeArea()
-                    .transition(.opacity)
-                    .onTapGesture {
-                        dismissFlow()
-                    }
-            }
-
-            if showCard {
-                VStack(spacing: 0.0) {
-                    convoCodeCard(qrSize: qrDisplaySize(in: geometry.size))
-
-                    Spacer()
+        QRCodeCardOverlay(
+            encodedURLString: invite.inviteURLString,
+            isPresented: $isPresented,
+            topSafeAreaInset: topSafeAreaInset,
+            header: {
+                HStack(alignment: .center) {
+                    Text("Convos code")
+                        .kerning(1.0)
+                    Image("convosOrangeIcon")
+                        .renderingMode(.template)
+                        .resizable()
+                        .scaledToFit()
+                        .frame(width: 14.0, height: 14.0)
+                        .foregroundStyle(.colorFillTertiary)
+                    Text("Scan to join")
+                        .kerning(1.0)
                 }
-                .padding(.top, topSafeAreaInset + DesignConstants.Spacing.step4x)
-                .transition(
-                    .asymmetric(
-                        insertion: .move(edge: .top).combined(with: .opacity),
-                        removal: .opacity
-                    )
-                )
+            },
+            center: {
+                centerChip
             }
-
-            Color.clear
-                .frame(width: 1, height: 1)
-                .background(
-                    ShareSheetPresenter(
-                        activityItems: [invite.inviteURLString],
-                        isPresented: $isShareSheetPresented,
-                        onDismiss: {
-                            dismissFlow()
-                        }
-                    )
-                )
-        }
+        )
         .cachedImage(for: conversation) { image in
             if let image {
                 conversationImage = Image(uiImage: image)
                 hasConversationImage = true
             }
         }
-        .task {
-            guard let inviteURL = invite.inviteURL else { return }
-            let options = QRCodeGenerator.Options(
-                scale: displayScale,
-                displaySize: Self.maxQRSize,
-                foregroundColor: UIColor(.colorTextPrimary),
-                backgroundColor: UIColor(.colorBackgroundSurfaceless)
-            )
-            let generated = await QRCodeGenerator.generate(from: inviteURL.absoluteString, options: options)
-            guard !Task.isCancelled else { return }
-            qrCodeImage = generated
-
-            withAnimation(.spring(response: 0.5, dampingFraction: 0.78)) {
-                showCard = true
-            }
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
-                isShareSheetPresented = true
-            }
-        }
-        }
     }
 
-    private func convoCodeCard(qrSize: CGFloat) -> some View {
-        let centerImageSize: CGFloat = qrSize * (50.0 / Self.maxQRSize)
-        let centerBackgroundSize: CGFloat = qrSize * (55.0 / Self.maxQRSize)
-        let cardInternalPadding: CGFloat = qrSize * (Self.cardPadding / Self.maxQRSize)
-
-        return VStack(spacing: 0.0) {
-            HStack(alignment: .center) {
-                Text("Convos code")
-                    .kerning(1.0)
-
-                Image("convosOrangeIcon")
-                    .renderingMode(.template)
+    private var centerChip: some View {
+        ZStack {
+            Rectangle()
+                .fill(.colorTextPrimary)
+            if hasConversationImage {
+                conversationImage
                     .resizable()
-                    .scaledToFit()
-                    .frame(width: 14.0, height: 14.0)
-                    .foregroundStyle(.colorFillTertiary)
-
-                Text("Scan to join")
-                    .kerning(1.0)
-            }
-            .offset(y: 5.0)
-            .foregroundStyle(.colorTextSecondary)
-            .textCase(.uppercase)
-            .font(.caption)
-            .frame(height: Self.headerHeight)
-
-            if let qrCodeImage {
-                ZStack {
-                    Image(uiImage: qrCodeImage)
+                    .aspectRatio(contentMode: .fill)
+            } else {
+                GeometryReader { proxy in
+                    let inset: CGFloat = min(proxy.size.width, proxy.size.height) * 0.2
+                    Image("convosOrangeIcon")
+                        .renderingMode(.template)
                         .resizable()
-                        .aspectRatio(1.0, contentMode: .fit)
-                        .frame(width: qrSize, height: qrSize)
-
-                    ZStack {
-                        Rectangle()
-                            .fill(.colorBackgroundSurfaceless)
-                            .frame(width: centerBackgroundSize, height: centerBackgroundSize)
-
-                        ZStack {
-                            Rectangle()
-                                .fill(.colorTextPrimary)
-                            if hasConversationImage {
-                                conversationImage
-                                    .resizable()
-                                    .aspectRatio(contentMode: .fill)
-                            } else {
-                                Image("convosOrangeIcon")
-                                    .renderingMode(.template)
-                                    .resizable()
-                                    .scaledToFit()
-                                    .foregroundStyle(.colorTextPrimaryInverted)
-                                    .padding(centerImageSize * 0.2)
-                            }
-                        }
-                        .frame(width: centerImageSize, height: centerImageSize)
-                        .clipShape(RoundedRectangle(cornerRadius: DesignConstants.CornerRadius.small))
-                    }
+                        .scaledToFit()
+                        .foregroundStyle(.colorTextPrimaryInverted)
+                        .padding(inset)
                 }
-                .padding([.leading, .trailing, .bottom], cardInternalPadding)
-                .accessibilityLabel("Share QR code for conversation invite")
-                .accessibilityIdentifier("share-qr-code")
             }
         }
-        .background(.white)
-        .clipShape(RoundedRectangle(cornerRadius: DesignConstants.CornerRadius.large))
-        .padding(.horizontal, DesignConstants.Spacing.step10x)
-    }
-
-    private func dismissFlow() {
-        withAnimation(.easeOut(duration: 0.25)) {
-            showCard = false
-        }
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
-            isPresented = false
-        }
-    }
-}
-
-private struct ShareSheetPresenter: UIViewControllerRepresentable {
-    let activityItems: [Any]
-    @Binding var isPresented: Bool
-    let onDismiss: () -> Void
-
-    func makeUIViewController(context: Context) -> UIViewController {
-        UIViewController()
-    }
-
-    func updateUIViewController(_ uiViewController: UIViewController, context: Context) {
-        if isPresented && uiViewController.presentedViewController == nil {
-            let activityVC = UIActivityViewController(
-                activityItems: activityItems,
-                applicationActivities: nil
-            )
-
-            if let popover = activityVC.popoverPresentationController {
-                popover.sourceView = uiViewController.view
-                popover.sourceRect = CGRect(
-                    x: uiViewController.view.bounds.midX,
-                    y: uiViewController.view.bounds.maxY,
-                    width: 0,
-                    height: 0
-                )
-                popover.permittedArrowDirections = .up
-            }
-
-            activityVC.completionWithItemsHandler = { _, _, _, _ in
-                isPresented = false
-                onDismiss()
-            }
-
-            uiViewController.present(activityVC, animated: true)
-        }
+        .clipShape(RoundedRectangle(cornerRadius: DesignConstants.CornerRadius.small))
     }
 }
 

--- a/Convos/MainTabView.swift
+++ b/Convos/MainTabView.swift
@@ -423,7 +423,13 @@ struct MainTabView: View {
     private var sharedAppIndicatorOverlay: some View {
         VStack(spacing: 0) {
             if let activeConvoVM = activeConvoVM {
-                centeredConversationIndicator(for: activeConvoVM)
+                // Hide the lifted conversation indicator while the share
+                // overlay is up. This pill renders above the presenter's
+                // share overlay, so without this it sits on top of the
+                // presented code card.
+                if !activeConvoVM.presentingShareView {
+                    centeredConversationIndicator(for: activeConvoVM)
+                }
             } else {
                 leadingAppIndicatorPill
             }

--- a/Convos/Shared Views/QRCodeCardOverlay.swift
+++ b/Convos/Shared Views/QRCodeCardOverlay.swift
@@ -18,6 +18,9 @@ struct QRCodeCardOverlay<Header: View, Center: View>: View {
     @State private var showCard: Bool = false
     @State private var isShareSheetPresented: Bool = false
     @State private var qrCodeImage: UIImage?
+    /// Defers presenting the share sheet until the card has animated in.
+    /// Tracked so dismissing during the gap cancels the pending present.
+    @State private var sharePresentTask: Task<Void, Never>?
     @Environment(\.displayScale) private var displayScale: CGFloat
 
     private static var headerHeight: CGFloat { 40.0 }
@@ -92,7 +95,9 @@ struct QRCodeCardOverlay<Header: View, Center: View>: View {
                 withAnimation(.spring(response: 0.5, dampingFraction: 0.78)) {
                     showCard = true
                 }
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
+                sharePresentTask = Task {
+                    try? await Task.sleep(nanoseconds: 150_000_000)
+                    guard !Task.isCancelled else { return }
                     isShareSheetPresented = true
                 }
             }
@@ -139,6 +144,7 @@ struct QRCodeCardOverlay<Header: View, Center: View>: View {
     }
 
     private func dismissFlow() {
+        sharePresentTask?.cancel()
         withAnimation(.easeOut(duration: 0.25)) {
             showCard = false
         }

--- a/Convos/Shared Views/QRCodeCardOverlay.swift
+++ b/Convos/Shared Views/QRCodeCardOverlay.swift
@@ -71,14 +71,12 @@ struct QRCodeCardOverlay<Header: View, Center: View>: View {
 
                 Color.clear
                     .frame(width: 1, height: 1)
-                    .background(
-                        ShareSheetPresenter(
-                            activityItems: [encodedURLString],
-                            isPresented: $isShareSheetPresented,
-                            onDismiss: {
-                                dismissFlow()
-                            }
-                        )
+                    .shareSheet(
+                        isPresented: $isShareSheetPresented,
+                        items: [encodedURLString],
+                        onDismiss: {
+                            dismissFlow()
+                        }
                     )
             }
             .task {
@@ -145,48 +143,14 @@ struct QRCodeCardOverlay<Header: View, Center: View>: View {
 
     private func dismissFlow() {
         sharePresentTask?.cancel()
+        // Signal the share-sheet presenter to tear down the activity controller;
+        // otherwise it stays orphaned on screen after the card animates away.
+        isShareSheetPresented = false
         withAnimation(.easeOut(duration: 0.25)) {
             showCard = false
         }
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
             isPresented = false
-        }
-    }
-}
-
-private struct ShareSheetPresenter: UIViewControllerRepresentable {
-    let activityItems: [Any]
-    @Binding var isPresented: Bool
-    let onDismiss: () -> Void
-
-    func makeUIViewController(context: Context) -> UIViewController {
-        UIViewController()
-    }
-
-    func updateUIViewController(_ uiViewController: UIViewController, context: Context) {
-        if isPresented && uiViewController.presentedViewController == nil {
-            let activityVC = UIActivityViewController(
-                activityItems: activityItems,
-                applicationActivities: nil
-            )
-
-            if let popover = activityVC.popoverPresentationController {
-                popover.sourceView = uiViewController.view
-                popover.sourceRect = CGRect(
-                    x: uiViewController.view.bounds.midX,
-                    y: uiViewController.view.bounds.maxY,
-                    width: 0,
-                    height: 0
-                )
-                popover.permittedArrowDirections = .up
-            }
-
-            activityVC.completionWithItemsHandler = { _, _, _, _ in
-                isPresented = false
-                onDismiss()
-            }
-
-            uiViewController.present(activityVC, animated: true)
         }
     }
 }

--- a/Convos/Shared Views/QRCodeCardOverlay.swift
+++ b/Convos/Shared Views/QRCodeCardOverlay.swift
@@ -1,0 +1,186 @@
+import ConvosCore
+import ConvosCoreiOS
+import SwiftUI
+
+/// Reusable "code card" overlay: a QR card animates down from the top with a
+/// custom header and center chip, and the native share sheet presents behind
+/// it. Used by the conversation "Convos code" share flow and the agent
+/// contact card's share action. Callers supply the encoded URL (used for both
+/// the QR and the share item), the header content, and the QR center chip.
+/// The overlay applies the shared uppercase-caption styling to `header`.
+struct QRCodeCardOverlay<Header: View, Center: View>: View {
+    let encodedURLString: String
+    @Binding var isPresented: Bool
+    let topSafeAreaInset: CGFloat
+    @ViewBuilder let header: () -> Header
+    @ViewBuilder let center: () -> Center
+
+    @State private var showCard: Bool = false
+    @State private var isShareSheetPresented: Bool = false
+    @State private var qrCodeImage: UIImage?
+    @Environment(\.displayScale) private var displayScale: CGFloat
+
+    private static var headerHeight: CGFloat { 40.0 }
+    private static var cardPadding: CGFloat { 40.0 }
+    private static var maxQRSize: CGFloat { 220.0 }
+    private static var shareSheetFraction: CGFloat { 0.55 }
+
+    private func qrDisplaySize(in size: CGSize) -> CGFloat {
+        let availableHeight = size.height * (1.0 - Self.shareSheetFraction)
+            - topSafeAreaInset
+            - DesignConstants.Spacing.step4x
+            - Self.headerHeight
+            - Self.cardPadding
+            - DesignConstants.Spacing.step10x
+        let availableWidth = size.width
+            - DesignConstants.Spacing.step10x * 2
+            - Self.cardPadding * 2
+        let maxFit = min(availableHeight, availableWidth)
+        return min(max(maxFit, 120.0), Self.maxQRSize)
+    }
+
+    var body: some View {
+        GeometryReader { geometry in
+            ZStack {
+                if showCard {
+                    Color.black.opacity(0.5)
+                        .background(.ultraThinMaterial)
+                        .ignoresSafeArea()
+                        .transition(.opacity)
+                        .onTapGesture {
+                            dismissFlow()
+                        }
+                }
+
+                if showCard {
+                    VStack(spacing: 0.0) {
+                        codeCard(qrSize: qrDisplaySize(in: geometry.size))
+                        Spacer()
+                    }
+                    .padding(.top, topSafeAreaInset + DesignConstants.Spacing.step4x)
+                    .transition(
+                        .asymmetric(
+                            insertion: .move(edge: .top).combined(with: .opacity),
+                            removal: .opacity
+                        )
+                    )
+                }
+
+                Color.clear
+                    .frame(width: 1, height: 1)
+                    .background(
+                        ShareSheetPresenter(
+                            activityItems: [encodedURLString],
+                            isPresented: $isShareSheetPresented,
+                            onDismiss: {
+                                dismissFlow()
+                            }
+                        )
+                    )
+            }
+            .task {
+                let options = QRCodeGenerator.Options(
+                    scale: displayScale,
+                    displaySize: Self.maxQRSize,
+                    foregroundColor: UIColor(.colorTextPrimary),
+                    backgroundColor: UIColor(.colorBackgroundSurfaceless)
+                )
+                let generated = await QRCodeGenerator.generate(from: encodedURLString, options: options)
+                guard !Task.isCancelled else { return }
+                qrCodeImage = generated
+
+                withAnimation(.spring(response: 0.5, dampingFraction: 0.78)) {
+                    showCard = true
+                }
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
+                    isShareSheetPresented = true
+                }
+            }
+        }
+    }
+
+    private func codeCard(qrSize: CGFloat) -> some View {
+        let centerContentSize: CGFloat = qrSize * (50.0 / Self.maxQRSize)
+        let centerBackgroundSize: CGFloat = qrSize * (55.0 / Self.maxQRSize)
+        let cardInternalPadding: CGFloat = qrSize * (Self.cardPadding / Self.maxQRSize)
+
+        return VStack(spacing: 0.0) {
+            header()
+                .offset(y: 5.0)
+                .foregroundStyle(.colorTextSecondary)
+                .textCase(.uppercase)
+                .font(.caption)
+                .frame(height: Self.headerHeight)
+
+            if let qrCodeImage {
+                ZStack {
+                    Image(uiImage: qrCodeImage)
+                        .resizable()
+                        .aspectRatio(1.0, contentMode: .fit)
+                        .frame(width: qrSize, height: qrSize)
+
+                    ZStack {
+                        Rectangle()
+                            .fill(.colorBackgroundSurfaceless)
+                            .frame(width: centerBackgroundSize, height: centerBackgroundSize)
+
+                        center()
+                            .frame(width: centerContentSize, height: centerContentSize)
+                    }
+                }
+                .padding([.leading, .trailing, .bottom], cardInternalPadding)
+                .accessibilityLabel("Share QR code")
+                .accessibilityIdentifier("share-qr-code")
+            }
+        }
+        .background(.white)
+        .clipShape(RoundedRectangle(cornerRadius: DesignConstants.CornerRadius.large))
+        .padding(.horizontal, DesignConstants.Spacing.step10x)
+    }
+
+    private func dismissFlow() {
+        withAnimation(.easeOut(duration: 0.25)) {
+            showCard = false
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
+            isPresented = false
+        }
+    }
+}
+
+private struct ShareSheetPresenter: UIViewControllerRepresentable {
+    let activityItems: [Any]
+    @Binding var isPresented: Bool
+    let onDismiss: () -> Void
+
+    func makeUIViewController(context: Context) -> UIViewController {
+        UIViewController()
+    }
+
+    func updateUIViewController(_ uiViewController: UIViewController, context: Context) {
+        if isPresented && uiViewController.presentedViewController == nil {
+            let activityVC = UIActivityViewController(
+                activityItems: activityItems,
+                applicationActivities: nil
+            )
+
+            if let popover = activityVC.popoverPresentationController {
+                popover.sourceView = uiViewController.view
+                popover.sourceRect = CGRect(
+                    x: uiViewController.view.bounds.midX,
+                    y: uiViewController.view.bounds.maxY,
+                    width: 0,
+                    height: 0
+                )
+                popover.permittedArrowDirections = .up
+            }
+
+            activityVC.completionWithItemsHandler = { _, _, _, _ in
+                isPresented = false
+                onDismiss()
+            }
+
+            uiViewController.present(activityVC, animated: true)
+        }
+    }
+}

--- a/Convos/Shared Views/ShareSheetPresenter.swift
+++ b/Convos/Shared Views/ShareSheetPresenter.swift
@@ -5,8 +5,9 @@ extension View {
     /// Presents the native share sheet (`UIActivityViewController`) directly over
     /// this view when `isPresented` becomes true, with no intermediate SwiftUI
     /// sheet or backdrop. `isPresented` is reset to false when the share sheet is
-    /// dismissed. Use this for "share over the current screen"; for a share sheet
-    /// with a visible backdrop card, present a backdrop view yourself.
+    /// dismissed; setting it back to false yourself also dismisses a sheet that is
+    /// still on screen. Use this for "share over the current screen"; for a share
+    /// sheet with a visible backdrop card, present a backdrop view yourself.
     ///
     /// `onPresented` fires once the share sheet has finished animating in - useful
     /// for clearing a caller's loading state that covers the tap-to-share gap.
@@ -38,7 +39,16 @@ private struct ShareSheetPresenter: UIViewControllerRepresentable {
     }
 
     func updateUIViewController(_ uiViewController: UIViewController, context: Context) {
-        guard isPresented, !items.isEmpty, uiViewController.presentedViewController == nil else {
+        guard isPresented else {
+            // The binding flipped to false while the sheet is still up (e.g. a
+            // backdrop tap dismissing a containing overlay) - tear it down so the
+            // activity controller can't outlive its presenter.
+            if uiViewController.presentedViewController != nil {
+                uiViewController.dismiss(animated: true)
+            }
+            return
+        }
+        guard !items.isEmpty, uiViewController.presentedViewController == nil else {
             return
         }
 

--- a/ConvosCore/Sources/ConvosCore/Mocks/MockRepositories.swift
+++ b/ConvosCore/Sources/ConvosCore/Mocks/MockRepositories.swift
@@ -32,6 +32,27 @@ public final class MockConversationsRepository: ConversationsRepositoryProtocol,
             return others.count == 1 && others.first?.profile.inboxId == inboxId
         }
     }
+
+    public func conversations(withAgentTemplateId templateId: String) throws -> AgentTemplateConversations {
+        var addedByCurrentUser: [Conversation] = []
+        var addedByOthers: [Conversation] = []
+        for conversation in mockConversations {
+            let agentMember = conversation.members.first { member in
+                member.isAgent && member.profile.agentTemplateId == templateId
+            }
+            guard let agentMember else { continue }
+            let currentUserInboxId = conversation.members.first { $0.isCurrentUser }?.profile.inboxId
+            if let inviterInboxId = agentMember.invitedBy?.inboxId, inviterInboxId == currentUserInboxId {
+                addedByCurrentUser.append(conversation)
+            } else {
+                addedByOthers.append(conversation)
+            }
+        }
+        return AgentTemplateConversations(
+            addedByCurrentUser: addedByCurrentUser,
+            addedByOthers: addedByOthers
+        )
+    }
 }
 
 // MARK: - Mock Conversations Count Repository

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/AgentTemplateConversations.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/AgentTemplateConversations.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+/// Conversations that contain an agent provisioned from a given template,
+/// split by who added that agent. Drives the agent contact card's "Convos
+/// with you" (added by the current user) and "someone else added them"
+/// sections. Attribution comes from the agent member's `invitedBy`.
+public struct AgentTemplateConversations: Sendable, Equatable {
+    public let addedByCurrentUser: [Conversation]
+    public let addedByOthers: [Conversation]
+
+    public init(addedByCurrentUser: [Conversation], addedByOthers: [Conversation]) {
+        self.addedByCurrentUser = addedByCurrentUser
+        self.addedByOthers = addedByOthers
+    }
+
+    public static let empty: AgentTemplateConversations = .init(addedByCurrentUser: [], addedByOthers: [])
+
+    public var isEmpty: Bool {
+        addedByCurrentUser.isEmpty && addedByOthers.isEmpty
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Storage/Repositories/ConversationsRepository.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Repositories/ConversationsRepository.swift
@@ -18,6 +18,14 @@ public protocol ConversationsRepositoryProtocol {
     /// unused exclusions as `fetchAll`. Returns nil when no other
     /// match exists.
     func findOneToOne(with inboxId: String, excluding excludedConversationId: String?) throws -> Conversation?
+
+    /// Conversations that contain an agent provisioned from `templateId`,
+    /// split by who added that agent: `addedByCurrentUser` when the agent
+    /// member's `invitedBy` is one of the current user's inboxes, otherwise
+    /// `addedByOthers`. Backs the agent contact card's "Convos with you" and
+    /// "someone else added them" sections. Honours the repo's `consent` scope
+    /// and the same draft / expired / unused exclusions as `fetchAll`.
+    func conversations(withAgentTemplateId templateId: String) throws -> AgentTemplateConversations
 }
 
 final class ConversationsRepository: ConversationsRepositoryProtocol {
@@ -56,6 +64,34 @@ final class ConversationsRepository: ConversationsRepositoryProtocol {
                 with: inboxId,
                 excluding: excludedConversationId,
                 consent: consent
+            )
+        }
+    }
+
+    func conversations(withAgentTemplateId templateId: String) throws -> AgentTemplateConversations {
+        try dbReader.read { [consent] db in
+            // Filter and partition in Swift over the hydrated conversations:
+            // `member.profile.agentTemplateId` is the trusted accessor over the
+            // profile metadata, and `invitedBy` already carries the agent's
+            // inviter, so this avoids a brittle SQL JSON_EXTRACT predicate.
+            let currentInboxIds = Set(try DBInbox.fetchAll(db).map(\.inboxId))
+            let conversations = try db.composeAllConversations(consent: consent)
+            var addedByCurrentUser: [Conversation] = []
+            var addedByOthers: [Conversation] = []
+            for conversation in conversations {
+                let agentMember = conversation.members.first { member in
+                    member.isAgent && member.profile.agentTemplateId == templateId
+                }
+                guard let agentMember else { continue }
+                if let inviterInboxId = agentMember.invitedBy?.inboxId, currentInboxIds.contains(inviterInboxId) {
+                    addedByCurrentUser.append(conversation)
+                } else {
+                    addedByOthers.append(conversation)
+                }
+            }
+            return AgentTemplateConversations(
+                addedByCurrentUser: addedByCurrentUser,
+                addedByOthers: addedByOthers
             )
         }
     }

--- a/ConvosCore/Sources/ConvosCore/Storage/Repositories/ConversationsRepository.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Repositories/ConversationsRepository.swift
@@ -74,6 +74,9 @@ final class ConversationsRepository: ConversationsRepositoryProtocol {
             // `member.profile.agentTemplateId` is the trusted accessor over the
             // profile metadata, and `invitedBy` already carries the agent's
             // inviter, so this avoids a brittle SQL JSON_EXTRACT predicate.
+            // Trade-off: this hydrates every allowed conversation and partitions
+            // in memory rather than filtering in SQL - fine at expected
+            // conversation counts; revisit with a SQL predicate if it gets hot.
             let currentInboxIds = Set(try DBInbox.fetchAll(db).map(\.inboxId))
             let conversations = try db.composeAllConversations(consent: consent)
             var addedByCurrentUser: [Conversation] = []


### PR DESCRIPTION
Builds on #939 to flesh out the agent contact card.

## What

1. **Prominent Share button** — the top-bar share button now uses the primary tint.
2. **"Share <agent name>" row** under Chat, triggering the same share action.
3. **Two conversation sections** listing conversations that already contain this agent template, split by who added the agent:
   - **"Convos with you"** — you added the agent (footer "You added them · Using your credits", plus the privacy note "For privacy, agents cannot share memories, context or skills between conversations.").
   - **"Someone else added them"** — conversations you're in where someone else added the agent.
   Rows reuse `ConversationsListItem`.
4. **Reusable QR "code card"** — the conversation "Convos code" overlay is extracted into `QRCodeCardOverlay` (header + center chip + encoded URL). The conversation flow is visually unchanged; the agent share action now presents the same card with the template name as the header and the template emoji over a `.colorLava` circle in the QR center, encoding the agent's published URL with the system share sheet behind it (replacing the plain share sheet).

## Data layer

New `ConversationsRepository.conversations(withAgentTemplateId:)` reuses the existing hydrated-conversation query and partitions in Swift by the agent member's `invitedBy` vs the current inbox(es). Attribution comes from `DBConversationMember.invitedByInboxId` — no schema change.

## Files

- `ConvosCore/.../Storage/Models/AgentTemplateConversations.swift` (new result type)
- `ConvosCore/.../Storage/Repositories/ConversationsRepository.swift` (+ mock)
- `Convos/Shared Views/QRCodeCardOverlay.swift` (new, extracted)
- `Convos/Conversation Detail/ConversationShareView.swift` (now a thin wrapper)
- `Convos/Contacts/AgentShareOverlay.swift`, `AgentTemplateConversationsSections.swift` (new)
- `Convos/Contacts/ContactDetailView.swift` (button tint, share row, sections, overlay swap)

## Notes for review

- Share-row footer copy ("Show a code or send a link to add this agent") and the agent card header (template name only, no "Scan to…" subtitle) are reasonable defaults — easy to adjust.
- The agent code overlay uses `topSafeAreaInset: 0` like the conversation flow; worth eyeballing its position when presented over the contact sheet.
- Conversation rows in the sections are display-only for now (no tap-to-open routing from this surface).

## Testing

- ConvosCore full suite: **1072 tests / 156 suites passed**.
- App (Dev scheme) builds; SwiftLint clean.
- Not yet visually verified in-sim (needs an agent contact with a published URL + conversations); happy to drive the simulator if you point me at that state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/940"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782968079&installation_id=128169237&pr_number=940&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F940&signature=1aef1c43af61738f4f197ec29b7d7fb193887a11e2adc452127a597a1bdda6e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add QR share overlay and conversation sections to agent contact cards
> - Introduces a reusable [`QRCodeCardOverlay`](https://github.com/xmtplabs/convos-ios/pull/940/files#diff-c65a8fb672194348dfb2218e7e941c2b793ac84fadb78d6508a64b222b086d41) that generates a QR code card, animates it in, and presents the native share sheet behind it — used by both conversation and agent share flows.
> - Adds [`AgentShareOverlay`](https://github.com/xmtplabs/convos-ios/pull/940/files#diff-7af52169a97c15dcb76bb86a8f538c7d28e86a7655701f8c6ed8a54f64f7df7c) to encode an agent template's `publishedUrl` into a QR card; the toolbar share button is hidden while the overlay is active and only appears when a `publishedUrl` exists.
> - Adds [`AgentTemplateConversationsSections`](https://github.com/xmtplabs/convos-ios/pull/940/files#diff-9718c4430bffcef6d1daf4205d4be4001758a9be1167930e0d545526b2d3c553) to display conversations already containing an agent template, grouped by who added the agent, within the contact detail view.
> - Adds `conversations(withAgentTemplateId:)` to [`ConversationsRepository`](https://github.com/xmtplabs/convos-ios/pull/940/files#diff-90928c87d10f44ba54e64041476d7947060aadc7a4a5be29360781e9145a21c4) to fetch and partition conversations by the agent's inviter.
> - Fixes orphaned `UIActivityViewController` instances by dismissing the share sheet when its controlling binding flips to false.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0e671bf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->