### PR TITLE
Enable production observability: on-device logging + Sentry crash reporting

### DIFF
--- a/.github/workflows/firebase-pr.yml
+++ b/.github/workflows/firebase-pr.yml
@@ -14,6 +14,10 @@
 #   CACHIX_AUTH_TOKEN             - Auth token for the xmtp Cachix cache
 #                                   (required if the cache is private)
 #
+# Optional repository secret:
+#   SENTRY_DSN_DEV                - Sentry DSN baked into dev/PR builds;
+#                                   Sentry is disabled when unset
+#
 # Required repository variables:
 #   FIREBASE_APP_ID_PR            - Firebase iOS app id (1:NNN:ios:HEX) for
 #                                   org.convos.ios-preview.pr
@@ -99,6 +103,7 @@ jobs:
       - name: Generate Secrets.swift
         env:
           BUILD_CONFIGURATION: Dev
+          SENTRY_DSN_DEV: ${{ secrets.SENTRY_DSN_DEV }}
         run: ./Scripts/generate-secrets-secure.sh
 
       - name: Run fastlane firebase_pr

--- a/.github/workflows/testflight-prod.yml
+++ b/.github/workflows/testflight-prod.yml
@@ -21,8 +21,12 @@
 #   APP_STORE_CONNECT_API_PRIVATE_KEY  - Raw .p8 contents of the ASC API key
 #   CACHIX_AUTH_TOKEN                  - Auth token for the xmtp Cachix cache
 #
-# Prod builds disable Sentry at compile time (generate-secrets-secure.sh sets
-# an empty DSN for the Release configuration), so no Sentry secrets are wired.
+# Optional repository secrets (Sentry crash reporting; prod builds ship
+# without Sentry when these are unset):
+#   SENTRY_DSN_PROD                    - DSN baked into prod builds
+#   SENTRY_AUTH_TOKEN                  - Token for dSYM upload (symbolication)
+#   SENTRY_ORG                         - Sentry org slug for dSYM upload
+#   SENTRY_PROJECT                     - Sentry project slug for dSYM upload
 
 name: Prod TestFlight Release
 
@@ -100,6 +104,7 @@ jobs:
       - name: Generate Secrets.swift
         env:
           BUILD_CONFIGURATION: Prod
+          SENTRY_DSN_PROD: ${{ secrets.SENTRY_DSN_PROD }}
         run: ./Scripts/generate-secrets-secure.sh
 
       - name: Run fastlane testflight_prod
@@ -115,6 +120,27 @@ jobs:
           GITHUB_SHA: ${{ github.sha }}
           GITHUB_REF_NAME: ${{ github.ref_name }}
         run: fastlane testflight_prod
