### PR TITLE
Move keyboard input settling to ConvosCoreiOS to fix archive type-check timeout

### DIFF
--- a/Convos/Shared Views/FocusCoordinator.swift
+++ b/Convos/Shared Views/FocusCoordinator.swift
@@ -1,3 +1,4 @@
+import ConvosCoreiOS
 import Foundation
 import Observation
 import SwiftUI
@@ -221,77 +222,14 @@ final class FocusCoordinator {
     /// the backing text view keeps the old text and the keyboard's next
     /// commit point syncs the stale text back into the binding.
     ///
-    /// Two settle strategies:
-    /// - `endingInputSession == false` (plain typing): re-assert the
-    ///   selection at the UIKit level. A selection change runs the same
-    ///   settle path the keyboard uses when the caret moves, with no first
-    ///   responder change, so the keyboard never hides or re-shows.
-    /// - `endingInputSession == true` (caller believes dictation is active):
-    ///   the selection nudge does not stop a dictation session - it keeps
-    ///   streaming hypothesis updates into the field after the mutation -
-    ///   so the input session has to end first. Resigning first responder
-    ///   does that but leaves a no-responder gap that visibly hides and
-    ///   re-shows the keyboard, so instead first responder is handed to a
-    ///   zero-frame off-screen text field in the same window: a text input
-    ///   stays focused throughout, the keyboard never moves, and the
-    ///   composer's input session is torn down exactly as on resign. Focus
-    ///   returns to the original field after the mutation. (Dictation is
-    ///   not detectable directly: on iOS 26.2 `textInputMode` stays the
-    ///   regular language during dictation and no input-mode-change
-    ///   notification fires, so callers infer it behaviorally - see
-    ///   `ConversationViewModel`.)
+    /// The settle strategies live in `KeyboardInputSettling` (ConvosCoreiOS).
+    /// Pass `endingInputSession: true` when dictation is believed active.
+    /// (Dictation is not detectable directly: on iOS 26.2 `textInputMode`
+    /// stays the regular language during dictation and no input-mode-change
+    /// notification fires, so callers infer it behaviorally - see
+    /// `ConversationViewModel`.)
     func withSettledKeyboardInput(endingInputSession: Bool, _ work: () -> Void) {
-        guard let input = Self.currentFirstResponder() as? (UIResponder & UITextInput) else {
-            work()
-            return
-        }
-        if endingInputSession {
-            endInputSessionKeepingKeyboard(for: input, work)
-        } else {
-            Log.info("Settling keyboard input via selection nudge")
-            let end = input.endOfDocument
-            input.selectedTextRange = input.textRange(from: end, to: end)
-            work()
-        }
-    }
-
-    /// Ends `input`'s input session (terminating any active dictation and
-    /// committing pending input) without letting the keyboard hide, by
-    /// handing first responder to a temporary off-screen text field while
-    /// `work` runs. Falls back to a plain resign/restore round-trip when the
-    /// input has no window or the handoff field refuses focus.
-    private func endInputSessionKeepingKeyboard(for input: UIResponder & UITextInput, _ work: () -> Void) {
-        guard let inputView = input as? UIView, let window = inputView.window else {
-            Log.info("Settling keyboard input via resign/restore (no window for handoff)")
-            input.resignFirstResponder()
-            work()
-            input.becomeFirstResponder()
-            return
-        }
-        // The handoff field deliberately keeps default input traits. The
-        // composer uses a default keyboard, so a default handoff field
-        // takes focus with no keyboard relayout (frame analysis shows no
-        // keyboard movement beyond the keycap shift-case recompute that
-        // every composer-clearing send produces, handoff or not). Revisit
-        // if a field with a non-default keyboard ever uses this settle
-        // path.
-        let handoff = UITextField(frame: .zero)
-        handoff.isAccessibilityElement = false
-        handoff.accessibilityElementsHidden = true
-        window.addSubview(handoff)
-        defer { handoff.removeFromSuperview() }
-        guard handoff.becomeFirstResponder() else {
-            Log.info("Settling keyboard input via resign/restore (handoff refused focus)")
-            input.resignFirstResponder()
-            work()
-            input.becomeFirstResponder()
-            return
-        }
-        Log.info("Settling keyboard input via focus handoff (ending input session)")
-        work()
-        if !input.becomeFirstResponder() {
-            Log.error("Focus handoff could not restore the original input; keyboard may dismiss")
-        }
+        KeyboardInputSettling.withSettledInput(endingInputSession: endingInputSession, work)
     }
 
     /// Called by the view when SwiftUI's @FocusState has updated
@@ -418,18 +356,6 @@ final class FocusCoordinator {
     }
 
     // MARK: - Private Methods
-
-    private static func currentFirstResponder() -> UIResponder? {
-        for scene in UIApplication.shared.connectedScenes {
-            guard let windowScene = scene as? UIWindowScene else { continue }
-            for window in windowScene.windows {
-                if let responder = window.firstResponderDescendant() {
-                    return responder
-                }
-            }
-        }
-        return nil
-    }
 
     private func setupKeyboardObservation() {
         KeyboardListener.shared.add(delegate: self)
@@ -618,20 +544,6 @@ extension FocusCoordinator: KeyboardListenerDelegate {
             let isShowingKeyboard = info.frameEnd.origin.y < screenHeight
             updateKeyboardState(frame: info.frameEnd, isShowEvent: isShowingKeyboard, screen: screen)
         }
-    }
-}
-
-// MARK: - First Responder Lookup
-
-private extension UIView {
-    func firstResponderDescendant() -> UIResponder? {
-        if isFirstResponder { return self }
-        for subview in subviews {
-            if let responder = subview.firstResponderDescendant() {
-                return responder
-            }
-        }
-        return nil
     }
 }
 

