### PR TITLE
fix(chats): keep tab bar visible in the empty/no-convos state

### DIFF
--- a/Convos/MainTabView.swift
+++ b/Convos/MainTabView.swift
@@ -21,8 +21,9 @@ struct MainTabView: View {
 
     /// Tracks which tab is currently active and drives the standard
     /// `TabView` selection. The system tab bar is hidden only while a
-    /// conversation / Stuff detail is pushed (or the inline empty-state
-    /// builder is up) via `.toolbar(_:for: .tabBar)`.
+    /// conversation / Stuff detail is pushed (so the detail owns the full
+    /// screen) via `.toolbar(_:for: .tabBar)`. It stays visible during the
+    /// inline empty-state builder so the user can still switch tabs.
     @State private var activeTab: ConvosTab = .chats
     /// NavigationStack path for the Stuff tab. Lifted to this shell so
     /// the bottom chrome can hide when Stuff has a detail pushed, same
@@ -411,7 +412,7 @@ struct MainTabView: View {
             }
             .toolbar { sharedToolbar(for: tab) }
             .toolbar(isConversationSelected ? .hidden : .visible, for: .navigationBar)
-            .toolbar((isConversationSelected || isInlineBuilderActive) ? .hidden : .visible, for: .tabBar)
+            .toolbar(isConversationSelected ? .hidden : .visible, for: .tabBar)
     }
 
     /// Shared toolbar (compose + add-agent) applied to each tab's


### PR DESCRIPTION
The system tab bar was hidden whenever the inline empty-state agent
builder was active (i.e. the user has no conversations yet), so a
brand-new user could not switch to the other tabs. Hide the tab bar
only when a conversation / Stuff detail is pushed, mirroring the
navigation-bar rule on the line directly above.

The inline builder uses safe-area-aware layout (no .ignoresSafeArea,
no assumption the tab bar is absent), so its composer and Terms footer
now sit naturally above the visible tab bar.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/957"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783049085&installation_id=128169237&pr_number=957&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F957&signature=c1cf5176a3e06009de72cad6c8006616ecac5b0f99772e9ec645453dace07afa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Keep tab bar visible during empty/no-conversations state in `MainTabView`
> Previously, the tab bar was hidden whenever the inline empty-state builder was active. Now it only hides when a conversation is selected, so the tab bar remains visible on the empty state screen. The change is a one-line condition update in the `tabChrome` view modifier in [MainTabView.swift](https://github.com/xmtplabs/convos-ios/pull/957/files#diff-2b02f95e9fabdce514b1dd6d74d930ca17fcc2380c7504789454c035484e9d67).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 522325a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->