### PR TITLE
Show the template description on the agent contact card while the agent joins

### DIFF
--- a/Convos/Contacts/Contact+SyntheticAgentMember.swift
+++ b/Convos/Contacts/Contact+SyntheticAgentMember.swift
@@ -61,3 +61,39 @@ extension AgentShareInfo {
         )
     }
 }
+
+extension ConversationMember {
+    /// Returns a copy with the supplied description merged into the profile
+    /// metadata when the member's own profile doesn't carry one yet. Used to
+    /// keep the template description on the agent contact card after the real
+    /// agent joins but before it writes its `description` metadata -- a no-op
+    /// when the profile already has a description or none is supplied. Like
+    /// the optimistic card member, the copy is only ever handed to the
+    /// messages-list repository, never inserted into `conversation.members`.
+    func withFallbackAgentDescription(_ description: String?) -> ConversationMember {
+        guard profile.agentDescription == nil, let description, !description.isEmpty else { return self }
+        var metadata: ProfileMetadata = profile.metadata ?? [:]
+        metadata["description"] = .string(description)
+        let updatedProfile = Profile(
+            inboxId: profile.inboxId,
+            conversationId: profile.conversationId,
+            name: profile.name,
+            avatar: profile.avatar,
+            avatarSalt: profile.avatarSalt,
+            avatarNonce: profile.avatarNonce,
+            avatarKey: profile.avatarKey,
+            isAgent: profile.isAgent,
+            imageSourceContentDigest: profile.imageSourceContentDigest,
+            metadata: metadata
+        )
+        return ConversationMember(
+            profile: updatedProfile,
+            role: role,
+            isCurrentUser: isCurrentUser,
+            isAgent: isAgent,
+            agentVerification: agentVerification,
+            invitedBy: invitedBy,
+            joinedAt: joinedAt
+        )
+    }
+}

