### PR TITLE
fix(tests): de-flake integration tests racing on shared libxmtp DB directory

### DIFF
--- a/ConvosCore/Sources/ConvosCore/Storage/Workers/ScheduledExplosionManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Workers/ScheduledExplosionManager.swift
@@ -15,6 +15,7 @@ final class ScheduledExplosionManager: ScheduledExplosionManagerProtocol, @unche
     nonisolated(unsafe) private var observers: [NSObjectProtocol] = []
     private let taskLock: NSLock = NSLock()
     private var _schedulingTasks: [String: Task<Void, Never>] = [:]
+    private var _completedSchedulingConversationIds: Set<String> = []
 
     private enum Constant {
         static let reminderIdentifierPrefix: String = "explosion-reminder-"
@@ -89,6 +90,7 @@ final class ScheduledExplosionManager: ScheduledExplosionManagerProtocol, @unche
     private nonisolated func removeSchedulingTask(for conversationId: String) {
         taskLock.lock()
         _schedulingTasks[conversationId] = nil
+        _completedSchedulingConversationIds.insert(conversationId)
         taskLock.unlock()
     }
 
@@ -96,6 +98,15 @@ final class ScheduledExplosionManager: ScheduledExplosionManagerProtocol, @unche
         taskLock.lock()
         defer { taskLock.unlock() }
         return _schedulingTasks[conversationId] != nil
+    }
+
+    /// Whether a scheduling task for this conversation ran to completion.
+    /// Tests poll this instead of the in-flight task, which can be created
+    /// and removed between two polls when scheduling finishes quickly.
+    func hasCompletedSchedulingTask(for conversationId: String) -> Bool {
+        taskLock.lock()
+        defer { taskLock.unlock() }
+        return _completedSchedulingConversationIds.contains(conversationId)
     }
 
     private func scheduleNotifications(

--- a/ConvosCore/Tests/ConvosCoreTests/ScheduledExplosionManagerTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ScheduledExplosionManagerTests.swift
@@ -298,19 +298,16 @@ private class ScheduledExplosionTestFixtures {
 }
 
 /// Wait for a scheduling task to start and then complete.
-/// The observer callback is dispatched async to the main queue, so we first
-/// need to yield to let it fire, then wait for the resulting task to finish.
+/// Polling for the in-flight task to appear and then disappear is racy:
+/// fast paths (e.g. an already-expired conversation) create and remove the
+/// task between two polls, so the "appear" phase times out. The manager
+/// records completed conversationIds instead, which observes the same
+/// lifecycle without a window to miss.
 private func waitForSchedulingTaskCompletion(
     fixtures: ScheduledExplosionTestFixtures,
     conversationId: String
 ) async throws {
-    // Phase 1: wait for the task to appear (callback has fired)
-    try await waitUntil(timeout: .seconds(3)) {
-        fixtures.manager.hasSchedulingTask(for: conversationId)
-    }
-
-    // Phase 2: wait for the task to complete (removed from dictionary)
-    try await waitUntil(timeout: .seconds(3)) {
-        !fixtures.manager.hasSchedulingTask(for: conversationId)
+    try await waitUntil(timeout: .seconds(6)) {
+        fixtures.manager.hasCompletedSchedulingTask(for: conversationId)
     }
 }

--- a/ConvosCore/Tests/ConvosCoreTests/TestHelpers.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/TestHelpers.swift
@@ -92,6 +92,16 @@ class TestFixtures {
     let keychainService: MockKeychainService
     let databaseManager: MockDatabaseManager
 
+    /// Unique per-fixture directory for libxmtp database files. In the
+    /// `.tests` environment `defaultDatabasesDirectory` is the shared
+    /// process temp directory, and production delete paths (for example
+    /// `SessionStateMachine.deleteDatabaseFiles`) sweep every `xmtp-*`
+    /// file in that directory. Suites run in parallel, so a delete-flow
+    /// test sweeping the shared directory destroys the live databases of
+    /// clients created by other suites mid-test. Giving each fixture its
+    /// own directory keeps those sweeps from reaching our clients.
+    let databasesDirectory: URL
+
     var clientA: (any XMTPClientProvider)?
     var clientB: (any XMTPClientProvider)?
     var clientC: (any XMTPClientProvider)?
@@ -105,6 +115,9 @@ class TestFixtures {
         self.identityStore = MockKeychainIdentityStore()
         self.keychainService = MockKeychainService()
         self.databaseManager = MockDatabaseManager.makeTestDatabase()
+        self.databasesDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("convos-test-fixtures-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: databasesDirectory, withIntermediateDirectories: true)
 
         // Configure logging for tests
         ConvosLog.configure(environment: .tests)
@@ -147,7 +160,7 @@ class TestFixtures {
                 TypingIndicatorCodec()
             ],
             dbEncryptionKey: keys.databaseKey,
-            dbDirectory: environment.defaultDatabasesDirectory
+            dbDirectory: databasesDirectory.path
         )
 
         let client = try await Client.create(account: keys.signingKey, options: clientOptions)
@@ -188,6 +201,7 @@ class TestFixtures {
 
         try await identityStore.delete()
         try databaseManager.erase()
+        try? FileManager.default.removeItem(at: databasesDirectory)
     }
 
     /// Builds a fresh MessagingService for tests that previously used


### PR DESCRIPTION
## Summary

Two pre-existing integration-test flakes surfaced on #1035's CI run (different victims on each of the job's two passes):

1. **Shared-directory wipe race** — `TestFixtures` created every XMTP client in the shared process temp directory (`.tests` `defaultDatabasesDirectory`). Delete-flow tests (`ConversationStateMachine`/`SessionStateMachine` `stopAndDelete()`) reach `SessionStateMachine.deleteDatabaseFiles()`, which sweeps every `xmtp-*` file in that directory. Suites run in parallel, so the sweep destroys live client databases of other suites mid-test — whichever test is in flight fails with libxmtp storage errors like `no such table: identity` / `no such table: identity_updates`. Each fixture now creates clients in its own unique temp subdirectory (the same pattern `InviteCoordinatorIntegrationTests` and `PushTopicSubscriptionDeniedDMTests` already use) and removes it in `cleanup()`.

2. **Scheduling-task observation race** — `ScheduledExplosionManagerTests`' `waitForSchedulingTaskCompletion` polled (50ms interval) for the transient scheduling task to appear before waiting for it to disappear. Fast paths (already-expired conversation) create and remove the task between two polls, so phase 1 times out (`TimeoutError` at ScheduledExplosionManagerTests.swift:95). The manager now records completed conversationIds and the helper waits on that instead.

## Testing

- `ScheduledExplosionManager` suite passes 7/7 locally, including the flaky "Skips notifications when already expired".
- Full package + test target compile; SwiftLint clean.
- Docker-dependent integration suites could not be run locally (Docker Desktop fails to launch headlessly on this machine) — this PR's Integration Tests job is the validation for fix 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1038"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783794388&installation_id=128169237&pr_number=1038&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1038&signature=da04f1bbcefad3afaac9f9fb67796d7a1f34bc1b840c0fd5dcf9ec3038b06dd8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix flaky integration tests racing on shared libxmtp database directory
> - Each `TestFixtures` instance now creates and uses a unique temporary directory for XMTP client database files, preventing races between parallel tests sharing the same directory. The directory is removed during teardown.
> - `ScheduledExplosionManager` gains a `hasCompletedSchedulingTask(for:)` method backed by a new `_completedSchedulingConversationIds` set, allowing callers to query whether scheduling has finished for a given conversation.
> - The `waitForSchedulingTaskCompletion` test helper is rewritten to poll `hasCompletedSchedulingTask(for:)` with a 6-second timeout instead of watching for task creation then disappearance, making it more reliable.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6568b38.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->