### PR TITLE
local-stack: don't abort `make up` when .dev.vars has no CONVOS_API_KEY

### DIFF
--- a/dev/local-stack/stack.sh
+++ b/dev/local-stack/stack.sh
@@ -90,7 +90,9 @@ sync_backend_url() {
 align_agent_key() {
   local dv="${WORKER_DIR}/.dev.vars" be="${BACKEND_DIR}/.env" key
   [[ -f "$be" ]] || { warn "backend/.env missing — can't align AGENT_ASSETS_API_KEY"; return; }
-  key="$(grep -E '^CONVOS_API_KEY=' "$dv" 2>/dev/null | cut -d= -f2-)"
+  # `|| true` keeps a missing key from aborting the script under set -e/pipefail;
+  # the guard below is the intended graceful path.
+  key="$(grep -E '^CONVOS_API_KEY=' "$dv" 2>/dev/null | cut -d= -f2- || true)"
   [[ -n "$key" ]] || { warn ".dev.vars CONVOS_API_KEY missing — can't align AGENT_ASSETS_API_KEY"; return; }
   [[ ${#key} -ge 32 ]] || { warn ".dev.vars CONVOS_API_KEY too short (${#key} < 32) — can't align"; return; }
   [[ "$(grep -E '^AGENT_ASSETS_API_KEY=' "$be" | cut -d= -f2-)" == "$key" ]] && { ok "backend AGENT_ASSETS_API_KEY aligned (current)"; return; }
@@ -104,7 +106,9 @@ align_agent_key() {
 # signing in. Idempotent: skips accounts already funded.
 seed_credits() {
   local key floor=1000000 grant=100000000 accts n=0 a bal
-  key="$(grep -E '^CONVOS_API_KEY=' "${WORKER_DIR}/.dev.vars" 2>/dev/null | cut -d= -f2-)"
+  # `|| true` keeps a missing key from aborting the script under set -e/pipefail;
+  # the guard below is the intended graceful path.
+  key="$(grep -E '^CONVOS_API_KEY=' "${WORKER_DIR}/.dev.vars" 2>/dev/null | cut -d= -f2- || true)"
   [[ -n "$key" ]] || { warn "no CONVOS_API_KEY; can't seed credits"; return; }
   accts="$(dc exec -T convos_db psql -U postgres -d postgres -tAc 'SELECT id FROM "Account";' 2>/dev/null | tr -d ' ')"
   [[ -z "$accts" ]] && { ok "no accounts yet — sign in via the app, then: make seed-credits"; return; }


### PR DESCRIPTION
## Problem

On a fresh `.dev.vars` (no `CONVOS_API_KEY` line yet), `make up` / `make up-core` aborts silently. `align_agent_key` and `seed_credits` both read the key with `grep -E '^CONVOS_API_KEY=' ... | cut -d= -f2-` into a plain assignment, then guard the empty result with a graceful `warn`/`return`. But under `set -euo pipefail` a missing key makes the pipeline exit non-zero, so the assignment trips `set -e` and kills the whole script **before** the guard runs — no message, just `make: *** [up] Error 1`.

## Fix

Append `|| true` to both reads so the substitution can't abort the script, letting the existing empty-key guard emit its `warn` and `return` as intended.

`sync_backend_url` in the same file already uses exactly this guard for the identical read, so this just brings the other two reads in line.

## Testing

- `bash -n dev/local-stack/stack.sh` (syntax OK).
- `make up-core` against a `.dev.vars` with no `CONVOS_API_KEY` now warns and continues instead of aborting; the backend comes up and App Check is disabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/996"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783217770&installation_id=128169237&pr_number=996&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F996&signature=92a63b7099c837aefcd7aa3b79ffc6c27e48d1edcca43d195c64918b764bc67f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `make up` abort in local-stack when `.dev.vars` has no `CONVOS_API_KEY`
> Adds `|| true` to the `grep | cut` pipelines in `align_agent_key` and `seed_credits` in [stack.sh](https://github.com/xmtplabs/convos-ios/pull/996/files#diff-ac74f42213bfd94cd92c5951d64ae7013a7155b648d52d642d4c25b01dfb3bd5), preventing `set -e`/`pipefail` from aborting the script when `CONVOS_API_KEY` is absent. Both functions already had guards that log a warning and return early when the key is missing, but the pipeline failure was terminating the script before those guards could run.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 36525da.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->