### PR TITLE
Remove the one-agent-per-conversation limit

### DIFF
--- a/Convos/Contacts/AddFromContactsPickerModifier.swift
+++ b/Convos/Contacts/AddFromContactsPickerModifier.swift
@@ -68,17 +68,12 @@ private struct AddFromContactsPickerModifier: ViewModifier {
         )
     }
 
-    private func handleConfirm(_ inboxIds: Set<String>, _ agentTemplateId: String?) {
-        // Selecting an agent spawns a fresh instance of its template into
+    private func handleConfirm(_ inboxIds: Set<String>, _ agentTemplateIds: [String]) {
+        // Selecting agents spawns a fresh instance of each template into
         // this conversation (the picker already showed the "one agent, many
         // convos" confirmation). Humans are added as members; both can be
-        // present in a single confirm. At most one agent per conversation -
-        // skip the spawn if this conversation already has one (the canonical
-        // agent row can collapse a different instance than the one in chat,
-        // so the picker's already-in-chat filter doesn't catch this).
-        if let agentTemplateId, !viewModel.conversation.hasAgent {
-            viewModel.requestAgentJoin(templateId: agentTemplateId)
-        }
+        // present in a single confirm.
+        viewModel.requestAgentJoins(templateIds: agentTemplateIds)
         let ids = Array(inboxIds)
         guard !ids.isEmpty else { return }
         Task {

--- a/Convos/Contacts/ContactDetailView.swift
+++ b/Convos/Contacts/ContactDetailView.swift
@@ -528,13 +528,13 @@ struct ContactDetailView: View {
     /// `ContactsView.handlePickerConfirm` and the invite-cell-tap pattern
     /// where the new-convo sheet is owned by the same view that hosted
     /// the picker.
-    private func handlePickerConfirm(_ memberInboxIds: Set<String>, _ agentTemplateId: String?) {
-        guard !memberInboxIds.isEmpty || agentTemplateId != nil, let session else { return }
+    private func handlePickerConfirm(_ memberInboxIds: Set<String>, _ agentTemplateIds: [String]) {
+        guard !memberInboxIds.isEmpty || !agentTemplateIds.isEmpty, let session else { return }
         presentingNewConvo = NewConversationViewModel(
             session: session,
             mode: .newConversationWithMembers(
                 initialMemberInboxIds: Array(memberInboxIds),
-                agentTemplateId: agentTemplateId
+                initialAgentTemplateIds: agentTemplateIds
             )
         )
     }

--- a/Convos/Contacts/ContactsPickerRow.swift
+++ b/Convos/Contacts/ContactsPickerRow.swift
@@ -6,13 +6,10 @@ import SwiftUI
 struct ContactsPickerRow: View {
     let row: ContactsPickerViewModel.Row
     let isSelected: Bool
-    /// True when this row is an agent that can't be selected because
-    /// another agent is already selected (one agent per conversation).
-    var isAgentSelectionBlocked: Bool = false
     let onTap: () -> Void
 
     var body: some View {
-        let isDisabled: Bool = row.isAlreadyInChat || isAgentSelectionBlocked
+        let isDisabled: Bool = row.isAlreadyInChat
         let opacity: Double = isDisabled ? 0.45 : 1.0
         Button(action: onTap) {
             HStack(spacing: DesignConstants.Spacing.step3x) {

--- a/Convos/Contacts/ContactsPickerView.swift
+++ b/Convos/Contacts/ContactsPickerView.swift
@@ -43,10 +43,10 @@ struct ContactsPickerView: View {
     @State private var agentInfoConfirmed: Bool = false
     @Environment(\.dismiss) private var dismiss: DismissAction
 
-    /// `memberInboxIds` are the selected humans; `agentTemplateId` is the
-    /// template of the single selected agent, if any (the picker allows at
-    /// most one, and only in new-conversation mode).
-    let onConfirm: (_ memberInboxIds: Set<String>, _ agentTemplateId: String?) -> Void
+    /// `memberInboxIds` are the selected humans; `agentTemplateIds` are the
+    /// templates of the selected agents (one fresh instance is spawned per
+    /// id), empty when no agent was picked.
+    let onConfirm: (_ memberInboxIds: Set<String>, _ agentTemplateIds: [String]) -> Void
     /// Optional source conversation that informs the indicator pill's
     /// emoji avatar. For the new-convo flow callers can pass the current
     /// draft so the picker reflects whatever emoji the convo will inherit;
@@ -67,7 +67,7 @@ struct ContactsPickerView: View {
         pillConversation: Conversation? = nil,
         embedsNavigationStack: Bool = true,
         suggestedAgentsService: (any SuggestedAgentsServiceProtocol)? = nil,
-        onConfirm: @escaping (_ memberInboxIds: Set<String>, _ agentTemplateId: String?) -> Void
+        onConfirm: @escaping (_ memberInboxIds: Set<String>, _ agentTemplateIds: [String]) -> Void
     ) {
         _viewModel = State(initialValue: ContactsPickerViewModel(
             mode: mode,
@@ -178,7 +178,7 @@ struct ContactsPickerView: View {
         // "One agent, many convos" sheet as a confirmation step first; its
         // "Got it" button proceeds via `performConfirm`. Human-only
         // selections create the conversation immediately.
-        if viewModel.selectedAgentTemplateId != nil {
+        if !viewModel.selectedAgentTemplateIds.isEmpty {
             presentingAgentInfo = true
         } else {
             performConfirm()
@@ -186,14 +186,11 @@ struct ContactsPickerView: View {
     }
 
     private func performConfirm() {
-        // Split the selection: the agent (if any) is spawned by template,
-        // not added as a member, so it's excluded from the member ids.
-        let agentTemplateId = viewModel.selectedAgentTemplateId
-        var memberIds = viewModel.selectedInboxIds
-        if let agentInboxId = viewModel.selectedAgentInboxId {
-            memberIds.remove(agentInboxId)
-        }
-        onConfirm(memberIds, agentTemplateId)
+        // Split the selection: agents are spawned by template, not added
+        // as members, so they're excluded from the member ids.
+        let agentTemplateIds = viewModel.selectedAgentTemplateIds
+        let memberIds = viewModel.selectedInboxIds.subtracting(viewModel.selectedAgentInboxIds)
+        onConfirm(memberIds, agentTemplateIds)
         // Compose hosts the picker in its own navigation stack and pushes
         // the new conversation, so it must not dismiss here.
         if !viewModel.mode.isCompose {
@@ -334,7 +331,6 @@ private struct ContactsPickerList: View {
         ContactsPickerRow(
             row: row,
             isSelected: viewModel.isSelected(inboxId: row.id),
-            isAgentSelectionBlocked: viewModel.isAgentSelectionBlocked(for: row.id),
             onTap: rowTapAction(for: row)
         )
         .onAppear {

--- a/Convos/Contacts/ContactsPickerViewModel.swift
+++ b/Convos/Contacts/ContactsPickerViewModel.swift
@@ -98,7 +98,7 @@ final class ContactsPickerViewModel {
     /// add-to-conversation entry point) yields no section.
     private let suggestedAgentsModel: SuggestedAgentsModel
     /// Synthetic contacts for the currently visible suggested agents. Kept so
-    /// selection lookups (one-agent rule, confirm-by-template) resolve a
+    /// selection lookups (agent detection, confirm-by-template) resolve a
     /// selected suggestion even while the section is hidden by a search query.
     private var suggestedAgentContacts: [Contact] = []
 
@@ -211,24 +211,8 @@ final class ContactsPickerViewModel {
         if selectedInboxIds.contains(inboxId) {
             selectedInboxIds.remove(inboxId)
         } else {
-            // At most one agent per conversation - agents are
-            // instance-per-conversation and can't share context. Once one
-            // is selected, other agent rows are disabled (see
-            // `isAgentSelectionBlocked`); selecting a second is a no-op.
-            // Humans are unrestricted.
-            if isAgent(inboxId), selectedAgentInboxId != nil {
-                return
-            }
             selectedInboxIds.insert(inboxId)
         }
-    }
-
-    /// True when `inboxId` is an unselected agent that can't be selected
-    /// because a different agent is already selected. The picker disables
-    /// these rows; the user deselects the current agent to pick another.
-    func isAgentSelectionBlocked(for inboxId: String) -> Bool {
-        guard isAgent(inboxId), !selectedInboxIds.contains(inboxId) else { return false }
-        return selectedAgentInboxId != nil
     }
 
     func deselect(inboxId: String) {
@@ -243,22 +227,16 @@ final class ContactsPickerViewModel {
         selectedInboxIds.contains(inboxId)
     }
 
-    /// `inboxId` of the currently selected agent, if any. At most one
-    /// agent may be selected (see `toggleSelection`).
-    var selectedAgentInboxId: String? {
-        selectedInboxIds.first { isAgent($0) }
+    /// `inboxId`s of the currently selected agents.
+    var selectedAgentInboxIds: Set<String> {
+        Set(selectedContacts.filter { $0.agentTemplateId != nil }.map(\.inboxId))
     }
 
-    /// `agentTemplateId` of the currently selected agent, threaded into
-    /// conversation creation so a fresh instance of that template is
+    /// `agentTemplateId`s of the currently selected agents, threaded into
+    /// conversation creation so a fresh instance of each template is
     /// spawned into the new (or existing) conversation.
-    var selectedAgentTemplateId: String? {
-        guard let agentInboxId = selectedAgentInboxId else { return nil }
-        return selectableContacts.first { $0.inboxId == agentInboxId }?.agentTemplateId
-    }
-
-    private func isAgent(_ inboxId: String) -> Bool {
-        selectableContacts.first { $0.inboxId == inboxId }?.agentTemplateId != nil
+    var selectedAgentTemplateIds: [String] {
+        selectedContacts.compactMap(\.agentTemplateId)
     }
 
     /// Single source of truth for "is this contact a valid picker row".

--- a/Convos/Contacts/ContactsView.swift
+++ b/Convos/Contacts/ContactsView.swift
@@ -238,13 +238,13 @@ struct ContactsView: View {
     /// invite-cell-tap pattern (`presentingNewConversationForInvite` on
     /// `ConversationViewModel`) where the sheet is owned by the same view
     /// that hosted the picker.
-    private func handlePickerConfirm(_ memberInboxIds: Set<String>, _ agentTemplateId: String?) {
-        guard !memberInboxIds.isEmpty || agentTemplateId != nil, let session else { return }
+    private func handlePickerConfirm(_ memberInboxIds: Set<String>, _ agentTemplateIds: [String]) {
+        guard !memberInboxIds.isEmpty || !agentTemplateIds.isEmpty, let session else { return }
         presentingNewConvo = NewConversationViewModel(
             session: session,
             mode: .newConversationWithMembers(
                 initialMemberInboxIds: Array(memberInboxIds),
-                agentTemplateId: agentTemplateId
+                initialAgentTemplateIds: agentTemplateIds
             )
         )
     }

--- a/Convos/Conversation Creation/ComposeFlowView.swift
+++ b/Convos/Conversation Creation/ComposeFlowView.swift
@@ -57,21 +57,18 @@ struct ComposeFlowView: View {
     }
 
     /// Skip (empty selection) opens the claimed conversation as-is; Continue
-    /// adds the picked humans as members and, if an agent was picked, spawns a
-    /// fresh instance of its template into the conversation (at most one agent
-    /// per conversation, enforced by the picker). The push happens immediately
-    /// either way -- the members / agent land in the open conversation a
-    /// moment later.
-    private func handleProceed(_ memberInboxIds: Set<String>, _ agentTemplateId: String?) {
+    /// adds the picked humans as members and spawns a fresh instance of each
+    /// picked agent template into the conversation. The push happens
+    /// immediately either way -- the members / agents land in the open
+    /// conversation a moment later.
+    private func handleProceed(_ memberInboxIds: Set<String>, _ agentTemplateIds: [String]) {
         if let conversationViewModel = composeConversationViewModel.conversationViewModel {
             if !memberInboxIds.isEmpty {
                 Task {
                     try? await conversationViewModel.addMembersFromContacts(Array(memberInboxIds))
                 }
             }
-            if let agentTemplateId {
-                conversationViewModel.requestAgentJoin(templateId: agentTemplateId)
-            }
+            conversationViewModel.requestAgentJoins(templateIds: agentTemplateIds)
         }
         pushedConversation = composeConversationViewModel
     }

--- a/Convos/Conversation Creation/NewConversationViewModel.swift
+++ b/Convos/Conversation Creation/NewConversationViewModel.swift
@@ -34,11 +34,13 @@ enum NewConversationMode {
     /// inbox IDs before emitting `.ready`. Used by the contacts picker
     /// "Start Conversation" path so navigation feels instant and the
     /// conversation arrives at `.ready` with the picked members already
-    /// in it. When `agentTemplateId` is non-nil the picker also selected
-    /// an agent: a fresh instance of that template is spawned into the
-    /// conversation once it reaches `.ready` (at most one agent per
-    /// conversation, enforced in the picker).
-    case newConversationWithMembers(initialMemberInboxIds: [String], agentTemplateId: String?)
+    /// in it. `initialAgentTemplateIds` (defaults to empty) requests one
+    /// fresh instance per id once the conversation reaches `.ready`,
+    /// mirroring the single-template `.newConversationWithTemplate` flow.
+    case newConversationWithMembers(
+        initialMemberInboxIds: [String],
+        initialAgentTemplateIds: [String] = []
+    )
     /// Opens an existing conversation in the same sheet presentation we
     /// use for the new-convo flows. Used when "Chat" on a contact card
     /// resolves to a 1:1 the user already has with that person, so the
@@ -185,11 +187,14 @@ class NewConversationViewModel: Identifiable, Hashable {
 
     private var conversationStateManager: (any ConversationStateManagerProtocol)?
     private var acquiredMessagingService: AnyMessagingService?
-    /// Agent template id to provision into the conversation once it
-    /// reaches `.ready`. Set for the `.newConversationWithTemplate`
-    /// deeplink mode and when a `convos://template/<id>` QR is scanned.
+    /// Agent template ids to provision into the conversation once it
+    /// reaches `.ready`. Seeded by the `.newConversationWithTemplate`
+    /// deeplink mode, a scanned `convos://template/<id>` QR, and the
+    /// contacts picker's mixed humans+templates new-conversation flow.
+    /// One entry per fresh instance to spawn; empty for the human-only
+    /// path.
     @ObservationIgnored
-    private var pendingAgentTemplateId: String?
+    private var pendingAgentTemplateIds: [String] = []
     /// Set when a template QR is scanned before the messaging service
     /// (and `conversationStateManager`) has been acquired; the create is
     /// kicked off once configuration completes. Mirrors `pendingInviteCode`.
@@ -248,13 +253,13 @@ class NewConversationViewModel: Identifiable, Hashable {
         self.qrScannerViewModel = QRScannerViewModel()
 
         if case .newConversationWithTemplate(let templateId, let optimisticIdentity) = mode {
-            self.pendingAgentTemplateId = templateId
+            self.pendingAgentTemplateIds = [templateId]
             self.isOptimisticAgentMode = true
             self.optimisticAgentIdentity = optimisticIdentity ?? .neutralPendingAgent(templateId: templateId)
             self.resolvesOptimisticAgentIdentity = (optimisticIdentity == nil)
         }
-        if case .newConversationWithMembers(_, let agentTemplateId) = mode, let agentTemplateId {
-            self.pendingAgentTemplateId = agentTemplateId
+        if case .newConversationWithMembers(_, let agentTemplateIds) = mode {
+            self.pendingAgentTemplateIds = agentTemplateIds
         }
 
         switch mode {
@@ -301,7 +306,7 @@ class NewConversationViewModel: Identifiable, Hashable {
     /// is already painted; this upgrades it in place once the resolver
     /// returns the real name + emoji/photo.
     private func resolveOptimisticAgentIdentityIfNeeded() {
-        guard resolvesOptimisticAgentIdentity, let templateId = pendingAgentTemplateId else { return }
+        guard resolvesOptimisticAgentIdentity, let templateId = pendingAgentTemplateIds.first else { return }
         let resolver = session.agentShareResolver()
         optimisticAgentResolveTask = Task { [weak self] in
             let info = await resolver.resolve(identifier: templateId)
@@ -617,7 +622,7 @@ class NewConversationViewModel: Identifiable, Hashable {
     /// conversation, then request an instance of the template into it
     /// once it reaches `.ready` (handled in `handleStateChange`).
     private func startAgentTemplateConversation(templateId: String) {
-        pendingAgentTemplateId = templateId
+        pendingAgentTemplateIds = [templateId]
         showingFullScreenScanner = false
         isCreatingConversation = true
 
@@ -956,12 +961,15 @@ extension NewConversationViewModel {
             Log.info("[PERF] NewConversation.ready: \(String(format: "%.0f", readyElapsed))ms (origin: \(result.origin))")
             Log.info("Conversation ready!")
 
-            // Agent-template deeplink: the conversation now exists with a
-            // shareable invite, so request a fresh instance of the
-            // template into it. One-shot - `.ready` may re-emit.
-            if let pendingAgentTemplateId, !didTriggerAgentJoin {
+            // Agent-template spawn: the conversation now exists with a
+            // shareable invite, so request a fresh instance for each
+            // pending templateId. Uses the batched method -- the
+            // single-flight `requestAgentJoin(templateId:)` would cancel
+            // each prior call as the loop advances, leaving only the
+            // last to land. One-shot - `.ready` may re-emit.
+            if !pendingAgentTemplateIds.isEmpty, !didTriggerAgentJoin {
                 didTriggerAgentJoin = true
-                conversationViewModel?.requestAgentJoin(templateId: pendingAgentTemplateId)
+                conversationViewModel?.requestAgentJoins(templateIds: pendingAgentTemplateIds)
             }
 
         case .joinFailed(_, let error):
@@ -986,9 +994,9 @@ extension NewConversationViewModel {
 
         // The include-info default applies to every conversation this VM
         // creates - the auto-create modes and the scanned-template path
-        // (which sets `pendingAgentTemplateId` but is not an auto-create
+        // (which seeds `pendingAgentTemplateIds` but is not an auto-create
         // mode). It does not apply when joining an existing invite.
-        guard autoCreateConversation || pendingAgentTemplateId != nil else { return }
+        guard autoCreateConversation || !pendingAgentTemplateIds.isEmpty else { return }
 
         do {
             try await stateManager.conversationMetadataWriter.updateIncludeInfoInPublicPreview(

--- a/Convos/Conversation Detail/AddToConversationMenu.swift
+++ b/Convos/Conversation Detail/AddToConversationMenu.swift
@@ -3,7 +3,6 @@ import SwiftUI
 
 struct AddToConversationMenu: View {
     let isFull: Bool
-    var hasAgent: Bool = false
     var isAgentJoinPending: Bool = false
     let isEnabled: Bool
     let onConvoCode: () -> Void
@@ -16,10 +15,9 @@ struct AddToConversationMenu: View {
     /// that's bound to that modifier's `isPresented`.
     let onAddFromContacts: () -> Void
 
-    private var isAgentActionDisabled: Bool { hasAgent || isAgentJoinPending }
+    private var isAgentActionDisabled: Bool { isAgentJoinPending }
 
     private var agentSubtitle: String {
-        if hasAgent { return "Already here" }
         if isAgentJoinPending { return "Joining…" }
         return "Made for this group"
     }

--- a/Convos/Conversation Detail/ConversationInfoView.swift
+++ b/Convos/Conversation Detail/ConversationInfoView.swift
@@ -586,7 +586,6 @@ struct ConversationInfoView: View {
                 } else {
                     AddToConversationMenu(
                         isFull: viewModel.isFull,
-                        hasAgent: viewModel.conversation.hasAgent,
                         isEnabled: true,
                         onConvoCode: {
                             if viewModel.isFull {

--- a/Convos/Conversation Detail/ConversationMembersListView.swift
+++ b/Convos/Conversation Detail/ConversationMembersListView.swift
@@ -73,7 +73,6 @@ struct ConversationMembersListView: View {
             ToolbarItem(placement: .topBarTrailing) {
                 AddToConversationMenu(
                     isFull: viewModel.isFull,
-                    hasAgent: viewModel.conversation.hasAgent,
                     isEnabled: true,
                     onConvoCode: {
                         viewModel.presentingShareView = true

--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -159,7 +159,6 @@ struct ConversationView<MessagesBottomBar: View>: View {
             },
             profileSheetForMember: profileSheetForMember,
             memberContactOverride: contactOverride,
-            hasAgent: viewModel.conversation.hasAgent,
             isAgentJoinPending: viewModel.isAgentJoinPending,
             headerMode: isReadOnly ? .suppressed : headerMode,
             agentBuilderSummary: viewModel.agentBuilderSummary,
@@ -246,7 +245,6 @@ struct ConversationView<MessagesBottomBar: View>: View {
     private var addToConversationMenu: some View {
         AddToConversationMenu(
             isFull: viewModel.isFull,
-            hasAgent: viewModel.conversation.hasAgent,
             isAgentJoinPending: viewModel.isAgentJoinPending,
             isEnabled: messagesTopBarTrailingItemEnabled && !isReadOnly,
             onConvoCode: {

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -2971,7 +2971,10 @@ extension ConversationViewModel {
     /// caller-facing `agents/join` body no longer accepts `instructions`.
     ///
     /// Single-flight: a new call cancels any prior in-flight join request
-    /// (retry-from-error semantics for the chat-header "+" menu).
+    /// (retry-from-error semantics for the chat-header "+" menu). For
+    /// multi-template fan-out (picker confirms N templates at once) use
+    /// `requestAgentJoins(templateIds:)` instead -- it runs the calls
+    /// sequentially without cancelling each other.
     func requestAgentJoin(templateId: String?) {
         let slug = invite.urlSlug
         guard !slug.isEmpty else { return }
@@ -3005,6 +3008,59 @@ extension ConversationViewModel {
     /// affordances. Kept so their call sites don't change.
     func requestAgentJoin() {
         requestAgentJoin(templateId: nil)
+    }
+
+    /// Sequential batched variant of `requestAgentJoin(templateId:)`. Used
+    /// when the picker confirmed multiple agent templates at once. Awaits
+    /// each call to completion before firing the next, with a short
+    /// inter-call delay so the previous broadcast's libxmtp activity fully
+    /// settles before the next API call starts. Does not touch
+    /// `agentJoinTask` / `agentJoinTaskId` (those remain dedicated to the
+    /// single-flight retry path).
+    ///
+    /// Band-aid for an unresolved issue where parallel `agents/join`
+    /// dispatch results in 2 of 3 URLSession data tasks being cancelled
+    /// (`URLError.cancelled`) -- see "concurrent agents/join cancellation"
+    /// investigation notes. Manual one-at-a-time clicks work fine, so
+    /// serialization mirrors what the user can do by hand. Slow but
+    /// reliable: ~10 seconds per agent. Remove and restore TaskGroup
+    /// fan-out once the underlying cancellation is root-caused (likely
+    /// libxmtp + URLSession shared-connection-pool interaction or a
+    /// transient `SessionStateError.clientIdInboxInconsistency` in the
+    /// session state machine under concurrent waiters).
+    func requestAgentJoins(templateIds: [String]) {
+        guard !templateIds.isEmpty else { return }
+        let slug = invite.urlSlug
+        guard !slug.isEmpty else { return }
+        Log.info("requestAgentJoins called with \(templateIds.count) templates (sequential): \(templateIds)")
+
+        let forceErrorCode = agentJoinForceErrorCode
+        let conversationId = conversation.id
+        let session = self.session
+        Task { [weak self] in
+            var anyFailed = false
+            for (index, templateId) in templateIds.enumerated() {
+                if index > 0 {
+                    // Brief gap between calls so the previous broadcast's
+                    // libxmtp message-send fully settles before the next
+                    // call's broadcast / API races against it.
+                    try? await Task.sleep(nanoseconds: 500_000_000)
+                }
+                let requestId = UUID().uuidString
+                let success = await Self.performAgentJoinCall(
+                    templateId: templateId,
+                    slug: slug,
+                    conversationId: conversationId,
+                    requestId: requestId,
+                    forceErrorCode: forceErrorCode,
+                    session: session
+                )
+                if !success { anyFailed = true }
+            }
+            if anyFailed {
+                await MainActor.run { self?.onAgentJoinError() }
+            }
+        }
     }
 
     /// Performs a single `agents/join` call: broadcasts `.pending` before,

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Cells/MessagesListItemTypeCell.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Cells/MessagesListItemTypeCell.swift
@@ -79,7 +79,6 @@ class MessagesListItemTypeCell: UICollectionViewCell {
                             onCopyLink: config.onCopyInviteLink,
                             onConvoCode: config.onConvoCode,
                             onInviteAgent: config.onInviteAgent,
-                            hasAgent: config.hasAgent,
                             isAgentJoinPending: config.isAgentJoinPending
                         )
                     }

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Data Source/CellFactory.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Data Source/CellFactory.swift
@@ -45,7 +45,6 @@ struct CellConfig {
     let onInviteAgent: () -> Void
     let onRetryTranscript: (VoiceMemoTranscriptListItem) -> Void
     let allVoiceMemoTranscripts: [String: VoiceMemoTranscriptListItem]
-    let hasAgent: Bool
     let isAgentJoinPending: Bool
     let headerMode: MessagesHeaderMode
     /// Mirrors `Conversation.hidesInviteCard`. When true the `.invite`

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Data Source/MessagesCollectionDataSource.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Data Source/MessagesCollectionDataSource.swift
@@ -35,7 +35,6 @@ protocol MessagesCollectionDataSource: UICollectionViewDataSource, MessagesLayou
     var onInviteAgent: (() -> Void)? { get set }
     var onRetryTranscript: ((VoiceMemoTranscriptListItem) -> Void)? { get set }
     var memberContactOverride: ((String) -> Contact?)? { get set }
-    var hasAgent: Bool { get set }
     var isAgentJoinPending: Bool { get set }
     var headerMode: MessagesHeaderMode { get set }
     var agentBuilderTransitionNamespace: Namespace.ID? { get set }

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Data Source/MessagesCollectionViewDataSource.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Data Source/MessagesCollectionViewDataSource.swift
@@ -42,7 +42,6 @@ final class MessagesCollectionViewDataSource: NSObject {
     var onInviteAgent: (() -> Void)?
     var onRetryTranscript: ((VoiceMemoTranscriptListItem) -> Void)?
     var memberContactOverride: ((String) -> Contact?)?
-    var hasAgent: Bool = false
     var isAgentJoinPending: Bool = false
     var headerMode: MessagesHeaderMode = .standard
     var agentBuilderTransitionNamespace: Namespace.ID?
@@ -166,7 +165,6 @@ extension MessagesCollectionViewDataSource: UICollectionViewDataSource {
                 self?.onRetryTranscript?(item)
             },
             allVoiceMemoTranscripts: allVoiceMemoTranscripts,
-            hasAgent: hasAgent,
             isAgentJoinPending: isAgentJoinPending,
             headerMode: headerMode,
             hidesInviteCard: hidesInviteCard,

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/MessagesViewController.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/MessagesViewController.swift
@@ -309,9 +309,6 @@ final class MessagesViewController: UIViewController {
     /// in-class UIKit `presentAttachmentPreview` path.
     var onPresentHTMLAttachmentPreview: ((HydratedAttachment, URL, ConversationMember, Date) -> Void)?
 
-    var hasAgent: Bool = false {
-        didSet { dataSource.hasAgent = hasAgent }
-    }
     var isAgentJoinPending: Bool = false {
         didSet { dataSource.isAgentJoinPending = isAgentJoinPending }
     }

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesBottomBar.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesBottomBar.swift
@@ -548,7 +548,6 @@ struct MessagesBottomBar<BottomBarContent: View>: View {
             onRetryTranscript: { _ in },
             profileSheetForMember: { _ in AnyView(EmptyView()) },
             memberContactOverride: { _ in nil },
-            hasAgent: false,
             isAgentJoinPending: false,
             bottomBarHeight: bottomBarHeight,
             scrollToBottomTrigger: { _ in },

--- a/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/NewConvoIdentityView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/NewConvoIdentityView.swift
@@ -4,15 +4,13 @@ struct NewConvoIdentityView: View {
     var onCopyLink: (() -> Void)?
     var onConvoCode: (() -> Void)?
     var onInviteAgent: (() -> Void)?
-    var hasAgent: Bool = false
     var isAgentJoinPending: Bool = false
 
     private var showInviteMenu: Bool { onCopyLink != nil }
 
-    private var isAgentActionDisabled: Bool { hasAgent || isAgentJoinPending }
+    private var isAgentActionDisabled: Bool { isAgentJoinPending }
 
     private var agentSubtitle: String {
-        if hasAgent { return "Already here" }
         if isAgentJoinPending { return "Joining…" }
         return "Made for this group"
     }

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessagesListView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessagesListView.swift
@@ -25,7 +25,6 @@ struct MessagesListView: View {
     let onConvoCode: () -> Void
     let onInviteAgent: () -> Void
     let allVoiceMemoTranscripts: [String: VoiceMemoTranscriptListItem]
-    let hasAgent: Bool
     let isAgentJoinPending: Bool
     let loadPrevious: () -> Void
 
@@ -58,7 +57,6 @@ var body: some View {
                     onCopyLink: onCopyInviteLink,
                     onConvoCode: onConvoCode,
                     onInviteAgent: onInviteAgent,
-                    hasAgent: hasAgent,
                     isAgentJoinPending: isAgentJoinPending
                 )
             }

--- a/Convos/Conversation Detail/Messages/MessagesView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesView.swift
@@ -92,7 +92,6 @@ struct MessagesView<BottomBarContent: View>: View {
     let onRetryTranscript: (VoiceMemoTranscriptListItem) -> Void
     let profileSheetForMember: (ConversationMember) -> AnyView
     let memberContactOverride: (String) -> Contact?
-    let hasAgent: Bool
     let isAgentJoinPending: Bool
     var headerMode: MessagesHeaderMode = .standard
     var agentBuilderSummary: AgentBuilderSummary?
@@ -156,7 +155,6 @@ struct MessagesView<BottomBarContent: View>: View {
             onRetryTranscript: onRetryTranscript,
             profileSheetForMember: profileSheetForMember,
             memberContactOverride: memberContactOverride,
-            hasAgent: hasAgent,
             isAgentJoinPending: isAgentJoinPending,
             headerMode: headerMode,
             agentBuilderSummary: agentBuilderSummary,

--- a/Convos/Conversation Detail/Messages/MessagesViewRepresentable.swift
+++ b/Convos/Conversation Detail/Messages/MessagesViewRepresentable.swift
@@ -38,7 +38,6 @@ struct MessagesViewRepresentable: UIViewControllerRepresentable {
     let onRetryTranscript: (VoiceMemoTranscriptListItem) -> Void
     let profileSheetForMember: (ConversationMember) -> AnyView
     let memberContactOverride: (String) -> Contact?
-    let hasAgent: Bool
     let isAgentJoinPending: Bool
     var headerMode: MessagesHeaderMode = .standard
     var agentBuilderSummary: AgentBuilderSummary?
@@ -131,7 +130,6 @@ struct MessagesViewRepresentable: UIViewControllerRepresentable {
         messagesViewController.onRetryTranscript = onRetryTranscript
         messagesViewController.profileSheetForMember = profileSheetForMember
         messagesViewController.memberContactOverride = memberContactOverride
-        messagesViewController.hasAgent = hasAgent
         messagesViewController.isAgentJoinPending = isAgentJoinPending
 let menuPresented = contextMenuState.isPresented
         let wasMenuPresented = !messagesViewController.view.isUserInteractionEnabled
@@ -195,7 +193,6 @@ let menuPresented = contextMenuState.isPresented
         onRetryTranscript: { _ in },
         profileSheetForMember: { _ in AnyView(EmptyView()) },
         memberContactOverride: { _ in nil },
-        hasAgent: false,
         isAgentJoinPending: false,
         bottomBarHeight: bottomBarHeight,
         scrollToBottomTrigger: { _ in },

--- a/Convos/Conversation Detail/ThinkingDetailView.swift
+++ b/Convos/Conversation Detail/ThinkingDetailView.swift
@@ -186,7 +186,6 @@ struct ThinkingDetailView: View {
             onRetryTranscript: { _ in },
             profileSheetForMember: { _ in AnyView(EmptyView()) },
             memberContactOverride: { _ in nil },
-            hasAgent: conversation.hasAgent,
             isAgentJoinPending: false,
             bottomBarHeight: bottomBarHeight,
             hasBottomBar: true,

--- a/ConvosTests/ContactsPickerViewModelTests.swift
+++ b/ConvosTests/ContactsPickerViewModelTests.swift
@@ -82,11 +82,9 @@ final class ContactsPickerViewModelTests: XCTestCase {
         XCTAssertEqual(allRowIds, [alice.inboxId, coffeeAgent.inboxId])
     }
 
-    /// At most one agent may be selected. Once an agent is selected, other
-    /// agents are blocked (selecting a second is a no-op and their rows are
-    /// disabled); the user must deselect the first to pick another. Humans
-    /// are unrestricted.
-    func testSecondAgentSelectionIsBlocked() {
+    /// Multiple agents can be selected alongside humans; each selected
+    /// agent contributes its template id to `selectedAgentTemplateIds`.
+    func testMultipleAgentsCanBeSelected() {
         let alice = Contact.mock(displayName: "Alice")
         let coffee = Contact.mock(
             displayName: "Americano",
@@ -103,22 +101,20 @@ final class ContactsPickerViewModelTests: XCTestCase {
 
         viewModel.toggleSelection(for: alice.inboxId)
         viewModel.toggleSelection(for: coffee.inboxId)
-        XCTAssertEqual(viewModel.selectedAgentTemplateId, "tmpl-coffee")
-        XCTAssertFalse(viewModel.isAgentSelectionBlocked(for: coffee.inboxId), "the selected agent itself isn't blocked")
-        XCTAssertTrue(viewModel.isAgentSelectionBlocked(for: tea.inboxId), "other agents are blocked once one is selected")
+        XCTAssertEqual(viewModel.selectedAgentTemplateIds, ["tmpl-coffee"])
 
-        // Tapping a second agent is a no-op: the first stays, the second is not added.
+        // Selecting a second agent keeps both.
         viewModel.toggleSelection(for: tea.inboxId)
-        XCTAssertEqual(viewModel.selectedAgentTemplateId, "tmpl-coffee")
-        XCTAssertFalse(viewModel.isSelected(inboxId: tea.inboxId))
+        XCTAssertTrue(viewModel.isSelected(inboxId: tea.inboxId))
         XCTAssertTrue(viewModel.isSelected(inboxId: coffee.inboxId))
         XCTAssertTrue(viewModel.isSelected(inboxId: alice.inboxId))
-        XCTAssertEqual(viewModel.selectionCount, 2)
+        XCTAssertEqual(viewModel.selectionCount, 3)
+        XCTAssertEqual(Set(viewModel.selectedAgentTemplateIds), ["tmpl-coffee", "tmpl-tea"])
+        XCTAssertEqual(viewModel.selectedAgentInboxIds, [coffee.inboxId, tea.inboxId])
 
-        // Deselecting the agent unblocks the others.
+        // Deselecting one agent leaves the other selected.
         viewModel.toggleSelection(for: coffee.inboxId)
-        XCTAssertNil(viewModel.selectedAgentTemplateId)
-        XCTAssertFalse(viewModel.isAgentSelectionBlocked(for: tea.inboxId))
+        XCTAssertEqual(viewModel.selectedAgentTemplateIds, ["tmpl-tea"])
     }
 
     func testHashBucketSortsLastForNonAlphaNames() {
@@ -440,8 +436,8 @@ final class ContactsPickerViewModelTests: XCTestCase {
         XCTAssertEqual(service.requestedLimits.count, 2)
     }
 
-    /// Selecting a suggested agent makes it the conversation's single agent
-    /// (resolved by template id) and follows the one-agent rule.
+    /// Selecting a suggested agent resolves it by template id through the
+    /// synthetic contact backing its row.
     func testSelectingSuggestedAgentSetsTemplateId() async {
         let service = MockSuggestedAgentsService(agents: [.mock(templateId: "trip", name: "Trip")])
         let viewModel = ContactsPickerViewModel(
@@ -456,8 +452,8 @@ final class ContactsPickerViewModelTests: XCTestCase {
         viewModel.toggleSelection(for: rowId)
 
         XCTAssertTrue(viewModel.isSelected(inboxId: rowId))
-        XCTAssertEqual(viewModel.selectedAgentTemplateId, "trip")
-        XCTAssertEqual(viewModel.selectedAgentInboxId, rowId)
+        XCTAssertEqual(viewModel.selectedAgentTemplateIds, ["trip"])
+        XCTAssertEqual(viewModel.selectedAgentInboxIds, [rowId])
         XCTAssertEqual(viewModel.selectedContacts.map(\.inboxId), [rowId])
     }
 


### PR DESCRIPTION
## Summary

Conversations can now have **multiple agents**. This removes every enforcement point of the old one-agent limit:

### Contacts picker
- `ContactsPickerViewModel.toggleSelection` no longer no-ops when a second agent is tapped; `isAgentSelectionBlocked(for:)` is gone and agent rows are never disabled (`ContactsPickerRow` drops the param)
- Singular `selectedAgentTemplateId` / `selectedAgentInboxId` become plural (`selectedAgentTemplateIds: [String]`, `selectedAgentInboxIds: Set<String>`)
- `ContactsPickerView.onConfirm` now passes `[String]` template ids; all four entry points updated (`ContactsView`, `ContactDetailView`, `ComposeFlowView`, `AddFromContactsPickerModifier`)

### Conversation creation
- `.newConversationWithMembers` carries `initialAgentTemplateIds: [String]` (was a single optional id); one fresh instance per template is spawned at `.ready`
- Restores the batched `ConversationViewModel.requestAgentJoins(templateIds:)` (sequential with a 500ms inter-call gap — the documented band-aid for the concurrent `agents/join` URLSession-cancellation issue; the single-flight `requestAgentJoin(templateId:)` would cancel each prior call)

### Add to an existing conversation
- `AddFromContactsPickerModifier` drops the `!conversation.hasAgent` guard that silently skipped the spawn when an agent was already present

### "New Agent" buttons
- The chat plus-menu, info view, members list, and invite-header entries are no longer disabled once an agent joins ("Already here" subtitle removed). The transient "Joining…" disable while a join is in flight remains
- Removes the now-dead `hasAgent` plumbing threaded through the messages-view chain solely to feed that gating

### Kept as-is
- `OneAgentManyConvosInfoSheet` still shows when confirming a selection that includes agents — its copy explains per-conversation instance isolation and funding, not the count limit. The "One agent, many convos" title may want a copy pass now that several agents can share a convo (flagging for design)

## Testing
- `Convos (Dev)` builds clean against latest `dev` (warnings-as-errors, type-check time limits)
- `ContactsPickerViewModelTests` pass, including the rewritten `testMultipleAgentsCanBeSelected` (was `testSecondAgentSelectionIsBlocked`)
- SwiftLint `--strict` clean on all 25 changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/968"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783103511&installation_id=128169237&pr_number=968&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F968&signature=06c02c577bbc016985ecbe53eaef3844b0f788263542dc460c623279f83dd524"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove the one-agent-per-conversation limit to allow multiple agents in a conversation
> - `ContactsPickerViewModel` no longer blocks selecting a second agent; `selectedAgentTemplateIds` and `selectedAgentInboxIds` are now arrays/sets instead of single optionals.
> - `ContactsPickerView` and all picker confirm handlers updated to pass `[String]` agent template IDs instead of `String?`.
> - `ConversationViewModel.requestAgentJoins(templateIds:)` added to sequentially join multiple agents with a ~0.5s delay between calls.
> - `NewConversationViewModel` updated to queue multiple pending agent templates and trigger a batched join when the conversation reaches `.ready`.
> - `hasAgent` flag removed from `AddToConversationMenu`, `NewConvoIdentityView`, `MessagesListView`, `MessagesViewController`, and related data sources — the "Invite agent" action and subtitle are now driven solely by `isAgentJoinPending`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 346c03c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->