### PR TITLE
feat(agents): direct-add agent joins — addMembers + confirm instead of the invite DM dance

### DIFF
--- a/Convos/Agent Builder/AgentBuilderViewModel.swift
+++ b/Convos/Agent Builder/AgentBuilderViewModel.swift
@@ -765,20 +765,18 @@ final class AgentBuilderViewModel: Identifiable {
                 textMessageId: textMessageId,
                 bundleMessageId: bundleMessageId
             )
-            let slug = innerVM.conversation.invite?.urlSlug ?? ""
-            guard !slug.isEmpty else {
-                Log.warning("AgentBuilder(existing): no invite slug; skipping agent join")
-                return
-            }
             // The join must finish even after the builder sheet dismisses.
             // Unlike the draft flow, there is no draft to discard -- the user's
             // group stays -- so the join survives the view closing (like
             // `ConversationViewModel`'s committed-conversation join, the
             // opposite of the draft path).
             do {
-                _ = try await session.requestAgentJoin(slug: slug, options: .agentBuilder)
+                _ = try await session.addAgentToConversation(
+                    conversationId: innerVM.conversation.id,
+                    options: .agentBuilder
+                )
             } catch {
-                Log.error("AgentBuilder(existing): requestAgentJoin failed: \(error.localizedDescription)")
+                Log.error("AgentBuilder(existing): addAgentToConversation failed: \(error.localizedDescription)")
             }
         }
         // No in-sheet morph: the builder targets a conversation the user is
@@ -937,13 +935,9 @@ final class AgentBuilderViewModel: Identifiable {
             Log.warning("AgentBuilderViewModel: reached .ready but no conversation available")
             return
         }
-        let slug = conversation.invite?.urlSlug ?? ""
-        guard !slug.isEmpty else {
-            Log.warning("AgentBuilderViewModel: reached .ready but invite slug is empty")
-            return
-        }
         didRequestAgentJoin = true
 
+        let conversationId = conversation.id
         agentJoinTask?.cancel()
         // Capture `session` only, not `self`: the join needs nothing back from
         // the VM, and not capturing `self` avoids a cycle through the stored
