### PR TITLE
Give the agent contact card one stable placement rule

### DIFF
--- a/Convos/Agent Builder/AgentContactCardView.swift
+++ b/Convos/Agent Builder/AgentContactCardView.swift
@@ -2,9 +2,9 @@ import ConvosCore
 import SwiftUI
 
 /// Per-conversation "contact card" for a verified Convos agent. Renders as
-/// the body of the agent's first message group — the surrounding
-/// `MessagesGroupView` already provides the sender label and avatar, so this
-/// view only owns the rounded-rect card itself: the agent's avatar,
+/// the body of a standalone contact-card row anchored near where the agent
+/// joined — the surrounding `MessagesGroupView` already provides the sender
+/// label and avatar, so this view only owns the rounded-rect card itself: the agent's avatar,
 /// display name, and `description` subtitle. While the agent hasn't yet
 /// written a `description` into its profile metadata, the subtitle reads
 /// "Learning more about my job" with a pulse highlight matching

--- a/Convos/Conversation Detail/ConversationViewModel+TypingIndicators.swift
+++ b/Convos/Conversation Detail/ConversationViewModel+TypingIndicators.swift
@@ -147,7 +147,7 @@ extension ConversationViewModel {
            case .messages(let lastGroup) = messages[lastIndex],
            lastGroup.sender.profile.inboxId == typer.profile.inboxId {
             var updated = messages
-            let updatedGroup = MessagesGroup(
+            var updatedGroup = MessagesGroup(
                 id: lastGroup.id,
                 sender: lastGroup.sender,
                 messages: lastGroup.rawMessages,
@@ -160,6 +160,16 @@ extension ConversationViewModel {
                 isLastGroupBeforeOtherMembers: lastGroup.isLastGroupBeforeOtherMembers,
                 voiceMemoTranscripts: lastGroup.voiceMemoTranscripts
             )
+            // Copy the presentation side-channel fields the initializer
+            // doesn't take, so e.g. the agent contact card doesn't vanish
+            // from its group while the agent is typing.
+            updatedGroup.agentContactCard = lastGroup.agentContactCard
+            updatedGroup.contactCardPrecedesAgentMessages = lastGroup.contactCardPrecedesAgentMessages
+            updatedGroup.contactCardThinkingDescriptor = lastGroup.contactCardThinkingDescriptor
+            updatedGroup.thinkingByMessageId = lastGroup.thinkingByMessageId
+            updatedGroup.hidesSenderLabel = lastGroup.hidesSenderLabel
+            updatedGroup.adjacentToFullBleedAbove = lastGroup.adjacentToFullBleedAbove
+            updatedGroup.adjacentToFullBleedBelow = lastGroup.adjacentToFullBleedBelow
             updated[lastIndex] = .messages(updatedGroup)
             return updated
         }

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupView.swift
@@ -299,11 +299,15 @@ struct MessagesGroupView: View {
 
     @ViewBuilder
     private func contactCardRow(card: AgentContactCardInfo) -> some View {
-        // The card is the visual "last item" of the group only when the
-        // agent hasn't sent any messages yet (synthesized empty group).
-        // Otherwise the regular `messageRowContent` avatar overlay handles
-        // the leading avatar on the last message — we don't want to double up.
-        let cardIsLast: Bool = displayGroup.allMessages.isEmpty && !displayGroup.showsTypingIndicator && !displayGroup.showsThinkingIndicator
+        // The card shows its own bottom-leading avatar only when it is the
+        // visual end of the agent's run: nothing else in this group below it
+        // and no agent message group directly underneath. When the agent's
+        // messages sit directly below, that group's avatar overlay handles
+        // the leading avatar — we don't want to double up.
+        let cardIsLast: Bool = displayGroup.allMessages.isEmpty
+            && !displayGroup.showsTypingIndicator
+            && !displayGroup.showsThinkingIndicator
+            && !displayGroup.contactCardPrecedesAgentMessages
         HStack(alignment: .bottom, spacing: avatarSpacing) {
             if !displayGroup.sender.isCurrentUser {
                 Color.clear

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessagesListRepository.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessagesListRepository.swift
@@ -17,9 +17,10 @@ protocol MessagesListRepositoryProtocol {
     var currentOtherMemberCount: Int { get set }
     var sendReadReceipts: Bool { get set }
     /// The verified Convos agent in the conversation, if any. When set,
-    /// the processor attaches an `AgentContactCardInfo` to the agent's
-    /// first messages group (or synthesizes an empty one) and suppresses the
-    /// legacy "Agent joined" update bubble.
+    /// the processor inserts a standalone contact-card row (an empty
+    /// `MessagesGroup` carrying an `AgentContactCardInfo`) at a stable
+    /// anchor in the list and suppresses the legacy "Agent joined" update
+    /// bubble.
     var verifiedAgent: ConversationMember? { get set }
     /// The persisted Agent Builder summary for this conversation, if any.
     /// When set, the processor prepends a `.agentBuilderSummary` cell and

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/MessagesGroup.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/MessagesGroup.swift
@@ -59,6 +59,12 @@ public struct MessagesGroup: Identifiable, Equatable, Sendable {
     /// (post-Make). The card is the canonical anchor for "the agent
     /// is thinking about your build input".
     public var contactCardThinkingDescriptor: ThinkingSessionDescriptor?
+    /// True when this synthesized contact-card row is immediately followed
+    /// by a message group from the same agent. The card defers its
+    /// bottom-leading avatar to that group's last message (and the group
+    /// below hides its duplicate sender label) so the pair reads as one
+    /// visual run.
+    public var contactCardPrecedesAgentMessages: Bool = false
 
     public var isMultiTyper: Bool {
         allTypingMembers.count > 1
@@ -148,7 +154,8 @@ public struct MessagesGroup: Identifiable, Equatable, Sendable {
         lhs.showsThinkingIndicator == rhs.showsThinkingIndicator &&
         lhs.thinkingContent == rhs.thinkingContent &&
         lhs.usesThoughtBubbleStyle == rhs.usesThoughtBubbleStyle &&
-        lhs.contactCardThinkingDescriptor == rhs.contactCardThinkingDescriptor
+        lhs.contactCardThinkingDescriptor == rhs.contactCardThinkingDescriptor &&
+        lhs.contactCardPrecedesAgentMessages == rhs.contactCardPrecedesAgentMessages
     }
 }
 
@@ -174,6 +181,7 @@ extension MessagesGroup: Hashable {
         hasher.combine(thinkingContent)
         hasher.combine(usesThoughtBubbleStyle)
         hasher.combine(contactCardThinkingDescriptor)
+        hasher.combine(contactCardPrecedesAgentMessages)
     }
 }
 

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/MessagesListProcessor.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/MessagesListProcessor.swift
@@ -73,6 +73,7 @@ public final class MessagesListProcessor: Sendable {
         rebuilt.thinkingContent = group.thinkingContent
         rebuilt.usesThoughtBubbleStyle = group.usesThoughtBubbleStyle
         rebuilt.contactCardThinkingDescriptor = group.contactCardThinkingDescriptor
+        rebuilt.contactCardPrecedesAgentMessages = group.contactCardPrecedesAgentMessages
         return rebuilt
     }
 
@@ -261,46 +262,7 @@ public final class MessagesListProcessor: Sendable {
         }
 
         if let agent = verifiedAgent {
-            let cardInfo = AgentContactCardInfo(
-                profile: agent.profile,
-                agentDescription: agent.profile.agentDescription
-            )
-            let firstAgentGroupIndex: Int? = items.firstIndex { item in
-                guard case .messages(let group) = item else { return false }
-                return group.sender.profile.inboxId == agent.profile.inboxId
-            }
-            if let idx = firstAgentGroupIndex, case .messages(var group) = items[idx] {
-                group.agentContactCard = cardInfo
-                items[idx] = .messages(group)
-            } else {
-                var cardGroup = MessagesGroup(
-                    id: "agent-contact-card-\(agent.profile.inboxId)",
-                    sender: agent,
-                    messages: [],
-                    isLastGroup: false,
-                    isLastGroupSentByCurrentUser: false
-                )
-                cardGroup.agentContactCard = cardInfo
-                // The summary card must always sit above the contact card. When a
-                // summary card exists, anchor the synthesized contact card right
-                // after it -- in the home flow the agent joins *before* the Make
-                // bundle, so the join-update row can sort above the summary;
-                // anchoring on the join row there would put the contact card
-                // first. Non-builder agent conversations (no summary card) fall
-                // back to the agent-join row, then index 0.
-                let builderCardIndex: Int? = items.lastIndex { item in
-                    if case .agentBuilderSummary = item { return true }
-                    return false
-                }
-                let joinUpdateIndex: Int? = items.firstIndex { item in
-                    guard case .update(_, let update, _) = item else { return false }
-                    return update.addedVerifiedAgent
-                }
-                let insertionIndex: Int = builderCardIndex.map { $0 + 1 }
-                    ?? joinUpdateIndex.map { $0 + 1 }
-                    ?? 0
-                items.insert(.messages(cardGroup), at: insertionIndex)
-            }
+            items = insertingContactCard(in: items, agent: agent)
         }
 
         return items
@@ -766,5 +728,63 @@ public final class MessagesListProcessor: Sendable {
             actor: summary.actor,
             grantedToInboxId: summary.grantedToInboxId
         )
+    }
+}
+
+private extension MessagesListProcessor {
+    /// Insert the agent contact card as its own standalone row. The card has
+    /// a single placement rule, so it never relocates as the agent's
+    /// messages, connection events, or user replies stream in around it.
+    /// Anchor chain: right after the last builder summary card (the summary
+    /// always sits above the card -- in the home flow the agent joins before
+    /// the Make bundle, so anchoring on the join row there would put the
+    /// card first); else right after the agent-join update row (non-builder
+    /// agent conversations); else right before the agent's first message
+    /// group (join row outside the loaded window); else the top of the list.
+    static func insertingContactCard(
+        in baseItems: [MessagesListItemType],
+        agent: ConversationMember
+    ) -> [MessagesListItemType] {
+        var items: [MessagesListItemType] = baseItems
+        var cardGroup = MessagesGroup(
+            id: "agent-contact-card-\(agent.profile.inboxId)",
+            sender: agent,
+            messages: [],
+            isLastGroup: false,
+            isLastGroupSentByCurrentUser: false
+        )
+        cardGroup.agentContactCard = AgentContactCardInfo(
+            profile: agent.profile,
+            agentDescription: agent.profile.agentDescription
+        )
+        let builderCardIndex: Int? = items.lastIndex { item in
+            if case .agentBuilderSummary = item { return true }
+            return false
+        }
+        let joinUpdateIndex: Int? = items.firstIndex { item in
+            guard case .update(_, let update, _) = item else { return false }
+            return update.addedVerifiedAgent
+        }
+        let firstAgentGroupIndex: Int? = items.firstIndex { item in
+            guard case .messages(let group) = item else { return false }
+            return group.sender.profile.inboxId == agent.profile.inboxId
+        }
+        let insertionIndex: Int = builderCardIndex.map { $0 + 1 }
+            ?? joinUpdateIndex.map { $0 + 1 }
+            ?? firstAgentGroupIndex
+            ?? 0
+        // When the agent's own messages sit directly below the card, the
+        // pair renders as one visual run: the card keeps the sender label,
+        // the group below drops its duplicate label, and the leading avatar
+        // attaches to that group's last message instead of the card.
+        if insertionIndex < items.count,
+           case .messages(var below) = items[insertionIndex],
+           below.sender.profile.inboxId == agent.profile.inboxId {
+            below.hidesSenderLabel = true
+            items[insertionIndex] = .messages(below)
+            cardGroup.contactCardPrecedesAgentMessages = true
+        }
+        items.insert(.messages(cardGroup), at: insertionIndex)
+        return items
     }
 }

--- a/ConvosCore/Tests/ConvosCoreTests/MessagesListProcessorTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/MessagesListProcessorTests.swift
@@ -1392,3 +1392,159 @@ struct MessagesListProcessorAgentBuilderCardTests {
         #expect(card?.creatorIsCurrentUser == true)
     }
 }
+
+// MARK: - Contact Card Placement Tests
+
+private let verifiedAgentMember: ConversationMember = .mock(
+    isCurrentUser: false,
+    name: "Agent",
+    isAgent: true,
+    agentVerification: .verified(.convos)
+)
+
+private func contactCardIndex(in items: [MessagesListItemType]) -> Int? {
+    items.firstIndex {
+        if case .messages(let group) = $0 { return group.agentContactCard != nil }
+        return false
+    }
+}
+
+private func contactCardGroup(in items: [MessagesListItemType]) -> MessagesGroup? {
+    groups(from: items).first { $0.agentContactCard != nil }
+}
+
+struct MessagesListProcessorContactCardPlacementTests {
+    @Test("Contact card is a standalone row and never attaches to the agent's message group")
+    func cardIsStandaloneRow() {
+        let now = Date()
+        let messages = [
+            makeMessage(id: "b-text", sender: currentUser, text: "Make it", date: now),
+            makeMessage(id: "greeting", sender: verifiedAgentMember, text: "Hi, I'm here!", date: now.addingTimeInterval(10)),
+        ]
+        let result = MessagesListProcessor.process(
+            messages,
+            verifiedAgent: verifiedAgentMember,
+            agentBuilderSummary: builderSummary(bundledMessageIds: ["b-text"]),
+            hiddenBundleMessageIds: ["b-text"]
+        )
+        let cardGroup = contactCardGroup(in: result)
+        #expect(cardGroup != nil)
+        #expect(cardGroup?.allMessages.isEmpty == true)
+        // The greeting group carries its messages but not the card.
+        let greetingGroup = groups(from: result).first { group in
+            group.messages.contains { $0.messageId == "greeting" }
+        }
+        #expect(greetingGroup != nil)
+        #expect(greetingGroup?.agentContactCard == nil)
+    }
+
+    @Test("Contact card stays anchored under the summary when rows land between it and the agent's first message")
+    func cardDoesNotMoveWhenRowsIntervene() {
+        let now = Date()
+        let summaryOnly = [
+            makeMessage(id: "b-text", sender: currentUser, text: "Make it", date: now),
+        ]
+        let withInterveningRows = [
+            makeMessage(id: "b-text", sender: currentUser, text: "Make it", date: now),
+            makeMessage(id: "user-extra", sender: currentUser, text: "Also do this", date: now.addingTimeInterval(5)),
+            makeMessage(id: "greeting", sender: verifiedAgentMember, text: "On it!", date: now.addingTimeInterval(10)),
+        ]
+        let summary = builderSummary(bundledMessageIds: ["b-text"])
+
+        let before = MessagesListProcessor.process(
+            summaryOnly,
+            verifiedAgent: verifiedAgentMember,
+            agentBuilderSummary: summary,
+            hiddenBundleMessageIds: ["b-text"]
+        )
+        let after = MessagesListProcessor.process(
+            withInterveningRows,
+            verifiedAgent: verifiedAgentMember,
+            agentBuilderSummary: summary,
+            hiddenBundleMessageIds: ["b-text"]
+        )
+
+        // The card sits directly under the summary in both passes -- it does
+        // not jump down to the agent's first message group once it exists.
+        for items in [before, after] {
+            let summaryIndex = items.firstIndex { if case .agentBuilderSummary = $0 { return true }; return false }
+            #expect(summaryIndex != nil)
+            if let summaryIndex {
+                #expect(contactCardIndex(in: items) == summaryIndex + 1)
+            }
+        }
+    }
+
+    @Test("Card anchors after the join row and merges visually with the agent group directly below")
+    func cardAnchorsOnJoinRowAndMergesWithAdjacentAgentGroup() {
+        let now = Date()
+        let messages = [
+            makeUpdate(id: "agent-joined", date: now, addedMembers: [verifiedAgentMember]),
+            makeMessage(id: "greeting", sender: verifiedAgentMember, text: "Hello!", date: now.addingTimeInterval(5)),
+        ]
+        let result = MessagesListProcessor.process(
+            messages,
+            verifiedAgent: verifiedAgentMember
+        )
+        let joinIndex = result.firstIndex {
+            guard case .update(_, let update, _) = $0 else { return false }
+            return update.addedVerifiedAgent
+        }
+        #expect(joinIndex != nil)
+        if let joinIndex {
+            #expect(contactCardIndex(in: result) == joinIndex + 1)
+        }
+        // Adjacent pair renders as one run: the card defers its avatar and
+        // the group below hides its duplicate sender label.
+        #expect(contactCardGroup(in: result)?.contactCardPrecedesAgentMessages == true)
+        let greetingGroup = groups(from: result).first { group in
+            group.messages.contains { $0.messageId == "greeting" }
+        }
+        #expect(greetingGroup?.hidesSenderLabel == true)
+    }
+
+    @Test("Adjacency flags stay off when another sender's group sits below the card")
+    func noAdjacencyFlagsWhenOtherSenderBelow() {
+        let now = Date()
+        let messages = [
+            makeMessage(id: "b-text", sender: currentUser, text: "Make it", date: now),
+            makeMessage(id: "user-extra", sender: currentUser, text: "One more thing", date: now.addingTimeInterval(5)),
+            makeMessage(id: "greeting", sender: verifiedAgentMember, text: "Done!", date: now.addingTimeInterval(10)),
+        ]
+        let result = MessagesListProcessor.process(
+            messages,
+            verifiedAgent: verifiedAgentMember,
+            agentBuilderSummary: builderSummary(bundledMessageIds: ["b-text"]),
+            hiddenBundleMessageIds: ["b-text"]
+        )
+        #expect(contactCardGroup(in: result)?.contactCardPrecedesAgentMessages == false)
+        let userGroup = groups(from: result).first { group in
+            group.messages.contains { $0.messageId == "user-extra" }
+        }
+        #expect(userGroup?.hidesSenderLabel == false)
+    }
+
+    @Test("Without a summary or join row the card sits before the agent's first message group")
+    func cardFallsBackToAgentFirstGroup() {
+        let now = Date()
+        let messages = [
+            makeMessage(id: "user-text", sender: currentUser, text: "Hi", date: now),
+            makeMessage(id: "greeting", sender: verifiedAgentMember, text: "Hello!", date: now.addingTimeInterval(5)),
+        ]
+        let result = MessagesListProcessor.process(
+            messages,
+            verifiedAgent: verifiedAgentMember
+        )
+        let cardIndex = contactCardIndex(in: result)
+        let greetingIndex = result.firstIndex {
+            guard case .messages(let group) = $0 else { return false }
+            return group.messages.contains { $0.messageId == "greeting" }
+        }
+        #expect(cardIndex != nil)
+        #expect(greetingIndex != nil)
+        if let cardIndex, let greetingIndex {
+            #expect(cardIndex == greetingIndex - 1)
+        }
+        #expect(contactCardGroup(in: result)?.contactCardPrecedesAgentMessages == true)
+    }
+}


### PR DESCRIPTION
## Problem

The agent contact card had two placement modes in `MessagesListProcessor`:

1. Attach to the agent's first message group when one exists.
2. Otherwise synthesize a standalone row after the builder summary card / agent-join row / index 0.

The mode switch made the card visibly jump in the agent-builder flow: the instant the agent's greeting arrived, the card detached from its anchored row and re-attached to the greeting group, leaping past any connection events or user replies that had landed in between. The index-0 fallback could also strand the card at the very top of the list during attestation races, and the typing-indicator group rebuild dropped `agentContactCard`, flickering the card out while the agent typed.

## Fix

The card is now always its own standalone row with a single anchor chain evaluated identically on every pass:

1. right after the **last builder summary card** (summary always sits above the card), else
2. right after the **agent-join update row**, else
3. right before the **agent's first message group** (join row outside the loaded window), else
4. the top of the list.

When the agent's messages sit directly below the card, the pair renders as one visual run: the group below hides its duplicate sender label (`hidesSenderLabel`) and the card defers its bottom-leading avatar to that group's last message (new `contactCardPrecedesAgentMessages` flag). The typing-indicator rebuild now copies the presentation side-channel fields, so the card survives the agent typing while its group is last.

## Testing

- 5 new processor tests pin the ruleset (standalone-row invariant, anchor stability under intervening rows, join-row anchoring + visual merge, adjacency flags off when another sender is below, no-anchors fallback); all 76 processor tests pass.
- Verified live on simulator against the Dev backend: built an agent through the home builder and confirmed the card holds its slot through agent join, profile-name/description streaming, greeting arrival (the old jump moment), follow-up messages, conversation re-entry, and app cold start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1031"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783712345&installation_id=128169237&pr_number=1031&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1031&signature=778479c6be9e102bb361f43e24fc7d4d6655e0051466cedb776848cb09357c2f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Give the agent contact card a stable standalone placement in the messages list
> - Replaces logic that attached the agent contact card to the agent's first message group with a new `insertingContactCard` helper in [`MessagesListProcessor`](https://github.com/xmtplabs/convos-ios/pull/1031/files#diff-c32ba383ca53d832eed02dc83f3d0a9546aad74da5c5919555079a4fc07383d7) that always inserts it as its own `MessagesGroup`.
> - Placement follows a strict anchor priority: after the last agent-builder summary, else after the agent-join update row, else before the agent's first message group, else at the top.
> - Adds a `contactCardPrecedesAgentMessages` flag to [`MessagesGroup`](https://github.com/xmtplabs/convos-ios/pull/1031/files#diff-8c4c494cab7e1a500d722d7f064a92825ce23194df3adfae9a3c70b324148312) to suppress the duplicate sender avatar and label when the card sits directly above an agent message group.
> - Fixes [`ConversationViewModel.messagesWithSingleTyper`](https://github.com/xmtplabs/convos-ios/pull/1031/files#diff-ffefb14f91f8d668eb095a38c46cbc45eeb2377e83f07886efcb6e533f574423) to preserve the contact card and related presentation fields when converting the last group into a typing-indicator group.
> - Five new tests in [`MessagesListProcessorContactCardPlacementTests`](https://github.com/xmtplabs/convos-ios/pull/1031/files#diff-02e4f56ebdce0ca714f81c9e2a1d074ff74e2ae60e2747c9d74bf3bbf942a213) cover all anchor cases and adjacency flag behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5828233.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->