### PR TITLE
feat(contacts): filter list by All / People / Agents

### DIFF
--- a/Convos/Contacts/ContactsFilter.swift
+++ b/Convos/Contacts/ContactsFilter.swift
@@ -1,0 +1,52 @@
+import ConvosCore
+import Foundation
+
+/// Audience filter applied to the contact list shown by the Contacts browse
+/// screen (`ContactsView`) and the contacts picker (`ContactsPickerView`).
+/// Toggled from the filter affordance in `ContactsSearchBar` and applied where
+/// each view model rebuilds its sections. People are humans; agents are
+/// template-backed contacts (`agentTemplateId != nil`), matching the picker's
+/// own agent discriminator.
+enum ContactsFilter: String, CaseIterable, Identifiable, Hashable {
+    case all
+    case people
+    case agents
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .all:
+            return "All"
+        case .people:
+            return "People"
+        case .agents:
+            return "Agents"
+        }
+    }
+
+    /// Whether the filter is narrowing the list. Drives the active-state
+    /// treatment on the search bar's filter icon.
+    var isActive: Bool {
+        self != .all
+    }
+
+    /// Whether the agents audience is part of the current filter. Used to hide
+    /// agent-only sections (e.g. "Suggested agents") under the People filter.
+    var includesAgents: Bool {
+        self != .people
+    }
+
+    /// Whether `contact` belongs to the current audience. Agents are
+    /// template-backed (`agentTemplateId != nil`); everything else is a person.
+    func includes(_ contact: Contact) -> Bool {
+        switch self {
+        case .all:
+            return true
+        case .people:
+            return contact.agentTemplateId == nil
+        case .agents:
+            return contact.agentTemplateId != nil
+        }
+    }
+}

