### PR TITLE
Profile metadata writes merge instead of clobbering richer entries

### DIFF
--- a/ConvosAppData/Sources/ConvosAppData/ProfileHelpers.swift
+++ b/ConvosAppData/Sources/ConvosAppData/ProfileHelpers.swift
@@ -78,6 +78,41 @@ extension ConversationProfile {
     }
 }
 
+// MARK: - ConversationProfile + Merging
+
+extension ConversationProfile {
+    /// Returns this profile layered over an existing entry, preserving fields
+    /// the incoming side does not carry. A device whose local state is
+    /// incomplete (fresh pairing, mid-hydration) must never downgrade the
+    /// richer entry already in group metadata by replacing it wholesale.
+    ///
+    /// Semantics:
+    /// - `name`: incoming wins, including an explicit clear.
+    /// - image fields: when the incoming profile carries no avatar of either
+    ///   kind, the existing `encryptedImage`/legacy `image` are preserved.
+    ///   When it carries one, its own fields stand (the initializers already
+    ///   clear the variant they don't use). Removal is an explicit operation
+    ///   (`clearProfileAvatar`), never a side effect of empty local state.
+    /// - `connections`: preserved when absent on the incoming side - it lives
+    ///   only in remote metadata and is managed by its own update/clear APIs.
+    public func merged(over existing: ConversationProfile) -> ConversationProfile {
+        var result = self
+        let carriesImage = (hasEncryptedImage && encryptedImage.isValid) || hasImage
+        if !carriesImage {
+            if existing.hasEncryptedImage {
+                result.encryptedImage = existing.encryptedImage
+            }
+            if existing.hasImage {
+                result.image = existing.image
+            }
+        }
+        if !hasConnections, existing.hasConnections {
+            result.connections = existing.connections
+        }
+        return result
+    }
+}
+
 // MARK: - ConversationCustomMetadata + Profiles
 
 extension ConversationCustomMetadata {
@@ -89,6 +124,18 @@ extension ConversationCustomMetadata {
         } else {
             profiles.append(profile)
         }
+    }
+
+    /// Add or update a profile, preserving fields the incoming side does not
+    /// carry (see `ConversationProfile.merged(over:)`). Use this instead of
+    /// `upsertProfile` for writes built from local state, which may be poorer
+    /// than what the metadata already holds.
+    public mutating func mergeProfile(_ incoming: ConversationProfile) {
+        guard let existing = profiles.first(where: { $0.inboxID == incoming.inboxID }) else {
+            upsertProfile(incoming)
+            return
+        }
+        upsertProfile(incoming.merged(over: existing))
     }
 
     /// Remove a profile by inbox ID

