### PR TITLE
Contact detail: label chat CTA "New chat" for agents only, "Chat" for members

### DIFF
--- a/Convos/Contacts/ContactDetailView.swift
+++ b/Convos/Contacts/ContactDetailView.swift
@@ -294,6 +294,7 @@ struct ContactDetailView: View {
                     // `handleChatWithAgentTemplate`).
                     canSendMessage: session != nil && (!isVerifiedAgent || isAgentTemplate),
                     showChat: !mode.isCurrentUser,
+                    isAgent: isVerifiedAgent || isAgentTemplate,
                     showShare: agentTemplateShareURL != nil,
                     showRemove: mode.isScopedToConversation
                         && !mode.isCurrentUser
@@ -697,7 +698,8 @@ private struct ContactDetailSubtitle: View {
 // MARK: - Action stack
 
 /// Renders the "Convos with you" sections (template-backed agents only),
-/// then New chat, Share, Remove, and Block - in that order. New chat is the
+/// then the chat CTA ("New chat" for agents, "Chat" for human members),
+/// Share, Remove, and Block - in that order. The chat CTA is the
 /// primary CTA (filled dark pill); the rest use the secondary action-row
 /// style (capsule label + caption below) so an agent and human card share
 /// one row framework and only differ in which rows render.
@@ -706,6 +708,10 @@ private struct ContactDetailActions: View {
     let isApplyingBlockChange: Bool
     let canSendMessage: Bool
     let showChat: Bool
+    /// Drives the chat CTA copy: "New chat" for agents (tapping spawns a
+    /// fresh conversation), "Chat" for human members (tapping routes to a
+    /// DM with that person).
+    let isAgent: Bool
     let showShare: Bool
     let showRemove: Bool
     let showBlock: Bool
@@ -772,8 +778,9 @@ private struct ContactDetailActions: View {
 
     private var chatButton: some View {
         let backgroundOpacity: Double = canSendMessage ? 1.0 : 0.4
+        let chatLabel: String = isAgent ? "New chat" : "Chat"
         return Button(action: onSendMessage) {
-            Text("New chat")
+            Text(chatLabel)
                 .font(.body.weight(.medium))
                 .foregroundStyle(.colorTextPrimaryInverted)
                 .frame(maxWidth: .infinity)
@@ -784,7 +791,7 @@ private struct ContactDetailActions: View {
                 )
         }
         .disabled(!canSendMessage)
-        .accessibilityLabel("New chat with \(contactDisplayName)")
+        .accessibilityLabel("\(chatLabel) with \(contactDisplayName)")
         .accessibilityIdentifier("contact-detail-chat")
     }
 


### PR DESCRIPTION
## Summary
- The contact detail chat button read "New chat" for every contact. That copy only fits agents, where tapping spawns a fresh conversation instance; for human members the button routes to a DM.
- `ContactDetailActions` gains an `isAgent` flag; the CTA label (and its accessibility label) is now "New chat" for agents and "Chat" for human members. The `contact-detail-chat` accessibility identifier is unchanged.
- Agent-ness is `isVerifiedAgent || isAgentTemplate`, which covers verified agents, template-backed agents, and suggested-agent placeholders (synthetic contacts carry both markers).

## Testing
- SwiftLint clean on the changed file.
- `xcodebuild build` of "Convos (Dev)" for iPhone 17 simulator succeeds.
- Test suite intentionally not run per request (copy-only change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/975"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783118376&installation_id=128169237&pr_number=975&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F975&signature=e510ef17b7d1ea1606f6e977c7686805129da7117ee0541524329a9e112b6d5f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Label chat CTA "New chat" for agents and "Chat" for members in contact detail
> Updates `ContactDetailActions` with an `isAgent` property that switches the chat button label and accessibility label between "New chat" (agents) and "Chat" (human members). `ContactDetailView` passes a computed boolean to determine agent status (verified agent or template-backed). Button functionality and disabled state are unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2e4ae31.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->