### PR TITLE
Add Support section to conversation info with Report an issue email row

### DIFF
--- a/Convos/App Settings/AppSettingsView.swift
+++ b/Convos/App Settings/AppSettingsView.swift
@@ -407,7 +407,7 @@ struct AppSettingsView: View {
     }
 
     private func sendFeedback() {
-        let email = "convos@xmtp.com"
+        let email = "hi@convos.org"
         let subject = "Convos Feedback"
         let mailtoString = "mailto:\(email)?subject=\(subject.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? subject)"
 

--- a/Convos/Conversation Detail/ConversationInfoView.swift
+++ b/Convos/Conversation Detail/ConversationInfoView.swift
@@ -77,7 +77,9 @@ struct ConversationInfoView: View {
     @State private var connectionsViewModel: ConversationConnectionsViewModel?
 
     @Environment(\.dismiss) private var dismiss: DismissAction
+    @Environment(\.openURL) private var openURL: OpenURLAction
     @State private var showingExplodeSheet: Bool = false
+    @State private var presentingMailCompose: Bool = false
     @State private var presentingEditView: Bool = false
     @State private var showingLockedInfo: Bool = false
     @State private var showingFullInfo: Bool = false
@@ -512,105 +514,6 @@ struct ConversationInfoView: View {
         }
     }
 
-    // The share-logs row ships in every environment so production users can
-    // send on-device diagnostics to support; the remaining rows are internal
-    // debugging tools and stay out of production builds.
-    @ViewBuilder
-    private var debugInfoSection: some View {
-        let isProduction = ConfigManager.shared.currentEnvironment.isProduction
-        let header: String = isProduction ? "Diagnostics" : "Debug info"
-        Section {
-            if !isProduction {
-                internalDebugRows
-            }
-            shareLogsRow
-        } header: {
-            Text(header)
-                .font(.footnote.weight(.medium))
-                .foregroundStyle(.colorTextSecondary)
-        }
-        .task {
-            await prepareExportedLogs()
-        }
-    }
-
-    @ViewBuilder
-    private var internalDebugRows: some View {
-        HStack {
-            Text("Fork status")
-            Spacer()
-            Text(viewModel.conversation.debugInfo.commitLogForkStatus.rawValue)
-                .foregroundStyle(.colorTextSecondary)
-        }
-        HStack {
-            Text("Epoch")
-            Spacer()
-            Text("\(viewModel.conversation.debugInfo.epoch)")
-                .foregroundStyle(.colorTextSecondary)
-        }
-        NavigationLink {
-            DebugLogsTextView(logs: viewModel.conversation.debugInfo.forkDetails)
-        } label: {
-            Text("Fork details")
-        }
-        NavigationLink {
-            DebugLogsTextView(logs: viewModel.conversation.debugInfo.localCommitLog)
-        } label: {
-            Text("Local commit log")
-        }
-        NavigationLink {
-            DebugLogsTextView(logs: viewModel.conversation.debugInfo.remoteCommitLog)
-        } label: {
-            Text("Remote commit log")
-        }
-        NavigationLink {
-            DebugLogsTextView(logs: metadataDebugText)
-                .task {
-                    metadataDebugText = await viewModel.conversationMetadataDebugText()
-                }
-        } label: {
-            Text("Metadata")
-        }
-        NavigationLink {
-            HiddenMessagesView { try await viewModel.hiddenMessagesDebugInfo() }
-        } label: {
-            Text("Hidden messages")
-        }
-        Button {
-            showingRestoreInviteTagAlert = true
-        } label: {
-            Text("Restore invite tag")
-        }
-    }
-
-    @ViewBuilder
-    private var shareLogsRow: some View {
-        if let url = exportedLogsURL {
-            ShareLink(item: url) {
-                HStack {
-                    Text("Share logs")
-                    Spacer()
-                    Image(systemName: "square.and.arrow.up")
-                }
-            }
-        } else {
-            HStack {
-                Text("Preparing logs…")
-                Spacer()
-                ProgressView()
-            }
-            .foregroundStyle(.colorTextSecondary)
-        }
-    }
-
-    private func prepareExportedLogs() async {
-        do {
-            exportedLogsURL = try await viewModel.exportDebugLogs()
-        } catch {
-            Log.error("Failed to export logs for conversation: \(error.localizedDescription)")
-        }
-    }
-
     private var navigationBarContent: some ToolbarContent {
         Group {
             ToolbarItem(placement: .topBarLeading) {
@@ -758,6 +661,156 @@ struct ConversationInfoView: View {
                         }
                 }
         }
+    }
+}
+
+// MARK: - Support and debug section
+
+extension ConversationInfoView {
+    // The support rows ship in every environment so production users can
+    // send on-device diagnostics to support; the remaining rows are internal
+    // debugging tools and stay out of production builds.
+    @ViewBuilder
+    private var debugInfoSection: some View {
+        let isProduction = ConfigManager.shared.currentEnvironment.isProduction
+        Section {
+            if !isProduction {
+                internalDebugRows
+            }
+            reportIssueRow
+            shareLogsRow
+        } header: {
+            Text("Support")
+                .font(.footnote.weight(.medium))
+                .foregroundStyle(.colorTextSecondary)
+        }
+        .task {
+            await prepareExportedLogs()
+        }
+    }
+
+    @ViewBuilder
+    private var internalDebugRows: some View {
+        HStack {
+            Text("Fork status")
+            Spacer()
+            Text(viewModel.conversation.debugInfo.commitLogForkStatus.rawValue)
+                .foregroundStyle(.colorTextSecondary)
+        }
+        HStack {
+            Text("Epoch")
+            Spacer()
+            Text("\(viewModel.conversation.debugInfo.epoch)")
+                .foregroundStyle(.colorTextSecondary)
+        }
+        NavigationLink {
+            DebugLogsTextView(logs: viewModel.conversation.debugInfo.forkDetails)
+        } label: {
+            Text("Fork details")
+        }
+        NavigationLink {
+            DebugLogsTextView(logs: viewModel.conversation.debugInfo.localCommitLog)
+        } label: {
+            Text("Local commit log")
+        }
+        NavigationLink {
+            DebugLogsTextView(logs: viewModel.conversation.debugInfo.remoteCommitLog)
+        } label: {
+            Text("Remote commit log")
+        }
+        NavigationLink {
+            DebugLogsTextView(logs: metadataDebugText)
+                .task {
+                    metadataDebugText = await viewModel.conversationMetadataDebugText()
+                }
+        } label: {
+            Text("Metadata")
+        }
+        NavigationLink {
+            HiddenMessagesView { try await viewModel.hiddenMessagesDebugInfo() }
+        } label: {
+            Text("Hidden messages")
+        }
+        Button {
+            showingRestoreInviteTagAlert = true
+        } label: {
+            Text("Restore invite tag")
+        }
+    }
+
+    @ViewBuilder
+    private var reportIssueRow: some View {
+        if exportedLogsURL != nil {
+            Button {
+                reportIssue()
+            } label: {
+                HStack {
+                    Text("Report an issue")
+                        .foregroundStyle(.colorTextPrimary)
+                    Spacer()
+                    Image(systemName: "envelope")
+                        .foregroundStyle(.colorTextSecondary)
+                }
+            }
+            .accessibilityIdentifier("report-issue-button")
+            .sheet(isPresented: $presentingMailCompose) {
+                MailComposeView(
+                    recipients: [Constant.supportEmail],
+                    subject: Constant.supportEmailSubject,
+                    attachmentURL: exportedLogsURL
+                )
+                .ignoresSafeArea()
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var shareLogsRow: some View {
+        if let url = exportedLogsURL {
+            ShareLink(item: url) {
+                HStack {
+                    Text("Share logs")
+                        .foregroundStyle(.colorTextPrimary)
+                    Spacer()
+                    Image(systemName: "square.and.arrow.up")
+                        .foregroundStyle(.colorTextSecondary)
+                }
+            }
+            .buttonStyle(.plain)
+        } else {
+            HStack {
+                Text("Preparing logs…")
+                Spacer()
+                ProgressView()
+            }
+            .foregroundStyle(.colorTextSecondary)
+        }
+    }
+
+    private func reportIssue() {
+        if MailComposeView.canSendMail {
+            presentingMailCompose = true
+        } else {
+            // No mail account configured for the system compose sheet: fall
+            // back to a mailto: draft, which cannot carry the logs attachment.
+            let subject = Constant.supportEmailSubject
+            let encodedSubject = subject.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? subject
+            guard let url = URL(string: "mailto:\(Constant.supportEmail)?subject=\(encodedSubject)") else { return }
+            openURL(url)
+        }
+    }
+
+    private func prepareExportedLogs() async {
+        do {
+            exportedLogsURL = try await viewModel.exportDebugLogs()
+        } catch {
+            Log.error("Failed to export logs for conversation: \(error.localizedDescription)")
+        }
+    }
+
+    private enum Constant {
+        static let supportEmail: String = "support@convos.org"
+        static let supportEmailSubject: String = "Convos Issue"
     }
 }
 

--- a/Convos/Conversation Detail/ConversationInfoView.swift
+++ b/Convos/Conversation Detail/ConversationInfoView.swift
@@ -80,6 +80,9 @@ struct ConversationInfoView: View {
     @Environment(\.openURL) private var openURL: OpenURLAction
     @State private var showingExplodeSheet: Bool = false
     @State private var presentingMailCompose: Bool = false
+    @State private var preparingReportIssueEmail: Bool = false
+    @State private var reportIssueAttachment: MailComposeView.Attachment?
+    @State private var exportLogsTask: Task<URL?, Never>?
     @State private var presentingEditView: Bool = false
     @State private var showingLockedInfo: Bool = false
     @State private var showingFullInfo: Bool = false
@@ -740,27 +743,29 @@ extension ConversationInfoView {
 
     @ViewBuilder
     private var reportIssueRow: some View {
-        if exportedLogsURL != nil {
-            Button {
-                reportIssue()
-            } label: {
-                HStack {
-                    Text("Report an issue")
-                        .foregroundStyle(.colorTextPrimary)
-                    Spacer()
+        Button {
+            reportIssue()
+        } label: {
+            HStack {
+                Text("Report an issue")
+                    .foregroundStyle(.colorTextPrimary)
+                Spacer()
+                if preparingReportIssueEmail {
+                    ProgressView()
+                } else {
                     Image(systemName: "envelope")
                         .foregroundStyle(.colorTextSecondary)
                 }
             }
-            .accessibilityIdentifier("report-issue-button")
-            .sheet(isPresented: $presentingMailCompose) {
-                MailComposeView(
-                    recipients: [Constant.supportEmail],
-                    subject: Constant.supportEmailSubject,
-                    attachmentURL: exportedLogsURL
-                )
-                .ignoresSafeArea()
-            }
+        }
+        .accessibilityIdentifier("report-issue-button")
+        .sheet(isPresented: $presentingMailCompose) {
+            MailComposeView(
+                recipients: [Constant.supportEmail],
+                subject: Constant.supportEmailSubject,
+                attachment: reportIssueAttachment
+            )
+            .ignoresSafeArea()
         }
     }
 
@@ -788,29 +793,56 @@ extension ConversationInfoView {
     }
 
     private func reportIssue() {
-        if MailComposeView.canSendMail {
-            presentingMailCompose = true
-        } else {
+        guard !preparingReportIssueEmail else { return }
+        guard MailComposeView.canSendMail else {
             // No mail account configured for the system compose sheet: fall
             // back to a mailto: draft, which cannot carry the logs attachment.
             let subject = Constant.supportEmailSubject
             let encodedSubject = subject.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? subject
             guard let url = URL(string: "mailto:\(Constant.supportEmail)?subject=\(encodedSubject)") else { return }
             openURL(url)
+            return
         }
+        preparingReportIssueEmail = true
+        Task {
+            reportIssueAttachment = await loadReportIssueAttachment()
+            preparingReportIssueEmail = false
+            presentingMailCompose = true
+        }
+    }
+
+    /// Waits for the log export if it is still running, then reads the
+    /// bundle into memory off the main thread so presenting the compose
+    /// sheet doesn't stall on a large file read.
+    private func loadReportIssueAttachment() async -> MailComposeView.Attachment? {
+        guard let url = await exportedLogsURLAwaitingExport() else { return nil }
+        let task = Task.detached { MailComposeView.Attachment(contentsOf: url) }
+        return await task.value
+    }
+
+    private func exportedLogsURLAwaitingExport() async -> URL? {
+        if let exportedLogsURL { return exportedLogsURL }
+        if let exportLogsTask { return await exportLogsTask.value }
+        // The section's export task hasn't started yet; run it directly.
+        return try? await viewModel.exportDebugLogs()
     }
 
     private func prepareExportedLogs() async {
-        do {
-            exportedLogsURL = try await viewModel.exportDebugLogs()
-        } catch {
-            Log.error("Failed to export logs for conversation: \(error.localizedDescription)")
+        let task = Task { () -> URL? in
+            do {
+                return try await viewModel.exportDebugLogs()
+            } catch {
+                Log.error("Failed to export logs for conversation: \(error.localizedDescription)")
+                return nil
+            }
         }
+        exportLogsTask = task
+        exportedLogsURL = await task.value
     }
 
     private enum Constant {
-        static let supportEmail: String = "support@convos.org"
-        static let supportEmailSubject: String = "Convos Issue"
+        static let supportEmail: String = "hi@convos.org"
+        static let supportEmailSubject: String = "I'm reporting an issue"
     }
 }
 

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -3298,6 +3298,7 @@ extension ConversationViewModel {
     @MainActor
     func exportDebugLogs() async throws -> URL {
         let environment = ConfigManager.shared.currentEnvironment
+        logAgentDebugInfo()
 
         var conversationDebugURL: URL?
         do {
@@ -3321,6 +3322,23 @@ extension ConversationViewModel {
                 conversationDebugInfo: debugInfoURL
             )
         }.value
+    }
+
+    /// Writes a summary of the convo's agents into the app log so exported
+    /// log bundles carry agent verification and provenance details.
+    private func logAgentDebugInfo() {
+        let agents = conversation.members.filter(\.isAgent)
+        guard !agents.isEmpty else { return }
+        Log.info("[AgentDebug] convo \(conversation.id) has \(agents.count) agent(s)")
+        for agent in agents {
+            let profile = agent.profile
+            let issuer = agent.agentVerification.issuer?.rawValue ?? "none"
+            let templateId = profile.agentTemplateId ?? "none"
+            let instanceId = profile.agentInstanceId ?? "none"
+            let publishedURL = profile.agentTemplatePublishedURL ?? "none"
+            let summary = "verified=\(agent.isVerifiedAgent), issuer=\(issuer), templateId=\(templateId), instanceId=\(instanceId), publishedUrl=\(publishedURL)"
+            Log.info("[AgentDebug] agent \(profile.inboxId): \(summary)")
+        }
     }
 
     private func metadataDebugFallbackText(reason: String) -> String {

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -3298,7 +3298,7 @@ extension ConversationViewModel {
     @MainActor
     func exportDebugLogs() async throws -> URL {
         let environment = ConfigManager.shared.currentEnvironment
-        logAgentDebugInfo()
+        let agentDebugInfo = agentDebugInfoText()
 
         var conversationDebugURL: URL?
         do {
@@ -3319,17 +3319,19 @@ extension ConversationViewModel {
         return try await Task.detached {
             try DebugLogExporter.exportAllLogs(
                 environment: environment,
-                conversationDebugInfo: debugInfoURL
+                conversationDebugInfo: debugInfoURL,
+                additionalInfo: agentDebugInfo
             )
         }.value
     }
 
-    /// Writes a summary of the convo's agents into the app log so exported
-    /// log bundles carry agent verification and provenance details.
-    private func logAgentDebugInfo() {
+    /// Summary of the convo's agents, staged into the exported bundle's
+    /// convos-info.txt so log bundles carry agent verification and
+    /// provenance details.
+    private func agentDebugInfoText() -> String? {
         let agents = conversation.members.filter(\.isAgent)
-        guard !agents.isEmpty else { return }
-        Log.info("[AgentDebug] convo \(conversation.id) has \(agents.count) agent(s)")
+        guard !agents.isEmpty else { return nil }
+        var lines: [String] = ["Agents in convo (\(agents.count)):"]
         for agent in agents {
             let profile = agent.profile
             let issuer = agent.agentVerification.issuer?.rawValue ?? "none"
@@ -3337,8 +3339,9 @@ extension ConversationViewModel {
             let instanceId = profile.agentInstanceId ?? "none"
             let publishedURL = profile.agentTemplatePublishedURL ?? "none"
             let summary = "verified=\(agent.isVerifiedAgent), issuer=\(issuer), templateId=\(templateId), instanceId=\(instanceId), publishedUrl=\(publishedURL)"
-            Log.info("[AgentDebug] agent \(profile.inboxId): \(summary)")
+            lines.append("agent \(profile.inboxId): \(summary)")
         }
+        return lines.joined(separator: "\n")
     }
 
     private func metadataDebugFallbackText(reason: String) -> String {

--- a/Convos/Debug View/DebugLogExporter.swift
+++ b/Convos/Debug View/DebugLogExporter.swift
@@ -5,14 +5,15 @@ import XMTPiOS
 enum DebugLogExporter {
     static func exportAllLogs(
         environment: AppEnvironment,
-        conversationDebugInfo: URL? = nil
+        conversationDebugInfo: URL? = nil,
+        additionalInfo: String? = nil
     ) throws -> URL {
         pruneXMTPLogs(environment: environment, keepRecentHours: 48)
 
         let stagingDir = try createStagingDirectory()
         defer { try? FileManager.default.removeItem(at: stagingDir) }
 
-        stageAppLog(to: stagingDir, environment: environment)
+        stageAppLog(to: stagingDir, environment: environment, additionalInfo: additionalInfo)
         stageXMTPLogs(to: stagingDir, environment: environment)
 
         if let conversationDebugInfo {
@@ -86,7 +87,7 @@ enum DebugLogExporter {
         return deletedCount
     }
 
-    private static func stageAppLog(to directory: URL, environment: AppEnvironment) {
+    private static func stageAppLog(to directory: URL, environment: AppEnvironment, additionalInfo: String?) {
         guard let containerURL = FileManager.default.containerURL(
             forSecurityApplicationGroupIdentifier: environment.appGroupIdentifier
         ) else { return }
@@ -102,7 +103,7 @@ enum DebugLogExporter {
             }
         }
 
-        let info = """
+        var info = """
         Convos Debug Information
 
         Bundle ID: \(Bundle.main.bundleIdentifier ?? "Unknown")
@@ -111,6 +112,9 @@ enum DebugLogExporter {
         Environment: \(environment)
         Date: \(Date())
         """
+        if let additionalInfo {
+            info += "\n\n\(additionalInfo)"
+        }
         let infoURL = directory.appendingPathComponent("convos-info.txt")
         try? info.write(to: infoURL, atomically: true, encoding: .utf8)
     }

--- a/Convos/Shared Views/MailComposeView.swift
+++ b/Convos/Shared Views/MailComposeView.swift
@@ -1,0 +1,66 @@
+import MessageUI
+import SwiftUI
+
+/// SwiftUI wrapper around the system mail compose sheet, used by support
+/// flows that need to attach files (mailto: links cannot carry attachments).
+/// Check `MailComposeView.canSendMail` before presenting and fall back to a
+/// mailto: link when no mail account is configured.
+struct MailComposeView: UIViewControllerRepresentable {
+    let recipients: [String]
+    let subject: String
+    let attachmentURL: URL?
+
+    @Environment(\.dismiss) private var dismiss: DismissAction
+
+    static var canSendMail: Bool {
+        MFMailComposeViewController.canSendMail()
+    }
+
+    func makeUIViewController(context: Context) -> MFMailComposeViewController {
+        let controller = MFMailComposeViewController()
+        controller.mailComposeDelegate = context.coordinator
+        controller.setToRecipients(recipients)
+        controller.setSubject(subject)
+        if let attachmentURL, let data = try? Data(contentsOf: attachmentURL) {
+            controller.addAttachmentData(
+                data,
+                mimeType: attachmentURL.mailAttachmentMimeType,
+                fileName: attachmentURL.lastPathComponent
+            )
+        }
+        return controller
+    }
+
+    func updateUIViewController(_ uiViewController: MFMailComposeViewController, context: Context) {}
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(onFinish: { dismiss() })
+    }
+
+    final class Coordinator: NSObject, MFMailComposeViewControllerDelegate {
+        private let onFinish: () -> Void
+
+        init(onFinish: @escaping () -> Void) {
+            self.onFinish = onFinish
+        }
+
+        func mailComposeController(
+            _ controller: MFMailComposeViewController,
+            didFinishWith result: MFMailComposeResult,
+            error: Error?
+        ) {
+            onFinish()
+        }
+    }
+}
+
+private extension URL {
+    var mailAttachmentMimeType: String {
+        switch pathExtension.lowercased() {
+        case "zip": "application/zip"
+        case "json": "application/json"
+        case "log", "txt": "text/plain"
+        default: "application/octet-stream"
+        }
+    }
+}

--- a/Convos/Shared Views/MailComposeView.swift
+++ b/Convos/Shared Views/MailComposeView.swift
@@ -5,10 +5,27 @@ import SwiftUI
 /// flows that need to attach files (mailto: links cannot carry attachments).
 /// Check `MailComposeView.canSendMail` before presenting and fall back to a
 /// mailto: link when no mail account is configured.
+///
+/// Attachments are passed pre-loaded so callers can read the file off the
+/// main thread before presenting (large log bundles would otherwise stall
+/// the sheet animation).
 struct MailComposeView: UIViewControllerRepresentable {
+    struct Attachment: Sendable {
+        let data: Data
+        let mimeType: String
+        let fileName: String
+
+        init?(contentsOf url: URL) {
+            guard let data = try? Data(contentsOf: url) else { return nil }
+            self.data = data
+            self.mimeType = url.mailAttachmentMimeType
+            self.fileName = url.lastPathComponent
+        }
+    }
+
     let recipients: [String]
     let subject: String
-    let attachmentURL: URL?
+    let attachment: Attachment?
 
     @Environment(\.dismiss) private var dismiss: DismissAction
 
@@ -21,11 +38,11 @@ struct MailComposeView: UIViewControllerRepresentable {
         controller.mailComposeDelegate = context.coordinator
         controller.setToRecipients(recipients)
         controller.setSubject(subject)
-        if let attachmentURL, let data = try? Data(contentsOf: attachmentURL) {
+        if let attachment {
             controller.addAttachmentData(
-                data,
-                mimeType: attachmentURL.mailAttachmentMimeType,
-                fileName: attachmentURL.lastPathComponent
+                attachment.data,
+                mimeType: attachment.mimeType,
+                fileName: attachment.fileName
             )
         }
         return controller


### PR DESCRIPTION
## Summary

Reworks the bottom section of the conversation info view into a user-facing Support section:

- **Header**: "Diagnostics" (prod) / "Debug info" (dev) is now **"Support"** in all environments. Internal debug rows (fork status, commit logs, etc.) remain dev-only.
- **"Report an issue" row** (new, above "Share logs"): opens the system mail compose sheet with the exported logs zip attached, addressed to `hi@convos.org` with subject "I'm reporting an issue". While the log export / attachment load is in flight, an activity indicator replaces the envelope icon. When no Mail account is configured, falls back to a `mailto:` draft in the user's default mail app (mailto: cannot carry attachments) — same pattern as App Settings' "Send feedback".
- **"Share logs" restyle**: now matches neighboring rows (primary text color, secondary trailing icon) instead of the default blue tint.
- **"Send feedback" (App Settings)**: now addresses `hi@convos.org` (was `convos@xmtp.com`).
- **Agent debug info in exported bundles**: the bundle's `convos-info.txt` now includes a per-agent summary — verification status, issuer, templateId, instanceId, and publishedUrl (each `none` when absent) — so support always sees agent provenance for the convo.

## Implementation notes

- New `MailComposeView` (`Convos/Shared Views/`) wraps `MFMailComposeViewController` for SwiftUI. It takes a pre-loaded `Attachment` (data + MIME type + filename) rather than a URL so callers read the file off the main thread before presenting — the synchronous read was stalling the sheet animation for large log bundles.
- Tapping "Report an issue" awaits the in-flight log export if it hasn't finished (starting one if needed), loads the attachment off-main, then presents; the row's icon swaps to a `ProgressView` for the duration.
- `DebugLogExporter.exportAllLogs` gained an `additionalInfo` parameter appended to `convos-info.txt`; `ConversationViewModel` builds the agent summary from the convo's members.
- The support/debug section moved into a same-file extension of `ConversationInfoView` because the struct crossed SwiftLint's type-body-length cap.

## Testing

- Full ConvosCore suite: 1101 tests in 157 suites, all passing (local XMTP node via Docker).
- Built `Convos (Dev)` for iPhone 17 simulator and verified on-sim: row order, styling (primary text / secondary icons), "Support" header, spinner replacing the envelope during log preparation, mailto fallback no-op without a mail handler, and well-formed `convos-info.txt` (no agent section for agentless convos).
- Agent fields verified against a real exported bundle from a convo with a verified agent (`verified=true, issuer=convos, templateId=…`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add 'Report an issue' support section to conversation info view
> - Adds a new 'Support' section to `ConversationInfoView` with a 'Report an issue' button that opens the system mail compose sheet (with logs attached) or falls back to a `mailto:` URL if no mail account is configured.
> - Adds a new [`MailComposeView`](https://github.com/xmtplabs/convos-ios/pull/985/files#diff-b58cb69be85bc6c875f0f4112ff413b87749feab5c71971ad67502f8bb672052) SwiftUI wrapper around `MFMailComposeViewController` supporting recipients, subject, and file attachments.
> - Log export is coordinated asynchronously so the report-issue flow and the existing share-logs flow share the same export task rather than starting duplicate exports.
> - Exported debug bundles now include agent provenance details (verification status, templateId, instanceId, etc.) appended to `convos-info.txt` via a new `agentDebugInfoText` helper in [`ConversationViewModel`](https://github.com/xmtplabs/convos-ios/pull/985/files#diff-d056b0b131534648b6d13cddafd053be956f5d23d035ad2538db85a8cc370d8d).
> - Updates the support email address from `convos@xmtp.com` to `hi@convos.org` in both `AppSettingsView` and the new `ConversationInfoView.Constant` enum.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ed2b1d9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->