### PR TITLE
Remove unused device-permission purpose strings from Info.plists

### DIFF
--- a/Convos/Config/Info.Dev.plist
+++ b/Convos/Config/Info.Dev.plist
@@ -15,25 +15,5 @@
 	<string>Convos needs access to your Photo Library to save photos from conversations.</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>Convos uses your photo library when an agent asks to read recent photos for a conversation.</string>
-	<key>NSContactsUsageDescription</key>
-	<string>Convos uses your contacts when an agent asks to look up a person you've mentioned in a conversation.</string>
-	<key>NSCalendarsUsageDescription</key>
-	<string>Convos uses your calendar when an agent asks to summarize or schedule events from a conversation.</string>
-	<key>NSCalendarsFullAccessUsageDescription</key>
-	<string>Convos uses your calendar when an agent asks to summarize or schedule events from a conversation.</string>
-	<key>NSRemindersFullAccessUsageDescription</key>
-	<string>Convos uses your reminders when an agent asks to capture tasks from a conversation.</string>
-	<key>NSAppleMusicUsageDescription</key>
-	<string>Convos uses your Apple Music library when an agent asks about what you've been listening to.</string>
-	<key>NSLocationWhenInUseUsageDescription</key>
-	<string>Convos uses your location when an agent asks where you are or to plan something nearby.</string>
-	<key>NSHomeKitUsageDescription</key>
-	<string>Convos uses HomeKit when an agent asks to check or control your home accessories.</string>
-	<key>NSHealthShareUsageDescription</key>
-	<string>Convos uses Apple Health when an agent asks about your activity, workouts, or sleep.</string>
-	<key>NSHealthUpdateUsageDescription</key>
-	<string>Convos uses Apple Health when an agent logs a workout or activity for you.</string>
-	<key>NSMotionUsageDescription</key>
-	<string>Convos uses motion data when an agent asks about your daily movement or workouts.</string>
 </dict>
 </plist>

--- a/Convos/Config/Info.Local.plist
+++ b/Convos/Config/Info.Local.plist
@@ -17,26 +17,6 @@
 	<string>Convos needs access to your Photo Library to save photos from conversations.</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>Convos uses your photo library when an agent asks to read recent photos for a conversation.</string>
-	<key>NSContactsUsageDescription</key>
-	<string>Convos uses your contacts when an agent asks to look up a person you've mentioned in a conversation.</string>
-	<key>NSCalendarsUsageDescription</key>
-	<string>Convos uses your calendar when an agent asks to summarize or schedule events from a conversation.</string>
-	<key>NSCalendarsFullAccessUsageDescription</key>
-	<string>Convos uses your calendar when an agent asks to summarize or schedule events from a conversation.</string>
-	<key>NSRemindersFullAccessUsageDescription</key>
-	<string>Convos uses your reminders when an agent asks to capture tasks from a conversation.</string>
-	<key>NSAppleMusicUsageDescription</key>
-	<string>Convos uses your Apple Music library when an agent asks about what you've been listening to.</string>
-	<key>NSLocationWhenInUseUsageDescription</key>
-	<string>Convos uses your location when an agent asks where you are or to plan something nearby.</string>
-	<key>NSHomeKitUsageDescription</key>
-	<string>Convos uses HomeKit when an agent asks to check or control your home accessories.</string>
-	<key>NSHealthShareUsageDescription</key>
-	<string>Convos uses Apple Health when an agent asks about your activity, workouts, or sleep.</string>
-	<key>NSHealthUpdateUsageDescription</key>
-	<string>Convos uses Apple Health when an agent logs a workout or activity for you.</string>
-	<key>NSMotionUsageDescription</key>
-	<string>Convos uses motion data when an agent asks about your daily movement or workouts.</string>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsLocalNetworking</key>

--- a/Convos/Config/Info.Prod.plist
+++ b/Convos/Config/Info.Prod.plist
@@ -15,25 +15,5 @@
 	<string>Convos needs access to your Photo Library to save photos from conversations.</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>Convos uses your photo library when an agent asks to read recent photos for a conversation.</string>
-	<key>NSContactsUsageDescription</key>
-	<string>Convos uses your contacts when an agent asks to look up a person you've mentioned in a conversation.</string>
-	<key>NSCalendarsUsageDescription</key>
-	<string>Convos uses your calendar when an agent asks to summarize or schedule events from a conversation.</string>
-	<key>NSCalendarsFullAccessUsageDescription</key>
-	<string>Convos uses your calendar when an agent asks to summarize or schedule events from a conversation.</string>
-	<key>NSRemindersFullAccessUsageDescription</key>
-	<string>Convos uses your reminders when an agent asks to capture tasks from a conversation.</string>
-	<key>NSAppleMusicUsageDescription</key>
-	<string>Convos uses your Apple Music library when an agent asks about what you've been listening to.</string>
-	<key>NSLocationWhenInUseUsageDescription</key>
-	<string>Convos uses your location when an agent asks where you are or to plan something nearby.</string>
-	<key>NSHomeKitUsageDescription</key>
-	<string>Convos uses HomeKit when an agent asks to check or control your home accessories.</string>
-	<key>NSHealthShareUsageDescription</key>
-	<string>Convos uses Apple Health when an agent asks about your activity, workouts, or sleep.</string>
-	<key>NSHealthUpdateUsageDescription</key>
-	<string>Convos uses Apple Health when an agent logs a workout or activity for you.</string>
-	<key>NSMotionUsageDescription</key>
-	<string>Convos uses motion data when an agent asks about your daily movement or workouts.</string>
 </dict>
 </plist>


### PR DESCRIPTION
Apple rejected the build citing HealthKit references. The app declared
NSHealthShare/NSHealthUpdate usage strings (plus Contacts, Calendars,
Reminders, Apple Music, Location, HomeKit, and Motion), but none of
those frameworks are linked into the binary. The ConvosConnections
per-kind device products (ConvosConnectionsHealth, etc.) are not linked
in the v1 cloud-only configuration, and the ConvosConnections umbrella
target excludes its DataSources so no HealthKit/EventKit/etc. symbols
enter the app.

Remove every device-permission purpose string that has no corresponding
framework usage. Photos stays -- it is genuinely used via PhotosUI.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1014"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783477187&installation_id=128169237&pr_number=1014&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1014&signature=9b781d6440f737ad27c778f4371a8826ba3b9f1203c93338eb194bb0ce5f6bf8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove unused device-permission purpose strings from all Info.plist targets
> Removes 10 unused `NS*UsageDescription` keys (Contacts, Calendars, Reminders, Apple Music, Location, HomeKit, Health, and Motion) from the [Dev](https://github.com/xmtplabs/convos-ios/pull/1014/files#diff-141e7d6debfeae43e3632fefc27682e3c4b502e8ccf1fbb70ea8e88975923390), [Local](https://github.com/xmtplabs/convos-ios/pull/1014/files#diff-bc07ca15b88054f3626f770ab5b21400936e856c3dcf84120c9a16dfd1143bf0), and [Prod](https://github.com/xmtplabs/convos-ios/pull/1014/files#diff-1a96ac2921b3ccde9e06962ea8ca899767136e4722d18ee35532c15b5584265e) Info.plist files. These strings are not needed by the app and their presence could trigger unnecessary App Store privacy disclosures.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4103dd8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->