### PR TITLE
Fix local-stack onboarding friction found during a fresh-machine /run local

### DIFF
--- a/.claude/commands/run.md
+++ b/.claude/commands/run.md
@@ -31,7 +31,7 @@ Bundle IDs by scheme:
 Skip this whole step for Dev/Prod schemes. The orchestration is committed in this repo at `dev/local-stack/` and resolves its external workspace itself (via the gitignored `.convos-stack` pointer or `$CONVOS_REPOS_DIR`).
 
 1. `LS="$(git rev-parse --show-toplevel)/dev/local-stack"`.
-2. **First-run:** `make -C "$LS" status` (30s). If it errors *"no workspace configured — run: make init"*, the machine isn't set up: run `make -C "$LS" init` (defaults the workspace to a sibling of this repo and clones the service repos; ~600000ms timeout), then **pause** and tell the user to set the `OP_*` 1Password refs in `<workspace>/stack.env` and run `make -C "$LS" bootstrap` once.
+2. **First-run:** `make -C "$LS" status` (30s). If it errors *"no workspace configured — run: make init"*, the machine isn't set up: run `make -C "$LS" init` (workspace defaults to a sibling of this repo — or to the parent dir itself when the service repos are already cloned there — and clones any missing service repos; ~600000ms timeout). The written `stack.env` ships working `op://Convos/...` refs, so next run `make -C "$LS" bootstrap` once. If bootstrap warns the 1Password CLI is not signed in, **pause** and ask the user to run `op signin` (account xmtpinc) or enable 1Password Settings > Developer > "Integrate with 1Password CLI", then re-run bootstrap (it re-fetches `.dev.vars` if it's missing or incomplete).
 3. **Bring it up if needed:** if `status` shows backend/worker down, run `make -C "$LS" up` with a **1200000ms (20 min)** timeout (first run builds the Hermes image — capped; later runs are fast). Relay any Docker-cap warning from `make -C "$LS" doctor`.
 4. **Configure this checkout as a thin client:** `make -C "$LS" ios-config IOS="$(pwd)"` — sets `config.local.json` `xmtpNetwork→dev` and writes `./.env` (shared Firebase Local token; `CONVOS_API_BASE_URL` left empty so Local auto-detects the Mac LAN IP and a Dev build on the same checkout isn't redirected to localhost).
 
@@ -68,6 +68,7 @@ Use `xcodebuild` via Bash. Do **not** use `mcp__XcodeBuildMCP__build_sim` — it
 
 **Dev / Prod schemes** (team signing). Pass an explicit `-configuration` (`Convos (Dev)` -> `Dev`, `Convos (Prod)` -> `Prod`). Without it the scheme can build targets under mismatched configurations: the SPM packages land in one config dir while the NotificationService extension looks in another (`unable to resolve module dependency: ConvosCore`), and the app's entitlements/identifiers stop matching `config.json`, surfacing at runtime as a nil app-group container crash (`Failed getting container URL`) or `-34018` (`errSecMissingEntitlement`) on first identity read. Those three are one configuration signature, not simulator limitations (issue #843, #1019); `rm -rf .derivedData` does not fix them, an explicit `-configuration` does.
 ```bash
+set -o pipefail
 xcodebuild build \
   -project Convos.xcodeproj \
   -scheme "Convos (Dev)" -configuration Dev \
@@ -77,6 +78,7 @@ xcodebuild build \
 
 **Local scheme** — `org.convos.ios-local` is **not** in convos-certificates, so CLI automatic signing drops the app-group entitlement and the app crashes at launch (`Failed getting container URL for group identifier`). Build **ad-hoc** so the simulated entitlements are applied:
 ```bash
+set -o pipefail
 xcodebuild build \
   -project Convos.xcodeproj \
   -scheme "Convos (Local)" -configuration Local \
@@ -85,6 +87,8 @@ xcodebuild build \
   CODE_SIGN_STYLE=Manual CODE_SIGN_IDENTITY="-" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=YES \
   PROVISIONING_PROFILE_SPECIFIER="" DEVELOPMENT_TEAM="" 2>&1 | tail -100
 ```
+
+The `set -o pipefail` is load-bearing: without it the `| tail` makes a failed build exit 0, so check for `** BUILD FAILED **` / `(N failures)` in the tail rather than trusting the exit code alone.
 
 Set a 600s timeout. If the build fails:
 - Surface the compilation errors from the tail.

--- a/dev/local-stack/README.md
+++ b/dev/local-stack/README.md
@@ -9,7 +9,8 @@ convos-ios/ (this repo — every checkout/worktree has these scripts)
   dev/local-stack/   Makefile  stack.sh  stack.compose.yml  stack.env.example  README.md
   .convos-stack      → points at your workspace (gitignored, machine-local)
 
-<workspace>/ (you pick this; default: sibling of convos-ios, e.g. ~/Code/xmtplabs/convos-stack)
+<workspace>/ (you pick this; default: sibling of convos-ios, e.g. ~/Code/xmtplabs/convos-stack —
+              or the parent dir itself when the service repos are already cloned next to convos-ios)
   convos-backend/  herald-lite/  convos-assistants/  convos-cli/   ← cloned by `make init`
   stack.env   .run/                                                ← machine-local, shared by all worktrees
 ```
@@ -22,7 +23,8 @@ cd <a convos-ios checkout>
 
 make -C dev/local-stack doctor       # check prereqs (node, pnpm, bun, docker, op, ...) + Docker CPU cap
 make -C dev/local-stack init         # pick a workspace dir + clone the 4 service repos into it
-# -> then edit <workspace>/stack.env and set the OP_* 1Password references (one-time, team-wide)
+# -> stack.env is written with the team's op://Convos/... refs; sign in to the 1Password CLI
+#    ('op signin', account xmtpinc, or 1Password Settings > Developer > CLI integration)
 make -C dev/local-stack bootstrap    # deps, generated backend secrets, .dev.vars (1Password), migrations
 make -C dev/local-stack up           # start the FULL stack (first run builds the Hermes image; capped)
 ```

--- a/dev/local-stack/stack.env.example
+++ b/dev/local-stack/stack.env.example
@@ -37,11 +37,12 @@ MINIO_BUCKET=assistants-private-dev
 # 1Password (op CLI) references — set these once for your team.
 #   Find them: op item get "Assistants Local .dev.vars" --format json
 # NOTE: values with spaces MUST be quoted (stack.env is sourced by bash).
-OP_VAULT=Engineering
-OP_DEV_VARS_REF="op://Engineering/Assistants Local .dev.vars/notesPlain"
-# Shared Local Firebase App Check debug token (registered in Firebase project convos-otr
-# for app 1:226420087156:ios:036b488464bec3c5c77421 / org.convos.ios-local):
-OP_FIREBASE_LOCAL_TOKEN_REF="op://Engineering/Convos iOS Local AppCheck/credential"
+OP_VAULT=Convos
+OP_DEV_VARS_REF="op://Convos/Assistants Local .dev.vars/notesPlain"
+# Shared Firebase App Check debug token (one item for Dev AND Local — registered in
+# Firebase project convos-otr for both org.convos.ios-preview and org.convos.ios-local;
+# same ref /firebase-token uses):
+OP_FIREBASE_LOCAL_TOKEN_REF="op://Convos/Firebase App Check Debug Token/credential"
 
 # Cap Docker Desktop CPUs to <= this (Settings > Resources) so the Hermes build can't
 # starve the host. `make doctor` only warns if your cap is higher.

--- a/dev/local-stack/stack.sh
+++ b/dev/local-stack/stack.sh
@@ -19,6 +19,23 @@ ok()   { printf '%s ok %s %s\n' "$c_grn" "$c_rst" "$*"; }
 warn() { printf '%s warn%s %s\n' "$c_yel" "$c_rst" "$*" >&2; }
 die()  { printf '%sfail%s %s\n' "$c_red" "$c_rst" "$*" >&2; exit 1; }
 have() { command -v "$1" >/dev/null 2>&1; }
+op_ready() { have op && op whoami >/dev/null 2>&1; }
+
+# Docker down is the #1 first-run failure — on macOS, start the Docker engine
+# app (OrbStack preferred, else Docker Desktop) and wait instead of dying, so
+# 'make bootstrap' / 'make up' work from a cold boot.
+ensure_docker() {
+  docker info >/dev/null 2>&1 && return 0
+  if [[ "$(uname)" == "Darwin" ]] && { open -ga OrbStack >/dev/null 2>&1 || open -ga Docker >/dev/null 2>&1; }; then
+    log "Docker not running — starting the engine app (waiting up to 120s)"
+    local i
+    for i in $(seq 1 60); do
+      sleep 2
+      docker info >/dev/null 2>&1 && { ok "Docker started"; return 0; }
+    done
+  fi
+  die "Docker not running — start OrbStack or Docker Desktop, then re-run"
+}
 
 resolve_workspace() {
   if   [[ -n "${CONVOS_REPOS_DIR:-}" ]]; then WORKSPACE="$CONVOS_REPOS_DIR"
@@ -131,7 +148,13 @@ seed_credits() {
 
 # ============================ init (clone wizard) ============================
 cmd_init() {
-  local default_ws; default_ws="$(dirname "$REPO_ROOT")/convos-stack"   # sibling of the convos-ios checkout
+  # Default workspace: a sibling of the convos-ios checkout — unless the parent dir
+  # already holds all the service repos (the "cloned everything into one dir" layout),
+  # in which case use the parent itself instead of cloning duplicates.
+  local parent; parent="$(dirname "$REPO_ROOT")"
+  local default_ws="${parent}/convos-stack" all_present=1
+  for r in "${SERVICE_REPOS[@]}"; do [[ -d "${parent}/${r}/.git" ]] || all_present=0; done
+  [[ "$all_present" == 1 ]] && default_ws="$parent"
   local ws="${1:-${CONVOS_REPOS_DIR:-}}"
   if [[ -z "$ws" ]]; then
     if [[ -t 0 ]]; then read -r -p "Workspace dir for the local stack [${default_ws}]: " ws || true; fi
@@ -148,7 +171,7 @@ cmd_init() {
 
   if [[ ! -f "${ws}/stack.env" ]]; then
     sed "s|^CONVOS_REPOS_DIR=.*|CONVOS_REPOS_DIR=${ws}|" "${SCRIPT_DIR}/stack.env.example" > "${ws}/stack.env"
-    ok "wrote ${ws}/stack.env — set OP_* 1Password refs in it before `make bootstrap`"
+    ok "wrote ${ws}/stack.env — set OP_* 1Password refs in it before 'make bootstrap'"
   else ok "${ws}/stack.env exists (left as-is)"; fi
   if [[ ! -f "${ws}/convos-ios.env" ]]; then
     printf '# Shared convos-ios DEV .env (Firebase App Check debug token, GATEWAY_URL, AGENT_DEBUG_JWKS, ...).\n# Dev convos-ios checkouts symlink their .env to this file; run /firebase-token to pin the token.\nFIREBASE_APP_CHECK_DEBUG_TOKEN=\nAGENT_DEBUG_JWKS=\nGATEWAY_URL=\nSENTRY_DSN=\n' > "${ws}/convos-ios.env"
@@ -168,11 +191,14 @@ cmd_doctor() {
   have op && ok "1Password CLI present" || warn "op MISSING (brew install 1password-cli) — secrets"
   have xcodebuild && ok "Xcode $(xcodebuild -version 2>/dev/null | head -1)" || warn "xcodebuild MISSING"
   if docker info >/dev/null 2>&1; then
-    local ncpu; ncpu="$(docker info --format '{{.NCPU}}' 2>/dev/null || echo '?')"
-    if [[ "$ncpu" =~ ^[0-9]+$ ]] && (( ncpu > ${DOCKER_MAX_CPUS:-6} )); then
+    local ncpu engine; ncpu="$(docker info --format '{{.NCPU}}' 2>/dev/null || echo '?')"
+    engine="$(docker info --format '{{.OperatingSystem}}' 2>/dev/null || echo '?')"
+    # The CPU cap only matters on Docker Desktop's static VM; OrbStack
+    # allocates dynamically and idles near zero, so don't nag there.
+    if [[ "$engine" == *"Docker Desktop"* ]] && [[ "$ncpu" =~ ^[0-9]+$ ]] && (( ncpu > ${DOCKER_MAX_CPUS:-6} )); then
       warn "Docker has ${ncpu} CPUs — cap to ${DOCKER_MAX_CPUS:-6} (Docker Desktop > Settings > Resources) so the Hermes build can't starve the host"
-    else ok "Docker running, ${ncpu} CPUs"; fi
-  else die "Docker not running"; fi
+    else ok "Docker running (${engine}), ${ncpu} CPUs"; fi
+  else warn "Docker not running — 'make bootstrap' / 'make up' will auto-start Docker Desktop"; fi
   # Agent-builder reachability: the worker's backend URL must track the host
   # IP (it's reachable from both the worker and the Hermes container). doctor
   # runs without load_env, so derive the path/port with the same defaults.
@@ -191,6 +217,8 @@ cmd_doctor() {
 # ============================ bootstrap ============================
 cmd_bootstrap() {
   load_env
+  ensure_docker
+  op_ready || warn "1Password CLI not signed in — 1Password secrets (.dev.vars, Firebase token) will be SKIPPED and agents won't fully work. Fix: 'op signin' (account xmtpinc) or enable 1Password Settings > Developer > 'Integrate with 1Password CLI', then re-run 'make bootstrap'"
   cmd_doctor || true
   have flock || brew install flock || warn "brew install flock failed"
   have uv    || brew install uv    || warn "brew install uv failed"
@@ -218,16 +246,29 @@ bootstrap_backend() {
   pnpm migrate:deploy >/dev/null && ok "migrations applied"; popd >/dev/null
 }
 bootstrap_herald() {
-  log "herald-lite: env + deps"; pushd "$HERALD_DIR" >/dev/null; pnpm install
+  log "herald-lite: env + deps"; pushd "$HERALD_DIR" >/dev/null
+  # Install via a login shell — the same env start_svc launches services with.
+  # herald pins node >=25 and ships a native module (better-sqlite3); if the
+  # caller's shell resolves a different node than the login shell, the native
+  # build targets the wrong ABI and herald crashes at startup (ERR_DLOPEN_FAILED).
+  bash -lc "cd '$HERALD_DIR' && pnpm install" || pnpm install
   [[ -f .env ]] || printf 'DATA_DIR=./data\nPORT=%s\nENV=dev\nXMTP_ENV=%s\nLOG_LEVEL=info\n' "$HERALD_PORT" "$XMTP_ENV" > .env
   ok "herald-lite/.env ready"; popd >/dev/null
 }
 bootstrap_assistants() {
   log "convos-assistants: deps + .dev.vars + repo-setup"; pushd "$ASSISTANTS_DIR" >/dev/null; pnpm install
   local dv="${WORKER_DIR}/.dev.vars"
-  if [[ ! -f "$dv" ]]; then
-    if have op && [[ -n "${OP_DEV_VARS_REF:-}" ]] && op read "$OP_DEV_VARS_REF" >"$dv" 2>/dev/null; then ok "fetched .dev.vars from 1Password"
-    else warn "populate ${dv} from 1Password item 'Assistants Local .dev.vars' (op not set up / OP_DEV_VARS_REF unset)"; fi
+  # Fetch when missing OR when a previous bootstrap ran without 1Password and
+  # left a skeleton (no CONVOS_API_KEY) — otherwise a pre-signin bootstrap
+  # stays broken forever. Local overrides (R2_PARENT_*, CONVOS_API_BASE_URL)
+  # are re-applied below / by sync_backend_url after the fetch.
+  if [[ ! -f "$dv" ]] || ! grep -q '^CONVOS_API_KEY=' "$dv"; then
+    if have op && [[ -n "${OP_DEV_VARS_REF:-}" ]] && op read "$OP_DEV_VARS_REF" >"${dv}.tmp" 2>/dev/null; then
+      mv "${dv}.tmp" "$dv"; ok "fetched .dev.vars from 1Password"
+    else
+      rm -f "${dv}.tmp"
+      warn "${dv} missing or incomplete (no CONVOS_API_KEY) — sign in to 1Password ('op signin', account xmtpinc) and re-run 'make bootstrap' to fetch item 'Assistants Local .dev.vars'"
+    fi
   fi
   if [[ -f "$dv" ]]; then
     sed -i '' -E "s|^R2_PARENT_ACCESS_KEY_ID=.*|R2_PARENT_ACCESS_KEY_ID=${MINIO_USER}|; s|^R2_PARENT_SECRET_ACCESS_KEY=.*|R2_PARENT_SECRET_ACCESS_KEY=${MINIO_PASSWORD}|" "$dv" 2>/dev/null || true
@@ -241,7 +282,7 @@ bootstrap_cli() { log "convos-cli: deps + build"; pushd "$CLI_DIR" >/dev/null; p
 
 # ============================ up / down ============================
 cmd_up() {
-  load_env; local tier="${1:-full}"; docker info >/dev/null 2>&1 || die "Docker not running"
+  load_env; local tier="${1:-full}"; ensure_docker
   sync_backend_url   # self-heal worker -> backend URL to the current host IP (before the worker starts)
   align_agent_key    # keep backend AGENT_ASSETS_API_KEY == worker CONVOS_API_KEY
   log "infra ($([[ $tier == full ]] && echo 'Postgres + MinIO' || echo 'Postgres'))"
@@ -284,7 +325,7 @@ cmd_status() {
 }
 cmd_logs() { load_env; local svc="${1:-}"; if [[ -n "$svc" ]]; then tail -f "$RUN_DIR/${svc}.log"; else [[ -n "$(ls "$RUN_DIR"/*.log 2>/dev/null||true)" ]] || die "no logs yet (make up)"; tail -f "$RUN_DIR"/*.log; fi; }
 
-cmd_hermes_build() { load_env; docker info >/dev/null 2>&1 || die "Docker not running"; log "building Hermes image (capped)"; pushd "$WORKER_DIR" >/dev/null; pnpm exec wrangler containers build ./../../runtime/hermes/Dockerfile || pnpm run prebuild; popd >/dev/null; ok "Hermes image cached"; }
+cmd_hermes_build() { load_env; ensure_docker; log "building Hermes image (capped)"; pushd "$WORKER_DIR" >/dev/null; pnpm exec wrangler containers build ./../../runtime/hermes/Dockerfile || pnpm run prebuild; popd >/dev/null; ok "Hermes image cached"; }
 
 # ============================ ios-config ============================
 cmd_ios_config() {
@@ -294,7 +335,7 @@ cmd_ios_config() {
   if grep -q '"xmtpNetwork": "dev"' "$ios/Convos/Config/config.local.json"; then ok "config.local.json xmtpNetwork already 'dev'"
   else sed -i '' 's/"xmtpNetwork": "local"/"xmtpNetwork": "dev"/' "$ios/Convos/Config/config.local.json" 2>/dev/null && ok "config.local.json xmtpNetwork -> dev"; fi
   local fb=""; { have op && [[ -n "${OP_FIREBASE_LOCAL_TOKEN_REF:-}" ]] && fb="$(op read "$OP_FIREBASE_LOCAL_TOKEN_REF" 2>/dev/null||true)"; } || true
-  [[ -z "$fb" ]] && warn "no Firebase Local token from 1Password — set FIREBASE_APP_CHECK_DEBUG_TOKEN in $ios/.env (shared Local token)"
+  [[ -z "$fb" ]] && warn "no Firebase Local token from 1Password — sign in ('op signin', account xmtpinc) and re-run 'make ios-config', or set FIREBASE_APP_CHECK_DEBUG_TOKEN in $ios/.env (shared Local token); without it sign-in fails with Firebase 403"
   rm -f "$ios/.env"   # break any Dev-shared symlink; the Local scheme uses a standalone .env
   # Leave CONVOS_API_BASE_URL EMPTY on purpose. The build phase reads this same
   # .env for BOTH schemes (copy-env-config-main-app.sh): a non-empty value here

--- a/dev/local-stack/stack.sh
+++ b/dev/local-stack/stack.sh
@@ -67,13 +67,37 @@ dc() { docker compose -p "$COMPOSE_PROJECT" -f "$COMPOSE_FILE" "$@"; }
 
 wait_http() { local url="$1" t="${2:-60}" i=0; while (( i < t )); do local c; c="$(curl -s -o /dev/null -w '%{http_code}' --max-time 8 "$url" 2>/dev/null || true)"; [[ "$c" =~ ^2[0-9][0-9]$ ]] && return 0; sleep 1; ((i++)); done; return 1; }
 
-start_svc() { local name="$1" dir="$2"; shift 2; if svc_running "$name"; then ok "$name already running"; return 0; fi; [[ -d "$dir" ]] || die "$name dir missing: $dir"; log "starting $name ${c_dim}($dir)${c_rst}"; ( cd "$dir" && nohup bash -lc "$*" >"$RUN_DIR/$name.log" 2>&1 & echo $! >"$RUN_DIR/$name.pid" ); }
-svc_running() { local n="$1"; [[ -f "$RUN_DIR/$n.pid" ]] && kill -0 "$(cat "$RUN_DIR/$n.pid")" 2>/dev/null; }
+start_svc() { local name="$1" dir="$2"; shift 2; if svc_running "$name" "$dir"; then ok "$name already running"; return 0; fi; [[ -d "$dir" ]] || die "$name dir missing: $dir"; log "starting $name ${c_dim}($dir)${c_rst}"; ( cd "$dir" && nohup bash -lc "$*" >"$RUN_DIR/$name.log" 2>&1 & echo $! >"$RUN_DIR/$name.pid" ); }
+# A bare kill -0 is fooled by pid reuse and by wrapper shells whose real service
+# child died (e.g. EADDRINUSE) — then start_svc skips the start and wait_http
+# spins for a minute against a dead port. When a dir is given, also require the
+# pid's cwd to be that service dir (the start_svc wrapper cd's there).
+svc_running() {
+  local n="$1" dir="${2:-}" pid cwd
+  [[ -f "$RUN_DIR/$n.pid" ]] || return 1
+  pid="$(cat "$RUN_DIR/$n.pid")"
+  kill -0 "$pid" 2>/dev/null || return 1
+  [[ -z "$dir" ]] && return 0
+  cwd="$(lsof -a -p "$pid" -d cwd -Fn 2>/dev/null | sed -n 's/^n//p' | head -1)"
+  [[ "$cwd" == "$dir" ]]
+}
+
+# Refuse to "start" a service whose port is already held by a foreign process —
+# otherwise the squatter (often a stale checkout's dev server) answers the
+# health checks and the whole stack looks green while pointing at old state.
+guard_port() {
+  local port="$1" name="$2" dir="$3" pid cmd
+  svc_running "$name" "$dir" && return 0
+  pid="$(lsof -tnP -iTCP:"$port" -sTCP:LISTEN 2>/dev/null | head -1)"
+  [[ -z "$pid" ]] && return 0
+  cmd="$(ps -o command= -p "$pid" 2>/dev/null | head -c 140)"
+  die "port ${port} is held by a foreign process (pid ${pid}: ${cmd}) — it would shadow ${name} and answer health checks with stale state. Kill it (kill ${pid}) and re-run."
+}
 stop_svc() { local name="$1" pat="${2:-}"; [[ -f "$RUN_DIR/$name.pid" ]] && kill "$(cat "$RUN_DIR/$name.pid")" 2>/dev/null || true; [[ -n "$pat" ]] && pkill -f "$pat" 2>/dev/null || true; rm -f "$RUN_DIR/$name.pid"; }
 # Note: key/token lookups below use `|| true` so a missing line degrades to the
 # guarded warn-and-return path instead of set -e killing the whole script (the
 # grep in a $(...) assignment otherwise propagates its non-zero exit status).
-disable_app_check() { local tok; tok="$(grep -E '^DEV_API_TOKEN=' "${BACKEND_DIR}/.env" 2>/dev/null | cut -d= -f2-)" || true; [[ -z "$tok" ]] && { warn "no DEV_API_TOKEN; can't disable App Check"; return; }; curl -s -X POST -H "Authorization: Bearer $tok" -H 'Content-Type: application/json' -d '{"enabled":false}' "http://localhost:${BACKEND_PORT}/api/v2/dev/app-attest" >/dev/null 2>&1 && ok "App Check disabled" || warn "couldn't disable App Check"; }
+disable_app_check() { local tok; tok="$(grep -E '^DEV_API_TOKEN=' "${BACKEND_DIR}/.env" 2>/dev/null | cut -d= -f2-)" || true; [[ -z "$tok" ]] && { warn "no DEV_API_TOKEN; can't disable App Check"; return; }; curl -sf -X POST -H "Authorization: Bearer $tok" -H 'Content-Type: application/json' -d '{"enabled":false}' "http://localhost:${BACKEND_PORT}/api/v2/dev/app-attest" >/dev/null 2>&1 && ok "App Check disabled" || warn "couldn't disable App Check (HTTP error — wrong DEV_API_TOKEN, or is something else answering on :${BACKEND_PORT}?)"; }
 
 # Host IP reachable from BOTH the worker (a host process) and the Hermes
 # container. `localhost` only works from the host, `host.docker.internal`
@@ -287,13 +311,16 @@ cmd_up() {
   align_agent_key    # keep backend AGENT_ASSETS_API_KEY == worker CONVOS_API_KEY
   log "infra ($([[ $tier == full ]] && echo 'Postgres + MinIO' || echo 'Postgres'))"
   if [[ "$tier" == full ]]; then dc up -d --wait || dc up -d; else dc up -d convos_db --wait || dc up -d convos_db; fi
+  guard_port "$BACKEND_PORT" backend "$BACKEND_DIR"
   start_svc backend "$BACKEND_DIR" "pnpm dev"
   wait_http "http://localhost:${BACKEND_PORT}/healthcheck" 60 && ok "backend up" || warn "backend not healthy (make logs SVC=backend)"
   disable_app_check
   seed_credits   # fund any unfunded accounts so the agent-builder isn't credit-gated ("lost power")
   if [[ "$tier" == full ]]; then
+    guard_port "$HERALD_PORT" herald "$HERALD_DIR"
     start_svc herald "$HERALD_DIR" "pnpm start"
     wait_http "http://localhost:${HERALD_PORT}/livez" 30 && ok "herald up" || warn "herald not healthy (make logs SVC=herald)"
+    guard_port "$WORKER_PORT" worker "$WORKER_DIR"
     start_svc worker "$WORKER_DIR" "pnpm dev"
     log "waiting for worker :${WORKER_PORT} (first run builds Hermes image — minutes, capped)"
     wait_http "http://localhost:${WORKER_PORT}/openapi.json" 1200 && ok "worker up (Hermes ready)" || warn "worker still starting (make logs SVC=worker)"


### PR DESCRIPTION
## Summary

Ran `/run local` end-to-end on a fresh machine (all xmtplabs repos newly cloned) and fixed every onboarding friction point hit along the way:

- **`stack.sh` init bug** — backticks in the "wrote stack.env" message were executed as command substitution, so `make init` accidentally ran `make bootstrap` mid-init, surfacing as a confusing "Docker not running / bootstrap Error 1" on every fresh machine.
- **Wrong 1Password vault in `stack.env.example`** — the shipped `OP_*` refs pointed at a nonexistent `Engineering` vault. The team items live in the **Convos** vault, and Dev/Local share the single "Firebase App Check Debug Token" item (same ref `/firebase-token` uses).
- **Silent, permanent secret failure** — bootstrap before `op signin` left a skeleton `.dev.vars` (no `CONVOS_API_KEY`) and never retried 1Password on later runs. Now it warns up front when the CLI isn't signed in and re-fetches when the file is missing or incomplete.
- **Herald Node-ABI crash** — herald pins node `>=25` and ships `better-sqlite3`; installing under the caller's (older) node builds the wrong ABI and herald dies at startup with `ERR_DLOPEN_FAILED`. Deps now install via a login shell, the same env `start_svc` launches services with.
- **Docker not running just died** — `bootstrap`/`up`/`hermes-build` now auto-start OrbStack or Docker Desktop on macOS and wait; `doctor` warns instead of aborting its remaining checks, and only nags about the CPU cap on Docker Desktop (OrbStack allocates dynamically).
- **`make init` cloned duplicate repos** — when all four service repos already sit next to convos-ios, init now defaults the workspace to that parent dir instead of cloning copies into `<parent>/convos-stack`.
- **Build failures masked as success** — the `xcodebuild ... | tail` snippets in `run.md` return exit 0 on `** BUILD FAILED **`. Added `set -o pipefail` and a note.

## Test plan

- [x] Full `/run local` flow on a fresh machine: `make init` (reused existing clones) → `bootstrap` → `up` → build/install/launch "Convos (Local)" on a dedicated simulator
- [x] All services healthy: backend/herald/worker/MinIO 200, Postgres healthy, Hermes ready, credits seeded
- [x] Verified under both Docker Desktop and OrbStack (engine auto-start + doctor behavior)
- [x] Herald recovers from the ABI mismatch with the login-shell install
- [x] `bash -n` on `stack.sh`; no Swift code touched (docs + shell only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1037"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783793534&installation_id=128169237&pr_number=1037&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1037&signature=b85b5520bcf4b5348995fe436ea53a774e1369727bbb5bf931febc44250b4aeb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix local-stack onboarding friction for fresh-machine setup
> - Adds `ensure_docker` to auto-start OrbStack or Docker Desktop on macOS and wait up to ~120s before failing, replacing immediate failures when Docker is not running
> - Adds `op_ready` helper and warns (rather than silently proceeding) when 1Password CLI is not signed in during `bootstrap`
> - Adds `guard_port` to abort early if a service port is already held by an unrelated process, preventing false-healthy states
> - Fixes `svc_running` to verify the recorded PID's working directory matches the expected service directory, reducing false positives from PID reuse
> - Fixes `bootstrap_herald` to install dependencies via a login shell first, reducing native module ABI mismatches
> - Fixes `bootstrap_assistants` to refetch `.dev.vars` when `CONVOS_API_KEY` is missing and use a temp file to avoid leaving a broken config after a pre-signin bootstrap
> - Updates `stack.env.example` vault references from `Engineering` to `Convos` and clarifies documentation in `run.md` and `local-stack/README.md`
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7bda62c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->