### PR TITLE
feat(contacts): interactive keyboard dismiss + Search return key

### DIFF
--- a/Convos/Contacts/ContactsListView.swift
+++ b/Convos/Contacts/ContactsListView.swift
@@ -57,6 +57,7 @@ struct ContactsListView<Row: Identifiable, RowContent: View, ListBackground: Vie
         }
         .listStyle(.plain)
         .scrollContentBackground(.hidden)
+        .scrollDismissesKeyboard(.interactively)
         .background(listBackground)
     }
 }

--- a/Convos/Contacts/ContactsSearchBar.swift
+++ b/Convos/Contacts/ContactsSearchBar.swift
@@ -36,6 +36,7 @@ struct ContactsSearchBar: View {
                 .textFieldStyle(.plain)
                 .autocorrectionDisabled()
                 .textInputAutocapitalization(.never)
+                .submitLabel(.search)
                 .accessibilityIdentifier(accessibilityIdentifier)
 
             trailingAccessory


### PR DESCRIPTION
## What

Two small UX tweaks to the Contacts tab "Search contacts" field:

- **Return key**: set `.submitLabel(.search)` so the keyboard's return key reads **Search**.
- **Interactive dismiss**: add `.scrollDismissesKeyboard(.interactively)` to the shared contacts list so dragging the list pulls the keyboard down with your finger.

## Where

- `Convos/Contacts/ContactsSearchBar.swift` — submit label on the text field.
- `Convos/Contacts/ContactsListView.swift` — interactive scroll-to-dismiss on the shared `List` (applies to both the Contacts tab and the contacts picker, since both have a search field above this list).

## Testing

- `xcodebuild build` (Convos Dev) passes clean (warnings-as-errors on).
- SwiftLint `--strict` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/945"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783027512&installation_id=128169237&pr_number=945&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F945&signature=bafeca381631cb869ab0d311eaa691dc8c5744320593259dcd2bf252d328bd3a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add interactive keyboard dismiss and Search return key label to contacts list
> - Adds `.scrollDismissesKeyboard(.interactively)` to the contacts list in [ContactsListView.swift](https://github.com/xmtplabs/convos-ios/pull/945/files#diff-15e9a2390eb75db13953cf65bb8b7762eb17a586babab37aced32c7352ff3695), so the keyboard dismisses as the user scrolls.
> - Applies `.submitLabel(.search)` to the search field in [ContactsSearchBar.swift](https://github.com/xmtplabs/convos-ios/pull/945/files#diff-8e98eff652c08a1d49c42fb8143dbab3f5ec277841e6e422ac7606c8c4470b1d), labeling the return key as "Search".
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9043dd3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->