### PR TITLE
Fix conversation-open flicker: keep bottom anchor pinned while the open transition settles

### DIFF
--- a/Convos/Conversation Detail/Messages/Messages Collection Layout/MessagesCollectionLayout.swift
+++ b/Convos/Conversation Detail/Messages/Messages Collection Layout/MessagesCollectionLayout.swift
@@ -145,6 +145,15 @@ open class MessagesCollectionLayout: UICollectionViewLayout {
 
     private var hasPendingOutOfBandGrowthNotification: Bool = false
 
+    /// While the owning controller's open transition is settling, initial
+    /// self-sizing of estimated cells produces large out-of-band growth whose
+    /// reveal callback is gated off (the controller is still loading or
+    /// applying the initial update). Skipping compensation then leaves the
+    /// bottom of the list below the fold until the load completion snaps it -
+    /// the conversation-open flicker. The controller sets this true until
+    /// `viewDidAppear`, restoring the immediate compensation for that window.
+    var compensatesAllSelfSizingGrowth: Bool = true
+
     private func notifyOutOfBandBottomGrowth() {
         guard !hasPendingOutOfBandGrowthNotification else { return }
         hasPendingOutOfBandGrowthNotification = true
@@ -526,7 +535,17 @@ open class MessagesCollectionLayout: UICollectionViewLayout {
             // Shrinks also keep it: skipping those would leave the offset
             // past the new content bottom and UIKit would clamp it in a
             // hard jump.
+            // Only growth of the final item takes the reveal path: that is
+            // the case it exists for (a send appending to the bottom group,
+            // media loading in the newest message). Growth anywhere else -
+            // e.g. a contact card's description arriving for a cell the user
+            // scrolled back to - keeps the immediate compensation so the
+            // visible content doesn't shift mid-read.
+            let isLastItem: Bool = preferredAttributesItemPath.section == (collectionView?.numberOfSections ?? 1) - 1
+                && preferredAttributesItemPath.item == (collectionView?.numberOfItems(inSection: preferredAttributesItemPath.section) ?? 0) - 1
             let isOutOfBandBottomGrowth: Bool = heightDifference > Constant.outOfBandGrowthRevealThreshold
+                && !compensatesAllSelfSizingGrowth
+                && isLastItem
                 && state == .beforeUpdate
                 && UIView.inheritedAnimationDuration == 0
                 && !isUserInitiatedScrolling

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Data Source/DefaultMessagesLayoutDelegate.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Data Source/DefaultMessagesLayoutDelegate.swift
@@ -60,6 +60,17 @@ final class DefaultMessagesLayoutDelegate: MessagesLayoutDelegate {
         var height: CGFloat = 16.0
         var childCount: Int = 0
 
+        // Agent contact card prefix (sender label + standard-style card:
+        // 32pt padding x2 + 40pt avatar + 16pt spacing + ~28pt name +
+        // ~2 subtitle lines). Without this, a card-only group is estimated
+        // at the bare 16pt baseline and self-sizes ~10x larger on first
+        // layout, which is exactly the growth the bottom anchor can't absorb
+        // during the open transition.
+        if group.agentContactCard != nil {
+            height += 164.0
+            childCount += 1
+        }
+
         for (index, message) in group.messages.enumerated() {
             let isFullBleed = message.content.isFullBleedAttachment
 
@@ -168,8 +179,14 @@ final class DefaultMessagesLayoutDelegate: MessagesLayoutDelegate {
             height = estimatedAttachmentHeight(for: first, width: width)
         case .emoji:
             height = 80.0
-        case .text:
-            height = 40.0
+        case .text(let text):
+            // One bubble line is ~21pt plus ~22pt of padding; scale by a
+            // rough characters-per-line so multi-line messages don't all
+            // collapse to a single-line estimate (long agent replies were
+            // off by hundreds of points, far outside what the layout's
+            // offset compensation can hide).
+            let estimatedLines = max(1.0, (CGFloat(text.count) / 35.0).rounded(.up))
+            height = 22.0 + estimatedLines * 21.0
         case .invite:
             height = 240.0
         case .agentShare:

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/MessagesViewController.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/MessagesViewController.swift
@@ -235,6 +235,20 @@ final class MessagesViewController: UIViewController {
     private var pendingComposerBottomInset: CGFloat?
 
     private func scheduleBottomBarInsetUpdate() {
+        // While the open transition is settling, the bar's measurement often
+        // arrives inside a `performWithoutAnimation` scope (SwiftUI updating
+        // the representable mid-transition), which the deferral branch below
+        // would postpone by a runloop tick - long enough for the list to
+        // paint anchored against the stale inset and then visibly snap when
+        // the initial load's completion flushes (the conversation-open
+        // flicker). Apply synchronously instead: the settling path routes to
+        // `applyBottomInsetInstantly`, which is plain property assignments
+        // and safe inside an in-flight layout pass.
+        if isSettlingInitialLayout {
+            hasPendingBottomBarInsetUpdate = false
+            updateBottomInsetForBottomBarHeight()
+            return
+        }
         // The deferral below exists only for the crash scenario above, whose
         // necessary ingredient is an enclosing `performWithoutAnimation`
         // scope (the inset change becomes a non-animated bounds change and
@@ -474,6 +488,19 @@ final class MessagesViewController: UIViewController {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         isSettlingInitialLayout = false
+        messagesLayout.compensatesAllSelfSizingGrowth = false
+    }
+
+    /// The SwiftUI bottom bar mounts into the safe area a render pass or two
+    /// after the list's first bottom anchor during the open transition, which
+    /// silently grows `adjustedContentInset.bottom` without re-anchoring -
+    /// the list paints short of the bottom until something else scrolls it.
+    /// Re-anchor arithmetically while settling; `scrollToBottom(animated:
+    /// false)` is plain property assignments, safe mid-layout.
+    override func viewSafeAreaInsetsDidChange() {
+        super.viewSafeAreaInsetsDidChange()
+        guard isSettlingInitialLayout, isViewLoaded, !isUserInitiatedScrolling else { return }
+        scrollToBottom(animated: false)
     }
 
     override func viewWillDisappear(_ animated: Bool) {
@@ -719,6 +746,19 @@ final class MessagesViewController: UIViewController {
         onLoadPreviousMessages()
     }
 
+    /// `adjustedContentInset.bottom`, except while the open transition is
+    /// settling: the SwiftUI bottom bar transiently registers in the safe
+    /// area on top of the contentInset mirror of the same bar, and anchoring
+    /// against that double-counted inset over-pins the list, which then
+    /// steps back down in a visible snap when the duplicate resolves. Cap
+    /// the anchor at the settled target (bar inset + window safe area).
+    private var bottomAnchorInset: CGFloat {
+        let adjusted = collectionView.adjustedContentInset.bottom
+        guard isSettlingInitialLayout, let window = view.window else { return adjusted }
+        let settledMax = collectionView.contentInset.bottom + window.safeAreaInsets.bottom
+        return min(adjusted, settledMax)
+    }
+
     func scrollToBottom(animated: Bool = true, completion: (() -> Void)? = nil) {
         // Deferred insets must land first so the bottom target below
         // reflects the final bar height.
@@ -729,7 +769,7 @@ final class MessagesViewController: UIViewController {
             x: collectionView.contentOffset.x,
             y: (messagesLayout.collectionViewContentSize.height -
                 collectionView.frame.height +
-                collectionView.adjustedContentInset.bottom)
+                bottomAnchorInset)
         )
 
         // Exit before cancelling in-flight animations: when the layout's
@@ -745,7 +785,15 @@ final class MessagesViewController: UIViewController {
         collectionView.setContentOffset(collectionView.contentOffset, animated: false)
 
         if !animated {
-            collectionView.contentOffset = contentOffsetAtBottom
+            // Plain assignment would inherit an enclosing animated context -
+            // during the open transition this method runs from
+            // viewSafeAreaInsetsDidChange inside the push's animation scope,
+            // and an implicitly animated offset change makes the whole list
+            // ride the bottom bar's entrance for the length of the push
+            // spring instead of anchoring instantly.
+            UIView.performWithoutAnimation {
+                collectionView.contentOffset = contentOffsetAtBottom
+            }
             completion?()
             return
         }
@@ -1167,8 +1215,10 @@ extension MessagesViewController: KeyboardListenerDelegate {
         let reach = collectionView.contentSize.height
             - (collectionView.contentOffset.y + collectionView.frame.height - adjustedTarget)
         if reach >= -0.5 {
-            collectionView.contentInset.bottom = target
-            collectionView.verticalScrollIndicatorInsets.bottom = target
+            UIView.performWithoutAnimation {
+                collectionView.contentInset.bottom = target
+                collectionView.verticalScrollIndicatorInsets.bottom = target
+            }
         } else {
             updateCollectionViewInsets(to: target, with: nil)
         }


### PR DESCRIPTION
## What

Fixes the conversation-open flicker that survived #987/#998, plus the warm-reopen "ride" where the composer and the bottom-pinned message list visibly slide up for the length of the push spring. Also fixes the agent contact-card cell's height estimation.

## Root causes (all confined to the open-transition window)

1. **Bar inset deferred mid-transition.** The composer's height measurement arrives inside a `performWithoutAnimation` scope, so `scheduleBottomBarInsetUpdate`'s `areAnimationsEnabled` check (#987) routed it to the deferred path — the list painted anchored against a stale inset, then snapped (+227pt in one frame, measured) when the initial load's completion flushed. The settling check now precedes the deferral and applies via `applyBottomInsetInstantly` (#998's path, plain property sets).
2. **Safe-area mount never re-anchored.** The SwiftUI bottom bar registers in the safe area a render pass after the list's first bottom anchor. New `viewSafeAreaInsetsDidChange` override re-anchors arithmetically while settling.
3. **Inherited animation on "non-animated" anchors.** `scrollToBottom(animated: false)` ended in a naked `contentOffset` assignment; during open it runs inside the push transition's animation scope, so CA animated the re-anchor with the transition spring — the whole bottom assembly rode the bar's entrance ~110pt for ~500ms on every warm re-open (cold opens mask it behind main-thread load). Now wrapped in `performWithoutAnimation` (same for `flushPendingComposerInset`).
4. **Transient safe-area double-count.** For a few frames the bar contributes to the safe area *and* to `contentInset` (97+83=180 vs settled 131); anchoring against it over-pinned the list, which then stepped down 49pt at push end. New `bottomAnchorInset` caps the settle-time anchor at the settled target (bar inset + window safe area).
5. **Out-of-band growth skip during initial self-sizing.** #982's >12pt growth skip fired for initial estimated-to-real cell sizing (one cell grew 601pt past its estimate) while its reveal callback is gated off during `.loadingInitialMessages`/`.updatingCollection` — nobody re-pinned. The layout now compensates all self-sizing growth until `viewDidAppear`, and the reveal path is scoped to last-item growth (the send/new-media case it was built for), so growth above the viewport no longer shifts content under a reader.
6. **Height estimates.** `estimatedHeight` ignored `agentContactCard` entirely (16pt baseline vs ~180pt real) and used a flat 40pt for `.text` regardless of length (long replies render at 400–500pt). Card height is now estimated and text scales by character count, shrinking every self-sizing delta the anchor has to absorb.

## Validation

- Instrumented builds with offset/inset logging at every anchor point: every paint now pins to the exact bottom for the current inset state; the initial-load completion's scroll is a no-op; zero post-`viewDidAppear` offset jumps across repeated open/close cycles.
- Frame-by-frame video measurement (composer-edge tracking) on a photo-heavy conversation: before, 45+ frames of upward creep per warm open; after, content and composer land at final position within ~5 frames and never move — 3/3 consecutive warm opens.
- Send-path smoke test: multi-line composer collapse + optimistic append still settle in one motion (steady-state #982 behavior unchanged after `viewDidAppear`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix conversation-open flicker by keeping the bottom anchor pinned during the open transition
> - During initial layout settling, bottom bar inset updates are applied synchronously and safe area inset changes trigger an immediate re-anchor to bottom, preventing the viewport from jumping.
> - Adds `compensatesAllSelfSizingGrowth` to `MessagesCollectionLayout` (default `true`) so all self-sizing growth is immediately compensated during settling; after `viewDidAppear`, this reverts to `false` to resume normal out-of-band reveal behavior.
> - Adds `bottomAnchorInset` to cap the anchor inset during settling, avoiding double-counting transient safe area contributions from the transition.
> - Non-animated `scrollToBottom` calls are wrapped in `UIView.performWithoutAnimation` to prevent inheriting ambient transition animations.
> - Improves estimated cell heights in `DefaultMessagesLayoutDelegate` — text messages now scale with character count and groups with an `agentContactCard` report a larger initial estimate — reducing first-layout underestimation that contributed to the flicker.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3a03a3d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->