### PR TITLE
Fix sheet keyboard crash: defer bottomBarHeight inset updates one runloop tick

### DIFF
--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/MessagesViewController.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/MessagesViewController.swift
@@ -173,12 +173,37 @@ final class MessagesViewController: UIViewController {
     var bottomBarHeight: CGFloat = 0.0 {
         didSet {
             if bottomBarHeight != oldValue {
-                updateBottomInsetForBottomBarHeight()
+                scheduleBottomBarInsetUpdate()
             }
 
             if bottomBarHeight > 0.0 {
                 currentInterfaceActions.options.remove(.determiningBottomBarHeight)
             }
+        }
+    }
+
+    /// `bottomBarHeight` is only written from `updateUIViewController`, which can run
+    /// synchronously inside an in-flight UIKit layout pass (e.g. a sheet's keyboard
+    /// relayout in `UISheetPresentationController`). Animating inset changes and forcing
+    /// collection view layout re-entrantly from there crashes in UIKit's
+    /// `_updateLayoutAttributesForExistingVisibleViewsFadingForBoundsChange:` assertion,
+    /// because `restoreContentOffset` suppresses layout attributes while the collection
+    /// view is mid bounds change. Deferring to the next run loop tick keeps the update
+    /// out of the enclosing layout pass; rapid changes coalesce into one update.
+    ///
+    /// Initial layout stays correct because `updateUIViewController` assigns
+    /// `bottomBarHeight` before `state`, so this deferred inset block is enqueued ahead
+    /// of the initial load's scroll-to-bottom (which runs via the collection view
+    /// reload's async completion). Keep that assignment order in the representable.
+    private var hasPendingBottomBarInsetUpdate: Bool = false
+
+    private func scheduleBottomBarInsetUpdate() {
+        guard !hasPendingBottomBarInsetUpdate else { return }
+        hasPendingBottomBarInsetUpdate = true
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            self.hasPendingBottomBarInsetUpdate = false
+            self.updateBottomInsetForBottomBarHeight()
         }
     }
 

--- a/Convos/Conversation Detail/Messages/MessagesViewRepresentable.swift
+++ b/Convos/Conversation Detail/Messages/MessagesViewRepresentable.swift
@@ -85,6 +85,8 @@ struct MessagesViewRepresentable: UIViewControllerRepresentable {
         messagesViewController.onUserInteraction = onUserInteraction
         messagesViewController.hasBottomBar = hasBottomBar
         messagesViewController.topContentInset = topContentInset
+        // Assign bottomBarHeight before state: its deferred inset update must be
+        // enqueued ahead of the initial load's scroll-to-bottom completion.
         messagesViewController.bottomBarHeight = bottomBarHeight
         messagesViewController.focusCoordinator = focusCoordinator
 


### PR DESCRIPTION
## Summary

Fixes a production crash from TestFlight feedback (2.0.0 build 883, iPad, comment "bg"): SIGABRT / `NSInternalInconsistencyException` in UIKit's `-[UICollectionView _updateLayoutAttributesForExistingVisibleViewsFadingForBoundsChange:]`.

## Root cause

When a conversation is hosted in a sheet (agent builder, committed conversation, thinking detail — all page sheets on iPad) and the keyboard appears (e.g. first-responder restore when re-foregrounding the app — hence "bg"):

1. `UISheetPresentationController _keyboardAboutToShow:` force-lays-out the sheet inside `UIView.performWithoutAnimation`
2. That layout runs the SwiftUI render synchronously, re-running `MessagesViewRepresentable.updateUIViewController`
3. The `bottomBarHeight` didSet ran `updateBottomInsetForBottomBarHeight()` synchronously: `UIView.animate` + `performBatchUpdates` + `MessagesCollectionLayout.restoreContentOffset(with:)`, which sets `dontReturnAttributes = true` and forces `layoutIfNeeded()`
4. With animations disabled by the enclosing `performWithoutAnimation`, the inset change becomes a non-animated bounds change → UICollectionView takes the fade-for-bounds-change path → layout returns nil attributes for visible cells → UIKit asserts

Full-screen conversations never hit this: outside `performWithoutAnimation` the inset change animates and the fade path isn't taken.

## Fix

The `bottomBarHeight` didSet now schedules the inset update one main-runloop tick later (`scheduleBottomBarInsetUpdate`, coalescing rapid changes) so it never runs re-entrantly inside an in-flight UIKit layout pass. Matches the existing in-file precedent for the context-menu case (`applyDeferredBottomInset`).

Initial-load layout stays correct because the deferred inset block is enqueued ahead of the initial scroll-to-bottom (which runs via the collection view reload's async completion); a comment now pins the `bottomBarHeight`-before-`state` assignment order in the representable that this relies on.

## Verification

- Full ConvosCore test suite: 1101 tests / 157 suites passed
- "Convos (Dev)" scheme builds clean; SwiftLint strict clean
- Adversarial code review (deferral correctness, stale-capture races, dealloc, mid-batch-update timing, initial-layout ordering, alternative fix layers): verdict sound — deferral reads state fresh at execution time, existing `.updatingCollection` / `contextMenuState` guards still apply on the deferred turn
- Crash-frame line numbers in build 883 matched current source exactly, so this code path was unchanged since the crash

Worth prioritizing for the next Prod build: Sentry isn't live on Prod yet, so recurrences are invisible outside TestFlight feedback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix keyboard crash in sheet by deferring `bottomBarHeight` inset updates one run loop tick
> A crash occurred when the keyboard appeared over a sheet because `updateBottomInsetForBottomBarHeight()` was called synchronously during layout, before the view was ready. The fix defers that call to the next main run loop tick via a new `scheduleBottomBarInsetUpdate()` method with a coalescing flag to prevent redundant enqueues. A comment in [MessagesViewRepresentable.swift](https://github.com/xmtplabs/convos-ios/pull/978/files#diff-8bd43c70f5fc921339d47bb5561db6bbb15e52ac55cfbdd958cc982716cd77e4) clarifies that `bottomBarHeight` must be assigned before `state` so the deferred update is enqueued ahead of the initial scroll-to-bottom.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e1abc5f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->