### PR TITLE
Fix composer text not clearing after send (keyboard + dictation)

### DIFF
--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -608,8 +608,25 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
     var messageText: String = "" {
         didSet {
             handleTextChanged()
+            trackBulkTextChange(oldValue: oldValue)
+            reclearResurrectedDictationTextIfNeeded(oldValue: oldValue)
         }
     }
+    /// When the composer last received a multi-character write in a single
+    /// update. Dictation streams hypothesis updates as bulk replacements
+    /// while typing changes one character at a time, so a recent bulk change
+    /// is the available signal that a send is interrupting dictation -
+    /// iOS exposes no direct way to ask (`textInputMode` stays the regular
+    /// language during dictation and no input-mode notification fires).
+    /// Pastes and link-strips also set this; the cost of that false positive
+    /// is one keyboard round-trip on the next send, which is cosmetic.
+    private var lastBulkTextChangeAt: Date?
+    /// Armed by a send that interrupted likely-dictation. The recognizer's
+    /// final transcription can arrive after the composer was already cleared
+    /// and re-insert text (no public API can cancel the in-flight result),
+    /// so for a short window after such a send any multi-character
+    /// repopulation of the emptied composer is cleared again.
+    private var dictationReclearArmedAt: Date?
     private var previousMessageTextLength: Int = 0
     var pastedLinkPreview: LinkPreview?
 
@@ -622,6 +639,45 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
         pastedLinkPreview = preview
         messageText = ""
         previousMessageTextLength = 0
+    }
+
+    private func trackBulkTextChange(oldValue: String) {
+        guard !messageText.isEmpty else { return }
+        if abs(messageText.count - oldValue.count) > 1 {
+            lastBulkTextChangeAt = Date()
+        }
+    }
+
+    /// `true` when the composer recently received dictation-style bulk
+    /// writes, meaning a send right now is likely interrupting an active
+    /// dictation session (see `lastBulkTextChangeAt`).
+    private var isLikelyDictating: Bool {
+        guard let lastBulkTextChangeAt else { return false }
+        return Date().timeIntervalSince(lastBulkTextChangeAt) < Constant.dictationActivityWindow
+    }
+
+    /// Clears the composer again when the dictation recognizer's late
+    /// transcription repopulates it after a mid-dictation send (see
+    /// `dictationReclearArmedAt`). The re-insert arrives as one
+    /// multi-character write into the emptied composer; its content is
+    /// unpredictable (the recognizer revises and continues the sent
+    /// hypothesis), so the check is content-free. Disarms on the first
+    /// single-character edit, so normal typing after a send is never
+    /// touched.
+    private func reclearResurrectedDictationTextIfNeeded(oldValue: String) {
+        guard let armedAt = dictationReclearArmedAt else { return }
+        guard Date().timeIntervalSince(armedAt) < Constant.dictationReclearWindow else {
+            dictationReclearArmedAt = nil
+            return
+        }
+        guard oldValue.isEmpty, !messageText.isEmpty else { return }
+        guard messageText.count > 1 else {
+            dictationReclearArmedAt = nil
+            return
+        }
+        Log.info("Re-clearing dictation text resurrected after send")
+        dictationReclearArmedAt = nil
+        messageText = ""
     }
 
     var typingMembers: [ConversationMember] = []
@@ -2005,6 +2061,15 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
         isEditingConversationName = false
         focusCoordinator.endEditing(for: .conversationName, context: context)
     }
+
+    private enum Constant {
+        /// How recently the composer must have received a bulk write for a
+        /// send to be treated as interrupting an active dictation session.
+        static let dictationActivityWindow: TimeInterval = 3.0
+        /// How long after a likely-dictation send a multi-character composer
+        /// repopulation is treated as the recognizer's late re-insert.
+        static let dictationReclearWindow: TimeInterval = 4.0
+    }
 }
 
 // MARK: - Conversation Settings Actions
