### PR TITLE
feat(contacts): add Contacts tab; remove App Settings Contacts row

### DIFF
--- a/Convos/App Settings/AppSettingsView.swift
+++ b/Convos/App Settings/AppSettingsView.swift
@@ -66,9 +66,8 @@ struct AppSettingsView: View {
             List {
                 headerSection
                 myInfoSection
-                contactsSection
-                connectionsSection
                 subscriptionSection
+                connectionsSection
                 devicesSection
                 customizeSection
                 linksSection
@@ -82,7 +81,6 @@ struct AppSettingsView: View {
             .toolbar { topToolbar }
             .onReceive(CreditsServices.shared.balancePublisher) { creditBalance = $0 }
             .onReceive(SubscriptionServices.shared.subscriptionPublisher) { currentSubscription = $0 }
-            .onReceive(session.messagingService().contactsRepository().contactsPublisher) { contactsCount = $0.filter(\.isVisibleInContactsList).count }
         }
     }
 
@@ -126,8 +124,6 @@ struct AppSettingsView: View {
         }
     }
 
-    @State private var contactsCount: Int = 0
-
     @ViewBuilder
     private var devicesSection: some View {
         Section {
@@ -157,31 +153,6 @@ struct AppSettingsView: View {
     }
 
     @ViewBuilder
-    private var contactsSection: some View {
-        Section {
-            NavigationLink {
-                contactsViewDestination
-            } label: {
-                contactsRowLabel
-            }
-            .accessibilityIdentifier("contacts-row")
-        } footer: {
-            Text("People and agents")
-        }
-    }
-
-    @ViewBuilder
-    private var contactsViewDestination: some View {
-        let messagingService = session.messagingService()
-        ContactsView(
-            contactsRepository: messagingService.contactsRepository(),
-            contactsWriter: messagingService.contactsWriter(),
-            session: session,
-            profileSettingsViewModel: profileSettingsViewModel
-        )
-    }
-
-    @ViewBuilder
     private var myInfoRowLabel: some View {
         HStack {
             Image(systemName: "lanyardcard.fill")
@@ -203,26 +174,6 @@ struct AppSettingsView: View {
                     useSystemPlaceholder: false
                 )
                 .frame(width: 16.0, height: 16.0)
-            }
-        }
-    }
-
-    @ViewBuilder
-    private var contactsRowLabel: some View {
-        HStack {
-            Image(systemName: "person.crop.circle")
-                .foregroundStyle(.colorTextPrimary)
-                .frame(width: DesignConstants.Spacing.step8x, alignment: .center)
-
-            Text("Contacts")
-                .foregroundStyle(.colorTextPrimary)
-
-            Spacer()
-
-            if contactsCount > 0 {
-                Text("\(contactsCount)")
-                    .foregroundStyle(.colorTextSecondary)
-                    .monospacedDigit()
             }
         }
     }

--- a/Convos/Contacts/ContactsView.swift
+++ b/Convos/Contacts/ContactsView.swift
@@ -10,12 +10,18 @@ struct ContactsView: View {
     private let contactsWriter: any ContactsWriterProtocol
     private let session: (any SessionManagerProtocol)?
     private let profileSettingsViewModel: ProfileSettingsViewModel
+    /// Whether to render the contacts-scoped compose button. The Contacts
+    /// tab hides it because the shell's shared toolbar already provides a
+    /// compose button (whose `onStartConvo` opens the same contacts picker),
+    /// so the tab's top bar matches Chats and Stuff exactly.
+    private let showsComposeButton: Bool
 
     init(
         contactsRepository: any ContactsRepositoryProtocol,
         contactsWriter: any ContactsWriterProtocol = MockContactsWriter(),
         session: (any SessionManagerProtocol)? = nil,
-        profileSettingsViewModel: ProfileSettingsViewModel = .shared
+        profileSettingsViewModel: ProfileSettingsViewModel = .shared,
+        showsComposeButton: Bool = true
     ) {
         _viewModel = State(initialValue: ContactsViewModel(
             contactsRepository: contactsRepository
@@ -24,6 +30,7 @@ struct ContactsView: View {
         self.contactsWriter = contactsWriter
         self.session = session
         self.profileSettingsViewModel = profileSettingsViewModel
+        self.showsComposeButton = showsComposeButton
     }
 
     var body: some View {
@@ -39,17 +46,16 @@ struct ContactsView: View {
             Color.colorBackgroundRaisedSecondary
                 .ignoresSafeArea()
         }
-        // The system `.largeTitle` doesn't transition cleanly during the
-        // navigation pop / search keyboard appearance, so render the
-        // header as an inline `Text` above the search bar instead. The
-        // nav bar is forced to inline mode so only the back / compose
-        // toolbar items remain visible at the top. The bar background
-        // is hidden so the list scrolls behind it with the iOS 26 glass
-        // blur, matching the `safeAreaBar` treatment we apply to the
-        // title + search bar below.
+        // The nav bar is forced to inline mode with a hidden background so
+        // only the toolbar items remain visible at the top and the list
+        // scrolls behind it with the iOS 26 glass blur, matching the
+        // `safeAreaBar` treatment applied to the search bar below.
         .navigationBarTitleDisplayMode(.inline)
         .toolbarBackground(.hidden, for: .navigationBar)
         .toolbar { toolbarContent }
+        .navigationDestination(for: Contact.self) { contact in
+            contactDetail(for: contact)
+        }
         .sheet(isPresented: $presentingPicker) { pickerSheet }
         .sheet(item: $presentingNewConvo) { vm in
             NewConversationView(
@@ -63,38 +69,20 @@ struct ContactsView: View {
     // MARK: - List
 
     /// Same `safeAreaBar` treatment the contacts picker and chat
-    /// composer use. The title + search bar float at the top with iOS 26
-    /// glass blur, and the underlying list's scroll inset is
-    /// auto-adjusted so rows scroll cleanly under the bar.
+    /// composer use. The search bar floats at the top with iOS 26 glass
+    /// blur, and the underlying list's scroll inset is auto-adjusted so
+    /// rows scroll cleanly under the bar.
     @ViewBuilder
     private var contactsContent: some View {
         contactList
             .background(.colorBackgroundRaisedSecondary)
             .safeAreaBar(edge: .top) {
-                VStack(spacing: 0.0) {
-                    titleLabel
-                    ContactsSearchBar(
-                        query: $viewModel.searchQuery,
-                        placeholder: "Search",
-                        accessibilityIdentifier: "contacts-search-field"
-                    )
-                }
+                ContactsSearchBar(
+                    query: $viewModel.searchQuery,
+                    placeholder: "Search contacts",
+                    accessibilityIdentifier: "contacts-search-field"
+                )
             }
-    }
-
-    /// Custom large-title replacement (see comment on `body`). Sized
-    /// per the figma `large/ios` style: SF Pro Bold 40pt with -1pt
-    /// tracking, anchored at 25pt from the leading edge so it lines up
-    /// with the contacts rows below.
-    private var titleLabel: some View {
-        Text("Contacts")
-            .font(.system(size: 40.0, weight: .bold))
-            .tracking(-1.0)
-            .foregroundStyle(.colorTextPrimary)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(.leading, 25.0)
-            .padding(.top, DesignConstants.Spacing.step2x)
-            .accessibilityAddTraits(.isHeader)
     }
 
     @ViewBuilder
@@ -108,20 +96,26 @@ struct ContactsView: View {
                 )
             },
             rowContent: { (row: ContactsViewModel.Row) in
-                NavigationLink {
-                    ContactDetailView(
-                        contact: row.contact,
-                        contactsWriter: contactsWriter,
-                        contactsRepository: contactsRepository,
-                        session: session,
-                        profileSettingsViewModel: profileSettingsViewModel,
-                        showsCloseButton: false
-                    )
-                } label: {
+                NavigationLink(value: row.contact) {
                     ContactRowView(contact: row.contact, subtitle: row.subtitle)
                 }
             },
             listBackground: { Color.colorBackgroundRaisedSecondary }
+        )
+    }
+
+    /// Detail pushed when a contact row is tapped. Built here (rather than
+    /// inline in the row) so navigation is value-based -- the host lifts the
+    /// stack path to know when a detail is on screen.
+    @ViewBuilder
+    private func contactDetail(for contact: Contact) -> some View {
+        ContactDetailView(
+            contact: contact,
+            contactsWriter: contactsWriter,
+            contactsRepository: contactsRepository,
+            session: session,
+            profileSettingsViewModel: profileSettingsViewModel,
+            showsCloseButton: false
         )
     }
 
@@ -134,14 +128,16 @@ struct ContactsView: View {
 
     @ToolbarContentBuilder
     private var toolbarContent: some ToolbarContent {
-        ToolbarItem(placement: .topBarTrailing) {
-            let canCompose = session != nil && viewModel.contactCount > 0
-            Button(action: presentPicker) {
-                Image(systemName: "square.and.pencil")
+        if showsComposeButton {
+            ToolbarItem(placement: .topBarTrailing) {
+                let canCompose = session != nil && viewModel.contactCount > 0
+                Button(action: presentPicker) {
+                    Image(systemName: "square.and.pencil")
+                }
+                .disabled(!canCompose)
+                .accessibilityLabel("Start a new conversation from contacts")
+                .accessibilityIdentifier("contacts-compose-button")
             }
-            .disabled(!canCompose)
-            .accessibilityLabel("Start a new conversation from contacts")
-            .accessibilityIdentifier("contacts-compose-button")
         }
     }
 

--- a/Convos/Conversations List/ConvosTab.swift
+++ b/Convos/Conversations List/ConvosTab.swift
@@ -2,19 +2,17 @@ import SwiftUI
 
 /// Source of truth for which lane of the main shell is active. Used as the
 /// `selection` of the standard SwiftUI `TabView` that renders the system
-/// tab bar for Chats and Stuff.
-///
-/// Search was a third lane that is temporarily removed; reintroduce a
-/// `.search` case here (and a `Tab` for it in `MainTabView`) to bring it
-/// back.
+/// tab bar for Chats, Stuff, and Contacts.
 enum ConvosTab: Hashable {
     case chats
     case stuff
+    case contacts
 
     var title: String {
         switch self {
         case .chats: "Chats"
         case .stuff: "Stuff"
+        case .contacts: "Contacts"
         }
     }
 
@@ -22,6 +20,7 @@ enum ConvosTab: Hashable {
         switch self {
         case .chats: "message.fill"
         case .stuff: "square.grid.2x2.fill"
+        case .contacts: "person.fill"
         }
     }
 }

--- a/Convos/MainTabView.swift
+++ b/Convos/MainTabView.swift
@@ -3,17 +3,18 @@ import PhotosUI
 import SwiftUI
 
 /// Root tab shell for the app. Hosts the existing `ConversationsView` under
-/// the "Chats" tab and `StuffTabView` under "Stuff", in a standard SwiftUI
-/// `TabView` with the system tab bar. (Search was a third tab that is
-/// temporarily removed.)
+/// the "Chats" tab, `StuffTabView` under "Stuff", and `ContactsView` under
+/// "Contacts", in a standard SwiftUI `TabView` with the system tab bar.
 ///
 /// The agent builder bar is pinned via a `safeAreaInset` on the edge
 /// opposite the tab bar (top on iPhone, where the tab bar is at the bottom;
 /// bottom on iPad, where the standard tab bar is at the top), shared across
-/// both tabs. It fades out on scroll and is replaced by a compact "add
-/// agent" button in the nav bar. The compose button lives in the shared
-/// toolbar; the app-indicator pill is a top-leading overlay (see
-/// `sharedAppIndicatorOverlay`).
+/// the Chats and Stuff tabs. It fades out on scroll and is replaced by a
+/// compact "add agent" button in the nav bar. The Contacts tab never shows
+/// the builder bar -- its search bar owns the top -- so the "add agent"
+/// button stays in the nav bar there regardless of scroll. The compose
+/// button lives in the shared toolbar; the app-indicator pill is a
+/// top-leading overlay (see `sharedAppIndicatorOverlay`).
 struct MainTabView: View {
     @Bindable var conversationsViewModel: ConversationsViewModel
     let profileSettingsViewModel: ProfileSettingsViewModel
@@ -32,6 +33,11 @@ struct MainTabView: View {
     /// (same morph as a chats push). Synced via `.onChange` on
     /// `stuffPushedItems` — created lazily, cleared on pop.
     @State private var stuffPushedConvoVM: ConversationViewModel?
+    /// NavigationStack path for the Contacts tab, lifted here so the shared
+    /// app-indicator overlay can tell when a contact detail is pushed and
+    /// re-center the pill (mirrors how `stuffPushedItems` lifts the Stuff
+    /// path). `ContactsView` pushes onto it via value-based `NavigationLink`s.
+    @State private var contactsPath: [Contact] = []
     /// Whether the top `AgentBuilderBar` is revealed (shown under the nav
     /// bar) versus faded out. Held in state with hysteresis thresholds
     /// rather than derived purely from scroll offset so a bouncy scroll
@@ -174,11 +180,19 @@ struct MainTabView: View {
         conversationsViewModel.isEmptyCTAActive
     }
 
+    /// `true` when the Contacts tab is active and has a contact detail pushed
+    /// onto its stack. Used to hide the app-indicator pill while a contact
+    /// detail is on screen.
+    private var isContactDetailPushed: Bool {
+        activeTab == .contacts && !contactsPath.isEmpty
+    }
+
     /// Scroll offset for whichever tab is currently active.
     private var activeTabScrollOffset: CGFloat {
         switch activeTab {
         case .chats: chatsScrollOffset
         case .stuff: stuffScrollOffset
+        case .contacts: 0
         }
     }
 
@@ -297,7 +311,7 @@ struct MainTabView: View {
     private var tabView: some View {
         TabView(selection: $activeTab) {
             Tab(ConvosTab.chats.title, systemImage: ConvosTab.chats.symbol, value: ConvosTab.chats) {
-                tabContainer {
+                tabContainer(for: .chats) {
                     ConversationsView(
                         viewModel: conversationsViewModel,
                         profileSettingsViewModel: profileSettingsViewModel,
@@ -317,7 +331,7 @@ struct MainTabView: View {
             }
 
             Tab(ConvosTab.stuff.title, systemImage: ConvosTab.stuff.symbol, value: ConvosTab.stuff) {
-                tabContainer {
+                tabContainer(for: .stuff) {
                     StuffTabView(
                         appIndicatorContext: appIndicatorContext,
                         conversationsViewModel: conversationsViewModel,
@@ -331,11 +345,32 @@ struct MainTabView: View {
                     )
                 }
             }
+
+            Tab(ConvosTab.contacts.title, systemImage: ConvosTab.contacts.symbol, value: ConvosTab.contacts) {
+                tabContainer(for: .contacts) {
+                    contactsTabContent
+                }
+            }
         }
         .tint(Color.colorTextPrimary)
         .onChange(of: activeTab) { _, _ in
             updateBuilderBarReveal(forOffset: activeTabScrollOffset)
         }
+    }
+
+    /// Builds the Contacts tab content from the live messaging service,
+    /// mirroring the wiring the App Settings "Contacts" row used before it
+    /// was promoted to a top-level tab.
+    @ViewBuilder
+    private var contactsTabContent: some View {
+        let messagingService = conversationsViewModel.session.messagingService()
+        ContactsView(
+            contactsRepository: messagingService.contactsRepository(),
+            contactsWriter: messagingService.contactsWriter(),
+            session: conversationsViewModel.session,
+            profileSettingsViewModel: profileSettingsViewModel,
+            showsComposeButton: false
+        )
     }
 
     /// Wraps each tab's content in its own `NavigationStack` carrying the
@@ -347,19 +382,35 @@ struct MainTabView: View {
     /// The conversation-detail push (via `ConversationsView`'s
     /// `navigationDestination`) lands on this per-tab stack.
     @ViewBuilder
-    private func tabContainer<Content: View>(@ViewBuilder content: () -> Content) -> some View {
-        NavigationStack {
-            content()
-                .safeAreaInset(edge: builderBarEdge, spacing: 0) {
-                    if !isConversationSelected && !isInlineBuilderActive {
-                        builderBar
-                            .transition(.blurReplace)
-                    }
-                }
-                .toolbar { sharedToolbar }
-                .toolbar(isConversationSelected ? .hidden : .visible, for: .navigationBar)
-                .toolbar((isConversationSelected || isInlineBuilderActive) ? .hidden : .visible, for: .tabBar)
+    private func tabContainer<Content: View>(for tab: ConvosTab, @ViewBuilder content: () -> Content) -> some View {
+        // The Contacts tab binds its stack path to `contactsPath` so the
+        // shared overlay can re-center the app-indicator pill when a contact
+        // detail is pushed; the other tabs use an internally-managed stack.
+        if tab == .contacts {
+            NavigationStack(path: $contactsPath) {
+                tabChrome(content(), for: tab)
+            }
+        } else {
+            NavigationStack {
+                tabChrome(content(), for: tab)
+            }
         }
+    }
+
+    /// Shared chrome (builder bar + toolbars) wrapped around each tab's root
+    /// content inside its `NavigationStack`.
+    @ViewBuilder
+    private func tabChrome(_ content: some View, for tab: ConvosTab) -> some View {
+        content
+            .safeAreaInset(edge: builderBarEdge, spacing: 0) {
+                if tab != .contacts && !isConversationSelected && !isInlineBuilderActive {
+                    builderBar
+                        .transition(.blurReplace)
+                }
+            }
+            .toolbar { sharedToolbar(for: tab) }
+            .toolbar(isConversationSelected ? .hidden : .visible, for: .navigationBar)
+            .toolbar((isConversationSelected || isInlineBuilderActive) ? .hidden : .visible, for: .tabBar)
     }
 
     /// Shared toolbar (compose + add-agent) applied to each tab's
@@ -368,7 +419,7 @@ struct MainTabView: View {
     /// It's rendered as a SwiftUI overlay anchored at top-leading instead
     /// (see `sharedAppIndicatorOverlay`).
     @ToolbarContentBuilder
-    private var sharedToolbar: some ToolbarContent {
+    private func sharedToolbar(for tab: ConvosTab) -> some ToolbarContent {
         ToolbarItem(placement: .topBarTrailing) {
             Button("Compose", systemImage: "square.and.pencil") {
                 conversationsViewModel.onStartConvo()
@@ -379,7 +430,7 @@ struct MainTabView: View {
         }
         // Declared after Compose so it sits at the trailing edge (to the
         // right of Compose) once the top builder bar has faded on scroll.
-        if showsToolbarBuilderButton {
+        if showsToolbarBuilderButton(for: tab) {
             ToolbarItem(placement: .topBarTrailing) {
                 Button(action: openBuilder) {
                     Image("addAgentIcon")
@@ -400,8 +451,15 @@ struct MainTabView: View {
     /// bar collapses to its own circle instead, so no nav-bar button. Also
     /// hidden while the bar is revealed, while a conversation is pushed, and
     /// during the inline empty-state builder.
-    private var showsToolbarBuilderButton: Bool {
-        horizontalSizeClass == .compact
+    ///
+    /// The Contacts tab is the exception: it never shows the builder bar (the
+    /// contacts search bar owns the top), so the "add agent" button lives in
+    /// the nav bar permanently there, on every size class.
+    private func showsToolbarBuilderButton(for tab: ConvosTab) -> Bool {
+        if tab == .contacts {
+            return !isConversationSelected && !isInlineBuilderActive
+        }
+        return horizontalSizeClass == .compact
             && !isBuilderBarRevealed
             && !isConversationSelected
             && !isInlineBuilderActive
@@ -430,12 +488,13 @@ struct MainTabView: View {
                 if !activeConvoVM.presentingShareView {
                     centeredConversationIndicator(for: activeConvoVM)
                 }
-            } else {
+            } else if !isContactDetailPushed {
                 leadingAppIndicatorPill
             }
             Spacer()
         }
         .animation(.bouncy(duration: 0.4, extraBounce: 0.15), value: activeConvoVM != nil)
+        .animation(.bouncy(duration: 0.4, extraBounce: 0.15), value: isContactDetailPushed)
         .ignoresSafeArea()
         .allowsHitTesting(true)
         .zIndex(1000)


### PR DESCRIPTION
## Summary

Adds a third **Contacts** tab to the main tab bar (third, after Chats and Stuff) using the `person.fill` SF Symbol, hosting the existing `ContactsView`. Removes the now-redundant Contacts row from App Settings.

- **Contacts tab**: on this tab the agent builder bar is hidden (the contacts search bar owns the top), and the top bar uses the **same shared toolbar** as Chats/Stuff — `[Compose][add-agent]`, in that order — with the "add agent" button always present (no builder bar to fade into).
- `ContactsView`: large title removed; search field placeholder is now **"Search contacts"**. Its own (redundant) compose button is suppressed on the tab since the shared Compose's `onStartConvo()` already opens the contacts picker.
- App-indicator pill: the contacts navigation path is lifted into the shell (value-based `ContactsView` navigation), so the pill **hides** while a contact detail is pushed and returns when you pop back.
- **App Settings**: removed the Contacts row (and its dead badge-count wiring); moved the **Power** row to sit directly after "My info".

## Test plan

- [x] `Convos (Dev)` builds clean (warnings-as-errors → no type-check-budget regressions)
- [x] SwiftLint `--strict` clean on all changed files
- [ ] Visual QA on a logged-in build: Contacts tab search-at-top, toolbar matches other tabs, pill hides on contact detail

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/944"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783016485&installation_id=128169237&pr_number=944&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F944&signature=814b4930bcd5a213d96b5592f799f4bf7d5788b9a935d414b016eee2b16ad247"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Contacts tab to main navigation and remove Contacts row from App Settings
> - Adds a new Contacts tab in [MainTabView.swift](https://github.com/xmtplabs/convos-ios/pull/944/files#diff-2b02f95e9fabdce514b1dd6d74d930ca17fcc2380c7504789454c035484e9d67) alongside Chats and Stuff, rendering `ContactsView` without a compose button.
> - Removes the Contacts section and associated state from [AppSettingsView.swift](https://github.com/xmtplabs/convos-ios/pull/944/files#diff-2fa17cdf36620cd943f7f1d58367392983f317278bd8aa913c5036f03e572c3f).
> - Adds a `showsComposeButton` parameter to `ContactsView` and switches contact row navigation to value-based routing via `navigationDestination`.
> - The agent builder bar is suppressed on the Contacts tab, and the app-indicator pill hides when a contact detail is pushed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 346f54a.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->