### PR TITLE
Verification-gate the agent contact-card template affordance + removed-member follow-ups

### DIFF
--- a/Convos/Contacts/ContactDetailView.swift
+++ b/Convos/Contacts/ContactDetailView.swift
@@ -376,15 +376,24 @@ struct ContactDetailView: View {
     /// True when this contact is a template-backed agent - it carries the
     /// `templateId` needed to spawn a fresh instance. Drives the Chat
     /// button's behavior: spawn a new conversation vs. the human DM path.
+    ///
+    /// Gated on `isVerifiedAgent` (a cryptographically-verified attestation
+    /// that a sender cannot forge): `templateId`/`publishedUrl` are unsigned
+    /// strings, and a snapshot from any member could in principle assert them
+    /// for another contact, so the template affordance only trusts them on a
+    /// verified agent.
     private var isAgentTemplate: Bool {
-        contact.agentTemplateId != nil
+        contact.agentTemplateId != nil && contact.isVerifiedAgent
     }
 
     /// The template share link for a template-backed agent, ready for the
-    /// Share row's `ShareLink`. `nil` for human contacts and for agents
-    /// without a published template, which hides the row.
+    /// Share row's `ShareLink`. `nil` for human contacts, for agents without a
+    /// published template, and for unverified contacts (the published URL is
+    /// unsigned metadata, so the share affordance is only trusted on a verified
+    /// agent - see `isAgentTemplate`).
     private var agentTemplateShareURL: URL? {
-        contact.agentTemplatePublishedURL.flatMap { URL(string: $0) }
+        guard contact.isVerifiedAgent else { return nil }
+        return contact.agentTemplatePublishedURL.flatMap { URL(string: $0) }
     }
 
     /// True on Dev/Local builds. Controls visibility of the instance id

--- a/ConvosCore/Sources/ConvosCore/Storage/Repositories/ConversationsCountRepository.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Repositories/ConversationsCountRepository.swift
@@ -39,11 +39,18 @@ class ConversationsCountRepository: ConversationsCountRepositoryProtocol {
 }
 
 fileprivate extension Database {
+    // Mirrors the visible conversation list (ConversationsRepository): the
+    // required join on a `conversationLocalState` row with `wasRemoved == false`
+    // excludes conversations the local user was removed from, so the count never
+    // exceeds what's actually shown. Every persisted conversation has a
+    // localState row (ConversationWriter inserts one), so the required join does
+    // not drop live conversations.
     func composeConversationsCount(consent: [Consent], kinds: [ConversationKind]) throws -> Int {
         try DBConversation
             .filter(!DBConversation.Columns.id.like("draft-%"))
             .filter(kinds.contains(DBConversation.Columns.kind))
             .filter(consent.contains(DBConversation.Columns.consent))
+            .joining(required: DBConversation.localState.filter(ConversationLocalState.Columns.wasRemoved == false))
             .fetchCount(self)
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationWriter.swift
@@ -402,8 +402,14 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
         currentMemberInboxIds: Set<String>,
         in db: Database
     ) throws {
-        guard let localInboxId = try DBInbox.currentInboxId(db),
-              currentMemberInboxIds.contains(localInboxId) else { return }
+        guard let localInboxId = try DBInbox.currentInboxId(db) else {
+            // Expected only during account teardown or before first inbox
+            // registration; logged so an unexpectedly missing inbox is
+            // visible in diagnostics rather than silently skipping the clear.
+            Log.warning("clearRemovedMarkerIfMember: no current inbox, skipping for \(conversationId)")
+            return
+        }
+        guard currentMemberInboxIds.contains(localInboxId) else { return }
         try ConversationLocalState
             .filter(ConversationLocalState.Columns.conversationId == conversationId)
             .filter(ConversationLocalState.Columns.wasRemoved == true)

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/IncomingMessageWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/IncomingMessageWriter.swift
@@ -102,8 +102,8 @@ class IncomingMessageWriter: IncomingMessageWriterProtocol, @unchecked Sendable 
         let messageExistsInDB = try DBMessage.exists(db, key: message.id)
         let localInboxId = try DBInbox.currentInboxId(db)
         let wasRemovedFromConversation: Bool = {
-            guard let localInboxId, let removed = message.update?.removedInboxIds else { return false }
-            return removed.contains(localInboxId)
+            guard let localInboxId, let removedInboxIds = message.update?.removedInboxIds else { return false }
+            return removedInboxIds.contains(localInboxId)
         }()
 
         Log.debug("Storing incoming message \(message.id) localId \(message.clientMessageId) echoDateNs=\(message.dateNs)")

--- a/ConvosCore/Sources/ConvosCore/Storage/XMTP DB Representations/DecodedMessage+DBRepresentation.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/XMTP DB Representations/DecodedMessage+DBRepresentation.swift
@@ -91,7 +91,7 @@ extension XMTPiOS.DecodedMessage {
             // inbound traffic (e.g. LeaveRequest) is visible in exported logs.
             let version = "\(encodedContentType.versionMajor).\(encodedContentType.versionMinor)"
             Log.warning(
-                "Dropping message \(id) in conversation \(conversationId) from \(senderInboxId): "
+                "Dropping message \(id) (dateNs=\(sentAtNs)) in conversation \(conversationId) from \(senderInboxId): "
                 + "unsupported content type \(encodedContentType.authorityID)/\(encodedContentType.typeID) v\(version)"
             )
             throw DecodedMessageDBRepresentationError.unsupportedContentType

--- a/ConvosCore/Tests/ConvosCoreTests/ConversationRemovedStateTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ConversationRemovedStateTests.swift
@@ -200,6 +200,18 @@ struct ConversationRemovedStateTests {
         #expect(!conversations.contains { $0.id == "convo-removed" })
     }
 
+    @Test("conversationsCount excludes removed conversations, matching the visible list")
+    func testCountExcludesRemoved() throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        try dbManager.dbWriter.write { db in
+            try Self.seedConversation(db: db, id: "convo-live")
+            try Self.seedConversation(db: db, id: "convo-removed", wasRemoved: true)
+        }
+
+        let countRepo = ConversationsCountRepository(databaseReader: dbManager.dbReader, consent: [.allowed])
+        #expect(try countRepo.fetchCount() == 1)
+    }
+
     @Test("findOneToOne does not resurface a removed 1:1")
     func testFindOneToOneExcludesRemoved() throws {
         let dbManager = MockDatabaseManager.makeTestDatabase()

--- a/ConvosCore/Tests/ConvosCoreTests/Integration/RemovedMarkerNSEFirstTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/Integration/RemovedMarkerNSEFirstTests.swift
@@ -1,0 +1,110 @@
+@testable import ConvosCore
+import Foundation
+import GRDB
+import Testing
+@preconcurrency import XMTPiOS
+
+/// NSE-first convergence for the removed-from-conversation marker, against a
+/// local XMTP node (`./dev/up`). When the Notification Service Extension
+/// saves the removal `GroupUpdated` message row first, the main app
+/// re-encounters it as an existing row (`messageAlreadyExists == true`) and
+/// must still persist the removed marker - the marker logic is deliberately
+/// independent of row existence. Regression coverage for the 2026-06-04
+/// incident where removal handling keyed off "new row" and a relaunch
+/// resurrected a dead conversation.
+@Suite("Removed marker NSE-first Integration Tests", .serialized)
+struct RemovedMarkerNSEFirstTests {
+    private enum TestError: Error {
+        case missingClients
+        case missingRemovalMessage
+    }
+
+    @Test("Re-storing an existing removal message still persists the marker")
+    func markerConvergesWhenMessageRowAlreadyExists() async throws {
+        let fixtures = TestFixtures()
+        try await fixtures.createTestClients()
+
+        guard let clientA = fixtures.clientA as? Client,
+              let clientB = fixtures.clientB as? Client,
+              let clientIdB = fixtures.clientIdB else {
+            throw TestError.missingClients
+        }
+        let inboxIdB = clientB.inboxID
+
+        try await fixtures.databaseManager.dbWriter.write { db in
+            try DBInbox(inboxId: inboxIdB, clientId: clientIdB, createdAt: Date()).insert(db)
+        }
+
+        // A creates a group with B; B syncs and persists its local view of
+        // the conversation (so the message row insert below has its parent).
+        let group = try await clientA.conversations.newGroup(
+            with: [clientB.inboxID],
+            name: "Removal Group"
+        )
+        try await clientB.conversations.sync()
+        let groupB = try #require(try clientB.conversations.listGroups().first { $0.id == group.id })
+
+        let messageWriter = IncomingMessageWriter(databaseWriter: fixtures.databaseManager.dbWriter)
+        let conversationWriter = ConversationWriter(
+            identityStore: fixtures.identityStore,
+            databaseWriter: fixtures.databaseManager.dbWriter,
+            messageWriter: messageWriter
+        )
+        _ = try await conversationWriter.store(
+            conversation: groupB,
+            inboxId: inboxIdB
+        )
+
+        // A removes B; B syncs so libxmtp processes the removal commit and
+        // materializes the GroupUpdated message naming B locally. The group
+        // is inactive for B afterwards, so further syncs may throw - the
+        // message list read below is local-only.
+        _ = try await group.removeMembers(inboxIds: [clientB.inboxID])
+        try? await groupB.sync()
+        try? await clientB.conversations.sync()
+
+        let recentMessages = try await groupB.messages(limit: 20, direction: .descending)
+        var foundMessage: XMTPiOS.DecodedMessage?
+        var foundDBMessage: DBMessage?
+        for message in recentMessages {
+            guard let dbMessage = try? message.dbRepresentation(),
+                  dbMessage.update?.removedInboxIds.contains(inboxIdB) == true else { continue }
+            foundMessage = message
+            foundDBMessage = dbMessage
+            break
+        }
+        guard let removalMessage = foundMessage, let removalDBMessage = foundDBMessage else {
+            throw TestError.missingRemovalMessage
+        }
+
+        // Simulate the NSE having saved the message row first: insert the
+        // row directly, without any of the writer's side effects. The marker
+        // must still be unset at this point.
+        try await fixtures.databaseManager.dbWriter.write { db in
+            try removalDBMessage.save(db)
+        }
+        let stateBeforeStore = try await fixtures.databaseManager.dbReader.read { db in
+            try ConversationLocalState
+                .filter(ConversationLocalState.Columns.conversationId == group.id)
+                .fetchOne(db)
+        }
+        #expect(stateBeforeStore?.wasRemoved != true, "Direct row insert must not set the marker")
+
+        // Main app re-encounters the same message through the writer.
+        let dbConversation = try #require(try await fixtures.databaseManager.dbReader.read { db in
+            try DBConversation.fetchOne(db, key: group.id)
+        })
+        let result = try await messageWriter.store(message: removalMessage, for: dbConversation)
+
+        #expect(result.messageAlreadyExists, "The NSE-saved row should be seen as existing")
+        #expect(result.wasRemovedFromConversation, "Removal detection must not key off row novelty")
+        let stateAfterStore = try await fixtures.databaseManager.dbReader.read { db in
+            try ConversationLocalState
+                .filter(ConversationLocalState.Columns.conversationId == group.id)
+                .fetchOne(db)
+        }
+        #expect(stateAfterStore?.wasRemoved == true, "Marker must converge on the existing-row path")
+
+        try? await fixtures.cleanup()
+    }
+}


### PR DESCRIPTION
The agent contact card's "New chat" / Share affordance is driven by **unsigned** profile-metadata fields (`templateId` / `publishedUrl`). This gates `ContactDetailView`'s `isAgentTemplate` and the share link on `contact.isVerifiedAgent` (cryptographically-verified attestation), so a spoofed or stale identity field on an *unverified* contact can't surface an actionable affordance.

## Why this is just the gate (the ingest merge was removed)

The intermittent grayed-out "New chat" symptom is **already fixed on dev**: the `DBContact` mirror (which the card reads) does timestamp-wins + preserve-on-omit for the template identity fields — landed in #930 and `aea4a507` ("contact updates from member profiles overwrite entire profile instead of just updated fields"), proven by `testStickyAgentTemplateIdentitySurvivesMetadataLessUpdate`.

An earlier version of this PR added a profile-metadata-ingest merge across StreamProcessor / NSE / ConversationWriter. On review that turned out to be:
- **redundant** with the mirror above (the card reads `DBContact.agentTemplateId`, already protected), and
- partly inapplicable — the NSE never processes `ProfileUpdate` / `ProfileSnapshot` (both codecs' `shouldPush` is `false`), and stripping identity from snapshots would have broken their "introduce other members" purpose.

So that machinery was removed; only the verification gate remains.

## Also carries (removed-member review follow-ups orphaned when #989 merged early)

- `ConversationsCountRepository` joins `wasRemoved == false`, so the count matches the visible list (`testCountExcludesRemoved`).
- `IncomingMessageWriter`: `removed` → `removedInboxIds` rename + a concurrency/idempotency note on the NSE+app double-process path.
- `clearRemovedMarkerIfMember`: split guard to log the unexpected nil-inbox case.
- Unknown-content-type drop log now includes `dateNs` + sender for incident correlation.
- `RemovedMarkerNSEFirstTests`: removal-marker convergence integration test (NSE saves the removal GroupUpdated first → main app re-encounters it as existing → `wasRemoved` still set).

Linear: IOS-460 (follow-ups), related IOS-452 / IOS-453 (removed-member).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Verification-gate agent contact-card template affordance and fix removed-conversation count
> - `ContactDetailView.isAgentTemplate` and `agentTemplateShareURL` now require `contact.isVerifiedAgent == true`; unverified contacts no longer expose the agent template share UI even if `agentTemplateId` is set.
> - `ConversationsCountRepository` excludes conversations where `wasRemoved` is true by joining on `DBConversation.localState`.
> - Adds `testCountExcludesRemoved` unit test and an NSE-first integration test verifying that re-storing a GroupUpdated removal message correctly sets the removed marker when the `DBMessage` row already exists.
> - `ConversationWriter.clearRemovedMarkerIfMember` now logs a warning when no current inbox is available instead of silently returning.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f71b100.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->