@@ -2392,15 +2457,14 @@ extension ConversationViewModel {
         // pending autocorrect right after a keystroke, or an active dictation
         // session), clearing the binding can be lost entirely and the sent
         // text resurrects in the composer at the keyboard's next commit
-        // point. Settling also commits a pending correction into messageText
-        // before capture, so the sent message matches what the keyboard
-        // would have produced.
-        focusCoordinator.withSettledKeyboardInput {
-            sendComposerContents(focusCoordinator: focusCoordinator)
+        // point.
+        let endingDictation = isLikelyDictating
+        focusCoordinator.withSettledKeyboardInput(endingInputSession: endingDictation) {
+            sendComposerContents(focusCoordinator: focusCoordinator, endedDictation: endingDictation)
         }
     }
 
-    private func sendComposerContents(focusCoordinator: FocusCoordinator) {
+    private func sendComposerContents(focusCoordinator: FocusCoordinator, endedDictation: Bool) {
         let hasText = !messageText.isEmpty
         let hasMedia = !pendingMediaAttachments.isEmpty
         let hasInvite = pendingInvite != nil
@@ -2431,6 +2495,9 @@ extension ConversationViewModel {
         pendingInviteImage = nil
         pendingAgentShare = nil
         pastedLinkPreview = nil
+        if endedDictation {
+            dictationReclearArmedAt = Date()
+        }
         focusCoordinator.endEditing(for: .message, context: .conversation)
 
         let messageWriter = cachedMessageWriter

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -612,14 +612,19 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
             reclearResurrectedDictationTextIfNeeded(oldValue: oldValue)
         }
     }
-    /// When the composer last received a multi-character write in a single
-    /// update. Dictation streams hypothesis updates as bulk replacements
-    /// while typing changes one character at a time, so a recent bulk change
-    /// is the available signal that a send is interrupting dictation -
-    /// iOS exposes no direct way to ask (`textInputMode` stays the regular
-    /// language during dictation and no input-mode notification fires).
-    /// Pastes and link-strips also set this; the cost of that false positive
-    /// is one keyboard round-trip on the next send, which is cosmetic.
+    /// When the composer last received a multi-character insertion in a
+    /// single update. Dictation streams hypothesis updates as bulk
+    /// replacements while typing changes one character at a time, so a
+    /// recent bulk change is the available signal that a send is
+    /// interrupting dictation - iOS exposes no direct way to ask
+    /// (`textInputMode` stays the regular language during dictation and no
+    /// input-mode notification fires). Autocorrect commits, QuickType taps,
+    /// pastes, and coalesced fast typing also set this; that false positive
+    /// is invisible (the send ends the input session via an off-screen
+    /// focus handoff that never moves the keyboard), so the heuristic
+    /// deliberately overtriggers rather than miss real dictation. Cleared
+    /// whenever the composer empties (sends and programmatic clears like
+    /// link-strips), so stale activity never flags a later send.
     private var lastBulkTextChangeAt: Date?
     /// Armed by a send that interrupted likely-dictation. The recognizer's
     /// final transcription can arrive after the composer was already cleared
@@ -642,8 +647,11 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
     }
 
     private func trackBulkTextChange(oldValue: String) {
-        guard !messageText.isEmpty else { return }
-        if abs(messageText.count - oldValue.count) > 1 {
+        guard !messageText.isEmpty else {
+            lastBulkTextChangeAt = nil
+            return
+        }
+        if messageText.count - oldValue.count > 1 {
             lastBulkTextChangeAt = Date()
         }
     }
@@ -2068,7 +2076,11 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
         static let dictationActivityWindow: TimeInterval = 3.0
         /// How long after a likely-dictation send a multi-character composer
         /// repopulation is treated as the recognizer's late re-insert.
-        static let dictationReclearWindow: TimeInterval = 4.0
+        /// Observed re-inserts land within roughly a second of the send;
+        /// the window is kept tight because a legitimate multi-character
+        /// write inside it (a paste, or the first hypothesis of the next
+        /// dictation) would be cleared too.
+        static let dictationReclearWindow: TimeInterval = 1.5
     }
 }
 
