### PR TITLE
chore(deps): track convos-shared main again

### DIFF
--- a/Convos.xcodeproj/project.pbxproj
+++ b/Convos.xcodeproj/project.pbxproj
@@ -1007,7 +1007,7 @@
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
-				OTHER_SWIFT_FLAGS = "-Xfrontend -warn-long-function-bodies -Xfrontend 100 -Xfrontend -warn-long-expression-type-checking -Xfrontend 100";
+				OTHER_SWIFT_FLAGS = "-Xfrontend -warn-long-function-bodies -Xfrontend 1000 -Xfrontend -warn-long-expression-type-checking -Xfrontend 1000";
 				SDKROOT = iphoneos;
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
@@ -2241,7 +2241,7 @@
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
-				OTHER_SWIFT_FLAGS = "-Xfrontend -warn-long-function-bodies -Xfrontend 300 -Xfrontend -warn-long-expression-type-checking -Xfrontend 300";
+				OTHER_SWIFT_FLAGS = "-Xfrontend -warn-long-function-bodies -Xfrontend 1000 -Xfrontend -warn-long-expression-type-checking -Xfrontend 1000";
 				SDKROOT = iphoneos;
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
@@ -2370,7 +2370,7 @@
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
-				OTHER_SWIFT_FLAGS = "-Xfrontend -warn-long-function-bodies -Xfrontend 300 -Xfrontend -warn-long-expression-type-checking -Xfrontend 300";
+				OTHER_SWIFT_FLAGS = "-Xfrontend -warn-long-function-bodies -Xfrontend 1000 -Xfrontend -warn-long-expression-type-checking -Xfrontend 1000";
 				SDKROOT = iphoneos;
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";

--- a/Convos.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Convos.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -34,7 +34,7 @@
       "location" : "https://github.com/xmtplabs/convos-shared.git",
       "state" : {
         "branch" : "main",
-        "revision" : "58373daace02914b2efd00bdb485e65ae68faafc"
+        "revision" : "b82d23fc47fd2a9ed41370369a783306b9fbdc8a"
       }
     },
     {

--- a/Convos.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Convos.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "bda0ed788167ae17f3a13ebcf47c374b7d3fb34bc58c18aed3aa73fa0c42c049",
+  "originHash" : "ea2aea7f0b30f28625ca65fde9563c44657e5fd6a2c3085d173ad16c8f36b6db",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/xmtplabs/convos-shared.git",
       "state" : {
-        "branch" : "jarod/assistant-join-metrics",
-        "revision" : "db0dde49c87c670758ca7a14488d863701a9be1d"
+        "branch" : "main",
+        "revision" : "58373daace02914b2efd00bdb485e65ae68faafc"
       }
     },
     {

--- a/Convos/Conversation Creation/NewConversationViewModel.swift
+++ b/Convos/Conversation Creation/NewConversationViewModel.swift
@@ -811,16 +811,16 @@ class NewConversationViewModel: Identifiable, Hashable {
 
     /// The join request is still unapproved after the wait window: the user
     /// has watched the "Verifying" state the whole time. Emits the
-    /// stuck-wait sample; `verificationStartedAt` is left in place so a
-    /// late approval still reports its true duration via
-    /// `joinedConversation` on success.
+    /// stuck-wait sample as a failed `joined_conversation` outcome;
+    /// `verificationStartedAt` is left in place so a late approval still
+    /// reports its true duration via the success outcome.
     @MainActor
     private func emitConversationJoinTimedOut() {
         guard let startedAt = verificationStartedAt else { return }
         let waitDuration = Float(CFAbsoluteTimeGetCurrent() - startedAt)
         let source: ConversationSource = joinSource
         let actions: any CoreActions = coreActions
-        Task { await actions.conversationJoinTimedOut(waitDuration: waitDuration, source: source) }
+        Task { await actions.joinedConversation(verificationDuration: waitDuration, memberCount: nil, hasAssistant: nil, source: source, isSuccess: false) }
     }
 
     // MARK: - Private
@@ -843,7 +843,8 @@ class NewConversationViewModel: Identifiable, Hashable {
                 verificationDuration: duration,
                 memberCount: memberCount,
                 hasAssistant: hasAssistant,
-                source: source
+                source: source,
+                isSuccess: true
             )
         }
     }

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -556,7 +556,7 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
         // persisted Make commit time. Only within the placeholder window -
         // a stale rehydrated summary isn't a join the user is watching.
         if !conversation.members.contains(where: \.isVerifiedConvosAgent) {
-            beginAssistantJoinWait(surface: .builderPlaceholder, startedAt: summary.cutoffDate)
+            beginAssistantJoinWait(source: .agentBuilder, startedAt: summary.cutoffDate)
         }
     }
 
