### PR TITLE
fix: Last known subscription for flicker free launch

### DIFF
--- a/Convos/Subscription/StoreKitSubscriptionService.swift
+++ b/Convos/Subscription/StoreKitSubscriptionService.swift
@@ -24,6 +24,10 @@ public actor StoreKitSubscriptionService: SubscriptionServiceProtocol {
     /// rules; no concurrent mutation happens past init.
     nonisolated(unsafe) private var updateListenerTask: Task<Void, Never>?
     private var lastFetchedAt: Date?
+    /// Transaction IDs we've already forwarded to `POST /subscription/verify`
+    /// in this process. See `refreshFromEntitlements()` for why per-launch
+    /// forwarding (not persisted) is the right granularity.
+    private var forwardedTransactionIds: Set<UInt64> = []
 
     public init(apiClient: any ConvosAPIClientProtocol) {
         self.apiClient = apiClient
@@ -174,13 +178,19 @@ public actor StoreKitSubscriptionService: SubscriptionServiceProtocol {
     /// payload itself, authenticates the caller via JWT, and refuses cross-
     /// account binding attempts — so the iOS side only needs to pass the JWS.
     ///
-    /// Failures are logged but do not fail the local purchase —
-    /// `Transaction.currentEntitlements` is still authoritative for UI state.
-    private func sendToBackendVerify(jwsRepresentation: String, transactionId: UInt64) async {
+    /// Returns `true` on success so callers that track forwarded transactions
+    /// (`refreshFromEntitlements`) can retry on the next refresh after a
+    /// transient failure instead of waiting for an app relaunch. Failures
+    /// are logged but never propagate — `Transaction.currentEntitlements`
+    /// is still authoritative for local UI state.
+    @discardableResult
+    private func sendToBackendVerify(jwsRepresentation: String, transactionId: UInt64) async -> Bool {
         do {
             _ = try await apiClient.verifySubscription(jwsRepresentation: jwsRepresentation)
+            return true
         } catch {
             Log.error("Backend verify failed for transaction \(transactionId): \(error)")
+            return false
         }
     }
 
@@ -195,12 +205,51 @@ public actor StoreKitSubscriptionService: SubscriptionServiceProtocol {
 
     private func refreshFromEntitlements() async {
         var latest: UserSubscription?
+        var forwardedAnyEntitlement: Bool = false
         for await result in Transaction.currentEntitlements {
             guard let transaction = try? verifiedTransaction(result) else { continue }
+            // Forward each entitlement to the backend at most once per
+            // process. Covers entitlements iOS reads locally that the
+            // backend doesn't know about yet:
+            //   - App Store install carried over into TestFlight (different
+            //     backend than the original purchase landed against).
+            //   - `restorePurchases()`.
+            //   - Family Sharing / parental purchase flows.
+            //   - Fresh install signing in to an account that bought Plus
+            //     elsewhere.
+            //   - Any past purchase whose verify roundtrip lost the race
+            //     with a network blip or backend error.
+            // The verify endpoint is idempotent on `originalTransactionId`,
+            // so the server already deduplicates; the in-memory set just
+            // avoids hammering it every refresh (TTL is 15s).
+            if !forwardedTransactionIds.contains(transaction.id) {
+                let succeeded = await sendToBackendVerify(
+                    jwsRepresentation: result.jwsRepresentation,
+                    transactionId: transaction.id
+                )
+                // Only mark forwarded on success so a transient failure
+                // (network blip, transient 5xx, backend deploy in flight)
+                // retries on the next refresh tick rather than waiting for
+                // an app relaunch.
+                if succeeded {
+                    forwardedTransactionIds.insert(transaction.id)
+                    forwardedAnyEntitlement = true
+                }
+            }
             guard let sub = await userSubscription(from: transaction) else { continue }
             latest = sub
         }
         subscriptionSubject.send(latest)
+        // If the backend just learned about an entitlement it didn't
+        // previously have, its `GET /credits` answer changes (tier-based
+        // grant kicks in). Force-refresh credits so the local depleted
+        // state flips without waiting for the next TTL window or pull-to-
+        // refresh. Without this, App Store -> TestFlight users see Plus
+        // in the UI but agents stuck in "No Power" until they manually
+        // refresh.
+        if forwardedAnyEntitlement {
+            await CreditsServices.shared.refresh(force: true)
+        }
     }
 
     private func verifiedTransaction<T>(_ result: VerificationResult<T>) throws -> T {

--- a/Convos/Subscription/StoreKitSubscriptionService.swift
+++ b/Convos/Subscription/StoreKitSubscriptionService.swift
@@ -31,7 +31,16 @@ public actor StoreKitSubscriptionService: SubscriptionServiceProtocol {
 
     public init(apiClient: any ConvosAPIClientProtocol) {
         self.apiClient = apiClient
-        self.subscriptionSubject = CurrentValueSubject(nil)
+        // Seed the subject with the last persisted snapshot so the first
+        // UI render after launch shows the user's actual tier (the common
+        // case) instead of flashing "Basic" for the few hundred ms it
+        // takes `refreshFromEntitlements()` to round-trip Apple +
+        // backend. `BackendCreditsService` already has this behavior for
+        // credits via its GRDB-backed read; subscriptions had no
+        // equivalent cache, which is why the HOME pill flickered Basic →
+        // Plus at every cold start. The cache is corrected by every
+        // subsequent publish (refresh / purchase / Apple update).
+        self.subscriptionSubject = CurrentValueSubject(Self.loadCachedSubscription())
         let listenerTask = Task.detached { [weak self] in
             guard let self else { return }
             await self.refreshFromEntitlements()
@@ -42,6 +51,16 @@ public actor StoreKitSubscriptionService: SubscriptionServiceProtocol {
 
     deinit {
         updateListenerTask?.cancel()
+    }
+
+    /// Single funnel for every subscription-state publish. Sends on the
+    /// in-memory subject (drives `subscriptionPublisher` / UI bindings)
+    /// AND writes through to UserDefaults so the next cold start can
+    /// seed the subject without flickering through nil. Use everywhere
+    /// instead of touching `subscriptionSubject` directly.
+    private func publish(_ subscription: UserSubscription?) {
+        subscriptionSubject.send(subscription)
+        Self.saveCachedSubscription(subscription)
     }
 
     nonisolated public var subscriptionPublisher: AnyPublisher<UserSubscription?, Never> {
@@ -110,7 +129,7 @@ public actor StoreKitSubscriptionService: SubscriptionServiceProtocol {
             // catches up; periodic foreground `refresh()` calls reconcile
             // beyond that.
             if let sub = await userSubscription(from: transaction) {
-                subscriptionSubject.send(sub)
+                publish(sub)
             }
             // Force a credits refresh: the tier just changed (or was set for
             // the first time), so `monthlyGrant` derived from
@@ -162,7 +181,7 @@ public actor StoreKitSubscriptionService: SubscriptionServiceProtocol {
             // revocations, where `userSubscription(from:)` returns a
             // non-nil snapshot with status `.revoked` or `.expired`.
             if let sub = await userSubscription(from: transaction) {
-                subscriptionSubject.send(sub)
+                publish(sub)
             }
             // Apple-side transition (renew, refund, tier change) → tier or
             // status may have changed → credits need to re-derive from the
@@ -239,7 +258,7 @@ public actor StoreKitSubscriptionService: SubscriptionServiceProtocol {
             guard let sub = await userSubscription(from: transaction) else { continue }
             latest = sub
         }
-        subscriptionSubject.send(latest)
+        publish(latest)
         // If the backend just learned about an entitlement it didn't
         // previously have, its `GET /credits` answer changes (tier-based
         // grant kicks in). Force-refresh credits so the local depleted
@@ -388,5 +407,31 @@ public actor StoreKitSubscriptionService: SubscriptionServiceProtocol {
 
     private enum Constant {
         static let appAccountTokenKey: String = "storeKit.appAccountToken"
+        static let lastKnownSubscriptionKey: String = "storeKit.lastKnownSubscription"
+    }
+
+    /// Persist the most recently published subscription snapshot so the next
+    /// app launch can seed its initial UI state without waiting for the
+    /// async `refreshFromEntitlements()` round-trip. Cleared (set to nil)
+    /// when the user no longer has an entitlement so the cached "Plus"
+    /// doesn't outlive the actual subscription.
+    private static func saveCachedSubscription(_ subscription: UserSubscription?) {
+        let defaults = UserDefaults.standard
+        guard let subscription else {
+            defaults.removeObject(forKey: Constant.lastKnownSubscriptionKey)
+            return
+        }
+        guard let data = try? JSONEncoder().encode(subscription) else {
+            defaults.removeObject(forKey: Constant.lastKnownSubscriptionKey)
+            return
+        }
+        defaults.set(data, forKey: Constant.lastKnownSubscriptionKey)
+    }
+
+    private static func loadCachedSubscription() -> UserSubscription? {
+        guard let data = UserDefaults.standard.data(forKey: Constant.lastKnownSubscriptionKey) else {
+            return nil
+        }
+        return try? JSONDecoder().decode(UserSubscription.self, from: data)
     }
 }

--- a/Convos/Subscription/SubscriptionServices.swift
+++ b/Convos/Subscription/SubscriptionServices.swift
@@ -9,18 +9,22 @@ enum SubscriptionServices {
     static var useRealStoreKit: Bool {
         let environment = ConfigManager.shared.currentEnvironment
         if environment.isProduction { return true }
+        // The UserDefaults override is intentionally DEBUG-only. On
+        // Release builds (TestFlight / App Store / Ad-Hoc) we always
+        // return the build-config default below so a stored `false`
+        // from a previous Debug build on the same device can't quietly
+        // pin a TestFlight tester to the mock service — UserDefaults
+        // survives reinstalls under the same bundle ID. The Debug menu
+        // toggle still works in Debug builds (where it's reachable).
+        #if DEBUG
         if let stored = UserDefaults.standard.object(forKey: Constant.useRealStoreKitKey) as? Bool {
             return stored
         }
-        // Mirror `CreditsServices.useRealBackend`: `buildEnvironment ==
-        // .distribution` reports false on TestFlight because TestFlight
-        // builds ship `embedded.mobileprovision` and so classify as
-        // `.development`. Use the build configuration instead so
-        // TestFlight / App Store / Ad-Hoc default to real StoreKit while
-        // local Xcode runs default to the mock.
-        #if DEBUG
         return false
         #else
+        // TestFlight builds ship `embedded.mobileprovision` and classify
+        // as `.development` per buildEnvironment, so we anchor on the
+        // build configuration instead: Release == real StoreKit.
         return true
         #endif
     }

--- a/ConvosCore/Sources/ConvosCore/Services/Credits/CreditsServices.swift
+++ b/ConvosCore/Sources/ConvosCore/Services/Credits/CreditsServices.swift
@@ -44,20 +44,25 @@ public enum CreditsServices {
     public static var useRealBackend: Bool {
         let environment = ConfigManager.shared.currentEnvironment
         if environment.isProduction { return true }
+        // The UserDefaults override is intentionally DEBUG-only. On
+        // Release builds (TestFlight / App Store / Ad-Hoc) we always
+        // return the build-config default below so a stored `false`
+        // from a previous Debug build on the same device can't quietly
+        // pin a TestFlight tester to the mock service — UserDefaults
+        // survives reinstalls under the same bundle ID. The Debug menu
+        // toggle still works in Debug builds (where it's reachable).
+        #if DEBUG
         if let stored = UserDefaults.standard.object(forKey: Constant.useRealBackendKey) as? Bool {
             return stored
         }
+        return false
+        #else
         // The previous `buildEnvironment == .distribution` check relied on
         // `hasEmbeddedMobileProvision()` returning `false`, but TestFlight
         // builds also ship `embedded.mobileprovision` — so they were being
         // classified as `.development` and silently falling back to the
-        // mock. Use the build configuration instead: Debug builds are local
-        // engineering runs (default to mock so HTTP isn't hit during
-        // iteration); Release builds are TestFlight / App Store / Ad-Hoc
-        // (default to the real backend so testers see production behavior).
-        #if DEBUG
-        return false
-        #else
+        // mock. Anchor on the build configuration instead: Release builds
+        // (TestFlight / App Store / Ad-Hoc) hit the real backend.
         return true
         #endif
     }


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/964"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783092938&installation_id=128169237&pr_number=964&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F964&signature=348df772f398ab6fc1332b6904f74767f97847065a2d2e03a0a2f15b117d49d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Cache last known subscription on disk for flicker-free app launch
> - `StoreKitSubscriptionService` now seeds its subscription publisher with a previously persisted snapshot via `loadCachedSubscription()` at init, so the app reflects the last known subscription tier immediately on launch instead of starting at `nil`.
> - A new `publish(_:)` helper saves every subscription update to UserDefaults so the cache stays current across launches.
> - `refreshFromEntitlements` forwards each verified entitlement's JWS to the backend at most once per process, retrying on transient failures, and triggers a credits refresh when new entitlements are forwarded.
> - Debug-only overrides for `useRealStoreKit` and `useRealBackend` are now guarded by `#if DEBUG`, ensuring Release builds always use real StoreKit and the real backend regardless of any persisted override.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e7b6a2f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->