--- a/ConvosCore/Sources/ConvosCoreiOS/KeyboardInputSettling.swift
+++ b/ConvosCore/Sources/ConvosCoreiOS/KeyboardInputSettling.swift
@@ -1,0 +1,115 @@
+#if canImport(UIKit)
+import ConvosLogging
+import UIKit
+
+/// UIKit-level helpers for settling pending keyboard input before
+/// programmatically mutating a focused field's bound text.
+///
+/// This lives in ConvosCoreiOS rather than the app target because the first
+/// member lookup through the `UIResponder & UITextInput` existential in the
+/// app module is expensive enough to trip the app target's type-check time
+/// limit (the app's import graph makes the lazy ObjC member-table load take
+/// 600ms+). Keep direct member access on that existential out of the app
+/// target; route it through helpers here instead.
+public enum KeyboardInputSettling {
+    /// Runs `work` with the current first responder's pending input settled,
+    /// so that `work` can safely mutate the focused field's bound text
+    /// programmatically.
+    ///
+    /// Two settle strategies:
+    /// - `endingInputSession == false` (plain typing): re-assert the
+    ///   selection at the UIKit level. A selection change runs the same
+    ///   settle path the keyboard uses when the caret moves, with no first
+    ///   responder change, so the keyboard never hides or re-shows.
+    /// - `endingInputSession == true` (caller believes dictation is active):
+    ///   the selection nudge does not stop a dictation session - it keeps
+    ///   streaming hypothesis updates into the field after the mutation -
+    ///   so the input session has to end first. Resigning first responder
+    ///   does that but leaves a no-responder gap that visibly hides and
+    ///   re-shows the keyboard, so instead first responder is handed to a
+    ///   zero-frame off-screen text field in the same window: a text input
+    ///   stays focused throughout, the keyboard never moves, and the
+    ///   composer's input session is torn down exactly as on resign. Focus
+    ///   returns to the original field after the mutation.
+    @MainActor
+    public static func withSettledInput(endingInputSession: Bool, _ work: () -> Void) {
+        guard let input = currentFirstResponder() as? (UIResponder & UITextInput) else {
+            work()
+            return
+        }
+        if endingInputSession {
+            endInputSessionKeepingKeyboard(for: input, work)
+        } else {
+            Log.info("Settling keyboard input via selection nudge")
+            let end = input.endOfDocument
+            input.selectedTextRange = input.textRange(from: end, to: end)
+            work()
+        }
+    }
+
+    /// Ends `input`'s input session (terminating any active dictation and
+    /// committing pending input) without letting the keyboard hide, by
+    /// handing first responder to a temporary off-screen text field while
+    /// `work` runs. Falls back to a plain resign/restore round-trip when the
+    /// input has no window or the handoff field refuses focus.
+    @MainActor
+    private static func endInputSessionKeepingKeyboard(for input: UIResponder & UITextInput, _ work: () -> Void) {
+        guard let inputView = input as? UIView, let window = inputView.window else {
+            Log.info("Settling keyboard input via resign/restore (no window for handoff)")
+            input.resignFirstResponder()
+            work()
+            input.becomeFirstResponder()
+            return
+        }
+        // The handoff field deliberately keeps default input traits. The
+        // composer uses a default keyboard, so a default handoff field
+        // takes focus with no keyboard relayout (frame analysis shows no
+        // keyboard movement beyond the keycap shift-case recompute that
+        // every composer-clearing send produces, handoff or not). Revisit
+        // if a field with a non-default keyboard ever uses this settle
+        // path.
+        let handoff = UITextField(frame: .zero)
+        handoff.isAccessibilityElement = false
+        handoff.accessibilityElementsHidden = true
+        window.addSubview(handoff)
+        defer { handoff.removeFromSuperview() }
+        guard handoff.becomeFirstResponder() else {
+            Log.info("Settling keyboard input via resign/restore (handoff refused focus)")
+            input.resignFirstResponder()
+            work()
+            input.becomeFirstResponder()
+            return
+        }
+        Log.info("Settling keyboard input via focus handoff (ending input session)")
+        work()
+        if !input.becomeFirstResponder() {
+            Log.error("Focus handoff could not restore the original input; keyboard may dismiss")
+        }
+    }
+
+    @MainActor
+    private static func currentFirstResponder() -> UIResponder? {
+        for scene in UIApplication.shared.connectedScenes {
+            guard let windowScene = scene as? UIWindowScene else { continue }
+            for window in windowScene.windows {
+                if let responder = window.firstResponderDescendant() {
+                    return responder
+                }
+            }
+        }
+        return nil
+    }
+}
+
+private extension UIView {
+    func firstResponderDescendant() -> UIResponder? {
+        if isFirstResponder { return self }
+        for subview in subviews {
+            if let responder = subview.firstResponderDescendant() {
+                return responder
+            }
+        }
+        return nil
+    }
+}
+#endif