@@ -921,7 +921,7 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
     @ObservationIgnored
     private var assistantJoinWaitStartedAt: Date?
     @ObservationIgnored
-    private var assistantJoinWaitSurface: AssistantJoinSurface?
+    private var assistantJoinWaitSource: AssistantJoinSource?
     @ObservationIgnored
     private var assistantJoinTimeoutTask: Task<Void, Never>?
 
@@ -3142,8 +3142,8 @@ extension ConversationViewModel {
         // here too), not at API success - a fast agent can arrive via the
         // stream before agents/join returns, which would otherwise lose the
         // assistant_joined sample.
-        let surface: AssistantJoinSurface = templateId == nil ? .statusMessage : .contactCard
-        beginAssistantJoinWait(surface: surface)
+        let source: AssistantJoinSource = templateId == nil ? .addToConversation : .agentTemplate
+        beginAssistantJoinWait(source: source)
 
         let forceErrorCode = agentJoinForceErrorCode
         let conversationId = conversation.id
@@ -3213,7 +3213,7 @@ extension ConversationViewModel {
         // in-stream pending status bubbles. Anchored at request time for the
         // same fast-arrival reason as requestAgentJoin; the first verified
         // arrival ends the wait measurement.
-        beginAssistantJoinWait(surface: .statusMessage)
+        beginAssistantJoinWait(source: .addToConversation)
 
         let forceErrorCode = agentJoinForceErrorCode
         let conversationId = conversation.id
@@ -3257,10 +3257,10 @@ extension ConversationViewModel {
     /// wait measurement. Anchored at `startedAt` so the agent-builder flow
     /// can use the persisted Make commit time; an already-running wait keeps
     /// its earlier anchor so retries don't shrink the measured duration.
-    private func beginAssistantJoinWait(surface: AssistantJoinSurface, startedAt: Date = Date()) {
+    private func beginAssistantJoinWait(source: AssistantJoinSource, startedAt: Date = Date()) {
         if assistantJoinWaitStartedAt == nil {
             assistantJoinWaitStartedAt = startedAt
-            assistantJoinWaitSurface = surface
+            assistantJoinWaitSource = source
         }
         armAssistantJoinTimeout()
     }
@@ -3277,10 +3277,11 @@ extension ConversationViewModel {
         }
     }
 
-    /// Emits `assistant_join_timed_out` when the wait window elapses without
-    /// a verified assistant appearing. The measurement stops here - an
-    /// assistant that arrives later is not counted as a completed wait (the
-    /// user already watched the joining state fail).
+    /// Emits `assistant_joined` with `is_success: false` when the wait
+    /// window elapses without a verified assistant appearing. The
+    /// measurement stops here - an assistant that arrives later is not
+    /// counted as a completed wait (the user already watched the joining
+    /// state fail).
     private func emitAssistantJoinTimedOut() {
         guard let startedAt = assistantJoinWaitStartedAt else { return }
         guard !conversation.members.contains(where: \.isVerifiedConvosAgent) else {
@@ -3288,10 +3289,17 @@ extension ConversationViewModel {
             return
         }
         let waitDuration = Float(Date().timeIntervalSince(startedAt))
-        let surface: AssistantJoinSurface = assistantJoinWaitSurface ?? .statusMessage
+        let source: AssistantJoinSource = assistantJoinWaitSource ?? .addToConversation
         clearAssistantJoinWait()
         let actions: any CoreActions = coreActions
-        Task { await actions.assistantJoinTimedOut(waitDuration: waitDuration, surface: surface) }
+        Task {
+            await actions.assistantJoined(
+                waitDuration: waitDuration,
+                source: source,
+                memberCount: nil,
+                isSuccess: false
+            )
+        }
     }
 
     /// Emits `assistant_joined` when a verified assistant transitions into
@@ -3302,18 +3310,25 @@ extension ConversationViewModel {
               !oldValue.members.contains(where: \.isVerifiedConvosAgent),
               conversation.members.contains(where: \.isVerifiedConvosAgent) else { return }
         let waitDuration = Float(Date().timeIntervalSince(startedAt))
-        let surface: AssistantJoinSurface = assistantJoinWaitSurface ?? .statusMessage
+        let source: AssistantJoinSource = assistantJoinWaitSource ?? .addToConversation
         let memberCount = conversation.members.count
         clearAssistantJoinWait()
         let actions: any CoreActions = coreActions
-        Task { await actions.assistantJoined(waitDuration: waitDuration, surface: surface, memberCount: memberCount) }
+        Task {
+            await actions.assistantJoined(
+                waitDuration: waitDuration,
+                source: source,
+                memberCount: memberCount,
+                isSuccess: true
+            )
+        }
     }
 
     private func clearAssistantJoinWait() {
         assistantJoinTimeoutTask?.cancel()
         assistantJoinTimeoutTask = nil
         assistantJoinWaitStartedAt = nil
-        assistantJoinWaitSurface = nil
+        assistantJoinWaitSource = nil
     }
 
     /// Discriminates the three outcomes of an `agents/join` call so callers

--- a/ConvosCore/Package.resolved
+++ b/ConvosCore/Package.resolved
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/xmtplabs/convos-shared.git",
       "state" : {
-        "branch" : "jarod/assistant-join-metrics",
-        "revision" : "db0dde49c87c670758ca7a14488d863701a9be1d"
+        "branch" : "main",
+        "revision" : "b82d23fc47fd2a9ed41370369a783306b9fbdc8a"
       }
     },
     {

--- a/ConvosCore/Package.swift
+++ b/ConvosCore/Package.swift
@@ -34,9 +34,7 @@ let package = Package(
         .package(url: "https://github.com/firebase/firebase-ios-sdk", from: "12.1.0"),
         .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.31.1"),
         .package(url: "https://github.com/getsentry/sentry-cocoa.git", from: "8.57.1"),
-        // Interim pin while the assistant-join metrics land: flip back to
-        // branch "main" once xmtplabs/convos-shared#2 merges.
-        .package(url: "https://github.com/xmtplabs/convos-shared.git", branch: "jarod/assistant-join-metrics"),
+        .package(url: "https://github.com/xmtplabs/convos-shared.git", branch: "main"),
         .package(path: "../ConvosLogging"),
         .package(path: "../ConvosInvites"),
         .package(path: "../ConvosAppData"),

--- a/ConvosCore/Sources/ConvosCore/Metrics/NoOpCoreActions.swift
+++ b/ConvosCore/Sources/ConvosCore/Metrics/NoOpCoreActions.swift
@@ -8,14 +8,10 @@ public final class NoOpCoreActions: CoreActions, @unchecked Sendable {
 
     public func joinedConversation(
         verificationDuration: Float,
-        memberCount: Int,
-        hasAssistant: Bool,
-        source: ConversationSource
-    ) async {}
-
-    public func conversationJoinTimedOut(
-        waitDuration: Float,
-        source: ConversationSource
+        memberCount: Int?,
+        hasAssistant: Bool?,
+        source: ConversationSource,
+        isSuccess: Bool
     ) async {}
 
     public func invitedToConversation(memberCount: Int, hasAssistant: Bool) async {}
@@ -24,13 +20,9 @@ public final class NoOpCoreActions: CoreActions, @unchecked Sendable {
 
     public func assistantJoined(
         waitDuration: Float,
-        surface: AssistantJoinSurface,
-        memberCount: Int
-    ) async {}
-
-    public func assistantJoinTimedOut(
-        waitDuration: Float,
-        surface: AssistantJoinSurface
+        source: AssistantJoinSource,
+        memberCount: Int?,
+        isSuccess: Bool
     ) async {}
 
     public func assistantJoinRescuedByPolling(


### PR DESCRIPTION
convos-shared#2 (assistant-join metrics) merged, so the interim `jarod/assistant-join-metrics` pin can flip back to `main` as its reminder comment said. `Package.resolved` re-pinned to `main` @ `58373da`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1035"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783784492&installation_id=128169237&pr_number=1035&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1035&signature=7b392084ca98e94942d73f64a99e242d32db4398708d7e052471e5c232bd94c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Track convos-shared main branch and consolidate join telemetry into unified success/failure events
> - Updates [Package.swift](https://github.com/xmtplabs/convos-ios/pull/1035/files#diff-a2bdca0eaceddfb5e4fbd6afdf3047a9c23f261d60140456b61baada4a24caa3) to track the `main` branch of `convos-shared` instead of the feature branch `jarod/assistant-join-metrics`.
> - Replaces separate `conversationJoinTimedOut` and `assistantJoinTimedOut` telemetry events with `joinedConversation` and `assistantJoined` events carrying an `isSuccess: false` flag on timeout.
> - Renames the `surface`/`AssistantJoinSurface` parameter to `source`/`AssistantJoinSource` across `ConversationViewModel` and updates call sites to use the new enum values.
> - Removes `conversationJoinTimedOut` and `assistantJoinTimedOut` no-op stubs from [NoOpCoreActions.swift](https://github.com/xmtplabs/convos-ios/pull/1035/files#diff-d366d2c3d6015ab117b28c22e98b586f3991c6e5cbb415f60e14cff2bca4bf36).
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #1035 opened
>
> - Updated package dependencies to track the main branch of `convos-shared` [755ae1d]
> - Increased Swift compiler warning thresholds for type-checking performance diagnostics [c4e08cf]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ce2d6b3.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->