### PR TITLE
Show the global contact name instead of Somebody in notification text

### DIFF
--- a/ConvosCore/Sources/ConvosCore/Inboxes/MessagingService+PushNotifications.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/MessagingService+PushNotifications.swift
@@ -426,8 +426,8 @@ extension MessagingService {
             currentInboxId: currentInboxId
         )) ?? (try? group.name()).orUntitled
 
-        let senderName = try await getSenderDisplayName(
-            senderInboxId: decodedMessage.senderInboxId,
+        let senderName = try await getMemberDisplayName(
+            inboxId: decodedMessage.senderInboxId,
             conversationId: conversationId
         )
 
@@ -457,19 +457,6 @@ extension MessagingService {
             isReaction: isReaction,
             userInfo: userInfo
         )
-    }
-
-    private func getSenderDisplayName(
-        senderInboxId: String,
-        conversationId: String
-    ) async throws -> String {
-        try await databaseReader.read { db in
-            let profile = try DBMemberProfile.fetchOne(db, conversationId: conversationId, inboxId: senderInboxId)
-            if let name = profile?.name, !name.isEmpty { return name }
-            // Mirror `Profile.displayName`: known agents read as "Agent",
-            // unknown / human profiles read as "Somebody".
-            return profile?.isAgent == true ? "Agent" : "Somebody"
-        }
     }
 
     private func getOtherMemberCount(
@@ -637,8 +624,8 @@ extension MessagingService {
         case .scheduled(let expiresAt):
             _ = try await storeConversation(group, inboxId: currentInboxId)
             let conversationName = (try? group.name()).orUntitled
-            let senderName = try await getSenderDisplayName(
-                senderInboxId: decodedMessage.senderInboxId,
+            let senderName = try await getMemberDisplayName(
+                inboxId: decodedMessage.senderInboxId,
                 conversationId: conversationId
             )
             let timeUntilExplosion = formatTimeUntilExplosion(expiresAt)
@@ -940,14 +927,24 @@ extension MessagingService {
                 return "New Convo"
             }
 
-            let namedProfiles = memberProfiles.compactMap { $0.name }.filter { !$0.isEmpty }.sorted()
-            // Bucket unnamed members by agent vs. human so the rendered title
-            // matches `Profile.formattedNamesString`: anonymous agents read
-            // as "Agent" / "Agents", anonymous humans as "Somebody" /
-            // "Somebodies".
-            let anonymousProfiles = memberProfiles.filter { ($0.name ?? "").isEmpty }
-            let anonymousAgentCount = anonymousProfiles.filter { $0.isAgent }.count
-            let anonymousHumanCount = anonymousProfiles.count - anonymousAgentCount
+            // Resolve each member like `Profile.formattedNamesString(memberNameOverride:)`:
+            // the contact's display name (the user's global profile snapshot
+            // for this inbox) wins over the per-conversation profile name.
+            // Unnamed members are bucketed by agent vs. human so the rendered
+            // title matches: anonymous agents read as "Agent" / "Agents",
+            // anonymous humans as "Somebody" / "Somebodies".
+            let resolved: [(name: String?, isAgent: Bool)] = try memberProfiles.map { (profile: DBMemberProfile) -> (name: String?, isAgent: Bool) in
+                if let contactName = try ContactsRepository.contactNameInTransaction(db: db, inboxId: profile.inboxId) {
+                    return (contactName, profile.isAgent)
+                }
+                if let name = profile.name, !name.isEmpty {
+                    return (name, profile.isAgent)
+                }
+                return (nil, profile.isAgent)
+            }
+            let namedProfiles: [String] = resolved.compactMap { $0.name }.sorted()
+            let anonymousAgentCount: Int = resolved.filter { $0.name == nil && $0.isAgent }.count
+            let anonymousHumanCount: Int = resolved.filter { $0.name == nil && !$0.isAgent }.count
 
             var allNames = namedProfiles
             if anonymousAgentCount == 1 {
@@ -974,12 +971,28 @@ extension MessagingService {
         conversationId: String
     ) async throws -> String {
         try await databaseReader.read { db in
-            let profile = try DBMemberProfile.fetchOne(db, conversationId: conversationId, inboxId: inboxId)
-            if let name = profile?.name, !name.isEmpty { return name }
-            // Mirror `Profile.displayName`: known agents read as "Agent",
-            // unknown / human profiles read as "Somebody".
-            return profile?.isAgent == true ? "Agent" : "Somebody"
+            try Self.notificationMemberDisplayName(db: db, inboxId: inboxId, conversationId: conversationId)
         }
+    }
+
+    /// Resolves the name shown for a member in notification text, mirroring
+    /// `Profile.formattedNamesString(memberNameOverride:)`: the contact's
+    /// display name (the user's global profile snapshot for this inbox) wins
+    /// over the per-conversation profile name, and nameless members fall back
+    /// to "Agent" / "Somebody" keyed on the profile's agent flag.
+    static func notificationMemberDisplayName(
+        db: Database,
+        inboxId: String,
+        conversationId: String
+    ) throws -> String {
+        if let contactName = try ContactsRepository.contactNameInTransaction(db: db, inboxId: inboxId) {
+            return contactName
+        }
+        let profile = try DBMemberProfile.fetchOne(db, conversationId: conversationId, inboxId: inboxId)
+        if let name = profile?.name, !name.isEmpty { return name }
+        // Mirror `Profile.displayName`: known agents read as "Agent",
+        // unknown / human profiles read as "Somebody".
+        return profile?.isAgent == true ? "Agent" : "Somebody"
     }
 
     // MARK: - Welcome Message Tracking

--- a/ConvosCore/Sources/ConvosCore/Storage/Repositories/ContactsRepository.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Repositories/ContactsRepository.swift
@@ -126,6 +126,18 @@ final class ContactsRepository: ContactsRepositoryProtocol, @unchecked Sendable 
         }
     }
 
+    /// In-transaction variant of `contactName(for:)` for callers already
+    /// inside a database read (e.g. notification display-name resolution).
+    /// Returns the contact's display name when present and non-empty,
+    /// otherwise `nil` so the caller's fallback chain (per-conversation
+    /// profile name, then "Agent" / "Somebody") applies.
+    static func contactNameInTransaction(db: Database, inboxId: String) throws -> String? {
+        guard let name = try DBContact.fetchOne(db, key: inboxId)?.displayName, !name.isEmpty else {
+            return nil
+        }
+        return name
+    }
+
     func sourceConversations(forIds ids: Set<String>) throws -> [String: ContactSourceConversation] {
         guard !ids.isEmpty else { return [:] }
         return try databaseReader.read { db in

--- a/ConvosCore/Sources/ConvosCore/Syncing/StreamProcessor.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/StreamProcessor.swift
@@ -663,10 +663,16 @@ actor StreamProcessor: StreamProcessorProtocol {
 
     private func getSenderDisplayName(senderInboxId: String, conversationId: String) async -> String {
         do {
-            let profile = try await databaseReader.read { db in
-                try DBMemberProfile.fetchOne(db, conversationId: conversationId, inboxId: senderInboxId)
+            // The contact's display name (the user's global profile snapshot
+            // for this inbox) wins over the per-conversation profile name,
+            // mirroring `Profile.formattedNamesString(memberNameOverride:)`.
+            let name: String? = try await databaseReader.read { db in
+                if let contactName = try ContactsRepository.contactNameInTransaction(db: db, inboxId: senderInboxId) {
+                    return contactName
+                }
+                return try DBMemberProfile.fetchOne(db, conversationId: conversationId, inboxId: senderInboxId)?.name
             }
-            if let name = profile?.name, !name.isEmpty {
+            if let name, !name.isEmpty {
                 return name
             }
         } catch {

--- a/ConvosCore/Tests/ConvosCoreTests/NotificationMemberDisplayNameTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/NotificationMemberDisplayNameTests.swift
@@ -1,0 +1,138 @@
+@testable import ConvosCore
+import Foundation
+import GRDB
+import Testing
+
+@Suite("Notification member display name resolution")
+struct NotificationMemberDisplayNameTests {
+    private let conversationId: String = "conversation-1"
+    private let memberInboxId: String = "member-1"
+
+    private func seedConversation(db: Database) throws {
+        try DBMember(inboxId: memberInboxId).save(db, onConflict: .ignore)
+        try DBConversation(
+            id: conversationId,
+            clientConversationId: "client-\(conversationId)",
+            inviteTag: "invite-tag-\(conversationId)",
+            creatorId: memberInboxId,
+            kind: .group,
+            consent: .allowed,
+            createdAt: Date(),
+            name: "Test",
+            description: nil,
+            imageURLString: nil,
+            publicImageURLString: nil,
+            includeInfoInPublicPreview: false,
+            expiresAt: nil,
+            debugInfo: .empty,
+            isLocked: false,
+            imageSalt: nil,
+            imageNonce: nil,
+            imageEncryptionKey: nil,
+            conversationEmoji: nil,
+            imageLastRenewed: nil,
+            isUnused: false,
+            hasHadVerifiedAgent: false,
+        ).insert(db)
+    }
+
+    private func seedMemberProfile(db: Database, name: String?, memberKind: DBMemberKind? = nil) throws {
+        try DBMemberProfile(
+            conversationId: conversationId,
+            inboxId: memberInboxId,
+            name: name,
+            avatar: nil,
+            memberKind: memberKind
+        ).insert(db)
+    }
+
+    private func seedContact(db: Database, displayName: String?) throws {
+        try DBContact(
+            inboxId: memberInboxId,
+            addedAt: Date(),
+            addedViaConversationId: nil,
+            displayName: displayName
+        ).save(db)
+    }
+
+    private func resolve(_ dbManager: MockDatabaseManager) throws -> String {
+        try dbManager.dbReader.read { db in
+            try MessagingService.notificationMemberDisplayName(
+                db: db,
+                inboxId: memberInboxId,
+                conversationId: conversationId
+            )
+        }
+    }
+
+    @Test("Contact name wins over per-conversation profile name")
+    func contactNameWinsOverProfileName() throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        try dbManager.dbWriter.write { db in
+            try seedConversation(db: db)
+            try seedMemberProfile(db: db, name: "ProfileName")
+            try seedContact(db: db, displayName: "ContactName")
+        }
+        #expect(try resolve(dbManager) == "ContactName")
+    }
+
+    @Test("Contact name fills in when the conversation has no profile row")
+    func contactNameFillsMissingProfile() throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        try dbManager.dbWriter.write { db in
+            try seedConversation(db: db)
+            try seedContact(db: db, displayName: "ContactName")
+        }
+        #expect(try resolve(dbManager) == "ContactName")
+    }
+
+    @Test("Profile name is used when there is no contact row")
+    func profileNameWhenNoContact() throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        try dbManager.dbWriter.write { db in
+            try seedConversation(db: db)
+            try seedMemberProfile(db: db, name: "ProfileName")
+        }
+        #expect(try resolve(dbManager) == "ProfileName")
+    }
+
+    @Test("Nameless contact falls through to profile name")
+    func namelessContactFallsThroughToProfileName() throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        try dbManager.dbWriter.write { db in
+            try seedConversation(db: db)
+            try seedMemberProfile(db: db, name: "ProfileName")
+            try seedContact(db: db, displayName: nil)
+        }
+        #expect(try resolve(dbManager) == "ProfileName")
+    }
+
+    @Test("No contact and no profile name resolves to Somebody")
+    func noNamesResolvesToSomebody() throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        try dbManager.dbWriter.write { db in
+            try seedConversation(db: db)
+            try seedMemberProfile(db: db, name: nil)
+        }
+        #expect(try resolve(dbManager) == "Somebody")
+    }
+
+    @Test("Unknown inbox with no rows at all resolves to Somebody")
+    func unknownInboxResolvesToSomebody() throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        try dbManager.dbWriter.write { db in
+            try seedConversation(db: db)
+        }
+        #expect(try resolve(dbManager) == "Somebody")
+    }
+
+    @Test("Nameless agent resolves to Agent")
+    func namelessAgentResolvesToAgent() throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        try dbManager.dbWriter.write { db in
+            try seedConversation(db: db)
+            try seedMemberProfile(db: db, name: nil, memberKind: .agent)
+        }
+        #expect(try resolve(dbManager) == "Agent")
+    }
+}


### PR DESCRIPTION
## Summary

Push notifications showed "Somebody" whenever the per-conversation `memberProfile` row had no name — most visibly in the "Somebody accepted your invite" notification. Profiles are per-inbox now, so when we know a name for that inbox ID globally we should use it.

This mirrors the precedence the app's UI already uses (`Profile.formattedNamesString(memberNameOverride:)`): **contact display name → per-conversation profile name → "Agent" / "Somebody"**.

## Changes

- `ContactsRepository.contactNameInTransaction(db:inboxId:)` — in-transaction variant of the canonical `contactName(for:)` global lookup.
- `MessagingService+PushNotifications` — new `notificationMemberDisplayName` helper applying the contact-first chain. Now drives:
  - "X accepted your invite" (welcome-topic and encrypted-DM paths)
  - message sender names in notification bodies (consolidates the duplicate `getSenderDisplayName` into `getMemberDisplayName`)
  - the computed conversation title (members unnamed in this conversation resolve to their contact name instead of the "Somebody / Somebodies" bucket)
  - "X set this convo to explode"
- `StreamProcessor.getSenderDisplayName` — same contact-first fallback for the foreground scheduled-explosion local notification.

## Testing

- New `NotificationMemberDisplayNameTests` (7 tests): contact wins over profile name, fills in when the conversation has no profile row, nameless contact falls through, and the Somebody/Agent fallbacks are preserved.
- Full ConvosCore suite: 1111 tests in 159 suites, all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show global contact name instead of 'Somebody' in push notification text
> - Notification display name resolution now checks `ContactsRepository` for a global contact name first, then falls back to the per-conversation profile name, then to "Agent" or "Somebody" based on the member's agent flag.
> - Adds `ContactsRepository.contactNameInTransaction` as a transaction-safe helper returning the contact's display name or nil.
> - Adds `MessagingService.notificationMemberDisplayName` as the central static resolver used by both push notification handling and stream processing.
> - Covers new-conversation notification titles, which now resolve each member's name with the same priority chain before bucketing unnamed members as anonymous agents or humans.
> - Adds a test suite in [NotificationMemberDisplayNameTests.swift](https://github.com/xmtplabs/convos-ios/pull/1007/files#diff-c081ed6dfd2103f25277d54e35c97c67fffe019c6b525ece8a671684322adbfa) covering all resolution scenarios.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 584241e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->