### PR TITLE
Add first-install iCloud pairing prompt with main-device auto-surface

### DIFF
--- a/Convos/Config/QALaunchHooks.swift
+++ b/Convos/Config/QALaunchHooks.swift
@@ -1,0 +1,37 @@
+import ConvosCore
+import Foundation
+import Security
+
+/// Launch-time hooks for QA automation. Every hook is double-gated: it
+/// only runs in non-production environments and only when its environment
+/// variable is set (pass to a simulator app by exporting the
+/// SIMCTL_CHILD_-prefixed name before `xcrun simctl launch`).
+enum QALaunchHooks {
+    static func run(environment: AppEnvironment) {
+        guard !environment.isProduction else { return }
+        wipePrimaryIdentityIfRequested(environment: environment)
+    }
+
+    /// CONVOS_QA_WIPE_PRIMARY_IDENTITY=1 deletes the device-local identity
+    /// slot while leaving the iCloud-synced backup slot intact. iCloud
+    /// Keychain doesn't sync between simulators, so two-simulator QA seeds
+    /// the "brand-new device on the same iCloud account" state by cloning
+    /// the onboarded simulator (clones copy the whole keychain) and wiping
+    /// the cloned primary slot with this hook on first launch. The app then
+    /// registers a fresh placeholder identity and finds the original
+    /// device's synced backup, which drives the first-install
+    /// "Pair <device>?" prompt. See qa/tests/44-icloud-pairing-prompt.md.
+    private static func wipePrimaryIdentityIfRequested(environment: AppEnvironment) {
+        guard ProcessInfo.processInfo.environment["CONVOS_QA_WIPE_PRIMARY_IDENTITY"] == "1" else { return }
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: KeychainIdentityStore.defaultService,
+            kSecAttrAccount as String: KeychainIdentityStore.identityAccount,
+            kSecAttrAccessGroup as String: environment.keychainAccessGroup,
+            kSecAttrSynchronizable as String: false
+        ]
+        let status = SecItemDelete(query as CFDictionary)
+        Log.info("QALaunchHooks: wiped primary identity slot (status=\(status))")
+        QAEvent.emit(.app, "qa_wiped_primary_identity", ["status": "\(status)"])
+    }
+}

--- a/Convos/Conversations List/ConversationsView.swift
+++ b/Convos/Conversations List/ConversationsView.swift
@@ -310,6 +310,26 @@ private struct ConversationsSheetModifier: ViewModifier {
         )
     }
 
