### PR TITLE
Render contact card for replies that are agent template share URLs

### DIFF
--- a/ConvosCore/Sources/ConvosCore/Storage/XMTP DB Representations/DecodedMessage+DBRepresentation.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/XMTP DB Representations/DecodedMessage+DBRepresentation.swift
@@ -189,6 +189,18 @@ extension XMTPiOS.DecodedMessage {
                     update: nil
                 )
             }
+            if !isContentEmoji, MessageAgentShare.from(text: contentString) != nil {
+                return DBMessageComponents(
+                    messageType: .reply,
+                    contentType: .agentShare,
+                    sourceMessageId: sourceMessageId,
+                    emoji: nil,
+                    invite: nil,
+                    attachmentUrls: [],
+                    text: contentString,
+                    update: nil
+                )
+            }
             if !isContentEmoji, let preview = LinkPreview.from(text: contentString) {
                 return DBMessageComponents(
                     messageType: .reply,


### PR DESCRIPTION
## Problem

When a message reply's **inner content is an agent template share URL**, the agent contact card was not rendered — the reply showed as a plain text bubble of the raw URL. The card *did* render when the **parent** of a reply was an agent share, which is why the gap was easy to miss.

## Root cause

`handleReplyContent()` in `DecodedMessage+DBRepresentation.swift` classifies a reply's inner text. It checked for **invites** and **link previews** but not **agent-template share URLs** — unlike the two sibling paths that get it right:

- `handleTextContent()` (standalone messages)
- `OutgoingMessageWriter.saveTextToDatabase()` (optimistic send)

So an agent-share reply decoded from the network (or the sender's own message echoed back after publish / on relaunch) was stored with `contentType: .text` and rendered as plain text. The downstream layers were already correct — `MessagesRepository.composeReplyMessage` maps `.agentShare` for reply content, and `MessagesGroupItemView` renders it via `AgentShareBubble`. Only the decode-time classification was missing.

## Fix

Add the agent-share branch to `handleReplyContent()`, mirroring `handleTextContent()`'s ordering (invite -> agentShare -> linkPreview).

## Testing

- `swift build --package-path ConvosCore` succeeds.
- A direct unit test isn't practical: `handleReplyContent` is private on the XMTP SDK's `DecodedMessage` and there's no existing infra to fabricate a real `Reply`-typed decoded message. Existing `AgentShareURLTests` cover URL parsing + the resolver, not the decode path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Render contact card for reply messages containing agent template share URLs
> In [`DecodedMessage+DBRepresentation.swift`](https://github.com/xmtplabs/convos-ios/pull/1021/files#diff-0c8920ce1ad42f1b82bde3939ef415a6dd892a0c4ca47450290b7d8067c6792c), `handleReplyContent` now checks if reply content matches `MessageAgentShare.from(text:)` and, if so, classifies the message as `.agentShare` instead of falling through to link preview or plain text handling.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a54bc44.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->