--- a/Convos/Contacts/ContactDetailView.swift
+++ b/Convos/Contacts/ContactDetailView.swift
@@ -604,12 +604,15 @@ struct ContactDetailView: View {
         guard let session, let templateId = contact.agentTemplateId else { return }
         // The contact card already has the agent's identity in hand, so paint
         // it optimistically while the conversation provisions and the agent
-        // joins -- no async resolve needed.
+        // joins -- no async resolve needed. `agentDescription` carries the
+        // template description (seeded from the contact or resolved on
+        // appear), so the optimistic contact card shows it instead of the
+        // "Learning more about my job" placeholder while the agent joins.
         let optimisticIdentity = AgentShareInfo(
             templateId: templateId,
             displayName: contact.displayName,
             emoji: contact.profileEmoji,
-            descriptionText: nil,
+            descriptionText: agentDescription,
             avatarURL: contact.avatarURL
         )
         presentingNewConvo = NewConversationViewModel(

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -361,11 +361,18 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
     /// processor synthesizes the contact card immediately. The synthetic
     /// member is only ever handed to the repository here -- it is never
     /// inserted into `conversation.members`.
+    ///
+    /// Once the real agent joins, its profile can briefly lack the
+    /// `description` metadata (the agent writes it after joining), so the
+    /// template description from the optimistic identity is kept as a
+    /// fallback -- otherwise the card would regress from the template
+    /// description back to the pulsing placeholder until the agent's own
+    /// description arrives.
     private func syncVerifiedAgentToRepo() {
         let realAgent: ConversationMember? = conversation.members.first(where: \.isVerifiedConvosAgent)
         let agent: ConversationMember?
         if let realAgent {
-            agent = realAgent
+            agent = realAgent.withFallbackAgentDescription(optimisticAgentIdentity?.descriptionText)
         } else if let presentation = pendingAgentPresentation,
                   presentation.showsContactCard,
                   let identity = optimisticAgentIdentity {

--- a/ConvosTests/PendingAgentPresentationTests.swift
+++ b/ConvosTests/PendingAgentPresentationTests.swift
@@ -43,6 +43,34 @@ final class PendingAgentPresentationTests: XCTestCase {
         XCTAssertTrue(member.isVerifiedConvosAgent)
     }
 
+    // MARK: - withFallbackAgentDescription
+
+    func testFallbackDescriptionMergesWhenProfileLacksOne() {
+        let member = makeAgentMember(metadata: ["emoji": .string("🧬")])
+
+        let merged = member.withFallbackAgentDescription("Longevity tips and protocols")
+
+        XCTAssertEqual(merged.profile.agentDescription, "Longevity tips and protocols")
+        XCTAssertEqual(merged.profile.profileEmoji, "🧬", "Existing metadata should be preserved")
+        XCTAssertEqual(merged.profile.inboxId, member.profile.inboxId)
+        XCTAssertEqual(merged.agentVerification, member.agentVerification)
+    }
+
+    func testFallbackDescriptionDoesNotOverrideAgentsOwn() {
+        let member = makeAgentMember(metadata: ["description": .string("Written by the agent")])
+
+        let merged = member.withFallbackAgentDescription("Template description")
+
+        XCTAssertEqual(merged.profile.agentDescription, "Written by the agent")
+    }
+
+    func testFallbackDescriptionNoOpWhenNilOrEmpty() {
+        let member = makeAgentMember(metadata: nil)
+
+        XCTAssertNil(member.withFallbackAgentDescription(nil).profile.agentDescription)
+        XCTAssertNil(member.withFallbackAgentDescription("").profile.agentDescription)
+    }
+
     // MARK: - pendingAgentPresentation
 
     func testNoPresentationWhenNotPending() {
@@ -126,6 +154,24 @@ final class PendingAgentPresentationTests: XCTestCase {
     }
 
     // MARK: - Helpers
+
+    private func makeAgentMember(metadata: ProfileMetadata?) -> ConversationMember {
+        let profile = Profile(
+            inboxId: "agent-inbox",
+            conversationId: "conv-1",
+            name: "Longevity Lab",
+            avatar: nil,
+            isAgent: true,
+            metadata: metadata
+        )
+        return ConversationMember(
+            profile: profile,
+            role: .member,
+            isCurrentUser: false,
+            isAgent: true,
+            agentVerification: .verified(.convos)
+        )
+    }
 
     private func makeViewModel(
         conversation: Conversation = .mock(id: "test-convo", name: nil, members: [.mock(isCurrentUser: true)])


### PR DESCRIPTION
## Summary

When starting a new conversation with an agent from a template via the contact card's **Chat** button, the optimistic agent contact card showed the pulsing "Learning more about my job" placeholder even though the template's description was already in hand. The other two template-start flows (the `convos://template/<id>` deep link and the web-slug agent share) already carried the description.

**Root cause:** `confirmChatWithAgentTemplate()` in `ContactDetailView` built its optimistic `AgentShareInfo` with a hardcoded `descriptionText: nil` — and because supplying an optimistic identity skips the async template resolve in `NewConversationViewModel`, nothing ever backfilled it.

## Changes

- **`ContactDetailView`**: pass the already-loaded `agentDescription` (seeded from the contact or resolved on appear) into the optimistic `AgentShareInfo`, so the card shows the template description immediately while the agent joins.
- **`ConversationViewModel.syncVerifiedAgentToRepo()`**: once the real agent joins but before it writes its own `description` metadata, fall back to the template description instead of regressing the card to the pulsing placeholder (no description → placeholder → description flicker).
- **`ConversationMember.withFallbackAgentDescription(_:)`** (new helper in `Contact+SyntheticAgentMember.swift`): merges a fallback description into the profile metadata only when the member's own profile doesn't carry one — the agent's own description always wins.

## Testing

- 3 new tests in `PendingAgentPresentationTests` covering the merge, the agent's-own-description-wins case, and the nil/empty no-op; all 10 tests in the class pass on simulator.
- Full ConvosCore suite (`swift test --package-path ConvosCore`) passes against the local XMTP node.
- Dev and Local scheme builds compile clean; SwiftLint `--strict` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/994"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783208075&installation_id=128169237&pr_number=994&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F994&signature=3d2fcaf9cd798942f7df3ac6540d5b459d02bd55c4320b3832288d9f0f33c75c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show template description on agent contact card while the agent joins
> - Passes the template `descriptionText` into `AgentShareInfo` optimisticIdentity in `ContactDetailView.confirmChatWithAgentTemplate`, so the description appears immediately on the optimistic contact card before the agent joins.
> - Adds `ConversationMember.withFallbackAgentDescription` in [Contact+SyntheticAgentMember.swift](https://github.com/xmtplabs/convos-ios/pull/994/files#diff-cadd099ce82bbcd3b41ea79a86f7a2359b50491a43b0b383d86c786aeaa88b1d), which returns a copy of the member with the template description merged into profile metadata only when the agent's own description is absent.
> - `ConversationViewModel.syncVerifiedAgentToRepo` now forwards the real agent with this fallback applied, so the template description persists on the card until the agent's own profile description is available.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0cebb36.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->