### PR TITLE
fix(tests): drop stale publishAgentTemplate forwarders so ConvosTests compiles

### DIFF
--- a/ConvosTests/ConversationViewModelGlobalDefaultsTests.swift
+++ b/ConvosTests/ConversationViewModelGlobalDefaultsTests.swift
@@ -239,10 +239,6 @@ private final class TestSessionManager: SessionManagerProtocol, @unchecked Senda
         )
     }
 
-    func publishAgentTemplate(id: String) async throws -> ConvosAPI.AgentTemplate {
-        try await base.publishAgentTemplate(id: id)
-    }
-
     func voiceMemoTranscriptRepository() -> any VoiceMemoTranscriptRepositoryProtocol {
         base.voiceMemoTranscriptRepository()
     }

--- a/ConvosTests/ConversationsViewModelDeleteTests.swift
+++ b/ConvosTests/ConversationsViewModelDeleteTests.swift
@@ -307,10 +307,6 @@ private final class TestSessionManager: SessionManagerProtocol, @unchecked Senda
         )
     }
 
-    func publishAgentTemplate(id: String) async throws -> ConvosAPI.AgentTemplate {
-        try await base.publishAgentTemplate(id: id)
-    }
-
     func voiceMemoTranscriptRepository() -> any VoiceMemoTranscriptRepositoryProtocol {
         base.voiceMemoTranscriptRepository()
     }


### PR DESCRIPTION
Stacked on #950.

The `ConvosTests` target does not compile on `dev`: two test decorator classes still declare `publishAgentTemplate(id:)` and forward to `base.publishAgentTemplate(id:)`, but that method was removed from `SessionManagerProtocol` (it exists nowhere in the codebase), so the build fails with:

```
value of type 'MockInboxesService' has no member 'publishAgentTemplate'
```

(There is a prior "Make the ConvosTests target compile again #905" — this target breaks periodically.)

This removes the two dead forwarders (`ConversationViewModelGlobalDefaultsTests`, `ConversationsViewModelDeleteTests`). With the target compiling again, the suggested-agents PR's `ContactsPickerViewModelTests` run green:

```
Test Suite 'ContactsPickerViewModelTests' — 28 tests, 0 failures
** TEST SUCCEEDED **
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/952"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783040794&installation_id=128169237&pr_number=952&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F952&signature=172d23c832ebab07ab2164a901f995965389fa3df70dcbc9d812a2cb06c0ed36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove stale `publishAgentTemplate` forwarders from test mocks to fix compilation
> Removes the `publishAgentTemplate(id:)` method from two `TestSessionManager` mock classes in [ConversationViewModelGlobalDefaultsTests.swift](https://github.com/xmtplabs/convos-ios/pull/952/files#diff-6176fad1dccf46092d896941d6fc5ca6cc122377540e6018440884a0f35a47d8) and [ConversationsViewModelDeleteTests.swift](https://github.com/xmtplabs/convos-ios/pull/952/files#diff-7971f76dbf8b3c53bc8e132b37480e21a47e3262f471ea7015d2cee2e06b2325). These forwarder methods were left over after a refactor and caused `ConvosTests` to fail to compile.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 664c354.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->