### PR TITLE
feat(contacts): add "Suggested agents" section to contacts list

### DIFF
--- a/Convos/Contacts/ContactDetailView.swift
+++ b/Convos/Contacts/ContactDetailView.swift
@@ -71,6 +71,9 @@ struct ContactDetailView: View {
     /// `onDismiss`.
     @State private var presentingAgentInfo: Bool = false
     @State private var agentInfoConfirmed: Bool = false
+    /// The agent template's description, resolved on appear for template-backed
+    /// agents (it isn't stored on the contact). Rendered under the name.
+    @State private var agentDescription: String?
 
     init(
         contact: Contact,
@@ -91,6 +94,9 @@ struct ContactDetailView: View {
         self.showsCloseButton = showsCloseButton
         self.onRemove = onRemove
         _isBlocked = State(initialValue: contact.isBlocked)
+        // Suggested-agent contacts carry the description, so it renders
+        // immediately; saved agent contacts seed nil and resolve it on appear.
+        _agentDescription = State(initialValue: contact.agentDescription)
     }
 
     var body: some View {
@@ -103,6 +109,7 @@ struct ContactDetailView: View {
             .toolbar { agentShareToolbarItem }
             .task(id: contact.inboxId) { await syncBlockedState() }
             .task(id: contact.agentTemplateId) { await loadAgentTemplateConversations() }
+            .task(id: contact.agentTemplateId) { await loadAgentDescription() }
     }
 
     /// `bodyContent` plus the modal / sheet / overlay presentation layer.
@@ -148,6 +155,16 @@ struct ContactDetailView: View {
             Log.error("Failed to load agent template conversations for \(templateId): \(error.localizedDescription)")
             agentTemplateConversations = .empty
         }
+    }
+
+    /// Resolves the agent template's description (id or slug) so the card can
+    /// show it under the name. `nil` for humans and when resolution fails.
+    private func loadAgentDescription() async {
+        // Suggested-agent contacts already carry the description (seeded in
+        // init), so skip the round-trip; only saved agent contacts resolve it.
+        guard agentDescription == nil, let session, let templateId = contact.agentTemplateId else { return }
+        let info = await session.agentShareResolver().resolve(identifier: templateId)
+        agentDescription = info?.descriptionText
     }
 
     /// Agent "code card" share flow: a QR encoding the template's published
@@ -222,13 +239,26 @@ struct ContactDetailView: View {
             // view, inflating the gap between subtitle and actions.
             VStack(spacing: 0.0) {
                 ContactDetailHeader(contact: contact)
-                ContactDetailSubtitle(
-                    contact: contact,
-                    invitedBy: mode.invitedBy,
-                    joinedAt: mode.joinedAt,
-                    isBlocked: isBlocked
-                )
-                .padding(.top, DesignConstants.Spacing.step2x)
+                if let agentDescription, !agentDescription.isEmpty {
+                    Text(agentDescription)
+                        .font(.body)
+                        .foregroundStyle(.colorTextPrimary)
+                        .multilineTextAlignment(.center)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .padding(.top, DesignConstants.Spacing.step2x)
+                        .padding(.horizontal, DesignConstants.Spacing.step6x)
+                }
+                // Suggested-agent placeholders aren't saved contacts, so the
+                // "Added X ago" line (and Block, below) don't apply.
+                if !contact.isSuggestedAgentPlaceholder {
+                    ContactDetailSubtitle(
+                        contact: contact,
+                        invitedBy: mode.invitedBy,
+                        joinedAt: mode.joinedAt,
+                        isBlocked: isBlocked
+                    )
+                    .padding(.top, DesignConstants.Spacing.step2x)
+                }
                 headerBadge
                 ContactDetailActions(
                     isBlocked: isBlocked,
@@ -246,7 +276,7 @@ struct ContactDetailView: View {
                     showRemove: mode.isScopedToConversation
                         && !mode.isCurrentUser
                         && mode.canRemoveMembers,
-                    showBlock: !mode.isCurrentUser,
+                    showBlock: !mode.isCurrentUser && !contact.isSuggestedAgentPlaceholder,
                     contactDisplayName: contact.resolvedDisplayName,
                     agentInstanceId: contact.agentInstanceId,
                     showsInstanceIdRow: showsInstanceIdRow,
@@ -325,6 +355,7 @@ struct ContactDetailView: View {
             mode: .newConversation,
             contactsRepository: contactsRepository,
             preselectedInboxIds: [contact.inboxId],
+            suggestedAgentsService: SuggestedAgentsService.live(),
             onConfirm: handlePickerConfirm
         )
     }
@@ -587,8 +618,12 @@ private struct ContactDetailSubtitle: View {
     let isBlocked: Bool
 
     var body: some View {
+        // The scoped-mode "Invited X ago by Y" line reads as a footnote; the
+        // standalone "Added X ago" keeps the subheadline size.
+        let subtitleFont: Font = joinedAt != nil ? .footnote : .subheadline
         VStack(spacing: DesignConstants.Spacing.stepX) {
             Text(subtitleText)
+                .font(subtitleFont)
                 .foregroundStyle(.colorTextSecondary)
             if isBlocked {
                 blockedRow

--- a/Convos/Contacts/ContactsListView.swift
+++ b/Convos/Contacts/ContactsListView.swift
@@ -27,26 +27,32 @@ struct ContactsListSection<Row: Identifiable>: Identifiable {
 }
 
 /// Sectioned contacts list shared by the contacts browser and the picker.
-/// Generic over the caller's row type and the row's rendered content view.
-struct ContactsListView<Row: Identifiable, RowContent: View, ListBackground: View>: View {
+/// Generic over the caller's row type, the row's rendered content view, and
+/// the per-section header. Most callers want the canonical letter header and
+/// reach for the convenience initializer below; the picker supplies a custom
+/// builder so its "Suggested agents" section can render a richer header.
+struct ContactsListView<Row: Identifiable, RowContent: View, SectionHeader: View, ListBackground: View>: View {
     let sections: [ContactsListSection<Row>]
     private let rowContent: (Row) -> RowContent
+    private let sectionHeader: (ContactsListSection<Row>) -> SectionHeader
     private let listBackground: ListBackground
 
     init(
         sections: [ContactsListSection<Row>],
         @ViewBuilder rowContent: @escaping (Row) -> RowContent,
+        @ViewBuilder sectionHeader: @escaping (ContactsListSection<Row>) -> SectionHeader,
         @ViewBuilder listBackground: () -> ListBackground
     ) {
         self.sections = sections
         self.rowContent = rowContent
+        self.sectionHeader = sectionHeader
         self.listBackground = listBackground()
     }
 
     var body: some View {
         List {
             ForEach(sections) { section in
-                SwiftUI.Section(header: ContactsListSectionHeader(title: section.title)) {
+                SwiftUI.Section(header: sectionHeader(section)) {
                     ForEach(section.rows) { row in
                         rowContent(row)
                             .listRowBackground(listBackground)
@@ -58,6 +64,22 @@ struct ContactsListView<Row: Identifiable, RowContent: View, ListBackground: Vie
         .listStyle(.plain)
         .scrollContentBackground(.hidden)
         .background(listBackground)
+    }
+}
+
+extension ContactsListView where SectionHeader == ContactsListSectionHeader {
+    /// Convenience for callers that just want the canonical letter header.
+    init(
+        sections: [ContactsListSection<Row>],
+        @ViewBuilder rowContent: @escaping (Row) -> RowContent,
+        @ViewBuilder listBackground: () -> ListBackground
+    ) {
+        self.init(
+            sections: sections,
+            rowContent: rowContent,
+            sectionHeader: { ContactsListSectionHeader(title: $0.title) },
+            listBackground: listBackground
+        )
     }
 }
 
@@ -73,6 +95,26 @@ struct ContactsListSectionHeader: View {
             .textCase(nil)
             .padding(.leading, DesignConstants.Spacing.step2x)
             .listRowBackground(Color.colorBackgroundRaisedSecondary)
+    }
+}
+
+/// Header for the trailing "Suggested agents" section, shared by the contacts
+/// browser and the picker. A single caption line that aligns with the
+/// alphabetical letter headers: the title in `.colorTextSecondary` followed by
+/// a "Chat to customize" hint in `.colorTextTertiary`.
+struct SuggestedAgentsSectionHeader: View {
+    var body: some View {
+        HStack(spacing: 0.0) {
+            Text(SuggestedAgentsSection.title)
+                .foregroundStyle(.colorTextSecondary)
+            Text(" · Chat to customize")
+                .foregroundStyle(.colorTextTertiary)
+        }
+        .font(.caption)
+        .textCase(nil)
+        .padding(.leading, DesignConstants.Spacing.step2x)
+        .padding(.top, DesignConstants.Spacing.step2x)
+        .listRowBackground(Color.colorBackgroundRaisedSecondary)
     }
 }
 

--- a/Convos/Contacts/ContactsPickerView.swift
+++ b/Convos/Contacts/ContactsPickerView.swift
@@ -66,13 +66,15 @@ struct ContactsPickerView: View {
         preselectedInboxIds: Set<String> = [],
         pillConversation: Conversation? = nil,
         embedsNavigationStack: Bool = true,
+        suggestedAgentsService: (any SuggestedAgentsServiceProtocol)? = nil,
         onConfirm: @escaping (_ memberInboxIds: Set<String>, _ agentTemplateId: String?) -> Void
     ) {
         _viewModel = State(initialValue: ContactsPickerViewModel(
             mode: mode,
             contactsRepository: contactsRepository,
             alreadyInChatInboxIds: alreadyInChatInboxIds,
-            preselectedInboxIds: preselectedInboxIds
+            preselectedInboxIds: preselectedInboxIds,
+            suggestedAgentsService: suggestedAgentsService
         ))
         self.pillConversation = pillConversation
         self.embedsNavigationStack = embedsNavigationStack
@@ -288,28 +290,70 @@ private struct ContactsPickerList: View {
     let onToggle: (String) -> Void
 
     var body: some View {
+        content
+            .task { await viewModel.loadSuggestedAgentsIfNeeded() }
+    }
+
+    @ViewBuilder
+    private var content: some View {
         if viewModel.sections.isEmpty {
-            emptyState
+            if viewModel.isLoadingSuggestedAgents {
+                loadingState
+            } else {
+                emptyState
+            }
         } else {
-            ContactsListView(
-                sections: viewModel.sections.map { section in
-                    ContactsListSection(
-                        id: section.id,
-                        title: section.title,
-                        rows: section.rows
-                    )
-                },
-                rowContent: { (row: ContactsPickerViewModel.Row) in
-                    ContactsPickerRow(
-                        row: row,
-                        isSelected: viewModel.isSelected(inboxId: row.id),
-                        isAgentSelectionBlocked: viewModel.isAgentSelectionBlocked(for: row.id),
-                        onTap: rowTapAction(for: row)
-                    )
-                },
-                listBackground: { Color.colorBackgroundRaisedSecondary }
-            )
+            list
         }
+    }
+
+    private var list: some View {
+        ContactsListView(
+            sections: viewModel.sections.map { section in
+                ContactsListSection(
+                    id: section.id,
+                    title: section.title,
+                    rows: section.rows
+                )
+            },
+            rowContent: { (row: ContactsPickerViewModel.Row) in
+                rowView(for: row)
+            },
+            sectionHeader: { (section: ContactsListSection<ContactsPickerViewModel.Row>) in
+                sectionHeader(for: section)
+            },
+            listBackground: { Color.colorBackgroundRaisedSecondary }
+        )
+    }
+
+    @ViewBuilder
+    private func rowView(for row: ContactsPickerViewModel.Row) -> some View {
+        ContactsPickerRow(
+            row: row,
+            isSelected: viewModel.isSelected(inboxId: row.id),
+            isAgentSelectionBlocked: viewModel.isAgentSelectionBlocked(for: row.id),
+            onTap: rowTapAction(for: row)
+        )
+        .onAppear {
+            guard row.isSuggestedAgent else { return }
+            let rowId = row.id
+            Task { await viewModel.suggestedAgentRowAppeared(id: rowId) }
+        }
+    }
+
+    @ViewBuilder
+    private func sectionHeader(for section: ContactsListSection<ContactsPickerViewModel.Row>) -> some View {
+        if section.id == SuggestedAgentsSection.id {
+            SuggestedAgentsSectionHeader()
+        } else {
+            ContactsListSectionHeader(title: section.title)
+        }
+    }
+
+    private var loadingState: some View {
+        ProgressView()
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .padding(DesignConstants.Spacing.step6x)
     }
 
     private var emptyState: some View {
@@ -370,6 +414,35 @@ private struct ContactsPickerConfirmButton: View {
     ContactsPickerView(
         mode: .newConversation,
         contactsRepository: MockContactsRepository(),
+        onConfirm: { _, _ in }
+    )
+}
+
+#Preview("Suggested agents") {
+    let suggested: [SuggestedAgent] = [
+        .mock(templateId: "trip", name: "Trip", description: "Travel agent", emoji: "🧳"),
+        .mock(templateId: "champ", name: "Champ", description: "Team manager", emoji: "🏆"),
+        .mock(templateId: "chef", name: "Chef", description: "Meal and nutrition partner", emoji: "🍽️"),
+        .mock(templateId: "scoop", name: "Scoop", description: "Neighborhood expert", emoji: "🗞️"),
+    ]
+    return ContactsPickerView(
+        mode: .newConversation,
+        contactsRepository: MockContactsRepository(),
+        suggestedAgentsService: MockSuggestedAgentsService(agents: suggested),
+        onConfirm: { _, _ in }
+    )
+}
+
+#Preview("Suggested agents, no contacts") {
+    let suggested: [SuggestedAgent] = [
+        .mock(templateId: "trip", name: "Trip", description: "Travel agent", emoji: "🧳"),
+        .mock(templateId: "champ", name: "Champ", description: "Team manager", emoji: "🏆"),
+        .mock(templateId: "chef", name: "Chef", description: "Meal and nutrition partner", emoji: "🍽️"),
+    ]
+    return ContactsPickerView(
+        mode: .newConversation,
+        contactsRepository: MockContactsRepository(contacts: []),
+        suggestedAgentsService: MockSuggestedAgentsService(agents: suggested),
         onConfirm: { _, _ in }
     )
 }

--- a/Convos/Contacts/ContactsPickerViewModel.swift
+++ b/Convos/Contacts/ContactsPickerViewModel.swift
@@ -57,6 +57,11 @@ final class ContactsPickerViewModel {
         /// line). Verified agents carry their role label in the trailing pill,
         /// not here. See `Contact.listSubtitle(sources:)`.
         let subtitle: String
+        /// True for rows in the "Suggested agents" section -- featured agent
+        /// templates fetched from the backend rather than the user's own
+        /// contacts. Drives the load-more trigger when the last such row
+        /// appears (see `suggestedAgentRowAppeared(id:)`).
+        var isSuggestedAgent: Bool = false
     }
 
     let mode: ContactsPickerMode
@@ -66,22 +71,41 @@ final class ContactsPickerViewModel {
         didSet { rebuildSections() }
     }
     var isLoading: Bool = true
+    /// True while the initial suggested-agents page request is in flight.
+    /// Drives the loading state when there are no contacts to show yet.
+    var isLoadingSuggestedAgents: Bool {
+        suggestedAgentsModel.isLoading
+    }
 
     private let contactsRepository: any ContactsRepositoryProtocol
     private let alreadyInChatInboxIds: Set<String>
     private var allContacts: [Contact] = []
     private var cancellable: AnyCancellable?
 
+    /// Shared suggested-agents fetch/pagination state. A nil service (e.g. the
+    /// add-to-conversation entry point) yields no section.
+    private let suggestedAgentsModel: SuggestedAgentsModel
+    /// Synthetic contacts for the currently visible suggested agents. Kept so
+    /// selection lookups (one-agent rule, confirm-by-template) resolve a
+    /// selected suggestion even while the section is hidden by a search query.
+    private var suggestedAgentContacts: [Contact] = []
+
     init(
         mode: ContactsPickerMode,
         contactsRepository: any ContactsRepositoryProtocol,
         alreadyInChatInboxIds: Set<String> = [],
-        preselectedInboxIds: Set<String> = []
+        preselectedInboxIds: Set<String> = [],
+        suggestedAgentsService: (any SuggestedAgentsServiceProtocol)? = nil
     ) {
         self.mode = mode
         self.contactsRepository = contactsRepository
         self.alreadyInChatInboxIds = alreadyInChatInboxIds
         self.selectedInboxIds = preselectedInboxIds.subtracting(alreadyInChatInboxIds)
+        self.suggestedAgentsModel = SuggestedAgentsModel(service: suggestedAgentsService)
+
+        suggestedAgentsModel.onAgentsChanged = { [weak self] in
+            self?.rebuildSections()
+        }
 
         cancellable = contactsRepository.contactsPublisher
             .receive(on: DispatchQueue.main)
@@ -96,8 +120,16 @@ final class ContactsPickerViewModel {
 
     // MARK: - Derived state
 
+    /// Everything a selection can point at: the user's contacts plus the
+    /// synthetic contacts backing the suggested-agents section. Selecting a
+    /// suggested agent inserts its synthetic inboxId, so agent detection,
+    /// template resolution, and the selected-pills row all read this union.
+    private var selectableContacts: [Contact] {
+        allContacts + suggestedAgentContacts
+    }
+
     var selectedContacts: [Contact] {
-        allContacts.filter { selectedInboxIds.contains($0.inboxId) }
+        selectableContacts.filter { selectedInboxIds.contains($0.inboxId) }
     }
 
     var selectionCount: Int {
@@ -210,11 +242,11 @@ final class ContactsPickerViewModel {
     /// spawned into the new (or existing) conversation.
     var selectedAgentTemplateId: String? {
         guard let agentInboxId = selectedAgentInboxId else { return nil }
-        return allContacts.first { $0.inboxId == agentInboxId }?.agentTemplateId
+        return selectableContacts.first { $0.inboxId == agentInboxId }?.agentTemplateId
     }
 
     private func isAgent(_ inboxId: String) -> Bool {
-        allContacts.first { $0.inboxId == inboxId }?.agentTemplateId != nil
+        selectableContacts.first { $0.inboxId == inboxId }?.agentTemplateId != nil
     }
 
     /// Single source of truth for "is this contact a valid picker row".
@@ -244,7 +276,11 @@ final class ContactsPickerViewModel {
         // blocked / a verified agent / unnamed would otherwise stay in
         // `selectedInboxIds`, counting toward `selectionCount` and passing
         // `canConfirm` with no UI for the user to remove it.
+        // Pruning keeps a selected suggested agent alive: its synthetic
+        // inboxId isn't a real contact, so it must be unioned in or a contacts
+        // publisher emission would silently drop the selection.
         let visibleInboxIds = Set(allContacts.filter(Self.isPickable).map(\.inboxId))
+            .union(suggestedAgentContacts.map(\.inboxId))
         selectedInboxIds = selectedInboxIds.intersection(visibleInboxIds)
         rebuildSections()
         isLoading = false
@@ -266,7 +302,7 @@ final class ContactsPickerViewModel {
         let viaIds: Set<String> = Set(filtered.compactMap { $0.addedViaConversationId })
         let sources: [String: ContactSourceConversation] = (try? contactsRepository.sourceConversations(forIds: viaIds)) ?? [:]
 
-        sections = sortedKeys.map { key in
+        var rebuilt: [Section] = sortedKeys.map { key in
             let rows = (grouped[key] ?? []).map { contact in
                 Row(
                     id: contact.inboxId,
@@ -277,6 +313,40 @@ final class ContactsPickerViewModel {
             }
             return Section(id: key, title: key, rows: rows)
         }
+
+        if let suggested = buildSuggestedAgentsSection() {
+            rebuilt.append(suggested)
+        }
+        sections = rebuilt
+    }
+
+    /// Builds the trailing "Suggested agents" section and refreshes
+    /// `suggestedAgentContacts` (kept in sync regardless of the search query so
+    /// selection lookups still resolve). Returns nil when there's nothing to
+    /// show, or while a search is active -- suggestions are a browse
+    /// affordance, and the server-paged list can't be meaningfully filtered
+    /// against a partial set on the client.
+    private func buildSuggestedAgentsSection() -> Section? {
+        // Drop suggestions the user already has as a contact so an agent never
+        // appears in both the alphabetical list and the suggested section.
+        let existingAgentTemplateIds = Set(allContacts.compactMap { $0.agentTemplateId })
+        let visibleSuggested = suggestedAgentsModel.visibleAgents(excludingTemplateIds: existingAgentTemplateIds)
+
+        let rows: [Row] = visibleSuggested.map { agent in
+            let contact = Contact.suggestedAgent(agent)
+            return Row(
+                id: contact.inboxId,
+                contact: contact,
+                isAlreadyInChat: false,
+                subtitle: agent.description ?? "",
+                isSuggestedAgent: true
+            )
+        }
+        suggestedAgentContacts = rows.map(\.contact)
+
+        let trimmedQuery = searchQuery.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmedQuery.isEmpty, !rows.isEmpty else { return nil }
+        return Section(id: SuggestedAgentsSection.id, title: SuggestedAgentsSection.title, rows: rows)
     }
 
     private func filterByQuery(_ contacts: [Contact]) -> [Contact] {
@@ -294,5 +364,24 @@ final class ContactsPickerViewModel {
         case (_, "#"): return true
         default: return lhs < rhs
         }
+    }
+
+    // MARK: - Suggested agents
+
+    /// Loads the first page of suggested agents the first time the picker
+    /// appears. Idempotent: safe to call from `.task` on every appear.
+    func loadSuggestedAgentsIfNeeded() async {
+        await suggestedAgentsModel.loadIfNeeded()
+    }
+
+    /// Loads the next page when the last suggested row scrolls into view,
+    /// until the backend reports there are no more.
+    func suggestedAgentRowAppeared(id rowId: String) async {
+        guard rowId == suggestedAgentContacts.last?.inboxId else { return }
+        await suggestedAgentsModel.loadMore()
+    }
+
+    func loadMoreSuggestedAgents() async {
+        await suggestedAgentsModel.loadMore()
     }
 }

--- a/Convos/Contacts/ContactsView.swift
+++ b/Convos/Contacts/ContactsView.swift
@@ -21,10 +21,12 @@ struct ContactsView: View {
         contactsWriter: any ContactsWriterProtocol = MockContactsWriter(),
         session: (any SessionManagerProtocol)? = nil,
         profileSettingsViewModel: ProfileSettingsViewModel = .shared,
-        showsComposeButton: Bool = true
+        showsComposeButton: Bool = true,
+        suggestedAgentsService: (any SuggestedAgentsServiceProtocol)? = nil
     ) {
         _viewModel = State(initialValue: ContactsViewModel(
-            contactsRepository: contactsRepository
+            contactsRepository: contactsRepository,
+            suggestedAgentsService: suggestedAgentsService
         ))
         self.contactsRepository = contactsRepository
         self.contactsWriter = contactsWriter
@@ -35,12 +37,13 @@ struct ContactsView: View {
 
     var body: some View {
         Group {
-            if viewModel.contactCount == 0 {
+            if viewModel.sections.isEmpty {
                 emptyState
             } else {
                 contactsContent
             }
         }
+        .task { await viewModel.loadSuggestedAgentsIfNeeded() }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background {
             Color.colorBackgroundRaisedSecondary
@@ -96,12 +99,34 @@ struct ContactsView: View {
                 )
             },
             rowContent: { (row: ContactsViewModel.Row) in
-                NavigationLink(value: row.contact) {
-                    ContactRowView(contact: row.contact, subtitle: row.subtitle)
-                }
+                contactRow(for: row)
+            },
+            sectionHeader: { (section: ContactsListSection<ContactsViewModel.Row>) in
+                contactsSectionHeader(for: section)
             },
             listBackground: { Color.colorBackgroundRaisedSecondary }
         )
+    }
+
+    @ViewBuilder
+    private func contactRow(for row: ContactsViewModel.Row) -> some View {
+        NavigationLink(value: row.contact) {
+            ContactRowView(contact: row.contact, subtitle: row.subtitle)
+        }
+        .onAppear {
+            guard row.isSuggestedAgent else { return }
+            let rowId = row.id
+            Task { await viewModel.suggestedAgentRowAppeared(id: rowId) }
+        }
+    }
+
+    @ViewBuilder
+    private func contactsSectionHeader(for section: ContactsListSection<ContactsViewModel.Row>) -> some View {
+        if section.id == SuggestedAgentsSection.id {
+            SuggestedAgentsSectionHeader()
+        } else {
+            ContactsListSectionHeader(title: section.title)
+        }
     }
 
     /// Detail pushed when a contact row is tapped. Built here (rather than
@@ -148,6 +173,7 @@ struct ContactsView: View {
         ContactsPickerView(
             mode: .newConversation,
             contactsRepository: contactsRepository,
+            suggestedAgentsService: SuggestedAgentsService.live(),
             onConfirm: handlePickerConfirm
         )
     }

--- a/Convos/Contacts/ContactsViewModel.swift
+++ b/Convos/Contacts/ContactsViewModel.swift
@@ -21,6 +21,10 @@ final class ContactsViewModel {
         /// Same resolver as the picker — convo name, then "DM" for 1:1
         /// source, then agent role label, then empty (caller hides line).
         let subtitle: String
+        /// True for rows in the trailing "Suggested agents" section (featured
+        /// agent templates, not the user's own contacts). Drives the load-more
+        /// trigger when the last such row appears.
+        var isSuggestedAgent: Bool = false
     }
 
     var sections: [Section] = []
@@ -29,13 +33,32 @@ final class ContactsViewModel {
     var searchQuery: String = "" {
         didSet { rebuildSections() }
     }
+    /// True while the initial suggested-agents page request is in flight.
+    var isLoadingSuggestedAgents: Bool {
+        suggestedAgentsModel.isLoading
+    }
 
     private let contactsRepository: any ContactsRepositoryProtocol
     private var cancellable: AnyCancellable?
     private var allContacts: [Contact] = []
 
-    init(contactsRepository: any ContactsRepositoryProtocol) {
+    /// Shared suggested-agents fetch/pagination state. A nil service yields no
+    /// section (e.g. previews that don't wire one).
+    private let suggestedAgentsModel: SuggestedAgentsModel
+    /// Synthetic contacts for the visible suggested agents, kept so the
+    /// load-more trigger can recognize the last suggested row.
+    private var suggestedAgentContacts: [Contact] = []
+
+    init(
+        contactsRepository: any ContactsRepositoryProtocol,
+        suggestedAgentsService: (any SuggestedAgentsServiceProtocol)? = nil
+    ) {
         self.contactsRepository = contactsRepository
+        self.suggestedAgentsModel = SuggestedAgentsModel(service: suggestedAgentsService)
+
+        suggestedAgentsModel.onAgentsChanged = { [weak self] in
+            self?.rebuildSections()
+        }
 
         cancellable = contactsRepository.contactsPublisher
             .receive(on: DispatchQueue.main)
@@ -99,12 +122,41 @@ final class ContactsViewModel {
         }
         let viaIds: Set<String> = Set(filtered.compactMap { $0.addedViaConversationId })
         let sources: [String: ContactSourceConversation] = (try? contactsRepository.sourceConversations(forIds: viaIds)) ?? [:]
-        sections = sortedKeys.map { key in
+        var rebuilt: [Section] = sortedKeys.map { key in
             let rows = (grouped[key] ?? []).map { contact in
                 Row(id: contact.inboxId, contact: contact, subtitle: contact.listSubtitle(sources: sources))
             }
             return Section(id: key, title: key, rows: rows)
         }
+
+        if let suggested = buildSuggestedAgentsSection() {
+            rebuilt.append(suggested)
+        }
+        sections = rebuilt
+    }
+
+    /// Builds the trailing "Suggested agents" section (and refreshes
+    /// `suggestedAgentContacts`). Returns nil when there's nothing to show, or
+    /// while a search is active -- suggestions are a browse affordance and the
+    /// server-paged list can't be filtered against a partial set on the client.
+    private func buildSuggestedAgentsSection() -> Section? {
+        let existingAgentTemplateIds = Set(allContacts.compactMap { $0.agentTemplateId })
+        let visibleSuggested = suggestedAgentsModel.visibleAgents(excludingTemplateIds: existingAgentTemplateIds)
+
+        let rows: [Row] = visibleSuggested.map { agent in
+            let contact = Contact.suggestedAgent(agent)
+            return Row(
+                id: contact.inboxId,
+                contact: contact,
+                subtitle: agent.description ?? "",
+                isSuggestedAgent: true
+            )
+        }
+        suggestedAgentContacts = rows.map(\.contact)
+
+        let trimmedQuery = searchQuery.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmedQuery.isEmpty, !rows.isEmpty else { return nil }
+        return Section(id: SuggestedAgentsSection.id, title: SuggestedAgentsSection.title, rows: rows)
     }
 
     private func filterByQuery(_ contacts: [Contact]) -> [Contact] {
@@ -113,5 +165,19 @@ final class ContactsViewModel {
         return contacts.filter { contact in
             contact.resolvedDisplayName.localizedCaseInsensitiveContains(trimmed)
         }
+    }
+
+    // MARK: - Suggested agents
+
+    /// Loads the first page of suggested agents the first time the list
+    /// appears. Idempotent: safe to call from `.task` on every appear.
+    func loadSuggestedAgentsIfNeeded() async {
+        await suggestedAgentsModel.loadIfNeeded()
+    }
+
+    /// Loads the next page when the last suggested row scrolls into view.
+    func suggestedAgentRowAppeared(id rowId: String) async {
+        guard rowId == suggestedAgentContacts.last?.inboxId else { return }
+        await suggestedAgentsModel.loadMore()
     }
 }

--- a/Convos/Contacts/SuggestedAgentsModel.swift
+++ b/Convos/Contacts/SuggestedAgentsModel.swift
@@ -1,0 +1,97 @@
+import ConvosCore
+import Foundation
+import Observation
+
+/// Stable id for the trailing "Suggested agents" section, shared by the
+/// contacts browser and the picker so each can swap in the section's custom
+/// header (see `SuggestedAgentsSectionHeader`).
+enum SuggestedAgentsSection {
+    static let id: String = "suggested-agents"
+    static let title: String = "Suggested agents"
+}
+
+/// Shared fetch + pagination state for the "Suggested agents" section. Owned
+/// by both `ContactsViewModel` (the Contacts tab) and `ContactsPickerViewModel`
+/// (the compose picker) so the section behaves identically across every
+/// contacts list. Pulls featured agent templates a page at a time; the host
+/// turns `agents` into rows -- de-duping against the contacts it already shows
+/// -- and rebuilds its sections from the `onAgentsChanged` callback.
+@Observable
+@MainActor
+final class SuggestedAgentsModel {
+    private let service: (any SuggestedAgentsServiceProtocol)?
+    private let pageSize: Int
+
+    private(set) var agents: [SuggestedAgent] = []
+    private(set) var isLoading: Bool = false
+
+    private var cursor: String?
+    private var hasMore: Bool = true
+    private var seenTemplateIds: Set<String> = []
+
+    /// Invoked on the main actor whenever `agents` changes so the host can
+    /// rebuild its sections.
+    var onAgentsChanged: (() -> Void)?
+
+    init(service: (any SuggestedAgentsServiceProtocol)?, pageSize: Int = 20) {
+        self.service = service
+        self.pageSize = pageSize
+    }
+
+    /// True when a service is wired and the section should participate.
+    var isActive: Bool {
+        service != nil
+    }
+
+    /// Loads (or refreshes) the first page. Called from `.task` on appear, so
+    /// re-opening the surface picks up newly-featured agents. The in-flight
+    /// guard in `fetch` collapses overlapping appears into a single request,
+    /// and the page is swapped in only once it arrives (no clear-then-flicker).
+    func loadIfNeeded() async {
+        await fetch(cursor: nil, reset: true)
+    }
+
+    /// Loads the next page when the last suggested row scrolls into view,
+    /// until the backend reports there are no more.
+    func loadMore() async {
+        guard hasMore, !isLoading, let cursor else { return }
+        await fetch(cursor: cursor, reset: false)
+    }
+
+    private func fetch(cursor: String?, reset: Bool) async {
+        guard let service, !isLoading else { return }
+        isLoading = true
+        defer { isLoading = false }
+        do {
+            let page = try await service.featuredAgents(limit: pageSize, cursor: cursor)
+            if reset {
+                agents = []
+                seenTemplateIds = []
+            }
+            for agent in page.agents {
+                guard seenTemplateIds.insert(agent.templateId).inserted else { continue }
+                agents.append(agent)
+            }
+            self.cursor = page.nextCursor
+            hasMore = page.nextCursor != nil
+            onAgentsChanged?()
+        } catch {
+            Log.error("Failed loading suggested agents: \(error.localizedDescription)")
+            // Stop advertising more only when the first page fails; a failed
+            // load-more leaves the cursor in place so a later scroll retries.
+            if reset {
+                hasMore = false
+            }
+        }
+    }
+}
+
+extension SuggestedAgentsModel {
+    /// Synthetic contacts for the agents not already present as contacts,
+    /// preserving fetch order. The host passes the template ids it already
+    /// renders so an agent never shows in both the alphabetical list and the
+    /// suggested section.
+    func visibleAgents(excludingTemplateIds excluded: Set<String>) -> [SuggestedAgent] {
+        agents.filter { !excluded.contains($0.templateId) }
+    }
+}

--- a/Convos/Contacts/SuggestedAgentsService+Live.swift
+++ b/Convos/Contacts/SuggestedAgentsService+Live.swift
@@ -1,0 +1,13 @@
+import ConvosCore
+import Foundation
+
+extension SuggestedAgentsService {
+    /// Builds the live service from the current environment's API client.
+    /// Used by the new-conversation / compose entry points of
+    /// `ContactsPickerView` to populate the "Suggested agents" section.
+    static func live() -> SuggestedAgentsService {
+        SuggestedAgentsService(
+            apiClient: ConvosAPIClientFactory.client(environment: ConfigManager.shared.currentEnvironment)
+        )
+    }
+}

--- a/Convos/Conversation Creation/ComposeFlowView.swift
+++ b/Convos/Conversation Creation/ComposeFlowView.swift
@@ -42,6 +42,7 @@ struct ComposeFlowView: View {
                 mode: .compose,
                 contactsRepository: contactsRepository,
                 embedsNavigationStack: false,
+                suggestedAgentsService: SuggestedAgentsService.live(),
                 onConfirm: handleProceed
             )
             .navigationDestination(item: $pushedConversation) { conversationViewModel in

--- a/Convos/MainTabView.swift
+++ b/Convos/MainTabView.swift
@@ -369,7 +369,8 @@ struct MainTabView: View {
             contactsWriter: messagingService.contactsWriter(),
             session: conversationsViewModel.session,
             profileSettingsViewModel: profileSettingsViewModel,
-            showsComposeButton: false
+            showsComposeButton: false,
+            suggestedAgentsService: SuggestedAgentsService.live()
         )
     }
 

--- a/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient+Models.swift
+++ b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient+Models.swift
@@ -246,6 +246,23 @@ public enum ConvosAPI {
         }
     }
 
+    /// One page of the agent-templates list endpoint
+    /// (`GET /v2/agent-templates/`). The backend returns a cursor-paginated
+    /// envelope: `data` is the page, `hasMore` signals another page exists,
+    /// and `nextCursor` is the opaque base64url cursor to pass back as
+    /// `&cursor=` for the following page (`nil` on the last page).
+    public struct AgentTemplatesPage: Codable, Sendable {
+        public let data: [AgentTemplate]
+        public let hasMore: Bool
+        public let nextCursor: String?
+
+        public init(data: [AgentTemplate], hasMore: Bool, nextCursor: String?) {
+            self.data = data
+            self.hasMore = hasMore
+            self.nextCursor = nextCursor
+        }
+    }
+
     // MARK: - Common Error Response
 
     public struct ErrorResponse: Codable {

--- a/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift
+++ b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift
@@ -97,6 +97,14 @@ public protocol ConvosAPIClientProtocol: AnyObject, Sendable {
     /// published templates to anonymous callers.
     func getAgentTemplate(idOrUrlSlug: String) async throws -> ConvosAPI.AgentTemplate
 
+    /// Lists featured (curated) published agent templates, cursor-paginated.
+    /// Backs the contacts picker's "Suggested agents" section. Pass `nil`
+    /// `cursor` for the first page, then thread `AgentTemplatesPage.nextCursor`
+    /// back for each following page until `hasMore` is `false`.
+    /// Unauthenticated: featured templates are published, so the backend
+    /// serves them to anonymous callers (mirrors `getAgentTemplate`).
+    func getFeaturedAgentTemplates(limit: Int, cursor: String?) async throws -> ConvosAPI.AgentTemplatesPage
+
     // Connections
     func initiateCloudConnection(serviceId: String, redirectUri: String) async throws -> CloudConnectionsAPI.InitiateResponse
     func completeCloudConnection(connectionRequestId: String) async throws -> CloudConnectionsAPI.CompleteResponse
@@ -761,6 +769,21 @@ final class ConvosAPIClient: ConvosAPIClientProtocol, Sendable {
         // (no auth header) and `performRequest` maps 404 -> APIError.notFound.
         let encoded = idOrUrlSlug.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? idOrUrlSlug
         let request = try request(for: "v2/agent-templates/\(encoded)")
+        return try await performRequest(request)
+    }
+
+    func getFeaturedAgentTemplates(limit: Int, cursor: String?) async throws -> ConvosAPI.AgentTemplatesPage {
+        // Public, unauthenticated GET -- featured templates are published, so
+        // the list endpoint serves them to anonymous callers. `request(for:)`
+        // builds a bare GET (no auth header).
+        var queryParameters: [String: String] = [
+            "featured": "true",
+            "limit": String(limit),
+        ]
+        if let cursor, !cursor.isEmpty {
+            queryParameters["cursor"] = cursor
+        }
+        let request = try request(for: "v2/agent-templates", queryParameters: queryParameters)
         return try await performRequest(request)
     }
 

--- a/ConvosCore/Sources/ConvosCore/API/MockAPIClient.swift
+++ b/ConvosCore/Sources/ConvosCore/API/MockAPIClient.swift
@@ -117,6 +117,15 @@ final class MockAPIClient: ConvosAPIClientProtocol, Sendable {
         )
     }
 
+    func getFeaturedAgentTemplates(limit: Int, cursor: String?) async throws -> ConvosAPI.AgentTemplatesPage {
+        let templates: [ConvosAPI.AgentTemplate] = [
+            .init(id: "tmpl-trip", status: "published", publishedUrl: nil, slug: "trip", agentName: "Trip", description: "Travel agent", emoji: "🧳", avatarUrl: nil),
+            .init(id: "tmpl-champ", status: "published", publishedUrl: nil, slug: "champ", agentName: "Champ", description: "Team manager", emoji: "🏆", avatarUrl: nil),
+            .init(id: "tmpl-chef", status: "published", publishedUrl: nil, slug: "chef", agentName: "Chef", description: "Meal and nutrition partner", emoji: "🍽️", avatarUrl: nil),
+        ]
+        return .init(data: templates, hasMore: false, nextCursor: nil)
+    }
+
     // MARK: - Connections
 
     func initiateCloudConnection(serviceId: String, redirectUri: String) async throws -> CloudConnectionsAPI.InitiateResponse {

--- a/ConvosCore/Sources/ConvosCore/Mocks/MockSuggestedAgentsService.swift
+++ b/ConvosCore/Sources/ConvosCore/Mocks/MockSuggestedAgentsService.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+/// Test/preview double for `SuggestedAgentsServiceProtocol`. Serves a fixed
+/// list of pages in order and records the requested limits/cursors so tests
+/// can assert paging behavior (initial page size, cursor threading).
+public final class MockSuggestedAgentsService: SuggestedAgentsServiceProtocol, @unchecked Sendable {
+    public private(set) var requestedLimits: [Int] = []
+    public private(set) var requestedCursors: [String?] = []
+
+    private let pages: [SuggestedAgentsPage]
+    private var nextPageIndex: Int = 0
+    private let delay: Duration?
+
+    public init(pages: [SuggestedAgentsPage], delay: Duration? = nil) {
+        self.pages = pages
+        self.delay = delay
+    }
+
+    /// Single-page convenience: all agents in one page with no further cursor.
+    public convenience init(agents: [SuggestedAgent], delay: Duration? = nil) {
+        self.init(pages: [SuggestedAgentsPage(agents: agents, nextCursor: nil)], delay: delay)
+    }
+
+    public func featuredAgents(limit: Int, cursor: String?) async throws -> SuggestedAgentsPage {
+        requestedLimits.append(limit)
+        requestedCursors.append(cursor)
+        if let delay {
+            try await Task.sleep(for: delay)
+        }
+        guard nextPageIndex < pages.count else {
+            return SuggestedAgentsPage(agents: [], nextCursor: nil)
+        }
+        let page = pages[nextPageIndex]
+        nextPageIndex += 1
+        return page
+    }
+}
+
+public extension SuggestedAgent {
+    static func mock(
+        templateId: String = UUID().uuidString,
+        name: String = "Mock Agent",
+        description: String? = "A mock suggested agent",
+        emoji: String? = "🤖",
+        avatarURL: String? = nil
+    ) -> SuggestedAgent {
+        SuggestedAgent(
+            templateId: templateId,
+            name: name,
+            description: description,
+            emoji: emoji,
+            avatarURL: avatarURL
+        )
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Services/SuggestedAgentsService.swift
+++ b/ConvosCore/Sources/ConvosCore/Services/SuggestedAgentsService.swift
@@ -1,0 +1,118 @@
+import Foundation
+
+/// A featured ("suggested") agent template surfaced in the contacts picker's
+/// "Suggested agents" section. A lightweight projection of
+/// `ConvosAPI.AgentTemplate` carrying only what a picker row needs.
+public struct SuggestedAgent: Identifiable, Hashable, Sendable {
+    public let templateId: String
+    public let name: String
+    public let description: String?
+    public let emoji: String?
+    public let avatarURL: String?
+
+    public var id: String { templateId }
+
+    public init(
+        templateId: String,
+        name: String,
+        description: String?,
+        emoji: String?,
+        avatarURL: String?
+    ) {
+        self.templateId = templateId
+        self.name = name
+        self.description = description
+        self.emoji = emoji
+        self.avatarURL = avatarURL
+    }
+}
+
+public extension SuggestedAgent {
+    /// Projects a backend template into a suggested agent, or `nil` when the
+    /// template carries no display name -- a nameless row can't be rendered.
+    init?(template: ConvosAPI.AgentTemplate) {
+        guard let name = template.agentName, !name.isEmpty else { return nil }
+        self.init(
+            templateId: template.id,
+            name: name,
+            description: template.description,
+            emoji: template.emoji,
+            avatarURL: template.avatarUrl
+        )
+    }
+}
+
+/// One page of suggested agents plus the cursor for the next page (`nil` when
+/// the list is exhausted).
+public struct SuggestedAgentsPage: Sendable {
+    public let agents: [SuggestedAgent]
+    public let nextCursor: String?
+
+    public init(agents: [SuggestedAgent], nextCursor: String?) {
+        self.agents = agents
+        self.nextCursor = nextCursor
+    }
+}
+
+/// Fetches featured agent templates for the contacts picker's suggested
+/// section. A narrow seam over `ConvosAPIClientProtocol` so the picker view
+/// model can be driven by a stub in previews and tests without conforming to
+/// the full API client surface.
+public protocol SuggestedAgentsServiceProtocol: Sendable {
+    func featuredAgents(limit: Int, cursor: String?) async throws -> SuggestedAgentsPage
+}
+
+public final class SuggestedAgentsService: SuggestedAgentsServiceProtocol {
+    private let apiClient: any ConvosAPIClientProtocol
+
+    public init(apiClient: any ConvosAPIClientProtocol) {
+        self.apiClient = apiClient
+    }
+
+    public func featuredAgents(limit: Int, cursor: String?) async throws -> SuggestedAgentsPage {
+        let page = try await apiClient.getFeaturedAgentTemplates(limit: limit, cursor: cursor)
+        let agents = page.data.compactMap(SuggestedAgent.init(template:))
+        // Collapse the cursor to nil once the backend says there is no more,
+        // so callers can stop paging on `nextCursor == nil` alone.
+        return SuggestedAgentsPage(agents: agents, nextCursor: page.hasMore ? page.nextCursor : nil)
+    }
+}
+
+public extension Contact {
+    /// Builds a synthetic, non-persisted contact representing a featured agent
+    /// template in the picker's "Suggested agents" section. These never enter
+    /// the contacts store: the picker uses the row purely for display and
+    /// selection, and confirms by `agentTemplateId` (a fresh instance of the
+    /// template is spawned into the new conversation).
+    ///
+    /// The list endpoint carries no verification signal, but suggested agents
+    /// are first-party curated, so they intentionally render with
+    /// verified-agent styling (the "Agent" pill and the agent avatar
+    /// treatment). The `inboxId` is prefixed so it can never collide with a
+    /// real inbox in the selection set.
+    static func suggestedAgent(_ agent: SuggestedAgent) -> Contact {
+        Contact(
+            inboxId: suggestedAgentInboxIdPrefix + agent.templateId,
+            displayName: agent.name,
+            avatarURL: agent.avatarURL,
+            addedAt: Date(timeIntervalSince1970: 0),
+            addedViaConversationId: nil,
+            agentVerification: .verified(.convos),
+            agentTemplateId: agent.templateId,
+            profileEmoji: agent.emoji,
+            agentDescription: agent.description
+        )
+    }
+
+    /// Prefix stamped onto a suggested agent's synthetic `inboxId`. Distinct
+    /// from any real inbox so a selected suggestion never aliases a contact.
+    static let suggestedAgentInboxIdPrefix: String = "suggested-agent:"
+
+    /// True for the synthetic contacts backing the "Suggested agents" section
+    /// -- a featured template the user hasn't added yet, not a saved contact.
+    /// Lets surfaces suppress contact-only affordances (the "Added X ago"
+    /// line, Block) for these placeholder rows.
+    var isSuggestedAgentPlaceholder: Bool {
+        inboxId.hasPrefix(Self.suggestedAgentInboxIdPrefix)
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/Contact.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/Contact.swift
@@ -58,6 +58,11 @@ public struct Contact: Hashable, Identifiable, Sendable {
     /// agent reads as verified or unverified. Overlaid via
     /// `with(agentAttestation:)`, applied last in `resolved(member:...)`.
     public let agentAttestation: String?
+    /// The agent template's description (tagline). Carried on the synthetic
+    /// "Suggested agents" contacts so the contact card renders it immediately
+    /// without a network round-trip. `nil` for humans and for saved agent
+    /// contacts (which don't persist it); those resolve it on demand.
+    public let agentDescription: String?
 
     public init(
         inboxId: String,
@@ -74,7 +79,8 @@ public struct Contact: Hashable, Identifiable, Sendable {
         agentTemplatePublishedURL: String? = nil,
         profileEmoji: String? = nil,
         agentInstanceId: String? = nil,
-        agentAttestation: String? = nil
+        agentAttestation: String? = nil,
+        agentDescription: String? = nil
     ) {
         self.inboxId = inboxId
         self.displayName = displayName
@@ -91,6 +97,7 @@ public struct Contact: Hashable, Identifiable, Sendable {
         self.profileEmoji = profileEmoji
         self.agentInstanceId = agentInstanceId
         self.agentAttestation = agentAttestation
+        self.agentDescription = agentDescription
     }
 
     /// True when this contact has the full set of AES-256-GCM material

--- a/ConvosCore/Tests/ConvosCoreTests/TestStubAPIClientDefaults.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/TestStubAPIClientDefaults.swift
@@ -59,6 +59,13 @@ extension ConvosAPIClientProtocol {
             avatarUrl: nil
         )
     }
+
+    /// Default for the featured agent-templates list backing the contacts
+    /// picker's suggested section. Tests that exercise it specifically should
+    /// override on their fixture.
+    func getFeaturedAgentTemplates(limit: Int, cursor: String?) async throws -> ConvosAPI.AgentTemplatesPage {
+        ConvosAPI.AgentTemplatesPage(data: [], hasMore: false, nextCursor: nil)
+    }
 }
 
 /// Open, fully-conforming `ConvosAPIClientProtocol` base for test fixtures that

--- a/ConvosTests/ContactsPickerViewModelTests.swift
+++ b/ConvosTests/ContactsPickerViewModelTests.swift
@@ -349,4 +349,155 @@ final class ContactsPickerViewModelTests: XCTestCase {
         let unnamed = Contact.mock(displayName: nil)
         XCTAssertTrue(ContactsPickerViewModel.pickableContacts([agent, blocked, unnamed]).isEmpty)
     }
+
+    // MARK: - Suggested agents
+
+    private func suggestedSection(_ viewModel: ContactsPickerViewModel) -> ContactsPickerViewModel.Section? {
+        viewModel.sections.first { $0.id == SuggestedAgentsSection.id }
+    }
+
+    private func suggestedTemplateIds(_ viewModel: ContactsPickerViewModel) -> [String] {
+        suggestedSection(viewModel)?.rows.compactMap { $0.contact.agentTemplateId } ?? []
+    }
+
+    /// With no service wired, the picker behaves exactly as before -- no
+    /// suggested section and no extra rows.
+    func testNoSuggestedSectionWithoutService() async {
+        let viewModel = ContactsPickerViewModel(
+            mode: .newConversation,
+            contactsRepository: MockContactsRepository()
+        )
+        await viewModel.loadSuggestedAgentsIfNeeded()
+        XCTAssertNil(suggestedSection(viewModel))
+    }
+
+    /// The suggested section is appended after the alphabetical contact
+    /// sections, with its sentinel id and "Suggested agents" title.
+    func testSuggestedSectionAppearsAfterContacts() async {
+        let service = MockSuggestedAgentsService(agents: [
+            .mock(templateId: "trip", name: "Trip"),
+            .mock(templateId: "chef", name: "Chef"),
+        ])
+        let viewModel = ContactsPickerViewModel(
+            mode: .newConversation,
+            contactsRepository: MockContactsRepository(),
+            suggestedAgentsService: service
+        )
+        await viewModel.loadSuggestedAgentsIfNeeded()
+
+        XCTAssertEqual(viewModel.sections.last?.id, SuggestedAgentsSection.id)
+        XCTAssertEqual(viewModel.sections.last?.title, "Suggested agents")
+        XCTAssertEqual(suggestedTemplateIds(viewModel), ["trip", "chef"])
+        XCTAssertTrue(suggestedSection(viewModel)?.rows.allSatisfy(\.isSuggestedAgent) == true)
+    }
+
+    /// Always fetches a full page of 20 featured agents, whether or not the
+    /// user already has contacts.
+    func testInitialLimitIsTwentyWhenUserHasContacts() async {
+        let service = MockSuggestedAgentsService(agents: [.mock(templateId: "a", name: "A")])
+        let viewModel = ContactsPickerViewModel(
+            mode: .newConversation,
+            contactsRepository: MockContactsRepository(),
+            suggestedAgentsService: service
+        )
+        await viewModel.loadSuggestedAgentsIfNeeded()
+        XCTAssertEqual(service.requestedLimits.first, 20)
+    }
+
+    func testInitialLimitIsTwentyWhenUserHasNoContacts() async {
+        let service = MockSuggestedAgentsService(agents: [.mock(templateId: "a", name: "A")])
+        let viewModel = ContactsPickerViewModel(
+            mode: .newConversation,
+            contactsRepository: MockContactsRepository(contacts: []),
+            suggestedAgentsService: service
+        )
+        await viewModel.loadSuggestedAgentsIfNeeded()
+        XCTAssertEqual(service.requestedLimits.first, 20)
+    }
+
+    /// Scrolling to the bottom loads the next page (threading the cursor) and
+    /// appends it, until the backend reports no more.
+    func testPaginationAppendsNextPage() async {
+        let service = MockSuggestedAgentsService(pages: [
+            SuggestedAgentsPage(agents: [.mock(templateId: "a", name: "A"), .mock(templateId: "b", name: "B")], nextCursor: "cursor-1"),
+            SuggestedAgentsPage(agents: [.mock(templateId: "c", name: "C")], nextCursor: nil),
+        ])
+        let viewModel = ContactsPickerViewModel(
+            mode: .newConversation,
+            contactsRepository: MockContactsRepository(contacts: []),
+            suggestedAgentsService: service
+        )
+
+        await viewModel.loadSuggestedAgentsIfNeeded()
+        XCTAssertEqual(suggestedTemplateIds(viewModel), ["a", "b"])
+
+        await viewModel.loadMoreSuggestedAgents()
+        XCTAssertEqual(suggestedTemplateIds(viewModel), ["a", "b", "c"])
+        XCTAssertEqual(service.requestedCursors, [nil, "cursor-1"])
+
+        // No further cursor -> a subsequent load-more is a no-op.
+        await viewModel.loadMoreSuggestedAgents()
+        XCTAssertEqual(service.requestedLimits.count, 2)
+    }
+
+    /// Selecting a suggested agent makes it the conversation's single agent
+    /// (resolved by template id) and follows the one-agent rule.
+    func testSelectingSuggestedAgentSetsTemplateId() async {
+        let service = MockSuggestedAgentsService(agents: [.mock(templateId: "trip", name: "Trip")])
+        let viewModel = ContactsPickerViewModel(
+            mode: .newConversation,
+            contactsRepository: MockContactsRepository(contacts: []),
+            suggestedAgentsService: service
+        )
+        await viewModel.loadSuggestedAgentsIfNeeded()
+
+        let row = try? XCTUnwrap(suggestedSection(viewModel)?.rows.first)
+        let rowId = row?.id ?? ""
+        viewModel.toggleSelection(for: rowId)
+
+        XCTAssertTrue(viewModel.isSelected(inboxId: rowId))
+        XCTAssertEqual(viewModel.selectedAgentTemplateId, "trip")
+        XCTAssertEqual(viewModel.selectedAgentInboxId, rowId)
+        XCTAssertEqual(viewModel.selectedContacts.map(\.inboxId), [rowId])
+    }
+
+    /// A suggested agent the user already has as a (template-backed) contact is
+    /// dropped from the suggested section so it never appears twice.
+    func testSuggestedAgentsDedupedAgainstExistingContacts() async {
+        let existing = Contact.mock(
+            displayName: "Trip",
+            agentVerification: .verified(.convos),
+            agentTemplateId: "trip"
+        )
+        let service = MockSuggestedAgentsService(agents: [
+            .mock(templateId: "trip", name: "Trip"),
+            .mock(templateId: "chef", name: "Chef"),
+        ])
+        let viewModel = ContactsPickerViewModel(
+            mode: .newConversation,
+            contactsRepository: MockContactsRepository(contacts: [existing]),
+            suggestedAgentsService: service
+        )
+        await viewModel.loadSuggestedAgentsIfNeeded()
+        XCTAssertEqual(suggestedTemplateIds(viewModel), ["chef"])
+    }
+
+    /// The suggested section is a browse affordance: an active search hides it
+    /// (the server-paged list can't be filtered against a partial set).
+    func testSuggestedSectionHiddenWhileSearching() async {
+        let service = MockSuggestedAgentsService(agents: [.mock(templateId: "trip", name: "Trip")])
+        let viewModel = ContactsPickerViewModel(
+            mode: .newConversation,
+            contactsRepository: MockContactsRepository(),
+            suggestedAgentsService: service
+        )
+        await viewModel.loadSuggestedAgentsIfNeeded()
+        XCTAssertNotNil(suggestedSection(viewModel))
+
+        viewModel.searchQuery = "zzz-no-match"
+        XCTAssertNil(suggestedSection(viewModel))
+
+        viewModel.searchQuery = ""
+        XCTAssertNotNil(suggestedSection(viewModel))
+    }
 }


### PR DESCRIPTION
Surfaces featured agent templates (GET /v2/agent-templates/?featured=true,
cursor-paginated) as a "Suggested agents" section after the user's contacts,
in both the compose picker and the Contacts tab.

- Shared SuggestedAgentsModel drives fetch/pagination for both surfaces and
  refreshes on each appearance, so newly-featured agents show without relaunch.
- Always pages 20; de-dupes agents the user already has as contacts; hidden
  while searching.
- Rows reuse the existing agent-row style with verified-agent styling and are
  selectable in the picker. Tapping opens the agent card (Chat + Learn about
  agents); the not-yet-added "Added X ago" / "Block" affordances are hidden.
- Agent description renders under the name on the contact card (.body),
  threaded onto suggested contacts so it shows immediately with no
  fetch/flicker; saved agent contacts resolve it on demand. "Invited by"
  subtitle now uses .footnote.

Adds SuggestedAgent / SuggestedAgentsService (narrow seam over the API client)
+ MockSuggestedAgentsService, Contact.suggestedAgent / agentDescription /
isSuggestedAgentPlaceholder, and getFeaturedAgentTemplates on the API client.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/950"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783040118&installation_id=128169237&pr_number=950&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F950&signature=4f34515175771a51c25c4793adedb6d1804d050d802c03682ff8e7009d66d150"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add "Suggested agents" section to contacts list and picker
> - Adds a paginated "Suggested agents" section to both the contacts list ([ContactsViewModel](https://github.com/xmtplabs/convos-ios/pull/950/files#diff-99446eaf0688b94fb2ff5d2f31cb1ea04efe01b762662e82909a1dcb74683a8a)) and contacts picker ([ContactsPickerViewModel](https://github.com/xmtplabs/convos-ios/pull/950/files#diff-7a4aa100f6c78f226bd8d1f4ba794c6f31df8ec0139bebb7d3e0163a97cc6a24)), fetching featured agent templates from a new `v2/agent-templates?featured=true` endpoint via [SuggestedAgentsService](https://github.com/xmtplabs/convos-ios/pull/950/files#diff-6981350acca7db7de7ac8e2a8e534fe5d16b82b758353c2758a023e98aafe89c).
> - Introduces [SuggestedAgentsModel](https://github.com/xmtplabs/convos-ios/pull/950/files#diff-2e47e039c63a759bda661b3e2b4f49e704b58af9dd8c774473be0051418e6151) as a shared, observable model handling fetch, pagination, and deduplication against existing contacts.
> - Synthetic `Contact` instances represent suggested agents in-memory without persistence; a new `isSuggestedAgentPlaceholder` flag suppresses contact-only UI (subtitle, block action).
> - Agent template descriptions are lazily resolved and displayed under the contact name in [ContactDetailView](https://github.com/xmtplabs/convos-ios/pull/950/files#diff-fa54c9aca0b6a99cd254f52934d6ffb2f3d79b79ff6ee084feb9ebda7d8d03a4).
> - The section is hidden during search and the compose flow picker also receives the live suggested agents service.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 832a808.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->