### PR TITLE
feat(settings): show subscription/Power row in production

### DIFF
--- a/Convos/App Settings/AppSettingsView.swift
+++ b/Convos/App Settings/AppSettingsView.swift
@@ -228,20 +228,18 @@ struct AppSettingsView: View {
 
     @ViewBuilder
     private var subscriptionSection: some View {
-        if !ConfigManager.shared.currentEnvironment.isProduction {
-            Section {
-                let subscribeAction = { presentingPaywall = true }
-                Button(action: subscribeAction) {
-                    powerRowLabel
-                }
-                .accessibilityIdentifier("subscription-row")
-                .sheet(isPresented: $presentingPaywall) {
-                    let viewModel = PaywallViewModel(subscriptionService: SubscriptionServices.shared)
-                    PaywallView(viewModel: viewModel)
-                }
-            } footer: {
-                Text(membershipFooterLabel)
+        Section {
+            let subscribeAction = { presentingPaywall = true }
+            Button(action: subscribeAction) {
+                powerRowLabel
             }
+            .accessibilityIdentifier("subscription-row")
+            .sheet(isPresented: $presentingPaywall) {
+                let viewModel = PaywallViewModel(subscriptionService: SubscriptionServices.shared)
+                PaywallView(viewModel: viewModel)
+            }
+        } footer: {
+            Text(membershipFooterLabel)
         }
     }
 


### PR DESCRIPTION
## What

Removes the `if !ConfigManager.shared.currentEnvironment.isProduction` guard around `subscriptionSection` in `AppSettingsView`, so the **Power** row (paywall entry point) and its **"Basic membership" / "Plus membership"** plan footer now appear in production builds — not just Dev/Local.

## Why

The plan row was reported missing from App Settings in production. Root cause: the section has been gated out of prod since it was first added in #840 ("IAP Subscription and StoreKit Wiring") and the guard survived the #880 redesign. The underlying IAP/StoreKit plumbing is already production-aware, so the row is safe to surface:

- Product IDs key off the **bundle ID** (`org.convos.ios` -> `app.convos.subs.plus.monthly` / `.plus.annual`) — `SubscriptionProductIDs`.
- `SubscriptionServices.useRealStoreKit` and `CreditsServices.useRealBackend` are forced `true` in production (mock overrides blocked there).
- Purchases set a stable per-install `appAccountToken` and verify via the prod backend (`/v2/accounts/me/subscription/verify`).

The separate `!isProduction` guard on the **Debug** row is intentionally left intact.

## Remaining (out of scope, external) before IAP is live in prod

These are App Store Connect / backend tasks, not iOS code:
- Create the `app.convos.subs.plus.monthly` / `.plus.annual` subscriptions in the **prod** App Store Connect app (one subscription group, priced, approved).
- Sign the Paid Applications Agreement (+ banking/tax) — products won't load otherwise.
- Configure the prod backend's App Store Server API credentials for `org.convos.ios`.
- Smoke-test the paywall + purchase on a prod-signed TestFlight build with a sandbox tester.

> Note: In-App Purchase needs no `.entitlements` key — it's enabled by default for all App IDs, so nothing changes in `Convos.entitlements`.

## Testing

- `Convos (Dev)` scheme compiles clean (`BUILD SUCCEEDED`).
- Per request, the ConvosCore test suite was skipped (this is a view-visibility change that the ConvosCore tests don't exercise).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/956"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783048277&installation_id=128169237&pr_number=956&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F956&signature=c8eef7fa5853363ca2f57a418c18d8ac2202c13d3ba8e0d2d46bc8d84aa2e18c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show subscription row in `AppSettingsView` in production
> Removes the environment guard in [AppSettingsView.swift](https://github.com/xmtplabs/convos-ios/pull/956/files#diff-30e98d39613710cf0f912b477ed30a8638995959caa9cb2e9facdc10e1c3f8b9) that previously hid the subscription section outside of production. The subscription row, paywall sheet, and footer text are now always rendered regardless of environment.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a5c292b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->