### PR TITLE
Fix conversations-list cells culling early at the tab-bar line

### DIFF
--- a/Convos/Conversations List/ConversationsView.swift
+++ b/Convos/Conversations List/ConversationsView.swift
@@ -206,9 +206,21 @@ struct ConversationsView: View {
         // (reserving its edge) *and* its height is re-applied here as the
         // collection view's `additionalSafeAreaInsets`. To avoid counting it
         // twice we ignore the system safe area on the bar's edge: `.top` on
-        // iPhone (bar pins to the top) and additionally `.bottom` on iPad
-        // (bar pins to the bottom, signalled by a non-zero bottom inset).
-        let ignoredSafeAreaEdges: Edge.Set = bottomChromeInset > 0 ? [.top, .bottom] : .top
+        // iPhone (bar pins to the top) and `.bottom` on iPad (bar pins to the
+        // bottom, signalled by a non-zero bottom inset).
+        //
+        // We ignore `.bottom` unconditionally so the collection view's frame
+        // reaches the physical screen bottom (under the floating tab bar)
+        // rather than stopping at the bottom safe-area line. The list cell
+        // hosting view has `clipsToBounds = false`, so cells render in the
+        // band under the tab bar, but UICollectionView culls cells the moment
+        // they leave its `bounds` regardless of clipping. If the frame stopped
+        // at the safe-area line, cells would be removed the instant their
+        // bottom crossed that line and visibly pop out mid-scroll instead of
+        // sliding off the bottom. Extending the frame moves the cull boundary
+        // to the screen edge; `contentInsetAdjustmentBehavior = .automatic`
+        // re-applies the tab-bar inset so the last row still rests above it.
+        let ignoredSafeAreaEdges: Edge.Set = [.top, .bottom]
         return ConversationsViewRepresentable(
             pinnedConversations: viewModel.pinnedConversations,
             unpinnedConversations: viewModel.unpinnedConversations,


### PR DESCRIPTION
## Summary

The conversations list (a `UICollectionView` hosted in a SwiftUI floating `TabView`) removed cells as soon as their bottom edge reached the tab bar, instead of letting them scroll off the screen bottom.

**Root cause:** on iPhone the list only ignored the *top* safe area, so the collection view's frame stopped at the bottom safe-area line (above the floating tab bar). `clipsToBounds = false` keeps *drawing* cells in the band below the frame, but `UICollectionView` culls cells based on its `bounds`, not on what clipping allows — so a cell was removed the instant it crossed the frame's bottom edge while still visually on screen.

**Fix:** ignore the bottom safe area unconditionally so the collection view's frame reaches the physical screen bottom. The cull boundary moves to the screen edge, and `contentInsetAdjustmentBehavior = .automatic` re-applies the tab-bar inset so the last row still rests above it. (iPad already used `[.top, .bottom]`; this aligns iPhone with it.)

Regression from the May home-shell refactor (#918) that introduced the floating tab bar.

## Verification (iPhone 17 simulator)

Drove the real collection view with a populated list and logged its runtime geometry, A/B on the one changed line:

| | collection-view frame in window | gap below frame | bottom content inset |
|---|---|---|---|
| Before | (0,0,402,**791**) | **83pt** | 0pt |
| After  | (0,0,402,**874**) | **0pt**  | 83pt |

After the fix the frame reaches the screen bottom (cull line at the screen edge, so cells scroll off naturally), and the 83pt bottom inset keeps the last row clear of the tab bar. Confirmed visually that cells now render continuously under the tab bar while scrolling.

## Note (unrelated)

`QuickEditView.swift:72/77` has an expression that type-checks at ~600ms (limit 300ms) and tripped the warnings-as-errors gate under heavy machine load during local builds. Not touched by this change; flagging as a latent CI/archive risk worth hoisting separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix conversations list cells culling early at the tab-bar line
> The `conversationsCollectionView` in [ConversationsView.swift](https://github.com/xmtplabs/convos-ios/pull/1022/files#diff-e334ebb478fd67135890a69270ef256dd0f442e21d1497561579d82fa86ab705) previously only ignored the bottom safe area when `bottomChromeInset` was non-zero, causing cells to be culled at the tab-bar line when the inset was absent. The ignored safe area edges are now unconditionally set to `[.top, .bottom]`, so the collection view frame always extends to the physical screen bottom.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7841644.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->