### PR TITLE
Fix conversation-open scroll flicker: apply bottom-bar insets synchronously outside performWithoutAnimation scopes

### DIFF
--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/MessagesViewController.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/MessagesViewController.swift
@@ -150,6 +150,11 @@ final class MessagesViewController: UIViewController {
                     let isNewMessage = currentLastMessageId != self.previousLastMessageId
                     self.previousLastMessageId = currentLastMessageId
 
+                    // Apply any pending deferred inset before reading
+                    // inset-dependent scroll heuristics below (`isNearBottom`)
+                    // or anchoring; this completion runs via the main queue,
+                    // never re-entrantly inside a UIKit layout pass.
+                    self.flushPendingBottomBarInsetUpdate()
                     let isInitialLoad = currentControllerActions.options.contains(.loadingInitialMessages)
                     let nearBottom = self.isNearBottom
                     let userScrolling = self.isUserInitiatedScrolling
@@ -184,20 +189,36 @@ final class MessagesViewController: UIViewController {
 
     /// `bottomBarHeight` is only written from `updateUIViewController`, which can run
     /// synchronously inside an in-flight UIKit layout pass (e.g. a sheet's keyboard
-    /// relayout in `UISheetPresentationController`). Animating inset changes and forcing
-    /// collection view layout re-entrantly from there crashes in UIKit's
+    /// relayout in `UISheetPresentationController`, which wraps it in
+    /// `performWithoutAnimation`). Animating inset changes and forcing collection view
+    /// layout re-entrantly from there crashes in UIKit's
     /// `_updateLayoutAttributesForExistingVisibleViewsFadingForBoundsChange:` assertion,
     /// because `restoreContentOffset` suppresses layout attributes while the collection
-    /// view is mid bounds change. Deferring to the next run loop tick keeps the update
-    /// out of the enclosing layout pass; rapid changes coalesce into one update.
+    /// view is mid bounds change. In that scope (animations disabled) the update is
+    /// deferred to the next run loop tick; rapid changes coalesce into one update.
+    /// Everywhere else the update applies synchronously - see
+    /// `scheduleBottomBarInsetUpdate`.
     ///
-    /// Initial layout stays correct because `updateUIViewController` assigns
-    /// `bottomBarHeight` before `state`, so this deferred inset block is enqueued ahead
-    /// of the initial load's scroll-to-bottom (which runs via the collection view
-    /// reload's async completion). Keep that assignment order in the representable.
+    /// Bottom-anchored positioning that runs while a deferred update is pending must
+    /// not compute against the stale inset; `flushPendingBottomBarInsetUpdate` applies
+    /// it first via the non-animated direct path.
     private var hasPendingBottomBarInsetUpdate: Bool = false
 
     private func scheduleBottomBarInsetUpdate() {
+        // The deferral below exists only for the crash scenario above, whose
+        // necessary ingredient is an enclosing `performWithoutAnimation`
+        // scope (the inset change becomes a non-animated bounds change and
+        // UIKit takes the fade-for-bounds-change path). When animations are
+        // enabled we are not in that scope, so the inset applies
+        // synchronously - keeping bottom-anchored positioning atomic with
+        // the height change that triggered it. Deferring in that case made
+        // the conversation-open layout re-anchor once per runloop tick as
+        // the bottom bar measured, which read as a scroll flicker.
+        if UIView.areAnimationsEnabled {
+            hasPendingBottomBarInsetUpdate = false
+            updateBottomInsetForBottomBarHeight()
+            return
+        }
         guard !hasPendingBottomBarInsetUpdate else { return }
         hasPendingBottomBarInsetUpdate = true
         DispatchQueue.main.async { [weak self] in
@@ -205,6 +226,25 @@ final class MessagesViewController: UIViewController {
             self.hasPendingBottomBarInsetUpdate = false
             self.updateBottomInsetForBottomBarHeight()
         }
+    }
+
+    /// Synchronously applies a deferred bottom-bar inset update, if one is
+    /// pending, using the same non-animated direct path as
+    /// `applyDeferredBottomInset` (no animated bounds change, no forced
+    /// collection view layout, so it stays safe inside an in-flight UIKit
+    /// layout pass).
+    ///
+    /// Bottom-anchored positioning (the initial load's restore-to-bottom and
+    /// `scrollToBottom`) reads `adjustedContentInset.bottom` at computation
+    /// time. With the inset application deferred a runloop tick, those
+    /// computations would otherwise use a stale inset and land the list short
+    /// of the real bottom, then visibly re-anchor once per tick as the
+    /// deferred updates apply - the "conversation opens slightly scrolled up,
+    /// then jumps" flicker. Flushing first keeps every paint self-consistent.
+    private func flushPendingBottomBarInsetUpdate() {
+        guard hasPendingBottomBarInsetUpdate else { return }
+        hasPendingBottomBarInsetUpdate = false
+        applyDeferredBottomInset()
     }
 
     /// Hosts that don't render a bottom bar (e.g. the thinking detail sheet)
@@ -604,6 +644,7 @@ final class MessagesViewController: UIViewController {
     }
 
     func scrollToBottom(animated: Bool = true, completion: (() -> Void)? = nil) {
+        flushPendingBottomBarInsetUpdate()
         collectionView.setContentOffset(collectionView.contentOffset, animated: false)
 
         let contentOffsetAtBottom = CGPoint(
@@ -817,6 +858,13 @@ extension MessagesViewController {
                         kind: .footer,
                         edge: .bottom
                     )
+                    // Safe to combine with the forced layout in
+                    // `restoreContentOffset` below: section inserts (the only
+                    // way into this interrupted-reload path) happen solely on
+                    // the initial load, never re-entrantly inside a sheet's
+                    // keyboard layout pass - the scenario the deferred inset
+                    // path exists to avoid.
+                    self.flushPendingBottomBarInsetUpdate()
                     self.collectionView.reloadData()
                     self.messagesLayout.restoreContentOffset(with: positionSnapshot)
                 },

--- a/Convos/Conversation Detail/Messages/MessagesView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesView.swift
@@ -169,6 +169,11 @@ struct MessagesView<BottomBarContent: View>: View {
                 )
             },
             bottomBarHeight: bottomBarHeight + extraBottomInset,
+            // Read-only hosts never render the composer (see the
+            // `safeAreaBar` below), so the controller must not wait for a
+            // bottom-bar measurement before applying its initial state and
+            // revealing the list.
+            hasBottomBar: !isReadOnly,
             scrollToBottomTrigger: { scrollFn in
                 scrollToBottom = scrollFn
             },


### PR DESCRIPTION
## Problem

Tapping into a conversation painted the message list slightly scrolled up from the bottom, then visibly staircased down (~200pt across 4-5 discrete offset jumps) while it settled — the recently introduced open-flicker.

## Root cause (established with diagnostic logging)

Reproduced by flooding a conversation with every message type (text, emoji, link previews, agent-share contact cards incl. real `agents-dev.convos.org/a/...` links, replies, reactions, rename update cells, 8 odd-size photos, video, voice memo) and instrumenting the scroll/inset pipeline:

1. **#978's deferred inset application.** `bottomBarHeight`'s didSet deferred every `contentInset.bottom` update one runloop tick (to avoid the sheet-keyboard fade-for-bounds-change crash). The initial reload's restore-to-bottom and the initial `scrollToBottom` therefore computed their anchors against a stale `adjustedContentInset.bottom`, then re-anchored a tick later when each deferred update applied.
2. **Progressive bottom-bar measurement.** The SwiftUI bottom bar measures over several runloop ticks (`bottomBarHeight` fires 0 → 24 → 97 → 177 during one open), so the already-visible list re-anchored at every step.

Captured log sequence pre-fix: restore at inset 0 → safe-area transient re-adjust → deferred inset re-anchor → scroll-to-bottom jump → second deferred inset re-anchor = **5 visible offset jumps on 10/10 opens**.

## Fix

The #978 deferral exists only for one crash, whose necessary ingredient is an enclosing `performWithoutAnimation` scope (the sheet's keyboard relayout): the inset change becomes a non-animated bounds change and UIKit's fade-for-bounds-change assert fires against `restoreContentOffset`'s suppressed attributes. That ingredient is directly detectable:

- **`scheduleBottomBarInsetUpdate` applies the inset synchronously when `UIView.areAnimationsEnabled`** (every normal path, including conversation open) — restoring pre-#978 atomicity: bottom-anchored positioning happens in the same runloop tick as the height change that triggered it, so every paint is self-consistent. The one-tick deferral remains only inside animations-disabled scopes — the crash scenario.
- **`flushPendingBottomBarInsetUpdate()`** — if positioning runs while a deferred update is pending (animations-disabled contexts), `scrollToBottom` and the initial interrupted-reload restore first apply it via the same non-animated direct path as `applyDeferredBottomInset` (no animated bounds change, no forced layout), so anchors are never computed against a stale inset.
- **`MessagesView` passes `hasBottomBar: !isReadOnly`** so a future read-only host (no composer) can't park the initial state update forever waiting for a bottom-bar measurement that never arrives.

> Note: an earlier revision of this PR hid the collection view (alpha 0) until the initial anchor settled. That eliminated the staircase but made the content visibly appear late ("animate in"). This revision drops the hiding entirely — content paints bottom-anchored from its first frame.

## Validation (iPhone 17 Pro sim, Dev scheme)

- Pre-fix: 10/10 opens showed 5 visible offset jumps each (instrumented `scrollViewDidScroll` jump detector + frame-by-frame video).
- Post-fix: 10/10 opens — initial restore computes against the already-applied inset, initial `scrollToBottom` is a no-op (already at bottom), content visible and bottom-anchored from its first paint mid-zoom-transition. The only subsequent motion is the smooth animated tracking as late bottom-bar elements (notifications pill) mount — identical to pre-#978 behavior.
- Send path, keyboard focus, and scrolling verified unchanged.

⚠️ Tests intentionally skipped per request — watching CI instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix scroll flicker on conversation open by applying bottom-bar insets synchronously
> - `scheduleBottomBarInsetUpdate` in [MessagesViewController.swift](https://github.com/xmtplabs/convos-ios/pull/987/files#diff-1427b816e5e93d8bc7ea882f5eabd9671135c6f9b9ebc6b0a6f7116a2f8a37c3) now applies inset updates synchronously when animations are enabled, and only defers via `DispatchQueue.main.async` inside `performWithoutAnimation` scopes.
> - Adds `flushPendingBottomBarInsetUpdate()` to force-apply any pending inset before bottom-anchored computations in `scrollToBottom`, `processUpdates`, and the controller state update completion closure.
> - [MessagesView.swift](https://github.com/xmtplabs/convos-ios/pull/987/files#diff-f2896da346a719372c7763c8516c4542fa2bd940568ea9c4d0ae5b0e6a2062f8) passes `hasBottomBar: false` for read-only hosts so the controller doesn't wait for a bottom-bar measurement that never arrives.
> - Behavioral Change: bottom inset updates that previously always deferred one runloop tick now apply immediately when animations are enabled, which changes timing of inset-dependent layout during conversation open.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 845be6e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->