### PR TITLE
/run + /build: make -configuration explicit (fixes the #843 config-split signature)

### DIFF
--- a/.claude/commands/build.md
+++ b/.claude/commands/build.md
@@ -55,17 +55,19 @@ Build, launch in simulator, and notify when running:
 
 > **NEVER use the MCP `build_sim` tool.** It has a known bug where app extension targets (NotificationService) fail to find SPM module dependencies (ConvosCore, ConvosCoreiOS, XMTPiOS) on fresh worktrees. **ALWAYS use xcodebuild directly via Bash.**
 
-Run this exact command via the Bash tool (on a single line):
+Pass an explicit `-configuration` matching the scheme (`Convos (Dev)` -> `Dev`, `Convos (Local)` -> `Local`, `Convos (Prod)` -> `Prod`). Without it the scheme can build targets under mismatched configurations -- the NotificationService extension fails with `unable to resolve module dependency: ConvosCore` (packages and extension land in different config dirs), and the app's entitlements/identifiers stop matching `config.json`, surfacing at runtime as a nil app-group container crash (`Failed getting container URL`) or `-34018` (`errSecMissingEntitlement`) on first identity read. That is a configuration signature, not a simulator limitation (issue #843, #1019); `rm -rf .derivedData` does not fix it, an explicit `-configuration` does.
+
+Run this command via the Bash tool:
 
 ```bash
-xcodebuild build -project Convos.xcodeproj -scheme "Convos (Dev)" -destination "platform=iOS Simulator,id=SIMULATOR_ID" -derivedDataPath .derivedData 2>&1 | tail -100
+xcodebuild build -project Convos.xcodeproj -scheme "Convos (Dev)" -configuration Dev -destination "platform=iOS Simulator,id=SIMULATOR_ID" -derivedDataPath .derivedData 2>&1 | tail -100
 ```
 
 Replace:
 - `SIMULATOR_ID` with the selected simulator UUID
-- `"Convos (Dev)"` with the requested scheme if different
+- `"Convos (Dev)" -configuration Dev` with the requested scheme and its matching configuration if different
 
-Set a timeout of 300000ms (5 minutes) for the build command.
+Set a timeout of 300000ms (5 minutes) for the build command. A `took NNNms to type-check` failure on a *trivial* expression that *moves between files* between builds is CPU contention, not a code problem -- rebuild with `-jobs 2`, do not edit the flagged code.
 
 **Why xcodebuild via Bash works but MCP fails:**
 - The MCP tool's parallelization breaks extension target dependency ordering

--- a/.claude/commands/run.md
+++ b/.claude/commands/run.md
@@ -66,11 +66,11 @@ xcrun simctl boot "$SIM_UUID" 2>/dev/null || true
 
 Use `xcodebuild` via Bash. Do **not** use `mcp__XcodeBuildMCP__build_sim` — it mis-sequences SPM extension dependencies (`ConvosCore`, `ConvosCoreiOS`, `XMTPiOS`) on fresh worktrees. See `CLAUDE.md`.
 
-**Dev / Prod schemes** (team signing):
+**Dev / Prod schemes** (team signing). Pass an explicit `-configuration` (`Convos (Dev)` -> `Dev`, `Convos (Prod)` -> `Prod`). Without it the scheme can build targets under mismatched configurations: the SPM packages land in one config dir while the NotificationService extension looks in another (`unable to resolve module dependency: ConvosCore`), and the app's entitlements/identifiers stop matching `config.json`, surfacing at runtime as a nil app-group container crash (`Failed getting container URL`) or `-34018` (`errSecMissingEntitlement`) on first identity read. Those three are one configuration signature, not simulator limitations (issue #843, #1019); `rm -rf .derivedData` does not fix them, an explicit `-configuration` does.
 ```bash
 xcodebuild build \
   -project Convos.xcodeproj \
-  -scheme "Convos (Dev)" \
+  -scheme "Convos (Dev)" -configuration Dev \
   -destination "platform=iOS Simulator,id=$SIM_UUID" \
   -derivedDataPath .derivedData 2>&1 | tail -100
 ```
@@ -88,7 +88,9 @@ xcodebuild build \
 
 Set a 600s timeout. If the build fails:
 - Surface the compilation errors from the tail.
-- For `module not found` errors, `rm -rf .derivedData` and rebuild once.
+- `unable to resolve module dependency` in the NotificationService extension almost always means `-configuration` was omitted (config split, see above), not stale build artifacts -- set `-configuration` first; `rm -rf .derivedData` does not fix this one.
+- For other `module not found` errors, `rm -rf .derivedData` and rebuild once.
+- A `took NNNms to type-check` failure on a *trivial* expression that *moves between files* across builds is CPU contention, not a code problem -- rebuild with `-jobs 2` (and close heavy apps if you can); do not edit the flagged code or raise the threshold. See `CLAUDE.md` "If type-check timeouts are firing everywhere".
 - Stop if it still fails.
 
 ### Step 3: Install and launch


### PR DESCRIPTION
## What

`/run` and `/build` built the Dev/Prod schemes for the simulator **without** an explicit `-configuration`. The `Convos (Dev)` scheme mixes `Dev` and `Release` across its actions, so an unqualified build can split targets across configuration dirs (SPM packages in one, the NotificationService extension in another).

This single root cause is what issue #843 repeatedly hit and misdiagnosed as *simulator limitations*. It surfaces as three symptoms:

- `unable to resolve module dependency: ConvosCore / ConvosCoreiOS / XMTPiOS` in the NotificationService extension (packages and extension resolve from different config dirs),
- a nil app-group container crash on launch (`Failed getting container URL for group identifier`),
- `keychainOperationFailed(-34018)` / `errSecMissingEntitlement` on the first identity read in a new convo.

`rm -rf .derivedData` does **not** fix these; an explicit `-configuration` does. Confirmed on a fresh clean-tree bring-up (libxmtp 4.10 -> 4.11, `Convos (Dev)`, no local patches): with `-configuration Dev` none of #843's Step 1-3 accommodations were needed.

## Change (docs only)

- Make `-configuration` explicit in the `/run` and `/build` Dev/Prod commands (`Dev`/`Local`/`Prod` per scheme). **Team signing is unchanged.**
- Document the config-split signature so the three symptoms self-explain as a configuration issue (per #843, #1019), instead of inviting simulator-only band-aids.
- Note the type-check-contention -> `-jobs 2` workaround (trivial expression, time hovers just over the limit, offending file changes between builds) so a CPU-starvation timeout isn't mistaken for slow code.

No effect on CI, device, or release signing (those go through fastlane + match, and never read `.claude/commands/`).

## Context

- Root cause and verification: #843
- Real fixes already shipped: #1018 (App Check debug token), #1019 (self-diagnosing app-group / keychain entitlement failures)
- Supersedes the need for a standalone "simulator-bringup" skill (#1009): with `/run` passing `-configuration`, the app comes up clean with no runtime accommodations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1020"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783619681&installation_id=128169237&pr_number=1020&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1020&signature=db35c3bf3e7dfa57f1867b9bd4565a17ce70d0c65acea58f5967f4727edd6cca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add explicit `-configuration` flag guidance to `/build` and `/run` commands to fix config-split signature (#843)
> - Updates [build.md](.claude/commands/build.md) and [run.md](.claude/commands/run.md) to require `-configuration` matching the selected scheme (Dev/Local/Prod) in all `xcodebuild` examples.
> - Documents concrete failure signatures when the flag is omitted: NotificationService extension failing to resolve SPM module dependencies, and entitlement/identifier mismatches causing app-group container `nil` or `-34018` at first identity read.
> - Clarifies that `derivedData` cleanup does not fix these failures — they are configuration issues.
> - Adds troubleshooting guidance for type-check timeout warnings on trivial expressions (rebuild with `-jobs 2`, avoid editing flagged code).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fd4992f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->