### PR TITLE
Enable file logging in production + surface Share logs in prod

### DIFF
--- a/Convos/Conversation Detail/ConversationInfoView.swift
+++ b/Convos/Conversation Detail/ConversationInfoView.swift
@@ -482,7 +482,43 @@ struct ConversationInfoView: View {
 
             permissionsSection
 
+            shareLogsSection
+
             debugInfoSection
+        }
+    }
+
+    /// Always-visible (including in production) so App Store users can
+    /// share logs when they hit a bug. Sits in its own section, separate
+    /// from `debugInfoSection`, so the technical debug rows below stay
+    /// hidden in production while this single user-facing affordance is
+    /// reachable everywhere.
+    @ViewBuilder
+    private var shareLogsSection: some View {
+        Section {
+            if let url = exportedLogsURL {
+                ShareLink(item: url) {
+                    HStack {
+                        Text("Share logs")
+                        Spacer()
+                        Image(systemName: "square.and.arrow.up")
+                    }
+                }
+            } else {
+                HStack {
+                    Text("Preparing logs…")
+                    Spacer()
+                    ProgressView()
+                }
+                .foregroundStyle(.colorTextSecondary)
+            }
+        }
+        .task {
+            do {
+                exportedLogsURL = try await viewModel.exportDebugLogs()
+            } catch {
+                Log.error("Failed to export logs for conversation: \(error.localizedDescription)")
+            }
         }
     }
 
@@ -535,33 +571,10 @@ struct ConversationInfoView: View {
                 } label: {
                     Text("Restore invite tag")
                 }
-                if let url = exportedLogsURL {
-                    ShareLink(item: url) {
-                        HStack {
-                            Text("Share logs")
-                            Spacer()
-                            Image(systemName: "square.and.arrow.up")
-                        }
-                    }
-                } else {
-                    HStack {
-                        Text("Preparing logs…")
-                        Spacer()
-                        ProgressView()
-                    }
-                    .foregroundStyle(.colorTextSecondary)
-                }
             } header: {
                 Text("Debug info")
                     .font(.footnote.weight(.medium))
                     .foregroundStyle(.colorTextSecondary)
-            }
-            .task {
-                do {
-                    exportedLogsURL = try await viewModel.exportDebugLogs()
-                } catch {
-                    Log.error("Failed to export logs for conversation: \(error.localizedDescription)")
-                }
             }
         }
     }

--- a/ConvosCore/Sources/ConvosCore/Logging/Logger.swift
+++ b/ConvosCore/Sources/ConvosCore/Logging/Logger.swift
@@ -39,17 +39,19 @@ public enum ConvosLog {
 
     // MARK: - Configuration
 
-    /// Configure the logging system with file-based handler
-    /// Call this once at app startup before using any loggers
-    /// Logging is automatically disabled in production environments
+    /// Configure the logging system with file-based handler.
+    /// Call this once at app startup before using any loggers.
+    ///
+    /// File logging is enabled in every environment, including production.
+    /// Logs stay local in the shared app group container, rotate at 10MB
+    /// (see `FileLogHandler.maxFileSize`), and are only emitted off-device
+    /// when the user explicitly taps the in-app "Share logs" affordance
+    /// in Settings -> Send feedback / Share logs. The combination is
+    /// privacy-respecting (no automatic telemetry) and unblocks support
+    /// triage for App Store users who can't run a Debug build.
     public static func configure(environment: AppEnvironment) {
         queue.sync {
             guard _logger == nil else { return }
-
-            // never enable logging in production
-            guard !environment.isProduction else {
-                return
-            }
 
             // First, bootstrap the logging system factory
             LoggingSystem.bootstrap { label in


### PR DESCRIPTION
Two coordinated changes so App Store users can capture and share logs when they hit a bug they can't reproduce on a Debug build.

## 1. \`ConvosLog.configure\` no longer disables file logging in production

Previously \`Logger.swift\` returned early on \`environment.isProduction\`, so \`FileLogHandler\` was never bootstrapped in App Store / production-TestFlight builds and \`convos.log\` stayed empty.

Drop that guard. File logging now runs in every environment. Logs stay local in the shared app group container, rotate at 10MB (per \`FileLogHandler.maxFileSize\`), and only leave the device via the user-initiated Share action below. **No automatic telemetry; privacy posture is unchanged.**

## 2. \`Share logs\` row moved out of the debug-only section

The "Share logs" row in \`ConversationInfoView\` was wrapped in \`debugInfoSection\`, which is itself gated by \`if !ConfigManager.shared.currentEnvironment.isProduction\`. So even after enabling logging in prod, there was no UI to reach the resulting log file.

Extracted into its own always-shown \`shareLogsSection\`. The technical debug rows (Fork status, Epoch, Fork details, Local/Remote commit log, Metadata, Hidden messages, Restore invite tag) stay where they were — gated to non-prod — since they're not useful to support triage and would just be noise in the App Store build.

## Why \`ConversationInfoView\` and not App Settings

The existing infrastructure already exports \`convos-app.log\` + XMTP logs + per-conversation debug info as a single zip via \`viewModel.exportDebugLogs()\` → \`DebugLogExporter.exportAllLogs\`, which is exactly what support needs. A separate global affordance in App Settings would duplicate the zip preparation without adding value — most bug reports that need logs are about a specific conversation anyway, and the user is already there when they hit the bug.

If a future bug pattern shows up that's NOT conversation-scoped (auth, payments, etc.), we can add a second entry point then. Easy to do once the underlying logging is enabled.

## Test plan

- [ ] Build with \`Convos (Prod)\` scheme → install → trigger any logged path → open a conversation → tap "..." → "Share logs" → confirm the share sheet appears with a \`convos-logs-<timestamp>.zip\` containing a non-empty \`convos-app.log\` plus XMTP logs
- [ ] Same on \`Convos (Dev)\` TestFlight build (where the bug was originally caught)
- [ ] Confirm the technical "Debug info" section (Fork status / Epoch / etc.) still appears in Dev and is still hidden in Prod
- [ ] Confirm log rotation: write >10MB of logs, verify file truncates to ~2.5MB (last 25%, per \`FileLogHandler.maxFileSize / 4\`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/972"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783112198&installation_id=128169237&pr_number=972&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F972&signature=28db7b3e0fc1f931a123059aff2ddead2563e7ecad1c8eb2ed3ac27da0b7e628"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enable file logging in production and surface 'Share logs' in the conversation info screen
> - Removes the production guard in `ConvosLog.configure` so file logging runs in all environments, writing to both the file handler and standard output via the existing `MultiplexLogHandler`.
> - Moves the 'Share logs' UI out of the debug-only section in [ConversationInfoView.swift](https://github.com/xmtplabs/convos-ios/pull/972/files#diff-30ae741e90f8fd3b2d28bd543f330b1bb685d691d37fd1e95edcc8bd87159a2a) into a new `shareLogsSection` that is always visible.
> - The new section asynchronously calls `viewModel.exportDebugLogs()` on load, showing a progress indicator until the export is ready.
> - Behavioral Change: logs are now written to disk in production; users can explicitly share them via the conversation info screen.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b4272b8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->