### PR DESCRIPTION
## Problem

The Dev archive on CI fails with:

```
Convos/Shared Views/FocusCoordinator.swift:252:23: error: expression took 610ms to type-check (limit: 300ms)
```

Line 252 (`let end = input.endOfDocument`, added in #977) looks trivial, but the cost is not solver ambiguity: it's the first member lookup through the `(UIResponder & UITextInput)` existential in the app module. Resolving that member forces a lazy ObjC member-table load whose cost scales with the app target's import graph, and the per-expression timer charges all of it to whichever expression touches the existential first.

Verified empirically (reproduces locally at 640–670ms):
- Adding explicit type annotations: still 670ms on the same line.
- Narrowing to `any UITextInput` first: 640ms, just moved to the narrowed lookup.
- Removing the first lookup entirely: 614ms popped up on `input.resignFirstResponder()` in `endInputSessionKeepingKeyboard` — the next member access through the composition.

So no in-file expression restructuring can fix this; the cold cost lands on whichever expression is first.

## Fix

Move the keyboard settle/handoff machinery from `FocusCoordinator` verbatim into a new `KeyboardInputSettling` helper in **ConvosCoreiOS** (the UIKit-specific package, which compiles without the type-check timing flags and where the same lookup is genuinely cheap thanks to the smaller frontend context). `FocusCoordinator.withSettledKeyboardInput(endingInputSession:_:)` keeps its API and delegates, so the app target no longer contains any member access through that existential — and the helper's doc comment warns against reintroducing one.

Behavior is unchanged: the moved code is identical, and the only caller (`ConversationViewModel`) uses the unchanged coordinator API.

## Verification

- `xcodebuild build` ("Convos (Dev)", iPhone 17 sim) succeeds with zero type-check timing diagnostics (failed before with 642–672ms errors)
- `swift test --package-path ConvosCore`: 1128 tests in 163 suites passed
- SwiftLint clean on both files

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Move keyboard input settling logic to `KeyboardInputSettling` in ConvosCoreiOS to fix archive type-check timeout
> - Extracts UIKit keyboard input settling from [`FocusCoordinator.swift`](https://github.com/xmtplabs/convos-ios/pull/1008/files#diff-40b3d28b766ebc0135d2e62700a55d912572d14966c5a3b6f048955c7ca841d7) into a new [`KeyboardInputSettling.swift`](https://github.com/xmtplabs/convos-ios/pull/1008/files#diff-5c1750f7bd508f2b4075ec2a1a364c1cbfba06066083022fcadb1e2a0e5cc45f) in ConvosCoreiOS, exposing it as `KeyboardInputSettling.withSettledInput`.
> - `FocusCoordinator.withSettledKeyboardInput` now delegates to the new shared helper, removing the local window-scanning, focus-handoff, and subview-search helpers that were inlined there.
> - The new file is conditionally compiled for UIKit and uses `ConvosLogging` for diagnostics.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f48f5f4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->