### PR TITLE
fix(contacts): keep search bar + "Show all" empty state when a contacts search matches nothing

### DIFF
--- a/Convos/Contacts/ContactsPickerView.swift
+++ b/Convos/Contacts/ContactsPickerView.swift
@@ -300,6 +300,8 @@ private struct ContactsPickerList: View {
         if viewModel.sections.isEmpty {
             if viewModel.isLoadingSuggestedAgents {
                 loadingState
+            } else if viewModel.isFiltering {
+                filteredEmptyState
             } else {
                 emptyState
             }
@@ -370,6 +372,21 @@ private struct ContactsPickerList: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .padding(DesignConstants.Spacing.step6x)
+    }
+
+    private var filteredEmptyState: some View {
+        VStack {
+            Spacer()
+            FilteredEmptyStateView(
+                message: "No contacts",
+                accessibilityLabel: "Show all contacts"
+            ) {
+                viewModel.clearFilters()
+            }
+            .padding(.horizontal, DesignConstants.Spacing.step6x)
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
     private func rowTapAction(for row: ContactsPickerViewModel.Row) -> () -> Void {

--- a/Convos/Contacts/ContactsPickerViewModel.swift
+++ b/Convos/Contacts/ContactsPickerViewModel.swift
@@ -83,6 +83,11 @@ final class ContactsPickerViewModel {
     var isLoadingSuggestedAgents: Bool {
         suggestedAgentsModel.isLoading
     }
+    /// True when a text search or audience filter is narrowing the list, so an
+    /// empty `sections` means "nothing matched" rather than "no contacts".
+    var isFiltering: Bool {
+        !searchQuery.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || filter.isActive
+    }
 
     private let contactsRepository: any ContactsRepositoryProtocol
     private let alreadyInChatInboxIds: Set<String>
@@ -370,6 +375,14 @@ final class ContactsPickerViewModel {
     private func filterByAudience(_ contacts: [Contact]) -> [Contact] {
         guard filter.isActive else { return contacts }
         return contacts.filter { filter.includes($0) }
+    }
+
+    /// Clears the active text search and audience filter so the full pickable
+    /// list is shown again. Backs the "Show all" button on the filtered empty
+    /// state. Selections are unaffected.
+    func clearFilters() {
+        searchQuery = ""
+        filter = .all
     }
 
     private static func sectionKeyOrder(_ lhs: String, _ rhs: String) -> Bool {

--- a/Convos/Contacts/ContactsView.swift
+++ b/Convos/Contacts/ContactsView.swift
@@ -37,7 +37,7 @@ struct ContactsView: View {
 
     var body: some View {
         Group {
-            if viewModel.sections.isEmpty {
+            if viewModel.sections.isEmpty && !viewModel.isFiltering {
                 emptyState
             } else {
                 contactsContent
@@ -77,7 +77,7 @@ struct ContactsView: View {
     /// rows scroll cleanly under the bar.
     @ViewBuilder
     private var contactsContent: some View {
-        contactList
+        listOrFilteredEmptyState
             .background(.colorBackgroundRaisedSecondary)
             .safeAreaBar(edge: .top) {
                 ContactsSearchBar(
@@ -87,6 +87,34 @@ struct ContactsView: View {
                     filter: $viewModel.filter
                 )
             }
+    }
+
+    /// Shows the filtered empty state when a search or filter matches nothing,
+    /// keeping the search bar above so the user can clear the search; otherwise
+    /// the contacts list. Reached only when `sections` is non-empty or a filter
+    /// is active, so an empty `sections` here always means "nothing matched".
+    @ViewBuilder
+    private var listOrFilteredEmptyState: some View {
+        if viewModel.sections.isEmpty {
+            filteredEmptyState
+        } else {
+            contactList
+        }
+    }
+
+    private var filteredEmptyState: some View {
+        VStack {
+            Spacer()
+            FilteredEmptyStateView(
+                message: "No contacts",
+                accessibilityLabel: "Show all contacts"
+            ) {
+                viewModel.clearFilters()
+            }
+            .padding(.horizontal, DesignConstants.Spacing.step6x)
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
     @ViewBuilder

--- a/Convos/Contacts/ContactsView.swift
+++ b/Convos/Contacts/ContactsView.swift
@@ -38,7 +38,15 @@ struct ContactsView: View {
     var body: some View {
         Group {
             if viewModel.sections.isEmpty && !viewModel.isFiltering {
-                emptyState
+                // No own contacts and no active search. Surface suggested
+                // agents once they load; show a spinner while they're in
+                // flight so we don't flash the onboarding empty state, and
+                // fall back to it only when there's genuinely nothing to show.
+                if viewModel.isLoadingSuggestedAgents {
+                    loadingState
+                } else {
+                    emptyState
+                }
             } else {
                 contactsContent
             }
@@ -175,6 +183,15 @@ struct ContactsView: View {
 
     private var emptyState: some View {
         ContactsEmptyStateView()
+            .background(.colorBackgroundRaisedSecondary)
+    }
+
+    /// Shown while the suggested-agents first page is in flight and the user
+    /// has no contacts yet, so the onboarding empty state doesn't flash before
+    /// the suggestions arrive.
+    private var loadingState: some View {
+        ProgressView()
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
             .background(.colorBackgroundRaisedSecondary)
     }
 

--- a/Convos/Contacts/ContactsViewModel.swift
+++ b/Convos/Contacts/ContactsViewModel.swift
@@ -44,6 +44,12 @@ final class ContactsViewModel {
     var isLoadingSuggestedAgents: Bool {
         suggestedAgentsModel.isLoading
     }
+    /// True when a text search or audience filter is narrowing the list. An
+    /// empty `sections` while filtering means "nothing matched", which the
+    /// view distinguishes from the "no contacts yet" onboarding empty state.
+    var isFiltering: Bool {
+        !searchQuery.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || filter.isActive
+    }
 
     private let contactsRepository: any ContactsRepositoryProtocol
     private var cancellable: AnyCancellable?
@@ -179,6 +185,13 @@ final class ContactsViewModel {
     private func filterByAudience(_ contacts: [Contact]) -> [Contact] {
         guard filter.isActive else { return contacts }
         return contacts.filter { filter.includes($0) }
+    }
+
+    /// Clears the active text search and audience filter so the full list is
+    /// shown again. Backs the "Show all" button on the filtered empty state.
+    func clearFilters() {
+        searchQuery = ""
+        filter = .all
     }
 
     // MARK: - Suggested agents

--- a/Convos/Conversations List/FilteredEmptyStateView.swift
+++ b/Convos/Conversations List/FilteredEmptyStateView.swift
@@ -3,6 +3,9 @@ import SwiftUI
 
 struct FilteredEmptyStateView: View {
     let message: String
+    /// Spoken label for the "Show all" button. Defaults to the conversations-
+    /// list phrasing; other surfaces (e.g. contacts) pass their own.
+    var accessibilityLabel: String = "Show all conversations"
     let onShowAll: () -> Void
 
     var body: some View {
@@ -16,7 +19,7 @@ struct FilteredEmptyStateView: View {
                 Text("Show all")
             }
             .convosButtonStyle(.rounded(fullWidth: false))
-            .accessibilityLabel("Show all conversations")
+            .accessibilityLabel(accessibilityLabel)
             .accessibilityIdentifier("show-all-button")
         }
         .frame(maxWidth: .infinity)

--- a/ConvosTests/ContactsPickerViewModelTests.swift
+++ b/ConvosTests/ContactsPickerViewModelTests.swift
@@ -500,4 +500,48 @@ final class ContactsPickerViewModelTests: XCTestCase {
         viewModel.searchQuery = ""
         XCTAssertNotNil(suggestedSection(viewModel))
     }
+
+    // MARK: - Filtered empty state
+
+    /// `isFiltering` lets the picker show the "Show all" empty state (rather
+    /// than the generic "no contacts" one) when a search or audience filter
+    /// matches nothing.
+    func testIsFilteringReflectsSearchAndAudienceFilter() {
+        let viewModel = ContactsPickerViewModel(
+            mode: .newConversation,
+            contactsRepository: MockContactsRepository(contacts: [.mock(displayName: "Alice")])
+        )
+
+        XCTAssertFalse(viewModel.isFiltering)
+
+        viewModel.searchQuery = "zzz"
+        XCTAssertTrue(viewModel.isFiltering)
+
+        viewModel.searchQuery = ""
+        XCTAssertFalse(viewModel.isFiltering)
+
+        viewModel.filter = .agents
+        XCTAssertTrue(viewModel.isFiltering)
+    }
+
+    /// "Show all" clears the search and audience filter, restoring the full
+    /// pickable list.
+    func testClearFiltersRestoresFullList() {
+        let alice = Contact.mock(displayName: "Alice")
+        let bob = Contact.mock(displayName: "Bob")
+        let viewModel = ContactsPickerViewModel(
+            mode: .newConversation,
+            contactsRepository: MockContactsRepository(contacts: [alice, bob])
+        )
+
+        viewModel.searchQuery = "zzz"
+        XCTAssertTrue(viewModel.sections.isEmpty)
+        XCTAssertTrue(viewModel.isFiltering)
+
+        viewModel.clearFilters()
+
+        XCTAssertFalse(viewModel.isFiltering)
+        let allRowIds: [String] = viewModel.sections.flatMap { $0.rows.map(\.id) }
+        XCTAssertEqual(allRowIds.sorted(), [alice.inboxId, bob.inboxId].sorted())
+    }
 }

--- a/ConvosTests/ContactsViewModelTests.swift
+++ b/ConvosTests/ContactsViewModelTests.swift
@@ -94,4 +94,47 @@ final class ContactsViewModelTests: XCTestCase {
         let allIds: [String] = viewModel.sections.flatMap { $0.rows.map(\.contact.inboxId) }
         XCTAssertEqual(allIds.sorted(), [alice.inboxId, aliceAssistant.inboxId].sorted())
     }
+
+    // MARK: - Filtered empty state
+
+    /// `isFiltering` distinguishes "nothing matched the search/filter" from
+    /// "no contacts at all", so the view keeps the search bar and shows the
+    /// "Show all" empty state instead of the onboarding empty state.
+    func testIsFilteringReflectsSearchAndAudienceFilter() {
+        let repo = MockContactsRepository(contacts: [.mock(displayName: "Alice")])
+        let viewModel = ContactsViewModel(contactsRepository: repo)
+
+        XCTAssertFalse(viewModel.isFiltering)
+
+        viewModel.searchQuery = "  "
+        XCTAssertFalse(viewModel.isFiltering, "whitespace-only query is not filtering")
+
+        viewModel.searchQuery = "zzz"
+        XCTAssertTrue(viewModel.isFiltering)
+
+        viewModel.searchQuery = ""
+        XCTAssertFalse(viewModel.isFiltering)
+
+        viewModel.filter = .agents
+        XCTAssertTrue(viewModel.isFiltering)
+    }
+
+    /// "Show all" clears both the text search and the audience filter, so the
+    /// full list comes back and `isFiltering` reads false again.
+    func testClearFiltersRestoresFullList() {
+        let alice = Contact.mock(displayName: "Alice")
+        let bob = Contact.mock(displayName: "Bob")
+        let repo = MockContactsRepository(contacts: [alice, bob])
+        let viewModel = ContactsViewModel(contactsRepository: repo)
+
+        viewModel.searchQuery = "zzz"
+        XCTAssertTrue(viewModel.sections.isEmpty)
+        XCTAssertTrue(viewModel.isFiltering)
+
+        viewModel.clearFilters()
+
+        XCTAssertFalse(viewModel.isFiltering)
+        let allIds: [String] = viewModel.sections.flatMap { $0.rows.map(\.contact.inboxId) }
+        XCTAssertEqual(allIds.sorted(), [alice.inboxId, bob.inboxId].sorted())
+    }
 }


### PR DESCRIPTION
## Problem

When searching contacts (or applying the People/Agents audience filter) and **nothing matches**, the Contacts tab replaced the entire screen — search bar included — with the full-screen "No contacts yet" onboarding empty state. The user was stranded with no way to clear or cancel the search.

Root cause: `ContactsView.body` branched on `viewModel.sections.isEmpty`, and `sections` is the *filtered* result. A no-match search/filter emptied it, so the body took the onboarding-empty-state branch (which doesn't render the search bar — that lives only in `contactsContent`). The view model even had a comment claiming a non-matching filter "renders an empty list rather than the onboarding empty state," which the `sections.isEmpty` check silently defeated.

| Before | After |
|--------|-------|
| No-result search → full-screen "No contacts yet", search bar gone, dead end | Search bar stays; "No contacts" + a **Show all** button that clears the search/filter |

## Change

- `ContactsViewModel` / `ContactsPickerViewModel`: add `isFiltering` (a text search or audience filter is active) and `clearFilters()` (resets both).
- `ContactsView`: show the onboarding empty state only when `sections.isEmpty && !isFiltering`. When a search/filter matches nothing, keep the search bar and render `FilteredEmptyStateView` ("No contacts" + "Show all") in the list area — the same pattern the conversations list uses for empty filter states.
- `ContactsPickerView`: same filtered empty state when a search/filter matches nothing (its search bar was already retained).
- `FilteredEmptyStateView`: optional `accessibilityLabel` (default preserves the conversations phrasing) so contacts reads "Show all contacts".
- Unit tests for `isFiltering` / `clearFilters` in both view-model suites.

## Verification

- ✅ Full Swift compilation succeeds (zero errors).
- ✅ `swiftlint --strict` passes on all changed files.
- ⚠️ **Unit tests not yet run to green in this environment** — the shared build disk was full (99%), so the simulator test build could not complete (two attempts failed on environmental issues: an arm64-only-framework arch mismatch and an ad-hoc CodeSign internal error, then `ENOSPC`). The new tests are straightforward and follow the existing pattern, but **please rely on CI / a local run with adequate disk to confirm the test suite passes before merging.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/955"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783047018&installation_id=128169237&pr_number=955&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F955&signature=797cf6da6b91a71061c3199dac8887f802f38944a24f1b72850e37e283b5f3f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show filtered empty state with 'Show all' button when contact search returns no results
> - Adds `isFiltering` and `clearFilters()` to `ContactsViewModel` and `ContactsPickerViewModel` to track and reset active search/audience filters.
> - When a search or filter returns no contacts, the contacts list and picker now show a `FilteredEmptyStateView` ("No contacts" + "Show all" button) instead of the generic onboarding empty state.
> - Tapping "Show all" calls `clearFilters()`, resetting `searchQuery` to empty and `filter` to `.all`, restoring the full list.
> - Adds a loading spinner in `ContactsView` while suggested agents are being fetched when there are no contacts and no active filters, preventing an incorrect flash of the empty state.
> - `FilteredEmptyStateView` gains a customizable `accessibilityLabel` parameter for the "Show all" button, defaulting to its previous hardcoded value.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e5c96b6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->