### PR TITLE
fix(ipad): cap Stuff grid at 5 square columns, message bubble and contact card widths

### DIFF
--- a/Convos/Conversation Detail/Messages/Messages Collection Layout/Extensions/RandomAccessCollection+Extension.swift
+++ b/Convos/Conversation Detail/Messages/Messages Collection Layout/Extensions/RandomAccessCollection+Extension.swift
@@ -6,8 +6,8 @@ extension RandomAccessCollection where Index == Int {
         var upperBound = endIndex
 
         while lowerBound < upperBound {
-            let midIndex = lowerBound &+ (upperBound &- lowerBound) / 2
-            let result = predicate(self[midIndex])
+            let midIndex: Int = lowerBound &+ (upperBound &- lowerBound) / 2
+            let result: ComparisonResult = predicate(self[midIndex])
             if result == .orderedSame {
                 return midIndex
             } else if result == .orderedAscending {
@@ -25,7 +25,7 @@ extension RandomAccessCollection where Index == Int {
             var upperBound = upperBound
 
             while lowerBound < upperBound {
-                let midIndex = (lowerBound &+ upperBound) / 2
+                let midIndex: Int = (lowerBound &+ upperBound) / 2
                 if predicate(self[midIndex]) == .orderedAscending {
                     lowerBound = midIndex &+ 1
                 } else {
@@ -44,7 +44,7 @@ extension RandomAccessCollection where Index == Int {
             var upperBound = upperBound
 
             while lowerBound < upperBound {
-                let midIndex = (lowerBound &+ upperBound &+ 1) / 2
+                let midIndex: Int = (lowerBound &+ upperBound &+ 1) / 2
                 if predicate(self[midIndex]) == .orderedDescending {
                     upperBound = midIndex &- 1
                 } else {

--- a/Convos/Conversation Detail/Messages/Messages View Controller/Constants.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/Constants.swift
@@ -5,4 +5,12 @@ enum Constant {
     static let maxWidth: CGFloat = 0.75
     static let bubbleCornerRadius: CGFloat = 20.0
     static let minimumPressDurationForReactions: CGFloat = 0.15
+    /// Logical width of the largest iPhone screen (Pro Max class).
+    private static let largestIPhoneWidth: CGFloat = 440.0
+    /// Caps a message bubble row (bubble + its 50pt low-priority spacer) at
+    /// the width it would be offered on the largest iPhone screen (its
+    /// logical width minus the 16pt trailing row padding). Without this cap,
+    /// bubbles and contact cards stretch nearly edge to edge on iPad.
+    /// Applied via `View.bubbleRowWidthCap(alignment:)`.
+    static let maxBubbleRowWidth: CGFloat = largestIPhoneWidth - 16.0
 }

--- a/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/MessageContainer.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/MessageContainer.swift
@@ -43,6 +43,12 @@ struct MessageContainer<Content: View>: View {
         }
     }
 
+    /// Pins the bubble to the sender's edge when the row is wider than
+    /// `Constant.maxBubbleRowWidth` (regular-width layouts like iPad).
+    private var bubbleAlignment: Alignment {
+        isOutgoing ? .trailing : .leading
+    }
+
     var body: some View {
         HStack(alignment: .bottom, spacing: 0.0) {
             if isOutgoing {
@@ -65,5 +71,16 @@ struct MessageContainer<Content: View>: View {
                 spacer
             }
         }
+        .bubbleRowWidthCap(alignment: bubbleAlignment)
+    }
+}
+
+extension View {
+    /// Caps a bubble row at `Constant.maxBubbleRowWidth`, pinning it to the
+    /// sender's edge when the container offers more width (regular-width
+    /// layouts like iPad), then re-expands so the row still spans the list.
+    func bubbleRowWidthCap(alignment: Alignment) -> some View {
+        frame(maxWidth: Constant.maxBubbleRowWidth, alignment: alignment)
+            .frame(maxWidth: .infinity, alignment: alignment)
     }
 }

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
@@ -207,10 +207,13 @@ struct MessagesGroupItemView: View {
     @ViewBuilder
     private func agentShareBubble(agentShare: MessageAgentShare) -> some View {
         let isOutgoing = message.sender.isCurrentUser
+        let cardAlignment: Alignment = isOutgoing ? .trailing : .leading
         // The card sizes to its content but is capped at the same max width as
         // text bubbles via a low-priority 50pt spacer (mirrors the in-convo
-        // `MessagesGroupView.contactCardRow`). The spacer sits opposite the
-        // sender so the card hugs the leading edge for incoming and the
+        // `MessagesGroupView.contactCardRow`) plus the same
+        // `maxBubbleRowWidth` cap text bubbles get from `MessageContainer`,
+        // so the card never outgrows them on iPad. The spacer sits opposite
+        // the sender so the card hugs the leading edge for incoming and the
         // trailing edge for outgoing.
         HStack(alignment: .bottom, spacing: 0.0) {
             if isOutgoing {
@@ -234,6 +237,7 @@ struct MessagesGroupItemView: View {
                     .layoutPriority(-1)
             }
         }
+        .bubbleRowWidthCap(alignment: cardAlignment)
         .padding(.trailing, trailingPadding)
     }
 

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupView.swift
@@ -276,21 +276,25 @@ struct MessagesGroupView: View {
             }
 
             let cardTap = { onTapSender(group.sender) }
-            AgentContactCardView(profile: card.profile, agentDescription: card.agentDescription)
-                .contentShape(Rectangle())
-                .onTapGesture(perform: cardTap)
-                .overlay(alignment: .bottomLeading) {
-                    if cardIsLast && !group.sender.isCurrentUser {
-                        avatarOverlay { onTapSender(group.sender) }
+            // Mirrors `MessageContainer` so the card caps at the same max
+            // width as text bubbles - natural sizing for short content,
+            // bounded by a 50pt trailing spacer with lower layout priority,
+            // plus the same `maxBubbleRowWidth` cap on regular-width layouts.
+            HStack(alignment: .bottom, spacing: 0.0) {
+                AgentContactCardView(profile: card.profile, agentDescription: card.agentDescription)
+                    .contentShape(Rectangle())
+                    .onTapGesture(perform: cardTap)
+                    .overlay(alignment: .bottomLeading) {
+                        if cardIsLast && !group.sender.isCurrentUser {
+                            avatarOverlay { onTapSender(group.sender) }
+                        }
                     }
-                }
 
-            // Mirrors `MessageContainer.spacer` so the card caps at the same
-            // max width as text bubbles — natural sizing for short content,
-            // bounded by a 50pt trailing spacer with lower layout priority.
-            Spacer()
-                .frame(minWidth: 50.0)
-                .layoutPriority(-1)
+                Spacer()
+                    .frame(minWidth: 50.0)
+                    .layoutPriority(-1)
+            }
+            .bubbleRowWidthCap(alignment: .leading)
         }
         .padding(.leading, !group.sender.isCurrentUser ? DesignConstants.Spacing.step4x : 0)
     }
@@ -330,6 +334,7 @@ struct MessagesGroupView: View {
                             .layoutPriority(-1)
                     }
                 }
+                .bubbleRowWidthCap(alignment: .leading)
                 .zIndex(100)
                 .id("messages-group-item-\(message.differenceIdentifier)")
                 .overlay(alignment: .bottomLeading) {

--- a/Convos/Conversations List/StuffTabView.swift
+++ b/Convos/Conversations List/StuffTabView.swift
@@ -1,7 +1,7 @@
 import ConvosCore
 import SwiftUI
 
-/// Cross-conversation "Stuff" tab. Renders a two-column grid of the most
+/// Cross-conversation "Stuff" tab. Renders a grid of the most
 /// recent agent-sent HTML attachment from every conversation, with the
 /// conversation's display name + unread dot under each preview square.
 /// See [[StuffOverviewViewModel]] for the data layer and
@@ -11,6 +11,9 @@ import SwiftUI
 /// - 24pt outer horizontal margins
 /// - 18pt between columns
 /// - 12pt between rows (and 12pt top/bottom outer padding)
+/// - 2 columns in compact width (iPhone); in regular width (iPad) the
+///   column count grows with the available width, capped at 5, so cells
+///   stay close to their iPhone size instead of stretching
 ///
 /// Tapping a cell pushes the conversation detail onto this tab's own
 /// `NavigationStack` (via `pushedConversations`), so the user stays on
@@ -40,6 +43,7 @@ struct StuffTabView: View {
     @State private var pushedConvoVM: ConversationViewModel?
     @State private var focusCoordinator: FocusCoordinator = FocusCoordinator(horizontalSizeClass: nil)
     @State private var sidebarColumnWidth: CGFloat = 0
+    @State private var gridWidth: CGFloat = 0
 
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass: UserInterfaceSizeClass?
     @Namespace private var localNamespace: Namespace.ID
@@ -60,10 +64,22 @@ struct StuffTabView: View {
     }
 
     private var columns: [GridItem] {
-        [
-            GridItem(.flexible(), spacing: Constant.interColumnSpacing),
-            GridItem(.flexible(), spacing: Constant.interColumnSpacing),
-        ]
+        let column = GridItem(.flexible(), spacing: Constant.interColumnSpacing)
+        return Array(repeating: column, count: columnCount)
+    }
+
+    /// 2 columns in compact width. In regular width (iPad), fit as many
+    /// columns of at least `minRegularCellWidth` as the measured grid
+    /// width allows, capped at `maxColumnCount`. Cells stay square via
+    /// `StuffPreviewCell`'s aspect ratio regardless of column width.
+    private var columnCount: Int {
+        guard horizontalSizeClass == .regular, gridWidth > 0 else {
+            return Constant.compactColumnCount
+        }
+        let available: CGFloat = max(0, gridWidth - 2 * Constant.outerHorizontalPadding)
+        let cellPlusSpacing: CGFloat = Constant.minRegularCellWidth + Constant.interColumnSpacing
+        let fitting = Int((available + Constant.interColumnSpacing) / cellPlusSpacing)
+        return min(max(fitting, Constant.compactColumnCount), Constant.maxColumnCount)
     }
 
     var body: some View {
@@ -145,6 +161,11 @@ struct StuffTabView: View {
             .padding(.vertical, Constant.outerVerticalPadding)
         }
         .background(.colorBackgroundSurfaceless)
+        .onGeometryChange(for: CGFloat.self) { proxy in
+            proxy.size.width
+        } action: { newValue in
+            gridWidth = newValue
+        }
         .onScrollGeometryChange(for: CGFloat.self) { geometry in
             geometry.contentOffset.y + geometry.contentInsets.top
         } action: { _, newValue in
@@ -186,5 +207,10 @@ struct StuffTabView: View {
         static let outerVerticalPadding: CGFloat = 12.0
         static let interColumnSpacing: CGFloat = 18.0
         static let interRowSpacing: CGFloat = 12.0
+        static let compactColumnCount: Int = 2
+        static let maxColumnCount: Int = 5
+        /// Roughly the cell width of the 2-column layout on an iPhone,
+        /// so regular-width cells never render smaller than iPhone cells.
+        static let minRegularCellWidth: CGFloat = 140.0
     }
 }


### PR DESCRIPTION
On iPad the Stuff tab rendered 2 huge columns and message bubbles /
agent contact cards stretched nearly edge to edge.

- Stuff tab: column count now adapts to the measured grid width in
  regular size class (cells at least 140pt, capped at 5 columns);
  iPhone stays at 2. Cells remain square via the cell's aspect ratio.
- Message bubbles (text, emoji, voice memo, link preview, file) cap at
  the row width they'd get on the largest iPhone (440pt - 16pt trailing
  padding = 424pt incl. the 50pt spacer, so 374pt of content), pinned
  to the sender's edge. Thought-bubble rows get the same cap.
- Agent contact cards (in-convo card row and agent-share bubble) share
  the same cap so they never outgrow text bubbles.
- Annotate types in RandomAccessCollection.binarySearch helpers: the
  generic &+ / &- arithmetic sat right at the type-check time limit and
  flakily failed device builds (308ms vs 300ms limit).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/974"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783112520&installation_id=128169237&pr_number=974&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F974&signature=44fa120a67c5db9b3d74a66a1d446fe32741b2cb711db4456d0007eeb345b202"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Cap Stuff grid at 5 columns and limit message bubble/card widths on iPad
> - The Stuff grid in [`StuffTabView`](https://github.com/xmtplabs/convos-ios/pull/974/files#diff-acaa9de1d33a863118e006e10a3fbdaad3cd416da8e46a58ba1216781dc47233) now measures available width and dynamically computes column count on regular-width layouts, fitting columns near iPhone cell size with a cap of 5 columns (2 fixed on compact).
> - Message bubble rows in [`MessageContainer`](https://github.com/xmtplabs/convos-ios/pull/974/files#diff-2e69221ad23300f6fb55033fdd640a0e676ad3e44d8f2ecb1675c600fc48104e) are capped at `maxBubbleRowWidth` (424pt) and pinned to the sender edge via a new `.bubbleRowWidthCap(alignment:)` view extension.
> - The same width cap is applied to agent-share cards in [`MessagesGroupItemView`](https://github.com/xmtplabs/convos-ios/pull/974/files#diff-34b33cae925fe553d357af97d04319b8de2de329c1903afe72c915e36aa98774) and contact card/transcript rows in [`MessagesGroupView`](https://github.com/xmtplabs/convos-ios/pull/974/files#diff-96fea19951f287381d9170a90ce9ac8ba6f9e59f9d477dd1c5be2bbc1b5cdbe2).
> - `maxBubbleRowWidth` is derived from a new `largestIPhoneWidth` constant (440pt minus 16pt padding) defined in [`Constants.swift`](https://github.com/xmtplabs/convos-ios/pull/974/files#diff-70a7a382d1f5df060173405de9aa0a4635dc4146bcea73671ae50859cb9c35e4).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 97690d6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->