### PR TITLE
feat(stuff): "See suggested agents" button in empty Stuff state

### DIFF
--- a/Convos/Contacts/ContactsListView.swift
+++ b/Convos/Contacts/ContactsListView.swift
@@ -59,6 +59,7 @@ struct ContactsListView<Row: Identifiable, RowContent: View, SectionHeader: View
                             .listRowSeparator(.hidden)
                     }
                 }
+                .id(section.id)
             }
         }
         .listStyle(.plain)

--- a/Convos/Contacts/ContactsView.swift
+++ b/Convos/Contacts/ContactsView.swift
@@ -15,6 +15,10 @@ struct ContactsView: View {
     /// compose button (whose `onStartConvo` opens the same contacts picker),
     /// so the tab's top bar matches Chats and Stuff exactly.
     private let showsComposeButton: Bool
+    /// Optional request from the shell to scroll the list to a given section
+    /// id once it appears. Used by the "See suggested agents" button in the
+    /// empty Stuff state; consumed (set back to nil) after the scroll lands.
+    private let scrollTarget: Binding<String?>?
 
     init(
         contactsRepository: any ContactsRepositoryProtocol,
@@ -22,7 +26,8 @@ struct ContactsView: View {
         session: (any SessionManagerProtocol)? = nil,
         profileSettingsViewModel: ProfileSettingsViewModel = .shared,
         showsComposeButton: Bool = true,
-        suggestedAgentsService: (any SuggestedAgentsServiceProtocol)? = nil
+        suggestedAgentsService: (any SuggestedAgentsServiceProtocol)? = nil,
+        scrollTarget: Binding<String?>? = nil
     ) {
         _viewModel = State(initialValue: ContactsViewModel(
             contactsRepository: contactsRepository,
@@ -33,6 +38,7 @@ struct ContactsView: View {
         self.session = session
         self.profileSettingsViewModel = profileSettingsViewModel
         self.showsComposeButton = showsComposeButton
+        self.scrollTarget = scrollTarget
     }
 
     var body: some View {
@@ -82,19 +88,28 @@ struct ContactsView: View {
     /// Same `safeAreaBar` treatment the contacts picker and chat
     /// composer use. The search bar floats at the top with iOS 26 glass
     /// blur, and the underlying list's scroll inset is auto-adjusted so
-    /// rows scroll cleanly under the bar.
+    /// rows scroll cleanly under the bar. Wrapped in a `ScrollViewReader`
+    /// so the shell can scroll the list to a section (see `scrollTarget`).
     @ViewBuilder
     private var contactsContent: some View {
-        listOrFilteredEmptyState
-            .background(.colorBackgroundRaisedSecondary)
-            .safeAreaBar(edge: .top) {
-                ContactsSearchBar(
-                    query: $viewModel.searchQuery,
-                    placeholder: "Search contacts",
-                    accessibilityIdentifier: "contacts-search-field",
-                    filter: $viewModel.filter
-                )
-            }
+        ScrollViewReader { proxy in
+            listOrFilteredEmptyState
+                .background(.colorBackgroundRaisedSecondary)
+                .safeAreaBar(edge: .top) {
+                    ContactsSearchBar(
+                        query: $viewModel.searchQuery,
+                        placeholder: "Search contacts",
+                        accessibilityIdentifier: "contacts-search-field",
+                        filter: $viewModel.filter
+                    )
+                }
+                .onChange(of: incomingScrollTarget) { _, target in
+                    handleScrollTargetChange(target, proxy: proxy)
+                }
+                .onChange(of: sectionIDs, initial: true) { _, _ in
+                    scrollToTargetIfPresent(incomingScrollTarget, proxy: proxy)
+                }
+        }
     }
 
     /// Shows the filtered empty state when a search or filter matches nothing,
@@ -123,6 +138,43 @@ struct ContactsView: View {
             Spacer()
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    // MARK: - Scroll to section
+
+    /// The section id the shell has asked us to scroll to, if any.
+    private var incomingScrollTarget: String? {
+        scrollTarget.flatMap(\.wrappedValue)
+    }
+
+    /// Section ids in render order. Watched so a pending scroll request can
+    /// fire once an async-loaded section (e.g. suggested agents) appears.
+    private var sectionIDs: [String] {
+        viewModel.sections.map(\.id)
+    }
+
+    /// Reacts to a new scroll request from the shell. For the suggested-agents
+    /// target, first clears any filter/search that would keep the section
+    /// hidden, then scrolls if it's already present; otherwise the `sectionIDs`
+    /// handler scrolls once the section loads.
+    private func handleScrollTargetChange(_ target: String?, proxy: ScrollViewProxy) {
+        guard let target else { return }
+        if target == SuggestedAgentsSection.id {
+            if !viewModel.filter.includesAgents { viewModel.filter = .all }
+            if !viewModel.searchQuery.isEmpty { viewModel.searchQuery = "" }
+        }
+        scrollToTargetIfPresent(target, proxy: proxy)
+    }
+
+    /// Scrolls to `target` when a matching section exists, then clears the
+    /// request. Deferred one runloop hop so a freshly-inserted section is laid
+    /// out before the scroll.
+    private func scrollToTargetIfPresent(_ target: String?, proxy: ScrollViewProxy) {
+        guard let target, viewModel.sections.contains(where: { $0.id == target }) else { return }
+        Task { @MainActor in
+            withAnimation { proxy.scrollTo(target, anchor: .top) }
+            scrollTarget?.wrappedValue = nil
+        }
     }
 
     @ViewBuilder

--- a/Convos/Conversations List/StuffTabView.swift
+++ b/Convos/Conversations List/StuffTabView.swift
@@ -32,6 +32,10 @@ struct StuffTabView: View {
     /// `MainTabView` aggregates this with the Chats tab's offset to drive
     /// the builder bar's expand/collapse state.
     var onScrollOffsetChange: ((CGFloat) -> Void)?
+    /// Invoked when the user taps "See suggested agents" in the empty state.
+    /// The shell switches to the Contacts tab and scrolls it to the
+    /// "Suggested agents" section. Nil hides the button (e.g. previews).
+    var onSeeSuggestedAgents: (() -> Void)?
     @State private var viewModel: StuffOverviewViewModel
     @State private var pushedConvoVM: ConversationViewModel?
     @State private var focusCoordinator: FocusCoordinator = FocusCoordinator(horizontalSizeClass: nil)
@@ -44,12 +48,14 @@ struct StuffTabView: View {
         appIndicatorContext: AppIndicatorContext,
         conversationsViewModel: ConversationsViewModel,
         pushedItems: Binding<[StuffOverviewItem]>,
-        onScrollOffsetChange: ((CGFloat) -> Void)? = nil
+        onScrollOffsetChange: ((CGFloat) -> Void)? = nil,
+        onSeeSuggestedAgents: (() -> Void)? = nil
     ) {
         self.appIndicatorContext = appIndicatorContext
         self.conversationsViewModel = conversationsViewModel
         _pushedItems = pushedItems
         self.onScrollOffsetChange = onScrollOffsetChange
+        self.onSeeSuggestedAgents = onSeeSuggestedAgents
         _viewModel = State(initialValue: StuffOverviewViewModel(session: conversationsViewModel.session))
     }
 
@@ -156,6 +162,15 @@ struct StuffTabView: View {
                 .font(.subheadline)
                 .foregroundStyle(.colorTextSecondary)
                 .padding(.horizontal, DesignConstants.Spacing.step8x)
+            if let onSeeSuggestedAgents {
+                let action = { onSeeSuggestedAgents() }
+                Button(action: action) {
+                    Text("See suggested agents")
+                }
+                .convosButtonStyle(.rounded(fullWidth: false))
+                .padding(.top, DesignConstants.Spacing.step2x)
+                .accessibilityIdentifier("see-suggested-agents-button")
+            }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(.colorBackgroundSurfaceless)

--- a/Convos/Conversations List/StuffTabView.swift
+++ b/Convos/Conversations List/StuffTabView.swift
@@ -165,7 +165,10 @@ struct StuffTabView: View {
             if let onSeeSuggestedAgents {
                 let action = { onSeeSuggestedAgents() }
                 Button(action: action) {
-                    Text("See suggested agents")
+                    HStack(spacing: DesignConstants.Spacing.stepX) {
+                        Text("See suggested agents")
+                        Image(systemName: "chevron.right")
+                    }
                 }
                 .convosButtonStyle(.rounded(fullWidth: false))
                 .padding(.top, DesignConstants.Spacing.step2x)

--- a/Convos/MainTabView.swift
+++ b/Convos/MainTabView.swift
@@ -39,6 +39,11 @@ struct MainTabView: View {
     /// re-center the pill (mirrors how `stuffPushedItems` lifts the Stuff
     /// path). `ContactsView` pushes onto it via value-based `NavigationLink`s.
     @State private var contactsPath: [Contact] = []
+    /// Section the Contacts tab should scroll to once it appears. Set when the
+    /// user taps "See suggested agents" in the empty Stuff state; `ContactsView`
+    /// consumes it (scrolling to the suggested-agents section once it has
+    /// loaded) and clears it back to nil.
+    @State private var contactsScrollTarget: String?
     /// Whether the top `AgentBuilderBar` is revealed (shown under the nav
     /// bar) versus faded out. Held in state with hysteresis thresholds
     /// rather than derived purely from scroll offset so a bouncy scroll
@@ -234,6 +239,14 @@ struct MainTabView: View {
         presentingCommittedConversation = nil
     }
 
+    /// "See suggested agents" from the empty Stuff state: jump to the Contacts
+    /// tab and ask it to scroll to the suggested-agents section. `ContactsView`
+    /// performs the scroll once the section has loaded, then clears the target.
+    private func showSuggestedAgents() {
+        activeTab = .contacts
+        contactsScrollTarget = SuggestedAgentsSection.id
+    }
+
     var body: some View {
         ZStack {
             tabView
@@ -342,7 +355,8 @@ struct MainTabView: View {
                             if activeTab == .stuff {
                                 updateBuilderBarReveal(forOffset: offset)
                             }
-                        }
+                        },
+                        onSeeSuggestedAgents: showSuggestedAgents
                     )
                 }
             }
@@ -371,7 +385,8 @@ struct MainTabView: View {
             session: conversationsViewModel.session,
             profileSettingsViewModel: profileSettingsViewModel,
             showsComposeButton: false,
-            suggestedAgentsService: SuggestedAgentsService.live()
+            suggestedAgentsService: SuggestedAgentsService.live(),
+            scrollTarget: $contactsScrollTarget
         )
     }
 


### PR DESCRIPTION
## What

When the **Stuff** tab is empty, show a capsule **"See suggested agents"** button below the empty-state text. Tapping it switches to the **Contacts** tab and scrolls to the **Suggested agents** section.

The button reuses the same capsule style as the empty search/filter "Show all" button (`.convosButtonStyle(.rounded(fullWidth: false))`).

## How

- **`StuffTabView`** - new optional `onSeeSuggestedAgents` callback; renders the button in the empty state only when the callback is wired (so previews stay clean). Accessibility id `see-suggested-agents-button`.
- **`MainTabView`** - owns the cross-tab navigation. `showSuggestedAgents()` flips `activeTab` to `.contacts` and sets a `contactsScrollTarget`, passed into `ContactsView` as a `Binding<String?>`.
- **`ContactsView`** - wraps the list in a `ScrollViewReader` and scrolls to the target section. Handles the async-loaded Suggested agents section (scrolls once `sectionIDs` changes, with `initial: true` to cover the case where the section is already present on first mount), and defensively clears a People filter / active search that would otherwise hide the section. Clears the target after the scroll lands.
- **`ContactsListView`** - tags each section with `.id(section.id)` so `scrollTo` can land (shared with the picker; harmless there).

## Testing

- `Convos (Dev)` builds clean (arm64 simulator).
- `swiftlint --strict` passes on all changed files.
- Interactive simulator verification of the scroll landing was not performed; CI runs the `ConvosCore` suite (these are app-target view-only changes that don't touch `ConvosCore`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/961"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783057928&installation_id=128169237&pr_number=961&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F961&signature=bc7d08bd82c394a48787514461bb9f56d58a73ea4c033db282f8908c6dd29a16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add 'See suggested agents' button to empty Stuff state that navigates to the Contacts tab
> - Adds an optional `onSeeSuggestedAgents` callback to [`StuffTabView`](https://github.com/xmtplabs/convos-ios/pull/961/files#diff-acaa9de1d33a863118e006e10a3fbdaad3cd416da8e46a58ba1216781dc47233); when set, a 'See suggested agents' button appears in the empty state.
> - [`MainTabView`](https://github.com/xmtplabs/convos-ios/pull/961/files#diff-2b02f95e9fabdce514b1dd6d74d930ca17fcc2380c7504789454c035484e9d67) wires the button to a `showSuggestedAgents` method that switches to the Contacts tab and sets a `contactsScrollTarget` binding.
> - [`ContactsView`](https://github.com/xmtplabs/convos-ios/pull/961/files#diff-100cced20d6f49dfda46f616cdaf24be3b4023cf85a615bebc4bf2b69fe133cc) accepts a `scrollTarget` binding and wraps its content in a `ScrollViewReader`; when the target is the suggested agents section, it clears any active filters and search before scrolling.
> - [`ContactsListView`](https://github.com/xmtplabs/convos-ios/pull/961/files#diff-15e9a2390eb75db13953cf65bb8b7762eb17a586babab37aced32c7352ff3695) adds stable `.id(section.id)` identifiers to each section to support programmatic scrolling via `ScrollViewProxy.scrollTo`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c46096c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->