### PR TITLE
Agent builder: drop empty-state autofocus, add interactive keyboard dismissal

### DIFF
--- a/Convos/Agent Builder/AgentBuilderView.swift
+++ b/Convos/Agent Builder/AgentBuilderView.swift
@@ -187,13 +187,11 @@ struct AgentBuilderView: View {
                 inlineTermsFooter
             }
         }
-        .onAppear {
-            // Voice-memo entry skips the composer focus so the keyboard
-            // doesn't pop up alongside the mic-permission prompt; the
-            // body's main `.onAppear` kicks off the recording itself.
-            guard viewModel.entryMode != .voiceMemo else { return }
-            focusCoordinator.moveFocus(to: .agentBuilder)
-        }
+        // Intentionally no default focus here: the inline builder is the
+        // chats-list empty state, and popping the keyboard on every visit
+        // to an empty chats tab is intrusive. The user taps the composer
+        // (or its card) to focus. The sheet presentation still focuses by
+        // default via `initialFocusOverride`.
         .onChange(of: focusCoordinator.currentFocus) { _, newFocus in
             inlineFocusState = newFocus
         }
@@ -300,7 +298,32 @@ struct AgentBuilderView: View {
         }
     }
 
+    /// Wraps the composer stack in a vertical scroll view purely so a
+    /// downward drag interactively tracks the keyboard down (mirroring
+    /// the messages list's `.scrollDismissesKeyboard(.interactively)`).
+    /// The content is pinned to the visible height via the geometry
+    /// proxy, so nothing actually scrolls - the scroll view exists for
+    /// its bounce + keyboard tracking. The proxy height already excludes
+    /// the keyboard (keyboard safe-area inset shrinks the proposal), so
+    /// the card keeps its existing shrink-above-the-keyboard behavior.
     private func composerRect(
+        focusState: FocusState<MessagesViewInputFocus?>.Binding
+    ) -> some View {
+        GeometryReader { proxy in
+            ScrollView {
+                composerStack(focusState: focusState)
+                    .frame(width: proxy.size.width, height: proxy.size.height)
+            }
+            .scrollIndicators(.hidden)
+            // Unclipped so the glass card's matched-geometry morph into
+            // the in-stream summary cell (and the sheet path's move/scale
+            // removal transition) isn't cut off at the scroll bounds.
+            .scrollClipDisabled()
+            .scrollDismissesKeyboard(.interactively)
+        }
+    }
+
+    private func composerStack(
         focusState: FocusState<MessagesViewInputFocus?>.Binding
     ) -> some View {
         VStack(spacing: 0) {


### PR DESCRIPTION
## What

Two keyboard-behavior changes to the agent builder, both in `AgentBuilderView.swift`:

1. **Inline builder (chats-list empty state) no longer autofocuses.** Previously `inlineBody` moved focus to the composer on appear, popping the keyboard on every visit to an empty chats tab. Now the keyboard stays down until the user taps the composer. The sheet presentation keeps its default autofocus via `initialFocusOverride`.

2. **Interactive keyboard dismissal in both builder presentations.** `composerRect` (shared by the inline and sheet builders) now hosts the composer card in a `ScrollView` with `.scrollDismissesKeyboard(.interactively)`, so a downward drag tracks the keyboard down — matching the messages list. The content is pinned to the visible height via `GeometryReader`, so nothing actually scrolls and the card keeps its existing shrink-above-the-keyboard behavior. `.scrollClipDisabled()` keeps the glass card's matched-geometry commit morph unclipped.

## Verification (manual, simulator)

- Empty chats state: keyboard does not appear on launch/appear; card layout unchanged
- Inline builder: tap focuses the composer; drag-down dismisses the keyboard
- Sheet builder: still autofocuses on open; with content typed (`interactiveDismissDisabled` active), drag-down dismisses the keyboard while the sheet stays up; an empty sheet still pulls down whole (unchanged stock behavior)
- "Make" commit morph into the conversation renders correctly through the new scroll container
- Dev build compiles clean — no type-check-time warnings, SwiftLint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Drop auto-focus on appear and add interactive keyboard dismissal in Agent Builder inline mode
> - Removes the `onAppear` auto-focus in [AgentBuilderView.swift](https://github.com/xmtplabs/convos-ios/pull/967/files#diff-112eb571b37e845cdd6337280b52c1c6b1cf8b2b100bf314a6b17aa960d0215e) so the keyboard no longer opens by default in inline mode; sheet mode focus behavior via `initialFocusOverride` is unchanged.
> - Wraps the composer area in a `ScrollView` with `.scrollDismissesKeyboard(.interactively)` so users can dismiss the keyboard by dragging down.
> - Scroll clipping is disabled to avoid clipping during matched-geometry transitions; content is pinned so it does not actually scroll.
> - Behavioral Change: in inline mode, users must tap to open the keyboard rather than it opening automatically on view appear.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 14d5bfd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->