### PR TITLE
fix(agents): position builder summary card chronologically and show to all members

### DIFF
--- a/Convos/Agent Builder/AgentBuilderSummaryView.swift
+++ b/Convos/Agent Builder/AgentBuilderSummaryView.swift
@@ -2,20 +2,35 @@ import AVFoundation
 import ConvosCore
 import SwiftUI
 
-/// The "summary card" cell that replaces the user's prompt + early agent
-/// chatter at the top of a post-Make agent conversation. Reproduces the
-/// AgentDraftComposer's rounded-rect liquid-glass styling (no bottom
-/// buttons, no Make button) and the same attachment chips minus their X
-/// buttons. Footer reads "You created an agent" in the group-update text
-/// style.
+/// The "summary card" cell shown where the user tapped Make. Reproduces the
+/// AgentDraftComposer's rounded-rect liquid-glass styling (no bottom buttons, no
+/// Make button) and the same attachment chips minus their X buttons. The footer
+/// reads "You created an agent" / "<name> created an agent" in the group-update
+/// text style.
+///
+/// The content is reconstructed by `MessagesListProcessor` from the build's own
+/// messages (the prompt + attachment bundle every member receives), so the card
+/// is visible to all members and sits in chronological order -- it is no longer
+/// pinned to the top from a creator-only local summary.
 struct AgentBuilderSummaryView: View {
-    let summary: AgentBuilderSummary
-    /// Namespace owned by `AgentBuilderView`. When non-nil the card pairs
-    /// with the composer's glass rect via `glassEffectID +
+    let content: AgentBuilderCardContent
+    /// Namespace owned by `AgentBuilderView`. When non-nil the card pairs with
+    /// the composer's glass rect via `glassEffectID +
     /// glassEffectTransition(.matchedGeometry)`, producing the morph on Make.
-    /// Nil for the "returning later" case where the card simply renders
-    /// in-place without an entry animation.
+    /// Nil for recipients and the "returning later" case where the card simply
+    /// renders in-place without an entry animation.
     var transitionNamespace: Namespace.ID?
+
+    private var footerText: String {
+        if content.creatorIsCurrentUser || content.creatorDisplayName.isEmpty {
+            return "You created an agent"
+        }
+        return "\(content.creatorDisplayName) created an agent"
+    }
+
+    private var hasChips: Bool {
+        !content.attachments.isEmpty || !content.connectionIdentifiers.isEmpty
+    }
 
     var body: some View {
         VStack(spacing: DesignConstants.Spacing.step3x) {
@@ -30,7 +45,7 @@ struct AgentBuilderSummaryView: View {
             GlassEffectContainer {
                 card
             }
-            Text("You created an agent")
+            Text(footerText)
                 .font(.footnote)
                 .foregroundStyle(.colorTextSecondary)
                 .multilineTextAlignment(.center)
@@ -49,17 +64,20 @@ struct AgentBuilderSummaryView: View {
 
     private var cardContent: some View {
         VStack(alignment: .leading, spacing: DesignConstants.Spacing.step2x) {
-            if !summary.prompt.isEmpty {
-                Text(summary.prompt)
+            if !content.prompt.isEmpty {
+                Text(content.prompt)
                     .font(.body)
                     .foregroundStyle(.colorTextPrimary)
                     .frame(maxWidth: .infinity, alignment: .topLeading)
             }
-            if !summary.attachments.isEmpty {
+            if hasChips {
                 ScrollView(.horizontal, showsIndicators: false) {
                     HStack(spacing: DesignConstants.Spacing.step2x) {
-                        ForEach(summary.attachments) { attachment in
+                        ForEach(content.attachments, id: \.key) { attachment in
                             chipView(for: attachment)
+                        }
+                        ForEach(content.connectionIdentifiers, id: \.self) { identifier in
+                            connectionChip(identifier: identifier)
                         }
                     }
                     .padding(.horizontal, DesignConstants.Spacing.step4x)
@@ -76,18 +94,16 @@ struct AgentBuilderSummaryView: View {
     }
 
     @ViewBuilder
-    private func chipView(for attachment: AgentBuilderSummaryAttachment) -> some View {
-        switch attachment {
-        case .photo(_, let thumbnailData):
-            photoVideoChip(thumbnailData: thumbnailData, isVideo: false)
-        case .video(_, let thumbnailData):
-            photoVideoChip(thumbnailData: thumbnailData, isVideo: true)
-        case let .file(_, filename, _, _):
-            fileChip(filename: filename)
-        case let .voiceMemo(_, duration, levels):
-            voiceMemoChip(duration: duration, levels: levels)
-        case let .connection(_, identifier):
-            connectionChip(identifier: identifier)
+    private func chipView(for attachment: HydratedAttachment) -> some View {
+        switch attachment.mediaType {
+        case .image:
+            photoVideoChip(thumbnailData: attachment.thumbnailData, isVideo: false)
+        case .video:
+            photoVideoChip(thumbnailData: attachment.thumbnailData, isVideo: true)
+        case .audio:
+            voiceMemoChip(duration: attachment.duration ?? 0, levels: attachment.waveformLevels ?? [])
+        case .file, .unknown:
+            fileChip(filename: attachment.filename ?? "File")
         }
     }
 
@@ -190,16 +206,21 @@ struct AgentBuilderSummaryView: View {
 }
 
 #Preview {
-    let summary = AgentBuilderSummary(
+    let content = AgentBuilderCardContent(
+        id: "preview",
         prompt: "Help me plan a backpacking trip across Patagonia. I want to camp 4 nights and finish in El Chaltén.",
         attachments: [
-            .photo(id: UUID(), thumbnailData: nil),
-            .file(id: UUID(), filename: "itinerary.pdf", mimeType: "application/pdf", fileSize: 12_345),
-            .voiceMemo(id: UUID(), duration: 18, levels: Array(repeating: 0.6, count: 40)),
-            .connection(id: UUID(), identifier: "googleCalendar"),
+            HydratedAttachment(key: "preview-photo", mimeType: "image/jpeg"),
+            HydratedAttachment(key: "preview-file", mimeType: "application/pdf", filename: "itinerary.pdf"),
+            HydratedAttachment(
+                key: "preview-voice",
+                mimeType: "audio/m4a",
+                duration: 18,
+                waveformLevels: Array(repeating: 0.6, count: 40)
+            ),
         ],
-        cutoffDate: Date()
+        connectionIdentifiers: ["googleCalendar"]
     )
-    return AgentBuilderSummaryView(summary: summary)
+    return AgentBuilderSummaryView(content: content)
         .padding()
 }

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Cells/MessagesListItemTypeCell.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Cells/MessagesListItemTypeCell.swift
@@ -122,10 +122,10 @@ class MessagesListItemTypeCell: UICollectionViewCell {
                         .padding(.vertical, DesignConstants.Spacing.step4x)
                         .padding(.horizontal, DesignConstants.Spacing.step4x)
 
-                case .agentBuilderSummary(let summary):
+                case .agentBuilderSummary(let content):
                     AgentBuilderSummaryView(
-                        summary: summary,
-                        transitionNamespace: config.agentBuilderTransitionNamespace
+                        content: content,
+                        transitionNamespace: content.transitionEligible ? config.agentBuilderTransitionNamespace : nil
                     )
                     .padding(.vertical, DesignConstants.Spacing.step4x)
                     .padding(.horizontal, DesignConstants.Spacing.step4x)

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessagesListView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessagesListView.swift
@@ -71,16 +71,26 @@ var body: some View {
         }
     }
 
-    private var messagesList: some View {
-        ForEach(messages.enumerated(), id: \.element.id) { index, item in
-            itemView(for: item)
-                .onScrollVisibilityChange(threshold: 0.1) { isVisible in
-                    guard lastItemIndex == nil else { return }
+    // Concrete tuple-array (not a lazy `EnumeratedSequence`) so the `ForEach`
+    // below works on a `RandomAccessCollection` with a fully-resolved element
+    // type, keeping its getter's type-check time well under the limit.
+    private var enumeratedMessages: [(offset: Int, element: MessagesListItemType)] {
+        Array(messages.enumerated())
+    }
 
-                    if isVisible && index == messages.count - 1 {
-                        lastItemIndex = index
-                    }
+    private var messagesList: some View {
+        ForEach(enumeratedMessages, id: \.element.id) { entry in
+            itemView(for: entry.element)
+                .onScrollVisibilityChange(threshold: 0.1) { isVisible in
+                    handleScrollVisibilityChange(isVisible: isVisible, index: entry.offset)
                 }
+        }
+    }
+
+    private func handleScrollVisibilityChange(isVisible: Bool, index: Int) {
+        guard lastItemIndex == nil else { return }
+        if isVisible, index == messages.count - 1 {
+            lastItemIndex = index
         }
     }
 
@@ -128,8 +138,8 @@ var body: some View {
             ConnectionEventSummaryView(summary: summary)
                 .padding(.vertical, DesignConstants.Spacing.step2x)
 
-        case .agentBuilderSummary(let summary):
-            AgentBuilderSummaryView(summary: summary)
+        case .agentBuilderSummary(let content):
+            AgentBuilderSummaryView(content: content)
                 .padding(.vertical, DesignConstants.Spacing.step2x)
 
         case .typingIndicator:

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/AgentBuilderCardContent.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/AgentBuilderCardContent.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+/// Render model for the agent-builder summary cell, reconstructed by
+/// `MessagesListProcessor` from the "build" messages every member receives
+/// (the prompt text + the attachment bundle the builder sent on the user's
+/// behalf, referenced by the networked `BuilderBundleManifest`). Because it is
+/// rebuilt from those messages rather than a local-only `AgentBuilderSummary`,
+/// the card is visible to every member and sits in chronological order at the
+/// point the user tapped Make -- not pinned to the top of the list.
+///
+/// `attachments` are the hydrated attachments from the bundle message, so the
+/// card renders the same thumbnails the chat already loaded (no thumbnail bytes
+/// travel in the manifest). `connectionIdentifiers` come from the creator's
+/// local summary and are therefore empty on other members' clients -- cloud /
+/// device connections are not messages and can't be reconstructed remotely.
+public struct AgentBuilderCardContent: Sendable, Equatable, Hashable, Identifiable {
+    /// Stable id derived from the anchor (earliest) build-message id, so the
+    /// cell identity is the same on the creator and every recipient and does
+    /// not churn across re-renders.
+    public let id: String
+    public let prompt: String
+    public let attachments: [HydratedAttachment]
+    /// Whether the build was created by the current user. Drives the footer copy
+    /// ("You created an agent" vs "<name> created an agent") now that the card is
+    /// visible to every member.
+    public let creatorIsCurrentUser: Bool
+    /// Display name of the member who created the agent (the build messages'
+    /// sender). Used for the footer copy when `creatorIsCurrentUser` is false.
+    public let creatorDisplayName: String
+    /// Raw values of the iOS-side `AgentBuilderConnection`s enabled at Make.
+    /// Populated only on the creator's client (from the local summary); empty
+    /// elsewhere.
+    public let connectionIdentifiers: [String]
+    /// True when the builder targeted a conversation the user was already in.
+    /// Drives invite-affordance behavior and the morph gate below.
+    public let existingConversation: Bool
+    /// Whether this card should pair with the composer's glass rect via the
+    /// matched-geometry morph. Only meaningful for the creator's own freshly
+    /// committed home-flow build (where the card sits at the top and the
+    /// composer is on screen); false otherwise.
+    public let transitionEligible: Bool
+
+    public init(
+        id: String,
+        prompt: String,
+        attachments: [HydratedAttachment] = [],
+        creatorIsCurrentUser: Bool = true,
+        creatorDisplayName: String = "",
+        connectionIdentifiers: [String] = [],
+        existingConversation: Bool = false,
+        transitionEligible: Bool = false
+    ) {
+        self.id = id
+        self.prompt = prompt
+        self.attachments = attachments
+        self.creatorIsCurrentUser = creatorIsCurrentUser
+        self.creatorDisplayName = creatorDisplayName
+        self.connectionIdentifiers = connectionIdentifiers
+        self.existingConversation = existingConversation
+        self.transitionEligible = transitionEligible
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/MessagesListItemType.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/MessagesListItemType.swift
@@ -52,7 +52,7 @@ public enum MessagesListItemType: Identifiable, Equatable, Hashable, Sendable {
     case agentJoinStatus(AgentJoinStatus, requesterName: String?, date: Date)
     case agentPresentInfo(agent: ConversationMember, inviterName: String?)
     case connectionEvent(id: String, summary: ConnectionEventSummary, origin: AnyMessage.Origin)
-    case agentBuilderSummary(AgentBuilderSummary)
+    case agentBuilderSummary(AgentBuilderCardContent)
     case typingIndicator(typers: [ConversationMember])
 
     public var id: String {
@@ -75,8 +75,8 @@ public enum MessagesListItemType: Identifiable, Equatable, Hashable, Sendable {
             return "agent-present-info"
         case .connectionEvent(let id, _, _):
             return "connection-event-\(id)"
-        case .agentBuilderSummary(let summary):
-            return "agent-builder-summary-\(summary.id.uuidString)"
+        case .agentBuilderSummary(let content):
+            return "agent-builder-summary-\(content.id)"
         case .typingIndicator:
             return "typing-indicator"
         }

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/MessagesListProcessor.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/MessagesListProcessor.swift
@@ -26,85 +26,219 @@ public final class MessagesListProcessor: Sendable {
             previousReadByMembers: previousReadByMembers,
             verifiedAgent: verifiedAgent
         )
-        // Hide agent-builder bundle messages flagged by a `BuilderBundleManifest`
-        // (see `DBBuilderBundleHiddenMessage`). Unlike the creator-only
-        // `agentBuilderSummary.bundledMessageIds` filter below, this applies to
-        // every member's client and to messages from any sender, so the brief
-        // is hidden group-wide. It renders no summary card — it only hides.
-        let visibleItems: [MessagesListItemType] = hiddenBundleMessageIds.isEmpty
-            ? baseItems
-            : filterHiddenBundleMessages(from: baseItems, hiddenIds: hiddenBundleMessageIds)
-        return applyAgentContactCardAndSummary(
-            to: visibleItems,
+        // The "build" is the prompt + attachment messages the builder sent on
+        // the user's behalf. Their ids reach the processor two ways: the
+        // networked `BuilderBundleManifest` populates `hiddenBundleMessageIds`
+        // on every member's client, and the creator's local `AgentBuilderSummary`
+        // carries `bundledMessageIds`. Union them -- on the sender the prompt
+        // renders under its client UUID (only in `bundledMessageIds`); on
+        // recipients it renders under its XMTP id (only in
+        // `hiddenBundleMessageIds`). The processor rebuilds the summary card from
+        // these messages and positions it where they landed, instead of dropping
+        // them silently or rendering them as bare bubbles.
+        let buildMessageIds: Set<String> = hiddenBundleMessageIds
+            .union(agentBuilderSummary?.bundledMessageIds ?? [])
+        return applyAgentBuilderCardsAndContactCard(
+            to: baseItems,
+            rawMessages: messages,
+            buildMessageIds: buildMessageIds,
             verifiedAgent: verifiedAgent,
             agentBuilderSummary: agentBuilderSummary,
             isInAgentBuilderFlow: isInAgentBuilderFlow
         )
     }
 
-    /// Remove messages whose id is in `hiddenIds` from every group (any
-    /// sender), drop groups left empty, and strip orphaned date separators.
-    private static func filterHiddenBundleMessages(
-        from items: [MessagesListItemType],
-        hiddenIds: Set<String>
-    ) -> [MessagesListItemType] {
-        let filtered: [MessagesListItemType] = items.compactMap { item -> MessagesListItemType? in
-            guard case .messages(let group) = item else { return item }
-            let kept: [AnyMessage] = group.messages.filter { !hiddenIds.contains($0.messageId) }
-            if kept.count == group.messages.count { return item }
-            if kept.isEmpty { return nil }
-            var rebuilt: MessagesGroup = MessagesGroup(
-                id: group.id,
-                sender: group.sender,
-                messages: kept,
-                isLastGroup: group.isLastGroup,
-                isLastGroupSentByCurrentUser: group.isLastGroupSentByCurrentUser,
-                showsTypingIndicator: group.showsTypingIndicator,
-                allTypingMembers: group.allTypingMembers,
-                readByMembers: group.readByMembers,
-                onlyVisibleToSender: group.onlyVisibleToSender,
-                isLastGroupBeforeOtherMembers: group.isLastGroupBeforeOtherMembers,
-                voiceMemoTranscripts: group.voiceMemoTranscripts
-            )
-            rebuilt.adjacentToFullBleedAbove = group.adjacentToFullBleedAbove
-            rebuilt.adjacentToFullBleedBelow = group.adjacentToFullBleedBelow
-            rebuilt.agentContactCard = group.agentContactCard
-            rebuilt.thinkingByMessageId = group.thinkingByMessageId
-            rebuilt.hidesSenderLabel = group.hidesSenderLabel
-            rebuilt.showsThinkingIndicator = group.showsThinkingIndicator
-            rebuilt.thinkingContent = group.thinkingContent
-            rebuilt.usesThoughtBubbleStyle = group.usesThoughtBubbleStyle
-            rebuilt.contactCardThinkingDescriptor = group.contactCardThinkingDescriptor
-            return .messages(rebuilt)
-        }
-        return dropOrphanDateSeparators(in: filtered)
+    /// Rebuild a `MessagesGroup` with a new id + message subset, copying the
+    /// presentation side-channel fields the initializer doesn't take.
+    private static func rebuiltGroup(_ group: MessagesGroup, id: String, messages: [AnyMessage]) -> MessagesGroup {
+        var rebuilt: MessagesGroup = MessagesGroup(
+            id: id,
+            sender: group.sender,
+            messages: messages,
+            isLastGroup: group.isLastGroup,
+            isLastGroupSentByCurrentUser: group.isLastGroupSentByCurrentUser,
+            showsTypingIndicator: group.showsTypingIndicator,
+            allTypingMembers: group.allTypingMembers,
+            readByMembers: group.readByMembers,
+            onlyVisibleToSender: group.onlyVisibleToSender,
+            isLastGroupBeforeOtherMembers: group.isLastGroupBeforeOtherMembers,
+            voiceMemoTranscripts: group.voiceMemoTranscripts
+        )
+        rebuilt.adjacentToFullBleedAbove = group.adjacentToFullBleedAbove
+        rebuilt.adjacentToFullBleedBelow = group.adjacentToFullBleedBelow
+        rebuilt.agentContactCard = group.agentContactCard
+        rebuilt.thinkingByMessageId = group.thinkingByMessageId
+        rebuilt.hidesSenderLabel = group.hidesSenderLabel
+        rebuilt.showsThinkingIndicator = group.showsThinkingIndicator
+        rebuilt.thinkingContent = group.thinkingContent
+        rebuilt.usesThoughtBubbleStyle = group.usesThoughtBubbleStyle
+        rebuilt.contactCardThinkingDescriptor = group.contactCardThinkingDescriptor
+        return rebuilt
     }
 
-    /// Post-process the raw item list to (a) hide the user's own builder-bundle
-    /// sends by id (`AgentBuilderSummary.bundledMessageIds`) and suppress the
-    /// legacy "Agent joined" row, (b) attach the contact-card prefix to the
-    /// agent's first messages group (synthesizing an empty group when the agent
-    /// hasn't said anything yet), and (c) prepend the summary cell.
-    private static func applyAgentContactCardAndSummary(
+    /// Group build messages into runs of entries adjacent in the message stream.
+    /// One Make sends its prompt + attachment bundle back to back, so they form a
+    /// single run (and a single card); separate Make events split by other
+    /// messages form separate runs and render separate cards.
+    private static func buildRuns(in rawMessages: [AnyMessage], buildMessageIds: Set<String>) -> [[AnyMessage]] {
+        guard !buildMessageIds.isEmpty else { return [] }
+        var runs: [[AnyMessage]] = []
+        var current: [AnyMessage] = []
+        var lastIndex: Int?
+        for (index, message) in rawMessages.enumerated() where buildMessageIds.contains(message.messageId) {
+            if let last = lastIndex, index == last + 1 {
+                current.append(message)
+            } else {
+                if !current.isEmpty { runs.append(current) }
+                current = [message]
+            }
+            lastIndex = index
+        }
+        if !current.isEmpty { runs.append(current) }
+        return runs
+    }
+
+    /// The `AgentBuilderConnection` raw values captured in a creator's local
+    /// summary, used for the connection chips. Empty for recipients (no summary).
+    private static func builderConnectionIdentifiers(from summary: AgentBuilderSummary) -> [String] {
+        summary.attachments.compactMap { attachment in
+            if case .connection(_, let identifier) = attachment { return identifier }
+            return nil
+        }
+    }
+
+    /// Assemble the card render model for one build run: prompt from the run's
+    /// text message, chips from its attachment message. Connection chips + the
+    /// morph flag come from the creator's local `summary` (nil on recipients).
+    private static func makeCardContent(
+        run: [AnyMessage],
+        anchor: String,
+        summary: AgentBuilderSummary?
+    ) -> AgentBuilderCardContent {
+        var prompt: String = ""
+        var attachments: [HydratedAttachment] = []
+        for message in run {
+            switch message.content {
+            case .text(let text):
+                if prompt.isEmpty { prompt = text }
+            case .attachment(let attachment):
+                attachments.append(attachment)
+            case .attachments(let bundled):
+                attachments.append(contentsOf: bundled)
+            default:
+                break
+            }
+        }
+        // The build messages are sent on the user's behalf, so their sender is
+        // the agent's creator. Use it for the footer attribution now that the
+        // card renders for every member.
+        let creator: ConversationMember? = run.first?.sender
+        let connectionIdentifiers: [String] = summary.map(builderConnectionIdentifiers(from:)) ?? []
+        let existingConversation: Bool = summary?.existingConversation ?? false
+        let transitionEligible: Bool = summary != nil && !existingConversation
+        return AgentBuilderCardContent(
+            id: "agent-builder-card-" + anchor,
+            prompt: prompt,
+            attachments: attachments,
+            creatorIsCurrentUser: creator?.isCurrentUser ?? true,
+            creatorDisplayName: creator?.profile.displayName ?? "",
+            connectionIdentifiers: connectionIdentifiers,
+            existingConversation: existingConversation,
+            transitionEligible: transitionEligible
+        )
+    }
+
+    /// Rebuild the agent-builder summary card(s) from the build's own messages
+    /// (`buildMessageIds`) and splice each in at the position those messages
+    /// occupied, dropping the raw build bubbles. Adjacent build messages (the
+    /// attachment bundle + the prompt text) collapse into a single card.
+    private static func reconstructBuilderCards(
+        in items: [MessagesListItemType],
+        rawMessages: [AnyMessage],
+        buildMessageIds: Set<String>,
+        agentBuilderSummary: AgentBuilderSummary?
+    ) -> [MessagesListItemType] {
+        let runs: [[AnyMessage]] = buildRuns(in: rawMessages, buildMessageIds: buildMessageIds)
+        guard !runs.isEmpty else { return items }
+
+        let summaryIds: Set<String> = Set(agentBuilderSummary?.bundledMessageIds ?? [])
+        var anchorByMessageId: [String: String] = [:]
+        var cardByAnchor: [String: AgentBuilderCardContent] = [:]
+        for run in runs {
+            guard let anchor = run.first?.messageId else { continue }
+            for message in run { anchorByMessageId[message.messageId] = anchor }
+            let ownsSummary: Bool = !summaryIds.isEmpty && run.contains { summaryIds.contains($0.messageId) }
+            cardByAnchor[anchor] = makeCardContent(
+                run: run,
+                anchor: anchor,
+                summary: ownsSummary ? agentBuilderSummary : nil
+            )
+        }
+
+        var result: [MessagesListItemType] = []
+        result.reserveCapacity(items.count)
+        var emittedAnchors: Set<String> = []
+
+        for item in items {
+            guard case .messages(let group) = item,
+                  group.messages.contains(where: { buildMessageIds.contains($0.messageId) }) else {
+                result.append(item)
+                continue
+            }
+            // Walk the group, splitting it into build vs non-build segments.
+            // Build segments collapse into their run's card (emitted once);
+            // non-build segments stay as their own group with a stable id.
+            var segment: [AnyMessage] = []
+            var segmentIsBuild: Bool = false
+            func flushSegment() {
+                guard let first = segment.first else { return }
+                if segmentIsBuild {
+                    if let anchor = anchorByMessageId[first.messageId],
+                       !emittedAnchors.contains(anchor),
+                       let card = cardByAnchor[anchor] {
+                        emittedAnchors.insert(anchor)
+                        result.append(.agentBuilderSummary(card))
+                    }
+                } else {
+                    result.append(.messages(rebuiltGroup(group, id: "group-" + first.messageId, messages: segment)))
+                }
+                segment = []
+            }
+            for message in group.messages {
+                let isBuild: Bool = buildMessageIds.contains(message.messageId)
+                if !segment.isEmpty, isBuild != segmentIsBuild { flushSegment() }
+                segmentIsBuild = isBuild
+                segment.append(message)
+            }
+            flushSegment()
+        }
+        return result
+    }
+
+    /// Rebuild the agent-builder summary card(s) from the build messages and
+    /// position them chronologically, then attach the agent contact card.
+    /// Replaces the old index-0 pinning of a local-only summary: the card is now
+    /// rebuilt from the prompt + attachment messages every member receives, so it
+    /// is visible to everyone and sits where Make happened.
+    private static func applyAgentBuilderCardsAndContactCard(
         to baseItems: [MessagesListItemType],
+        rawMessages: [AnyMessage],
+        buildMessageIds: Set<String>,
         verifiedAgent: ConversationMember?,
         agentBuilderSummary: AgentBuilderSummary?,
         isInAgentBuilderFlow: Bool
     ) -> [MessagesListItemType] {
         var items: [MessagesListItemType] = baseItems
 
-        // Suppress the legacy "Agent joined" update row throughout the
-        // entire builder flow — pre-Make the builder overlay covers the
-        // chat, and post-Make the summary + contact card morph announce
-        // arrival, so the update row would only briefly flash through the
-        // overlay fade-out. Done outside the `agentBuilderSummary`
-        // block because the flag is set on builder appearance, before the
-        // summary exists. Gates on `addedAgent` (not
-        // `addedVerifiedAgent`) because the attestation result lands
-        // after the member-added event: filtering on verification would
-        // miss the brief window where the agent is in the convo but its
-        // Convos verification hasn't been validated yet, and that window
-        // is exactly when the user sees the flash.
+        // Suppress the legacy "Agent joined" update row while the builder UI is
+        // on screen (home flow): pre-Make it sits under the builder overlay, and
+        // during the post-Make morph the summary + contact card already announce
+        // arrival, so the row would only flash through the fade-out. Recipients
+        // and the dismissed existing-conversation builder are never
+        // `isInAgentBuilderFlow`, so they keep the join row as a real event and
+        // as the contact-card anchor. Gates on `addedAgent` (not
+        // `addedVerifiedAgent`): attestation lands after the member-added event,
+        // and the flash window is before verification completes.
         if isInAgentBuilderFlow {
             items = items.filter { item in
                 guard case .update(_, let update, _) = item else { return true }
@@ -112,77 +246,17 @@ public final class MessagesListProcessor: Sendable {
             }
         }
 
-        if let summary = agentBuilderSummary {
-            items = items.flatMap { item -> [MessagesListItemType] in
-                switch item {
-                case .messages(let group):
-                    if group.sender.isCurrentUser {
-                        // User-side: filter by `bundledMessageIds`. The set
-                        // is populated synchronously in
-                        // `AgentBuilderViewModel.commit()` before the
-                        // writer is called, so the prompt text + multi-remote
-                        // bundle are caught the instant they appear in the
-                        // DB. Messages the user types after Make (not in the
-                        // set) flow through normally. A group can contain
-                        // both — consecutive same-sender messages stay in
-                        // one group regardless of the gap.
-                        let kept: [AnyMessage] = group.messages.filter {
-                            !summary.bundledMessageIds.contains($0.messageId)
-                        }
-                        if kept.isEmpty { return [] }
-                        if kept.count == group.messages.count { return [item] }
-                        var rebuilt: MessagesGroup = MessagesGroup(
-                            id: group.id,
-                            sender: group.sender,
-                            messages: kept,
-                            isLastGroup: group.isLastGroup,
-                            isLastGroupSentByCurrentUser: group.isLastGroupSentByCurrentUser,
-                            showsTypingIndicator: group.showsTypingIndicator,
-                            allTypingMembers: group.allTypingMembers,
-                            readByMembers: group.readByMembers,
-                            onlyVisibleToSender: group.onlyVisibleToSender,
-                            isLastGroupBeforeOtherMembers: group.isLastGroupBeforeOtherMembers,
-                            voiceMemoTranscripts: group.voiceMemoTranscripts
-                        )
-                        rebuilt.adjacentToFullBleedAbove = group.adjacentToFullBleedAbove
-                        rebuilt.adjacentToFullBleedBelow = group.adjacentToFullBleedBelow
-                        rebuilt.agentContactCard = group.agentContactCard
-                        rebuilt.thinkingByMessageId = group.thinkingByMessageId
-                        rebuilt.hidesSenderLabel = group.hidesSenderLabel
-                        rebuilt.showsThinkingIndicator = group.showsThinkingIndicator
-                        rebuilt.thinkingContent = group.thinkingContent
-                        rebuilt.usesThoughtBubbleStyle = group.usesThoughtBubbleStyle
-                        rebuilt.contactCardThinkingDescriptor = group.contactCardThinkingDescriptor
-                        return [.messages(rebuilt)]
-                    } else {
-                        // Agent / other-member groups always stay: the backend
-                        // now skips the agent's pre-Make greeting, so there's
-                        // no time-based chatter to cut. (The old
-                        // `sentAt < cutoffDate` filter was removed -- the user's
-                        // own bundle is hidden by id, not by timestamp.)
-                        return [item]
-                    }
-                case .update(_, let update, _):
-                    // Builder flow: the summary + contact card already
-                    // announce the agent's arrival, so the legacy
-                    // "Agent joined · see its skills" update bubble
-                    // would just compete with them. Drop the row for any
-                    // agent add (not just `addedVerifiedAgent`)
-                    // because verification lands after the member-added
-                    // event — filtering on verification would miss the
-                    // brief pre-attestation window. Regular non-agent
-                    // member adds / removes still surface as normal.
-                    return update.addedAgent ? [] : [item]
-                default:
-                    return [item]
-                }
-            }
-            // Drop date separators that no longer precede a visible message
-            // group. The base processor emits a `.date(...)` row before the
-            // first message of a new calendar window, but if every message
-            // in that window was a builder-bundle send (just filtered
-            // above), the separator is now orphaned and flashes briefly
-            // post-Make while the agent provisions.
+        if !buildMessageIds.isEmpty {
+            items = reconstructBuilderCards(
+                in: items,
+                rawMessages: rawMessages,
+                buildMessageIds: buildMessageIds,
+                agentBuilderSummary: agentBuilderSummary
+            )
+            // Splicing out the build bubbles can orphan the date separator that
+            // preceded them; the card now anchors that day, so re-run the sweep
+            // (the card counts as an anchor) to keep a valid separator and drop a
+            // truly empty one.
             items = dropOrphanDateSeparators(in: items)
         }
 
@@ -207,24 +281,26 @@ public final class MessagesListProcessor: Sendable {
                     isLastGroupSentByCurrentUser: false
                 )
                 cardGroup.agentContactCard = cardInfo
-                // Anchor the synthesized card group right after the
-                // "Agent joined" update row (if any). In builder flow
-                // that row was just filtered out above, so we fall back to
-                // index 0; in every other conversation the join row sits
-                // where the agent actually arrived, so the card lands
-                // immediately beneath it. Without a join row to anchor on
-                // we also fall back to index 0.
+                // The summary card must always sit above the contact card. When a
+                // summary card exists, anchor the synthesized contact card right
+                // after it -- in the home flow the agent joins *before* the Make
+                // bundle, so the join-update row can sort above the summary;
+                // anchoring on the join row there would put the contact card
+                // first. Non-builder agent conversations (no summary card) fall
+                // back to the agent-join row, then index 0.
+                let builderCardIndex: Int? = items.lastIndex { item in
+                    if case .agentBuilderSummary = item { return true }
+                    return false
+                }
                 let joinUpdateIndex: Int? = items.firstIndex { item in
                     guard case .update(_, let update, _) = item else { return false }
                     return update.addedVerifiedAgent
                 }
-                let insertionIndex: Int = joinUpdateIndex.map { $0 + 1 } ?? 0
+                let insertionIndex: Int = builderCardIndex.map { $0 + 1 }
+                    ?? joinUpdateIndex.map { $0 + 1 }
+                    ?? 0
                 items.insert(.messages(cardGroup), at: insertionIndex)
             }
-        }
-
-        if let summary = agentBuilderSummary {
-            items.insert(.agentBuilderSummary(summary), at: 0)
         }
 
         return items
@@ -232,9 +308,9 @@ public final class MessagesListProcessor: Sendable {
 
     /// Strip date separators that no longer precede a message group. A
     /// `.date(...)` row is kept iff there is at least one anchorable row
-    /// (`.messages`, `.update`, or `.connectionEvent`) before the next
-    /// `.date(...)` (or end of list). Typing indicators, info rows, and
-    /// other purely ephemeral items don't anchor — a stretch with only
+    /// (`.messages`, `.update`, `.connectionEvent`, or `.agentBuilderSummary`)
+    /// before the next `.date(...)` (or end of list). Typing indicators, info
+    /// rows, and other purely ephemeral items don't anchor — a stretch with only
     /// those leaves the date separator orphaned and it is dropped.
     private static func dropOrphanDateSeparators(in items: [MessagesListItemType]) -> [MessagesListItemType] {
         var result: [MessagesListItemType] = []
@@ -245,7 +321,7 @@ public final class MessagesListProcessor: Sendable {
                 for later in items[(index + 1)...] {
                     if case .date = later { break }
                     switch later {
-                    case .messages, .update, .connectionEvent:
+                    case .messages, .update, .connectionEvent, .agentBuilderSummary:
                         hasFollowingAnchor = true
                     default:
                         break
@@ -332,7 +408,7 @@ public final class MessagesListProcessor: Sendable {
                     currentSenderId = nil
                 }
                 // Always emit verified-agent join updates; the post-process
-                // step in `applyAgentContactCardAndSummary` suppresses them
+                // step in `applyAgentBuilderCardsAndContactCard` suppresses them
                 // for builder-flow conversations (where the summary card and
                 // contact card both already announce arrival) and uses them
                 // as the anchor for the synthesized contact-card row in

--- a/ConvosCore/Tests/ConvosCoreTests/MessagesListProcessorTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/MessagesListProcessorTests.swift
@@ -1135,3 +1135,260 @@ struct MessagesListProcessorReadReceiptTests {
         #expect(readers.first?.agentVerification == .unverified)
     }
 }
+
+// MARK: - Agent Builder Card Reconstruction Tests
+
+private func builderCards(from items: [MessagesListItemType]) -> [AgentBuilderCardContent] {
+    items.compactMap {
+        if case .agentBuilderSummary(let content) = $0 { return content }
+        return nil
+    }
+}
+
+private func builderSummary(
+    bundledMessageIds: Set<String>,
+    connectionIdentifiers: [String] = [],
+    existingConversation: Bool = false
+) -> AgentBuilderSummary {
+    AgentBuilderSummary(
+        prompt: "",
+        attachments: connectionIdentifiers.map { .connection(id: UUID(), identifier: $0) },
+        cutoffDate: Date(),
+        bundledMessageIds: bundledMessageIds,
+        existingConversation: existingConversation
+    )
+}
+
+struct MessagesListProcessorAgentBuilderCardTests {
+    @Test("Recipient rebuilds the card from the bundle messages, positioned where Make happened")
+    func recipientReconstruction() {
+        let now = Date()
+        let messages = [
+            makeMessage(id: "hey", sender: otherUser, text: "Hey", date: now),
+            makeAttachment(id: "b-att", sender: currentUser, date: now.addingTimeInterval(10)),
+            makeMessage(id: "b-text", sender: currentUser, text: "Track the fog", date: now.addingTimeInterval(11)),
+            makeMessage(id: "later", sender: otherUser, text: "Cool", date: now.addingTimeInterval(20)),
+        ]
+        let result = MessagesListProcessor.process(
+            messages,
+            hiddenBundleMessageIds: ["b-att", "b-text"]
+        )
+
+        // The raw bundle bubbles never render.
+        #expect(messageIds(from: result) == ["hey", "later"])
+
+        let cards = builderCards(from: result)
+        #expect(cards.count == 1)
+        #expect(cards.first?.prompt == "Track the fog")
+        #expect(cards.first?.attachments.count == 1)
+
+        // Card sits between the prior message and the later one.
+        let cardIndex = result.firstIndex { if case .agentBuilderSummary = $0 { return true }; return false }
+        let laterIndex = result.firstIndex {
+            if case .messages(let group) = $0 { return group.messages.contains { $0.messageId == "later" } }
+            return false
+        }
+        let heyIndex = result.firstIndex {
+            if case .messages(let group) = $0 { return group.messages.contains { $0.messageId == "hey" } }
+            return false
+        }
+        #expect(cardIndex != nil && heyIndex != nil && laterIndex != nil)
+        if let cardIndex, let heyIndex, let laterIndex {
+            #expect(heyIndex < cardIndex)
+            #expect(cardIndex < laterIndex)
+        }
+    }
+
+    @Test("Sender rebuilds the card from bundledMessageIds even when the hidden set is empty")
+    func senderReconstructionViaBundledMessageIds() {
+        let now = Date()
+        let messages = [
+            makeMessage(id: "hey", sender: otherUser, text: "Hey", date: now),
+            makeMessage(id: "b-text", sender: currentUser, text: "Be my assistant", date: now.addingTimeInterval(10)),
+        ]
+        // hiddenBundleMessageIds empty (own manifest not yet round-tripped); only
+        // the local summary knows the bundle ids.
+        let result = MessagesListProcessor.process(
+            messages,
+            agentBuilderSummary: builderSummary(bundledMessageIds: ["b-text"]),
+            hiddenBundleMessageIds: []
+        )
+        #expect(messageIds(from: result) == ["hey"])
+        let cards = builderCards(from: result)
+        #expect(cards.count == 1)
+        #expect(cards.first?.prompt == "Be my assistant")
+        #expect(cards.first?.creatorIsCurrentUser == true)
+    }
+
+    @Test("Hidden ids present but bundle messages absent renders no card and no bare bubbles")
+    func hiddenIdsWithoutMessages() {
+        let now = Date()
+        let messages = [
+            makeMessage(id: "hey", sender: otherUser, text: "Hey", date: now),
+            makeMessage(id: "later", sender: otherUser, text: "Still here", date: now.addingTimeInterval(10)),
+        ]
+        let result = MessagesListProcessor.process(
+            messages,
+            hiddenBundleMessageIds: ["b-att", "b-text"]
+        )
+        #expect(builderCards(from: result).isEmpty)
+        #expect(messageIds(from: result) == ["hey", "later"])
+    }
+
+    @Test("Date separator above the bundle is kept, anchored by the card")
+    func dateSeparatorAnchoredByCard() {
+        let now = Date()
+        let messages = [
+            makeMessage(id: "hey", sender: otherUser, text: "Morning", date: now),
+            // > 1 hour later: a new date window starts at the bundle.
+            makeMessage(id: "b-text", sender: currentUser, text: "New agent", date: now.addingTimeInterval(7200)),
+        ]
+        let result = MessagesListProcessor.process(
+            messages,
+            hiddenBundleMessageIds: ["b-text"]
+        )
+        let counts = itemCounts(from: result)
+        #expect(counts.dates == 2)
+        #expect(builderCards(from: result).count == 1)
+        // Last item is the card, preceded by its date separator.
+        if case .agentBuilderSummary = result.last {} else {
+            Issue.record("Expected the card as the last item")
+        }
+    }
+
+    @Test("Contact card lands directly under the builder card in the home flow")
+    func contactCardUnderBuilderCard() {
+        let now = Date()
+        let agent: ConversationMember = .mock(
+            isCurrentUser: false,
+            name: "Agent",
+            isAgent: true,
+            agentVerification: .verified(.convos)
+        )
+        let messages = [
+            makeMessage(id: "hey", sender: otherUser, text: "Hey", date: now),
+            makeMessage(id: "b-text", sender: currentUser, text: "Make it", date: now.addingTimeInterval(10)),
+        ]
+        let result = MessagesListProcessor.process(
+            messages,
+            verifiedAgent: agent,
+            agentBuilderSummary: builderSummary(bundledMessageIds: ["b-text"]),
+            hiddenBundleMessageIds: ["b-text"],
+            isInAgentBuilderFlow: true
+        )
+        let cardIndex = result.firstIndex { if case .agentBuilderSummary = $0 { return true }; return false }
+        let contactCardIndex = result.firstIndex {
+            if case .messages(let group) = $0 { return group.agentContactCard != nil }
+            return false
+        }
+        #expect(cardIndex != nil)
+        #expect(contactCardIndex != nil)
+        if let cardIndex, let contactCardIndex {
+            #expect(contactCardIndex == cardIndex + 1)
+        }
+    }
+
+    @Test("Summary stays above the contact card even when the agent joined before Make")
+    func summaryAboveContactCardWhenAgentJoinedFirst() {
+        let now = Date()
+        let agent = ConversationMember(
+            profile: Profile(inboxId: "agent-1", conversationId: "conv", name: "Trail Roller", avatar: nil, isAgent: true),
+            role: .member,
+            isCurrentUser: false,
+            isAgent: true,
+            agentVerification: .verified(.convos)
+        )
+        // Home flow: the agent joins *before* the Make bundle is sent.
+        let messages = [
+            AnyMessage.message(Message(
+                id: "agent-joined",
+                sender: otherUser,
+                source: .incoming,
+                status: .published,
+                content: .update(ConversationUpdate(
+                    creator: otherUser,
+                    addedMembers: [agent],
+                    removedMembers: [],
+                    metadataChanges: []
+                )),
+                date: now,
+                reactions: []
+            ), .existing),
+            makeMessage(id: "b-text", sender: currentUser, text: "Plan my trip", date: now.addingTimeInterval(10)),
+        ]
+        // isInAgentBuilderFlow false -> the join row is NOT suppressed and sorts
+        // above the summary, reproducing the contact-card-first ordering bug.
+        let result = MessagesListProcessor.process(
+            messages,
+            verifiedAgent: agent,
+            agentBuilderSummary: builderSummary(bundledMessageIds: ["b-text"]),
+            hiddenBundleMessageIds: ["b-text"],
+            isInAgentBuilderFlow: false
+        )
+        let cardIndex = result.firstIndex { if case .agentBuilderSummary = $0 { return true }; return false }
+        let contactCardIndex = result.firstIndex {
+            if case .messages(let group) = $0 { return group.agentContactCard != nil }
+            return false
+        }
+        #expect(cardIndex != nil)
+        #expect(contactCardIndex != nil)
+        if let cardIndex, let contactCardIndex {
+            #expect(cardIndex < contactCardIndex)
+        }
+    }
+
+    @Test("Two separate Make events render two cards")
+    func multipleBuildRuns() {
+        let now = Date()
+        let messages = [
+            makeMessage(id: "hey", sender: otherUser, text: "Hey", date: now),
+            makeMessage(id: "b1", sender: currentUser, text: "First agent", date: now.addingTimeInterval(10)),
+            makeMessage(id: "mid", sender: otherUser, text: "Interesting", date: now.addingTimeInterval(20)),
+            makeMessage(id: "b2", sender: currentUser, text: "Second agent", date: now.addingTimeInterval(30)),
+            makeMessage(id: "later", sender: otherUser, text: "Nice", date: now.addingTimeInterval(40)),
+        ]
+        let result = MessagesListProcessor.process(
+            messages,
+            hiddenBundleMessageIds: ["b1", "b2"]
+        )
+        let cards = builderCards(from: result)
+        #expect(cards.count == 2)
+        #expect(Set(cards.map(\.prompt)) == ["First agent", "Second agent"])
+        #expect(messageIds(from: result) == ["hey", "mid", "later"])
+    }
+
+    @Test("Recipient card attributes the creator and shows no connection chips")
+    func recipientAttributionAndNoConnections() {
+        let now = Date()
+        let messages = [
+            makeMessage(id: "b-text", sender: otherUser, text: "Alice's agent", date: now),
+        ]
+        let result = MessagesListProcessor.process(
+            messages,
+            hiddenBundleMessageIds: ["b-text"]
+        )
+        let card = builderCards(from: result).first
+        #expect(card?.creatorIsCurrentUser == false)
+        #expect(card?.creatorDisplayName == "Alice")
+        #expect(card?.connectionIdentifiers.isEmpty == true)
+    }
+
+    @Test("Creator card carries the connection identifiers from the local summary")
+    func creatorConnectionChips() {
+        let now = Date()
+        let messages = [
+            makeMessage(id: "b-text", sender: currentUser, text: "Calendar agent", date: now),
+        ]
+        let result = MessagesListProcessor.process(
+            messages,
+            agentBuilderSummary: builderSummary(
+                bundledMessageIds: ["b-text"],
+                connectionIdentifiers: ["googleCalendar"]
+            ),
+            hiddenBundleMessageIds: ["b-text"]
+        )
+        let card = builderCards(from: result).first
+        #expect(card?.connectionIdentifiers == ["googleCalendar"])
+        #expect(card?.creatorIsCurrentUser == true)
+    }
+}


### PR DESCRIPTION
## Summary

The agent-builder **summary card** and the synthesized **agent contact card** were pinned to the top of the conversation, and the summary was visible **only to the creator**. This fixes both: the cards now render at the chronological position where **Make agent** happened, and the summary is visible to every member.

## Approach

Rather than enriching the `BuilderBundleManifest` content type, the card is **reconstructed on every client from the build's own networked messages** (the prompt-text message + the remote-attachment bundle each member already receives). No content-type / codec / DB migration change.

- New render model `AgentBuilderCardContent` (ConvosCore), reconstructed from the referenced build messages and positioned at the earliest build message's slot.
- Build-message identity = `hiddenBundleMessageIds` ∪ `agentBuilderSummary?.bundledMessageIds`. The union covers both sides of the id-swap: client UUIDs on the sender, XMTP ids on recipients — preventing a bare-bubble flash.
- Multiple **Make** events in one conversation produce **one card per contiguous run**.
- The synthesized **contact card** anchors directly under the summary card (summary always renders above the contact card), falling back to the agent-join update when there is no builder card.
- `dropOrphanDateSeparators` now treats the card as an anchor, so a date separator above the (removed) build messages stays put.

### Tradeoffs (per plan)

- **Connection chips** (Apple Health / Google Calendar) remain **creator-only** — they aren't networked messages, so recipients can't reconstruct them. Recipients see prompt + media chips.
- **Legacy chats**: if the build messages were purged, the top card simply no longer shows (the agent is already present; the card is cosmetic history). Single path, no fallback.
- **Morph**: when reconstructed below the fold (existing-conversation flow), the matched-geometry morph degrades to a fade — inherent to moving off index 0. Flagged to design; not a correctness issue.

## Testing

- New `MessagesListProcessorAgentBuilderCardTests` suite (9 cases): recipient reconstruction + position, sender via `bundledMessageIds`, hidden-ids-without-messages -> no card/no bubbles, date-separator anchoring, contact-card-under-builder-card, multiple runs, recipient attribution + empty connections, creator connection chips, and the regression "summary stays above the contact card even when the agent joined before Make".
- ConvosCore builds clean post-rebase; the processor suite (70 tests) passed locally in the prior session. CI runs the full suite on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/953"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783041065&installation_id=128169237&pr_number=953&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F953&signature=e660b38975daf9081a176be634e50bef322ecfbf7b1ab8aa4f3b17667f7fa7d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Position agent builder summary card chronologically and show it to all conversation members
> - Introduces `AgentBuilderCardContent` as the unified render model for the agent builder summary card, replacing `AgentBuilderSummary` across the messages list pipeline.
> - Reworks `MessagesListProcessor` to collapse raw build messages into a single summary card per Make event, inserted at the position where those messages occurred, removing the original build bubbles; recipients now see the card alongside creators.
> - Personalizes the card footer with
>
> #### 🖇️ Linked Issues
> created an agent
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b5c303f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->