### PR TITLE
Fix tab bar overlapping conversations opened from the contact card

### DIFF
--- a/Convos/Contacts/ContactDetailView.swift
+++ b/Convos/Contacts/ContactDetailView.swift
@@ -49,6 +49,15 @@ struct ContactDetailView: View {
     /// (where the system already renders a chevron back button) pass false
     /// so the user doesn't see two redundant dismiss controls.
     let showsCloseButton: Bool
+    /// Whether a conversation pushed from the "Convos with you" rows should
+    /// inset its indicator below the device's top safe area. Only the
+    /// Contacts tab passes true - its push lands full screen, extending
+    /// under the status bar. Every sheet-hosted card (member tap in a chat,
+    /// members list) keeps the default false: the sheet's top edge already
+    /// sits below the status bar, so the device inset would render the
+    /// indicator too far down. Not derivable from `showsCloseButton` - the
+    /// members list pushes the card (no X) but its stack lives in a sheet.
+    let pushedConversationInsetsTopSafeArea: Bool
     private let contactsWriter: any ContactsWriterProtocol
     private let contactsRepository: any ContactsRepositoryProtocol
     private let session: (any SessionManagerProtocol)?
@@ -101,6 +110,7 @@ struct ContactDetailView: View {
         coreActions: any CoreActions,
         profileSettingsViewModel: ProfileSettingsViewModel = .shared,
         showsCloseButton: Bool = true,
+        pushedConversationInsetsTopSafeArea: Bool = false,
         onRemove: (() -> Void)? = nil
     ) {
         self.contact = contact
@@ -111,6 +121,7 @@ struct ContactDetailView: View {
         self.coreActions = coreActions
         self.profileSettingsViewModel = profileSettingsViewModel
         self.showsCloseButton = showsCloseButton
+        self.pushedConversationInsetsTopSafeArea = pushedConversationInsetsTopSafeArea
         self.onRemove = onRemove
         _isBlocked = State(initialValue: contact.isBlocked)
         // Suggested-agent contacts carry the description, so it renders
@@ -183,7 +194,7 @@ struct ContactDetailView: View {
             viewModel: viewModel,
             profileSettingsViewModel: profileSettingsViewModel,
             embedsNavigationStack: false,
-            insetsTopSafeArea: true
+            insetsTopSafeArea: pushedConversationInsetsTopSafeArea
         )
         .background(.colorBackgroundSurfaceless)
         .toolbarVisibility(.hidden, for: .tabBar)

--- a/Convos/Contacts/ContactDetailView.swift
+++ b/Convos/Contacts/ContactDetailView.swift
@@ -172,7 +172,11 @@ struct ContactDetailView: View {
 
     /// Existing conversation pushed when a "Convos with you" row is tapped.
     /// `embedsNavigationStack: false` lands the view on the host stack with
-    /// the system back button instead of nesting a second stack.
+    /// the system back button instead of nesting a second stack. The tab bar
+    /// is hidden here (mirroring `StuffDetailView`) because the Contacts tab
+    /// entry point pushes onto a tab stack whose shell only hides the bar for
+    /// Chats/Stuff selections; without this the bar overlaps the composer.
+    /// Harmless in sheet entry points, which have no tab bar.
     @ViewBuilder
     private func pushedConversationView(_ viewModel: NewConversationViewModel) -> some View {
         NewConversationView(
@@ -181,6 +185,7 @@ struct ContactDetailView: View {
             embedsNavigationStack: false
         )
         .background(.colorBackgroundSurfaceless)
+        .toolbarVisibility(.hidden, for: .tabBar)
     }
 
     /// Streams conversations already containing this agent template,

--- a/Convos/Contacts/ContactDetailView.swift
+++ b/Convos/Contacts/ContactDetailView.swift
@@ -182,7 +182,8 @@ struct ContactDetailView: View {
         NewConversationView(
             viewModel: viewModel,
             profileSettingsViewModel: profileSettingsViewModel,
-            embedsNavigationStack: false
+            embedsNavigationStack: false,
+            insetsTopSafeArea: true
         )
         .background(.colorBackgroundSurfaceless)
         .toolbarVisibility(.hidden, for: .tabBar)

--- a/Convos/Contacts/ContactsView.swift
+++ b/Convos/Contacts/ContactsView.swift
@@ -235,7 +235,8 @@ struct ContactsView: View {
             session: session,
             coreActions: coreActions,
             profileSettingsViewModel: profileSettingsViewModel,
-            showsCloseButton: false
+            showsCloseButton: false,
+            pushedConversationInsetsTopSafeArea: true
         )
     }
 

--- a/Convos/Conversation Creation/NewConversationView.swift
+++ b/Convos/Conversation Creation/NewConversationView.swift
@@ -19,6 +19,15 @@ struct NewConversationView: View {
     /// picker's stack; when `nil` (standalone sheet) the close button
     /// dismisses via the environment `dismiss`.
     var onClose: (() -> Void)?
+    /// Whether the conversation indicator should inset below the device's
+    /// top safe area. Sheet presentations (every call site except the
+    /// contact card's pushed conversation) keep the default `false` -- a
+    /// sheet's top edge already sits below the status bar, so the indicator
+    /// only needs its small fixed padding. A full-screen push extends under
+    /// the status bar, so its entry point passes `true` to keep the
+    /// indicator out of the status bar (mirrors the Chats tab's pushed
+    /// conversation, which sets this on its own `ConversationPresenter`).
+    var insetsTopSafeArea: Bool = false
     @State private var hasShownScannerOnAppear: Bool = false
     @State private var sidebarWidth: CGFloat = 0.0
     @State private var focusCoordinator: FocusCoordinator = FocusCoordinator(horizontalSizeClass: nil)
@@ -45,7 +54,7 @@ struct NewConversationView: View {
         ConversationPresenter(
             viewModel: viewModel.conversationViewModel,
             focusCoordinator: focusCoordinator,
-            insetsTopSafeArea: false,
+            insetsTopSafeArea: insetsTopSafeArea,
             sidebarColumnWidth: $sidebarWidth
         ) { focusState, coordinator in
             ConditionalNavigationStack(embedsStack: embedsNavigationStack) {

--- a/Convos/MainTabView.swift
+++ b/Convos/MainTabView.swift
@@ -430,7 +430,14 @@ struct MainTabView: View {
             }
             .toolbar { sharedToolbar(for: tab) }
             .toolbar(isConversationSelected ? .hidden : .visible, for: .navigationBar)
-            .toolbar(isConversationSelected ? .hidden : .visible, for: .tabBar)
+            // `.automatic`, not `.visible`, when no conversation is selected:
+            // an explicit `.visible` at the stack root overrides the
+            // `.toolbarVisibility(.hidden, for: .tabBar)` that pushed
+            // destinations (StuffDetailView, the contact card's pushed
+            // conversation) set for themselves, leaving the tab bar floating
+            // over their bottom chrome. `.automatic` keeps the bar visible on
+            // tab roots while letting those destinations hide it.
+            .toolbar(isConversationSelected ? .hidden : .automatic, for: .tabBar)
     }
 
     /// Shared toolbar (compose + add-agent) applied to each tab's

--- a/Convos/Shared Views/QuickEditView.swift
+++ b/Convos/Shared Views/QuickEditView.swift
@@ -65,16 +65,24 @@ struct QuickEditView: View {
         .accessibilityIdentifier("quick-edit-done-button")
     }
 
-    private var nameTextField: some View {
-        let leadingPadding: CGFloat = DesignConstants.Spacing.step4x
-        let fieldHeight: CGFloat = 52.0
-        let borderColor: Color = .colorBorderSubtle
-        return TextField(placeholderText, text: $text)
+    /// The bare field with focus and UIKit introspection, split from
+    /// `nameTextField` so the type-checker solves the introspect generics
+    /// separately from the long modifier tail. The combined chain sat near
+    /// the type-check budget and tripped it on loaded machines.
+    private var introspectedNameField: some View {
+        TextField(placeholderText, text: $text)
             .focused($focusState, equals: focused)
             .introspect(.textField, on: .iOS(.v26)) { (textField: UITextField) in
                 textFieldDelegate.action = onSubmit
                 textField.delegate = textFieldDelegate
             }
+    }
+
+    private var nameTextField: some View {
+        let leadingPadding: CGFloat = DesignConstants.Spacing.step4x
+        let fieldHeight: CGFloat = 52.0
+        let borderColor: Color = .colorBorderSubtle
+        return introspectedNameField
             .padding(.leading, leadingPadding)
             .font(.body)
             .tint(.colorTextPrimary)
@@ -86,12 +94,16 @@ struct QuickEditView: View {
             .accessibilityIdentifier("quick-edit-display-name-field")
             .safeAreaInset(edge: .trailing) { settingsButton }
             .onChange(of: text) { _, newValue in
-                let maxLength: Int = NameLimits.maxDisplayNameLength
-                if newValue.count > maxLength {
-                    text = String(newValue.prefix(maxLength))
-                }
+                handleTextChanged(to: newValue)
             }
             .background(Capsule().stroke(borderColor, lineWidth: 1.0))
+    }
+
+    private func handleTextChanged(to newValue: String) {
+        let maxLength: Int = NameLimits.maxDisplayNameLength
+        if newValue.count > maxLength {
+            text = String(newValue.prefix(maxLength))
+        }
     }
 
     var body: some View {


### PR DESCRIPTION
Layout fixes for conversations opened from a contact card's "Convos with you" rows, plus a build-budget fix the work surfaced.

## Bug 1: tab bar overlaps the composer (full-screen push from the Contacts tab)

### Root cause

Tab bar visibility is owned centrally by `MainTabView.tabChrome`, driven by `isConversationSelected` - which only tracks Chats-tab selection and Stuff-tab pushes. The Contacts-tab push (`ContactDetailView.pushedConversation`) was invisible to it. On top of that, the chrome set an explicit `.visible` at each tab root when nothing is selected, which overrides any pushed destination's `.toolbarVisibility(.hidden, for: .tabBar)` - a destination-side fix alone provably had no effect (reproduced in simulator before adding the second change).

### Fix (two changes, both required)

- `ContactDetailView`: hide the tab bar on the pushed conversation destination (mirrors `StuffDetailView`).
- `MainTabView`: relax the root tab-bar visibility from `.visible` to `.automatic` when no conversation is selected, letting pushed destinations' hidden preference take effect. The navigation-bar branch is untouched, so the pushed conversation keeps the system back button it relies on (`NewConversationView(embedsNavigationStack: false)` renders no close button of its own).

## Bug 2: conversation indicator misplaced (both hosting contexts)

### Root cause

`ConversationPresenter` positions the indicator from the literal screen top (`.ignoresSafeArea()`), offset by the device's top safe area only when `insetsTopSafeArea` is passed. `NewConversationView` hardcoded `false`: right for sheets, wrong for the full-screen push - the pill rendered into the status bar (hidden behind the Dynamic Island on island devices). An unconditional `true` on the push path would invert the bug for sheet-hosted cards (member tap in a chat, members list), whose pushed conversation would render the pill a full device inset below the sheet's top.

### Fix

`insetsTopSafeArea` is exposed on `NewConversationView` (default `false`; every sheet call site unchanged) and threaded as `pushedConversationInsetsTopSafeArea` through `ContactDetailView` (default `false`). Only `ContactsView` - the lone host whose card push lands full screen - passes `true`. Not derivable from `showsCloseButton`: the members list pushes the card (no X) but its stack lives in a sheet.

## Build fix: QuickEditView type-check budget

The branch repeatedly failed to build on a loaded machine: `QuickEditView.nameTextField` - a single 13-modifier `TextField` expression (focus + UIKit introspect + layout tail + inline `onChange` body) - sat near the 300ms type-check limit. Split the introspected base field into its own property and extracted the `onChange` body, per the CLAUDE.md build-performance guidance.

## Verification

Driven in the simulator on a fresh account, per fix:
- Contacts > agent card > "Convos with you" row: tab bar hidden, composer unobstructed, indicator below the status bar matching the Chats path; back pop restores the tab bar
- Chat > member avatar > card sheet > "Convos with you" row: indicator at the sheet's top row, aligned with back/+ buttons
- New-convo sheet, Chats-tab push, all tab roots: unchanged
- Full ConvosCore suite green before each push: 1101 tests / 157 suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix tab bar overlapping conversations opened from the contact card
> - Adds `.toolbarVisibility(.hidden, for: .tabBar)` to conversations pushed from `ContactDetailView`, preventing the tab bar from overlapping the conversation view.
> - Changes the root-level tab bar visibility in [MainTabView.swift](https://github.com/xmtplabs/convos-ios/pull/988/files#diff-2b02f95e9fabdce514b1dd6d74d930ca17fcc2380c7504789454c035484e9d67) from `.visible` to `.automatic`, so pushed destinations (e.g. contact card conversations) can successfully hide the tab bar without being overridden.
> - Adds an `insetsTopSafeArea` flag to `NewConversationView` and threads it through `ContactDetailView` so conversations pushed from the Contacts tab correctly inset below the device's top safe area.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c6849f2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->