@@ -954,13 +948,16 @@ final class AgentBuilderViewModel: Identifiable {
         // leaving / deleting the group -- so there's nothing left to join.
         agentJoinTask = Task { [session] in
             do {
-                _ = try await session.requestAgentJoin(slug: slug, options: .agentBuilder)
+                _ = try await session.addAgentToConversation(
+                    conversationId: conversationId,
+                    options: .agentBuilder
+                )
             } catch is CancellationError {
                 return
             } catch let urlError as URLError where urlError.code == .cancelled {
                 return
             } catch {
-                Log.error("AgentBuilderViewModel: requestAgentJoin failed: \(error.localizedDescription)")
+                Log.error("AgentBuilderViewModel: addAgentToConversation failed: \(error.localizedDescription)")
             }
         }
     }

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -3133,9 +3133,6 @@ extension ConversationViewModel {
     /// `requestAgentJoins(templateIds:)` instead -- it runs the calls
     /// sequentially without cancelling each other.
     func requestAgentJoin(templateId: String?) {
-        let slug = invite.urlSlug
-        guard !slug.isEmpty else { return }
-
         agentJoinTask?.cancel()
 
         // Anchor the wait measurement at request time (the pending UI starts
@@ -3154,7 +3151,6 @@ extension ConversationViewModel {
         agentJoinTask = Task { [weak self] in
             let outcome = await Self.performAgentJoinCall(
                 templateId: templateId,
-                slug: slug,
                 conversationId: conversationId,
                 requestId: requestId,
                 forceErrorCode: forceErrorCode,
@@ -3205,8 +3201,6 @@ extension ConversationViewModel {
     /// session state machine under concurrent waiters).
     func requestAgentJoins(templateIds: [String]) {
         guard !templateIds.isEmpty else { return }
-        let slug = invite.urlSlug
-        guard !slug.isEmpty else { return }
         Log.info("requestAgentJoins called with \(templateIds.count) templates (sequential): \(templateIds)")
 
         // Batch adds return to the chat, so the join progress shows as
@@ -3231,7 +3225,6 @@ extension ConversationViewModel {
                 let requestId = UUID().uuidString
                 let outcome = await Self.performAgentJoinCall(
                     templateId: templateId,
-                    slug: slug,
                     conversationId: conversationId,
                     requestId: requestId,
                     forceErrorCode: forceErrorCode,
@@ -3333,7 +3326,6 @@ extension ConversationViewModel {
     /// holding `self`.
     private static func performAgentJoinCall(
         templateId: String?,
-        slug: String,
         conversationId: String,
         requestId: String,
         forceErrorCode: Int?,
@@ -3346,8 +3338,8 @@ extension ConversationViewModel {
         )
         Log.info("performAgentJoinCall about to POST agents/join templateId=\(templateId ?? "nil") requestId=\(requestId)")
         do {
-            _ = try await session.requestAgentJoin(
-                slug: slug,
+            _ = try await session.addAgentToConversation(
+                conversationId: conversationId,
                 templateId: templateId,
                 options: nil,
                 forceErrorCode: forceErrorCode

--- a/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient+Models.swift
+++ b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient+Models.swift
@@ -164,15 +164,20 @@ public enum ConvosAPI {
     // POST /v2/agents/join
     // The body is validated strictly server-side: unknown keys are rejected.
     // `templateId` is optional - omitting it requests a bare join (the
-    // backend provisions a default agent). A nil `templateId` is omitted
-    // from the encoded JSON by Codable's synthesized encoder.
+    // backend provisions a default agent). Nil optionals are omitted from
+    // the encoded JSON by Codable's synthesized encoder.
+    //
+    // `slug` is omitted in direct-add mode: the backend provisions the agent
+    // and responds with its `inboxId`; the client adds that inbox to the
+    // group itself with addMembers, then confirms via
+    // POST /v2/agents/confirm-join.
 
     public struct AgentJoinRequest: Codable {
-        public let slug: String
+        public let slug: String?
         public let templateId: String?
         public let options: AgentJoinOptions?
 
-        public init(slug: String, templateId: String? = nil, options: AgentJoinOptions? = nil) {
+        public init(slug: String? = nil, templateId: String? = nil, options: AgentJoinOptions? = nil) {
             self.slug = slug
             self.templateId = templateId
             self.options = options
@@ -199,10 +204,75 @@ public enum ConvosAPI {
     public struct AgentJoinResponse: Codable {
         public let success: Bool
         public let joined: Bool
+        /// Populated on every dispatch; required for the direct-add
+        /// confirm call and the join-status poll.
+        public let instanceId: String?
+        /// Direct-add only: the agent's XMTP inbox to add with addMembers.
+        /// Nil when registration outlasted the backend's wait budget — poll
+        /// GET /v2/agents/join/:instanceId until it lands.
+        public let inboxId: String?
 
-        public init(success: Bool, joined: Bool) {
+        public init(success: Bool, joined: Bool, instanceId: String? = nil, inboxId: String? = nil) {
             self.success = success
             self.joined = joined
+            self.instanceId = instanceId
+            self.inboxId = inboxId
+        }
+    }
+
+    // MARK: - v2/agents/confirm-join
+    // POST /v2/agents/confirm-join
+    // Direct-add companion: after the client has added the agent's inbox to
+    // the group, this relays the conversation id so the runtime attaches the
+    // agent and boots it. Idempotent for already-joined agents.
+
+    public struct AgentConfirmJoinRequest: Codable {
+        public let instanceId: String
+        public let conversationId: String
+
+        public init(instanceId: String, conversationId: String) {
+            self.instanceId = instanceId
+            self.conversationId = conversationId
+        }
+    }
+
+    public struct AgentConfirmJoinResponse: Codable {
+        public let success: Bool
+        public let joinStatus: String?
+
+        public init(success: Bool, joinStatus: String? = nil) {
+            self.success = success
+            self.joinStatus = joinStatus
+        }
+    }
+
+    // MARK: - v2/agents/join/:instanceId
+
+    public struct AgentJoinStatusResponse: Codable {
+        public let success: Bool
+        public let instanceId: String
+        public let joinStatus: String
+        public let joined: Bool
+        public let inboxId: String?
+        public let conversationId: String?
+        public let joinFailureReason: String?
+
+        public init(
+            success: Bool,
+            instanceId: String,
+            joinStatus: String,
+            joined: Bool,
+            inboxId: String? = nil,
+            conversationId: String? = nil,
+            joinFailureReason: String? = nil
+        ) {
+            self.success = success
+            self.instanceId = instanceId
+            self.joinStatus = joinStatus
+            self.joined = joined
+            self.inboxId = inboxId
+            self.conversationId = conversationId
+            self.joinFailureReason = joinFailureReason
         }
     }
 

--- a/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift
+++ b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift
@@ -83,12 +83,26 @@ public protocol ConvosAPIClientProtocol: AnyObject, Sendable {
     func renewAssetsBatch(assetKeys: [String]) async throws -> AssetRenewalResult
 
     // Agents
+    /// `slug == nil` selects direct-add mode: the backend provisions the
+    /// agent and returns its `inboxId` for the caller to add with
+    /// addMembers + `confirmAgentJoin`.
     func requestAgentJoin(
-        slug: String,
+        slug: String?,
         templateId: String?,
         options: ConvosAPI.AgentJoinOptions?,
         forceErrorCode: Int?
     ) async throws -> ConvosAPI.AgentJoinResponse
+
+    /// Direct-add companion: relays the local addMembers result so the
+    /// runtime attaches the agent to the conversation and boots it.
+    func confirmAgentJoin(
+        instanceId: String,
+        conversationId: String
+    ) async throws -> ConvosAPI.AgentConfirmJoinResponse
+
+    /// Polls a dispatched agent's provisioning status. Direct-add callers
+    /// use it to obtain `inboxId` when the join response didn't carry one.
+    func getAgentJoinStatus(instanceId: String) async throws -> ConvosAPI.AgentJoinStatusResponse
 
     // Agent templates
     /// Public detail fetch for a published agent template, keyed by its
@@ -712,7 +726,7 @@ final class ConvosAPIClient: ConvosAPIClientProtocol, Sendable {
     // MARK: - Agents
 
     func requestAgentJoin(
-        slug: String,
+        slug: String? = nil,
         templateId: String? = nil,
         options: ConvosAPI.AgentJoinOptions? = nil,
         forceErrorCode: Int? = nil
@@ -759,6 +773,52 @@ final class ConvosAPIClient: ConvosAPIClientProtocol, Sendable {
         default:
             throw APIError.serverError(parseErrorMessage(from: data))
         }
+    }
+
+    func confirmAgentJoin(
+        instanceId: String,
+        conversationId: String
+    ) async throws -> ConvosAPI.AgentConfirmJoinResponse {
+        var request = try authenticatedRequest(for: "v2/agents/confirm-join", method: "POST")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try JSONEncoder().encode(
+            ConvosAPI.AgentConfirmJoinRequest(
+                instanceId: instanceId,
+                conversationId: conversationId
+            )
+        )
+
+        let (data, httpResponse) = try await performAuthenticatedRequest(request)
+
+        switch httpResponse.statusCode {
+        case 200...299:
+            return try JSONDecoder().decode(ConvosAPI.AgentConfirmJoinResponse.self, from: data)
+        case 502:
+            throw APIError.agentProvisionFailed
+        case 503:
+            throw APIError.noAgentsAvailable
+        case 504:
+            throw APIError.agentPoolTimeout
+        case 400:
+            throw APIError.badRequest(parseErrorMessage(from: data))
+        case 403:
+            throw APIError.forbidden
+        case 404:
+            throw APIError.notFound
+        case 409:
+            // The runtime is not waiting for a confirmation (already
+            // confirmed, or the workflow timed out). Safe to surface as a
+            // provision failure; retries go through requestAgentJoin.
+            throw APIError.agentProvisionFailed
+        default:
+            throw APIError.serverError(parseErrorMessage(from: data))
+        }
+    }
+
+    func getAgentJoinStatus(instanceId: String) async throws -> ConvosAPI.AgentJoinStatusResponse {
+        let encoded = instanceId.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? instanceId
+        let request = try authenticatedRequest(for: "v2/agents/join/\(encoded)", method: "GET")
+        return try await performRequest(request)
     }
 
     // MARK: - Agent templates

--- a/ConvosCore/Sources/ConvosCore/API/MockAPIClient.swift
+++ b/ConvosCore/Sources/ConvosCore/API/MockAPIClient.swift
@@ -96,12 +96,29 @@ final class MockAPIClient: ConvosAPIClientProtocol, Sendable {
     }
 
     func requestAgentJoin(
-        slug: String,
+        slug: String? = nil,
         templateId: String? = nil,
         options: ConvosAPI.AgentJoinOptions? = nil,
         forceErrorCode: Int? = nil
     ) async throws -> ConvosAPI.AgentJoinResponse {
-        .init(success: true, joined: true)
+        .init(success: true, joined: true, instanceId: "mock-instance", inboxId: "mock-agent-inbox")
+    }
+
+    func confirmAgentJoin(
+        instanceId: String,
+        conversationId: String
+    ) async throws -> ConvosAPI.AgentConfirmJoinResponse {
+        .init(success: true, joinStatus: "starting")
+    }
+
+    func getAgentJoinStatus(instanceId: String) async throws -> ConvosAPI.AgentJoinStatusResponse {
+        .init(
+            success: true,
+            instanceId: instanceId,
+            joinStatus: "starting",
+            joined: false,
+            inboxId: "mock-agent-inbox"
+        )
     }
 
     func getAgentTemplate(idOrUrlSlug: String) async throws -> ConvosAPI.AgentTemplate {

--- a/ConvosCore/Sources/ConvosCore/Inboxes/MockInboxesService.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/MockInboxesService.swift
@@ -92,8 +92,8 @@ public final class MockInboxesService: SessionManagerProtocol, @unchecked Sendab
         MockInviteRepository()
     }
 
-    public func requestAgentJoin(
-        slug: String,
+    public func addAgentToConversation(
+        conversationId: String,
         templateId: String? = nil,
         options: ConvosAPI.AgentJoinOptions? = nil,
         forceErrorCode: Int? = nil
@@ -106,7 +106,7 @@ public final class MockInboxesService: SessionManagerProtocol, @unchecked Sendab
             default: throw APIError.serverError("Mock forced error \(forceErrorCode)")
             }
         }
-        return .init(success: true, joined: true)
+        return .init(success: true, joined: true, instanceId: "mock-instance", inboxId: "mock-agent-inbox")
     }
 
     public func conversationRepository(for conversationId: String) -> any ConversationRepositoryProtocol {

--- a/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
@@ -591,25 +591,59 @@ public final class SessionManager: SessionManagerProtocol, @unchecked Sendable {
         )
     }
 
-    public func requestAgentJoin(
-        slug: String,
+    /// How long to keep polling for the agent's inboxId when registration
+    /// outlasts the backend's synchronous wait budget.
+    private static let agentRegistrationDeadline: TimeInterval = 30
+    private static let agentRegistrationPollInterval: TimeInterval = 1
+
+    public func addAgentToConversation(
+        conversationId: String,
         templateId: String? = nil,
         options: ConvosAPI.AgentJoinOptions? = nil,
         forceErrorCode: Int? = nil
     ) async throws -> ConvosAPI.AgentJoinResponse {
+        // 1. Provision: the backend registers the agent's XMTP inbox and
+        //    returns it. No invite slug — this device performs the add.
         let response = try await apiClient.requestAgentJoin(
-            slug: slug,
+            slug: nil,
             templateId: templateId,
             options: options,
             forceErrorCode: forceErrorCode
         )
-        // Temporary diagnostic: the agent now sends a join-request DM that
-        // the message stream is expected to deliver. Poll for it for a
-        // bounded window in case the stream has died, so the agent doesn't
-        // time out and stream death shows up in the logs. Covers every
-        // agents/join entry point (add agent, contacts picker, compose,
-        // agent builder) since they all route through here.
-        await messagingService().sessionStateManager.startAgentJoinRequestPolling()
+        guard let instanceId = response.instanceId else {
+            throw APIError.agentProvisionFailed
+        }
+
+        var inboxId = response.inboxId
+        let deadline = Date().addingTimeInterval(Self.agentRegistrationDeadline)
+        while inboxId == nil {
+            guard Date() < deadline else { throw APIError.agentPoolTimeout }
+            try await Task.sleep(nanoseconds: UInt64(Self.agentRegistrationPollInterval * 1_000_000_000))
+            let status = try await apiClient.getAgentJoinStatus(instanceId: instanceId)
+            guard status.joinStatus != "failed" else {
+                throw APIError.agentProvisionFailed
+            }
+            inboxId = status.inboxId
+        }
+        guard let agentInboxId = inboxId else {
+            throw APIError.agentPoolTimeout
+        }
+
+        // 2. Add: a plain member add by this device — synchronous, no DM
+        //    round-trip, no online-accepter dependency. Point of no return:
+        //    a cancelled caller aborts cleanly here; once the add lands, a
+        //    missing confirm leaves the agent inbox in the group unbooted
+        //    until the runtime's 10-minute abandon timeout fails it.
+        try Task.checkCancellation()
+        try await messagingService().conversationMetadataWriter()
+            .addMembers([agentInboxId], to: conversationId)
+
+        // 3. Confirm: tells the runtime its inbox is in the group so it
+        //    attaches and boots.
+        _ = try await apiClient.confirmAgentJoin(
+            instanceId: instanceId,
+            conversationId: conversationId
+        )
         return response
     }
 

--- a/ConvosCore/Sources/ConvosCore/Sessions/SessionManagerProtocol.swift
+++ b/ConvosCore/Sources/ConvosCore/Sessions/SessionManagerProtocol.swift
@@ -100,8 +100,12 @@ public protocol SessionManagerProtocol: AnyObject, Sendable {
     // MARK: Factory methods for repositories
 
     func inviteRepository(for conversationId: String) -> any InviteRepositoryProtocol
-    func requestAgentJoin(
-        slug: String,
+
+    /// Direct-add agent join: provisions the agent via the backend, adds its
+    /// XMTP inbox to the conversation with addMembers, then confirms so the
+    /// runtime attaches and boots. No invite slug involved.
+    func addAgentToConversation(
+        conversationId: String,
         templateId: String?,
         options: ConvosAPI.AgentJoinOptions?,
         forceErrorCode: Int?
@@ -230,21 +234,21 @@ extension SessionManagerProtocol {
         NoopInviteMembershipResolver()
     }
 
-    public func requestAgentJoin(slug: String) async throws -> ConvosAPI.AgentJoinResponse {
-        try await requestAgentJoin(slug: slug, templateId: nil, options: nil, forceErrorCode: nil)
+    public func addAgentToConversation(conversationId: String) async throws -> ConvosAPI.AgentJoinResponse {
+        try await addAgentToConversation(conversationId: conversationId, templateId: nil, options: nil, forceErrorCode: nil)
     }
 
-    public func requestAgentJoin(
-        slug: String,
+    public func addAgentToConversation(
+        conversationId: String,
         options: ConvosAPI.AgentJoinOptions?
     ) async throws -> ConvosAPI.AgentJoinResponse {
-        try await requestAgentJoin(slug: slug, templateId: nil, options: options, forceErrorCode: nil)
+        try await addAgentToConversation(conversationId: conversationId, templateId: nil, options: options, forceErrorCode: nil)
     }
 
-    public func requestAgentJoin(
-        slug: String,
+    public func addAgentToConversation(
+        conversationId: String,
         templateId: String?
     ) async throws -> ConvosAPI.AgentJoinResponse {
-        try await requestAgentJoin(slug: slug, templateId: templateId, options: nil, forceErrorCode: nil)
+        try await addAgentToConversation(conversationId: conversationId, templateId: templateId, options: nil, forceErrorCode: nil)
     }
 }

--- a/ConvosCore/Tests/ConvosCoreTests/TestStubAPIClientDefaults.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/TestStubAPIClientDefaults.swift
@@ -36,12 +36,37 @@ extension ConvosAPIClientProtocol {
     /// `requestAgentJoin` specifically should still override this on
     /// their fixture.
     func requestAgentJoin(
-        slug: String,
+        slug: String?,
         templateId: String?,
         options: ConvosAPI.AgentJoinOptions?,
         forceErrorCode: Int?
     ) async throws -> ConvosAPI.AgentJoinResponse {
-        ConvosAPI.AgentJoinResponse(success: true, joined: true)
+        ConvosAPI.AgentJoinResponse(
+            success: true,
+            joined: true,
+            instanceId: "test-instance",
+            inboxId: "test-agent-inbox"
+        )
+    }
+
+    /// Defaults for the direct-add companions so pre-existing stubs don't
+    /// re-stub them. Tests that exercise the direct-add flow specifically
+    /// should override these on their fixture.
+    func confirmAgentJoin(
+        instanceId: String,
+        conversationId: String
+    ) async throws -> ConvosAPI.AgentConfirmJoinResponse {
+        ConvosAPI.AgentConfirmJoinResponse(success: true, joinStatus: "starting")
+    }
+
+    func getAgentJoinStatus(instanceId: String) async throws -> ConvosAPI.AgentJoinStatusResponse {
+        ConvosAPI.AgentJoinStatusResponse(
+            success: true,
+            instanceId: instanceId,
+            joinStatus: "starting",
+            joined: false,
+            inboxId: "test-agent-inbox"
+        )
     }
 
     /// Default for the public agent-template detail fetch used by the

--- a/ConvosTests/ConversationViewModelGlobalDefaultsTests.swift
+++ b/ConvosTests/ConversationViewModelGlobalDefaultsTests.swift
@@ -293,14 +293,14 @@ private final class TestSessionManager: SessionManagerProtocol, @unchecked Senda
         await base.inboxId(for: conversationId)
     }
 
-    func requestAgentJoin(
-        slug: String,
+    func addAgentToConversation(
+        conversationId: String,
         templateId: String?,
         options: ConvosAPI.AgentJoinOptions?,
         forceErrorCode: Int?
     ) async throws -> ConvosAPI.AgentJoinResponse {
-        try await base.requestAgentJoin(
-            slug: slug,
+        try await base.addAgentToConversation(
+            conversationId: conversationId,
             templateId: templateId,
             options: options,
             forceErrorCode: forceErrorCode

--- a/ConvosTests/ConversationsViewModelDeleteTests.swift
+++ b/ConvosTests/ConversationsViewModelDeleteTests.swift
@@ -293,14 +293,14 @@ private final class TestSessionManager: SessionManagerProtocol, @unchecked Senda
         await base.inboxId(for: conversationId)
     }
 
-    func requestAgentJoin(
-        slug: String,
+    func addAgentToConversation(
+        conversationId: String,
         templateId: String?,
         options: ConvosAPI.AgentJoinOptions?,
         forceErrorCode: Int?
     ) async throws -> ConvosAPI.AgentJoinResponse {
-        try await base.requestAgentJoin(
-            slug: slug,
+        try await base.addAgentToConversation(
+            conversationId: conversationId,
             templateId: templateId,
             options: options,
             forceErrorCode: forceErrorCode


### PR DESCRIPTION
## Summary

Replaces the slug-based agent join with **direct-add**. `SessionManager.requestAgentJoin(slug:)` becomes `addAgentToConversation(conversationId:)`:

1. `POST /v2/agents/join` **without a slug** — the backend provisions the agent and returns its XMTP `inboxId` (short poll of `GET /v2/agents/join/:instanceId` covers slow registration).
2. This device adds that inbox to the group with a plain `addMembers` — synchronous, while the user is right there, in the foreground.
3. `POST /v2/agents/confirm-join` tells the runtime its inbox is in the group so it attaches and boots.

All four agent entry points (chat-header add, contacts picker, compose, Agent Builder draft + existing) route through the one new method. The `guard !slug.isEmpty` checks die with the slug — conversations no longer need a live invite to add an agent. The `startAgentJoinRequestPolling()` stream-death diagnostic call also goes: there is no join-request DM to poll for anymore. Human invite joins are untouched.

## Why

The old flow routed the user's own tap through an XMTP DM back to their own devices: Herald sent a join-request, whichever of the user's devices/processes woke first re-validated the invite and ran `addMembers`, and every hop had a documented failure mode (online-accepter dependency, invite-tag races, `consentState`/appData read errors masquerading as rejections, `invite_join_error` replies nobody can decode). Direct-add deletes the round trip instead of patching it.

Requires (deploy order): xmtplabs/herald-lite#109 → xmtplabs/convos-assistants#2074 → xmtplabs/convos-backend#302 → this.

## Notes for review

- A cancellation between `addMembers` and confirm leaves the inbox in the group unbooted until the runtime's 10-minute abandon timeout marks the assistant failed; `Task.checkCancellation()` right before the add keeps the normal cancel paths (builder discard, retry re-tap) clean of that window.
- `ConvosCore` package and the `Convos (Dev)` app target both build clean; protocol mocks/test stubs migrated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1032"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783730394&installation_id=128169237&pr_number=1032&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1032&signature=0e131813418c0500f0c97350a0fc7278072c03d4c55125f291647f59dab1596a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace slug-based agent invite flow with direct `addMembers` + confirm join
> - `SessionManager.addAgentToConversation` now provisions the agent via the backend, polls for `inboxId` if not returned immediately, adds the agent inbox to the conversation locally via `conversationMetadataWriter.addMembers`, then confirms with `confirmAgentJoin` — eliminating the previous invite-DM round-trip.
> - New API methods `confirmAgentJoin` and `getAgentJoinStatus` are added to `ConvosAPIClient` and its protocol, with corresponding mock and test stub implementations.
> - `AgentJoinRequest.slug` is now optional; `AgentJoinResponse` carries new `instanceId` and `inboxId` fields needed by the new flow.
> - Call sites in `ConversationViewModel` and `AgentBuilderViewModel` drop all slug extraction and empty-slug guards, calling `addAgentToConversation(conversationId:...)` directly.
> - Behavioral Change: agent joins no longer no-op when an invite slug is absent; the operation always proceeds using the conversation id.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 3505b1d. 8 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->