### PR TITLE
dev/test: leave the shared Docker stack running and propagate the test exit code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -549,19 +549,18 @@ cp -r ~/Downloads/SamplePhotoPickerApp claude-code-resources/
 Use the `./dev/test` script for running tests. **Most tests require Docker** for the local XMTP node:
 
 ```bash
-# Full test suite (starts Docker automatically)
+# Full test suite (starts Docker automatically, leaves the stack running)
 ./dev/test
 
-# Start Docker manually, run tests, then stop
+# Start Docker manually if needed, then run tests
 ./dev/up
 swift test --package-path ConvosCore
-./dev/down
 
 # Run a single test
-./dev/up  # Start Docker first
 swift test --filter "TestClassName" --package-path ConvosCore
-./dev/down  # Stop when done
 ```
+
+**The Docker stack is shared.** Every checkout, worktree, and agent session on the machine uses the same compose project, so do not run `./dev/down` (or `./dev/test --down`) as routine cleanup — tearing the stack down kills any other session's in-flight integration tests, which then fail with `Connection refused 127.0.0.1:5556` or hang. Leave the stack running; only stop it when you know nothing else is using it.
 
 **Docker is required.** If Docker is not running, start it with `./dev/up` before running tests. If Docker fails to start (not installed, daemon not running, port conflicts), **do not skip the tests** — stop and notify the user that Docker cannot start and tests cannot run. Never push untested code.
 

--- a/dev/test
+++ b/dev/test
@@ -1,20 +1,32 @@
 #!/bin/bash
 set -eou pipefail
 
-# Usage: dev/test [--unit]
+# Usage: dev/test [--unit] [--down]
 #   --unit   Run only unit tests (no Docker required)
+#   --down   Stop the Docker stack after the test run
 #   (none)   Run all tests with local XMTP node (requires Docker)
+#
+# The Docker stack is shared by every checkout and worktree on this
+# machine (the compose project name is fixed), so by default the stack
+# is left running after the test run. Tearing it down here would kill
+# any other session's in-flight integration tests. Pass --down to stop
+# it anyway, or run ./dev/down when nothing else is using it.
 
 UNIT_TESTS=false
+TEARDOWN=false
 
 for arg in "$@"; do
     case $arg in
         --unit)
             UNIT_TESTS=true
             ;;
+        --down)
+            TEARDOWN=true
+            ;;
         --help|-h)
-            echo "Usage: dev/test [--unit]"
+            echo "Usage: dev/test [--unit] [--down]"
             echo "  --unit   Run only unit tests (no Docker required)"
+            echo "  --down   Stop the Docker stack after the test run"
             echo "  (none)   Run all tests with local XMTP node (requires Docker)"
             exit 0
             ;;
@@ -53,9 +65,15 @@ if ! docker info > /dev/null 2>&1; then
     exit 1
 fi
 
-# Start the XMTP node
-echo "🐳 Starting local XMTP node..."
-"$(dirname "$0")/up"
+# Start the XMTP node unless it is already serving. dev/up runs
+# `compose pull` + `up -d`, which can recreate the node container when a
+# newer image exists -- disruptive to other sessions mid-test-run.
+if nc -z localhost 5556 2>/dev/null; then
+    echo "🐳 Local XMTP node already running, reusing it."
+else
+    echo "🐳 Starting local XMTP node..."
+    "$(dirname "$0")/up"
+fi
 
 # Wait for the node to be ready
 echo "⏳ Waiting for XMTP node to be ready..."
@@ -89,19 +107,20 @@ cd "$SCRIPT_DIR/../ConvosCore"
 echo "📦 Building tests..."
 if ! swift build --build-tests -q 2>&1 | filter_xmtp_logs; then
     echo "❌ Build failed!"
-    cd "$SCRIPT_DIR"
-    ./compose down
     exit 1
 fi
 
 echo "🏃 Running tests..."
-swift test --skip-build || true
-test_exit_code=$?
+test_exit_code=0
+swift test --skip-build || test_exit_code=$?
 
-# Stop the XMTP node
 echo ""
-echo "🛑 Stopping Docker containers..."
-cd "$SCRIPT_DIR"
-./compose down
+if [ "$TEARDOWN" = true ]; then
+    echo "🛑 Stopping Docker containers..."
+    cd "$SCRIPT_DIR"
+    ./compose down
+else
+    echo "ℹ️  Leaving the Docker stack running (shared across sessions). Use ./dev/down to stop it."
+fi
 
 exit $test_exit_code


### PR DESCRIPTION
## Problem

Integration suites (e.g. `LockConversationTests`) flake locally — but the tests themselves are fine: the Lock suite passes 5/5 consecutive runs in ~4.5s against a stable node, even under concurrent load.

The real mechanism, caught live while investigating:

1. The local XMTP compose stack (`convos-ios-*`) is **one shared instance** for every checkout, worktree, and agent session on a machine.
2. `dev/test` ended with an unconditional `compose down`, so whichever session finished first destroyed the node under everyone else's in-flight tests. Those runs then fail wholesale with `Connection refused 127.0.0.1:5556` — or hang forever in suites without a `.timeLimit` trait (orphaned day-old `swift-test` processes were still around).
3. Separately, `dev/test` could never report failure: `swift test --skip-build || true` followed by `test_exit_code=$?` captures the exit code of `|| true`, so the script always exited 0 even when tests failed.

## Changes

- **Leave the Docker stack running by default**; `--down` opts into teardown. The build-failure path also no longer tears the stack down.
- **Skip `dev/up` when the node is already serving on 5556** — `compose pull` + `up -d` can recreate the node container when a newer image exists, which is the same class of mid-run disruption.
- **Fix the exit-code capture** so test failures propagate to the caller.
- **Update CLAUDE.md** testing guidance to stop instructing sessions to run `./dev/down` as routine cleanup, and document the shared-stack hazard.

## Test plan

- `bash -n` clean; verified the `set -e`-safe exit-code construct (`false || ec=$?` → 1, `true || ec=$?` → 0)
- `./dev/test --help` and unknown-flag paths exit 0/1 as expected
- Full `./dev/test` run end-to-end with the new script: reused the already-running node, **1104 tests in 158 suites passed**, stack left running afterwards

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Leave the shared Docker stack running by default and propagate test exit codes in `dev/test`
> - The [dev/test](https://github.com/xmtplabs/convos-ios/pull/999/files#diff-20c04bb8529d71d3c6a1a55e5cdf47f9737a908e2592f3f85594fbd71cfb45a0) script now checks if an XMTP node is already serving on `localhost:5556` (via `nc -z`) before starting containers, reusing it if found.
> - The Docker stack is no longer torn down after a test run by default; pass `--down` to stop it explicitly.
> - Build failures no longer trigger automatic teardown.
> - Test exit codes are now captured via `swift test --skip-build || test_exit_code=$?` instead of being swallowed by a pipe to `true`.
> - [CLAUDE.md](https://github.com/xmtplabs/convos-ios/pull/999/files#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7) is updated to reflect the shared stack behavior and remove `./dev/down` from routine cleanup examples.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ec86678.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->