### PR TITLE
Fix reply/attachment not focusing the composer when focus value is stale

### DIFF
--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesBottomBar.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Views/MessagesBottomBar.swift
@@ -119,6 +119,13 @@ struct MessagesBottomBar<BottomBarContent: View>: View {
             .onChange(of: focusCoordinator.currentFocus) { _, newValue in
                 handleFocusChanged(to: newValue)
             }
+            .onChange(of: focusCoordinator.refocusNonce) { _, _ in
+                // A same-value re-focus request (e.g. reply/attachment asking for
+                // `.message` when the coordinator already holds it) doesn't change
+                // `currentFocus`, so re-run the expand/collapse logic here too or
+                // the bar would stay collapsed.
+                handleFocusChanged(to: focusCoordinator.currentFocus)
+            }
             .onChange(of: messageText) { _, _ in
                 handleMessageTextChanged()
             }

--- a/Convos/Shared Views/ConversationPresenter.swift
+++ b/Convos/Shared Views/ConversationPresenter.swift
@@ -112,6 +112,9 @@ struct ConversationPresenter<Content: View>: View {
             // The transition flags will prevent race conditions in the opposite direction
             focusState = newFocus
         }
+        .onChange(of: focusCoordinator.refocusNonce) { _, _ in
+            reassertFocus()
+        }
         .onChange(of: focusState) { _, newFocus in
             // Delegate all synchronization logic to the coordinator
             focusCoordinator.syncFocusState(newFocus)
@@ -119,6 +122,23 @@ struct ConversationPresenter<Content: View>: View {
         .task(id: viewModel?.conversation.id) {
             // Set default focus when conversation changes
             focusState = defaultFocusOverride ?? focusCoordinator.defaultFocus
+        }
+    }
+
+    /// Re-applies `@FocusState` for a same-value `moveFocus` request (see
+    /// `FocusCoordinator.refocusNonce`). When `@FocusState` already equals the
+    /// target the real first responder may still be gone, so bounce through nil
+    /// on the next runloop tick to force SwiftUI to re-acquire it; otherwise a
+    /// plain assignment is enough.
+    private func reassertFocus() {
+        let target = focusCoordinator.currentFocus
+        guard focusState == target else {
+            focusState = target
+            return
+        }
+        focusState = nil
+        DispatchQueue.main.async {
+            focusState = target
         }
     }
 

--- a/Convos/Shared Views/FocusCoordinator.swift
+++ b/Convos/Shared Views/FocusCoordinator.swift
@@ -23,6 +23,17 @@ final class FocusCoordinator {
     /// The current focus state - synchronized with SwiftUI's @FocusState
     private(set) var currentFocus: MessagesViewInputFocus?
 
+    /// Bumped by `moveFocus(to:)` only when the requested focus already equals
+    /// `currentFocus`. Observers (`ConversationPresenter`, `MessagesBottomBar`)
+    /// re-assert SwiftUI's `@FocusState` on this change, because a same-value
+    /// `moveFocus` leaves `currentFocus` unchanged and the value-driven
+    /// `onChange(of: currentFocus)` syncs never fire. This happens when the
+    /// messages list dismisses the keyboard via its interactive drag gesture
+    /// without SwiftUI clearing `@FocusState`, leaving the stored focus and the
+    /// real first responder out of sync - so a reply or attachment that asks to
+    /// re-focus `.message` would otherwise never raise the keyboard again.
+    private(set) var refocusNonce: Int = 0
+
     /// The type of keyboard currently detected
     private(set) var keyboardType: KeyboardType = .unknown
 
@@ -161,7 +172,18 @@ final class FocusCoordinator {
         Log.info("moveFocus called with: \(String(describing: focus)), saving previous: \(String(describing: currentFocus))")
         previousFocus = currentFocus
         beginProgrammaticTransition(to: focus)
-        currentFocus = focus
+        if currentFocus == focus {
+            // The stored value isn't changing, so the value-driven `@FocusState`
+            // syncs won't fire. Re-assert focus anyway: the real first responder
+            // may have been dropped (e.g. the messages list dismissed the
+            // keyboard via its interactive drag) without SwiftUI clearing
+            // `@FocusState`. The transition began above so the nil intermediate
+            // of the observers' re-assert is treated as an interrupted
+            // transition, not a manual dismissal.
+            refocusNonce &+= 1
+        } else {
+            currentFocus = focus
+        }
     }
 
     /// Called when a field finishes editing to determine next focus

--- a/ConvosTests/FocusCoordinatorTests.swift
+++ b/ConvosTests/FocusCoordinatorTests.swift
@@ -90,4 +90,49 @@ final class FocusCoordinatorTests: XCTestCase {
         // `.sideConvoName` when a non-quickEditor end-of-edit signal arrives.
         XCTAssertNotEqual(coordinator.currentFocus, .sideConvoName)
     }
+
+    func testReFocusToSameValueBumpsRefocusNonceWithoutChangingFocus() {
+        coordinator.moveFocus(to: .message)
+        coordinator.syncFocusState(.message)
+
+        let nonceBefore = coordinator.refocusNonce
+
+        // Re-requesting the field that is already current must not change
+        // `currentFocus` (so the value-driven `onChange` syncs stay silent) but
+        // must bump `refocusNonce` so observers re-assert `@FocusState`. This is
+        // the reply / attachment path when the keyboard was dismissed without
+        // SwiftUI clearing focus, leaving the coordinator's value stale.
+        coordinator.moveFocus(to: .message)
+
+        XCTAssertEqual(coordinator.currentFocus, .message)
+        XCTAssertEqual(coordinator.refocusNonce, nonceBefore + 1)
+    }
+
+    func testMoveToNewValueDoesNotBumpRefocusNonce() {
+        coordinator.moveFocus(to: .message)
+        coordinator.syncFocusState(.message)
+
+        let nonceBefore = coordinator.refocusNonce
+
+        // A genuine focus change is carried by `currentFocus` itself, so the
+        // nonce must stay put - otherwise observers would double-apply and
+        // bounce `@FocusState` through nil on every ordinary transition.
+        coordinator.moveFocus(to: .sideConvoName)
+
+        XCTAssertEqual(coordinator.currentFocus, .sideConvoName)
+        XCTAssertEqual(coordinator.refocusNonce, nonceBefore)
+    }
+
+    func testReFocusFromNilDoesNotBumpNonceAndUpdatesFocus() {
+        // Starting from the dismissed state, focusing the message field is a
+        // real value change, not a re-assert, so it flows through `currentFocus`
+        // and leaves the nonce untouched.
+        XCTAssertNil(coordinator.currentFocus)
+        let nonceBefore = coordinator.refocusNonce
+
+        coordinator.moveFocus(to: .message)
+
+        XCTAssertEqual(coordinator.currentFocus, .message)
+        XCTAssertEqual(coordinator.refocusNonce, nonceBefore)
+    }
 }


### PR DESCRIPTION
## Problem

Two regressions in the conversation composer:

1. **Replying to a message no longer focuses the text input** (keyboard doesn't come up).
2. **Adding an attachment doesn't expand the bottom bar or move focus to the text field.**

## Root cause

Both paths call `focusCoordinator.moveFocus(to: .message)` (reply in `ConversationView.onReply`; attachments in `MessagesBottomBar`). The coordinator drives SwiftUI's `@FocusState` **only** through `ConversationPresenter`'s `.onChange(of: currentFocus)`, which fires on a *value change*.

When the messages list dismisses the keyboard via its interactive drag gesture, it resigns the text field's first responder **without** SwiftUI clearing `@FocusState`, so the coordinator's `currentFocus` stays stale at `.message`. A subsequent `moveFocus(to: .message)` is then a silent no-op — the keyboard never returns, and `MessagesBottomBar.handleFocusChanged` (same value-change dependency) never re-expands the composer.

Confirmed in the app-group log: `moveFocus ... saving previous: message` with no following `onChange(currentFocus)`.

## Fix

- **`FocusCoordinator`** — add `refocusNonce`, bumped by `moveFocus` only when the requested focus already equals `currentFocus` (the no-op case).
- **`ConversationPresenter`** — observe `refocusNonce` and re-assert `@FocusState`, bouncing through `nil` on the next runloop tick when the value already matches so SwiftUI re-acquires the first responder.
- **`MessagesBottomBar`** — re-run the expand/collapse logic on the nonce so the bar expands.

The programmatic transition begins before the nil-bounce, so the intermediate `nil` is treated as an interrupted transition (retry) rather than a manual dismissal that would collapse the bar.

## Testing

- 3 new `FocusCoordinatorTests` (nonce bumps only on same-value re-focus; new-value and from-nil paths leave it untouched). All 10 FocusCoordinator tests pass; SwiftLint `--strict` clean on changed files.
- Verified live on the simulator from the exact stale-focus state:
  - **Reply** raised the keyboard and expanded the composer.
  - **Attachment** (photo picker) staged the chip, expanded the bar, and focused the field.

Log trace of the fixed path:
```
moveFocus ... saving previous: message     (currentFocus already .message)
syncFocusState called with: nil            (reassert bounce)
Programmatic transition interrupted - will retry
syncFocusState called with: message
Programmatic transition completed successfully
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/995"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783217176&installation_id=128169237&pr_number=995&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F995&signature=65feca518ec56e0abc14a39a12a3f29102b82a45def6fa3515e2461f543c366b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix stale focus state preventing composer from focusing on reply/attachment
> - Adds `refocusNonce` to [`FocusCoordinator`](https://github.com/xmtplabs/convos-ios/pull/995/files#diff-40b3d28b766ebc0135d2e62700a55d912572d14966c5a3b6f048955c7ca841d7): when `moveFocus(to:)` is called with the same value already set, it increments `refocusNonce` instead of reassigning `currentFocus`, since SwiftUI ignores no-op `@FocusState` assignments.
> - [`ConversationPresenter`](https://github.com/xmtplabs/convos-ios/pull/995/files#diff-b43cd7da077f6223cf5e0d1281de02cd00c32eb7b922b573c843b347811dec97) observes `refocusNonce` and calls `reassertFocus()`, which bounces `@FocusState` to `nil` then back to the target on the next runloop tick to force SwiftUI to reacquire the first responder.
> - [`MessagesBottomBar`](https://github.com/xmtplabs/convos-ios/pull/995/files#diff-b66861cd8ab11a6d499676511b14e2fba66afdb7467461c01255f35000b416a2) also observes `refocusNonce` to re-run its expand/collapse logic when focus is reasserted.
> - Three new tests in [`FocusCoordinatorTests`](https://github.com/xmtplabs/convos-ios/pull/995/files#diff-7b79ffc6826bf719e49f902445f880448555ec26bc71079bf0dcf4efac1a15f1) cover same-value refocus, new-value focus, and nil-to-value transitions.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3f365fd.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->