### PR TITLE
Fix iPad photo context menu preview aspect ratio and rounded corners

### DIFF
--- a/Convos/Conversation Detail/Messages/MessagesListView/MessageContextMenu/MessageContextMenuOverlay.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessageContextMenu/MessageContextMenuOverlay.swift
@@ -25,6 +25,7 @@ struct MessageContextMenuOverlay: View {
     @State private var isDragDismissing: Bool = false
     @State private var isPoofDismissing: Bool = false
     @State private var keyboardHeight: CGFloat = 0
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass: UserInterfaceSizeClass?
 
     private var message: AnyMessage? { state.presentedMessage }
 
@@ -635,10 +636,16 @@ struct MessageContextMenuOverlay: View {
                 profile: profile
             )
         } else {
+            // Match the list's resting corner radius (rounded on regular
+            // width, full bleed on compact) so dismissal lands seamlessly.
+            let restingRadius: CGFloat = horizontalSizeClass == .regular ? DesignConstants.CornerRadius.medium : 0
+            let previewRadius: CGFloat = state.isReplyParent
+                ? DesignConstants.CornerRadius.regular
+                : (appeared ? C.photoCornerRadius : restingRadius)
             ContextMenuPhotoPreview(
                 attachmentKey: attachment.key,
                 shouldBlur: shouldBlurPhoto,
-                cornerRadius: state.isReplyParent ? DesignConstants.CornerRadius.regular : (appeared ? C.photoCornerRadius : 0),
+                cornerRadius: previewRadius,
                 isVideo: attachment.mediaType == .video,
                 isReplyParent: state.isReplyParent
             )

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessageContextMenuWrapper.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessageContextMenuWrapper.swift
@@ -30,6 +30,7 @@ struct MessageGestureModifier: ViewModifier {
     @State private var isPressed: Bool = false
     @State private var hasAppeared: Bool = false
     @State private var interactiveExclusionFrames: [CGRect] = []
+    @State private var mediaContentFrame: CGRect?
     @Environment(\.messageContextMenuState) private var contextMenuState: MessageContextMenuState
     @Environment(\.isConversationReadOnly) private var isReadOnly: Bool
 
@@ -44,6 +45,7 @@ struct MessageGestureModifier: ViewModifier {
 
     func body(content: Content) -> some View {
         content
+            .coordinateSpace(name: MessageMediaContentFrameKey.coordinateSpaceName)
             .environment(\.messagePressed, isPressed)
             .scaleEffect(
                 isPressed && hasAppeared ? 1.03 : 1.0,
@@ -54,8 +56,11 @@ struct MessageGestureModifier: ViewModifier {
             .background { sourceBubbleFrameTracker }
             .onPreferenceChange(SourceFrameKey.self) { frame in
                 if isSourceBubble, let frame {
-                    contextMenuState.currentSourceFrame = frame
+                    contextMenuState.currentSourceFrame = bubbleFrame(within: frame)
                 }
+            }
+            .onPreferenceChange(MessageMediaContentFrameKey.self) { frame in
+                mediaContentFrame = frame
             }
             .onPreferenceChange(MessageGestureExclusionFrameKey.self) { frames in
                 interactiveExclusionFrames = frames
@@ -129,12 +134,21 @@ struct MessageGestureModifier: ViewModifier {
 
     private func handleLongPress(geometry: GeometryProxy) {
         UIImpactFeedbackGenerator(style: .medium).impactOccurred()
-        let frame = geometry.frame(in: .global)
+        let frame = bubbleFrame(within: geometry.frame(in: .global))
         contextMenuState.present(
             message: message,
             bubbleFrame: frame,
             bubbleStyle: bubbleStyle
         )
+    }
+
+    /// Media attachments expand to the full row width while the visible photo
+    /// can be narrower (e.g. capped at a max width on iPad). When a media
+    /// frame is reported, offset it into the row's global frame so the
+    /// context menu anchors on the photo instead of the row.
+    private func bubbleFrame(within contentFrame: CGRect) -> CGRect {
+        guard let mediaContentFrame else { return contentFrame }
+        return mediaContentFrame.offsetBy(dx: contentFrame.minX, dy: contentFrame.minY)
     }
 
     private func handleSwipeOffsetChanged(_ offset: CGFloat) {
@@ -161,6 +175,19 @@ struct MessageGestureExclusionFrameKey: PreferenceKey {
 
     static func reduce(value: inout [CGRect], nextValue: () -> [CGRect]) {
         value.append(contentsOf: nextValue())
+    }
+}
+
+/// Reports the visible media content frame, relative to the message gesture
+/// coordinate space, so the context menu can anchor on the photo rather than
+/// the full-width attachment row. Measured in the named space (anchored below
+/// the press scale effect) to stay in pure layout coordinates.
+struct MessageMediaContentFrameKey: PreferenceKey {
+    static let coordinateSpaceName: String = "messageGestureContent"
+    static let defaultValue: CGRect? = nil
+
+    static func reduce(value: inout CGRect?, nextValue: () -> CGRect?) {
+        value = nextValue() ?? value
     }
 }
 

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
@@ -502,6 +502,7 @@ private struct MediaAttachmentView: View {
                 }
             }
         }
+        .modifier(MediaRowAlignment(isOutgoing: isOutgoing))
         .messageGesture(
             message: message,
             bubbleStyle: .normal,
@@ -599,24 +600,20 @@ private actor VideoURLCache {
     }
 }
 
-/// Shared trailing layout for photo and video rows: rounds and caps the
-/// visible media (on regular width), reports its frame for context menu
-/// anchoring, then expands to the full row width with the proper alignment.
-private struct MediaRowLayout: ViewModifier {
-    let isRegularWidth: Bool
-    let isOutgoing: Bool
+/// Rounds and caps the visible media box (on regular width) and reports its
+/// frame for context menu anchoring. Applied inside each media content state
+/// so overlay chips and the context menu anchor on the photo, not the row.
+private struct MediaBoxLayout: ViewModifier {
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass: UserInterfaceSizeClass?
 
     func body(content: Content) -> some View {
+        let isRegularWidth: Bool = horizontalSizeClass == .regular
         let cornerRadius: CGFloat = isRegularWidth ? DesignConstants.CornerRadius.medium : 0
         let mediaMaxWidth: CGFloat = isRegularWidth ? AttachmentPlaceholder.maxPhotoWidth : .infinity
-        let rowAlignment: Alignment = isRegularWidth ? (isOutgoing ? .trailing : .leading) : .leading
-        let paddedEdges: Edge.Set = isRegularWidth ? (isOutgoing ? .trailing : .leading) : []
         content
             .clipShape(RoundedRectangle(cornerRadius: cornerRadius))
             .background { mediaFrameReader }
             .frame(maxWidth: mediaMaxWidth)
-            .frame(maxWidth: .infinity, alignment: rowAlignment)
-            .padding(paddedEdges, DesignConstants.Spacing.step4x)
     }
 
     private var mediaFrameReader: some View {
@@ -626,6 +623,24 @@ private struct MediaRowLayout: ViewModifier {
                 value: geometry.frame(in: .named(MessageMediaContentFrameKey.coordinateSpaceName))
             )
         }
+    }
+}
+
+/// Expands a media box to the full row width with the proper alignment and
+/// edge padding for the current size class. Applied after the overlay chips
+/// so they stay anchored to the media box.
+private struct MediaRowAlignment: ViewModifier {
+    let isOutgoing: Bool
+
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass: UserInterfaceSizeClass?
+
+    func body(content: Content) -> some View {
+        let isRegularWidth: Bool = horizontalSizeClass == .regular
+        let rowAlignment: Alignment = isRegularWidth ? (isOutgoing ? .trailing : .leading) : .leading
+        let paddedEdges: Edge.Set = isRegularWidth ? (isOutgoing ? .trailing : .leading) : []
+        content
+            .frame(maxWidth: .infinity, alignment: rowAlignment)
+            .padding(paddedEdges, DesignConstants.Spacing.step4x)
     }
 }
 
@@ -643,8 +658,6 @@ private struct AttachmentPlaceholder: View {
     @Binding var resolvedDuration: Double?
     @Binding var pendingPlayAfterReveal: Bool
     let onDimensionsLoaded: (Int, Int) -> Void
-
-    @Environment(\.horizontalSizeClass) private var horizontalSizeClass: UserInterfaceSizeClass?
 
     @State private var loadedImage: UIImage?
     @State private var isLoading: Bool = true
@@ -665,10 +678,6 @@ private struct AttachmentPlaceholder: View {
 
     private var showBlurOverlay: Bool {
         shouldBlur
-    }
-
-    private var isRegularWidth: Bool {
-        horizontalSizeClass == .regular
     }
 
     private var blurRadius: CGFloat {
@@ -736,7 +745,7 @@ private struct AttachmentPlaceholder: View {
             .aspectRatio(placeholderAspectRatio, contentMode: .fit)
             .clipped()
             .compositingGroup()
-            .modifier(MediaRowLayout(isRegularWidth: isRegularWidth, isOutgoing: isOutgoing))
+            .modifier(MediaBoxLayout())
             .animation(.easeOut(duration: 0.25), value: showBlurOverlay)
     }
 
@@ -752,7 +761,7 @@ private struct AttachmentPlaceholder: View {
                 }
             }
         }
-        .modifier(MediaRowLayout(isRegularWidth: isRegularWidth, isOutgoing: isOutgoing))
+        .modifier(MediaBoxLayout())
     }
 
     private func handleBlurChange() {
@@ -1095,10 +1104,7 @@ private struct AttachmentPlaceholder: View {
             .overlay {
                 ProgressView()
             }
-            .clipShape(RoundedRectangle(cornerRadius: isRegularWidth ? DesignConstants.CornerRadius.medium : 0))
-            .frame(maxWidth: isRegularWidth ? Self.maxPhotoWidth : .infinity)
-            .frame(maxWidth: .infinity, alignment: isRegularWidth ? (isOutgoing ? .trailing : .leading) : .leading)
-            .padding(isRegularWidth ? (isOutgoing ? .trailing : .leading) : [], DesignConstants.Spacing.step4x)
+            .modifier(MediaBoxLayout())
     }
 
     private var errorPlaceholder: some View {
@@ -1115,10 +1121,7 @@ private struct AttachmentPlaceholder: View {
                         .foregroundStyle(.secondary)
                 }
             }
-            .clipShape(RoundedRectangle(cornerRadius: isRegularWidth ? DesignConstants.CornerRadius.medium : 0))
-            .frame(maxWidth: isRegularWidth ? Self.maxPhotoWidth : .infinity)
-            .frame(maxWidth: .infinity, alignment: isRegularWidth ? (isOutgoing ? .trailing : .leading) : .leading)
-            .padding(isRegularWidth ? (isOutgoing ? .trailing : .leading) : [], DesignConstants.Spacing.step4x)
+            .modifier(MediaBoxLayout())
     }
 }
 

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
@@ -599,6 +599,36 @@ private actor VideoURLCache {
     }
 }
 
+/// Shared trailing layout for photo and video rows: rounds and caps the
+/// visible media (on regular width), reports its frame for context menu
+/// anchoring, then expands to the full row width with the proper alignment.
+private struct MediaRowLayout: ViewModifier {
+    let isRegularWidth: Bool
+    let isOutgoing: Bool
+
+    func body(content: Content) -> some View {
+        let cornerRadius: CGFloat = isRegularWidth ? DesignConstants.CornerRadius.medium : 0
+        let mediaMaxWidth: CGFloat = isRegularWidth ? AttachmentPlaceholder.maxPhotoWidth : .infinity
+        let rowAlignment: Alignment = isRegularWidth ? (isOutgoing ? .trailing : .leading) : .leading
+        let paddedEdges: Edge.Set = isRegularWidth ? (isOutgoing ? .trailing : .leading) : []
+        content
+            .clipShape(RoundedRectangle(cornerRadius: cornerRadius))
+            .background { mediaFrameReader }
+            .frame(maxWidth: mediaMaxWidth)
+            .frame(maxWidth: .infinity, alignment: rowAlignment)
+            .padding(paddedEdges, DesignConstants.Spacing.step4x)
+    }
+
+    private var mediaFrameReader: some View {
+        GeometryReader { geometry in
+            Color.clear.preference(
+                key: MessageMediaContentFrameKey.self,
+                value: geometry.frame(in: .named(MessageMediaContentFrameKey.coordinateSpaceName))
+            )
+        }
+    }
+}
+
 private struct AttachmentPlaceholder: View {
     static let maxPhotoWidth: CGFloat = 430
     static let videoPlaybackStarted: Notification.Name = Notification.Name("AttachmentPlaceholder.videoPlaybackStarted")
@@ -706,10 +736,7 @@ private struct AttachmentPlaceholder: View {
             .aspectRatio(placeholderAspectRatio, contentMode: .fit)
             .clipped()
             .compositingGroup()
-            .clipShape(RoundedRectangle(cornerRadius: isRegularWidth ? DesignConstants.CornerRadius.medium : 0))
-            .frame(maxWidth: isRegularWidth ? Self.maxPhotoWidth : .infinity)
-            .frame(maxWidth: .infinity, alignment: isRegularWidth ? (isOutgoing ? .trailing : .leading) : .leading)
-            .padding(isRegularWidth ? (isOutgoing ? .trailing : .leading) : [], DesignConstants.Spacing.step4x)
+            .modifier(MediaRowLayout(isRegularWidth: isRegularWidth, isOutgoing: isOutgoing))
             .animation(.easeOut(duration: 0.25), value: showBlurOverlay)
     }
 
@@ -725,10 +752,7 @@ private struct AttachmentPlaceholder: View {
                 }
             }
         }
-        .clipShape(RoundedRectangle(cornerRadius: isRegularWidth ? DesignConstants.CornerRadius.medium : 0))
-        .frame(maxWidth: isRegularWidth ? Self.maxPhotoWidth : .infinity)
-        .frame(maxWidth: .infinity, alignment: isRegularWidth ? (isOutgoing ? .trailing : .leading) : .leading)
-        .padding(isRegularWidth ? (isOutgoing ? .trailing : .leading) : [], DesignConstants.Spacing.step4x)
+        .modifier(MediaRowLayout(isRegularWidth: isRegularWidth, isOutgoing: isOutgoing))
     }
 
     private func handleBlurChange() {


### PR DESCRIPTION
## Problem

On iPad (regular width), photo/video messages render capped at 430pt and aligned within a full-width row, but several pieces of UI assumed the row and the photo were the same thing (true only when full bleed on iPhone):

1. **Context menu**: long-pressing a photo showed the preview stretched to a landscape band — only the middle strip of the photo, wrong aspect ratio, square corners.
2. **Sender label**: the avatar + name chip anchored to the row corner, so it sat flush with the photo edge (incoming) or floated at the opposite side of the screen, off the photo entirely (outgoing).
3. **Reactions / video info chips**: same anchoring bug — reactions on outgoing photos rendered at the far-left of the screen, way outside the image container.

## Root cause

The long-press gesture captured the full-width row frame as the context menu source bubble, and the overlay chips were applied after the attachment view expanded to the row width. `endBubbleRect()` then derived the preview aspect from `rowHeight / rowWidth`, and chips anchored to row corners instead of the photo.

## Fix

- `MessagesGroupItemView`: split the media layout into `MediaBoxLayout` (rounds + caps the visible photo box, reports its frame via a new `MessageMediaContentFrameKey` preference) and `MediaRowAlignment` (expands to the row width with alignment + edge padding). The sender label, video info, and reactions chips now overlay the photo box, before the row expansion, so each keeps the same inset from the photo edge that it has from the screen edge when full bleed. The loading/error placeholders share the same layout instead of duplicating it.
- `MessageContextMenuWrapper`: `MessageGestureModifier` anchors a named coordinate space below the press scale effect and, when a media frame is reported, offsets it into the row's global frame for both `present(...)` and `currentSourceFrame` tracking (keeping the poof-dismiss heuristic consistent). Non-media messages fall back to the row frame as before.
- `MessageContextMenuOverlay`: the photo preview's resting corner radius now matches the list (16pt on regular width, 0 on compact) so dismissal lands seamlessly instead of flashing square corners.

On compact width the reported media frame equals the row frame, so iPhone behavior is unchanged by construction.

## Verification

On an iPad Pro 11" (iOS 26.2) simulator with a portrait photo marked TOP/MIDDLE/BOTTOM:

- Context menu preview shows the full portrait photo at correct aspect with rounded corners, menu and reactions bar anchored to the photo, dismissal animating cleanly back into place (previously: landscape crop of just MIDDLE).
- Sender chip sits at the photo's top-left corner with the full-bleed-equivalent inset.
- A heart reaction on an outgoing (trailing-aligned) photo renders at the photo's bottom-left corner (previously: far-left edge of the screen).
- Full ConvosCore suite: 1104 tests in 158 suites passed (run before each push).
- SwiftLint clean; Dev scheme builds with warnings-as-errors and the type-check budget intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix iPad photo context menu preview aspect ratio and rounded corners
> - Introduces `MediaBoxLayout` and `MediaRowAlignment` view modifiers in [MessagesGroupItemView.swift](https://github.com/xmtplabs/convos-ios/pull/1000/files#diff-34b33cae925fe553d357af97d04319b8de2de329c1903afe72c915e36aa98774) to consolidate media rounding, max-width capping, and alignment logic across size classes.
> - Publishes the visible media content frame via a new `MessageMediaContentFrameKey` preference key so the context menu can anchor to the photo bounds rather than the full-width attachment row.
> - Updates `MessageGestureModifier` in [MessageContextMenuWrapper.swift](https://github.com/xmtplabs/convos-ios/pull/1000/files#diff-56c11050397716624973b3debe7a9f3701baf1e15d9d091cabc6e9ed0acaf076) to use the reported media frame when available, via a new `bubbleFrame(within:)` helper.
> - Fixes the context menu preview corner radius in [MessageContextMenuOverlay.swift](https://github.com/xmtplabs/convos-ios/pull/1000/files#diff-3841c67fb70fc3069c2f14c71cff885be69b673383e92f30a46cbc89b69e6411) to match the resting list style: full-bleed on compact width, rounded on regular width.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6367e94.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->