### PR TITLE
Handle pairing join requests in the Notification Service Extension

### DIFF
--- a/Convos/Conversations List/ConversationsViewModel.swift
+++ b/Convos/Conversations List/ConversationsViewModel.swift
@@ -1036,6 +1036,15 @@ extension ConversationsViewModel {
 
     private func presentIncomingPairingSheet(joinerInboxId: String, deviceName: String) {
         QAEvent.emit(.pairing, "incoming_request_surfaced", ["joinerInboxId": joinerInboxId])
+        // The NSE stashes for pushes that arrive while the app is
+        // foregrounded too; presenting from the stream path must discard
+        // that stash (and any delivered banners), or the next activation
+        // would re-present a ghost PIN sheet for an already-handled
+        // request.
+        _ = PendingPairRequestStore.consumePending(
+            appGroup: ConfigManager.shared.currentEnvironment.appGroupIdentifier
+        )
+        removeDeliveredPairingNotifications()
         incomingPairingPresentedAt = Date()
         incomingPairingRequest = PairingSheetViewModel(
             pairingService: DeferredInitiatorPairingService(session: session),
@@ -1045,17 +1054,52 @@ extension ConversationsViewModel {
     }
 
     private func presentPendingIncomingPairRequestIfNeeded() {
-        guard let pending = pendingIncomingPairRequest else { return }
-        pendingIncomingPairRequest = nil
-        UNUserNotificationCenter.current().removeDeliveredNotifications(
-            withIdentifiers: [Constant.incomingPairingNotificationId]
-        )
+        // Bail before consuming anything when a pairing flow is already
+        // on screen: a second initiator coordinator would race PIN
+        // generation for the same joiner. Consuming first and bailing
+        // after would destructively drop the stash (the app-group read
+        // removes it), losing the request if the joiner has stopped
+        // re-sending (killed/backgrounded). Leave it stashed so the next
+        // activation, once the active flow ends, can present it.
+        guard PairingSheetViewModel.active == nil, incomingPairingRequest == nil else { return }
+        // Two stash sources: in-memory (request arrived while this
+        // process was backgrounded) and the app-group store written by
+        // the NSE (request arrived while the app wasn't running at all).
+        var pending: PendingIncomingPairRequest?
+        if let inMemory = pendingIncomingPairRequest {
+            pendingIncomingPairRequest = nil
+            pending = inMemory
+        } else if let stashed = PendingPairRequestStore.consumePending(
+            appGroup: ConfigManager.shared.currentEnvironment.appGroupIdentifier
+        ) {
+            pending = PendingIncomingPairRequest(
+                joinerInboxId: stashed.joinerInboxId,
+                deviceName: stashed.deviceName,
+                receivedAt: stashed.receivedAt
+            )
+        }
+        guard let pending else { return }
+        removeDeliveredPairingNotifications()
         // The joiner re-sends its request for the length of the pairing
         // window; past that the handshake would just expire on send, so
         // stale stashes are dropped instead of surfaced.
         guard Date().timeIntervalSince(pending.receivedAt) < Constant.foundDevicePairingWindow else { return }
-        guard PairingSheetViewModel.active == nil, incomingPairingRequest == nil else { return }
         presentIncomingPairingSheet(joinerInboxId: pending.joinerInboxId, deviceName: pending.deviceName)
+    }
+
+    /// Removes every delivered "is requesting to pair" banner: the app's
+    /// own local one (fixed request identifier) and any the NSE produced
+    /// for remote pushes, whose request identifiers are system-assigned
+    /// and only findable via the shared pairing thread identifier.
+    private func removeDeliveredPairingNotifications() {
+        let center = UNUserNotificationCenter.current()
+        center.getDeliveredNotifications { notifications in
+            let pairingIds = notifications
+                .filter { $0.request.content.threadIdentifier == PairingNotificationThread.identifier }
+                .map(\.request.identifier)
+            let ids = pairingIds + [Constant.incomingPairingNotificationId]
+            center.removeDeliveredNotifications(withIdentifiers: ids)
+        }
     }
 
     private func scheduleIncomingPairingNotification(deviceName: String) {
@@ -1063,6 +1107,7 @@ extension ConversationsViewModel {
         content.title = "Pair new device"
         content.body = "\"\(deviceName)\" is requesting to pair"
         content.sound = .default
+        content.threadIdentifier = PairingNotificationThread.identifier
         let request = UNNotificationRequest(
             identifier: Constant.incomingPairingNotificationId,
             content: content,
@@ -1086,11 +1131,18 @@ extension ConversationsViewModel {
         pendingPairDevice = nil
     }
 
-    /// Sheet-dismissal hook for the auto-surfaced initiator flow.
+    /// Sheet-dismissal hook for the auto-surfaced initiator flow. Also
+    /// discards any stash the NSE wrote for resends that landed while
+    /// the sheet was up - the request was handled either way, and a
+    /// leftover stash would re-present a ghost sheet on next activation.
     func dismissIncomingPairingRequest() {
         incomingPairingRequest?.triggerCancel()
         incomingPairingRequest = nil
         incomingPairingPresentedAt = nil
+        _ = PendingPairRequestStore.consumePending(
+            appGroup: ConfigManager.shared.currentEnvironment.appGroupIdentifier
+        )
+        removeDeliveredPairingNotifications()
     }
 
     private enum Constant {

--- a/ConvosCore/Sources/ConvosCore/Inboxes/MessagingService+PushNotifications.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/MessagingService+PushNotifications.swift
@@ -133,6 +133,14 @@ extension MessagingService {
         // Sync all conversations - this will fetch any groups we've been added to
         _ = try await client.conversationsProvider.syncAllConversations(consentStates: [.unknown])
 
+        // The pairing DM is a brand-new conversation, so a pairing join
+        // request's first delivery is this welcome push. Detect it before
+        // anything else can return - the joiner only waits a few minutes,
+        // and with no topic subscription for the new DM there may be no
+        // second push. Detection has no side effects; the invite
+        // processing below still runs either way.
+        let pairingRequest = await detectRecentPairingJoinRequest(client: client)
+
         // Case 1: Process join requests (others accepting our invites)
         let joinRequestOutcomes = await joinRequestsManager.processJoinRequestOutcomes(since: lastProcessed, client: client)
         await handleJoinRequestOutcomesForPush(
@@ -141,6 +149,19 @@ extension MessagingService {
             apiClient: apiClient,
             context: "welcome"
         )
+
+        if let pairingRequest {
+            // Only let a genuinely surfaced pairing request short-circuit.
+            // The scan spans all recent DMs, not just this push's topic, so
+            // a deduped duplicate (.droppedMessage) might belong to an
+            // earlier push - returning it here would suppress a join-result
+            // or new-group notification this same push legitimately carries.
+            // On a duplicate, fall through to those checks instead.
+            let notification = pairingRequestNotification(pairingRequest, userInfo: userInfo)
+            if !notification.isDroppedMessage {
+                return notification
+            }
+        }
 
         if let result = joinRequestOutcomes.compactMap(\.result).first {
             setLastWelcomeProcessed(processTime, for: client.inboxId)
@@ -333,6 +354,14 @@ extension MessagingService {
             if decodedMessage.senderInboxId == currentInboxId {
                 Log.debug("Dropping DM notification - message from self")
                 return .droppedMessage
+            }
+
+            // A pairing join request (the joiner re-sends every few
+            // seconds while connecting) - surface "<device> is requesting
+            // to pair" instead of feeding it to the invite flow.
+            if let identity = try? identityStore.loadSync(),
+               let pairingRequest = PairingJoinRequestDetector.verifiedJoinRequest(in: decodedMessage, identity: identity) {
+                return pairingRequestNotification(pairingRequest, userInfo: userInfo)
             }
 
             // DMs are only used for join requests (invite acceptance flow)
@@ -1247,5 +1276,95 @@ extension MessagingService {
         } catch {
             Log.error("NSE: Failed to schedule explosion notification: \(error.localizedDescription)")
         }
+    }
+}
+
+// MARK: - Pairing Join Requests
+
+extension MessagingService {
+    /// Scans recently created unknown-consent DMs for a verified pairing
+    /// join request (see `PairingJoinRequestDetector` for the security
+    /// model). Used by the welcome-push path, where the request's content
+    /// isn't in the payload - the pairing DM was just synced from the
+    /// network. Bounded to a handful of fresh DMs and their latest
+    /// messages so it stays cheap inside the NSE's time budget.
+    func detectRecentPairingJoinRequest(client: any XMTPClientProvider) async -> VerifiedPairingJoinRequest? {
+        guard let identity = try? identityStore.loadSync() else { return nil }
+        let cutoff = Date().addingTimeInterval(-PairingPushConstant.requestWindow)
+        let cutoffNs = Int64(cutoff.timeIntervalSince1970 * 1_000_000_000)
+        let dms: [Dm]
+        do {
+            dms = try client.conversationsProvider.listDms(
+                createdAfterNs: cutoffNs,
+                createdBeforeNs: nil,
+                lastActivityBeforeNs: nil,
+                lastActivityAfterNs: nil,
+                limit: PairingPushConstant.maxScannedDms,
+                consentStates: [.unknown],
+                orderBy: .createdAt
+            )
+        } catch {
+            Log.warning("NSE: failed to list DMs for pairing scan: \(error)")
+            return nil
+        }
+        for dm in dms {
+            let messages = (try? await dm.messages(limit: PairingPushConstant.maxScannedMessagesPerDm)) ?? []
+            for message in messages {
+                if let request = PairingJoinRequestDetector.verifiedJoinRequest(in: message, identity: identity) {
+                    return request
+                }
+            }
+        }
+        return nil
+    }
+
+    /// Builds the "<device> is requesting to pair" notification and
+    /// stashes the request for the main app to present on next activation
+    /// (`PendingPairRequestStore`). The stash doubles as the dedupe
+    /// record: the joiner re-sends its request every few seconds, and one
+    /// banner per burst is plenty.
+    func pairingRequestNotification(
+        _ request: VerifiedPairingJoinRequest,
+        userInfo: [AnyHashable: Any]
+    ) -> DecodedNotificationContent {
+        let appGroup = environment.appGroupIdentifier
+        if let existing = PendingPairRequestStore.pending(appGroup: appGroup),
+           existing.joinerInboxId == request.joinerInboxId,
+           Date().timeIntervalSince(existing.receivedAt) < PairingPushConstant.dedupeWindow {
+            Log.debug("NSE: suppressing duplicate pairing request notification")
+            return .droppedMessage
+        }
+        PendingPairRequestStore.setPending(
+            .init(
+                joinerInboxId: request.joinerInboxId,
+                deviceName: request.deviceName,
+                receivedAt: Date()
+            ),
+            appGroup: appGroup
+        )
+        Log.info("NSE: surfacing pairing join request from \(request.joinerInboxId)")
+        // The conversationId becomes the notification's threadIdentifier.
+        // Stamping the fixed pairing thread lets the system collapse a
+        // resend burst's banners and lets the app's activation cleanup
+        // find and remove NSE-posted ones (whose request identifiers are
+        // system-assigned and unknowable here).
+        return .init(
+            title: "Pair new device",
+            body: "\"\(request.deviceName)\" is requesting to pair",
+            conversationId: PairingNotificationThread.identifier,
+            userInfo: userInfo
+        )
+    }
+
+    private enum PairingPushConstant {
+        /// How far back a DM can have been created and still be scanned;
+        /// matches the joiner's resend window.
+        static let requestWindow: TimeInterval = 300
+        /// One banner per request burst: the joiner re-sends every ~5s,
+        /// and each NSE invocation is a fresh process, so dedupe lives in
+        /// the app-group stash rather than memory.
+        static let dedupeWindow: TimeInterval = 60
+        static let maxScannedDms: Int = 10
+        static let maxScannedMessagesPerDm: Int = 5
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Pairing/PairingJoinRequestDetector.swift
+++ b/ConvosCore/Sources/ConvosCore/Pairing/PairingJoinRequestDetector.swift
@@ -1,0 +1,67 @@
+import Foundation
+@preconcurrency import XMTPiOS
+
+/// A pairing join request that passed self-signature verification.
+public struct VerifiedPairingJoinRequest: Sendable, Equatable {
+    public let joinerInboxId: String
+    public let deviceName: String
+    public let slug: String
+
+    public init(joinerInboxId: String, deviceName: String, slug: String) {
+        self.joinerInboxId = joinerInboxId
+        self.deviceName = deviceName
+        self.slug = slug
+    }
+}
+
+/// Shared verification for pairing join requests that arrive outside an
+/// active pairing session - on the main message stream (`StreamProcessor`)
+/// or in a push notification (the NSE's welcome and message paths).
+///
+/// Only requests whose embedded invite slug is signed by this inbox's own
+/// identity key are surfaced: the iCloud-discovery joiner mints its slug
+/// from the synced keychain backup and the QR flow signs its slug locally,
+/// so both carry our signature, while a forged request can't - producing a
+/// valid slug requires the private key. The address comparison anchors
+/// that verification to our key: the slug's inboxId and address fields are
+/// attacker-choosable, but the signature only ever recovers to the
+/// signer's own address.
+public enum PairingJoinRequestDetector {
+    /// Returns the verified join request carried by `message`, or nil when
+    /// the message isn't a pairing join request or fails verification.
+    /// Decodes via the codec directly so it works on clients that never
+    /// registered the pairing codecs (the NSE's).
+    public static func verifiedJoinRequest(
+        in message: DecodedMessage,
+        identity: KeychainIdentity
+    ) -> VerifiedPairingJoinRequest? {
+        guard let typeId = try? message.encodedContent.type.typeID,
+              typeId == ContentTypePairingJoinRequest.typeID,
+              let content = try? PairingJoinRequestCodec().decode(content: message.encodedContent) else {
+            return nil
+        }
+        guard verify(slug: content.slug, senderInboxId: message.senderInboxId, identity: identity) else {
+            return nil
+        }
+        return VerifiedPairingJoinRequest(
+            joinerInboxId: message.senderInboxId,
+            deviceName: content.deviceName,
+            slug: content.slug
+        )
+    }
+
+    /// Pure verification core, separated from `DecodedMessage` extraction
+    /// so it can be unit tested with minted slugs. True when `slug` is a
+    /// valid, unexpired invite signed by `identity`'s own key and the
+    /// sender isn't this inbox itself.
+    public static func verify(
+        slug: String,
+        senderInboxId: String,
+        identity: KeychainIdentity
+    ) -> Bool {
+        guard senderInboxId != identity.inboxId else { return false }
+        guard let invite = try? PairingInvite.fromURLSafeSlug(slug) else { return false }
+        return invite.initiatorInboxId == identity.inboxId
+            && invite.initiatorAddress.lowercased() == identity.keys.privateKey.walletAddress.lowercased()
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Pairing/PendingPairRequestStore.swift
+++ b/ConvosCore/Sources/ConvosCore/Pairing/PendingPairRequestStore.swift
@@ -1,0 +1,79 @@
+import Foundation
+
+/// Hands a verified pairing join request from the Notification Service
+/// Extension to the main app. The NSE can't present the pairing sheet, so
+/// it stashes the request here (and shows a "<device> is requesting to
+/// pair" banner); the app consumes the stash on its next activation and
+/// presents the initiator flow. Also acts as the NSE's notification
+/// dedupe: the joiner re-sends its request every few seconds, and one
+/// banner per request burst is plenty.
+///
+/// Storage is app-group UserDefaults so both processes see it, mirroring
+/// `PairedDeviceNameStore`. UserDefaults is process-safe.
+public enum PendingPairRequestStore {
+    /// Display metadata only - deliberately no invite slug. A valid
+    /// unexpired slug is a bearer credential (it passes
+    /// `PairingJoinRequestDetector.verify` from any inbox), and the
+    /// app-group plist is plaintext and included in device backups; the
+    /// consumer only needs the joiner identity and a name to present
+    /// the PIN sheet.
+    public struct Pending: Codable, Sendable, Equatable {
+        public let joinerInboxId: String
+        public let deviceName: String
+        public let receivedAt: Date
+
+        public init(joinerInboxId: String, deviceName: String, receivedAt: Date) {
+            self.joinerInboxId = joinerInboxId
+            self.deviceName = deviceName
+            self.receivedAt = receivedAt
+        }
+    }
+
+    private static let pendingKey: String = "convos.pairing.pendingJoinRequest.v1"
+
+    private static func defaults(for appGroup: String) -> UserDefaults {
+        guard let suite = UserDefaults(suiteName: appGroup) else {
+            // Falling back means the NSE and the app each write their own
+            // standard defaults and the handoff silently never happens -
+            // make that observable.
+            Log.warning("PendingPairRequestStore: app-group suite unavailable, falling back to standard defaults")
+            return .standard
+        }
+        return suite
+    }
+
+    /// Stashes the request, replacing any previous one.
+    public static func setPending(_ pending: Pending, appGroup: String) {
+        guard let data = try? JSONEncoder().encode(pending) else { return }
+        defaults(for: appGroup).set(data, forKey: pendingKey)
+    }
+
+    /// Reads without clearing. The NSE uses this for dedupe decisions.
+    public static func pending(appGroup: String) -> Pending? {
+        guard let data = defaults(for: appGroup).data(forKey: pendingKey) else { return nil }
+        return try? JSONDecoder().decode(Pending.self, from: data)
+    }
+
+    /// Reads and clears. The app calls this on activation, and also when
+    /// the stream path presents a request directly - the NSE stashes for
+    /// pushes that arrive while the app is foregrounded too, and a stash
+    /// left behind after the flow was handled would re-present a ghost
+    /// PIN sheet on the next activation.
+    public static func consumePending(appGroup: String) -> Pending? {
+        let defs = defaults(for: appGroup)
+        guard let data = defs.data(forKey: pendingKey) else { return nil }
+        defs.removeObject(forKey: pendingKey)
+        return try? JSONDecoder().decode(Pending.self, from: data)
+    }
+}
+
+/// Thread identifier stamped on every "is requesting to pair"
+/// notification - the NSE's remote ones (via
+/// `DecodedNotificationContent.conversationId`, which the extension maps
+/// to `threadIdentifier`) and the app's local one - so the system
+/// collapses a resend burst into one thread and the app's activation
+/// cleanup can remove NSE-posted banners whose request identifiers are
+/// system-assigned.
+public enum PairingNotificationThread {
+    public static let identifier: String = "incoming-pairing-request"
+}

--- a/ConvosCore/Sources/ConvosCore/Syncing/StreamProcessor.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/StreamProcessor.swift
@@ -983,16 +983,9 @@ extension StreamProcessor {
     /// Pre-conversation-lookup fast path for `PairingJoinRequestContent`,
     /// so "another device wants to pair" surfaces even when the Devices
     /// pairing screen isn't open (the iCloud-discovery joiner sends its
-    /// request unsolicited).
-    ///
-    /// Only requests whose embedded invite slug is signed by this inbox's
-    /// own identity key are surfaced: the iCloud-discovery joiner mints
-    /// its slug from the synced keychain backup and the QR flow signs its
-    /// slug locally, so both carry our signature, while a forged request
-    /// can't - producing a valid slug requires the private key. The
-    /// address comparison anchors that verification to our key: the
-    /// slug's inboxId and address fields are attacker-choosable, but the
-    /// signature only ever recovers to the signer's own address.
+    /// request unsolicited). Verification - the slug must be signed by
+    /// this inbox's own identity key - lives in
+    /// `PairingJoinRequestDetector`, shared with the NSE's push paths.
     ///
     /// Returns true whenever the message is a pairing join request (valid
     /// or not) so normal message processing skips it either way.
@@ -1001,21 +994,9 @@ extension StreamProcessor {
               typeId == ContentTypePairingJoinRequest.typeID else {
             return false
         }
-        guard message.senderInboxId != params.client.inboxId,
-              let content = try? message.content() as PairingJoinRequestContent else {
-            return true
-        }
-        let invite: PairingInvite
-        do {
-            invite = try PairingInvite.fromURLSafeSlug(content.slug)
-        } catch {
-            Log.warning("StreamProcessor: ignoring pairing join request with undecodable or expired slug: \(error)")
-            return true
-        }
-        guard let identity = try? identityStore.loadSync(),
-              invite.initiatorInboxId == identity.inboxId,
-              invite.initiatorAddress.lowercased() == identity.keys.privateKey.walletAddress.lowercased() else {
-            Log.warning("StreamProcessor: ignoring pairing join request whose slug wasn't signed by this identity")
+        guard let identity = try? identityStore.loadSync() else { return true }
+        guard let request = PairingJoinRequestDetector.verifiedJoinRequest(in: message, identity: identity) else {
+            Log.warning("StreamProcessor: ignoring pairing join request that failed verification")
             return true
         }
         // Bind the slug's nonce to the first joiner that used it: the
@@ -1024,20 +1005,22 @@ extension StreamProcessor {
         // QR still inside its expiry window) is dropped instead of
         // popping an unsolicited PIN sheet. In-memory is enough - slugs
         // expire in minutes and the processor outlives any handshake.
+        // The re-decode cannot fail: the detector just verified the slug.
+        guard let invite = try? PairingInvite.fromURLSafeSlug(request.slug) else { return true }
         if let boundJoiner = PairingNonceLedger.shared.joiner(for: invite.nonce),
-           boundJoiner != message.senderInboxId {
+           boundJoiner != request.joinerInboxId {
             Log.warning("StreamProcessor: ignoring pairing join request replaying another joiner's slug")
             return true
         }
-        PairingNonceLedger.shared.bind(nonce: invite.nonce, toJoiner: message.senderInboxId)
-        Log.info("StreamProcessor: verified pairing join request from joiner \(message.senderInboxId) - surfacing")
+        PairingNonceLedger.shared.bind(nonce: invite.nonce, toJoiner: request.joinerInboxId)
+        Log.info("StreamProcessor: verified pairing join request from joiner \(request.joinerInboxId) - surfacing")
         NotificationCenter.default.post(
             name: .pairingDidReceiveVerifiedJoinRequest,
             object: nil,
             userInfo: [
-                "joinerInboxId": message.senderInboxId,
-                "deviceName": content.deviceName,
-                "slug": content.slug
+                "joinerInboxId": request.joinerInboxId,
+                "deviceName": request.deviceName,
+                "slug": request.slug
             ]
         )
         return true

--- a/ConvosCore/Tests/ConvosCoreTests/Integration/PairingPushDetectionIntegrationTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/Integration/PairingPushDetectionIntegrationTests.swift
@@ -1,0 +1,99 @@
+@testable import ConvosCore
+import Foundation
+import Testing
+@preconcurrency import XMTPiOS
+
+/// Integration coverage for the NSE's welcome-push pairing detection, run
+/// against a local XMTP node (`./dev/up`). Simulators never spawn the
+/// real notification extension for `simctl push`, so this exercises the
+/// exact code the NSE runs - `detectRecentPairingJoinRequest` over a real
+/// synced DM and `pairingRequestNotification`'s stash + dedupe - with a
+/// real joiner client sending a real `PairingJoinRequestContent`.
+@Suite("Pairing Push Detection Integration", .serialized)
+struct PairingPushDetectionIntegrationTests {
+    @Test("Welcome-path scan surfaces only a self-signed join request")
+    func welcomeScanSurfacesVerifiedRequest() async throws {
+        let fixtures = TestFixtures()
+        // Create the joiner first: `createClient` saves each identity into
+        // the single keychain slot, and the service must verify against
+        // the initiator's identity (the slot's final occupant).
+        let (joiner, _, _) = try await fixtures.createClient()
+        let (initiator, _, initiatorKeys) = try await fixtures.createClient()
+        defer {
+            try? joiner.deleteLocalDatabase()
+            try? initiator.deleteLocalDatabase()
+        }
+        let service = fixtures.makeFreshMessagingService()
+
+        let dm = try await joiner.conversationsProvider.findOrCreateDm(with: initiator.inboxId)
+
+        // A forged request first: valid signature from a random key that
+        // names the initiator's inboxId - the spoof the address check
+        // rejects. With only this in the DM, nothing may surface.
+        let attackerKey = try PrivateKey.generate()
+        let forgedInvite = try await PairingInvite.signed(
+            initiatorInboxId: initiator.inboxId,
+            privateKey: attackerKey,
+            expiresAt: Date().addingTimeInterval(300)
+        )
+        try await sendJoinRequest(
+            slug: try forgedInvite.toURLSafeSlug(),
+            deviceName: "Attacker Phone",
+            from: joiner,
+            on: dm
+        )
+        _ = try await initiator.conversationsProvider.syncAllConversations(consentStates: [.unknown])
+        let forgedResult = await service.detectRecentPairingJoinRequest(client: initiator)
+        #expect(forgedResult == nil)
+
+        // The real request: slug minted from the initiator's own key,
+        // exactly what the iCloud-discovery joiner sends.
+        let invite = try await PairingInvite.signed(
+            initiatorInboxId: initiator.inboxId,
+            privateKey: initiatorKeys.privateKey,
+            expiresAt: Date().addingTimeInterval(300)
+        )
+        let slug = try invite.toURLSafeSlug()
+        try await sendJoinRequest(slug: slug, deviceName: "Joiner Phone", from: joiner, on: dm)
+        _ = try await initiator.conversationsProvider.syncAllConversations(consentStates: [.unknown])
+
+        let request = try #require(await service.detectRecentPairingJoinRequest(client: initiator))
+        #expect(request.joinerInboxId == joiner.inboxId)
+        #expect(request.deviceName == "Joiner Phone")
+        #expect(request.slug == slug)
+
+        // Notification building: first call stashes + notifies, the
+        // immediate repeat (a resend hitting another NSE invocation)
+        // dedupes against the stash.
+        let appGroup = fixtures.environment.appGroupIdentifier
+        _ = PendingPairRequestStore.consumePending(appGroup: appGroup)
+        defer { _ = PendingPairRequestStore.consumePending(appGroup: appGroup) }
+
+        let notification = service.pairingRequestNotification(request, userInfo: [:])
+        #expect(notification.body == "\"Joiner Phone\" is requesting to pair")
+        #expect(notification.isDroppedMessage == false)
+        // conversationId doubles as the threadIdentifier the app's
+        // delivered-banner cleanup matches on.
+        #expect(notification.conversationId == PairingNotificationThread.identifier)
+        let stashed = try #require(PendingPairRequestStore.pending(appGroup: appGroup))
+        #expect(stashed.joinerInboxId == joiner.inboxId)
+
+        let repeated = service.pairingRequestNotification(request, userInfo: [:])
+        #expect(repeated.isDroppedMessage)
+    }
+
+    private func sendJoinRequest(
+        slug: String,
+        deviceName: String,
+        from joiner: any XMTPClientProvider,
+        on dm: Dm
+    ) async throws {
+        let content = PairingJoinRequestContent(
+            slug: slug,
+            joinerInboxId: joiner.inboxId,
+            deviceName: deviceName
+        )
+        let encoded = try PairingJoinRequestCodec().encode(content: content)
+        _ = try await dm.send(encodedContent: encoded)
+    }
+}

--- a/ConvosCore/Tests/ConvosCoreTests/PairingJoinRequestDetectorTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/PairingJoinRequestDetectorTests.swift
@@ -1,0 +1,130 @@
+@testable import ConvosCore
+import Foundation
+import Testing
+@preconcurrency import XMTPiOS
+
+/// Covers the verification core shared by the main stream's fast path and
+/// the NSE's push paths: a join request only surfaces when its slug is a
+/// valid, unexpired invite signed by this device's own identity key.
+@Suite("Pairing Join Request Detector")
+struct PairingJoinRequestDetectorTests {
+    private func makeIdentity(inboxId: String = "own-inbox") throws -> KeychainIdentity {
+        let keys = try KeychainIdentityKeys.generate()
+        return KeychainIdentity(inboxId: inboxId, clientId: UUID().uuidString, keys: keys)
+    }
+
+    private func mintSlug(
+        inboxId: String,
+        privateKey: PrivateKey,
+        expiresAt: Date = Date().addingTimeInterval(300)
+    ) async throws -> String {
+        let invite = try await PairingInvite.signed(
+            initiatorInboxId: inboxId,
+            privateKey: privateKey,
+            expiresAt: expiresAt
+        )
+        return try invite.toURLSafeSlug()
+    }
+
+    @Test("Self-signed unexpired slug from another inbox verifies")
+    func selfSignedSlugVerifies() async throws {
+        let identity = try makeIdentity()
+        let slug = try await mintSlug(inboxId: identity.inboxId, privateKey: identity.keys.privateKey)
+
+        #expect(PairingJoinRequestDetector.verify(slug: slug, senderInboxId: "joiner-x", identity: identity))
+    }
+
+    @Test("Slug signed by a foreign key naming our inboxId is rejected")
+    func foreignKeySlugIsRejected() async throws {
+        let identity = try makeIdentity()
+        let attackerKey = try PrivateKey.generate()
+        // The attacker can put our inboxId in the slug, but the signature
+        // recovers to the attacker's own address, not our key's.
+        let slug = try await mintSlug(inboxId: identity.inboxId, privateKey: attackerKey)
+
+        #expect(!PairingJoinRequestDetector.verify(slug: slug, senderInboxId: "joiner-x", identity: identity))
+    }
+
+    @Test("Expired slug is rejected")
+    func expiredSlugIsRejected() async throws {
+        let identity = try makeIdentity()
+        let slug = try await mintSlug(
+            inboxId: identity.inboxId,
+            privateKey: identity.keys.privateKey,
+            expiresAt: Date().addingTimeInterval(-60)
+        )
+
+        #expect(!PairingJoinRequestDetector.verify(slug: slug, senderInboxId: "joiner-x", identity: identity))
+    }
+
+    @Test("Request sent by our own inbox is rejected")
+    func selfSenderIsRejected() async throws {
+        let identity = try makeIdentity()
+        let slug = try await mintSlug(inboxId: identity.inboxId, privateKey: identity.keys.privateKey)
+
+        #expect(!PairingJoinRequestDetector.verify(slug: slug, senderInboxId: identity.inboxId, identity: identity))
+    }
+
+    @Test("Slug for a different inboxId is rejected")
+    func differentInboxIdIsRejected() async throws {
+        let identity = try makeIdentity()
+        let slug = try await mintSlug(inboxId: "someone-else", privateKey: identity.keys.privateKey)
+
+        #expect(!PairingJoinRequestDetector.verify(slug: slug, senderInboxId: "joiner-x", identity: identity))
+    }
+
+    @Test("Garbage slug is rejected")
+    func garbageSlugIsRejected() throws {
+        let identity = try makeIdentity()
+
+        #expect(!PairingJoinRequestDetector.verify(slug: "not-a-slug", senderInboxId: "joiner-x", identity: identity))
+    }
+}
+
+@Suite("Pending Pair Request Store")
+struct PendingPairRequestStoreTests {
+    // Tests run in parallel; each gets its own defaults suite so writes
+    // can't bleed between them.
+    private func clearSuite(_ suite: String) {
+        UserDefaults(suiteName: suite)?.removePersistentDomain(forName: suite)
+    }
+
+    @Test("Round-trips a pending request through set, peek, and consume")
+    func roundTrips() {
+        let suite = "pending-pair-request-store-tests-roundtrip"
+        clearSuite(suite)
+        defer { clearSuite(suite) }
+        let pending = PendingPairRequestStore.Pending(
+            joinerInboxId: "joiner-a",
+            deviceName: "Joiner Phone",
+            receivedAt: Date(timeIntervalSince1970: 1_000)
+        )
+
+        PendingPairRequestStore.setPending(pending, appGroup: suite)
+        #expect(PendingPairRequestStore.pending(appGroup: suite) == pending)
+        // Peeking doesn't clear.
+        #expect(PendingPairRequestStore.pending(appGroup: suite) == pending)
+
+        #expect(PendingPairRequestStore.consumePending(appGroup: suite) == pending)
+        #expect(PendingPairRequestStore.pending(appGroup: suite) == nil)
+        #expect(PendingPairRequestStore.consumePending(appGroup: suite) == nil)
+    }
+
+    @Test("A newer request replaces the previous one")
+    func newerRequestReplaces() {
+        let suite = "pending-pair-request-store-tests-replace"
+        clearSuite(suite)
+        defer { clearSuite(suite) }
+        let first = PendingPairRequestStore.Pending(
+            joinerInboxId: "joiner-a", deviceName: "First", receivedAt: Date(timeIntervalSince1970: 1_000)
+        )
+        let second = PendingPairRequestStore.Pending(
+            joinerInboxId: "joiner-b", deviceName: "Second", receivedAt: Date(timeIntervalSince1970: 2_000)
+        )
+
+        PendingPairRequestStore.setPending(first, appGroup: suite)
+        PendingPairRequestStore.setPending(second, appGroup: suite)
+
+        #expect(PendingPairRequestStore.consumePending(appGroup: suite) == second)
+    }
+}

--- a/qa/tests/44-icloud-pairing-prompt.md
+++ b/qa/tests/44-icloud-pairing-prompt.md
@@ -42,7 +42,7 @@ Simulators don't sync iCloud Keychain, so the "new device on the same iCloud acc
 
 11. Device B's conversation list mirrors Device A's history with no "Add your name and pic" CTA - proof the found inbox id became this device's identity.
 12. Relaunch Device B once more: the prompt must not return even though the decline flag was cleared in step 5 - B's identity now matches the backup, so it is excluded from the pairable list.
-13. (Manual, timing-sensitive) Background Device A's app, start a fresh pair attempt on a reset Device B within ~10s: Device A posts a local notification "<device>" is requesting to pair; foregrounding A presents the PIN sheet from the stashed request. A killed app gets nothing until the NSE handles pairing pushes (documented follow-up).
+13. (Manual, timing-sensitive) Background Device A's app, start a fresh pair attempt on a reset Device B within ~10s: Device A posts a local notification "<device>" is requesting to pair; foregrounding A presents the PIN sheet from the stashed request. For a killed app, the NSE detects the join request in the welcome/message push, shows the same banner, and stashes via `PendingPairRequestStore` - real devices only (simulators receive no remote APNS).
 
 ## Teardown
 

--- a/qa/tests/structured/44-icloud-pairing-prompt.yaml
+++ b/qa/tests/structured/44-icloud-pairing-prompt.yaml
@@ -307,11 +307,12 @@ steps:
       Requires a separate pair attempt with Device A's app freshly
       backgrounded (press home on A, then tap Pair on B within ~10s -
       iOS suspends the stream shortly after backgrounding, so timing is
-      tight by design; a killed app gets nothing until the NSE handles
-      pairing pushes, a documented follow-up). Foregrounding A afterwards
-      presents the PIN sheet from the stashed request. Optional and
-      timing-sensitive - run manually when validating the notification
-      path.
+      tight by design). Foregrounding A afterwards presents the PIN sheet
+      from the stashed request. For a killed app the NSE handles the
+      welcome/message push, shows the same banner, and stashes via
+      PendingPairRequestStore - but simulators receive no remote APNS, so
+      the NSE path needs a real device. Optional and timing-sensitive -
+      run manually when validating the notification path.
 
   - id: no_reprompt_after_pairing
     name: "No re-prompt once the identities match"


### PR DESCRIPTION
## What

Stacked on #983. A pairing join request now reaches the user even when the app isn't running: the Notification Service Extension detects `PairingJoinRequestContent` in incoming pushes, verifies it, and shows **"\<device\>" is requesting to pair** - so the main device responds to an iCloud-discovery pair attempt without the app being open.

- **Welcome-push path**: the pairing DM is a brand-new conversation, so its first delivery is a welcome push with no encrypted content. After the NSE's existing `syncAllConversations`, a bounded scan of recently created unknown-consent DMs (10 DMs x 5 messages, 5-minute window) finds the join request. Detection has no side effects and invite-join processing still runs.
- **Message-push path**: resends arriving as encrypted DM pushes are checked before the invite-join flow.
- **Handoff to the app**: the verified request is stashed in app-group defaults (`PendingPairRequestStore`); the app consumes the stash on next activation and presents the initiator PIN sheet directly. The stash doubles as the NSE's dedupe record against the joiner's 5s resend cadence (one banner per 60s burst; each NSE invocation is a fresh process, so dedupe can't live in memory).

## Verification model

Extracted `PairingJoinRequestDetector`, now shared by the main stream's fast path and both NSE paths: a request only surfaces when its embedded invite slug is a valid, unexpired invite **signed by this device's own identity key** (the slug's inboxId/address fields are attacker-choosable, but the signature only recovers to the signer's address - producing a valid slug requires the private key, i.e. the same iCloud keychain). Decoding uses the codec directly so it works on the NSE's client, which never registers pairing codecs.

## Tests

- `PairingJoinRequestDetector.verify`: self-signed slug accepted; foreign-key slug naming our inboxId, expired slug, self-sender, wrong inboxId, and garbage slugs all rejected (the foreign-key case is the spoof the address check exists for).
- `PendingPairRequestStore`: set/peek/consume round-trip, newer-request replacement.
- Full ConvosCore suite: 1118 tests in 161 suites, all passing.

## Caveat

Simulators receive no remote APNS, so the NSE paths compile-verified + unit-tested here; end-to-end validation needs two real devices (QA test 42's optional notification step documents the procedure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Handle pairing join requests in the Notification Service Extension
> - The NSE ([MessagingService+PushNotifications.swift](https://github.com/xmtplabs/convos-ios/pull/984/files#diff-e3600c561fc30fca5b793ab019a6c9384b2f81973531eff39d65eba919fddf4b)) now detects pairing join requests on welcome and DM pushes, posts a grouped pairing notification banner, and stashes the request in an app-group `UserDefaults` store for handoff to the main app.
> - A new [PairingJoinRequestDetector.swift](https://github.com/xmtplabs/convos-ios/pull/984/files#diff-740d4be2d4b1083e8da9e2f1f92d3169ef1cc593c0faf1d9dee2e3c8d0fb391e) verifies join requests by checking content type, decoding the slug, and confirming the initiator identity matches the sender.
> - A new [PendingPairRequestStore.swift](https://github.com/xmtplabs/convos-ios/pull/984/files#diff-96bd5f44496f0133ce3eee0d572f46f606c74460584f8f9c6ba0e97d59c3baa0) provides a cross-process store (app-group `UserDefaults`) for stashing and consuming pending pairing request metadata, and defines a shared `PairingNotificationThread` identifier for grouping and cleanup.
> - `ConversationsViewModel` is updated to consume the NSE stash and remove all delivered pairing notifications when presenting, dismissing, or checking for pending pairing requests on app activation.
> - Integration and unit tests cover NSE welcome-path detection, forged-request rejection, notification building, stash round-trips, and deduplication.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized a6252ab. 5 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->