### PR TITLE
Add temporary join-request polling to diagnose agents timing out while joining

### DIFF
--- a/ConvosCore/Sources/ConvosCore/Inboxes/FailedIdentityLoadOperation.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/FailedIdentityLoadOperation.swift
@@ -48,6 +48,8 @@ final class FailedIdentityLoadSessionStateManager: SessionStateManagerProtocol, 
 
     func requestDiscovery() async {}
 
+    func startAgentJoinRequestPolling() async {}
+
     func addObserver(_ observer: SessionStateObserver) {
         observer.sessionStateDidChange(currentState)
     }

--- a/ConvosCore/Sources/ConvosCore/Inboxes/SessionStateMachine.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/SessionStateMachine.swift
@@ -374,6 +374,11 @@ public actor SessionStateMachine: SessionStateManagerProtocol {
         await syncingManager.requestDiscovery()
     }
 
+    public func startAgentJoinRequestPolling() async {
+        guard let syncingManager else { return }
+        await syncingManager.startAgentJoinRequestPolling()
+    }
+
     // MARK: - SessionStateManagerProtocol
 
     public func waitForInboxReadyResult() async throws -> InboxReadyResult {

--- a/ConvosCore/Sources/ConvosCore/Inboxes/SessionStateManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/SessionStateManager.swift
@@ -16,6 +16,11 @@ public protocol SessionStateManagerProtocol: AnyObject, Sendable {
 
     func requestDiscovery() async
 
+    /// Temporary diagnostic for agents timing out while joining. Starts a
+    /// bounded poll for unprocessed join-request DMs in case the message
+    /// stream has died. See `SyncingManager.startAgentJoinRequestPolling`.
+    func startAgentJoinRequestPolling() async
+
     func addObserver(_ observer: SessionStateObserver)
     func removeObserver(_ observer: SessionStateObserver)
 

--- a/ConvosCore/Sources/ConvosCore/Mocks/MockSessionStateManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Mocks/MockSessionStateManager.swift
@@ -43,6 +43,9 @@ public final class MockSessionStateManager: SessionStateManagerProtocol, @unchec
     public func requestDiscovery() async {
     }
 
+    public func startAgentJoinRequestPolling() async {
+    }
+
     public func addObserver(_ observer: any SessionStateObserver) {
         observers.removeAll { $0.observer == nil }
         observers.append(WeakStateObserver(observer: observer))

--- a/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
@@ -597,12 +597,20 @@ public final class SessionManager: SessionManagerProtocol, @unchecked Sendable {
         options: ConvosAPI.AgentJoinOptions? = nil,
         forceErrorCode: Int? = nil
     ) async throws -> ConvosAPI.AgentJoinResponse {
-        try await apiClient.requestAgentJoin(
+        let response = try await apiClient.requestAgentJoin(
             slug: slug,
             templateId: templateId,
             options: options,
             forceErrorCode: forceErrorCode
         )
+        // Temporary diagnostic: the agent now sends a join-request DM that
+        // the message stream is expected to deliver. Poll for it for a
+        // bounded window in case the stream has died, so the agent doesn't
+        // time out and stream death shows up in the logs. Covers every
+        // agents/join entry point (add agent, contacts picker, compose,
+        // agent builder) since they all route through here.
+        await messagingService().sessionStateManager.startAgentJoinRequestPolling()
+        return response
     }
 
     public func agentShareResolver() -> any AgentShareResolving {

--- a/ConvosCore/Sources/ConvosCore/Syncing/InviteJoinRequestsManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/InviteJoinRequestsManager.swift
@@ -22,6 +22,7 @@ enum InviteJoinRequestOutcome: Sendable {
     case accepted(JoinRequestResult, dmConversationId: String)
     case benignFailure(dmConversationId: String, senderInboxId: String?, error: JoinRequestError)
     case malicious(dmConversationId: String, senderInboxId: String, error: JoinRequestError)
+    case alreadyMember(dmConversationId: String, joinerInboxId: String)
     case noJoinRequest
 
     var result: JoinRequestResult? {
@@ -37,6 +38,8 @@ enum InviteJoinRequestOutcome: Sendable {
             return dmConversationId
         case .malicious(let dmConversationId, _, _):
             return dmConversationId
+        case .alreadyMember(let dmConversationId, _):
+            return dmConversationId
         case .noJoinRequest:
             return nil
         }
@@ -44,7 +47,7 @@ enum InviteJoinRequestOutcome: Sendable {
 
     var shouldKeepDMSubscribed: Bool {
         switch self {
-        case .accepted, .benignFailure:
+        case .accepted, .benignFailure, .alreadyMember:
             return true
         case .malicious, .noJoinRequest:
             return false
@@ -242,6 +245,12 @@ final class InviteJoinRequestsManager: InviteJoinRequestsManagerProtocol, Sendab
                 dmConversationId: dmConversationId,
                 senderInboxId: senderInboxId,
                 error: error
+            )
+        case let .alreadyMember(dmConversationId, joinerInboxId):
+            Log.debug("Join request for \(joinerInboxId) already handled by another pass (DM \(dmConversationId))")
+            return .alreadyMember(
+                dmConversationId: dmConversationId,
+                joinerInboxId: joinerInboxId
             )
         case .noJoinRequest:
             return .noJoinRequest

--- a/ConvosCore/Sources/ConvosCore/Syncing/SyncingManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/SyncingManager.swift
@@ -17,6 +17,13 @@ public protocol SyncingManagerProtocol: Actor {
     func setInviteJoinErrorHandler(_ handler: (any InviteJoinErrorHandler)?) async
     func setTypingIndicatorHandler(_ handler: @escaping @Sendable (String, String, Bool) -> Void) async
 
+    /// Temporary diagnostic for agents timing out while joining (suspected
+    /// silent message-stream death). Polls for unprocessed join-request DMs
+    /// for a bounded window after an agents/join call, processing anything
+    /// the stream missed. Remove once the stream issue is confirmed and
+    /// fixed. See `SyncingManager.startAgentJoinRequestPolling`.
+    func startAgentJoinRequestPolling() async
+
     /// Drain the backlog of activity since `cursor` in one batched transaction,
     /// before streams resume. Runs the message-side `BatchCatchUp` and the
     /// invite-side `InviteJoinRequestsManager.processJoinRequestOutcomes`
@@ -118,6 +125,12 @@ actor SyncingManager: SyncingManagerProtocol {
     private var conversationStreamTask: Task<Void, Never>?
     private var syncTask: Task<Void, Never>?
 
+    /// Temporary diagnostic state for the agent-join poll. The task is the
+    /// bounded polling loop; the date stamps the last message the stream
+    /// actually delivered, so poll logs can report how stale the stream is.
+    private var agentJoinPollTask: Task<Void, Never>?
+    private var lastMessageStreamEventDate: Date?
+
     /// Reconciles conversation consent against contact-block state (the
     /// source of truth for feed visibility). Reconstructed per session
     /// start because it captures the live XMTP client.
@@ -206,6 +219,7 @@ actor SyncingManager: SyncingManagerProtocol {
         notificationTask?.cancel()
         messageStreamTask?.cancel()
         conversationStreamTask?.cancel()
+        agentJoinPollTask?.cancel()
         currentTask?.cancel()
 
         // Remove observers
@@ -796,6 +810,7 @@ actor SyncingManager: SyncingManagerProtocol {
         syncTask?.cancel()
         messageStreamTask?.cancel()
         conversationStreamTask?.cancel()
+        agentJoinPollTask?.cancel()
 
         if let task = syncTask {
             _ = await task.value
@@ -808,6 +823,10 @@ actor SyncingManager: SyncingManagerProtocol {
         if let task = conversationStreamTask {
             _ = await task.value
             conversationStreamTask = nil
+        }
+        if let task = agentJoinPollTask {
+            _ = await task.value
+            agentJoinPollTask = nil
         }
     }
 
@@ -846,6 +865,10 @@ actor SyncingManager: SyncingManagerProtocol {
                 for try await message in stream {
                     // Check cancellation
                     try Task.checkCancellation()
+
+                    // Diagnostic stamp for the agent-join poll: how recently
+                    // the message stream actually delivered anything.
+                    lastMessageStreamEventDate = Date()
 
                     // Reset retry count after first successful message (stream is healthy)
                     if isFirstMessage {
@@ -948,9 +971,11 @@ actor SyncingManager: SyncingManagerProtocol {
             enqueueAction(.streamFailed)
         }
     }
+}
 
-    // MARK: - Mutation
+// MARK: - Mutation
 
+extension SyncingManager {
     func setActiveConversationId(_ conversationId: String?) {
         // Update the active conversation
         activeConversationId = conversationId
@@ -962,6 +987,111 @@ actor SyncingManager: SyncingManagerProtocol {
 
     func setTypingIndicatorHandler(_ handler: @escaping @Sendable (String, String, Bool) -> Void) async {
         await streamProcessor.setTypingIndicatorHandler(handler)
+    }
+}
+
+// MARK: - Agent Join Request Polling (temporary diagnostic)
+
+extension SyncingManager {
+    /// Bounded polling fallback for agent join requests. Agents join by
+    /// sending a join-request DM to the conversation creator; that DM is
+    /// normally picked up by the message stream. When the stream dies
+    /// silently the request is never processed and the agent backend gives
+    /// up after about two minutes. While we diagnose the stream issue, this
+    /// polls the network for a short window after each agents/join call and
+    /// processes anything the stream missed, logging loudly when that
+    /// happens so stream death is observable in the logs.
+    ///
+    /// Re-processing a request the stream already handled is safe: the
+    /// coordinator returns `.alreadyMember` (no re-add, no duplicate
+    /// snapshot), which also keeps the "stream missed it" log signal free
+    /// of false positives.
+    func startAgentJoinRequestPolling() {
+        agentJoinPollTask?.cancel()
+        let startedAt = Date()
+        Log.info("[agent-join-poll] starting: every \(Int(Constant.agentJoinPollInterval))s for \(Int(Constant.agentJoinPollWindow))s")
+        agentJoinPollTask = Task { [weak self] in
+            await self?.runAgentJoinRequestPolling(startedAt: startedAt)
+        }
+    }
+
+    private func runAgentJoinRequestPolling(startedAt: Date) async {
+        var cursor = startedAt.addingTimeInterval(-Constant.agentJoinPollCursorOverlap)
+        let deadline = startedAt.addingTimeInterval(Constant.agentJoinPollWindow)
+        var tick = 0
+        while !Task.isCancelled && Date() < deadline {
+            do {
+                try await Task.sleep(nanoseconds: UInt64(Constant.agentJoinPollInterval * 1_000_000_000))
+            } catch {
+                break
+            }
+            tick += 1
+            guard case .ready(let params) = _state else {
+                Log.debug("[agent-join-poll] tick \(tick) skipped - sync not ready (\(_state))")
+                continue
+            }
+            let tickStartedAt = Date()
+            do {
+                _ = try await params.client.conversationsProvider.syncAllConversations(consentStates: params.consentStates)
+            } catch {
+                Log.warning("[agent-join-poll] tick \(tick): syncAllConversations failed, will retry: \(error)")
+                continue
+            }
+            let acceptedCount = await runAgentJoinPollBatch(params: params, since: cursor)
+            if acceptedCount > 0 {
+                let lastStreamEvent: String = lastMessageStreamEventDate.map { "\(Int(Date().timeIntervalSince($0)))s ago" } ?? "never"
+                Log.warning(
+                    "[agent-join-poll] tick \(tick): accepted \(acceptedCount) join request(s) the message stream had not processed" +
+                    " (last stream message: \(lastStreamEvent)) - message stream is likely dead"
+                )
+            } else {
+                Log.debug("[agent-join-poll] tick \(tick): no unprocessed join requests")
+            }
+            cursor = tickStartedAt.addingTimeInterval(-Constant.agentJoinPollCursorOverlap)
+        }
+        Log.info("[agent-join-poll] finished after \(tick) tick(s)")
+    }
+
+    /// Processes join-request DMs since `since`, then pulls the message-side
+    /// backlog so the resulting membership change (group_updated) lands in
+    /// the local database even while the stream is down. Returns the number
+    /// of join requests this pass actually accepted - requests another path
+    /// already handled surface as `.alreadyMember` and don't count, so a
+    /// healthy stream keeps this at zero.
+    ///
+    /// `nonisolated` for the same reason as `runBatchCatchUp`: the only
+    /// state it touches is the immutable `identityStore` / `databaseWriter`,
+    /// and it keeps the non-Sendable client out of the actor's isolation
+    /// domain.
+    private nonisolated func runAgentJoinPollBatch(params: SyncClientParams, since: Date?) async -> Int {
+        let client = params.client
+        let manager = InviteJoinRequestsManager(
+            identityStore: identityStore,
+            databaseWriter: databaseWriter
+        )
+        let outcomes = await manager.processJoinRequestOutcomes(since: since, client: client)
+        var acceptedCount = 0
+        for outcome in outcomes {
+            if case .accepted = outcome {
+                acceptedCount += 1
+            }
+        }
+        await runMessageBatch(client: client, since: since)
+        return acceptedCount
+    }
+
+    private enum Constant {
+        /// How often the temporary agent-join poll checks for unprocessed
+        /// join requests.
+        static let agentJoinPollInterval: TimeInterval = 5
+        /// How long the poll keeps checking after an agents/join call. The
+        /// agent backend gives up after about two minutes; poll a bit past
+        /// that so the tail end of the window is still observable.
+        static let agentJoinPollWindow: TimeInterval = 150
+        /// Back-overlap applied when advancing the poll cursor so messages
+        /// that land while a sync pass is in flight aren't skipped by the
+        /// next tick.
+        static let agentJoinPollCursorOverlap: TimeInterval = 5
     }
 }
 

--- a/ConvosCore/Tests/ConvosCoreTests/TestHelpers.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/TestHelpers.swift
@@ -281,6 +281,9 @@ actor MockSyncingManager: SyncingManagerProtocol {
     func setInviteJoinErrorHandler(_ handler: (any InviteJoinErrorHandler)?) async {
     }
 
+    func startAgentJoinRequestPolling() {
+    }
+
     func setTypingIndicatorHandler(_ handler: @escaping @Sendable (String, String, Bool) -> Void) async {
     }
 

--- a/ConvosInvites/Sources/ConvosInvites/InviteCoordinator.swift
+++ b/ConvosInvites/Sources/ConvosInvites/InviteCoordinator.swift
@@ -343,6 +343,19 @@ public final class InviteCoordinator: @unchecked Sendable {
 
         try? await group.sync()
 
+        // Multiple processing paths (message stream, batch catch-up, and the
+        // temporary agent-join poll) can see the same join-request message.
+        // If the joiner is already in the group, a previous pass handled it -
+        // skip the re-add so we don't send duplicate profile snapshots or,
+        // worse, a spurious error DM back to a joiner that already joined.
+        if let memberInboxIds = try? await group.members.map(\.inboxId),
+           memberInboxIds.contains(request.joinerInboxId) {
+            return .alreadyMember(
+                dmConversationId: request.dmConversationId,
+                joinerInboxId: request.joinerInboxId
+            )
+        }
+
         do {
             let currentTag = try tagStorage.getInviteTag(for: group)
             guard signedInvite.invitePayload.tag == currentTag else {
@@ -411,6 +424,8 @@ public final class InviteCoordinator: @unchecked Sendable {
                 continue
             case .accepted:
                 try? await dm.updateConsentState(state: .allowed)
+                return outcome
+            case .alreadyMember:
                 return outcome
             case .malicious:
                 return outcome

--- a/ConvosInvites/Sources/ConvosInvites/Models.swift
+++ b/ConvosInvites/Sources/ConvosInvites/Models.swift
@@ -149,11 +149,16 @@ public struct JoinResult: Sendable {
 /// - `malicious`: Signature verification failed in a way that indicates
 ///   tampering. The DM is denied and the device unsubscribes from its
 ///   topic so it can no longer wake the inbox.
+/// - `alreadyMember`: The request decoded and verified, but the joiner is
+///   already in the group - another processing path (stream vs batch vs
+///   poll) handled this request first. No re-add, no snapshot, no error
+///   DM; the DM stays subscribed like `accepted`.
 /// - `noJoinRequest`: The message was not a join-request candidate.
 public enum JoinRequestDMOutcome: Sendable {
     case accepted(JoinResult, dmConversationId: String)
     case benignFailure(dmConversationId: String, senderInboxId: String?, error: JoinRequestError)
     case malicious(dmConversationId: String, senderInboxId: String, error: JoinRequestError)
+    case alreadyMember(dmConversationId: String, joinerInboxId: String)
     case noJoinRequest
 
     public var joinResult: JoinResult? {
@@ -169,6 +174,8 @@ public enum JoinRequestDMOutcome: Sendable {
             return dmConversationId
         case .malicious(let dmConversationId, _, _):
             return dmConversationId
+        case .alreadyMember(let dmConversationId, _):
+            return dmConversationId
         case .noJoinRequest:
             return nil
         }
@@ -176,7 +183,7 @@ public enum JoinRequestDMOutcome: Sendable {
 
     public var shouldKeepDMSubscribed: Bool {
         switch self {
-        case .accepted, .benignFailure:
+        case .accepted, .benignFailure, .alreadyMember:
             return true
         case .malicious, .noJoinRequest:
             return false

--- a/ConvosInvites/Tests/ConvosInvitesTests/JoinRequestProcessingTests.swift
+++ b/ConvosInvites/Tests/ConvosInvitesTests/JoinRequestProcessingTests.swift
@@ -326,6 +326,10 @@ struct JoinRequestProcessingTests {
             senderInboxId: "joiner-123",
             error: .invalidSignature
         )
+        let alreadyMember = JoinRequestDMOutcome.alreadyMember(
+            dmConversationId: "dm-123",
+            joinerInboxId: "joiner-123"
+        )
 
         #expect(accepted.shouldKeepDMSubscribed)
         #expect(accepted.dmConversationId == "dm-123")
@@ -333,6 +337,10 @@ struct JoinRequestProcessingTests {
         #expect(benignFailure.shouldKeepDMSubscribed)
         #expect(!malicious.shouldKeepDMSubscribed)
         #expect(malicious.isMalicious)
+        #expect(alreadyMember.shouldKeepDMSubscribed)
+        #expect(alreadyMember.dmConversationId == "dm-123")
+        #expect(alreadyMember.joinResult == nil)
+        #expect(!alreadyMember.isMalicious)
     }
 
     // MARK: - InviteJoinError Feedback


### PR DESCRIPTION
## Why

When adding an agent, the agent backend times out after ~2 minutes waiting to join. The suspected cause: the iOS client's XMTP **message stream dies silently**, so the agent's join-request DM is never processed (`InviteCoordinator.processJoinRequest` -> `group.addMembers` never runs). There is currently no fallback for this path — the join-flow discovery poll only covers the *joiner* side, not the *creator* side that approves requests.

This PR adds a **temporary, bounded polling fallback** so we can (a) confirm stream death is the root cause via logs, and (b) unblock agent joins in the meantime.

## What

**Polling (temporary — remove once the stream issue is fixed)**
- `SyncingManager.startAgentJoinRequestPolling()`: polls every **5s for 150s** after each `agents/join` call. Each tick: `syncAllConversations` (pulls the agent's DM even with dead streams) -> process join-request DMs since a per-tick cursor -> run the message batch so the membership change reaches the local DB/UI.
- Triggered from `SessionManager.requestAgentJoin`, which **every** agents/join entry point routes through (add agent, contacts picker, compose flow, agent builder).
- Poll task is cancelled on stop/teardown; ticks skip while paused/backgrounded.

**The diagnostic signal**
- Every streamed message now stamps `lastMessageStreamEventDate`. When a poll tick accepts a request the stream hadn't handled, it logs:
  `[agent-join-poll] tick N: accepted 1 join request(s) the message stream had not processed (last stream message: 47s ago) - message stream is likely dead`
- If this warning shows up in `convos.log` where agents previously timed out, stream death is confirmed.

**Safety: new `JoinRequestDMOutcome.alreadyMember` (worth keeping)**
- If the joiner is already in the group, a previous pass (stream vs batch vs poll) handled the request — skip the re-add. Prevents duplicate `addMembers` commits, duplicate ProfileSnapshots, and spurious error DMs back to an already-joined agent, and keeps the diagnostic warning free of false positives when the stream is healthy. This also hardens the pre-existing stream/batch-catch-up overlap.

## Testing

- ConvosCore: **1,104 tests in 158 suites passed** against the local XMTP node
- ConvosInvites: **168 tests passed**, including new `.alreadyMember` outcome coverage
- SwiftLint `--strict` clean on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add temporary join-request polling to diagnose agents timing out while joining
> - After a successful `agents/join` API call, `SessionManager.requestAgentJoin` triggers a bounded background poll loop via `SyncingManager.startAgentJoinRequestPolling` to catch join-request DMs that the message stream may have missed.
> - The poll runs every 5s within a 150s window, syncing conversations and processing join-request outcomes; it logs warnings if accepted requests were missed by the stream.
> - Adds an `alreadyMember` outcome to `JoinRequestDMOutcome` and `InviteJoinRequestOutcome` so the coordinator skips re-adding users who are already group members.
> - Behavioral Change: `SessionStateManagerProtocol` and `SyncingManagerProtocol` both gain a required `startAgentJoinRequestPolling()` method; all conforming types (including mocks) must implement it.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized edb61f9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->