### PR TITLE
Fix messages animating up during conversation open: snap bar-height re-anchors until the view has appeared

### DIFF
--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/MessagesViewController.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/MessagesViewController.swift
@@ -104,6 +104,10 @@ final class MessagesViewController: UIViewController {
 
     private var isFirstStateUpdate: Bool = true
     private var hasPendingInterrupt: Bool = false
+    /// True from init until the view has fully appeared (the open transition
+    /// finished). While set, bar-height inset changes re-anchor instantly
+    /// instead of animating - see `applyBottomInsetInstantly`.
+    private var isSettlingInitialLayout: Bool = true
     private var previousLastMessageId: String?
     private var previousFocusState: MessagesViewInputFocus?
     private var pendingScrollToBottomAfterKeyboard: Bool = false
@@ -412,6 +416,11 @@ final class MessagesViewController: UIViewController {
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         handleViewTransition(to: size, with: coordinator)
         super.viewWillTransition(to: size, with: coordinator)
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        isSettlingInitialLayout = false
     }
 
     override func viewWillDisappear(_ animated: Bool) {
@@ -1012,7 +1021,29 @@ extension MessagesViewController: KeyboardListenerDelegate {
     private func updateBottomInset(inset: CGFloat, info: KeyboardInfo?) {
         guard !contextMenuState.isPresented else { return }
         guard collectionView.contentInset.bottom != inset else { return }
+        if info == nil, isSettlingInitialLayout {
+            applyBottomInsetInstantly(inset)
+            return
+        }
         updateCollectionViewInsets(to: inset, with: info)
+    }
+
+    /// Applies a bar-height inset change with no animation and re-anchors the
+    /// list arithmetically. Used while the conversation-open transition is
+    /// still settling: the bar's measurement can land a render pass or two
+    /// after the list's first paint, and animating the catch-up re-anchor
+    /// (the steady-state behavior) visibly slides the messages up mid
+    /// transition. Both steps below are plain property assignments - no batch
+    /// updates, no snapshot restore, no forced layout - so this is also safe
+    /// inside an in-flight UIKit layout pass.
+    private func applyBottomInsetInstantly(_ inset: CGFloat) {
+        UIView.performWithoutAnimation {
+            collectionView.contentInset.bottom = inset
+            collectionView.verticalScrollIndicatorInsets.bottom = inset
+        }
+        if !isUserInitiatedScrolling {
+            scrollToBottom(animated: false)
+        }
     }
 
     func keyboardWillHide(info: KeyboardInfo) {


### PR DESCRIPTION
## Problem

Follow-up to #987. On device, messages still visibly slid up ~100pt during the open transition: the last message group started hidden behind the composer and animated up into view (confirmed by frame-stepping a device recording).

## Root cause

The bottom bar's SwiftUI measurement arrives in steps across render passes (24 → 97 → 177 observed). A step landing after the list's first paint re-anchored it with the steady-state 0.2s animation — that animated catch-up is the visible slide.

## Fix

Bar-height inset changes that land before `viewDidAppear` now re-anchor **instantly** instead of animating: a direct inset set + an arithmetic scroll-to-bottom — both plain property assignments (no batch updates, no snapshot restore, no forced layout), so the path is also safe inside an in-flight UIKit layout pass (the #978 crash recipe is unreachable). Any mid-transition catch-up becomes a same-frame correction rather than a visible slide. Steady-state behavior (composer growth, reply bar, keyboard, late onboarding-pill mounts) keeps the existing animated re-anchor.

## What this PR deliberately does NOT do

An earlier revision also debounced the `.determiningBottomBarHeight` gate release (waiting for a "settled" height before first paint). Timing instrumentation showed that was both unnecessary and harmful:

- **Harmful**: SwiftUI re-runs `updateUIViewController` frequently during open, and each repeat `bottomBarHeight` assignment re-armed the debounce — the gate held the parked initial state for ~500ms, leaving the conversation visibly blank before messages appeared.
- **Unnecessary**: the initial reload's own first-render sizing work outlasts the bar settling in practice, so the restore already computes against the settled inset without any gating; the instant catch-up covers true stragglers.

The gate is back to releasing on the first nonzero height (pre-#998 behavior).

## Validation (iPhone 17 Pro sim, Dev scheme, timing logs + frame analysis)

- State arrives **unparked** (no artificial gate delay); initial paint lands at the settled bottom offset on both cold and warm opens.
- Cold open: blank window reduced to the pre-existing first-render sizing cost only; the open transition begins with content already bottom-anchored in place.
- Warm reopen: state → painted in ~290ms, no post-transition movement.
- Frame analysis across cold/warm opens: zero content movement after the transition; async cell content (agent-share card) renders in place without layout shift.

⚠️ Tests intentionally skipped per request — watching CI instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix messages animating up by snapping bottom inset instantly during conversation open
> - Adds an `isSettlingInitialLayout` flag to `MessagesViewController` that is `true` until `viewDidAppear` fires, marking the initial conversation-open transition phase.
> - During this phase, `updateBottomInset` skips its normal animated path and calls a new `applyBottomInsetInstantly` helper instead, preventing bar-height re-anchors from visually animating the message list upward.
> - `applyBottomInsetInstantly` sets `collectionView` content and scroll indicator insets without animation and scrolls to the bottom if the user is not actively scrolling.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 49bb623.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->