### PR TITLE
fix(media): bound memory in the receive-side image pipeline (background OOM crash)

### DIFF
--- a/ConvosCore/Sources/ConvosCore/Image Cache/ImageCache.swift
+++ b/ConvosCore/Sources/ConvosCore/Image Cache/ImageCache.swift
@@ -527,8 +527,9 @@ public final class ImageCache: ImageCacheProtocol, @unchecked Sendable {
                 Log.error("Invalid URL for cacheAfterUpload: \(url), caching without URL tracking")
             }
 
-            // Create image from data for memory cache
-            guard let image = UIImage(data: imageData) else {
+            // Create image from data for memory cache (bounded decode:
+            // the data came off the network and is sender-controlled)
+            guard let image = BoundedImageDecode.image(from: imageData) else {
                 Log.error("Failed to create UIImage from data: \(identifier)")
                 return
             }
@@ -567,7 +568,10 @@ public final class ImageCache: ImageCacheProtocol, @unchecked Sendable {
             }
 
             do {
-                let (data, response) = try await URLSession.shared.data(from: url)
+                // Stream to a temporary file so the encoded payload is never
+                // fully buffered in memory, then decode with a bounded size.
+                let (tempFileURL, response) = try await URLSession.shared.download(from: url)
+                defer { try? FileManager.default.removeItem(at: tempFileURL) }
 
                 // Validate response
                 guard let httpResponse = response as? HTTPURLResponse,
@@ -576,7 +580,7 @@ public final class ImageCache: ImageCacheProtocol, @unchecked Sendable {
                     return nil
                 }
 
-                guard let image = UIImage(data: data) else {
+                guard let image = BoundedImageDecode.image(contentsOf: tempFileURL) else {
                     Log.error("Failed to decode image from URL: \(url)")
                     return nil
                 }
@@ -631,7 +635,7 @@ public final class ImageCache: ImageCacheProtocol, @unchecked Sendable {
                 groupKey: key
             )
 
-            guard let image = UIImage(data: decryptedData) else {
+            guard let image = BoundedImageDecode.image(from: decryptedData) else {
                 Log.error("Failed to create UIImage from decrypted data: \(identifier)")
                 return nil
             }
@@ -749,7 +753,7 @@ public final class ImageCache: ImageCacheProtocol, @unchecked Sendable {
     // MARK: - Persistent Storage (chat photo attachments)
 
     public func cacheData(_ data: Data, for identifier: String, storageTier: ImageStorageTier) {
-        guard let image = UIImage(data: data) else {
+        guard let image = BoundedImageDecode.image(from: data) else {
             Log.error("Failed to create UIImage from data for persistent cache: \(identifier)")
             return
         }
@@ -860,20 +864,17 @@ public final class ImageCache: ImageCacheProtocol, @unchecked Sendable {
         return await performDiskOperation(default: nil) { cache in
             for fileURL in [persistentURL, cacheURL] {
                 guard cache.fileManager.fileExists(atPath: fileURL.path) else { continue }
-                do {
-                    let data = try Data(contentsOf: fileURL)
-                    guard let image = UIImage(data: data) else {
-                        Log.error("Failed to decode image from disk: \(identifier)")
-                        continue
-                    }
-                    var mutableURL = fileURL
-                    var resourceValues = URLResourceValues()
-                    resourceValues.contentAccessDate = Date()
-                    try? mutableURL.setResourceValues(resourceValues)
-                    return image
-                } catch {
-                    Log.error("Failed to load image from disk: \(identifier) - \(error)")
+                // Decode straight from the file (bounded) instead of reading
+                // the encoded bytes into memory first.
+                guard let image = BoundedImageDecode.image(contentsOf: fileURL) else {
+                    Log.error("Failed to decode image from disk: \(identifier)")
+                    continue
                 }
+                var mutableURL = fileURL
+                var resourceValues = URLResourceValues()
+                resourceValues.contentAccessDate = Date()
+                try? mutableURL.setResourceValues(resourceValues)
+                return image
             }
             return nil
         }

--- a/ConvosCore/Sources/ConvosCore/Image Cache/ImageCache.swift
+++ b/ConvosCore/Sources/ConvosCore/Image Cache/ImageCache.swift
@@ -357,9 +357,11 @@ public final class ImageCache: ImageCacheProtocol, @unchecked Sendable {
         }
 
         // Cold path: nothing in memory or on disk. Block on the network so
-        // the caller gets the image rather than a placeholder.
+        // the caller gets the image rather than a placeholder. Interactive
+        // priority: the UI is waiting on this fetch, so it must not queue
+        // behind background sync's prefetch burst.
         if object.isEncryptedImage {
-            return await fetchEncryptedImageInline(for: object, url: url, identifier: identifier)
+            return await fetchEncryptedImageInline(for: object, url: url, identifier: identifier, priority: .interactive)
         }
         if let networkImage = await fetchImageFromNetwork(url: url, identifier: identifier) {
             _ = await urlTracker.track(url, for: identifier)
@@ -376,7 +378,7 @@ public final class ImageCache: ImageCacheProtocol, @unchecked Sendable {
     private func scheduleBackgroundRefresh(for object: any ImageCacheable, url: URL, identifier: String) {
         Task.detached(priority: .background) {
             if object.isEncryptedImage {
-                _ = await self.fetchEncryptedImageInline(for: object, url: url, identifier: identifier)
+                _ = await self.fetchEncryptedImageInline(for: object, url: url, identifier: identifier, priority: .background)
                 return
             }
             if await self.fetchImageFromNetwork(url: url, identifier: identifier) != nil {
@@ -617,7 +619,8 @@ public final class ImageCache: ImageCacheProtocol, @unchecked Sendable {
     private func fetchEncryptedImageInline(
         for object: any ImageCacheable,
         url: URL,
-        identifier: String
+        identifier: String,
+        priority: EncryptedImageFetchPriority
     ) async -> UIImage? {
         guard let key = object.encryptionKey,
               let salt = object.encryptionSalt,
@@ -632,7 +635,8 @@ public final class ImageCache: ImageCacheProtocol, @unchecked Sendable {
                 url: url,
                 salt: salt,
                 nonce: nonce,
-                groupKey: key
+                groupKey: key,
+                priority: priority
             )
 
             guard let image = BoundedImageDecode.image(from: decryptedData) else {
@@ -861,23 +865,34 @@ public final class ImageCache: ImageCacheProtocol, @unchecked Sendable {
         let persistentURL = persistentCacheURL.appendingPathComponent(filename)
         let cacheURL = diskCacheURL.appendingPathComponent(filename)
 
-        return await performDiskOperation(default: nil) { cache in
+        // Only the existence checks and access-date touches run on the serial
+        // disk queue; decodes run on the caller's task so concurrent loads
+        // (e.g. a screenful of avatars) don't serialize their decodes behind
+        // one another.
+        let existingFileURLs: [URL] = await performDiskOperation(default: []) { cache in
+            var existing: [URL] = []
             for fileURL in [persistentURL, cacheURL] {
                 guard cache.fileManager.fileExists(atPath: fileURL.path) else { continue }
-                // Decode straight from the file (bounded) instead of reading
-                // the encoded bytes into memory first.
-                guard let image = BoundedImageDecode.image(contentsOf: fileURL) else {
-                    Log.error("Failed to decode image from disk: \(identifier)")
-                    continue
-                }
                 var mutableURL = fileURL
                 var resourceValues = URLResourceValues()
                 resourceValues.contentAccessDate = Date()
                 try? mutableURL.setResourceValues(resourceValues)
-                return image
+                existing.append(fileURL)
             }
-            return nil
+            return existing
         }
+
+        // Decode straight from the file (bounded) instead of reading the
+        // encoded bytes into memory first. The bound matters here too:
+        // persistent-tier files store the original sender-controlled payload.
+        for fileURL in existingFileURLs {
+            guard let image = BoundedImageDecode.image(contentsOf: fileURL) else {
+                Log.error("Failed to decode image from disk: \(identifier)")
+                continue
+            }
+            return image
+        }
+        return nil
     }
 
     private func directoryURL(for tier: ImageStorageTier) -> URL {

--- a/ConvosCore/Sources/ConvosCore/Profiles/Crypto/EncryptedImageLoader.swift
+++ b/ConvosCore/Sources/ConvosCore/Profiles/Crypto/EncryptedImageLoader.swift
@@ -39,24 +39,46 @@ public struct EncryptedImageParams: Sendable {
 
 /// Utility for downloading and decrypting encrypted images
 public enum EncryptedImageLoader {
+    /// Process-wide cap on concurrent encrypted-image downloads. Sync can
+    /// schedule one fetch per conversation/profile in a burst; without a
+    /// global bound those all hold ciphertext and plaintext buffers at
+    /// once, which is enough to exhaust the background memory budget.
+    private static let downloadGate: AsyncSemaphore = AsyncSemaphore(width: 4)
+
     /// Download ciphertext from URL and decrypt using provided parameters
     /// - Parameter params: Encryption parameters including URL and crypto values
     /// - Returns: Decrypted image data
     /// - Throws: Network errors or `ImageEncryptionError` on decryption failure
     public static func loadAndDecrypt(params: EncryptedImageParams) async throws -> Data {
-        let (ciphertext, response) = try await URLSession.shared.data(from: params.url)
+        try await downloadGate.withSlot {
+            try await downloadAndDecrypt(params: params)
+        }
+    }
+
+    /// Streams the ciphertext to a temporary file instead of buffering it in
+    /// memory, then decrypts from a memory-mapped read. Peak footprint per
+    /// download is the plaintext only, instead of ciphertext + plaintext.
+    private static func downloadAndDecrypt(params: EncryptedImageParams) async throws -> Data {
+        let (fileURL, response) = try await URLSession.shared.download(from: params.url)
+        defer { try? FileManager.default.removeItem(at: fileURL) }
+
         guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
             throw URLError(.badServerResponse)
         }
 
-        let plaintext = try ImageEncryption.decrypt(
+        let attributes = try FileManager.default.attributesOfItem(atPath: fileURL.path)
+        let byteCount = (attributes[.size] as? NSNumber)?.intValue ?? 0
+        guard byteCount <= Constant.maxCiphertextBytes else {
+            throw URLError(.dataLengthExceedsMaximum)
+        }
+
+        let ciphertext = try Data(contentsOf: fileURL, options: .mappedIfSafe)
+        return try ImageEncryption.decrypt(
             ciphertext: ciphertext,
             groupKey: params.groupKey,
             salt: params.salt,
             nonce: params.nonce
         )
-
-        return plaintext
     }
 
     /// Convenience method with individual parameters
@@ -68,6 +90,13 @@ public enum EncryptedImageLoader {
     ) async throws -> Data {
         let params = EncryptedImageParams(url: url, salt: salt, nonce: nonce, groupKey: groupKey)
         return try await loadAndDecrypt(params: params)
+    }
+
+    private enum Constant {
+        /// Refuse ciphertext payloads larger than this. Avatars and group
+        /// images are compressed to well under 1MB by the upload pipeline,
+        /// so anything beyond this is not a legitimate image payload.
+        static let maxCiphertextBytes: Int = 20 * 1024 * 1024
     }
 }
 

--- a/ConvosCore/Sources/ConvosCore/Profiles/Crypto/EncryptedImageLoader.swift
+++ b/ConvosCore/Sources/ConvosCore/Profiles/Crypto/EncryptedImageLoader.swift
@@ -37,31 +37,72 @@ public struct EncryptedImageParams: Sendable {
     }
 }
 
+/// Whose latency budget an encrypted-image fetch belongs to. Interactive and
+/// background fetches are gated by separate concurrency limits so a burst of
+/// sync-driven prefetches can never queue ahead of a fetch the UI is
+/// blocked on.
+public enum EncryptedImageFetchPriority: Sendable {
+    /// A fetch the user is waiting on (cold cache miss for something on screen)
+    case interactive
+    /// Sync/prefetch work; the user is not blocked on it
+    case background
+}
+
 /// Utility for downloading and decrypting encrypted images
 public enum EncryptedImageLoader {
-    /// Process-wide cap on concurrent encrypted-image downloads. Sync can
+    /// Per-priority caps on concurrent encrypted-image downloads. Sync can
     /// schedule one fetch per conversation/profile in a burst; without a
-    /// global bound those all hold ciphertext and plaintext buffers at
-    /// once, which is enough to exhaust the background memory budget.
-    private static let downloadGate: AsyncSemaphore = AsyncSemaphore(width: 4)
+    /// bound those all hold ciphertext and plaintext buffers at once, which
+    /// is enough to exhaust the background memory budget. Separate gates
+    /// keep user-blocking fetches out of the background queue.
+    private static let interactiveGate: AsyncSemaphore = AsyncSemaphore(width: 4)
+    private static let backgroundGate: AsyncSemaphore = AsyncSemaphore(width: 4)
+
+    /// The production transport: streams the payload to a temporary file so
+    /// the encoded bytes are never fully buffered in memory.
+    private static let urlSessionTransport: DownloadTransport = { url in
+        try await URLSession.shared.download(from: url)
+    }
+
+    /// Downloads a URL to a temporary file and returns its location plus the
+    /// response. Injectable so tests can drive error paths and concurrency
+    /// without a live network.
+    typealias DownloadTransport = @Sendable (URL) async throws -> (URL, URLResponse)
 
     /// Download ciphertext from URL and decrypt using provided parameters
-    /// - Parameter params: Encryption parameters including URL and crypto values
+    /// - Parameters:
+    ///   - params: Encryption parameters including URL and crypto values
+    ///   - priority: Which concurrency budget the fetch belongs to
     /// - Returns: Decrypted image data
     /// - Throws: Network errors or `ImageEncryptionError` on decryption failure
-    public static func loadAndDecrypt(params: EncryptedImageParams) async throws -> Data {
-        try await downloadGate.withSlot {
-            try await downloadAndDecrypt(params: params)
+    public static func loadAndDecrypt(
+        params: EncryptedImageParams,
+        priority: EncryptedImageFetchPriority = .background
+    ) async throws -> Data {
+        try await loadAndDecrypt(params: params, priority: priority, transport: urlSessionTransport)
+    }
+
+    static func loadAndDecrypt(
+        params: EncryptedImageParams,
+        priority: EncryptedImageFetchPriority,
+        transport: @escaping DownloadTransport
+    ) async throws -> Data {
+        try await gate(for: priority).withSlot {
+            let (fileURL, response) = try await transport(params.url)
+            defer { try? FileManager.default.removeItem(at: fileURL) }
+            return try decryptDownloadedFile(at: fileURL, response: response, params: params)
         }
     }
 
-    /// Streams the ciphertext to a temporary file instead of buffering it in
-    /// memory, then decrypts from a memory-mapped read. Peak footprint per
-    /// download is the plaintext only, instead of ciphertext + plaintext.
-    private static func downloadAndDecrypt(params: EncryptedImageParams) async throws -> Data {
-        let (fileURL, response) = try await URLSession.shared.download(from: params.url)
-        defer { try? FileManager.default.removeItem(at: fileURL) }
-
+    /// Validates the response and ciphertext size, then decrypts from a
+    /// memory-mapped read of the downloaded file. Peak footprint per download
+    /// is the plaintext only, instead of ciphertext + plaintext. Internal so
+    /// the size and status error paths are testable without a network.
+    static func decryptDownloadedFile(
+        at fileURL: URL,
+        response: URLResponse,
+        params: EncryptedImageParams
+    ) throws -> Data {
         guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
             throw URLError(.badServerResponse)
         }
@@ -81,15 +122,23 @@ public enum EncryptedImageLoader {
         )
     }
 
+    private static func gate(for priority: EncryptedImageFetchPriority) -> AsyncSemaphore {
+        switch priority {
+        case .interactive: return interactiveGate
+        case .background: return backgroundGate
+        }
+    }
+
     /// Convenience method with individual parameters
     public static func loadAndDecrypt(
         url: URL,
         salt: Data,
         nonce: Data,
-        groupKey: Data
+        groupKey: Data,
+        priority: EncryptedImageFetchPriority = .background
     ) async throws -> Data {
         let params = EncryptedImageParams(url: url, salt: salt, nonce: nonce, groupKey: groupKey)
-        return try await loadAndDecrypt(params: params)
+        return try await loadAndDecrypt(params: params, priority: priority)
     }
 
     private enum Constant {

--- a/ConvosCore/Sources/ConvosCore/Shared/BoundedImageDecode.swift
+++ b/ConvosCore/Sources/ConvosCore/Shared/BoundedImageDecode.swift
@@ -1,0 +1,57 @@
+#if os(macOS)
+import AppKit
+#elseif os(iOS) || os(tvOS) || os(watchOS)
+import UIKit
+#endif
+
+import CoreGraphics
+import Foundation
+import ImageIO
+
+/// Decodes images with a hard cap on the decoded bitmap's dimensions.
+///
+/// Network payloads and decrypted attachments are sender-controlled: a tiny
+/// encoded file can decode to a gigabyte-scale bitmap (decompression bomb),
+/// and even honest full-resolution photos decode to tens of megabytes each.
+/// Decoding through ImageIO's thumbnail API bounds the bitmap to
+/// `maxPixelSize` on the longest edge, so a burst of image loads (e.g.
+/// background sync) cannot exhaust process memory the way unbounded
+/// `UIImage(data:)` decodes can.
+public enum BoundedImageDecode {
+    /// Matches the sender-side photo attachment cap (see
+    /// `ImageCompression.compressForPhotoAttachment`), so images sent by
+    /// Convos clients decode pixel-perfect while oversized payloads from
+    /// other clients are clamped to a display-quality size.
+    public static let defaultMaxPixelSize: Int = 2048
+
+    /// Decode encoded image bytes, clamped to `maxPixelSize` on the longest edge.
+    public static func image(from data: Data, maxPixelSize: Int = defaultMaxPixelSize) -> ImageType? {
+        let sourceOptions: [CFString: Any] = [kCGImageSourceShouldCache: false]
+        guard let source = CGImageSourceCreateWithData(data as CFData, sourceOptions as CFDictionary) else { return nil }
+        return image(from: source, maxPixelSize: maxPixelSize)
+    }
+
+    /// Decode an image file, clamped to `maxPixelSize` on the longest edge.
+    /// Reads straight from the file, so the encoded bytes are never fully
+    /// buffered in memory.
+    public static func image(contentsOf url: URL, maxPixelSize: Int = defaultMaxPixelSize) -> ImageType? {
+        let sourceOptions: [CFString: Any] = [kCGImageSourceShouldCache: false]
+        guard let source = CGImageSourceCreateWithURL(url as CFURL, sourceOptions as CFDictionary) else { return nil }
+        return image(from: source, maxPixelSize: maxPixelSize)
+    }
+
+    private static func image(from source: CGImageSource, maxPixelSize: Int) -> ImageType? {
+        let thumbnailOptions: [CFString: Any] = [
+            kCGImageSourceCreateThumbnailFromImageAlways: true,
+            kCGImageSourceCreateThumbnailWithTransform: true,
+            kCGImageSourceShouldCacheImmediately: true,
+            kCGImageSourceThumbnailMaxPixelSize: maxPixelSize,
+        ]
+        guard let cgImage = CGImageSourceCreateThumbnailAtIndex(source, 0, thumbnailOptions as CFDictionary) else { return nil }
+        #if os(macOS)
+        return NSImage(cgImage: cgImage, size: NSSize(width: cgImage.width, height: cgImage.height))
+        #else
+        return UIImage(cgImage: cgImage)
+        #endif
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Utilities/AsyncSemaphore.swift
+++ b/ConvosCore/Sources/ConvosCore/Utilities/AsyncSemaphore.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+/// A counting semaphore for structured concurrency, used to bound how many
+/// tasks run a section at once (e.g. parallel downloads).
+///
+/// Waiters resume in FIFO order. Waiting is not cancellation-aware: a
+/// cancelled task still waits for its slot, so callers whose work is
+/// cancellable should check `Task.isCancelled` inside the slot.
+actor AsyncSemaphore {
+    private let width: Int
+    private var active: Int = 0
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    init(width: Int) {
+        self.width = max(1, width)
+    }
+
+    /// Run `body` once a slot is free, releasing the slot when it returns or throws.
+    func withSlot<T: Sendable>(_ body: @Sendable () async throws -> T) async rethrows -> T {
+        await acquire()
+        defer { release() }
+        return try await body()
+    }
+
+    private func acquire() async {
+        if active < width {
+            active += 1
+            return
+        }
+        await withCheckedContinuation { continuation in
+            waiters.append(continuation)
+        }
+    }
+
+    private func release() {
+        if waiters.isEmpty {
+            active -= 1
+        } else {
+            // Hand the slot directly to the next waiter; active is unchanged.
+            waiters.removeFirst().resume()
+        }
+    }
+}

--- a/ConvosCore/Tests/ConvosCoreTests/AsyncSemaphoreTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/AsyncSemaphoreTests.swift
@@ -1,0 +1,64 @@
+@testable import ConvosCore
+import Foundation
+import Testing
+
+/// Tracks how many tasks are inside a section at once.
+private actor ConcurrencyCounter {
+    private(set) var current: Int = 0
+    private(set) var peak: Int = 0
+    private(set) var completed: Int = 0
+
+    func enter() {
+        current += 1
+        peak = max(peak, current)
+    }
+
+    func exit() {
+        current -= 1
+        completed += 1
+    }
+}
+
+struct AsyncSemaphoreTests {
+    @Test func boundsConcurrencyToWidth() async {
+        let semaphore = AsyncSemaphore(width: 3)
+        let counter = ConcurrencyCounter()
+
+        await withTaskGroup(of: Void.self) { group in
+            for _ in 0..<20 {
+                group.addTask {
+                    await semaphore.withSlot {
+                        await counter.enter()
+                        try? await Task.sleep(nanoseconds: 5_000_000)
+                        await counter.exit()
+                    }
+                }
+            }
+        }
+
+        #expect(await counter.peak <= 3)
+        #expect(await counter.completed == 20)
+        #expect(await counter.current == 0)
+    }
+
+    @Test func releasesSlotWhenBodyThrows() async throws {
+        struct TestError: Error {}
+        let semaphore = AsyncSemaphore(width: 1)
+
+        await #expect(throws: TestError.self) {
+            try await semaphore.withSlot { throw TestError() }
+        }
+
+        // The slot must be free again after the failure.
+        let value = await semaphore.withSlot { 42 }
+        #expect(value == 42)
+    }
+
+    @Test func returnsBodyValue() async {
+        let semaphore = AsyncSemaphore(width: 2)
+
+        let value = await semaphore.withSlot { "result" }
+
+        #expect(value == "result")
+    }
+}

--- a/ConvosCore/Tests/ConvosCoreTests/BoundedImageDecodeTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/BoundedImageDecodeTests.swift
@@ -1,0 +1,97 @@
+@testable import ConvosCore
+import CoreGraphics
+import Foundation
+import ImageIO
+import Testing
+import UniformTypeIdentifiers
+
+/// Renders a solid-color PNG at the given pixel dimensions using only
+/// CoreGraphics/ImageIO, so these tests run on macOS and iOS alike.
+private func makePNGData(width: Int, height: Int) throws -> Data {
+    let colorSpace = CGColorSpaceCreateDeviceRGB()
+    let context = try #require(CGContext(
+        data: nil,
+        width: width,
+        height: height,
+        bitsPerComponent: 8,
+        bytesPerRow: 0,
+        space: colorSpace,
+        bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+    ))
+    context.setFillColor(CGColor(red: 1, green: 0, blue: 0, alpha: 1))
+    context.fill(CGRect(x: 0, y: 0, width: width, height: height))
+    let cgImage = try #require(context.makeImage())
+
+    let mutableData = try #require(CFDataCreateMutable(nil, 0))
+    let destination = try #require(
+        CGImageDestinationCreateWithData(mutableData, UTType.png.identifier as CFString, 1, nil)
+    )
+    CGImageDestinationAddImage(destination, cgImage, nil)
+    #expect(CGImageDestinationFinalize(destination))
+    return mutableData as Data
+}
+
+/// Pixel dimensions of a decoded image, platform-independently. Decoded
+/// images come from `CGImage`s at scale 1, so point size equals pixel size.
+private func pixelSize(of image: ImageType) -> CGSize {
+    image.size
+}
+
+struct BoundedImageDecodeTests {
+    @Test func oversizedImageIsClampedToDefaultMax() throws {
+        let data = try makePNGData(width: 4096, height: 1024)
+
+        let image = try #require(BoundedImageDecode.image(from: data))
+
+        let size = pixelSize(of: image)
+        #expect(Int(size.width) == BoundedImageDecode.defaultMaxPixelSize)
+        #expect(Int(size.height) == 512)
+    }
+
+    @Test func smallImageKeepsItsDimensions() throws {
+        let data = try makePNGData(width: 300, height: 200)
+
+        let image = try #require(BoundedImageDecode.image(from: data))
+
+        let size = pixelSize(of: image)
+        #expect(Int(size.width) == 300)
+        #expect(Int(size.height) == 200)
+    }
+
+    @Test func customMaxPixelSizePreservesAspectRatio() throws {
+        let data = try makePNGData(width: 1000, height: 500)
+
+        let image = try #require(BoundedImageDecode.image(from: data, maxPixelSize: 100))
+
+        let size = pixelSize(of: image)
+        #expect(Int(size.width) == 100)
+        #expect(Int(size.height) == 50)
+    }
+
+    @Test func invalidDataReturnsNil() {
+        let garbage = Data([0xde, 0xad, 0xbe, 0xef, 0x00, 0x01, 0x02, 0x03])
+
+        #expect(BoundedImageDecode.image(from: garbage) == nil)
+    }
+
+    @Test func decodesFromFileURLWithClamping() throws {
+        let data = try makePNGData(width: 3000, height: 3000)
+        let fileURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("bounded-decode-test-\(UUID().uuidString).png")
+        try data.write(to: fileURL)
+        defer { try? FileManager.default.removeItem(at: fileURL) }
+
+        let image = try #require(BoundedImageDecode.image(contentsOf: fileURL))
+
+        let size = pixelSize(of: image)
+        #expect(Int(size.width) == BoundedImageDecode.defaultMaxPixelSize)
+        #expect(Int(size.height) == BoundedImageDecode.defaultMaxPixelSize)
+    }
+
+    @Test func missingFileReturnsNil() {
+        let missing = FileManager.default.temporaryDirectory
+            .appendingPathComponent("does-not-exist-\(UUID().uuidString).png")
+
+        #expect(BoundedImageDecode.image(contentsOf: missing) == nil)
+    }
+}

--- a/ConvosCore/Tests/ConvosCoreTests/BoundedImageDecodeTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/BoundedImageDecodeTests.swift
@@ -8,6 +8,17 @@ import UniformTypeIdentifiers
 /// Renders a solid-color PNG at the given pixel dimensions using only
 /// CoreGraphics/ImageIO, so these tests run on macOS and iOS alike.
 private func makePNGData(width: Int, height: Int) throws -> Data {
+    try makeImageData(width: width, height: height, type: .png, properties: nil)
+}
+
+/// Renders a JPEG carrying an EXIF orientation tag, for exercising the
+/// decoder's transform path (PNG has no standard orientation metadata).
+private func makeJPEGData(width: Int, height: Int, orientation: CGImagePropertyOrientation) throws -> Data {
+    let properties: [CFString: Any] = [kCGImagePropertyOrientation: orientation.rawValue]
+    return try makeImageData(width: width, height: height, type: .jpeg, properties: properties)
+}
+
+private func makeImageData(width: Int, height: Int, type: UTType, properties: [CFString: Any]?) throws -> Data {
     let colorSpace = CGColorSpaceCreateDeviceRGB()
     let context = try #require(CGContext(
         data: nil,
@@ -24,9 +35,9 @@ private func makePNGData(width: Int, height: Int) throws -> Data {
 
     let mutableData = try #require(CFDataCreateMutable(nil, 0))
     let destination = try #require(
-        CGImageDestinationCreateWithData(mutableData, UTType.png.identifier as CFString, 1, nil)
+        CGImageDestinationCreateWithData(mutableData, type.identifier as CFString, 1, nil)
     )
-    CGImageDestinationAddImage(destination, cgImage, nil)
+    CGImageDestinationAddImage(destination, cgImage, properties as CFDictionary?)
     #expect(CGImageDestinationFinalize(destination))
     return mutableData as Data
 }
@@ -93,5 +104,29 @@ struct BoundedImageDecodeTests {
             .appendingPathComponent("does-not-exist-\(UUID().uuidString).png")
 
         #expect(BoundedImageDecode.image(contentsOf: missing) == nil)
+    }
+
+    @Test func exifOrientationIsBakedIntoPixels() throws {
+        // Orientation .right (EXIF 6) means the stored bitmap is rotated 90
+        // degrees clockwise on display, so decoded width/height swap.
+        let data = try makeJPEGData(width: 400, height: 200, orientation: .right)
+
+        let image = try #require(BoundedImageDecode.image(from: data))
+
+        let size = pixelSize(of: image)
+        #expect(Int(size.width) == 200)
+        #expect(Int(size.height) == 400)
+    }
+
+    @Test func clampingAppliesToPostTransformDimensions() throws {
+        let data = try makeJPEGData(width: 3000, height: 1500, orientation: .right)
+
+        let image = try #require(BoundedImageDecode.image(from: data))
+
+        // Post-transform the image is 1500x3000; the long edge clamps to
+        // 2048 and the aspect ratio holds.
+        let size = pixelSize(of: image)
+        #expect(Int(size.width) == 1024)
+        #expect(Int(size.height) == BoundedImageDecode.defaultMaxPixelSize)
     }
 }

--- a/ConvosCore/Tests/ConvosCoreTests/EncryptedImageLoaderTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/EncryptedImageLoaderTests.swift
@@ -1,0 +1,180 @@
+@testable import ConvosCore
+import Foundation
+import Testing
+
+private func makeTempFile(_ data: Data) throws -> URL {
+    let url = FileManager.default.temporaryDirectory
+        .appendingPathComponent("encrypted-loader-test-\(UUID().uuidString)")
+    try data.write(to: url)
+    return url
+}
+
+private func makeHTTPResponse(statusCode: Int) throws -> HTTPURLResponse {
+    let url = try #require(URL(string: "https://example.com/image"))
+    return try #require(HTTPURLResponse(url: url, statusCode: statusCode, httpVersion: nil, headerFields: nil))
+}
+
+private func makeParams(salt: Data = Data(count: 32), nonce: Data = Data(count: 12), groupKey: Data = Data(count: 32)) throws -> EncryptedImageParams {
+    let url = try #require(URL(string: "https://example.com/image"))
+    return EncryptedImageParams(url: url, salt: salt, nonce: nonce, groupKey: groupKey)
+}
+
+struct EncryptedImageLoaderDecryptTests {
+    @Test func roundTripDecryptsDownloadedFile() throws {
+        let original = Data("the plaintext image bytes".utf8)
+        let groupKey = try ImageEncryption.generateGroupKey()
+        let payload = try ImageEncryption.encrypt(imageData: original, groupKey: groupKey)
+        let fileURL = try makeTempFile(payload.ciphertext)
+        defer { try? FileManager.default.removeItem(at: fileURL) }
+        let params = try makeParams(salt: payload.salt, nonce: payload.nonce, groupKey: groupKey)
+
+        let plaintext = try EncryptedImageLoader.decryptDownloadedFile(
+            at: fileURL,
+            response: makeHTTPResponse(statusCode: 200),
+            params: params
+        )
+
+        #expect(plaintext == original)
+    }
+
+    @Test func rejectsOversizedCiphertext() throws {
+        // One byte past the loader's 20MB ciphertext cap
+        let oversized = Data(count: 20 * 1024 * 1024 + 1)
+        let fileURL = try makeTempFile(oversized)
+        defer { try? FileManager.default.removeItem(at: fileURL) }
+        let response = try makeHTTPResponse(statusCode: 200)
+        let params = try makeParams()
+
+        #expect(throws: URLError(.dataLengthExceedsMaximum)) {
+            try EncryptedImageLoader.decryptDownloadedFile(at: fileURL, response: response, params: params)
+        }
+    }
+
+    @Test func rejectsNon2xxResponse() throws {
+        let fileURL = try makeTempFile(Data(count: 64))
+        defer { try? FileManager.default.removeItem(at: fileURL) }
+        let response = try makeHTTPResponse(statusCode: 500)
+        let params = try makeParams()
+
+        #expect(throws: URLError(.badServerResponse)) {
+            try EncryptedImageLoader.decryptDownloadedFile(at: fileURL, response: response, params: params)
+        }
+    }
+
+    @Test func rejectsNonHTTPResponse() throws {
+        let fileURL = try makeTempFile(Data(count: 64))
+        defer { try? FileManager.default.removeItem(at: fileURL) }
+        let url = try #require(URL(string: "https://example.com/image"))
+        let response = URLResponse(url: url, mimeType: nil, expectedContentLength: 0, textEncodingName: nil)
+        let params = try makeParams()
+
+        #expect(throws: URLError(.badServerResponse)) {
+            try EncryptedImageLoader.decryptDownloadedFile(at: fileURL, response: response, params: params)
+        }
+    }
+}
+
+/// Tracks how many transports are in flight at once.
+private actor TransportCounter {
+    private(set) var current: Int = 0
+    private(set) var peak: Int = 0
+    private(set) var completed: Int = 0
+
+    func enter() {
+        current += 1
+        peak = max(peak, current)
+    }
+
+    func exit() {
+        current -= 1
+        completed += 1
+    }
+}
+
+/// A gate the test holds closed until it wants blocked transports to finish.
+private actor TestLatch {
+    private var isOpen = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func wait() async {
+        if isOpen { return }
+        await withCheckedContinuation { waiters.append($0) }
+    }
+
+    func open() {
+        isOpen = true
+        for waiter in waiters {
+            waiter.resume()
+        }
+        waiters.removeAll()
+    }
+}
+
+/// The loader's gates are process-wide statics, so these tests must not run
+/// concurrently with each other.
+@Suite(.serialized)
+struct EncryptedImageLoaderGateTests {
+    @Test func backgroundDownloadsAreCappedAtFour() async throws {
+        let counter = TransportCounter()
+        let params = try makeParams()
+        let transport: EncryptedImageLoader.DownloadTransport = { _ in
+            await counter.enter()
+            try? await Task.sleep(nanoseconds: 10_000_000)
+            await counter.exit()
+            throw URLError(.cancelled)
+        }
+
+        await withTaskGroup(of: Void.self) { group in
+            for _ in 0..<12 {
+                group.addTask {
+                    _ = try? await EncryptedImageLoader.loadAndDecrypt(params: params, priority: .background, transport: transport)
+                }
+            }
+        }
+
+        #expect(await counter.peak <= 4)
+        #expect(await counter.completed == 12)
+    }
+
+    @Test func interactiveFetchDoesNotQueueBehindBackgroundBacklog() async throws {
+        let params = try makeParams()
+        let latch = TestLatch()
+        let backgroundCounter = TransportCounter()
+        let backgroundTransport: EncryptedImageLoader.DownloadTransport = { _ in
+            await backgroundCounter.enter()
+            await latch.wait()
+            await backgroundCounter.exit()
+            throw URLError(.cancelled)
+        }
+
+        // Saturate the background gate (4 holding slots, 4 queued behind them).
+        let backgroundTasks = Task {
+            await withTaskGroup(of: Void.self) { group in
+                for _ in 0..<8 {
+                    group.addTask {
+                        _ = try? await EncryptedImageLoader.loadAndDecrypt(params: params, priority: .background, transport: backgroundTransport)
+                    }
+                }
+            }
+        }
+
+        // Wait until all four background slots are actually held.
+        while await backgroundCounter.current < 4 {
+            try await Task.sleep(nanoseconds: 1_000_000)
+        }
+
+        // An interactive fetch must complete while the background gate is
+        // saturated; before the priority split it would queue behind all 8.
+        let interactiveTransport: EncryptedImageLoader.DownloadTransport = { _ in
+            throw URLError(.cancelled)
+        }
+        _ = try? await EncryptedImageLoader.loadAndDecrypt(params: params, priority: .interactive, transport: interactiveTransport)
+
+        // Background work is still parked: nothing has completed.
+        #expect(await backgroundCounter.completed == 0)
+
+        await latch.open()
+        await backgroundTasks.value
+        #expect(await backgroundCounter.completed == 8)
+    }
+}


### PR DESCRIPTION
## Why

A TestFlight crash (2.0.0 build 914, `EXC_BAD_ACCESS` in `_platform_memset`) turned out to be an out-of-memory failure in disguise: the app was running **in the background** (`Role: Non UI`) when a ~900-byte allocation inside CFNetwork's `HTTPProtocol::_instantiateProtocol` returned NULL and Apple's code bzero'd `NULL + 0x10` without checking. Disassembly of CFNetwork confirms the pattern, and the crash registers (`x0=0x10`, `x2=0x388`) match exactly.

A process that can't allocate 900 bytes has truly exhausted its memory budget — and background jetsam budgets are far smaller than foreground. The crash-time threads point at the media pipeline: one thread mid-`Data.write(to:options:.atomic)` (image cache disk write), another starting the next HTTP request.

## What was wrong

The receive-side media pipeline had three compounding unbounded-memory behaviors:

1. **Full in-memory buffering of downloads.** `EncryptedImageLoader` and `ImageCache.fetchImageFromNetwork` used `URLSession.shared.data(from:)`, holding the entire encoded payload in RAM — for encrypted images, ciphertext *and* plaintext simultaneously.
2. **Unbounded decode of sender-controlled payloads.** Five call sites decoded network/disk bytes with `UIImage(data:)`, which decodes at full resolution. A 20k x 20k JPEG decodes to ~1.6 GB; even honest 12 MP photos decode to ~48 MB each. Senders outside our upload pipeline (which caps at 2048px) can send anything.
3. **Unbounded fan-out during sync.** `ConversationWriter` fires a detached `Task` per conversation for group-image prefetch; the avatar prefetcher caps per-call but not process-wide. A background sync over many conversations stacks N concurrent downloads, each holding full buffers.

## The fix

- **`BoundedImageDecode`** (new, cross-platform): decodes via ImageIO's thumbnail API with a hard cap (default 2048px, matching the sender-side attachment cap) on the longest edge, reading from data or straight from a file. Replaces `UIImage(data:)` at all five receive-side decode sites in `ImageCache`, including disk loads.
- **`EncryptedImageLoader`** now streams ciphertext to a temp file (`URLSession.download(from:)`), rejects payloads over 20 MB, decrypts from a memory-mapped read, and bounds process-wide concurrency with a new **`AsyncSemaphore`** (width 4). Every encrypted-image call site (writers, prefetcher, inline cache fetch) funnels through it, so sync bursts are globally capped.
- **`ImageCache.fetchImageFromNetwork`** streams to a temp file instead of buffering, then bounded-decodes from the file.
- **`ImageCache.loadImageFromDisk`** decodes directly from the file URL instead of reading encoded bytes into memory first.

Worst-case per-image footprint drops from *(encoded payload + unbounded decoded bitmap)* to *(bounded ≤2048px bitmap ≈ 17 MB max)*, and at most 4 encrypted downloads hold buffers at once regardless of how many conversations sync.

## Tests

- `BoundedImageDecodeTests` (cross-platform, runs on macOS CI): oversized clamp, aspect preservation, small-image passthrough, custom cap, file-URL variant, invalid data/missing file.
- `AsyncSemaphoreTests`: concurrency bound holds under 20 contending tasks, slot released on throw, value passthrough.
- Full ConvosCore suite green locally (Docker XMTP node); app target builds clean for iOS sim under the 100 ms type-check budget.

## Out of scope

- `RemoteAttachment.content()` (XMTP SDK) still buffers attachment downloads in memory — needs an upstream SDK change.
- Sentry `enableWatchdogTerminationTracking` for OOM visibility is covered by the Sentry rollout (#949).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1001"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783272298&installation_id=128169237&pr_number=1001&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1001&signature=70144e1630789f19fc97a978f301635b50bde61fc685660e6bd0d4560432ffd4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bound memory in the receive-side image pipeline to fix background OOM crashes
> - Adds [`BoundedImageDecode`](https://github.com/xmtplabs/convos-ios/pull/1001/files#diff-06876b1e7f29ec8a732eee168fe20f8f5cd5db16aa65f8f578f1f99ed5db6b1d) which uses ImageIO thumbnail APIs to clamp decoded bitmaps to 2048px on the longest edge; replaces all `UIImage(data:)` calls in `ImageCache` and `EncryptedImageLoader`.
> - Adds [`AsyncSemaphore`](https://github.com/xmtplabs/convos-ios/pull/1001/files#diff-90285d486b3e9ceb05045be358012d5575fc0da34cecbf92ed9984c5e23d1b78), a FIFO async counting semaphore, used to cap concurrent encrypted-image downloads to 4 per priority tier (interactive vs. background).
> - Refactors [`EncryptedImageLoader`](https://github.com/xmtplabs/convos-ios/pull/1001/files#diff-7b33fc0530e99a3e9a50f447631666ada9ade550b718395a93709803597b28bd) to stream ciphertext to a temp file via `URLSession.download`, reject payloads >20 MB, and decrypt from a memory-mapped file instead of an in-memory buffer.
> - Refactors [`ImageCache`](https://github.com/xmtplabs/convos-ios/pull/1001/files#diff-445c3a2d9023d5d29469046555d79fa387c40b98bfcf772c84cdf1679fc38b91) network fetches to use `URLSession.download` and disk cache reads to decode directly from file URL, avoiding full in-memory buffering of encoded payloads.
> - Behavioral Change: decoded image dimensions are now capped at 2048px; images larger than 20 MB ciphertext are rejected with `URLError(.dataLengthExceedsMaximum)`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized aad24cb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->