### PR TITLE
feat(picker): optimistic end-state conversation indicator for picked members and agents

### DIFF
--- a/Convos/Contacts/Contact+SyntheticAgentMember.swift
+++ b/Convos/Contacts/Contact+SyntheticAgentMember.swift
@@ -2,11 +2,16 @@ import ConvosCore
 import Foundation
 
 extension AgentShareInfo {
+    /// Prefix of the sentinel inbox id carried by optimistic agent members.
+    /// Lets the picker-seeding overlay tell presentation-only synthetics
+    /// apart from real members (see `ConversationMember.isOptimisticAgentMember`).
+    static let optimisticInboxIdPrefix: String = "optimistic-agent-"
+
     /// Sentinel inbox id for the optimistic agent card member. Built from the
     /// template id so it never collides with a real member's inbox id, and so
     /// the "real verified agent joined" checks can recognize and ignore it.
     func optimisticAgentInboxId() -> String {
-        "optimistic-agent-\(templateId ?? "pending")"
+        Self.optimisticInboxIdPrefix + (templateId ?? "pending")
     }
 
     /// Builds a presentation-only `ConversationMember` from this agent-share
@@ -59,6 +64,44 @@ extension AgentShareInfo {
             descriptionText: nil,
             avatarURL: nil
         )
+    }
+}
+
+extension Contact {
+    /// The agent's public identity in `AgentShareInfo` form; nil for human
+    /// contacts. Used by the contacts picker flows to build optimistic
+    /// members for picked agents via `optimisticCardMember(conversationId:)`,
+    /// so the chat header renders the agent's name and emoji before the
+    /// provisioned instance joins. Mirrors the identity
+    /// `ContactDetailView.confirmChatWithAgentTemplate` paints for the
+    /// single-agent chat action.
+    var agentShareInfo: AgentShareInfo? {
+        guard let agentTemplateId else { return nil }
+        return AgentShareInfo(
+            templateId: agentTemplateId,
+            displayName: displayName,
+            emoji: profileEmoji,
+            descriptionText: agentDescription,
+            avatarURL: avatarURL
+        )
+    }
+}
+
+extension ConversationMember {
+    /// True for the presentation-only optimistic agent members built by
+    /// `AgentShareInfo.optimisticCardMember(conversationId:)`, recognized
+    /// by their sentinel inbox id.
+    var isOptimisticAgentMember: Bool {
+        profile.inboxId.hasPrefix(AgentShareInfo.optimisticInboxIdPrefix)
+    }
+
+    /// The template id encoded in an optimistic agent member's sentinel
+    /// inbox id. nil for real members and for the deep link's neutral
+    /// placeholder (whose share info had no template id yet).
+    var optimisticAgentTemplateId: String? {
+        guard isOptimisticAgentMember else { return nil }
+        let suffix = String(profile.inboxId.dropFirst(AgentShareInfo.optimisticInboxIdPrefix.count))
+        return suffix == "pending" ? nil : suffix
     }
 }
 

--- a/Convos/Contacts/Contact+SyntheticAgentMember.swift
+++ b/Convos/Contacts/Contact+SyntheticAgentMember.swift
@@ -101,7 +101,8 @@ extension ConversationMember {
     var optimisticAgentTemplateId: String? {
         guard isOptimisticAgentMember else { return nil }
         let suffix = String(profile.inboxId.dropFirst(AgentShareInfo.optimisticInboxIdPrefix.count))
-        return suffix == "pending" ? nil : suffix
+        guard !suffix.isEmpty, suffix != "pending" else { return nil }
+        return suffix
     }
 }
 

