### PR TITLE
Fix reveal/blur toggle showing on non-image attachments

### DIFF
--- a/Convos/Conversation Detail/Messages/MessagesListView/MessageContextMenu/MessageContextMenuOverlay.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessageContextMenu/MessageContextMenuOverlay.swift
@@ -489,25 +489,27 @@ struct MessageContextMenuOverlay: View {
                     }
                     ContextMenuRow(icon: "square.and.arrow.down", title: "Save", action: saveAction)
 
-                    let isBlurred = shouldBlurPhoto
-                    let key = attachment.key
-                    let revealCallback = onPhotoRevealed
-                    let hideCallback = onPhotoHidden
-                    let toggleAction = {
-                        if isBlurred {
-                            blurOverride = false
-                            revealCallback(key)
-                        } else {
-                            blurOverride = true
-                            hideCallback(key)
+                    if attachment.supportsBlur {
+                        let isBlurred = shouldBlurPhoto
+                        let key = attachment.key
+                        let revealCallback = onPhotoRevealed
+                        let hideCallback = onPhotoHidden
+                        let toggleAction = {
+                            if isBlurred {
+                                blurOverride = false
+                                revealCallback(key)
+                            } else {
+                                blurOverride = true
+                                hideCallback(key)
+                            }
+                            dismissMenu(afterStateChange: true)
                         }
-                        dismissMenu(afterStateChange: true)
+                        ContextMenuRow(
+                            icon: isBlurred ? "eye" : "eye.slash",
+                            title: isBlurred ? "Reveal" : "Blur",
+                            action: toggleAction
+                        )
                     }
-                    ContextMenuRow(
-                        icon: isBlurred ? "eye" : "eye.slash",
-                        title: isBlurred ? "Reveal" : "Blur",
-                        action: toggleAction
-                    )
                 }
             }
             .padding(.vertical, 10)

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/HydratedAttachment.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/HydratedAttachment.swift
@@ -84,6 +84,14 @@ public struct HydratedAttachment: Hashable, Codable, Sendable {
         return .file
     }
 
+    /// Whether this attachment renders as visual media that can be blurred and revealed.
+    /// Mirrors the routing in `MessagesGroupItemView`: voice memos, files, and HTML tiles
+    /// render in their own bubbles and never receive the blur overlay, so the reveal/blur
+    /// toggle must not be offered for them.
+    public var supportsBlur: Bool {
+        !isHTMLFile && mediaType != .audio && mediaType != .file
+    }
+
     public var aspectRatio: CGFloat? {
         guard let w = width, let h = height, h > 0 else { return nil }
         return CGFloat(w) / CGFloat(h)


### PR DESCRIPTION
## Problem

The **Reveal / Blur** action appeared in the message context menu for attachment types that never get a blur overlay — voice memos, files (e.g. a `.GZ` log file), and HTML / agent-share tiles. Tapping it did nothing meaningful for those types.

The toggle was gated only on the *presence* of an attachment (`if let attachment = photoAttachment`), which returns any attachment regardless of media type. But blur is only ever rendered for attachments that route to `MediaAttachmentView` (images, videos, unknown) — voice memos, files, and HTML tiles render in their own bubbles and never receive the `.blur()` overlay.

## Fix

- Add `HydratedAttachment.supportsBlur` (`!isHTMLFile && mediaType != .audio && mediaType != .file`) as a single source of truth that mirrors the routing in `MessagesGroupItemView`.
- Gate the Reveal/Blur context-menu row on `attachment.supportsBlur`.
- **Save** remains available for all attachment types — only the Reveal/Blur toggle is affected.

## Test plan

- `swift build` on ConvosCore — passes.
- Full app build (`Convos (Dev)`, arm64 simulator) — **BUILD SUCCEEDED**.
- Full ConvosCore test suite — 1087 tests / 156 suites pass.
- Manual: built + launched on simulator; Reveal/Blur no longer shows on file / HTML / voice-memo attachments, still shows on photos/videos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/943"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783012923&installation_id=128169237&pr_number=943&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F943&signature=a68db3352cf4eabc1f1ff6270e2360a225dda2436efe3ce09a4ba615c486f1d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Reveal/Blur toggle appearing on non-image attachments
> Adds a `supportsBlur` computed property to `HydratedAttachment` that returns `true` only for visual media (i.e. not audio, file, or HTML types). The Reveal/Blur context menu item in `MessageContextMenuOverlay` is now gated on this property, so audio and file attachments no longer show the toggle.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4967dbb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->