### PR TITLE
Add iCloud-synced keychain backup slot for identity recovery

### DIFF
--- a/.github/workflows/keychain-identity-store-tests.yml
+++ b/.github/workflows/keychain-identity-store-tests.yml
@@ -63,7 +63,7 @@ jobs:
           xcodebuild test \
             -project Convos.xcodeproj \
             -scheme KeychainIdentityStoreTests \
-            -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.1' \
+            -destination 'platform=iOS Simulator,name=iPhone 17' \
             -enableCodeCoverage YES \
             -skipPackagePluginValidation \
             -resultBundlePath TestResults.xcresult \

--- a/ConvosCore/Sources/ConvosCore/Auth/Keychain/KeychainIdentityStore.swift
+++ b/ConvosCore/Sources/ConvosCore/Auth/Keychain/KeychainIdentityStore.swift
@@ -79,6 +79,44 @@ public struct KeychainIdentity: Codable, Sendable {
     public let keys: KeychainIdentityKeys
 }
 
+/// Identity material mirrored into the iCloud-synced backup slot.
+/// Deliberately excludes the SQLCipher database key: it only decrypts
+/// this device's local database, which never leaves the device, so
+/// escrowing it in iCloud would add exposure without recovery value.
+/// A recovering device generates a fresh database key.
+public struct KeychainIdentityBackup: Codable, Sendable {
+    public let inboxId: String
+    public let clientId: String
+    public let privateKey: PrivateKey
+
+    private enum CodingKeys: String, CodingKey {
+        case inboxId
+        case clientId
+        case privateKeyData
+    }
+
+    init(identity: KeychainIdentity) {
+        inboxId = identity.inboxId
+        clientId = identity.clientId
+        privateKey = identity.keys.privateKey
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        inboxId = try container.decode(String.self, forKey: .inboxId)
+        clientId = try container.decode(String.self, forKey: .clientId)
+        let privateKeyData = try container.decode(Data.self, forKey: .privateKeyData)
+        privateKey = try PrivateKey(privateKeyData)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(inboxId, forKey: .inboxId)
+        try container.encode(clientId, forKey: .clientId)
+        try container.encode(privateKey.secp256K1.bytes, forKey: .privateKeyData)
+    }
+}
+
 // MARK: - Errors
 
 public enum KeychainIdentityStoreError: Error, LocalizedError {
@@ -162,33 +200,83 @@ public protocol KeychainIdentityStoreProtocol: Actor {
     /// directly instead of paying an actor hop.
     nonisolated func loadSync() throws -> KeychainIdentity?
 
-    /// Removes the identity. Idempotent.
+    /// Returns every identity present in the iCloud-synced backup slot.
+    /// Each identity is backed up under its own account (keyed by
+    /// inboxId), so unpaired identities on devices sharing an iCloud
+    /// account coexist instead of overwriting each other. Nothing reads
+    /// this during normal operation; it exists for an explicit recovery
+    /// flow after the user loses their device.
+    func loadSyncedBackups() throws -> [KeychainIdentityBackup]
+
+    /// Mirrors the primary identity into the synced backup slot when its
+    /// backup is missing. Installs that registered before the backup
+    /// slot existed only ever wrote the primary slot; calling this on
+    /// authorize makes them recoverable too. Best-effort: failures are
+    /// logged, never thrown.
+    func backfillSyncedBackupIfNeeded()
+
+    /// Removes the identity from the primary slot and its mirror from
+    /// the synced backup slot. Backups belonging to other identities are
+    /// left untouched. Idempotent.
     func delete() throws
 }
 
 /// Secure storage for the user's XMTP identity keys in the device keychain.
 ///
-/// The app holds one identity per install. The slot is device-local —
-/// `kSecAttrSynchronizable = false` + `kSecAttrAccessibleAfterFirstUnlock`
-/// so identity keys never leave this device via iCloud Keychain. The
-/// item is stored in the app-group keychain so the Notification Service
-/// Extension can read it.
+/// The app holds one identity per install, kept in two keychain slots:
+///
+/// - The primary slot is device-local (`kSecAttrSynchronizable = false` +
+///   `kSecAttrAccessibleAfterFirstUnlock`) and is the only slot the app
+///   reads at runtime. Device sync stays an explicit user action: another
+///   device never picks up the identity just by sharing an iCloud account.
+/// - The synced backup slot (`kSecAttrSynchronizable = true`, separate
+///   service) mirrors the identity (minus the database key, see
+///   `KeychainIdentityBackup`) into iCloud Keychain so the user can
+///   recover after losing the device. Each identity is backed up under its
+///   own account (keyed by inboxId), so unpaired identities on devices
+///   sharing an iCloud account back up side by side instead of overwriting
+///   each other. Only an explicit recovery flow reads it.
+///
+/// When a save displaces a different identity (e.g. pairing overwrites the
+/// fresh-install placeholder), the displaced identity's backup is removed:
+/// its key material would otherwise sit in iCloud forever with no owner.
+///
+/// Surfaces that must not escrow keys (the App Clip, whose auto-registered
+/// identity the user never opted to back up) construct the store with
+/// `syncedBackupEnabled: false`, which disables the mirror and backfill
+/// write paths; the full app backfills the identity on first authorize.
+///
+/// Both slots live in the app-group keychain so the Notification Service
+/// Extension can read the primary slot.
 public final actor KeychainIdentityStore: KeychainIdentityStoreProtocol {
     // MARK: - Properties
 
     private let keychainService: String
     private let keychainAccessGroup: String
+    private let syncedBackupEnabled: Bool
 
     public static let defaultService: String = "org.convos.ios.KeychainIdentityStore.v3"
 
-    /// Fixed account key for the stored identity.
+    /// Service for the iCloud-synced backup slot. Distinct from
+    /// `defaultService` so queries can never confuse the two slots, and
+    /// listed in `LegacyDataWipe.identityKeychainServices` so generation
+    /// bumps sweep the iCloud copy as well. Items in this service use the
+    /// identity's inboxId as the account, one item per backed-up identity.
+    public static let syncedBackupService: String = "org.convos.ios.KeychainIdentityStore.v3-synced-backup"
+
+    /// Fixed account key for the identity in the primary slot.
     public static let identityAccount: String = "convos-identity"
 
     // MARK: - Initialization
 
-    public init(accessGroup: String) {
+    /// - Parameter syncedBackupEnabled: pass `false` from surfaces whose
+    ///   identities must not be escrowed to iCloud (the App Clip). Gates
+    ///   only the backup write paths (mirror + backfill); reads and the
+    ///   scoped backup delete stay active so cleanup still works.
+    public init(accessGroup: String, syncedBackupEnabled: Bool = true) {
         self.keychainAccessGroup = accessGroup
         self.keychainService = Self.defaultService
+        self.syncedBackupEnabled = syncedBackupEnabled
     }
 
     // MARK: - Public Interface
@@ -200,12 +288,17 @@ public final actor KeychainIdentityStore: KeychainIdentityStoreProtocol {
     public func save(inboxId: String, clientId: String, keys: KeychainIdentityKeys) throws -> KeychainIdentity {
         let identity = KeychainIdentity(inboxId: inboxId, clientId: clientId, keys: keys)
         let data = try JSONEncoder().encode(identity)
-        let query = KeychainQuery(
-            account: Self.identityAccount,
-            service: keychainService,
-            accessGroup: keychainAccessGroup
-        )
-        try saveData(data, with: query)
+        // When this save displaces a different identity (pairing over the
+        // fresh-install placeholder), remove the displaced identity's
+        // backup before overwriting the primary: once the primary is gone
+        // its inboxId can't be recovered to scope the deletion. If the
+        // primary write below then fails, the old identity is still in
+        // place and the next authorize's backfill restores its backup.
+        if let displacedInboxId = (try? loadSync())?.inboxId, displacedInboxId != inboxId {
+            removeSyncedBackup(inboxId: displacedInboxId)
+        }
+        try saveData(data, with: identityQuery)
+        mirrorToSyncedBackup(identity)
         return identity
     }
 
@@ -214,26 +307,120 @@ public final actor KeychainIdentityStore: KeychainIdentityStoreProtocol {
     }
 
     public nonisolated func loadSync() throws -> KeychainIdentity? {
-        let query = KeychainQuery(
-            account: Self.identityAccount,
-            service: keychainService,
-            accessGroup: keychainAccessGroup
-        )
+        try Self.loadIdentity(with: identityQuery)
+    }
+
+    public func loadSyncedBackups() throws -> [KeychainIdentityBackup] {
+        var query = syncedBackupServiceQuery()
+        query[kSecReturnData as String] = true
+        query[kSecMatchLimit as String] = kSecMatchLimitAll
+
+        var item: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &item)
+        guard status != errSecItemNotFound else { return [] }
+        guard status == errSecSuccess, let blobs = item as? [Data] else {
+            throw KeychainIdentityStoreError.keychainOperationFailed(status, "loadBackups")
+        }
+        return blobs.compactMap { (data: Data) -> KeychainIdentityBackup? in
+            do {
+                return try JSONDecoder().decode(KeychainIdentityBackup.self, from: data)
+            } catch {
+                Log.error("Skipping undecodable synced backup item: \(error)")
+                return nil
+            }
+        }
+    }
+
+    public func backfillSyncedBackupIfNeeded() {
+        guard syncedBackupEnabled else { return }
         do {
-            let data = try Self.loadKeychainData(with: query.toReadDictionary())
-            return try JSONDecoder().decode(KeychainIdentity.self, from: data)
-        } catch KeychainIdentityStoreError.identityNotFound {
-            return nil
+            guard let identity = try loadSync() else { return }
+            let readQuery = syncedBackupQuery(inboxId: identity.inboxId).toReadDictionary()
+            do {
+                _ = try Self.loadKeychainData(with: readQuery)
+            } catch KeychainIdentityStoreError.identityNotFound {
+                mirrorToSyncedBackup(identity)
+            }
+        } catch {
+            Log.error("Failed to backfill synced backup slot: \(error)")
         }
     }
 
     public func delete() throws {
-        let query = KeychainQuery(
+        // Remove the backup first: if the backup delete fails the primary
+        // is still intact, so a retry can locate the backup again. The
+        // deletion is scoped to this identity's account so backups from
+        // other (unpaired) identities on the same iCloud account survive.
+        // If the primary can't be read the backup can't be located; the
+        // primary is still deleted and the backup is left as an orphan
+        // (reclaimable via LegacyDataWipe on a generation bump).
+        let primary: KeychainIdentity?
+        do {
+            primary = try loadSync()
+        } catch {
+            primary = nil
+            Log.warning("Could not read primary slot during delete; any synced backup is left orphaned: \(error)")
+        }
+        if let inboxId = primary?.inboxId {
+            try deleteData(with: syncedBackupQuery(inboxId: inboxId))
+        }
+        try deleteData(with: identityQuery)
+    }
+
+    // MARK: - Slot Queries
+
+    private nonisolated var identityQuery: KeychainQuery {
+        KeychainQuery(
             account: Self.identityAccount,
             service: keychainService,
             accessGroup: keychainAccessGroup
         )
-        try deleteData(with: query)
+    }
+
+    private nonisolated func syncedBackupQuery(inboxId: String) -> KeychainQuery {
+        KeychainQuery(
+            account: inboxId,
+            service: Self.syncedBackupService,
+            accessGroup: keychainAccessGroup,
+            synchronizable: true
+        )
+    }
+
+    /// Service-wide query matching every item in the synced backup slot,
+    /// regardless of account. Used to enumerate backups for recovery.
+    private func syncedBackupServiceQuery() -> [String: Any] {
+        [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: Self.syncedBackupService,
+            kSecAttrAccessGroup as String: keychainAccessGroup,
+            kSecAttrSynchronizable as String: true
+        ]
+    }
+
+    /// Best-effort write of the identity (as a `KeychainIdentityBackup`)
+    /// into the synced backup slot. Failures are logged, never thrown:
+    /// the primary slot is the source of truth and a failed backup write
+    /// must not block registration or pairing.
+    private func mirrorToSyncedBackup(_ identity: KeychainIdentity) {
+        guard syncedBackupEnabled else { return }
+        do {
+            let data = try JSONEncoder().encode(KeychainIdentityBackup(identity: identity))
+            try saveData(data, with: syncedBackupQuery(inboxId: identity.inboxId))
+        } catch {
+            Log.error("Failed to write identity to synced backup slot: \(error)")
+        }
+    }
+
+    /// Best-effort removal of one identity's backup item. Used when a
+    /// save displaces a different identity; a failure here only leaves
+    /// the displaced backup as a logged orphan, it must not block the
+    /// incoming save.
+    private func removeSyncedBackup(inboxId: String) {
+        do {
+            try deleteData(with: syncedBackupQuery(inboxId: inboxId))
+        } catch {
+            Log.error("Failed to remove displaced identity's synced backup: \(error)")
+        }
     }
 
     // MARK: - Generic Keychain Operations
@@ -257,8 +444,14 @@ public final actor KeychainIdentityStore: KeychainIdentityStoreProtocol {
         }
     }
 
-    private func loadData(with query: KeychainQuery) throws -> Data {
-        try Self.loadKeychainData(with: query.toReadDictionary())
+    /// Static so `nonisolated` entry points can call it without an actor hop.
+    private static func loadIdentity(with query: KeychainQuery) throws -> KeychainIdentity? {
+        do {
+            let data = try loadKeychainData(with: query.toReadDictionary())
+            return try JSONDecoder().decode(KeychainIdentity.self, from: data)
+        } catch KeychainIdentityStoreError.identityNotFound {
+            return nil
+        }
     }
 
     /// Static so `nonisolated` entry points can call it without an actor hop.

--- a/ConvosCore/Sources/ConvosCore/Auth/Keychain/KeychainIdentityStore.swift
+++ b/ConvosCore/Sources/ConvosCore/Auth/Keychain/KeychainIdentityStore.swift
@@ -84,21 +84,36 @@ public struct KeychainIdentity: Codable, Sendable {
 /// this device's local database, which never leaves the device, so
 /// escrowing it in iCloud would add exposure without recovery value.
 /// A recovering device generates a fresh database key.
+///
+/// Carries restore-display metadata alongside the key material: the
+/// user-visible name of the device that wrote the backup and the write
+/// date, so a restore picker can show "Alice's iPhone, backed up
+/// June 3" instead of a bare inboxId. Both decode as optional so a
+/// missing metadata field can never make a backup unrecoverable.
 public struct KeychainIdentityBackup: Codable, Sendable {
     public let inboxId: String
     public let clientId: String
     public let privateKey: PrivateKey
+    /// Name of the device that last wrote this backup (mirrors the
+    /// pairing flow's `DeviceInfo.deviceName`), when the writer had one.
+    public let deviceName: String?
+    /// When this backup blob was last written.
+    public let backedUpAt: Date?
 
     private enum CodingKeys: String, CodingKey {
         case inboxId
         case clientId
         case privateKeyData
+        case deviceName
+        case backedUpAt
     }
 
-    init(identity: KeychainIdentity) {
+    init(identity: KeychainIdentity, deviceName: String?, backedUpAt: Date) {
         inboxId = identity.inboxId
         clientId = identity.clientId
         privateKey = identity.keys.privateKey
+        self.deviceName = deviceName
+        self.backedUpAt = backedUpAt
     }
 
     public init(from decoder: Decoder) throws {
@@ -107,6 +122,8 @@ public struct KeychainIdentityBackup: Codable, Sendable {
         clientId = try container.decode(String.self, forKey: .clientId)
         let privateKeyData = try container.decode(Data.self, forKey: .privateKeyData)
         privateKey = try PrivateKey(privateKeyData)
+        deviceName = try container.decodeIfPresent(String.self, forKey: .deviceName)
+        backedUpAt = try container.decodeIfPresent(Date.self, forKey: .backedUpAt)
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -114,6 +131,8 @@ public struct KeychainIdentityBackup: Codable, Sendable {
         try container.encode(inboxId, forKey: .inboxId)
         try container.encode(clientId, forKey: .clientId)
         try container.encode(privateKey.secp256K1.bytes, forKey: .privateKeyData)
+        try container.encodeIfPresent(deviceName, forKey: .deviceName)
+        try container.encodeIfPresent(backedUpAt, forKey: .backedUpAt)
     }
 }
 
@@ -254,6 +273,7 @@ public final actor KeychainIdentityStore: KeychainIdentityStoreProtocol {
     private let keychainService: String
     private let keychainAccessGroup: String
     private let syncedBackupEnabled: Bool
+    private let deviceNameProvider: (@Sendable () -> String?)?
 
     public static let defaultService: String = "org.convos.ios.KeychainIdentityStore.v3"
 
@@ -269,14 +289,27 @@ public final actor KeychainIdentityStore: KeychainIdentityStoreProtocol {
 
     // MARK: - Initialization
 
-    /// - Parameter syncedBackupEnabled: pass `false` from surfaces whose
-    ///   identities must not be escrowed to iCloud (the App Clip). Gates
-    ///   only the backup write paths (mirror + backfill); reads and the
-    ///   scoped backup delete stay active so cleanup still works.
-    public init(accessGroup: String, syncedBackupEnabled: Bool = true) {
+    /// - Parameters:
+    ///   - syncedBackupEnabled: pass `false` from surfaces whose
+    ///     identities must not be escrowed to iCloud (the App Clip).
+    ///     Gates only the backup write paths (mirror + backfill); reads
+    ///     and the scoped backup delete stay active so cleanup still
+    ///     works.
+    ///   - deviceNameProvider: evaluated lazily at each backup write to
+    ///     stamp the blob with the user-visible device name for the
+    ///     restore picker (the app passes `{ DeviceInfo.deviceName }`).
+    ///     Injected rather than read from `DeviceInfo.shared` directly so
+    ///     contexts that never configure `DeviceInfo` (tests, extensions)
+    ///     can use the store without tripping its configuration check.
+    public init(
+        accessGroup: String,
+        syncedBackupEnabled: Bool = true,
+        deviceNameProvider: (@Sendable () -> String?)? = nil
+    ) {
         self.keychainAccessGroup = accessGroup
         self.keychainService = Self.defaultService
         self.syncedBackupEnabled = syncedBackupEnabled
+        self.deviceNameProvider = deviceNameProvider
     }
 
     // MARK: - Public Interface
@@ -404,7 +437,12 @@ public final actor KeychainIdentityStore: KeychainIdentityStoreProtocol {
     private func mirrorToSyncedBackup(_ identity: KeychainIdentity) {
         guard syncedBackupEnabled else { return }
         do {
-            let data = try JSONEncoder().encode(KeychainIdentityBackup(identity: identity))
+            let backup = KeychainIdentityBackup(
+                identity: identity,
+                deviceName: deviceNameProvider?(),
+                backedUpAt: Date()
+            )
+            let data = try JSONEncoder().encode(backup)
             try saveData(data, with: syncedBackupQuery(inboxId: identity.inboxId))
         } catch {
             Log.error("Failed to write identity to synced backup slot: \(error)")

--- a/ConvosCore/Sources/ConvosCore/Auth/Keychain/MockKeychainIdentityStore.swift
+++ b/ConvosCore/Sources/ConvosCore/Auth/Keychain/MockKeychainIdentityStore.swift
@@ -2,6 +2,10 @@ import Foundation
 import os
 
 actor MockKeychainIdentityStore: KeychainIdentityStoreProtocol {
+    /// Fixed device name stamped on mock backups, mirroring the real
+    /// store's lazily-provided `DeviceInfo.deviceName`.
+    static let mockDeviceName: String = "Mock Device"
+
     /// Backed by an unfair lock so `loadSync` can read without hopping
     /// actor isolation — mirrors the real store's keychain-daemon-owned
     /// concurrency model.
@@ -27,7 +31,11 @@ actor MockKeychainIdentityStore: KeychainIdentityStoreProtocol {
             if let displacedInboxId, displacedInboxId != inboxId {
                 backups.removeValue(forKey: displacedInboxId)
             }
-            backups[inboxId] = KeychainIdentityBackup(identity: identity)
+            backups[inboxId] = KeychainIdentityBackup(
+                identity: identity,
+                deviceName: Self.mockDeviceName,
+                backedUpAt: Date()
+            )
         }
         return identity
     }
@@ -51,7 +59,11 @@ actor MockKeychainIdentityStore: KeychainIdentityStoreProtocol {
         guard let identity = try? loadSync() else { return }
         backupState.withLock { backups in
             if backups[identity.inboxId] == nil {
-                backups[identity.inboxId] = KeychainIdentityBackup(identity: identity)
+                backups[identity.inboxId] = KeychainIdentityBackup(
+                    identity: identity,
+                    deviceName: Self.mockDeviceName,
+                    backedUpAt: Date()
+                )
             }
         }
     }

--- a/ConvosCore/Sources/ConvosCore/Auth/Keychain/MockKeychainIdentityStore.swift
+++ b/ConvosCore/Sources/ConvosCore/Auth/Keychain/MockKeychainIdentityStore.swift
@@ -6,6 +6,10 @@ actor MockKeychainIdentityStore: KeychainIdentityStoreProtocol {
     /// actor isolation — mirrors the real store's keychain-daemon-owned
     /// concurrency model.
     private let state: OSAllocatedUnfairLock<KeychainIdentity?> = .init(initialState: nil)
+    /// In-memory stand-in for the iCloud-synced backup slot, keyed by
+    /// inboxId — one entry per backed-up identity, like the real store's
+    /// per-identity accounts.
+    private let backupState: OSAllocatedUnfairLock<[String: KeychainIdentityBackup]> = .init(initialState: [:])
     /// Optional error injection for the load path. Tests simulating a
     /// transient keychain daemon failure set this to a non-nil `Error`;
     /// `loadSync` and `load` both throw it until the test clears it.
@@ -17,7 +21,14 @@ actor MockKeychainIdentityStore: KeychainIdentityStoreProtocol {
 
     func save(inboxId: String, clientId: String, keys: KeychainIdentityKeys) throws -> KeychainIdentity {
         let identity = KeychainIdentity(inboxId: inboxId, clientId: clientId, keys: keys)
+        let displacedInboxId = state.withLock { $0?.inboxId }
         state.withLock { $0 = identity }
+        backupState.withLock { backups in
+            if let displacedInboxId, displacedInboxId != inboxId {
+                backups.removeValue(forKey: displacedInboxId)
+            }
+            backups[inboxId] = KeychainIdentityBackup(identity: identity)
+        }
         return identity
     }
 
@@ -32,13 +43,37 @@ actor MockKeychainIdentityStore: KeychainIdentityStoreProtocol {
         return state.withLock { $0 }
     }
 
+    func loadSyncedBackups() throws -> [KeychainIdentityBackup] {
+        backupState.withLock { Array($0.values) }
+    }
+
+    func backfillSyncedBackupIfNeeded() {
+        guard let identity = try? loadSync() else { return }
+        backupState.withLock { backups in
+            if backups[identity.inboxId] == nil {
+                backups[identity.inboxId] = KeychainIdentityBackup(identity: identity)
+            }
+        }
+    }
+
     func delete() throws {
+        let inboxId = state.withLock { $0?.inboxId }
         state.withLock { $0 = nil }
+        if let inboxId {
+            backupState.withLock { $0.removeValue(forKey: inboxId) }
+        }
     }
 
     /// Test-only — inject an error for the next `loadSync`/`load` calls.
     /// Pass `nil` to clear.
     nonisolated func _setLoadError(_ error: (any Error)?) {
         loadError.withLock { $0 = error }
+    }
+
+    /// Test-only — clears just the synced backup slot so backfill paths
+    /// can be exercised (every `save` mirrors into the backup, so this
+    /// state is otherwise unreachable through the public API).
+    nonisolated func _clearSyncedBackups() {
+        backupState.withLock { $0.removeAll() }
     }
 }

--- a/ConvosCore/Sources/ConvosCore/ConvosClient+App.swift
+++ b/ConvosCore/Sources/ConvosCore/ConvosClient+App.swift
@@ -9,7 +9,13 @@ extension ConvosClient {
         let databaseManager = DatabaseManager(environment: environment)
         let databaseWriter = databaseManager.dbWriter
         let databaseReader = databaseManager.dbReader
-        let identityStore = KeychainIdentityStore(accessGroup: environment.keychainAccessGroup)
+        // Device name is read lazily at each backup write (it can change
+        // in Settings) and stamps the synced backup blob for the restore
+        // picker, mirroring the pairing flow's device labels.
+        let identityStore = KeychainIdentityStore(
+            accessGroup: environment.keychainAccessGroup,
+            deviceNameProvider: { DeviceInfo.deviceName }
+        )
         let sessionManager = SessionManager(
             databaseWriter: databaseWriter,
             databaseReader: databaseReader,

--- a/ConvosCore/Sources/ConvosCore/Inboxes/SessionStateMachine.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/SessionStateMachine.swift
@@ -516,6 +516,11 @@ public actor SessionStateMachine: SessionStateManagerProtocol {
             throw KeychainIdentityStoreError.identityNotFound("ClientId mismatch: expected \(initialClientId), got \(identity.clientId)")
         }
 
+        // Installs that registered before the synced backup slot existed
+        // only ever wrote the primary slot; mirror the identity here so
+        // they become recoverable too. Best-effort, no-op once populated.
+        await identityStore.backfillSyncedBackupIfNeeded()
+
         emitStateChange(.authorizing(inboxId: inboxId))
         Log.info("Started authorization flow for inbox: \(inboxId), clientId: \(initialClientId)")
 

--- a/ConvosCore/Sources/ConvosCore/Sessions/ClipIdentityBootstrap.swift
+++ b/ConvosCore/Sources/ConvosCore/Sessions/ClipIdentityBootstrap.swift
@@ -32,7 +32,14 @@ public enum ClipIdentityBootstrap {
         platformProviders: PlatformProviders
     ) -> ClipSession {
         let databaseManager = DatabaseManager(environment: environment)
-        let identityStore = KeychainIdentityStore(accessGroup: environment.keychainAccessGroup)
+        // The clip's auto-registered identity must not be escrowed to
+        // iCloud Keychain -- the user never opted into a backup from this
+        // ephemeral surface. The full app backfills the synced backup on
+        // first authorize once the identity is actually adopted.
+        let identityStore = KeychainIdentityStore(
+            accessGroup: environment.keychainAccessGroup,
+            syncedBackupEnabled: false
+        )
         let sessionManager = SessionManager(
             databaseWriter: databaseManager.dbWriter,
             databaseReader: databaseManager.dbReader,

--- a/ConvosCore/Sources/ConvosCore/Storage/LegacyDataWipe.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/LegacyDataWipe.swift
@@ -45,6 +45,12 @@ enum LegacyDataWipe {
     /// both the local and the iCloud-synced copies of each get removed.
     private static let identityKeychainServices: [String] = [
         "org.convos.ios.KeychainIdentityStore.v3",
+        // Synced backup slot: holds one item per identity. Sweeping it
+        // with kSecAttrSynchronizableAny propagates through iCloud
+        // Keychain and removes every identity's recovery backup on every
+        // device on the account -- acceptable only because a generation
+        // bump is a deliberate total reset.
+        "org.convos.ios.KeychainIdentityStore.v3-synced-backup",
         "org.convos.ios.KeychainIdentityStore.v4-local",
         "org.convos.ios.KeychainIdentityStore.v2",
         "org.convos.ios.KeychainIdentityStore.v1"

--- a/ConvosCore/Tests/ConvosCoreTests/KeychainSyncConfigTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/KeychainSyncConfigTests.swift
@@ -1,23 +1,33 @@
 @testable import ConvosCore
 import Foundation
 import Testing
+@preconcurrency import XMTPiOS
 
 /// Smoke tests for keychain identity storage configuration.
 ///
-/// The identity slot is device-local (`kSecAttrSynchronizable: false`). These
-/// tests verify the knobs we control without hitting the real keychain:
-/// the service name, the fixed account key, and the API contract on the
+/// The primary identity slot is device-local (`kSecAttrSynchronizable:
+/// false`); a separate synced backup slot (`kSecAttrSynchronizable: true`)
+/// mirrors the identity into iCloud Keychain for recovery. These tests
+/// verify the knobs we control without hitting the real keychain: the
+/// service names, the fixed account key, and the API contract on the
 /// mock store.
 ///
 /// Attribute-level verification (`kSecAttrSynchronizable == false` on the
-/// real saved item, `kSecAttrAccessible == kSecAttrAccessibleAfterFirstUnlock`)
-/// lives in the separate `KeychainIdentityStoreTests` target, which runs
-/// against a real keychain with the necessary entitlements.
+/// real saved item, `kSecAttrAccessible == kSecAttrAccessibleAfterFirstUnlock`,
+/// the backup landing in the synced store) lives in the separate
+/// `KeychainIdentityStoreTests` target, which runs against a real keychain
+/// with the necessary entitlements.
 @Suite("Keychain Sync Config")
 struct KeychainSyncConfigTests {
     @Test("Service name is stable across launches")
     func serviceNameIsStable() {
         #expect(KeychainIdentityStore.defaultService == "org.convos.ios.KeychainIdentityStore.v3")
+    }
+
+    @Test("Synced backup service name is stable and distinct from the primary")
+    func syncedBackupServiceNameIsStable() {
+        #expect(KeychainIdentityStore.syncedBackupService == "org.convos.ios.KeychainIdentityStore.v3-synced-backup")
+        #expect(KeychainIdentityStore.syncedBackupService != KeychainIdentityStore.defaultService)
     }
 
     @Test("Identity account key is a fixed, non-empty string")
@@ -111,5 +121,140 @@ struct KeychainSyncConfigTests {
 
         try await store.delete()
         #expect(try await store.load() == nil)
+    }
+
+    @Test("loadSyncedBackups returns empty on a fresh store")
+    func syncedBackupsAreEmptyOnFreshStore() async throws {
+        let store = MockKeychainIdentityStore()
+        let backups = try await store.loadSyncedBackups()
+        #expect(backups.isEmpty)
+    }
+
+    @Test("save mirrors the identity into the synced backup slot")
+    func saveMirrorsIntoSyncedBackup() async throws {
+        let store = MockKeychainIdentityStore()
+        let keys = try await store.generateKeys()
+
+        _ = try await store.save(
+            inboxId: "backup-inbox",
+            clientId: "backup-client",
+            keys: keys
+        )
+
+        let backups = try await store.loadSyncedBackups()
+        #expect(backups.count == 1)
+        #expect(backups.first?.inboxId == "backup-inbox")
+        #expect(backups.first?.clientId == "backup-client")
+    }
+
+    @Test("delete clears the deleted identity's synced backup too")
+    func deleteClearsSyncedBackup() async throws {
+        let store = MockKeychainIdentityStore()
+        let keys = try await store.generateKeys()
+
+        _ = try await store.save(
+            inboxId: "backup-inbox",
+            clientId: "backup-client",
+            keys: keys
+        )
+        #expect(try await store.loadSyncedBackups().count == 1)
+
+        try await store.delete()
+        #expect(try await store.loadSyncedBackups().isEmpty)
+    }
+
+    @Test("a displacing save removes the displaced identity's backup")
+    func displacingSaveRemovesDisplacedBackup() async throws {
+        let store = MockKeychainIdentityStore()
+        let placeholderKeys = try await store.generateKeys()
+        let pairedKeys = try await store.generateKeys()
+
+        // Models pairing: the fresh-install placeholder identity is
+        // displaced by the shared identity. The placeholder's backup
+        // must not be left orphaned in iCloud.
+        _ = try await store.save(
+            inboxId: "placeholder-inbox",
+            clientId: "placeholder-client",
+            keys: placeholderKeys
+        )
+        _ = try await store.save(
+            inboxId: "paired-inbox",
+            clientId: "paired-client",
+            keys: pairedKeys
+        )
+
+        let backups = try await store.loadSyncedBackups()
+        #expect(backups.map(\.inboxId) == ["paired-inbox"])
+    }
+
+    @Test("re-saving the same identity keeps a single backup entry")
+    func resavingSameIdentityKeepsSingleBackup() async throws {
+        let store = MockKeychainIdentityStore()
+        let firstKeys = try await store.generateKeys()
+        let secondKeys = try await store.generateKeys()
+
+        _ = try await store.save(
+            inboxId: "stable-inbox",
+            clientId: "client-one",
+            keys: firstKeys
+        )
+        _ = try await store.save(
+            inboxId: "stable-inbox",
+            clientId: "client-two",
+            keys: secondKeys
+        )
+
+        let backups = try await store.loadSyncedBackups()
+        #expect(backups.count == 1)
+        #expect(backups.first?.clientId == "client-two")
+    }
+
+    @Test("backup excludes the database key")
+    func backupExcludesDatabaseKey() async throws {
+        let store = MockKeychainIdentityStore()
+        let keys = try await store.generateKeys()
+
+        let saved = try await store.save(
+            inboxId: "slim-inbox",
+            clientId: "slim-client",
+            keys: keys
+        )
+
+        let backup = try #require(try await store.loadSyncedBackups().first)
+        let encoded = try JSONEncoder().encode(backup)
+        let json = try #require(try JSONSerialization.jsonObject(with: encoded) as? [String: Any])
+        #expect(json["databaseKey"] == nil)
+        #expect(json["privateKeyData"] != nil)
+        #expect(backup.privateKey.secp256K1.bytes == saved.keys.privateKey.secp256K1.bytes)
+    }
+
+    @Test("backfill repopulates a missing synced backup from the primary slot")
+    func backfillRepopulatesMissingBackup() async throws {
+        let store = MockKeychainIdentityStore()
+        let keys = try await store.generateKeys()
+
+        _ = try await store.save(
+            inboxId: "backfill-inbox",
+            clientId: "backfill-client",
+            keys: keys
+        )
+        store._clearSyncedBackups()
+        #expect(try await store.loadSyncedBackups().isEmpty)
+
+        await store.backfillSyncedBackupIfNeeded()
+
+        let backups = try await store.loadSyncedBackups()
+        #expect(backups.first?.inboxId == "backfill-inbox")
+        #expect(backups.first?.clientId == "backfill-client")
+    }
+
+    @Test("backfill is a no-op on an empty store")
+    func backfillIsNoOpOnEmptyStore() async throws {
+        let store = MockKeychainIdentityStore()
+
+        await store.backfillSyncedBackupIfNeeded()
+
+        #expect(try await store.load() == nil)
+        #expect(try await store.loadSyncedBackups().isEmpty)
     }
 }

--- a/ConvosCore/Tests/ConvosCoreTests/KeychainSyncConfigTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/KeychainSyncConfigTests.swift
@@ -145,6 +145,26 @@ struct KeychainSyncConfigTests {
         #expect(backups.count == 1)
         #expect(backups.first?.inboxId == "backup-inbox")
         #expect(backups.first?.clientId == "backup-client")
+        #expect(backups.first?.deviceName == MockKeychainIdentityStore.mockDeviceName)
+        #expect(backups.first?.backedUpAt != nil)
+    }
+
+    @Test("backup metadata fields are optional when decoding")
+    func backupMetadataIsOptionalWhenDecoding() throws {
+        // A blob written without restore-display metadata must still
+        // decode -- metadata can never make a backup unrecoverable.
+        let keys = try KeychainIdentityKeys.generate()
+        let json: [String: Any] = [
+            "inboxId": "bare-inbox",
+            "clientId": "bare-client",
+            "privateKeyData": keys.privateKey.secp256K1.bytes.base64EncodedString()
+        ]
+        let data = try JSONSerialization.data(withJSONObject: json)
+
+        let decoded = try JSONDecoder().decode(KeychainIdentityBackup.self, from: data)
+        #expect(decoded.inboxId == "bare-inbox")
+        #expect(decoded.deviceName == nil)
+        #expect(decoded.backedUpAt == nil)
     }
 
     @Test("delete clears the deleted identity's synced backup too")

--- a/KeychainIdentityStoreTests/KeychainIdentityStoreTests.swift
+++ b/KeychainIdentityStoreTests/KeychainIdentityStoreTests.swift
@@ -391,6 +391,39 @@ import Testing
         #expect(backups.map(\.inboxId) == ["valid-inbox"])
     }
 
+    /// The backup blob carries restore-display metadata: the writing
+    /// device's name (from the injected provider, evaluated lazily at
+    /// write time) and the backup date.
+    @Test func backupRecordsDeviceNameAndDate() async throws {
+        let namedStore = KeychainIdentityStore(
+            accessGroup: testAccessGroup,
+            deviceNameProvider: { "Test iPhone" }
+        )
+        let keys = try await namedStore.generateKeys()
+        let beforeSave = Date()
+        _ = try await namedStore.save(
+            inboxId: "named-inbox",
+            clientId: "named-client",
+            keys: keys
+        )
+
+        let backup = try #require(try await namedStore.loadSyncedBackups().first)
+        #expect(backup.deviceName == "Test iPhone")
+        let backedUpAt = try #require(backup.backedUpAt)
+        #expect(backedUpAt >= beforeSave)
+        #expect(backedUpAt <= Date())
+
+        // The default store (no provider) writes nil rather than failing.
+        _ = try await keychainStore.save(
+            inboxId: "named-inbox",
+            clientId: "named-client-two",
+            keys: keys
+        )
+        let rewritten = try #require(try await keychainStore.loadSyncedBackups().first)
+        #expect(rewritten.deviceName == nil)
+        #expect(rewritten.clientId == "named-client-two")
+    }
+
     /// Confirms the kSecMatchLimitAll enumeration holds beyond two items.
     @Test func loadSyncedBackupsEnumeratesManyItems() async throws {
         for index in 1...3 {

--- a/KeychainIdentityStoreTests/KeychainIdentityStoreTests.swift
+++ b/KeychainIdentityStoreTests/KeychainIdentityStoreTests.swift
@@ -14,6 +14,26 @@ import Testing
 
     init() throws {
         keychainStore = KeychainIdentityStore(accessGroup: testAccessGroup)
+        Self.sweepAllSlots(accessGroup: testAccessGroup)
+    }
+
+    /// Swift Testing creates a fresh suite instance per test, so this runs
+    /// before every test: it clears the primary slot and every backup item
+    /// (including orphans from interrupted earlier runs), so no test
+    /// depends on declaration order or a prior test's cleanup. `delete()`
+    /// alone can't guarantee this because it scopes backup removal to the
+    /// current primary's inboxId.
+    private static func sweepAllSlots(accessGroup: String) {
+        let services = [KeychainIdentityStore.defaultService, KeychainIdentityStore.syncedBackupService]
+        for service in services {
+            let query: [String: Any] = [
+                kSecClass as String: kSecClassGenericPassword,
+                kSecAttrService as String: service,
+                kSecAttrAccessGroup as String: accessGroup,
+                kSecAttrSynchronizable as String: kSecAttrSynchronizableAny
+            ]
+            _ = SecItemDelete(query as CFDictionary)
+        }
     }
 
     @Test func generatesKeys() async throws {
@@ -173,6 +193,266 @@ import Testing
         var syncResult: CFTypeRef?
         let syncStatus = SecItemCopyMatching(syncQuery as CFDictionary, &syncResult)
         #expect(syncStatus == errSecItemNotFound, "Item must not be in the iCloud-synced slot (status=\(syncStatus))")
+    }
+
+    /// `save` mirrors the identity into the synced backup slot
+    /// (`syncedBackupService`, account = inboxId, `kSecAttrSynchronizable:
+    /// true`), so a pinned sync query on the backup service must find it
+    /// and a pinned non-sync query must miss it — the inverse of the
+    /// primary slot.
+    @Test func savedIdentityIsMirroredIntoSyncedBackupSlot() async throws {
+        let keys = try await keychainStore.generateKeys()
+        _ = try await keychainStore.save(
+            inboxId: "backup-check-inbox",
+            clientId: "backup-check-client",
+            keys: keys
+        )
+
+        // Pinned sync query on the backup service → must find the item.
+        var syncResult: CFTypeRef?
+        let syncStatus = SecItemCopyMatching(
+            backupSlotReadQuery(inboxId: "backup-check-inbox", synchronizable: true) as CFDictionary,
+            &syncResult
+        )
+        #expect(syncStatus == errSecSuccess, "Backup must be present in the iCloud-synced slot (status=\(syncStatus))")
+
+        // Pinned non-sync query on the backup service → must NOT find the item.
+        var nonSyncResult: CFTypeRef?
+        let nonSyncStatus = SecItemCopyMatching(
+            backupSlotReadQuery(inboxId: "backup-check-inbox", synchronizable: false) as CFDictionary,
+            &nonSyncResult
+        )
+        #expect(nonSyncStatus == errSecItemNotFound, "Backup must not be in the device-local store (status=\(nonSyncStatus))")
+    }
+
+    @Test func loadSyncedBackupsRoundTrip() async throws {
+        let keys = try await keychainStore.generateKeys()
+        _ = try await keychainStore.save(
+            inboxId: "backup-load-inbox",
+            clientId: "backup-load-client",
+            keys: keys
+        )
+
+        let backups = try await keychainStore.loadSyncedBackups()
+        #expect(backups.count == 1)
+        #expect(backups.first?.inboxId == "backup-load-inbox")
+        #expect(backups.first?.clientId == "backup-load-client")
+    }
+
+    /// Re-saving the same inboxId hits the `errSecDuplicateItem` ->
+    /// `SecItemUpdate` path on the synchronizable backup item — semantics
+    /// the mock cannot model. The updated clientId proves the blob was
+    /// rewritten in place rather than duplicated or left stale.
+    @Test func resavingSameIdentityUpdatesBackupInPlace() async throws {
+        let firstKeys = try await keychainStore.generateKeys()
+        _ = try await keychainStore.save(
+            inboxId: "resave-inbox",
+            clientId: "resave-client-one",
+            keys: firstKeys
+        )
+
+        let secondKeys = try await keychainStore.generateKeys()
+        _ = try await keychainStore.save(
+            inboxId: "resave-inbox",
+            clientId: "resave-client-two",
+            keys: secondKeys
+        )
+
+        let backups = try await keychainStore.loadSyncedBackups()
+        #expect(backups.count == 1)
+        #expect(backups.first?.inboxId == "resave-inbox")
+        #expect(backups.first?.clientId == "resave-client-two")
+    }
+
+    /// A save that displaces a different identity (pairing overwriting the
+    /// fresh-install placeholder) must remove the displaced identity's
+    /// backup instead of leaving it orphaned in iCloud.
+    @Test func displacingSaveRemovesDisplacedBackup() async throws {
+        let placeholderKeys = try await keychainStore.generateKeys()
+        _ = try await keychainStore.save(
+            inboxId: "displaced-inbox",
+            clientId: "displaced-client",
+            keys: placeholderKeys
+        )
+
+        let pairedKeys = try await keychainStore.generateKeys()
+        _ = try await keychainStore.save(
+            inboxId: "incoming-inbox",
+            clientId: "incoming-client",
+            keys: pairedKeys
+        )
+
+        let backups = try await keychainStore.loadSyncedBackups()
+        #expect(backups.map(\.inboxId) == ["incoming-inbox"])
+    }
+
+    @Test func deleteClearsSyncedBackupSlot() async throws {
+        let keys = try await keychainStore.generateKeys()
+        _ = try await keychainStore.save(
+            inboxId: "backup-delete-inbox",
+            clientId: "backup-delete-client",
+            keys: keys
+        )
+        #expect(try await keychainStore.loadSyncedBackups().count == 1)
+
+        try await keychainStore.delete()
+        #expect(try await keychainStore.loadSyncedBackups().isEmpty)
+    }
+
+    /// Two unpaired identities sharing an iCloud account must back up
+    /// side by side. Simulated by saving identity A, clearing only the
+    /// device-local primary slot (as if this were a different device),
+    /// then saving identity B. With no primary present, B's save sees no
+    /// displaced identity, so A's backup survives.
+    @Test func unpairedIdentitiesCoexistInBackupSlot() async throws {
+        let firstKeys = try await keychainStore.generateKeys()
+        _ = try await keychainStore.save(
+            inboxId: "coexist-inbox-a",
+            clientId: "coexist-client-a",
+            keys: firstKeys
+        )
+        deletePrimarySlotOnly()
+
+        let secondKeys = try await keychainStore.generateKeys()
+        _ = try await keychainStore.save(
+            inboxId: "coexist-inbox-b",
+            clientId: "coexist-client-b",
+            keys: secondKeys
+        )
+
+        let backedUpInboxIds = Set(try await keychainStore.loadSyncedBackups().map(\.inboxId))
+        #expect(backedUpInboxIds == ["coexist-inbox-a", "coexist-inbox-b"])
+
+        // Deleting the current identity (B) must leave A's backup intact.
+        try await keychainStore.delete()
+        let remaining = try await keychainStore.loadSyncedBackups()
+        #expect(remaining.map(\.inboxId) == ["coexist-inbox-a"])
+    }
+
+    /// Simulates an install that saved its identity before the backup
+    /// slot existed: primary populated, backup missing. Backfill must
+    /// mirror the primary into the backup without touching the primary.
+    @Test func backfillRestoresMissingSyncedBackup() async throws {
+        let keys = try await keychainStore.generateKeys()
+        _ = try await keychainStore.save(
+            inboxId: "backfill-inbox",
+            clientId: "backfill-client",
+            keys: keys
+        )
+
+        // Remove just the backup copy, leaving the primary slot intact.
+        let deleteStatus = SecItemDelete(backupSlotQuery(inboxId: "backfill-inbox", synchronizable: true) as CFDictionary)
+        #expect(deleteStatus == errSecSuccess)
+        #expect(try await keychainStore.loadSyncedBackups().isEmpty)
+
+        await keychainStore.backfillSyncedBackupIfNeeded()
+
+        let backups = try await keychainStore.loadSyncedBackups()
+        #expect(backups.first?.inboxId == "backfill-inbox")
+        #expect(backups.first?.clientId == "backfill-client")
+
+        let primary = try await keychainStore.load()
+        #expect(primary?.inboxId == "backfill-inbox")
+    }
+
+    /// Documents the orphan edge: when the primary slot is already gone,
+    /// `delete()` cannot scope the backup removal, so the backup survives
+    /// (reclaimable via LegacyDataWipe on a generation bump). This is the
+    /// deliberate trade-off versus sweeping the whole backup service,
+    /// which would destroy other devices' backups.
+    @Test func deleteWithMissingPrimaryLeavesBackupOrphaned() async throws {
+        let keys = try await keychainStore.generateKeys()
+        _ = try await keychainStore.save(
+            inboxId: "orphan-inbox",
+            clientId: "orphan-client",
+            keys: keys
+        )
+        deletePrimarySlotOnly()
+
+        try await keychainStore.delete()
+
+        #expect(try await keychainStore.load() == nil)
+        #expect(try await keychainStore.loadSyncedBackups().map(\.inboxId) == ["orphan-inbox"])
+    }
+
+    /// One corrupt blob must not poison recovery: `loadSyncedBackups`
+    /// skips items that fail to decode and returns the rest.
+    @Test func loadSyncedBackupsSkipsCorruptBlob() async throws {
+        addRawBackupItem(account: "corrupt-account", data: Data("not json".utf8))
+
+        let keys = try await keychainStore.generateKeys()
+        _ = try await keychainStore.save(
+            inboxId: "valid-inbox",
+            clientId: "valid-client",
+            keys: keys
+        )
+
+        let backups = try await keychainStore.loadSyncedBackups()
+        #expect(backups.map(\.inboxId) == ["valid-inbox"])
+    }
+
+    /// Confirms the kSecMatchLimitAll enumeration holds beyond two items.
+    @Test func loadSyncedBackupsEnumeratesManyItems() async throws {
+        for index in 1...3 {
+            let keys = try await keychainStore.generateKeys()
+            _ = try await keychainStore.save(
+                inboxId: "many-inbox-\(index)",
+                clientId: "many-client-\(index)",
+                keys: keys
+            )
+            deletePrimarySlotOnly()
+        }
+
+        let backedUpInboxIds = Set(try await keychainStore.loadSyncedBackups().map(\.inboxId))
+        #expect(backedUpInboxIds == ["many-inbox-1", "many-inbox-2", "many-inbox-3"])
+    }
+
+    /// Removes only the device-local primary slot, leaving every synced
+    /// backup in place — simulates a different device sharing the same
+    /// iCloud account.
+    private func deletePrimarySlotOnly() {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: KeychainIdentityStore.defaultService,
+            kSecAttrAccount as String: KeychainIdentityStore.identityAccount,
+            kSecAttrAccessGroup as String: testAccessGroup,
+            kSecAttrSynchronizable as String: false
+        ]
+        _ = SecItemDelete(query as CFDictionary)
+    }
+
+    /// Writes a raw item directly into the backup service, bypassing the
+    /// store — used to plant corrupt blobs.
+    private func addRawBackupItem(account: String, data: Data) {
+        var query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: KeychainIdentityStore.syncedBackupService,
+            kSecAttrAccount as String: account,
+            kSecAttrAccessGroup as String: testAccessGroup,
+            kSecAttrSynchronizable as String: true
+        ]
+        query[kSecValueData as String] = data
+        _ = SecItemAdd(query as CFDictionary, nil)
+    }
+
+    /// Base attribute query for one identity's backup item. Suitable for
+    /// `SecItemDelete`, which rejects read-only keys like `kSecMatchLimit`
+    /// on iOS.
+    private func backupSlotQuery(inboxId: String, synchronizable: Bool) -> [String: Any] {
+        [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: KeychainIdentityStore.syncedBackupService,
+            kSecAttrAccount as String: inboxId,
+            kSecAttrAccessGroup as String: testAccessGroup,
+            kSecAttrSynchronizable as String: synchronizable
+        ]
+    }
+
+    private func backupSlotReadQuery(inboxId: String, synchronizable: Bool) -> [String: Any] {
+        var query = backupSlotQuery(inboxId: inboxId, synchronizable: synchronizable)
+        query[kSecMatchLimit as String] = kSecMatchLimitOne
+        query[kSecReturnAttributes as String] = true
+        return query
     }
 
     @Test func encodesIdentityRoundTrip() async throws {


### PR DESCRIPTION
## What

The user's identity (secp256k1 private key) currently lives only in a device-local keychain slot, so a lost phone means a lost identity. This adds a second, iCloud-synced keychain slot that backs up the identity for recovery — while keeping device sync an explicit user action.

## Design

| | Primary slot | Synced backup slot |
|---|---|---|
| Service | `…KeychainIdentityStore.v3` (unchanged) | `…KeychainIdentityStore.v3-synced-backup` (new) |
| `kSecAttrSynchronizable` | `false` | `true` |
| Account | `convos-identity` (fixed) | the identity's `inboxId` (one item per identity) |
| Contents | full identity incl. database key | `KeychainIdentityBackup`: inboxId, clientId, private key + restore-display metadata (device name, backup date) |
| Read at runtime | yes (`load`/`loadSync`) | never — future recovery flow only |

- **Sync stays explicit**: nothing in the runtime read path touches the backup slot, so another device sharing the iCloud account never silently adopts the identity.
- **Per-identity accounts**: unpaired identities on devices sharing an iCloud account back up side by side instead of clobbering one fixed slot (covers both save and delete).
- **Displacement cleanup**: when a save overwrites a *different* inboxId (pairing over the fresh-install placeholder), the displaced identity's backup is removed rather than orphaned in iCloud.
- **Database key excluded** from the backup: it only decrypts this device's local DB, which never leaves the device — escrowing it would add exposure with no recovery value. A recovering device generates a fresh one.
- **Restore-display metadata**: each backup is stamped with the user-visible device name (same `DeviceInfo.deviceName` the pairing flow uses, lazily injected) and the write date, so the restore picker can show "Alice's iPhone, backed up June 3" instead of a bare inboxId. Both fields decode as optional so missing metadata can never make a backup unrecoverable.
- **App Clip never escrows**: the clip constructs the store with `syncedBackupEnabled: false`; its auto-registered identity is backed up only after the full app adopts it (authorize-time backfill).
- **Backfill on authorize** covers existing installs that registered before the backup slot existed.
- **`delete()` scopes** backup removal to the deleted identity's inboxId; if the primary is unreadable the backup is left as a logged orphan (documented trade-off — sweeping would destroy other devices' backups; `LegacyDataWipe` reclaims orphans on generation bumps).
- **`LegacyDataWipe`** sweeps the new service (`kSecAttrSynchronizableAny`) on generation bumps; note the cross-device blast radius is documented inline and is intentional for a total reset.

## CI fix

The `KeychainIdentityStore Tests` workflow pinned `OS=26.1`, which the macos-26 runner image no longer carries (job has been failing on infra since the image moved to 26.2+; last green run on dev was May 1). Dropped the OS pin so it matches any available iPhone 17.

## Review process

Four parallel review agents (security/key-material, Security-framework correctness + concurrency, lifecycle/integration edge cases, test adequacy) reviewed the initial implementation. All major findings were addressed: App Clip escrow gating, displaced-backup cleanup in the pairing flow, database-key exclusion, the synchronizable `SecItemUpdate` re-save test, and per-test keychain sweeps in the integration suite.

## Open product questions

- A displaced identity's backup is deleted (no zombie keys in iCloud). If we ever want displaced identities to remain recoverable, that's a deliberate product decision to make later.
- Generation bumps wipe all backups across all devices on the account (existing wipe semantics, now with bigger blast radius). Flagged inline; needs no action unless we bump generations casually.

## Testing

- `KeychainSyncConfigTests` (unit, mock): 18/18 — incl. displacement, re-save dedupe, metadata-optional decoding, JSON-level proof the database key is absent from the backup blob
- `KeychainIdentityStoreRealKeychainTests` (real keychain on simulator): 23/23 — incl. pinned sync/non-sync placement queries for both slots, two-identity coexistence, displacement, the `errSecDuplicateItem → SecItemUpdate` re-save path on the synchronizable item, device-name/date stamping, orphan edge, corrupt-blob skip, 3-item enumeration
- SwiftLint strict + SwiftFormat clean; full ConvosCore suite runs in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add iCloud-synced keychain backup slot for identity recovery
> - Adds a `KeychainIdentityBackup` struct and an iCloud-synced secondary keychain slot (service `org.convos.ios.KeychainIdentityStore.v3-synced-backup`) that mirrors the primary identity on every `save()`.
> - Introduces `loadSyncedBackups()` and `backfillSyncedBackupIfNeeded()` on `KeychainIdentityStoreProtocol`; backfill is triggered during the `SessionStateMachine` authorization flow.
> - Backup metadata includes device name (stamped via a `deviceNameProvider` closure) and a timestamp; the App Clip disables synced backups via `syncedBackupEnabled: false`.
> - Legacy data wipe now sweeps the synced backup service so generation bumps propagate deletions across devices via iCloud.
> - Risk: the synced slot uses `kSecAttrSynchronizable = true`, meaning backup items can appear on other devices signed into the same iCloud account before the user explicitly initiates recovery.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7e076f5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->