+
+      # Sentry symbolicates prod crash reports server-side using the dSYMs
+      # from the archive (gym zips them next to the IPA). Skips cleanly when
+      # the Sentry secrets are not configured.
+      - name: Upload dSYMs to Sentry
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+        run: |
+          if [ -z "$SENTRY_AUTH_TOKEN" ]; then
+            echo "SENTRY_AUTH_TOKEN not set - skipping dSYM upload."
+            exit 0
+          fi
+          shopt -s nullglob
+          dsym_zips=(build/*.dSYM.zip)
+          if [ ${#dsym_zips[@]} -eq 0 ]; then
+            echo "No dSYM zips found in build/ - nothing to upload."
+            exit 0
+          fi
+          sentry-cli debug-files upload "${dsym_zips[@]}"
 
       - name: Upload IPA artifact
         if: always()

--- a/Convos/Config/SentryConfiguration.swift
+++ b/Convos/Config/SentryConfiguration.swift
@@ -4,52 +4,61 @@ import Sentry
 
 enum SentryConfiguration {
     static func configure() {
-        guard shouldEnableSentry() else {
-            Log.info("Sentry disabled: not a Convos (Dev) distribution build")
+        let environment = ConfigManager.shared.currentEnvironment
+        guard shouldEnableSentry(for: environment) else {
+            Log.info("Sentry disabled for environment: \(environment.name)")
             return
         }
 
         let dsn = Secrets.SENTRY_DSN
         guard !dsn.isEmpty else {
-            Log.error("Sentry DSN is empty, skipping initialization")
+            Log.warning("Sentry DSN is empty, skipping initialization")
             return
         }
 
-        let envName = ConfigManager.shared.currentEnvironment.name
+        let envName = environment.name
+        let isProduction = environment.isProduction
         Log.info("Initializing Sentry for environment: \(envName)")
 
         SentrySDK.start { options in
             options.dsn = dsn
-            options.debug = true
-            options.attachScreenshot = true
+            options.debug = !isProduction
             options.enableSigtermReporting = true
             options.attachStacktrace = true
-            options.attachViewHierarchy = true
 
-            // Enable PII for internal team debugging in dev builds
-            // This captures IP addresses, user IDs, and request data
-            // Safe because .dev builds are only distributed to internal team via TestFlight
-            options.sendDefaultPii = true
-
-            options.environment = "\(envName)-debug"
+            if isProduction {
+                // Crash and error reporting only. Screenshots, view hierarchy,
+                // and default PII can carry message content and user identifiers,
+                // so they never leave a production device.
+                options.attachScreenshot = false
+                options.attachViewHierarchy = false
+                options.sendDefaultPii = false
+                options.environment = envName
+            } else {
+                // Richer context (screenshots, view hierarchy, IP addresses,
+                // user IDs, request data) for internal team debugging.
+                // Safe because .dev builds are only distributed to the internal
+                // team via TestFlight.
+                options.attachScreenshot = true
+                options.attachViewHierarchy = true
+                options.sendDefaultPii = true
+                options.environment = "\(envName)-debug"
+            }
         }
 
         Log.info("Sentry initialized successfully")
     }
 
-    private static func shouldEnableSentry() -> Bool {
-        let environment = ConfigManager.shared.currentEnvironment
-
+    private static func shouldEnableSentry(for environment: AppEnvironment) -> Bool {
         switch environment {
-        case .local:
-            // Local builds never use Sentry
+        case .local, .tests:
+            // Local builds and test runs never report to Sentry
             return false
-        case .dev:
-            // Dev builds (TestFlight) use Sentry even with DEBUG flag
-            // This is intentional: Dev.xcconfig defines DEBUG for debugging Swift packages
+        case .dev, .production:
+            // Dev (TestFlight) and production builds report to Sentry.
+            // Dev stays enabled even with the DEBUG flag: Dev.xcconfig defines
+            // DEBUG for debugging Swift packages, and that is intentional.
             return true
-        case .production, .tests:
-            return false
         }
     }
 }

--- a/Convos/Conversation Detail/ConversationInfoView.swift
+++ b/Convos/Conversation Detail/ConversationInfoView.swift
@@ -486,83 +486,102 @@ struct ConversationInfoView: View {
         }
     }
 
+    // The share-logs row ships in every environment so production users can
+    // send on-device diagnostics to support; the remaining rows are internal
+    // debugging tools and stay out of production builds.
     @ViewBuilder
     private var debugInfoSection: some View {
-        if !ConfigManager.shared.currentEnvironment.isProduction {
-            Section {
-                HStack {
-                    Text("Fork status")
-                    Spacer()
-                    Text(viewModel.conversation.debugInfo.commitLogForkStatus.rawValue)
-                        .foregroundStyle(.colorTextSecondary)
-                }
-                HStack {
-                    Text("Epoch")
-                    Spacer()
-                    Text("\(viewModel.conversation.debugInfo.epoch)")
-                        .foregroundStyle(.colorTextSecondary)
-                }
-                NavigationLink {
-                    DebugLogsTextView(logs: viewModel.conversation.debugInfo.forkDetails)
-                } label: {
-                    Text("Fork details")
-                }
-                NavigationLink {
-                    DebugLogsTextView(logs: viewModel.conversation.debugInfo.localCommitLog)
-                } label: {
-                    Text("Local commit log")
-                }
-                NavigationLink {
-                    DebugLogsTextView(logs: viewModel.conversation.debugInfo.remoteCommitLog)
-                } label: {
-                    Text("Remote commit log")
-                }
-                NavigationLink {
-                    DebugLogsTextView(logs: metadataDebugText)
-                        .task {
-                            metadataDebugText = await viewModel.conversationMetadataDebugText()
-                        }
-                } label: {
-                    Text("Metadata")
-                }
-                NavigationLink {
-                    HiddenMessagesView { try await viewModel.hiddenMessagesDebugInfo() }
-                } label: {
-                    Text("Hidden messages")
-                }
-                Button {
-                    showingRestoreInviteTagAlert = true
-                } label: {
-                    Text("Restore invite tag")
-                }
-                if let url = exportedLogsURL {
-                    ShareLink(item: url) {
-                        HStack {
-                            Text("Share logs")
-                            Spacer()
-                            Image(systemName: "square.and.arrow.up")
-                        }
-                    }
-                } else {
-                    HStack {
-                        Text("Preparing logs…")
-                        Spacer()
-                        ProgressView()
-                    }
-                    .foregroundStyle(.colorTextSecondary)
-                }
-            } header: {
-                Text("Debug info")
-                    .font(.footnote.weight(.medium))
-                    .foregroundStyle(.colorTextSecondary)
+        let isProduction = ConfigManager.shared.currentEnvironment.isProduction
+        let header: String = isProduction ? "Diagnostics" : "Debug info"
+        Section {
+            if !isProduction {
+                internalDebugRows
             }
-            .task {
-                do {
-                    exportedLogsURL = try await viewModel.exportDebugLogs()
-                } catch {
-                    Log.error("Failed to export logs for conversation: \(error.localizedDescription)")
+            shareLogsRow
+        } header: {
+            Text(header)
+                .font(.footnote.weight(.medium))
+                .foregroundStyle(.colorTextSecondary)
+        }
+        .task {
+            await prepareExportedLogs()
+        }
+    }
+
+    @ViewBuilder
+    private var internalDebugRows: some View {
+        HStack {
+            Text("Fork status")
+            Spacer()
+            Text(viewModel.conversation.debugInfo.commitLogForkStatus.rawValue)
+                .foregroundStyle(.colorTextSecondary)
+        }
+        HStack {
+            Text("Epoch")
+            Spacer()
+            Text("\(viewModel.conversation.debugInfo.epoch)")
+                .foregroundStyle(.colorTextSecondary)
+        }
+        NavigationLink {
+            DebugLogsTextView(logs: viewModel.conversation.debugInfo.forkDetails)
+        } label: {
+            Text("Fork details")
+        }
+        NavigationLink {
+            DebugLogsTextView(logs: viewModel.conversation.debugInfo.localCommitLog)
+        } label: {
+            Text("Local commit log")
+        }
+        NavigationLink {
+            DebugLogsTextView(logs: viewModel.conversation.debugInfo.remoteCommitLog)
+        } label: {
+            Text("Remote commit log")
+        }
+        NavigationLink {
+            DebugLogsTextView(logs: metadataDebugText)
+                .task {
+                    metadataDebugText = await viewModel.conversationMetadataDebugText()
+                }
+        } label: {
+            Text("Metadata")
+        }
+        NavigationLink {
+            HiddenMessagesView { try await viewModel.hiddenMessagesDebugInfo() }
+        } label: {
+            Text("Hidden messages")
+        }
+        Button {
+            showingRestoreInviteTagAlert = true
+        } label: {
+            Text("Restore invite tag")
+        }
+    }
+
+    @ViewBuilder
+    private var shareLogsRow: some View {
+        if let url = exportedLogsURL {
+            ShareLink(item: url) {
+                HStack {
+                    Text("Share logs")
+                    Spacer()
+                    Image(systemName: "square.and.arrow.up")
                 }
             }
+        } else {
+            HStack {
+                Text("Preparing logs…")
+                Spacer()
+                ProgressView()
+            }
+            .foregroundStyle(.colorTextSecondary)
+        }
+    }
+
+    private func prepareExportedLogs() async {
+        do {
+            exportedLogsURL = try await viewModel.exportDebugLogs()
+        } catch {
+            Log.error("Failed to export logs for conversation: \(error.localizedDescription)")
         }
     }
 

--- a/Convos/ConvosApp.swift
+++ b/Convos/ConvosApp.swift
@@ -24,20 +24,18 @@ struct ConvosApp: App {
         let environment = ConfigManager.shared.currentEnvironment
         ConvosLog.configure(environment: environment)
 
-        if !environment.isProduction {
-            Log.info("Activating LibXMTP file log writer at \(environment.defaultXMTPLogsDirectoryURL.path) (level=.debug, rotation=hourly, maxFiles=10)…")
-            Client.activatePersistentLibXMTPLogWriter(
-                logLevel: .debug,
-                rotationSchedule: .hourly,
-                maxFiles: 10,
-                customLogDirectory: environment.defaultXMTPLogsDirectoryURL,
-                processType: .main
-            )
-            Log.info("LibXMTP file log writer activated")
-            Log.info("Setting LibXMTP native log level to .debug…")
-            Client.setLibXMTPNativeLogLevel(.debug)
-            Log.info("LibXMTP native log level set to .debug")
-        }
+        Log.info("Activating LibXMTP file log writer at \(environment.defaultXMTPLogsDirectoryURL.path) (level=.debug, rotation=hourly, maxFiles=10)…")
+        Client.activatePersistentLibXMTPLogWriter(
+            logLevel: .debug,
+            rotationSchedule: .hourly,
+            maxFiles: 10,
+            customLogDirectory: environment.defaultXMTPLogsDirectoryURL,
+            processType: .main
+        )
+        Log.info("LibXMTP file log writer activated")
+        Log.info("Setting LibXMTP native log level to .debug…")
+        Client.setLibXMTPNativeLogLevel(.debug)
+        Log.info("LibXMTP native log level set to .debug")
         Log.info("App starting with environment: \(environment)")
         let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "unknown"
         let appBuild = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "unknown"

--- a/Convos/ConvosApp.swift
+++ b/Convos/ConvosApp.swift
@@ -24,18 +24,21 @@ struct ConvosApp: App {
         let environment = ConfigManager.shared.currentEnvironment
         ConvosLog.configure(environment: environment)
 
-        Log.info("Activating LibXMTP file log writer at \(environment.defaultXMTPLogsDirectoryURL.path) (level=.debug, rotation=hourly, maxFiles=10)…")
+        // Verbose libxmtp logs are invaluable in dev/local but too chatty (and too
+        // revealing of protocol internals) to persist on every production device.
+        let libXMTPLogLevel: Client.LogLevel = environment.isProduction ? .warn : .debug
+        Log.info("Activating LibXMTP file log writer at \(environment.defaultXMTPLogsDirectoryURL.path) (level=\(libXMTPLogLevel), rotation=hourly, maxFiles=10)…")
         Client.activatePersistentLibXMTPLogWriter(
-            logLevel: .debug,
+            logLevel: libXMTPLogLevel,
             rotationSchedule: .hourly,
             maxFiles: 10,
             customLogDirectory: environment.defaultXMTPLogsDirectoryURL,
             processType: .main
         )
         Log.info("LibXMTP file log writer activated")
-        Log.info("Setting LibXMTP native log level to .debug…")
-        Client.setLibXMTPNativeLogLevel(.debug)
-        Log.info("LibXMTP native log level set to .debug")
+        Log.info("Setting LibXMTP native log level to \(libXMTPLogLevel)…")
+        Client.setLibXMTPNativeLogLevel(libXMTPLogLevel)
+        Log.info("LibXMTP native log level set to \(libXMTPLogLevel)")
         Log.info("App starting with environment: \(environment)")
         let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "unknown"
         let appBuild = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "unknown"

--- a/ConvosCore/Sources/ConvosCore/Logging/Logger.swift
+++ b/ConvosCore/Sources/ConvosCore/Logging/Logger.swift
@@ -43,6 +43,11 @@ public enum ConvosLog {
     /// Call this once at app startup before using any loggers
     /// Logging is enabled in every environment, including production, so
     /// production issues can be diagnosed from the on-device log file.
+    /// The handlers record .info and above in every environment: app-level
+    /// info logs are low-volume, app-authored messages (API failures,
+    /// lifecycle milestones) and are the signal needed to debug production
+    /// issues, unlike the libxmtp protocol firehose, which ConvosApp gates
+    /// to .warn in production.
     public static func configure(environment: AppEnvironment) {
         queue.sync {
             guard _logger == nil else { return }

--- a/ConvosCore/Sources/ConvosCore/Logging/Logger.swift
+++ b/ConvosCore/Sources/ConvosCore/Logging/Logger.swift
@@ -41,15 +41,11 @@ public enum ConvosLog {
 
     /// Configure the logging system with file-based handler
     /// Call this once at app startup before using any loggers
-    /// Logging is automatically disabled in production environments
+    /// Logging is enabled in every environment, including production, so
+    /// production issues can be diagnosed from the on-device log file.
     public static func configure(environment: AppEnvironment) {
         queue.sync {
             guard _logger == nil else { return }
-
-            // never enable logging in production
-            guard !environment.isProduction else {
-                return
-            }
 
             // First, bootstrap the logging system factory
             LoggingSystem.bootstrap { label in

--- a/Scripts/generate-secrets-secure.sh
+++ b/Scripts/generate-secrets-secure.sh
@@ -33,7 +33,8 @@ BUILD_CONFIG="${BITRISE_BUILD_CONFIG:-${BUILD_CONFIGURATION:-Release}}"
 
 echo "Build configuration: $BUILD_CONFIG"
 
-# Only use dev DSN for Dev CI builds, empty for Release/Prod
+# Dev builds use the dev DSN; Prod/Release builds use the prod DSN.
+# An unset DSN leaves Sentry disabled in the resulting build.
 if [[ "$BUILD_CONFIG" == "Dev" ]]; then
     # Dev CI build - use dev DSN if available
     if [[ -n "${SENTRY_DSN_DEV}" ]]; then
@@ -43,10 +44,15 @@ if [[ "$BUILD_CONFIG" == "Dev" ]]; then
         ESCAPED_SENTRY_DSN=$(swift_escape "${SENTRY_DSN:-}")
         echo "Dev CI build - using SENTRY_DSN (fallback)"
     fi
-elif [[ "$BUILD_CONFIG" == "Release" ]]; then
-    # Production build - explicitly disable Sentry
-    ESCAPED_SENTRY_DSN=""
-    echo "Production build - Sentry DSN set to empty"
+elif [[ "$BUILD_CONFIG" == "Release" || "$BUILD_CONFIG" == "Prod" ]]; then
+    # Production build - use prod DSN if available
+    if [[ -n "${SENTRY_DSN_PROD:-}" ]]; then
+        ESCAPED_SENTRY_DSN=$(swift_escape "${SENTRY_DSN_PROD}")
+        echo "Production build - using SENTRY_DSN_PROD"
+    else
+        ESCAPED_SENTRY_DSN=""
+        echo "Production build - SENTRY_DSN_PROD not set, Sentry disabled"
+    fi
 else
     # Unknown configuration - default to empty for safety
     ESCAPED_SENTRY_DSN=""

--- a/nix/modules/devshell.nix
+++ b/nix/modules/devshell.nix
@@ -29,6 +29,8 @@ _: {
         packages = [
           gems
           (lib.lowPrio gems.wrappedRuby)
+          # dSYM upload to Sentry in the prod TestFlight workflow
+          pkgs.sentry-cli
         ];
         DEVELOPER_DIR = "${xcode}";
         LANG = "en_US.UTF-8";


### PR DESCRIPTION
## What

Production builds get observability through two complementary channels (both previously disabled):

**On-device logging**
- `ConvosLog.configure` no longer early-returns for `.production` - the file + console log handlers are installed in every environment. The file handler records `.info` and above (its default level; nothing in the codebase raises it to `.debug`), capped at 10MB with rotation.
- The libxmtp persistent log writer is now active in every environment, with an environment-gated level: `.debug` for dev/local (unchanged), **`.warn` for production**. Hourly rotation, 10 files max.
- The conversation info screen now shows the **share-logs row in production** (under a "Diagnostics" header) so users can send on-device logs to support via a share sheet. The internal-only debug rows (fork status, commit logs, restore invite tag) remain hidden in production.

**Sentry crash + error reporting in production**
- `SentryConfiguration` now enables Sentry for `.production` with privacy-safe options: no screenshots, no view hierarchy, no default PII - crash/error reports with stack traces only. Dev builds keep their richer debugging context (unchanged).
- `generate-secrets-secure.sh` accepts the `Prod`/`Release` build configurations and bakes in `SENTRY_DSN_PROD` (empty when unset, which leaves Sentry disabled - safe default).
- `testflight-prod.yml` wires `SENTRY_DSN_PROD` and uploads dSYMs to Sentry after the build so prod crash reports are symbolicated (skips cleanly when secrets are unset). `sentry-cli` added to the nix dev shell.
- `firebase-pr.yml` now passes `SENTRY_DSN_DEV` - dev CI builds were silently shipping an empty DSN, so Sentry was effectively off in dev CI builds too.

## Why

Production builds emitted no diagnostics - app logs off, libxmtp logs off, Sentry dev-only. That made prod-only failures impossible to debug (see the "New Convo fails every time" report this branch was used to diagnose).

This now provides two tiers: Sentry reports crashes and errors remotely from every prod device (symbolicated), and on-device logs provide deeper context when a device is available, at a level that keeps the volume and privacy footprint small.

## How the code-review concerns were addressed

| Concern | Resolution |
|---|---|
| Debug-level PII written on every prod device | App file log records `.info`+ (not `.debug`); libxmtp gated to `.warn` in prod. Logs leave the device only through the user-initiated share-logs row in conversation info; nothing is transmitted automatically, and the prod Sentry config sends no screenshots/view-hierarchy/PII. |
| No remote kill-switch | Footprint is now small and hard-bounded (app log capped at 10MB; libxmtp at `.warn`, hourly rotation, 10 files). Remote-config gating remains a follow-up if we later want `.debug` in prod. |
| LibXMTP rotation insufficient for `.debug` volume | Prod runs at `.warn`; hourly/10-files is generous at that volume. Dev keeps `.debug` as before. |
| Disk I/O per log statement | `.warn` cuts prod libxmtp write volume by orders of magnitude; app log volume at `.info` is unchanged from what dev builds have run all along. |
| No test coverage for logging | Meaningful tests need a testability refactor of `ConvosLogging`: `FileLogHandler` requires an app-group container (unavailable in SPM test processes, so the handler no-ops) and `LoggingSystem.bootstrap` is once-per-process. Deliberately out of scope right before release; tracked as follow-up. |

## To activate (repo secrets)

Sentry stays disabled until these are added - the code paths all degrade gracefully:
- `SENTRY_DSN_PROD` - prod DSN (reuse the existing project or create a prod one; events are tagged `environment: production`)
- `SENTRY_DSN_DEV` - dev DSN for PR/dev CI builds (currently unset, so dev CI Sentry has been silently off)
- `SENTRY_AUTH_TOKEN`, `SENTRY_ORG`, `SENTRY_PROJECT` - for the dSYM upload step (symbolicated prod crashes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enable on-device logging and Sentry crash reporting in production builds
> - Activates persistent file logging in production via `ConvosLog.configure` (previously disabled) at `warn` level for LibXMTP and production Sentry environment; non-production retains `debug` level with richer context (screenshots, view hierarchy, PII).
> - `SentryConfiguration` now enables Sentry for `.production` and `.dev` environments; `.local` and `.tests` remain disabled. Production omits screenshots, view hierarchy, and PII from reports.
> - CI workflows ([firebase-pr.yml](.github/workflows/firebase-pr.yml), [testflight-prod.yml](.github/workflows/testflight-prod.yml)) now inject `SENTRY_DSN_DEV`/`SENTRY_DSN_PROD` into `Secrets.swift` and the prod workflow conditionally uploads dSYMs to Sentry for symbolication.
> - Adds a "Diagnostics" section in `ConversationInfoView` for production users, exposing only a Share Logs row; full internal debug rows remain visible in non-production.
> - Behavioral Change: logging and Sentry are now active in production releases; PII/screenshot capture is explicitly disabled for production Sentry events.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #949 opened
>
> - Added documentation comments to `ConvosLog.configure` configuration function explaining logging handler behavior [96577eb]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2b85ac0.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->