### PR TITLE
feat(firebase): source App Check debug token from 1Password (cache-first)

### DIFF
--- a/.claude/DESIGNER.md
+++ b/.claude/DESIGNER.md
@@ -57,4 +57,4 @@ If you accidentally try to push to main or dev, STOP and create a feature branch
 | `/build` | Build the app |
 | `/build --run` | Build and launch in simulator |
 | `/test` | Run tests |
-| `/firebase-token` | Get Firebase debug token from logs |
+| `/firebase-token` | Sync/rotate the shared Firebase debug token (from 1Password) |

--- a/.claude/commands/firebase-token.md
+++ b/.claude/commands/firebase-token.md
@@ -1,33 +1,50 @@
 ---
-description: Fetch the Firebase App Check debug token from simulator logs and pin it in the shared workspace convos-ios.env so every worktree reuses one token.
+description: Sync (or rotate) the shared Firebase App Check debug token. Source of truth is the team "Convos" 1Password vault; each checkout's .env is a cache the build reads.
 ---
 
 # /firebase-token
 
-Retrieve a Firebase App Check debug token from the running app, pin it in the **shared `convos-ios.env`** (in the local-stack workspace), and make sure this checkout's `.env` symlinks to that shared file. One token, one place to rotate it, every worktree picks it up.
+The Firebase App Check debug token is a single shared team secret. Its source of
+truth is the **"Convos" 1Password vault** (`op://Convos/Firebase App Check Debug
+Token/credential`), registered once in the Firebase Console for both the Dev and
+Local apps. Every checkout's `.env` is just a **cache** of that value, which the
+build phase reads (`Scripts/secrets-utils.sh` -> `resolve_firebase_debug_token`).
+
+This command has two jobs:
+- **Sync** this checkout to the latest token in 1Password (the common case).
+- **Rotate** the token (when it expired / Firebase removed it): mint a new one,
+  push it to 1Password, register it in the Console.
 
 ## When to use
