### PR TITLE
Fix message-list animations: receipts, sends, reactions, composer interplay

### DIFF
--- a/Convos/Conversation Detail/Messages/Messages Collection Layout/MessagesCollectionLayout.swift
+++ b/Convos/Conversation Detail/Messages/Messages Collection Layout/MessagesCollectionLayout.swift
@@ -136,6 +136,34 @@ open class MessagesCollectionLayout: UICollectionViewLayout {
 
     var hasPinnedHeaderOrFooter: Bool = false
 
+    /// Invoked (coalesced, on the next runloop tick) after the layout skips
+    /// the bottom-pinning compensation for out-of-band self-sizing growth
+    /// (see `invalidationContext(forPreferredLayoutAttributes:withOriginalAttributes:)`).
+    /// The owner reveals the growth with an animated scroll when the list
+    /// was pinned to the bottom.
+    var onOutOfBandBottomGrowth: (() -> Void)?
+
+    private var hasPendingOutOfBandGrowthNotification: Bool = false
+
+    private func notifyOutOfBandBottomGrowth() {
+        guard !hasPendingOutOfBandGrowthNotification else { return }
+        hasPendingOutOfBandGrowthNotification = true
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            hasPendingOutOfBandGrowthNotification = false
+            onOutOfBandBottomGrowth?()
+        }
+    }
+
+    /// True while the layout is processing a batch update (between
+    /// `prepare(forCollectionViewUpdates:)` and the state switch after
+    /// `finalizeCollectionViewUpdates`). `MessagesCollectionView` uses this
+    /// to keep batch layout passes animated while applying all other passes
+    /// without inherited animations.
+    var isInBatchUpdates: Bool {
+        state == .afterUpdate
+    }
+
     // MARK: Constructors
 
     init(flipsHorizontallyInOppositeLayoutDirection: Bool = true) {
@@ -485,8 +513,30 @@ open class MessagesCollectionLayout: UICollectionViewLayout {
                 + adjustedContentInset.bottom + adjustedContentInset.top,
                 heightDifference
             )
-            context.contentOffsetAdjustment.y += offsetCompensation
-            invalidationActions.formUnion([.shouldInvalidateOnBoundsChange])
+            // Large self-sizing growth that arrives outside a batch update
+            // (state .beforeUpdate, no inherited animation) comes from
+            // in-place cell content changes, e.g. a sent message appending
+            // to the bottom group's hosting view, or media finishing its
+            // async load. Compensating here would snap the whole list in a
+            // single frame; skipping lets the growth land below the fold,
+            // and the owner re-pins with an animated scroll via
+            // `onOutOfBandBottomGrowth`. Small deltas keep the immediate
+            // compensation: per-tick compensation of animated in-cell
+            // resizes is what keeps the list pinned while content slides.
+            // Shrinks also keep it: skipping those would leave the offset
+            // past the new content bottom and UIKit would clamp it in a
+            // hard jump.
+            let isOutOfBandBottomGrowth: Bool = heightDifference > Constant.outOfBandGrowthRevealThreshold
+                && state == .beforeUpdate
+                && UIView.inheritedAnimationDuration == 0
+                && !isUserInitiatedScrolling
+                && keepContentOffsetAtBottomOnBatchUpdates
+            if isOutOfBandBottomGrowth {
+                notifyOutOfBandBottomGrowth()
+            } else {
+                context.contentOffsetAdjustment.y += offsetCompensation
+                invalidationActions.formUnion([.shouldInvalidateOnBoundsChange])
+            }
         }
 
         if let attributes = controller.itemAttributes(for: preferredAttributesItemPath,
@@ -1076,6 +1126,16 @@ extension MessagesCollectionLayout {
             return false
         }
         return collectionView.isDragging || collectionView.isDecelerating
+    }
+
+    private enum Constant {
+        // Out-of-band growth at or above this size is revealed with an
+        // animated scroll instead of immediate offset compensation. Sized
+        // to pass through the few-points-per-frame deltas of in-cell layout
+        // animations (which need per-tick compensation to stay pinned,
+        // including a dropped frame's double delta) while catching one-shot
+        // content growth like a sent message.
+        static let outOfBandGrowthRevealThreshold: CGFloat = 12.0
     }
 }
 

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Cells/MessagesListItemTypeCell.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Cells/MessagesListItemTypeCell.swift
@@ -55,6 +55,16 @@ class MessagesListItemTypeCell: UICollectionViewCell {
     }
 
     func setup(item: MessagesListItemType, config: CellConfig) {
+        // Top-anchor the hosting content (maxHeight + top alignment): when an
+        // in-cell animation grows the content, the cell frame jumps to the
+        // final height in one self-sizing invalidation while the SwiftUI
+        // content is still mid-animation. A height-hugging root re-centers
+        // in the taller bounds, shifting the visible rows down by half the
+        // height delta for a few frames; pinning to the top leaves the
+        // transient gap at the cell's bottom instead. Self-sizing
+        // measurement is unaffected: it proposes an unspecified height,
+        // where maxHeight .infinity still reports the content's ideal size.
+        let rootAlignment: Alignment = item.alignment == .center ? .top : .topLeading
         contentConfiguration = UIHostingConfiguration {
             Group {
                 switch item {
@@ -133,7 +143,7 @@ class MessagesListItemTypeCell: UICollectionViewCell {
                     EmptyView()
                 }
             }
-            .frame(maxWidth: .infinity, alignment: item.alignment == .center ? .center : .leading)
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: rootAlignment)
             .id("message-cell-\(item.differenceIdentifier)")
             .environment(\.messageContextMenuState, config.contextMenuState)
             .environment(\.agentShareResolver, config.agentShareResolver)

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/MessagesCollectionView.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/MessagesCollectionView.swift
@@ -1,0 +1,24 @@
+import UIKit
+
+/// Collection view that applies quiescent layout passes without inherited
+/// animations. Self-sizing invalidations triggered from an animated SwiftUI
+/// render (e.g. a sent message appending inside the bottom group's cell)
+/// otherwise inherit the in-flight CA transaction: the cell's bounds growth
+/// animates while its center applies instantly, which reads as the visible
+/// content dipping by half the height delta for a few frames. Two kinds of
+/// passes keep their animations: batch updates (the layout reports those
+/// via `isInBatchUpdates`) and passes inside an explicit UIView animation
+/// (keyboard inset changes, rotation), which report a nonzero inherited
+/// duration -- the SwiftUI transaction case measures zero there.
+final class MessagesCollectionView: UICollectionView {
+    override func layoutSubviews() {
+        let layoutIsBatching = (collectionViewLayout as? MessagesCollectionLayout)?.isInBatchUpdates ?? false
+        if layoutIsBatching || UIView.inheritedAnimationDuration > 0 {
+            super.layoutSubviews()
+        } else {
+            UIView.performWithoutAnimation {
+                super.layoutSubviews()
+            }
+        }
+    }
+}

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/MessagesViewController.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/MessagesViewController.swift
@@ -114,13 +114,25 @@ final class MessagesViewController: UIViewController {
 
     /// Whether the user is near the bottom of the scroll view (within one screen height)
     private var isNearBottom: Bool {
+        distanceFromBottom <= collectionView.frame.height
+    }
+
+    private var distanceFromBottom: CGFloat {
         let contentHeight = collectionView.contentSize.height
         let scrollViewHeight = collectionView.frame.height
         let currentOffset = collectionView.contentOffset.y
         let bottomInset = collectionView.adjustedContentInset.bottom
-        let distanceFromBottom = contentHeight - (currentOffset + scrollViewHeight - bottomInset)
-        return distanceFromBottom <= scrollViewHeight
+        return contentHeight - (currentOffset + scrollViewHeight - bottomInset)
     }
+
+    /// Whether the list sat at the very bottom the last time the content
+    /// offset changed. Unlike a live distance check, this is not fooled by
+    /// in-place content growth at the bottom (which changes the content size
+    /// but not the offset), so it answers "was the user pinned before this
+    /// update?" -- the gate for the re-pin scroll that reveals such growth.
+    /// Scrolling up flips it false via `scrollViewDidScroll`; programmatic
+    /// scrolls to the bottom flip it back.
+    private var isPinnedToBottom: Bool = true
 
     // MARK: - Public
 
@@ -173,6 +185,17 @@ final class MessagesViewController: UIViewController {
                         } else if nearBottom && !userScrolling {
                             self.scrollToBottom()
                         }
+                    } else if self.isPinnedToBottom && !userScrolling {
+                        // Re-pin after in-place growth at the bottom (e.g. a
+                        // message appending to the last group or a reaction
+                        // landing on it). The growth renders below the fold
+                        // unanimated (see MessagesGroupView's animatedGroup
+                        // mirror); this scroll reveals it. Gated on the
+                        // pinned flag, not a live distance check, so a user
+                        // who scrolled up to read is never pulled back down
+                        // by receipts, reactions, or typing changes. No-ops
+                        // when the list is already at the bottom.
+                        self.scrollToBottom()
                     }
                 }
             isFirstStateUpdate = false
@@ -207,6 +230,9 @@ final class MessagesViewController: UIViewController {
     /// not compute against the stale inset; `flushPendingBottomBarInsetUpdate` applies
     /// it first via the non-animated direct path.
     private var hasPendingBottomBarInsetUpdate: Bool = false
+    private var pendingContextMenuInsetFallback: DispatchWorkItem?
+    private var pendingComposerSettleFallback: DispatchWorkItem?
+    private var pendingComposerBottomInset: CGFloat?
 
     private func scheduleBottomBarInsetUpdate() {
         // The deferral below exists only for the crash scenario above, whose
@@ -249,6 +275,33 @@ final class MessagesViewController: UIViewController {
         guard hasPendingBottomBarInsetUpdate else { return }
         hasPendingBottomBarInsetUpdate = false
         applyDeferredBottomInset()
+    }
+
+    /// Silently applies the current bar-height inset target, preserving the
+    /// content offset. Plain property assignments only, so it stays safe
+    /// inside an in-flight UIKit layout pass. A shrink while pinned to the
+    /// bottom (outside the open transition) is converted into the
+    /// composer-collapse deferral instead: applying it here would leave the
+    /// offset past the new maximum and UIKit would clamp it down in a hard
+    /// jump; the deferral applies it clamp-free once the content has grown.
+    private func applyDeferredBottomInset() {
+        let targetInset: CGFloat
+        if let lastKeyboardFrameChange {
+            targetInset = calculateNewBottomInset(for: lastKeyboardFrameChange)
+        } else {
+            targetInset = bottomBarHeight
+        }
+        guard abs(collectionView.contentInset.bottom - targetInset) > 0.5 else { return }
+        if targetInset < collectionView.contentInset.bottom, isPinnedToBottom, !isSettlingInitialLayout {
+            pendingComposerBottomInset = targetInset
+            return
+        }
+        let offset = collectionView.contentOffset
+        UIView.performWithoutAnimation {
+            collectionView.contentInset.bottom = targetInset
+            collectionView.verticalScrollIndicatorInsets.bottom = targetInset
+            collectionView.contentOffset = offset
+        }
     }
 
     /// Hosts that don't render a bottom bar (e.g. the thinking detail sheet)
@@ -303,7 +356,7 @@ final class MessagesViewController: UIViewController {
 
     init() {
         self.dataSource = MessagesCollectionViewDataSource()
-        self.collectionView = UICollectionView(
+        self.collectionView = MessagesCollectionView(
             frame: .zero,
             collectionViewLayout: messagesLayout
         )
@@ -491,6 +544,20 @@ final class MessagesViewController: UIViewController {
         )
         messagesLayout.keepContentOffsetAtBottomOnBatchUpdates = true
         messagesLayout.processOnlyVisibleItemsOnAnimatedBatchUpdates = true
+        // Covers bottom growth that never produces a state update (e.g. an
+        // attachment finishing its async load while the list sits at the
+        // bottom); state-driven growth is re-pinned by the state-update
+        // completion, and scrollToBottom no-ops if that already ran.
+        messagesLayout.onOutOfBandBottomGrowth = { [weak self] in
+            guard let self,
+                  isPinnedToBottom,
+                  !isUserInitiatedScrolling,
+                  !currentControllerActions.options.contains(.loadingInitialMessages),
+                  // Growth from a state update is revealed by that update's
+                  // completion; scrolling here too would restart it mid-flight.
+                  !currentControllerActions.options.contains(.updatingCollection) else { return }
+            scrollToBottom()
+        }
     }
 
     private func setupCollectionViewInstance() {
@@ -653,8 +720,10 @@ final class MessagesViewController: UIViewController {
     }
 
     func scrollToBottom(animated: Bool = true, completion: (() -> Void)? = nil) {
+        // Deferred insets must land first so the bottom target below
+        // reflects the final bar height.
         flushPendingBottomBarInsetUpdate()
-        collectionView.setContentOffset(collectionView.contentOffset, animated: false)
+        flushPendingComposerInset()
 
         let contentOffsetAtBottom = CGPoint(
             x: collectionView.contentOffset.x,
@@ -663,11 +732,17 @@ final class MessagesViewController: UIViewController {
                 collectionView.adjustedContentInset.bottom)
         )
 
+        // Exit before cancelling in-flight animations: when the layout's
+        // animated bottom-pinning compensation is already scrolling to the
+        // bottom, the model offset is at the target and this call must not
+        // stamp the presentation mid-flight (which would snap the scroll).
         guard contentOffsetAtBottom.y > 0,
               abs(contentOffsetAtBottom.y - collectionView.contentOffset.y) > 0.5 else {
             completion?()
             return
         }
+
+        collectionView.setContentOffset(collectionView.contentOffset, animated: false)
 
         if !animated {
             collectionView.contentOffset = contentOffsetAtBottom
@@ -931,6 +1006,8 @@ extension MessagesViewController: UIScrollViewDelegate, UICollectionViewDelegate
     }
 
     private func handleScrollViewDidScroll(_ scrollView: UIScrollView) {
+        isPinnedToBottom = distanceFromBottom <= Constant.pinnedToBottomTolerance
+
         if currentControllerActions.options.contains(.updatingCollection), collectionView.isDragging {
             interruptCurrentUpdateAnimation()
         }
@@ -963,20 +1040,28 @@ extension MessagesViewController: UIScrollViewDelegate, UICollectionViewDelegate
         }
     }
 
-    func applyDeferredBottomInset() {
-        let targetInset: CGFloat
-        if let lastKeyboardFrameChange {
-            targetInset = calculateNewBottomInset(for: lastKeyboardFrameChange)
-        } else {
-            targetInset = bottomBarHeight
+    /// Called when the message context menu dismisses. Keyboard-driven
+    /// inset updates are suppressed while the menu is up (see
+    /// `updateBottomInset`), so the keyboard's dismissal under the overlay
+    /// left the inset at its keyboard-up value and the list never moved.
+    /// iOS usually restores first responder right after the menu goes away,
+    /// and the returning keyboard matches the preserved inset -- zero
+    /// motion. Dropping the inset eagerly here instead would clamp the
+    /// offset down and the returning keyboard would push it back up, a
+    /// visible down/up bounce. So wait briefly, and only if no keyboard
+    /// change arrives settle the inset with the regular animated update.
+    func restoreBottomInsetAfterContextMenu() {
+        pendingContextMenuInsetFallback?.cancel()
+        let fallback = DispatchWorkItem { [weak self] in
+            guard let self else { return }
+            pendingContextMenuInsetFallback = nil
+            updateBottomInsetForBottomBarHeight()
         }
-        guard collectionView.contentInset.bottom != targetInset else { return }
-        let offset = collectionView.contentOffset
-        UIView.performWithoutAnimation {
-            collectionView.contentInset.bottom = targetInset
-            collectionView.verticalScrollIndicatorInsets.bottom = targetInset
-            collectionView.contentOffset = offset
-        }
+        pendingContextMenuInsetFallback = fallback
+        DispatchQueue.main.asyncAfter(
+            deadline: .now() + Constant.contextMenuInsetFallbackDelay,
+            execute: fallback
+        )
     }
 
     private func updateBottomInsetForBottomBarHeight() {
@@ -986,9 +1071,9 @@ extension MessagesViewController: UIScrollViewDelegate, UICollectionViewDelegate
 
         if let lastKeyboardFrameChange {
             let newBottomInset = calculateNewBottomInset(for: lastKeyboardFrameChange)
-            updateBottomInset(inset: newBottomInset, info: lastKeyboardFrameChange)
+            updateBottomInset(inset: newBottomInset, info: lastKeyboardFrameChange, isComposerDriven: true)
         } else {
-            updateBottomInset(inset: bottomBarHeight, info: nil)
+            updateBottomInset(inset: bottomBarHeight, info: nil, isComposerDriven: true)
         }
     }
 }
@@ -998,6 +1083,14 @@ extension MessagesViewController: UIScrollViewDelegate, UICollectionViewDelegate
 extension MessagesViewController: KeyboardListenerDelegate {
     func keyboardWillChangeFrame(info: KeyboardInfo) {
         self.lastKeyboardFrameChange = info
+
+        // The keyboard taking over again after a context-menu dismissal is
+        // the no-motion path; the deferred fallback is only for when it
+        // never comes back.
+        if !contextMenuState.isPresented {
+            pendingContextMenuInsetFallback?.cancel()
+            pendingContextMenuInsetFallback = nil
+        }
 
         guard shouldHandleKeyboardFrameChange(info: info) else { return }
 
@@ -1018,14 +1111,68 @@ extension MessagesViewController: KeyboardListenerDelegate {
         updateBottomInset(inset: newBottomInset, info: info)
     }
 
-    private func updateBottomInset(inset: CGFloat, info: KeyboardInfo?) {
+    private func updateBottomInset(inset: CGFloat, info: KeyboardInfo?, isComposerDriven: Bool = false) {
         guard !contextMenuState.isPresented else { return }
-        guard collectionView.contentInset.bottom != inset else { return }
-        if info == nil, isSettlingInitialLayout {
+        if isComposerDriven, isSettlingInitialLayout {
+            // Bar-height changes during the open transition re-anchor
+            // instantly (see applyBottomInsetInstantly); the send-time
+            // deferral below is steady-state behavior.
+            pendingComposerBottomInset = nil
+            guard abs(collectionView.contentInset.bottom - inset) > 0.5 else { return }
             applyBottomInsetInstantly(inset)
             return
         }
+        if isComposerDriven, inset < collectionView.contentInset.bottom, isPinnedToBottom {
+            // The composer collapsed while the list was pinned -- typically
+            // a multi-line draft being sent. Neither immediate option works
+            // here: the anchored update drags the list down behind the
+            // receding bar and the reveal scroll pulls it back up, and a
+            // silent inset change clamps the pinned offset down by the
+            // shrink in a single frame. So defer the change entirely: the
+            // outgoing message lands a beat later and its reveal scroll
+            // flushes the pending inset first (no clamp once the content
+            // has grown) and settles in one motion. The fallback only fires
+            // when no message follows (e.g. the user deleted their draft).
+            pendingComposerBottomInset = inset
+            pendingComposerSettleFallback?.cancel()
+            let settle = DispatchWorkItem { [weak self] in
+                self?.settlePendingComposerInset()
+            }
+            pendingComposerSettleFallback = settle
+            DispatchQueue.main.asyncAfter(
+                deadline: .now() + Constant.composerSettleFallbackDelay,
+                execute: settle
+            )
+            return
+        }
+        pendingComposerBottomInset = nil
+        guard abs(collectionView.contentInset.bottom - inset) > 0.5 else { return }
         updateCollectionViewInsets(to: inset, with: info)
+    }
+
+    private func settlePendingComposerInset() {
+        guard !currentInterfaceActions.options.contains(.scrollingToBottom) else { return }
+        guard flushPendingComposerInset() else { return }
+        scrollToBottom()
+    }
+
+    /// Applies a deferred composer-collapse inset, silently when the content
+    /// reaches the new bottom (no clamp, nothing moves) and via the anchored
+    /// animated update otherwise. Returns whether an inset was applied.
+    @discardableResult
+    private func flushPendingComposerInset() -> Bool {
+        guard let target = pendingComposerBottomInset else { return false }
+        pendingComposerBottomInset = nil
+        let adjustedTarget = target + collectionView.safeAreaInsets.bottom
+        let reach = collectionView.contentSize.height
+            - (collectionView.contentOffset.y + collectionView.frame.height - adjustedTarget)
+        if reach >= -0.5 {
+            collectionView.contentInset.bottom = target
+            collectionView.verticalScrollIndicatorInsets.bottom = target
+        } else {
+            updateCollectionViewInsets(to: target, with: nil)
+        }
+        return true
     }
 
     /// Applies a bar-height inset change with no animation and re-anchors the
@@ -1133,6 +1280,17 @@ extension MessagesViewController: KeyboardListenerDelegate {
         // micro adjustments (e.g. autocorrect bar resizes, sub-point
         // accessory-view recalculations).
         static let minKeyboardInsetGrowthForScrollAnchor: CGFloat = 1.0
+        // How close to the bottom (in points) the last settled offset must
+        // be for the list to count as pinned. Covers float fuzz and inset
+        // micro adjustments without absorbing intentional scrolling.
+        static let pinnedToBottomTolerance: CGFloat = 8.0
+        // How long after a context-menu dismissal to wait for the keyboard
+        // to take back over before settling the bottom inset ourselves.
+        // First-responder restoration lands well within this on device.
+        static let contextMenuInsetFallbackDelay: TimeInterval = 0.6
+        // How long after a composer collapse to wait for the outgoing
+        // message's reveal scroll before settling to the bottom ourselves.
+        static let composerSettleFallbackDelay: TimeInterval = 0.35
     }
 }
 

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupView.swift
@@ -41,13 +41,36 @@ struct MessagesGroupView: View {
     @Environment(\.displayScale) private var displayScale: CGFloat
     @State private var isAppearing: Bool = true
     @State private var hasAnimated: Bool = false
+    /// Animated mirror of `group.readByMembers` for the status row. Cell
+    /// reconfigures evaluate this view in a sizing pass before the render
+    /// pass, which consumes value-based `.animation(value:)` triggers, so
+    /// the Sent -> Read swap would render without animation. Mutating this
+    /// mirror inside `withAnimation` from `onChange` creates a fresh
+    /// transaction that survives the two-pass update and drives the
+    /// `.blurReplace` morph. nil until the first change so the initial
+    /// render falls through to the live value without a flash.
+    @State private var animatedReadByMembers: [ConversationMember]?
+    /// Animated mirror of the whole `group`, same mechanism as
+    /// `animatedReadByMembers` but covering every within-group change: a
+    /// sent message appending to the group, the status caption moving to
+    /// the new last message, reactions, etc. The sizing pass renders the
+    /// old mirror value (so the cell reports its old height and the batch
+    /// update applies no instant offset jump), then `onChange` mutates the
+    /// mirror inside `withAnimation`, animating the content and height
+    /// through self-sizing invalidation. nil until the first change so the
+    /// initial render uses the live value.
+    @State private var animatedGroup: MessagesGroup?
+
+    /// The group value the body renders: the animated mirror once seeded,
+    /// the live configuration value before that.
+    private var displayGroup: MessagesGroup { animatedGroup ?? group }
 
     private var animates: Bool {
-        group.messages.first?.origin == .inserted
+        displayGroup.messages.first?.origin == .inserted
     }
 
     private var avatarWidth: CGFloat {
-        group.sender.isCurrentUser ? 0 : DesignConstants.ImageSizes.smallAvatar + DesignConstants.Spacing.step2x
+        displayGroup.sender.isCurrentUser ? 0 : DesignConstants.ImageSizes.smallAvatar + DesignConstants.Spacing.step2x
     }
 
     private var avatarSize: CGFloat {
@@ -65,17 +88,17 @@ struct MessagesGroupView: View {
             .offset(x: 0.0, y: isAppearing ? 100 : 0)
             .blur(radius: isAppearing ? 10.0 : 0.0)
             .font(.footnote)
-            .foregroundColor(group.sender.isAgent ? group.sender.agentVerification.nameColor : .secondary)
+            .foregroundColor(displayGroup.sender.isAgent ? displayGroup.sender.agentVerification.nameColor : .secondary)
             .padding(.leading, avatarWidth + DesignConstants.Spacing.step4x + DesignConstants.Spacing.step3x)
             .padding(.bottom, DesignConstants.Spacing.stepHalf)
     }
 
     private var senderLabelContent: some View {
-        let tapAction = { onTapSender(group.sender) }
+        let tapAction = { onTapSender(displayGroup.sender) }
         return Button(action: tapAction) {
             HStack(spacing: DesignConstants.Spacing.stepX) {
-                Text(group.sender.profile.displayName)
-                if group.sender.isAgent && creditsDepleted {
+                Text(displayGroup.sender.profile.displayName)
+                if displayGroup.sender.isAgent && creditsDepleted {
                     Image(systemName: "bolt.fill")
                         .foregroundStyle(.colorLava)
                 }
@@ -85,7 +108,7 @@ struct MessagesGroupView: View {
     }
 
     private func avatarOverlay(onTap: (() -> Void)? = nil) -> some View {
-        MessageAvatarView(profile: group.sender.profile, size: avatarSize, agentVerification: group.sender.agentVerification)
+        MessageAvatarView(profile: displayGroup.sender.profile, size: avatarSize, agentVerification: displayGroup.sender.agentVerification)
             .offset(x: -(avatarSize + avatarSpacing))
             .onTapGesture { onTap?() }
             .scaleEffect(isAppearing ? 0.9 : 1.0)
@@ -94,63 +117,63 @@ struct MessagesGroupView: View {
                 x: isAppearing ? -80 : 0,
                 y: 0.0
             )
-            .id("profile-\(group.id)")
-            .accessibilityLabel("View \(group.sender.profile.displayName)'s profile")
+            .id("profile-\(displayGroup.id)")
+            .accessibilityLabel("View \(displayGroup.sender.profile.displayName)'s profile")
             .accessibilityAddTraits(.isButton)
     }
 
     private var singleTyperIndicator: some View {
-        let isTypingOnly = group.allMessages.isEmpty
+        let isTypingOnly = displayGroup.allMessages.isEmpty
 
         return Group {
-            if isTypingOnly && !group.sender.isCurrentUser {
+            if isTypingOnly && !displayGroup.sender.isCurrentUser {
                 senderLabel
             }
 
             HStack(alignment: .bottom, spacing: avatarSpacing) {
-                if !group.sender.isCurrentUser {
+                if !displayGroup.sender.isCurrentUser {
                     Color.clear
                         .frame(width: avatarSize, height: avatarSize)
                 }
 
-                TypingIndicatorBubbleView(senderName: group.sender.profile.displayName)
+                TypingIndicatorBubbleView(senderName: displayGroup.sender.profile.displayName)
                     .overlay(alignment: .bottomLeading) {
-                        if !group.sender.isCurrentUser {
+                        if !displayGroup.sender.isCurrentUser {
                             avatarOverlay()
                         }
                     }
             }
-            .padding(.leading, !group.sender.isCurrentUser ? DesignConstants.Spacing.step4x : 0)
+            .padding(.leading, !displayGroup.sender.isCurrentUser ? DesignConstants.Spacing.step4x : 0)
         }
         .transition(.opacity.combined(with: .scale(scale: 0.8, anchor: .bottomLeading)))
-        .id("typing-indicator-\(group.id)")
+        .id("typing-indicator-\(displayGroup.id)")
     }
 
     private var thinkingIndicator: some View {
         HStack(alignment: .bottom, spacing: avatarSpacing) {
-            if !group.sender.isCurrentUser {
+            if !displayGroup.sender.isCurrentUser {
                 Color.clear
                     .frame(width: avatarSize, height: avatarSize)
             }
 
             ThinkingIndicatorBubbleView(
-                content: group.thinkingContent ?? "",
-                senderName: group.sender.profile.displayName,
+                content: displayGroup.thinkingContent ?? "",
+                senderName: displayGroup.sender.profile.displayName,
                 hidesContent: true
             )
             .overlay(alignment: .bottomLeading) {
-                if !group.sender.isCurrentUser {
+                if !displayGroup.sender.isCurrentUser {
                     avatarOverlay()
                 }
             }
         }
-        .padding(.leading, !group.sender.isCurrentUser ? DesignConstants.Spacing.step4x : 0)
+        .padding(.leading, !displayGroup.sender.isCurrentUser ? DesignConstants.Spacing.step4x : 0)
         .transition(.opacity.combined(with: .scale(scale: 0.8, anchor: .bottomLeading)))
-        .id("thinking-indicator-bubble-\(group.id)")
+        .id("thinking-indicator-bubble-\(displayGroup.id)")
     }
 
     private var multiTyperIndicator: some View {
-        let typers = group.allTypingMembers
+        let typers = displayGroup.allTypingMembers
         let names = typers.compactMap(\.profile.displayName)
         let accessibilityText: String = {
             switch names.count {
@@ -195,19 +218,26 @@ struct MessagesGroupView: View {
         // The sender label is hoisted to the body via `shouldShowSenderLabelAtTop`
         // so it can sit above the agent contact card prefix as well as the
         // first message bubble.
-        if index == 0 && !group.sender.isCurrentUser && !isFullWidthAttachment && !isReply
-            && group.agentContactCard == nil && !group.hidesSenderLabel {
+        if index == 0 && !displayGroup.sender.isCurrentUser && !isFullWidthAttachment && !isReply
+            && displayGroup.agentContactCard == nil && !displayGroup.hidesSenderLabel {
             senderLabel
         }
 
-        let isLastInGroup: Bool = message == group.messages.last
-        let isLast: Bool = isLastInGroup && !group.showsTypingIndicator && !group.showsThinkingIndicator
+        let isLastInGroup: Bool = message == displayGroup.messages.last
+        let isLast: Bool = isLastInGroup && !displayGroup.showsTypingIndicator && !displayGroup.showsThinkingIndicator
         // When the last message is a voice memo with a transcript row attached, the
         // transcript becomes the visual bottom of the group, so the tail moves from
         // the voice memo bubble down onto the transcript row.
-        let transcriptIsTailed: Bool = isLast && group.voiceMemoTranscripts[message.messageId] != nil
+        let transcriptIsTailed: Bool = isLast && displayGroup.voiceMemoTranscripts[message.messageId] != nil
         let bubbleType: MessageBubbleType = (isLast && !transcriptIsTailed) ? .tailed : .normal
-        let showsSentStatus: Bool = isLastInGroup && (group.isLastGroupSentByCurrentUser || group.isLastGroupBeforeOtherMembers) && message.status == .published
+        // Include unpublished (optimistic) sends so the caption row's layout
+        // space is reserved at append time; the row content stays invisible
+        // until the message publishes (see statusRow's opacity). Inserting
+        // the row only at publish allocated its space in a single frame --
+        // SwiftUI transitions animate a view's appearance, not the layout
+        // space it occupies -- which read as a vertical jump of the list.
+        let showsSentStatus: Bool = isLastInGroup && (displayGroup.isLastGroupSentByCurrentUser || displayGroup.isLastGroupBeforeOtherMembers)
+            && (message.status == .published || message.status == .unpublished)
         let isFailed: Bool = message.sender.isCurrentUser && message.status == .failed
 
         messageRowContent(
@@ -220,8 +250,13 @@ struct MessagesGroupView: View {
         )
         reactionRow(message: message, isFullWidthAttachment: isFullWidthAttachment)
 
-        let thinkingDescriptor: ThinkingSessionDescriptor? = group.thinkingByMessageId[message.messageId]
-        let mergesThinkingIntoStatus: Bool = showsSentStatus && thinkingDescriptor != nil && !group.onlyVisibleToSender
+        let thinkingDescriptor: ThinkingSessionDescriptor? = displayGroup.thinkingByMessageId[message.messageId]
+        // Requires .published (unlike the plain status row, which reserves
+        // invisible space for unpublished sends): the merged row has no
+        // opacity gate, so rendering it for an optimistic message would
+        // reintroduce the layout pop the reservation exists to prevent.
+        let mergesThinkingIntoStatus: Bool = showsSentStatus && message.status == .published
+            && thinkingDescriptor != nil && !displayGroup.onlyVisibleToSender
         if mergesThinkingIntoStatus, let descriptor = thinkingDescriptor {
             mergedThinkingStatusRow(message: message, descriptor: descriptor)
         } else {
@@ -233,7 +268,7 @@ struct MessagesGroupView: View {
     @ViewBuilder
     private func mergedThinkingStatusRow(message: AnyMessage, descriptor: ThinkingSessionDescriptor) -> some View {
         let agent: ConversationMember = descriptor.sender
-        let dedupedReaders: [ConversationMember] = group.readByMembers.filter { $0.profile.inboxId != agent.profile.inboxId }
+        let dedupedReaders: [ConversationMember] = displayGroup.readByMembers.filter { $0.profile.inboxId != agent.profile.inboxId }
         let hasOtherReaders: Bool = !dedupedReaders.isEmpty
         let tap: () -> Void = { onTapThinkingIndicator?(descriptor) }
 
@@ -268,14 +303,14 @@ struct MessagesGroupView: View {
         // agent hasn't sent any messages yet (synthesized empty group).
         // Otherwise the regular `messageRowContent` avatar overlay handles
         // the leading avatar on the last message — we don't want to double up.
-        let cardIsLast: Bool = group.allMessages.isEmpty && !group.showsTypingIndicator && !group.showsThinkingIndicator
+        let cardIsLast: Bool = displayGroup.allMessages.isEmpty && !displayGroup.showsTypingIndicator && !displayGroup.showsThinkingIndicator
         HStack(alignment: .bottom, spacing: avatarSpacing) {
-            if !group.sender.isCurrentUser {
+            if !displayGroup.sender.isCurrentUser {
                 Color.clear
                     .frame(width: avatarSize, height: avatarSize)
             }
 
-            let cardTap = { onTapSender(group.sender) }
+            let cardTap = { onTapSender(displayGroup.sender) }
             // Mirrors `MessageContainer` so the card caps at the same max
             // width as text bubbles - natural sizing for short content,
             // bounded by a 50pt trailing spacer with lower layout priority,
@@ -285,8 +320,8 @@ struct MessagesGroupView: View {
                     .contentShape(Rectangle())
                     .onTapGesture(perform: cardTap)
                     .overlay(alignment: .bottomLeading) {
-                        if cardIsLast && !group.sender.isCurrentUser {
-                            avatarOverlay { onTapSender(group.sender) }
+                        if cardIsLast && !displayGroup.sender.isCurrentUser {
+                            avatarOverlay { onTapSender(displayGroup.sender) }
                         }
                     }
 
@@ -296,7 +331,7 @@ struct MessagesGroupView: View {
             }
             .bubbleRowWidthCap(alignment: .leading)
         }
-        .padding(.leading, !group.sender.isCurrentUser ? DesignConstants.Spacing.step4x : 0)
+        .padding(.leading, !displayGroup.sender.isCurrentUser ? DesignConstants.Spacing.step4x : 0)
     }
 
     @ViewBuilder
@@ -309,12 +344,12 @@ struct MessagesGroupView: View {
         voiceMemoTranscriptIsTailed: Bool
     ) -> some View {
         HStack(alignment: .bottom, spacing: avatarSpacing) {
-            if !group.sender.isCurrentUser && !isFullWidthAttachment {
+            if !displayGroup.sender.isCurrentUser && !isFullWidthAttachment {
                 Color.clear
                     .frame(width: avatarSize, height: avatarSize)
             }
 
-            if group.usesThoughtBubbleStyle, let text = thoughtBubbleText(for: message) {
+            if displayGroup.usesThoughtBubbleStyle, let text = thoughtBubbleText(for: message) {
                 ThoughtBubbleAppearance(animates: message.origin == .inserted) {
                     HStack(spacing: 0.0) {
                         ThoughtBubble {
@@ -338,7 +373,7 @@ struct MessagesGroupView: View {
                 .zIndex(100)
                 .id("messages-group-item-\(message.differenceIdentifier)")
                 .overlay(alignment: .bottomLeading) {
-                    if isLast && !group.sender.isCurrentUser {
+                    if isLast && !displayGroup.sender.isCurrentUser {
                         avatarOverlay { onTapAvatar(message) }
                     }
                 }
@@ -359,7 +394,7 @@ struct MessagesGroupView: View {
                     onTapReactions: onTapReactions,
                     onReaction: onReaction,
                     onToggleReaction: onToggleReaction,
-                    voiceMemoTranscript: group.voiceMemoTranscripts[message.messageId],
+                    voiceMemoTranscript: displayGroup.voiceMemoTranscripts[message.messageId],
                     voiceMemoTranscriptIsTailed: voiceMemoTranscriptIsTailed,
                     onRetryTranscript: onRetryTranscript,
                     parentAudioTranscriptText: parentAudioTranscriptText(for: message),
@@ -374,7 +409,7 @@ struct MessagesGroupView: View {
                     )
                 )
                 .overlay(alignment: .bottomLeading) {
-                    if isLast && !group.sender.isCurrentUser {
+                    if isLast && !displayGroup.sender.isCurrentUser {
                         avatarOverlay { onTapAvatar(message) }
                     }
                 }
@@ -390,7 +425,7 @@ struct MessagesGroupView: View {
                 .padding(.trailing, DesignConstants.Spacing.step4x)
             }
         }
-        .padding(.leading, !group.sender.isCurrentUser && !isFullWidthAttachment ? DesignConstants.Spacing.step4x : 0)
+        .padding(.leading, !displayGroup.sender.isCurrentUser && !isFullWidthAttachment ? DesignConstants.Spacing.step4x : 0)
     }
 
     /// Returns the plain text of `message` when it should render in a
@@ -412,13 +447,22 @@ struct MessagesGroupView: View {
 
     @ViewBuilder
     private func reactionRow(message: AnyMessage, isFullWidthAttachment: Bool) -> some View {
-        if !message.reactions.isEmpty, !isFullWidthAttachment {
+        // Reactions render from the live group, not the animatedGroup
+        // mirror: with live data the row's height change is measured during
+        // the reconfigure's sizing pass and lands inside the batch update,
+        // where UIKit animates the surrounding cells and the bottom-pinning
+        // compensation natively (the smooth pre-existing behavior). Routing
+        // it through the mirror would move the growth out of the batch into
+        // the out-of-band reveal path that exists for message appends.
+        let liveReactions: [MessageReaction] = group.rawMessages
+            .first(where: { $0.messageId == message.messageId })?.reactions ?? message.reactions
+        if !liveReactions.isEmpty, !isFullWidthAttachment {
             ReactionIndicatorView(
-                reactions: message.reactions,
+                reactions: liveReactions,
                 isOutgoing: message.sender.isCurrentUser,
                 onTap: { onTapReactions(message) }
             )
-            .padding(.leading, message.sender.isCurrentUser ? 0 : (isFullWidthAttachment ? DesignConstants.Spacing.step4x : avatarWidth + avatarSpacing + DesignConstants.Spacing.step2x))
+            .padding(.leading, message.sender.isCurrentUser ? 0 : avatarWidth + avatarSpacing + DesignConstants.Spacing.step2x)
             .padding(.trailing, message.sender.isCurrentUser ? DesignConstants.Spacing.step4x : 0)
             .padding(.bottom, DesignConstants.Spacing.stepX)
             .transition(.identity)
@@ -451,7 +495,7 @@ struct MessagesGroupView: View {
 
     @ViewBuilder
     private func thinkingFooterRow(message: AnyMessage) -> some View {
-        if let descriptor = group.thinkingByMessageId[message.messageId] {
+        if let descriptor = displayGroup.thinkingByMessageId[message.messageId] {
             let isOutgoing: Bool = message.sender.isCurrentUser
             // Skip the leading avatar when the thinker is also the message's
             // sender — the message's avatar already conveys "who" on that side
@@ -499,24 +543,29 @@ struct MessagesGroupView: View {
             .id("failed-status-\(message.differenceIdentifier)")
             .accessibilityLabel("Message not delivered")
         } else if showsSentStatus {
+            let readByMembers: [ConversationMember] = animatedReadByMembers ?? group.readByMembers
+            // Reserve the row's layout space while the message is still
+            // unpublished but keep it invisible; publishing fades it in
+            // without shifting the list (see showsSentStatus).
+            let statusOpacity: Double = message.status == .published ? 1 : 0
             HStack(spacing: DesignConstants.Spacing.stepX) {
                 Spacer()
-                if group.onlyVisibleToSender {
+                if displayGroup.onlyVisibleToSender {
                     Text("Only visible to you")
                         .font(.caption)
                     ProfileAvatarView(
-                        profile: group.sender.profile,
+                        profile: displayGroup.sender.profile,
                         profileImage: ProfileSettingsViewModel.shared.profileImage,
                         useSystemPlaceholder: false
                     )
                     .frame(width: 16, height: 16)
-                } else if !group.readByMembers.isEmpty {
+                } else if !readByMembers.isEmpty {
                     let readReceiptTap: () -> Void = { onTapReadReceipts?(group) }
                     Button(action: readReceiptTap) {
                         HStack(spacing: DesignConstants.Spacing.stepX) {
                             Text("Read")
                                 .font(.caption)
-                            ReadReceiptAvatarsView(members: group.readByMembers)
+                            ReadReceiptAvatarsView(members: readByMembers)
                         }
                         .contentShape(Rectangle())
                     }
@@ -530,6 +579,8 @@ struct MessagesGroupView: View {
                         .frame(width: 16, height: 16)
                 }
             }
+            .opacity(statusOpacity)
+            .animation(.easeInOut(duration: 0.2), value: statusOpacity)
             .transition(.blurReplace)
             .padding(.vertical, DesignConstants.Spacing.stepX)
             .padding(.leading, DesignConstants.Spacing.step2x)
@@ -538,52 +589,84 @@ struct MessagesGroupView: View {
             .zIndex(-1)
             .id("sent-status-\(message.differenceIdentifier)")
             .accessibilityLabel(
-                group.onlyVisibleToSender
+                displayGroup.onlyVisibleToSender
                     ? "Only visible to you"
-                    : (group.readByMembers.isEmpty
+                    : (readByMembers.isEmpty
                         ? "Message sent"
-                        : "Message read by \(group.readByMembers.count) \(group.readByMembers.count == 1 ? "member" : "members")")
+                        : "Message read by \(readByMembers.count) \(readByMembers.count == 1 ? "member" : "members")")
             )
+            .accessibilityHidden(message.status != .published)
+            .onAppear {
+                if animatedReadByMembers == nil {
+                    animatedReadByMembers = group.readByMembers
+                }
+            }
+            .onChange(of: group.readByMembers) { _, newValue in
+                withAnimation(.spring(response: 0.35, dampingFraction: 0.8)) {
+                    animatedReadByMembers = newValue
+                }
+            }
         }
     }
 
     var body: some View {
         VStack(alignment: .leading, spacing: DesignConstants.Spacing.stepX) {
-            if let card = group.agentContactCard {
+            if let card = displayGroup.agentContactCard {
                 senderLabel
                 contactCardRow(card: card)
-                if let descriptor = group.contactCardThinkingDescriptor {
+                if let descriptor = displayGroup.contactCardThinkingDescriptor {
                     contactCardThinkingFooterRow(descriptor: descriptor)
                 }
             }
 
-            ForEach(Array(group.allMessages.enumerated()), id: \.element.messageId) { index, message in
+            ForEach(Array(displayGroup.allMessages.enumerated()), id: \.element.messageId) { index, message in
                 messageGroup(index: index, message: message)
             }
 
-            if group.showsTypingIndicator {
-                if group.isMultiTyper {
+            if displayGroup.showsTypingIndicator {
+                if displayGroup.isMultiTyper {
                     multiTyperIndicator
                 } else {
                     singleTyperIndicator
                 }
             }
 
-            if group.showsThinkingIndicator {
+            if displayGroup.showsThinkingIndicator {
                 thinkingIndicator
             }
         }
-        .id("message-group-container-\(group.id)")
+        .id("message-group-container-\(displayGroup.id)")
         .transition(
             .asymmetric(
                 insertion: .identity,
                 removal: .opacity
             )
         )
-        .padding(.top, group.adjacentToFullBleedAbove ? (1.0 / displayScale) : DesignConstants.Spacing.step2x)
-        .padding(.bottom, group.adjacentToFullBleedBelow ? (1.0 / displayScale) : DesignConstants.Spacing.step2x)
-        .animation(.spring(response: 0.35, dampingFraction: 0.8), value: group)
+        .padding(.top, displayGroup.adjacentToFullBleedAbove ? (1.0 / displayScale) : DesignConstants.Spacing.step2x)
+        .padding(.bottom, displayGroup.adjacentToFullBleedBelow ? (1.0 / displayScale) : DesignConstants.Spacing.step2x)
+        // Apply group changes through the mirror without animating layout:
+        // the mirror only updates in `onChange` -- after the reconfigure's
+        // sizing pass -- so the cell reports its old height during the batch
+        // update and the new content lands below the fold unanimated (no
+        // single-frame jump, no transient re-centering while the cell frame
+        // snaps). The view controller then reveals the appended content
+        // with an animated scroll-to-bottom. Height-neutral changes that
+        // should still animate (read receipts, the status caption fade)
+        // carry their own scoped animations.
+        .onChange(of: group) { _, newValue in
+            animatedGroup = newValue
+        }
+        // Snap the read-receipt mirror without animation when the status row
+        // moves to a different message (a new send) so the fresh row starts
+        // from "Sent" instead of morphing out of the previous message's
+        // "Read" state.
+        .onChange(of: group.messages.last?.messageId) { _, _ in
+            animatedReadByMembers = group.readByMembers
+        }
         .onAppear {
+            if animatedGroup == nil {
+                animatedGroup = group
+            }
             guard isAppearing, !hasAnimated else { return }
             hasAnimated = true
 
@@ -597,7 +680,7 @@ struct MessagesGroupView: View {
                 }
             }
         }
-        .id("messages-group-\(group.id)")
+        .id("messages-group-\(displayGroup.id)")
     }
 }
 

--- a/Convos/Conversation Detail/Messages/MessagesViewRepresentable.swift
+++ b/Convos/Conversation Detail/Messages/MessagesViewRepresentable.swift
@@ -141,7 +141,7 @@ let menuPresented = contextMenuState.isPresented
             messagesViewController.collectionView.panGestureRecognizer.isEnabled = true
         }
         if wasMenuPresented, !menuPresented {
-            messagesViewController.applyDeferredBottomInset()
+            messagesViewController.restoreBottomInsetAfterContextMenu()
         }
         messagesViewController.onPresentHTMLAttachmentPreview = onPresentHTMLAttachmentPreview
         messagesViewController.state = .init(


### PR DESCRIPTION
Fixes four families of message-list animation jank. The history is squashed to one commit (the iterative exploration added and later removed scaffolding that made per-commit review misleading) and rebased onto dev to integrate with #987 and #998.

## Receipts: Sent -> Read morph

The status row's swap rendered as a one-frame hard cut: cell reconfigures evaluate the hosting view in a sizing pass before the render pass, which consumes value-based `.animation(value:)` triggers (verified with transaction probes). The row now renders from a seeded `readByMembers` mirror mutated inside `withAnimation` from `onChange` -- a transaction the two-pass update can't eat. The caption's layout space is reserved while a message is unpublished (it fades in at publish), so the status flip is height-neutral.

## Sends: grow below the fold, reveal with a scroll

A sent message appends to the bottom group's cell (one group = one cell), so a send is a height-growing reconfigure whose bottom-pinning compensation applied instantly -- a one-frame ~43pt jump, twice per send. In-cell animation cannot mask it: the hosting view reports the final height in a single atomic invalidation (verified across five masking strategies). Instead, the group renders from an `animatedGroup` mirror applied without animation in `onChange`: the sizing pass reports the old height, the growth lands below the fold invisibly, and an animated scroll reveals it. The layout skips immediate compensation for large out-of-band growth and notifies the controller (`onOutOfBandBottomGrowth`) so growth without a state update (async media) re-pins the same way. The re-pin is gated on a tracked `isPinnedToBottom` flag (updated on offset changes), so receipts/reactions/typing updates never yank a reading user to the bottom.

## Reactions: native batch path

Reactions render from the **live** group rather than the mirror, so their height change is measured in the sizing pass and lands inside the batch update, where UIKit animates surrounding cells and compensation natively -- the smooth pre-existing behavior validated again after #998. (Earlier revisions routed reactions through the mirror and rebuilt the animation with a per-frame squeeze; that scaffolding is gone.)

## Composer interplay

- Reacting from the context menu no longer bounces the list down/up: keyboard-driven inset updates stay suppressed while the menu is up, and the returning keyboard matches the preserved inset with zero motion; a deferred fallback settles if focus never returns.
- Sending a multi-line draft no longer dips the list below the bar: the composer collapse's inset change is deferred (`pendingComposerBottomInset`) and flushed at the start of the reveal scroll, where it applies clamp-free against the grown content. #987's `applyDeferredBottomInset` converts shrink-while-pinned flushes into the same deferral so its silent path can't reintroduce the clamp jump.
- `MessagesCollectionView` applies quiescent layout passes without inherited animations (explicit UIView animations like keyboard/rotation are exempt), and cells top-anchor their hosting content so transient cell/content height mismatches stay below the fold.

## Verification

Every fix was verified by frame-diffing and landmark-tracking 60fps simulator recordings (profiles in the review thread): sends are a monotonic ease ramp with no dip frame; the multi-line composer send shows zero downward displacement; the context-menu reaction flow measures +0px end to end; reactions match the dev/#998 motion profile. A four-agent adversarial review of an earlier revision surfaced and fixed two high-severity gates (re-pin tolerance, shrink compensation). Full `swift test --package-path ConvosCore` run green on the pre-rebase head; final suite run on this head reported separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix message-list animations for receipts, sends, reactions, and composer interplay
> - Introduces a mirrored `animatedGroup` state in [`MessagesGroupView`](https://github.com/xmtplabs/convos-ios/pull/982/files#diff-96fea19951f287381d9170a90ce9ac8ba6f9e59f9d477dd1c5be2bbc1b5cdbe2) so group-level layout changes apply after the sizing pass, preventing instant frame jumps while enabling scoped content animations.
> - Defers composer inset shrinks while pinned to bottom in [`MessagesViewController`](https://github.com/xmtplabs/convos-ios/pull/982/files#diff-1427b816e5e93d8bc7ea882f5eabd9671135c6f9b9ebc6b0a6f7116a2f8a37c3) to avoid clamp or drag artifacts; flushes deferred insets before scrolling to bottom.
> - Adds `onOutOfBandBottomGrowth` callback in [`MessagesCollectionLayout`](https://github.com/xmtplabs/convos-ios/pull/982/files#diff-4c22b0b8d30661ba1bf904fb3bfb896554201ff97fe825099213e2ed967066d7) so large self-sizing height increases outside batch updates trigger an animated scroll instead of an immediate offset jump.
> - Overrides `layoutSubviews` in [`MessagesCollectionView`](https://github.com/xmtplabs/convos-ios/pull/982/files#diff-cb9c0963c13db853c9bf20ed227f212d6e890a556de39835348635ec0dc58873) to suppress inherited animations during quiescent layout passes, preserving animation only during batch updates or explicit `UIView` animations.
> - Restores bottom inset after context menu dismissal with a delayed fallback when the keyboard does not reappear, avoiding a visible bounce.
> - Read receipt avatars now morph with a spring animation; status row space is reserved for unpublished messages to prevent layout pops on send.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2e06c39.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->