### PR TITLE
Temporarily hide the file attachment button in the agent builder

### DIFF
--- a/Convos/Agent Builder/AgentDraftComposer.swift
+++ b/Convos/Agent Builder/AgentDraftComposer.swift
@@ -293,6 +293,7 @@ struct AgentDraftComposer: View {
                 isMediaCapacityFull: isMediaCapacityFull,
                 isVoiceMemoDisabled: viewModel.recordedVoiceMemo != nil,
                 showsSideConvoButton: false,
+                showsFileButton: false,
                 buttonSpacing: DesignConstants.Spacing.step4x,
                 onConnectionsTap: {
                     focusState.wrappedValue = nil

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesMediaInputView.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesMediaInputView.swift
@@ -10,6 +10,9 @@ struct MessagesMediaButtonsView: View {
     var isVoiceMemoDisabled: Bool = false
     var isSideConvoDisabled: Bool = false
     var showsSideConvoButton: Bool = true
+    /// File attachment button. Temporarily hidden in the Agent Builder while
+    /// file attachments are disabled there; the regular chat composer keeps it.
+    var showsFileButton: Bool = true
     var buttonSpacing: CGFloat = DesignConstants.Spacing.step2x
     /// Connections button (Agent Builder only). Nil hides the button — the
     /// regular chat composer doesn't surface a connections affordance here.
@@ -75,21 +78,23 @@ struct MessagesMediaButtonsView: View {
             .accessibilityLabel("Voice memo")
             .accessibilityIdentifier("voice-memo-button")
 
-            Button {
-                onFilePickerTap()
-            } label: {
-                Image(systemName: "document.fill")
-                    .font(.system(size: 18.0, weight: .medium))
-                    .foregroundStyle(mediaTint)
-                    .frame(width: Constant.buttonSize, height: Constant.buttonSize)
-                    .contentShape(.circle)
+            if showsFileButton {
+                Button {
+                    onFilePickerTap()
+                } label: {
+                    Image(systemName: "document.fill")
+                        .font(.system(size: 18.0, weight: .medium))
+                        .foregroundStyle(mediaTint)
+                        .frame(width: Constant.buttonSize, height: Constant.buttonSize)
+                        .contentShape(.circle)
+                }
+                .buttonStyle(.plain)
+                .disabled(isMediaCapacityFull)
+                .hoverEffect(.lift)
+                .hoverEffectDisabled(isMediaCapacityFull)
+                .accessibilityLabel("Attach file")
+                .accessibilityIdentifier("file-picker-button")
             }
-            .buttonStyle(.plain)
-            .disabled(isMediaCapacityFull)
-            .hoverEffect(.lift)
-            .hoverEffectDisabled(isMediaCapacityFull)
-            .accessibilityLabel("Attach file")
-            .accessibilityIdentifier("file-picker-button")
 
             if let onConnectionsTap {
                 Button {


### PR DESCRIPTION
Temporarily hides the "file" attachment (document picker) button in the **agent builder** composer while file attachments are disabled there.

## What changed
- `MessagesMediaButtonsView` gains a `showsFileButton` flag, defaulting to `true` (mirrors the existing `showsSideConvoButton` convention).
- `AgentDraftComposer` passes `showsFileButton: false`, so the `document.fill` button no longer renders in the agent builder.
- The regular chat composer (`MessagesBottomBar`) and the in-file `#Preview` are untouched and keep the file button.

The `.fileImporter` modifier and file-staging logic in `AgentDraftComposer` stay in place but become unreachable, so re-enabling is a one-line flip of the flag.

## Testing
- Clean `xcodebuild` of `Convos (Dev)` for the iOS Simulator: **BUILD SUCCEEDED**.
- SwiftLint `--strict` on both changed files: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Hide file attachment button in the Agent Builder composer
> Adds a `showsFileButton` parameter to `MessagesMediaButtonsView` (default `true`) and passes `false` from the Agent Builder's [`AgentDraftComposer`](https://github.com/xmtplabs/convos-ios/pull/942/files#diff-a9efd932548b1a0786239eaaddd5f4e1cba9cc0ca3fbfb7253a70e3571480cfc), omitting the file picker button entirely when composing agent drafts.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 19dce05.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->