-- You've launched the app on a fresh simulator and are seeing App Check rejections.
-- You want to set up the shared-token pattern for the first time.
-- The token rotated (expired / Firebase removed it) and you need a new one.
+- App Check rejections after the token rotated (they expire ~monthly).
+- A fresh checkout/simulator whose `.env` cache is stale or missing.
+- First-time setup of the shared token.
+
+## Prerequisite: 1Password CLI
+
+`op` must be installed and signed in (`op signin`, account `xmtpinc`). For the
+token to also resolve inside Xcode **build phases** (not just shell), enable
+1Password **desktop-app CLI integration** (Settings -> Developer -> "Integrate
+with 1Password CLI") so the session is visible across processes. Without it,
+builds fall back to the cached `.env`, and this command refreshes that cache.
 
 ## Instructions
 
-### Step 1: Resolve the shared `.env`
+### Step 1: Resolve the shared `.env` cache and the op reference
 
 ```bash
 REPO_ROOT=$(git rev-parse --show-toplevel)
-# Shared convos-ios DEV .env: prefer the local-stack workspace (CONVOS_REPOS_DIR env, or the
-# .convos-stack pointer at the repo root) -> <workspace>/convos-ios.env. Fall back to the legacy
-# parent (<dirname repo>/.env) when no workspace is configured.
+# Shared convos-ios DEV .env cache: prefer the local-stack workspace (CONVOS_REPOS_DIR env,
+# or the .convos-stack pointer at the repo root) -> <workspace>/convos-ios.env. Fall back to
+# the legacy parent (<dirname repo>/.env) when no workspace is configured.
 WS="${CONVOS_REPOS_DIR:-}"
 [ -z "$WS" ] && [ -f "$REPO_ROOT/.convos-stack" ] && WS="$(tr -d '\n' < "$REPO_ROOT/.convos-stack")"
 if [ -n "$WS" ] && [ -d "$WS" ]; then SHARED_ENV="$WS/convos-ios.env"; else SHARED_ENV="$(dirname "$REPO_ROOT")/.env"; fi
 LOCAL_ENV="$REPO_ROOT/.env"
+OP_REF="op://Convos/Firebase App Check Debug Token/credential"
 ```
-With the local stack set up (`make -C dev/local-stack init`), `$SHARED_ENV` is `<workspace>/convos-ios.env`. Without it, it's the legacy `<parent>/.env`. Every checkout's `.env` symlinks to `$SHARED_ENV`.
 
-### Step 2: Ensure the symlink exists
+### Step 2: Ensure the `.env` cache symlink exists
 
 Ensure `$SHARED_ENV` exists first — if missing, `touch "$SHARED_ENV"`.
 
@@ -40,13 +57,27 @@ Four cases for `$LOCAL_ENV`:
 | Symlink pointing elsewhere | Warn, stop. Don't clobber. (A `Convos (Local)` checkout intentionally has a *standalone* `.env` written by `ios-config` — leave it.) |
 | Regular file | Warn, stop. Print the migration recipe: `cat .env >> "$SHARED_ENV" && rm .env && ln -s "$SHARED_ENV" .env` (after confirming the user wants the contents moved). |
 
-### Step 3: Verify the app is running
+### Step 3: Sync — pull the canonical token from 1Password into the cache
 
-Take a screenshot or `xcrun simctl listapps $UDID | grep -q org.convos.ios-preview`. If the app isn't running, tell the user to `/run` first and stop — no live app, no token.
+This is the common path. No app or logs needed.
 
-### Step 4: Capture logs and extract the token
+```bash
+TOKEN="$(op read "$OP_REF" --no-newline)" || { echo "op read failed — run 'op signin' (account xmtpinc) and retry"; exit 1; }
+if grep -q '^FIREBASE_APP_CHECK_DEBUG_TOKEN=' "$SHARED_ENV"; then
+  sed -i '' "s|^FIREBASE_APP_CHECK_DEBUG_TOKEN=.*|FIREBASE_APP_CHECK_DEBUG_TOKEN=${TOKEN}|" "$SHARED_ENV"
+else
+  echo "FIREBASE_APP_CHECK_DEBUG_TOKEN=${TOKEN}" >> "$SHARED_ENV"
+fi
+```
 
-Preferred (MCP):
+If the sync succeeds, skip to Step 6. Only continue to Steps 4-5 if you are
+**rotating** (the token in 1Password is dead) or the vault item does not exist yet.
+
+### Step 4: Rotate — capture a fresh token from the running app
+
+Verify the app is running: take a screenshot or `xcrun simctl listapps $UDID | grep -q org.convos.ios-preview`. If it isn't, tell the user to `/run` first and stop — no live app, no token.
+
+Capture logs and extract the UUID. Preferred (MCP):
 ```
 mcp__XcodeBuildMCP__start_sim_log_cap with bundleId and captureConsole: true
 wait 3-5 seconds
@@ -59,17 +90,21 @@ xcrun simctl spawn "$UDID" log show \
   --predicate 'eventMessage CONTAINS "App Check debug token"' \
   --last 5m --style compact 2>/dev/null | tail -50
 ```
-Find: `[AppCheckCore][I-GAC004001] App Check debug token: 'XXXXXXXX-...'` — a UUID in single quotes.
+Find: `[AppCheckCore][I-GAC004001] App Check debug token: 'XXXXXXXX-...'` — a UUID
+in single quotes. (You can also mint one yourself with `uuidgen` and register it.)
 
-### Step 5: Write the token to the shared `.env`
+### Step 5: Rotate — push the new token to 1Password, then cache it
 
 ```bash
 TOKEN="<extracted-uuid>"
-if grep -q '^FIREBASE_APP_CHECK_DEBUG_TOKEN=' "$SHARED_ENV"; then
-  sed -i '' "s|^FIREBASE_APP_CHECK_DEBUG_TOKEN=.*|FIREBASE_APP_CHECK_DEBUG_TOKEN=${TOKEN}|" "$SHARED_ENV"
+# Update the existing vault item, or create it the first time.
+if op item get "Firebase App Check Debug Token" --vault Convos >/dev/null 2>&1; then
+  op item edit "Firebase App Check Debug Token" --vault Convos "credential=${TOKEN}"
 else
-  echo "FIREBASE_APP_CHECK_DEBUG_TOKEN=${TOKEN}" >> "$SHARED_ENV"
+  op item create --category "API Credential" --vault Convos \
+    --title "Firebase App Check Debug Token" "credential=${TOKEN}"
 fi
+# Then refresh the .env cache (Step 3's write block) with the same TOKEN.
 ```
 
 ### Step 6: Report
@@ -79,20 +114,22 @@ fi
 
 Token: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
 
-✓ Pinned in <SHARED_ENV>
+✓ Source of truth: op://Convos/Firebase App Check Debug Token/credential
+✓ Cached in <SHARED_ENV>
 ✓ .env → <SHARED_ENV> symlink in place at <LOCAL_ENV>
-  (every convos-ios checkout/worktree sharing this workspace reuses this token)
+  (every convos-ios checkout/worktree resolves the same token)
 
-Register it in Firebase Console if you haven't already:
+If you ROTATED, register the new UUID in Firebase Console:
 https://console.firebase.google.com/u/1/project/convos-otr/appcheck/apps
-  → pick the app for your scheme (Dev: org.convos.ios-preview, Local: org.convos.ios-local,
-    Prod: org.convos.ios) → ⋮ → Manage debug tokens → Add debug token → paste the UUID.
-  (Register in BOTH the Dev and Local apps if you build both schemes against this token.)
+  → pick the app (Dev: org.convos.ios-preview, Local: org.convos.ios-local)
+    → ⋮ → Manage debug tokens → Add debug token → paste the UUID.
+  (Register in BOTH the Dev and Local apps — they share one token.)
 
 Relaunch the app (/run) to pick it up.
 ```
 
-If no token found, or the local `.env` blocked the symlink, report that and the migration recipe (Step 2), and still report the symlink status.
+If `op read` failed and there is no cached token, report that and the `op signin`
+fix. Always report the symlink status.
 
 ## Bundle IDs per scheme
 | Scheme | Bundle id |
@@ -101,5 +138,18 @@ If no token found, or the local `.env` blocked the symlink, report that and the 
 | Convos (Local) | `org.convos.ios-local` |
 | Convos (Prod) | `org.convos.ios` |
 
-## Why the shared-workspace pattern
-One Firebase debug token across all your convos-ios worktrees: one place to rotate it, no per-worktree drift. It lives in the **local-stack workspace** (`<workspace>/convos-ios.env`) alongside the rest of the shared local-dev state, resolved via the `.convos-stack` pointer. `/setup` and `convos-task` create the same symlink for new checkouts/worktrees. (Falls back to the legacy `<parent>/.env` when no workspace is configured.) A `Convos (Local)` checkout keeps a *standalone* `.env` (written by `ios-config` / `/run local`) instead of the symlink, since Local needs a localhost backend URL.
+## Why 1Password is the source of truth
+A debug token is a low-sensitivity shared team secret. Storing it in the "Convos"
+vault gives one authoritative value the whole team resolves — across machines and
+worktrees — instead of each person scraping logs and self-registering.
+
+Builds are **cache-first**: they read the token cached in `.env` and only call
+`op read` when that cache is empty (a fresh worktree), so a normal build makes no
+network call and triggers no 1Password prompt. Routine refresh and rotation happen
+deliberately in shell context — run `/firebase-token` (this command) or `/setup`,
+which pull the latest from the vault and rewrite the cache. After a rotation, run
+this command per machine (or set `FIREBASE_TOKEN_REFRESH=1` on one build) to pull
+the new value; worktrees with a stale cached token keep using it until then.
+
+CI never reads this token: archive builds attest with App Attest, and
+`resolve_firebase_debug_token` returns empty under `CI` / `GITHUB_ACTIONS`.

--- a/.claude/commands/run.md
+++ b/.claude/commands/run.md
@@ -111,7 +111,7 @@ For **local mode**, also one line on stack health (from `make -C "$LS" status`) 
 
 ## Local-mode failure notes
 - Crash on app-group container at launch → you built Local without the ad-hoc flags (Step 2). Rebuild with them.
-- Firebase 403 / auth never completes → `./.env` is missing the shared `FIREBASE_APP_CHECK_DEBUG_TOKEN`; re-run `make -C "$LS" ios-config IOS="$(pwd)"`.
+- Firebase 403 / auth never completes → `./.env` is missing the shared `FIREBASE_APP_CHECK_DEBUG_TOKEN`; run `/firebase-token` to sync it from 1Password (or re-run `make -C "$LS" ios-config IOS="$(pwd)"`).
 - Backend 500 on `/auth/*` → backend lost Postgres (Docker bounced); `make -C "$LS" up` re-brings infra and re-disables App Check.
 
 ## DerivedData isolation

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -453,7 +453,7 @@ This project is configured for Claude Code CLI with specialized subagents, slash
 | `/test` | Run tests (ConvosCore by default) |
 | `/lint` | Check code with SwiftLint (run before committing) |
 | `/format` | Format code with SwiftFormat |
-| `/firebase-token` | Get Firebase App Check debug token from simulator logs |
+| `/firebase-token` | Sync/rotate the shared Firebase App Check debug token (1Password source of truth, .env cache) |
 
 **Pre-commit workflow:** SwiftFormat auto-formats and SwiftLint blocks the commit on violations (both via `Scripts/hooks/pre-commit`). Pre-push lints the diff against `dev` again as a final gate before the push hits GitHub. SwiftLint does not run during Xcode builds (for faster compilation). A full-tree `/lint` runs in ~1-2 seconds with the current config.
 

--- a/Scripts/build-phases/copy-env-config-app-clip.sh
+++ b/Scripts/build-phases/copy-env-config-app-clip.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+source "${SRCROOT}/Scripts/secrets-utils.sh"
+
 # Part 1: Generate Secrets.swift for App Clip (Local and Dev builds)
 if [ "$CONFIGURATION" = "Local" ] || [ "$CONFIGURATION" = "Dev" ]; then
     echo "🔧 $CONFIGURATION build detected - generating App Clip secrets from .env"
@@ -8,19 +10,17 @@ if [ "$CONFIGURATION" = "Local" ] || [ "$CONFIGURATION" = "Dev" ]; then
     SECRETS_FILE="${SRCROOT}/ConvosAppClip/Config/Secrets.swift"
     mkdir -p "${SRCROOT}/ConvosAppClip/Config"
 
-    # Read Firebase debug token from .env
-    FIREBASE_TOKEN=""
+    # Firebase debug token: cached .env first, else 1Password ("Convos" vault); empty in CI.
+    FIREBASE_TOKEN="$(resolve_firebase_debug_token "${SRCROOT}/.env")"
     CONVOS_API_BASE_URL=""
     if [ -f "${SRCROOT}/.env" ]; then
-        FIREBASE_TOKEN=$(grep -v '^#' "${SRCROOT}/.env" | grep '^FIREBASE_APP_CHECK_DEBUG_TOKEN=' | cut -d'=' -f2- | sed -e 's/^"//' -e 's/"$//' || true)
-
         CONVOS_API_BASE_URL=$(grep -v '^#' "${SRCROOT}/.env" | grep '^CONVOS_API_BASE_URL=' | cut -d'=' -f2- | sed -e 's/^"//' -e 's/"$//' || true)
     fi
 
     if [ -n "$FIREBASE_TOKEN" ]; then
-        echo "✅ Found Firebase debug token in .env"
+        echo "✅ Resolved Firebase debug token (1Password or .env cache)"
     else
-        echo "⚠️  No Firebase debug token in .env"
+        echo "⚠️  No Firebase debug token from 1Password or .env"
     fi
     
     cat > "$SECRETS_FILE" << EOF

--- a/Scripts/build-phases/copy-env-config-main-app.sh
+++ b/Scripts/build-phases/copy-env-config-main-app.sh
@@ -98,6 +98,11 @@ HEADER_EOF
 
     echo "    static let GIT_COMMIT_SHA: String = \"$(swift_escape "$GIT_SHA")\"" >> "$SECRETS_FILE"
 
+    # Populate the Firebase token cache from the "Convos" 1Password vault if .env
+    # has none (cache-first: no-op when .env already has a token, in CI, or when op
+    # is unavailable) so the .env dump below can emit it.
+    resolve_firebase_debug_token "${SRCROOT}/.env" >/dev/null
+
     # Add other secrets from .env if available
     if [ -f "${SRCROOT}/.env" ]; then
         echo "📋 Adding additional secrets from .env file..."
@@ -124,22 +129,22 @@ elif [ "$TARGET_NAME" = "Convos" ] && [ "$CONFIGURATION" = "Dev" ]; then
     # Create directory if needed
     mkdir -p "${SRCROOT}/Convos/Config"
 
-    # Read Firebase debug token from .env
-    FIREBASE_TOKEN=""
+    # Firebase debug token: cached .env first, else the team "Convos" 1Password
+    # vault on a cache miss. Always empty in CI. See resolve_firebase_debug_token
+    # in Scripts/secrets-utils.sh.
+    FIREBASE_TOKEN="$(resolve_firebase_debug_token "${SRCROOT}/.env")"
     CONVOS_API_BASE_URL=""
     AGENT_DEBUG_JWKS=""
     if [ -f "${SRCROOT}/.env" ]; then
-        FIREBASE_TOKEN=$(grep -v '^#' "${SRCROOT}/.env" | grep '^FIREBASE_APP_CHECK_DEBUG_TOKEN=' | cut -d'=' -f2- | sed -e 's/^"//' -e 's/"$//' || true)
-
         CONVOS_API_BASE_URL=$(grep -v '^#' "${SRCROOT}/.env" | grep '^CONVOS_API_BASE_URL=' | cut -d'=' -f2- | sed -e 's/^"//' -e 's/"$//' || true)
 
         AGENT_DEBUG_JWKS=$(grep -v '^#' "${SRCROOT}/.env" | grep '^AGENT_DEBUG_JWKS=' | cut -d'=' -f2- | sed -e "s/^'//" -e "s/'$//" || true)
     fi
 
     if [ -n "$FIREBASE_TOKEN" ]; then
-        echo "✅ Found Firebase debug token in .env"
+        echo "✅ Resolved Firebase debug token (1Password or .env cache)"
     else
-        echo "⚠️  No Firebase debug token in .env - you may need to register tokens manually"
+        echo "⚠️  No Firebase debug token from 1Password or .env - you may need to register one (run /firebase-token)"
     fi
 
     if [ -n "$AGENT_DEBUG_JWKS" ]; then

--- a/Scripts/build-phases/copy-env-config-notification-service.sh
+++ b/Scripts/build-phases/copy-env-config-notification-service.sh
@@ -30,9 +30,10 @@ if [ "$CONFIGURATION" = "Local" ]; then
     if [ -f "${SRCROOT}/.env" ]; then
         CONVOS_API_BASE_URL=$(grep -v '^#' "${SRCROOT}/.env" | grep '^CONVOS_API_BASE_URL=' | cut -d'=' -f2- | sed -e 's/^"//' -e 's/"$//' || true)
         XMTP_CUSTOM_HOST=$(grep -v '^#' "${SRCROOT}/.env" | grep '^XMTP_CUSTOM_HOST=' | cut -d'=' -f2- | sed -e 's/^"//' -e 's/"$//' || true)
-        FIREBASE_TOKEN=$(grep -v '^#' "${SRCROOT}/.env" | grep '^FIREBASE_APP_CHECK_DEBUG_TOKEN=' | cut -d'=' -f2- | sed -e 's/^"//' -e 's/"$//' || true)
         AGENT_DEBUG_JWKS=$(grep -v '^#' "${SRCROOT}/.env" | grep '^AGENT_DEBUG_JWKS=' | cut -d'=' -f2- | sed -e "s/^'//" -e "s/'$//" || true)
     fi
+    # Firebase debug token: cached .env first, else 1Password ("Convos" vault); empty in CI.
+    FIREBASE_TOKEN="$(resolve_firebase_debug_token "${SRCROOT}/.env")"
 
     ESCAPED_AGENT_DEBUG_JWKS=$(swift_escape "$AGENT_DEBUG_JWKS")
 
@@ -60,21 +61,20 @@ elif [ "$CONFIGURATION" = "Dev" ]; then
     SECRETS_FILE="${SRCROOT}/Convos/Config/Secrets.swift"
     mkdir -p "${SRCROOT}/Convos/Config"
 
-    FIREBASE_TOKEN=""
+    # Firebase debug token: cached .env first, else 1Password ("Convos" vault); empty in CI.
+    FIREBASE_TOKEN="$(resolve_firebase_debug_token "${SRCROOT}/.env")"
     CONVOS_API_BASE_URL=""
     AGENT_DEBUG_JWKS=""
     if [ -f "${SRCROOT}/.env" ]; then
-        FIREBASE_TOKEN=$(grep -v '^#' "${SRCROOT}/.env" | grep '^FIREBASE_APP_CHECK_DEBUG_TOKEN=' | cut -d'=' -f2- | sed -e 's/^"//' -e 's/"$//' || true)
-
         CONVOS_API_BASE_URL=$(grep -v '^#' "${SRCROOT}/.env" | grep '^CONVOS_API_BASE_URL=' | cut -d'=' -f2- | sed -e 's/^"//' -e 's/"$//' || true)
 
         AGENT_DEBUG_JWKS=$(grep -v '^#' "${SRCROOT}/.env" | grep '^AGENT_DEBUG_JWKS=' | cut -d'=' -f2- | sed -e "s/^'//" -e "s/'$//" || true)
     fi
 
     if [ -n "$FIREBASE_TOKEN" ]; then
-        echo "✅ Found Firebase debug token in .env"
+        echo "✅ Resolved Firebase debug token (1Password or .env cache)"
     else
-        echo "⚠️  No Firebase debug token in .env - you may need to register tokens manually"
+        echo "⚠️  No Firebase debug token from 1Password or .env - run /firebase-token"
     fi
 
     if [ -n "$AGENT_DEBUG_JWKS" ]; then

--- a/Scripts/secrets-utils.sh
+++ b/Scripts/secrets-utils.sh
@@ -37,6 +37,100 @@ ensure_secrets_directories() {
     mkdir -p "ConvosAppClip/Config"
 }
 
+# 1Password secret reference for the shared Firebase App Check debug token.
+# One token lives in the team "Convos" vault and is registered in the Firebase
+# Console for both the Dev (org.convos.ios-preview) and Local (org.convos.ios-local)
+# apps. This is the source of truth; each checkout's .env is only a cache.
+FIREBASE_DEBUG_TOKEN_OP_REF="op://Convos/Firebase App Check Debug Token/credential"
+
+# Reads FIREBASE_APP_CHECK_DEBUG_TOKEN from an env file (follows symlinks) and
+# prints it, stripping any surrounding double quotes. Prints empty when missing.
+# pipefail-safe: never returns non-zero on a missing key.
+read_env_firebase_token() {
+    local env_file="$1"
+    [ -f "$env_file" ] || { printf '%s' ""; return 0; }
+    local line
+    line="$(grep '^FIREBASE_APP_CHECK_DEBUG_TOKEN=' "$env_file" 2>/dev/null | tail -1 || true)"
+    line="${line#FIREBASE_APP_CHECK_DEBUG_TOKEN=}"
+    line="${line%\"}"
+    line="${line#\"}"
+    printf '%s' "$line"
+    return 0
+}
+
+# Upserts FIREBASE_APP_CHECK_DEBUG_TOKEN into an env file, writing *through*
+# symlinks so a worktree's ".env -> shared convos-ios.env" link is preserved
+# (BSD `sed -i` would replace the symlink with a regular file). No-op for an
+# empty token or an unchanged value. Creates the file if it does not exist.
+cache_firebase_token_to_env() {
+    local env_file="$1"
+    local token="$2"
+    [ -n "$token" ] || return 0
+    if [ -f "$env_file" ] && grep -q '^FIREBASE_APP_CHECK_DEBUG_TOKEN=' "$env_file" 2>/dev/null; then
+        [ "$(read_env_firebase_token "$env_file")" = "$token" ] && return 0
+        local tmp
+        tmp="$(mktemp)"
+        # Rewrite by dropping the old line and appending the new value rather than
+        # a sed substitution, so a token with sed-special characters (& | \) can't
+        # corrupt the line or abort the build under set -e.
+        { grep -v '^FIREBASE_APP_CHECK_DEBUG_TOKEN=' "$env_file" 2>/dev/null || true; printf 'FIREBASE_APP_CHECK_DEBUG_TOKEN=%s\n' "$token"; } > "$tmp"
+        cat "$tmp" > "$env_file"
+        rm -f "$tmp"
+    else
+        printf 'FIREBASE_APP_CHECK_DEBUG_TOKEN=%s\n' "$token" >> "$env_file"
+    fi
+    return 0
+}
+
+# Resolves the Firebase App Check debug token for a build and prints it.
+#
+# Cache-first: a token already cached in the given env file is used as-is, so a
+# normal build makes no network call and triggers no 1Password prompt. `op read`
+# is only consulted when the cache is empty (e.g. a fresh worktree), and a
+# successful fetch is written back so later builds stay offline-friendly. Set
+# FIREBASE_TOKEN_REFRESH=1 to force a fresh fetch (e.g. after a rotation).
+#
+# Routine refresh and rotation otherwise happen in shell context via /setup and
+# /firebase-token, where a 1Password auth tap is expected and deliberate rather
+# than mid-compile.
+#
+# Never reads the token in CI: CI builds must not carry a debug token (they
+# attest with App Attest), so this prints empty under CI / CI runners.
+#
+# Note: a cache-miss `op read` only succeeds when 1Password desktop-app CLI
+# integration is enabled (the session is process-global). With plain `op signin`
+# shell sessions it falls back to the (possibly empty) cache; populate it via
+# /setup or /firebase-token first.
+resolve_firebase_debug_token() {
+    local env_file="$1"
+    local cached
+    cached="$(read_env_firebase_token "$env_file")"
+
+    if [ "${CI:-}" = "true" ] || [ -n "${GITHUB_ACTIONS:-}" ] || [ -n "${BITRISE_IO:-}" ]; then
+        printf '%s' ""
+        return 0
+    fi
+
+    # Cache hit: use it, no op call (unless an explicit refresh is requested).
+    if [ -n "$cached" ] && [ "${FIREBASE_TOKEN_REFRESH:-}" != "1" ]; then
+        printf '%s' "$cached"
+        return 0
+    fi
+
+    if command -v op >/dev/null 2>&1; then
+        local fetched
+        fetched="$(op read "$FIREBASE_DEBUG_TOKEN_OP_REF" --no-newline 2>/dev/null || true)"
+        if [ -n "$fetched" ]; then
+            cache_firebase_token_to_env "$env_file" "$fetched"
+            printf '%s' "$fetched"
+            return 0
+        fi
+    fi
+
+    printf '%s' "$cached"
+    return 0
+}
+
 # Detect git commit SHA.
 # Optional first argument: repo directory to cd into (use for Xcode build phases
 # where the working directory is not the repo root). Omit for standalone scripts

--- a/Scripts/setup.sh
+++ b/Scripts/setup.sh
@@ -267,6 +267,22 @@ if [ ! "${CI}" = true ] || [ "${CLAUDE_SETUP}" = "1" ]; then
         echo "4. Paste the UUID above"
     }
 
+    # Source of truth is the team "Convos" 1Password vault. Refresh the shared
+    # .env from it when op is available (soft: skipped if op is missing/signed
+    # out; the cached .env stays the fallback). This runs in shell context where
+    # an `op signin` session is visible, so it works even without 1Password
+    # desktop-app integration.
+    # shellcheck source=Scripts/secrets-utils.sh
+    . "${DIRNAME}/secrets-utils.sh"
+    if command -v op > /dev/null 2>&1; then
+        _op_token="$(op read "${FIREBASE_DEBUG_TOKEN_OP_REF}" --no-newline 2>/dev/null || true)"
+        if [ -n "${_op_token}" ]; then
+            touch "${PARENT_ENV}" 2>/dev/null || true
+            cache_firebase_token_to_env "${PARENT_ENV}" "${_op_token}"
+            echo "🔐 Refreshed Firebase debug token from 1Password (Convos vault)"
+        fi
+    fi
+
     LOCAL_TOKEN="$(read_firebase_token "${LOCAL_ENV}")"
     PARENT_TOKEN="$(read_firebase_token "${PARENT_ENV}")"
 
@@ -276,6 +292,12 @@ if [ ! "${CI}" = true ] || [ "${CLAUDE_SETUP}" = "1" ]; then
         elif [ -f "${LOCAL_ENV}" ] && [ -n "${LOCAL_TOKEN}" ]; then
             echo "✅ Firebase App Check debug token is configured in ${LOCAL_ENV}"
         else
+            # Token lives in the shared/parent env but this checkout has no .env yet
+            # (fresh worktree). Link it so the build phase finds the cached token.
+            if [ ! -e "${LOCAL_ENV}" ] && [ ! -L "${LOCAL_ENV}" ]; then
+                ln -s "${PARENT_ENV}" "${LOCAL_ENV}"
+                echo "✓ Linked .env → ${PARENT_ENV} at ${LOCAL_ENV}"
+            fi
             echo "✅ Firebase App Check debug token is configured in ${PARENT_ENV}"
         fi
     else


### PR DESCRIPTION
The shared Firebase App Check debug token now lives in the team "Convos"
1Password vault (op://Convos/Firebase App Check Debug Token/credential). Builds
are cache-first: they read the token cached in .env and only call `op read` on a
cache miss (fresh worktree), so normal builds make no network call and trigger
no 1Password prompt. A cache-miss fetch is written back through .env (preserving
worktree symlinks). Set FIREBASE_TOKEN_REFRESH=1 to force a fresh fetch.

- New resolve_firebase_debug_token / cache_firebase_token_to_env helpers in
  secrets-utils.sh, wired into all four build paths (main app, App Clip,
  Notification Service; Dev and Local).
- CI never reads the token: resolver returns empty under CI/GITHUB_ACTIONS, and
  CI only builds PR Preview/Release (not Dev/Local) anyway.
- setup.sh and /firebase-token refresh the shared .env from 1Password in shell
  context (the deliberate place for an auth tap); /firebase-token reworked to
  sync-from / rotate-to 1Password instead of scraping logs per worktree.
- setup.sh links a fresh worktree's .env to the shared cache.

Cache-miss fetch in an Xcode build phase requires 1Password desktop-app CLI
integration so the session is process-global; otherwise populate the cache via
/setup or /firebase-token in shell first.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/946"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783031983&installation_id=128169237&pr_number=946&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F946&signature=0202653d328208872b56458b596b2ed078d81687052bd6ca9bbda7cc86d46fd1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Source Firebase App Check debug token from 1Password with cache-first fallback in build scripts
> - Adds `resolve_firebase_debug_token` to [secrets-utils.sh](https://github.com/xmtplabs/convos-ios/pull/946/files#diff-d9c4b5c221e5be2ead8b9ee0d2d0e9cb1ae57c0a604edb18c0d0110449a63206): reads from the `.env` cache first, falls back to `op read` from the 1Password "Convos" vault, then writes the result back to cache. Returns empty in CI.
> - Updates [copy-env-config-main-app.sh](https://github.com/xmtplabs/convos-ios/pull/946/files#diff-70ff2e26adae8d6f9ca7352b29379af3ec6c31c345fb891598d331e529c05c4f), [copy-env-config-app-clip.sh](https://github.com/xmtplabs/convos-ios/pull/946/files#diff-afc343a9e812a8b74b34d0581a1158d3967b83b1de0a031e36c4362624edf297), and [copy-env-config-notification-service.sh](https://github.com/xmtplabs/convos-ios/pull/946/files#diff-1e0c207a3a3730323155f8961cc14f82400a67570af79ce68f0056588224e15a) to replace manual `.env` grep with `resolve_firebase_debug_token`.
> - Updates [setup.sh](https://github.com/xmtplabs/convos-ios/pull/946/files#diff-490f2d9bc338440322d4b7d5bcb8c209ee7633cdb9f4245ceb2cb78bc6486314) to refresh the shared `convos-ios.env` token from 1Password on setup and auto-create a `.env` symlink on fresh worktrees.
> - Behavioral Change: developers without a cached token in `.env` will now trigger a `op read` call during builds, requiring 1Password CLI with desktop-app integration installed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3813d22.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->