### PR TITLE
Log dropped messages with unregistered content types

### DIFF
--- a/ConvosCore/Sources/ConvosCore/Storage/XMTP DB Representations/DecodedMessage+DBRepresentation.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/XMTP DB Representations/DecodedMessage+DBRepresentation.swift
@@ -86,6 +86,14 @@ extension XMTPiOS.DecodedMessage {
         case ContentTypeReadReceipt:
             throw DecodedMessageDBRepresentationError.unsupportedContentType
         default:
+            // Read receipts are dropped silently above because of their volume;
+            // anything else without a registered codec gets a trace so unknown
+            // inbound traffic (e.g. LeaveRequest) is visible in exported logs.
+            let version = "\(encodedContentType.versionMajor).\(encodedContentType.versionMinor)"
+            Log.warning(
+                "Dropping message \(id) in conversation \(conversationId) from \(senderInboxId): "
+                + "unsupported content type \(encodedContentType.authorityID)/\(encodedContentType.typeID) v\(version)"
+            )
             throw DecodedMessageDBRepresentationError.unsupportedContentType
         }
 


### PR DESCRIPTION
DecodedMessage.dbRepresentation() silently threw unsupportedContentType for
any codec the app does not register (LeaveRequest, ProfileUpdate-as-message,
future types), leaving no trace in exported logs. Diagnosing the 2026-06-04
removed-member incident required three devices' logs partly because of this
gap.

Log the content type authority/type/version plus message, conversation, and
sender ids before throwing. Read receipts stay silent because of their
volume. No behavior change.

Part of the removed-member-handling stack (see docs/plans/removed-member-handling.md). Linear: IOS-455

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/990"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783196926&installation_id=128169237&pr_number=990&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F990&signature=2d431a1abe4552aaaa8698fea3d884d05b7333efa76c99299774bb43d25a13f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Log dropped messages with unregistered content types in `DecodedMessage.dbRepresentation`
> When `dbRepresentation` encounters an unsupported content type in its `default` case, it now emits a warning log before throwing `DecodedMessageDBRepresentationError.unsupportedContentType`. The log includes the message ID, conversation ID, sender inbox ID, and the content type's authority/type ID with version, making it easier to diagnose silently dropped messages.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized becffbd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->