### PR TITLE
Fix clean-install bootstrap conversations flashing as visible rows

### DIFF
--- a/Convos/Agent Builder/AgentBuilderViewModel.swift
+++ b/Convos/Agent Builder/AgentBuilderViewModel.swift
@@ -650,7 +650,7 @@ final class AgentBuilderViewModel: Identifiable {
             withAnimation(.easeInOut(duration: 0.35)) {
                 self.hasCommitted = true
             }
-            // Promote the claimed cache row into a visible conversation
+            // Promote the hidden conversation row into a visible one
             // AFTER `hasCommitted` flips. The `.onChange(of: hasCommitted)`
             // inside `AgentBuilderView` fires the `onCommitted` callback,
             // which the inline-builder host (`ConversationsView`) uses to
@@ -659,11 +659,11 @@ final class AgentBuilderViewModel: Identifiable {
             // `isEmptyCTAActive` flips, the inline builder unmounts, and
             // the onChange handler never fires — leaving no sheet.
             // Sequencing the commit AFTER the state change keeps the
-            // host's callback intact, then the cache flip arrives once
-            // the sheet is already on its way up.
-            if let claimedId = self.newConversationViewModel.claimedConversationId {
-                await self.session.commitClaimedConversation(id: claimedId)
-            }
+            // host's callback intact, then the visibility flip arrives once
+            // the sheet is already on its way up. Covers both the cache-
+            // claimed row and the cache-miss auto-created row (queued until
+            // `.ready` if creation is still in flight).
+            await self.newConversationViewModel.commitConversationVisibility()
         }
 
         Task { @MainActor [weak self] in

--- a/Convos/Conversation Creation/NewConversationViewModel.swift
+++ b/Convos/Conversation Creation/NewConversationViewModel.swift
@@ -739,76 +739,6 @@ class NewConversationViewModel: Identifiable, Hashable {
         }
     }
 
-    /// Promotes this VM's hidden conversation row into a visible one.
-    /// Covers both deferred-visibility shapes: the cache-claimed row
-    /// (id known since acquire) and the auto-created `startsUnused` row
-    /// (id known at `.ready`). When called before the auto-created
-    /// conversation is ready, the commit is queued and flushed by
-    /// `handleStateChange(.ready)` - mirroring how message sends queue
-    /// until the conversation exists.
-    func commitConversationVisibility() async {
-        if let claimedConversationId {
-            // Order behind the `.ready` hook's claim registration so the
-            // commit's claim removal can't be overwritten by a late
-            // registration insert.
-            await claimRegistrationTask?.value
-            await session.commitClaimedConversation(id: claimedConversationId)
-            return
-        }
-        pendingVisibilityCommit = true
-    }
-
-    /// Send a first message through the state machine. Used by wrapping
-    /// flows (e.g. AgentBuilderViewModel) that commit a draft before
-    /// the user sees the chat view. If the state machine hasn't reached
-    /// `.ready` yet, the existing message-stream queue inside
-    /// `ConversationStateMachine.sendMessage` holds the send until it does.
-    func send(text: String) async throws {
-        guard let conversationStateManager else {
-            throw ConversationStateMachineError.noConversationStateManager
-        }
-        try await conversationStateManager.send(text: text)
-    }
-
-    func deleteConversation() {
-        Log.info("Deleting conversation")
-        newConversationTask?.cancel()
-        joinConversationTask?.cancel()
-        // A queued visibility commit must not survive dismissal - the user
-        // abandoned the builder, so a late `.ready` shouldn't promote the
-        // conversation into the chats list.
-        pendingVisibilityCommit = false
-        // Drop the conversation row claimed via `prepareNewConversation()`
-        // when the user backs out without engaging. Key off
-        // `claimedConversationId` so existing-conversation flows
-        // (`.existingConversation(...)`) don't accidentally delete the
-        // user's real conversation. The single-inbox refactor turned the
-        // old per-conversation `session.deleteInbox` cleanup into a no-op
-        // (it would destroy the user's account), so without this the
-        // warm-cached group would persist in the conversations list.
-        // Drafts skip — they don't have a visible row.
-        if let claimedId = claimedConversationId {
-            Task { [session] in
-                await session.discardClaimedConversation(id: claimedId)
-            }
-        }
-    }
-
-    func setDismissAction(_ action: DismissAction) {
-        dismissAction = action
-    }
-
-    func dismissWithDeletion() {
-        _cleanedUp = true
-        displayError = nil
-        currentError = nil
-        isCreatingConversation = false
-        conversationViewModel?.isWaitingForInviteAcceptance = false
-        inboxAcquisitionTask?.cancel()
-        deleteConversation()
-        dismissAction?()
-    }
-
     func retryAction(_ action: RetryAction) {
         displayError = nil
         let delay = retryDelay
@@ -960,6 +890,85 @@ class NewConversationViewModel: Identifiable, Hashable {
         static let retryDelayShort: TimeInterval = 2
         static let retryDelayMedium: TimeInterval = 4
         static let retryDelayMax: TimeInterval = 8
+    }
+}
+
+// MARK: - Conversation lifecycle actions
+
+/// Visibility commit, first-message send, and the delete / dismiss paths.
+/// Split into an extension purely to keep the type body within SwiftLint's
+/// `type_body_length` budget; everything stays `@MainActor`-isolated
+/// (inherited from the type), so behavior is identical to when these
+/// lived inline.
+extension NewConversationViewModel {
+    /// Promotes this VM's hidden conversation row into a visible one.
+    /// Covers both deferred-visibility shapes: the cache-claimed row
+    /// (id known since acquire) and the auto-created `startsUnused` row
+    /// (id known at `.ready`). When called before the auto-created
+    /// conversation is ready, the commit is queued and flushed by
+    /// `handleStateChange(.ready)` - mirroring how message sends queue
+    /// until the conversation exists.
+    func commitConversationVisibility() async {
+        if let claimedConversationId {
+            // Order behind the `.ready` hook's claim registration so the
+            // commit's claim removal can't be overwritten by a late
+            // registration insert.
+            await claimRegistrationTask?.value
+            await session.commitClaimedConversation(id: claimedConversationId)
+            return
+        }
+        pendingVisibilityCommit = true
+    }
+
+    /// Send a first message through the state machine. Used by wrapping
+    /// flows (e.g. AgentBuilderViewModel) that commit a draft before
+    /// the user sees the chat view. If the state machine hasn't reached
+    /// `.ready` yet, the existing message-stream queue inside
+    /// `ConversationStateMachine.sendMessage` holds the send until it does.
+    func send(text: String) async throws {
+        guard let conversationStateManager else {
+            throw ConversationStateMachineError.noConversationStateManager
+        }
+        try await conversationStateManager.send(text: text)
+    }
+
+    func deleteConversation() {
+        Log.info("Deleting conversation")
+        newConversationTask?.cancel()
+        joinConversationTask?.cancel()
+        // A queued visibility commit must not survive dismissal - the user
+        // abandoned the builder, so a late `.ready` shouldn't promote the
+        // conversation into the chats list.
+        pendingVisibilityCommit = false
+        // Drop the conversation row claimed via `prepareNewConversation()`
+        // when the user backs out without engaging. Key off
+        // `claimedConversationId` so existing-conversation flows
+        // (`.existingConversation(...)`) don't accidentally delete the
+        // user's real conversation. The single-inbox refactor turned the
+        // old per-conversation `session.deleteInbox` cleanup into a no-op
+        // (it would destroy the user's account), so without this the
+        // warm-cached group would persist in the conversations list.
+        // Drafts skip — they don't have a visible row.
+        if let claimedId = claimedConversationId {
+            Task { [session] in
+                await session.discardClaimedConversation(id: claimedId)
+            }
+        }
+    }
+
+    func setDismissAction(_ action: DismissAction) {
+        dismissAction = action
+    }
+
+    func dismissWithDeletion() {
+        _cleanedUp = true
+        displayError = nil
+        currentError = nil
+        isCreatingConversation = false
+        conversationViewModel?.isWaitingForInviteAcceptance = false
+        inboxAcquisitionTask?.cancel()
+        deleteConversation()
+        dismissAction?()
     }
 }
 

--- a/Convos/Conversation Creation/NewConversationViewModel.swift
+++ b/Convos/Conversation Creation/NewConversationViewModel.swift
@@ -179,8 +179,16 @@ class NewConversationViewModel: Identifiable, Hashable {
 
     /// Set when `commitConversationVisibility()` runs before the
     /// auto-created conversation reaches `.ready` (no id to flip yet).
-    /// Flushed by `handleStateChange(.ready)`.
+    /// Flushed by `handleStateChange(.ready)`; cleared by
+    /// `deleteConversation()` so a dismissed builder can't promote a
+    /// conversation the user abandoned.
     private var pendingVisibilityCommit: Bool = false
+
+    /// The `.ready` hook's register(+queued commit) work. Awaited by
+    /// `commitConversationVisibility()` so a Make tap landing right after
+    /// `.ready` can't run its commit before the claim registration and
+    /// leave a stale id in the cache's claim set.
+    private var claimRegistrationTask: Task<Void, Never>?
 
     private(set) var isCreatingConversation: Bool = false
     private(set) var currentError: Error?
@@ -740,6 +748,10 @@ class NewConversationViewModel: Identifiable, Hashable {
     /// until the conversation exists.
     func commitConversationVisibility() async {
         if let claimedConversationId {
+            // Order behind the `.ready` hook's claim registration so the
+            // commit's claim removal can't be overwritten by a late
+            // registration insert.
+            await claimRegistrationTask?.value
             await session.commitClaimedConversation(id: claimedConversationId)
             return
         }
@@ -762,6 +774,10 @@ class NewConversationViewModel: Identifiable, Hashable {
         Log.info("Deleting conversation")
         newConversationTask?.cancel()
         joinConversationTask?.cancel()
+        // A queued visibility commit must not survive dismissal - the user
+        // abandoned the builder, so a late `.ready` shouldn't promote the
+        // conversation into the chats list.
+        pendingVisibilityCommit = false
         // Drop the conversation row claimed via `prepareNewConversation()`
         // when the user backs out without engaging. Key off
         // `claimedConversationId` so existing-conversation flows
@@ -1054,7 +1070,7 @@ extension NewConversationViewModel {
                 claimedConversationId = conversationId
                 let shouldCommitNow = pendingVisibilityCommit
                 pendingVisibilityCommit = false
-                Task { [session] in
+                claimRegistrationTask = Task { [session] in
                     await session.registerClaimedConversation(id: conversationId)
                     if shouldCommitNow {
                         await session.commitClaimedConversation(id: conversationId)

--- a/Convos/Conversation Creation/NewConversationViewModel.swift
+++ b/Convos/Conversation Creation/NewConversationViewModel.swift
@@ -160,14 +160,27 @@ class NewConversationViewModel: Identifiable, Hashable {
         }
     }
 
-    /// The id returned by `session.prepareNewConversation()` when this VM
-    /// claimed a row from the unused-conversation cache, or `nil` if the
-    /// pool was empty (and the state machine created one on demand). Kept
-    /// here so wrapping VMs (e.g. `AgentBuilderViewModel`) can call
-    /// `session.commitClaimedConversation(id:)` at their own commit
-    /// moment without re-deriving the id from the draft-vs-real
+    /// The id of the hidden (`isUnused = true`) row this VM owns: either
+    /// the row claimed from the unused-conversation cache via
+    /// `session.prepareNewConversation()`, or - for deferred-visibility
+    /// modes when the pool was empty - the row the state machine created
+    /// on demand (`startsUnused`), captured at `.ready`. Kept here so
+    /// wrapping VMs (e.g. `AgentBuilderViewModel`) can promote the row at
+    /// their own commit moment via `commitConversationVisibility()` without
+    /// re-deriving the id from the draft-vs-real
     /// `conversationViewModel.conversation.id`.
     private(set) var claimedConversationId: String?
+
+    /// `.newAgent` keeps its conversation row hidden until the user taps
+    /// Make. The cache-claimed path defers by skipping the commit at
+    /// acquire; the cache-miss path defers by creating the conversation
+    /// with `startsUnused: true`.
+    private let defersVisibilityUntilCommit: Bool
+
+    /// Set when `commitConversationVisibility()` runs before the
+    /// auto-created conversation reaches `.ready` (no id to flip yet).
+    /// Flushed by `handleStateChange(.ready)`.
+    private var pendingVisibilityCommit: Bool = false
 
     private(set) var isCreatingConversation: Bool = false
     private(set) var currentError: Error?
@@ -283,6 +296,10 @@ class NewConversationViewModel: Identifiable, Hashable {
             self.pendingAgentTemplateIds = agentTemplateIds
         }
 
+        // Only `.newAgent` defers row visibility to the Make tap; every
+        // other mode shows the conversation as soon as it exists.
+        self.defersVisibilityUntilCommit = if case .newAgent = mode { true } else { false }
+
         switch mode {
         case .newConversation, .newAgent, .newConversationWithMembers, .newConversationWithTemplate:
             self.autoCreateConversation = true
@@ -353,6 +370,7 @@ class NewConversationViewModel: Identifiable, Hashable {
         self.startedWithFullscreenScanner = showingFullScreenScanner
         self.startedWithSeededMembers = false
         self.seededMemberInboxIds = []
+        self.defersVisibilityUntilCommit = false
         // Tests-only init - the warm-cache flow goes through the
         // public init. Existing-conversation cleanup guard stays off.
         self.isExistingConversation = false
@@ -585,11 +603,12 @@ class NewConversationViewModel: Identifiable, Hashable {
 
         if autoCreateConversation && existingConversationId == nil {
             let actions: any CoreActions = coreActions
+            let startsUnused: Bool = defersVisibilityUntilCommit
             newConversationTask = Task { [weak self, stateManager] in
                 guard self != nil else { return }
                 guard !Task.isCancelled else { return }
                 do {
-                    try await stateManager.createConversation()
+                    try await stateManager.createConversation(startsUnused: startsUnused)
                     Task { await actions.startedConversation() }
                     await self?.applyGlobalConversationDefaultsIfNeeded(using: stateManager)
                     await self?.persistHidesInviteCardIfNeeded(stateManager: stateManager)
@@ -712,6 +731,21 @@ class NewConversationViewModel: Identifiable, Hashable {
         }
     }
 
+    /// Promotes this VM's hidden conversation row into a visible one.
+    /// Covers both deferred-visibility shapes: the cache-claimed row
+    /// (id known since acquire) and the auto-created `startsUnused` row
+    /// (id known at `.ready`). When called before the auto-created
+    /// conversation is ready, the commit is queued and flushed by
+    /// `handleStateChange(.ready)` - mirroring how message sends queue
+    /// until the conversation exists.
+    func commitConversationVisibility() async {
+        if let claimedConversationId {
+            await session.commitClaimedConversation(id: claimedConversationId)
+            return
+        }
+        pendingVisibilityCommit = true
+    }
+
     /// Send a first message through the state machine. Used by wrapping
     /// flows (e.g. AgentBuilderViewModel) that commit a draft before
     /// the user sees the chat view. If the state machine hasn't reached
@@ -767,6 +801,7 @@ class NewConversationViewModel: Identifiable, Hashable {
             guard let conversationStateManager else { return }
             newConversationTask?.cancel()
             let actions: any CoreActions = coreActions
+            let startsUnused: Bool = defersVisibilityUntilCommit
             newConversationTask = Task { [weak self, conversationStateManager] in
                 guard self != nil else { return }
                 guard !Task.isCancelled else { return }
@@ -775,7 +810,7 @@ class NewConversationViewModel: Identifiable, Hashable {
                     guard !Task.isCancelled else { return }
                 }
                 do {
-                    try await conversationStateManager.createConversation()
+                    try await conversationStateManager.createConversation(startsUnused: startsUnused)
                     Task { await actions.startedConversation() }
                     await self?.applyGlobalConversationDefaultsIfNeeded(using: conversationStateManager)
                 } catch {
@@ -1007,6 +1042,25 @@ extension NewConversationViewModel {
             let readyElapsed = (CFAbsoluteTimeGetCurrent() - perfStartTime) * 1000
             Log.info("[PERF] NewConversation.ready: \(String(format: "%.0f", readyElapsed))ms (origin: \(result.origin))")
             Log.info("Conversation ready!")
+
+            // Deferred-visibility cache-miss path: the state machine created
+            // this conversation hidden (`startsUnused`), so adopt its id as
+            // the claimed row. Registering the claim keeps
+            // `prepareNewConversation()` from handing the same hidden row to
+            // another caller while this flow is alive; a commit requested
+            // before `.ready` (Make tapped during creation) is flushed here.
+            if defersVisibilityUntilCommit, result.origin == .created, claimedConversationId == nil {
+                let conversationId = result.conversationId
+                claimedConversationId = conversationId
+                let shouldCommitNow = pendingVisibilityCommit
+                pendingVisibilityCommit = false
+                Task { [session] in
+                    await session.registerClaimedConversation(id: conversationId)
+                    if shouldCommitNow {
+                        await session.commitClaimedConversation(id: conversationId)
+                    }
+                }
+            }
 
             // Agent-template spawn: the conversation now exists with a
             // shareable invite, so request a fresh instance for each

--- a/ConvosCore/Sources/ConvosCore/Inboxes/ConversationStateMachine.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/ConversationStateMachine.swift
@@ -44,7 +44,13 @@ public actor ConversationStateMachine {
         /// failure transitions to `.error(addMembersFailed(...))`, never
         /// half-built `.ready`. Empty means no hook call (default behavior
         /// for the "+" button flow).
-        case create(initialMemberInboxIds: [String])
+        /// `startsUnused`: when true, the created conversation's row is
+        /// written with `isUnused = true` before publish, keeping it hidden
+        /// from the chats list until a caller explicitly commits it (see
+        /// `SessionManagerProtocol.commitClaimedConversation`). Used by the
+        /// agent builder so its auto-created draft never surfaces as a
+        /// visible row before the user taps Make.
+        case create(initialMemberInboxIds: [String], startsUnused: Bool)
         /// `initialMemberInboxIds`: same semantics as `.create`, but for
         /// the warm-cached / resume-existing path. Required so the
         /// contacts picker flow can route a pre-warmed conversation
@@ -278,8 +284,8 @@ public actor ConversationStateMachine {
 
     // MARK: - Public Actions
 
-    func create(initialMemberInboxIds: [String] = []) {
-        enqueueAction(.create(initialMemberInboxIds: initialMemberInboxIds))
+    func create(initialMemberInboxIds: [String] = [], startsUnused: Bool = false) {
+        enqueueAction(.create(initialMemberInboxIds: initialMemberInboxIds, startsUnused: startsUnused))
     }
 
     func useExisting(conversationId: String, initialMemberInboxIds: [String] = []) {
@@ -349,11 +355,12 @@ public actor ConversationStateMachine {
     private func processAction(_ action: Action) async {
         do {
             switch (_state, action) {
-            case (.uninitialized, let .create(initialMemberInboxIds)), (.error, let .create(initialMemberInboxIds)):
+            case (.uninitialized, let .create(initialMemberInboxIds, startsUnused)),
+                 (.error, let .create(initialMemberInboxIds, startsUnused)):
                 if case .error = _state {
                     await handleStop()
                 }
-                try await handleCreate(initialMemberInboxIds: initialMemberInboxIds)
+                try await handleCreate(initialMemberInboxIds: initialMemberInboxIds, startsUnused: startsUnused)
 
             case (.uninitialized, let .useExisting(conversationId, initialMemberInboxIds)),
                  (.error, let .useExisting(conversationId, initialMemberInboxIds)):
@@ -404,7 +411,7 @@ public actor ConversationStateMachine {
 
     // MARK: - Action Handlers
 
-    private func handleCreate(initialMemberInboxIds: [String]) async throws {
+    private func handleCreate(initialMemberInboxIds: [String], startsUnused: Bool = false) async throws {
         emitStateChange(.creating)
 
         let inboxReady = try await sessionStateManager.waitForInboxReadyResult()
@@ -417,6 +424,34 @@ public actor ConversationStateMachine {
         // here because prepareConversation() is a one-shot operation, not a long-running
         // stream that could overlap with other XMTP operations.
         nonisolated(unsafe) let optimisticConversation = try client.prepareConversation()
+
+        // Deferred-visibility creation: write the hidden row before publish
+        // so the conversation stream's echo of the new group preserves
+        // `isUnused = true` instead of inserting a fresh visible row. The
+        // row stays hidden until the owning flow commits it (agent builder's
+        // Make tap via `commitClaimedConversation`). The provisional invite
+        // tag satisfies the column's UNIQUE constraint until the stream
+        // processor's `ensureInviteTag` stores the real one. If publish
+        // below throws, the row stays - a thrown publish doesn't guarantee
+        // the group missed the network, and a hidden row is harmless (it is
+        // recycled as a future prewarm) while deleting it would let the
+        // stream echo re-insert it visible.
+        if startsUnused, let group = optimisticConversation as? XMTPiOS.Group {
+            let conversationId = group.id
+            let createdAt = group.createdAt
+            let inboxId = client.inboxId
+            let clientConversationId = self.clientConversationId
+            try await databaseWriter.write { db in
+                try UnusedConversationCache.writeUnusedConversationRow(
+                    db: db,
+                    conversationId: conversationId,
+                    clientConversationId: clientConversationId,
+                    inviteTag: UnusedConversationCache.provisionalInviteTag(for: conversationId),
+                    inboxId: inboxId,
+                    createdAt: createdAt
+                )
+            }
+        }
 
         // Publish the conversation
         try await optimisticConversation.publish()

--- a/ConvosCore/Sources/ConvosCore/Inboxes/MockInboxesService.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/MockInboxesService.swift
@@ -25,6 +25,9 @@ public final class MockInboxesService: SessionManagerProtocol, @unchecked Sendab
     public func releaseClaimedConversation(id conversationId: String) async {
     }
 
+    public func registerClaimedConversation(id conversationId: String) async {
+    }
+
     public func discardClaimedConversation(id conversationId: String) async {
     }
 

--- a/ConvosCore/Sources/ConvosCore/Messaging/UnusedConversationCache.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/UnusedConversationCache.swift
@@ -48,6 +48,13 @@ public protocol UnusedConversationCacheProtocol: Actor {
     /// itself — the claim must be cleared so a fresh prewarm can run.
     func releaseClaimedConversationId(_ conversationId: String) async
 
+    /// Registers an externally-created conversation id as claimed so
+    /// `consumeUnusedConversationId` can't hand the same row to another
+    /// caller while it's actively in use (e.g. the agent builder's
+    /// auto-created hidden conversation). In-memory only: an app restart
+    /// clears the claim, which makes an abandoned row consumable again.
+    func registerClaimedConversation(id conversationId: String) async
+
     /// Cancels any in-flight preparation task and awaits its unwind. Call
     /// during inbox teardown so a late-resolving prewarm can't land a stale
     /// row in a fresh DB after teardown returns.
@@ -160,6 +167,10 @@ public actor UnusedConversationCache: UnusedConversationCacheProtocol {
         claimedConversationIds.remove(conversationId)
     }
 
+    public func registerClaimedConversation(id conversationId: String) async {
+        claimedConversationIds.insert(conversationId)
+    }
+
     public func cancel() async {
         let task = backgroundCreationTask
         backgroundCreationTask = nil
@@ -200,19 +211,18 @@ public actor UnusedConversationCache: UnusedConversationCacheProtocol {
         // deterministically. Relying on the underlying XMTP/GRDB awaits to
         // honor cancellation is not reliable — libxmtp's FFI wrappers and
         // GRDB's serial writer both tend to run to completion. A cancelled
-        // task post-publish must hit the catch block so the network group
-        // and any DB row are rolled back in tandem.
+        // task must hit the catch block so the network group and any DB row
+        // are rolled back in tandem.
         let inboxId: String
         let group: XMTPiOS.Group
+        nonisolated(unsafe) let optimisticConversation: any ConversationSender
         do {
             try Task.checkCancellation()
             let inboxReady = try await service.sessionStateManager.waitForInboxReadyResult()
             try Task.checkCancellation()
             let client = inboxReady.client
             inboxId = client.inboxId
-            nonisolated(unsafe) let optimisticConversation = try client.prepareConversation()
-            try await optimisticConversation.publish()
-            try Task.checkCancellation()
+            optimisticConversation = try client.prepareConversation()
             guard let xmtpGroup = optimisticConversation as? XMTPiOS.Group else {
                 Log.error("Pre-created conversation was not a group; abandoning")
                 lastPreparationFailure = Date()
@@ -221,10 +231,8 @@ public actor UnusedConversationCache: UnusedConversationCacheProtocol {
             group = xmtpGroup
         } catch is CancellationError {
             // Teardown asked us to stop; no cooldown because this isn't a
-            // real failure, and nothing to roll back since publish was the
-            // only network side effect and it either didn't run or ran to
-            // completion (in which case the post-publish branch below owns
-            // rollback).
+            // real failure, and nothing to roll back - preparation is local
+            // until the row write and publish below.
             return
         } catch {
             Log.error("Failed to pre-create unused conversation: \(error)")
@@ -232,13 +240,32 @@ public actor UnusedConversationCache: UnusedConversationCacheProtocol {
             return
         }
 
-        // Post-publish work: the group is live on the XMTP network. Any
-        // failure past this point must leave both sides in sync —
-        // `leaveGroup()` to get off the network, and the DB row deleted
-        // (if we already wrote it) so `consumeUnusedConversationId` can't
-        // hand out an id pointing to a group we already left.
+        // Write the hidden row before `publish()` so the conversation
+        // stream's echo of the new group finds an existing `isUnused = true`
+        // row and preserves it. Without this, the echo raced the post-publish
+        // write below and inserted a fresh visible row - the conversation
+        // briefly flashed in the chats list until this method flipped it
+        // back to hidden. The provisional tag (unique per conversation)
+        // avoids colliding on the column's UNIQUE constraint when several
+        // hidden stubs exist at once; `ensureInviteTag` below replaces it
+        // with the real tag. Self-claim for the whole preparation window so
+        // `consumeUnusedConversationId` can't hand out a group that hasn't
+        // finished publishing; the claim is dropped once the row is fully
+        // prepared (or rolled back).
+        claimedConversationIds.insert(group.id)
         var dbRowWritten = false
+        var published = false
         do {
+            _ = try await writeUnusedConversation(
+                conversation: group,
+                inviteTag: Self.provisionalInviteTag(for: group.id),
+                inboxId: inboxId,
+                databaseWriter: databaseWriter
+            )
+            dbRowWritten = true
+            try Task.checkCancellation()
+            try await optimisticConversation.publish()
+            published = true
             try Task.checkCancellation()
             try await group.ensureInviteTag()
             try Task.checkCancellation()
@@ -251,10 +278,10 @@ public actor UnusedConversationCache: UnusedConversationCacheProtocol {
 
             let dbConversation = try await writeUnusedConversation(
                 conversation: group,
+                inviteTag: try group.inviteTag,
                 inboxId: inboxId,
                 databaseWriter: databaseWriter
             )
-            dbRowWritten = true
             try Task.checkCancellation()
 
             let inviteWriter = InviteWriter(
@@ -265,15 +292,32 @@ public actor UnusedConversationCache: UnusedConversationCacheProtocol {
             _ = try await inviteWriter.generate(for: dbConversation)
 
             lastPreparationFailure = nil
+            claimedConversationIds.remove(group.id)
             Log.debug("Pre-created unused conversation: \(group.id)")
         } catch {
             let isCancellation = error is CancellationError
             if isCancellation {
-                Log.debug("Unused conversation preparation cancelled post-publish; rolling back.")
+                Log.debug("Unused conversation preparation cancelled; rolling back.")
             } else {
-                Log.error("Failed to finish unused conversation setup post-publish: \(error). Rolling back to keep state consistent.")
+                Log.error("Failed to finish unused conversation setup: \(error). Rolling back to keep state consistent.")
                 lastPreparationFailure = Date()
             }
+
+            // A thrown `publish()` does not guarantee the group missed the
+            // network - libxmtp can fail on its local Diesel write after the
+            // payload landed, and the stream then echoes the group back. If
+            // the row were deleted here, that echo would re-insert it as a
+            // visible row (the exact flash this method exists to prevent).
+            // So a publish-failure keeps the hidden row and its claim: if
+            // the group landed it gets recycled as the next prewarm after
+            // restart; if it didn't, the row stays hidden and harmless.
+            // Cancellation still rolls back fully - teardown must leave a
+            // clean DB.
+            if !published && dbRowWritten && !isCancellation {
+                Log.warning("Keeping hidden unused-conversation row \(group.id) after publish failure; it is recycled or stays hidden.")
+                return
+            }
+
             // Log leave-group failures at error level so telemetry can
             // detect orphaned MLS groups (live on the XMTP network with no
             // local record). Low-probability — we're the sole member and
@@ -281,10 +325,12 @@ public actor UnusedConversationCache: UnusedConversationCacheProtocol {
             // of these would point to a libxmtp reconnect issue worth
             // investigating. Group id is included so the orphan can be
             // matched against XMTP-side state if needed.
-            do {
-                try await group.leaveGroup()
-            } catch {
-                Log.error("Failed to leave unused-conversation group \(group.id) after post-publish rollback: \(error). Group may remain live on the XMTP network.")
+            if published {
+                do {
+                    try await group.leaveGroup()
+                } catch {
+                    Log.error("Failed to leave unused-conversation group \(group.id) after post-publish rollback: \(error). Group may remain live on the XMTP network.")
+                }
             }
             if dbRowWritten {
                 let conversationId = group.id
@@ -301,88 +347,129 @@ public actor UnusedConversationCache: UnusedConversationCacheProtocol {
                     try DBConversation.deleteOne(db, key: conversationId)
                 }
             }
+            claimedConversationIds.remove(group.id)
         }
     }
 
-    /// Writes the freshly-published group to GRDB in one pass, using the real
-    /// invite tag from the MLS group. Called once per preparation after
-    /// `publish()` and `ensureInviteTag()` have resolved. Treats a pre-existing
-    /// row with the same id as a benign collision (carry its local state, flip
-    /// `isUnused` back to true) rather than a surprise — callers of the cache
-    /// may have touched the row in flight.
+    /// Unique placeholder for the pre-publish row write. The real tag only
+    /// exists after `ensureInviteTag()`, but `conversation.inviteTag` has a
+    /// UNIQUE constraint, so concurrent hidden stubs (prewarm + agent
+    /// builder) can't both use an empty string.
+    static func provisionalInviteTag(for conversationId: String) -> String {
+        "pending-\(conversationId)"
+    }
+
+    /// Writes the pre-created group to GRDB in one pass. Called twice per
+    /// preparation: once before `publish()` with an empty invite tag (so the
+    /// stream's echo of the new group preserves the hidden row instead of
+    /// inserting a visible one), and once after `ensureInviteTag()` with the
+    /// real tag. Treats a pre-existing row with the same id as a benign
+    /// collision (carry its local state, flip `isUnused` back to true)
+    /// rather than a surprise - callers of the cache may have touched the
+    /// row in flight.
     private func writeUnusedConversation(
         conversation: XMTPiOS.Group,
+        inviteTag: String,
         inboxId: String,
         databaseWriter: any DatabaseWriter
     ) async throws -> DBConversation {
         let conversationId = conversation.id
-        let creatorInboxId = try await conversation.creatorInboxId()
-        let inviteTag = try conversation.inviteTag
+        let createdAt = conversation.createdAt
 
         return try await databaseWriter.write { db in
-            try DBMember(inboxId: inboxId).save(db, onConflict: .ignore)
-
-            let dbConversation: DBConversation
-            if let existing = try DBConversation.fetchOne(db, key: conversationId) {
-                dbConversation = existing
-                    .with(isUnused: true)
-                    .with(inviteTag: inviteTag)
-                try dbConversation.update(db)
-            } else {
-                dbConversation = DBConversation(
-                    id: conversationId,
-                    clientConversationId: conversationId,
-                    inviteTag: inviteTag,
-                    creatorId: creatorInboxId,
-                    kind: .group,
-                    consent: .allowed,
-                    createdAt: conversation.createdAt,
-                    name: nil,
-                    description: nil,
-                    imageURLString: nil,
-                    publicImageURLString: nil,
-                    includeInfoInPublicPreview: true,
-                    expiresAt: nil,
-                    debugInfo: .empty,
-                    isLocked: false,
-                    imageSalt: nil,
-                    imageNonce: nil,
-                    imageEncryptionKey: nil,
-                    conversationEmoji: nil,
-                    imageLastRenewed: nil,
-                    isUnused: true,
-                    hasHadVerifiedAgent: false
-                )
-                try dbConversation.save(db)
-            }
-
-            try DBConversationMember(
+            try Self.writeUnusedConversationRow(
+                db: db,
                 conversationId: conversationId,
+                clientConversationId: conversationId,
+                inviteTag: inviteTag,
                 inboxId: inboxId,
-                role: .superAdmin,
-                consent: .allowed,
-                createdAt: Date(),
-                invitedByInboxId: nil
-            ).save(db, onConflict: .ignore)
-
-            try DBMemberProfile(
-                conversationId: conversationId,
-                inboxId: inboxId,
-                name: nil,
-                avatar: nil
-            ).save(db, onConflict: .ignore)
-
-            try ConversationLocalState(
-                conversationId: conversationId,
-                isPinned: false,
-                isUnread: false,
-                isUnreadUpdatedAt: Date.distantPast,
-                isMuted: false,
-                pinnedOrder: nil,
-                hidesInviteCard: false
-            ).save(db, onConflict: .ignore)
-
-            return dbConversation
+                createdAt: createdAt
+            )
         }
+    }
+
+    /// Shared row-shape for a hidden (`isUnused = true`) conversation,
+    /// usable inside any GRDB write. Also used by
+    /// `ConversationStateMachine.handleCreate` when a flow creates its
+    /// conversation with deferred visibility (`startsUnused`), so both
+    /// hidden-creation paths stay byte-identical. `inboxId` is both the
+    /// creator and sole member - these rows only exist for self-created
+    /// groups. An existing row with the same id is flipped back to hidden;
+    /// an empty or provisional `inviteTag` never clobbers a real tag
+    /// already on the row.
+    @discardableResult
+    static func writeUnusedConversationRow(
+        db: Database,
+        conversationId: String,
+        clientConversationId: String,
+        inviteTag: String,
+        inboxId: String,
+        createdAt: Date
+    ) throws -> DBConversation {
+        try DBMember(inboxId: inboxId).save(db, onConflict: .ignore)
+
+        let dbConversation: DBConversation
+        if let existing = try DBConversation.fetchOne(db, key: conversationId) {
+            let incomingIsPlaceholder: Bool = inviteTag.isEmpty || inviteTag.hasPrefix("pending-")
+            let preservedTag: String = incomingIsPlaceholder && !existing.inviteTag.isEmpty ? existing.inviteTag : inviteTag
+            dbConversation = existing
+                .with(isUnused: true)
+                .with(inviteTag: preservedTag)
+            try dbConversation.update(db)
+        } else {
+            dbConversation = DBConversation(
+                id: conversationId,
+                clientConversationId: clientConversationId,
+                inviteTag: inviteTag,
+                creatorId: inboxId,
+                kind: .group,
+                consent: .allowed,
+                createdAt: createdAt,
+                name: nil,
+                description: nil,
+                imageURLString: nil,
+                publicImageURLString: nil,
+                includeInfoInPublicPreview: true,
+                expiresAt: nil,
+                debugInfo: .empty,
+                isLocked: false,
+                imageSalt: nil,
+                imageNonce: nil,
+                imageEncryptionKey: nil,
+                conversationEmoji: nil,
+                imageLastRenewed: nil,
+                isUnused: true,
+                hasHadVerifiedAgent: false
+            )
+            try dbConversation.save(db)
+        }
+
+        try DBConversationMember(
+            conversationId: conversationId,
+            inboxId: inboxId,
+            role: .superAdmin,
+            consent: .allowed,
+            createdAt: Date(),
+            invitedByInboxId: nil
+        ).save(db, onConflict: .ignore)
+
+        try DBMemberProfile(
+            conversationId: conversationId,
+            inboxId: inboxId,
+            name: nil,
+            avatar: nil
+        ).save(db, onConflict: .ignore)
+
+        try ConversationLocalState(
+            conversationId: conversationId,
+            isPinned: false,
+            isUnread: false,
+            isUnreadUpdatedAt: Date.distantPast,
+            isMuted: false,
+            pinnedOrder: nil,
+            hidesInviteCard: false
+        ).save(db, onConflict: .ignore)
+
+        return dbConversation
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Messaging/UnusedConversationCache.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/UnusedConversationCache.swift
@@ -123,8 +123,7 @@ public actor UnusedConversationCache: UnusedConversationCacheProtocol {
         let claimedSnapshot = claimedConversationIds
         do {
             let claimedId: String? = try await databaseWriter.read { db -> String? in
-                var request = DBConversation
-                    .filter(DBConversation.Columns.isUnused == true)
+                var request = Self.consumableUnusedConversationRequest()
                 if !claimedSnapshot.isEmpty {
                     request = request.filter(!claimedSnapshot.contains(DBConversation.Columns.id))
                 }
@@ -138,6 +137,23 @@ public actor UnusedConversationCache: UnusedConversationCacheProtocol {
             Log.error("Failed to consume unused conversation: \(error)")
             return nil
         }
+    }
+
+    /// Rows eligible for handout: hidden, cache-shaped
+    /// (`clientConversationId == id`), and fully prepared (real invite
+    /// tag). The agent builder's deferred-visibility stubs carry their
+    /// draft client id and are owned by that flow until committed or
+    /// discarded - handing one to a second caller would put two flows on
+    /// one conversation. Rows still carrying a provisional or empty tag
+    /// never finished preparation (publish or tag write failed), so they
+    /// stay out of the pool rather than risk surfacing a placeholder tag
+    /// in an invite.
+    private static func consumableUnusedConversationRequest() -> QueryInterfaceRequest<DBConversation> {
+        DBConversation
+            .filter(DBConversation.Columns.isUnused == true)
+            .filter(DBConversation.Columns.clientConversationId == DBConversation.Columns.id)
+            .filter(length(DBConversation.Columns.inviteTag) > 0)
+            .filter(!DBConversation.Columns.inviteTag.like("\(provisionalInviteTagPrefix)%"))
     }
 
     public func commitClaimedConversation(
@@ -186,8 +202,10 @@ public actor UnusedConversationCache: UnusedConversationCacheProtocol {
         let claimedSnapshot = claimedConversationIds
         do {
             return try await databaseReader.read { db in
-                var request = DBConversation
-                    .filter(DBConversation.Columns.isUnused == true)
+                // Mirrors `consumeUnusedConversationId`'s eligibility so a
+                // row consume would skip (builder stub, half-prepared row)
+                // can't suppress preparing a fresh consumable one.
+                var request = Self.consumableUnusedConversationRequest()
                 if !claimedSnapshot.isEmpty {
                     request = request.filter(!claimedSnapshot.contains(DBConversation.Columns.id))
                 }
@@ -242,10 +260,11 @@ public actor UnusedConversationCache: UnusedConversationCacheProtocol {
 
         // Write the hidden row before `publish()` so the conversation
         // stream's echo of the new group finds an existing `isUnused = true`
-        // row and preserves it. Without this, the echo raced the post-publish
-        // write below and inserted a fresh visible row - the conversation
-        // briefly flashed in the chats list until this method flipped it
-        // back to hidden. The provisional tag (unique per conversation)
+        // row and preserves it. Before this ordering, the row was only
+        // written after publish, so the echo raced it and inserted a fresh
+        // visible row - the conversation briefly flashed in the chats list
+        // until the late write flipped it back to hidden. The provisional
+        // tag (unique per conversation)
         // avoids colliding on the column's UNIQUE constraint when several
         // hidden stubs exist at once; `ensureInviteTag` below replaces it
         // with the real tag. Self-claim for the whole preparation window so
@@ -351,12 +370,21 @@ public actor UnusedConversationCache: UnusedConversationCacheProtocol {
         }
     }
 
+    /// Prefix marking an invite tag as a pre-publish placeholder. Mirrors
+    /// the `DBConversation.draftPrefix` pattern: every producer and
+    /// consumer of provisional tags derives from this one constant.
+    static let provisionalInviteTagPrefix: String = "pending-"
+
     /// Unique placeholder for the pre-publish row write. The real tag only
     /// exists after `ensureInviteTag()`, but `conversation.inviteTag` has a
     /// UNIQUE constraint, so concurrent hidden stubs (prewarm + agent
     /// builder) can't both use an empty string.
     static func provisionalInviteTag(for conversationId: String) -> String {
-        "pending-\(conversationId)"
+        "\(provisionalInviteTagPrefix)\(conversationId)"
+    }
+
+    static func isProvisionalInviteTag(_ inviteTag: String) -> Bool {
+        inviteTag.hasPrefix(provisionalInviteTagPrefix)
     }
 
     /// Writes the pre-created group to GRDB in one pass. Called twice per
@@ -410,7 +438,7 @@ public actor UnusedConversationCache: UnusedConversationCacheProtocol {
 
         let dbConversation: DBConversation
         if let existing = try DBConversation.fetchOne(db, key: conversationId) {
-            let incomingIsPlaceholder: Bool = inviteTag.isEmpty || inviteTag.hasPrefix("pending-")
+            let incomingIsPlaceholder: Bool = inviteTag.isEmpty || isProvisionalInviteTag(inviteTag)
             let preservedTag: String = incomingIsPlaceholder && !existing.inviteTag.isEmpty ? existing.inviteTag : inviteTag
             dbConversation = existing
                 .with(isUnused: true)

--- a/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
@@ -415,6 +415,10 @@ public final class SessionManager: SessionManagerProtocol, @unchecked Sendable {
         await unusedConversationCache.releaseClaimedConversationId(conversationId)
     }
 
+    public func registerClaimedConversation(id conversationId: String) async {
+        await unusedConversationCache.registerClaimedConversation(id: conversationId)
+    }
+
     public func discardClaimedConversation(id conversationId: String) async {
         await unusedConversationCache.releaseClaimedConversationId(conversationId)
         guard !DBConversation.isDraft(id: conversationId) else { return }

--- a/ConvosCore/Sources/ConvosCore/Sessions/SessionManagerProtocol.swift
+++ b/ConvosCore/Sources/ConvosCore/Sessions/SessionManagerProtocol.swift
@@ -68,6 +68,14 @@ public protocol SessionManagerProtocol: AnyObject, Sendable {
     /// flow re-enters and wants to re-claim from a fresh prewarm.
     func releaseClaimedConversation(id conversationId: String) async
 
+    /// Registers a conversation created outside the cache (e.g. the agent
+    /// builder's auto-created hidden draft, `createConversation(startsUnused:)`)
+    /// as claimed, so `prepareNewConversation()` can't hand the same row to
+    /// another caller while it's actively in use. In-memory only: an app
+    /// restart clears the claim, making an abandoned hidden row consumable
+    /// by the cache again.
+    func registerClaimedConversation(id conversationId: String) async
+
     /// Drops a conversation that was claimed via `prepareNewConversation()` but
     /// never engaged with by the user — typically called from the new-
     /// conversation / Agent Builder X-cancel path when no messages have

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationStateManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationStateManager.swift
@@ -227,7 +227,14 @@ public final class ConversationStateManager: ConversationStateManagerProtocol, @
     // MARK: - DraftConversationWriterProtocol Methods
 
     public func createConversation() async throws {
-        await stateMachine.create(initialMemberInboxIds: initialMemberInboxIds)
+        try await createConversation(startsUnused: false)
+    }
+
+    public func createConversation(startsUnused: Bool) async throws {
+        await stateMachine.create(
+            initialMemberInboxIds: initialMemberInboxIds,
+            startsUnused: startsUnused
+        )
     }
 
     public func joinConversation(inviteCode: String) async throws {

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationWriter.swift
@@ -681,6 +681,13 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
             if !localConversation.isUnused {
                 conversationToSave = conversationToSave.with(createdAt: localConversation.createdAt)
             }
+            // Preserve hidden state, mirroring `updateExistingConversation`'s
+            // by-id branch: a row only becomes visible through an explicit
+            // commit (`commitClaimedConversation`), never via a stream echo
+            // replacing it by invite tag.
+            if localConversation.isUnused {
+                conversationToSave = conversationToSave.with(isUnused: true)
+            }
             // This row is replacing `localConversation`, so its sticky-on
             // agent flag must carry forward.
             let mergedHasAgentByTag: Bool = localConversation.hasHadVerifiedAgent || conversationToSave.hasHadVerifiedAgent

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/DraftConversationWriterProtocol.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/DraftConversationWriterProtocol.swift
@@ -7,5 +7,19 @@ public protocol DraftConversationWriterProtocol: OutgoingMessageWriterProtocol {
     var conversationMetadataWriter: any ConversationMetadataWriterProtocol { get }
 
     func createConversation() async throws
+    /// Creates the conversation with deferred visibility: the row is written
+    /// `isUnused = true` (hidden from the chats list) and stays hidden until
+    /// a caller commits it via `SessionManagerProtocol.commitClaimedConversation`.
+    /// Used by the agent builder so its auto-created draft never surfaces
+    /// before the user taps Make.
+    func createConversation(startsUnused: Bool) async throws
     func joinConversation(inviteCode: String) async throws
+}
+
+public extension DraftConversationWriterProtocol {
+    /// Default forwards to the plain create so conformers that don't
+    /// support deferred visibility (mocks, previews) keep compiling.
+    func createConversation(startsUnused: Bool) async throws {
+        try await createConversation()
+    }
 }

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/DraftConversationWriterProtocol.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/DraftConversationWriterProtocol.swift
@@ -17,8 +17,10 @@ public protocol DraftConversationWriterProtocol: OutgoingMessageWriterProtocol {
 }
 
 public extension DraftConversationWriterProtocol {
-    /// Default forwards to the plain create so conformers that don't
-    /// support deferred visibility (mocks, previews) keep compiling.
+    /// Default forwards to the plain create, dropping the flag. This is
+    /// for mocks and previews only - any production conformer must
+    /// override it, or deferred-visibility creation silently degrades to
+    /// a visible row.
     func createConversation(startsUnused: Bool) async throws {
         try await createConversation()
     }


### PR DESCRIPTION
## Summary

On a clean install with zero user interaction, two "New Convo" rows appeared in the chats list: the prewarmed cache conversation flashed visible for ~14s before flipping back to hidden, and the inline agent builder's auto-created draft became a permanently visible row. Both were captured live on a factory-erased simulator (DB polling at 50ms + screen recording + app logs).

**Repro trace (factory-clean sim, no interaction):**

| time | event |
|---|---|
| 16:44:58 | Agent-builder auto-create publishes group `8b5670…`, stored `isUnused=0` -> visible forever |
| 16:45:38 | Prewarm group `7671ae…` echoed back by the stream, stored `isUnused=0` -> visible |
| 16:45:52 | Cache's own write flips `7671ae…` back to `isUnused=1` -> 14-second flash |

## Root cause

The store path defaults every new conversation row to visible (`isUnused: false`), and "hidden" was only enforced after the fact:

1. **Prewarm flash**: `UnusedConversationCache.runPreparation()` published the group on XMTP, then did more async work (`ensureInviteTag`, `ensureImageEncryptionKey`), and only then wrote the hidden DB row. In that window the conversation stream echoed the group back and `ConversationWriter` inserted it as a fresh visible row; the cache's later write flipped it back (the code even called this a "benign collision").
2. **Agent-builder phantom row**: `.newAgent` mode auto-creates its conversation on mount. With an empty cache (always true on first install, prewarm still in flight), `prepareNewConversation()` returns nil and `ConversationStateMachine.handleCreate` publishes a brand-new group that gets stored visible. The deferred-commit logic only protected the cache-claimed path; the auto-created row had no claimed id, so nothing ever hid or committed it.

## Fix

Make "hidden until committed" hold from the row's birth, for both creation paths:

- **`UnusedConversationCache`**: write the hidden row *before* `publish()` so the stream echo finds an existing `isUnused = true` row and preserves it (the by-id update path already preserves hidden state). The cache self-claims the id for the whole preparation window so `consumeUnusedConversationId` can't hand out a group that hasn't finished publishing. Rollback now also covers the pre-publish row (delete row; `leaveGroup()` only if publish succeeded).
- **`ConversationStateMachine.handleCreate(startsUnused:)`**: new flag threaded from `NewConversationViewModel` (`.newAgent` only) through `DraftConversationWriterProtocol.createConversation(startsUnused:)`. When set, the same hidden-row shape (shared `UnusedConversationCache.writeUnusedConversationRow`) is written between `prepareConversation()` and `publish()`.
- **Commit side**: `NewConversationViewModel.commitConversationVisibility()` promotes the row at the Make tap. Covers the cache-claimed row (id known at acquire) and the auto-created row (id adopted as `claimedConversationId` at `.ready`, registered with the cache claim set so no other flow can consume it while the builder is alive). A Make tap that lands before `.ready` queues the commit and flushes it at `.ready`, mirroring how message sends queue.
- **`ConversationWriter.saveConversation`**: the match-by-invite-tag branch now preserves `isUnused` like the match-by-id branch already did — a row only becomes visible through an explicit commit, never via a stream echo replacing it.

Abandoned hidden rows (app killed mid-builder) are claimable by the cache again on next launch (claims are in-memory), so they get recycled as the next prewarmed conversation instead of accumulating.

## Bonus effects

- `hasAnyUsedConversations()` (pairing destructive-warning gate) is now accurate on fresh installs: bootstrap rows stay `isUnused = true` until real engagement.
- The inline agent builder no longer unmounts/remounts on first install (its own phantom row was flipping the list out of the empty state).

## Verification

- Fresh-install run on a factory-erased simulator: conversation table shows both bootstrap rows `isUnused=1` from creation; chats list stays empty; no flash.
- Make-tap flow: typed a prompt, tapped Make — row flips `isUnused=0`, conversation appears in the list, sheet presents.
- App builds (`Convos (Dev)`); SwiftLint clean on changed files.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix bootstrap conversations flashing as visible rows during clean-install agent creation
> - New conversations created in `.newAgent` mode are now written as hidden rows (via `startsUnused`) before being published to the network, preventing them from appearing in the chats list prematurely.
> - Introduces deferred visibility coordination in [`NewConversationViewModel`](https://github.com/xmtplabs/convos-ios/pull/986/files#diff-bc0af06ca6587e88461a662416743a0ef38cc55d66fc169caad65a62fb3abe47): a `commitConversationVisibility()` method promotes hidden rows to visible, handling both cache-claimed and auto-created paths, including taps that arrive before `.ready`.
> - [`UnusedConversationCache`](https://github.com/xmtplabs/convos-ios/pull/986/files#diff-927068b0d884e130c12a37c911c53ee25bd89d9fe2c772600c66cd42edd25220) now writes hidden rows with a provisional invite tag before publish, so prewarmed conversations are never visible mid-preparation; stream echoes replacing hidden rows by invite tag no longer flip them visible.
> - [`ConversationWriter`](https://github.com/xmtplabs/convos-ios/pull/986/files#diff-113bfd0c28b1a3b561f19e4574a0937082fe5c92a262e57573eee7728940a726) preserves `isUnused == true` when upserting by invite tag to prevent network echoes from revealing hidden rows.
> - Risk: The ordering contract between `claimRegistrationTask` and `commitConversationVisibility()` is new; a race during dismissal before `.ready` is mitigated by clearing `pendingVisibilityCommit` on deletion, but error-path rollbacks in `UnusedConversationCache` are more complex than before.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 282b70e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->