### PR TITLE
Default Reveal mode to off: unset conversations fall back to the global photo-reveal default

### DIFF
--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -821,7 +821,7 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
     @ObservationIgnored
     private var agentJoinTaskId: String?
 
-    var autoRevealPhotos: Bool = false
+    var autoRevealPhotos: Bool = GlobalConvoDefaults.shared.autoRevealPhotos
     var sendReadReceipts: Bool = true
     var isViewingConversation: Bool = false
 
@@ -1163,8 +1163,7 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
             guard let self else { return }
             do {
                 let prefs = try await photoPreferencesRepository.preferences(for: conversation.id)
-                let defaultAutoReveal: Bool = applyGlobalDefaultsForNewConversation ? GlobalConvoDefaults.shared.autoRevealPhotos : false
-                setAutoRevealPhotosLocally(prefs?.autoReveal ?? defaultAutoReveal)
+                setAutoRevealPhotosLocally(prefs?.autoReveal ?? GlobalConvoDefaults.shared.autoRevealPhotos)
                 let readReceiptsPref = prefs?.sendReadReceipts ?? GlobalConvoDefaults.shared.sendReadReceipts
                 sendReadReceipts = readReceiptsPref
                 messagesListRepository.sendReadReceipts = readReceiptsPref
@@ -1384,15 +1383,11 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
             .receive(on: DispatchQueue.main)
             .sink { [weak self] prefs in
                 guard let self else { return }
-                setAutoRevealPhotosLocally(prefs?.autoReveal ?? defaultAutoRevealForNewConversation)
+                setAutoRevealPhotosLocally(prefs?.autoReveal ?? GlobalConvoDefaults.shared.autoRevealPhotos)
                 let readReceiptsPref = prefs?.sendReadReceipts ?? GlobalConvoDefaults.shared.sendReadReceipts
                 sendReadReceipts = readReceiptsPref
                 messagesListRepository.sendReadReceipts = readReceiptsPref
             }
-    }
-
-    private var defaultAutoRevealForNewConversation: Bool {
-        applyGlobalDefaultsForNewConversation ? GlobalConvoDefaults.shared.autoRevealPhotos : false
     }
 
     private func applyGlobalDefaultsForDraftConversationIfNeeded() {

--- a/ConvosCore/Sources/ConvosCore/Storage/Database Models/DBPhotoPreferences.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Database Models/DBPhotoPreferences.swift
@@ -55,7 +55,8 @@ extension DBPhotoPreferences {
     static func defaultPreferences(for conversationId: String) -> DBPhotoPreferences {
         DBPhotoPreferences(
             conversationId: conversationId,
-            autoReveal: false,
+            // Photos are auto-revealed by default (Reveal Mode toggle is off).
+            autoReveal: true,
             hasRevealedFirst: false,
             updatedAt: Date(),
             sendReadReceipts: nil

--- a/ConvosCore/Sources/ConvosCore/Storage/Repositories/PhotoPreferencesRepository.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Repositories/PhotoPreferencesRepository.swift
@@ -8,6 +8,13 @@ public struct PhotoPreferences: Hashable, Sendable {
     public let hasRevealedFirst: Bool
     public let sendReadReceipts: Bool?
 
+    public init(conversationId: String, autoReveal: Bool, hasRevealedFirst: Bool, sendReadReceipts: Bool?) {
+        self.conversationId = conversationId
+        self.autoReveal = autoReveal
+        self.hasRevealedFirst = hasRevealedFirst
+        self.sendReadReceipts = sendReadReceipts
+    }
+
     public var shouldBlurPhotos: Bool {
         !hasRevealedFirst || !autoReveal
     }

--- a/ConvosTests/ConversationViewModelGlobalDefaultsTests.swift
+++ b/ConvosTests/ConversationViewModelGlobalDefaultsTests.swift
@@ -42,6 +42,74 @@ final class ConversationViewModelGlobalDefaultsTests: XCTestCase {
         XCTAssertFalse(viewModel.includeInfoInPublicPreview)
     }
 
+    func testRevealModeDefaultsToOffWhenNoPerConversationPreference() async throws {
+        let session = TestSessionManager(
+            base: MockInboxesService(),
+            photoPreferencesRepository: MockPhotoPreferencesRepository(preferences: nil),
+            photoPreferencesWriter: MockPhotoPreferencesWriter()
+        )
+
+        let viewModel = ConversationViewModel(
+            conversation: .mock(id: "no-prefs-conversation", name: "Real"),
+            session: session,
+            messagingService: MockMessagingService(),
+            applyGlobalDefaultsForNewConversation: false
+        )
+
+        try await Task.sleep(for: .milliseconds(150))
+
+        XCTAssertTrue(viewModel.autoRevealPhotos)
+        XCTAssertFalse(viewModel.shouldBlurPhotos)
+    }
+
+    func testRevealModeFallsBackToGlobalDefaultWhenBlurEnabledGlobally() async throws {
+        GlobalConvoDefaults.shared.autoRevealPhotos = false
+
+        let session = TestSessionManager(
+            base: MockInboxesService(),
+            photoPreferencesRepository: MockPhotoPreferencesRepository(preferences: nil),
+            photoPreferencesWriter: MockPhotoPreferencesWriter()
+        )
+
+        let viewModel = ConversationViewModel(
+            conversation: .mock(id: "global-blur-conversation", name: "Real"),
+            session: session,
+            messagingService: MockMessagingService(),
+            applyGlobalDefaultsForNewConversation: false
+        )
+
+        try await Task.sleep(for: .milliseconds(150))
+
+        XCTAssertFalse(viewModel.autoRevealPhotos)
+        XCTAssertTrue(viewModel.shouldBlurPhotos)
+    }
+
+    func testExplicitConversationPreferenceOverridesGlobalDefault() async throws {
+        let preferences = PhotoPreferences(
+            conversationId: "explicit-prefs-conversation",
+            autoReveal: false,
+            hasRevealedFirst: false,
+            sendReadReceipts: nil
+        )
+        let session = TestSessionManager(
+            base: MockInboxesService(),
+            photoPreferencesRepository: MockPhotoPreferencesRepository(preferences: preferences),
+            photoPreferencesWriter: MockPhotoPreferencesWriter()
+        )
+
+        let viewModel = ConversationViewModel(
+            conversation: .mock(id: "explicit-prefs-conversation", name: "Real"),
+            session: session,
+            messagingService: MockMessagingService(),
+            applyGlobalDefaultsForNewConversation: false
+        )
+
+        try await Task.sleep(for: .milliseconds(150))
+
+        XCTAssertFalse(viewModel.autoRevealPhotos)
+        XCTAssertTrue(viewModel.shouldBlurPhotos)
+    }
+
     func testRevealPreferenceSeededWhenConversationReadyAfterCreation() async throws {
         GlobalConvoDefaults.shared.autoRevealPhotos = true
 


### PR DESCRIPTION
## Summary

"Reveal mode" (blur incoming photos) should be off by default, but conversations without a saved photo preference hard-coded blur as the fallback - so every joined or pre-existing conversation behaved as if Reveal mode were on, even though the global setting already defaulted to off.

- `ConversationViewModel`: conversations with no saved photo preference now fall back to `GlobalConvoDefaults.autoRevealPhotos` (default: revealed/unblurred), matching how the read-receipts preference already resolves. The pre-load initial value seeds from the same default so photos don't flash blurred.
- `DBPhotoPreferences.defaultPreferences`: implicitly created preference rows (e.g. from toggling read receipts) now seed `autoReveal: true`, so touching another preference no longer switches blur on as a side effect.
- `PhotoPreferences`: added a public memberwise init (needed to construct preferences in app-target tests; `MockPhotoPreferencesRepository` already accepted one but it wasn't constructible outside ConvosCore).

Explicit user choices are untouched: per-conversation prefs and the global Customize toggle still override the default in both directions.

## Testing

- 3 new regression tests in `ConversationViewModelGlobalDefaultsTests` (default-off with no pref, global blur-on respected as fallback, explicit per-convo pref overrides global); class passes 7/7 on the iOS simulator
- Full ConvosCore suite: 1101 tests in 157 suites, all passing (`./dev/test` with Docker)
- Full-tree SwiftLint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/979"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783134938&installation_id=128169237&pr_number=979&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F979&signature=b8f81bbde2299ae69a231d47b7258137cc23a5e5139bca2cf3447a0f250f1af1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Default photo reveal mode to fall back to the global `autoRevealPhotos` setting for unset conversations
> - `ConversationViewModel` now initializes `autoRevealPhotos` from `GlobalConvoDefaults.shared.autoRevealPhotos` instead of hardcoded `false`, and uses the same global default as a fallback when per-conversation preferences are absent in both `loadPhotoPreferences` and `observePhotoPreferences`.
> - Removes the `defaultAutoRevealForNewConversation` computed property, which previously gated global-default fallback behind a separate `applyGlobalDefaultsForNewConversation` flag.
> - `DBPhotoPreferences.defaultPreferences(for:)` now sets `autoReveal` to `true` when creating default records, consistent with Reveal Mode being off by default (blur disabled).
> - Three new tests in `ConversationViewModelGlobalDefaultsTests` cover: global default applied when no per-conversation pref exists, fallback when global default is `false`, and explicit per-conversation override.
> - Behavioral Change: `ConversationViewModel` instances that previously had no per-conversation preference will now reflect the global default instead of always starting with `autoRevealPhotos = false`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cfa97e1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->