### PR TITLE
Cache last-known subscription so the HOME pill doesn't flicker Basic on launch

### DIFF
--- a/Convos/Subscription/StoreKitSubscriptionService.swift
+++ b/Convos/Subscription/StoreKitSubscriptionService.swift
@@ -31,7 +31,16 @@ public actor StoreKitSubscriptionService: SubscriptionServiceProtocol {
 
     public init(apiClient: any ConvosAPIClientProtocol) {
         self.apiClient = apiClient
-        self.subscriptionSubject = CurrentValueSubject(nil)
+        // Seed the subject with the last persisted snapshot so the first
+        // UI render after launch shows the user's actual tier (the common
+        // case) instead of flashing "Basic" for the few hundred ms it
+        // takes `refreshFromEntitlements()` to round-trip Apple +
+        // backend. `BackendCreditsService` already has this behavior for
+        // credits via its GRDB-backed read; subscriptions had no
+        // equivalent cache, which is why the HOME pill flickered Basic →
+        // Plus at every cold start. The cache is corrected by every
+        // subsequent publish (refresh / purchase / Apple update).
+        self.subscriptionSubject = CurrentValueSubject(Self.loadCachedSubscription())
         let listenerTask = Task.detached { [weak self] in
             guard let self else { return }
             await self.refreshFromEntitlements()
@@ -42,6 +51,16 @@ public actor StoreKitSubscriptionService: SubscriptionServiceProtocol {
 
     deinit {
         updateListenerTask?.cancel()
+    }
+
+    /// Single funnel for every subscription-state publish. Sends on the
+    /// in-memory subject (drives `subscriptionPublisher` / UI bindings)
+    /// AND writes through to UserDefaults so the next cold start can
+    /// seed the subject without flickering through nil. Use everywhere
+    /// instead of touching `subscriptionSubject` directly.
+    private func publish(_ subscription: UserSubscription?) {
+        subscriptionSubject.send(subscription)
+        Self.saveCachedSubscription(subscription)
     }
 
     nonisolated public var subscriptionPublisher: AnyPublisher<UserSubscription?, Never> {
@@ -110,7 +129,7 @@ public actor StoreKitSubscriptionService: SubscriptionServiceProtocol {
             // catches up; periodic foreground `refresh()` calls reconcile
             // beyond that.
             if let sub = await userSubscription(from: transaction) {
-                subscriptionSubject.send(sub)
+                publish(sub)
             }
             // Force a credits refresh: the tier just changed (or was set for
             // the first time), so `monthlyGrant` derived from
@@ -162,7 +181,7 @@ public actor StoreKitSubscriptionService: SubscriptionServiceProtocol {
             // revocations, where `userSubscription(from:)` returns a
             // non-nil snapshot with status `.revoked` or `.expired`.
             if let sub = await userSubscription(from: transaction) {
-                subscriptionSubject.send(sub)
+                publish(sub)
             }
             // Apple-side transition (renew, refund, tier change) → tier or
             // status may have changed → credits need to re-derive from the
@@ -239,7 +258,7 @@ public actor StoreKitSubscriptionService: SubscriptionServiceProtocol {
             guard let sub = await userSubscription(from: transaction) else { continue }
             latest = sub
         }
-        subscriptionSubject.send(latest)
+        publish(latest)
         // If the backend just learned about an entitlement it didn't
         // previously have, its `GET /credits` answer changes (tier-based
         // grant kicks in). Force-refresh credits so the local depleted
@@ -388,5 +407,36 @@ public actor StoreKitSubscriptionService: SubscriptionServiceProtocol {
 
     private enum Constant {
         static let appAccountTokenKey: String = "storeKit.appAccountToken"
+        static let lastKnownSubscriptionKey: String = "storeKit.lastKnownSubscription"
+    }
+
+    /// Persist the most recently published subscription snapshot so the next
+    /// app launch can seed its initial UI state without waiting for the
+    /// async `refreshFromEntitlements()` round-trip. Cleared (set to nil)
+    /// when the user no longer has an entitlement so the cached "Plus"
+    /// doesn't outlive the actual subscription.
+    ///
+    /// `internal` rather than `private` so unit tests can exercise the
+    /// cache round-trip directly without driving a full StoreKit purchase
+    /// flow. The type as a whole is `internal` so this doesn't widen the
+    /// public surface.
+    static func saveCachedSubscription(_ subscription: UserSubscription?) {
+        let defaults = UserDefaults.standard
+        guard let subscription else {
+            defaults.removeObject(forKey: Constant.lastKnownSubscriptionKey)
+            return
+        }
+        guard let data = try? JSONEncoder().encode(subscription) else {
+            defaults.removeObject(forKey: Constant.lastKnownSubscriptionKey)
+            return
+        }
+        defaults.set(data, forKey: Constant.lastKnownSubscriptionKey)
+    }
+
+    static func loadCachedSubscription() -> UserSubscription? {
+        guard let data = UserDefaults.standard.data(forKey: Constant.lastKnownSubscriptionKey) else {
+            return nil
+        }
+        return try? JSONDecoder().decode(UserSubscription.self, from: data)
     }
 }

--- a/ConvosTests/StoreKitSubscriptionServiceCacheTests.swift
+++ b/ConvosTests/StoreKitSubscriptionServiceCacheTests.swift
@@ -1,0 +1,101 @@
+@testable import Convos
+import ConvosCore
+import Foundation
+import XCTest
+
+/// Covers the persisted-subscription cache added so the HOME pill doesn't
+/// flicker `Basic` -> `Plus` on every cold start. The cache lives in
+/// `UserDefaults.standard` under `Constant.lastKnownSubscriptionKey`; the
+/// service reads it on `init` to seed `subscriptionSubject`, and writes
+/// through to it on every `publish(_:)`.
+///
+/// We test the static `saveCachedSubscription` / `loadCachedSubscription`
+/// pair directly because that's the entire cache surface. The init's
+/// seeding (`CurrentValueSubject(Self.loadCachedSubscription())`) is a
+/// single line of glue; testing it independently would require either
+/// promoting `MockAPIClient` to public or stubbing all 59 protocol
+/// methods inline. Round-trip + decode-failure coverage on the static
+/// helpers is enough to keep the seeding behavior honest.
+final class StoreKitSubscriptionServiceCacheTests: XCTestCase {
+    /// `UserDefaults.standard` is process-wide; any leftover value would
+    /// poison other tests in this file (and any others touching the same
+    /// key). Clear before each test and after, regardless of which path
+    /// the test exercises.
+    private static let cacheKey: String = "storeKit.lastKnownSubscription"
+
+    override func setUp() {
+        super.setUp()
+        UserDefaults.standard.removeObject(forKey: Self.cacheKey)
+    }
+
+    override func tearDown() {
+        UserDefaults.standard.removeObject(forKey: Self.cacheKey)
+        super.tearDown()
+    }
+
+    func testSaveCachedSubscription_persistsRoundTrip() {
+        let original: UserSubscription = makeSubscription()
+        StoreKitSubscriptionService.saveCachedSubscription(original)
+
+        let roundTripped: UserSubscription? = StoreKitSubscriptionService.loadCachedSubscription()
+
+        XCTAssertEqual(
+            roundTripped,
+            original,
+            "saveCachedSubscription -> loadCachedSubscription must preserve the full UserSubscription shape so the init seeding can hand the cached value back to SwiftUI on the next launch"
+        )
+    }
+
+    func testSaveCachedSubscription_nilClearsCache() {
+        // Seed the cache, then clear it via the nil-write path. This is
+        // the path `refreshFromEntitlements()` takes when the user no
+        // longer has an entitlement (cancelled, refunded, expired); the
+        // cache must follow so the next cold launch doesn't seed a stale
+        // "Plus" that outlives the actual subscription.
+        StoreKitSubscriptionService.saveCachedSubscription(makeSubscription())
+        XCTAssertNotNil(StoreKitSubscriptionService.loadCachedSubscription())
+
+        StoreKitSubscriptionService.saveCachedSubscription(nil)
+
+        XCTAssertNil(
+            StoreKitSubscriptionService.loadCachedSubscription(),
+            "Writing nil must clear the cache; otherwise the cancelled subscription would re-flash on next launch"
+        )
+    }
+
+    func testLoadCachedSubscription_emptyCacheReturnsNil() {
+        // setUp already cleared the key; this just makes the contract
+        // explicit so the test name documents what `loadCachedSubscription`
+        // returns when there's nothing to load (vs corrupt bytes).
+        XCTAssertNil(
+            StoreKitSubscriptionService.loadCachedSubscription(),
+            "An empty cache must return nil so init falls through to the historical pre-cache behavior"
+        )
+    }
+
+    func testLoadCachedSubscription_corruptDataReturnsNil() {
+        // Anyone fiddling with UserDefaults externally — or a future
+        // `UserSubscription` model-shape change between app versions —
+        // could leave the key holding bytes we can't decode. Must not
+        // crash on startup; must surface as "no cached value" so the
+        // next refresh re-establishes truth.
+        UserDefaults.standard.set(Data("not a UserSubscription".utf8), forKey: Self.cacheKey)
+
+        XCTAssertNil(
+            StoreKitSubscriptionService.loadCachedSubscription(),
+            "loadCachedSubscription must return nil (not throw / crash) on corrupt bytes so a malformed cache can't take down the app at launch"
+        )
+    }
+
+    private func makeSubscription() -> UserSubscription {
+        UserSubscription(
+            tier: .plus,
+            period: .monthly,
+            status: .active,
+            productId: "app.convos.subs.monthly",
+            currentPeriodEnd: Date(timeIntervalSince1970: 1_780_000_000),
+            willRenew: true,
+            isInTrial: false
+        )
+    }
+}


### PR DESCRIPTION
Stacked on top of #963.

## Problem

On cold start the HOME-top-left "Convos" pill shows **Basic** for a few hundred ms before flipping to **Plus**. The flicker is a real cold-start race:

\`StoreKitSubscriptionService.subscriptionSubject\` initializes to \`nil\`, and the subject is only filled later by a detached \`refreshFromEntitlements()\` task that round-trips Apple's \`Transaction.currentEntitlements\` (and now, after #963, our backend verify). SwiftUI's first render of \`MainTabView.indicatorSubtitle\` therefore sees \`userSubscription == nil\` and falls through to \`"Basic"\`; the publisher fires moments later with the real entitlement and the pill flips.

\`BackendCreditsService.currentBalance\` already avoids this for the bolt-icon by reading the persisted GRDB row synchronously. Subscription had no equivalent cache.

## Fix

Persist the most recently published \`UserSubscription\` to UserDefaults on every publish, and seed the \`CurrentValueSubject\` with that value on \`init\`. First frame after launch shows the user's actual tier (common case) instead of nil.

To prevent future call sites from forgetting to write through, all three existing \`subscriptionSubject.send(...)\` sites (\`purchase()\`, \`listenForTransactionUpdates()\`, \`refreshFromEntitlements()\`) now route through a single \`publish(_:)\` funnel.

## Tradeoffs

- ✅ Returning Plus subscribers: no flicker.
- ✅ Fresh installs: still see "Basic" first — correct, that's their actual state, not a flicker.
- ⚠️ Edge case: user cancels Plus while the app is killed. Next cold start seeds with cached Plus, real refresh corrects within ~1s. The reverse "Plus → Basic" flicker is possible, but the cancel-while-killed window is small.

## Tests

Added \`StoreKitSubscriptionServiceCacheTests\` with four cases covering the entire cache surface:

- \`testSaveCachedSubscription_persistsRoundTrip\` — save then load returns the same \`UserSubscription\`.
- \`testSaveCachedSubscription_nilClearsCache\` — nil-write clears the cache so a cancelled sub doesn't outlive itself.
- \`testLoadCachedSubscription_emptyCacheReturnsNil\` — empty cache returns nil (init falls through to pre-cache behavior).
- \`testLoadCachedSubscription_corruptDataReturnsNil\` — model-shape drift or corrupted bytes degrade gracefully to nil instead of crashing at launch.

The init's seeding (\`CurrentValueSubject(Self.loadCachedSubscription())\`) is a single line of glue; testing it independently would require either promoting \`MockAPIClient\` to public or stubbing all 59 \`ConvosAPIClientProtocol\` methods inline. Round-trip + decode-failure coverage on the static helpers is sufficient for the seeding behavior to be honest.

Visibility bump: \`saveCachedSubscription\` / \`loadCachedSubscription\` go from \`private static\` to \`static\` (internal) so the test target can reach them via \`@testable import Convos\`. The type as a whole stays internal so this doesn't widen the public surface.

## Follow-up

Filed [CON-390](https://linear.app/convos/issue/CON-390) — when centralized sign-out cleanup lands, \`storeKit.lastKnownSubscription\` should be added to the cleanup list so a second account on the same device doesn't briefly see the first account's cached subscription on first launch.

## Test plan

- [x] Unit tests cover the cache round-trip, nil-clear, empty-cache, and corrupt-data paths
- [x] Cold-launch as a Plus subscriber → pill shows "Plus" on the first frame (no Basic flash)
- [x] Fresh install or never-subscribed account → pill shows "Basic" (no false "Plus")
- [x] Subscribe via paywall → kill app → relaunch → pill shows "Plus" immediately
- [x] Cancel subscription via Manage Subscriptions → relaunch → pill briefly shows cached "Plus" → corrects to "Basic" within ~1s

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Cache last-known subscription in UserDefaults so the HOME pill doesn't show Basic on launch
> - `StoreKitSubscriptionService` now seeds `subscriptionSubject` with the last persisted `UserSubscription` at init time instead of `nil`, so the UI reflects the correct tier immediately on launch.
> - A new `publish(_:)` helper centralizes all subscription updates, writing each snapshot to `UserDefaults` via `saveCachedSubscription` alongside the in-memory publish.
> - All subscription update paths (purchase, transaction listener, entitlement refresh) now route through `publish(_:)`, keeping the cache consistent.
> - New tests in [StoreKitSubscriptionServiceCacheTests.swift](https://github.com/xmtplabs/convos-ios/pull/965/files#diff-f0257f55a25e1988efc0f9227b9a4022c897a5fe58231db9f3d596cfc0cef3be) cover round-trip persistence, nil-clearing, empty-cache, and corrupt-data cases.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1eeba47.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->