### PR TITLE
Document task-sim teardown and add an orphaned-sim sweep script

### DIFF
--- a/.claude/commands/setup.md
+++ b/.claude/commands/setup.md
@@ -73,6 +73,23 @@ Inform the user:
 Ready to build! Use /build or /build --run
 ```
 
+## Teardown (when the task is done)
+
+The simulator created here is task-scoped. Delete it from disk once the task
+is done - PR merged or work abandoned, not merely session end:
+
+```bash
+xcrun simctl shutdown "$(cat .claude/.simulator_id)" 2>/dev/null
+xcrun simctl delete "$(cat .claude/.simulator_id)"
+rm -f .claude/.simulator_id
+```
+
+Each clone holds 1-6 GB of app data and the shared disk runs chronically
+near-full. `convos-task cleanup` already deletes its task's sim; every other
+creation path (worktree /setup, branch /setup, ad-hoc QA clones) must clean
+up after itself. To sweep accumulated orphans, run
+`.claude/scripts/cleanup-orphaned-sims` (dry run by default; add `--delete`).
+
 ## Example Flows
 
 **In a convos-task worktree:**

--- a/.claude/scripts/cleanup-orphaned-sims
+++ b/.claude/scripts/cleanup-orphaned-sims
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Sweep orphaned convos-* simulator clones.
+
+Dry run by default: prints what would be deleted and why each kept sim is
+kept. Pass --delete to actually shut down and delete the orphans.
+
+Task simulators are created by /setup and `convos-task new` but only
+`convos-task cleanup` deletes one; the other paths leak clones (1-6 GB
+each of app data) on a disk that runs chronically near-full. This script
+finds clones whose task is done and removes them.
+
+A convos-* sim is kept when any of:
+- its UDID is pinned by a .claude/.simulator_id or .simulator_id_partner
+  file in this repo, any .claude/worktrees/* worktree, or any sibling
+  convos-ios* checkout in the workspace
+- its name matches an existing .claude/worktrees/* worktree or sibling
+  convos-ios-<task> checkout (convos-<name> or convos-worktree-<name>)
+- its name matches an open PR head branch (convos-<sanitized-branch>),
+  when gh is available
+- it was booted within --max-idle-hours (default 24; lastBootedAt is UTC)
+- it is protected by name: convos-main, convos-qa-partner
+
+Non-convos-* devices (stock iPhones etc.) are never touched.
+"""
+
+import argparse
+import datetime
+import json
+import pathlib
+import re
+import subprocess
+import sys
+
+PROTECTED_NAMES = {"convos-main", "convos-qa-partner"}
+
+
+def run(cmd, **kwargs):
+    return subprocess.run(cmd, capture_output=True, text=True, **kwargs)
+
+
+def main_repo_root():
+    # Resolves to the main checkout even when run from a worktree copy.
+    out = run(["git", "-C", str(pathlib.Path(__file__).resolve().parent), "rev-parse", "--git-common-dir"])
+    if out.returncode != 0:
+        sys.exit(f"error: cannot locate main repo: {out.stderr.strip()}")
+    return pathlib.Path(out.stdout.strip()).resolve().parent
+
+
+def sanitize(name):
+    # Mirrors /setup's branch-to-sim-name derivation.
+    return re.sub(r"[^a-z0-9]+", "-", name.lower()).strip("-")
+
+
+def collect_pins(main_repo):
+    pins = {}
+    workspace = main_repo.parent
+    pin_files = []
+    for base in [main_repo, *main_repo.glob(".claude/worktrees/*"), *workspace.glob("convos-ios*")]:
+        pin_files += [base / ".claude/.simulator_id", base / ".claude/.simulator_id_partner"]
+    for f in pin_files:
+        try:
+            udid = f.read_text().strip().upper()
+        except OSError:
+            continue
+        if udid:
+            pins.setdefault(udid, str(f))
+    return pins
+
+
+def collect_task_names(main_repo):
+    names = set()
+    for d in main_repo.glob(".claude/worktrees/*"):
+        if d.is_dir():
+            names.add(sanitize(d.name))
+            names.add(f"worktree-{sanitize(d.name)}")
+    prefix = f"{main_repo.name}-"
+    for d in main_repo.parent.glob(f"{prefix}*"):
+        if d.is_dir():
+            names.add(sanitize(d.name[len(prefix):]))
+    return names
+
+
+def collect_open_pr_branches(main_repo):
+    out = run(["gh", "pr", "list", "--state", "open", "--limit", "100", "--json", "headRefName"], cwd=main_repo)
+    if out.returncode != 0:
+        print("note: gh unavailable, skipping open-PR branch matching", file=sys.stderr)
+        return set()
+    return {sanitize(pr["headRefName"]) for pr in json.loads(out.stdout)}
+
+
+def list_devices():
+    out = run(["xcrun", "simctl", "list", "devices", "-j"])
+    if out.returncode != 0:
+        sys.exit(f"error: simctl list failed: {out.stderr.strip()}")
+    devices = []
+    for runtime_devices in json.loads(out.stdout)["devices"].values():
+        devices += [d for d in runtime_devices if d.get("isAvailable")]
+    return devices
+
+
+def keep_reason(device, pins, task_names, pr_branches, max_idle_hours):
+    name, udid = device["name"], device["udid"].upper()
+    if not name.startswith("convos-"):
+        return "not a convos clone"
+    if name in PROTECTED_NAMES:
+        return "protected name"
+    if udid in pins:
+        return f"pinned by {pins[udid]}"
+    suffix = sanitize(name[len("convos-"):])
+    if suffix in task_names:
+        return "matches existing worktree/checkout"
+    if suffix in pr_branches:
+        return "matches open PR branch"
+    last_booted = device.get("lastBootedAt")
+    if last_booted:
+        booted_at = datetime.datetime.fromisoformat(last_booted.replace("Z", "+00:00"))
+        idle = datetime.datetime.now(datetime.timezone.utc) - booted_at
+        if idle < datetime.timedelta(hours=max_idle_hours):
+            return f"booted {idle.total_seconds() / 3600:.1f}h ago (guard: {max_idle_hours}h)"
+    return None
+
+
+def delete_device(device):
+    udid = device["udid"]
+    run(["xcrun", "simctl", "shutdown", udid])
+    out = run(["xcrun", "simctl", "delete", udid])
+    if out.returncode != 0:
+        print(f"  failed to delete {device['name']}: {out.stderr.strip()}", file=sys.stderr)
+        return False
+    run(["pkill", "-f", f"idb_companion.*{udid}"])
+    return True
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Sweep orphaned convos-* simulator clones (dry run by default).")
+    parser.add_argument("--delete", action="store_true", help="actually delete the orphans")
+    parser.add_argument("--max-idle-hours", type=float, default=24, help="keep sims booted within this window (default 24)")
+    args = parser.parse_args()
+
+    main_repo = main_repo_root()
+    pins = collect_pins(main_repo)
+    task_names = collect_task_names(main_repo)
+    pr_branches = collect_open_pr_branches(main_repo)
+
+    orphans = []
+    for device in sorted(list_devices(), key=lambda d: d["name"]):
+        if not device["name"].startswith("convos-"):
+            continue
+        size_gb = device.get("dataPathSize", 0) / 1e9
+        reason = keep_reason(device, pins, task_names, pr_branches, args.max_idle_hours)
+        if reason:
+            print(f"keep    {device['name']} ({size_gb:.1f} GB) - {reason}")
+        else:
+            print(f"orphan  {device['name']} ({size_gb:.1f} GB)")
+            orphans.append(device)
+
+    if not orphans:
+        print("\nno orphans found")
+        return
+    total_gb = sum(d.get("dataPathSize", 0) for d in orphans) / 1e9
+    if args.delete:
+        deleted = [d for d in orphans if delete_device(d)]
+        print(f"\ndeleted {len(deleted)}/{len(orphans)} orphans (~{total_gb:.1f} GB; APFS reclaims asynchronously)")
+    else:
+        print(f"\n{len(orphans)} orphans (~{total_gb:.1f} GB). Re-run with --delete to remove them.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Task simulators are created by `/setup` and `convos-task new`, but only `convos-task cleanup` ever deletes one - worktree `/setup`, branch `/setup`, and ad-hoc QA clones all leak 1-6 GB sims on a disk that runs chronically near-full.

## Changes

- **`/setup` Teardown section**: documents that sims are task-scoped - delete on PR merge/abandon, not session end - with the exact `simctl shutdown` / `delete` commands.
- **`.claude/scripts/cleanup-orphaned-sims`**: sweep script for accumulated orphans. Dry run by default (prints what would be deleted and why each kept sim is kept); `--delete` to act. A `convos-*` sim is kept when any of:
  - its UDID is pinned by a `.simulator_id` file in this repo, any worktree, or any sibling checkout
  - its name matches a live worktree or sibling `convos-ios-<task>` checkout
  - its name matches an open PR head branch (when `gh` is available)
  - it was booted within `--max-idle-hours` (default 24)

## Verification

- Full ConvosCore suite green on this exact tree: 1104 tests / 158 suites (docs + script only; no Swift changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/997"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783267298&installation_id=128169237&pr_number=997&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F997&signature=6fc2cb8665f020de0a20b69b35af50570d2a731e18fc536eb71cb6a88535c2da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add orphaned simulator sweep script and document task-sim teardown
> - Adds [`.claude/scripts/cleanup-orphaned-sims`](https://github.com/xmtplabs/convos-ios/pull/997/files#diff-2dbee5c210c9022d40f922f290842466bb9f5500f9c550c502a30c659a6546c6), a Python CLI that enumerates `convos-*` iOS Simulator clones and identifies orphans by checking pinned UDIDs, active worktrees, sibling checkouts, open PR branches, and recent boot activity.
> - Runs as a dry run by default; pass `--delete` to shut down and remove orphaned simulators (also kills any associated `idb_companion` process). `--max-idle-hours` controls the recency threshold.
> - Updates [`.claude/commands/setup.md`](https://github.com/xmtplabs/convos-ios/pull/997/files#diff-d14aaa538301886449a7d96f95b0ea4ba793f754504541a5198bd80897ceaa11) with a Teardown section covering manual cleanup steps, disk space notes, and a reference to the new sweep script.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b10ec4f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->