### PR TITLE
Render avatars without GeometryReader when the size is known

### DIFF
--- a/Convos/Conversations List/PinnedConversationItem.swift
+++ b/Convos/Conversations List/PinnedConversationItem.swift
@@ -29,7 +29,7 @@ struct PinnedConversationItem: View {
 
     var body: some View {
         VStack(alignment: .center, spacing: DesignConstants.Spacing.step2x) {
-            ConversationAvatarView(conversation: conversation, conversationImage: nil)
+            ConversationAvatarView(conversation: conversation, conversationImage: nil, size: avatarSize)
                 .frame(width: avatarSize, height: avatarSize)
                 .padding(.top, DesignConstants.Spacing.stepX)
                 .overlay(alignment: .top) {
@@ -144,7 +144,7 @@ struct PinnedConversationContextPreview: View {
                     )
             }
 
-            ConversationAvatarView(conversation: conversation, conversationImage: nil)
+            ConversationAvatarView(conversation: conversation, conversationImage: nil, size: avatarSize)
                 .frame(width: avatarSize, height: avatarSize)
 
             HStack(spacing: DesignConstants.Spacing.stepX) {

--- a/Convos/Shared Views/AvatarView.swift
+++ b/Convos/Shared Views/AvatarView.swift
@@ -8,6 +8,10 @@ struct AvatarView: View {
     let placeholderEmoji: String?
     let placeholderImageName: String?
     let agentVerification: AgentVerification
+    /// Forwarded to the emoji/monogram fallbacks so they render without a
+    /// `GeometryReader` when the caller already knows the avatar size (see
+    /// `EmojiAvatarView.size`). Nil keeps the self-sizing path.
+    let explicitSize: CGFloat?
     @State private var cachedImage: UIImage?
 
     init(
@@ -16,7 +20,8 @@ struct AvatarView: View {
         placeholderImage: UIImage?,
         placeholderEmoji: String? = nil,
         placeholderImageName: String?,
-        agentVerification: AgentVerification = .unverified
+        agentVerification: AgentVerification = .unverified,
+        explicitSize: CGFloat? = nil
     ) {
         self.fallbackName = fallbackName
         self.cacheableObject = cacheableObject
@@ -24,6 +29,7 @@ struct AvatarView: View {
         self.placeholderEmoji = placeholderEmoji
         self.placeholderImageName = placeholderImageName
         self.agentVerification = agentVerification
+        self.explicitSize = explicitSize
         _cachedImage = State(initialValue: ImageCache.shared.image(for: cacheableObject))
     }
 
@@ -35,7 +41,7 @@ struct AvatarView: View {
                     .scaledToFit()
                     .aspectRatio(contentMode: .fill)
             } else if let placeholderEmoji, !placeholderEmoji.isEmpty {
-                EmojiAvatarView(emoji: placeholderEmoji, agentVerification: agentVerification)
+                EmojiAvatarView(emoji: placeholderEmoji, agentVerification: agentVerification, size: explicitSize)
             } else if let placeholderImageName {
                 Image(systemName: placeholderImageName)
                     .resizable()
@@ -46,7 +52,7 @@ struct AvatarView: View {
                     .foregroundStyle(.colorTextPrimaryInverted)
                     .background(agentVerification.avatarBackgroundColor)
             } else {
-                MonogramView(name: fallbackName, agentVerification: agentVerification)
+                MonogramView(name: fallbackName, agentVerification: agentVerification, size: explicitSize)
             }
         }
         .aspectRatio(1.0, contentMode: .fit)
@@ -61,6 +67,9 @@ struct ProfileAvatarView: View {
     let profileImage: UIImage?
     let useSystemPlaceholder: Bool
     var agentVerification: AgentVerification = .unverified
+    /// Forwarded to `AvatarView` so the emoji/monogram fallbacks skip their
+    /// `GeometryReader` when the size is already known (clustered avatars).
+    var size: CGFloat?
 
     var body: some View {
         AvatarView(
@@ -69,7 +78,8 @@ struct ProfileAvatarView: View {
             placeholderImage: profileImage,
             placeholderEmoji: profile.profileEmoji,
             placeholderImageName: useSystemPlaceholder ? "person.crop.circle.fill" : nil,
-            agentVerification: profile.isAgent ? agentVerification : .unverified
+            agentVerification: profile.isAgent ? agentVerification : .unverified,
+            explicitSize: size
         )
     }
 }
@@ -79,6 +89,11 @@ struct ProfileAvatarView: View {
 struct ConversationAvatarView: View {
     let conversation: Conversation
     let conversationImage: UIImage?
+    /// Forwarded to the emoji/monogram/clustered fallbacks so they render
+    /// without a `GeometryReader` when the caller knows the avatar size (the
+    /// pinned cell passes its fixed avatar size). Nil keeps the self-sizing
+    /// path for list rows that only constrain with an outer `.frame`.
+    var size: CGFloat?
 
     @Environment(\.forcedAgentVerification) private var forcedVerification: AgentVerification?
     @Environment(\.pendingAgentIdentity) private var pendingAgentIdentity: PendingAgentAvatarIdentity?
@@ -145,21 +160,21 @@ struct ConversationAvatarView: View {
     private var fallbackContent: some View {
         switch conversation.avatarType {
         case .customImage:
-            MonogramView(name: conversation.computedDisplayName(memberNameOverride: memberNameOverride))
+            MonogramView(name: conversation.computedDisplayName(memberNameOverride: memberNameOverride), size: size)
         case let .profile(profile, verification):
             if let emoji = profile.profileEmoji, !emoji.isEmpty {
-                EmojiAvatarView(emoji: emoji, agentVerification: verification)
+                EmojiAvatarView(emoji: emoji, agentVerification: verification, size: size)
             } else if verification == .unverified {
-                EmojiAvatarView(emoji: conversation.defaultEmoji)
+                EmojiAvatarView(emoji: conversation.defaultEmoji, size: size)
             } else {
-                MonogramView(name: profile.displayName, agentVerification: verification)
+                MonogramView(name: profile.displayName, agentVerification: verification, size: size)
             }
         case .clustered(let profiles):
-            ClusteredAvatarView(profiles: profiles)
+            ClusteredAvatarView(profiles: profiles, size: size)
         case .emoji(let emoji):
-            EmojiAvatarView(emoji: emoji)
+            EmojiAvatarView(emoji: emoji, size: size)
         case .monogram(let name):
-            MonogramView(name: name)
+            MonogramView(name: name, size: size)
         case .pendingAgent:
             PendingAgentAvatarView()
         }

--- a/Convos/Shared Views/ClusteredAvatarView.swift
+++ b/Convos/Shared Views/ClusteredAvatarView.swift
@@ -3,45 +3,57 @@ import SwiftUI
 
 struct ClusteredAvatarView: View {
     let profiles: [Profile]
+    /// When set, the cluster lays out at this exact side length without a
+    /// `GeometryReader`. The cluster nests one sub-avatar per member, so the
+    /// self-sizing path otherwise stacks ~N+1 geometry-feedback passes per
+    /// cell during scroll. Nil keeps the self-sizing path.
+    var size: CGFloat?
 
     private let containerBase: CGFloat = 44.0
 
     var body: some View {
-        GeometryReader { geometry in
-            let side = min(geometry.size.width, geometry.size.height)
-            let scale = side / containerBase
-
-            ZStack {
-                switch profiles.count {
-                case 0:
-                    MonogramView(name: "")
-                case 1:
-                    singleAvatar(profile: profiles[0], size: side)
-                case 2:
-                    twoAvatarLayout(scale: scale)
-                case 3:
-                    threeAvatarLayout(scale: scale)
-                case 4:
-                    fourAvatarLayout(scale: scale)
-                case 5:
-                    fiveAvatarLayout(scale: scale)
-                case 6:
-                    sixAvatarLayout(scale: scale)
-                default:
-                    sevenAvatarLayout(scale: scale)
-                }
+        if let size {
+            clusterContent(side: size).accessibilityHidden(true)
+        } else {
+            GeometryReader { geometry in
+                clusterContent(side: min(geometry.size.width, geometry.size.height))
             }
-            .frame(width: side, height: side)
-            .background(.colorFillMinimal)
-            .clipShape(Circle())
+            .aspectRatio(1.0, contentMode: .fit)
+            .accessibilityHidden(true)
         }
-        .aspectRatio(1.0, contentMode: .fit)
-        .accessibilityHidden(true)
+    }
+
+    @ViewBuilder
+    private func clusterContent(side: CGFloat) -> some View {
+        let scale = side / containerBase
+        ZStack {
+            switch profiles.count {
+            case 0:
+                MonogramView(name: "", size: side)
+            case 1:
+                singleAvatar(profile: profiles[0], size: side)
+            case 2:
+                twoAvatarLayout(scale: scale)
+            case 3:
+                threeAvatarLayout(scale: scale)
+            case 4:
+                fourAvatarLayout(scale: scale)
+            case 5:
+                fiveAvatarLayout(scale: scale)
+            case 6:
+                sixAvatarLayout(scale: scale)
+            default:
+                sevenAvatarLayout(scale: scale)
+            }
+        }
+        .frame(width: side, height: side)
+        .background(.colorFillMinimal)
+        .clipShape(Circle())
     }
 
     @ViewBuilder
     private func singleAvatar(profile: Profile, size: CGFloat) -> some View {
-        ProfileAvatarView(profile: profile, profileImage: nil, useSystemPlaceholder: false)
+        ProfileAvatarView(profile: profile, profileImage: nil, useSystemPlaceholder: false, size: size)
             .frame(width: size, height: size)
     }
 
@@ -146,7 +158,7 @@ struct ClusteredAvatarView: View {
 
     @ViewBuilder
     private func avatarCircle(profile: Profile, size: CGFloat) -> some View {
-        ProfileAvatarView(profile: profile, profileImage: nil, useSystemPlaceholder: false)
+        ProfileAvatarView(profile: profile, profileImage: nil, useSystemPlaceholder: false, size: size)
             .frame(width: size, height: size)
             .clipShape(Circle())
             .overlay {

--- a/Convos/Shared Views/EmojiAvatarView.swift
+++ b/Convos/Shared Views/EmojiAvatarView.swift
@@ -4,24 +4,37 @@ import SwiftUI
 struct EmojiAvatarView: View {
     let emoji: String
     var agentVerification: AgentVerification = .unverified
+    /// When set, the view renders at this exact side length without a
+    /// `GeometryReader`. Callers that already know the avatar size (e.g. the
+    /// clustered avatar, which lays its sub-avatars out at computed sizes)
+    /// pass it so a scrolling list doesn't pay a geometry-feedback pass per
+    /// avatar - a clustered cell otherwise nests one `GeometryReader` per
+    /// member. Nil keeps the self-sizing path for callers that only constrain
+    /// the avatar with an outer `.frame`.
+    var size: CGFloat?
 
     private var background: Color {
         agentVerification.isVerified ? agentVerification.avatarBackgroundColor : .colorFillMinimal
     }
 
     var body: some View {
-        GeometryReader { geometry in
-            let side = min(geometry.size.width, geometry.size.height)
-            let fontSize = side * 0.43
-
-            Text(emoji)
-                .font(.system(size: fontSize, weight: .semibold, design: .rounded))
-                .frame(width: side, height: side)
-                .background(background)
-                .clipShape(Circle())
+        if let size {
+            circle(side: size).accessibilityHidden(true)
+        } else {
+            GeometryReader { geometry in
+                circle(side: min(geometry.size.width, geometry.size.height))
+            }
+            .aspectRatio(1.0, contentMode: .fit)
+            .accessibilityHidden(true)
         }
-        .aspectRatio(1.0, contentMode: .fit)
-        .accessibilityHidden(true)
+    }
+
+    private func circle(side: CGFloat) -> some View {
+        Text(emoji)
+            .font(.system(size: side * 0.43, weight: .semibold, design: .rounded))
+            .frame(width: side, height: side)
+            .background(background)
+            .clipShape(Circle())
     }
 }
 

--- a/Convos/Shared Views/MonogramView.swift
+++ b/Convos/Shared Views/MonogramView.swift
@@ -4,15 +4,21 @@ import SwiftUI
 struct MonogramView: View {
     private let initials: String
     private let agentVerification: AgentVerification
+    /// When set, renders at this exact side length without a `GeometryReader`.
+    /// See the matching note on `EmojiAvatarView.size` - the clustered avatar
+    /// passes it so each member sub-avatar skips a per-avatar geometry pass.
+    private let size: CGFloat?
 
-    init(text: String, agentVerification: AgentVerification = .unverified) {
+    init(text: String, agentVerification: AgentVerification = .unverified, size: CGFloat? = nil) {
         self.initials = text
         self.agentVerification = agentVerification
+        self.size = size
     }
 
-    init(name: String, agentVerification: AgentVerification = .unverified) {
+    init(name: String, agentVerification: AgentVerification = .unverified, size: CGFloat? = nil) {
         self.initials = Self.initials(from: name)
         self.agentVerification = agentVerification
+        self.size = size
     }
 
     private var isAgent: Bool {
@@ -20,19 +26,24 @@ struct MonogramView: View {
     }
 
     var body: some View {
-        GeometryReader { geometry in
-            let side = min(geometry.size.width, geometry.size.height)
-            let fontSize = side * 0.5
-            let padding = side * 0.25
-
-            Group {
-                Text(initials)
-                    .font(.system(size: fontSize, weight: .semibold, design: .rounded))
-                    .minimumScaleFactor(0.01)
-                    .lineLimit(1)
-                    .foregroundColor(.colorTextPrimaryInverted)
-                    .padding(padding)
+        if let size {
+            circle(side: size).accessibilityHidden(true)
+        } else {
+            GeometryReader { geometry in
+                circle(side: min(geometry.size.width, geometry.size.height))
             }
+            .aspectRatio(1.0, contentMode: .fit)
+            .accessibilityHidden(true)
+        }
+    }
+
+    private func circle(side: CGFloat) -> some View {
+        Text(initials)
+            .font(.system(size: side * 0.5, weight: .semibold, design: .rounded))
+            .minimumScaleFactor(0.01)
+            .lineLimit(1)
+            .foregroundColor(.colorTextPrimaryInverted)
+            .padding(side * 0.25)
             .frame(width: side, height: side)
             .background {
                 if !isAgent {
@@ -45,9 +56,6 @@ struct MonogramView: View {
             }
             .background(agentVerification.avatarBackgroundColor)
             .clipShape(Circle())
-        }
-        .aspectRatio(1.0, contentMode: .fit)
-        .accessibilityHidden(true)
     }
 
     private static func initials(from fullName: String) -> String {


### PR DESCRIPTION
## What

Fav'd/pinned conversations scroll worse than the rest of the Chats list. The pinned section renders large (96pt) avatars, and group pins use the clustered avatar (one sub-avatar per member). Every avatar view (`EmojiAvatarView`, `MonogramView`, `ClusteredAvatarView`) wrapped its content in a `GeometryReader` to read its own side length — so a single clustered pinned cell stacked up to ~8 nested `GeometryReader`s, each re-running its content closure on every layout/measure pass during scroll.

## Change

The avatar size is already known at these call sites (the pinned cell fixes it at 96pt; the cluster computes each sub-avatar's size). Thread that size down so the avatar views render at an exact side length **without** a `GeometryReader` — mirroring `MessageAvatarView`, which already avoids `GeometryReader` for exactly this scroll-perf reason.

- `EmojiAvatarView`, `MonogramView`, `ClusteredAvatarView`: render geometry-free when a `size` is provided; keep the `GeometryReader` self-sizing path when it's nil.
- `AvatarView` / `ProfileAvatarView` / `ConversationAvatarView`: forward the size to those fallbacks.
- `PinnedConversationItem`: pass its fixed avatar size.

Other surfaces (list rows that only constrain with an outer `.frame`) are untouched — they keep the self-sizing path. Visuals are identical: same font/padding ratios, just fed an explicit side instead of a measured one (verified on the simulator).

## Diagnosis

Time Profiler on a seeded clustered-pin list (5 fav'd groups with multi-member image avatars, pinned via direct DB writes since invite-join is currently flaky on dev) showed `sizeThatFits` / `Layout` dominating the pinned section's render cost — consistent with the nested `GeometryReader`s.

## Validation note (please read)

This is a **structural** reduction (removes up to ~8 nested `GeometryReader`s per clustered pinned cell), verified to preserve appearance. It is **not yet confirmed against the on-device hitch**:
- The simulator (M-series Mac) renders too fast to reproduce the dropped frames — three hypotheses (snapshot-feedback loop, raw clustered-cell cost, GeometryReader) all showed no measurable per-frame delta in-sim, and a snapshot-rebuild-per-frame theory was instrumented and disproven.
- On-device Animation Hitches capture was blocked this session: one iPhone's instruments server returned "an unknown problem is preventing this device from recording"; the other device lacked the pinned test data.

Landing this as a sound, low-risk improvement that directly targets the measured layout cost. An on-device before/after Animation Hitches comparison is the right follow-up to confirm the frame-drop reduction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Render avatars without GeometryReader when explicit size is known
> - Adds an optional `size` parameter to `MonogramView`, `EmojiAvatarView`, `ClusteredAvatarView`, `AvatarView`, `ProfileAvatarView`, and `ConversationAvatarView`.
> - When `size` is provided, each view renders directly at the given dimensions using an extracted `circle(side:)` or `clusterContent(side:)` helper, skipping the `GeometryReader` path entirely.
> - Call sites in `PinnedConversationItem` pass `avatarSize` explicitly to `ConversationAvatarView` to take advantage of this path.
> - Behavioral Change: views with a known size no longer go through `GeometryReader`, which changes the layout measurement lifecycle for those call sites.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f3a65f9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->