@@ -2458,6 +2470,13 @@ extension ConversationViewModel {
         // session), clearing the binding can be lost entirely and the sent
         // text resurrects in the composer at the keyboard's next commit
         // point.
+        //
+        // The session-ending handoff is reserved for likely-dictation sends
+        // rather than used for every send deliberately: the selection nudge
+        // changes no responder state at all, so the common typed path keeps
+        // zero focus churn (VoiceOver, third-party keyboards, responder
+        // restore edge cases), while the handoff's responder round-trip is
+        // confined to sends that actually need the input session ended.
         let endingDictation = isLikelyDictating
         focusCoordinator.withSettledKeyboardInput(endingInputSession: endingDictation) {
             sendComposerContents(focusCoordinator: focusCoordinator, endedDictation: endingDictation)

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -2387,6 +2387,20 @@ extension ConversationViewModel {
     }
 
     func onSendMessage(focusCoordinator: FocusCoordinator) {
+        // Settle the keyboard before reading and clearing messageText. If the
+        // send lands while the keyboard still holds uncommitted input (a
+        // pending autocorrect right after a keystroke, or an active dictation
+        // session), clearing the binding can be lost entirely and the sent
+        // text resurrects in the composer at the keyboard's next commit
+        // point. Settling also commits a pending correction into messageText
+        // before capture, so the sent message matches what the keyboard
+        // would have produced.
+        focusCoordinator.withSettledKeyboardInput {
+            sendComposerContents(focusCoordinator: focusCoordinator)
+        }
+    }
+
+    private func sendComposerContents(focusCoordinator: FocusCoordinator) {
         let hasText = !messageText.isEmpty
         let hasMedia = !pendingMediaAttachments.isEmpty
         let hasInvite = pendingInvite != nil

--- a/Convos/Shared Views/FocusCoordinator.swift
+++ b/Convos/Shared Views/FocusCoordinator.swift
@@ -190,27 +190,28 @@ final class FocusCoordinator {
         currentFocus = nextFocus
     }
 
-    /// Runs `work` with the keyboard's pending input settled: synchronously
-    /// drops first responder (forcing the keyboard to commit any uncommitted
-    /// input, like a pending autocorrect or an active dictation hypothesis,
-    /// into the focused field), runs `work`, then restores first responder.
+    /// Runs `work` with the keyboard's pending input settled: re-asserts the
+    /// focused field's selection at the UIKit level first, which makes the
+    /// keyboard resolve any uncommitted input session (a pending autocorrect
+    /// right after a keystroke, or an active dictation hypothesis) before
+    /// `work` mutates the field's bound text programmatically.
     ///
     /// Use this around programmatic mutations of a focused field's bound text
     /// (e.g. clearing the composer on send). Mutating the binding while the
     /// keyboard still holds pending input can lose the write entirely: the
     /// backing text view keeps the old text and the keyboard's next commit
-    /// point syncs the stale text back into the binding. Resigning first
-    /// settles the input session so the mutation lands on stable state;
-    /// restoring synchronously keeps the keyboard up without a visible
-    /// flicker.
+    /// point syncs the stale text back into the binding. A selection change
+    /// runs the same settle path the keyboard uses when the caret moves, with
+    /// no first responder change, so the keyboard never hides or re-shows.
+    /// (An earlier resign/become approach settled input too, but round-
+    /// tripped the keyboard with a visible dismiss-and-reshow in the real
+    /// view hierarchy.)
     func withSettledKeyboardInput(_ work: () -> Void) {
-        guard let responder = Self.currentFirstResponder() else {
-            work()
-            return
+        if let input = Self.currentFirstResponder() as? (UIResponder & UITextInput) {
+            let end = input.endOfDocument
+            input.selectedTextRange = input.textRange(from: end, to: end)
         }
-        responder.resignFirstResponder()
         work()
-        responder.becomeFirstResponder()
     }
 
     /// Called by the view when SwiftUI's @FocusState has updated

--- a/Convos/Shared Views/FocusCoordinator.swift
+++ b/Convos/Shared Views/FocusCoordinator.swift
@@ -207,28 +207,68 @@ final class FocusCoordinator {
     /// - `endingInputSession == true` (caller believes dictation is active):
     ///   the selection nudge does not stop a dictation session - it keeps
     ///   streaming hypothesis updates into the field after the mutation -
-    ///   so drop and restore first responder, the one available way to
-    ///   terminate the session first. This visibly round-trips the keyboard,
-    ///   which is why it is reserved for dictation, where the dictation UI
-    ///   ending on send is expected. (Dictation is not detectable directly:
-    ///   on iOS 26.2 `textInputMode` stays the regular language during
-    ///   dictation and no input-mode-change notification fires, so callers
-    ///   infer it behaviorally - see `ConversationViewModel`.)
+    ///   so the input session has to end first. Resigning first responder
+    ///   does that but leaves a no-responder gap that visibly hides and
+    ///   re-shows the keyboard, so instead first responder is handed to a
+    ///   zero-frame off-screen text field in the same window: a text input
+    ///   stays focused throughout, the keyboard never moves, and the
+    ///   composer's input session is torn down exactly as on resign. Focus
+    ///   returns to the original field after the mutation. (Dictation is
+    ///   not detectable directly: on iOS 26.2 `textInputMode` stays the
+    ///   regular language during dictation and no input-mode-change
+    ///   notification fires, so callers infer it behaviorally - see
+    ///   `ConversationViewModel`.)
     func withSettledKeyboardInput(endingInputSession: Bool, _ work: () -> Void) {
         guard let input = Self.currentFirstResponder() as? (UIResponder & UITextInput) else {
             work()
             return
         }
         if endingInputSession {
-            Log.info("Settling keyboard input via resign/restore (ending input session)")
-            input.resignFirstResponder()
-            work()
-            input.becomeFirstResponder()
+            endInputSessionKeepingKeyboard(for: input, work)
         } else {
             Log.info("Settling keyboard input via selection nudge")
             let end = input.endOfDocument
             input.selectedTextRange = input.textRange(from: end, to: end)
             work()
+        }
+    }
+
+    /// Ends `input`'s input session (terminating any active dictation and
+    /// committing pending input) without letting the keyboard hide, by
+    /// handing first responder to a temporary off-screen text field while
+    /// `work` runs. Falls back to a plain resign/restore round-trip when the
+    /// input has no window or the handoff field refuses focus.
+    private func endInputSessionKeepingKeyboard(for input: UIResponder & UITextInput, _ work: () -> Void) {
+        guard let inputView = input as? UIView, let window = inputView.window else {
+            Log.info("Settling keyboard input via resign/restore (no window for handoff)")
+            input.resignFirstResponder()
+            work()
+            input.becomeFirstResponder()
+            return
+        }
+        // The handoff field deliberately keeps default input traits. The
+        // composer uses a default keyboard, so a default handoff field
+        // takes focus with no keyboard relayout (frame analysis shows no
+        // keyboard movement beyond the keycap shift-case recompute that
+        // every composer-clearing send produces, handoff or not). Revisit
+        // if a field with a non-default keyboard ever uses this settle
+        // path.
+        let handoff = UITextField(frame: .zero)
+        handoff.isAccessibilityElement = false
+        handoff.accessibilityElementsHidden = true
+        window.addSubview(handoff)
+        defer { handoff.removeFromSuperview() }
+        guard handoff.becomeFirstResponder() else {
+            Log.info("Settling keyboard input via resign/restore (handoff refused focus)")
+            input.resignFirstResponder()
+            work()
+            input.becomeFirstResponder()
+            return
+        }
+        Log.info("Settling keyboard input via focus handoff (ending input session)")
+        work()
+        if !input.becomeFirstResponder() {
+            Log.error("Focus handoff could not restore the original input; keyboard may dismiss")
         }
     }
 

--- a/Convos/Shared Views/FocusCoordinator.swift
+++ b/Convos/Shared Views/FocusCoordinator.swift
@@ -190,6 +190,29 @@ final class FocusCoordinator {
         currentFocus = nextFocus
     }
 
+    /// Runs `work` with the keyboard's pending input settled: synchronously
+    /// drops first responder (forcing the keyboard to commit any uncommitted
+    /// input, like a pending autocorrect or an active dictation hypothesis,
+    /// into the focused field), runs `work`, then restores first responder.
+    ///
+    /// Use this around programmatic mutations of a focused field's bound text
+    /// (e.g. clearing the composer on send). Mutating the binding while the
+    /// keyboard still holds pending input can lose the write entirely: the
+    /// backing text view keeps the old text and the keyboard's next commit
+    /// point syncs the stale text back into the binding. Resigning first
+    /// settles the input session so the mutation lands on stable state;
+    /// restoring synchronously keeps the keyboard up without a visible
+    /// flicker.
+    func withSettledKeyboardInput(_ work: () -> Void) {
+        guard let responder = Self.currentFirstResponder() else {
+            work()
+            return
+        }
+        responder.resignFirstResponder()
+        work()
+        responder.becomeFirstResponder()
+    }
+
     /// Called by the view when SwiftUI's @FocusState has updated
     /// This handles all synchronization logic between SwiftUI's focus state and the coordinator
     func syncFocusState(_ newFocus: MessagesViewInputFocus?) {
@@ -314,6 +337,18 @@ final class FocusCoordinator {
     }
 
     // MARK: - Private Methods
+
+    private static func currentFirstResponder() -> UIResponder? {
+        for scene in UIApplication.shared.connectedScenes {
+            guard let windowScene = scene as? UIWindowScene else { continue }
+            for window in windowScene.windows {
+                if let responder = window.firstResponderDescendant() {
+                    return responder
+                }
+            }
+        }
+        return nil
+    }
 
     private func setupKeyboardObservation() {
         KeyboardListener.shared.add(delegate: self)
@@ -502,6 +537,20 @@ extension FocusCoordinator: KeyboardListenerDelegate {
             let isShowingKeyboard = info.frameEnd.origin.y < screenHeight
             updateKeyboardState(frame: info.frameEnd, isShowEvent: isShowingKeyboard, screen: screen)
         }
+    }
+}
+
+// MARK: - First Responder Lookup
+
+private extension UIView {
+    func firstResponderDescendant() -> UIResponder? {
+        if isFirstResponder { return self }
+        for subview in subviews {
+            if let responder = subview.firstResponderDescendant() {
+                return responder
+            }
+        }
+        return nil
     }
 }
 

--- a/Convos/Shared Views/FocusCoordinator.swift
+++ b/Convos/Shared Views/FocusCoordinator.swift
@@ -199,27 +199,33 @@ final class FocusCoordinator {
     /// the backing text view keeps the old text and the keyboard's next
     /// commit point syncs the stale text back into the binding.
     ///
-    /// Two settle strategies, by input session type:
-    /// - Pending autocorrect (typing): re-assert the selection at the UIKit
-    ///   level. A selection change runs the same settle path the keyboard
-    ///   uses when the caret moves, with no first responder change, so the
-    ///   keyboard never hides or re-shows.
-    /// - Active dictation: the selection nudge does not stop the session;
-    ///   its hypothesis finalizes via insertText after the mutation and
-    ///   resurrects the text. Dropping and restoring first responder is the
-    ///   one available way to terminate the session first. The keyboard
-    ///   round-trip that made resign/become unacceptable for plain typing is
-    ///   fine here: the dictation UI visibly ends on send anyway.
-    func withSettledKeyboardInput(_ work: () -> Void) {
+    /// Two settle strategies:
+    /// - `endingInputSession == false` (plain typing): re-assert the
+    ///   selection at the UIKit level. A selection change runs the same
+    ///   settle path the keyboard uses when the caret moves, with no first
+    ///   responder change, so the keyboard never hides or re-shows.
+    /// - `endingInputSession == true` (caller believes dictation is active):
+    ///   the selection nudge does not stop a dictation session - it keeps
+    ///   streaming hypothesis updates into the field after the mutation -
+    ///   so drop and restore first responder, the one available way to
+    ///   terminate the session first. This visibly round-trips the keyboard,
+    ///   which is why it is reserved for dictation, where the dictation UI
+    ///   ending on send is expected. (Dictation is not detectable directly:
+    ///   on iOS 26.2 `textInputMode` stays the regular language during
+    ///   dictation and no input-mode-change notification fires, so callers
+    ///   infer it behaviorally - see `ConversationViewModel`.)
+    func withSettledKeyboardInput(endingInputSession: Bool, _ work: () -> Void) {
         guard let input = Self.currentFirstResponder() as? (UIResponder & UITextInput) else {
             work()
             return
         }
-        if input.textInputMode?.primaryLanguage == Constant.dictationInputMode {
+        if endingInputSession {
+            Log.info("Settling keyboard input via resign/restore (ending input session)")
             input.resignFirstResponder()
             work()
             input.becomeFirstResponder()
         } else {
+            Log.info("Settling keyboard input via selection nudge")
             let end = input.endOfDocument
             input.selectedTextRange = input.textRange(from: end, to: end)
             work()
@@ -492,12 +498,6 @@ final class FocusCoordinator {
         Log.info("Keyboard type changed: \(previousKeyboardType) → \(newKeyboardType), updating focus to: \(String(describing: newDefault))")
         beginProgrammaticTransition(to: newDefault)
         currentFocus = newDefault
-    }
-
-    /// The `UITextInputMode.primaryLanguage` value reported while a dictation
-    /// session is active.
-    private enum Constant {
-        static let dictationInputMode: String = "dictation"
     }
 }
 

--- a/Convos/Shared Views/FocusCoordinator.swift
+++ b/Convos/Shared Views/FocusCoordinator.swift
@@ -190,28 +190,40 @@ final class FocusCoordinator {
         currentFocus = nextFocus
     }
 
-    /// Runs `work` with the keyboard's pending input settled: re-asserts the
-    /// focused field's selection at the UIKit level first, which makes the
-    /// keyboard resolve any uncommitted input session (a pending autocorrect
-    /// right after a keystroke, or an active dictation hypothesis) before
-    /// `work` mutates the field's bound text programmatically.
+    /// Runs `work` with the keyboard's pending input settled, so that `work`
+    /// can safely mutate the focused field's bound text programmatically.
     ///
     /// Use this around programmatic mutations of a focused field's bound text
     /// (e.g. clearing the composer on send). Mutating the binding while the
-    /// keyboard still holds pending input can lose the write entirely: the
-    /// backing text view keeps the old text and the keyboard's next commit
-    /// point syncs the stale text back into the binding. A selection change
-    /// runs the same settle path the keyboard uses when the caret moves, with
-    /// no first responder change, so the keyboard never hides or re-shows.
-    /// (An earlier resign/become approach settled input too, but round-
-    /// tripped the keyboard with a visible dismiss-and-reshow in the real
-    /// view hierarchy.)
+    /// keyboard still holds uncommitted input can lose the write entirely:
+    /// the backing text view keeps the old text and the keyboard's next
+    /// commit point syncs the stale text back into the binding.
+    ///
+    /// Two settle strategies, by input session type:
+    /// - Pending autocorrect (typing): re-assert the selection at the UIKit
+    ///   level. A selection change runs the same settle path the keyboard
+    ///   uses when the caret moves, with no first responder change, so the
+    ///   keyboard never hides or re-shows.
+    /// - Active dictation: the selection nudge does not stop the session;
+    ///   its hypothesis finalizes via insertText after the mutation and
+    ///   resurrects the text. Dropping and restoring first responder is the
+    ///   one available way to terminate the session first. The keyboard
+    ///   round-trip that made resign/become unacceptable for plain typing is
+    ///   fine here: the dictation UI visibly ends on send anyway.
     func withSettledKeyboardInput(_ work: () -> Void) {
-        if let input = Self.currentFirstResponder() as? (UIResponder & UITextInput) {
+        guard let input = Self.currentFirstResponder() as? (UIResponder & UITextInput) else {
+            work()
+            return
+        }
+        if input.textInputMode?.primaryLanguage == Constant.dictationInputMode {
+            input.resignFirstResponder()
+            work()
+            input.becomeFirstResponder()
+        } else {
             let end = input.endOfDocument
             input.selectedTextRange = input.textRange(from: end, to: end)
+            work()
         }
-        work()
     }
 
     /// Called by the view when SwiftUI's @FocusState has updated
@@ -480,6 +492,12 @@ final class FocusCoordinator {
         Log.info("Keyboard type changed: \(previousKeyboardType) → \(newKeyboardType), updating focus to: \(String(describing: newDefault))")
         beginProgrammaticTransition(to: newDefault)
         currentFocus = newDefault
+    }
+
+    /// The `UITextInputMode.primaryLanguage` value reported while a dictation
+    /// session is active.
+    private enum Constant {
+        static let dictationInputMode: String = "dictation"
     }
 }
 


### PR DESCRIPTION
## Problem

Long-standing prod bug: the composer still shows the sent text after sending a message (most recently reported by Caroline in prod). The message itself sends fine; the text stays in the input box and the send button re-enables as if the message were never sent. Reproducible with both plain typing and voice dictation.

## Root cause (verified empirically on iOS 26.2 simulators with an instrumented repro app and real dictation)

The composer intentionally stays first responder across send (`FocusCoordinator.nextFocus` returns `.message` for `(.message, .conversation)`), so `onSendMessage`'s synchronous `messageText = ""` lands while the keyboard input session is still live. If the keyboard holds uncommitted input at that moment, the clear is lost. Two trigger paths, one mechanism:

- **Plain keyboard (reproduced 2/2):** if the send button tap lands within ~100ms of the final keystroke and that word has a pending autocorrect, the binding clears but the write never reaches the backing `UITextView` (field keeps the full text, binding briefly empty, send button disabled). The pending correction then commits at the keyboard's *next touch event* - seconds or minutes later - and the field-to-binding sync repopulates `messageText` with the full text. With a ~120ms+ pause before sending the correction flushes synchronously before the clear, which is why the bug is timing-dependent.
- **Dictation (reproduced with real dictation in the simulator):** an active dictation session survives the send and keeps streaming hypothesis updates and revisions into the field after the clear, repopulating the composer with already-sent text. Sending mid-speech also delivers the recognizer's late final transcription after the clear. (Matches the `cancelDictation -> insertText:` machinery in the flutter/flutter#84419 LLDB trace.)

Ruled out by direct measurement on 26.2:

- `textInputMode?.primaryLanguage == "dictation"` does not detect dictation (stays the regular language while the mic is visibly active), and `UITextInputMode.currentInputModeDidChangeNotification` does not fire on dictation start/stop. There is no public signal that dictation is running.
- Resign/restore first responder settles everything, but the no-responder gap visibly hides and re-shows the keyboard on every send it runs on - including inside `UIView.performWithoutAnimation` (frame analysis shows the keyboard mid-slide). This was the first shipped revision of this branch and it flickered in real use.
- Time-boxed or exact-match re-clear guards for the typed path (the autocorrect resurrect arrives at the next touch, not on a timer, and comes back mutated).
- Threshold tweaks to the dictation heuristic (requiring streaks of bulk writes): hardware-keyboard fast typing coalesces multiple characters per binding write and still trips it; chasing precision was a losing game, so the flagged path was made invisible instead (below).

A previous attempt (#291) only made `sendButtonEnabled` derived and could not have fixed this.

## Fix

`FocusCoordinator.withSettledKeyboardInput(endingInputSession:_:)` settles the keyboard before the capture-and-clear, with the strategy chosen by the caller:

- **Typed sends** (the default): re-assert the focused field's `selectedTextRange` at the UIKit level. A selection change runs the same settle path the keyboard uses when the caret moves, with no first responder change - the keyboard never hides or re-shows, and the zero-delay autocorrect race no longer loses the clear.
- **Likely-dictation sends**: end the input session by handing first responder to a temporary zero-frame off-screen `UITextField` in the same window, then handing it back (`endInputSessionKeepingKeyboard`). A text input stays focused throughout, so UIKit never schedules a keyboard hide - the keyboard stays put (verified by frame analysis, below) - while the composer's input session is torn down exactly as on resign, which is what terminates dictation. The handoff field is excluded from accessibility so VoiceOver never sees the transient focus; if the handoff field cannot take focus (or the input has no window) the code falls back to plain resign/restore and logs it. Since dictation is not directly detectable, `ConversationViewModel` infers it behaviorally: dictation streams multi-character insertions into `messageText` (typing changes one character at a time), so a send within 3s of a bulk insertion is treated as interrupting dictation. False positives (autocorrect commits, QuickType taps, pastes, coalesced fast typing) cost nothing visible, so the heuristic deliberately overtriggers rather than miss real dictation. The flag resets whenever the composer empties, so link-strip flows and sends never leave stale state behind.
- **Re-clear guard for dictation residue**: the recognizer's final transcription can still arrive after a mid-speech send (no public API can cancel the in-flight result), as a multi-character write into the emptied composer. For 1.5s after a likely-dictation send, such a repopulation is cleared once. Single-character edits (typing) disarm the guard immediately and are never touched; the guard does not arm for typed sends at all. The window is deliberately tight (observed re-inserts land within ~1s) so a legitimate paste or next-message dictation shortly after a send is not eaten.

The two-strategy split is deliberate (rather than always ending the session): the selection nudge changes no responder state at all, keeping the common typed path at zero focus churn (VoiceOver, third-party keyboards, responder-restore edge cases), while the handoff's responder round-trip is confined to sends that actually need the session ended.

## Verification (iOS 26.2)

- Instrumented repro app: 3/3 clean under the exact zero-delay autocorrect race that failed 2/2 unfixed; normal-pace sends keep the usual flush-then-clear ordering.
- Real app, typed sends: race send clears the composer and stays clear through next-touch triggers; frame-by-frame video analysis shows the keyboard never moves on nudge sends.
- Real app, flagged (handoff) sends: exercised end-to-end (`sinceBulk 0.23s` -> handoff -> clear held); frame analysis across the full recording shows zero keyboard movement. The only key-area pixel change is the keycap shift-case recompute, and an A/B against the nudge path shows that same recompute on ordinary sends - it is inherent send behavior, not a handoff artifact.
- Real app, real dictation (driven via host audio loopback): one clean pass on the resign-based revision (session terminated, composer stayed empty 10+ s mid-speech, message sent exactly once). The handoff performs the same session teardown; a final on-device dictation pass is still recommended.
- Manual testing: typed sends with autocorrect/QuickType at speed - no keyboard flicker, no text resurrection.
- Four independent review passes (UIKit lifecycle, races/data-loss, design simplicity, UX/accessibility) - actioned: accessibility suppression on the handoff field, restore-failure logging + `defer` cleanup, 4s -> 1.5s re-clear window, insertion-only bulk tracking with reset-on-empty, doc fixes.
- `swift test --package-path ConvosCore`: 1101/1101 passing.

## Changes

- `FocusCoordinator.withSettledKeyboardInput(endingInputSession:_:)` + `endInputSessionKeepingKeyboard` (off-screen focus handoff) + private first-responder lookup
- `ConversationViewModel`: bulk-insertion dictation heuristic, send-path wiring (`sendComposerContents`), and the scoped post-send re-clear guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix composer text not clearing after send when using keyboard input or dictation
> - Wraps the send flow in a new `FocusCoordinator.withSettledKeyboardInput` method that commits pending keyboard input before clearing the composer, preventing uncommitted text from repopulating the field after send.
> - Adds dictation detection in `ConversationViewModel` using a time-window heuristic (`lastBulkTextChangeAt`) to identify bulk text insertions characteristic of dictation.
> - When a send ends a dictation session, `dictationReclearArmedAt` is set so that any late transcription text that repopulates the composer within 1.5s is automatically cleared.
> - Adds `FocusCoordinator.endInputSessionKeepingKeyboard`, which hands first responder to a temporary off-screen field to terminate the input session without dismissing the keyboard, reducing keyboard flicker.
> - Behavioral Change: send now ends the dictation input session when dictation-like activity is detected, which changes first-responder focus briefly during the send operation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6baf0c5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->