+    /// Routes every dismissal of the joiner pairing sheet through
+    /// `dismissJoinerPairing()` so the ephemeral pairing client is torn
+    /// down before the reference drops. Interactive (swipe) dismissal
+    /// nils a plain item binding before `onDismiss` runs, which would
+    /// orphan the joiner's streaming task and temp database - the same
+    /// gap `MainTabSheetsModifier.incomingPairingBinding` closes for the
+    /// initiator sheet.
+    private var joinerPairingBinding: Binding<JoinerPairingSheetViewModel?> {
+        Binding(
+            get: { viewModel.pendingJoinerPairing },
+            set: { newValue in
+                if newValue == nil {
+                    viewModel.dismissJoinerPairing()
+                } else {
+                    viewModel.pendingJoinerPairing = newValue
+                }
+            }
+        )
+    }
+
     func body(content: Content) -> some View {
         content
             // The `NewConversationView` and `AgentBuilderView` sheets
@@ -325,14 +345,24 @@ private struct ConversationsSheetModifier: ViewModifier {
                 .presentationDetents([.medium])
             }
             .selfSizingSheet(
-                item: $viewModel.pendingJoinerPairing,
-                onDismiss: {
-                    viewModel.pendingPairDevice = nil
-                    viewModel.pendingJoinerPairing = nil
-                },
+                item: joinerPairingBinding,
                 content: { pairingVM in
                     JoinerPairingSheetView(viewModel: pairingVM)
                         .padding(.top, DesignConstants.Spacing.step5x)
+                }
+            )
+            .selfSizingSheet(
+                item: $viewModel.foundDevicePairingPrompt,
+                onDismiss: {
+                    viewModel.onFoundDevicePromptDismissed()
+                },
+                content: { prompt in
+                    PairFoundDeviceInfoSheet(
+                        deviceName: prompt.deviceName,
+                        onPair: { viewModel.pairWithFoundDevice() },
+                        onSkip: { viewModel.skipFoundDevicePairing() }
+                    )
+                    .padding(.top, DesignConstants.Spacing.step5x)
                 }
             )
             .selfSizingSheet(isPresented: $viewModel.presentingExplodeInfo) {

--- a/Convos/Conversations List/ConversationsViewModel.swift
+++ b/Convos/Conversations List/ConversationsViewModel.swift
@@ -821,6 +821,15 @@ extension ConversationsViewModel {
                 guard let session = self?.session else { return }
                 var seeded: Bool = false
                 do {
+                    // The writer drops `imageAssetIdentifier` when
+                    // `imageData` is nil, and that is correct here: the
+                    // identifier is a PhotoKit local identifier scoped to
+                    // the initiator's photo library and cannot resolve on
+                    // this device, and the identity share carries no image
+                    // bytes. Persisting it would only hand the photo
+                    // picker a dangling reference. The avatar itself
+                    // arrives later through per-conversation profile
+                    // snapshots.
                     try await session.messagingService().myGlobalProfileWriter().save(
                         name: displayName,
                         imageData: nil,
@@ -1002,28 +1011,35 @@ extension ConversationsViewModel {
         }
     }
 
-    private func handleVerifiedJoinRequest(joinerInboxId: String, deviceName: String) {
-        // An initiator flow already mid-handshake (the Devices QR sheet
-        // or a previously surfaced request) owns the exchange; a second
-        // coordinator would race PIN generation for the same joiner. The
-        // joiner re-sends its request every few seconds, so a dropped
-        // one here is recovered as soon as the active flow ends.
-        guard PairingSheetViewModel.active == nil else { return }
-        if incomingPairingRequest != nil {
-            // The sheet sets `PairingSheetViewModel.active` from its
-            // `.task` the moment it actually presents. A request that
-            // has sat un-presented well past that point means SwiftUI
-            // dropped the presentation (another sheet was up when it was
-            // assigned); without this reset the stale reference blocks
-            // every resend until app restart.
-            guard let presentedAt = incomingPairingPresentedAt,
-                  Date().timeIntervalSince(presentedAt) > Constant.incomingPairingPresentationGrace else {
-                return
-            }
-            Log.warning("Incoming pairing sheet never presented; resetting and retrying")
-            incomingPairingRequest = nil
-            incomingPairingPresentedAt = nil
+    /// Whether a new auto-surfaced initiator sheet may be presented,
+    /// recovering from dropped presentations along the way. False while
+    /// another initiator flow owns (or is about to own) the exchange - a
+    /// second coordinator would race PIN generation for the same joiner.
+    ///
+    /// The sheet sets `PairingSheetViewModel.active` from its `.task` the
+    /// moment it actually presents. A request that has sat un-presented
+    /// well past that point means SwiftUI dropped the presentation
+    /// (another sheet was up when it was assigned); without the reset the
+    /// stale reference would block every resend - and the NSE stash - until
+    /// app restart.
+    private func canSurfaceIncomingPairingRequest() -> Bool {
+        guard !PairingSheetViewModel.isFlowActiveOrStarting else { return false }
+        guard incomingPairingRequest != nil else { return true }
+        guard let presentedAt = incomingPairingPresentedAt,
+              Date().timeIntervalSince(presentedAt) > Constant.incomingPairingPresentationGrace else {
+            return false
         }
+        Log.warning("Incoming pairing sheet never presented; resetting and retrying")
+        incomingPairingRequest = nil
+        incomingPairingPresentedAt = nil
+        return true
+    }
+
+    private func handleVerifiedJoinRequest(joinerInboxId: String, deviceName: String) {
+        // The joiner re-sends its request every few seconds, so one
+        // dropped here (another flow active, stale sheet inside its
+        // grace window) is recovered as soon as the active flow ends.
+        guard canSurfaceIncomingPairingRequest() else { return }
         if UIApplication.shared.applicationState == .active {
             presentIncomingPairingSheet(joinerInboxId: joinerInboxId, deviceName: deviceName)
         } else {
@@ -1064,13 +1080,14 @@ extension ConversationsViewModel {
 
     private func presentPendingIncomingPairRequestIfNeeded() {
         // Bail before consuming anything when a pairing flow is already
-        // on screen: a second initiator coordinator would race PIN
-        // generation for the same joiner. Consuming first and bailing
-        // after would destructively drop the stash (the app-group read
-        // removes it), losing the request if the joiner has stopped
-        // re-sending (killed/backgrounded). Leave it stashed so the next
-        // activation, once the active flow ends, can present it.
-        guard PairingSheetViewModel.active == nil, incomingPairingRequest == nil else { return }
+        // on screen (the shared helper also recovers a stale
+        // never-presented sheet first, so a dropped presentation can't
+        // strand the stash). Consuming first and bailing after would
+        // destructively drop the stash (the app-group read removes it),
+        // losing the request if the joiner has stopped re-sending
+        // (killed/backgrounded). Leave it stashed so the next activation,
+        // once the active flow ends, can present it.
+        guard canSurfaceIncomingPairingRequest() else { return }
         // Two stash sources: in-memory (request arrived while this
         // process was backgrounded) and the app-group store written by
         // the NSE (request arrived while the app wasn't running at all).

--- a/Convos/Conversations List/ConversationsViewModel.swift
+++ b/Convos/Conversations List/ConversationsViewModel.swift
@@ -84,6 +84,34 @@ final class ConversationsViewModel {
     var pendingGrantRequest: PendingGrantRequest?
     var pendingPairDevice: PendingPairDevice?
     var pendingJoinerPairing: JoinerPairingSheetViewModel?
+    /// Drives the first-install "Pair <device>?" sheet when another
+    /// device's identity is found in the iCloud-synced keychain backup.
+    var foundDevicePairingPrompt: FoundDevicePairingPrompt?
+    /// Joiner pairing flow prepared by `pairWithFoundDevice()`, promoted
+    /// to `pendingJoinerPairing` once the prompt sheet finishes
+    /// dismissing - presenting both sheets in the same tick can drop the
+    /// second presentation.
+    @ObservationIgnored
+    private var preparedFoundDevicePairing: JoinerPairingSheetViewModel?
+    /// Whether the prompt sheet's dismissal has completed. Minting and
+    /// dismissal race in both directions: whichever finishes second
+    /// performs the promotion (see `pairWithFoundDevice`).
+    @ObservationIgnored
+    private var foundDevicePromptDismissalComplete: Bool = false
+    @ObservationIgnored
+    private var didCheckForPairableDevice: Bool = false
+    /// Initiator pairing sheet auto-surfaced by a verified join request
+    /// arriving on the main message stream. Presented at MainTabView
+    /// level so it shows over any tab.
+    var incomingPairingRequest: PairingSheetViewModel?
+    /// When the current `incomingPairingRequest` was assigned. Drives the
+    /// dropped-presentation watchdog in `handleVerifiedJoinRequest`.
+    @ObservationIgnored
+    private var incomingPairingPresentedAt: Date?
+    @ObservationIgnored
+    private var pendingIncomingPairRequest: PendingIncomingPairRequest?
+    @ObservationIgnored
+    private let incomingPairingObservers: PairingNotificationObservers = .init()
     let staleDeviceObserver: StaleDeviceObserver = .init()
 
     var newConversationViewModel: NewConversationViewModel? {
@@ -221,6 +249,7 @@ final class ConversationsViewModel {
 
     static func resetUserDefaults() {
         UserDefaults.standard.removeObject(forKey: hasCreatedMoreThanOneConvoKey)
+        UserDefaults.standard.removeObject(forKey: hasDeclinedFoundDevicePairingKey)
     }
 
     // MARK: - Private
@@ -281,6 +310,7 @@ final class ConversationsViewModel {
             self.conversationsCount = 0
         }
         observe()
+        observeIncomingPairingRequests()
     }
 
     func updateHorizontalSizeClass(_ sizeClass: UserInterfaceSizeClass?) {
@@ -292,6 +322,7 @@ final class ConversationsViewModel {
     func onAppear() {
         isVisible = true
         updateListVisibility()
+        checkForPairableDeviceIfNeeded()
     }
 
     func onDisappear() {
@@ -348,66 +379,10 @@ final class ConversationsViewModel {
                 expiresAt: expiresAt,
                 initiatorName: initiatorName
             )
-            let capturedSession = session
-            pendingJoinerPairing = JoinerPairingSheetViewModel(
+            pendingJoinerPairing = makeJoinerPairingViewModel(
                 pairingId: pairingId,
                 expiresAt: expiresAt,
-                initiatorName: initiatorName,
-                pairingService: capturedSession.joinerPairingService(),
-                onPairingAdopted: { [weak self] in
-                    await self?.session.refreshAfterPairingCompleted()
-                },
-                onApplyAdoptedProfile: { [weak self] displayName, imageAssetIdentifier in
-                    // The joiner just adopted the initiator's identity, so
-                    // it shouldn't be asked to onboard a profile from
-                    // scratch. Three side-effects in order:
-                    //   1. Seed DBMyProfile from the share payload (may fail).
-                    //   2. Re-bind the shared profile VM unconditionally.
-                    //      Identity adoption already happened, so the
-                    //      VM's cached writer / repository for the
-                    //      placeholder session are stale either way — a
-                    //      failed seed doesn't reverse the adoption, and
-                    //      leaving the VM bound to the now-stopped
-                    //      MessagingService risks crashes on subsequent
-                    //      profile operations.
-                    //   3. Flip global onboarding flags *only* on a
-                    //      successful seed, so a failed save doesn't
-                    //      permanently suppress prompts under an empty
-                    //      DBMyProfile.
-                    guard let session = self?.session else { return }
-                    var seeded: Bool = false
-                    do {
-                        try await session.messagingService().myGlobalProfileWriter().save(
-                            name: displayName,
-                            imageData: nil,
-                            imageAssetIdentifier: imageAssetIdentifier,
-                            metadata: nil
-                        )
-                        // Propagate the adopted profile through the canonical
-                        // repository so it fans out to every conversation via
-                        // the durable publisher. No image bytes are available on
-                        // the adoption path, so only the display name is sent.
-                        try await session.messagingService().profilesRepository().publishMyProfile(
-                            displayName: displayName,
-                            avatarBytes: nil,
-                            priorityConversationId: nil
-                        )
-                        seeded = true
-                    } catch {
-                        Log.warning("Pairing: failed to seed DBMyProfile after adoption: \(error)")
-                    }
-                    ProfileSettingsViewModel.shared.rebind(session: session)
-                    if seeded {
-                        ConversationOnboardingCoordinator.markCompletedForPairedDevice()
-                    }
-                },
-                onDeleteExistingData: { [weak self] in
-                    try await self?.session.deleteAllInboxes()
-                },
-                checkHasExistingData: { [weak self] in
-                    guard let session = self?.session else { return false }
-                    return await session.hasAnyUsedConversations()
-                }
+                initiatorName: initiatorName
             )
         case .agentTemplate(templateId: let templateId):
             startConversation(withAgentTemplateId: templateId)
@@ -799,6 +774,363 @@ final class ConversationsViewModel {
             }
         }
     }
+}
+
+// MARK: - Device Pairing
+
+extension ConversationsViewModel {
+    /// Builds a joiner-side pairing sheet VM with the session callbacks
+    /// shared by both entry points: the `/pair/<slug>` deep link and the
+    /// first-install iCloud-discovery prompt.
+    func makeJoinerPairingViewModel(
+        pairingId: String,
+        expiresAt: Date?,
+        initiatorName: String?,
+        timeoutInterval: TimeInterval = 60,
+        connectingMessage: String? = nil,
+        resendJoinRequestInterval: TimeInterval? = nil
+    ) -> JoinerPairingSheetViewModel {
+        JoinerPairingSheetViewModel(
+            pairingId: pairingId,
+            expiresAt: expiresAt,
+            initiatorName: initiatorName,
+            timeoutInterval: timeoutInterval,
+            connectingMessage: connectingMessage,
+            resendJoinRequestInterval: resendJoinRequestInterval,
+            pairingService: session.joinerPairingService(),
+            onPairingAdopted: { [weak self] in
+                await self?.session.refreshAfterPairingCompleted()
+            },
+            onApplyAdoptedProfile: { [weak self] displayName, imageAssetIdentifier in
+                // The joiner just adopted the initiator's identity, so
+                // it shouldn't be asked to onboard a profile from
+                // scratch. Three side-effects in order:
+                //   1. Seed DBMyProfile from the share payload (may fail).
+                //   2. Re-bind the shared profile VM unconditionally.
+                //      Identity adoption already happened, so the
+                //      VM's cached writer / repository for the
+                //      placeholder session are stale either way — a
+                //      failed seed doesn't reverse the adoption, and
+                //      leaving the VM bound to the now-stopped
+                //      MessagingService risks crashes on subsequent
+                //      profile operations.
+                //   3. Flip global onboarding flags *only* on a
+                //      successful seed, so a failed save doesn't
+                //      permanently suppress prompts under an empty
+                //      DBMyProfile.
+                guard let session = self?.session else { return }
+                var seeded: Bool = false
+                do {
+                    try await session.messagingService().myGlobalProfileWriter().save(
+                        name: displayName,
+                        imageData: nil,
+                        imageAssetIdentifier: imageAssetIdentifier,
+                        metadata: nil
+                    )
+                    // Propagate the adopted profile through the canonical
+                    // repository so it fans out to every conversation via
+                    // the durable publisher. No image bytes are available on
+                    // the adoption path, so only the display name is sent.
+                    try await session.messagingService().profilesRepository().publishMyProfile(
+                        displayName: displayName,
+                        avatarBytes: nil,
+                        priorityConversationId: nil
+                    )
+                    seeded = true
+                } catch {
+                    Log.warning("Pairing: failed to seed DBMyProfile after adoption: \(error)")
+                }
+                ProfileSettingsViewModel.shared.rebind(session: session)
+                if seeded {
+                    ConversationOnboardingCoordinator.markCompletedForPairedDevice()
+                }
+            },
+            onDeleteExistingData: { [weak self] in
+                try await self?.session.deleteAllInboxes()
+            },
+            checkHasExistingData: { [weak self] in
+                guard let session = self?.session else { return false }
+                return await session.hasAnyUsedConversations()
+            }
+        )
+    }
+
+    private static let hasDeclinedFoundDevicePairingKey: String = "hasDeclinedFoundDevicePairing"
+    private var hasDeclinedFoundDevicePairing: Bool {
+        get {
+            UserDefaults.standard.bool(forKey: Self.hasDeclinedFoundDevicePairingKey)
+        }
+        set {
+            UserDefaults.standard.set(newValue, forKey: Self.hasDeclinedFoundDevicePairingKey)
+        }
+    }
+
+    /// First-install check for another device's identity in the
+    /// iCloud-synced keychain backup. Runs once per launch from
+    /// `onAppear`; re-running on later launches covers iCloud Keychain's
+    /// sync latency (a backup that hadn't synced yet on first launch).
+    ///
+    /// Deliberately not gated on local "engagement" signals:
+    /// fresh-install bootstrap pollutes all of them with zero user
+    /// interaction (`hasAnyUsedConversations()` flips once the inline
+    /// agent builder's auto-claimed draft commits on first termination,
+    /// and the conversations count includes the hidden prewarmed convo),
+    /// which would permanently suppress the prompt from the second launch
+    /// on. The prompt therefore shows whenever another identity's backup
+    /// exists and the user hasn't declined; data on an established
+    /// install stays safe because the joiner flow runs its own
+    /// hold-to-erase guard before anything destructive.
+    func checkForPairableDeviceIfNeeded() {
+        guard !didCheckForPairableDevice else { return }
+        didCheckForPairableDevice = true
+        guard !hasDeclinedFoundDevicePairing else { return }
+        Task { [weak self] in
+            guard let self else { return }
+            let backups = await self.session.pairableDeviceBackups()
+            QAEvent.emit(.pairing, "found_device_check", ["pairableCount": "\(backups.count)"])
+            guard let newest = backups.first else { return }
+            // Don't fight an in-flight deep-link pairing flow.
+            guard self.pendingJoinerPairing == nil, self.foundDevicePairingPrompt == nil else { return }
+            self.foundDevicePairingPrompt = FoundDevicePairingPrompt(
+                inboxId: newest.inboxId,
+                deviceName: newest.deviceName
+            )
+            QAEvent.emit(.pairing, "found_device_prompt_shown", [
+                "inboxId": newest.inboxId,
+                "deviceName": newest.deviceName ?? ""
+            ])
+        }
+    }
+
+    /// Primary action of the prompt sheet: dismisses the prompt
+    /// immediately, mints a pairing invite signed by the found device's
+    /// backed-up key (so the standard joiner flow can target it as the
+    /// main device), then presents the joiner flow.
+    ///
+    /// The prompt is nil'ed synchronously, before the mint Task, so a
+    /// rapid second tap finds it nil and bails - concurrent mints would
+    /// each build a `JoinerPairingSheetViewModel` whose notification
+    /// observers stay live even on the orphaned loser, double-handling
+    /// pairing messages. Minting and the dismissal animation then race
+    /// in both directions; whichever finishes second performs the
+    /// promotion (promoting while the prompt sheet is still animating
+    /// out can drop the new presentation).
+    func pairWithFoundDevice() {
+        guard let prompt = foundDevicePairingPrompt else { return }
+        foundDevicePromptDismissalComplete = false
+        foundDevicePairingPrompt = nil
+        Task { [weak self] in
+            guard let self else { return }
+            do {
+                let expiresAt = Date().addingTimeInterval(Constant.foundDevicePairingWindow)
+                let slug = try await self.session.pairingInviteSlug(
+                    forBackupInboxId: prompt.inboxId,
+                    expiresAt: expiresAt
+                )
+                let deviceLabel = prompt.deviceName ?? "your other device"
+                self.preparedFoundDevicePairing = self.makeJoinerPairingViewModel(
+                    pairingId: slug,
+                    expiresAt: expiresAt,
+                    initiatorName: prompt.deviceName,
+                    // Match the initiator sheet's window. The PIN-entry
+                    // countdown rebases to this on PIN arrival; the
+                    // deep-link flow's 60s is tight when the user is
+                    // juggling two devices they didn't stage in advance.
+                    timeoutInterval: Constant.foundDevicePairingStageTimeout,
+                    connectingMessage: "Open Convos on \"\(deviceLabel)\" to continue pairing.",
+                    resendJoinRequestInterval: Constant.foundDevicePairingResendInterval
+                )
+                QAEvent.emit(.pairing, "found_device_invite_minted", ["inboxId": prompt.inboxId])
+            } catch {
+                Log.error("Failed to mint pairing invite from synced backup: \(error)")
+                // Re-arm the once-per-launch check so a later chats-list
+                // appearance offers the prompt again; with the latch left
+                // set, a transient keychain/signing failure would strand
+                // the user until the next app launch with no retry path.
+                self.didCheckForPairableDevice = false
+            }
+            if self.foundDevicePromptDismissalComplete {
+                self.promotePreparedFoundDevicePairing()
+            }
+            // Otherwise the sheet is still animating out; onDismiss
+            // promotes when it completes.
+        }
+    }
+
+    /// Secondary action of the prompt sheet. Persistent: once skipped,
+    /// the prompt never comes back (until app data is reset).
+    func skipFoundDevicePairing() {
+        hasDeclinedFoundDevicePairing = true
+        foundDevicePairingPrompt = nil
+        QAEvent.emit(.pairing, "found_device_prompt_skipped")
+    }
+
+    /// Called when the prompt sheet finishes dismissing; presents the
+    /// joiner pairing flow prepared by `pairWithFoundDevice()` if the
+    /// mint already finished (no-op for Skip / swipe-away dismissals).
+    func onFoundDevicePromptDismissed() {
+        foundDevicePromptDismissalComplete = true
+        promotePreparedFoundDevicePairing()
+    }
+
+    private func promotePreparedFoundDevicePairing() {
+        guard let prepared = preparedFoundDevicePairing else { return }
+        preparedFoundDevicePairing = nil
+        pendingJoinerPairing = prepared
+    }
+
+    // MARK: Incoming Pairing Requests (initiator side)
+
+    /// Auto-surfaces the initiator pairing flow when a verified join
+    /// request arrives on the main message stream (posted by
+    /// `StreamProcessor` after checking the slug signature against this
+    /// device's own identity key). Foregrounded: present the PIN sheet
+    /// immediately. Otherwise: stash the request and raise a local
+    /// notification; the stash is redeemed on the next activation.
+    private func observeIncomingPairingRequests() {
+        incomingPairingObservers.add(for: .pairingDidReceiveVerifiedJoinRequest) { [weak self] notification in
+            guard let joinerInboxId = notification.userInfo?["joinerInboxId"] as? String,
+                  let deviceName = notification.userInfo?["deviceName"] as? String else { return }
+            Task { @MainActor in
+                self?.handleVerifiedJoinRequest(joinerInboxId: joinerInboxId, deviceName: deviceName)
+            }
+        }
+        incomingPairingObservers.add(for: UIApplication.didBecomeActiveNotification) { [weak self] _ in
+            Task { @MainActor in
+                self?.presentPendingIncomingPairRequestIfNeeded()
+            }
+        }
+    }
+
+    private func handleVerifiedJoinRequest(joinerInboxId: String, deviceName: String) {
+        // An initiator flow already mid-handshake (the Devices QR sheet
+        // or a previously surfaced request) owns the exchange; a second
+        // coordinator would race PIN generation for the same joiner. The
+        // joiner re-sends its request every few seconds, so a dropped
+        // one here is recovered as soon as the active flow ends.
+        guard PairingSheetViewModel.active == nil else { return }
+        if incomingPairingRequest != nil {
+            // The sheet sets `PairingSheetViewModel.active` from its
+            // `.task` the moment it actually presents. A request that
+            // has sat un-presented well past that point means SwiftUI
+            // dropped the presentation (another sheet was up when it was
+            // assigned); without this reset the stale reference blocks
+            // every resend until app restart.
+            guard let presentedAt = incomingPairingPresentedAt,
+                  Date().timeIntervalSince(presentedAt) > Constant.incomingPairingPresentationGrace else {
+                return
+            }
+            Log.warning("Incoming pairing sheet never presented; resetting and retrying")
+            incomingPairingRequest = nil
+            incomingPairingPresentedAt = nil
+        }
+        if UIApplication.shared.applicationState == .active {
+            presentIncomingPairingSheet(joinerInboxId: joinerInboxId, deviceName: deviceName)
+        } else {
+            // Latch the banner per joiner: the resend cadence would
+            // otherwise re-alert every few seconds while backgrounded.
+            // The stash still refreshes so the staleness window keys
+            // off the latest resend, not the first.
+            let alreadyNotified = pendingIncomingPairRequest?.joinerInboxId == joinerInboxId
+            pendingIncomingPairRequest = PendingIncomingPairRequest(
+                joinerInboxId: joinerInboxId,
+                deviceName: deviceName,
+                receivedAt: Date()
+            )
+            if !alreadyNotified {
+                scheduleIncomingPairingNotification(deviceName: deviceName)
+            }
+        }
+    }
+
+    private func presentIncomingPairingSheet(joinerInboxId: String, deviceName: String) {
+        QAEvent.emit(.pairing, "incoming_request_surfaced", ["joinerInboxId": joinerInboxId])
+        incomingPairingPresentedAt = Date()
+        incomingPairingRequest = PairingSheetViewModel(
+            pairingService: DeferredInitiatorPairingService(session: session),
+            mode: .respondToJoinRequest(joinerInboxId: joinerInboxId, deviceName: deviceName),
+            appGroupIdentifier: ConfigManager.shared.currentEnvironment.appGroupIdentifier
+        )
+    }
+
+    private func presentPendingIncomingPairRequestIfNeeded() {
+        guard let pending = pendingIncomingPairRequest else { return }
+        pendingIncomingPairRequest = nil
+        UNUserNotificationCenter.current().removeDeliveredNotifications(
+            withIdentifiers: [Constant.incomingPairingNotificationId]
+        )
+        // The joiner re-sends its request for the length of the pairing
+        // window; past that the handshake would just expire on send, so
+        // stale stashes are dropped instead of surfaced.
+        guard Date().timeIntervalSince(pending.receivedAt) < Constant.foundDevicePairingWindow else { return }
+        guard PairingSheetViewModel.active == nil, incomingPairingRequest == nil else { return }
+        presentIncomingPairingSheet(joinerInboxId: pending.joinerInboxId, deviceName: pending.deviceName)
+    }
+
+    private func scheduleIncomingPairingNotification(deviceName: String) {
+        let content = UNMutableNotificationContent()
+        content.title = "Pair new device"
+        content.body = "\"\(deviceName)\" is requesting to pair"
+        content.sound = .default
+        let request = UNNotificationRequest(
+            identifier: Constant.incomingPairingNotificationId,
+            content: content,
+            trigger: nil
+        )
+        UNUserNotificationCenter.current().add(request) { error in
+            if let error {
+                Log.warning("Failed to schedule pairing request notification: \(error)")
+            }
+        }
+    }
+
+    /// Dismissal hook for the joiner pairing sheet (interactive and
+    /// programmatic): tears down the ephemeral pairing client before the
+    /// reference drops. Safe on every terminal state - the joiner-side
+    /// `cancel()` signals nothing to the peer and the service stop is
+    /// idempotent, so a completed flow just gets its temp client wiped.
+    func dismissJoinerPairing() {
+        pendingJoinerPairing?.cancel()
+        pendingJoinerPairing = nil
+        pendingPairDevice = nil
+    }
+
+    /// Sheet-dismissal hook for the auto-surfaced initiator flow.
+    func dismissIncomingPairingRequest() {
+        incomingPairingRequest?.triggerCancel()
+        incomingPairingRequest = nil
+        incomingPairingPresentedAt = nil
+    }
+
+    private enum Constant {
+        /// Validity window for an invite minted from an iCloud backup.
+        /// Longer than the QR flow's window because the user still has to
+        /// fetch the other device and open the app on it.
+        static let foundDevicePairingWindow: TimeInterval = 300
+        /// Cadence for re-sending the join request while connecting. The
+        /// found device only sees requests that arrive while its app is
+        /// streaming, so the first send is almost always too early.
+        static let foundDevicePairingResendInterval: TimeInterval = 5
+        /// Per-stage (PIN entry, emoji confirmation) window, matching the
+        /// initiator sheet's 120s.
+        static let foundDevicePairingStageTimeout: TimeInterval = 120
+        /// Fixed identifier so a joiner's resend burst replaces (not
+        /// stacks) the "is requesting to pair" local notification.
+        static let incomingPairingNotificationId: String = "incoming-pairing-request"
+        /// How long an assigned `incomingPairingRequest` may sit without
+        /// the sheet's `.task` firing before the watchdog concludes the
+        /// presentation was dropped. Generous against slow presentation
+        /// animations; tiny against the 5s resend cadence that retries.
+        static let incomingPairingPresentationGrace: TimeInterval = 3
+    }
+}
+
+/// A verified join request that arrived while the app wasn't active,
+/// awaiting presentation on the next foreground.
+private struct PendingIncomingPairRequest {
+    let joinerInboxId: String
+    let deviceName: String
+    let receivedAt: Date
 }
 
 extension ConversationsViewModel {

--- a/Convos/Conversations List/ConversationsViewModel.swift
+++ b/Convos/Conversations List/ConversationsViewModel.swift
@@ -898,8 +898,16 @@ extension ConversationsViewModel {
             let backups = await self.session.pairableDeviceBackups()
             QAEvent.emit(.pairing, "found_device_check", ["pairableCount": "\(backups.count)"])
             guard let newest = backups.first else { return }
-            // Don't fight an in-flight deep-link pairing flow.
-            guard self.pendingJoinerPairing == nil, self.foundDevicePairingPrompt == nil else { return }
+            // Don't fight an in-flight deep-link pairing flow - but
+            // un-latch so the next chats-list appearance re-offers the
+            // prompt once that flow ends. Without the reset, a launch
+            // that starts with a /pair deep link would suppress the
+            // found-device prompt for the whole session even if the
+            // deep-link flow is abandoned.
+            guard self.pendingJoinerPairing == nil, self.foundDevicePairingPrompt == nil else {
+                self.didCheckForPairableDevice = false
+                return
+            }
             self.foundDevicePairingPrompt = FoundDevicePairingPrompt(
                 inboxId: newest.inboxId,
                 deviceName: newest.deviceName
@@ -985,6 +993,14 @@ extension ConversationsViewModel {
     private func promotePreparedFoundDevicePairing() {
         guard let prepared = preparedFoundDevicePairing else { return }
         preparedFoundDevicePairing = nil
+        // A /pair deep link may have claimed the slot while the
+        // found-device invite was minting; replacing it mid-flight would
+        // drop the user into the wrong pairing session. Yield to it and
+        // tear down the prepared flow's ephemeral client instead.
+        guard pendingJoinerPairing == nil else {
+            prepared.cancel()
+            return
+        }
         pendingJoinerPairing = prepared
     }
 
@@ -1106,10 +1122,14 @@ extension ConversationsViewModel {
         }
         guard let pending else { return }
         removeDeliveredPairingNotifications()
-        // The joiner re-sends its request for the length of the pairing
-        // window; past that the handshake would just expire on send, so
-        // stale stashes are dropped instead of surfaced.
-        guard Date().timeIntervalSince(pending.receivedAt) < Constant.foundDevicePairingWindow else { return }
+        // A live joiner's resend loop keeps refreshing receivedAt, so a
+        // fresh stash means an active handshake. Cap the surfacing window
+        // at the shortest supported invite lifetime (the QR flow's 120s)
+        // rather than the iCloud flow's 300s: the stash doesn't carry the
+        // slug (deliberately, it's a bearer credential), so the invite's
+        // actual expiry can't be re-checked here and a longer window
+        // could present a PIN sheet for an invite that already expired.
+        guard Date().timeIntervalSince(pending.receivedAt) < Constant.stashedPairRequestWindow else { return }
         presentIncomingPairingSheet(joinerInboxId: pending.joinerInboxId, deviceName: pending.deviceName)
     }
 
@@ -1180,6 +1200,10 @@ extension ConversationsViewModel {
         /// found device only sees requests that arrive while its app is
         /// streaming, so the first send is almost always too early.
         static let foundDevicePairingResendInterval: TimeInterval = 5
+        /// How old a stashed join request may be and still be surfaced on
+        /// activation. Matches the shortest invite lifetime (QR flow,
+        /// 120s) because the stash can't re-check the invite's own expiry.
+        static let stashedPairRequestWindow: TimeInterval = 120
         /// Per-stage (PIN entry, emoji confirmation) window, matching the
         /// initiator sheet's 120s.
         static let foundDevicePairingStageTimeout: TimeInterval = 120

--- a/Convos/Conversations List/ConversationsViewModel.swift
+++ b/Convos/Conversations List/ConversationsViewModel.swift
@@ -850,7 +850,16 @@ extension ConversationsViewModel {
                     Log.warning("Pairing: failed to seed DBMyProfile after adoption: \(error)")
                 }
                 ProfileSettingsViewModel.shared.rebind(session: session)
-                if seeded {
+                // Only suppress profile onboarding when the adopted
+                // payload actually carried a usable profile. A nil or
+                // empty display name means the initiator never set one
+                // up, and the joiner would otherwise be stranded as
+                // "Somebody" with the prompt permanently suppressed.
+                // (The asset identifier alone doesn't count: it's a
+                // PhotoKit id from the initiator's library and can't
+                // resolve here.)
+                let adoptedUsableProfile = displayName?.isEmpty == false
+                if seeded && adoptedUsableProfile {
                     ConversationOnboardingCoordinator.markCompletedForPairedDevice()
                 }
             },

--- a/Convos/Conversations List/ConversationsViewModel.swift
+++ b/Convos/Conversations List/ConversationsViewModel.swift
@@ -1045,6 +1045,15 @@ extension ConversationsViewModel {
 
     private func presentIncomingPairingSheet(joinerInboxId: String, deviceName: String) {
         QAEvent.emit(.pairing, "incoming_request_surfaced", ["joinerInboxId": joinerInboxId])
+        // The NSE stashes for pushes that arrive while the app is
+        // foregrounded too; presenting from the stream path must discard
+        // that stash (and any delivered banners), or the next activation
+        // would re-present a ghost PIN sheet for an already-handled
+        // request.
+        _ = PendingPairRequestStore.consumePending(
+            appGroup: ConfigManager.shared.currentEnvironment.appGroupIdentifier
+        )
+        removeDeliveredPairingNotifications()
         incomingPairingPresentedAt = Date()
         incomingPairingRequest = PairingSheetViewModel(
             pairingService: DeferredInitiatorPairingService(session: session),
@@ -1054,17 +1063,52 @@ extension ConversationsViewModel {
     }
 
     private func presentPendingIncomingPairRequestIfNeeded() {
-        guard let pending = pendingIncomingPairRequest else { return }
-        pendingIncomingPairRequest = nil
-        UNUserNotificationCenter.current().removeDeliveredNotifications(
-            withIdentifiers: [Constant.incomingPairingNotificationId]
-        )
+        // Bail before consuming anything when a pairing flow is already
+        // on screen: a second initiator coordinator would race PIN
+        // generation for the same joiner. Consuming first and bailing
+        // after would destructively drop the stash (the app-group read
+        // removes it), losing the request if the joiner has stopped
+        // re-sending (killed/backgrounded). Leave it stashed so the next
+        // activation, once the active flow ends, can present it.
+        guard PairingSheetViewModel.active == nil, incomingPairingRequest == nil else { return }
+        // Two stash sources: in-memory (request arrived while this
+        // process was backgrounded) and the app-group store written by
+        // the NSE (request arrived while the app wasn't running at all).
+        var pending: PendingIncomingPairRequest?
+        if let inMemory = pendingIncomingPairRequest {
+            pendingIncomingPairRequest = nil
+            pending = inMemory
+        } else if let stashed = PendingPairRequestStore.consumePending(
+            appGroup: ConfigManager.shared.currentEnvironment.appGroupIdentifier
+        ) {
+            pending = PendingIncomingPairRequest(
+                joinerInboxId: stashed.joinerInboxId,
+                deviceName: stashed.deviceName,
+                receivedAt: stashed.receivedAt
+            )
+        }
+        guard let pending else { return }
+        removeDeliveredPairingNotifications()
         // The joiner re-sends its request for the length of the pairing
         // window; past that the handshake would just expire on send, so
         // stale stashes are dropped instead of surfaced.
         guard Date().timeIntervalSince(pending.receivedAt) < Constant.foundDevicePairingWindow else { return }
-        guard PairingSheetViewModel.active == nil, incomingPairingRequest == nil else { return }
         presentIncomingPairingSheet(joinerInboxId: pending.joinerInboxId, deviceName: pending.deviceName)
+    }
+
+    /// Removes every delivered "is requesting to pair" banner: the app's
+    /// own local one (fixed request identifier) and any the NSE produced
+    /// for remote pushes, whose request identifiers are system-assigned
+    /// and only findable via the shared pairing thread identifier.
+    private func removeDeliveredPairingNotifications() {
+        let center = UNUserNotificationCenter.current()
+        center.getDeliveredNotifications { notifications in
+            let pairingIds = notifications
+                .filter { $0.request.content.threadIdentifier == PairingNotificationThread.identifier }
+                .map(\.request.identifier)
+            let ids = pairingIds + [Constant.incomingPairingNotificationId]
+            center.removeDeliveredNotifications(withIdentifiers: ids)
+        }
     }
 
     private func scheduleIncomingPairingNotification(deviceName: String) {
@@ -1072,6 +1116,7 @@ extension ConversationsViewModel {
         content.title = "Pair new device"
         content.body = "\"\(deviceName)\" is requesting to pair"
         content.sound = .default
+        content.threadIdentifier = PairingNotificationThread.identifier
         let request = UNNotificationRequest(
             identifier: Constant.incomingPairingNotificationId,
             content: content,
@@ -1095,11 +1140,18 @@ extension ConversationsViewModel {
         pendingPairDevice = nil
     }
 
-    /// Sheet-dismissal hook for the auto-surfaced initiator flow.
+    /// Sheet-dismissal hook for the auto-surfaced initiator flow. Also
+    /// discards any stash the NSE wrote for resends that landed while
+    /// the sheet was up - the request was handled either way, and a
+    /// leftover stash would re-present a ghost sheet on next activation.
     func dismissIncomingPairingRequest() {
         incomingPairingRequest?.triggerCancel()
         incomingPairingRequest = nil
         incomingPairingPresentedAt = nil
+        _ = PendingPairRequestStore.consumePending(
+            appGroup: ConfigManager.shared.currentEnvironment.appGroupIdentifier
+        )
+        removeDeliveredPairingNotifications()
     }
 
     private enum Constant {

--- a/Convos/ConvosApp.swift
+++ b/Convos/ConvosApp.swift
@@ -65,6 +65,7 @@ struct ConvosApp: App {
         let appBuild = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "unknown"
         Log.info("Launch: version=\(appVersion) build=\(appBuild) commit=\(Secrets.GIT_COMMIT_SHA) environment=\(environment.name)")
         QAEvent.emit(.app, "launched", ["environment": environment.name])
+        QALaunchHooks.run(environment: environment)
 
         // Firebase must be configured before ConvosClient is created so AppCheck is ready when auth begins
         switch environment {

--- a/Convos/Devices/JoinerPairingSheetView.swift
+++ b/Convos/Devices/JoinerPairingSheetView.swift
@@ -102,8 +102,10 @@ struct JoinerPairingSheetView: View {
     }
 
     private var connectingContent: some View {
-        VStack(spacing: DesignConstants.Spacing.step4x) {
-            Text("\"\(viewModel.initiatorDeviceName)\" is requesting to pair. Paired devices sync all conversations.")
+        let message: String = viewModel.connectingMessage
+            ?? "\"\(viewModel.initiatorDeviceName)\" is requesting to pair. Paired devices sync all conversations."
+        return VStack(spacing: DesignConstants.Spacing.step4x) {
+            Text(message)
                 .font(.subheadline)
                 .foregroundStyle(.colorTextPrimary)
                 .frame(maxWidth: .infinity, alignment: .leading)

--- a/Convos/Devices/JoinerPairingSheetViewModel.swift
+++ b/Convos/Devices/JoinerPairingSheetViewModel.swift
@@ -30,7 +30,20 @@ final class JoinerPairingSheetViewModel: Identifiable {
     private let timeoutInterval: TimeInterval
     private let pairingService: any PairingServiceProtocol
     private let initiatorName: String?
+    /// Copy shown while `.connecting`; nil falls back to the default
+    /// "<device> is requesting to pair" text. The iCloud-discovery entry
+    /// point overrides it with instructions to open the pairing screen on
+    /// the other device.
+    let connectingMessage: String?
+    /// When set, the join request is re-sent on this cadence while the
+    /// flow stays in `.connecting`. The QR flow never needs this - the
+    /// initiator is already streaming when its QR is scanned - but the
+    /// iCloud-discovery flow sends the first request before the user has
+    /// opened the pairing screen on the other device, and the initiator
+    /// only sees requests that arrive while it streams.
+    private let resendJoinRequestInterval: TimeInterval?
     private var countdownTask: Task<Void, Never>?
+    private var resendTask: Task<Void, Never>?
     @ObservationIgnored
     private let observers: PairingNotificationObservers
     private var initiatorInboxId: String?
@@ -52,6 +65,8 @@ final class JoinerPairingSheetViewModel: Identifiable {
         expiresAt: Date? = nil,
         initiatorName: String? = nil,
         timeoutInterval: TimeInterval = 60,
+        connectingMessage: String? = nil,
+        resendJoinRequestInterval: TimeInterval? = nil,
         pairingService: any PairingServiceProtocol,
         onPairingAdopted: (@MainActor () async -> Void)? = nil,
         onApplyAdoptedProfile: (@MainActor (_ displayName: String?, _ imageAssetIdentifier: String?) async -> Void)? = nil,
@@ -62,6 +77,8 @@ final class JoinerPairingSheetViewModel: Identifiable {
         self.pairingId = pairingId
         self.timeoutInterval = timeoutInterval
         self.initiatorName = initiatorName
+        self.connectingMessage = connectingMessage
+        self.resendJoinRequestInterval = resendJoinRequestInterval
         self.pairingService = pairingService
         self.onPairingAdopted = onPairingAdopted
         self.onApplyAdoptedProfile = onApplyAdoptedProfile
@@ -140,8 +157,35 @@ final class JoinerPairingSheetViewModel: Identifiable {
                 slug: pairingId,
                 deviceName: DeviceInfo.deviceName
             )
+            startResendLoopIfNeeded()
         } catch {
             flowState = .failed(error.localizedDescription)
+        }
+    }
+
+    /// Re-sends the join request on a fixed cadence while the flow stays
+    /// in `.connecting`. Duplicate requests are harmless on the initiator:
+    /// before its pairing screen opens nothing is listening, and once a
+    /// handshake is underway `PairingCoordinator.receivedJoinRequest`
+    /// ignores repeats. Send failures are logged and retried - the loop
+    /// only stops when the flow leaves `.connecting`.
+    private func startResendLoopIfNeeded() {
+        guard let interval = resendJoinRequestInterval else { return }
+        resendTask?.cancel()
+        resendTask = Task { [weak self] in
+            while !Task.isCancelled {
+                try? await Task.sleep(for: .seconds(interval))
+                guard !Task.isCancelled, let self else { return }
+                guard self.flowState == .connecting else { return }
+                do {
+                    try await self.pairingService.sendPairingJoinRequest(
+                        slug: self.pairingId,
+                        deviceName: DeviceInfo.deviceName
+                    )
+                } catch {
+                    Log.warning("Pairing: join request resend failed: \(error)")
+                }
+            }
         }
     }
 
@@ -209,6 +253,7 @@ final class JoinerPairingSheetViewModel: Identifiable {
     }
 
     private func onPinReceived(_ pin: String, from senderInboxId: String) {
+        resendTask?.cancel()
         initiatorInboxId = senderInboxId
         // Rebase the countdown when the PIN arrives. The initial window
         // is the slug's expiresAt — by the time the PIN lands the user
@@ -226,6 +271,7 @@ final class JoinerPairingSheetViewModel: Identifiable {
         guard !didComplete else { return }
         didComplete = true
         countdownTask?.cancel()
+        resendTask?.cancel()
         title = "Adopting identity"
         flowState = .syncing
         canDismiss = false
@@ -242,12 +288,14 @@ final class JoinerPairingSheetViewModel: Identifiable {
     }
 
     func onPairingFailed(_ message: String) {
+        resendTask?.cancel()
         flowState = .failed(message)
         canDismiss = true
     }
 
     func cancel() {
         countdownTask?.cancel()
+        resendTask?.cancel()
         Task {
             await pairingService.stop()
         }

--- a/Convos/Devices/PairFoundDeviceInfoSheet.swift
+++ b/Convos/Devices/PairFoundDeviceInfoSheet.swift
@@ -1,0 +1,76 @@
+import SwiftUI
+
+// First-install pairing prompt. When a fresh install finds another
+// device's identity in the iCloud-synced keychain backup slot,
+// ConversationsViewModel surfaces this sheet offering to pair with that
+// device instead of continuing with the placeholder account. "Pair" runs
+// the standard joiner pairing flow targeting the found device as the main
+// device; "Skip" declines persistently.
+
+/// Drives presentation of `PairFoundDeviceInfoSheet`: one backed-up
+/// device identity discovered in iCloud, identified by the inboxId this
+/// install would adopt on pair.
+struct FoundDevicePairingPrompt: Identifiable, Equatable {
+    let inboxId: String
+    let deviceName: String?
+
+    var id: String { inboxId }
+}
+
+struct PairFoundDeviceInfoSheet: View {
+    let deviceName: String?
+    let onPair: () -> Void
+    let onSkip: () -> Void
+
+    private var title: String {
+        guard let deviceName else { return "Pair your other device?" }
+        return "Pair \(deviceName)?"
+    }
+
+    private var subtitle: String {
+        guard let deviceName else {
+            return "Another device was found in iCloud, if you have it nearby, you can pair it now"
+        }
+        return "Your \(deviceName) was found in iCloud, if you have it nearby, you can pair it now"
+    }
+
+    private var primaryButtonTitle: String {
+        guard let deviceName else { return "Pair device" }
+        return "Pair \(deviceName)"
+    }
+
+    var body: some View {
+        // No container-level accessibilityIdentifier: applied to the sheet
+        // as a whole it propagates to every child element and clobbers the
+        // two button identifiers below. Automation anchors on
+        // pair-found-device-button instead.
+        FeatureInfoSheet(
+            title: title,
+            subtitle: subtitle,
+            primaryButtonTitle: primaryButtonTitle,
+            primaryButtonAction: onPair,
+            primaryButtonAccessibilityIdentifier: "pair-found-device-button",
+            secondaryButtonTitle: "Skip",
+            secondaryButtonAction: onSkip,
+            secondaryButtonAccessibilityIdentifier: "skip-found-device-pairing-button"
+        )
+    }
+}
+
+#Preview("Named device") {
+    @Previewable @State var isPresented: Bool = true
+    VStack { Button { isPresented.toggle() } label: { Text("Show") } }
+        .selfSizingSheet(isPresented: $isPresented) {
+            PairFoundDeviceInfoSheet(deviceName: "Jarod's iPhone", onPair: {}, onSkip: {})
+                .padding(.top, 20)
+        }
+}
+
+#Preview("Unnamed device") {
+    @Previewable @State var isPresented: Bool = true
+    VStack { Button { isPresented.toggle() } label: { Text("Show") } }
+        .selfSizingSheet(isPresented: $isPresented) {
+            PairFoundDeviceInfoSheet(deviceName: nil, onPair: {}, onSkip: {})
+                .padding(.top, 20)
+        }
+}

--- a/Convos/Devices/PairingSheetViewModel.swift
+++ b/Convos/Devices/PairingSheetViewModel.swift
@@ -33,6 +33,30 @@ final class PairingSheetViewModel: Identifiable {
     /// the same joiner and the handshake would fail on a stale PIN.
     private(set) static weak var active: PairingSheetViewModel?
 
+    /// The most recently created sheet VM and when it was created. A VM
+    /// exists only to be presented, but `active` isn't claimed until the
+    /// sheet's `.task` runs `startPairing()` - leaving a short window
+    /// (creation to first frame) where a concurrent verified join request
+    /// sees `active == nil` and would spawn a second coordinator for the
+    /// same joiner. `isFlowActiveOrStarting` closes that window without
+    /// breaking the dropped-presentation watchdog: a VM whose presentation
+    /// SwiftUI dropped never becomes `active` and stops blocking once the
+    /// grace period lapses.
+    private static weak var starting: PairingSheetViewModel?
+    private static var startingAt: Date?
+
+    /// True while an initiator flow owns, or is about to own, the
+    /// exchange. Callers gating auto-surfaced join requests should check
+    /// this rather than `active` alone; see `starting`.
+    static var isFlowActiveOrStarting: Bool {
+        if active != nil { return true }
+        if starting != nil, let startingAt,
+           Date().timeIntervalSince(startingAt) < Constant.startingGrace {
+            return true
+        }
+        return false
+    }
+
     var flowState: PairingFlowState = .qrCode(url: "")
     var canDismiss: Bool = true
     var title: String = "Pair new device"
@@ -68,6 +92,8 @@ final class PairingSheetViewModel: Identifiable {
             // pairing service bootstraps toward `.showingPin`.
             self.flowState = .syncing
         }
+        Self.starting = self
+        Self.startingAt = Date()
         observeNotifications()
     }
 
@@ -325,5 +351,13 @@ final class PairingSheetViewModel: Identifiable {
 
     func triggerCancel() {
         Task { await cancel() }
+    }
+
+    private enum Constant {
+        /// How long a freshly created VM blocks a second flow before its
+        /// sheet must have presented (and claimed `active`). Matches the
+        /// auto-surface watchdog's presentation grace in
+        /// `ConversationsViewModel` so both sides age out together.
+        static let startingGrace: TimeInterval = 3
     }
 }

--- a/Convos/Devices/PairingSheetViewModel.swift
+++ b/Convos/Devices/PairingSheetViewModel.swift
@@ -228,6 +228,15 @@ final class PairingSheetViewModel: Identifiable {
 
     func onJoinRequestReceived(deviceName: String, joinerInboxId: String) async {
         guard let coordinator else { return }
+        // The joiner's resend loop re-delivers requests this flow has
+        // already answered. The coordinator no-ops on them (it only
+        // accepts from `.waitingForScan`) and keeps its own expiration
+        // timer, so re-processing here would rebase the VM countdown
+        // past the coordinator's real expiry and re-send the PIN for
+        // nothing.
+        if case .showingPin = flowState, joinerInboxId == self.joinerInboxId {
+            return
+        }
 
         do {
             // Let the coordinator validate first — it rejects duplicate

--- a/Convos/Devices/PairingSheetViewModel.swift
+++ b/Convos/Devices/PairingSheetViewModel.swift
@@ -12,9 +12,27 @@ enum PairingFlowState: Equatable {
     case expired
 }
 
+/// How the initiator pairing sheet was entered.
+enum PairingSheetMode: Equatable {
+    /// Settings > Devices > Add new device: create an invite and show
+    /// the QR for a joiner to scan.
+    case createInvite
+    /// A verified join request already arrived via the main message
+    /// stream (iCloud-discovery joiner); respond with a PIN immediately,
+    /// no QR step.
+    case respondToJoinRequest(joinerInboxId: String, deviceName: String)
+}
+
 @Observable
 @MainActor
-final class PairingSheetViewModel {
+final class PairingSheetViewModel: Identifiable {
+    /// The initiator sheet currently mid-flow, if any. Weak so dismissal
+    /// (either host nils its reference) clears it automatically. The
+    /// auto-surface path checks this to avoid presenting a second
+    /// initiator flow - two coordinators would race PIN generation for
+    /// the same joiner and the handshake would fail on a stale PIN.
+    private(set) static weak var active: PairingSheetViewModel?
+
     var flowState: PairingFlowState = .qrCode(url: "")
     var canDismiss: Bool = true
     var title: String = "Pair new device"
@@ -23,6 +41,7 @@ final class PairingSheetViewModel {
     private let pairingService: any PairingServiceProtocol
     private let appGroupIdentifier: String?
     private let timeoutInterval: TimeInterval
+    private let mode: PairingSheetMode
     private(set) var coordinator: PairingCoordinator?
     private var joinerDeviceName: String = "New Device"
     private var joinerInboxId: String?
@@ -34,13 +53,21 @@ final class PairingSheetViewModel {
     init(
         pairingService: any PairingServiceProtocol,
         timeoutInterval: TimeInterval = 120,
+        mode: PairingSheetMode = .createInvite,
         appGroupIdentifier: String? = nil
     ) {
         self.pairingService = pairingService
         self.appGroupIdentifier = appGroupIdentifier
         self.timeoutInterval = timeoutInterval
+        self.mode = mode
         self.secondsRemaining = Int(timeoutInterval)
         self.observers = PairingNotificationObservers()
+        if case .respondToJoinRequest = mode {
+            // Respond mode never shows a QR; start in the spinner state
+            // so the sheet doesn't flash the empty QR layout while the
+            // pairing service bootstraps toward `.showingPin`.
+            self.flowState = .syncing
+        }
         observeNotifications()
     }
 
@@ -75,6 +102,16 @@ final class PairingSheetViewModel {
     }
 
     func startPairing() async {
+        Self.active = self
+        switch mode {
+        case .createInvite:
+            await startInviteFlow()
+        case let .respondToJoinRequest(joinerInboxId, deviceName):
+            await startRespondFlow(joinerInboxId: joinerInboxId, deviceName: deviceName)
+        }
+    }
+
+    private func startInviteFlow() async {
         let coordinator = PairingCoordinator(pairingService: pairingService, timeoutInterval: timeoutInterval)
         self.coordinator = coordinator
 
@@ -99,6 +136,47 @@ final class PairingSheetViewModel {
             startCountdown()
         } catch {
             Log.error("Pairing start failed: \(error)")
+            // The service may have started before the failing call; stop
+            // it so its stream doesn't outlive the failed flow (mirrors
+            // confirmEmoji's failure handling).
+            await pairingService.stop()
+            flowState = .failed(error.localizedDescription)
+        }
+    }
+
+    /// Mirrors the back half of `onJoinRequestReceived`: the join request
+    /// already arrived (verified by the stream layer), so the coordinator
+    /// starts directly in `.showingPin` and the PIN goes straight to the
+    /// joiner.
+    private func startRespondFlow(joinerInboxId: String, deviceName: String) async {
+        let coordinator = PairingCoordinator(pairingService: pairingService, timeoutInterval: timeoutInterval)
+        self.coordinator = coordinator
+
+        do {
+            try await pairingService.start()
+            guard let initiatorInboxId = await pairingService.pairingInboxId() else {
+                await pairingService.stop()
+                flowState = .failed("Pairing service is not ready")
+                return
+            }
+            let pin = try await coordinator.startPairing(
+                respondingToJoinerInboxId: joinerInboxId,
+                deviceName: deviceName,
+                initiatorInboxId: initiatorInboxId
+            )
+            joinerDeviceName = deviceName
+            self.joinerInboxId = joinerInboxId
+            expiresAt = Date().addingTimeInterval(timeoutInterval)
+            secondsRemaining = Int(timeoutInterval)
+            try await pairingService.sendPinToJoiner(pin, joinerInboxId: joinerInboxId)
+            QAEvent.emit(.pairing, "responding_to_join_request", ["joinerInboxId": joinerInboxId])
+            flowState = .showingPin(pin: pin, deviceName: deviceName)
+            startCountdown()
+        } catch {
+            Log.error("Pairing respond flow failed: \(error)")
+            // Mirrors confirmEmoji's failure handling: the service was
+            // started above, so stop its stream before parking in .failed.
+            await pairingService.stop()
             flowState = .failed(error.localizedDescription)
         }
     }

--- a/Convos/MainTabView.swift
+++ b/Convos/MainTabView.swift
@@ -931,6 +931,29 @@ struct MainTabSheetsModifier: ViewModifier {
     let onCameraImageCaptured: (UIImage) -> Void
     let onCameraVideoCaptured: (URL) -> Void
 
+    /// Routes every dismissal of the incoming-pairing sheet through
+    /// `dismissIncomingPairingRequest()` so the flow is cancelled before
+    /// the view model reference is dropped. A plain item binding with an
+    /// `onDismiss` can't do this for interactive (swipe) dismissal:
+    /// SwiftUI nils the binding before `onDismiss` runs, so by then
+    /// there's no view model left to cancel and the pairing service's
+    /// stream keeps running. Cancelling is safe on every path - the view
+    /// model only sends the joiner-facing cancellation error from
+    /// mid-handshake states, and stopping the service after completion
+    /// or failure is the same cleanup the QR flow does on sheet close.
+    private var incomingPairingBinding: Binding<PairingSheetViewModel?> {
+        Binding(
+            get: { conversationsViewModel.incomingPairingRequest },
+            set: { newValue in
+                if newValue == nil {
+                    conversationsViewModel.dismissIncomingPairingRequest()
+                } else {
+                    conversationsViewModel.incomingPairingRequest = newValue
+                }
+            }
+        )
+    }
+
     func body(content: Content) -> some View {
         content
             .sheet(item: $conversationsViewModel.agentBuilderViewModel) { builderViewModel in
@@ -973,6 +996,13 @@ struct MainTabSheetsModifier: ViewModifier {
                 )
                 .interactiveDismissDisabled(conversationsViewModel.appSettingsViewModel.isDeleting)
             }
+            .selfSizingSheet(
+                item: incomingPairingBinding,
+                content: { pairingVM in
+                    PairingSheetView(viewModel: pairingVM)
+                        .padding(.top, DesignConstants.Spacing.step5x)
+                }
+            )
             .sheet(item: $conversationsViewModel.newConversationViewModel) { newConvoViewModel in
                 NewConversationView(
                     viewModel: newConvoViewModel,

--- a/Convos/Shared Views/FeatureInfoSheet.swift
+++ b/Convos/Shared Views/FeatureInfoSheet.swift
@@ -7,6 +7,10 @@ struct FeatureInfoSheet: View {
     let paragraphs: [FeatureInfoParagraph]
     let primaryButtonTitle: String
     let primaryButtonAction: () -> Void
+    let primaryButtonAccessibilityIdentifier: String?
+    let secondaryButtonTitle: String?
+    let secondaryButtonAction: (() -> Void)?
+    let secondaryButtonAccessibilityIdentifier: String?
     let learnMoreTitle: String
     let learnMoreURL: URL?
     let showDragIndicator: Bool
@@ -20,6 +24,10 @@ struct FeatureInfoSheet: View {
         paragraphs: [FeatureInfoParagraph] = [],
         primaryButtonTitle: String = "Got it",
         primaryButtonAction: @escaping () -> Void,
+        primaryButtonAccessibilityIdentifier: String? = nil,
+        secondaryButtonTitle: String? = nil,
+        secondaryButtonAction: (() -> Void)? = nil,
+        secondaryButtonAccessibilityIdentifier: String? = nil,
         learnMoreTitle: String = "Learn more",
         learnMoreURL: URL? = nil,
         showDragIndicator: Bool = false
@@ -30,6 +38,10 @@ struct FeatureInfoSheet: View {
         self.paragraphs = paragraphs
         self.primaryButtonTitle = primaryButtonTitle
         self.primaryButtonAction = primaryButtonAction
+        self.primaryButtonAccessibilityIdentifier = primaryButtonAccessibilityIdentifier
+        self.secondaryButtonTitle = secondaryButtonTitle
+        self.secondaryButtonAction = secondaryButtonAction
+        self.secondaryButtonAccessibilityIdentifier = secondaryButtonAccessibilityIdentifier
         self.learnMoreTitle = learnMoreTitle
         self.learnMoreURL = learnMoreURL
         self.showDragIndicator = showDragIndicator
@@ -63,6 +75,17 @@ struct FeatureInfoSheet: View {
                     Text(primaryButtonTitle)
                 }
                 .convosButtonStyle(.rounded(fullWidth: true))
+                .accessibilityIdentifier(primaryButtonAccessibilityIdentifier ?? "")
+
+                if let secondaryButtonTitle, let secondaryButtonAction {
+                    let secondaryAction = { secondaryButtonAction() }
+                    Button(action: secondaryAction) {
+                        Text(secondaryButtonTitle)
+                    }
+                    .convosButtonStyle(.text)
+                    .frame(maxWidth: .infinity)
+                    .accessibilityIdentifier(secondaryButtonAccessibilityIdentifier ?? "")
+                }
 
                 if let learnMoreURL {
                     let learnMoreAction = { openURL(learnMoreURL) }

--- a/ConvosCore/Sources/ConvosCore/Inboxes/MessagingService+PushNotifications.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/MessagingService+PushNotifications.swift
@@ -151,18 +151,56 @@ extension MessagingService {
         )
 
         if let pairingRequest {
-            // Only let a genuinely surfaced pairing request short-circuit.
-            // The scan spans all recent DMs, not just this push's topic, so
-            // a deduped duplicate (.droppedMessage) might belong to an
-            // earlier push - returning it here would suppress a join-result
-            // or new-group notification this same push legitimately carries.
-            // On a duplicate, fall through to those checks instead.
+            // Only let a genuinely surfaced pairing request take the
+            // banner. The scan spans all recent DMs, not just this push's
+            // topic, so a deduped duplicate (.droppedMessage) might belong
+            // to an earlier push - returning it here would suppress a
+            // join-result or new-group notification this same push
+            // legitimately carries. On a duplicate, fall through instead.
             let notification = pairingRequestNotification(pairingRequest, userInfo: userInfo)
             if !notification.isDroppedMessage {
+                // The join-result / new-group handling still must run to
+                // completion: its state writes (setLastWelcomeProcessed,
+                // the GRDB bridge for a new group) can't be deferred to a
+                // later push, which would no longer see either event as
+                // new. Only the banner is superseded. A failure in that
+                // pass shouldn't cost the pairing banner, hence the catch.
+                do {
+                    _ = try await welcomeOutcomeNotification(
+                        joinRequestOutcomes: joinRequestOutcomes,
+                        existingGroupIds: existingGroupIds,
+                        processTime: processTime,
+                        client: client,
+                        userInfo: userInfo
+                    )
+                } catch {
+                    Log.error("Welcome outcome handling failed after pairing detection: \(error.localizedDescription)")
+                }
                 return notification
             }
         }
 
+        return try await welcomeOutcomeNotification(
+            joinRequestOutcomes: joinRequestOutcomes,
+            existingGroupIds: existingGroupIds,
+            processTime: processTime,
+            client: client,
+            userInfo: userInfo
+        )
+    }
+
+    /// The join-result ("accepted your invite") or new-group ("invite was
+    /// verified") notification for this welcome push, running the state
+    /// writes that go with each. Factored out of `handleWelcomeMessage` so
+    /// the pairing-request path can run it for its side effects while
+    /// keeping the pairing banner.
+    private func welcomeOutcomeNotification(
+        joinRequestOutcomes: [InviteJoinRequestOutcome],
+        existingGroupIds: Set<String>,
+        processTime: Date,
+        client: any XMTPClientProvider,
+        userInfo: [AnyHashable: Any]
+    ) async throws -> DecodedNotificationContent? {
         if let result = joinRequestOutcomes.compactMap(\.result).first {
             setLastWelcomeProcessed(processTime, for: client.inboxId)
 

--- a/ConvosCore/Sources/ConvosCore/Inboxes/MessagingService+PushNotifications.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/MessagingService+PushNotifications.swift
@@ -133,6 +133,14 @@ extension MessagingService {
         // Sync all conversations - this will fetch any groups we've been added to
         _ = try await client.conversationsProvider.syncAllConversations(consentStates: [.unknown])
 
+        // The pairing DM is a brand-new conversation, so a pairing join
+        // request's first delivery is this welcome push. Detect it before
+        // anything else can return - the joiner only waits a few minutes,
+        // and with no topic subscription for the new DM there may be no
+        // second push. Detection has no side effects; the invite
+        // processing below still runs either way.
+        let pairingRequest = await detectRecentPairingJoinRequest(client: client)
+
         // Case 1: Process join requests (others accepting our invites)
         let joinRequestOutcomes = await joinRequestsManager.processJoinRequestOutcomes(since: lastProcessed, client: client)
         await handleJoinRequestOutcomesForPush(
@@ -141,6 +149,19 @@ extension MessagingService {
             apiClient: apiClient,
             context: "welcome"
         )
+
+        if let pairingRequest {
+            // Only let a genuinely surfaced pairing request short-circuit.
+            // The scan spans all recent DMs, not just this push's topic, so
+            // a deduped duplicate (.droppedMessage) might belong to an
+            // earlier push - returning it here would suppress a join-result
+            // or new-group notification this same push legitimately carries.
+            // On a duplicate, fall through to those checks instead.
+            let notification = pairingRequestNotification(pairingRequest, userInfo: userInfo)
+            if !notification.isDroppedMessage {
+                return notification
+            }
+        }
 
         if let result = joinRequestOutcomes.compactMap(\.result).first {
             setLastWelcomeProcessed(processTime, for: client.inboxId)
@@ -333,6 +354,14 @@ extension MessagingService {
             if decodedMessage.senderInboxId == currentInboxId {
                 Log.debug("Dropping DM notification - message from self")
                 return .droppedMessage
+            }
+
+            // A pairing join request (the joiner re-sends every few
+            // seconds while connecting) - surface "<device> is requesting
+            // to pair" instead of feeding it to the invite flow.
+            if let identity = try? identityStore.loadSync(),
+               let pairingRequest = PairingJoinRequestDetector.verifiedJoinRequest(in: decodedMessage, identity: identity) {
+                return pairingRequestNotification(pairingRequest, userInfo: userInfo)
             }
 
             // DMs are only used for join requests (invite acceptance flow)
@@ -1171,5 +1200,95 @@ extension MessagingService {
         } catch {
             Log.error("NSE: Failed to schedule explosion notification: \(error.localizedDescription)")
         }
+    }
+}
+
+// MARK: - Pairing Join Requests
+
+extension MessagingService {
+    /// Scans recently created unknown-consent DMs for a verified pairing
+    /// join request (see `PairingJoinRequestDetector` for the security
+    /// model). Used by the welcome-push path, where the request's content
+    /// isn't in the payload - the pairing DM was just synced from the
+    /// network. Bounded to a handful of fresh DMs and their latest
+    /// messages so it stays cheap inside the NSE's time budget.
+    func detectRecentPairingJoinRequest(client: any XMTPClientProvider) async -> VerifiedPairingJoinRequest? {
+        guard let identity = try? identityStore.loadSync() else { return nil }
+        let cutoff = Date().addingTimeInterval(-PairingPushConstant.requestWindow)
+        let cutoffNs = Int64(cutoff.timeIntervalSince1970 * 1_000_000_000)
+        let dms: [Dm]
+        do {
+            dms = try client.conversationsProvider.listDms(
+                createdAfterNs: cutoffNs,
+                createdBeforeNs: nil,
+                lastActivityBeforeNs: nil,
+                lastActivityAfterNs: nil,
+                limit: PairingPushConstant.maxScannedDms,
+                consentStates: [.unknown],
+                orderBy: .createdAt
+            )
+        } catch {
+            Log.warning("NSE: failed to list DMs for pairing scan: \(error)")
+            return nil
+        }
+        for dm in dms {
+            let messages = (try? await dm.messages(limit: PairingPushConstant.maxScannedMessagesPerDm)) ?? []
+            for message in messages {
+                if let request = PairingJoinRequestDetector.verifiedJoinRequest(in: message, identity: identity) {
+                    return request
+                }
+            }
+        }
+        return nil
+    }
+
+    /// Builds the "<device> is requesting to pair" notification and
+    /// stashes the request for the main app to present on next activation
+    /// (`PendingPairRequestStore`). The stash doubles as the dedupe
+    /// record: the joiner re-sends its request every few seconds, and one
+    /// banner per burst is plenty.
+    func pairingRequestNotification(
+        _ request: VerifiedPairingJoinRequest,
+        userInfo: [AnyHashable: Any]
+    ) -> DecodedNotificationContent {
+        let appGroup = environment.appGroupIdentifier
+        if let existing = PendingPairRequestStore.pending(appGroup: appGroup),
+           existing.joinerInboxId == request.joinerInboxId,
+           Date().timeIntervalSince(existing.receivedAt) < PairingPushConstant.dedupeWindow {
+            Log.debug("NSE: suppressing duplicate pairing request notification")
+            return .droppedMessage
+        }
+        PendingPairRequestStore.setPending(
+            .init(
+                joinerInboxId: request.joinerInboxId,
+                deviceName: request.deviceName,
+                receivedAt: Date()
+            ),
+            appGroup: appGroup
+        )
+        Log.info("NSE: surfacing pairing join request from \(request.joinerInboxId)")
+        // The conversationId becomes the notification's threadIdentifier.
+        // Stamping the fixed pairing thread lets the system collapse a
+        // resend burst's banners and lets the app's activation cleanup
+        // find and remove NSE-posted ones (whose request identifiers are
+        // system-assigned and unknowable here).
+        return .init(
+            title: "Pair new device",
+            body: "\"\(request.deviceName)\" is requesting to pair",
+            conversationId: PairingNotificationThread.identifier,
+            userInfo: userInfo
+        )
+    }
+
+    private enum PairingPushConstant {
+        /// How far back a DM can have been created and still be scanned;
+        /// matches the joiner's resend window.
+        static let requestWindow: TimeInterval = 300
+        /// One banner per request burst: the joiner re-sends every ~5s,
+        /// and each NSE invocation is a fresh process, so dedupe lives in
+        /// the app-group stash rather than memory.
+        static let dedupeWindow: TimeInterval = 60
+        static let maxScannedDms: Int = 10
+        static let maxScannedMessagesPerDm: Int = 5
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Inboxes/MessagingService+PushNotifications.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/MessagingService+PushNotifications.swift
@@ -1252,6 +1252,19 @@ extension MessagingService {
         userInfo: [AnyHashable: Any]
     ) -> DecodedNotificationContent {
         let appGroup = environment.appGroupIdentifier
+        // Same replay guard as the stream fast path
+        // (`StreamProcessor.handlePairingJoinRequestFastPath`): the ledger
+        // is app-group backed, so a nonce already bound to the legitimate
+        // joiner rejects a different inbox replaying a captured slug even
+        // though this extension is a fresh process per push. The re-decode
+        // cannot fail: the detector just verified the slug.
+        guard let invite = try? PairingInvite.fromURLSafeSlug(request.slug) else { return .droppedMessage }
+        if let boundJoiner = PairingNonceLedger.shared.joiner(for: invite.nonce),
+           boundJoiner != request.joinerInboxId {
+            Log.warning("NSE: ignoring pairing join request replaying another joiner's slug")
+            return .droppedMessage
+        }
+        PairingNonceLedger.shared.bind(nonce: invite.nonce, toJoiner: request.joinerInboxId)
         if let existing = PendingPairRequestStore.pending(appGroup: appGroup),
            existing.joinerInboxId == request.joinerInboxId,
            Date().timeIntervalSince(existing.receivedAt) < PairingPushConstant.dedupeWindow {

--- a/ConvosCore/Sources/ConvosCore/Messaging/MessagingService.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/MessagingService.swift
@@ -93,6 +93,10 @@ final class MessagingService: MessagingServiceProtocol, @unchecked Sendable {
         self.environment = environment
         self.backgroundUploadManager = backgroundUploadManager
         self.coreActions = coreActions
+        // Both the app and the NSE construct a MessagingService, so this
+        // is the one bootstrap point common to every process that can
+        // verify a pairing join request.
+        PairingNonceLedger.shared.configure(appGroup: environment.appGroupIdentifier)
     }
 
     /// Constructs a MessagingService that represents the failed-keychain-read

--- a/ConvosCore/Sources/ConvosCore/Pairing/LivePairingService.swift
+++ b/ConvosCore/Sources/ConvosCore/Pairing/LivePairingService.swift
@@ -356,33 +356,10 @@ public final class LivePairingService: PairingServiceProtocol, @unchecked Sendab
         guard let identity = try identityStore.loadSync() else {
             throw LivePairingServiceError.identityUnavailable
         }
-        var nonce = Data(count: 16)
-        let nonceStatus: OSStatus = nonce.withUnsafeMutableBytes { bytes in
-            guard let baseAddress = bytes.baseAddress else { return errSecUnknownFormat }
-            return SecRandomCopyBytes(kSecRandomDefault, 16, baseAddress)
-        }
-        guard nonceStatus == errSecSuccess else {
-            Log.warning("Pairing: nonce generation failed status=\(nonceStatus); refusing to sign invite")
-            throw LivePairingServiceError.xmtpUnavailable
-        }
-        let issuedAt = Int64(Date().timeIntervalSince1970)
-        let expiresAtUnix = Int64(expiresAt.timeIntervalSince1970)
-        let address = identity.keys.privateKey.walletAddress
-        let payload = PairingInvite.signingPayload(
+        let invite = try await PairingInvite.signed(
             initiatorInboxId: identity.inboxId,
-            initiatorAddress: address,
-            nonce: nonce,
-            issuedAt: issuedAt,
-            expiresAt: expiresAtUnix
-        )
-        let signed = try await identity.keys.privateKey.sign(payload.toHexString())
-        let invite = PairingInvite(
-            initiatorInboxId: identity.inboxId,
-            initiatorAddress: address,
-            nonce: nonce,
-            issuedAt: issuedAt,
-            expiresAt: expiresAtUnix,
-            signature: signed.rawData
+            privateKey: identity.keys.privateKey,
+            expiresAt: expiresAt
         )
         return try invite.toURLSafeSlug()
     }

--- a/ConvosCore/Sources/ConvosCore/Pairing/PairableDeviceBackup.swift
+++ b/ConvosCore/Sources/ConvosCore/Pairing/PairableDeviceBackup.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+/// A device identity found in the iCloud-synced keychain backup slot that
+/// doesn't match this install's identity - i.e. another device on the same
+/// iCloud account the user can pair with. Carries only display metadata;
+/// the backup's key material stays inside ConvosCore
+/// (`SessionManager.pairingInviteSlug(forBackupInboxId:expiresAt:)` signs
+/// with it on demand).
+public struct PairableDeviceBackup: Sendable, Equatable {
+    public let inboxId: String
+    public let deviceName: String?
+    public let backedUpAt: Date?
+
+    public init(inboxId: String, deviceName: String?, backedUpAt: Date?) {
+        self.inboxId = inboxId
+        self.deviceName = deviceName
+        self.backedUpAt = backedUpAt
+    }
+}
+
+extension PairableDeviceBackup {
+    /// Filters raw synced backups down to identities other than
+    /// `currentInboxId` (a fresh install's own placeholder identity mirrors
+    /// itself into the backup slot, so the current identity is usually
+    /// present too), newest backup first. Static and pure so it can be
+    /// unit tested without a keychain.
+    static func pairableBackups(
+        from backups: [KeychainIdentityBackup],
+        excludingInboxId currentInboxId: String?
+    ) -> [PairableDeviceBackup] {
+        backups
+            .filter { $0.inboxId != currentInboxId }
+            .map { (backup: KeychainIdentityBackup) -> PairableDeviceBackup in
+                PairableDeviceBackup(
+                    inboxId: backup.inboxId,
+                    deviceName: backup.deviceName,
+                    backedUpAt: backup.backedUpAt
+                )
+            }
+            .sorted { ($0.backedUpAt ?? .distantPast) > ($1.backedUpAt ?? .distantPast) }
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Pairing/PairableDeviceBackup.swift
+++ b/ConvosCore/Sources/ConvosCore/Pairing/PairableDeviceBackup.swift
@@ -28,7 +28,13 @@ extension PairableDeviceBackup {
         from backups: [KeychainIdentityBackup],
         excludingInboxId currentInboxId: String?
     ) -> [PairableDeviceBackup] {
-        backups
+        // A nil current identity means the keychain read failed, not that
+        // there is nothing to exclude - without the exclusion this
+        // install's own backup would surface in the "Pair <device>?"
+        // prompt and offer a self-pair. Hide the prompt until the
+        // identity read succeeds (the check re-runs on next activation).
+        guard let currentInboxId else { return [] }
+        return backups
             .filter { $0.inboxId != currentInboxId }
             .map { (backup: KeychainIdentityBackup) -> PairableDeviceBackup in
                 PairableDeviceBackup(

--- a/ConvosCore/Sources/ConvosCore/Pairing/PairingCoordinator.swift
+++ b/ConvosCore/Sources/ConvosCore/Pairing/PairingCoordinator.swift
@@ -95,6 +95,29 @@ public actor PairingCoordinator {
         startExpirationTimer()
     }
 
+    /// Initiator entry for a join request that arrived before any pairing
+    /// UI was open (the iCloud-discovery joiner sends its request
+    /// unsolicited; the stream layer verified the slug signature before
+    /// surfacing it). Skips `.waitingForScan` and goes straight to
+    /// `.showingPin` for the given joiner. The caller sends the returned
+    /// PIN to the joiner, mirroring `receivedJoinRequest`.
+    public func startPairing(
+        respondingToJoinerInboxId joinerInboxId: String,
+        deviceName: String,
+        initiatorInboxId: String
+    ) async throws -> String {
+        guard case .idle = state else {
+            throw PairingError.alreadyPairing
+        }
+
+        self.initiatorInboxId = initiatorInboxId
+        let pin = Self.generatePin()
+        generatedPin = pin
+        updateState(.showingPin(pin: pin, deviceName: deviceName, joinerInboxId: joinerInboxId))
+        startExpirationTimer()
+        return pin
+    }
+
     public func receivedJoinRequest(joinerInboxId: String, deviceName: String) async throws {
         guard case .waitingForScan = state else { return }
 

--- a/ConvosCore/Sources/ConvosCore/Pairing/PairingInvite.swift
+++ b/ConvosCore/Sources/ConvosCore/Pairing/PairingInvite.swift
@@ -1,5 +1,6 @@
 import CryptoKit
 import Foundation
+import Security
 @preconcurrency import XMTPiOS
 
 /// The payload carried by the URL-safe slug in a `https://<domain>/pair/<slug>`
@@ -65,6 +66,7 @@ public enum PairingInviteError: Error, LocalizedError, Sendable {
     case expired
     case signatureInvalid
     case nonceInvalid
+    case nonceGenerationFailed
 
     public var errorDescription: String? {
         switch self {
@@ -78,6 +80,8 @@ public enum PairingInviteError: Error, LocalizedError, Sendable {
             return "Pairing invite signature is invalid"
         case .nonceInvalid:
             return "Pairing invite nonce is invalid"
+        case .nonceGenerationFailed:
+            return "Could not generate pairing invite nonce"
         }
     }
 }
@@ -111,6 +115,47 @@ public extension PairingInvite {
         }
         try invite.verifySignature()
         return invite
+    }
+
+    /// Creates a fully-signed invite for the given identity - the same
+    /// payload the initiator's QR flow encodes into a slug. Also used to
+    /// mint an invite on behalf of a device whose identity was found in
+    /// the iCloud-synced keychain backup: holding that backup's private
+    /// key carries the same authority the QR flow proves, so
+    /// `fromURLSafeSlug`'s signature check passes and the joiner's
+    /// identity-share validation anchors to the expected address.
+    static func signed(
+        initiatorInboxId: String,
+        privateKey: PrivateKey,
+        expiresAt: Date
+    ) async throws -> PairingInvite {
+        var nonce = Data(count: 16)
+        let nonceStatus: OSStatus = nonce.withUnsafeMutableBytes { bytes in
+            guard let baseAddress = bytes.baseAddress else { return errSecUnknownFormat }
+            return SecRandomCopyBytes(kSecRandomDefault, 16, baseAddress)
+        }
+        guard nonceStatus == errSecSuccess else {
+            throw PairingInviteError.nonceGenerationFailed
+        }
+        let issuedAt = Int64(Date().timeIntervalSince1970)
+        let expiresAtUnix = Int64(expiresAt.timeIntervalSince1970)
+        let address = privateKey.walletAddress
+        let payload = signingPayload(
+            initiatorInboxId: initiatorInboxId,
+            initiatorAddress: address,
+            nonce: nonce,
+            issuedAt: issuedAt,
+            expiresAt: expiresAtUnix
+        )
+        let signature = try await privateKey.sign(payload.toHexString())
+        return PairingInvite(
+            initiatorInboxId: initiatorInboxId,
+            initiatorAddress: address,
+            nonce: nonce,
+            issuedAt: issuedAt,
+            expiresAt: expiresAtUnix,
+            signature: signature.rawData
+        )
     }
 
     /// Recovers the signing address from `signature` over the canonical

--- a/ConvosCore/Sources/ConvosCore/Pairing/PairingJoinRequestDetector.swift
+++ b/ConvosCore/Sources/ConvosCore/Pairing/PairingJoinRequestDetector.swift
@@ -1,0 +1,67 @@
+import Foundation
+@preconcurrency import XMTPiOS
+
+/// A pairing join request that passed self-signature verification.
+public struct VerifiedPairingJoinRequest: Sendable, Equatable {
+    public let joinerInboxId: String
+    public let deviceName: String
+    public let slug: String
+
+    public init(joinerInboxId: String, deviceName: String, slug: String) {
+        self.joinerInboxId = joinerInboxId
+        self.deviceName = deviceName
+        self.slug = slug
+    }
+}
+
+/// Shared verification for pairing join requests that arrive outside an
+/// active pairing session - on the main message stream (`StreamProcessor`)
+/// or in a push notification (the NSE's welcome and message paths).
+///
+/// Only requests whose embedded invite slug is signed by this inbox's own
+/// identity key are surfaced: the iCloud-discovery joiner mints its slug
+/// from the synced keychain backup and the QR flow signs its slug locally,
+/// so both carry our signature, while a forged request can't - producing a
+/// valid slug requires the private key. The address comparison anchors
+/// that verification to our key: the slug's inboxId and address fields are
+/// attacker-choosable, but the signature only ever recovers to the
+/// signer's own address.
+public enum PairingJoinRequestDetector {
+    /// Returns the verified join request carried by `message`, or nil when
+    /// the message isn't a pairing join request or fails verification.
+    /// Decodes via the codec directly so it works on clients that never
+    /// registered the pairing codecs (the NSE's).
+    public static func verifiedJoinRequest(
+        in message: DecodedMessage,
+        identity: KeychainIdentity
+    ) -> VerifiedPairingJoinRequest? {
+        guard let typeId = try? message.encodedContent.type.typeID,
+              typeId == ContentTypePairingJoinRequest.typeID,
+              let content = try? PairingJoinRequestCodec().decode(content: message.encodedContent) else {
+            return nil
+        }
+        guard verify(slug: content.slug, senderInboxId: message.senderInboxId, identity: identity) else {
+            return nil
+        }
+        return VerifiedPairingJoinRequest(
+            joinerInboxId: message.senderInboxId,
+            deviceName: content.deviceName,
+            slug: content.slug
+        )
+    }
+
+    /// Pure verification core, separated from `DecodedMessage` extraction
+    /// so it can be unit tested with minted slugs. True when `slug` is a
+    /// valid, unexpired invite signed by `identity`'s own key and the
+    /// sender isn't this inbox itself.
+    public static func verify(
+        slug: String,
+        senderInboxId: String,
+        identity: KeychainIdentity
+    ) -> Bool {
+        guard senderInboxId != identity.inboxId else { return false }
+        guard let invite = try? PairingInvite.fromURLSafeSlug(slug) else { return false }
+        return invite.initiatorInboxId == identity.inboxId
+            && invite.initiatorAddress.lowercased() == identity.keys.privateKey.walletAddress.lowercased()
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Pairing/PairingNonceLedger.swift
+++ b/ConvosCore/Sources/ConvosCore/Pairing/PairingNonceLedger.swift
@@ -1,0 +1,62 @@
+import Foundation
+import os
+
+/// Binds each verified pairing-invite nonce to the first joiner inbox
+/// that presented it, so a slug captured in transit (photographed QR,
+/// leaked pair URL) can't be replayed by a different inbox to pop an
+/// unsolicited PIN sheet while the original is still unexpired. The
+/// legitimate joiner re-sends its request on a fixed cadence and always
+/// matches its own binding.
+///
+/// Process-wide singleton because more than one `StreamProcessor` exists
+/// per process (the syncing manager's and the conversation state
+/// machine's) and a replay can arrive on either. In-memory only: slugs
+/// expire within minutes, so a process restart forgetting bindings
+/// re-opens nothing beyond what expiry already allows.
+public final class PairingNonceLedger: Sendable {
+    public static let shared: PairingNonceLedger = PairingNonceLedger()
+
+    private struct Binding {
+        let joinerInboxId: String
+        let boundAt: Date
+    }
+
+    private let bindings: OSAllocatedUnfairLock<[Data: Binding]> = .init(initialState: [:])
+
+    init() {}
+
+    /// The joiner inbox the nonce is bound to, if any unexpired binding
+    /// exists.
+    public func joiner(for nonce: Data) -> String? {
+        bindings.withLock { state in
+            prune(&state)
+            return state[nonce]?.joinerInboxId
+        }
+    }
+
+    /// Binds the nonce to the joiner. First writer wins; rebinding the
+    /// same pair refreshes the timestamp so a long handshake's resends
+    /// keep the binding alive.
+    public func bind(nonce: Data, toJoiner joinerInboxId: String) {
+        bindings.withLock { state in
+            prune(&state)
+            if let existing = state[nonce], existing.joinerInboxId != joinerInboxId {
+                return
+            }
+            state[nonce] = Binding(joinerInboxId: joinerInboxId, boundAt: Date())
+        }
+    }
+
+    /// Drops bindings comfortably older than any slug's validity window,
+    /// keeping the table bounded without a timer.
+    private func prune(_ state: inout [Data: Binding]) {
+        let cutoff = Date().addingTimeInterval(-Constant.retention)
+        state = state.filter { $0.value.boundAt > cutoff }
+    }
+
+    private enum Constant {
+        /// Longest slug validity in the codebase is the iCloud-discovery
+        /// flow's 300s window; double it for clock skew headroom.
+        static let retention: TimeInterval = 600
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Pairing/PairingNonceLedger.swift
+++ b/ConvosCore/Sources/ConvosCore/Pairing/PairingNonceLedger.swift
@@ -39,10 +39,13 @@ public final class PairingNonceLedger: Sendable {
     /// only, which is sufficient inside one long-lived process but blind
     /// to bindings made by the other.
     public func configure(appGroup: String) {
-        guard UserDefaults(suiteName: appGroup) != nil else {
+        guard let defaults = UserDefaults(suiteName: appGroup) else {
             Log.warning("PairingNonceLedger: app-group suite unavailable, staying in-memory")
             return
         }
+        // Pre-release builds stored the whole ledger under one key; the
+        // blob is unreadable by the per-key format, so clear the residue.
+        defaults.removeObject(forKey: "convos.pairing.nonceLedger.v1")
         state.withLock { state in
             guard state.appGroup == nil else { return }
             state.appGroup = appGroup
@@ -69,24 +72,34 @@ public final class PairingNonceLedger: Sendable {
             if let existing = state.bindings[nonce], existing.joinerInboxId != joinerInboxId {
                 return
             }
-            state.bindings[nonce] = Binding(joinerInboxId: joinerInboxId, boundAt: Date())
-            persist(state)
+            let binding = Binding(joinerInboxId: joinerInboxId, boundAt: Date())
+            state.bindings[nonce] = binding
+            persist(nonce: nonce, binding: binding, appGroup: state.appGroup)
         }
     }
 
-    /// Folds the other process's persisted bindings into memory. On a
-    /// joiner conflict the earlier binding wins, preserving
-    /// first-writer-wins across processes.
+    /// Folds the other process's persisted bindings into memory, and
+    /// deletes expired persisted entries along the way. On a joiner
+    /// conflict the earlier binding wins, preserving first-writer-wins
+    /// across processes.
     private func mergePersisted(into state: inout State) {
         guard let appGroup = state.appGroup,
               let defaults = UserDefaults(suiteName: appGroup),
-              let stored = defaults.dictionary(forKey: Constant.storageKey) else { return }
-        for (key, value) in stored {
-            guard let nonce = Data(base64Encoded: key),
+              let domain = defaults.persistentDomain(forName: appGroup) else { return }
+        let cutoff = Date().addingTimeInterval(-Constant.retention)
+        for (key, value) in domain where key.hasPrefix(Constant.keyPrefix) {
+            guard let nonce = Data(base64Encoded: String(key.dropFirst(Constant.keyPrefix.count))),
                   let entry = value as? [String: Any],
                   let joiner = entry[Constant.joinerField] as? String,
-                  let timestamp = entry[Constant.boundAtField] as? TimeInterval else { continue }
+                  let timestamp = entry[Constant.boundAtField] as? TimeInterval else {
+                defaults.removeObject(forKey: key)
+                continue
+            }
             let persisted = Binding(joinerInboxId: joiner, boundAt: Date(timeIntervalSince1970: timestamp))
+            guard persisted.boundAt > cutoff else {
+                defaults.removeObject(forKey: key)
+                continue
+            }
             if let existing = state.bindings[nonce],
                existing.joinerInboxId != persisted.joinerInboxId,
                existing.boundAt <= persisted.boundAt {
@@ -96,21 +109,24 @@ public final class PairingNonceLedger: Sendable {
         }
     }
 
-    private func persist(_ state: State) {
-        guard let appGroup = state.appGroup,
+    /// Writes one binding under its own per-nonce key. Whole-ledger
+    /// snapshot writes would race the other process: the app binding
+    /// nonce A and the NSE binding nonce B concurrently would each
+    /// overwrite the other's entry, silently dropping replay-guard
+    /// state. Per-key writes only ever touch the caller's own nonce.
+    private func persist(nonce: Data, binding: Binding, appGroup: String?) {
+        guard let appGroup,
               let defaults = UserDefaults(suiteName: appGroup) else { return }
-        var stored: [String: [String: Any]] = [:]
-        for (nonce, binding) in state.bindings {
-            stored[nonce.base64EncodedString()] = [
-                Constant.joinerField: binding.joinerInboxId,
-                Constant.boundAtField: binding.boundAt.timeIntervalSince1970,
-            ]
-        }
-        defaults.set(stored, forKey: Constant.storageKey)
+        let entry: [String: Any] = [
+            Constant.joinerField: binding.joinerInboxId,
+            Constant.boundAtField: binding.boundAt.timeIntervalSince1970,
+        ]
+        defaults.set(entry, forKey: Constant.keyPrefix + nonce.base64EncodedString())
     }
 
     /// Drops bindings comfortably older than any slug's validity window,
-    /// keeping the table bounded without a timer.
+    /// keeping the table bounded without a timer. Persisted entries are
+    /// pruned as they're encountered in `mergePersisted`.
     private func prune(_ bindings: inout [Data: Binding]) {
         let cutoff = Date().addingTimeInterval(-Constant.retention)
         bindings = bindings.filter { $0.value.boundAt > cutoff }
@@ -120,7 +136,7 @@ public final class PairingNonceLedger: Sendable {
         /// Longest slug validity in the codebase is the iCloud-discovery
         /// flow's 300s window; double it for clock skew headroom.
         static let retention: TimeInterval = 600
-        static let storageKey: String = "convos.pairing.nonceLedger.v1"
+        static let keyPrefix: String = "convos.pairing.nonceLedger.v2."
         static let joinerField: String = "j"
         static let boundAtField: String = "t"
     }

--- a/ConvosCore/Sources/ConvosCore/Pairing/PairingNonceLedger.swift
+++ b/ConvosCore/Sources/ConvosCore/Pairing/PairingNonceLedger.swift
@@ -4,15 +4,18 @@ import os
 /// Binds each verified pairing-invite nonce to the first joiner inbox
 /// that presented it, so a slug captured in transit (photographed QR,
 /// leaked pair URL) can't be replayed by a different inbox to pop an
-/// unsolicited PIN sheet while the original is still unexpired. The
-/// legitimate joiner re-sends its request on a fixed cadence and always
-/// matches its own binding.
+/// unsolicited PIN sheet or pairing banner while the original is still
+/// unexpired. The legitimate joiner re-sends its request on a fixed
+/// cadence and always matches its own binding.
 ///
 /// Process-wide singleton because more than one `StreamProcessor` exists
 /// per process (the syncing manager's and the conversation state
-/// machine's) and a replay can arrive on either. In-memory only: slugs
-/// expire within minutes, so a process restart forgetting bindings
-/// re-opens nothing beyond what expiry already allows.
+/// machine's) and a replay can arrive on either. Optionally backed by
+/// app-group storage (see `configure(appGroup:)`) so bindings also span
+/// processes: the Notification Service Extension is a fresh process per
+/// push, and without a shared backing its ledger would always be empty.
+/// Bindings expire within minutes either way, so losing them re-opens
+/// nothing beyond what slug expiry already allows.
 public final class PairingNonceLedger: Sendable {
     public static let shared: PairingNonceLedger = PairingNonceLedger()
 
@@ -21,16 +24,38 @@ public final class PairingNonceLedger: Sendable {
         let boundAt: Date
     }
 
-    private let bindings: OSAllocatedUnfairLock<[Data: Binding]> = .init(initialState: [:])
+    private struct State {
+        var bindings: [Data: Binding] = [:]
+        var appGroup: String?
+    }
+
+    private let state: OSAllocatedUnfairLock<State> = .init(initialState: State())
 
     init() {}
+
+    /// Backs the ledger with app-group UserDefaults so the app and the
+    /// NSE share bindings. Call once per process at messaging bootstrap;
+    /// later calls are ignored. Without this the ledger is in-memory
+    /// only, which is sufficient inside one long-lived process but blind
+    /// to bindings made by the other.
+    public func configure(appGroup: String) {
+        guard UserDefaults(suiteName: appGroup) != nil else {
+            Log.warning("PairingNonceLedger: app-group suite unavailable, staying in-memory")
+            return
+        }
+        state.withLock { state in
+            guard state.appGroup == nil else { return }
+            state.appGroup = appGroup
+        }
+    }
 
     /// The joiner inbox the nonce is bound to, if any unexpired binding
     /// exists.
     public func joiner(for nonce: Data) -> String? {
-        bindings.withLock { state in
-            prune(&state)
-            return state[nonce]?.joinerInboxId
+        state.withLock { state in
+            mergePersisted(into: &state)
+            prune(&state.bindings)
+            return state.bindings[nonce]?.joinerInboxId
         }
     }
 
@@ -38,25 +63,65 @@ public final class PairingNonceLedger: Sendable {
     /// same pair refreshes the timestamp so a long handshake's resends
     /// keep the binding alive.
     public func bind(nonce: Data, toJoiner joinerInboxId: String) {
-        bindings.withLock { state in
-            prune(&state)
-            if let existing = state[nonce], existing.joinerInboxId != joinerInboxId {
+        state.withLock { state in
+            mergePersisted(into: &state)
+            prune(&state.bindings)
+            if let existing = state.bindings[nonce], existing.joinerInboxId != joinerInboxId {
                 return
             }
-            state[nonce] = Binding(joinerInboxId: joinerInboxId, boundAt: Date())
+            state.bindings[nonce] = Binding(joinerInboxId: joinerInboxId, boundAt: Date())
+            persist(state)
         }
+    }
+
+    /// Folds the other process's persisted bindings into memory. On a
+    /// joiner conflict the earlier binding wins, preserving
+    /// first-writer-wins across processes.
+    private func mergePersisted(into state: inout State) {
+        guard let appGroup = state.appGroup,
+              let defaults = UserDefaults(suiteName: appGroup),
+              let stored = defaults.dictionary(forKey: Constant.storageKey) else { return }
+        for (key, value) in stored {
+            guard let nonce = Data(base64Encoded: key),
+                  let entry = value as? [String: Any],
+                  let joiner = entry[Constant.joinerField] as? String,
+                  let timestamp = entry[Constant.boundAtField] as? TimeInterval else { continue }
+            let persisted = Binding(joinerInboxId: joiner, boundAt: Date(timeIntervalSince1970: timestamp))
+            if let existing = state.bindings[nonce],
+               existing.joinerInboxId != persisted.joinerInboxId,
+               existing.boundAt <= persisted.boundAt {
+                continue
+            }
+            state.bindings[nonce] = persisted
+        }
+    }
+
+    private func persist(_ state: State) {
+        guard let appGroup = state.appGroup,
+              let defaults = UserDefaults(suiteName: appGroup) else { return }
+        var stored: [String: [String: Any]] = [:]
+        for (nonce, binding) in state.bindings {
+            stored[nonce.base64EncodedString()] = [
+                Constant.joinerField: binding.joinerInboxId,
+                Constant.boundAtField: binding.boundAt.timeIntervalSince1970,
+            ]
+        }
+        defaults.set(stored, forKey: Constant.storageKey)
     }
 
     /// Drops bindings comfortably older than any slug's validity window,
     /// keeping the table bounded without a timer.
-    private func prune(_ state: inout [Data: Binding]) {
+    private func prune(_ bindings: inout [Data: Binding]) {
         let cutoff = Date().addingTimeInterval(-Constant.retention)
-        state = state.filter { $0.value.boundAt > cutoff }
+        bindings = bindings.filter { $0.value.boundAt > cutoff }
     }
 
     private enum Constant {
         /// Longest slug validity in the codebase is the iCloud-discovery
         /// flow's 300s window; double it for clock skew headroom.
         static let retention: TimeInterval = 600
+        static let storageKey: String = "convos.pairing.nonceLedger.v1"
+        static let joinerField: String = "j"
+        static let boundAtField: String = "t"
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Pairing/PairingService.swift
+++ b/ConvosCore/Sources/ConvosCore/Pairing/PairingService.swift
@@ -23,6 +23,14 @@ public extension Notification.Name {
     /// Posted by the initiator-side PairingService when the joiner echoes
     /// the PIN back. `userInfo` contains `pin: String` and `joinerInboxId: String`.
     static let pairingDidReceivePinEcho: Notification.Name = Notification.Name("convos.pairing.didReceivePinEcho")
+
+    /// Posted by `StreamProcessor` when a `PairingJoinRequest` DM arrives
+    /// via the main message stream (no pairing screen open) and its
+    /// embedded invite slug verifies against this device's own identity
+    /// key. The host app surfaces an initiator pairing sheet in response.
+    /// `userInfo` contains `joinerInboxId: String`, `deviceName: String`,
+    /// and `slug: String`.
+    static let pairingDidReceiveVerifiedJoinRequest: Notification.Name = Notification.Name("convos.pairing.didReceiveVerifiedJoinRequest")
 }
 
 /// Carried in `PairingService.pairingJoinRequestStream` for the initiator

--- a/ConvosCore/Sources/ConvosCore/Pairing/PendingPairRequestStore.swift
+++ b/ConvosCore/Sources/ConvosCore/Pairing/PendingPairRequestStore.swift
@@ -1,0 +1,79 @@
+import Foundation
+
+/// Hands a verified pairing join request from the Notification Service
+/// Extension to the main app. The NSE can't present the pairing sheet, so
+/// it stashes the request here (and shows a "<device> is requesting to
+/// pair" banner); the app consumes the stash on its next activation and
+/// presents the initiator flow. Also acts as the NSE's notification
+/// dedupe: the joiner re-sends its request every few seconds, and one
+/// banner per request burst is plenty.
+///
+/// Storage is app-group UserDefaults so both processes see it, mirroring
+/// `PairedDeviceNameStore`. UserDefaults is process-safe.
+public enum PendingPairRequestStore {
+    /// Display metadata only - deliberately no invite slug. A valid
+    /// unexpired slug is a bearer credential (it passes
+    /// `PairingJoinRequestDetector.verify` from any inbox), and the
+    /// app-group plist is plaintext and included in device backups; the
+    /// consumer only needs the joiner identity and a name to present
+    /// the PIN sheet.
+    public struct Pending: Codable, Sendable, Equatable {
+        public let joinerInboxId: String
+        public let deviceName: String
+        public let receivedAt: Date
+
+        public init(joinerInboxId: String, deviceName: String, receivedAt: Date) {
+            self.joinerInboxId = joinerInboxId
+            self.deviceName = deviceName
+            self.receivedAt = receivedAt
+        }
+    }
+
+    private static let pendingKey: String = "convos.pairing.pendingJoinRequest.v1"
+
+    private static func defaults(for appGroup: String) -> UserDefaults {
+        guard let suite = UserDefaults(suiteName: appGroup) else {
+            // Falling back means the NSE and the app each write their own
+            // standard defaults and the handoff silently never happens -
+            // make that observable.
+            Log.warning("PendingPairRequestStore: app-group suite unavailable, falling back to standard defaults")
+            return .standard
+        }
+        return suite
+    }
+
+    /// Stashes the request, replacing any previous one.
+    public static func setPending(_ pending: Pending, appGroup: String) {
+        guard let data = try? JSONEncoder().encode(pending) else { return }
+        defaults(for: appGroup).set(data, forKey: pendingKey)
+    }
+
+    /// Reads without clearing. The NSE uses this for dedupe decisions.
+    public static func pending(appGroup: String) -> Pending? {
+        guard let data = defaults(for: appGroup).data(forKey: pendingKey) else { return nil }
+        return try? JSONDecoder().decode(Pending.self, from: data)
+    }
+
+    /// Reads and clears. The app calls this on activation, and also when
+    /// the stream path presents a request directly - the NSE stashes for
+    /// pushes that arrive while the app is foregrounded too, and a stash
+    /// left behind after the flow was handled would re-present a ghost
+    /// PIN sheet on the next activation.
+    public static func consumePending(appGroup: String) -> Pending? {
+        let defs = defaults(for: appGroup)
+        guard let data = defs.data(forKey: pendingKey) else { return nil }
+        defs.removeObject(forKey: pendingKey)
+        return try? JSONDecoder().decode(Pending.self, from: data)
+    }
+}
+
+/// Thread identifier stamped on every "is requesting to pair"
+/// notification - the NSE's remote ones (via
+/// `DecodedNotificationContent.conversationId`, which the extension maps
+/// to `threadIdentifier`) and the app's local one - so the system
+/// collapses a resend burst into one thread and the app's activation
+/// cleanup can remove NSE-posted banners whose request identifiers are
+/// system-assigned.
+public enum PairingNotificationThread {
+    public static let identifier: String = "incoming-pairing-request"
+}

--- a/ConvosCore/Sources/ConvosCore/Pairing/PendingPairRequestStore.swift
+++ b/ConvosCore/Sources/ConvosCore/Pairing/PendingPairRequestStore.swift
@@ -62,8 +62,16 @@ public enum PendingPairRequestStore {
     public static func consumePending(appGroup: String) -> Pending? {
         let defs = defaults(for: appGroup)
         guard let data = defs.data(forKey: pendingKey) else { return nil }
+        // Decode before removing so a decode failure (schema drift from a
+        // version skew between the NSE and the app) doesn't silently
+        // destroy the request; an undecodable blob is left for the
+        // joiner's next resend to overwrite via `setPending`.
+        guard let pending = try? JSONDecoder().decode(Pending.self, from: data) else {
+            Log.warning("PendingPairRequestStore: pending request failed to decode, leaving for overwrite")
+            return nil
+        }
         defs.removeObject(forKey: pendingKey)
-        return try? JSONDecoder().decode(Pending.self, from: data)
+        return pending
     }
 }
 

--- a/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
@@ -1114,6 +1114,47 @@ public extension SessionManager {
         }
     }
 
+    /// Reads the iCloud-synced backup slot and returns every identity that
+    /// isn't this install's own (a fresh install's placeholder identity
+    /// mirrors itself into the slot, so it must be excluded), newest
+    /// backup first. Best-effort: keychain failures return an empty list
+    /// so the prompt simply doesn't show.
+    ///
+    /// The backups are read before the primary slot on purpose: a backup
+    /// mirror is only ever written after its primary, so any identity
+    /// present in the backups read here is guaranteed visible to the
+    /// `loadSync()` that follows. Reading in the other order races silent
+    /// identity registration and could report this install's own
+    /// just-created placeholder as pairable.
+    func pairableDeviceBackups() async -> [PairableDeviceBackup] {
+        do {
+            let backups = try await identityStore.loadSyncedBackups()
+            let currentInboxId = (try? identityStore.loadSync())?.inboxId
+            return PairableDeviceBackup.pairableBackups(from: backups, excludingInboxId: currentInboxId)
+        } catch {
+            Log.warning("SessionManager.pairableDeviceBackups failed: \(error)")
+            return []
+        }
+    }
+
+    /// Signs a pairing invite with the synced backup's private key. The
+    /// key never leaves ConvosCore - the caller only receives the slug,
+    /// which carries the same authority as a slug minted by the backed-up
+    /// device itself, so the joiner's signature and identity-share address
+    /// checks hold unchanged.
+    func pairingInviteSlug(forBackupInboxId inboxId: String, expiresAt: Date) async throws -> String {
+        let backups = try await identityStore.loadSyncedBackups()
+        guard let backup = backups.first(where: { $0.inboxId == inboxId }) else {
+            throw KeychainIdentityStoreError.identityNotFound("synced backup for pairing")
+        }
+        let invite = try await PairingInvite.signed(
+            initiatorInboxId: backup.inboxId,
+            privateKey: backup.privateKey,
+            expiresAt: expiresAt
+        )
+        return try invite.toURLSafeSlug()
+    }
+
     /// Called after a successful pairing on the joiner side. The paired
     /// secp256k1 key was already saved to the keychain by
     /// `LivePairingService.handleIdentityShare` before this runs. We:

--- a/ConvosCore/Sources/ConvosCore/Sessions/SessionManagerProtocol.swift
+++ b/ConvosCore/Sources/ConvosCore/Sessions/SessionManagerProtocol.swift
@@ -38,6 +38,19 @@ public protocol SessionManagerProtocol: AnyObject, Sendable {
     /// without a destructive warning.
     func hasAnyUsedConversations() async -> Bool
 
+    /// Identities found in the iCloud-synced keychain backup slot that
+    /// don't match this install's identity - other devices on the same
+    /// iCloud account the user could pair with. Newest backup first.
+    /// Drives the first-install "Pair <device>?" prompt; returns an empty
+    /// array when there is nothing to offer.
+    func pairableDeviceBackups() async -> [PairableDeviceBackup]
+
+    /// Mints a signed pairing-invite slug on behalf of the backed-up
+    /// device (its synced private key signs the invite, exactly like the
+    /// QR flow does on the initiator), so the joiner flow can target that
+    /// device without scanning anything.
+    func pairingInviteSlug(forBackupInboxId inboxId: String, expiresAt: Date) async throws -> String
+
     // MARK: Inbox Management
 
     /// Returns the shared messaging service and an optional conversation id
@@ -244,6 +257,18 @@ public protocol SessionManagerProtocol: AnyObject, Sendable {
 }
 
 extension SessionManagerProtocol {
+    /// Default for conformers without keychain access (test mocks): no
+    /// other devices to pair with. The real lookup lives on `SessionManager`.
+    public func pairableDeviceBackups() async -> [PairableDeviceBackup] {
+        []
+    }
+
+    /// Default for conformers without keychain access (test mocks). The
+    /// real signing path lives on `SessionManager`.
+    public func pairingInviteSlug(forBackupInboxId inboxId: String, expiresAt: Date) async throws -> String {
+        throw KeychainIdentityStoreError.identityNotFound("synced backup for pairing")
+    }
+
     /// Default agent-share resolver. Returns the mock until the API-backed
     /// resolver is wired into `SessionManager`, so every conformer (including
     /// test mocks) gets a working resolver without bespoke wiring.

--- a/ConvosCore/Sources/ConvosCore/Syncing/StreamProcessor.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/StreamProcessor.swift
@@ -233,7 +233,7 @@ actor StreamProcessor: StreamProcessorProtocol {
         params: SyncClientParams,
         activeConversationId: String?
     ) async {
-        if handleDeviceRemovedFastPath(message: message, params: params) { return }
+        if handleFastPaths(message: message, params: params) { return }
 
         let perfStart = CFAbsoluteTimeGetCurrent()
         do {
@@ -340,6 +340,14 @@ actor StreamProcessor: StreamProcessorProtocol {
     }
 
     // MARK: - Private Helpers
+
+    /// Pre-conversation-lookup handlers for system-signal content types
+    /// that need no conversation context. Returns true when the message
+    /// was consumed and normal processing should stop.
+    private func handleFastPaths(message: DecodedMessage, params: SyncClientParams) -> Bool {
+        if handleDeviceRemovedFastPath(message: message, params: params) { return true }
+        return handlePairingJoinRequestFastPath(message: message, params: params)
+    }
 
     private func decodeInviteJoinError(from message: DecodedMessage) -> InviteJoinError? {
         guard let encodedContentType = try? message.encodedContent.type,
@@ -878,6 +886,73 @@ extension StreamProcessor {
             name: .installationWasRevokedByPeer,
             object: nil,
             userInfo: ["revokedInstallationId": removal.revokedInstallationId]
+        )
+        return true
+    }
+}
+
+// MARK: - Pairing Join Requests
+
+extension StreamProcessor {
+    /// Pre-conversation-lookup fast path for `PairingJoinRequestContent`,
+    /// so "another device wants to pair" surfaces even when the Devices
+    /// pairing screen isn't open (the iCloud-discovery joiner sends its
+    /// request unsolicited).
+    ///
+    /// Only requests whose embedded invite slug is signed by this inbox's
+    /// own identity key are surfaced: the iCloud-discovery joiner mints
+    /// its slug from the synced keychain backup and the QR flow signs its
+    /// slug locally, so both carry our signature, while a forged request
+    /// can't - producing a valid slug requires the private key. The
+    /// address comparison anchors that verification to our key: the
+    /// slug's inboxId and address fields are attacker-choosable, but the
+    /// signature only ever recovers to the signer's own address.
+    ///
+    /// Returns true whenever the message is a pairing join request (valid
+    /// or not) so normal message processing skips it either way.
+    func handlePairingJoinRequestFastPath(message: DecodedMessage, params: SyncClientParams) -> Bool {
+        guard let typeId = try? message.encodedContent.type.typeID,
+              typeId == ContentTypePairingJoinRequest.typeID else {
+            return false
+        }
+        guard message.senderInboxId != params.client.inboxId,
+              let content = try? message.content() as PairingJoinRequestContent else {
+            return true
+        }
+        let invite: PairingInvite
+        do {
+            invite = try PairingInvite.fromURLSafeSlug(content.slug)
+        } catch {
+            Log.warning("StreamProcessor: ignoring pairing join request with undecodable or expired slug: \(error)")
+            return true
+        }
+        guard let identity = try? identityStore.loadSync(),
+              invite.initiatorInboxId == identity.inboxId,
+              invite.initiatorAddress.lowercased() == identity.keys.privateKey.walletAddress.lowercased() else {
+            Log.warning("StreamProcessor: ignoring pairing join request whose slug wasn't signed by this identity")
+            return true
+        }
+        // Bind the slug's nonce to the first joiner that used it: the
+        // legit joiner's resend loop reuses its slug freely, but a
+        // different inbox replaying a captured slug (e.g. a photographed
+        // QR still inside its expiry window) is dropped instead of
+        // popping an unsolicited PIN sheet. In-memory is enough - slugs
+        // expire in minutes and the processor outlives any handshake.
+        if let boundJoiner = PairingNonceLedger.shared.joiner(for: invite.nonce),
+           boundJoiner != message.senderInboxId {
+            Log.warning("StreamProcessor: ignoring pairing join request replaying another joiner's slug")
+            return true
+        }
+        PairingNonceLedger.shared.bind(nonce: invite.nonce, toJoiner: message.senderInboxId)
+        Log.info("StreamProcessor: verified pairing join request from joiner \(message.senderInboxId) - surfacing")
+        NotificationCenter.default.post(
+            name: .pairingDidReceiveVerifiedJoinRequest,
+            object: nil,
+            userInfo: [
+                "joinerInboxId": message.senderInboxId,
+                "deviceName": content.deviceName,
+                "slug": content.slug
+            ]
         )
         return true
     }

--- a/ConvosCore/Sources/ConvosCore/Syncing/StreamProcessor.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/StreamProcessor.swift
@@ -897,16 +897,9 @@ extension StreamProcessor {
     /// Pre-conversation-lookup fast path for `PairingJoinRequestContent`,
     /// so "another device wants to pair" surfaces even when the Devices
     /// pairing screen isn't open (the iCloud-discovery joiner sends its
-    /// request unsolicited).
-    ///
-    /// Only requests whose embedded invite slug is signed by this inbox's
-    /// own identity key are surfaced: the iCloud-discovery joiner mints
-    /// its slug from the synced keychain backup and the QR flow signs its
-    /// slug locally, so both carry our signature, while a forged request
-    /// can't - producing a valid slug requires the private key. The
-    /// address comparison anchors that verification to our key: the
-    /// slug's inboxId and address fields are attacker-choosable, but the
-    /// signature only ever recovers to the signer's own address.
+    /// request unsolicited). Verification - the slug must be signed by
+    /// this inbox's own identity key - lives in
+    /// `PairingJoinRequestDetector`, shared with the NSE's push paths.
     ///
     /// Returns true whenever the message is a pairing join request (valid
     /// or not) so normal message processing skips it either way.
@@ -915,21 +908,9 @@ extension StreamProcessor {
               typeId == ContentTypePairingJoinRequest.typeID else {
             return false
         }
-        guard message.senderInboxId != params.client.inboxId,
-              let content = try? message.content() as PairingJoinRequestContent else {
-            return true
-        }
-        let invite: PairingInvite
-        do {
-            invite = try PairingInvite.fromURLSafeSlug(content.slug)
-        } catch {
-            Log.warning("StreamProcessor: ignoring pairing join request with undecodable or expired slug: \(error)")
-            return true
-        }
-        guard let identity = try? identityStore.loadSync(),
-              invite.initiatorInboxId == identity.inboxId,
-              invite.initiatorAddress.lowercased() == identity.keys.privateKey.walletAddress.lowercased() else {
-            Log.warning("StreamProcessor: ignoring pairing join request whose slug wasn't signed by this identity")
+        guard let identity = try? identityStore.loadSync() else { return true }
+        guard let request = PairingJoinRequestDetector.verifiedJoinRequest(in: message, identity: identity) else {
+            Log.warning("StreamProcessor: ignoring pairing join request that failed verification")
             return true
         }
         // Bind the slug's nonce to the first joiner that used it: the
@@ -938,20 +919,22 @@ extension StreamProcessor {
         // QR still inside its expiry window) is dropped instead of
         // popping an unsolicited PIN sheet. In-memory is enough - slugs
         // expire in minutes and the processor outlives any handshake.
+        // The re-decode cannot fail: the detector just verified the slug.
+        guard let invite = try? PairingInvite.fromURLSafeSlug(request.slug) else { return true }
         if let boundJoiner = PairingNonceLedger.shared.joiner(for: invite.nonce),
-           boundJoiner != message.senderInboxId {
+           boundJoiner != request.joinerInboxId {
             Log.warning("StreamProcessor: ignoring pairing join request replaying another joiner's slug")
             return true
         }
-        PairingNonceLedger.shared.bind(nonce: invite.nonce, toJoiner: message.senderInboxId)
-        Log.info("StreamProcessor: verified pairing join request from joiner \(message.senderInboxId) - surfacing")
+        PairingNonceLedger.shared.bind(nonce: invite.nonce, toJoiner: request.joinerInboxId)
+        Log.info("StreamProcessor: verified pairing join request from joiner \(request.joinerInboxId) - surfacing")
         NotificationCenter.default.post(
             name: .pairingDidReceiveVerifiedJoinRequest,
             object: nil,
             userInfo: [
-                "joinerInboxId": message.senderInboxId,
-                "deviceName": content.deviceName,
-                "slug": content.slug
+                "joinerInboxId": request.joinerInboxId,
+                "deviceName": request.deviceName,
+                "slug": request.slug
             ]
         )
         return true

--- a/ConvosCore/Tests/ConvosCoreTests/Integration/PairingPushDetectionIntegrationTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/Integration/PairingPushDetectionIntegrationTests.swift
@@ -1,0 +1,99 @@
+@testable import ConvosCore
+import Foundation
+import Testing
+@preconcurrency import XMTPiOS
+
+/// Integration coverage for the NSE's welcome-push pairing detection, run
+/// against a local XMTP node (`./dev/up`). Simulators never spawn the
+/// real notification extension for `simctl push`, so this exercises the
+/// exact code the NSE runs - `detectRecentPairingJoinRequest` over a real
+/// synced DM and `pairingRequestNotification`'s stash + dedupe - with a
+/// real joiner client sending a real `PairingJoinRequestContent`.
+@Suite("Pairing Push Detection Integration", .serialized)
+struct PairingPushDetectionIntegrationTests {
+    @Test("Welcome-path scan surfaces only a self-signed join request")
+    func welcomeScanSurfacesVerifiedRequest() async throws {
+        let fixtures = TestFixtures()
+        // Create the joiner first: `createClient` saves each identity into
+        // the single keychain slot, and the service must verify against
+        // the initiator's identity (the slot's final occupant).
+        let (joiner, _, _) = try await fixtures.createClient()
+        let (initiator, _, initiatorKeys) = try await fixtures.createClient()
+        defer {
+            try? joiner.deleteLocalDatabase()
+            try? initiator.deleteLocalDatabase()
+        }
+        let service = fixtures.makeFreshMessagingService()
+
+        let dm = try await joiner.conversationsProvider.findOrCreateDm(with: initiator.inboxId)
+
+        // A forged request first: valid signature from a random key that
+        // names the initiator's inboxId - the spoof the address check
+        // rejects. With only this in the DM, nothing may surface.
+        let attackerKey = try PrivateKey.generate()
+        let forgedInvite = try await PairingInvite.signed(
+            initiatorInboxId: initiator.inboxId,
+            privateKey: attackerKey,
+            expiresAt: Date().addingTimeInterval(300)
+        )
+        try await sendJoinRequest(
+            slug: try forgedInvite.toURLSafeSlug(),
+            deviceName: "Attacker Phone",
+            from: joiner,
+            on: dm
+        )
+        _ = try await initiator.conversationsProvider.syncAllConversations(consentStates: [.unknown])
+        let forgedResult = await service.detectRecentPairingJoinRequest(client: initiator)
+        #expect(forgedResult == nil)
+
+        // The real request: slug minted from the initiator's own key,
+        // exactly what the iCloud-discovery joiner sends.
+        let invite = try await PairingInvite.signed(
+            initiatorInboxId: initiator.inboxId,
+            privateKey: initiatorKeys.privateKey,
+            expiresAt: Date().addingTimeInterval(300)
+        )
+        let slug = try invite.toURLSafeSlug()
+        try await sendJoinRequest(slug: slug, deviceName: "Joiner Phone", from: joiner, on: dm)
+        _ = try await initiator.conversationsProvider.syncAllConversations(consentStates: [.unknown])
+
+        let request = try #require(await service.detectRecentPairingJoinRequest(client: initiator))
+        #expect(request.joinerInboxId == joiner.inboxId)
+        #expect(request.deviceName == "Joiner Phone")
+        #expect(request.slug == slug)
+
+        // Notification building: first call stashes + notifies, the
+        // immediate repeat (a resend hitting another NSE invocation)
+        // dedupes against the stash.
+        let appGroup = fixtures.environment.appGroupIdentifier
+        _ = PendingPairRequestStore.consumePending(appGroup: appGroup)
+        defer { _ = PendingPairRequestStore.consumePending(appGroup: appGroup) }
+
+        let notification = service.pairingRequestNotification(request, userInfo: [:])
+        #expect(notification.body == "\"Joiner Phone\" is requesting to pair")
+        #expect(notification.isDroppedMessage == false)
+        // conversationId doubles as the threadIdentifier the app's
+        // delivered-banner cleanup matches on.
+        #expect(notification.conversationId == PairingNotificationThread.identifier)
+        let stashed = try #require(PendingPairRequestStore.pending(appGroup: appGroup))
+        #expect(stashed.joinerInboxId == joiner.inboxId)
+
+        let repeated = service.pairingRequestNotification(request, userInfo: [:])
+        #expect(repeated.isDroppedMessage)
+    }
+
+    private func sendJoinRequest(
+        slug: String,
+        deviceName: String,
+        from joiner: any XMTPClientProvider,
+        on dm: Dm
+    ) async throws {
+        let content = PairingJoinRequestContent(
+            slug: slug,
+            joinerInboxId: joiner.inboxId,
+            deviceName: deviceName
+        )
+        let encoded = try PairingJoinRequestCodec().encode(content: content)
+        _ = try await dm.send(encodedContent: encoded)
+    }
+}

--- a/ConvosCore/Tests/ConvosCoreTests/PairableDeviceBackupTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/PairableDeviceBackupTests.swift
@@ -1,0 +1,148 @@
+@testable import ConvosCore
+import Foundation
+import Testing
+@preconcurrency import XMTPiOS
+
+/// Covers the first-install "Pair <device>?" discovery plumbing: filtering
+/// iCloud-synced backups down to pairable devices, and minting a signed
+/// pairing invite from a backup's private key that survives the joiner's
+/// full slug validation (decode, expiry, signature recovery).
+@Suite("Pairable Device Backup")
+struct PairableDeviceBackupTests {
+    private func makeBackup(
+        inboxId: String,
+        deviceName: String? = nil,
+        backedUpAt: Date? = nil
+    ) throws -> KeychainIdentityBackup {
+        let keys = try KeychainIdentityKeys.generate()
+        let identity = KeychainIdentity(inboxId: inboxId, clientId: UUID().uuidString, keys: keys)
+        if let backedUpAt {
+            return KeychainIdentityBackup(identity: identity, deviceName: deviceName, backedUpAt: backedUpAt)
+        }
+        // A nil backedUpAt only occurs for blobs written before the
+        // metadata fields existed; produce one via the decode path.
+        let stamped = KeychainIdentityBackup(identity: identity, deviceName: deviceName, backedUpAt: Date())
+        let encoded = try JSONEncoder().encode(stamped)
+        var json = try JSONSerialization.jsonObject(with: encoded) as? [String: Any] ?? [:]
+        json.removeValue(forKey: "backedUpAt")
+        let data = try JSONSerialization.data(withJSONObject: json)
+        return try JSONDecoder().decode(KeychainIdentityBackup.self, from: data)
+    }
+
+    @Test("Excludes the current install's own identity")
+    func excludesCurrentIdentity() throws {
+        let own = try makeBackup(inboxId: "own-inbox", backedUpAt: Date())
+        let other = try makeBackup(inboxId: "other-inbox", deviceName: "Other iPhone", backedUpAt: Date())
+
+        let pairable = PairableDeviceBackup.pairableBackups(
+            from: [own, other],
+            excludingInboxId: "own-inbox"
+        )
+
+        #expect(pairable.map(\.inboxId) == ["other-inbox"])
+        #expect(pairable.first?.deviceName == "Other iPhone")
+    }
+
+    @Test("Returns everything when there is no current identity")
+    func keepsAllBackupsWithoutCurrentIdentity() throws {
+        let first = try makeBackup(inboxId: "inbox-a", backedUpAt: Date())
+        let second = try makeBackup(inboxId: "inbox-b", backedUpAt: Date())
+
+        let pairable = PairableDeviceBackup.pairableBackups(
+            from: [first, second],
+            excludingInboxId: nil
+        )
+
+        #expect(pairable.count == 2)
+    }
+
+    @Test("Sorts newest backup first, undated backups last")
+    func sortsNewestFirst() throws {
+        let old = try makeBackup(inboxId: "old", backedUpAt: Date(timeIntervalSince1970: 1_000))
+        let new = try makeBackup(inboxId: "new", backedUpAt: Date(timeIntervalSince1970: 2_000))
+        let undated = try makeBackup(inboxId: "undated")
+        #expect(undated.backedUpAt == nil)
+
+        let pairable = PairableDeviceBackup.pairableBackups(
+            from: [undated, old, new],
+            excludingInboxId: nil
+        )
+
+        #expect(pairable.map(\.inboxId) == ["new", "old", "undated"])
+    }
+}
+
+@Suite("Pairing Invite Signing")
+struct PairingInviteSigningTests {
+    @Test("Signed invite round-trips through full slug validation")
+    func signedInviteRoundTripsAndVerifies() async throws {
+        let privateKey = try PrivateKey.generate()
+        let expiresAt = Date().addingTimeInterval(300)
+
+        let invite = try await PairingInvite.signed(
+            initiatorInboxId: "backup-inbox",
+            privateKey: privateKey,
+            expiresAt: expiresAt
+        )
+        let slug = try invite.toURLSafeSlug()
+        // fromURLSafeSlug runs the same checks the joiner runs on a
+        // scanned QR slug: schema, nonce, expiry, signature recovery.
+        let decoded = try PairingInvite.fromURLSafeSlug(slug)
+
+        #expect(decoded.initiatorInboxId == "backup-inbox")
+        #expect(decoded.initiatorAddress.lowercased() == privateKey.walletAddress.lowercased())
+        #expect(decoded.expiresAt == Int64(expiresAt.timeIntervalSince1970))
+    }
+
+    @Test("Expired signed invite is rejected")
+    func expiredSignedInviteIsRejected() async throws {
+        let privateKey = try PrivateKey.generate()
+        let invite = try await PairingInvite.signed(
+            initiatorInboxId: "backup-inbox",
+            privateKey: privateKey,
+            expiresAt: Date().addingTimeInterval(-60)
+        )
+        let slug = try invite.toURLSafeSlug()
+
+        do {
+            _ = try PairingInvite.fromURLSafeSlug(slug)
+            Issue.record("Expected an expired invite to be rejected")
+        } catch let error as PairingInviteError {
+            guard case .expired = error else {
+                Issue.record("Expected .expired, got \(error)")
+                return
+            }
+        }
+    }
+
+    @Test("Tampered invite fails signature verification")
+    func tamperedInviteFailsSignature() async throws {
+        let privateKey = try PrivateKey.generate()
+        let invite = try await PairingInvite.signed(
+            initiatorInboxId: "backup-inbox",
+            privateKey: privateKey,
+            expiresAt: Date().addingTimeInterval(300)
+        )
+        // Swap the inboxId while keeping the original signature - the
+        // recovered address no longer matches the signed payload.
+        let tampered = PairingInvite(
+            initiatorInboxId: "attacker-inbox",
+            initiatorAddress: invite.initiatorAddress,
+            nonce: invite.nonce,
+            issuedAt: invite.issuedAt,
+            expiresAt: invite.expiresAt,
+            signature: invite.signature
+        )
+        let slug = try tampered.toURLSafeSlug()
+
+        do {
+            _ = try PairingInvite.fromURLSafeSlug(slug)
+            Issue.record("Expected a tampered invite to be rejected")
+        } catch let error as PairingInviteError {
+            guard case .signatureInvalid = error else {
+                Issue.record("Expected .signatureInvalid, got \(error)")
+                return
+            }
+        }
+    }
+}

--- a/ConvosCore/Tests/ConvosCoreTests/PairableDeviceBackupTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/PairableDeviceBackupTests.swift
@@ -43,8 +43,11 @@ struct PairableDeviceBackupTests {
         #expect(pairable.first?.deviceName == "Other iPhone")
     }
 
-    @Test("Returns everything when there is no current identity")
-    func keepsAllBackupsWithoutCurrentIdentity() throws {
+    @Test("Returns nothing when the current identity is unknown")
+    func hidesAllBackupsWithoutCurrentIdentity() throws {
+        // A nil current inbox means the keychain read failed, not that
+        // there is nothing to exclude; surfacing anything risks offering
+        // this install's own backup as a self-pair.
         let first = try makeBackup(inboxId: "inbox-a", backedUpAt: Date())
         let second = try makeBackup(inboxId: "inbox-b", backedUpAt: Date())
 
@@ -53,7 +56,7 @@ struct PairableDeviceBackupTests {
             excludingInboxId: nil
         )
 
-        #expect(pairable.count == 2)
+        #expect(pairable.isEmpty)
     }
 
     @Test("Sorts newest backup first, undated backups last")
@@ -65,7 +68,7 @@ struct PairableDeviceBackupTests {
 
         let pairable = PairableDeviceBackup.pairableBackups(
             from: [undated, old, new],
-            excludingInboxId: nil
+            excludingInboxId: "unrelated-inbox"
         )
 
         #expect(pairable.map(\.inboxId) == ["new", "old", "undated"])

--- a/ConvosCore/Tests/ConvosCoreTests/PairingCoordinatorTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/PairingCoordinatorTests.swift
@@ -48,6 +48,60 @@ struct PairingCoordinatorTests {
         #expect(url == "https://example/pair/abc")
     }
 
+    @Test func startPairingRespondingToJoinRequestSkipsToShowingPin() async throws {
+        let service = MockPairingService()
+        let coordinator = PairingCoordinator(pairingService: service)
+        let pin = try await coordinator.startPairing(
+            respondingToJoinerInboxId: "joiner-b",
+            deviceName: "Joiner Phone",
+            initiatorInboxId: "inbox-a"
+        )
+        #expect(pin.count == 6)
+        let state = await coordinator.currentState
+        guard case let .showingPin(shownPin, deviceName, joinerInboxId) = state else {
+            Issue.record("expected showingPin, got \(state)")
+            return
+        }
+        #expect(shownPin == pin)
+        #expect(deviceName == "Joiner Phone")
+        #expect(joinerInboxId == "joiner-b")
+    }
+
+    @Test func respondEntryRejectsWhenAlreadyPairing() async throws {
+        let service = MockPairingService()
+        let coordinator = PairingCoordinator(pairingService: service)
+        _ = try await coordinator.startPairing(
+            respondingToJoinerInboxId: "joiner-b",
+            deviceName: "Joiner Phone",
+            initiatorInboxId: "inbox-a"
+        )
+        await #expect(throws: PairingError.alreadyPairing) {
+            _ = try await coordinator.startPairing(
+                respondingToJoinerInboxId: "joiner-c",
+                deviceName: "Other Phone",
+                initiatorInboxId: "inbox-a"
+            )
+        }
+    }
+
+    @Test func respondEntryContinuesThroughPinEchoToEmoji() async throws {
+        let service = MockPairingService()
+        let coordinator = PairingCoordinator(pairingService: service)
+        let pin = try await coordinator.startPairing(
+            respondingToJoinerInboxId: "joiner-b",
+            deviceName: "Joiner Phone",
+            initiatorInboxId: "inbox-a"
+        )
+        try await coordinator.receivedPinEcho(pin, from: "joiner-b")
+        let state = await coordinator.currentState
+        guard case let .waitingForEmojiConfirmation(emojis, joinerInboxId) = state else {
+            Issue.record("expected waitingForEmojiConfirmation, got \(state)")
+            return
+        }
+        #expect(emojis.count == 3)
+        #expect(joinerInboxId == "joiner-b")
+    }
+
     @Test func wrongPinFails() async throws {
         let service = MockPairingService()
         let coordinator = PairingCoordinator(pairingService: service)

--- a/ConvosCore/Tests/ConvosCoreTests/PairingJoinRequestDetectorTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/PairingJoinRequestDetectorTests.swift
@@ -1,0 +1,130 @@
+@testable import ConvosCore
+import Foundation
+import Testing
+@preconcurrency import XMTPiOS
+
+/// Covers the verification core shared by the main stream's fast path and
+/// the NSE's push paths: a join request only surfaces when its slug is a
+/// valid, unexpired invite signed by this device's own identity key.
+@Suite("Pairing Join Request Detector")
+struct PairingJoinRequestDetectorTests {
+    private func makeIdentity(inboxId: String = "own-inbox") throws -> KeychainIdentity {
+        let keys = try KeychainIdentityKeys.generate()
+        return KeychainIdentity(inboxId: inboxId, clientId: UUID().uuidString, keys: keys)
+    }
+
+    private func mintSlug(
+        inboxId: String,
+        privateKey: PrivateKey,
+        expiresAt: Date = Date().addingTimeInterval(300)
+    ) async throws -> String {
+        let invite = try await PairingInvite.signed(
+            initiatorInboxId: inboxId,
+            privateKey: privateKey,
+            expiresAt: expiresAt
+        )
+        return try invite.toURLSafeSlug()
+    }
+
+    @Test("Self-signed unexpired slug from another inbox verifies")
+    func selfSignedSlugVerifies() async throws {
+        let identity = try makeIdentity()
+        let slug = try await mintSlug(inboxId: identity.inboxId, privateKey: identity.keys.privateKey)
+
+        #expect(PairingJoinRequestDetector.verify(slug: slug, senderInboxId: "joiner-x", identity: identity))
+    }
+
+    @Test("Slug signed by a foreign key naming our inboxId is rejected")
+    func foreignKeySlugIsRejected() async throws {
+        let identity = try makeIdentity()
+        let attackerKey = try PrivateKey.generate()
+        // The attacker can put our inboxId in the slug, but the signature
+        // recovers to the attacker's own address, not our key's.
+        let slug = try await mintSlug(inboxId: identity.inboxId, privateKey: attackerKey)
+
+        #expect(!PairingJoinRequestDetector.verify(slug: slug, senderInboxId: "joiner-x", identity: identity))
+    }
+
+    @Test("Expired slug is rejected")
+    func expiredSlugIsRejected() async throws {
+        let identity = try makeIdentity()
+        let slug = try await mintSlug(
+            inboxId: identity.inboxId,
+            privateKey: identity.keys.privateKey,
+            expiresAt: Date().addingTimeInterval(-60)
+        )
+
+        #expect(!PairingJoinRequestDetector.verify(slug: slug, senderInboxId: "joiner-x", identity: identity))
+    }
+
+    @Test("Request sent by our own inbox is rejected")
+    func selfSenderIsRejected() async throws {
+        let identity = try makeIdentity()
+        let slug = try await mintSlug(inboxId: identity.inboxId, privateKey: identity.keys.privateKey)
+
+        #expect(!PairingJoinRequestDetector.verify(slug: slug, senderInboxId: identity.inboxId, identity: identity))
+    }
+
+    @Test("Slug for a different inboxId is rejected")
+    func differentInboxIdIsRejected() async throws {
+        let identity = try makeIdentity()
+        let slug = try await mintSlug(inboxId: "someone-else", privateKey: identity.keys.privateKey)
+
+        #expect(!PairingJoinRequestDetector.verify(slug: slug, senderInboxId: "joiner-x", identity: identity))
+    }
+
+    @Test("Garbage slug is rejected")
+    func garbageSlugIsRejected() throws {
+        let identity = try makeIdentity()
+
+        #expect(!PairingJoinRequestDetector.verify(slug: "not-a-slug", senderInboxId: "joiner-x", identity: identity))
+    }
+}
+
+@Suite("Pending Pair Request Store")
+struct PendingPairRequestStoreTests {
+    // Tests run in parallel; each gets its own defaults suite so writes
+    // can't bleed between them.
+    private func clearSuite(_ suite: String) {
+        UserDefaults(suiteName: suite)?.removePersistentDomain(forName: suite)
+    }
+
+    @Test("Round-trips a pending request through set, peek, and consume")
+    func roundTrips() {
+        let suite = "pending-pair-request-store-tests-roundtrip"
+        clearSuite(suite)
+        defer { clearSuite(suite) }
+        let pending = PendingPairRequestStore.Pending(
+            joinerInboxId: "joiner-a",
+            deviceName: "Joiner Phone",
+            receivedAt: Date(timeIntervalSince1970: 1_000)
+        )
+
+        PendingPairRequestStore.setPending(pending, appGroup: suite)
+        #expect(PendingPairRequestStore.pending(appGroup: suite) == pending)
+        // Peeking doesn't clear.
+        #expect(PendingPairRequestStore.pending(appGroup: suite) == pending)
+
+        #expect(PendingPairRequestStore.consumePending(appGroup: suite) == pending)
+        #expect(PendingPairRequestStore.pending(appGroup: suite) == nil)
+        #expect(PendingPairRequestStore.consumePending(appGroup: suite) == nil)
+    }
+
+    @Test("A newer request replaces the previous one")
+    func newerRequestReplaces() {
+        let suite = "pending-pair-request-store-tests-replace"
+        clearSuite(suite)
+        defer { clearSuite(suite) }
+        let first = PendingPairRequestStore.Pending(
+            joinerInboxId: "joiner-a", deviceName: "First", receivedAt: Date(timeIntervalSince1970: 1_000)
+        )
+        let second = PendingPairRequestStore.Pending(
+            joinerInboxId: "joiner-b", deviceName: "Second", receivedAt: Date(timeIntervalSince1970: 2_000)
+        )
+
+        PendingPairRequestStore.setPending(first, appGroup: suite)
+        PendingPairRequestStore.setPending(second, appGroup: suite)
+
+        #expect(PendingPairRequestStore.consumePending(appGroup: suite) == second)
+    }
+}

--- a/ConvosCore/Tests/ConvosCoreTests/PairingJoinRequestDetectorTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/PairingJoinRequestDetectorTests.swift
@@ -110,6 +110,28 @@ struct PendingPairRequestStoreTests {
         #expect(PendingPairRequestStore.consumePending(appGroup: suite) == nil)
     }
 
+    @Test("An undecodable stash is left in place for the next resend to overwrite")
+    func undecodableStashIsNotDestroyed() {
+        let suite = "pending-pair-request-store-tests-corrupt"
+        clearSuite(suite)
+        defer { clearSuite(suite) }
+        let defaults = UserDefaults(suiteName: suite)
+        defaults?.set(Data("not json".utf8), forKey: "convos.pairing.pendingJoinRequest.v1")
+
+        #expect(PendingPairRequestStore.consumePending(appGroup: suite) == nil)
+        // The blob survives the failed consume...
+        #expect(defaults?.data(forKey: "convos.pairing.pendingJoinRequest.v1") != nil)
+
+        // ...and the joiner's next resend replaces it with a good one.
+        let pending = PendingPairRequestStore.Pending(
+            joinerInboxId: "joiner-a",
+            deviceName: "Joiner Phone",
+            receivedAt: Date(timeIntervalSince1970: 1_000)
+        )
+        PendingPairRequestStore.setPending(pending, appGroup: suite)
+        #expect(PendingPairRequestStore.consumePending(appGroup: suite) == pending)
+    }
+
     @Test("A newer request replaces the previous one")
     func newerRequestReplaces() {
         let suite = "pending-pair-request-store-tests-replace"

--- a/ConvosCore/Tests/ConvosCoreTests/PairingNonceLedgerTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/PairingNonceLedgerTests.swift
@@ -36,4 +36,36 @@ struct PairingNonceLedgerTests {
         #expect(ledger.joiner(for: Data("nonce-c".utf8)) == "joiner-1")
         #expect(ledger.joiner(for: Data("nonce-d".utf8)) == "joiner-2")
     }
+
+    @Test("Configured ledgers share bindings across instances")
+    func appGroupBackingSpansInstances() {
+        // Two instances with the same suite stand in for the app and NSE
+        // processes: a binding made by one must reject a different joiner
+        // replaying the same nonce through the other.
+        let suite = "pairing-nonce-ledger-tests-shared"
+        UserDefaults(suiteName: suite)?.removePersistentDomain(forName: suite)
+        defer { UserDefaults(suiteName: suite)?.removePersistentDomain(forName: suite) }
+        let nonce = Data("nonce-e".utf8)
+
+        let appLedger = PairingNonceLedger()
+        appLedger.configure(appGroup: suite)
+        appLedger.bind(nonce: nonce, toJoiner: "joiner-1")
+
+        let nseLedger = PairingNonceLedger()
+        nseLedger.configure(appGroup: suite)
+        #expect(nseLedger.joiner(for: nonce) == "joiner-1")
+        nseLedger.bind(nonce: nonce, toJoiner: "attacker")
+        #expect(nseLedger.joiner(for: nonce) == "joiner-1")
+        #expect(appLedger.joiner(for: nonce) == "joiner-1")
+    }
+
+    @Test("Unconfigured ledger stays in-memory")
+    func unconfiguredLedgerIsIsolated() {
+        let first = PairingNonceLedger()
+        let second = PairingNonceLedger()
+        let nonce = Data("nonce-f".utf8)
+
+        first.bind(nonce: nonce, toJoiner: "joiner-1")
+        #expect(second.joiner(for: nonce) == nil)
+    }
 }

--- a/ConvosCore/Tests/ConvosCoreTests/PairingNonceLedgerTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/PairingNonceLedgerTests.swift
@@ -1,0 +1,39 @@
+@testable import ConvosCore
+import Foundation
+import Testing
+
+@Suite("Pairing Nonce Ledger")
+struct PairingNonceLedgerTests {
+    @Test("First joiner binds the nonce; resends keep matching")
+    func firstJoinerBinds() {
+        let ledger = PairingNonceLedger()
+        let nonce = Data("nonce-a".utf8)
+
+        #expect(ledger.joiner(for: nonce) == nil)
+        ledger.bind(nonce: nonce, toJoiner: "joiner-1")
+        #expect(ledger.joiner(for: nonce) == "joiner-1")
+        // The legit joiner's resend loop rebinding is a no-op match.
+        ledger.bind(nonce: nonce, toJoiner: "joiner-1")
+        #expect(ledger.joiner(for: nonce) == "joiner-1")
+    }
+
+    @Test("A different joiner cannot steal an existing binding")
+    func replayingJoinerCannotRebind() {
+        let ledger = PairingNonceLedger()
+        let nonce = Data("nonce-b".utf8)
+
+        ledger.bind(nonce: nonce, toJoiner: "joiner-1")
+        ledger.bind(nonce: nonce, toJoiner: "attacker")
+        #expect(ledger.joiner(for: nonce) == "joiner-1")
+    }
+
+    @Test("Distinct nonces bind independently")
+    func distinctNoncesAreIndependent() {
+        let ledger = PairingNonceLedger()
+
+        ledger.bind(nonce: Data("nonce-c".utf8), toJoiner: "joiner-1")
+        ledger.bind(nonce: Data("nonce-d".utf8), toJoiner: "joiner-2")
+        #expect(ledger.joiner(for: Data("nonce-c".utf8)) == "joiner-1")
+        #expect(ledger.joiner(for: Data("nonce-d".utf8)) == "joiner-2")
+    }
+}

--- a/qa/SKILL.md
+++ b/qa/SKILL.md
@@ -52,6 +52,7 @@ Run end-to-end QA tests for the Convos iOS app using the iOS simulator tools and
 | 33 | `qa/tests/33-read-receipts.md` | Read receipts: send on view, display avatars, opt-out setting |
 | 42 | `qa/tests/42-agent-builder-attachment-summary.md` | Agent builder: create agent with prompt + photo attachment, verify summary card renders the photo thumbnail (pre- and post-rehydration) |
 | 43 | `qa/tests/43-long-message-rendering.md` | Long-message UX: short renders unchanged, long shows Read More + inline expand, pathological pushes MessageDetailView (Back/Copy/Reply), no-hang guard |
+| 44 | `qa/tests/44-icloud-pairing-prompt.md` | First-install iCloud pairing prompt: Pair <device>? sheet from a synced keychain backup, Skip persistence, and the full no-QR pair handshake (two simulators; Device B is a clone of Device A) |
 
 ## Running Tests
 

--- a/qa/tests/44-icloud-pairing-prompt.md
+++ b/qa/tests/44-icloud-pairing-prompt.md
@@ -42,7 +42,7 @@ Simulators don't sync iCloud Keychain, so the "new device on the same iCloud acc
 
 11. Device B's conversation list mirrors Device A's history with no "Add your name and pic" CTA - proof the found inbox id became this device's identity.
 12. Relaunch Device B once more: the prompt must not return even though the decline flag was cleared in step 5 - B's identity now matches the backup, so it is excluded from the pairable list.
-13. (Manual, timing-sensitive) Background Device A's app, start a fresh pair attempt on a reset Device B within ~10s: Device A posts a local notification "<device>" is requesting to pair; foregrounding A presents the PIN sheet from the stashed request. A killed app gets nothing until the NSE handles pairing pushes (documented follow-up).
+13. (Manual, timing-sensitive) Background Device A's app, start a fresh pair attempt on a reset Device B within ~10s: Device A posts a local notification "<device>" is requesting to pair; foregrounding A presents the PIN sheet from the stashed request. For a killed app, the NSE detects the join request in the welcome/message push, shows the same banner, and stashes via `PendingPairRequestStore` - real devices only (simulators receive no remote APNS).
 
 ## Teardown
 

--- a/qa/tests/44-icloud-pairing-prompt.md
+++ b/qa/tests/44-icloud-pairing-prompt.md
@@ -1,0 +1,68 @@
+# Test: iCloud Pairing Prompt (Two Simulators)
+
+Verify the first-install "Pair <device>?" prompt: a fresh install that finds another device's identity in the iCloud-synced keychain backup slot offers to pair with it, Skip declines persistently, and Pair runs the standard joiner pairing handshake with the found inbox id as the main device - no QR scan on either side.
+
+## Prerequisites
+
+- Two simulators. Device A is the branch primary, fully onboarded (its app mirrors its identity into the synced-backup keychain slot automatically on registration). Device B is created in setup as a clone of Device A.
+- The app build used on Device A is also installed on Device B (non-production build - the QA launch hook is runtime-gated off in production).
+
+## Setup
+
+Simulators don't sync iCloud Keychain, so the "new device on the same iCloud account" state is seeded by cloning, then wiping only the device-local identity:
+
+1. Shut down Device A (`simctl clone` requires it), clone it as `convos-qa-icloud-b`, boot both, relaunch the app on A. The clone's keychain contains both A's primary identity item and A's synced-backup item.
+2. On Device B: uninstall the app (clears app + group containers; the keychain survives), reinstall the built `Convos.app`, then launch with `SIMCTL_CHILD_CONVOS_QA_WIPE_PRIMARY_IDENTITY=1`. The `QALaunchHooks` hook deletes the device-local identity slot before session bootstrap and emits `app.qa_wiped_primary_identity`; the synced-backup item survives. The app registers a fresh placeholder identity and discovers A's backup.
+
+> Single-sim debugging shortcut: launching the app once normally and relaunching with the same env var on the *primary* simulator reproduces the prompt without cloning (the prior identity's backup is still in the slot). Only the handshake portion needs the second simulator.
+
+## Steps
+
+### Seed verification and prompt
+
+1. Check Device B's logs for the `app.qa_wiped_primary_identity` event with `status=0`. A `-25300` status means the slot was already empty - almost always a sign Device B was not cloned from Device A.
+2. Wait for the prompt sheet (anchor: `pair-found-device-button`) on Device B. It reads "Pair <name>?" / "Your <name> was found in iCloud, if you have it nearby, you can pair it now", with a "Pair <name>" primary button and a "Skip" text button. The `pairing.found_device_prompt_shown` event fires with the found inboxId and deviceName (a `pairing.found_device_check` event with `pairableCount=<n>` fires on every launch's check and is the first thing to look at when the prompt doesn't show).
+
+### Skip path
+
+3. Tap Skip (`skip-found-device-pairing-button`). The sheet dismisses to the chats list and `pairing.found_device_prompt_skipped` fires.
+4. Terminate and relaunch the app (without the wipe env var). The prompt must not reappear - the decline persists in UserDefaults. This is a negative check: settle on `compose-button`, then poll for the sheet over ~8 seconds and require zero matches.
+5. Terminate the app and delete the flag from the app container's preferences - the domain must be the container plist path, not the bundle id (`PREFS="$(xcrun simctl get_app_container $B org.convos.ios-preview data)/Library/Preferences/org.convos.ios-preview"; xcrun simctl spawn $B defaults delete "$PREFS" hasDeclinedFoundDevicePairing`). Relaunch: the prompt reappears - the decline flag is the only suppressor while the backup is present.
+
+### Pair path
+
+6. Tap "Pair <name>" (`pair-found-device-button`). The prompt dismisses and the joiner sheet ("Request to pair") presents with instruction copy: 'Open Convos on "<name>" to continue pairing.' The `pairing.found_device_invite_minted` event fires. The joiner immediately sends a join request and re-sends every 5 seconds while connecting (5-minute window).
+   - Conditional: if the "This device already has a Convos account" erase guard appears instead of the connecting state, hold "Hold to erase and pair" through (3s) and the flow continues. The relaunches in steps 4-5 commit Device B's auto-created inline-builder draft to a visible conversation, which trips the joiner flow's existing-data check (same guard as test 38).
+7. Device A (foregrounded, no navigation) auto-presents the initiator sheet directly in the PIN state (`pairing-pin-display`) within ~10-15 seconds - its StreamProcessor verified the join request's slug against A's own identity key and the app surfaced it (`pairing.incoming_request_surfaced` event). If A's app is backgrounded instead, a local notification ("<device>" is requesting to pair) posts and the sheet presents on next activation. Save the PIN. Manual fallback for debugging: Settings > Devices > Add new device still works (test 38 path).
+8. On Device B, enter the PIN in `pin-entry-field` and submit.
+9. Both devices show the 3-emoji fingerprint - verify the emojis match visually (per the multi-simulator rules in RULES.md).
+10. Device A taps Confirm. Both devices reach the completed state ("Device added" on A, "Device paired" on B); dismiss with Got it.
+
+### Post-pair checks (optional)
+
+11. Device B's conversation list mirrors Device A's history with no "Add your name and pic" CTA - proof the found inbox id became this device's identity.
+12. Relaunch Device B once more: the prompt must not return even though the decline flag was cleared in step 5 - B's identity now matches the backup, so it is excluded from the pairable list.
+13. (Manual, timing-sensitive) Background Device A's app, start a fresh pair attempt on a reset Device B within ~10s: Device A posts a local notification "<device>" is requesting to pair; foregrounding A presents the PIN sheet from the stashed request. A killed app gets nothing until the NSE handles pairing pushes (documented follow-up).
+
+## Teardown
+
+Shut down and delete the cloned `convos-qa-icloud-b` simulator. Do not delete Device A. Optionally revoke Device B's installation from A's Devices list (swipe row > Delete > hold) to leave A single-device for later tests.
+
+## Pass/Fail Criteria
+
+- [ ] The wipe hook fires on Device B with status=0
+- [ ] The "Pair <name>?" sheet appears with the found-in-iCloud copy and Pair/Skip buttons
+- [ ] Skip dismisses the sheet and emits `found_device_prompt_skipped`
+- [ ] The prompt does not reappear after relaunch (decline persists)
+- [ ] Deleting the decline flag re-prompts on the next launch
+- [ ] Pair opens the joiner sheet with the open-Convos instruction copy and emits `found_device_invite_minted`
+- [ ] (Conditional) The erase-and-pair guard is held through when Device B's auto-created draft has committed
+- [ ] Device A auto-presents the PIN sheet from the verified join request - no navigation, no QR
+- [ ] PIN entry, emoji match, and confirmation complete the handshake
+- [ ] Both devices reach Device added / Device paired
+- [ ] (Optional) Device B mirrors A's history with no onboarding CTA
+- [ ] (Optional) No re-prompt after pairing despite the cleared decline flag
+
+## Accessibility Improvements Needed
+
+None known - the prompt sheet ships with `pair-found-device-button`, and `skip-found-device-pairing-button`; the handshake reuses test 38's identifiers (`pairing-pin-display`, `pin-entry-field`, `submit-pin-button`, `pairing-emoji-fingerprint`, `confirm-emoji-button`, `got-it-button`).

--- a/qa/tests/structured/44-icloud-pairing-prompt.yaml
+++ b/qa/tests/structured/44-icloud-pairing-prompt.yaml
@@ -307,11 +307,12 @@ steps:
       Requires a separate pair attempt with Device A's app freshly
       backgrounded (press home on A, then tap Pair on B within ~10s -
       iOS suspends the stream shortly after backgrounding, so timing is
-      tight by design; a killed app gets nothing until the NSE handles
-      pairing pushes, a documented follow-up). Foregrounding A afterwards
-      presents the PIN sheet from the stashed request. Optional and
-      timing-sensitive - run manually when validating the notification
-      path.
+      tight by design). Foregrounding A afterwards presents the PIN sheet
+      from the stashed request. For a killed app the NSE handles the
+      welcome/message push, shows the same banner, and stashes via
+      PendingPairRequestStore - but simulators receive no remote APNS, so
+      the NSE path needs a real device. Optional and timing-sensitive -
+      run manually when validating the notification path.
 
   - id: no_reprompt_after_pairing
     name: "No re-prompt once the identities match"

--- a/qa/tests/structured/44-icloud-pairing-prompt.yaml
+++ b/qa/tests/structured/44-icloud-pairing-prompt.yaml
@@ -1,0 +1,373 @@
+id: "44"
+name: "iCloud Pairing Prompt (Two Simulators)"
+description: >
+  Verify the first-install "Pair <device>?" prompt: a fresh install that
+  finds another device's identity in the iCloud-synced keychain backup slot
+  offers to pair with it. Covers Skip (decline persists across relaunch),
+  re-prompt after the decline flag is cleared, and the full Pair path where
+  the found inbox id becomes the main device: tapping Pair mints an invite
+  signed by the backed-up key and runs the standard joiner handshake with
+  join-request resend (PIN, emoji, identity adoption) - no QR scan on
+  either device. Requires TWO simulators; Device B is a clone of Device A
+  with the primary identity wiped via the CONVOS_QA_WIPE_PRIMARY_IDENTITY
+  launch hook (sim clones copy the whole keychain, which stands in for
+  iCloud Keychain sync that simulators don't have).
+tags: [pairing, multi-device, devices, icloud, keychain]
+depends_on: ["01"]
+estimated_duration_s: 720
+
+prerequisites:
+  two_simulators: true
+  app_installed_on_both: true
+  # Device A is fully onboarded; its app has mirrored its identity into
+  # the synced-backup keychain slot (happens automatically on registration
+  # or first authorize). Device B is created in setup.
+  device_a_onboarded: true
+  screen: conversations_list
+
+state:
+  device_a_udid: null
+  device_b_udid: null
+  found_device_name: null
+  pairing_pin: null
+
+setup:
+  - action: clone_device_a_as_device_b
+    save:
+      device_a_udid: "branch primary simulator"
+      device_b_udid: "from clone"
+    note: >
+      Unlike test 38 (which clones a pristine base sim), Device B must be a
+      clone of DEVICE A so its keychain contains A's synced-backup item:
+      `xcrun simctl shutdown $A`, `xcrun simctl clone $A convos-qa-icloud-b`,
+      boot both, relaunch the app on A. simctl clone requires the source to
+      be shut down - expect a brief Device A outage here.
+
+  - action: reset_device_b_to_new_device_state
+    note: >
+      On Device B simulate a brand-new device on the same iCloud account.
+      First `xcrun simctl uninstall $B org.convos.ios-preview` (clears the
+      app and app-group containers; the keychain survives uninstall),
+      reinstall the built Convos.app, then launch with the wipe hook:
+      `SIMCTL_CHILD_CONVOS_QA_WIPE_PRIMARY_IDENTITY=1 xcrun simctl launch
+      $B org.convos.ios-preview`. The hook (QALaunchHooks, non-production
+      builds only) deletes the device-local identity item before session
+      bootstrap; the iCloud-synced backup item survives. The app then
+      registers a fresh placeholder identity and discovers A's backup.
+      Handle the notifications permission dialog if it appears (allow).
+      Single-sim debugging shortcut: the same hook on the PRIMARY sim
+      (launch once normally, relaunch with the env var) reproduces steps
+      1-6 without any cloning - the prior identity's backup is still in
+      the slot and the relaunched app treats it as another device's.
+
+steps:
+  # ----------------------------------------------------------------------
+  # Seed verification + prompt
+  # ----------------------------------------------------------------------
+  - id: wipe_hook_fired
+    name: "Device B's launch hook wiped the primary identity"
+    device: B
+    actions:
+      - sim_log_events: { event_filter: "app.qa_wiped_primary_identity" }
+    verify:
+      - event_exists: { name: "app.qa_wiped_primary_identity" }
+    expect_event: "app.qa_wiped_primary_identity"
+    criteria: primary_identity_wiped
+    note: >
+      The event carries status=<OSStatus>; 0 (errSecSuccess) means an item
+      was deleted, -25300 (errSecItemNotFound) means the slot was already
+      empty - that usually indicates Device B was not cloned from Device A
+      and the rest of the test will fail at prompt_appears.
+
+  - id: prompt_appears
+    name: "Device B shows the Pair <device>? prompt"
+    device: B
+    actions:
+      - wait_for_element: { id: "pair-found-device-button", timeout: 45 }
+      - screenshot: {}
+    verify:
+      - element_exists: { label_contains: "was found in iCloud" }
+      - element_exists: { id: "pair-found-device-button" }
+      - element_exists: { id: "skip-found-device-pairing-button" }
+    expect_event: "pairing.found_device_prompt_shown"
+    criteria: prompt_appears
+    save:
+      found_device_name: "deviceName= param of pairing.found_device_prompt_shown (underscores stand in for spaces)"
+    note: >
+      The prompt waits on placeholder registration plus the chats list
+      appearing, hence the generous timeout. Title reads "Pair <name>?"
+      where <name> is the device name stamped on A's backup (for a sim
+      clone this is A's simulator name); subtitle: "Your <name> was found
+      in iCloud, if you have it nearby, you can pair it now". The only
+      suppressors are the hasDeclinedFoundDevicePairing flag and the
+      identity match after pairing - local "engagement" signals are
+      deliberately not consulted (fresh-install bootstrap pollutes them
+      without user interaction). A pairing.found_device_check event with
+      pairableCount=<n> fires on every launch's check.
+
+  # ----------------------------------------------------------------------
+  # Skip path: decline persists, clearing the flag re-prompts
+  # ----------------------------------------------------------------------
+  - id: skip_dismisses
+    name: "Skip dismisses the prompt"
+    device: B
+    actions:
+      - tap: { id: "skip-found-device-pairing-button" }
+      - wait_for_element: { id: "compose-button", timeout: 10 }
+    verify:
+      - element_not_exists: { id: "pair-found-device-button" }
+    expect_event: "pairing.found_device_prompt_skipped"
+    criteria: skip_dismisses
+
+  - id: skip_persists
+    name: "Skip persists across relaunch"
+    device: B
+    actions:
+      - terminate_app: {}
+      - launch_app: {}
+      - wait_for_element: { id: "compose-button", timeout: 30 }
+    verify:
+      - element_not_exists: { id: "pair-found-device-button" }
+    criteria: skip_persists
+    note: >
+      Relaunch WITHOUT the wipe env var. The prompt check runs once per
+      launch from the chats list onAppear; after compose-button is
+      interactive, poll find_elements for the sheet a few more times over
+      ~8s and require zero matches throughout (negative check - the
+      asynchronous keychain read can land a beat after the list renders).
+
+  - id: reprompt_after_clearing_decline
+    name: "Clearing the decline flag re-prompts on next launch"
+    device: B
+    actions:
+      - terminate_app: {}
+      - host_command: 'PREFS="$(xcrun simctl get_app_container $device_b_udid org.convos.ios-preview data)/Library/Preferences/org.convos.ios-preview"; xcrun simctl spawn $device_b_udid defaults delete "$PREFS" hasDeclinedFoundDevicePairing'
+      - launch_app: {}
+      - wait_for_element: { id: "pair-found-device-button", timeout: 45 }
+    verify:
+      - element_exists: { id: "pair-found-device-button" }
+    criteria: reprompt_after_clear
+    note: >
+      The flag lives in the app container's sandboxed preferences, so the
+      defaults domain must be the container plist PATH (without .plist) -
+      a bare "defaults delete org.convos.ios-preview" via simctl spawn
+      targets the simulator-global domain and silently misses it.
+      Terminate before editing so cfprefsd doesn't overwrite the deletion
+      from the app's cache. This proves the decline flag is the only
+      suppressor: the backup is still present, so the prompt returns.
+
+  # ----------------------------------------------------------------------
+  # Pair path: joiner flow targets the found device, no QR scan
+  # ----------------------------------------------------------------------
+  - id: tap_pair
+    name: "Pair launches the joiner flow against the found device"
+    device: B
+    actions:
+      - tap: { id: "pair-found-device-button" }
+      - wait_for_element: { label_contains: "Request to pair", timeout: 15 }
+    verify:
+      - element_exists: { label_contains: "Request to pair" }
+      - element_exists: { label_contains: "Open Convos on" }
+      - element_exists: { id: "pairing-countdown" }
+    expect_event: "pairing.found_device_invite_minted"
+    criteria: pair_launches_joiner_flow
+    note: >
+      The prompt dismisses first; the joiner sheet presents from the
+      prompt's onDismiss. Connecting copy is the instruction string ("To
+      pair, open Convos on \"<name>\" to continue pairing."), not the
+      deep-link flow's "is requesting to pair" copy. The joiner sends a
+      join request immediately and re-sends every 5s while connecting
+      (5-minute window) - Device A does not need to be listening yet.
+
+  - id: erase_guard_conditional
+    name: "Erase-and-pair guard (fires when B's builder draft committed)"
+    device: B
+    optional: true
+    actions:
+      - wait_for_element: { id: "hold-to-erase-and-pair-button", timeout: 8 }
+      - long_press: { id: "hold-to-erase-and-pair-button", duration: 3.2 }
+    verify:
+      - element_exists: { label_contains: "This device already has a Convos account" }
+    criteria: erase_guard_handled
+    note: >
+      Conditional, same control as test 38's destructive guard. The
+      relaunches in the Skip steps commit Device B's auto-created inline
+      builder draft to a visible conversation, so the joiner flow's
+      hasAnyUsedConversations check reports true and the "Hold to erase
+      and pair" guard fires before the join request is sent. Hold it
+      through (3s); the flow erases local data and re-enters connecting.
+      If the guard doesn't appear within ~8s the flow already went
+      straight to connecting - skip this step.
+
+  - id: device_a_autosurfaces_request
+    name: "Device A auto-presents the pairing request with the PIN"
+    device: A
+    actions:
+      - wait_for_element: { id: "pairing-pin-display", timeout: 30 }
+    verify:
+      - element_exists: { label_contains: "Pair new device" }
+      - element_exists: { id: "pairing-pin-display" }
+    expect_event: "pairing.incoming_request_surfaced"
+    criteria: device_a_autosurfaces
+    save:
+      pairing_pin: "read the 6 digits from pairing-pin-display (strip the space separator)"
+    note: >
+      Core assertion of the feature: no navigation happens on Device A.
+      Its StreamProcessor verifies the join request's embedded slug
+      against A's own identity key (only a device holding the key - i.e.
+      sharing the iCloud keychain - can mint a valid one) and the app
+      presents the initiator sheet directly in the PIN state. Requires
+      A's app to be foregrounded; backgrounded, a local notification
+      ("<device> is requesting to pair") posts instead and the sheet
+      presents on the next activation. B re-sends every 5s, so allow
+      ~10-15s. Manual fallback for debugging: Settings > Devices > Add
+      new device still works exactly like test 38.
+
+  - id: enter_pin_on_b
+    name: "Device B enters the PIN and submits"
+    device: B
+    actions:
+      - wait_for_element: { id: "pin-entry-field", timeout: 30 }
+      - type_in_field: { id: "pin-entry-field", text: "$pairing_pin" }
+      - tap: { id: "submit-pin-button" }
+    verify:
+      - element_exists: { label_contains: "Enter the code" }
+    criteria: pin_entered
+    note: >
+      Same PIN-entry mechanics as test 38: 6-box masked field, submit
+      disabled until 6 digits.
+
+  - id: emoji_fingerprint_match
+    name: "Both devices show a matching 3-emoji fingerprint"
+    actions:
+      - device_a_wait: { id: "pairing-emoji-fingerprint", timeout: 30 }
+      - device_b_wait: { id: "pairing-emoji-fingerprint", timeout: 30 }
+      - device_a_screenshot: {}
+      - device_b_screenshot: {}
+    verify:
+      - device_a_has: { id: "pairing-emoji-fingerprint" }
+      - device_b_has: { id: "pairing-emoji-fingerprint" }
+      - visual_check: "the 3 emojis are identical on Device A and Device B"
+    criteria: emoji_fingerprint_matches
+
+  - id: device_a_confirms
+    name: "Device A confirms the emoji fingerprint"
+    device: A
+    actions:
+      - tap: { id: "confirm-emoji-button" }
+    verify:
+      - element_not_exists: { id: "confirm-emoji-button" }
+    criteria: emoji_confirmed_on_a
+
+  - id: pairing_completes
+    name: "Both devices reach the completed state"
+    actions:
+      - device_a_wait: { id: "got-it-button", timeout: 45 }
+      - device_b_wait: { id: "got-it-button", timeout: 45 }
+      - device_a_tap: { id: "got-it-button" }
+      - device_b_tap: { id: "got-it-button" }
+    verify:
+      - device_a_has: { label_contains: "Device added" }
+      - device_b_has: { label_contains: "Device paired" }
+    criteria: pairing_completed
+    note: >
+      Identical completion mechanics to test 38: A retitles to "Device
+      added", B to "Device paired", both with got-it-button. Run the
+      verify checks before tapping the buttons.
+
+  # ----------------------------------------------------------------------
+  # Post-pair checks
+  # ----------------------------------------------------------------------
+  - id: device_b_adopted_main_identity
+    name: "Device B mirrors Device A's history (adopted the found inbox id)"
+    device: B
+    optional: true
+    actions:
+      - wait_for_element: { id: "compose-button", timeout: 60 }
+    verify:
+      - element_exists: { id: "compose-button" }
+      - element_not_exists: { label_contains: "Add your name and pic" }
+    criteria: b_adopts_main_identity
+    note: >
+      After XMTP sync Device B's conversation list mirrors Device A's -
+      proof the FOUND inbox id (from the iCloud backup) became this
+      device's identity. Optional: full history sync timing varies on
+      simulators.
+
+  - id: background_notification_optional
+    name: "Backgrounded Device A gets a local pairing notification"
+    device: A
+    optional: true
+    actions:
+      - screenshot: {}
+    verify:
+      - visual_check: "notification banner '<device> is requesting to pair' on Device A"
+    criteria: background_notification
+    note: >
+      Requires a separate pair attempt with Device A's app freshly
+      backgrounded (press home on A, then tap Pair on B within ~10s -
+      iOS suspends the stream shortly after backgrounding, so timing is
+      tight by design; a killed app gets nothing until the NSE handles
+      pairing pushes, a documented follow-up). Foregrounding A afterwards
+      presents the PIN sheet from the stashed request. Optional and
+      timing-sensitive - run manually when validating the notification
+      path.
+
+  - id: no_reprompt_after_pairing
+    name: "No re-prompt once the identities match"
+    device: B
+    optional: true
+    actions:
+      - terminate_app: {}
+      - launch_app: {}
+      - wait_for_element: { id: "compose-button", timeout: 30 }
+    verify:
+      - element_not_exists: { id: "pair-found-device-button" }
+    criteria: no_reprompt_when_paired
+    note: >
+      Device B now holds the same identity the backup describes, so
+      pairableDeviceBackups excludes it and the prompt stays away even
+      though the decline flag was cleared earlier. Same negative-check
+      technique as skip_persists.
+
+teardown:
+  - action: cleanup_device_b
+    optional: true
+    note: >
+      Shut down and delete the cloned simulator (xcrun simctl shutdown +
+      delete convos-qa-icloud-b). Do NOT delete Device A - it is the
+      branch primary. Note Device A's Devices list now contains Device
+      B's installation; optionally revoke it there (swipe row > Delete >
+      hold) to leave A in a single-device state for later tests.
+
+criteria:
+  primary_identity_wiped:
+    description: "CONVOS_QA_WIPE_PRIMARY_IDENTITY launch hook fires on Device B with status=0"
+  prompt_appears:
+    description: "Pair <device>? sheet appears on Device B with found-in-iCloud copy, Pair and Skip buttons"
+  skip_dismisses:
+    description: "Skip dismisses the sheet and emits found_device_prompt_skipped"
+  skip_persists:
+    description: "After relaunch the prompt does not reappear (decline flag persisted)"
+  reprompt_after_clear:
+    description: "Deleting hasDeclinedFoundDevicePairing re-prompts on next launch"
+  pair_launches_joiner_flow:
+    description: "Pair mints an invite from the backup and opens the joiner sheet with the open-Convos instruction copy"
+  erase_guard_handled:
+    description: "Erase-and-pair guard is held through when B's auto-created draft has committed (conditional)"
+  device_a_autosurfaces:
+    description: "Device A auto-presents the initiator PIN sheet from the verified join request - no navigation, no QR"
+  background_notification:
+    description: "Backgrounded Device A posts a local '<device> is requesting to pair' notification (optional, manual)"
+  pin_entered:
+    description: "Device B enters and submits the PIN"
+  emoji_fingerprint_matches:
+    description: "Both devices show an identical 3-emoji fingerprint"
+  emoji_confirmed_on_a:
+    description: "Device A confirms the emoji fingerprint"
+  pairing_completed:
+    description: "Both devices reach Device added / Device paired"
+  b_adopts_main_identity:
+    description: "Device B mirrors A's history with no onboarding CTA (optional)"
+  no_reprompt_when_paired:
+    description: "No prompt after pairing even with the decline flag cleared (optional)"


### PR DESCRIPTION
## What

When the app is installed on a new device sharing the user's iCloud account, it now finds the other device's identity in the iCloud-synced keychain backup and offers to pair with it:

- **"Pair \<device\>?" info sheet** on first install ("Your \<device\> was found in iCloud, if you have it nearby, you can pair it now") with **Pair** / **Skip**. Skip persists across launches; the check re-runs each launch to cover iCloud Keychain sync latency.
- **Pair** mints a pairing invite locally, *signed by the backed-up private key*, and runs the standard joiner handshake (PIN + emoji + identity share) with the found inbox id as the main device - no QR scan on either side. The joiner re-sends its join request every 5s while connecting since the main device may not be listening yet.
- **The main device auto-surfaces the request**: `StreamProcessor` verifies the join request's embedded slug against its *own identity key* (only a device holding the key - i.e. sharing the iCloud keychain - can mint a valid one, so strangers can't trigger this) and presents the initiator PIN sheet directly when foregrounded, or posts a local notification ("\<device\> is requesting to pair") otherwise.

## How it stays safe

- Key material never leaves ConvosCore; the app layer only sees inboxId/deviceName and the resulting slug.
- The joiner's existing slug-signature and identity-share address verification hold unchanged.
- Pairing still requires physical confirmation on the main device (PIN + emoji fingerprint) - iCloud access alone can't clone an identity.
- Established installs keep the joiner flow's hold-to-erase guard before anything destructive.

## Notes

- The prompt is deliberately not gated on local "engagement" heuristics: fresh-install bootstrap commits a visible conversation with zero user interaction, which poisons `hasAnyUsedConversations` and the conversation counts (see the comment in `checkForPairableDeviceIfNeeded`). That pre-existing clean-install bug (visible "New Convo" rows on fresh installs) deserves its own ticket; it also makes the erase guard fire for effectively-fresh devices (affects test 38 too).
- Remote push for the killed-app case (NSE handling of pairing join requests) is a documented follow-up; the local notification covers backgrounded-but-running.

## QA

- New two-simulator test **42-icloud-pairing-prompt** (structured YAML + md, registered in the suite). Simulators don't sync iCloud Keychain, so Device B is a *clone of Device A* reset via the new non-production `CONVOS_QA_WIPE_PRIMARY_IDENTITY` launch hook (deletes only the device-local identity slot; the synced backup item survives).
- Validated end-to-end on two simulators: prompt -> Skip persistence -> re-prompt -> Pair -> main device auto-presents the PIN in ~4s -> matching emoji fingerprints -> identity adopted (both devices report the same inboxId and the conversation list mirrors over).
- Unit tests: invite signing round-trip/expiry/tamper, backup filtering, coordinator respond entry. Full ConvosCore suite: 1110 tests in 159 suites, all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add first-install iCloud pairing prompt with automatic main-device detection and no-QR pairing flow
> - Adds a first-install prompt (`PairFoundDeviceInfoSheet`) that surfaces when another device's identity is found in the iCloud-synced keychain backup, allowing the user to pair or skip without scanning a QR code.
> - Introduces `PairingNonceLedger` for nonce-to-joiner binding and replay prevention, and `PendingPairRequestStore` for cross-process handoff of verified join requests from the Notification Service Extension to the main app.
> - `StreamProcessor` now fast-paths incoming `PairingJoinRequestContent` messages: verified requests post a `.pairingDidReceiveVerifiedJoinRequest` notification and bypass normal conversation processing.
> - `MessagingService` push handling detects verified pairing join requests from welcome pushes, constructs deduplicated pairing notifications with nonce-replay protection, and stashes requests for the main app to present.
> - `PairingSheetViewModel` gains a `respondToJoinRequest` mode that skips QR display and sends the PIN directly to the joiner; a single-active-flow gate prevents concurrent initiator sessions.
> - `JoinerPairingSheetViewModel` gains a periodic join-request resend loop while in `.connecting`, stopping when a PIN arrives or the flow ends.
> - Risk: The nonce ledger and pending-request store use `UserDefaults` app-group storage; if the app group suite is unavailable, the ledger falls back to in-memory only and the store falls back to standard defaults with a warning, which could cause missed deduplication across processes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 91ba6d5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->