--- a/Convos/Conversation Creation/ComposeFlowView.swift
+++ b/Convos/Conversation Creation/ComposeFlowView.swift
@@ -60,12 +60,25 @@ struct ComposeFlowView: View {
     /// adds the picked humans as members and spawns a fresh instance of each
     /// picked agent template into the conversation. The push happens
     /// immediately either way -- the members / agents land in the open
-    /// conversation a moment later.
+    /// conversation a moment later. The selection is seeded into the view
+    /// model optimistically first, so the conversation indicator shows the
+    /// picked end state (names and avatars) instead of "New Convo" while
+    /// those calls are in flight; a failed add-members call rolls the
+    /// optimistic humans back.
     private func handleProceed(_ memberInboxIds: Set<String>, _ agentTemplateIds: [String]) {
         if let conversationViewModel = composeConversationViewModel.conversationViewModel {
+            conversationViewModel.seedOptimisticPickedMembers(
+                inboxIds: Array(memberInboxIds),
+                agentTemplateIds: agentTemplateIds
+            )
             if !memberInboxIds.isEmpty {
                 Task {
-                    try? await conversationViewModel.addMembersFromContacts(Array(memberInboxIds))
+                    do {
+                        try await conversationViewModel.addMembersFromContacts(Array(memberInboxIds))
+                    } catch {
+                        Log.error("Compose add-members failed, rolling back optimistic members: \(error.localizedDescription)")
+                        conversationViewModel.rollbackOptimisticPickedMembers()
+                    }
                 }
             }
             conversationViewModel.requestAgentJoins(templateIds: agentTemplateIds)

--- a/Convos/Conversation Creation/NewConversationViewModel.swift
+++ b/Convos/Conversation Creation/NewConversationViewModel.swift
@@ -141,6 +141,12 @@ class NewConversationViewModel: Identifiable, Hashable {
     /// through "New Convo" while the state machine creates the real
     /// group.
     private let seededMemberInboxIds: [String]
+    /// Captured agent-template ids for the seeded-members flow. Used to
+    /// seed each draft `Conversation` with template-derived optimistic
+    /// members (name + emoji) so the chat header renders the picked end
+    /// state from the moment the sheet opens - the provisioned instances
+    /// only join well after `.ready`, via `agents/join`.
+    private let seededAgentTemplateIds: [String]
     let allowsDismissingScanner: Bool
     private let autoCreateConversation: Bool
     private(set) var showingFullScreenScanner: Bool
@@ -331,12 +337,14 @@ class NewConversationViewModel: Identifiable, Hashable {
             self.allowsDismissingScanner = true
         }
 
-        if case .newConversationWithMembers(let ids, _) = mode {
+        if case .newConversationWithMembers(let ids, let templateIds) = mode {
             self.startedWithSeededMembers = true
             self.seededMemberInboxIds = ids
+            self.seededAgentTemplateIds = templateIds
         } else {
             self.startedWithSeededMembers = false
             self.seededMemberInboxIds = []
+            self.seededAgentTemplateIds = []
         }
 
         self.isExistingConversation = if case .existingConversation = mode { true } else { false }
@@ -378,6 +386,7 @@ class NewConversationViewModel: Identifiable, Hashable {
         self.startedWithFullscreenScanner = showingFullScreenScanner
         self.startedWithSeededMembers = false
         self.seededMemberInboxIds = []
+        self.seededAgentTemplateIds = []
         self.defersVisibilityUntilCommit = false
         // Tests-only init - the warm-cache flow goes through the
         // public init. Existing-conversation cleanup guard stays off.
@@ -518,26 +527,46 @@ class NewConversationViewModel: Identifiable, Hashable {
     /// `ConversationViewModel` is "gate open"; arming here matches
     /// the synthetic draft we just constructed so DB emissions with
     /// fewer non-self members are dropped until the state machine's
-    /// addMembers hook catches up. No-op when the draft has no seeded
-    /// members (e.g. `.newConversation`, scanner, joinInvite).
+    /// addMembers hook catches up. Optimistic agent members are excluded
+    /// from the gate count - the provisioned instances only join well
+    /// after `.ready`, so they're handed over as overlay members instead
+    /// (see `ConversationViewModel.markSeeded(expectingMemberCount:pendingAgentMembers:)`).
+    /// No-op when the draft has no seeded members (e.g.
+    /// `.newConversation`, scanner, joinInvite).
     private func armSeededExpectationIfNeeded(
         on convoVM: ConversationViewModel,
         for draftConversation: Conversation
     ) {
         guard startedWithSeededMembers else { return }
-        convoVM.markSeeded(expectingMemberCount: draftConversation.membersWithoutCurrent.count)
+        let seededMembers = draftConversation.membersWithoutCurrent
+        let pendingAgentMembers = seededMembers.filter(\.isOptimisticAgentMember)
+        convoVM.markSeeded(
+            expectingMemberCount: seededMembers.count - pendingAgentMembers.count,
+            pendingAgentMembers: pendingAgentMembers
+        )
     }
 
     private func makeDraftConversation(id: String) -> Conversation {
-        guard startedWithSeededMembers, !seededMemberInboxIds.isEmpty else {
+        guard startedWithSeededMembers,
+              !(seededMemberInboxIds.isEmpty && seededAgentTemplateIds.isEmpty) else {
             return .empty(id: id)
         }
         let contactsRepository = session.messagingServiceSync().contactsRepository()
         let seededContacts: [Contact] = seededMemberInboxIds.compactMap { contactsRepository.contact(for: $0) }
-        guard !seededContacts.isEmpty else {
+        // Agent contacts are canonical rows keyed by agentTemplateId (one
+        // per template), so picked templates resolve back through the same
+        // contacts repository. A templateId with no contact row (e.g. a
+        // suggested agent the user never chatted with) is skipped - that
+        // selection just keeps the non-optimistic behavior.
+        let allContacts: [Contact] = (try? contactsRepository.fetchAll()) ?? []
+        let seededAgentInfos: [AgentShareInfo] = seededAgentTemplateIds.compactMap { templateId in
+            allContacts.first(where: { $0.agentTemplateId == templateId })?.agentShareInfo
+        }
+        guard !seededContacts.isEmpty || !seededAgentInfos.isEmpty else {
             return .empty(id: id)
         }
         var members: [ConversationMember] = seededContacts.map { $0.syntheticMember(conversationId: id) }
+        members += seededAgentInfos.map { $0.optimisticCardMember(conversationId: id) }
         if case .authorized(let selfInboxId) = session.messagingServiceSync().state {
             let selfProfile = Profile(
                 inboxId: selfInboxId,

--- a/Convos/Conversation Creation/NewConversationViewModel.swift
+++ b/Convos/Conversation Creation/NewConversationViewModel.swift
@@ -513,75 +513,6 @@ class NewConversationViewModel: Identifiable, Hashable {
         self.conversationViewModel = convoVM
     }
 
-    /// Returns a draft `Conversation` for use as a placeholder. When this
-    /// VM was started by the contacts picker
-    /// (`startedWithSeededMembers == true`), the draft carries synthetic
-    /// `ConversationMember`s built from the contact list so the chat
-    /// header renders the contact's name + avatar (and `kind = .dm` for
-    /// a single contact) from the moment the sheet opens. The
-    /// conversation publisher's `.ready` emission later replaces the
-    /// synthetic members with the real ones keyed by the same `inboxId`,
-    /// so the transition is a no-op re-render rather than a flicker.
-    /// Arms the `ConversationViewModel` publisher-emission gate for
-    /// picker-seeded VMs only. The default state on
-    /// `ConversationViewModel` is "gate open"; arming here matches
-    /// the synthetic draft we just constructed so DB emissions with
-    /// fewer non-self members are dropped until the state machine's
-    /// addMembers hook catches up. Optimistic agent members are excluded
-    /// from the gate count - the provisioned instances only join well
-    /// after `.ready`, so they're handed over as overlay members instead
-    /// (see `ConversationViewModel.markSeeded(expectingMemberCount:pendingAgentMembers:)`).
-    /// No-op when the draft has no seeded members (e.g.
-    /// `.newConversation`, scanner, joinInvite).
-    private func armSeededExpectationIfNeeded(
-        on convoVM: ConversationViewModel,
-        for draftConversation: Conversation
-    ) {
-        guard startedWithSeededMembers else { return }
-        let seededMembers = draftConversation.membersWithoutCurrent
-        let pendingAgentMembers = seededMembers.filter(\.isOptimisticAgentMember)
-        convoVM.markSeeded(
-            expectingMemberCount: seededMembers.count - pendingAgentMembers.count,
-            pendingAgentMembers: pendingAgentMembers
-        )
-    }
-
-    private func makeDraftConversation(id: String) -> Conversation {
-        guard startedWithSeededMembers,
-              !(seededMemberInboxIds.isEmpty && seededAgentTemplateIds.isEmpty) else {
-            return .empty(id: id)
-        }
-        let contactsRepository = session.messagingServiceSync().contactsRepository()
-        let seededContacts: [Contact] = seededMemberInboxIds.compactMap { contactsRepository.contact(for: $0) }
-        // Agent contacts are canonical rows keyed by agentTemplateId (one
-        // per template), so picked templates resolve back through the same
-        // contacts repository. A templateId with no contact row (e.g. a
-        // suggested agent the user never chatted with) is skipped - that
-        // selection just keeps the non-optimistic behavior.
-        let allContacts: [Contact] = (try? contactsRepository.fetchAll()) ?? []
-        let seededAgentInfos: [AgentShareInfo] = seededAgentTemplateIds.compactMap { templateId in
-            allContacts.first(where: { $0.agentTemplateId == templateId })?.agentShareInfo
-        }
-        guard !seededContacts.isEmpty || !seededAgentInfos.isEmpty else {
-            return .empty(id: id)
-        }
-        var members: [ConversationMember] = seededContacts.map { $0.syntheticMember(conversationId: id) }
-        members += seededAgentInfos.map { $0.optimisticCardMember(conversationId: id) }
-        if case .authorized(let selfInboxId) = session.messagingServiceSync().state {
-            let selfProfile = Profile(
-                inboxId: selfInboxId,
-                conversationId: id,
-                name: nil,
-                avatar: nil
-            )
-            members.insert(
-                ConversationMember(profile: selfProfile, role: .superAdmin, isCurrentUser: true),
-                at: 0
-            )
-        }
-        return .draft(id: id, seededMembers: members)
-    }
-
     private func configureWithMessagingService(
         _ messagingService: AnyMessagingService,
         existingConversationId: String?,
@@ -1265,5 +1196,79 @@ private extension NewConversationMode {
         case .existingConversation, .scanner, .joinInvite:
             return false
         }
+    }
+}
+
+// MARK: - Seeded draft construction
+
+private extension NewConversationViewModel {
+    /// Arms the `ConversationViewModel` publisher-emission gate for
+    /// picker-seeded VMs only. The default state on
+    /// `ConversationViewModel` is "gate open"; arming here matches
+    /// the synthetic draft we just constructed so DB emissions with
+    /// fewer non-self members are dropped until the state machine's
+    /// addMembers hook catches up. Optimistic agent members are excluded
+    /// from the gate count - the provisioned instances only join well
+    /// after `.ready`, so they're handed over as overlay members instead
+    /// (see `ConversationViewModel.markSeeded(expectingMemberCount:pendingAgentMembers:)`).
+    /// No-op when the draft has no seeded members (e.g.
+    /// `.newConversation`, scanner, joinInvite).
+    func armSeededExpectationIfNeeded(
+        on convoVM: ConversationViewModel,
+        for draftConversation: Conversation
+    ) {
+        guard startedWithSeededMembers else { return }
+        let seededMembers = draftConversation.membersWithoutCurrent
+        let pendingAgentMembers = seededMembers.filter(\.isOptimisticAgentMember)
+        convoVM.markSeeded(
+            expectingMemberCount: seededMembers.count - pendingAgentMembers.count,
+            pendingAgentMembers: pendingAgentMembers
+        )
+    }
+
+    /// Returns a draft `Conversation` for use as a placeholder. When this
+    /// VM was started by the contacts picker
+    /// (`startedWithSeededMembers == true`), the draft carries synthetic
+    /// `ConversationMember`s built from the contact list - and optimistic
+    /// members for picked agent templates - so the chat header renders
+    /// the picked end state from the moment the sheet opens. The
+    /// conversation publisher's `.ready` emission later replaces the
+    /// synthetic human members with the real ones keyed by the same
+    /// `inboxId`, so the transition is a no-op re-render rather than a
+    /// flicker.
+    func makeDraftConversation(id: String) -> Conversation {
+        guard startedWithSeededMembers,
+              !(seededMemberInboxIds.isEmpty && seededAgentTemplateIds.isEmpty) else {
+            return .empty(id: id)
+        }
+        let contactsRepository = session.messagingServiceSync().contactsRepository()
+        let seededContacts: [Contact] = seededMemberInboxIds.compactMap { contactsRepository.contact(for: $0) }
+        // Agent contacts are canonical rows keyed by agentTemplateId (one
+        // per template), so picked templates resolve back through the same
+        // contacts repository. A templateId with no contact row (e.g. a
+        // suggested agent the user never chatted with) is skipped - that
+        // selection just keeps the non-optimistic behavior.
+        let allContacts: [Contact] = (try? contactsRepository.fetchAll()) ?? []
+        let seededAgentInfos: [AgentShareInfo] = seededAgentTemplateIds.compactMap { templateId in
+            allContacts.first(where: { $0.agentTemplateId == templateId })?.agentShareInfo
+        }
+        guard !seededContacts.isEmpty || !seededAgentInfos.isEmpty else {
+            return .empty(id: id)
+        }
+        var members: [ConversationMember] = seededContacts.map { $0.syntheticMember(conversationId: id) }
+        members += seededAgentInfos.map { $0.optimisticCardMember(conversationId: id) }
+        if case .authorized(let selfInboxId) = session.messagingServiceSync().state {
+            let selfProfile = Profile(
+                inboxId: selfInboxId,
+                conversationId: id,
+                name: nil,
+                avatar: nil
+            )
+            members.insert(
+                ConversationMember(profile: selfProfile, role: .superAdmin, isCurrentUser: true),
+                at: 0
+            )
+        }
+        return .draft(id: id, seededMembers: members)
     }
 }

--- a/Convos/Conversation Creation/NewConversationViewModel.swift
+++ b/Convos/Conversation Creation/NewConversationViewModel.swift
@@ -1248,10 +1248,8 @@ private extension NewConversationViewModel {
         // contacts repository. A templateId with no contact row (e.g. a
         // suggested agent the user never chatted with) is skipped - that
         // selection just keeps the non-optimistic behavior.
-        let allContacts: [Contact] = (try? contactsRepository.fetchAll()) ?? []
-        let seededAgentInfos: [AgentShareInfo] = seededAgentTemplateIds.compactMap { templateId in
-            allContacts.first(where: { $0.agentTemplateId == templateId })?.agentShareInfo
-        }
+        let agentContacts: [Contact] = (try? contactsRepository.fetchContacts(templateIds: seededAgentTemplateIds)) ?? []
+        let seededAgentInfos: [AgentShareInfo] = agentContacts.compactMap(\.agentShareInfo)
         guard !seededContacts.isEmpty || !seededAgentInfos.isEmpty else {
             return .empty(id: id)
         }

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -1575,20 +1575,23 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
     func seedOptimisticPickedMembers(inboxIds: [String], agentTemplateIds: [String]) {
         let conversationId = conversation.id
         let contactsRepository = messagingService.contactsRepository()
+        // Skip anyone already in the displayed conversation so seeding can
+        // never duplicate a real member (or a prior seed of the same pick).
+        let existingInboxIds = Set(conversation.members.map(\.profile.inboxId))
         let humanMembers: [ConversationMember] = inboxIds
             .compactMap { contactsRepository.contact(for: $0) }
             .map { $0.syntheticMember(conversationId: conversationId) }
+            .filter { !existingInboxIds.contains($0.profile.inboxId) }
         // Agent contacts are canonical rows keyed by agentTemplateId, so
         // picked templates resolve back through the same contacts
         // repository. A templateId with no contact row (e.g. a suggested
         // agent the user never chatted with) is skipped - that selection
         // just keeps the non-optimistic behavior.
-        let allContacts: [Contact] = (try? contactsRepository.fetchAll()) ?? []
-        let agentMembers: [ConversationMember] = agentTemplateIds
-            .compactMap { templateId in
-                allContacts.first(where: { $0.agentTemplateId == templateId })?.agentShareInfo
-            }
+        let agentContacts: [Contact] = (try? contactsRepository.fetchContacts(templateIds: agentTemplateIds)) ?? []
+        let agentMembers: [ConversationMember] = agentContacts
+            .compactMap(\.agentShareInfo)
             .map { $0.optimisticCardMember(conversationId: conversationId) }
+            .filter { !existingInboxIds.contains($0.profile.inboxId) }
         guard !(humanMembers.isEmpty && agentMembers.isEmpty) else { return }
         if latestRawConversation == nil {
             latestRawConversation = conversation
@@ -1635,6 +1638,10 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
                 unmatchedSynthetics.append(synthetic)
             }
         }
+        // Count-based fallback: a joined agent whose templateId metadata
+        // hasn't resolved yet consumes one unmatched synthetic. With several
+        // simultaneous joins this can briefly pair the wrong identities, but
+        // it self-corrects on the next emission once metadata arrives.
         var stillPending: [ConversationMember] = []
         for synthetic in unmatchedSynthetics {
             if let index = unmatchedAgents.firstIndex(where: { $0.profile.agentTemplateId == nil }) {

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -275,6 +275,27 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
     /// regular conversation open, etc.) are unaffected.
     private var expectedSeededMemberCount: Int = 0
     private var hasMetSeededExpectation: Bool = true
+    /// Synthetic agent members for picked templates (built via
+    /// `AgentShareInfo.optimisticCardMember(conversationId:)`) overlaid
+    /// onto every incoming DB emission until the real provisioned
+    /// instance joins. Unlike picked humans - who are added before the
+    /// state machine emits `.ready`, so the count gate above covers them -
+    /// agent instances join asynchronously via `agents/join` well after
+    /// `.ready`. Gating emissions on them would block invite and metadata
+    /// updates for the whole provisioning window, so they're overlaid
+    /// instead: emissions flow through, and the indicator keeps rendering
+    /// the picked end state. Cleared per-template as the matching real
+    /// member lands, or wholesale when the join call fails. Distinct from
+    /// `optimisticAgentIdentity` above: that paints a single pending agent
+    /// for the template flows; this carries the picker's multi-member end
+    /// state (title and avatar cluster) inside `conversation.members`.
+    @ObservationIgnored
+    private var pendingSyntheticAgentMembers: [ConversationMember] = []
+    /// Latest conversation as emitted by the DB publisher, before any
+    /// synthetic-member overlay. Kept so optimistic state can be rolled
+    /// back to ground truth when an add-members or agents/join call fails.
+    @ObservationIgnored
+    private var latestRawConversation: Conversation?
     let typingIndicatorManager: TypingIndicatorManager
 
     @ObservationIgnored
@@ -1364,15 +1385,17 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
                 // stays open so later member additions / removals
                 // propagate normally. Non-seeded VMs default to "gate
                 // open", so this is a no-op for them.
+                latestRawConversation = conversation
                 if !hasMetSeededExpectation {
                     if conversation.membersWithoutCurrent.count < expectedSeededMemberCount {
                         return
                     }
                     hasMetSeededExpectation = true
                 }
+                let displayConversation = overlayingPendingSyntheticAgents(on: conversation)
                 let previousId = self.conversation.id
                 let wasViewingConversation = self.isViewingConversation
-                self.conversation = conversation
+                self.conversation = displayConversation
                 self.loadConversationImage(for: conversation)
                 if conversation.id != previousId {
                     self.observePhotoPreferences(for: conversation.id)
@@ -1527,10 +1550,118 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
     /// already reflects the picked contacts. Other code paths must
     /// not call this - the default state is "gate open" so DB
     /// emissions flow through normally.
-    func markSeeded(expectingMemberCount count: Int) {
+    ///
+    /// `count` covers picked humans only - they're added before the state
+    /// machine emits `.ready`, so gating on them is short-lived. Picked
+    /// agent templates go in `pendingAgentMembers` instead and are
+    /// overlaid onto emissions until the provisioned instance joins (see
+    /// `pendingSyntheticAgentMembers`).
+    func markSeeded(expectingMemberCount count: Int, pendingAgentMembers: [ConversationMember] = []) {
+        pendingSyntheticAgentMembers = pendingAgentMembers
         guard count > 0 else { return }
         expectedSeededMemberCount = count
         hasMetSeededExpectation = false
+    }
+
+    /// Optimistically renders the picker's selection into the displayed
+    /// conversation before the real add-members / agents-join calls land,
+    /// so the indicator shows the end state instead of "New Convo".
+    /// Used by the Compose flow, where the conversation already exists
+    /// when the picker confirms (unlike the seeded-draft flow, which goes
+    /// through `markSeeded` at VM construction). Humans are appended as
+    /// synthetic members and the emission gate is armed until the real
+    /// rows catch up; agent templates are overlaid until each provisioned
+    /// instance joins.
+    func seedOptimisticPickedMembers(inboxIds: [String], agentTemplateIds: [String]) {
+        let conversationId = conversation.id
+        let contactsRepository = messagingService.contactsRepository()
+        let humanMembers: [ConversationMember] = inboxIds
+            .compactMap { contactsRepository.contact(for: $0) }
+            .map { $0.syntheticMember(conversationId: conversationId) }
+        // Agent contacts are canonical rows keyed by agentTemplateId, so
+        // picked templates resolve back through the same contacts
+        // repository. A templateId with no contact row (e.g. a suggested
+        // agent the user never chatted with) is skipped - that selection
+        // just keeps the non-optimistic behavior.
+        let allContacts: [Contact] = (try? contactsRepository.fetchAll()) ?? []
+        let agentMembers: [ConversationMember] = agentTemplateIds
+            .compactMap { templateId in
+                allContacts.first(where: { $0.agentTemplateId == templateId })?.agentShareInfo
+            }
+            .map { $0.optimisticCardMember(conversationId: conversationId) }
+        guard !(humanMembers.isEmpty && agentMembers.isEmpty) else { return }
+        if latestRawConversation == nil {
+            latestRawConversation = conversation
+        }
+        pendingSyntheticAgentMembers += agentMembers
+        if !humanMembers.isEmpty {
+            expectedSeededMemberCount = conversation.membersWithoutCurrent.count + humanMembers.count
+            hasMetSeededExpectation = false
+        }
+        conversation = conversation.withMembers(conversation.members + humanMembers + agentMembers)
+    }
+
+    /// Rolls the optimistic human members back to the latest DB ground
+    /// truth and reopens the emission gate. Called when the real
+    /// add-members call fails, so the indicator stops promising members
+    /// that will never arrive. Pending synthetic agents are left alone -
+    /// their lifecycle is tied to the agents/join call instead.
+    func rollbackOptimisticPickedMembers() {
+        guard !hasMetSeededExpectation else { return }
+        hasMetSeededExpectation = true
+        expectedSeededMemberCount = 0
+        guard let raw = latestRawConversation else { return }
+        conversation = overlayingPendingSyntheticAgents(on: raw)
+    }
+
+    /// Overlays not-yet-joined synthetic agent members onto a DB-emitted
+    /// conversation so the indicator keeps showing the picked end state
+    /// while agent instances provision. A synthetic is dropped once a real
+    /// member covers it - matched by the templateId profile metadata the
+    /// agent runtime writes, with a count-based fallback for joined agents
+    /// whose metadata hasn't resolved yet.
+    private func overlayingPendingSyntheticAgents(on conversation: Conversation) -> Conversation {
+        guard !pendingSyntheticAgentMembers.isEmpty else { return conversation }
+        var unmatchedAgents = conversation.membersWithoutCurrent.filter { member in
+            member.isAgent && !member.isOptimisticAgentMember
+        }
+        var unmatchedSynthetics: [ConversationMember] = []
+        for synthetic in pendingSyntheticAgentMembers {
+            let templateId = synthetic.optimisticAgentTemplateId
+            if templateId != nil,
+               let index = unmatchedAgents.firstIndex(where: { $0.profile.agentTemplateId == templateId }) {
+                unmatchedAgents.remove(at: index)
+            } else {
+                unmatchedSynthetics.append(synthetic)
+            }
+        }
+        var stillPending: [ConversationMember] = []
+        for synthetic in unmatchedSynthetics {
+            if let index = unmatchedAgents.firstIndex(where: { $0.profile.agentTemplateId == nil }) {
+                unmatchedAgents.remove(at: index)
+            } else {
+                stillPending.append(synthetic)
+            }
+        }
+        pendingSyntheticAgentMembers = stillPending
+        // An emission can already carry the synthetics themselves (the
+        // placeholder VM's mock repository re-emits the seeded draft);
+        // skip those so members never duplicate.
+        let existingInboxIds = Set(conversation.members.map(\.profile.inboxId))
+        let overlayMembers = stillPending.filter { !existingInboxIds.contains($0.profile.inboxId) }
+        guard !overlayMembers.isEmpty else { return conversation }
+        return conversation.withMembers(conversation.members + overlayMembers)
+    }
+
+    /// Drops any not-yet-joined synthetic agent members and re-renders
+    /// from the latest raw DB emission, so a failed agents/join doesn't
+    /// leave the indicator promising an agent that will never arrive.
+    private func clearPendingSyntheticAgents() {
+        guard !pendingSyntheticAgentMembers.isEmpty else { return }
+        pendingSyntheticAgentMembers = []
+        guard let raw = latestRawConversation else { return }
+        guard hasMetSeededExpectation else { return }
+        conversation = raw
     }
 
     func startOnboarding() {
@@ -3299,6 +3430,7 @@ extension ConversationViewModel {
 
     private func onAgentJoinError() {
         UIImpactFeedbackGenerator(style: .light).impactOccurred()
+        clearPendingSyntheticAgents()
     }
 
     func leaveConvo() {

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/Conversation.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/Conversation.swift
@@ -62,6 +62,46 @@ public extension Conversation {
         members.filter { !$0.isCurrentUser }
     }
 
+    /// Copy of this conversation with `members` replaced. Used by the
+    /// optimistic contacts-picker flows to overlay synthetic members onto
+    /// a DB-emitted conversation so the chat header keeps rendering the
+    /// picked end state while the real member additions are in flight.
+    func withMembers(_ newMembers: [ConversationMember]) -> Conversation {
+        Conversation(
+            id: id,
+            clientConversationId: clientConversationId,
+            creator: creator,
+            createdAt: createdAt,
+            consent: consent,
+            kind: kind,
+            name: name,
+            description: description,
+            members: newMembers,
+            otherMember: otherMember,
+            messages: messages,
+            isPinned: isPinned,
+            isUnread: isUnread,
+            isMuted: isMuted,
+            pinnedOrder: pinnedOrder,
+            hidesInviteCard: hidesInviteCard,
+            lastMessage: lastMessage,
+            imageURL: imageURL,
+            imageSalt: imageSalt,
+            imageNonce: imageNonce,
+            imageEncryptionKey: imageEncryptionKey,
+            conversationEmoji: conversationEmoji,
+            includeInfoInPublicPreview: includeInfoInPublicPreview,
+            isDraft: isDraft,
+            invite: invite,
+            expiresAt: expiresAt,
+            debugInfo: debugInfo,
+            isLocked: isLocked,
+            agentJoinStatus: agentJoinStatus,
+            hasHadVerifiedAgent: hasHadVerifiedAgent,
+            wasCreatedFromAgentBuilder: wasCreatedFromAgentBuilder
+        )
+    }
+
     var displayName: String {
         computedDisplayName
     }

--- a/ConvosCore/Sources/ConvosCore/Storage/Repositories/ContactsRepository.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Repositories/ContactsRepository.swift
@@ -31,6 +31,14 @@ public protocol ContactsRepositoryProtocol: Sendable {
     /// Fetches a single contact by inboxId.
     func fetchContact(inboxId: String) throws -> Contact?
 
+    /// Targeted lookup of the canonical agent contacts for the given
+    /// template ids - at most one contact per id, with the same
+    /// per-template collapsing as `fetchAll()`. Used by the picker flows
+    /// to resolve picked agent templates without loading the whole
+    /// contacts table. Ids with no contact row are absent from the
+    /// result; order is unspecified.
+    func fetchContacts(templateIds: [String]) throws -> [Contact]
+
     /// Batch lookup of source-conversation metadata (name + kind) for the
     /// "you met them in X" subtitle on contact rows. Callers index by
     /// `addedViaConversationId`. Missing ids are absent from the result
@@ -66,6 +74,18 @@ extension ContactsRepositoryProtocol {
     /// handle a thrown error mid-paint.
     public func contact(for inboxId: String) -> Contact? {
         try? fetchContact(inboxId: inboxId)
+    }
+
+    /// Default `fetchContacts(templateIds:)` backed by `fetchAll()`, so
+    /// mock conformers stay minimal. The live repository overrides this
+    /// with an indexed query.
+    public func fetchContacts(templateIds: [String]) throws -> [Contact] {
+        guard !templateIds.isEmpty else { return [] }
+        let ids = Set(templateIds)
+        return try fetchAll().filter { contact in
+            guard let templateId = contact.agentTemplateId else { return false }
+            return ids.contains(templateId)
+        }
     }
 
     /// Convenience adapter for ConvosCore APIs that take a name-only
@@ -123,6 +143,24 @@ final class ContactsRepository: ContactsRepositoryProtocol, @unchecked Sendable 
     func fetchContact(inboxId: String) throws -> Contact? {
         try databaseReader.read { db in
             try DBContact.fetchOne(db, key: inboxId).map(Contact.init(dbContact:))
+        }
+    }
+
+    /// Indexed variant of the protocol's default implementation: fetches
+    /// only rows whose `agentTemplateId` is in `templateIds`, then applies
+    /// the same canonical per-template collapsing as `fetchAll()`. The
+    /// fetch order matches `canonicalContacts` so the representative
+    /// chosen per template is identical to the browse list's.
+    func fetchContacts(templateIds: [String]) throws -> [Contact] {
+        guard !templateIds.isEmpty else { return [] }
+        return try databaseReader.read { db in
+            let templates = try ContactsRepository.templateMap(db)
+            return try DBContact
+                .filter(templateIds.contains(DBContact.Columns.agentTemplateId))
+                .order(DBContact.Columns.addedAt, DBContact.Columns.inboxId)
+                .fetchAll(db)
+                .map(Contact.init(dbContact:))
+                .dedupingAgentsByTemplate(using: templates)
         }
     }
 


### PR DESCRIPTION
## Summary

Selecting contacts in the compose or contacts-tab picker and tapping Continue now shows the picked end state (names + avatars/emoji) in the conversation indicator immediately, instead of "New Convo", before the add-members / agents-join calls finish.

Picked humans were already seeded as synthetic draft members in the `.newConversationWithMembers` flow; this extends the same optimism to picked agents and to the compose flow:

- **Picked agents**: templateIds resolve back through `ContactsRepository`'s canonical agent contacts and are seeded as optimistic members built with the existing `AgentShareInfo.optimisticCardMember` vehicle, so the indicator title and avatar cluster include the agents (name + emoji) while their instances provision.
- **Overlay instead of gate**: agents join well after `.ready`, so widening the seeded-member count gate would block invite/metadata updates for the whole provisioning window. Pending agent synthetics are instead overlaid onto each DB emission and dropped per-template once the real member lands (matched by `templateId` profile metadata, count-based fallback for metadata lag). A failed `agents/join` clears the overlay and re-renders ground truth, so the indicator never permanently promises an agent that won't arrive.
- **Compose flow**: `ComposeFlowView` seeds the full selection optimistically at Continue (`seedOptimisticPickedMembers`), and rolls the optimistic humans back if the real add-members call throws.
- `Conversation.withMembers(_:)` (ConvosCore) is a small copy helper for the overlay.

Known limitation: a suggested agent with no contact row keeps the current non-optimistic behavior — painting it needs the async share-resolver path (follow-up).

## Test plan

- ConvosCore suite: 1129 tests / 163 suites pass (local XMTP node via Docker).
- SwiftLint clean; `Convos (Dev)` builds; all changed files pass the 100ms type-check gate with zero warnings. (The two type-check failures the flagged Debug build surfaces in `CloudConnectionGrantRequestCardView` / `AddFromContactsPickerModifier` reproduce on a clean `origin/dev` checkout and are not from this diff.)
- Simulator-verified on both picker entry points: agent-only selection renders "Fitness Trainer" + emoji avatar + contact card with "Agent is joining..." before the instance joins; a rejected `agents/join` rolls the indicator back to ground truth; human selection shows the picked name immediately with no flicker when the real member lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1028"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783705135&installation_id=128169237&pr_number=1028&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1028&signature=2f0ee77794f6ac6873bcbb0cc7078dbd357a45c68b69102255f49046597c55e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add optimistic end-state conversation indicators for picked members and agents
> - Shows selected participants (names, avatars, emojis) immediately in the conversation header while `add-members` and `agents/join` backend calls are in flight, using synthetic overlay members.
> - Adds `ConversationViewModel.seedOptimisticPickedMembers` and `rollbackOptimisticPickedMembers` to inject and remove optimistic human members; on `add-members` failure, human overlays are rolled back to the latest DB state.
> - Introduces `overlayingPendingSyntheticAgents` in `ConversationViewModel` to maintain selected agents in the header until the real agent appears, then de-duplicates; clears on join failure via `onAgentJoinError`.
> - Extends `ContactsRepository` with `fetchContacts(templateIds:)` to resolve agent contacts by template id without loading the full contacts table.
> - Risk: optimistic agent members persist until the join call completes or fails — a slow or silently dropped join could leave stale synthetic agents visible longer than expected.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cb4c600.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->