### PR TITLE
handle edge case where agent has not set name yet, UI should show agent, not Somebody

### DIFF
--- a/ConvosCore/Sources/ConvosCore/Inboxes/MessagingService+PushNotifications.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/MessagingService+PushNotifications.swift
@@ -465,7 +465,10 @@ extension MessagingService {
     ) async throws -> String {
         try await databaseReader.read { db in
             let profile = try DBMemberProfile.fetchOne(db, conversationId: conversationId, inboxId: senderInboxId)
-            return profile?.name ?? "Somebody"
+            if let name = profile?.name, !name.isEmpty { return name }
+            // Mirror `Profile.displayName`: known agents read as "Agent",
+            // unknown / human profiles read as "Somebody".
+            return profile?.isAgent == true ? "Agent" : "Somebody"
         }
     }
 
@@ -937,13 +940,24 @@ extension MessagingService {
             }
 
             let namedProfiles = memberProfiles.compactMap { $0.name }.filter { !$0.isEmpty }.sorted()
-            let anonymousCount = memberProfiles.count - namedProfiles.count
+            // Bucket unnamed members by agent vs. human so the rendered title
+            // matches `Profile.formattedNamesString`: anonymous agents read
+            // as "Agent" / "Agents", anonymous humans as "Somebody" /
+            // "Somebodies".
+            let anonymousProfiles = memberProfiles.filter { ($0.name ?? "").isEmpty }
+            let anonymousAgentCount = anonymousProfiles.filter { $0.isAgent }.count
+            let anonymousHumanCount = anonymousProfiles.count - anonymousAgentCount
 
             var allNames = namedProfiles
