### PR TITLE
fix(agent-share): position and size the agent QR card against the window, not the presenting container

### DIFF
--- a/Convos/Contacts/AgentShareOverlay.swift
+++ b/Convos/Contacts/AgentShareOverlay.swift
@@ -17,7 +17,7 @@ struct AgentShareOverlay: View {
             encodedURLString: publishedURLString,
             isPresented: $isPresented,
             topPadding: DesignConstants.Spacing.step6x,
-            ignoresTopSafeArea: true,
+            ignoresToolbarSafeArea: true,
             header: {
                 Text(displayName)
                     .kerning(1.0)

--- a/Convos/Shared Views/QRCodeCardOverlay.swift
+++ b/Convos/Shared Views/QRCodeCardOverlay.swift
@@ -11,14 +11,16 @@ import SwiftUI
 struct QRCodeCardOverlay<Header: View, Center: View>: View {
     let encodedURLString: String
     @Binding var isPresented: Bool
-    /// Flat top padding above the card, measured from the top of whatever
-    /// region the card occupies (the safe area, or the screen top when
-    /// `ignoresTopSafeArea` is set).
+    /// Flat top padding above the card, measured from the top of the region
+    /// the card occupies (the container safe area, or the device safe-area
+    /// top when `ignoresToolbarSafeArea` is set).
     let topPadding: CGFloat
-    /// When set, the card extends into the top safe area so `topPadding` is
-    /// measured from the screen's top edge. Lets a caller pull the card up out
-    /// of the safe-area band so a tall card clears the share sheet below it.
-    var ignoresTopSafeArea: Bool = false
+    /// When set, the card extends up into the toolbar band of the top safe
+    /// area while still respecting the window's device safe area (status bar
+    /// and Dynamic Island). Lets a caller pull a tall card up out of the
+    /// toolbar band so it clears the share sheet below it without sliding
+    /// under the status bar.
+    var ignoresToolbarSafeArea: Bool = false
     @ViewBuilder let header: () -> Header
     @ViewBuilder let center: () -> Center
 
@@ -29,27 +31,59 @@ struct QRCodeCardOverlay<Header: View, Center: View>: View {
     /// Tracked so dismissing during the gap cancels the pending present.
     @State private var sharePresentTask: Task<Void, Never>?
     @Environment(\.displayScale) private var displayScale: CGFloat
+    /// Window-level safe area (device bezel only, no toolbar contribution),
+    /// used to keep the card below the status bar while it ignores the
+    /// toolbar's safe-area band.
+    @Environment(\.safeAreaInsets) private var windowSafeAreaInsets: EdgeInsets
 
     private static var headerHeight: CGFloat { 40.0 }
     private static var cardPadding: CGFloat { 40.0 }
     private static var maxQRSize: CGFloat { 220.0 }
     private static var shareSheetFraction: CGFloat { 0.55 }
 
-    private func qrDisplaySize(in size: CGSize) -> CGFloat {
-        let availableHeight = size.height * (1.0 - Self.shareSheetFraction)
-            - topPadding
+    /// Sizes the QR so the card fits between its top position and the share
+    /// sheet, which covers the bottom `shareSheetFraction` of the screen.
+    /// Measured in window coordinates: the overlay's container is shorter
+    /// than the screen when the contact card is presented inside a sheet, so
+    /// container-local math would over-estimate the available height and the
+    /// card would render larger there than on a navigation stack.
+    private func qrDisplaySize(in geometry: GeometryProxy, cardTopPadding: CGFloat) -> CGFloat {
+        let globalFrame: CGRect = geometry.frame(in: .global)
+        let shareSheetTop: CGFloat = globalFrame.maxY * (1.0 - Self.shareSheetFraction)
+        let cardTop: CGFloat = globalFrame.minY + cardTopPadding
+        let availableHeight = shareSheetTop
+            - cardTop
             - Self.headerHeight
             - Self.cardPadding
             - DesignConstants.Spacing.step10x
-        let availableWidth = size.width
+        let availableWidth = geometry.size.width
             - DesignConstants.Spacing.step10x * 2
             - Self.cardPadding * 2
         let maxFit = min(availableHeight, availableWidth)
         return min(max(maxFit, 120.0), Self.maxQRSize)
     }
 
+    /// The edges the overlay's container extends past; hoisted so the
+    /// modifier argument in `body` stays ternary-free.
+    private var ignoredEdges: Edge.Set {
+        ignoresToolbarSafeArea ? .top : []
+    }
+
+    /// The card's top padding resolved against the (possibly expanded)
+    /// container. When the card ignores the toolbar safe area, the
+    /// container's top edge can sit above the device safe area (navigation
+    /// stack) or already below it (sheet); clamp so the card never rises
+    /// above the window's safe area.
+    private func resolvedTopPadding(in geometry: GeometryProxy) -> CGFloat {
+        guard ignoresToolbarSafeArea else { return topPadding }
+        let containerTop: CGFloat = geometry.frame(in: .global).minY
+        let deviceInset: CGFloat = max(windowSafeAreaInsets.top - containerTop, 0.0)
+        return deviceInset + topPadding
+    }
+
     var body: some View {
         GeometryReader { geometry in
+            let cardTopPadding: CGFloat = resolvedTopPadding(in: geometry)
             ZStack {
                 if showCard {
                     Color.black.opacity(0.5)
@@ -62,13 +96,11 @@ struct QRCodeCardOverlay<Header: View, Center: View>: View {
                 }
 
                 if showCard {
-                    let ignoredEdges: Edge.Set = ignoresTopSafeArea ? .top : []
                     VStack(spacing: 0.0) {
-                        codeCard(qrSize: qrDisplaySize(in: geometry.size))
+                        codeCard(qrSize: qrDisplaySize(in: geometry, cardTopPadding: cardTopPadding))
                         Spacer()
                     }
-                    .padding(.top, topPadding)
-                    .ignoresSafeArea(.container, edges: ignoredEdges)
+                    .padding(.top, cardTopPadding)
                     .transition(
                         .asymmetric(
                             insertion: .move(edge: .top).combined(with: .opacity),
@@ -108,6 +140,7 @@ struct QRCodeCardOverlay<Header: View, Center: View>: View {
                 }
             }
         }
+        .ignoresSafeArea(.container, edges: ignoredEdges)
     }
 
     private func codeCard(qrSize: CGFloat) -> some View {


### PR DESCRIPTION
## Problem

Follow-up to #954, which let the agent QR card ignore the top safe area so a tall card clears the share sheet. Two issues remained, both from measuring against the presenting container instead of the window:

1. **Position** — `topPadding` was measured from the container's physical top. That's right inside a sheet (the sheet's top edge already sits below the Dynamic Island) but wrong on a navigation stack, where the container top is the screen top: the card slid under the status bar / Dynamic Island.
2. **Size** — the QR sizing math measured share-sheet clearance against the local container height. Inside a sheet (shorter container, smaller top padding) it over-estimated the available room, hit the 220pt cap, and rendered a visibly larger card than the navigation-stack presentation (~190pt).

## Fix

Resolve both the card's top padding and the QR size in window coordinates inside `QRCodeCardOverlay`:

- The overlay expands past the container's top safe area (the toolbar band), then clamps the card below the window's device safe area: `max(windowSafeTop - containerGlobalTop, 0) + topPadding`. On a navigation stack the card sits at the status-bar inset + step6x; inside a sheet the container top is already below the device inset, so placement is unchanged.
- QR sizing measures the card top and the share-sheet top (bottom `shareSheetFraction` of the screen) in global coordinates, so both presentations now agree on size.

Uses the existing `\.safeAreaInsets` environment (window-level insets, no toolbar contribution). The flag is renamed `ignoresTopSafeArea` -> `ignoresToolbarSafeArea` to match the new semantics.

The conversation "Convos code" flow (flag off) keeps its behavior: flat padding inside the safe area, and its overlay container already spans the full screen so the sizing math is identical.

## Verification

- Built "Convos (Dev)" and exercised both presentations on an iPhone 17 Pro simulator:
  - Contacts tab -> saved agent (navigation stack): card now sits below the Dynamic Island, same ~190pt size as before.
  - In-convo agent card -> contact sheet: position unchanged (step6x below the sheet top), size now matches the stack presentation instead of capping at 220pt.
- SwiftLint clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/966"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783103402&installation_id=128169237&pr_number=966&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F966&signature=f42b480cedc85c54413b8db4f6cc52183ef41a1fb8d364e8ce8b0f62f0077e3a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix QR card positioning in agent share overlay to use window coordinates instead of container
> - Renames `ignoresTopSafeArea` to `ignoresToolbarSafeArea` in [QRCodeCardOverlay.swift](https://github.com/xmtplabs/convos-ios/pull/966/files#diff-c65a8fb672194348dfb2218e7e941c2b793ac84fadb78d6508a64b222b086d41), with new semantics: ignores only the toolbar band of the top safe area while still respecting the device safe area inset.
> - Adds `resolvedTopPadding(in:)` to clamp card top padding against the window safe area, preventing the card from sliding behind the status bar.
> - Rewrites `qrDisplaySize` to compute available space from global/window coordinates rather than the local container, so card and QR sizes are consistent across sheets and navigation contexts.
> - Moves `.ignoresSafeArea(.container, edges:)` from the inner `VStack` to the outermost container, driven by the new `ignoredEdges` computed property.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 745fccc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->