--- a/ConvosAppData/Tests/ConvosAppDataTests/ProfileMergeTests.swift
+++ b/ConvosAppData/Tests/ConvosAppDataTests/ProfileMergeTests.swift
@@ -1,0 +1,140 @@
+@testable import ConvosAppData
+import Foundation
+import Testing
+
+/// Coverage for `ConversationProfile.merged(over:)` and
+/// `ConversationCustomMetadata.mergeProfile(_:)` - the merge-don't-clobber
+/// semantics that stop a device with incomplete local state from downgrading
+/// a member's richer profile entry in group metadata. Regression coverage for
+/// the 2026-06-04 incident where a profile rewrite from a freshly-launched
+/// paired device dropped the user's avatar fields (metadata shrank
+/// 1478 -> 1376 bytes) and the degraded profile got the user removed from the
+/// group.
+@Suite("ConversationProfile merge Tests")
+struct ProfileMergeTests {
+    private static let inboxIdHex: String = "436afb6134c259f150e8b38a35e5d4ea"
+
+    private static func validImageRef(url: String = "https://assets.example/avatar.bin") -> EncryptedImageRef {
+        var ref = EncryptedImageRef()
+        ref.url = url
+        ref.salt = Data(repeating: 0xAB, count: 32)
+        ref.nonce = Data(repeating: 0xCD, count: 12)
+        return ref
+    }
+
+    private static func richProfile(name: String = "Jarod") -> ConversationProfile {
+        var profile = ConversationProfile(
+            inboxIdString: inboxIdHex,
+            name: name,
+            encryptedImageRef: validImageRef()
+        ) ?? ConversationProfile()
+        profile.connections = #"{"services":["calendar"]}"#
+        return profile
+    }
+
+    private static func nameOnlyProfile(name: String = "Jarod") -> ConversationProfile {
+        ConversationProfile(inboxIdString: inboxIdHex, name: name) ?? ConversationProfile()
+    }
+
+    // MARK: - merged(over:)
+
+    @Test("Avatar-less incoming profile preserves the existing encrypted image")
+    func preservesEncryptedImage() {
+        let merged = Self.nameOnlyProfile().merged(over: Self.richProfile())
+
+        #expect(merged.hasEncryptedImage)
+        #expect(merged.encryptedImage == Self.validImageRef())
+    }
+
+    @Test("Avatar-less incoming profile preserves an existing legacy image")
+    func preservesLegacyImage() {
+        var existing = Self.nameOnlyProfile()
+        existing.image = "https://assets.example/legacy.png"
+
+        let merged = Self.nameOnlyProfile().merged(over: existing)
+
+        #expect(merged.hasImage)
+        #expect(merged.image == "https://assets.example/legacy.png")
+    }
+
+    @Test("Connections are always preserved when the incoming side has none")
+    func preservesConnections() {
+        let merged = Self.nameOnlyProfile().merged(over: Self.richProfile())
+
+        #expect(merged.hasConnections)
+        #expect(merged.connections == #"{"services":["calendar"]}"#)
+    }
+
+    @Test("A name change applies while the avatar is preserved")
+    func nameChangePreservesAvatar() {
+        let merged = Self.nameOnlyProfile(name: "Jarod L").merged(over: Self.richProfile(name: "Jarod"))
+
+        #expect(merged.name == "Jarod L")
+        #expect(merged.effectiveImageUrl == Self.validImageRef().url)
+    }
+
+    @Test("An incoming valid encrypted image replaces the existing one")
+    func richerIncomingImageWins() {
+        let newRef = Self.validImageRef(url: "https://assets.example/new-avatar.bin")
+        let incoming = ConversationProfile(
+            inboxIdString: Self.inboxIdHex,
+            name: "Jarod",
+            encryptedImageRef: newRef
+        ) ?? ConversationProfile()
+
+        let merged = incoming.merged(over: Self.richProfile())
+
+        #expect(merged.encryptedImage == newRef)
+        // A new encrypted avatar must not resurrect a stale legacy image url.
+        #expect(!merged.hasImage)
+    }
+
+    @Test("An incoming legacy image wins over an existing encrypted image")
+    func incomingLegacyImageWins() {
+        var incoming = Self.nameOnlyProfile()
+        incoming.image = "https://assets.example/fresh-legacy.png"
+
+        let merged = incoming.merged(over: Self.richProfile())
+
+        #expect(merged.effectiveImageUrl == "https://assets.example/fresh-legacy.png")
+        #expect(!merged.hasEncryptedImage)
+    }
+
+    // MARK: - mergeProfile(_:)
+
+    @Test("mergeProfile appends when no existing entry matches")
+    func mergeProfileAppendsNewInbox() {
+        var metadata = ConversationCustomMetadata()
+        metadata.mergeProfile(Self.nameOnlyProfile())
+
+        #expect(metadata.profiles.count == 1)
+        #expect(metadata.findProfile(inboxId: Self.inboxIdHex)?.name == "Jarod")
+    }
+
+    @Test("mergeProfile merges into the existing entry by inbox id")
+    func mergeProfileMergesExisting() {
+        var metadata = ConversationCustomMetadata()
+        metadata.upsertProfile(Self.richProfile())
+
+        metadata.mergeProfile(Self.nameOnlyProfile(name: "Jarod L"))
+
+        #expect(metadata.profiles.count == 1)
+        let final = metadata.findProfile(inboxId: Self.inboxIdHex)
+        #expect(final?.name == "Jarod L")
+        #expect(final?.effectiveImageUrl == Self.validImageRef().url)
+        #expect(final?.hasConnections == true)
+    }
+
+    @Test("Merging an avatar-less profile never shrinks the encoded metadata")
+    func mergeNeverShrinksEncodedMetadata() throws {
+        var metadata = ConversationCustomMetadata()
+        metadata.tag = "dL6ICreUdZ"
+        metadata.upsertProfile(Self.richProfile())
+        let beforeCount = try metadata.toCompactString().utf8.count
+
+        metadata.mergeProfile(Self.nameOnlyProfile())
+        let afterCount = try metadata.toCompactString().utf8.count
+
+        #expect(afterCount >= beforeCount)
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Invites & Custom Metadata/XMTPGroup+CustomMetadata.swift
+++ b/ConvosCore/Sources/ConvosCore/Invites & Custom Metadata/XMTPGroup+CustomMetadata.swift
@@ -276,10 +276,36 @@ extension XMTPiOS.Group {
         guard let conversationProfile = profile.conversationProfile else {
             throw ConversationCustomMetadataError.invalidInboxIdHex(profile.inboxId)
         }
+        // Merge instead of replacing wholesale: a profile built from
+        // incomplete local state (fresh pairing, mid-hydration) must not drop
+        // avatar or connections fields that already exist in the metadata.
+        // The verify closure checks the merged invariant - exact equality
+        // would reject every preserved field and burn the retries.
         try await atomicUpdateMetadata(operation: "updateProfile") { metadata in
-            metadata.upsertProfile(conversationProfile)
+            metadata.mergeProfile(conversationProfile)
         } verify: { metadata in
-            metadata.findProfile(inboxId: profile.inboxId) == conversationProfile
+            guard let final = metadata.findProfile(inboxId: profile.inboxId) else { return false }
+            let incomingName: String? = conversationProfile.hasName ? conversationProfile.name : nil
+            let finalName: String? = final.hasName ? final.name : nil
+            guard finalName == incomingName else { return false }
+            guard let incomingImageUrl = conversationProfile.effectiveImageUrl else { return true }
+            return final.effectiveImageUrl == incomingImageUrl
+        }
+    }
+
+    /// Explicitly removes the avatar fields from a member's profile entry.
+    /// `updateProfile` deliberately preserves existing image fields when the
+    /// incoming profile carries none, so removal has to be a named operation
+    /// rather than a side effect of writing an avatar-less profile.
+    func clearProfileAvatar(inboxId: String) async throws {
+        try await atomicUpdateMetadata(operation: "clearProfileAvatar") { metadata in
+            guard var profile = metadata.findProfile(inboxId: inboxId) else { return }
+            profile.clearEncryptedImage()
+            profile.clearImage()
+            metadata.upsertProfile(profile)
+        } verify: { metadata in
+            let profile = metadata.findProfile(inboxId: inboxId)
+            return profile == nil || profile?.effectiveImageUrl == nil
         }
     }
 

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/MyProfileWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/MyProfileWriter.swift
@@ -143,9 +143,12 @@ final class MyProfileWriter: MyProfileWriterProtocol, @unchecked Sendable {
                 try updatedProfile.save(db)
             }
             do {
-                try await group.updateProfile(updatedProfile)
+                // updateProfile merges (it preserves image fields absent on
+                // the incoming side), so removal goes through the explicit
+                // clearing API.
+                try await group.clearProfileAvatar(inboxId: updatedProfile.inboxId)
             } catch {
-                Log.warning("Failed to write profile to appData (best-effort): \(error.localizedDescription)")
+                Log.warning("Failed to clear avatar in appData (best-effort): \(error.localizedDescription)")
             }
             await sendProfileUpdate(profile: updatedProfile, group: group)
             return
@@ -222,8 +225,11 @@ final class MyProfileWriter: MyProfileWriterProtocol, @unchecked Sendable {
 
         if global.imageData == nil {
             // Global avatar was cleared. Propagate the removal so the per-conversation avatar
-            // doesn't outlive it.
-            if member?.avatar != nil {
+            // doesn't outlive it. Requires the digest to be cleared too: image bytes that are
+            // merely not rehydrated yet (fresh pairing, mid-hydration launch) keep their
+            // digest, and propagating a "removal" the user never made would strip the avatar
+            // for every other member.
+            if global.imageContentDigest == nil, member?.avatar != nil {
                 try await update(
                     avatar: nil,
                     imageSourceContentDigest: nil,


### PR DESCRIPTION
Group.updateProfile replaced a member's whole ConversationProfile entry with
one built from the local DBMemberProfile. A device with incomplete local
state (fresh pairing, mid-hydration launch) writing a name-only profile
dropped the member's encryptedImage/image/connections from group metadata -
in the 2026-06-04 incident the blob shrank 1478 -> 1376 bytes, the profile
visibly degraded for other members, and the group creator removed the user.

- ConversationProfile.merged(over:) + ConversationCustomMetadata.mergeProfile:
  incoming wins for name; image fields are preserved when the incoming side
  carries no avatar; connections (remote-only) are always preserved.
- updateProfile uses merge semantics; its verify closure checks the merged
  invariant instead of exact equality (which would reject every preserved
  field and burn the retries).
- Avatar removal becomes the explicit clearProfileAvatar operation, called
  by the user-initiated removal path - never a side effect of empty local
  state.
- syncFromGlobalProfile only propagates an avatar removal when the global
  digest is cleared too, so un-rehydrated image bytes don't strip the avatar.

Part of the removed-member-handling stack. Linear: IOS-452

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/992"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783196930&installation_id=128169237&pr_number=992&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F992&signature=30644d10be0cde3174c4bdfed60b8aa8dce1381491520fdb5d531bd73dfe58f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Merge profile metadata writes to preserve existing avatar and connections fields
> - Adds `ConversationProfile.merged(over:)` in [ProfileHelpers.swift](https://github.com/xmtplabs/convos-ios/pull/992/files#diff-59615f019ec0551bb4f2a3ddd8598f30420a4cb492a893857d1a79dabeab6752) to overlay an incoming profile while retaining the existing encrypted/legacy image and connections when the incoming profile omits them; incoming name always wins.
> - Adds `ConversationCustomMetadata.mergeProfile(_:)` which inserts or merges profiles using the new merge semantics instead of clobbering existing entries.
> - Replaces `upsertProfile` with `mergeProfile` in [XMTPGroup+CustomMetadata.swift](https://github.com/xmtplabs/convos-ios/pull/992/files#diff-35053f59de2f9203f7233b5ab1da286f7a754c2f03c64829c0ccd3951762a01f) and adds `clearProfileAvatar(inboxId:)` to explicitly remove avatar fields when clearing.
> - Updates [MyProfileWriter.swift](https://github.com/xmtplabs/convos-ios/pull/992/files#diff-f3ce93052543335859b22b5d9723929fba25b7e4d7dec7508ee0f6c4d9970747) to call `clearProfileAvatar` instead of `updateProfile` when avatar is nil, and suppresses global avatar removal propagation when the digest exists but image bytes are not yet rehydrated.
> - Behavioral Change: profile updates that previously overwrote avatar and connections with empty values now preserve the existing fields; an explicit clear is required to remove them.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b39bc4f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
