### PR TITLE
Show only verified, template-backed agents in Contacts

### DIFF
--- a/Convos/Contacts/Contact+BrowseVisibility.swift
+++ b/Convos/Contacts/Contact+BrowseVisibility.swift
@@ -4,15 +4,23 @@ import Foundation
 extension Contact {
     /// Whether this contact renders in the Contacts browse list - and thus
     /// counts toward the App Settings "Contacts" badge, which must agree
-    /// with the list. Shown: humans with a display name, and template-backed
-    /// agents (tagged with the Agent pill). Hidden: legacy verified
-    /// assistants without a template, agents whose template metadata hasn't
-    /// mirrored yet, and unnamed humans (they'd render as "Somebody" with
-    /// nothing to distinguish them). All agents stay in `DBContact` so
-    /// chat-side surfaces can still resolve them.
+    /// with the list. Shown: humans with a display name, and verified,
+    /// template-backed agents (tagged with the Agent pill). Hidden:
+    /// unverified agents, verified agents whose template hasn't mirrored yet,
+    /// and unnamed humans (they'd render as "Somebody" with nothing to
+    /// distinguish them). All agents stay in `DBContact` so chat-side
+    /// surfaces can still resolve them.
+    ///
+    /// An agent must be BOTH verified and template-backed to appear:
+    /// - `isVerifiedAgent` (unforgeable attestation) - so a stale or spoofed
+    ///   `templateId` on a non-verified contact never surfaces it, and only
+    ///   real agents show.
+    /// - `agentTemplateId != nil` - the contact list collapses agent
+    ///   instances to one canonical row per template (`dedupingAgentsByTemplate`),
+    ///   so an agent with no template has no canonical key and can't be shown.
     var isVisibleInContactsList: Bool {
-        if agentVerification != nil {
-            return agentTemplateId != nil
+        if isAgent {
+            return isVerifiedAgent && agentTemplateId != nil
         }
         guard let displayName, !displayName.isEmpty else { return false }
         return true


### PR DESCRIPTION
## What

Gate `Contact.isVisibleInContactsList` on **`isVerifiedAgent && agentTemplateId != nil`** instead of `agentVerification != nil`.

An agent now appears in the Contacts browse list / picker / App Settings badge only when it is **both**:
- **verified** (`isVerifiedAgent` — cryptographic attestation), so a stale or spoofed `templateId` on a non-verified contact never surfaces it, and
- **template-backed** (`agentTemplateId != nil`) — the list collapses agent instances to one canonical row per template (`dedupingAgentsByTemplate`), so an agent with no template has no canonical key and can't be shown.

## Why

The previous predicate keyed agent visibility on `agentVerification != nil`, which is also true for `.unverified` agents — so an **unverified** agent carrying a `templateId` could show up in Contacts. Visibility should be limited to verified, template-keyed agents. Humans are unchanged (shown once they have a display name); all agents remain in `DBContact` so chat-side surfaces still resolve them.

| Contact | Before | After |
|---|---|---|
| Verified + templateId | shown | **shown** |
| Unverified + templateId | shown | **hidden** |
| templateId only, not verified (spoof) | shown if named | **hidden** |
| Verified, no templateId | hidden | hidden |
| Human + name / no name | shown / hidden | unchanged |

## Test plan

Verified live against the Dev stack with a locally-attested debug agent (`/debug-assistant`):
- A **verified + template-backed** agent (`agent:convos`, `templateId` set) appears in Contacts.
- **Verified-but-templateless** agents stay hidden.
- The "Suggested agents" section is unaffected (separate code path).

Also: SwiftLint `--strict` clean; Convos (Dev) builds.

Related area: agent-template contacts (cf. IOS-458 / #1017, which addresses the separate templateId-on-ingest drop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1025"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783698466&installation_id=128169237&pr_number=1025&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1025&signature=28d43ffc764dc5f3baefa4826c00656c0411a5c224d119b22c9d4691c11f0d34"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show only verified, template-backed agents in Contacts list
> Updates `Contact.isVisibleInContactsList` in [Contact+BrowseVisibility.swift](https://github.com/xmtplabs/convos-ios/pull/1025/files#diff-d093d0e41bd58c6de496cfc9aa22a0f327d78ebf04e251b03c0ccb983d7575c8) to require agents to pass both `isVerifiedAgent` and a non-nil `agentTemplateId` checks before appearing in the list. Previously, unverified agents with a display name could appear as humans due to a looser check order. Unverified agents and verified agents without a template are now always hidden.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 760fe7e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->