### PR TITLE
Paywall: log StoreKit storefront + per-product currency (debug)

### DIFF
--- a/Convos/Subscription/StoreKitSubscriptionService.swift
+++ b/Convos/Subscription/StoreKitSubscriptionService.swift
@@ -50,8 +50,34 @@ public actor StoreKitSubscriptionService: SubscriptionServiceProtocol {
 
     public func availableProducts() async throws -> [PaywallProduct] {
         let storeProducts = try await Product.products(for: SubscriptionProductIDs.all)
+        await logStorefrontDiagnostics(for: storeProducts)
         return storeProducts.compactMap { paywallProduct(from: $0) }
             .sorted { lhs, rhs in lhs.id < rhs.id }
+    }
+
+    /// Diagnostic logging for the "paywall shows USD on a EUR account" class of
+    /// bug. In StoreKit 2, `Product.displayPrice` and
+    /// `priceFormatStyle.currencyCode` are pure renders of whatever storefront
+    /// StoreKit currently resolves for the App Store account in
+    /// Settings ▸ [name] ▸ Media & Purchases — they ignore device region and
+    /// the iCloud account. So when the wrong currency shows, the answer is
+    /// always "what storefront did StoreKit hand us?", which only
+    /// `Storefront.current` can tell us. We log it alongside each product's
+    /// currency so a TestFlight/prod log capture settles whether the cause is a
+    /// US storefront (wrong/stale Media & Purchases account) vs. anything in our
+    /// own formatting (it isn't — we pass StoreKit's values straight through).
+    private func logStorefrontDiagnostics(for products: [Product]) async {
+        if let storefront = await Storefront.current {
+            Log.info("StoreKit storefront: \(storefront.countryCode) (id=\(storefront.id))")
+        } else {
+            Log.info("StoreKit storefront: nil — no App Store account signed in, or not yet loaded")
+        }
+        for product in products {
+            Log.info(
+                "StoreKit product \(product.id): displayPrice=\(product.displayPrice) " +
+                "currency=\(product.priceFormatStyle.currencyCode) price=\(product.price)"
+            )
+        }
     }
 
     public func purchase(productId: String) async throws {


### PR DESCRIPTION
## Why

Investigating the report that the subscription paywall shows **USD prices on a FR/DE App Store account paying in EUR**, in TestFlight/prod builds.

Deep dive conclusion: our SK2 code is correct and **identical to how RevenueCat derives displayed price/currency** — we pass `product.displayPrice` and `product.priceFormatStyle.currencyCode` straight through, with no hardcoded locale anywhere in the subscription/paywall code. In StoreKit 2 both of those are pure renders of whichever **storefront** StoreKit resolves for the **Media & Purchases** account (Settings ▸ [name] ▸ Media & Purchases). They ignore device region and the iCloud account.

So the only unknown is: **what storefront did StoreKit actually hand us?** — which only `Storefront.current` can answer, and which the app never logged.

## What

In `StoreKitSubscriptionService.availableProducts()`, log at fetch time:
- `Storefront.current` → `countryCode` + `id` (e.g. `USA` vs `FRA`/`DEU`)
- each product's `displayPrice`, `priceFormatStyle.currencyCode`, and `price`

## How to read the logs

- `Storefront … USA` → the storefront itself is US → wrong/stale Media & Purchases account (or OS storefront cache not refreshed after a country change). Our formatting is exonerated.
- `Storefront … FRA/DEU` but `displayPrice` still USD → genuine anomaly → reinstall to drop StoreKit 2's per-process product cache, and check FR/DE pricing/availability in App Store Connect.

## Notes

- **Logging only — no behavior change.**
- Passes pre-commit (SwiftFormat + SwiftLint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/962"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783074755&installation_id=128169237&pr_number=962&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F962&signature=4c8d3c45d0a3221604a09eea2ee3c253344475acf55c89aaa3d17fb8e71f8938"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Log StoreKit storefront and per-product currency in debug diagnostics
> Adds a new private `logStorefrontDiagnostics` method to `StoreKitSubscriptionService` that logs the current storefront (`countryCode`, `id`) and each product's `id`, `displayPrice`, `currencyCode`, and `price`. This method is called in `availableProducts` immediately after fetching products from StoreKit, with no changes to the returned list or sorting logic.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4cdc977.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->