### PR TITLE
Track assistant join wait, timeout, and poll-rescue in PostHog/Sentry

### DIFF
--- a/Convos.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Convos.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "6d7728d9b1fb7fa0ef24007891317f13cfbd2082accdfa2aae24097c13efe508",
+  "originHash" : "bda0ed788167ae17f3a13ebcf47c374b7d3fb34bc58c18aed3aa73fa0c42c049",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/xmtplabs/convos-shared.git",
       "state" : {
-        "branch" : "main",
-        "revision" : "8b7bfe0e865239b6b018dbfad75398e8ebcfd3bb"
+        "branch" : "jarod/assistant-join-metrics",
+        "revision" : "db0dde49c87c670758ca7a14488d863701a9be1d"
       }
     },
     {
@@ -222,8 +222,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log",
       "state" : {
-        "revision" : "bc386b95f2a16ccd0150a8235e7c69eab2b866ca",
-        "version" : "1.8.0"
+        "revision" : "2aed77ae5ec9a86d8fe42c12275e4c2653a286ee",
+        "version" : "1.13.1"
       }
     },
     {

--- a/Convos/Conversation Creation/NewConversationViewModel.swift
+++ b/Convos/Conversation Creation/NewConversationViewModel.swift
@@ -264,6 +264,12 @@ class NewConversationViewModel: Identifiable, Hashable {
     private var newConversationTask: Task<Void, Error>?
     @ObservationIgnored
     private var joinConversationTask: Task<Void, Error>?
+    /// Emits `conversation_join_timed_out` when the join is still unverified
+    /// after the wait window - the conversation creator's device never
+    /// approved the join request while the user watched the "Verifying"
+    /// state. Cancelled on success, failure, and teardown.
+    @ObservationIgnored
+    private var joinTimeoutTask: Task<Void, Never>?
     @ObservationIgnored
     private var resetTask: Task<Void, Never>?
     @ObservationIgnored
@@ -396,6 +402,7 @@ class NewConversationViewModel: Identifiable, Hashable {
         inboxAcquisitionTask?.cancel()
         newConversationTask?.cancel()
         joinConversationTask?.cancel()
+        joinTimeoutTask?.cancel()
         resetTask?.cancel()
         stateObservationTask?.cancel()
         optimisticAgentResolveTask?.cancel()
@@ -718,6 +725,7 @@ class NewConversationViewModel: Identifiable, Hashable {
         }
 
         joinConversationTask?.cancel()
+        armJoinTimeout()
         joinConversationTask = Task { [weak self, conversationStateManager] in
             guard self != nil else { return }
             guard !Task.isCancelled else { return }
@@ -792,10 +800,35 @@ class NewConversationViewModel: Identifiable, Hashable {
         }
     }
 
+    private func armJoinTimeout() {
+        joinTimeoutTask?.cancel()
+        joinTimeoutTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .seconds(Constant.joinWaitWindow))
+            guard !Task.isCancelled else { return }
+            self?.emitConversationJoinTimedOut()
+        }
+    }
+
+    /// The join request is still unapproved after the wait window: the user
+    /// has watched the "Verifying" state the whole time. Emits the
+    /// stuck-wait sample; `verificationStartedAt` is left in place so a
+    /// late approval still reports its true duration via
+    /// `joinedConversation` on success.
+    @MainActor
+    private func emitConversationJoinTimedOut() {
+        guard let startedAt = verificationStartedAt else { return }
+        let waitDuration = Float(CFAbsoluteTimeGetCurrent() - startedAt)
+        let source: ConversationSource = joinSource
+        let actions: any CoreActions = coreActions
+        Task { await actions.conversationJoinTimedOut(waitDuration: waitDuration, source: source) }
+    }
+
     // MARK: - Private
 
     @MainActor
     private func handleJoinSuccess() {
+        joinTimeoutTask?.cancel()
+        joinTimeoutTask = nil
         presentingJoinConversationSheet = false
         displayError = nil
 
@@ -817,6 +850,9 @@ class NewConversationViewModel: Identifiable, Hashable {
 
     @MainActor
     private func handleJoinError(_ error: Error) {
+        // The user is watching the failure UI now, not the verifying state.
+        joinTimeoutTask?.cancel()
+        joinTimeoutTask = nil
         withAnimation {
             qrScannerViewModel.resetScanning()
 
@@ -890,6 +926,10 @@ class NewConversationViewModel: Identifiable, Hashable {
         static let retryDelayShort: TimeInterval = 2
         static let retryDelayMedium: TimeInterval = 4
         static let retryDelayMax: TimeInterval = 8
+        /// How long an invite join may sit in the "Verifying" state before
+        /// `conversation_join_timed_out` is emitted. Matches the assistant
+        /// join wait window so the two stuck-wait metrics are comparable.
+        static let joinWaitWindow: TimeInterval = 150
     }
 }
 
@@ -936,6 +976,7 @@ extension NewConversationViewModel {
         Log.info("Deleting conversation")
         newConversationTask?.cancel()
         joinConversationTask?.cancel()
+        joinTimeoutTask?.cancel()
         // A queued visibility commit must not survive dismissal - the user
         // abandoned the builder, so a late `.ready` shouldn't promote the
         // conversation into the chats list.

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -323,6 +323,7 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
         didSet {
             messagesListRepository.currentOtherMemberCount = conversation.membersWithoutCurrent.count
             syncVerifiedAgentToRepo()
+            trackAssistantJoinedIfNeeded(oldValue: oldValue)
             presentingConversationForked = shouldPresentConversationForked
             if oldValue.isDraft, !conversation.isDraft {
                 // Keep the draft include-info override until remote metadata changes propagate.
@@ -549,6 +550,13 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
             try? await Task.sleep(for: .seconds(remaining))
             guard !Task.isCancelled else { return }
             self?.agentBuilderPlaceholderExpired = true
+        }
+        // The builder's agents/join call happens in AgentBuilderViewModel,
+        // so the wait measurement is anchored here instead, on the summary's
+        // persisted Make commit time. Only within the placeholder window -
+        // a stale rehydrated summary isn't a join the user is watching.
+        if !conversation.members.contains(where: \.isVerifiedConvosAgent) {
+            beginAssistantJoinWait(surface: .builderPlaceholder, startedAt: summary.cutoffDate)
         }
     }
 
@@ -842,6 +850,17 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
     @ObservationIgnored
     private var agentJoinTaskId: String?
 
+    /// Telemetry anchors for the assistant joining/verifying wait: set when
+    /// an agents/join call succeeds (or rebased on the agent builder's Make
+    /// commit time), cleared when the verified assistant arrives or the wait
+    /// window elapses. Session-scoped - a relaunch mid-wait drops the sample.
+    @ObservationIgnored
+    private var assistantJoinWaitStartedAt: Date?
+    @ObservationIgnored
+    private var assistantJoinWaitSurface: AssistantJoinSurface?
+    @ObservationIgnored
+    private var assistantJoinTimeoutTask: Task<Void, Never>?
+
     var autoRevealPhotos: Bool = GlobalConvoDefaults.shared.autoRevealPhotos
     var sendReadReceipts: Bool = true
     var isViewingConversation: Bool = false
@@ -969,6 +988,7 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
         convosButtonTask?.cancel()
         explodeDurationTask?.cancel()
         agentBuilderPlaceholderExpiryTask?.cancel()
+        assistantJoinTimeoutTask?.cancel()
     }
 
     // MARK: - Init
@@ -3013,6 +3033,13 @@ extension ConversationViewModel {
 
         agentJoinTask?.cancel()
 
+        // Anchor the wait measurement at request time (the pending UI starts
+        // here too), not at API success - a fast agent can arrive via the
+        // stream before agents/join returns, which would otherwise lose the
+        // assistant_joined sample.
+        let surface: AssistantJoinSurface = templateId == nil ? .statusMessage : .contactCard
+        beginAssistantJoinWait(surface: surface)
+
         let forceErrorCode = agentJoinForceErrorCode
         let conversationId = conversation.id
         let requestId = UUID().uuidString
@@ -3031,7 +3058,13 @@ extension ConversationViewModel {
             let memberCount: Int = await MainActor.run { self?.conversation.members.count ?? 0 }
             await MainActor.run {
                 guard let self else { return }
-                if outcome == .failed { self.onAgentJoinError() }
+                if outcome == .failed {
+                    self.onAgentJoinError()
+                    // The user is watching the failure UI now, not a join
+                    // wait. A superseding retap exits as .cancelled, so this
+                    // never clears a newer request's anchor.
+                    self.clearAssistantJoinWait()
+                }
                 self.clearAgentJoinTask(id: taskId)
             }
             if outcome == .succeeded {
@@ -3071,11 +3104,18 @@ extension ConversationViewModel {
         guard !slug.isEmpty else { return }
         Log.info("requestAgentJoins called with \(templateIds.count) templates (sequential): \(templateIds)")
 
+        // Batch adds return to the chat, so the join progress shows as
+        // in-stream pending status bubbles. Anchored at request time for the
+        // same fast-arrival reason as requestAgentJoin; the first verified
+        // arrival ends the wait measurement.
+        beginAssistantJoinWait(surface: .statusMessage)
+
         let forceErrorCode = agentJoinForceErrorCode
         let conversationId = conversation.id
         let session = self.session
         Task { [weak self] in
             var anyFailed = false
+            var anySucceeded = false
             for (index, templateId) in templateIds.enumerated() {
                 if index > 0 {
                     // Brief gap between calls so the previous broadcast's
@@ -3093,11 +3133,82 @@ extension ConversationViewModel {
                     session: session
                 )
                 if outcome == .failed { anyFailed = true }
+                if outcome == .succeeded { anySucceeded = true }
             }
             if anyFailed {
                 await MainActor.run { self?.onAgentJoinError() }
             }
+            if !anySucceeded {
+                // Every call failed or was cancelled - nothing is joining,
+                // so stop measuring the wait.
+                await MainActor.run { self?.clearAssistantJoinWait() }
+            }
         }
+    }
+
+    // MARK: - Assistant Join Wait Telemetry
+
+    /// Starts (or rebases the timeout of) the assistant joining/verifying
+    /// wait measurement. Anchored at `startedAt` so the agent-builder flow
+    /// can use the persisted Make commit time; an already-running wait keeps
+    /// its earlier anchor so retries don't shrink the measured duration.
+    private func beginAssistantJoinWait(surface: AssistantJoinSurface, startedAt: Date = Date()) {
+        if assistantJoinWaitStartedAt == nil {
+            assistantJoinWaitStartedAt = startedAt
+            assistantJoinWaitSurface = surface
+        }
+        armAssistantJoinTimeout()
+    }
+
+    private func armAssistantJoinTimeout() {
+        assistantJoinTimeoutTask?.cancel()
+        guard let startedAt = assistantJoinWaitStartedAt else { return }
+        let elapsed = Date().timeIntervalSince(startedAt)
+        let remaining: TimeInterval = max(0, Constant.assistantJoinWaitWindow - elapsed)
+        assistantJoinTimeoutTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .seconds(remaining))
+            guard !Task.isCancelled else { return }
+            self?.emitAssistantJoinTimedOut()
+        }
+    }
+
+    /// Emits `assistant_join_timed_out` when the wait window elapses without
+    /// a verified assistant appearing. The measurement stops here - an
+    /// assistant that arrives later is not counted as a completed wait (the
+    /// user already watched the joining state fail).
+    private func emitAssistantJoinTimedOut() {
+        guard let startedAt = assistantJoinWaitStartedAt else { return }
+        guard !conversation.members.contains(where: \.isVerifiedConvosAgent) else {
+            clearAssistantJoinWait()
+            return
+        }
+        let waitDuration = Float(Date().timeIntervalSince(startedAt))
+        let surface: AssistantJoinSurface = assistantJoinWaitSurface ?? .statusMessage
+        clearAssistantJoinWait()
+        let actions: any CoreActions = coreActions
+        Task { await actions.assistantJoinTimedOut(waitDuration: waitDuration, surface: surface) }
+    }
+
+    /// Emits `assistant_joined` when a verified assistant transitions into
+    /// the member list while a wait is being measured. Called from the
+    /// `conversation` didSet.
+    private func trackAssistantJoinedIfNeeded(oldValue: Conversation) {
+        guard let startedAt = assistantJoinWaitStartedAt,
+              !oldValue.members.contains(where: \.isVerifiedConvosAgent),
+              conversation.members.contains(where: \.isVerifiedConvosAgent) else { return }
+        let waitDuration = Float(Date().timeIntervalSince(startedAt))
+        let surface: AssistantJoinSurface = assistantJoinWaitSurface ?? .statusMessage
+        let memberCount = conversation.members.count
+        clearAssistantJoinWait()
+        let actions: any CoreActions = coreActions
+        Task { await actions.assistantJoined(waitDuration: waitDuration, surface: surface, memberCount: memberCount) }
+    }
+
+    private func clearAssistantJoinWait() {
+        assistantJoinTimeoutTask?.cancel()
+        assistantJoinTimeoutTask = nil
+        assistantJoinWaitStartedAt = nil
+        assistantJoinWaitSurface = nil
     }
 
     /// Discriminates the three outcomes of an `agents/join` call so callers
@@ -3676,6 +3787,14 @@ extension ConversationViewModel {
                 self.explodeState = .ready
             }
         }
+    }
+
+    private enum Constant {
+        /// How long the assistant join wait is measured before emitting
+        /// `assistant_join_timed_out`. Matches the join-request polling
+        /// window in SyncingManager, which itself covers the assistant
+        /// backend's roughly two-minute give-up with margin.
+        static let assistantJoinWaitWindow: TimeInterval = 150
     }
 }
 

--- a/Convos/Metrics/PostHogCollector.swift
+++ b/Convos/Metrics/PostHogCollector.swift
@@ -3,6 +3,7 @@ import ConvosCore
 import ConvosMetrics
 import Foundation
 import PostHog
+import Sentry
 
 final class PostHogCollector: CollectorDelegate {
     var userPropertiesCancellable: AnyCancellable?
@@ -49,5 +50,19 @@ final class PostHogCollector: CollectorDelegate {
             name,
             properties: properties.compactMapValues { $0 }
         )
+        captureDiagnosticEventInSentry(name: name, properties: properties)
+    }
+
+    /// Engineering diagnostics that should alert through Sentry rather than
+    /// only landing in product analytics: a poll-rescued assistant join is
+    /// direct evidence of a silently dead message stream. No-op when the
+    /// SDK isn't started (local/test builds) and carries no PII - only the
+    /// stream-staleness numbers from the metric.
+    private func captureDiagnosticEventInSentry(name: String, properties: [String: Any?]) {
+        guard name == MetricsCoreActions.eventAssistantJoinRescuedByPolling else { return }
+        let event = Event(level: .warning)
+        event.message = SentryMessage(formatted: "assistant join rescued by polling - message stream likely dead")
+        event.extra = properties.compactMapValues { $0 }
+        SentrySDK.capture(event: event)
     }
 }

--- a/ConvosCore/Package.resolved
+++ b/ConvosCore/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "4cc47b4918e3106a8d7c076112da65047aab9dc16a763f9f248f98517809b7c7",
+  "originHash" : "0b364bfb8f0346d1f6144dd2f64db564429002e9293bc18e0ec046475b7ca1b2",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/xmtplabs/convos-shared.git",
       "state" : {
-        "branch" : "main",
-        "revision" : "8b7bfe0e865239b6b018dbfad75398e8ebcfd3bb"
+        "branch" : "jarod/assistant-join-metrics",
+        "revision" : "db0dde49c87c670758ca7a14488d863701a9be1d"
       }
     },
     {

--- a/ConvosCore/Package.swift
+++ b/ConvosCore/Package.swift
@@ -34,7 +34,9 @@ let package = Package(
         .package(url: "https://github.com/firebase/firebase-ios-sdk", from: "12.1.0"),
         .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.31.1"),
         .package(url: "https://github.com/getsentry/sentry-cocoa.git", from: "8.57.1"),
-        .package(url: "https://github.com/xmtplabs/convos-shared.git", branch: "main"),
+        // Interim pin while the assistant-join metrics land: flip back to
+        // branch "main" once xmtplabs/convos-shared#2 merges.
+        .package(url: "https://github.com/xmtplabs/convos-shared.git", branch: "jarod/assistant-join-metrics"),
         .package(path: "../ConvosLogging"),
         .package(path: "../ConvosInvites"),
         .package(path: "../ConvosAppData"),

--- a/ConvosCore/Sources/ConvosCore/Metrics/NoOpCoreActions.swift
+++ b/ConvosCore/Sources/ConvosCore/Metrics/NoOpCoreActions.swift
@@ -13,9 +13,30 @@ public final class NoOpCoreActions: CoreActions, @unchecked Sendable {
         source: ConversationSource
     ) async {}
 
+    public func conversationJoinTimedOut(
+        waitDuration: Float,
+        source: ConversationSource
+    ) async {}
+
     public func invitedToConversation(memberCount: Int, hasAssistant: Bool) async {}
 
     public func addedAssistant(memberCount: Int) async {}
+
+    public func assistantJoined(
+        waitDuration: Float,
+        surface: AssistantJoinSurface,
+        memberCount: Int
+    ) async {}
+
+    public func assistantJoinTimedOut(
+        waitDuration: Float,
+        surface: AssistantJoinSurface
+    ) async {}
+
+    public func assistantJoinRescuedByPolling(
+        streamAgeSecs: Float,
+        pollTick: Int
+    ) async {}
 
     public func sentMessage(
         sendingTime: Float,

--- a/ConvosCore/Sources/ConvosCore/Syncing/SyncingManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/SyncingManager.swift
@@ -1039,11 +1039,13 @@ extension SyncingManager {
             }
             let acceptedCount = await runAgentJoinPollBatch(params: params, since: cursor)
             if acceptedCount > 0 {
-                let lastStreamEvent: String = lastMessageStreamEventDate.map { "\(Int(Date().timeIntervalSince($0)))s ago" } ?? "never"
+                let streamAgeSecs: Float = lastMessageStreamEventDate.map { Float(Date().timeIntervalSince($0)) } ?? -1
+                let lastStreamEvent: String = streamAgeSecs >= 0 ? "\(Int(streamAgeSecs))s ago" : "never"
                 Log.warning(
                     "[agent-join-poll] tick \(tick): accepted \(acceptedCount) join request(s) the message stream had not processed" +
                     " (last stream message: \(lastStreamEvent)) - message stream is likely dead"
                 )
+                await coreActions.assistantJoinRescuedByPolling(streamAgeSecs: streamAgeSecs, pollTick: tick)
             } else {
                 Log.debug("[agent-join-poll] tick \(tick): no unprocessed join requests")
             }


### PR DESCRIPTION
> Stacked on #1004. Depends on [convos-shared#2](https://github.com/xmtplabs/convos-shared/pull/2) — merge that first, then flip `ConvosCore/Package.swift` back to `branch: "main"` (currently pinned to the feature branch so CI can resolve the new symbols).

## Why

#1004 diagnoses agents timing out while joining (suspected silent message-stream death) with a temporary polling fallback. This PR makes both the user experience and the root cause **measurable**: how many users sit in the "Joining…/verifying" state, for how long, how often it times out — and how often the stream demonstrably died.

## What

**PostHog (via the new `CoreActions` events from convos-shared#2):**
- `assistant_joined` — `ConversationViewModel` anchors a wait when an `agents/join` call succeeds (bare add, template add, batch picker adds) or on the agent builder's persisted Make commit time, and emits `wait_duration` + `surface` + `member_count` when a verified assistant transitions into the member list.
- `assistant_join_timed_out` — emitted when the 150s wait window (matching the polling window in #1004, which covers the agent backend's ~2min give-up) elapses with no verified assistant.
- `assistant_join_rescued_by_polling` — `SyncingManager`'s poll emits this (it already holds `coreActions`) whenever it accepts a join request the stream missed, with `stream_age_secs` = staleness of the message stream.

**Standard invite joins (`conversation_join_timed_out`):** the same stuck-wait measurement for users joining a conversation via invite link/QR. `NewConversationViewModel` arms the 150s window when the join starts and emits `wait_duration` + `source` (url/scan/paste) if the creator's device never approves the join request - `joined_conversation.verification_duration` only samples successes, so stuck joiners were previously invisible. The anchor survives the timeout, so a late approval still reports its true duration via `joined_conversation` (you get both "stuck past 150s" and "eventually took 4 min").

**Sentry:** `PostHogCollector` routes `assistant_join_rescued_by_polling` to Sentry as a warning event (numbers only, no PII; no-op when the SDK isn't started) so stream death can alert, not just appear on a dashboard later.

**Dashboards this enables:** funnel `added_assistant` → `assistant_joined` (stuck rate), `wait_duration` distribution by `surface`, timeout rate, and stream-death rate (`rescued / added`).

## Semantics & limitations
- Wait measurement is session-scoped: relaunch mid-wait drops the sample; leaving the conversation before resolution emits nothing (the timeout task lives on the conversation view model).
- A late assistant arrival after `assistant_join_timed_out` fired is not double-counted as `assistant_joined`.
- Retries keep the earliest wait anchor so the measured duration reflects the user's full wait.

## Testing
- ConvosCore: 1,104 tests in 158 suites pass against the local XMTP node
- App target (`Convos (Dev)`) builds clean with the new ViewModel/collector code
- SwiftLint `--strict` clean on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Track assistant join wait, timeout, and poll-rescue metrics in PostHog and Sentry
> - Adds telemetry to `ConversationViewModel` that measures how long a verified assistant takes to appear after a join request, emitting `assistant_joined`, `assistant_join_timed_out`, or `assistant_join_rescued_by_polling` via `CoreActions` depending on outcome.
> - Adds a 150-second timeout window (`assistantJoinWaitWindow`) after which `assistant_join_timed_out` is emitted if no verified assistant has appeared; the timeout task is cancelled on success, error, or view model deallocation.
> - Adds parallel join-timeout tracking to `NewConversationViewModel` with the same 150-second window, emitting `conversationJoinTimedOut` if invite verification does not complete in time.
> - `PostHogCollector` now forwards `assistant_join_rescued_by_polling` events to Sentry as a warning-level diagnostic event via the new `captureDiagnosticEventInSentry` helper.
> - `SyncingManager` computes `streamAgeSecs` in the polling loop and emits `assistantJoinRescuedByPolling` when polling picks up join requests missed by the message stream.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized edfd895.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->
