### PR TITLE
Keep the agent builder bar anchored to the tab root during pushes

### DIFF
--- a/Convos/MainTabView.swift
+++ b/Convos/MainTabView.swift
@@ -198,10 +198,11 @@ struct MainTabView: View {
     }
 
     /// `true` once a conversation has been pushed onto the Chats tab's
-    /// navigation stack. Hides the builder bar (via the safe-area inset
-    /// conditional) and the tab bar so the conversation detail can use
-    /// the full screen. Bound to `conversationsViewModel` because the
-    /// selection model lives there.
+    /// navigation stack. Hides the nav bar and the tab bar so the
+    /// conversation detail can use the full screen. The builder bar is not
+    /// keyed to this: it stays in the tab root's safe-area inset and slides
+    /// away with the root during the push. Bound to `conversationsViewModel`
+    /// because the selection model lives there.
     private var isConversationSelected: Bool {
         conversationsViewModel.selectedConversationViewModel != nil
             || !stuffPushedItems.isEmpty
@@ -423,7 +424,12 @@ struct MainTabView: View {
     private func tabChrome(_ content: some View, for tab: ConvosTab) -> some View {
         content
             .safeAreaInset(edge: builderBarEdge, spacing: 0) {
-                if tab != .contacts && !isConversationSelected && !isInlineBuilderActive {
+                // Intentionally not keyed to `isConversationSelected`: the
+                // inset belongs to the tab root's layout, so a pushed detail
+                // covers it and the bar rides offscreen with the root during
+                // the push. Removing it here instead collapsed the inset and
+                // reflowed the list mid-transition.
+                if tab != .contacts && !isInlineBuilderActive {
                     builderBar
                         .transition(.blurReplace)
                 }


### PR DESCRIPTION
## Why

Tapping a conversation on the Chats tab (or a detail on Stuff) yanked the agent builder bar out of the safe-area inset the moment the push started. The inset collapsed while the outgoing list was still on screen, so the whole chats list visibly reflowed upward mid-transition — especially jarring on iPhone where the bar pins to the top, directly above the list.

## What

`MainTabView.tabChrome` no longer keys the builder-bar safe-area inset on `isConversationSelected`. The inset belongs to the tab root's layout, so a pushed detail covers it anyway; the bar now simply rides offscreen with the root during the push and is already in place when the root slides back on pop.

The nav-bar and tab-bar hiding behavior is unchanged — `isConversationSelected` still drives those, and the pushed conversation still gets the full screen.

## Verification

- Full ConvosCore test suite: 1104 tests in 158 suites, all passing
- Recorded the push/pop transition on simulator and stepped through frames at 30fps:
  - Push: outgoing chats list slides left with the bar intact at its original position — no collapse, no reflow, no blur-out
  - Pushed state: conversation detail owns the full screen; no bar bleed-through
  - Pop: list slides back in with the bar already in place — no late blur-in

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Keep the agent builder bar anchored to the tab root during navigation pushes
> Previously, the builder bar's safe-area inset was removed when a conversation or Stuff detail was selected, causing it to collapse and reflow mid-transition. Now the inset is retained regardless of selection state, so the bar slides offscreen with the root view during a push instead of reflowing. The fix is in [MainTabView.swift](https://github.com/xmtplabs/convos-ios/pull/1006/files#diff-2b02f95e9fabdce514b1dd6d74d930ca17fcc2380c7504789454c035484e9d67) by dropping `!isConversationSelected` from the inset condition.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 28ec58e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->