### PR TITLE
Forward existing entitlements to backend; harden mock-toggle gating (CON-386)

### DIFF
--- a/Convos/Subscription/StoreKitSubscriptionService.swift
+++ b/Convos/Subscription/StoreKitSubscriptionService.swift
@@ -24,6 +24,10 @@ public actor StoreKitSubscriptionService: SubscriptionServiceProtocol {
     /// rules; no concurrent mutation happens past init.
     nonisolated(unsafe) private var updateListenerTask: Task<Void, Never>?
     private var lastFetchedAt: Date?
+    /// Transaction IDs we've already forwarded to `POST /subscription/verify`
+    /// in this process. See `refreshFromEntitlements()` for why per-launch
+    /// forwarding (not persisted) is the right granularity.
+    private var forwardedTransactionIds: Set<UInt64> = []
 
     public init(apiClient: any ConvosAPIClientProtocol) {
         self.apiClient = apiClient
@@ -174,13 +178,19 @@ public actor StoreKitSubscriptionService: SubscriptionServiceProtocol {
     /// payload itself, authenticates the caller via JWT, and refuses cross-
     /// account binding attempts — so the iOS side only needs to pass the JWS.
     ///
-    /// Failures are logged but do not fail the local purchase —
-    /// `Transaction.currentEntitlements` is still authoritative for UI state.
-    private func sendToBackendVerify(jwsRepresentation: String, transactionId: UInt64) async {
+    /// Returns `true` on success so callers that track forwarded transactions
+    /// (`refreshFromEntitlements`) can retry on the next refresh after a
+    /// transient failure instead of waiting for an app relaunch. Failures
+    /// are logged but never propagate — `Transaction.currentEntitlements`
+    /// is still authoritative for local UI state.
+    @discardableResult
+    private func sendToBackendVerify(jwsRepresentation: String, transactionId: UInt64) async -> Bool {
         do {
             _ = try await apiClient.verifySubscription(jwsRepresentation: jwsRepresentation)
+            return true
         } catch {
             Log.error("Backend verify failed for transaction \(transactionId): \(error)")
+            return false
         }
     }
 
@@ -195,12 +205,51 @@ public actor StoreKitSubscriptionService: SubscriptionServiceProtocol {
 
     private func refreshFromEntitlements() async {
         var latest: UserSubscription?
+        var forwardedAnyEntitlement: Bool = false
         for await result in Transaction.currentEntitlements {
             guard let transaction = try? verifiedTransaction(result) else { continue }
+            // Forward each entitlement to the backend at most once per
+            // process. Covers entitlements iOS reads locally that the
+            // backend doesn't know about yet:
+            //   - App Store install carried over into TestFlight (different
+            //     backend than the original purchase landed against).
+            //   - `restorePurchases()`.
+            //   - Family Sharing / parental purchase flows.
+            //   - Fresh install signing in to an account that bought Plus
+            //     elsewhere.
+            //   - Any past purchase whose verify roundtrip lost the race
+            //     with a network blip or backend error.
+            // The verify endpoint is idempotent on `originalTransactionId`,
+            // so the server already deduplicates; the in-memory set just
+            // avoids hammering it every refresh (TTL is 15s).
+            if !forwardedTransactionIds.contains(transaction.id) {
+                let succeeded = await sendToBackendVerify(
+                    jwsRepresentation: result.jwsRepresentation,
+                    transactionId: transaction.id
+                )
+                // Only mark forwarded on success so a transient failure
+                // (network blip, transient 5xx, backend deploy in flight)
+                // retries on the next refresh tick rather than waiting for
+                // an app relaunch.
+                if succeeded {
+                    forwardedTransactionIds.insert(transaction.id)
+                    forwardedAnyEntitlement = true
+                }
+            }
             guard let sub = await userSubscription(from: transaction) else { continue }
             latest = sub
         }
         subscriptionSubject.send(latest)
+        // If the backend just learned about an entitlement it didn't
+        // previously have, its `GET /credits` answer changes (tier-based
+        // grant kicks in). Force-refresh credits so the local depleted
+        // state flips without waiting for the next TTL window or pull-to-
+        // refresh. Without this, App Store -> TestFlight users see Plus
+        // in the UI but agents stuck in "No Power" until they manually
+        // refresh.
+        if forwardedAnyEntitlement {
+            await CreditsServices.shared.refresh(force: true)
+        }
     }
 
     private func verifiedTransaction<T>(_ result: VerificationResult<T>) throws -> T {

--- a/Convos/Subscription/SubscriptionServices.swift
+++ b/Convos/Subscription/SubscriptionServices.swift
@@ -9,18 +9,22 @@ enum SubscriptionServices {
     static var useRealStoreKit: Bool {
         let environment = ConfigManager.shared.currentEnvironment
         if environment.isProduction { return true }
+        // The UserDefaults override is intentionally DEBUG-only. On
+        // Release builds (TestFlight / App Store / Ad-Hoc) we always
+        // return the build-config default below so a stored `false`
+        // from a previous Debug build on the same device can't quietly
+        // pin a TestFlight tester to the mock service — UserDefaults
+        // survives reinstalls under the same bundle ID. The Debug menu
+        // toggle still works in Debug builds (where it's reachable).
+        #if DEBUG
         if let stored = UserDefaults.standard.object(forKey: Constant.useRealStoreKitKey) as? Bool {
             return stored
         }
-        // Mirror `CreditsServices.useRealBackend`: `buildEnvironment ==
-        // .distribution` reports false on TestFlight because TestFlight
-        // builds ship `embedded.mobileprovision` and so classify as
-        // `.development`. Use the build configuration instead so
-        // TestFlight / App Store / Ad-Hoc default to real StoreKit while
-        // local Xcode runs default to the mock.
-        #if DEBUG
         return false
         #else
+        // TestFlight builds ship `embedded.mobileprovision` and classify
+        // as `.development` per buildEnvironment, so we anchor on the
+        // build configuration instead: Release == real StoreKit.
         return true
         #endif
     }

--- a/ConvosCore/Sources/ConvosCore/Services/Credits/CreditsServices.swift
+++ b/ConvosCore/Sources/ConvosCore/Services/Credits/CreditsServices.swift
@@ -44,20 +44,25 @@ public enum CreditsServices {
     public static var useRealBackend: Bool {
         let environment = ConfigManager.shared.currentEnvironment
         if environment.isProduction { return true }
+        // The UserDefaults override is intentionally DEBUG-only. On
+        // Release builds (TestFlight / App Store / Ad-Hoc) we always
+        // return the build-config default below so a stored `false`
+        // from a previous Debug build on the same device can't quietly
+        // pin a TestFlight tester to the mock service — UserDefaults
+        // survives reinstalls under the same bundle ID. The Debug menu
+        // toggle still works in Debug builds (where it's reachable).
+        #if DEBUG
         if let stored = UserDefaults.standard.object(forKey: Constant.useRealBackendKey) as? Bool {
             return stored
         }
+        return false
+        #else
         // The previous `buildEnvironment == .distribution` check relied on
         // `hasEmbeddedMobileProvision()` returning `false`, but TestFlight
         // builds also ship `embedded.mobileprovision` — so they were being
         // classified as `.development` and silently falling back to the
-        // mock. Use the build configuration instead: Debug builds are local
-        // engineering runs (default to mock so HTTP isn't hit during
-        // iteration); Release builds are TestFlight / App Store / Ad-Hoc
-        // (default to the real backend so testers see production behavior).
-        #if DEBUG
-        return false
-        #else
+        // mock. Anchor on the build configuration instead: Release builds
+        // (TestFlight / App Store / Ad-Hoc) hit the real backend.
         return true
         #endif
     }


### PR DESCRIPTION
Fixes [CON-386](https://linear.app/convos/issue/CON-386/plus-upgrade-leaves-agents-in-no-power-state) on the iOS side. Pairs with the backend cert-bundling fix being shipped separately.

## Summary

Two related fixes for the "Plus upgrade leaves agents in No Power state" report.

### 1. Forward locally-known entitlements to backend on refresh

`StoreKitSubscriptionService.refreshFromEntitlements()` previously read `Transaction.currentEntitlements` and only published the subscription to the local Combine subject. It never POSTed to `/v2/accounts/me/subscription/verify`, so any entitlement iOS already held on launch was invisible to the backend, which meant `GET /credits` returned the free-tier daily-cap shape (`balance: 0, monthlyGrant: 100`) and the UI flipped to "No Power" even though the subscription pill correctly showed Plus.

Cases where this happens:

- App Store install carried over into TestFlight (install keeps the entitlement but lands against a different backend than the original purchase)
- `restorePurchases()`
- Family Sharing / parental purchase flows
- Fresh install signing in to a Convos account that bought Plus on a different device
- Any past purchase whose verify roundtrip failed at the time (network blip, transient backend error, or the recent cert-bundling bug on otr-dev/otr-prod)

`refreshFromEntitlements()` now forwards each verified entitlement to the backend at most once per process via `sendToBackendVerify`, tracked in a new `forwardedTransactionIds: Set<UInt64>`. The verify endpoint is idempotent on `originalTransactionId` (backend already deduplicates via the `appleReceipt` unique constraint), so the in-memory set just avoids re-POSTing on every TTL refresh.

When a forward happens, force-refresh `CreditsServices.shared` so the depleted state flips without waiting for the next 15s TTL or pull-to-refresh.

The set is intentionally per-process (not persisted): relaunch retries everything, which is the right behavior when a backend error caused the previous attempt to fail silently — the user just needs to launch the app again after the backend is fixed.

### 2. Move debug-only mock toggle behind \`#if DEBUG\`

\`SubscriptionServices.useRealStoreKit\` and \`CreditsServices.useRealBackend\` each read a \`UserDefaults\` override ahead of the \`#if DEBUG\` build-config fallback. UserDefaults survives reinstalls under the same bundle ID, so a stored \`false\` from any prior Debug build silently pinned later Release builds (TestFlight / App Store / Ad-Hoc on the same device) to the mock service — explaining why a Dev TestFlight tester could end up with no backend traffic at all.

Wrap both UserDefaults reads in \`#if DEBUG\` so Release builds always take the build-config path (\`return true\`). The Debug menu toggle still works in Debug builds where it's reachable; it just no longer leaks into Release-config installs.

## Test plan

- [x] On Dev TestFlight: install fresh, sign in to an account that already has Plus → agent should show Power within seconds (entitlement forwarded on launch + credits refreshed)
- [x] On Dev TestFlight: \`restorePurchases()\` from Subscription Settings → confirms Subscription row written on backend
- [x] On Dev (Xcode) with mock toggles off → flip both toggles to true → real Apple sheet appears on Upgrade → backend gets Subscription row
- [x] Cycle launch a few times while logging — confirm we don't spam \`/subscription/verify\` (per-process dedup working)
- [x] On Release-config build with a previously-stored \`useRealStoreKit = false\` UserDefaults → confirm Release ignores it and uses real StoreKit

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/963"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783083817&installation_id=128169237&pr_number=963&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F963&signature=fa22f4cbcc88e99f9b41eb63a29e80103d720eca038f0a267aec4f91c1e19dc0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Forward existing StoreKit entitlements to backend and harden mock-toggle gating
> - `StoreKitSubscriptionService.refreshFromEntitlements` now forwards each entitlement to the backend at most once per app launch using a `forwardedTransactionIds` set; retries occur on subsequent refreshes after transient failures.
> - After any successful entitlement forward, a forced credits refresh is triggered via `CreditsServices.shared.refresh(force: true)`.
> - `sendToBackendVerify` now returns a `Bool` so callers can distinguish success from failure without throwing.
> - `SubscriptionServices.useRealStoreKit` and `CreditsServices.useRealBackend` now ignore UserDefaults overrides in Release builds, always defaulting to real StoreKit/backend; DEBUG builds default to mocks unless overridden.
> - Behavioral Change: any persisted debug override that previously forced mock behavior in TestFlight/App Store builds is now ignored.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e0e0672.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->