### PR TITLE
Open contact detail from agent-share message cards instead of auto-creating a convo

### DIFF
--- a/Convos/Contacts/ContactDetailView.swift
+++ b/Convos/Contacts/ContactDetailView.swift
@@ -292,9 +292,10 @@ struct ContactDetailView: View {
                         .padding(.top, DesignConstants.Spacing.step2x)
                         .padding(.horizontal, DesignConstants.Spacing.step6x)
                 }
-                // Suggested-agent placeholders aren't saved contacts, so the
-                // "Added X ago" line (and Block, below) don't apply.
-                if !contact.isSuggestedAgentPlaceholder {
+                // Suggested-agent and agent-share placeholders aren't saved
+                // contacts, so the "Added X ago" line (and Block, below)
+                // don't apply.
+                if !contact.isUnsavedAgentPlaceholder {
                     ContactDetailSubtitle(
                         contact: contact,
                         invitedBy: mode.invitedBy,
@@ -320,7 +321,7 @@ struct ContactDetailView: View {
                     showRemove: mode.isScopedToConversation
                         && !mode.isCurrentUser
                         && mode.canRemoveMembers,
-                    showBlock: !mode.isCurrentUser && !contact.isSuggestedAgentPlaceholder,
+                    showBlock: !mode.isCurrentUser && !contact.isUnsavedAgentPlaceholder,
                     contactDisplayName: contact.resolvedDisplayName,
                     agentInstanceId: contact.agentInstanceId,
                     showsInstanceIdRow: showsInstanceIdRow,

--- a/Convos/Conversation Detail/ConversationView+MetricsObservers.swift
+++ b/Convos/Conversation Detail/ConversationView+MetricsObservers.swift
@@ -1,14 +1,11 @@
 import ConvosCore
 import SwiftUI
 
-/// Extracted modifiers carrying the 17 Bool-keyed metrics `.onChange`
-/// observers for the conversation screen. Split into two modifiers
-/// because chaining all 17 into a single `body(content:)` blew past the
-/// 300ms type-check threshold (see CLAUDE.md build-performance notes).
-/// The two object-keyed observers (`presentingProfileForMember`,
-/// `presentingReactionsForMessage`) stay on `ConversationView.body` —
-/// only two modifiers and their types (`ConversationMember?` /
-/// `AnyMessage?`) don't fit a uniform shape.
+/// Extracted modifiers carrying the metrics `.onChange` observers for the
+/// conversation screen. Split into multiple modifiers because chaining all
+/// of them into a single `body(content:)` blew past the type-check
+/// threshold (see CLAUDE.md build-performance notes). Parts 1 and 2 carry
+/// the Bool-keyed observers; Part 3 carries the object-keyed ones.
 extension ConversationView {
     struct MetricsObserversPart1: ViewModifier {
         let presentingConversationSettings: Bool
@@ -51,7 +48,6 @@ extension ConversationView {
         let presentingPhotosInfo: Bool
         let presentingAgentBuilder: Bool
         let presentingNewConvoForInvite: Bool
-        let presentingNewConvoForAgentShare: Bool
         let presentingAddFromContactsPicker: Bool
 
         let onFullInfoChanged: (Bool, Bool) -> Void
@@ -59,7 +55,6 @@ extension ConversationView {
         let onPhotosInfoChanged: (Bool, Bool) -> Void
         let onAgentBuilderChanged: (Bool, Bool) -> Void
         let onNewConvoInviteChanged: (Bool, Bool) -> Void
-        let onNewConvoAgentShareChanged: (Bool, Bool) -> Void
         let onAddFromContactsChanged: (Bool, Bool) -> Void
 
         func body(content: Content) -> some View {
@@ -69,23 +64,25 @@ extension ConversationView {
                 .onChange(of: presentingPhotosInfo) { o, n in onPhotosInfoChanged(o, n) }
                 .onChange(of: presentingAgentBuilder) { o, n in onAgentBuilderChanged(o, n) }
                 .onChange(of: presentingNewConvoForInvite) { o, n in onNewConvoInviteChanged(o, n) }
-                .onChange(of: presentingNewConvoForAgentShare) { o, n in onNewConvoAgentShareChanged(o, n) }
                 .onChange(of: presentingAddFromContactsPicker) { o, n in onAddFromContactsChanged(o, n) }
         }
     }
 
     struct MetricsObserversPart3: ViewModifier {
         let presentingProfileForMember: ConversationMember?
+        let presentingContactForAgentShare: Contact?
         let presentingReactionsForMessage: AnyMessage?
         let presentingThinkingDetail: ThinkingSessionDescriptor?
 
         let onMemberProfileChanged: (ConversationMember?, ConversationMember?) -> Void
+        let onAgentShareContactChanged: (Contact?, Contact?) -> Void
         let onReactionsChanged: (AnyMessage?, AnyMessage?) -> Void
         let onThinkingDetailChanged: (ThinkingSessionDescriptor?, ThinkingSessionDescriptor?) -> Void
 
         func body(content: Content) -> some View {
             content
                 .onChange(of: presentingProfileForMember) { o, n in onMemberProfileChanged(o, n) }
+                .onChange(of: presentingContactForAgentShare) { o, n in onAgentShareContactChanged(o, n) }
                 .onChange(of: presentingReactionsForMessage) { o, n in onReactionsChanged(o, n) }
                 .onChange(of: presentingThinkingDetail) { o, n in onThinkingDetailChanged(o, n) }
         }

--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -127,9 +127,18 @@ struct ConversationView<MessagesBottomBar: View>: View {
         navigator?.present(newConversation: NewConversationNavigatorArgs(mode: .joinInvite))
     }
 
-    private func handleNewConvoAgentShareChanged(from wasPresenting: Bool, to isPresenting: Bool) {
-        guard !wasPresenting, isPresenting else { return }
-        navigator?.present(newConversation: NewConversationNavigatorArgs(mode: .create))
+    /// The agent-share placeholder card reports as a member-profile present
+    /// with the placeholder's sentinel inbox id (`agent-share:<templateId>`),
+    /// keeping "a profile card opened from this conversation" consistent in
+    /// analytics with the member-avatar path while staying distinguishable.
+    private func handleAgentShareContactChanged(from oldContact: Contact?, to newContact: Contact?) {
+        guard oldContact == nil, let newContact else { return }
+        navigator?.present(
+            memberProfile: MemberProfileNavigatorArgs(
+                conversationId: conversationIdForMetrics,
+                memberId: newContact.inboxId
+            )
+        )
     }
 
     private func handleMemberProfileChanged(from oldMember: ConversationMember?, to newMember: ConversationMember?) {
@@ -405,6 +414,11 @@ struct ConversationView<MessagesBottomBar: View>: View {
         MemberContactDetailSheetContent(viewModel: viewModel, member: member, profileSettingsViewModel: profileSettingsViewModel)
     }
 
+    @ViewBuilder
+    private func agentShareContactDetailSheet(for contact: Contact) -> some View {
+        AgentShareContactDetailSheetContent(viewModel: viewModel, contact: contact, profileSettingsViewModel: profileSettingsViewModel)
+    }
+
     private var scanInviteButton: some View {
         Button {
             onScanInviteCode()
@@ -484,9 +498,11 @@ struct ConversationView<MessagesBottomBar: View>: View {
     private var metricsObserversPart3: MetricsObserversPart3 {
         MetricsObserversPart3(
             presentingProfileForMember: viewModel.presentingProfileForMember,
+            presentingContactForAgentShare: viewModel.presentingContactForAgentShare,
             presentingReactionsForMessage: viewModel.presentingReactionsForMessage,
             presentingThinkingDetail: viewModel.presentingThinkingDetail,
             onMemberProfileChanged: handleMemberProfileChanged(from:to:),
+            onAgentShareContactChanged: handleAgentShareContactChanged(from:to:),
             onReactionsChanged: handleReactionsChanged(from:to:),
             onThinkingDetailChanged: handleThinkingDetailChanged(from:to:)
         )
@@ -499,14 +515,12 @@ struct ConversationView<MessagesBottomBar: View>: View {
             presentingPhotosInfo: viewModel.presentingPhotosInfoSheet,
             presentingAgentBuilder: viewModel.presentingAgentBuilder != nil,
             presentingNewConvoForInvite: viewModel.presentingNewConversationForInvite != nil,
-            presentingNewConvoForAgentShare: viewModel.presentingNewConversationForAgentShare != nil,
             presentingAddFromContactsPicker: presentingAddFromContactsPicker,
             onFullInfoChanged: handleFullInfoChanged(from:to:),
             onRevealMediaInfoChanged: handleRevealMediaInfoChanged(from:to:),
             onPhotosInfoChanged: handlePhotosInfoChanged(from:to:),
             onAgentBuilderChanged: handleAgentBuilderChanged(from:to:),
             onNewConvoInviteChanged: handleNewConvoInviteChanged(from:to:),
-            onNewConvoAgentShareChanged: handleNewConvoAgentShareChanged(from:to:),
             onAddFromContactsChanged: handleAddFromContactsChanged(from:to:)
         )
     }
@@ -593,8 +607,8 @@ struct ConversationView<MessagesBottomBar: View>: View {
         .sheet(item: $viewModel.presentingNewConversationForInvite) { viewModel in
             newConversationSheet(viewModel)
         }
-        .sheet(item: $viewModel.presentingNewConversationForAgentShare) { viewModel in
-            newConversationSheet(viewModel)
+        .sheet(item: $viewModel.presentingContactForAgentShare) { contact in
+            agentShareContactDetailSheet(for: contact)
         }
         .selfSizingSheet(isPresented: $viewModel.presentingExplodedInviteInfo) {
             ExplodeInfoView()
@@ -726,6 +740,33 @@ struct MemberContactDetailSheetContent: View {
     }
 }
 
+/// Contact detail sheet for a tapped agent-share message card whose template
+/// has no running agent in this conversation. The contact is a placeholder
+/// built from the share link's resolved profile (see
+/// `Contact.agentSharePlaceholder`), so the card renders in `.standalone`
+/// mode: no "Remove from convo", and the unsaved-placeholder gating hides
+/// the "Added X ago" line and Block. "New chat" spawns a fresh instance of
+/// the template via the card's own confirmation flow.
+struct AgentShareContactDetailSheetContent: View {
+    let viewModel: ConversationViewModel
+    let contact: Contact
+    @Bindable var profileSettingsViewModel: ProfileSettingsViewModel
+
+    var body: some View {
+        let messagingService = viewModel.messagingService
+        NavigationStack {
+            ContactDetailView(
+                contact: contact,
+                contactsWriter: messagingService.contactsWriter(),
+                contactsRepository: messagingService.contactsRepository(),
+                session: viewModel.session,
+                coreActions: viewModel.coreActions,
+                profileSettingsViewModel: profileSettingsViewModel
+            )
+        }
+    }
+}
+
 #Preview {
     @Previewable @State var viewModel: ConversationViewModel = makeConversationViewPreviewViewModel()
     @Previewable @State var profileSettingsViewModel: ProfileSettingsViewModel = .shared
@@ -744,83 +785,5 @@ struct MemberContactDetailSheetContent: View {
             messagesTextFieldEnabled: true,
             bottomBarContent: { EmptyView() }
         )
-    }
-}
-
-private struct MetricsObserversPart1: ViewModifier {
-    let presentingConversationSettings: Bool
-    let presentingProfileSettings: Bool
-    let presentingShareView: Bool
-    let presentingConversationForked: Bool
-    let presentingExplodedInviteInfo: Bool
-    let presentingAgentsIntro: Bool
-    let presentingPaywall: Bool
-    let showingAgentsInfo: Bool
-    let showingLockedInfo: Bool
-    let onConversationSettingsChanged: (Bool, Bool) -> Void
-    let onProfileSettingsChanged: (Bool, Bool) -> Void
-    let onShareViewChanged: (Bool, Bool) -> Void
-    let onConversationForkedChanged: (Bool, Bool) -> Void
-    let onExplodedInviteInfoChanged: (Bool, Bool) -> Void
-    let onAgentsIntroChanged: (Bool, Bool) -> Void
-    let onPaywallChanged: (Bool, Bool) -> Void
-    let onAgentsInfoChanged: (Bool, Bool) -> Void
-    let onLockedInfoChanged: (Bool, Bool) -> Void
-
-    func body(content: Content) -> some View {
-        content
-            .onChange(of: presentingConversationSettings) { o, n in onConversationSettingsChanged(o, n) }
-            .onChange(of: presentingProfileSettings) { o, n in onProfileSettingsChanged(o, n) }
-            .onChange(of: presentingShareView) { o, n in onShareViewChanged(o, n) }
-            .onChange(of: presentingConversationForked) { o, n in onConversationForkedChanged(o, n) }
-            .onChange(of: presentingExplodedInviteInfo) { o, n in onExplodedInviteInfoChanged(o, n) }
-            .onChange(of: presentingAgentsIntro) { o, n in onAgentsIntroChanged(o, n) }
-            .onChange(of: presentingPaywall) { o, n in onPaywallChanged(o, n) }
-            .onChange(of: showingAgentsInfo) { o, n in onAgentsInfoChanged(o, n) }
-            .onChange(of: showingLockedInfo) { o, n in onLockedInfoChanged(o, n) }
-    }
-}
-
-private struct MetricsObserversPart2: ViewModifier {
-    let showingFullInfo: Bool
-    let presentingRevealMediaInfo: Bool
-    let presentingPhotosInfo: Bool
-    let presentingAgentBuilder: Bool
-    let presentingNewConvoForInvite: Bool
-    let presentingNewConvoForAgentShare: Bool
-    let presentingAddFromContactsPicker: Bool
-    let onFullInfoChanged: (Bool, Bool) -> Void
-    let onRevealMediaInfoChanged: (Bool, Bool) -> Void
-    let onPhotosInfoChanged: (Bool, Bool) -> Void
-    let onAgentBuilderChanged: (Bool, Bool) -> Void
-    let onNewConvoInviteChanged: (Bool, Bool) -> Void
-    let onNewConvoAgentShareChanged: (Bool, Bool) -> Void
-    let onAddFromContactsChanged: (Bool, Bool) -> Void
-
-    func body(content: Content) -> some View {
-        content
-            .onChange(of: showingFullInfo) { o, n in onFullInfoChanged(o, n) }
-            .onChange(of: presentingRevealMediaInfo) { o, n in onRevealMediaInfoChanged(o, n) }
-            .onChange(of: presentingPhotosInfo) { o, n in onPhotosInfoChanged(o, n) }
-            .onChange(of: presentingAgentBuilder) { o, n in onAgentBuilderChanged(o, n) }
-            .onChange(of: presentingNewConvoForInvite) { o, n in onNewConvoInviteChanged(o, n) }
-            .onChange(of: presentingNewConvoForAgentShare) { o, n in onNewConvoAgentShareChanged(o, n) }
-            .onChange(of: presentingAddFromContactsPicker) { o, n in onAddFromContactsChanged(o, n) }
-    }
-}
-
-private struct MetricsObserversPart3: ViewModifier {
-    let presentingProfileForMember: ConversationMember?
-    let presentingReactionsForMessage: AnyMessage?
-    let presentingThinkingDetail: ThinkingSessionDescriptor?
-    let onMemberProfileChanged: (ConversationMember?, ConversationMember?) -> Void
-    let onReactionsChanged: (AnyMessage?, AnyMessage?) -> Void
-    let onThinkingDetailChanged: (ThinkingSessionDescriptor?, ThinkingSessionDescriptor?) -> Void
-
-    func body(content: Content) -> some View {
-        content
-            .onChange(of: presentingProfileForMember) { o, n in onMemberProfileChanged(o, n) }
-            .onChange(of: presentingReactionsForMessage) { o, n in onReactionsChanged(o, n) }
-            .onChange(of: presentingThinkingDetail) { o, n in onThinkingDetailChanged(o, n) }
     }
 }

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -775,11 +775,12 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
     var presentingNewConversationForInvite: NewConversationViewModel? {
         didSet { oldValue?.cleanUpIfNeeded() }
     }
-    /// Drives the new-conversation flow opened by tapping a shared agent's
-    /// contact card. Mirrors `presentingNewConversationForInvite`.
-    var presentingNewConversationForAgentShare: NewConversationViewModel? {
-        didSet { oldValue?.cleanUpIfNeeded() }
-    }
+    /// Drives the contact detail sheet opened by tapping a shared agent's
+    /// message card when no agent running that template is a member of this
+    /// conversation. Carries a placeholder `Contact` built from the share
+    /// link's resolved profile; the card's "New chat" action spawns a fresh
+    /// instance of the template. Mirrors `presentingProfileForMember`.
+    var presentingContactForAgentShare: Contact?
     var presentingConversationForked: Bool = false
     var presentingReactionsForMessage: AnyMessage?
     var presentingReadByForGroup: MessagesGroup?
@@ -2830,15 +2831,16 @@ extension ConversationViewModel {
         session.inviteMembershipResolver()
     }
 
-    /// Tapping a shared agent's contact card opens that agent's contact
-    /// detail when an agent running the same template is already a member of
-    /// this conversation; otherwise it opens a new conversation seeded with
-    /// the template (the same flow the `convos://template/<id>` deep link
-    /// uses). The custom-scheme form carries the template id directly; a
-    /// web-slug share is resolved to its id via the API resolver first.
+    /// Tapping a shared agent's message card opens that agent's contact
+    /// detail. When an agent running the same template is already a member of
+    /// this conversation, the member's card opens directly; otherwise a
+    /// placeholder card is built from the share link's resolved profile, and
+    /// its "New chat" action spawns a fresh instance of the template. The
+    /// custom-scheme form carries the template id directly; a web-slug share
+    /// is resolved to its id via the API resolver first.
     func onTapAgentShare(_ agentShare: MessageAgentShare) {
-        if isValidTemplateId(agentShare.identifier) {
-            presentAgentMemberOrTemplate(templateId: agentShare.identifier)
+        if isValidTemplateId(agentShare.identifier),
+           presentAgentMemberIfInConversation(templateId: agentShare.identifier) {
             return
         }
         let resolver = agentShareResolver
@@ -2846,34 +2848,37 @@ extension ConversationViewModel {
         Task { [weak self] in
             let info = await resolver.resolve(identifier: identifier)
             await MainActor.run {
-                guard let self, let templateId = info?.templateId else { return }
-                // The web-slug resolve already returned the agent's profile;
-                // pass it through so the new conversation paints it optimistically.
-                self.presentAgentMemberOrTemplate(templateId: templateId, optimisticIdentity: info)
+                guard let self else { return }
+                self.presentAgentShareContactCard(for: agentShare, resolved: info)
             }
         }
     }
 
-    /// Routes a tapped agent template to the in-conversation member's contact
-    /// detail when present, falling back to the spawn-a-new-conversation
-    /// template flow otherwise. The post-builder contact card reaches the same
-    /// member detail directly via `onTapAvatar` (it already has the member).
-    private func presentAgentMemberOrTemplate(templateId: String, optimisticIdentity: AgentShareInfo? = nil) {
+    /// Opens the in-conversation member's contact detail for `templateId`,
+    /// returning false when no agent running that template is a member. The
+    /// post-builder contact card reaches the same member detail directly via
+    /// `onTapAvatar` (it already has the member).
+    private func presentAgentMemberIfInConversation(templateId: String) -> Bool {
         let member: ConversationMember? = conversation.members.first { member in
             member.isAgent && member.profile.agentTemplateId == templateId
         }
-        if let member {
-            presentingProfileForMember = member
-            return
-        }
-        openAgentTemplate(templateId: templateId, optimisticIdentity: optimisticIdentity)
+        guard let member else { return false }
+        presentingProfileForMember = member
+        return true
     }
 
-    private func openAgentTemplate(templateId: String, optimisticIdentity: AgentShareInfo? = nil) {
-        presentingNewConversationForAgentShare = NewConversationViewModel(
-            session: session,
-            mode: .newConversationWithTemplate(templateId: templateId, optimisticIdentity: optimisticIdentity),
-            coreActions: coreActions
+    /// Presents the shared agent's contact detail from a placeholder contact
+    /// built from the resolved profile. When the resolve failed but the link
+    /// carried the template id itself, a neutral identity stands in so the
+    /// card (and its "New chat" action) still works without the profile.
+    private func presentAgentShareContactCard(for agentShare: MessageAgentShare, resolved info: AgentShareInfo?) {
+        let fallbackTemplateId: String? = isValidTemplateId(agentShare.identifier) ? agentShare.identifier : nil
+        guard let templateId = info?.templateId ?? fallbackTemplateId else { return }
+        if presentAgentMemberIfInConversation(templateId: templateId) { return }
+        presentingContactForAgentShare = .agentSharePlaceholder(
+            templateId: templateId,
+            shareURL: agentShare.url,
+            info: info
         )
     }
 

--- a/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/AgentShareBubble.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/AgentShareBubble.swift
@@ -8,8 +8,8 @@ import SwiftUI
 /// While resolving, the card's own pulsing "Learning more about my job"
 /// placeholder stands in.
 ///
-/// This view is display-only: the tap that opens the shared agent's template
-/// flow is owned by the enclosing `messageGesture` (`onSingleTap`), so the
+/// This view is display-only: the tap that opens the shared agent's contact
+/// detail is owned by the enclosing `messageGesture` (`onSingleTap`), so the
 /// same gesture pipeline as other message bubbles handles it -- and the
 /// context-menu preview, which renders this view without that gesture, stays
 /// correctly non-interactive.

--- a/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/AgentShareEnvironment.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/AgentShareEnvironment.swift
@@ -3,7 +3,7 @@ import SwiftUI
 
 /// Environment delivery for the agent-share message card's two cross-cutting
 /// dependencies -- the resolver that turns a share link into displayable agent
-/// info, and the tap handler that opens the shared agent's template flow.
+/// info, and the tap handler that opens the shared agent's contact detail.
 /// Injected once at the cell (like `messageContextMenuState`) so they don't
 /// have to thread through the deep messages-view hierarchy.
 

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
@@ -32,7 +32,7 @@ struct MessagesGroupItemView: View {
 
     /// Tap handler for an agent-share card, delivered via the environment from
     /// the cell (like `agentShareResolver`) rather than threaded through the
-    /// messages-view hierarchy. Opens the shared agent's template flow.
+    /// messages-view hierarchy. Opens the shared agent's contact detail.
     @Environment(\.onTapAgentShare) private var onTapAgentShare: @MainActor @Sendable (MessageAgentShare) -> Void
 
     @State private var isAppearing: Bool = true

--- a/ConvosCore/Sources/ConvosCore/AgentShare/Contact+AgentSharePlaceholder.swift
+++ b/ConvosCore/Sources/ConvosCore/AgentShare/Contact+AgentSharePlaceholder.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+public extension Contact {
+    /// Builds a synthetic, non-persisted contact for a tapped agent-share
+    /// message card when no agent running the template is a member of the
+    /// conversation. The card uses it purely for display: "New chat" spawns
+    /// a fresh instance by `agentTemplateId`, and Share re-shares the link
+    /// the message carried. Mirrors `Contact.suggestedAgent(_:)`.
+    ///
+    /// The share link itself carries no verification signal, but the resolve
+    /// goes through the backend's template endpoint, so the card renders
+    /// with verified-agent styling - matching the message card
+    /// (`AgentShareInfo.optimisticCardMember`).
+    static func agentSharePlaceholder(
+        templateId: String,
+        shareURL: String,
+        info: AgentShareInfo?
+    ) -> Contact {
+        Contact(
+            inboxId: agentSharePlaceholderInboxIdPrefix + templateId,
+            displayName: info?.displayName,
+            avatarURL: info?.avatarURL,
+            addedAt: Date(timeIntervalSince1970: 0),
+            addedViaConversationId: nil,
+            agentVerification: .verified(.convos),
+            agentTemplateId: templateId,
+            agentTemplatePublishedURL: shareURL,
+            profileEmoji: info?.emoji,
+            agentDescription: info?.descriptionText
+        )
+    }
+
+    /// Prefix stamped onto an agent-share placeholder's synthetic `inboxId`.
+    /// Distinct from any real inbox so the placeholder never aliases a
+    /// stored contact. Mirrors `suggestedAgentInboxIdPrefix`.
+    static let agentSharePlaceholderInboxIdPrefix: String = "agent-share:"
+
+    /// True for the synthetic contact backing a tapped agent-share card.
+    var isAgentSharePlaceholder: Bool {
+        inboxId.hasPrefix(Self.agentSharePlaceholderInboxIdPrefix)
+    }
+
+    /// True for any synthetic agent contact that is not a saved contact -- a
+    /// suggested agent or a shared agent link. Lets surfaces suppress
+    /// contact-only affordances (the "Added X ago" line, Block) for these
+    /// placeholder rows.
+    var isUnsavedAgentPlaceholder: Bool {
+        isSuggestedAgentPlaceholder || isAgentSharePlaceholder
+    }
+}

--- a/ConvosCore/Tests/ConvosCoreTests/ContactAgentSharePlaceholderTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ContactAgentSharePlaceholderTests.swift
@@ -1,0 +1,82 @@
+@testable import ConvosCore
+import Foundation
+import Testing
+
+@Suite("Agent-share placeholder contact")
+struct ContactAgentSharePlaceholderTests {
+    private let templateId: String = "11111111-1111-4111-8111-111111111111"
+    private let shareURL: String = "https://convos.org/a/tifoso.pnw1o"
+
+    private var resolvedInfo: AgentShareInfo {
+        AgentShareInfo(
+            templateId: templateId,
+            displayName: "Tifoso",
+            emoji: "🚴",
+            descriptionText: "Pro cycling expert.",
+            avatarURL: "https://example.com/avatar.png"
+        )
+    }
+
+    @Test("maps the resolved profile onto the placeholder contact")
+    func mapsResolvedProfile() {
+        let contact = Contact.agentSharePlaceholder(
+            templateId: templateId,
+            shareURL: shareURL,
+            info: resolvedInfo
+        )
+        #expect(contact.inboxId == "agent-share:\(templateId)")
+        #expect(contact.displayName == "Tifoso")
+        #expect(contact.profileEmoji == "🚴")
+        #expect(contact.agentDescription == "Pro cycling expert.")
+        #expect(contact.avatarURL == "https://example.com/avatar.png")
+        #expect(contact.agentTemplateId == templateId)
+        #expect(contact.agentTemplatePublishedURL == shareURL)
+        #expect(contact.isVerifiedAgent)
+    }
+
+    @Test("placeholder gating distinguishes share placeholders from suggested and saved contacts")
+    func placeholderGating() {
+        let sharePlaceholder = Contact.agentSharePlaceholder(
+            templateId: templateId,
+            shareURL: shareURL,
+            info: resolvedInfo
+        )
+        #expect(sharePlaceholder.isAgentSharePlaceholder)
+        #expect(sharePlaceholder.isUnsavedAgentPlaceholder)
+        #expect(!sharePlaceholder.isSuggestedAgentPlaceholder)
+
+        let suggested = Contact.suggestedAgent(
+            SuggestedAgent(
+                templateId: templateId,
+                name: "Tifoso",
+                description: nil,
+                emoji: nil,
+                avatarURL: nil
+            )
+        )
+        #expect(suggested.isUnsavedAgentPlaceholder)
+        #expect(!suggested.isAgentSharePlaceholder)
+
+        let saved = Contact(
+            inboxId: "a-real-inbox-id",
+            displayName: "Pat",
+            avatarURL: nil,
+            addedAt: Date(),
+            addedViaConversationId: nil
+        )
+        #expect(!saved.isUnsavedAgentPlaceholder)
+    }
+
+    @Test("a failed resolve still yields a chat-capable agent placeholder")
+    func failedResolveFallback() {
+        let contact = Contact.agentSharePlaceholder(
+            templateId: templateId,
+            shareURL: shareURL,
+            info: nil
+        )
+        #expect(contact.agentTemplateId == templateId)
+        #expect(contact.agentTemplatePublishedURL == shareURL)
+        #expect(contact.isAgent)
+        #expect(contact.resolvedDisplayName == "Agent")
+    }
+}


### PR DESCRIPTION
## What

Tapping a shared agent's message card now presents the agent's `ContactDetailView` (standalone mode), where the user can choose **"New chat"** — rather than immediately spawning a new conversation with the template. If an agent running that template is already a member of the conversation, their member card is shown as before (unchanged).

## How

- **`Contact.agentSharePlaceholder(templateId:shareURL:info:)`** (new, ConvosCore): a non-persisted placeholder contact built from the share link's resolved profile, mirroring `Contact.suggestedAgent`. Sentinel inboxId prefix `agent-share:`. A failed resolve still yields a chat-capable generic "Agent" placeholder when the link carries a template id; a failed slug resolve presents nothing (unchanged from current behavior).
- **`ConversationViewModel`**: `onTapAgentShare` resolves the share and sets a new `presentingContactForAgentShare: Contact?`; the auto-create path (`openAgentTemplate` / `presentingNewConversationForAgentShare`) is removed. "New chat" goes through the card's existing "New chat, new context" confirmation flow.
- **`ContactDetailView`**: subtitle ("Added X ago") and Block gates generalized from `isSuggestedAgentPlaceholder` to a new `isUnsavedAgentPlaceholder`, so the share placeholder hides both; the Share row re-shares the message's link.
- **`ConversationView`**: new `AgentShareContactDetailSheetContent` sheet (standalone mode, so no "Remove from convo"); metrics report a profile-present with the sentinel id instead of a new-conversation event.
- Removes three dead private `MetricsObserversPart` structs in `ConversationView.swift` that shadowed the live copies in `ConversationView+MetricsObservers.swift` and had silently diverged.

## Verification

- Full ConvosCore test suite vs local XMTP node: **1104 tests in 158 suites, all passing** (includes 3 new placeholder tests in `ContactAgentSharePlaceholderTests`)
- App simulator build of "Convos (Dev)": succeeds (type-check budget + warnings-as-errors clean)
- SwiftLint full-tree: clean
- Manually verified on simulator: tapping an agent-share card opens the contact detail sheet with working "New chat"

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/981"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783179133&installation_id=128169237&pr_number=981&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F981&signature=27372ee4aa80a71f4d4c4415afdc342669f1b4825a09129b7c9848bcf4707fc7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Open contact detail sheet when tapping agent-share message cards instead of starting a new conversation
> - Tapping an agent-share bubble now presents a `ContactDetailView` sheet for the shared agent placeholder instead of launching the new-conversation flow.
> - If the shared agent is already a member of the conversation, their existing member profile is shown directly.
> - Adds `Contact.agentSharePlaceholder(templateId:shareURL:info:)` in [Contact+AgentSharePlaceholder.swift](https://github.com/xmtplabs/convos-ios/pull/981/files#diff-9e834925a4e1bd623e71d15706c32e6b6dbf0111e76a384fe5ce0c75047cb28a) to construct a non-persisted placeholder `Contact` from resolved `AgentShareInfo`, with `isAgentSharePlaceholder` and `isUnsavedAgentPlaceholder` flags.
> - `ConversationViewModel` replaces `presentingNewConversationForAgentShare: NewConversationViewModel?` with `presentingContactForAgentShare: Contact?`, and `ConversationView` swaps the sheet binding accordingly.
> - The 'Added X ago' subtitle and 'Block' action in `ContactDetailView` are suppressed for any unsaved agent placeholder.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 50e7333.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->