### PR TITLE
Fix duplicate Constant enum redeclaration in ConversationViewModel

### DIFF
--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -2127,6 +2127,11 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
         /// write inside it (a paste, or the first hypothesis of the next
         /// dictation) would be cleared too.
         static let dictationReclearWindow: TimeInterval = 1.5
+        /// How long the assistant join wait is measured before emitting
+        /// `assistant_join_timed_out`. Matches the join-request polling
+        /// window in SyncingManager, which itself covers the assistant
+        /// backend's roughly two-minute give-up with margin.
+        static let assistantJoinWaitWindow: TimeInterval = 150
     }
 }
 
@@ -3889,13 +3894,6 @@ extension ConversationViewModel {
         }
     }
 
-    private enum Constant {
-        /// How long the assistant join wait is measured before emitting
-        /// `assistant_join_timed_out`. Matches the join-request polling
-        /// window in SyncingManager, which itself covers the assistant
-        /// backend's roughly two-minute give-up with margin.
-        static let assistantJoinWaitWindow: TimeInterval = 150
-    }
 }
 
 extension UNUserNotificationCenter {

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -3893,7 +3893,6 @@ extension ConversationViewModel {
             }
         }
     }
-
 }
 
 extension UNUserNotificationCenter {


### PR DESCRIPTION
## Summary
- #1005 added a second `private enum Constant` to a `ConversationViewModel` extension, which fails to compile in the app target (`invalid redeclaration of 'Constant'`) and broke the Prod TestFlight build on dev ([failed run](https://github.com/xmtplabs/convos-ios/actions/runs/27296716013)).
- Merge `assistantJoinWaitWindow` into the existing `Constant` enum and remove the duplicate declaration.

The ConvosCore Tests and SwiftLint jobs passed on the broken commit because neither compiles the app target, which is why this slipped through to the TestFlight job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1029"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783710384&installation_id=128169237&pr_number=1029&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1029&signature=fc9ad5a6bacd613edd5a5a6e919edca0c926b8a2368d2e09154218d136f206ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix duplicate `Constant` enum redeclaration in `ConversationViewModel`
> Moves `assistantJoinWaitWindow` from a trailing private `Constant` enum into the main `Constant` namespace in [ConversationViewModel.swift](https://github.com/xmtplabs/convos-ios/pull/1029/files#diff-d056b0b131534648b6d13cddafd053be956f5d23d035ad2538db85a8cc370d8d), removing the duplicate declaration.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ec04011.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->