### PR TITLE
Make app-group / keychain entitlement failures self-diagnosing (#843)

### DIFF
--- a/ConvosCore/Sources/ConvosCore/AppEnvironment.swift
+++ b/ConvosCore/Sources/ConvosCore/AppEnvironment.swift
@@ -241,24 +241,41 @@ public extension AppEnvironment {
         guard !isTestingEnvironment else {
             return FileManager.default.temporaryDirectory
         }
-
-        guard let groupUrl = FileManager.default.containerURL(
-            forSecurityApplicationGroupIdentifier: appGroupIdentifier
-        ) else {
-            fatalError("Failed getting container URL for group identifier: \(appGroupIdentifier)")
-        }
-        return groupUrl.appendingPathComponent("logs", isDirectory: true)
+        return appGroupContainerURL.appendingPathComponent("logs", isDirectory: true)
     }
 
     var defaultDatabasesDirectoryURL: URL {
         guard !isTestingEnvironment else {
             return FileManager.default.temporaryDirectory
         }
+        return appGroupContainerURL
+    }
 
+    /// Shared app-group container, used for logs and databases.
+    ///
+    /// A nil container is not a simulator limitation -- the simulator honors
+    /// app-group entitlements like a device. It means the running build was
+    /// not signed with an app-group entitlement that grants
+    /// `appGroupIdentifier`. Common causes: the app was built or installed
+    /// without the entitlement applied (a simulator build needs
+    /// `-configuration Local` or `Dev`, not the default Release), or
+    /// config.json's `appGroupIdentifier` does not match the build
+    /// configuration's `APP_GROUP_IDENTIFIER` entitlement. The message names
+    /// the requested identifier and bundle id so the mismatch is obvious.
+    private var appGroupContainerURL: URL {
         guard let groupUrl = FileManager.default.containerURL(
             forSecurityApplicationGroupIdentifier: appGroupIdentifier
         ) else {
-            fatalError("Failed getting container URL for group identifier: \(appGroupIdentifier)")
+            let bundleId = Bundle.main.bundleIdentifier ?? "unknown"
+            let message = """
+            Could not resolve the app group container for '\(appGroupIdentifier)'. \
+            The running build's app-group entitlement does not grant this identifier. \
+            Verify the app was built and installed with its entitlement applied \
+            (simulator builds need -configuration Local or Dev) and that config.json's \
+            appGroupIdentifier matches the build configuration's APP_GROUP_IDENTIFIER. \
+            Bundle id: \(bundleId).
+            """
+            fatalError(message)
         }
         return groupUrl
     }

--- a/ConvosCore/Sources/ConvosCore/Auth/Keychain/KeychainIdentityStore.swift
+++ b/ConvosCore/Sources/ConvosCore/Auth/Keychain/KeychainIdentityStore.swift
@@ -147,6 +147,14 @@ public enum KeychainIdentityStoreError: Error, LocalizedError {
     public var errorDescription: String? {
         switch self {
         case let .keychainOperationFailed(status, operation):
+            if status == errSecMissingEntitlement {
+                return """
+                Keychain \(operation) failed: missing entitlement (errSecMissingEntitlement, -34018). \
+                The running build lacks a keychain-access-groups entitlement that grants the requested \
+                access group. This is not a simulator limitation -- verify the build was signed with its \
+                keychain-access-groups entitlement (simulator builds need -configuration Local or Dev).
+                """
+            }
             return "Keychain \(operation) failed with status: \(status)"
         case let .dataDecodingFailed(context):
             return "Failed to decode data for \(context)"


### PR DESCRIPTION
## Context

Follow-up to the simulator bring-up issue #843. That runbook diagnoses two fresh-simulator symptoms as fundamental simulator limitations:

- Step 1: `containerURL(forSecurityApplicationGroupIdentifier:)` returns nil -> `AppEnvironment` `fatalError`s on launch.
- Step 2: Keychain identity read fails with `-34018` (`errSecMissingEntitlement`).

It proposes simulator-only workarounds (Application Support fallback, a `FileBackedIdentityStore`). Those are mis-targeted: **the simulator honors app-group and keychain-access-group entitlements just like a device.** The app already writes its logs to the app-group container and uses the Keychain on the simulator in everyday dev — if the simulator couldn't do either, nobody could run the app.

A nil app-group container **and** `errSecMissingEntitlement` together are the signature of one root cause: the running build's entitlements don't match what the runtime asks for. In this project the runtime app-group id (`config.json`) and the entitlement (`APP_GROUP_IDENTIFIER`) are both derived from the same per-config xcconfig, so a clean `-configuration Local`/`Dev` build can't mismatch them. They diverge when the entitlement isn't applied (e.g. a simulator build under the default Release configuration, the gotcha already documented in #843's own follow-up comment) or the configs are otherwise split.

## Change

Make those two failures self-diagnosing instead of papering over them:

- `AppEnvironment`: replace the duplicated, opaque `"Failed getting container URL for group identifier: …"` `fatalError` with a shared `appGroupContainerURL` helper whose message names the requested app-group identifier, the bundle id, and the likely cause (entitlement not applied / config mismatch / built without `-configuration`).
- `KeychainIdentityStoreError`: special-case `errSecMissingEntitlement` (-34018) with the same actionable guidance, surfaced through `LocalizedError`.

Deliberately **not** adding a fallback: the failure stays loud (it's genuinely unrecoverable — the app has no data directory), but now explains itself rather than sending the next engineer toward a simulator-only band-aid that would diverge sim behavior from what ships to device.

## Notes

- No behavior change on the success path; ConvosCore compiles (macOS) and SwiftLint `--strict` is clean.
- Related: #843 Step 3's App Check 403 is the token-wipe bug fixed in #1018 (the printed `<uuid>` is a random unregistered token, not a missing-JWT problem), so the proposed simulator JWT override is also unnecessary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1019"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783553333&installation_id=128169237&pr_number=1019&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1019&signature=3a7b4ddb354616cc52ef5c400bdbe722632dcb94104bb9d0eb2c5b8ae66d088c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make app-group and keychain entitlement failures self-diagnosing with actionable error messages
> - Introduces a centralized `appGroupContainerURL` computed property in [`AppEnvironment.swift`](https://github.com/xmtplabs/convos-ios/pull/1019/files#diff-c41b4b73606649b51abcec3156d536e2b3978a8771275ac4be74dc15927c3580) that replaces inline container resolution in `defaultXMTPLogsDirectoryURL` and `defaultDatabasesDirectoryURL`.
> - When the app-group container cannot be resolved, `fatalError` now emits a detailed message explaining the missing entitlement, suggests using Local or Dev configurations for simulator builds, and includes the bundle ID.
> - In [`KeychainIdentityStore.swift`](https://github.com/xmtplabs/convos-ios/pull/1019/files#diff-76438f813aa83a36d04ff40aa4d37157853f7f80cf8e8bb4e6523acc222ee65c), `errorDescription` for `errSecMissingEntitlement` (-34018) now returns a specific message clarifying the missing `keychain-access-groups` entitlement instead of a generic status string.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f19ce0b.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->