### PR TITLE
Add simulator-bringup skill (from #843)

### DIFF
--- a/.claude/skills/simulator-bringup/SKILL.md
+++ b/.claude/skills/simulator-bringup/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: simulator-bringup
+description: Use when building, upgrading a dependency (e.g. libxmtp), or installing the Convos iOS app in a local simulator - especially if the app crashes on launch or shows the generic "Something went wrong" sheet when starting a new convo. Encodes the issue #843 bring-up procedure (scheme choice; app-group, Keychain, and App Check accommodations; the local backend on :4000) plus the build-contention type-check workaround learned in practice.
+---
+
+# Convos iOS simulator bring-up
+
+A clean simulator bring-up needs a few simulator-specific accommodations. Without
+them, `Convos (Local)` crashes on launch and `Convos (Dev)` reaches the UI but
+shows the generic `Something went wrong` sheet when starting a new convo. This
+skill is the procedure for getting a build running in a local simulator and
+verifying it, e.g. after a dependency upgrade or a fresh install.
+
+Source of record: GitHub issue
+[#843](https://github.com/xmtplabs/convos-ios/issues/843).
+
+## When to run this
+
+- After upgrading a dependency (libxmtp bump, package re-resolve) and you want to
+  confirm the app still builds and launches.
+- On a fresh checkout / first simulator install.
+- Any time a simulator build crashes on launch or shows `Something went wrong`.
+
+For the plain build-and-launch mechanics, `/run` (or `/build --run`) already does
+the heavy lifting. This skill adds the bring-up gotchas and the contention
+workaround on top.
+
+## Step 0 - pick the scheme
+
+| Scheme | API base | Local backend required? | Bundle id |
+|--------|----------|-------------------------|-----------|
+| `Convos (Dev)` (recommended) | `https://api.dev.convos.xyz/api` | No | `org.convos.ios-preview` |
+| `Convos (Local)` | `http://<host>:4000/api` | Yes - API on `:4000` | `org.convos.ios-local` |
+
+Default to `Convos (Dev)` unless you specifically need local backend data.
+`dev/docker-compose.yml` / the local stack start XMTP infra but a Convos backend
+API on `:4000` must also be running for `Convos (Local)`; otherwise new-convo
+shows the error sheet. Use `/run local` (see `.claude/commands/run.md`) to bring
+up the shared local stack before a `Convos (Local)` run.
+
+## Step 1 - build and launch
+
+1. Resolve the dedicated simulator (`.claude/.simulator_id`, else `.convos-task`
+   `SIMULATOR_NAME`, else derive `convos-<branch>`; `main` -> `convos-main`). On
+   a generic machine this is typically the booted `convos-dev` simulator.
+2. After a dependency bump, re-resolve first so the new revision is fetched:
+   ```bash
+   xcodebuild -resolvePackageDependencies -project Convos.xcodeproj \
+     -scheme "Convos (Dev)" -derivedDataPath .derivedData
+   ```
+3. Build, install, and launch (XcodeBuildMCP `build_run_sim`, or `/run`). Keep
+   builds isolated to this worktree with `-derivedDataPath .derivedData`.
+4. Confirm it actually came up with a screenshot - do not trust "launched"
+   alone. Expected: the Chats home screen, no error modal.
+
+### Build under machine load (type-check contention)
+
+The project compiles with `-warn-long-expression-type-checking 100` /
+`-warn-long-function-bodies 100` and `SWIFT_TREAT_WARNINGS_AS_ERRORS=YES`, so a
+slow type-check is a hard build failure. Two very different causes:
+
+- **Genuinely slow expression** - the error names one specific non-trivial
+  expression and reproduces on the same line every build. Fix the code (hoist
+  typed `let`s, split the body). Never raise the threshold. See CLAUDE.md
+  "Build Performance: Type-Check Time".
+- **CPU contention** - the timeout is a *trivial* expression (a two-property
+  bool, a `guard let`), the reported time hovers just over the limit
+  (~305-370ms), and which file trips it *changes between builds*. This is the
+  machine being starved (e.g. OrbStack/Docker, browser), not the code.
+
+For contention only:
+
+1. Reduce competing load if you can (close heavy apps). Do not pause a user's
+   running stack (OrbStack/Docker) without asking - it may be in active use.
+2. Lower build parallelism: pass `-jobs 2` (or `-jobs 1`) to reduce the build's
+   own internal contention.
+3. If load cannot be freed and you just need a runnable local build, override
+   warnings-as-errors **on the command line only** for that one run:
+   ```
+   extraArgs: ["-jobs", "2", "SWIFT_TREAT_WARNINGS_AS_ERRORS=NO"]
+   ```
+   This keeps the contention-induced timeouts as warnings so the build can link
+   and launch. It does **not** raise the threshold and must **never** be
+   committed or used to paper over a genuinely slow expression - only for
+   provably environmental timeouts on trivial code.
+
+## Step 2 - launch crash: app group container fallback
+
+Symptom on launch:
+```
+EXC_BREAKPOINT / _assertionFailure
+AppEnvironment.defaultXMTPLogsDirectoryURL.getter   (AppEnvironment.swift)
+fatalError("Failed getting container URL for group identifier...")
+```
+The XMTP logs / databases dirs come from the app group container via
+`FileManager.default.containerURL(forSecurityApplicationGroupIdentifier:)`, which
+can be unavailable in the simulator.
+
+Accommodation: use the app group container when available, else fall back to
+`Application Support/<bundle id>/` (`AppEnvironment.swift`,
+`defaultXMTPLogsDirectoryURL` / `defaultDatabasesDirectoryURL`).
+
+## Step 3 - new-convo fails: file-backed identity store on simulator
+
+Symptom:
+```
+Keychain identity read failed (keychainOperationFailed(-34018, "load"))
+```
+`-34018` (`errSecMissingEntitlement`) is the simulator Keychain access-group
+blocker.
+
+Accommodation (simulator builds only): use a `FileBackedIdentityStore` instead of
+`KeychainIdentityStore`, persisting under the app data/database dir (e.g.
+`SimulatorIdentity/identity.json`). Device behavior stays on the Keychain path.
+Touches `Auth/Keychain/KeychainIdentityStore.swift` and `ConvosClient+App.swift`.
+
+## Step 4 - backend auth blocked: App Check
+
+Symptom once an identity exists:
+```
+Firebase App Check debug token: '<uuid>'
+HTTP 403  "App attestation failed."
+```
+This blocks `SessionStateMachine.authenticateBackend()` from reaching authorized.
+
+Two options:
+
+- Register the printed App Check debug token in Firebase (preferred) - see the
+  `/firebase-token` flow.
+- Or, simulator builds only (`.local` / `.dev`): return a dummy
+  `defaultOverrideJWTToken` so `authenticateBackend()` follows the existing
+  override path and skips App Check-backed auth.
+
+## Verification
+
+Expected console after the accommodations:
+```
+JWT override mode: skipping authentication, will use JWT from push payload
+Starting message and conversation streams...
+syncAllConversations completed, sync ready
+```
+The app reaches the Convos home screen with no error modal. Push/device
+registration may still log an App Check 403 - expected, and it does not block
+initial simulator use. Take a screenshot to confirm.
+
+## Notes
+
+- Steps 2-4 are pragmatic simulator-only accommodations from #843, not
+  production implementations, and may not currently be committed on `dev`. If a
+  launch works but new-convo fails, that is where to look.
+- The contention workaround in Step 1 is a local escape hatch only. Genuinely
+  slow expressions still get fixed in code per CLAUDE.md.

--- a/.claude/skills/simulator-bringup/SKILL.md
+++ b/.claude/skills/simulator-bringup/SKILL.md
@@ -49,9 +49,26 @@ up the shared local stack before a `Convos (Local)` run.
      -scheme "Convos (Dev)" -derivedDataPath .derivedData
    ```
 3. Build, install, and launch (XcodeBuildMCP `build_run_sim`, or `/run`). Keep
-   builds isolated to this worktree with `-derivedDataPath .derivedData`.
+   builds isolated to this worktree with `-derivedDataPath .derivedData`, and
+   **set `configuration: Dev`** (session defaults or `-configuration Dev`) - see
+   the NotificationService note below.
 4. Confirm it actually came up with a screenshot - do not trust "launched"
    alone. Expected: the Chats home screen, no error modal.
+
+### First build fails: NotificationService module resolution
+
+Symptom on the first `Convos (Dev)` simulator build:
+```
+unable to resolve module dependency: 'ConvosCore' / 'ConvosCoreiOS' / 'XMTPiOS'
+```
+in the NotificationService extension, even though ConvosCore itself compiled
+fine. This is a build-configuration mismatch, not stale DerivedData. With no
+configuration set, SPM packages land in `Debug-iphonesimulator/` while the
+extension looks in `Release-iphonesimulator/PackageFrameworks/` (empty). `rm -rf
+.derivedData` does **not** fix it.
+
+Fix: set `configuration: Dev` so everything lands in `Dev-iphonesimulator/`.
+Setting it up front (step 3) avoids the wasted first build entirely.
 
 ### Build under machine load (type-check contention)
 
@@ -67,6 +84,11 @@ slow type-check is a hard build failure. Two very different causes:
   bool, a `guard let`), the reported time hovers just over the limit
   (~305-370ms), and which file trips it *changes between builds*. This is the
   machine being starved (e.g. OrbStack/Docker, browser), not the code.
+
+Confirm it is contention before touching anything: `sysctl -n vm.loadavg` and
+`ps -Ao %cpu,comm -r | head` against `sysctl -n hw.ncpu`. A load average near or
+above the core count, with heavy non-build processes on top, is the tell - then
+treat it as contention, not slow code.
 
 For contention only:
 

--- a/.claude/skills/simulator-bringup/SKILL.md
+++ b/.claude/skills/simulator-bringup/SKILL.md
@@ -1,15 +1,16 @@
 ---
 name: simulator-bringup
-description: Use when building, upgrading a dependency (e.g. libxmtp), or installing the Convos iOS app in a local simulator - especially if the app crashes on launch or shows the generic "Something went wrong" sheet when starting a new convo. Encodes the issue #843 bring-up procedure (scheme choice; app-group, Keychain, and App Check accommodations; the local backend on :4000) plus the build-contention type-check workaround learned in practice.
+description: Use when building, upgrading a dependency (e.g. libxmtp), or installing the Convos iOS app in a local simulator - especially if the app crashes on launch or shows the generic "Something went wrong" sheet when starting a new convo. Encodes the issue #843 bring-up procedure (scheme choice; the configuration:Dev gotcha behind the NotificationService, app-group, Keychain, and App Check failures; the local backend on :4000) plus the build-contention type-check workaround learned in practice.
 ---
 
 # Convos iOS simulator bring-up
 
-A clean simulator bring-up needs a few simulator-specific accommodations. Without
-them, `Convos (Local)` crashes on launch and `Convos (Dev)` reaches the UI but
-shows the generic `Something went wrong` sheet when starting a new convo. This
-skill is the procedure for getting a build running in a local simulator and
-verifying it, e.g. after a dependency upgrade or a fresh install.
+This skill is the procedure for getting a build running in a local simulator and
+verifying it, e.g. after a dependency upgrade or a fresh install. The two things
+that bite a clean bring-up are building under the wrong configuration (which
+shows up as a NotificationService module-resolution failure, then an app-group
+crash on launch, then a `Something went wrong` sheet on new-convo) and
+type-check timeouts under machine load. Both are covered below.
 
 Source of record: GitHub issue
 [#843](https://github.com/xmtplabs/convos-ios/issues/843).
@@ -106,69 +107,67 @@ For contention only:
    committed or used to paper over a genuinely slow expression - only for
    provably environmental timeouts on trivial code.
 
-## Step 2 - launch crash: app group container fallback
+## Step 2 - launch / new-convo failures are a configuration symptom
 
-Symptom on launch:
+The #843 runbook originally proposed simulator-only accommodations (app-group
+`Application Support` fallback, a `FileBackedIdentityStore`, a dummy JWT
+override) for the failures below. PRs [#1019] and [#1018] (both merged)
+established those are **mis-targeted**: the simulator honors app-group and
+keychain-access-group entitlements exactly like a device. Do not add the
+fallbacks. Each symptom below means you built under the wrong configuration -
+the fix is Step 1's `configuration: Dev` (or `Local`), not a code workaround.
+
+Confirmed on a clean `Convos (Dev)` build (no local patches): launch reaches a
+live conversation with none of these accommodations.
+
+**Launch crash - app group container:**
 ```
-EXC_BREAKPOINT / _assertionFailure
-AppEnvironment.defaultXMTPLogsDirectoryURL.getter   (AppEnvironment.swift)
-fatalError("Failed getting container URL for group identifier...")
+fatalError  AppEnvironment.appGroupContainerURL   (AppEnvironment.swift)
+"... entitlement not applied / config mismatch / built without -configuration ..."
 ```
-The XMTP logs / databases dirs come from the app group container via
-`FileManager.default.containerURL(forSecurityApplicationGroupIdentifier:)`, which
-can be unavailable in the simulator.
+The app-group container is nil because the build's entitlements don't match the
+runtime app-group id. Same root cause as the NotificationService
+module-resolution failure in Step 1. Build with `configuration: Dev`. The
+message is self-diagnosing as of #1019 (it names the app-group id and bundle id).
 
-Accommodation: use the app group container when available, else fall back to
-`Application Support/<bundle id>/` (`AppEnvironment.swift`,
-`defaultXMTPLogsDirectoryURL` / `defaultDatabasesDirectoryURL`).
-
-## Step 3 - new-convo fails: file-backed identity store on simulator
-
-Symptom:
+**New-convo fails - Keychain `-34018`:**
 ```
 Keychain identity read failed (keychainOperationFailed(-34018, "load"))
 ```
-`-34018` (`errSecMissingEntitlement`) is the simulator Keychain access-group
-blocker.
+`-34018` (`errSecMissingEntitlement`) is the keychain-access-group entitlement
+not being applied - the other face of the wrong-configuration build, not a
+simulator Keychain limitation. Build with `configuration: Dev`. #1019 special-
+cases this error with actionable guidance.
 
-Accommodation (simulator builds only): use a `FileBackedIdentityStore` instead of
-`KeychainIdentityStore`, persisting under the app data/database dir (e.g.
-`SimulatorIdentity/identity.json`). Device behavior stays on the Keychain path.
-Touches `Auth/Keychain/KeychainIdentityStore.swift` and `ConvosClient+App.swift`.
-
-## Step 4 - backend auth blocked: App Check
-
-Symptom once an identity exists:
+**Backend auth - App Check 403:**
 ```
 Firebase App Check debug token: '<uuid>'
 HTTP 403  "App attestation failed."
 ```
-This blocks `SessionStateMachine.authenticateBackend()` from reaching authorized.
-
-Two options:
-
-- Register the printed App Check debug token in Firebase (preferred) - see the
-  `/firebase-token` flow.
-- Or, simulator builds only (`.local` / `.dev`): return a dummy
-  `defaultOverrideJWTToken` so `authenticateBackend()` follows the existing
-  override path and skips App Check-backed auth.
+The printed `<uuid>` is a random, unregistered token. On fresh-install first
+launch this was the token-wipe bug fixed in #1018 (`LegacyDataWipe` was deleting
+the pinned `GACAppCheckDebugToken` within the same `init()`). With #1018 merged
+the pinned token survives; if you still see a 403, register the printed debug
+token via the `/firebase-token` flow.
 
 ## Verification
 
-Expected console after the accommodations:
+Expected console on a healthy build:
 ```
-JWT override mode: skipping authentication, will use JWT from push payload
 Starting message and conversation streams...
 syncAllConversations completed, sync ready
 ```
-The app reaches the Convos home screen with no error modal. Push/device
-registration may still log an App Check 403 - expected, and it does not block
-initial simulator use. Take a screenshot to confirm.
+The app reaches the Convos home screen with no error modal. Take a screenshot to
+confirm - do not trust "launched" alone.
 
 ## Notes
 
-- Steps 2-4 are pragmatic simulator-only accommodations from #843, not
-  production implementations, and may not currently be committed on `dev`. If a
-  launch works but new-convo fails, that is where to look.
+- The Step 2 symptoms are now self-diagnosing in code (#1019) and the App Check
+  fresh-install bug is fixed (#1018). If you hit any of them, re-check the build
+  configuration first - the historical simulator-only accommodations are not the
+  fix and should not be reintroduced.
 - The contention workaround in Step 1 is a local escape hatch only. Genuinely
   slow expressions still get fixed in code per CLAUDE.md.
+
+[#1018]: https://github.com/xmtplabs/convos-ios/pull/1018
+[#1019]: https://github.com/xmtplabs/convos-ios/pull/1019


### PR DESCRIPTION
Adds a Claude Code skill at `.claude/skills/simulator-bringup/SKILL.md` that turns issue #843 from a one-off post-mortem into a repeatable procedure for building/running the app in a local simulator — meant to be run on any dependency upgrade or fresh install.

## What it covers
- **Scheme choice** — `Convos (Dev)` (no local backend) vs `Convos (Local)` (needs API on `:4000`)
- **Build/launch** + the **type-check contention** playbook: how to distinguish a genuinely slow expression from CPU-starvation timeouts (trivial expression, ~305-370ms, hops between files), `-jobs` tuning, and a clearly-fenced `SWIFT_TREAT_WARNINGS_AS_ERRORS=NO` command-line-only escape hatch (never committed, contention-only — does not raise the 100ms thresholds CLAUDE.md governs)
- **The three #843 runtime accommodations** — app-group fallback (launch crash), file-backed identity store (Keychain `-34018`), App Check 403 (`/firebase-token` or sim-only JWT override)
- **Verification** — expected logs, home screen, screenshot

Cross-references the existing `/run`, `/build`, and `/firebase-token` rather than duplicating them.

Docs-only; no code changes. Companion to #843 (reframed as the source-of-record procedure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1009"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783363630&installation_id=128169237&pr_number=1009&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1009&signature=62f86256cabeda2b54fc0fe5abb1b889ed3fb663dacf82f60555aaaf3b47b991"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add simulator bring-up skill document for the Convos iOS app
> Adds [SKILL.md](.claude/skills/simulator-bringup/SKILL.md) documenting the procedure for building and launching the Convos iOS app in the simulator.
>
> - Covers scheme selection (`Convos (Dev)` vs `Convos (Local)`), including API bases, bundle IDs, and the required `configuration: Dev` build setting
> - Documents the first-build `NotificationService` module-resolution failure and its fix
> - Explains type-check contention under load with diagnostics and a `-jobs`/`SWIFT_TREAT_WARNINGS_AS_ERRORS=NO` workaround
> - Clarifies that app-group container crashes, Keychain `-34018`, and Firebase App Check 403 errors are configuration issues, not simulator limitations
> - Includes `xcodebuild` commands with a dedicated `DerivedData` path and verification/console output examples
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cfcc3ad.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->