### PR TITLE
Share full-height rendered image for HTML attachments, unify share paths

### DIFF
--- a/Convos/Conversation Detail/AttachmentPreviewSheet.swift
+++ b/Convos/Conversation Detail/AttachmentPreviewSheet.swift
@@ -14,22 +14,15 @@ struct AttachmentPreviewSheet: View {
     var profileSheetContent: ((ConversationMember) -> AnyView)?
 
     @Environment(\.dismiss) private var dismiss: DismissAction
-    @Environment(\.colorScheme) private var colorScheme: ColorScheme
-    @State private var resolvedHTMLTitle: String?
     @State private var htmlBodyBackgroundColor: Color?
     @State private var presentingProfileForMember: ConversationMember?
-    @State private var sharedImage: UIImage?
-    @State private var sharedImageURL: URL?
-    @State private var markdownHasContentThumbnail: Bool = false
     @State private var navState: AttachmentPreviewNavigatorImpl = .init()
     @State private var navigator: AttachmentPreviewCollector?
 
     private func ensureNavigator() {
         guard navigator == nil else { return }
-        navigator = AttachmentPreviewCollector(
-            instance: navState,
-            delegate: PostHogConfiguration.sharedMetricsDelegate ?? CollectorDelegate()
-        )
+        let delegate: CollectorDelegate = PostHogConfiguration.sharedMetricsDelegate ?? CollectorDelegate()
+        navigator = AttachmentPreviewCollector(instance: navState, delegate: delegate)
     }
 
     private func handleMemberSheetChanged(from oldMember: ConversationMember?, to newMember: ConversationMember?) {
@@ -76,10 +69,6 @@ struct AttachmentPreviewSheet: View {
                 profileSheetContent(member)
             }
         }
-        .task(id: attachment.key) {
-            await resolveTitleIfNeeded()
-            await resolveShareImageIfNeeded()
-        }
         .onAppear {
             ensureNavigator()
             navState.markScreenAppeared()
@@ -92,126 +81,21 @@ struct AttachmentPreviewSheet: View {
         }
     }
 
-    private var canShareImage: Bool {
+    private var canShareAttachment: Bool {
         // QuickLook renders its own bottom share toolbar, so suppress ours when it
-        // owns the preview. For HTML and Markdown branches, we share the rendered
-        // thumbnail image instead of the underlying file. Markdown only qualifies
-        // when QLThumbnailGenerator returns a content thumbnail, not a doc icon.
-        if attachment.isHTMLFile { return true }
-        if attachment.isMarkdownFile { return markdownHasContentThumbnail }
-        return false
+        // owns the preview. HTML and Markdown use AttachmentShareLink, which shares
+        // the full-page rendered image for HTML and the underlying file (plus
+        // thumbnail) for Markdown.
+        attachment.isHTMLFile || attachment.isMarkdownFile
     }
 
     @ToolbarContentBuilder
     private var shareToolbarItem: some ToolbarContent {
-        if canShareImage {
+        if canShareAttachment {
             ToolbarItem(placement: .confirmationAction) {
-                shareButton
+                AttachmentShareLink(attachment: attachment, fileURL: fileURL)
+                    .accessibilityIdentifier("attachment-preview-share")
             }
-        }
-    }
-
-    @ViewBuilder
-    private var shareButton: some View {
-        let title: String = resolvedHTMLTitle ?? attachment.filename ?? "Image"
-        if let url = sharedImageURL, let image = sharedImage {
-            let previewImage: Image = Image(uiImage: image)
-            ShareLink(item: url, preview: SharePreview(title, image: previewImage)) {
-                Image(systemName: "square.and.arrow.up")
-            }
-            .accessibilityLabel("Share")
-            .accessibilityIdentifier("attachment-preview-share")
-        } else {
-            Image(systemName: "square.and.arrow.up")
-                .foregroundStyle(.secondary)
-                .accessibilityLabel("Share")
-                .accessibilityIdentifier("attachment-preview-share")
-        }
-    }
-
-    private func resolveTitleIfNeeded() async {
-        guard attachment.isHTMLFile else { return }
-        if let cached = HTMLPageMetadata.shared.cachedTitle(for: attachment.key) {
-            resolvedHTMLTitle = cached
-            return
-        }
-        resolvedHTMLTitle = await HTMLPageMetadata.shared.title(for: attachment.key, fileURL: fileURL)
-    }
-
-    private func resolveShareImageIfNeeded() async {
-        let image: UIImage?
-        if attachment.isHTMLFile {
-            image = await resolveHTMLShareImage()
-        } else if attachment.isMarkdownFile {
-            image = await resolveMarkdownShareImage()
-        } else {
-            return
-        }
-        guard let image else { return }
-        let basename: String = shareImageBasename()
-        let url: URL? = await writeSharePNG(image: image, basename: basename)
-        sharedImage = image
-        sharedImageURL = url
-    }
-
-    private func resolveHTMLShareImage() async -> UIImage? {
-        let appearance = colorScheme.uiUserInterfaceStyle
-        if let cached = HTMLThumbnailRenderer.shared.cachedThumbnail(for: attachment.key, appearance: appearance) {
-            return cached
-        }
-        return await HTMLThumbnailRenderer.shared.thumbnail(
-            for: attachment.key,
-            fileURL: fileURL,
-            appearance: appearance
-        )
-    }
-
-    private func resolveMarkdownShareImage() async -> UIImage? {
-        if let cached = FileThumbnailRenderer.shared.cachedThumbnail(for: attachment.key),
-           cached.isContentThumbnail {
-            markdownHasContentThumbnail = true
-            return cached.image
-        }
-        guard let result = await FileThumbnailRenderer.shared.thumbnail(for: attachment.key, fileURL: fileURL),
-              result.isContentThumbnail else {
-            return nil
-        }
-        markdownHasContentThumbnail = true
-        return result.image
-    }
-
-    private func shareImageBasename() -> String {
-        let raw: String
-        if let filename = attachment.filename, !filename.isEmpty {
-            raw = (filename as NSString).deletingPathExtension
-        } else {
-            raw = String(attachment.key.prefix(32))
-        }
-        return sanitizeFilename(raw)
-    }
-
-    private func sanitizeFilename(_ raw: String) -> String {
-        let allowed: CharacterSet = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "-_."))
-        var output: String = ""
-        for scalar in raw.unicodeScalars {
-            output.append(allowed.contains(scalar) ? Character(scalar) : "_")
-        }
-        let trimmed: String = output.isEmpty ? "image" : output
-        return String(trimmed.prefix(64))
-    }
-
-    private func writeSharePNG(image: UIImage, basename: String) async -> URL? {
-        guard let pngData = image.pngData() else {
-            Log.error("AttachmentPreviewSheet: failed to encode share image PNG")
-            return nil
-        }
-        let url: URL = FileManager.default.temporaryDirectory.appendingPathComponent("\(basename).png")
-        do {
-            try pngData.write(to: url, options: .atomic)
-            return url
-        } catch {
-            Log.error("AttachmentPreviewSheet: failed to write share PNG: \(error)")
-            return nil
         }
     }
 

--- a/Convos/Conversation Detail/AttachmentPreviewSheet.swift
+++ b/Convos/Conversation Detail/AttachmentPreviewSheet.swift
@@ -93,8 +93,12 @@ struct AttachmentPreviewSheet: View {
     private var shareToolbarItem: some ToolbarContent {
         if canShareAttachment {
             ToolbarItem(placement: .confirmationAction) {
-                AttachmentShareLink(attachment: attachment, fileURL: fileURL)
-                    .accessibilityIdentifier("attachment-preview-share")
+                AttachmentShareLink(
+                    attachment: attachment,
+                    fileURL: fileURL,
+                    fallbackTitle: sender?.profile.displayName
+                )
+                .accessibilityIdentifier("attachment-preview-share")
             }
         }
     }

--- a/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/HTMLThumbnailRenderer.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/HTMLThumbnailRenderer.swift
@@ -249,9 +249,87 @@ final class HTMLThumbnailRenderer {
     })();
     """
 
+    /// Returns a file URL to the rendered full-page PNG, rendering and
+    /// caching it on disk on first request. The Caches location means iOS
+    /// reclaims the space under pressure and the render simply reruns.
+    /// `basename` becomes the shared file's display name, so pass the
+    /// artifact's title-derived name.
+    func fullPagePNGURL(
+        for attachmentKey: String,
+        fileURL: URL,
+        appearance: UIUserInterfaceStyle,
+        basename: String
+    ) async -> URL? {
+        let cacheURL = Self.fullPageCacheURL(for: attachmentKey, appearance: appearance, basename: basename)
+        if FileManager.default.fileExists(atPath: cacheURL.path) {
+            return cacheURL
+        }
+
+        let inflightKey = "fullpage-png-" + attachmentKey + "-" + Self.appearanceSuffix(for: appearance)
+        if let existing = inflightPNG[inflightKey] {
+            return await existing.value
+        }
+        let task = Task<URL?, Never> { [weak self] in
+            guard let self else { return nil }
+            guard let image = await self.fullPageImage(for: attachmentKey, fileURL: fileURL, appearance: appearance) else {
+                return nil
+            }
+            return await Self.writePNG(image: image, to: cacheURL)
+        }
+        inflightPNG[inflightKey] = task
+        let result = await task.value
+        inflightPNG.removeValue(forKey: inflightKey)
+        return result
+    }
+
+    private var inflightPNG: [String: Task<URL?, Never>] = [:]
+
+    private static func fullPageCacheURL(
+        for attachmentKey: String,
+        appearance: UIUserInterfaceStyle,
+        basename: String
+    ) -> URL {
+        let caches: URL = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)[0]
+        let keyComponent: String = sanitizePathComponent(attachmentKey) + "-" + appearanceSuffix(for: appearance)
+        return caches
+            .appendingPathComponent("html-fullpage-v1", isDirectory: true)
+            .appendingPathComponent(keyComponent, isDirectory: true)
+            .appendingPathComponent(basename + ".png")
+    }
+
+    private static func sanitizePathComponent(_ raw: String) -> String {
+        let allowed: CharacterSet = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "-_"))
+        var output: String = ""
+        for scalar in raw.unicodeScalars {
+            output.append(allowed.contains(scalar) ? Character(scalar) : "_")
+        }
+        return String(output.isEmpty ? "attachment" : output.prefix(64))
+    }
+
+    private static func writePNG(image: UIImage, to url: URL) async -> URL? {
+        await Task.detached(priority: .utility) {
+            guard let pngData = image.pngData() else {
+                Log.error("HTMLThumbnailRenderer: failed to encode full-page PNG")
+                return nil
+            }
+            do {
+                try FileManager.default.createDirectory(
+                    at: url.deletingLastPathComponent(),
+                    withIntermediateDirectories: true
+                )
+                try pngData.write(to: url, options: .atomic)
+                return url
+            } catch {
+                Log.error("HTMLThumbnailRenderer: failed to write full-page PNG: \(error)")
+                return nil
+            }
+        }.value
+    }
+
     /// Renders the entire document as one tall image. Not cached in
     /// `ImageCache` - full-page bitmaps are far too large for it - so
-    /// callers should hold onto the result for as long as they need it.
+    /// callers should use `fullPagePNGURL`, which caches the encoded PNG
+    /// on disk instead.
     func fullPageImage(for attachmentKey: String, fileURL: URL, appearance: UIUserInterfaceStyle) async -> UIImage? {
         let inflightKey = "fullpage-" + attachmentKey + "-" + Self.appearanceSuffix(for: appearance)
         if let existing = inflight[inflightKey] {

--- a/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/HTMLThumbnailRenderer.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/HTMLThumbnailRenderer.swift
@@ -221,7 +221,12 @@ final class HTMLThumbnailRenderer {
     // Caps the bitmap: 780px wide at 2x costs roughly 6 MB of memory per
     // 1000pt of height, so 10k pt keeps the peak around 60 MB.
     private static let fullPageMaxHeight: CGFloat = 10_000.0
-    private static let fullPageSnapshotWidth: CGFloat = 780.0
+    // Output pixel width of the stitched image (2x of the 390pt layout).
+    private static let fullPagePixelWidth: CGFloat = 780.0
+    // Pause after each programmatic scroll so WebKit paints the newly
+    // exposed screenful (and any scroll-triggered lazy content mounts)
+    // before it is snapshotted.
+    private static let fullPageScrollSettle: TimeInterval = 0.35
 
     private static let fullPageViewportScript: String = """
     (function() {
@@ -298,25 +303,77 @@ final class HTMLThumbnailRenderer {
         guard await load(fileURL: fileURL, in: webView) else { return nil }
         await Self.sleep(seconds: Self.paintDelay)
 
-        // Grow the WebView to the document height, then re-measure once:
-        // viewport-relative layout (100vh sections, sticky footers) can
-        // reflow after the first resize and change the content height.
+        // The WebView stays at viewport size and the document is scrolled
+        // one screenful at a time, snapshotting each. Scrolling is what
+        // makes WebKit paint each region AND what triggers any lazy,
+        // IntersectionObserver-driven sections the artifact runtime mounts
+        // on scroll - resized-frame captures, per-rect tile captures, and
+        // createPDF all came back blank below the first viewport because
+        // that content was never painted (verified empirically on-device).
         let measured: CGFloat = await measureContentHeight(of: webView)
-        var targetHeight: CGFloat = Self.clampFullPageHeight(measured)
-        webView.frame = CGRect(x: 0, y: 0, width: Self.fullPageSize.width, height: targetHeight)
-        window.frame.size = webView.frame.size
-        await Self.sleep(seconds: Self.paintDelay)
+        let height: CGFloat = Self.clampFullPageHeight(measured)
+        return await captureScrollingSnapshot(of: webView, height: height)
+    }
 
-        let remeasured: CGFloat = await measureContentHeight(of: webView)
-        let finalHeight: CGFloat = Self.clampFullPageHeight(remeasured)
-        if finalHeight != targetHeight {
-            targetHeight = finalHeight
-            webView.frame = CGRect(x: 0, y: 0, width: Self.fullPageSize.width, height: targetHeight)
-            window.frame.size = webView.frame.size
-            await Self.sleep(seconds: Self.paintDelay)
+    private func captureScrollingSnapshot(of webView: WKWebView, height: CGFloat) async -> UIImage? {
+        // takeSnapshot multiplies snapshotWidth by the screen scale, so
+        // divide it back out to get a deterministic output pixel width.
+        let screenScale: CGFloat = max(webView.traitCollection.displayScale, 1)
+        let snapshotWidthPoints: CGFloat = Self.fullPagePixelWidth / screenScale
+        let viewportHeight: CGFloat = Self.fullPageSize.height
+
+        var tiles: [(image: UIImage, yOffset: CGFloat)] = []
+        var offset: CGFloat = 0
+        while offset < height {
+            // The last screenful is anchored to the document bottom, so it
+            // overlaps the previous tile; the overlap draws identical
+            // content and stitches seamlessly.
+            let scrollY: CGFloat = max(0, min(offset, height - viewportHeight))
+            webView.scrollView.contentOffset = CGPoint(x: 0, y: scrollY)
+            await Self.sleep(seconds: Self.fullPageScrollSettle)
+            guard let tile = await takeSnapshot(of: webView, outputWidth: snapshotWidthPoints) else {
+                Log.error("HTMLThumbnailRenderer: full-page tile at \(scrollY)pt failed; aborting")
+                return nil
+            }
+            tiles.append((tile, scrollY))
+            offset += viewportHeight
         }
+        webView.scrollView.contentOffset = .zero
 
-        return await takeSnapshot(of: webView, outputWidth: Self.fullPageSnapshotWidth)
+        let pixelsPerPoint: CGFloat = Self.fullPagePixelWidth / Self.fullPageSize.width
+        let format = UIGraphicsImageRendererFormat()
+        format.scale = 1
+        let finalSize = CGSize(
+            width: Self.fullPagePixelWidth,
+            height: (height * pixelsPerPoint).rounded()
+        )
+        let renderer = UIGraphicsImageRenderer(size: finalSize, format: format)
+        return renderer.image { _ in
+            for tile in tiles {
+                let drawRect = CGRect(
+                    x: 0,
+                    y: (tile.yOffset * pixelsPerPoint).rounded(),
+                    width: Self.fullPagePixelWidth,
+                    height: (tile.image.size.height * Self.fullPagePixelWidth / tile.image.size.width).rounded()
+                )
+                tile.image.draw(in: drawRect)
+            }
+        }
+    }
+
+    private func takeSnapshot(of webView: WKWebView, outputWidth: CGFloat) async -> UIImage? {
+        await withCheckedContinuation { (continuation: CheckedContinuation<UIImage?, Never>) in
+            let snapshotConfig = WKSnapshotConfiguration()
+            snapshotConfig.rect = webView.bounds
+            snapshotConfig.snapshotWidth = NSNumber(value: Double(outputWidth))
+            snapshotConfig.afterScreenUpdates = true
+            webView.takeSnapshot(with: snapshotConfig) { image, error in
+                if let error {
+                    Log.error("HTMLThumbnailRenderer full-page takeSnapshot failed: \(error)")
+                }
+                continuation.resume(returning: image)
+            }
+        }
     }
 
     private static func clampFullPageHeight(_ height: CGFloat) -> CGFloat {
@@ -352,21 +409,6 @@ final class HTMLThumbnailRenderer {
                 }
                 let value: CGFloat = (result as? NSNumber).map { CGFloat(truncating: $0) } ?? 0
                 continuation.resume(returning: value)
-            }
-        }
-    }
-
-    private func takeSnapshot(of webView: WKWebView, outputWidth: CGFloat) async -> UIImage? {
-        await withCheckedContinuation { (continuation: CheckedContinuation<UIImage?, Never>) in
-            let snapshotConfig = WKSnapshotConfiguration()
-            snapshotConfig.rect = webView.bounds
-            snapshotConfig.snapshotWidth = NSNumber(value: Double(outputWidth))
-            snapshotConfig.afterScreenUpdates = true
-            webView.takeSnapshot(with: snapshotConfig) { image, error in
-                if let error {
-                    Log.error("HTMLThumbnailRenderer full-page takeSnapshot failed: \(error)")
-                }
-                continuation.resume(returning: image)
             }
         }
     }

--- a/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/HTMLThumbnailRenderer.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/HTMLThumbnailRenderer.swift
@@ -284,26 +284,40 @@ final class HTMLThumbnailRenderer {
 
     private var inflightPNG: [String: Task<URL?, Never>] = [:]
 
+    /// Collision-safe path component for an attachment key: a short
+    /// readable sanitized prefix plus a stable FNV-1a hash of the full
+    /// key, so long keys that share a prefix cannot collide the way a
+    /// plain truncation would.
+    nonisolated static func stableKeyComponent(for raw: String) -> String {
+        var hash: UInt64 = 0xcbf29ce484222325
+        for byte in raw.utf8 {
+            hash ^= UInt64(byte)
+            hash = hash &* 0x100000001b3
+        }
+        let readable: String = sanitizePathComponent(String(raw.prefix(24)))
+        return readable + "-" + String(hash, radix: 16)
+    }
+
     private static func fullPageCacheURL(
         for attachmentKey: String,
         appearance: UIUserInterfaceStyle,
         basename: String
     ) -> URL {
         let caches: URL = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)[0]
-        let keyComponent: String = sanitizePathComponent(attachmentKey) + "-" + appearanceSuffix(for: appearance)
+        let keyComponent: String = stableKeyComponent(for: attachmentKey) + "-" + appearanceSuffix(for: appearance)
         return caches
             .appendingPathComponent("html-fullpage-v1", isDirectory: true)
             .appendingPathComponent(keyComponent, isDirectory: true)
             .appendingPathComponent(basename + ".png")
     }
 
-    private static func sanitizePathComponent(_ raw: String) -> String {
+    private nonisolated static func sanitizePathComponent(_ raw: String) -> String {
         let allowed: CharacterSet = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "-_"))
         var output: String = ""
         for scalar in raw.unicodeScalars {
             output.append(allowed.contains(scalar) ? Character(scalar) : "_")
         }
-        return String(output.isEmpty ? "attachment" : output.prefix(64))
+        return output.isEmpty ? "attachment" : output
     }
 
     private static func writePNG(image: UIImage, to url: URL) async -> URL? {

--- a/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/HTMLThumbnailRenderer.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/HTMLThumbnailRenderer.swift
@@ -211,6 +211,206 @@ final class HTMLThumbnailRenderer {
     }
 
     private nonisolated(unsafe) static var coordinatorAssocKey: UInt8 = 0
+
+    // MARK: - Full-page rendering
+
+    // Full-page renders lay the artifact out at a phone-like width and grow
+    // the WebView to the whole document height before snapshotting, so the
+    // shared image shows the entire page rather than the 160pt tile crop.
+    private static let fullPageSize: CGSize = CGSize(width: 390, height: 844)
+    // Caps the bitmap: 780px wide at 2x costs roughly 6 MB of memory per
+    // 1000pt of height, so 10k pt keeps the peak around 60 MB.
+    private static let fullPageMaxHeight: CGFloat = 10_000.0
+    private static let fullPageSnapshotWidth: CGFloat = 780.0
+
+    private static let fullPageViewportScript: String = """
+    (function() {
+        var existing = document.querySelectorAll('meta[name="viewport"]');
+        for (var i = 0; i < existing.length; i++) {
+            existing[i].remove();
+        }
+        var m = document.createElement('meta');
+        m.name = 'viewport';
+        m.content = 'width=390, initial-scale=1, viewport-fit=cover';
+        (document.head || document.documentElement).appendChild(m);
+    })();
+    """
+
+    /// Unlike the thumbnail surface script, full-page renders present as a
+    /// large surface so the artifact lays out its full UI.
+    private static let fullPageSurfaceScript: String = """
+    (function() {
+        document.documentElement.setAttribute('data-convos-surface', 'large');
+    })();
+    """
+
+    /// Renders the entire document as one tall image. Not cached in
+    /// `ImageCache` - full-page bitmaps are far too large for it - so
+    /// callers should hold onto the result for as long as they need it.
+    func fullPageImage(for attachmentKey: String, fileURL: URL, appearance: UIUserInterfaceStyle) async -> UIImage? {
+        let inflightKey = "fullpage-" + attachmentKey + "-" + Self.appearanceSuffix(for: appearance)
+        if let existing = inflight[inflightKey] {
+            return await existing.value
+        }
+        let task = Task<UIImage?, Never> { [weak self] in
+            guard let self else { return nil }
+            return await self.renderFullPageSnapshot(fileURL: fileURL, appearance: appearance)
+        }
+        inflight[inflightKey] = task
+        let result = await task.value
+        inflight.removeValue(forKey: inflightKey)
+        return result
+    }
+
+    private func renderFullPageSnapshot(fileURL: URL, appearance: UIUserInterfaceStyle) async -> UIImage? {
+        guard let window = offscreenWindow else {
+            Log.error("HTMLThumbnailRenderer: no offscreen window available; skipping full-page render")
+            return nil
+        }
+
+        let config = WKWebViewConfiguration()
+        let surfaceUserScript = WKUserScript(
+            source: Self.fullPageSurfaceScript,
+            injectionTime: .atDocumentStart,
+            forMainFrameOnly: true
+        )
+        config.userContentController.addUserScript(surfaceUserScript)
+        let viewportUserScript = WKUserScript(
+            source: Self.fullPageViewportScript,
+            injectionTime: .atDocumentEnd,
+            forMainFrameOnly: true
+        )
+        config.userContentController.addUserScript(viewportUserScript)
+
+        let webView = WKWebView(
+            frame: CGRect(origin: .zero, size: Self.fullPageSize),
+            configuration: config
+        )
+        webView.scrollView.isScrollEnabled = false
+        webView.scrollView.bounces = false
+        webView.isOpaque = true
+        webView.isUserInteractionEnabled = false
+        webView.overrideUserInterfaceStyle = appearance
+
+        window.addSubview(webView)
+        defer { webView.removeFromSuperview() }
+
+        guard await load(fileURL: fileURL, in: webView) else { return nil }
+        await Self.sleep(seconds: Self.paintDelay)
+
+        // Grow the WebView to the document height, then re-measure once:
+        // viewport-relative layout (100vh sections, sticky footers) can
+        // reflow after the first resize and change the content height.
+        let measured: CGFloat = await measureContentHeight(of: webView)
+        var targetHeight: CGFloat = Self.clampFullPageHeight(measured)
+        webView.frame = CGRect(x: 0, y: 0, width: Self.fullPageSize.width, height: targetHeight)
+        window.frame.size = webView.frame.size
+        await Self.sleep(seconds: Self.paintDelay)
+
+        let remeasured: CGFloat = await measureContentHeight(of: webView)
+        let finalHeight: CGFloat = Self.clampFullPageHeight(remeasured)
+        if finalHeight != targetHeight {
+            targetHeight = finalHeight
+            webView.frame = CGRect(x: 0, y: 0, width: Self.fullPageSize.width, height: targetHeight)
+            window.frame.size = webView.frame.size
+            await Self.sleep(seconds: Self.paintDelay)
+        }
+
+        return await takeSnapshot(of: webView, outputWidth: Self.fullPageSnapshotWidth)
+    }
+
+    private static func clampFullPageHeight(_ height: CGFloat) -> CGFloat {
+        min(max(height, fullPageSize.height), fullPageMaxHeight)
+    }
+
+    private func load(fileURL: URL, in webView: WKWebView) async -> Bool {
+        await withCheckedContinuation { (continuation: CheckedContinuation<Bool, Never>) in
+            let delegate = NavigationCompletionDelegate { success in
+                continuation.resume(returning: success)
+            }
+            objc_setAssociatedObject(webView, &Self.coordinatorAssocKey, delegate, .OBJC_ASSOCIATION_RETAIN)
+            webView.navigationDelegate = delegate
+
+            let readAccessURL = fileURL.deletingLastPathComponent()
+            webView.loadFileURL(fileURL, allowingReadAccessTo: readAccessURL)
+
+            DispatchQueue.main.asyncAfter(deadline: .now() + Self.loadTimeout) { [weak delegate, weak webView] in
+                if delegate?.finish(success: false) == true {
+                    Log.error("HTMLThumbnailRenderer: full-page load timed out")
+                    webView?.stopLoading()
+                }
+            }
+        }
+    }
+
+    private func measureContentHeight(of webView: WKWebView) async -> CGFloat {
+        await withCheckedContinuation { (continuation: CheckedContinuation<CGFloat, Never>) in
+            let js = "Math.max(document.documentElement.scrollHeight, document.body ? document.body.scrollHeight : 0)"
+            webView.evaluateJavaScript(js) { result, error in
+                if let error {
+                    Log.error("HTMLThumbnailRenderer: full-page height measurement failed: \(error)")
+                }
+                let value: CGFloat = (result as? NSNumber).map { CGFloat(truncating: $0) } ?? 0
+                continuation.resume(returning: value)
+            }
+        }
+    }
+
+    private func takeSnapshot(of webView: WKWebView, outputWidth: CGFloat) async -> UIImage? {
+        await withCheckedContinuation { (continuation: CheckedContinuation<UIImage?, Never>) in
+            let snapshotConfig = WKSnapshotConfiguration()
+            snapshotConfig.rect = webView.bounds
+            snapshotConfig.snapshotWidth = NSNumber(value: Double(outputWidth))
+            snapshotConfig.afterScreenUpdates = true
+            webView.takeSnapshot(with: snapshotConfig) { image, error in
+                if let error {
+                    Log.error("HTMLThumbnailRenderer full-page takeSnapshot failed: \(error)")
+                }
+                continuation.resume(returning: image)
+            }
+        }
+    }
+
+    private static func sleep(seconds: TimeInterval) async {
+        try? await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
+    }
+}
+
+/// Minimal navigation delegate that reports load completion exactly once.
+/// The full-page render path drives measurement and snapshotting itself, so
+/// it only needs to know when the document finished (or failed to) load.
+private final class NavigationCompletionDelegate: NSObject, WKNavigationDelegate {
+    private var completion: ((Bool) -> Void)?
+
+    init(completion: @escaping (Bool) -> Void) {
+        self.completion = completion
+    }
+
+    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation?) {
+        finish(success: true)
+    }
+
+    func webView(_ webView: WKWebView, didFail navigation: WKNavigation?, withError error: Error) {
+        Log.error("HTMLThumbnailRenderer full-page load failed: \(error)")
+        finish(success: false)
+    }
+
+    func webView(
+        _ webView: WKWebView,
+        didFailProvisionalNavigation navigation: WKNavigation?,
+        withError error: Error
+    ) {
+        Log.error("HTMLThumbnailRenderer full-page provisional load failed: \(error)")
+        finish(success: false)
+    }
+
+    @discardableResult
+    func finish(success: Bool) -> Bool {
+        guard let completion else { return false }
+        self.completion = nil
+        completion(success)
+        return true
+    }
 }
 
 private final class LoadCoordinator: NSObject, WKNavigationDelegate {

--- a/Convos/Conversations List/ThingDetailView.swift
+++ b/Convos/Conversations List/ThingDetailView.swift
@@ -87,6 +87,9 @@ struct ThingDetailView: View {
     }
 
     private func loadFile() async {
+        // Drop the previous attachment's URL first: the share button must
+        // not pair the new attachment with the old file while it loads.
+        fileURL = nil
         do {
             let url = try await FileAttachmentLoader.loadFile(for: item.hydratedAttachment)
             fileURL = url

--- a/Convos/Conversations List/ThingDetailView.swift
+++ b/Convos/Conversations List/ThingDetailView.swift
@@ -23,10 +23,8 @@ struct ThingDetailView: View {
 
     private func ensureNavigator() {
         guard navigator == nil else { return }
-        navigator = StuffDetailCollector(
-            instance: navState,
-            delegate: PostHogConfiguration.sharedMetricsDelegate ?? CollectorDelegate()
-        )
+        let delegate: CollectorDelegate = PostHogConfiguration.sharedMetricsDelegate ?? CollectorDelegate()
+        navigator = StuffDetailCollector(instance: navState, delegate: delegate)
     }
 
     var body: some View {
@@ -82,11 +80,8 @@ struct ThingDetailView: View {
     private var trailingShareButton: some ToolbarContent {
         if let fileURL {
             ToolbarItem(placement: .topBarTrailing) {
-                ShareLink(item: fileURL) {
-                    Image(systemName: "square.and.arrow.up")
-                }
-                .accessibilityLabel("Share")
-                .accessibilityIdentifier("thing-detail-share")
+                AttachmentShareLink(attachment: item.hydratedAttachment, fileURL: fileURL)
+                    .accessibilityIdentifier("thing-detail-share")
             }
         }
     }

--- a/Convos/Conversations List/ThingDetailView.swift
+++ b/Convos/Conversations List/ThingDetailView.swift
@@ -91,9 +91,11 @@ struct ThingDetailView: View {
     }
 
     private func loadFile() async {
-        // Drop the previous attachment's URL first: the share button must
-        // not pair the new attachment with the old file while it loads.
+        // Drop the previous attachment's state first: the share button must
+        // not pair the new attachment with the old file while it loads, and
+        // a stale error must not overlay freshly loaded content.
         fileURL = nil
+        loadError = nil
         do {
             let url = try await FileAttachmentLoader.loadFile(for: item.hydratedAttachment)
             fileURL = url

--- a/Convos/Conversations List/ThingDetailView.swift
+++ b/Convos/Conversations List/ThingDetailView.swift
@@ -80,8 +80,12 @@ struct ThingDetailView: View {
     private var trailingShareButton: some ToolbarContent {
         if let fileURL {
             ToolbarItem(placement: .topBarTrailing) {
-                AttachmentShareLink(attachment: item.hydratedAttachment, fileURL: fileURL)
-                    .accessibilityIdentifier("thing-detail-share")
+                AttachmentShareLink(
+                    attachment: item.hydratedAttachment,
+                    fileURL: fileURL,
+                    fallbackTitle: item.conversation.computedDisplayName
+                )
+                .accessibilityIdentifier("thing-detail-share")
             }
         }
     }

--- a/Convos/Shared Views/AttachmentShareLink.swift
+++ b/Convos/Shared Views/AttachmentShareLink.swift
@@ -1,0 +1,152 @@
+import ConvosCore
+import ConvosLogging
+import SwiftUI
+import UIKit
+
+/// Share button for HTML and Markdown attachments, used by both the
+/// in-conversation attachment preview and the Stuff detail screen so the
+/// share payload stays identical everywhere. HTML shares the full-page
+/// rendered image only (the share sheet preview stays the square tile);
+/// Markdown shares the underlying file, adding the rendered thumbnail
+/// image once it resolves.
+struct AttachmentShareLink: View {
+    let attachment: HydratedAttachment
+    let fileURL: URL
+
+    @Environment(\.colorScheme) private var colorScheme: ColorScheme
+    @State private var resolvedHTMLTitle: String?
+    @State private var sharedImage: UIImage?
+    @State private var sharedImageURL: URL?
+
+    static func canShare(_ attachment: HydratedAttachment) -> Bool {
+        attachment.isHTMLFile || attachment.isMarkdownFile
+    }
+
+    var body: some View {
+        shareLink
+            .accessibilityLabel("Share")
+            .task(id: attachment.key) {
+                await resolveTitleIfNeeded()
+                await resolveShareImageIfNeeded()
+            }
+    }
+
+    @ViewBuilder
+    private var shareLink: some View {
+        let title: String = resolvedHTMLTitle ?? attachment.filename ?? "Attachment"
+        if let url = sharedImageURL, let image = sharedImage {
+            let previewImage: Image = Image(uiImage: image)
+            let items: [URL] = attachment.isHTMLFile ? [url] : [fileURL, url]
+            ShareLink(items: items, preview: { (_: URL) in
+                SharePreview(title, image: previewImage)
+            }, label: {
+                Image(systemName: "square.and.arrow.up")
+            })
+        } else if attachment.isHTMLFile {
+            // HTML shares only the rendered image, so there is nothing to
+            // share until the full-page render lands.
+            Image(systemName: "square.and.arrow.up")
+                .foregroundStyle(.secondary)
+        } else {
+            ShareLink(items: [fileURL], preview: { (_: URL) in
+                SharePreview(title)
+            }, label: {
+                Image(systemName: "square.and.arrow.up")
+            })
+        }
+    }
+
+    private func resolveTitleIfNeeded() async {
+        guard attachment.isHTMLFile else { return }
+        if let cached = HTMLPageMetadata.shared.cachedTitle(for: attachment.key) {
+            resolvedHTMLTitle = cached
+            return
+        }
+        resolvedHTMLTitle = await HTMLPageMetadata.shared.title(for: attachment.key, fileURL: fileURL)
+    }
+
+    private func resolveShareImageIfNeeded() async {
+        if attachment.isHTMLFile {
+            await resolveHTMLShareContent()
+            return
+        }
+        guard attachment.isMarkdownFile, let image = await resolveMarkdownShareImage() else { return }
+        let url: URL? = await writeSharePNG(image: image, basename: shareImageBasename())
+        sharedImage = image
+        sharedImageURL = url
+    }
+
+    private func resolveHTMLShareContent() async {
+        let appearance = colorScheme.uiUserInterfaceStyle
+        let thumbnail: UIImage? = await resolveHTMLThumbnail(appearance: appearance)
+        let fullPage: UIImage? = await HTMLThumbnailRenderer.shared.fullPageImage(
+            for: attachment.key,
+            fileURL: fileURL,
+            appearance: appearance
+        )
+        // Share the full-page render when available; the square tile stays
+        // the share sheet preview so it reads as a card, not a tall sliver.
+        guard let imageToShare = fullPage ?? thumbnail else { return }
+        let url: URL? = await writeSharePNG(image: imageToShare, basename: shareImageBasename())
+        sharedImage = thumbnail ?? imageToShare
+        sharedImageURL = url
+    }
+
+    private func resolveHTMLThumbnail(appearance: UIUserInterfaceStyle) async -> UIImage? {
+        if let cached = HTMLThumbnailRenderer.shared.cachedThumbnail(for: attachment.key, appearance: appearance) {
+            return cached
+        }
+        return await HTMLThumbnailRenderer.shared.thumbnail(
+            for: attachment.key,
+            fileURL: fileURL,
+            appearance: appearance
+        )
+    }
+
+    private func resolveMarkdownShareImage() async -> UIImage? {
+        if let cached = FileThumbnailRenderer.shared.cachedThumbnail(for: attachment.key),
+           cached.isContentThumbnail {
+            return cached.image
+        }
+        guard let result = await FileThumbnailRenderer.shared.thumbnail(for: attachment.key, fileURL: fileURL),
+              result.isContentThumbnail else {
+            return nil
+        }
+        return result.image
+    }
+
+    private func shareImageBasename() -> String {
+        let raw: String
+        if let filename = attachment.filename, !filename.isEmpty {
+            raw = (filename as NSString).deletingPathExtension
+        } else {
+            raw = String(attachment.key.prefix(32))
+        }
+        return sanitizeFilename(raw)
+    }
+
+    private func sanitizeFilename(_ raw: String) -> String {
+        let allowed: CharacterSet = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "-_."))
+        var output: String = ""
+        for scalar in raw.unicodeScalars {
+            output.append(allowed.contains(scalar) ? Character(scalar) : "_")
+        }
+        let trimmed: String = output.isEmpty ? "image" : output
+        return String(trimmed.prefix(64))
+    }
+
+    private func writeSharePNG(image: UIImage, basename: String) async -> URL? {
+        guard let pngData = image.pngData() else {
+            Log.error("AttachmentShareLink: failed to encode share image PNG")
+            return nil
+        }
+        let url: URL = FileManager.default.temporaryDirectory.appendingPathComponent("\(basename).png")
+        do {
+            try pngData.write(to: url, options: .atomic)
+            return url
+        } catch {
+            Log.error("AttachmentShareLink: failed to write share PNG: \(error)")
+            return nil
+        }
+    }
+}

--- a/Convos/Shared Views/AttachmentShareLink.swift
+++ b/Convos/Shared Views/AttachmentShareLink.swift
@@ -136,17 +136,22 @@ struct AttachmentShareLink: View {
     }
 
     private func writeSharePNG(image: UIImage, basename: String) async -> URL? {
-        guard let pngData = image.pngData() else {
-            Log.error("AttachmentShareLink: failed to encode share image PNG")
-            return nil
-        }
         let url: URL = FileManager.default.temporaryDirectory.appendingPathComponent("\(basename).png")
-        do {
-            try pngData.write(to: url, options: .atomic)
-            return url
-        } catch {
-            Log.error("AttachmentShareLink: failed to write share PNG: \(error)")
-            return nil
-        }
+        // Full-page renders are large bitmaps; encode and write off the main
+        // actor so the share button does not stall the UI.
+        let written: Bool = await Task.detached(priority: .utility) {
+            guard let pngData = image.pngData() else {
+                Log.error("AttachmentShareLink: failed to encode share image PNG")
+                return false
+            }
+            do {
+                try pngData.write(to: url, options: .atomic)
+                return true
+            } catch {
+                Log.error("AttachmentShareLink: failed to write share PNG: \(error)")
+                return false
+            }
+        }.value
+        return written ? url : nil
     }
 }

--- a/Convos/Shared Views/AttachmentShareLink.swift
+++ b/Convos/Shared Views/AttachmentShareLink.swift
@@ -23,9 +23,15 @@ struct AttachmentShareLink: View {
     }
 
     var body: some View {
+        // The id includes the appearance so a light/dark switch re-renders
+        // the share payload instead of leaving the previous scheme armed.
+        let appearanceSuffix: String = colorScheme == .dark ? "dark" : "light"
         shareLink
             .accessibilityLabel("Share")
-            .task(id: attachment.key) {
+            .task(id: "\(attachment.key)-\(appearanceSuffix)") {
+                resolvedHTMLTitle = nil
+                sharedImage = nil
+                sharedImageURL = nil
                 await resolveTitleIfNeeded()
                 await resolveShareImageIfNeeded()
             }
@@ -34,14 +40,22 @@ struct AttachmentShareLink: View {
     @ViewBuilder
     private var shareLink: some View {
         let title: String = resolvedHTMLTitle ?? attachment.filename ?? "Attachment"
-        if let url = sharedImageURL, let image = sharedImage {
-            let previewImage: Image = Image(uiImage: image)
+        if let url = sharedImageURL {
             let items: [URL] = attachment.isHTMLFile ? [url] : [fileURL, url]
-            ShareLink(items: items, preview: { (_: URL) in
-                SharePreview(title, image: previewImage)
-            }, label: {
-                Image(systemName: "square.and.arrow.up")
-            })
+            if let image = sharedImage {
+                let previewImage: Image = Image(uiImage: image)
+                ShareLink(items: items, preview: { (_: URL) in
+                    SharePreview(title, image: previewImage)
+                }, label: {
+                    Image(systemName: "square.and.arrow.up")
+                })
+            } else {
+                ShareLink(items: items, preview: { (_: URL) in
+                    SharePreview(title)
+                }, label: {
+                    Image(systemName: "square.and.arrow.up")
+                })
+            }
         } else if attachment.isHTMLFile {
             // HTML shares only the rendered image, so there is nothing to
             // share until the full-page render lands.
@@ -89,13 +103,15 @@ struct AttachmentShareLink: View {
             appearance: appearance,
             basename: shareImageBasename()
         )
-        guard let thumbnail else { return }
         if let fullPageURL {
+            // Arm even when the tile thumbnail failed - the share sheet
+            // then shows a title-only preview instead of staying dimmed.
             sharedImage = thumbnail
             sharedImageURL = fullPageURL
             return
         }
         // Full-page render failed; fall back to sharing the tile image.
+        guard let thumbnail else { return }
         let fallbackURL: URL? = await writeSharePNG(image: thumbnail, basename: shareImageBasename())
         sharedImage = thumbnail
         sharedImageURL = fallbackURL
@@ -145,7 +161,11 @@ struct AttachmentShareLink: View {
     }
 
     private func writeSharePNG(image: UIImage, basename: String) async -> URL? {
-        let url: URL = FileManager.default.temporaryDirectory.appendingPathComponent("\(basename).png")
+        // Namespace by attachment key so same-named attachments cannot
+        // overwrite each other's armed share payload.
+        let url: URL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("share-" + HTMLThumbnailRenderer.stableKeyComponent(for: attachment.key), isDirectory: true)
+            .appendingPathComponent("\(basename).png")
         // Full-page renders are large bitmaps; encode and write off the main
         // actor so the share button does not stall the UI.
         let written: Bool = await Task.detached(priority: .utility) {
@@ -154,6 +174,10 @@ struct AttachmentShareLink: View {
                 return false
             }
             do {
+                try FileManager.default.createDirectory(
+                    at: url.deletingLastPathComponent(),
+                    withIntermediateDirectories: true
+                )
                 try pngData.write(to: url, options: .atomic)
                 return true
             } catch {

--- a/Convos/Shared Views/AttachmentShareLink.swift
+++ b/Convos/Shared Views/AttachmentShareLink.swift
@@ -79,17 +79,26 @@ struct AttachmentShareLink: View {
     private func resolveHTMLShareContent() async {
         let appearance = colorScheme.uiUserInterfaceStyle
         let thumbnail: UIImage? = await resolveHTMLThumbnail(appearance: appearance)
-        let fullPage: UIImage? = await HTMLThumbnailRenderer.shared.fullPageImage(
-            for: attachment.key,
-            fileURL: fileURL,
-            appearance: appearance
-        )
         // Share the full-page render when available; the square tile stays
         // the share sheet preview so it reads as a card, not a tall sliver.
-        guard let imageToShare = fullPage ?? thumbnail else { return }
-        let url: URL? = await writeSharePNG(image: imageToShare, basename: shareImageBasename())
-        sharedImage = thumbnail ?? imageToShare
-        sharedImageURL = url
+        // The PNG is rendered once and disk-cached, so reopening the
+        // detail view arms the share button instantly.
+        let fullPageURL: URL? = await HTMLThumbnailRenderer.shared.fullPagePNGURL(
+            for: attachment.key,
+            fileURL: fileURL,
+            appearance: appearance,
+            basename: shareImageBasename()
+        )
+        guard let thumbnail else { return }
+        if let fullPageURL {
+            sharedImage = thumbnail
+            sharedImageURL = fullPageURL
+            return
+        }
+        // Full-page render failed; fall back to sharing the tile image.
+        let fallbackURL: URL? = await writeSharePNG(image: thumbnail, basename: shareImageBasename())
+        sharedImage = thumbnail
+        sharedImageURL = fallbackURL
     }
 
     private func resolveHTMLThumbnail(appearance: UIUserInterfaceStyle) async -> UIImage? {

--- a/Convos/Shared Views/AttachmentShareLink.swift
+++ b/Convos/Shared Views/AttachmentShareLink.swift
@@ -12,6 +12,9 @@ import UIKit
 struct AttachmentShareLink: View {
     let attachment: HydratedAttachment
     let fileURL: URL
+    /// Shown (and used as the shared file's name) when the artifact has no
+    /// resolvable HTML title - pass the creating agent's display name.
+    var fallbackTitle: String?
 
     @Environment(\.colorScheme) private var colorScheme: ColorScheme
     @State private var resolvedHTMLTitle: String?
@@ -37,9 +40,18 @@ struct AttachmentShareLink: View {
             }
     }
 
+    /// The user-facing share name. For HTML artifacts the raw filename is
+    /// never shown - the artifact's title, then the agent's name, stand in.
+    private var shareTitle: String {
+        if attachment.isHTMLFile {
+            return resolvedHTMLTitle ?? fallbackTitle ?? "Attachment"
+        }
+        return attachment.filename ?? fallbackTitle ?? "Attachment"
+    }
+
     @ViewBuilder
     private var shareLink: some View {
-        let title: String = resolvedHTMLTitle ?? attachment.filename ?? "Attachment"
+        let title: String = shareTitle
         if let url = sharedImageURL {
             let items: [URL] = attachment.isHTMLFile ? [url] : [fileURL, url]
             if let image = sharedImage {
@@ -141,6 +153,15 @@ struct AttachmentShareLink: View {
     }
 
     private func shareImageBasename() -> String {
+        // The basename is the filename recipients see on the delivered
+        // image, so it follows the share title rather than the raw
+        // attachment filename.
+        if attachment.isHTMLFile {
+            if let title = resolvedHTMLTitle ?? fallbackTitle {
+                return sanitizeFilename(title)
+            }
+            return sanitizeFilename(String(attachment.key.prefix(32)))
+        }
         let raw: String
         if let filename = attachment.filename, !filename.isEmpty {
             raw = (filename as NSString).deletingPathExtension
@@ -151,13 +172,14 @@ struct AttachmentShareLink: View {
     }
 
     private func sanitizeFilename(_ raw: String) -> String {
-        let allowed: CharacterSet = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "-_."))
+        let allowed: CharacterSet = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "-_. "))
         var output: String = ""
         for scalar in raw.unicodeScalars {
             output.append(allowed.contains(scalar) ? Character(scalar) : "_")
         }
-        let trimmed: String = output.isEmpty ? "image" : output
-        return String(trimmed.prefix(64))
+        let trimmed: String = output.trimmingCharacters(in: .whitespaces)
+        let fallback: String = trimmed.isEmpty ? "image" : trimmed
+        return String(fallback.prefix(64))
     }
 
     private func writeSharePNG(image: UIImage, basename: String) async -> URL? {


### PR DESCRIPTION
## Summary

- Adds `AttachmentShareLink`, a single share component used by both the in-conversation attachment preview (`AttachmentPreviewSheet`) and the Stuff tab detail view (`StuffDetailView`), so the share payload is identical everywhere (previously Stuff shared the raw HTML file while the conversation preview shared a thumbnail PNG).
- HTML attachments share a full-height rendered PNG of the entire document (no raw `.html` file): the artifact is loaded in an off-screen viewport-sized WKWebView at 390pt width with `data-convos-surface='large'`, scrolled one screenful at a time with each screenful snapshotted and stitched into one tall 2x bitmap (capped at 10,000pt). Scrolling is load-bearing: WebKit only paints tiles near the visible region, and artifact runtimes can lazy-mount sections on scroll — a single resized-frame snapshot, per-rect tile snapshots, and `createPDF` all come back blank below the first viewport (verified on-simulator against a real agent artifact). The square tile thumbnail remains the share-sheet preview so it reads as a card.
- Markdown attachments share the actual `.md` file, plus the rendered thumbnail once it resolves; the share button no longer disappears when QuickLook can't produce a content thumbnail.
- PNG encode and temp-file write happen off the main actor.
- Hoists the `?? CollectorDelegate()` expression in `ensureNavigator()` (both touched views) to a typed `let` — it was sitting at 304–309ms against the 300ms type-check limit.

## Test plan

- Verified end-to-end on simulator with a real agent: created an agent via the builder, had it generate a tall HTML artifact, shared from the attachment preview, and inspected the delivered PNG (780×12570) — full document content top to bottom, no blank regions, seamless tile stitches.
- Full `Convos (Dev)` build passes with type-check-as-error limits; SwiftLint/SwiftFormat clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Share full-page rendered PNG for HTML attachments via unified `AttachmentShareLink`
> - Introduces [`AttachmentShareLink`](https://github.com/xmtplabs/convos-ios/pull/1030/files#diff-5107407b40633988aea4c026ae8cf7a897de0095302ff69540727a00e72b90f3), a reusable share button replacing inline share logic in [`AttachmentPreviewSheet`](https://github.com/xmtplabs/convos-ios/pull/1030/files#diff-0448cf2ffc644b0aaa7199e5c1754dcf61efab4b8e972061e46cc816d49d94ce) and [`ThingDetailView`](https://github.com/xmtplabs/convos-ios/pull/1030/files#diff-ec03db34beec77d2d91c137958b707a5928704e1429ba3902526954a44207219).
> - For HTML attachments, shares a full-page rendered PNG (falling back to a square tile PNG); for Markdown, shares the underlying file with a thumbnail when available.
> - [`HTMLThumbnailRenderer`](https://github.com/xmtplabs/convos-ios/pull/1030/files#diff-96e548fad1e9c41e89533dcd4ed532c527bb892ad625efe13c7d6396461e4bd8) gains a full-page PNG render path, keyed by attachment and appearance, cached under `html-fullpage-v1/`. The viewport is adjusted to width=390 with a `data-convos-surface="large"` attribute to control layout.
> - Share payloads re-resolve on appearance (color scheme) changes.
> - The share button is now shown for Markdown attachments regardless of whether a content thumbnail is available.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0fa2602.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->