### PR TITLE
Stop invite_join_error floods: typed-only join requests, error dedupe, diagnostic reason

### DIFF
--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -284,7 +284,7 @@ struct ConversationView<MessagesBottomBar: View>: View {
             onTapUpdateMember: { viewModel.presentingProfileForMember = $0 },
             onRetryMessage: viewModel.retryMessage(_:),
             onDeleteMessage: viewModel.deleteMessage(_:),
-            onRetryAgentJoin: { viewModel.requestAgentJoin() },
+            onRetryAgentJoin: { viewModel.retryAgentJoin() },
             onCopyInviteLink: { viewModel.copyInviteLink() },
             onConvoCode: {
                 if viewModel.isFull {

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -914,6 +914,24 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
     @ObservationIgnored
     private var agentJoinTaskId: String?
 
+    /// One agents/join call: the template requested (nil means the backend's
+    /// default agent) and the requestId that keys its in-stream status
+    /// bubble.
+    struct AgentJoinAttempt {
+        let templateId: String?
+        let requestId: String
+    }
+
+    /// The agents/join call(s) behind the most recent failure bubble. The
+    /// retry affordance replays these so a failed templated join retries the
+    /// same template instead of falling back to a bare default-agent join,
+    /// and reuses the original requestId so the existing status bubble
+    /// updates in place. Note the backend may have processed a call whose
+    /// response was lost, so a retry can still double-join until agents/join
+    /// gains a server-side idempotency key.
+    @ObservationIgnored
+    private var failedAgentJoins: [AgentJoinAttempt] = []
+
     /// Telemetry anchors for the assistant joining/verifying wait: set when
     /// an agents/join call succeeds (or rebased on the agent builder's Make
     /// commit time), cleared when the verified assistant arrives or the wait
@@ -3126,13 +3144,15 @@ extension ConversationViewModel {
     /// is a bare join (the backend provisions its default agent); a
     /// non-nil id provisions a fresh instance of that template. The
     /// caller-facing `agents/join` body no longer accepts `instructions`.
+    /// Pass `requestId` only when replaying a failed attempt, so the
+    /// replay updates the existing status bubble instead of adding one.
     ///
     /// Single-flight: a new call cancels any prior in-flight join request
     /// (retry-from-error semantics for the chat-header "+" menu). For
     /// multi-template fan-out (picker confirms N templates at once) use
     /// `requestAgentJoins(templateIds:)` instead -- it runs the calls
     /// sequentially without cancelling each other.
-    func requestAgentJoin(templateId: String?) {
+    func requestAgentJoin(templateId: String?, requestId: String = UUID().uuidString) {
         let slug = invite.urlSlug
         guard !slug.isEmpty else { return }
 
@@ -3147,7 +3167,6 @@ extension ConversationViewModel {
 
         let forceErrorCode = agentJoinForceErrorCode
         let conversationId = conversation.id
-        let requestId = UUID().uuidString
         let taskId = requestId
         let session = self.session
         let actions: any CoreActions = coreActions
@@ -3164,6 +3183,7 @@ extension ConversationViewModel {
             await MainActor.run {
                 guard let self else { return }
                 if outcome == .failed {
+                    self.failedAgentJoins = [AgentJoinAttempt(templateId: templateId, requestId: requestId)]
                     self.onAgentJoinError()
                     // The user is watching the failure UI now, not a join
                     // wait. A superseding retap exits as .cancelled, so this
@@ -3177,6 +3197,25 @@ extension ConversationViewModel {
             }
         }
         agentJoinTaskId = taskId
+    }
+
+    /// Replays the agents/join call(s) behind the failure bubble's retry
+    /// button. Without the recorded attempts (e.g. the process restarted
+    /// since the failure was written), falls back to a bare default-agent
+    /// join, the pre-existing behavior.
+    func retryAgentJoin() {
+        let failures = failedAgentJoins
+        failedAgentJoins = []
+        guard !failures.isEmpty else {
+            requestAgentJoin(templateId: nil)
+            return
+        }
+        Log.info("retryAgentJoin replaying \(failures.count) failed join(s)")
+        if failures.count == 1, let failure = failures.first {
+            requestAgentJoin(templateId: failure.templateId, requestId: failure.requestId)
+        } else {
+            runSequentialAgentJoins(failures)
+        }
     }
 
     /// Bare-join convenience for the in-conversation "add an agent"
@@ -3205,9 +3244,15 @@ extension ConversationViewModel {
     /// session state machine under concurrent waiters).
     func requestAgentJoins(templateIds: [String]) {
         guard !templateIds.isEmpty else { return }
+        Log.info("requestAgentJoins called with \(templateIds.count) templates (sequential): \(templateIds)")
+        let joins = templateIds.map { AgentJoinAttempt(templateId: $0, requestId: UUID().uuidString) }
+        runSequentialAgentJoins(joins)
+    }
+
+    private func runSequentialAgentJoins(_ joins: [AgentJoinAttempt]) {
+        guard !joins.isEmpty else { return }
         let slug = invite.urlSlug
         guard !slug.isEmpty else { return }
-        Log.info("requestAgentJoins called with \(templateIds.count) templates (sequential): \(templateIds)")
 
         // Batch adds return to the chat, so the join progress shows as
         // in-stream pending status bubbles. Anchored at request time for the
@@ -3219,29 +3264,33 @@ extension ConversationViewModel {
         let conversationId = conversation.id
         let session = self.session
         Task { [weak self] in
-            var anyFailed = false
+            var failed: [AgentJoinAttempt] = []
             var anySucceeded = false
-            for (index, templateId) in templateIds.enumerated() {
+            for (index, join) in joins.enumerated() {
                 if index > 0 {
                     // Brief gap between calls so the previous broadcast's
                     // libxmtp message-send fully settles before the next
                     // call's broadcast / API races against it.
                     try? await Task.sleep(nanoseconds: 500_000_000)
                 }
-                let requestId = UUID().uuidString
                 let outcome = await Self.performAgentJoinCall(
-                    templateId: templateId,
+                    templateId: join.templateId,
                     slug: slug,
                     conversationId: conversationId,
-                    requestId: requestId,
+                    requestId: join.requestId,
                     forceErrorCode: forceErrorCode,
                     session: session
                 )
-                if outcome == .failed { anyFailed = true }
+                if outcome == .failed { failed.append(join) }
                 if outcome == .succeeded { anySucceeded = true }
             }
-            if anyFailed {
-                await MainActor.run { self?.onAgentJoinError() }
+            let failedJoins = failed
+            if !failedJoins.isEmpty {
+                await MainActor.run {
+                    guard let self else { return }
+                    self.failedAgentJoins = failedJoins
+                    self.onAgentJoinError()
+                }
             }
             if !anySucceeded {
                 // Every call failed or was cancelled - nothing is joining,

--- a/ConvosCore/Sources/ConvosCore/Inboxes/ConversationStateMachine.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/ConversationStateMachine.swift
@@ -744,8 +744,8 @@ public actor ConversationStateMachine {
         }
 
         let dm = try await client.newConversation(with: inviterInboxId)
-        let text = try invite.toURLSafeSlug()
-        _ = try await dm.prepare(text: text)
+        let joinRequest = JoinRequestContent(inviteSlug: try invite.toURLSafeSlug())
+        _ = try await dm.prepare(joinRequest: joinRequest)
         try await dm.publish()
 
         Log.info("[PERF] NewConversation.joinRequestSent")

--- a/ConvosCore/Sources/ConvosCore/Messaging/XMTPClientProvider.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/XMTPClientProvider.swift
@@ -7,6 +7,7 @@ public protocol MessageSender {
     func sendTypingIndicator(isTyping: Bool) async throws
     func sendReadReceipt() async throws
     func prepare(text: String) async throws -> String
+    func prepare(joinRequest: JoinRequestContent) async throws -> String
     func prepare(remoteAttachment: RemoteAttachment) async throws -> String
     func prepare(multiRemoteAttachment: MultiRemoteAttachment) async throws -> String
     func prepare(reply: Reply) async throws -> String
@@ -281,6 +282,13 @@ extension XMTPiOS.Conversation: MessageSender {
 
     public func prepare(text: String) async throws -> String {
         return try await prepareMessage(content: text)
+    }
+
+    public func prepare(joinRequest: JoinRequestContent) async throws -> String {
+        return try await prepareMessage(
+            content: joinRequest,
+            options: .init(contentType: JoinRequestCodec().contentType)
+        )
     }
 
     public func prepare(remoteAttachment: RemoteAttachment) async throws -> String {

--- a/ConvosCore/Sources/ConvosCore/Mocks/MockMessageSender.swift
+++ b/ConvosCore/Sources/ConvosCore/Mocks/MockMessageSender.swift
@@ -1,3 +1,4 @@
+import ConvosInvites
 import Foundation
 @preconcurrency import XMTPiOS
 
@@ -19,6 +20,12 @@ public final class MockMessageSender: MessageSender, @unchecked Sendable {
     }
 
     public func prepare(text: String) async throws -> String {
+        let messageId = UUID().uuidString
+        preparedMessages.append(messageId)
+        return messageId
+    }
+
+    public func prepare(joinRequest: JoinRequestContent) async throws -> String {
         let messageId = UUID().uuidString
         preparedMessages.append(messageId)
         return messageId

--- a/ConvosCore/Sources/ConvosCore/Syncing/InviteClientProviderAdapter.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/InviteClientProviderAdapter.swift
@@ -20,6 +20,10 @@ struct InviteClientProviderAdapter: InviteClientProvider {
         try await provider.conversationsProvider.findOrCreateDm(with: inboxId)
     }
 
+    func syncConversations() async throws {
+        try await provider.conversationsProvider.sync()
+    }
+
     // swiftlint:disable:next function_parameter_count
     func listDms(
         createdAfterNs: Int64?,

--- a/ConvosCore/Sources/ConvosCore/Syncing/InviteJoinRequestsManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/InviteJoinRequestsManager.swift
@@ -138,8 +138,15 @@ final class InviteJoinRequestsManager: InviteJoinRequestsManagerProtocol, Sendab
         since: Date?,
         client: AnyClientProvider
     ) async -> [InviteJoinRequestOutcome] {
+        // A nil or very old cursor (fresh install, restore, long-dormant
+        // device) would revalidate every historical join request in every
+        // DM and reply with stale invite_join_error messages to joiners
+        // whose requests died long ago. Joiners give up within minutes, so
+        // bound the sweep to a recent window.
+        let oldestUsefulRequestDate = Date().addingTimeInterval(-Constant.maxCatchUpWindow)
+        let effectiveSince = max(since ?? .distantPast, oldestUsefulRequestDate)
         let outcomes = await coordinator.processJoinRequestOutcomes(
-            since: since,
+            since: effectiveSince,
             client: InviteClientProviderAdapter(client)
         )
         var mapped: [InviteJoinRequestOutcome] = []
@@ -281,5 +288,12 @@ final class InviteJoinRequestsManager: InviteJoinRequestsManagerProtocol, Sendab
         } catch {
             Log.warning("Failed to send ProfileSnapshot after join: \(error.localizedDescription)")
         }
+    }
+
+    private enum Constant {
+        /// Oldest join request a catch-up pass will still act on. Joining
+        /// clients time out within minutes, so anything older only produces
+        /// noise (and stale error replies) if revalidated.
+        static let maxCatchUpWindow: TimeInterval = 24 * 60 * 60
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Syncing/InviteJoinRequestsManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/InviteJoinRequestsManager.swift
@@ -138,13 +138,7 @@ final class InviteJoinRequestsManager: InviteJoinRequestsManagerProtocol, Sendab
         since: Date?,
         client: AnyClientProvider
     ) async -> [InviteJoinRequestOutcome] {
-        // A nil or very old cursor (fresh install, restore, long-dormant
-        // device) would revalidate every historical join request in every
-        // DM and reply with stale invite_join_error messages to joiners
-        // whose requests died long ago. Joiners give up within minutes, so
-        // bound the sweep to a recent window.
-        let oldestUsefulRequestDate = Date().addingTimeInterval(-Constant.maxCatchUpWindow)
-        let effectiveSince = max(since ?? .distantPast, oldestUsefulRequestDate)
+        let effectiveSince = Self.effectiveCatchUpSince(since: since, now: Date())
         let outcomes = await coordinator.processJoinRequestOutcomes(
             since: effectiveSince,
             client: InviteClientProviderAdapter(client)
@@ -288,6 +282,16 @@ final class InviteJoinRequestsManager: InviteJoinRequestsManagerProtocol, Sendab
         } catch {
             Log.warning("Failed to send ProfileSnapshot after join: \(error.localizedDescription)")
         }
+    }
+
+    /// A nil or very old cursor (fresh install, restore, long-dormant
+    /// device) would revalidate every historical join request in every
+    /// DM and reply with stale invite_join_error messages to joiners
+    /// whose requests died long ago. Joiners give up within minutes, so
+    /// bound the sweep to a recent window.
+    static func effectiveCatchUpSince(since: Date?, now: Date) -> Date {
+        let oldestUsefulRequestDate = now.addingTimeInterval(-Constant.maxCatchUpWindow)
+        return max(since ?? .distantPast, oldestUsefulRequestDate)
     }
 
     private enum Constant {

--- a/ConvosCore/Sources/ConvosCore/Syncing/StreamProcessor.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/StreamProcessor.swift
@@ -343,7 +343,8 @@ actor StreamProcessor: StreamProcessorProtocol {
     }
 
     private func handleInviteJoinError(_ error: InviteJoinError, senderInboxId: String) async {
-        Log.info("Received InviteJoinError (\(error.errorType.rawValue)) for inviteTag: \(error.inviteTag) from \(senderInboxId)")
+        let reason = error.reason ?? "none"
+        Log.info("Received InviteJoinError (\(error.errorType.rawValue)) for inviteTag: \(error.inviteTag) from \(senderInboxId), reason: \(reason)")
         await inviteJoinErrorHandler?.handleInviteJoinError(error)
     }
 

--- a/ConvosCore/Tests/ConvosCoreTests/Integration/InviteCoordinatorIntegrationTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/Integration/InviteCoordinatorIntegrationTests.swift
@@ -108,4 +108,96 @@ struct InviteCoordinatorIntegrationTests {
         // Sanity: the second pass should not double-emit the first join.
         #expect(!secondAccepted.contains { $0.conversationId == group1.id })
     }
+
+    /// Plain-text slug messages are no longer join requests: no member is
+    /// added and, critically, no invite_join_error is sent back. Herald
+    /// still sends a text copy of the slug next to its typed join request,
+    /// and the text copy must be inert.
+    @Test("Plain-text slug message is ignored: no join, no error reply")
+    func plainTextSlugIsIgnored() async throws {
+        let creatorClient = try await createClient()
+        let joinerClient = try await createClient()
+        defer {
+            try? creatorClient.deleteLocalDatabase()
+            try? joinerClient.deleteLocalDatabase()
+        }
+        let coordinator = makeCoordinator()
+
+        let group = try await creatorClient.conversations.newGroup(with: [])
+        try await group.updateConsentState(state: .allowed)
+        _ = try await coordinator.revokeInvites(for: group)
+        let invite = try await coordinator.createInvite(for: group, client: creatorClient)
+
+        // Send the slug as plain text, the pre-typed wire format.
+        let dm = try await joinerClient.conversations.findOrCreateDm(with: creatorClient.inboxID)
+        _ = try await dm.send(content: invite.slug)
+
+        _ = try await creatorClient.conversations.syncAllConversations(consentStates: nil)
+        let outcomes = await coordinator.processJoinRequestOutcomes(
+            since: nil,
+            client: creatorClient
+        )
+
+        #expect(outcomes.compactMap(\.joinResult).isEmpty, "Text slug must not join the group")
+
+        let memberInboxIds = try await group.members.map(\.inboxId)
+        #expect(!memberInboxIds.contains(joinerClient.inboxID))
+
+        let errorCount = try await joinErrorCount(inDmWith: joinerClient.inboxID, client: creatorClient)
+        #expect(errorCount == 0, "Ignored text slug must not produce an error reply")
+    }
+
+    /// The error-reply dedupe: revalidating the same failed join request
+    /// (stream, catch-up, and the agent-join poll all see the same message)
+    /// sends exactly one invite_join_error - but a fresh retry by the joiner
+    /// is a new attempt and gets a fresh reply.
+    @Test("Failed join gets one error per attempt across repeated processing passes")
+    func failedJoinErrorIsDedupedPerAttempt() async throws {
+        let creatorClient = try await createClient()
+        let joinerClient = try await createClient()
+        defer {
+            try? creatorClient.deleteLocalDatabase()
+            try? joinerClient.deleteLocalDatabase()
+        }
+        let coordinator = makeCoordinator()
+
+        let group = try await creatorClient.conversations.newGroup(with: [])
+        try await group.updateConsentState(state: .allowed)
+        _ = try await coordinator.revokeInvites(for: group)
+        let invite = try await coordinator.createInvite(for: group, client: creatorClient)
+        // Rotate the tag so the invite above is revoked and every join
+        // attempt with it fails down the error-sending path.
+        _ = try await coordinator.revokeInvites(for: group)
+
+        _ = try await coordinator.sendJoinRequest(for: invite.signedInvite, client: joinerClient)
+
+        _ = try await creatorClient.conversations.syncAllConversations(consentStates: nil)
+        _ = await coordinator.processJoinRequestOutcomes(since: nil, client: creatorClient)
+        var errorCount = try await joinErrorCount(inDmWith: joinerClient.inboxID, client: creatorClient)
+        #expect(errorCount == 1, "First failed attempt sends exactly one error")
+
+        // Revalidate the same request, as batch catch-up and the agent-join
+        // poll do. The existing reply must suppress a duplicate.
+        _ = await coordinator.processJoinRequestOutcomes(since: nil, client: creatorClient)
+        errorCount = try await joinErrorCount(inDmWith: joinerClient.inboxID, client: creatorClient)
+        #expect(errorCount == 1, "Reprocessing the same request must not send another error")
+
+        // A fresh retry is a new attempt and deserves a new reply.
+        try await Task.sleep(nanoseconds: 200_000_000)
+        _ = try await coordinator.sendJoinRequest(for: invite.signedInvite, client: joinerClient)
+
+        _ = try await creatorClient.conversations.syncAllConversations(consentStates: nil)
+        _ = await coordinator.processJoinRequestOutcomes(since: nil, client: creatorClient)
+        errorCount = try await joinErrorCount(inDmWith: joinerClient.inboxID, client: creatorClient)
+        #expect(errorCount == 2, "A retried join request gets its own error reply")
+    }
+
+    private func joinErrorCount(inDmWith peerInboxId: String, client: Client) async throws -> Int {
+        let dm = try await client.conversations.findOrCreateDm(with: peerInboxId)
+        let messages = try await dm.messages()
+        return messages.filter { message in
+            guard let contentType = try? message.encodedContent.type else { return false }
+            return contentType == ContentTypeInviteJoinError
+        }.count
+    }
 }

--- a/ConvosCore/Tests/ConvosCoreTests/InviteJoinRequestsManagerTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/InviteJoinRequestsManagerTests.swift
@@ -1,0 +1,36 @@
+@testable import ConvosCore
+import Foundation
+import Testing
+
+@Suite("InviteJoinRequestsManager Tests")
+struct InviteJoinRequestsManagerTests {
+    let now = Date(timeIntervalSince1970: 1_780_000_000)
+    let day: TimeInterval = 24 * 60 * 60
+
+    @Test("Nil cursor clamps to the 24h window instead of sweeping all history")
+    func nilCursorClampsToWindow() {
+        let effective = InviteJoinRequestsManager.effectiveCatchUpSince(since: nil, now: now)
+        #expect(effective == now.addingTimeInterval(-day))
+    }
+
+    @Test("Recent cursor passes through unchanged")
+    func recentCursorUnchanged() {
+        let recent = now.addingTimeInterval(-300)
+        let effective = InviteJoinRequestsManager.effectiveCatchUpSince(since: recent, now: now)
+        #expect(effective == recent)
+    }
+
+    @Test("Cursor older than the window clamps to the window")
+    func ancientCursorClamps() {
+        let ancient = now.addingTimeInterval(-90 * day)
+        let effective = InviteJoinRequestsManager.effectiveCatchUpSince(since: ancient, now: now)
+        #expect(effective == now.addingTimeInterval(-day))
+    }
+
+    @Test("Cursor exactly at the window boundary is preserved")
+    func boundaryCursorPreserved() {
+        let boundary = now.addingTimeInterval(-day)
+        let effective = InviteJoinRequestsManager.effectiveCatchUpSince(since: boundary, now: now)
+        #expect(effective == boundary)
+    }
+}

--- a/ConvosCore/Tests/ConvosCoreTests/SyncingManagerTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/SyncingManagerTests.swift
@@ -1,4 +1,5 @@
 @testable import ConvosCore
+import ConvosInvites
 import Foundation
 import GRDB
 import os.lock
@@ -316,6 +317,10 @@ class TestableMockMessageSender: MessageSender {
     }
 
     func prepare(text: String) async throws -> String {
+        ""
+    }
+
+    func prepare(joinRequest: JoinRequestContent) async throws -> String {
         ""
     }
 

--- a/ConvosInvites/Sources/ConvosInvites/InviteClientProvider.swift
+++ b/ConvosInvites/Sources/ConvosInvites/InviteClientProvider.swift
@@ -9,6 +9,9 @@ public protocol InviteClientProvider {
     var inviteInboxId: String { get }
     func findConversation(conversationId: String) async throws -> XMTPiOS.Conversation?
     func findOrCreateDm(with inboxId: String) async throws -> XMTPiOS.Dm
+    /// Pulls new conversations (welcomes) from the network so a recently
+    /// created group can be found locally before a join request is rejected.
+    func syncConversations() async throws
     // swiftlint:disable:next function_parameter_count
     func listDms(
         createdAfterNs: Int64?,
@@ -30,6 +33,10 @@ extension XMTPiOS.Client: InviteClientProvider {
 
     public func findOrCreateDm(with inboxId: String) async throws -> XMTPiOS.Dm {
         try await conversations.findOrCreateDm(with: inboxId)
+    }
+
+    public func syncConversations() async throws {
+        try await conversations.sync()
     }
 
     // swiftlint:disable:next function_parameter_count

--- a/ConvosInvites/Sources/ConvosInvites/InviteCoordinator.swift
+++ b/ConvosInvites/Sources/ConvosInvites/InviteCoordinator.swift
@@ -144,6 +144,11 @@ public final class InviteCoordinator: @unchecked Sendable {
     ) async -> JoinRequestDMOutcome {
         guard message.senderInboxId != client.inviteInboxId else { return .noJoinRequest }
 
+        // Only the typed join_request content type is accepted. Plain-text
+        // slug messages (the original wire format, kept as a fallback until
+        // mid-2026) are deliberately ignored: senders that still emit a text
+        // copy alongside the typed message would otherwise produce duplicate
+        // processing and duplicate error replies.
         guard let joinRequest: JoinRequestContent = try? message.content() else {
             return .noJoinRequest
         }
@@ -157,6 +162,7 @@ public final class InviteCoordinator: @unchecked Sendable {
             dmConversationId: message.conversationId,
             signedInvite: signedInvite,
             messageId: message.id,
+            sentAt: message.sentAt,
             profile: joinRequest.profile,
             metadata: joinRequest.metadata
         )
@@ -271,18 +277,6 @@ public final class InviteCoordinator: @unchecked Sendable {
             return .stop(benignFailure(request, error: .expired))
         }
 
-        guard !signedInvite.conversationHasExpired else {
-            let expiresAt = signedInvite.conversationExpiresAt.map { "\($0)" } ?? "unknown"
-            await sendJoinError(
-                .conversationExpired,
-                reason: "conversation expired at \(expiresAt)",
-                for: request,
-                client: client
-            )
-            delegate?.coordinator(self, didRejectJoinRequest: request, error: .conversationExpired)
-            return .stop(benignFailure(request, error: .conversationExpired))
-        }
-
         let creatorInboxId = signedInvite.invitePayload.creatorInboxIdString
 
         guard !creatorInboxId.isEmpty else {
@@ -299,9 +293,10 @@ public final class InviteCoordinator: @unchecked Sendable {
         do {
             privateKey = try await privateKeyProvider(creatorInboxId)
         } catch {
+            Log.warning("Rejecting join (inviteTag: \(signedInvite.invitePayload.tag)): private key unavailable: \(error)")
             await sendJoinError(
                 .genericFailure,
-                reason: "creator private key unavailable: \(error)",
+                reason: "creator private key unavailable",
                 for: request,
                 client: client
             )
@@ -337,6 +332,21 @@ public final class InviteCoordinator: @unchecked Sendable {
             return .stop(benignFailure(request, error: .processingFailed))
         }
 
+        // Checked only after signature verification: this branch sends an
+        // error reply, and replying to unverified slugs would let anyone
+        // forge an "expired" invite and reflect outbound DMs off the creator.
+        guard !signedInvite.conversationHasExpired else {
+            let expiresAt = signedInvite.conversationExpiresAt.map { "\($0)" } ?? "unknown"
+            await sendJoinError(
+                .conversationExpired,
+                reason: "conversation expired at \(expiresAt)",
+                for: request,
+                client: client
+            )
+            delegate?.coordinator(self, didRejectJoinRequest: request, error: .conversationExpired)
+            return .stop(benignFailure(request, error: .conversationExpired))
+        }
+
         do {
             let conversationId = try InviteToken.decrypt(
                 tokenBytes: signedInvite.invitePayload.conversationToken,
@@ -361,7 +371,17 @@ public final class InviteCoordinator: @unchecked Sendable {
             // missing from this installation's store even though it exists
             // (fresh install, secondary device), so pull new conversations
             // once before telling the joiner the conversation is gone.
-            try? await client.syncConversations()
+            Log.info("Conversation \(conversationId) not found locally for join request, syncing conversations before rejecting")
+            do {
+                try await client.syncConversations()
+            } catch {
+                // A failed sync means we cannot distinguish "group doesn't
+                // exist" from "we just couldn't fetch it" - treat it like
+                // the consentState() throw below: transient, no error sent.
+                Log.warning("Conversation sync failed while resolving join request for \(conversationId): \(error)")
+                delegate?.coordinator(self, didRejectJoinRequest: request, error: .processingFailed)
+                return .stop(benignFailure(request, error: .processingFailed))
+            }
             foundConversation = try? await client.findConversation(conversationId: conversationId)
         }
         guard let conversation = foundConversation else {
@@ -451,9 +471,10 @@ public final class InviteCoordinator: @unchecked Sendable {
                 return benignFailure(request, error: .revoked)
             }
         } catch {
+            Log.warning("Rejecting join (inviteTag: \(signedInvite.invitePayload.tag)): reading invite tag failed: \(error)")
             await sendJoinError(
                 .conversationExpired,
-                reason: "creator could not read the group's invite tag: \(error)",
+                reason: "creator could not read the group's invite tag",
                 for: request,
                 client: client
             )
@@ -464,9 +485,14 @@ public final class InviteCoordinator: @unchecked Sendable {
         do {
             _ = try await group.addMembers(inboxIds: [request.joinerInboxId])
         } catch {
+            // The full error stays in creator-side logs; the wire reason
+            // carries only the error type name. Raw libxmtp descriptions can
+            // embed member inbox IDs and storage internals, and the joiner
+            // is an untrusted party.
+            Log.warning("Rejecting join (inviteTag: \(signedInvite.invitePayload.tag)): addMembers failed: \(error)")
             await sendJoinError(
                 .genericFailure,
-                reason: "addMembers failed: \(error)",
+                reason: "addMembers failed (\(type(of: error)))",
                 for: request,
                 client: client
             )
@@ -504,6 +530,11 @@ public final class InviteCoordinator: @unchecked Sendable {
             )
         }
 
+        // ContentTypeText is deliberately absent: plain-text slug messages
+        // are no longer join requests. Senders like Herald still emit a text
+        // copy next to the typed message for older creators; treating it as
+        // a second join request produced duplicate processing and duplicate
+        // error replies. Do not re-add text support here.
         let candidates = messages.filter { message in
             guard let contentType = try? message.encodedContent.type,
                   contentType == ContentTypeJoinRequest,
@@ -575,10 +606,13 @@ public final class InviteCoordinator: @unchecked Sendable {
         // (message stream, batch catch-up, agent-join poll), and nothing
         // marks a failure as handled the way `.alreadyMember` does for
         // successes. Skip the send if this DM already carries an error for
-        // the same invite tag so the joiner gets exactly one reply per
-        // failed invite instead of one per processing pass.
+        // the same invite tag sent after this request's message, so each
+        // failed attempt gets exactly one reply no matter how many passes
+        // revalidate it. Errors older than the request don't count: a fresh
+        // retry of the same invite deserves a fresh reply, otherwise the
+        // joiner waits forever on an error that will never arrive.
         let inviteTag = request.signedInvite.invitePayload.tag
-        if await hasAlreadySentJoinError(forTag: inviteTag, in: dm, client: client) {
+        if await hasAlreadySentJoinError(forTag: inviteTag, since: request.sentAt, in: dm, client: client) {
             return
         }
 
@@ -598,6 +632,7 @@ public final class InviteCoordinator: @unchecked Sendable {
 
     private func hasAlreadySentJoinError(
         forTag tag: String,
+        since requestSentAt: Date?,
         in dm: XMTPiOS.Conversation,
         client: any InviteClientProvider
     ) async -> Bool {
@@ -609,6 +644,9 @@ public final class InviteCoordinator: @unchecked Sendable {
             guard let contentType = try? message.encodedContent.type,
                   contentType == ContentTypeInviteJoinError,
                   let priorError = try? codec.decode(content: message.encodedContent) else {
+                continue
+            }
+            if let requestSentAt, message.sentAt < requestSentAt {
                 continue
             }
             if priorError.inviteTag == tag {

--- a/ConvosInvites/Sources/ConvosInvites/InviteCoordinator.swift
+++ b/ConvosInvites/Sources/ConvosInvites/InviteCoordinator.swift
@@ -124,7 +124,6 @@ public final class InviteCoordinator: @unchecked Sendable {
             content: joinRequest,
             options: .init(contentType: codec.contentType)
         )
-        _ = try await dm.send(content: slug)
 
         return dm
     }
@@ -145,21 +144,11 @@ public final class InviteCoordinator: @unchecked Sendable {
     ) async -> JoinRequestDMOutcome {
         guard message.senderInboxId != client.inviteInboxId else { return .noJoinRequest }
 
-        let slug: String
-        var profile: JoinRequestProfile?
-        var metadata: [String: String]?
-
-        if let joinRequest: JoinRequestContent = try? message.content() {
-            slug = joinRequest.inviteSlug
-            profile = joinRequest.profile
-            metadata = joinRequest.metadata
-        } else if let text: String = try? message.content() {
-            slug = text
-        } else {
+        guard let joinRequest: JoinRequestContent = try? message.content() else {
             return .noJoinRequest
         }
 
-        guard let signedInvite = try? SignedInvite.fromURLSafeSlug(slug) else {
+        guard let signedInvite = try? SignedInvite.fromURLSafeSlug(joinRequest.inviteSlug) else {
             return .noJoinRequest
         }
 
@@ -168,8 +157,8 @@ public final class InviteCoordinator: @unchecked Sendable {
             dmConversationId: message.conversationId,
             signedInvite: signedInvite,
             messageId: message.id,
-            profile: profile,
-            metadata: metadata
+            profile: joinRequest.profile,
+            metadata: joinRequest.metadata
         )
 
         return await processJoinRequest(request, client: client)
@@ -241,49 +230,89 @@ public final class InviteCoordinator: @unchecked Sendable {
 
     // MARK: - Core Processing
 
-    // swiftlint:disable:next cyclomatic_complexity
+    /// Result of one validation phase of join-request processing: either the
+    /// value the next phase needs, or the outcome to return to the caller.
+    private enum JoinStep<Value> {
+        case proceed(Value)
+        case stop(JoinRequestDMOutcome)
+    }
+
     private func processJoinRequest(
         _ request: JoinRequest,
         client: any InviteClientProvider
     ) async -> JoinRequestDMOutcome {
+        let conversationId: String
+        switch await validateInviteAndDecryptConversationId(request, client: client) {
+        case .proceed(let value):
+            conversationId = value
+        case .stop(let outcome):
+            return outcome
+        }
+
+        let group: XMTPiOS.Group
+        switch await resolveInvitedGroup(conversationId: conversationId, request: request, client: client) {
+        case .proceed(let value):
+            group = value
+        case .stop(let outcome):
+            return outcome
+        }
+
+        return await addJoinerToGroup(group, conversationId: conversationId, request: request, client: client)
+    }
+
+    private func validateInviteAndDecryptConversationId(
+        _ request: JoinRequest,
+        client: any InviteClientProvider
+    ) async -> JoinStep<String> {
         let signedInvite = request.signedInvite
 
         guard !signedInvite.hasExpired else {
             delegate?.coordinator(self, didRejectJoinRequest: request, error: .expired)
-            return benignFailure(request, error: .expired)
+            return .stop(benignFailure(request, error: .expired))
         }
 
         guard !signedInvite.conversationHasExpired else {
-            await sendJoinError(.conversationExpired, for: request, client: client)
+            let expiresAt = signedInvite.conversationExpiresAt.map { "\($0)" } ?? "unknown"
+            await sendJoinError(
+                .conversationExpired,
+                reason: "conversation expired at \(expiresAt)",
+                for: request,
+                client: client
+            )
             delegate?.coordinator(self, didRejectJoinRequest: request, error: .conversationExpired)
-            return benignFailure(request, error: .conversationExpired)
+            return .stop(benignFailure(request, error: .conversationExpired))
         }
 
         let creatorInboxId = signedInvite.invitePayload.creatorInboxIdString
 
         guard !creatorInboxId.isEmpty else {
             delegate?.coordinator(self, didRejectJoinRequest: request, error: .invalidFormat)
-            return benignFailure(request, error: .invalidFormat)
+            return .stop(benignFailure(request, error: .invalidFormat))
         }
 
         guard creatorInboxId == client.inviteInboxId else {
             delegate?.coordinator(self, didRejectJoinRequest: request, error: .creatorMismatch)
-            return benignFailure(request, error: .creatorMismatch)
+            return .stop(benignFailure(request, error: .creatorMismatch))
         }
 
         let privateKey: Data
         do {
             privateKey = try await privateKeyProvider(creatorInboxId)
         } catch {
-            await sendJoinError(.genericFailure, for: request, client: client)
+            await sendJoinError(
+                .genericFailure,
+                reason: "creator private key unavailable: \(error)",
+                for: request,
+                client: client
+            )
             delegate?.coordinator(self, didRejectJoinRequest: request, error: .processingFailed)
-            return benignFailure(request, error: .processingFailed)
+            return .stop(benignFailure(request, error: .processingFailed))
         }
 
         do {
             let expectedPublicKey = try Data.derivePublicKey(from: privateKey)
             guard try signedInvite.verify(with: expectedPublicKey) else {
-                return await denyDmForMaliciousInvite(request, client: client, error: .invalidSignature)
+                return .stop(await denyDmForMaliciousInvite(request, client: client, error: .invalidSignature))
             }
         } catch let error as InviteSignatureError {
             // Threat-model split:
@@ -297,49 +326,100 @@ public final class InviteCoordinator: @unchecked Sendable {
             //   so the same joiner can retry without being blocked.
             switch error {
             case .invalidSignature, .verificationFailure:
-                return await denyDmForMaliciousInvite(request, client: client, error: .invalidSignature)
+                return .stop(await denyDmForMaliciousInvite(request, client: client, error: .invalidSignature))
             case .invalidContext, .invalidPublicKey, .invalidPrivateKey,
                  .invalidFormat, .signatureFailure, .encodingFailure:
                 delegate?.coordinator(self, didRejectJoinRequest: request, error: .processingFailed)
-                return benignFailure(request, error: .processingFailed)
+                return .stop(benignFailure(request, error: .processingFailed))
             }
         } catch {
             delegate?.coordinator(self, didRejectJoinRequest: request, error: .processingFailed)
-            return benignFailure(request, error: .processingFailed)
+            return .stop(benignFailure(request, error: .processingFailed))
         }
 
-        let conversationId: String
         do {
-            conversationId = try InviteToken.decrypt(
+            let conversationId = try InviteToken.decrypt(
                 tokenBytes: signedInvite.invitePayload.conversationToken,
                 creatorInboxId: creatorInboxId,
                 privateKey: privateKey
             )
+            return .proceed(conversationId)
         } catch {
             delegate?.coordinator(self, didRejectJoinRequest: request, error: .invalidFormat)
-            return benignFailure(request, error: .invalidFormat)
+            return .stop(benignFailure(request, error: .invalidFormat))
         }
+    }
 
-        guard let conversation = try? await client.findConversation(conversationId: conversationId) else {
-            Log.warning("Rejecting join for \(conversationId) (inviteTag: \(request.signedInvite.invitePayload.tag)): conversation not found in local store")
-            await sendJoinError(.conversationNotFound, for: request, client: client)
+    private func resolveInvitedGroup(
+        conversationId: String,
+        request: JoinRequest,
+        client: any InviteClientProvider
+    ) async -> JoinStep<XMTPiOS.Group> {
+        var foundConversation = try? await client.findConversation(conversationId: conversationId)
+        if foundConversation == nil {
+            // findConversation is a local-only lookup. The group can be
+            // missing from this installation's store even though it exists
+            // (fresh install, secondary device), so pull new conversations
+            // once before telling the joiner the conversation is gone.
+            try? await client.syncConversations()
+            foundConversation = try? await client.findConversation(conversationId: conversationId)
+        }
+        guard let conversation = foundConversation else {
+            Log.warning("Rejecting join for \(conversationId) (inviteTag: \(request.signedInvite.invitePayload.tag)): conversation not found in local store after sync")
+            await sendJoinError(
+                .conversationNotFound,
+                reason: "conversation not found in creator's local store after sync",
+                for: request,
+                client: client
+            )
             delegate?.coordinator(self, didRejectJoinRequest: request, error: .conversationNotFound(conversationId))
-            return benignFailure(request, error: .conversationNotFound(conversationId))
+            return .stop(benignFailure(request, error: .conversationNotFound(conversationId)))
         }
 
-        let consent = (try? conversation.consentState()) ?? .unknown
+        let consent: ConsentState
+        do {
+            consent = try conversation.consentState()
+        } catch {
+            // A throw here is a local read failure, not an actual denial.
+            // Treat it as transient so the joiner isn't told their valid
+            // invite was rejected.
+            Log.warning("Skipping join for \(conversationId) (inviteTag: \(request.signedInvite.invitePayload.tag)): reading consent state failed: \(error)")
+            delegate?.coordinator(self, didRejectJoinRequest: request, error: .processingFailed)
+            return .stop(benignFailure(request, error: .processingFailed))
+        }
         guard consent == .allowed else {
             Log.warning("Rejecting join for \(conversationId) (inviteTag: \(request.signedInvite.invitePayload.tag)): consent state '\(consent)' is not .allowed")
-            await sendJoinError(.consentNotAllowed, for: request, client: client)
+            await sendJoinError(
+                .consentNotAllowed,
+                reason: "creator consent state is '\(consent)'",
+                for: request,
+                client: client
+            )
             delegate?.coordinator(self, didRejectJoinRequest: request, error: .consentNotAllowed(conversationId, consent))
-            return benignFailure(request, error: .consentNotAllowed(conversationId, consent))
+            return .stop(benignFailure(request, error: .consentNotAllowed(conversationId, consent)))
         }
 
         guard case .group(let group) = conversation else {
-            await sendJoinError(.genericFailure, for: request, client: client)
+            await sendJoinError(
+                .genericFailure,
+                reason: "invite target is a DM, not a group",
+                for: request,
+                client: client
+            )
             delegate?.coordinator(self, didRejectJoinRequest: request, error: .invalidFormat)
-            return benignFailure(request, error: .invalidFormat)
+            return .stop(benignFailure(request, error: .invalidFormat))
         }
+
+        return .proceed(group)
+    }
+
+    private func addJoinerToGroup(
+        _ group: XMTPiOS.Group,
+        conversationId: String,
+        request: JoinRequest,
+        client: any InviteClientProvider
+    ) async -> JoinRequestDMOutcome {
+        let signedInvite = request.signedInvite
 
         try? await group.sync()
 
@@ -359,12 +439,24 @@ public final class InviteCoordinator: @unchecked Sendable {
         do {
             let currentTag = try tagStorage.getInviteTag(for: group)
             guard signedInvite.invitePayload.tag == currentTag else {
-                await sendJoinError(.conversationExpired, for: request, client: client)
+                // errorType stays .conversationExpired for older-client UX;
+                // the reason distinguishes revocation from actual expiry.
+                await sendJoinError(
+                    .conversationExpired,
+                    reason: "invite tag revoked or rotated since the invite was created",
+                    for: request,
+                    client: client
+                )
                 delegate?.coordinator(self, didRejectJoinRequest: request, error: .revoked)
                 return benignFailure(request, error: .revoked)
             }
         } catch {
-            await sendJoinError(.conversationExpired, for: request, client: client)
+            await sendJoinError(
+                .conversationExpired,
+                reason: "creator could not read the group's invite tag: \(error)",
+                for: request,
+                client: client
+            )
             delegate?.coordinator(self, didRejectJoinRequest: request, error: .revoked)
             return benignFailure(request, error: .revoked)
         }
@@ -372,7 +464,12 @@ public final class InviteCoordinator: @unchecked Sendable {
         do {
             _ = try await group.addMembers(inboxIds: [request.joinerInboxId])
         } catch {
-            await sendJoinError(.genericFailure, for: request, client: client)
+            await sendJoinError(
+                .genericFailure,
+                reason: "addMembers failed: \(error)",
+                for: request,
+                client: client
+            )
             delegate?.coordinator(self, didRejectJoinRequest: request, error: .addMemberFailed)
             return benignFailure(request, error: .addMemberFailed)
         }
@@ -409,7 +506,7 @@ public final class InviteCoordinator: @unchecked Sendable {
 
         let candidates = messages.filter { message in
             guard let contentType = try? message.encodedContent.type,
-                  contentType == ContentTypeText || contentType == ContentTypeJoinRequest,
+                  contentType == ContentTypeJoinRequest,
                   message.senderInboxId != client.inviteInboxId else {
                 return false
             }
@@ -466,6 +563,7 @@ public final class InviteCoordinator: @unchecked Sendable {
 
     private func sendJoinError(
         _ errorType: InviteJoinErrorType,
+        reason: String,
         for request: JoinRequest,
         client: any InviteClientProvider
     ) async {
@@ -473,10 +571,22 @@ public final class InviteCoordinator: @unchecked Sendable {
             return
         }
 
+        // The same failed join request can be revalidated by several paths
+        // (message stream, batch catch-up, agent-join poll), and nothing
+        // marks a failure as handled the way `.alreadyMember` does for
+        // successes. Skip the send if this DM already carries an error for
+        // the same invite tag so the joiner gets exactly one reply per
+        // failed invite instead of one per processing pass.
+        let inviteTag = request.signedInvite.invitePayload.tag
+        if await hasAlreadySentJoinError(forTag: inviteTag, in: dm, client: client) {
+            return
+        }
+
         let error = InviteJoinError(
             errorType: errorType,
-            inviteTag: request.signedInvite.invitePayload.tag,
-            timestamp: Date()
+            inviteTag: inviteTag,
+            timestamp: Date(),
+            reason: String(reason.prefix(Constant.joinErrorReasonMaxLength))
         )
 
         let codec = InviteJoinErrorCodec()
@@ -484,6 +594,38 @@ public final class InviteCoordinator: @unchecked Sendable {
             content: error,
             options: .init(contentType: codec.contentType)
         )
+    }
+
+    private func hasAlreadySentJoinError(
+        forTag tag: String,
+        in dm: XMTPiOS.Conversation,
+        client: any InviteClientProvider
+    ) async -> Bool {
+        guard let messages = try? await dm.messages(limit: Constant.joinErrorDedupeScanLimit) else {
+            return false
+        }
+        let codec = InviteJoinErrorCodec()
+        for message in messages where message.senderInboxId == client.inviteInboxId {
+            guard let contentType = try? message.encodedContent.type,
+                  contentType == ContentTypeInviteJoinError,
+                  let priorError = try? codec.decode(content: message.encodedContent) else {
+                continue
+            }
+            if priorError.inviteTag == tag {
+                return true
+            }
+        }
+        return false
+    }
+
+    private enum Constant {
+        /// How many recent DM messages to scan when checking whether an
+        /// error reply for an invite tag was already sent. Join-request DMs
+        /// carry very little traffic, so a small window is plenty.
+        static let joinErrorDedupeScanLimit: Int = 50
+        /// Underlying error descriptions (libxmtp, keychain) can be very
+        /// long; cap the diagnostic reason so error replies stay small.
+        static let joinErrorReasonMaxLength: Int = 500
     }
 }
 

--- a/ConvosInvites/Sources/ConvosInvites/Models.swift
+++ b/ConvosInvites/Sources/ConvosInvites/Models.swift
@@ -296,10 +296,18 @@ public struct InviteJoinError: Codable, Equatable, Sendable {
     public let inviteTag: String
     public let timestamp: Date
 
-    public init(errorType: InviteJoinErrorType, inviteTag: String, timestamp: Date) {
+    /// Diagnostic detail about what actually failed (e.g. the underlying
+    /// error description, or which validation step rejected the request).
+    /// Not shown to users - joiner-side telemetry records it so failures
+    /// can be tracked down without access to the creator's device. Optional
+    /// on the wire: payloads from older clients decode with nil.
+    public let reason: String?
+
+    public init(errorType: InviteJoinErrorType, inviteTag: String, timestamp: Date, reason: String? = nil) {
         self.errorType = errorType
         self.inviteTag = inviteTag
         self.timestamp = timestamp
+        self.reason = reason
     }
 
     public var userFacingMessage: String {

--- a/ConvosInvites/Sources/ConvosInvites/Models.swift
+++ b/ConvosInvites/Sources/ConvosInvites/Models.swift
@@ -78,6 +78,11 @@ public struct JoinRequest: Sendable {
     /// The message containing the join request
     public let messageId: String
 
+    /// When the join-request message was sent. Used to scope error-reply
+    /// deduplication to this attempt: only an error sent after this moment
+    /// counts as already answering it.
+    public let sentAt: Date?
+
     /// The joiner's profile (name, image) if provided
     public let profile: JoinRequestProfile?
 
@@ -89,6 +94,7 @@ public struct JoinRequest: Sendable {
         dmConversationId: String,
         signedInvite: SignedInvite,
         messageId: String,
+        sentAt: Date? = nil,
         profile: JoinRequestProfile? = nil,
         metadata: [String: String]? = nil
     ) {
@@ -96,6 +102,7 @@ public struct JoinRequest: Sendable {
         self.dmConversationId = dmConversationId
         self.signedInvite = signedInvite
         self.messageId = messageId
+        self.sentAt = sentAt
         self.profile = profile
         self.metadata = metadata
     }

--- a/ConvosInvites/Tests/ConvosInvitesTests/ContentTypes/InviteJoinErrorCodecTests.swift
+++ b/ConvosInvites/Tests/ConvosInvitesTests/ContentTypes/InviteJoinErrorCodecTests.swift
@@ -395,6 +395,49 @@ struct InviteJoinErrorCodecTests {
         }
     }
 
+    @Test("Reason round-trips through encode and decode")
+    func reasonRoundTrip() throws {
+        let error = InviteJoinError(
+            errorType: .genericFailure,
+            inviteTag: "test-tag",
+            timestamp: Date(),
+            reason: "addMembers failed: GroupError.commitValidation"
+        )
+
+        let encodedContent = try codec.encode(content: error)
+        let decodedError: InviteJoinError = try codec.decode(content: encodedContent)
+
+        #expect(decodedError.reason == "addMembers failed: GroupError.commitValidation")
+    }
+
+    @Test("Backward compatibility: payload without reason decodes with nil reason")
+    func backwardCompatMissingReasonDecodesToNil() throws {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+
+        struct LegacyError: Codable {
+            let errorType: String
+            let inviteTag: String
+            let timestamp: Date
+        }
+
+        let legacyError = LegacyError(
+            errorType: "generic_failure",
+            inviteTag: "legacy-tag",
+            timestamp: Date()
+        )
+
+        let jsonData = try encoder.encode(legacyError)
+        var encodedContent = EncodedContent()
+        encodedContent.type = ContentTypeInviteJoinError
+        encodedContent.content = jsonData
+
+        let decodedError: InviteJoinError = try codec.decode(content: encodedContent)
+
+        #expect(decodedError.errorType == .genericFailure)
+        #expect(decodedError.reason == nil)
+    }
+
     @Test("Multiple errors with same tag are distinct")
     func multipleErrorsSameTag() throws {
         let tag = "shared-tag"


### PR DESCRIPTION
## Problem

Herald's prod logs are flooded with inbound `convos.org/invite_join_error:1.0` messages (xmtplabs/herald-lite#83). These are error replies iOS creators send to joiners (mostly Herald-managed agents) when a join request fails — and the volume is amplified by several iOS-side issues rather than by that many actual distinct failures.

Investigation found four root causes, all on the iOS side:

1. **Every Herald join arrives twice.** Herald sends a typed `join_request` plus a plain-text slug fallback (for old iOS creators). The creator treated both as independent join requests, so one failed join produced two error replies.
2. **Failed requests are re-processed without dedupe.** The message stream, batch catch-up, and the agent-join poll (added June 5 in #1005-era diagnostics) can all revalidate the same join-request message. `.alreadyMember` dedupes successes, but nothing marks a *failure* as handled — every pass re-sent the error.
3. **A nil catch-up cursor sweeps all history.** On fresh install/restore, `runBatchCatchUp(since: nil)` revalidated every historical join request in every DM and replied with stale errors for invites that died long ago.
4. **Legitimate joins were falsely rejected.** `findConversation` is local-only (no sync attempt → spurious `conversation_not_found` on secondary devices/fresh syncs), and a thrown `consentState()` read was reported to the joiner as `consent_not_allowed`.
5. **The error carried no detail.** `invite_join_error` only had the coarse `errorType`, so even with Herald's codec (herald-lite#84) telemetry couldn't say what actually failed on the creator's device.

## Changes

- **Joiner sends the typed `JoinRequestContent`.** The production join path (`ConversationStateMachine.handleJoin`) still sent the plain-text slug from the original backend-less invites implementation (#167); the typed content type added in #556 was never wired up. Now it is.
- **Creator no longer accepts plain text as a join request** (`processMessageOutcome` / `processDm`), and the coordinator's test-path dual send drops its text copy. Herald's text fallback is simply ignored; its typed message still works.
- **`sendJoinError` dedupes by invite tag**: before sending, it scans the DM for an existing error reply for the same tag and skips if present. One failed invite → exactly one error reply, regardless of how many passes revalidate it.
- **Batch catch-up bounds the join-request sweep to 24h** (`InviteJoinRequestsManager.processJoinRequestOutcomes`). Joining clients give up within minutes; older requests only generate noise.
- **`syncConversations()` before rejecting as not-found**, and a `consentState()` read failure is treated as a transient local error instead of telling the joiner their invite was rejected.
- **`InviteJoinError` gains an optional `reason` field** carrying the real failure detail: the underlying `addMembers`/keychain error description, the actual consent state, expiry timestamp, or "tag revoked" (finally distinguishable from real expiry, which the coarse `errorType` masks for old-client UX). Capped at 500 chars. Optional on the wire in both directions — older clients decode payloads without it as `nil`, and they ignore the unknown key in new payloads (codec tests cover both). Herald's codec (herald-lite#84) can pick it up with a one-line field addition, after which its telemetry shows exactly why each join failed.
- `processJoinRequest` split into validate / resolve / add phases to stay inside the function-body-length lint limit.

The `invite_join_error` spec in `convos-shared/docs/protocol/messaging/codec-002-invite-join-error.md` should get a follow-up documenting the `reason` field.

## Adversarial-review hardening (second commit)

A multi-agent adversarial review of the first commit surfaced these, all addressed:

- **Dedupe is now per-attempt, not per-tag-forever**: `JoinRequest` carries the request message's `sentAt`, and only an error sent *after* the current attempt counts as a duplicate. Without this, a joiner retrying the same invite later would never get a second reply — and the iOS joiner would hang in `.joining` (it only exits failure on a freshly streamed error). Covered by a new integration test.
- **`conversationExpired` reply moved after signature verification**: previously anyone could forge an expired slug with a fresh tag and reflect outbound error DMs off a creator, unauthenticated.
- **`reason` no longer interpolates raw error descriptions**: libxmtp/keychain errors can embed member inbox IDs, SQL/storage internals, and file paths, and the joiner is untrusted. The wire reason now carries only a coarse description (error *type* name for addMembers); full details stay in creator-side logs.
- **Transient sync failure no longer sends a permanent `conversationNotFound`**: if the pre-reject `syncConversations()` throws, the pass is treated as transient (same policy as the consentState-throw path) instead of telling the joiner the conversation is gone.
- **Tests**: integration tests for the two headline behaviors (plain-text slug is inert — no join, no error reply; exactly one error per failed attempt across repeated processing passes, fresh retry gets a fresh reply), plus unit tests for the 24h catch-up clamp (extracted into a testable function).
- Compat-break comments at both enforcement sites so nobody "re-adds" text support as a bug fix.

## Compatibility

- Older app builds that send text-only join requests will be **ignored** by updated creators (approved compatibility break).
- The reverse also holds: updated iOS joiners send typed-only, so **creators on builds older than #556 (pre-March 2026)** will ignore their join requests. Herald and the CLI are unaffected (they still send a text fallback for old creators).
- Text-slug spam no longer reaches the malicious-deny path — it's simply ignored (the DM stays `.unknown` instead of being denied).
- Herald needs no changes; registering the `invite_join_error` codec (herald-lite#84) is still worth merging for visibility into the remaining legitimate errors.

## Agent-join retry fix (third commit)

Field repro while testing this branch: picking a suggested agent fired `agents/join` with its templateId; the response was lost ("network connection was lost") but the backend had processed it and the agent joined seconds later. The failure bubble's retry then called the bare `requestAgentJoin()` (`templateId=nil`), so the backend provisioned its **default** agent too — two agents in the conversation.

- Failed `agents/join` calls now record their `templateId` + `requestId`; the retry affordance replays them via `retryAgentJoin()` (same template, same requestId so the status bubble updates in place).
- Backend follow-up: `agents/join` has no idempotency key (the body carries no client request identifier), so an ambiguous network failure + retry can still double-provision. Plumbing the recorded `requestId` through the API and deduping server-side closes that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Deduplicate `invite_join_error` replies and send typed-only join requests with diagnostic reasons
> - Join requests now send only a typed `JoinRequestContent` message via `prepare(joinRequest:)` instead of a plain-text slug; the coordinator ignores plain-text messages as join candidates.
> - `InviteCoordinator.sendJoinError` deduplicates error replies by scanning the last 50 DM messages and skipping if an error for the same invite tag was already sent after the request's `sentAt` timestamp.
> - Error replies now include an optional `reason` field in `InviteJoinError` for diagnostics; wire format is backward compatible.
> - `retryAgentJoin()` replays the original failed attempts (preserving `templateId` and `requestId`) so UI status bubbles update in place instead of issuing a fresh default-agent join.
> - Catch-up processing of join requests is clamped to the last 24 hours via `effectiveCatchUpSince(since:now:)` to avoid reprocessing stale requests.
> - Behavioral Change: plain-text slug DMs sent before this change will no longer be processed as join requests by the coordinator.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized efeb4d3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->