### PR TITLE
Change "Add from Contacts" subtitle copy to "People and agents"

### DIFF
--- a/Convos/Conversation Detail/AddToConversationMenu.swift
+++ b/Convos/Conversation Detail/AddToConversationMenu.swift
@@ -47,7 +47,7 @@ struct AddToConversationMenu: View {
 
             Button(action: onAddFromContacts) {
                 Text("Add from Contacts")
-                Text("Pick from people you've talked to")
+                Text("People and agents")
                 Image(systemName: "person.crop.circle.badge.plus")
             }
             .accessibilityIdentifier("context-menu-add-from-contacts")

--- a/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/NewConvoIdentityView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/NewConvoIdentityView.swift
@@ -45,7 +45,7 @@ struct NewConvoIdentityView: View {
                     }
                     Button(action: addFromContactsAction) {
                         Text("Add from Contacts")
-                        Text("Pick from people you've talked to")
+                        Text("People and agents")
                         Image(systemName: "person.crop.circle.badge.plus")
                     }
                     .accessibilityIdentifier("new-convo-add-from-contacts")


### PR DESCRIPTION
Changes the subtitle under the "Add from Contacts" menu item from "Pick from people you've talked to" to "People and agents".

Two occurrences updated:
- `AddToConversationMenu` (conversation detail "+" menu)
- `NewConvoIdentityView` (new convo identity card "Invite members" menu)

Tested: full ConvosCore suite passing (1101 tests, 157 suites).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/993"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783204834&installation_id=128169237&pr_number=993&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F993&signature=ad48dfaaf4bafcd1b0cf54cc83a17e6e88bd94c26d4b400a562311808f27344f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Change 'Add from Contacts' subtitle to 'People and agents'
> Updates the subtitle text in two menu locations: [AddToConversationMenu.swift](https://github.com/xmtplabs/convos-ios/pull/993/files#diff-f6e06423faa4e48b42b7efec551df2a2613981c654133cf3bdb3a5ebf0502323) and [NewConvoIdentityView.swift](https://github.com/xmtplabs/convos-ios/pull/993/files#diff-5436ae1224e9549c5f918eecb1210affad9e821bd95890aeab7cc21f1dfe7259). No logic or structure is changed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 56926d2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->