### PR TITLE
Stop re-presenting the forked-conversation "Network issue" sheet after dismissal

### DIFF
--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -323,7 +323,7 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
         didSet {
             messagesListRepository.currentOtherMemberCount = conversation.membersWithoutCurrent.count
             syncVerifiedAgentToRepo()
-            presentingConversationForked = conversation.isForked
+            presentingConversationForked = shouldPresentConversationForked
             if oldValue.isDraft, !conversation.isDraft {
                 // Keep the draft include-info override until remote metadata changes propagate.
                 // Clearing it here can briefly show stale false values during async sync.
@@ -788,7 +788,20 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
     /// link's resolved profile; the card's "New chat" action spawns a fresh
     /// instance of the template. Mirrors `presentingProfileForMember`.
     var presentingContactForAgentShare: Contact?
-    var presentingConversationForked: Bool = false
+    /// Conversation IDs whose forked info sheet was dismissed this app session.
+    /// The conversation row updates on every observed change (new message, read
+    /// receipt, metadata), so without this the sheet would re-present after
+    /// every dismissal. Cleared on app relaunch.
+    private static var forkedSheetDismissedConversationIds: Set<String> = []
+    var presentingConversationForked: Bool = false {
+        didSet {
+            guard oldValue, !presentingConversationForked, conversation.isForked else { return }
+            Self.forkedSheetDismissedConversationIds.insert(conversation.id)
+        }
+    }
+    private var shouldPresentConversationForked: Bool {
+        conversation.isForked && !Self.forkedSheetDismissedConversationIds.contains(conversation.id)
+    }
     var presentingReactionsForMessage: AnyMessage?
     var presentingReadByForGroup: MessagesGroup?
     var presentingThinkingDetail: ThinkingSessionDescriptor?
@@ -1063,7 +1076,7 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
         editingConversationName = self.conversation.name ?? ""
         editingDescription = self.conversation.description ?? ""
 
-        presentingConversationForked = self.conversation.isForked
+        presentingConversationForked = shouldPresentConversationForked
 
         let perfElapsed = String(format: "%.0f", (CFAbsoluteTimeGetCurrent() - perfStart) * 1000)
         let individualMessageCount = messages.reduce(0) { count, item in


### PR DESCRIPTION
## Problem

The forked-conversation "Network issue" info sheet re-presents constantly. `ConversationViewModel.conversation`'s `didSet` fires on every observed DB update (new message, read receipt, metadata change) and unconditionally re-set `presentingConversationForked = conversation.isForked` — so on a forked conversation, the sheet popped right back up after every dismissal.

## Fix

Track dismissals in an app-session-scoped static set keyed by conversation ID:

- A `didSet` on `presentingConversationForked` records the conversation ID when the flag flips true → false while the conversation is still forked (a genuine user dismissal).
- Both presentation sites (`init` and the `conversation` `didSet`) now gate on that set via `shouldPresentConversationForked`.

## Behavior

- The sheet shows once per app session per forked conversation.
- Dismissing it keeps it away for the rest of the session, including closing and reopening the conversation.
- It returns on the next app launch as a reminder the convo is still broken.
- An unfork clearing the flag is not recorded as a dismissal, so a later re-fork can still present.
- "Delete convo" is unaffected.

## Testing

- Full ConvosCore suite: 1104 tests in 158 suites passed.
- `Convos (Dev)` scheme builds clean (warnings-as-errors).
- SwiftLint `--strict` clean on the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1002"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783275421&installation_id=128169237&pr_number=1002&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1002&signature=101af05ff704a375beb812fc9416da6389a5c89a410b1b8d9f74a3d2217d2e1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Stop re-presenting the forked-conversation sheet after dismissal in `ConversationViewModel`
> Tracks dismissed forked-conversation sheet IDs in a class-scoped static set on `ConversationViewModel`. On subsequent conversation updates or app-session reloads, the sheet is suppressed if its ID already appears in that set. The new `shouldPresentConversationForked` computed property encapsulates this gating logic, replacing direct use of the raw fork status.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2d5ea15.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->