### PR TITLE
fix(agent-share): keep the agent QR code clear of the share sheet

### DIFF
--- a/Convos/Contacts/AgentShareOverlay.swift
+++ b/Convos/Contacts/AgentShareOverlay.swift
@@ -11,13 +11,13 @@ struct AgentShareOverlay: View {
     let emoji: String?
     let publishedURLString: String
     @Binding var isPresented: Bool
-    let topSafeAreaInset: CGFloat
 
     var body: some View {
         QRCodeCardOverlay(
             encodedURLString: publishedURLString,
             isPresented: $isPresented,
-            topSafeAreaInset: topSafeAreaInset,
+            topPadding: DesignConstants.Spacing.step6x,
+            ignoresTopSafeArea: true,
             header: {
                 Text(displayName)
                     .kerning(1.0)

--- a/Convos/Contacts/ContactDetailView.swift
+++ b/Convos/Contacts/ContactDetailView.swift
@@ -178,8 +178,7 @@ struct ContactDetailView: View {
                 displayName: contact.resolvedDisplayName,
                 emoji: contact.profileEmoji,
                 publishedURLString: publishedURL,
-                isPresented: $presentingAgentShareSheet,
-                topSafeAreaInset: 0.0
+                isPresented: $presentingAgentShareSheet
             )
         }
     }

--- a/Convos/Conversation Detail/ConversationShareView.swift
+++ b/Convos/Conversation Detail/ConversationShareView.swift
@@ -22,7 +22,7 @@ struct ConversationShareOverlay: View {
         QRCodeCardOverlay(
             encodedURLString: invite.inviteURLString,
             isPresented: $isPresented,
-            topSafeAreaInset: topSafeAreaInset,
+            topPadding: topSafeAreaInset + DesignConstants.Spacing.step4x,
             header: {
                 HStack(alignment: .center) {
                     Text("Convos code")

--- a/Convos/Shared Views/QRCodeCardOverlay.swift
+++ b/Convos/Shared Views/QRCodeCardOverlay.swift
@@ -11,7 +11,14 @@ import SwiftUI
 struct QRCodeCardOverlay<Header: View, Center: View>: View {
     let encodedURLString: String
     @Binding var isPresented: Bool
-    let topSafeAreaInset: CGFloat
+    /// Flat top padding above the card, measured from the top of whatever
+    /// region the card occupies (the safe area, or the screen top when
+    /// `ignoresTopSafeArea` is set).
+    let topPadding: CGFloat
+    /// When set, the card extends into the top safe area so `topPadding` is
+    /// measured from the screen's top edge. Lets a caller pull the card up out
+    /// of the safe-area band so a tall card clears the share sheet below it.
+    var ignoresTopSafeArea: Bool = false
     @ViewBuilder let header: () -> Header
     @ViewBuilder let center: () -> Center
 
@@ -30,8 +37,7 @@ struct QRCodeCardOverlay<Header: View, Center: View>: View {
 
     private func qrDisplaySize(in size: CGSize) -> CGFloat {
         let availableHeight = size.height * (1.0 - Self.shareSheetFraction)
-            - topSafeAreaInset
-            - DesignConstants.Spacing.step4x
+            - topPadding
             - Self.headerHeight
             - Self.cardPadding
             - DesignConstants.Spacing.step10x
@@ -56,11 +62,13 @@ struct QRCodeCardOverlay<Header: View, Center: View>: View {
                 }
 
                 if showCard {
+                    let ignoredEdges: Edge.Set = ignoresTopSafeArea ? .top : []
                     VStack(spacing: 0.0) {
                         codeCard(qrSize: qrDisplaySize(in: geometry.size))
                         Spacer()
                     }
-                    .padding(.top, topSafeAreaInset + DesignConstants.Spacing.step4x)
+                    .padding(.top, topPadding)
+                    .ignoresSafeArea(.container, edges: ignoredEdges)
                     .transition(
                         .asymmetric(
                             insertion: .move(edge: .top).combined(with: .opacity),


### PR DESCRIPTION
## Problem

The agent "code card" (the QR shown when sharing an agent from its contact card) is presented via `.overlay { }` inside a `NavigationStack`, so it inherits a safe-area-respecting context. The card was pinned at `safeAreaTop + step4x` (~66pt down), so a tall QR card slid **under** the system share sheet that animates up from the bottom.

The old `topSafeAreaInset` parameter on `QRCodeCardOverlay` was vestigial — every caller passed `0`.

## Fix

Let the agent card **ignore the top safe area** and pin it `step6x` (24pt) from the screen's top edge, pulling it up out of the safe-area band so it stays above the share sheet.

- `QRCodeCardOverlay.swift` — replaced `topSafeAreaInset` with a caller-controlled `topPadding`, plus an opt-in `ignoresTopSafeArea` flag (`.ignoresSafeArea(.container, edges: .top)`).
- `AgentShareOverlay.swift` — passes `topPadding: step6x` + `ignoresTopSafeArea: true`; dropped its own `topSafeAreaInset`.
- `ContactDetailView.swift` — removed the now-gone `topSafeAreaInset: 0.0` argument.
- `ConversationShareView.swift` — translated to `topPadding: topSafeAreaInset + step4x` so the conversation "Convos code" flow is unchanged.

## Testing

- Builds clean (Swift compile: zero errors/type-check warnings on `Convos (Dev)`, arm64 simulator).
- SwiftFormat + SwiftLint `--strict` clean on all changed files.
- Conversation "Convos code" share flow is byte-for-byte unchanged (same effective top padding).

## Note for reviewers

`step6x` (24pt from the screen top) is intentionally high so the card clears the sheet. On a Dynamic Island device the agent-name header sits close to the Island — if that reads as tight, it's a one-line bump (`step8x`/`step10x`). I wasn't able to run the live agent-share flow (needs a published agent) to pixel-verify, only compile-verify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/954"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783043863&installation_id=128169237&pr_number=954&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F954&signature=e2f6a335cc81bdf88177b8ffc90df5457153ebd40ef9f421e9d6303aee0e8309"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix agent QR code position to stay clear of the share sheet
> - Refactors `QRCodeCardOverlay` to replace `topSafeAreaInset` with explicit `topPadding` and an `ignoresTopSafeArea` flag (default `false`), giving callers direct control over vertical placement.
> - Updates `AgentShareOverlay` to use a fixed `topPadding` of `step6x` and sets `ignoresTopSafeArea: true`, pulling the QR card up so the share sheet no longer obscures it.
> - Updates `ConversationShareOverlay` to pass `topSafeAreaInset + step4x` as `topPadding`, preserving its prior card position.
> - Behavioral Change: `QRCodeCardOverlay` callers must now pass `topPadding` directly; the implicit safe-area offset is no longer added internally.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5e6ad19.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->