### PR TITLE
Fix phantom ~200pt top inset above a single new convo

### DIFF
--- a/Convos/Conversations List/ConversationsView.swift
+++ b/Convos/Conversations List/ConversationsView.swift
@@ -215,7 +215,6 @@ struct ConversationsView: View {
             selectedConversationId: viewModel.selectedConversationId,
             isFilteredResultEmpty: viewModel.isFilteredResultEmpty,
             filterEmptyMessage: viewModel.activeFilter.emptyStateMessage,
-            hasCreatedMoreThanOneConvo: viewModel.hasCreatedMoreThanOneConvo,
             onSelectConversation: { conversation in
                 viewModel.selectedConversationId = conversation.id
             },
@@ -234,8 +233,6 @@ struct ConversationsView: View {
             onTogglePin: { conversation in
                 viewModel.togglePin(conversation: conversation)
             },
-            onStartConvo: viewModel.onStartConvo,
-            onJoinConvo: viewModel.onJoinConvo,
             onShowAllFilter: { viewModel.activeFilter = .all },
             onScrollOffsetChange: onScrollOffsetChange,
             topChromeInset: topChromeInset,

--- a/Convos/Conversations List/View Controller/Cells/EmptyStateCell.swift
+++ b/Convos/Conversations List/View Controller/Cells/EmptyStateCell.swift
@@ -3,7 +3,6 @@ import SwiftUI
 import UIKit
 
 enum EmptyStateType {
-    case cta(onStartConvo: () -> Void, onJoinConvo: () -> Void)
     case filtered(message: String, onShowAll: () -> Void)
 }
 
@@ -27,19 +26,6 @@ final class EmptyStateCell: UICollectionViewCell {
 
     func configure(with type: EmptyStateType) {
         switch type {
-        case .cta:
-            // The first-run "Pop-up private convos" card has been replaced
-            // by an inline `AgentBuilderView` mounted at the `MainTabView`
-            // level (gated on `ConversationsViewModel.isEmptyCTAActive`).
-            // This cell still renders so the collection-view diff stays
-            // happy, but it's intentionally empty — when the inline
-            // builder is active the chats tab itself is swapped out, so
-            // this branch is effectively only hit when the tab is briefly
-            // re-mounted during the transition.
-            contentConfiguration = UIHostingConfiguration { EmptyView() }
-                .margins(.all, 0)
-                .background(.clear)
-
         case let .filtered(message, onShowAll):
             contentConfiguration = UIHostingConfiguration {
                 FilteredEmptyStateView(
@@ -67,7 +53,7 @@ final class EmptyStateCell: UICollectionViewCell {
             withHorizontalFittingPriority: .required,
             verticalFittingPriority: .fittingSizeLevel
         )
-        layoutAttributes.size.height = max(fittingSize.height, 200)
+        layoutAttributes.size.height = fittingSize.height
         return layoutAttributes
     }
 }

--- a/Convos/Conversations List/View Controller/ConversationsViewController.swift
+++ b/Convos/Conversations List/View Controller/ConversationsViewController.swift
@@ -13,14 +13,7 @@ final class ConversationsViewController: UIViewController {
         var selectedConversationId: String?
         var isFilteredResultEmpty: Bool
         var filterEmptyMessage: String
-        var hasCreatedMoreThanOneConvo: Bool
         var horizontalSizeClass: UserInterfaceSizeClass?
-
-        @MainActor var shouldShowEmptyCTA: Bool {
-            unpinnedConversations.count == 1 &&
-            !hasCreatedMoreThanOneConvo &&
-            UIDevice.current.userInterfaceIdiom == .phone
-        }
 
         static let empty: State = State(
             pinnedConversations: [],
@@ -28,7 +21,6 @@ final class ConversationsViewController: UIViewController {
             selectedConversationId: nil,
             isFilteredResultEmpty: false,
             filterEmptyMessage: "",
-            hasCreatedMoreThanOneConvo: false,
             horizontalSizeClass: nil
         )
     }
@@ -36,7 +28,6 @@ final class ConversationsViewController: UIViewController {
     enum Item: Hashable {
         case pinned(Conversation)
         case conversation(Conversation)
-        case emptyCTA
         case filteredEmpty(String)
 
         func hash(into hasher: inout Hasher) {
@@ -47,8 +38,6 @@ final class ConversationsViewController: UIViewController {
             case .conversation(let conversation):
                 hasher.combine("conversation")
                 hasher.combine(conversation.id)
-            case .emptyCTA:
-                hasher.combine("emptyCTA")
             case .filteredEmpty(let message):
                 hasher.combine("filteredEmpty")
                 hasher.combine(message)
@@ -61,8 +50,6 @@ final class ConversationsViewController: UIViewController {
                 return lConv.id == rConv.id
             case let (.conversation(lConv), .conversation(rConv)):
                 return lConv.id == rConv.id
-            case (.emptyCTA, .emptyCTA):
-                return true
             case let (.filteredEmpty(lMsg), .filteredEmpty(rMsg)):
                 return lMsg == rMsg
             default:
@@ -106,8 +93,6 @@ final class ConversationsViewController: UIViewController {
     var onToggleMute: ((Conversation) -> Void)?
     var onToggleReadState: ((Conversation) -> Void)?
     var onTogglePin: ((Conversation) -> Void)?
-    var onStartConvo: (() -> Void)?
-    var onJoinConvo: (() -> Void)?
     var onShowAllFilter: (() -> Void)?
     /// Fired on every scroll tick with the latest content offset Y. Used
     /// by the host SwiftUI shell (`MainTabView`) to flip the agent
@@ -426,17 +411,6 @@ final class ConversationsViewController: UIViewController {
                     item: conversation
                 )
 
-            case .emptyCTA:
-                let type = EmptyStateType.cta(
-                    onStartConvo: { self.onStartConvo?() },
-                    onJoinConvo: { self.onJoinConvo?() }
-                )
-                return collectionView.dequeueConfiguredReusableCell(
-                    using: emptyCellRegistration,
-                    for: indexPath,
-                    item: type
-                )
-
             case .filteredEmpty(let message):
                 let type = EmptyStateType.filtered(
                     message: message,
@@ -465,10 +439,6 @@ final class ConversationsViewController: UIViewController {
         if currentState.isFilteredResultEmpty {
             snapshot.appendItems([.filteredEmpty(currentState.filterEmptyMessage)], toSection: .list)
         } else {
-            if currentState.shouldShowEmptyCTA {
-                snapshot.appendItems([.emptyCTA], toSection: .list)
-            }
-
             let listItems = currentState.unpinnedConversations.map { Item.conversation($0) }
             snapshot.appendItems(listItems, toSection: .list)
         }
@@ -481,7 +451,7 @@ final class ConversationsViewController: UIViewController {
                 switch item {
                 case .pinned(let c), .conversation(let c):
                     return changedIds.contains(c.id)
-                case .emptyCTA, .filteredEmpty:
+                case .filteredEmpty:
                     return false
                 }
             }
@@ -512,7 +482,7 @@ final class ConversationsViewController: UIViewController {
                 switch item {
                 case .pinned(let conversation), .conversation(let conversation):
                     conversationId = conversation.id
-                case .emptyCTA, .filteredEmpty:
+                case .filteredEmpty:
                     conversationId = nil
                 }
 
@@ -540,7 +510,7 @@ final class ConversationsViewController: UIViewController {
             switch item {
             case .pinned(let c), .conversation(let c):
                 matchesId = c.id == conversation.id
-            case .emptyCTA, .filteredEmpty:
+            case .filteredEmpty:
                 matchesId = false
             }
             if matchesId, let indexPath = dataSource.indexPath(for: item) {
@@ -667,7 +637,7 @@ extension ConversationsViewController: UICollectionViewDelegate {
         switch item {
         case .pinned(let conversation), .conversation(let conversation):
             return conversation
-        case .emptyCTA, .filteredEmpty:
+        case .filteredEmpty:
             return nil
         }
     }

--- a/Convos/Conversations List/View Controller/ConversationsViewRepresentable.swift
+++ b/Convos/Conversations List/View Controller/ConversationsViewRepresentable.swift
@@ -8,7 +8,6 @@ struct ConversationsViewRepresentable: UIViewControllerRepresentable {
     let selectedConversationId: String?
     let isFilteredResultEmpty: Bool
     let filterEmptyMessage: String
-    let hasCreatedMoreThanOneConvo: Bool
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass: UserInterfaceSizeClass?
     @Environment(\.memberContactOverride) private var memberContactOverride: @Sendable (String) -> Contact?
 
@@ -19,8 +18,6 @@ struct ConversationsViewRepresentable: UIViewControllerRepresentable {
     var onToggleMute: ((Conversation) -> Void)?
     var onToggleReadState: ((Conversation) -> Void)?
     var onTogglePin: ((Conversation) -> Void)?
-    var onStartConvo: (() -> Void)?
-    var onJoinConvo: (() -> Void)?
     var onShowAllFilter: (() -> Void)?
     var onScrollOffsetChange: ((CGFloat) -> Void)?
     var topChromeInset: CGFloat = 0
@@ -40,7 +37,6 @@ struct ConversationsViewRepresentable: UIViewControllerRepresentable {
             selectedConversationId: selectedConversationId,
             isFilteredResultEmpty: isFilteredResultEmpty,
             filterEmptyMessage: filterEmptyMessage,
-            hasCreatedMoreThanOneConvo: hasCreatedMoreThanOneConvo,
             horizontalSizeClass: horizontalSizeClass
         )
         viewController.memberContactOverride = memberContactOverride
@@ -59,8 +55,6 @@ struct ConversationsViewRepresentable: UIViewControllerRepresentable {
         viewController.onToggleMute = onToggleMute
         viewController.onToggleReadState = onToggleReadState
         viewController.onTogglePin = onTogglePin
-        viewController.onStartConvo = onStartConvo
-        viewController.onJoinConvo = onJoinConvo
         viewController.onShowAllFilter = onShowAllFilter
         viewController.onScrollOffsetChange = onScrollOffsetChange
     }


### PR DESCRIPTION
## Problem

A large (~200pt) blank inset appears at the top of the conversations list whenever a user has **exactly one** conversation — looking as if the inline agent builder is reserving space when it isn't. It reproduces persistently on fresh simulator state, which is why it keeps showing up during QA.

## Root cause

Two "empty CTA" gates had drifted apart:

- `ConversationsViewModel.isEmptyCTAActive` (SwiftUI) fires at **zero** convos and swaps the whole list for the full-screen inline `AgentBuilderView`.
- `ConversationsViewController.State.shouldShowEmptyCTA` fires at **exactly one** convo and prepends an in-list `.emptyCTA` cell.

When the first-run CTA card was replaced by the tab-level inline builder, the `.emptyCTA` cell's content was gutted to `EmptyView()` — but it was still inserted at one convo, and `EmptyStateCell.preferredLayoutAttributesFitting` still forced `max(height, 200)`. So an empty 200pt cell rendered above the single conversation. Because `hasCreatedMoreThanOneConvo` is a latched `UserDefaults` flag, this reproduces for any account/simulator that has never had more than one convo.

The cell's own comment claimed this branch was "only hit … briefly … during the transition" — that was incorrect; at one convo it renders persistently.

## Fix

Remove the dead path:

- `EmptyStateType.cta` + its `EmptyStateCell` branch
- the 200pt minimum-height floor (only `.filtered` remains; it now self-sizes)
- `State.shouldShowEmptyCTA`, `Item.emptyCTA`, and the `.emptyCTA` snapshot insert
- the `onStartConvo` / `onJoinConvo` / `hasCreatedMoreThanOneConvo` plumbing into the collection view that existed solely to feed the cell (`ConversationsViewRepresentable` + `ConversationsView`)

`ConversationsViewModel.hasCreatedMoreThanOneConvo` and `resetUserDefaults()` are kept (the latter is called by delete-all-data / debug reset).

Net: **4 files, +5 / −58.**

## Behavior change to note

The `.filtered` empty-state cell (shown when you have pinned convos **and** an active filter with no matches) no longer has a 200pt floor; it now self-sizes to its content. This is the only path that still used `EmptyStateCell`.

## Testing

- SwiftLint: clean on all changed files.
- Compilation: all Swift sources (including the changed files) compile for the `Convos (Dev)` scheme / iOS Simulator. A fully green end-to-end local archive was blocked only by fresh-worktree provisioning (libxmtp ships an arm64-only simulator slice; the `Secrets.swift` codegen Run Script needs env vars a headless build lacks) — neither related to this change. CI builds with proper secrets are authoritative.
- ConvosCore unit tests were not run: this change is confined to the Convos app target (views / view controller) and does not touch ConvosCore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/960"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783050981&installation_id=128169237&pr_number=960&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F960&signature=8e6e5d5f7419049c4b60afe1cd9787a1c1971d757141cae7a180afe10641cae9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix phantom 200pt top inset above a single new conversation
> - Removes the `emptyCTA` item type and its associated state (`hasCreatedMoreThanOneConvo`, `shouldShowEmptyCTA`) from `ConversationsViewController`, `ConversationsViewRepresentable`, and `ConversationsView`.
> - Removes the 200pt minimum height constraint in `EmptyStateCell.preferredLayoutAttributesFitting`, which was the source of the phantom inset when only one conversation existed.
> - The `cta` case is removed from `EmptyStateType`; only the `filtered` case remains, and its cell now sizes to fit its content exactly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6640090.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->