### PR TITLE
Add agent email Contact Info row to the contact card

### DIFF
--- a/Convos/Contacts/ContactDetailView.swift
+++ b/Convos/Contacts/ContactDetailView.swift
@@ -969,7 +969,7 @@ private struct ContactDetailEmailSection: View {
         .padding(.vertical, DesignConstants.Spacing.step4x)
         .padding(.horizontal, DesignConstants.Spacing.step4x)
         .background(
-            RoundedRectangle(cornerRadius: DesignConstants.CornerRadius.large)
+            RoundedRectangle(cornerRadius: DesignConstants.CornerRadius.mediumLarge)
                 .fill(.colorBackgroundRaised)
         )
     }
@@ -977,9 +977,9 @@ private struct ContactDetailEmailSection: View {
     private var emailButton: some View {
         let action = { openMailComposer() }
         return Button(action: action) {
-            VStack(alignment: .leading, spacing: DesignConstants.Spacing.stepX) {
+            VStack(alignment: .leading, spacing: DesignConstants.Spacing.stepHalf) {
                 Text(email)
-                    .font(.body)
+                    .font(.callout.weight(.medium))
                     .foregroundStyle(.colorTextPrimary)
                     .lineLimit(1)
                     .truncationMode(.middle)

--- a/Convos/Contacts/ContactDetailView.swift
+++ b/Convos/Contacts/ContactDetailView.swift
@@ -32,6 +32,9 @@ import SwiftUI
 //     opening the picker so a synthetic / non-yet-stored contact is
 //     promoted to a real one
 //   - Share - template-backed agents with a published link, after New chat
+//   - Contact Info - agents with an email address in their profile
+//     metadata; the row opens the mail composer, the trailing button
+//     copies the address
 //   - Remove - scoped mode only, when the viewer is an admin
 //     (`canRemoveMembers`) and the tapped member is not the current user
 //   - Block / Unblock - hidden for the current user; both modes otherwise
@@ -340,6 +343,7 @@ struct ContactDetailView: View {
                         && mode.canRemoveMembers,
                     showBlock: !mode.isCurrentUser && !contact.isUnsavedAgentPlaceholder,
                     contactDisplayName: contact.resolvedDisplayName,
+                    agentEmail: contact.agentEmail,
                     agentInstanceId: contact.agentInstanceId,
                     showsInstanceIdRow: showsInstanceIdRow,
                     agentAttestation: contact.agentAttestation,
@@ -762,6 +766,10 @@ private struct ContactDetailActions: View {
     let showRemove: Bool
     let showBlock: Bool
     let contactDisplayName: String
+    /// Agent's email address from its profile metadata. Renders the
+    /// "Contact Info" section under Share when present; nil (humans and
+    /// older agents created before addresses were assigned) hides it.
+    let agentEmail: String?
     /// Always plumbed through when the contact has one. Display gate
     /// is `showsInstanceIdRow`, not nullability of this field.
     let agentInstanceId: String?
@@ -797,6 +805,12 @@ private struct ContactDetailActions: View {
             }
             if showShare {
                 shareRow
+            }
+            if let agentEmail {
+                ContactDetailEmailSection(
+                    email: agentEmail,
+                    contactDisplayName: contactDisplayName
+                )
             }
             if showRemove {
                 removeRow
@@ -921,7 +935,97 @@ private struct ContactDetailActionRow: View {
     }
 }
 
-// MARK: - Share row (template-backed agents)
+// MARK: - Contact Info section (agents with an email address)
+
+/// The "Contact Info" section on an agent's contact card: a labeled card
+/// with the agent's email address. Tapping the row opens the user's
+/// default mail client via a `mailto:` link; the trailing button copies
+/// the address and briefly swaps to a checkmark as confirmation. Rendered
+/// only when the agent's profile metadata carries an email - older agents
+/// created before the runtime assigned addresses don't have one. Header +
+/// rounded-card shape mirrors `AgentTemplateConversationsSection`.
+private struct ContactDetailEmailSection: View {
+    let email: String
+    let contactDisplayName: String
+
+    @Environment(\.openURL) private var openURL: OpenURLAction
+    @State private var didCopy: Bool = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: DesignConstants.Spacing.step2x) {
+            Text("Contact Info")
+                .font(.footnote)
+                .foregroundStyle(.colorTextSecondary)
+                .padding(.leading, DesignConstants.Spacing.step2x)
+            emailCard
+        }
+    }
+
+    private var emailCard: some View {
+        HStack(spacing: DesignConstants.Spacing.step2x) {
+            emailButton
+            copyButton
+        }
+        .padding(.vertical, DesignConstants.Spacing.step4x)
+        .padding(.horizontal, DesignConstants.Spacing.step4x)
+        .background(
+            RoundedRectangle(cornerRadius: DesignConstants.CornerRadius.large)
+                .fill(.colorBackgroundRaised)
+        )
+    }
+
+    private var emailButton: some View {
+        let action = { openMailComposer() }
+        return Button(action: action) {
+            VStack(alignment: .leading, spacing: DesignConstants.Spacing.stepX) {
+                Text(email)
+                    .font(.body)
+                    .foregroundStyle(.colorTextPrimary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                Text("Email")
+                    .font(.footnote)
+                    .foregroundStyle(.colorTextSecondary)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Email \(contactDisplayName) at \(email)")
+        .accessibilityIdentifier("contact-detail-email")
+    }
+
+    private var copyButton: some View {
+        let iconName: String = didCopy ? "checkmark" : "square.on.square"
+        let iconColor: Color = didCopy ? .colorTextPrimary : .colorTextSecondary
+        let label: String = didCopy ? "Copied" : "Copy email address"
+        let action = { copyToClipboard() }
+        return Button(action: action) {
+            Image(systemName: iconName)
+                .font(.title3)
+                .foregroundStyle(iconColor)
+                .frame(width: 44.0, height: 44.0)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(label)
+        .accessibilityIdentifier("contact-detail-email-copy")
+    }
+
+    private func openMailComposer() {
+        guard let url = URL(string: "mailto:\(email)") else { return }
+        openURL(url)
+    }
+
+    private func copyToClipboard() {
+        UIPasteboard.general.string = email
+        didCopy = true
+        Task {
+            try? await Task.sleep(nanoseconds: 1_500_000_000)
+            didCopy = false
+        }
+    }
+}
 
 // MARK: - Debug instance id row (internal builds only)
 
@@ -1119,7 +1223,8 @@ extension Contact {
         agentTemplateId: String? = nil,
         agentTemplatePublishedURL: String? = nil,
         profileEmoji: String? = nil,
-        agentInstanceId: String? = nil
+        agentInstanceId: String? = nil,
+        agentEmail: String? = nil
     ) -> Contact {
         Contact(
             inboxId: inboxId,
@@ -1135,7 +1240,8 @@ extension Contact {
             agentTemplateId: agentTemplateId,
             agentTemplatePublishedURL: agentTemplatePublishedURL,
             profileEmoji: profileEmoji,
-            agentInstanceId: agentInstanceId
+            agentInstanceId: agentInstanceId,
+            agentEmail: agentEmail
         )
     }
 
@@ -1164,6 +1270,7 @@ extension Contact {
         let templatePublishedURL: String? = member.profile.agentTemplatePublishedURL
         let emoji: String? = member.profile.profileEmoji
         let instanceId: String? = member.profile.agentInstanceId
+        let email: String? = member.profile.agentEmail
         let attestation: String? = member.profile.agentAttestation
         if let stored = try? contactsRepository.fetchContact(inboxId: member.profile.inboxId) {
             let resolvedPublishedURL: String? = templatePublishedURL ?? stored.agentTemplatePublishedURL
@@ -1173,6 +1280,7 @@ extension Contact {
                 .with(profileEmoji: emoji)
                 .with(agentInstanceId: instanceId)
                 .with(agentVerification: member.agentVerification)
+                .with(agentEmail: email)
                 .with(agentAttestation: attestation)
         }
         return .synthetic(
@@ -1187,7 +1295,8 @@ extension Contact {
             agentTemplateId: templateId,
             agentTemplatePublishedURL: templatePublishedURL,
             profileEmoji: emoji,
-            agentInstanceId: instanceId
+            agentInstanceId: instanceId,
+            agentEmail: email
         )
         .with(agentAttestation: attestation)
     }
@@ -1236,6 +1345,22 @@ extension Contact {
                 displayName: "Tifoso",
                 agentVerification: .verified(.convos),
                 agentTemplatePublishedURL: "https://agents-dev.convos.org/tifoso.pnw1o"
+            ),
+            contactsWriter: MockContactsWriter(),
+            contactsRepository: MockContactsRepository(),
+            coreActions: NoOpCoreActions()
+        )
+    }
+}
+
+#Preview("Agent template with email") {
+    NavigationStack {
+        ContactDetailView(
+            contact: .mock(
+                displayName: "Tifoso",
+                agentVerification: .verified(.convos),
+                agentTemplatePublishedURL: "https://agents-dev.convos.org/tifoso.pnw1o",
+                agentEmail: "tifoso.123456@ai.convos.org"
             ),
             contactsWriter: MockContactsWriter(),
             contactsRepository: MockContactsRepository(),

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/Contact.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/Contact.swift
@@ -51,6 +51,13 @@ public struct Contact: Hashable, Identifiable, Sendable {
     /// Not persisted on `DBContact`; overlaid at resolution time from the
     /// per-conversation member profile (see `Contact.resolved(member:...)`).
     public let agentInstanceId: String?
+    /// The agent's email address, read from the per-conversation member
+    /// profile metadata at resolution time. Not persisted on `DBContact`;
+    /// overlaid via `with(agentEmail:)` in `Contact.resolved(member:...)`.
+    /// nil for human contacts and for older agents created before the
+    /// runtime assigned addresses. Drives the contact card's Contact Info
+    /// section.
+    public let agentEmail: String?
     /// The agent's published attestation signature, read from the
     /// per-conversation member profile metadata at resolution time. Not
     /// persisted on `DBContact`. Surfaced on the contact card behind a
@@ -79,6 +86,7 @@ public struct Contact: Hashable, Identifiable, Sendable {
         agentTemplatePublishedURL: String? = nil,
         profileEmoji: String? = nil,
         agentInstanceId: String? = nil,
+        agentEmail: String? = nil,
         agentAttestation: String? = nil,
         agentDescription: String? = nil
     ) {
@@ -96,6 +104,7 @@ public struct Contact: Hashable, Identifiable, Sendable {
         self.agentTemplatePublishedURL = agentTemplatePublishedURL
         self.profileEmoji = profileEmoji
         self.agentInstanceId = agentInstanceId
+        self.agentEmail = agentEmail
         self.agentAttestation = agentAttestation
         self.agentDescription = agentDescription
     }
@@ -191,7 +200,8 @@ extension Contact {
         agentTemplateId: String? = nil,
         agentTemplatePublishedURL: String? = nil,
         profileEmoji: String? = nil,
-        agentInstanceId: String? = nil
+        agentInstanceId: String? = nil,
+        agentEmail: String? = nil
     ) -> Contact {
         Contact(
             inboxId: inboxId,
@@ -207,7 +217,8 @@ extension Contact {
             agentTemplateId: agentTemplateId,
             agentTemplatePublishedURL: agentTemplatePublishedURL,
             profileEmoji: profileEmoji,
-            agentInstanceId: agentInstanceId
+            agentInstanceId: agentInstanceId,
+            agentEmail: agentEmail
         )
     }
 
@@ -230,7 +241,8 @@ extension Contact {
             agentTemplateId: agentTemplateId,
             agentTemplatePublishedURL: agentTemplatePublishedURL,
             profileEmoji: profileEmoji,
-            agentInstanceId: agentInstanceId
+            agentInstanceId: agentInstanceId,
+            agentEmail: agentEmail
         )
     }
 
@@ -253,7 +265,8 @@ extension Contact {
             agentTemplateId: agentTemplateId,
             agentTemplatePublishedURL: agentTemplatePublishedURL,
             profileEmoji: profileEmoji,
-            agentInstanceId: agentInstanceId
+            agentInstanceId: agentInstanceId,
+            agentEmail: agentEmail
         )
     }
 
@@ -280,7 +293,8 @@ extension Contact {
             agentTemplateId: agentTemplateId,
             agentTemplatePublishedURL: agentTemplatePublishedURL,
             profileEmoji: profileEmoji,
-            agentInstanceId: agentInstanceId
+            agentInstanceId: agentInstanceId,
+            agentEmail: agentEmail
         )
     }
 
@@ -303,7 +317,8 @@ extension Contact {
             agentTemplateId: agentTemplateId,
             agentTemplatePublishedURL: agentTemplatePublishedURL,
             profileEmoji: profileEmoji,
-            agentInstanceId: agentInstanceId
+            agentInstanceId: agentInstanceId,
+            agentEmail: agentEmail
         )
     }
 
@@ -324,6 +339,32 @@ extension Contact {
             agentTemplatePublishedURL: agentTemplatePublishedURL,
             profileEmoji: profileEmoji,
             agentInstanceId: agentInstanceId,
+            agentEmail: agentEmail,
+            agentAttestation: agentAttestation
+        )
+    }
+
+    /// Returns a copy with `agentEmail` overlaid. Used by
+    /// `Contact.resolved(member:...)` to surface the email address from a
+    /// live per-conversation member profile; `agentEmail` is not persisted
+    /// on `DBContact`.
+    public func with(agentEmail: String?) -> Contact {
+        Contact(
+            inboxId: inboxId,
+            displayName: displayName,
+            avatarURL: avatarURL,
+            avatarSalt: avatarSalt,
+            avatarNonce: avatarNonce,
+            avatarKey: avatarKey,
+            addedAt: addedAt,
+            addedViaConversationId: addedViaConversationId,
+            isBlocked: isBlocked,
+            agentVerification: agentVerification,
+            agentTemplateId: agentTemplateId,
+            agentTemplatePublishedURL: agentTemplatePublishedURL,
+            profileEmoji: profileEmoji,
+            agentInstanceId: agentInstanceId,
+            agentEmail: agentEmail,
             agentAttestation: agentAttestation
         )
     }
@@ -348,6 +389,7 @@ extension Contact {
             agentTemplatePublishedURL: agentTemplatePublishedURL,
             profileEmoji: profileEmoji,
             agentInstanceId: agentInstanceId,
+            agentEmail: agentEmail,
             agentAttestation: agentAttestation
         )
     }

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/Profile.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/Profile.swift
@@ -209,6 +209,7 @@ public struct Profile: Codable, Identifiable, Hashable, Sendable {
         static let templateIdKey: String = "templateId"
         static let publishedURLKey: String = "publishedUrl"
         static let instanceIdKey: String = "instanceId"
+        static let emailKey: String = "email"
     }
 }
 
@@ -251,6 +252,19 @@ extension Profile {
     /// log correlation.
     public var agentInstanceId: String? {
         metadata?[Constant.instanceIdKey]?.stringValue
+    }
+
+    /// The agent's email address, read from the agent's per-conversation
+    /// profile metadata. The runtime assigns an address when the agent is
+    /// created; nil for human members and for older agents created before
+    /// addresses were assigned. Drives the contact card's Contact Info
+    /// section. Empty / whitespace-only values are coerced to nil, mirroring
+    /// `agentTemplateId` above.
+    public var agentEmail: String? {
+        metadata?[Constant.emailKey]?.stringValue.flatMap { value in
+            let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimmed.isEmpty ? nil : trimmed
+        }
     }
 
     /// The Ed25519 attestation signature this agent published in its


### PR DESCRIPTION
## Summary

Agents are now assigned an email address at creation, published in their profile metadata under the `email` key. This PR exposes that field and surfaces it on the agent contact card.

- **`Profile.agentEmail`**: reads `metadata["email"]`, coercing empty/whitespace values to nil. The field is optional — older agents created before addresses were assigned don't carry it, which simply hides the row.
- **`Contact.agentEmail`**: presentation-only field overlaid at resolution time from the live per-conversation member profile (same pattern as `agentInstanceId`; not persisted on `DBContact`).
- **Contact card "Contact Info" section**: renders under the "Share <template name>" row when an email is present. Tapping the row opens the user's default mail client via `mailto:`; the trailing `square.on.square` button copies the address and briefly swaps to a checkmark as confirmation.

Unlike the earlier provisioning branch, there is no provision flow or status fallback — the address is either in the profile metadata or the section doesn't render.

## Testing

- `swift build --package-path ConvosCore` passes
- `xcodebuild build` of Convos (Dev) for the iOS simulator passes (project enforces the 100ms type-check limit as errors)
- SwiftLint clean; pre-commit and pre-push hooks passed
- Added an "Agent template with email" preview for the new section

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add agent email Contact Info row to the contact card
> - Adds `agentEmail` to the `Contact` model, read from `member.profile.agentEmail` (backed by a new `email` metadata key in `Profile`).
> - `ContactDetailActions` conditionally renders a new `ContactDetailEmailSection` between the Share and Remove rows when an agent email is present.
> - `ContactDetailEmailSection` lets users tap to open a `mailto:` URL or copy the email to the clipboard, with a brief icon/accessibility-label toggle to confirm the copy.
> - All existing `Contact.with(...)` overlay builders are updated to propagate `agentEmail` so it is not dropped during contact updates.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0148d19.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1036"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783794113&installation_id=128169237&pr_number=1036&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1036&signature=a3886fe234470edab6b06c701d5acf8f69d6dbd849c8f54fe4acb590e6f8b1ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->