-            if anonymousCount > 1 {
-                allNames.append("Somebodies")
-            } else if anonymousCount == 1 {
+            if anonymousAgentCount == 1 {
+                allNames.append("Agent")
+            } else if anonymousAgentCount > 1 {
+                allNames.append("Agents")
+            }
+            if anonymousHumanCount == 1 {
                 allNames.append("Somebody")
+            } else if anonymousHumanCount > 1 {
+                allNames.append("Somebodies")
             }
 
             if allNames.isEmpty {
@@ -960,7 +974,10 @@ extension MessagingService {
     ) async throws -> String {
         try await databaseReader.read { db in
             let profile = try DBMemberProfile.fetchOne(db, conversationId: conversationId, inboxId: inboxId)
-            return profile?.name ?? "Somebody"
+            if let name = profile?.name, !name.isEmpty { return name }
+            // Mirror `Profile.displayName`: known agents read as "Agent",
+            // unknown / human profiles read as "Somebody".
+            return profile?.isAgent == true ? "Agent" : "Somebody"
         }
     }
 

--- a/ConvosCore/Sources/ConvosCore/Mocks/ModelMocks.swift
+++ b/ConvosCore/Sources/ConvosCore/Mocks/ModelMocks.swift
@@ -281,7 +281,8 @@ public extension ConversationUpdate {
 
 /// Resolves a member's rendered display name with the precedence:
 /// contact-list override, then per-conversation profile name, then
-/// "Somebody". `isCurrentUser` always renders as "You" for system messages.
+/// "Agent" for known agents or "Somebody" for unnamed humans.
+/// `isCurrentUser` always renders as "You" for system messages.
 ///
 /// Hoisted to file scope so its branches don't count against
 /// `ConversationUpdate.summary(memberNameOverride:)`'s cyclomatic
@@ -298,7 +299,9 @@ private func resolvedMemberDisplayName(
         return overridden
     }
     if let name = member.profile.name, !name.isEmpty { return name }
-    return "Somebody"
+    // Mirror `Profile.displayName`: known agents read as "Agent",
+    // unknown / human profiles read as "Somebody".
+    return member.isAgent ? "Agent" : "Somebody"
 }
 
 private func summaryFromFirstMetadataChange(

--- a/ConvosCore/Sources/ConvosCore/Storage/Hydration/DBMessage+MessagePreview.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Hydration/DBMessage+MessagePreview.swift
@@ -19,7 +19,13 @@ extension DBLastMessageWithSource {
         let text: String
         let isCurrentUser = senderId == currentInboxId
         let senderProfile = members.first { $0.memberProfile.inboxId == senderId }
-        let senderName = isCurrentUser ? "You" : (senderProfile?.memberProfile.name ?? "Somebody")
+        // Hoisted to a static helper so its branches don't count against
+        // this function's cyclomatic complexity score, mirroring the same
+        // pattern `resolvedMemberDisplayName` uses in ModelMocks.swift.
+        let senderName = Self.resolveSenderName(
+            isCurrentUser: isCurrentUser,
+            profile: senderProfile?.memberProfile
+        )
         let attachmentsCount = attachmentUrls.count
         let attachmentsString = Self.attachmentsPreviewString(attachmentUrls: attachmentUrls, count: attachmentsCount)
 
@@ -134,6 +140,21 @@ extension DBLastMessageWithSource {
             }
         }
         return .init(text: text, createdAt: date)
+    }
+
+    /// Resolves the sender's rendered name for a message preview row.
+    /// Precedence: "You" for the local user, the per-conversation profile
+    /// name when set, then "Agent" / "Somebody" keyed on the profile's
+    /// `isAgent` (mirrors `Profile.displayName`). Hoisted out of
+    /// `hydrateMessagePreview` so the agent-aware branch doesn't push that
+    /// function past the cyclomatic complexity threshold.
+    private static func resolveSenderName(
+        isCurrentUser: Bool,
+        profile: DBMemberProfile?
+    ) -> String {
+        if isCurrentUser { return "You" }
+        if let name = profile?.name, !name.isEmpty { return name }
+        return profile?.isAgent == true ? "Agent" : "Somebody"
     }
 
     static func attachmentsPreviewString(attachmentUrls: [String], count: Int) -> String {

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/Contact.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/Contact.swift
@@ -113,16 +113,27 @@ public struct Contact: Hashable, Identifiable, Sendable {
         agentVerification?.isVerified == true
     }
 
+    /// True when we have any signal that this contact is an agent - any
+    /// stored `agentVerification` (verified or unverified) or a known
+    /// `agentTemplateId` from a template-backed provisioning. Used by
+    /// `resolvedDisplayName` to swap the unnamed-contact placeholder from
+    /// "Somebody" to "Agent" so the contact card doesn't read as a human
+    /// when the agent badge or instance id is already on screen.
+    public var isAgent: Bool {
+        agentVerification != nil || agentTemplateId != nil
+    }
+
     /// Display label that always returns something printable. Falls back
-    /// to "Somebody" rather than a truncated inboxId -- exposing a hex
-    /// prefix in any user-facing surface reads as a bug. Same placeholder
-    /// the message-input and profile-settings surfaces use for unnamed
-    /// participants.
+    /// to "Agent" for unnamed agent contacts (matches the role pill shown
+    /// on the contact card) and "Somebody" otherwise -- exposing a hex
+    /// inboxId prefix in any user-facing surface reads as a bug. Same
+    /// placeholder convention the message-input and profile-settings
+    /// surfaces use for unnamed participants.
     public var resolvedDisplayName: String {
         if let name = displayName, !name.isEmpty {
             return name
         }
-        return "Somebody"
+        return isAgent ? "Agent" : "Somebody"
     }
 
     /// Used for alphabetical sectioning. Returns "#" for contacts whose

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/Profile.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/Profile.swift
@@ -84,7 +84,7 @@ public struct Profile: Codable, Identifiable, Hashable, Sendable {
 
     public var displayName: String {
         if let name, !name.isEmpty { return name }
-        return "Somebody"
+        return isAgent ? "Agent" : "Somebody"
     }
 
     public var profileEmoji: String? {
@@ -283,30 +283,53 @@ public extension Array where Element == Profile {
     /// and should appear consistently across every surface that renders a
     /// member, regardless of what the per-conversation profile snapshot
     /// happens to say. The per-conversation profile name is the next
-    /// fallback, and the "Somebody / Somebodies" bucketing remains the
-    /// final fallback for nameless members. Pass `{ _ in nil }` for the
-    /// legacy behavior (no override).
+    /// fallback, and the "Agent / Agents" or "Somebody / Somebodies"
+    /// bucketing (keyed on `profile.isAgent`) remains the final fallback
+    /// for nameless members. Pass `{ _ in nil }` for the legacy behavior
+    /// (no override).
     func formattedNamesString(
         memberNameOverride: (String) -> String?
     ) -> String {
-        let resolved: [String?] = map { profile -> String? in
+        let resolved: [(name: String?, isAgent: Bool)] = map { profile in
             if let overridden = memberNameOverride(profile.inboxId), !overridden.isEmpty {
-                return overridden
+                return (overridden, profile.isAgent)
             }
-            if let name = profile.name, !name.isEmpty { return name }
-            return nil
+            if let name = profile.name, !name.isEmpty {
+                return (name, profile.isAgent)
+            }
+            return (nil, profile.isAgent)
         }
-        let namedProfiles: [String] = resolved.compactMap { $0 }.sorted()
-        let anonymousCount: Int = resolved.filter { $0 == nil }.count
+        let namedProfiles: [String] = resolved.compactMap { $0.name }.sorted()
+        let anonymousAgentCount: Int = resolved.filter { $0.name == nil && $0.isAgent }.count
+        let anonymousHumanCount: Int = resolved.filter { $0.name == nil && !$0.isAgent }.count
+        let anonymousCount: Int = anonymousAgentCount + anonymousHumanCount
         let totalCount: Int = namedProfiles.count + anonymousCount
 
+        // Anonymous bucket labels, agents before humans so "Agent & Somebody"
+        // reads naturally. Pluralized independently: a group with two unnamed
+        // agents and one unnamed human reads "Agents & Somebody".
+        var anonymousLabels: [String] = []
+        if anonymousAgentCount == 1 {
+            anonymousLabels.append("Agent")
+        } else if anonymousAgentCount > 1 {
+            anonymousLabels.append("Agents")
+        }
+        if anonymousHumanCount == 1 {
+            anonymousLabels.append("Somebody")
+        } else if anonymousHumanCount > 1 {
+            anonymousLabels.append("Somebodies")
+        }
+
         if namedProfiles.isEmpty {
-            if anonymousCount == 0 {
+            switch anonymousLabels.count {
+            case 0:
                 return ""
-            } else if anonymousCount == 1 {
-                return "Somebody"
-            } else {
-                return "Somebodies"
+            case 1:
+                return anonymousLabels[0]
+            case 2:
+                return anonymousLabels.joined(separator: " & ")
+            default:
+                return anonymousLabels.joined(separator: ", ")
             }
         }
 
@@ -314,11 +337,7 @@ public extension Array where Element == Profile {
 
         if totalCount <= maxNames {
             var allNames = namedProfiles
-            if anonymousCount > 1 {
-                allNames.append("Somebodies")
-            } else if anonymousCount == 1 {
-                allNames.append("Somebody")
-            }
+            allNames.append(contentsOf: anonymousLabels)
 
             switch allNames.count {
             case 1:

--- a/ConvosCore/Tests/ConvosCoreTests/ContactsRepositoryTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ContactsRepositoryTests.swift
@@ -136,6 +136,39 @@ struct ContactsRepositoryTests {
         #expect(names == ["Mid", "Somebody"])
     }
 
+    @Test("Agent contacts with nil displayName fall back to \"Agent\"")
+    func testNilDisplayNameAgentFallback() throws {
+        // Verified-agent signal: badge would render; placeholder should
+        // match the badge by reading "Agent" instead of "Somebody".
+        let verifiedAgent = Contact.mock(
+            displayName: nil,
+            agentVerification: .verified(.convos)
+        )
+        #expect(verifiedAgent.resolvedDisplayName == "Agent")
+
+        // Template-backed agent with no verification snapshot yet still
+        // reads as an agent - covers the brief window where templateId has
+        // mirrored from the member profile before verification propagates.
+        let templateAgent = Contact.mock(
+            displayName: nil,
+            agentTemplateId: "tpl-1"
+        )
+        #expect(templateAgent.resolvedDisplayName == "Agent")
+
+        // Unverified-but-known agent (we have an agentVerification of
+        // .unverified) is still an agent; calling it "Somebody" reads as
+        // a bug.
+        let unverifiedAgent = Contact.mock(
+            displayName: nil,
+            agentVerification: .unverified
+        )
+        #expect(unverifiedAgent.resolvedDisplayName == "Agent")
+
+        // Sanity: no agent signal at all still resolves to "Somebody".
+        let unnamedHuman = Contact.mock(displayName: nil)
+        #expect(unnamedHuman.resolvedDisplayName == "Somebody")
+    }
+
     @Test("sourceConversations returns the convo name + kind for each id, drops missing ids")
     func testSourceConversationsBatched() throws {
         let dbManager = MockDatabaseManager.makeTestDatabase()

--- a/ConvosCore/Tests/ConvosCoreTests/DefaultConversationDisplayTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/DefaultConversationDisplayTests.swift
@@ -130,6 +130,97 @@ struct DefaultConversationDisplayTests {
         #expect(profiles.formattedNamesString == "Alice & Somebody")
     }
 
+    // MARK: - Agent fallback labels
+
+    @Test("Single anonymous agent returns Agent")
+    func singleAnonymousAgent() {
+        let profiles = [Self.anonymousAgent(inboxId: "agent-1")]
+        #expect(profiles.formattedNamesString == "Agent")
+    }
+
+    @Test("Two anonymous agents return Agents")
+    func twoAnonymousAgents() {
+        let profiles = [
+            Self.anonymousAgent(inboxId: "agent-1"),
+            Self.anonymousAgent(inboxId: "agent-2")
+        ]
+        #expect(profiles.formattedNamesString == "Agents")
+    }
+
+    @Test("Anonymous agent and anonymous human read as \"Agent & Somebody\"")
+    func anonymousAgentAndAnonymousHuman() {
+        let profiles = [
+            Self.anonymousAgent(inboxId: "agent-1"),
+            Profile.empty(inboxId: "human-1")
+        ]
+        #expect(profiles.formattedNamesString == "Agent & Somebody")
+    }
+
+    @Test("Plural agent + plural human read as \"Agents & Somebodies\"")
+    func pluralAgentsAndPluralHumans() {
+        let profiles = [
+            Self.anonymousAgent(inboxId: "agent-1"),
+            Self.anonymousAgent(inboxId: "agent-2"),
+            Profile.empty(inboxId: "human-1"),
+            Profile.empty(inboxId: "human-2")
+        ]
+        // Three buckets total (named, agents, humans), but only two
+        // anonymous labels: rendered as "Agents & Somebodies".
+        #expect(profiles.formattedNamesString == "Agents & Somebodies")
+    }
+
+    @Test("Named + anonymous agent within limit reads as \"Alice & Agent\"")
+    func namedAndAnonymousAgentWithinLimit() {
+        let profiles = [
+            Profile.mock(name: "Alice"),
+            Self.anonymousAgent(inboxId: "agent-1")
+        ]
+        #expect(profiles.formattedNamesString == "Alice & Agent")
+    }
+
+    @Test("Named + agent + human within limit reads as \"Alice, Agent, Somebody\"")
+    func namedPlusAgentPlusHumanWithinLimit() {
+        let profiles = [
+            Profile.mock(name: "Alice"),
+            Self.anonymousAgent(inboxId: "agent-1"),
+            Profile.empty(inboxId: "human-1")
+        ]
+        #expect(profiles.formattedNamesString == "Alice, Agent, Somebody")
+    }
+
+    /// Builds an anonymous agent profile -- name unset, `isAgent` flipped on.
+    /// Mirrors `Profile.empty` but with the agent flag, so test sites stay
+    /// readable.
+    private static func anonymousAgent(inboxId: String) -> Profile {
+        Profile(
+            inboxId: inboxId,
+            conversationId: "mock-conversation",
+            name: nil,
+            avatar: nil,
+            isAgent: true
+        )
+    }
+
+    // MARK: - Profile.displayName
+
+    @Test("Profile.displayName uses the name when set")
+    func profileDisplayNameUsesName() {
+        let p = Profile.mock(name: "Alice")
+        #expect(p.displayName == "Alice")
+    }
+
+    @Test("Profile.displayName falls back to Somebody for unnamed humans")
+    func profileDisplayNameFallsBackToSomebody() {
+        let p = Profile.empty(inboxId: "human-1")
+        #expect(p.displayName == "Somebody")
+    }
+
+    @Test("Profile.displayName falls back to Agent for unnamed agents")
+    func profileDisplayNameFallsBackToAgent() {
+        let agent = Self.anonymousAgent(inboxId: "agent-1")
+        #expect(agent.displayName == "Agent")
+    }
+
     // MARK: - Profile Array Helper Tests
 
     @Test("hasAnyNamedProfile returns true when named profile exists")


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/948"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783038327&installation_id=128169237&pr_number=948&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F948&signature=7a42f9f722aeeb796ecaae87723542e43020eaa3a037f295980a6e17b5d0202a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show 'Agent' instead of 'Somebody' for unnamed agents in conversation UI and push notifications
> - Adds agent-aware fallback naming across `Contact.resolvedDisplayName`, `Profile.displayName`, and push notification helpers so unnamed agents display as "Agent" rather than "Somebody".
> - `Array<Profile>.formattedNamesString` now splits anonymous members into separate agent and human buckets, producing labels like "Agent & Somebody" or "Agents & Somebodies" in group conversation titles.
> - A new `Contact.isAgent` computed property drives the fallback logic, returning `true` when `agentVerification` or `agentTemplateId` is set.
> - New tests in `ContactsRepositoryTests` and `DefaultConversationDisplayTests` cover the agent fallback cases.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 89706e8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->