--- a/Convos/Contacts/ContactsPickerView.swift
+++ b/Convos/Contacts/ContactsPickerView.swift
@@ -130,7 +130,8 @@ struct ContactsPickerView: View {
                 ContactsSearchBar(
                     query: $viewModel.searchQuery,
                     placeholder: "Contacts",
-                    accessibilityIdentifier: "contacts-picker-search-field"
+                    accessibilityIdentifier: "contacts-picker-search-field",
+                    filter: $viewModel.filter
                 )
                 ContactsPickerSelectedPills(
                     contacts: viewModel.selectedContacts,

--- a/Convos/Contacts/ContactsPickerViewModel.swift
+++ b/Convos/Contacts/ContactsPickerViewModel.swift
@@ -70,6 +70,13 @@ final class ContactsPickerViewModel {
     var searchQuery: String = "" {
         didSet { rebuildSections() }
     }
+    /// Audience filter toggled from the search bar's filter menu. Narrows the
+    /// pickable list to people or agents; selections persist across filter
+    /// changes -- a selected contact hidden by the filter stays selected and
+    /// still appears in the selected-pills row.
+    var filter: ContactsFilter = .all {
+        didSet { rebuildSections() }
+    }
     var isLoading: Bool = true
     /// True while the initial suggested-agents page request is in flight.
     /// Drives the loading state when there are no contacts to show yet.
@@ -288,7 +295,7 @@ final class ContactsPickerViewModel {
 
     private func rebuildSections() {
         let visible = allContacts.filter(Self.isPickable)
-        let filtered = filterByQuery(visible)
+        let filtered = filterByQuery(filterByAudience(visible))
         let grouped: [String: [Contact]] = Dictionary(
             grouping: filtered,
             by: { $0.alphabeticalSectionKey }
@@ -345,7 +352,10 @@ final class ContactsPickerViewModel {
         suggestedAgentContacts = rows.map(\.contact)
 
         let trimmedQuery = searchQuery.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard trimmedQuery.isEmpty, !rows.isEmpty else { return nil }
+        // Suggested agents are agents, so hide the whole section under the
+        // People filter. `suggestedAgentContacts` stays complete above so a
+        // selected suggested agent still resolves in the pills row.
+        guard trimmedQuery.isEmpty, filter.includesAgents, !rows.isEmpty else { return nil }
         return Section(id: SuggestedAgentsSection.id, title: SuggestedAgentsSection.title, rows: rows)
     }
 
@@ -355,6 +365,11 @@ final class ContactsPickerViewModel {
         return contacts.filter { contact in
             contact.resolvedDisplayName.localizedCaseInsensitiveContains(trimmed)
         }
+    }
+
+    private func filterByAudience(_ contacts: [Contact]) -> [Contact] {
+        guard filter.isActive else { return contacts }
+        return contacts.filter { filter.includes($0) }
     }
 
     private static func sectionKeyOrder(_ lhs: String, _ rhs: String) -> Bool {

--- a/Convos/Contacts/ContactsSearchBar.swift
+++ b/Convos/Contacts/ContactsSearchBar.swift
@@ -2,28 +2,33 @@ import ConvosCore
 import SwiftUI
 
 /// Shared search-bar component used by both the contacts list (`ContactsView`)
-/// and the contacts picker (`ContactsPickerView`). The two surfaces only
-/// differ in placeholder copy, so the styling lives here and the placeholder
-/// is the single configurable knob.
+/// and the contacts picker (`ContactsPickerView`). The two surfaces differ in
+/// placeholder copy, so the styling lives here and the placeholder is a
+/// configurable knob.
 ///
 /// Visually: a capsule-shaped liquid-glass container with a leading
-/// magnifying-glass icon, the text field in the middle, and a trailing
-/// action icon on the right — `line.3.horizontal` as a placeholder for a
-/// future filter affordance when the field is empty, replaced by a clear-X
-/// button once the user has typed something.
+/// magnifying-glass icon, the text field in the middle, and a trailing action
+/// icon on the right. When the field is empty the trailing icon is the filter
+/// affordance (`line.3.horizontal.decrease`): if a `filter` binding is supplied
+/// it opens a menu that narrows the list to All / People / Agents, otherwise it
+/// renders as a static placeholder. Once the user types, the icon is replaced
+/// by a clear-X button.
 struct ContactsSearchBar: View {
     @Binding var query: String
     let placeholder: String
     let accessibilityIdentifier: String
+    private let filter: Binding<ContactsFilter>?
 
     init(
         query: Binding<String>,
         placeholder: String,
-        accessibilityIdentifier: String
+        accessibilityIdentifier: String,
+        filter: Binding<ContactsFilter>? = nil
     ) {
         self._query = query
         self.placeholder = placeholder
         self.accessibilityIdentifier = accessibilityIdentifier
+        self.filter = filter
     }
 
     var body: some View {
@@ -52,10 +57,7 @@ struct ContactsSearchBar: View {
     @ViewBuilder
     private var trailingAccessory: some View {
         if query.isEmpty {
-            Image(systemName: "line.3.horizontal.decrease")
-                .font(.title3)
-                .foregroundStyle(.colorTextSecondary)
-                .padding(DesignConstants.Spacing.stepX)
+            emptyQueryAccessory
         } else {
             Button(action: clearAction) {
                 Image(systemName: "xmark.circle.fill")
@@ -65,6 +67,37 @@ struct ContactsSearchBar: View {
             }
             .accessibilityLabel("Clear search")
         }
+    }
+
+    @ViewBuilder
+    private var emptyQueryAccessory: some View {
+        if let filter {
+            filterMenu(filter)
+        } else {
+            Image(systemName: "line.3.horizontal.decrease")
+                .font(.title3)
+                .foregroundStyle(.colorTextSecondary)
+                .padding(DesignConstants.Spacing.stepX)
+        }
+    }
+
+    @ViewBuilder
+    private func filterMenu(_ filter: Binding<ContactsFilter>) -> some View {
+        let iconColor: Color = filter.wrappedValue.isActive ? .colorTextPrimary : .colorTextSecondary
+        Menu {
+            Picker("Filter contacts", selection: filter) {
+                ForEach(ContactsFilter.allCases) { option in
+                    Text(option.title).tag(option)
+                }
+            }
+        } label: {
+            Image(systemName: "line.3.horizontal.decrease")
+                .font(.title3)
+                .foregroundStyle(iconColor)
+                .padding(DesignConstants.Spacing.stepX)
+        }
+        .accessibilityLabel("Filter contacts")
+        .accessibilityIdentifier("contacts-filter-button")
     }
 
     private var clearAction: () -> Void {

--- a/Convos/Contacts/ContactsView.swift
+++ b/Convos/Contacts/ContactsView.swift
@@ -83,7 +83,8 @@ struct ContactsView: View {
                 ContactsSearchBar(
                     query: $viewModel.searchQuery,
                     placeholder: "Search contacts",
-                    accessibilityIdentifier: "contacts-search-field"
+                    accessibilityIdentifier: "contacts-search-field",
+                    filter: $viewModel.filter
                 )
             }
     }

--- a/Convos/Contacts/ContactsViewModel.swift
+++ b/Convos/Contacts/ContactsViewModel.swift
@@ -33,6 +33,13 @@ final class ContactsViewModel {
     var searchQuery: String = "" {
         didSet { rebuildSections() }
     }
+    /// Audience filter toggled from the search bar's filter menu. Narrows the
+    /// list to people or agents; `contactCount` stays unfiltered so a filter
+    /// that matches nothing renders an empty list rather than the "no contacts"
+    /// onboarding empty state.
+    var filter: ContactsFilter = .all {
+        didSet { rebuildSections() }
+    }
     /// True while the initial suggested-agents page request is in flight.
     var isLoadingSuggestedAgents: Bool {
         suggestedAgentsModel.isLoading
@@ -109,7 +116,7 @@ final class ContactsViewModel {
     /// `searchQuery`. Mirrors the picker's filter/group pipeline so both
     /// surfaces sort and bucket identically.
     private func rebuildSections() {
-        let filtered = filterByQuery(visibleContacts())
+        let filtered = filterByQuery(filterByAudience(visibleContacts()))
         let grouped: [String: [Contact]] = Dictionary(grouping: filtered) { $0.alphabeticalSectionKey }
         let sortedKeys = grouped.keys.sorted { lhs, rhs in
             // "#" sorts last so non-alpha names land after Z.
@@ -155,7 +162,9 @@ final class ContactsViewModel {
         suggestedAgentContacts = rows.map(\.contact)
 
         let trimmedQuery = searchQuery.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard trimmedQuery.isEmpty, !rows.isEmpty else { return nil }
+        // Suggested agents are agents, so hide the whole section under the
+        // People filter (and while a search is active).
+        guard trimmedQuery.isEmpty, filter.includesAgents, !rows.isEmpty else { return nil }
         return Section(id: SuggestedAgentsSection.id, title: SuggestedAgentsSection.title, rows: rows)
     }
 
@@ -165,6 +174,11 @@ final class ContactsViewModel {
         return contacts.filter { contact in
             contact.resolvedDisplayName.localizedCaseInsensitiveContains(trimmed)
         }
+    }
+
+    private func filterByAudience(_ contacts: [Contact]) -> [Contact] {
+        guard filter.isActive else { return contacts }
+        return contacts.filter { filter.includes($0) }
     }
 
     // MARK: - Suggested agents


### PR DESCRIPTION
## What

Wires up the previously-static filter icon in the Contacts search bar so it opens a menu to narrow the list to **All / People / Agents**. Applies to both surfaces that render the shared `ContactsSearchBar`:

- the Contacts browse list (`ContactsView`)
- the contacts picker (`ContactsPickerView`)

When a narrowing filter is active, the icon switches from secondary to primary text color.

## How

- New `ContactsFilter` enum (`all` / `people` / `agents`) with an `includes(_:)` predicate. People are humans; agents are template-backed contacts (`agentTemplateId != nil`), matching the picker's existing agent discriminator.
- `ContactsSearchBar` gains an optional `filter: Binding<ContactsFilter>?`. When supplied, the empty-query trailing icon becomes an interactive `Menu` + `Picker` (native inline checkmarks); when omitted it renders as the static placeholder, so existing callers are unaffected.
- Both view models gain a `filter` property and apply it via a small `filterByAudience(_:)` step alongside the existing `filterByQuery(_:)` in `rebuildSections()`.

## Notes

- Filtering is display-only: it never touches selection state in the picker (a selected contact hidden by the filter stays selected and still appears in the selected-pills row).
- `contactCount` stays unfiltered, so filtering to an empty audience shows an empty list rather than the onboarding empty state.

## Testing

- `Convos (Dev)` builds clean against latest `dev`; SwiftLint `--strict` passes on all changed files.
- Changes are confined to the app target's contacts UI (no `ConvosCore` changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add All/People/Agents filter to contacts list and picker search bar
> - Adds a `ContactsFilter` enum with `all`, `people`, and `agents` cases to classify contacts by whether they have an `agentTemplateId`.
> - Updates `ContactsSearchBar` to show an interactive filter menu (via `Menu` + `Picker`) when the query is empty and a filter binding is provided; falls back to a static icon otherwise.
> - Wires the filter binding into both `ContactsView` and `ContactsPickerView`, with their respective view models applying audience filtering before query filtering in `rebuildSections()`.
> - Hides the Suggested Agents section when the People filter is active or when a search query is present.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 75d6234.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->