### PR TITLE
feat(agent-share): show reply preview for agent contact cards

### DIFF
--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/ReplyComposerBar.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/ReplyComposerBar.swift
@@ -8,7 +8,9 @@ struct ReplyComposerBar: View {
     var audioTranscriptText: String?
     let onDismiss: () -> Void
 
+    @Environment(\.agentShareResolver) private var agentShareResolver: any AgentShareResolving
     @State private var resolvedHTMLTitle: String?
+    @State private var resolvedAgentShare: AgentShareInfo?
 
     private var senderName: String {
         message.sender.profile.displayName
@@ -30,6 +32,12 @@ struct ReplyComposerBar: View {
             return "Photo"
         case .invite:
             return "Invite"
+        case .agentShare:
+            let name = resolvedAgentShare?.displayName
+            if let name, !name.isEmpty {
+                return name
+            }
+            return "Agent"
         case .linkPreview(let preview):
             return preview.title ?? preview.displayHost
         default:
@@ -51,6 +59,17 @@ struct ReplyComposerBar: View {
         default:
             return nil
         }
+    }
+
+    private var agentShare: MessageAgentShare? {
+        if case .agentShare(let share) = message.content {
+            return share
+        }
+        return nil
+    }
+
+    private var hasLeadingThumbnail: Bool {
+        attachment != nil || agentShare != nil
     }
 
     private var shouldBlurAttachment: Bool {
@@ -103,6 +122,8 @@ struct ReplyComposerBar: View {
                     shouldBlur: shouldBlurAttachment,
                     isVideo: isVideo
                 )
+            } else if agentShare != nil {
+                ReplyAgentShareThumbnail(emoji: resolvedAgentShare?.emoji)
             }
 
             VStack(alignment: .leading, spacing: 2.0) {
@@ -134,11 +155,11 @@ struct ReplyComposerBar: View {
             .accessibilityLabel("Cancel reply")
             .accessibilityIdentifier("cancel-reply-button")
         }
-        .padding(.leading, attachment != nil ? DesignConstants.Spacing.step2x : DesignConstants.Spacing.step4x)
+        .padding(.leading, hasLeadingThumbnail ? DesignConstants.Spacing.step2x : DesignConstants.Spacing.step4x)
         .padding(.trailing, DesignConstants.Spacing.step2x)
         .padding(.vertical, DesignConstants.Spacing.step2x)
         .fixedSize(horizontal: false, vertical: true)
-        .glassEffect(.regular.interactive(), in: .rect(cornerRadius: attachment != nil ? 16.0 : 26.0))
+        .glassEffect(.regular.interactive(), in: .rect(cornerRadius: hasLeadingThumbnail ? 16.0 : 26.0))
         .padding(.horizontal, DesignConstants.Spacing.step4x)
         .padding(.bottom, DesignConstants.Spacing.stepHalf)
         .accessibilityElement(children: .combine)
@@ -147,6 +168,17 @@ struct ReplyComposerBar: View {
         .task(id: htmlAttachment?.key) {
             await loadHTMLTitle()
         }
+        .task(id: agentShare?.identifier) {
+            await resolveAgentShare()
+        }
+    }
+
+    private func resolveAgentShare() async {
+        guard let agentShare else {
+            resolvedAgentShare = nil
+            return
+        }
+        resolvedAgentShare = await agentShareResolver.resolve(identifier: agentShare.identifier)
     }
 
     private func loadHTMLTitle() async {
@@ -300,6 +332,26 @@ private struct ReplyPhotoThumbnail: View {
     }
 }
 
+private struct ReplyAgentShareThumbnail: View {
+    let emoji: String?
+
+    private static let thumbnailSize: CGFloat = 40.0
+    private static let cornerRadius: CGFloat = 8.0
+
+    var body: some View {
+        let emojiFontSize: CGFloat = Self.thumbnailSize * 0.43
+        RoundedRectangle(cornerRadius: Self.cornerRadius)
+            .fill(Color.colorLava)
+            .frame(width: Self.thumbnailSize, height: Self.thumbnailSize)
+            .overlay {
+                if let emoji, !emoji.isEmpty {
+                    Text(emoji)
+                        .font(.system(size: emojiFontSize, weight: .semibold, design: .rounded))
+                }
+            }
+    }
+}
+
 #Preview("Reply Composer Bar") {
     VStack {
         Spacer()
@@ -322,6 +374,21 @@ private struct ReplyPhotoThumbnail: View {
             message: .message(Message.mock(
                 text: "I was thinking we could implement a new feature that allows users to customize their profile",
                 sender: .mock(isCurrentUser: false, name: "Shane"),
+                status: .published
+            ), .existing),
+            shouldBlurPhotos: false,
+            onDismiss: {}
+        )
+    }
+}
+
+#Preview("Reply Composer Bar - Agent Share") {
+    VStack {
+        Spacer()
+        ReplyComposerBar(
+            message: .message(Message.mock(
+                content: .agentShare(.mock),
+                sender: .mock(isCurrentUser: false, name: "Louis"),
                 status: .published
             ), .existing),
             shouldBlurPhotos: false,

--- a/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/ReplyReferenceView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/ReplyReferenceView.swift
@@ -82,6 +82,13 @@ struct ReplyReferenceView: View {
         return nil
     }
 
+    private var parentAgentShare: MessageAgentShare? {
+        if case .agentShare(let share) = parentMessage.content {
+            return share
+        }
+        return nil
+    }
+
     private var shouldBlurAttachment: Bool {
         guard let parentAttachment else { return false }
         if parentAttachment.isHiddenByOwner { return true }
@@ -155,6 +162,11 @@ struct ReplyReferenceView: View {
             } else if let preview = parentLinkPreview {
                 ReplyReferenceLinkPreview(preview: preview)
                     .padding(.trailing, isOutgoing ? DesignConstants.Spacing.step4x : 0.0)
+            } else if let agentShare = parentAgentShare {
+                AgentShareBubble(agentShare: agentShare)
+                    .frame(maxWidth: C.agentShareReferenceMaxWidth, alignment: isOutgoing ? .trailing : .leading)
+                    .allowsHitTesting(false)
+                    .padding(.trailing, isOutgoing ? DesignConstants.Spacing.step4x : 0.0)
             } else {
                 HStack(spacing: 0) {
                     if isOutgoing {
@@ -193,6 +205,7 @@ struct ReplyReferenceView: View {
 
     private enum C {
         static let maxReplyPreviewTextWidth: CGFloat = 220
+        static let agentShareReferenceMaxWidth: CGFloat = 240
     }
 }
 
@@ -234,6 +247,22 @@ struct ReplyReferenceView: View {
         sender: .mock(isCurrentUser: true),
         parentText: "I was thinking we could implement a new feature that allows users to customize their profile with different themes and colors",
         parentSender: .mock(isCurrentUser: false, name: "Sam")
+    )
+    ReplyReferenceView(
+        replySender: reply.sender,
+        parentMessage: reply.parentMessage,
+        isOutgoing: true,
+        shouldBlurPhotos: false
+    )
+    .padding()
+}
+
+#Preview("Reply - Agent Share") {
+    let reply = MessageReply.mock(
+        text: "Nice",
+        sender: .mock(isCurrentUser: true),
+        parentContent: .agentShare(.mock),
+        parentSender: .mock(isCurrentUser: false, name: "Louis")
     )
     ReplyReferenceView(
         replySender: reply.sender,

--- a/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/ReplyReferenceView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/ReplyReferenceView.swift
@@ -163,10 +163,12 @@ struct ReplyReferenceView: View {
                 ReplyReferenceLinkPreview(preview: preview)
                     .padding(.trailing, isOutgoing ? DesignConstants.Spacing.step4x : 0.0)
             } else if let agentShare = parentAgentShare {
+                // No extra trailing padding: the enclosing `MessagesGroupItemView`
+                // already insets the whole reply reference by `trailingPadding`,
+                // so the card's trailing edge lines up with the text bubble's.
                 AgentShareBubble(agentShare: agentShare)
                     .frame(maxWidth: C.agentShareReferenceMaxWidth, alignment: isOutgoing ? .trailing : .leading)
                     .allowsHitTesting(false)
-                    .padding(.trailing, isOutgoing ? DesignConstants.Spacing.step4x : 0.0)
             } else {
                 HStack(spacing: 0) {
                     if isOutgoing {

--- a/Convos/Conversation Detail/Messages/MessagesView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesView.swift
@@ -243,6 +243,10 @@ struct MessagesView<BottomBarContent: View>: View {
                                 audioTranscriptText: replyingToAudioTranscriptText,
                                 onDismiss: onCancelReply
                             )
+                            // The bottom bar is hosted in the representable's
+                            // own tree, so inject the resolver directly on the
+                            // bar (same reason the context-menu overlay does).
+                            .environment(\.agentShareResolver, agentShareResolver)
                         }
                     }
                 )


### PR DESCRIPTION
## What

Agent-share contact cards were missing previews in two reply surfaces:

1. **Reply composer bar** — replying to an agent card showed only the sender name, no thumbnail/label (the `.agentShare` content fell through to the empty `default` in `ReplyComposerBar`).
2. **Parent reply reference** — a sent reply to an agent card rendered the parent as a plain `"agent"` text pill instead of the card.

This PR fixes both.

### 1. Reply composer bar

Reuses the photo-reply layout: a 40×40 rounded square at the leading edge with the same 8pt corner radius, but filled with `.colorLava` and the **agent's emoji** centered instead of an image. The label shows the resolved agent **display name**, falling back to **"Agent"**.

### 2. Parent reply reference

Renders the standard (smaller) `AgentContactCardView` via the existing `AgentShareBubble` — capped to a compact width and non-interactive — so a reply to an agent card previews the card itself, consistent with how invite/link reply references show their content.

## How

- `ReplyComposerBar.swift`
  - `.agentShare` case in `previewText` → display name, else `"Agent"`.
  - `agentShare` extractor + `hasLeadingThumbnail` helper driving the tighter leading inset and 16pt glass corner radius (same treatment photo replies get).
  - New `ReplyAgentShareThumbnail`: 40×40, 8pt radius, `.colorLava` fill, emoji centered using the app's `side * 0.43` `.semibold` `.rounded` convention (matches `EmojiAvatarView`).
  - A `.task` resolves the share's `identifier` through the injected `AgentShareResolving` — the same resolver path `AgentShareBubble` uses.
- `MessagesView.swift`
  - Injects `agentShareResolver` directly onto the composer bar (it's hosted in the representable's separate tree, same reason the context-menu overlay re-injects it).
- `ReplyReferenceView.swift`
  - `parentAgentShare` accessor + a branch rendering `AgentShareBubble` capped at a compact width, aligned to the sender side, `allowsHitTesting(false)`. The resolver is already injected on the cell that hosts the reply reference.
- Added `#Preview`s for both the composer-bar and reply-reference agent-share cases.

## Testing

- `Convos (Dev)` scheme builds clean (the scheme enforces the 100ms type-check ceiling as a hard error; the new bodies stay within budget).
- SwiftLint `--strict` passes on all changed files; pre-push lint passed.
- UI-only change — not covered by the ConvosCore test suite. The new previews exercise both views via the mock resolver for visual review in Xcode canvas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show agent contact card previews in the reply composer bar and reply references
> - `ReplyComposerBar` now detects `agentShare` message content and renders a `ReplyAgentShareThumbnail` (a 40×40 lava-colored rounded rectangle with an optional emoji overlay) alongside a resolved agent display name in the preview text.
> - Agent metadata is resolved asynchronously via `AgentShareResolving` injected through the SwiftUI environment from `MessagesView`.
> - `ReplyReferenceView` renders an `AgentShareBubble` instead of the generic text/photo/link preview when the parent message contains agent share content.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f67b54b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->