### PR TITLE
Fix App Check debug token lost on fresh-install first launch

### DIFF
--- a/ConvosCore/Sources/ConvosCore/Storage/LegacyDataWipe.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/LegacyDataWipe.swift
@@ -65,9 +65,15 @@ enum LegacyDataWipe {
         "hasRegisteredDevice_",
         "lastRegisteredDevicePushToken_"
     ]
+    /// `GACAppCheckDebugToken` is deliberately not wiped here. It is a
+    /// build-time constant that `FirebaseHelperCore.configure` re-pins on
+    /// every launch, and that pin happens *before* this wipe runs in the
+    /// launch sequence. Wiping it deletes the freshly pinned token on the
+    /// first launch of a fresh install, so App Check falls back to an
+    /// unregistered random UUID until the next launch -- the exact
+    /// "force-quit-and-relaunch to recognize the debug token" bug.
     private static let standardDefaultsKeys: [String] = [
-        "convos_fallback_device_id",
-        "GACAppCheckDebugToken"
+        "convos_fallback_device_id"
     ]
 
     /// Checks whether a wipe is needed for the current install and runs it before

--- a/ConvosCore/Tests/ConvosCoreTests/LegacyDataWipeTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/LegacyDataWipeTests.swift
@@ -158,6 +158,26 @@ struct LegacyDataWipeTests {
         #expect(fixture.standardDefaults.string(forKey: "unrelated_user_pref") == "keep")
     }
 
+    @Test("App Check debug token survives a generation bump (re-pinned before the wipe)")
+    func appCheckDebugTokenSurvivesWipe() throws {
+        let fixture = try TempFixture()
+        fixture.defaults.set("single-inbox-v2", forKey: "convos.schemaGeneration")
+
+        // FirebaseHelperCore.configure pins this build-time constant before the
+        // wipe runs in the launch sequence. Wiping it broke App Check on the
+        // first launch of a fresh install until a force-quit-and-relaunch.
+        fixture.standardDefaults.set("pinned-debug-token", forKey: "GACAppCheckDebugToken")
+
+        LegacyDataWipe.runIfNeeded(
+            defaults: fixture.defaults,
+            standardDefaults: fixture.standardDefaults,
+            databasesDirectory: fixture.databasesDirectory,
+            legacyKeychainAccessGroup: legacyAccessGroup
+        )
+
+        #expect(fixture.standardDefaults.string(forKey: "GACAppCheckDebugToken") == "pinned-debug-token")
+    }
+
     @Test("Cold install but with legacy artifacts (no marker): still wipes + marks")
     func noMarkerButArtifactsTriggersWipe() throws {
         let fixture = try TempFixture()


### PR DESCRIPTION
## Problem

On a brand-new simulator, the first launch of the app does not recognize the Firebase App Check debug token. The app has to be force-quit and relaunched before App Check works.

## Root cause

A launch-ordering conflict between the token pin and `LegacyDataWipe`:

1. `ConvosApp.init` calls `FirebaseHelperCore.configure(...)`, which pins the debug token to `UserDefaults.standard["GACAppCheckDebugToken"]` (simulator-only, every launch).
2. A few statements later, `.client(...)` builds `DatabaseManager`, which runs `LegacyDataWipe.runIfNeeded` — *after* the pin.
3. On a fresh install the generation marker is absent, so the wipe runs. `GACAppCheckDebugToken` was in the wipe's delete list, so the just-pinned token was removed within the same `init()`.
4. App Check reads the token lazily later in the launch, finds it gone, and falls back to an auto-generated **unregistered** random UUID — so App Check stays unrecognized.
5. On the second launch the marker exists, the wipe is skipped, the pin survives, and App Check works. Hence the "force-quit and relaunch" workaround.

This also affected the App Clip, which follows the same `configure -> DatabaseManager -> wipe` sequence.

## Fix

Remove `GACAppCheckDebugToken` from `LegacyDataWipe`'s delete list. The pinned debug token is a build-time constant re-pinned on every launch — not stale per-install identity/conversation/device state, which is all the wipe is meant to clear. A comment documents why it must stay out of the list. One change covers both the main app and the App Clip since they share `LegacyDataWipe`.

## Tests

Added a regression test (`appCheckDebugTokenSurvivesWipe`) asserting the pinned token survives a generation-bump wipe. The full `LegacyDataWipe` suite passes locally (10/10) and SwiftLint strict is clean. Docker was unavailable locally, so the integration suite runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1018"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783546701&installation_id=128169237&pr_number=1018&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1018&signature=6951297e659fc777eb9786020c581e01d622ad68e20d4f23c9b27d7c0181f02a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `GACAppCheckDebugToken` being wiped on fresh-install first launch
> On a generation bump, `LegacyDataWipe.runIfNeeded` was wiping the `GACAppCheckDebugToken` UserDefaults key, which is pinned before the wipe runs and must survive it. The key is removed from the `standardDefaultsKeys` wipe list in [LegacyDataWipe.swift](https://github.com/xmtplabs/convos-ios/pull/1018/files#diff-f0b3b981cd41187b104f0ad92d78baf19ef4f183ffe348850127ee9728cc997a), and a new test in [LegacyDataWipeTests.swift](https://github.com/xmtplabs/convos-ios/pull/1018/files#diff-1aca0f802e5247fb10b22f903b8c62e91db3da13d6d81d2ad0715d93eb3c7dab) asserts the token is preserved after a wipe.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e43f04d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->