### PR TITLE
Fix dev build: pass wasRemoved at two Conversation call sites

### DIFF
--- a/ConvosCore/Sources/ConvosCore/Mocks/ModelMocks.swift
+++ b/ConvosCore/Sources/ConvosCore/Mocks/ModelMocks.swift
@@ -111,6 +111,7 @@ public extension Conversation {
             isMuted: false,
             pinnedOrder: nil,
             hidesInviteCard: false,
+            wasRemoved: false,
             lastMessage: lastMessage,
             imageURL: nil,
             imageSalt: nil,

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/Conversation.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/Conversation.swift
@@ -90,6 +90,7 @@ public extension Conversation {
             isMuted: isMuted,
             pinnedOrder: pinnedOrder,
             hidesInviteCard: hidesInviteCard,
+            wasRemoved: wasRemoved,
             lastMessage: lastMessage,
             imageURL: imageURL,
             imageSalt: imageSalt,


### PR DESCRIPTION
## Summary

`dev` does not compile at tip: the removed-member-handling merge added `Conversation.wasRemoved` while two call sites merged in parallel without the new argument (semantic merge conflict — each PR was green alone):

- `Conversation.withMembers(_:)` — now passes `wasRemoved: wasRemoved` through the copy
- `ModelMocks` conversation builder — now passes `wasRemoved: false`

## Test plan

- [x] `swift build --package-path ConvosCore` — clean (both previously-failing files)

Merging without CI per @jarod (status checks temporarily not required) to unbreak dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1039"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783796498&installation_id=128169237&pr_number=1039&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1039&signature=9f770de0efa80d7f40d6c76d60315b1facd413b8a039514ea79d2cda12030439"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix dev build by passing `wasRemoved` at two `Conversation` call sites
> Fixes a dev build failure by supplying the `wasRemoved` argument where it was missing. `Conversation.withMembers` now propagates `wasRemoved` from the source instance, and both mock factory overloads in [ModelMocks.swift](https://github.com/xmtplabs/convos-ios/pull/1039/files#diff-772603937c1e0966b591b930c6c6a6d0f7a57fa42b96c828c5c471babc57c5cb) pass `wasRemoved: false` explicitly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 417a3ad.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->