### PR TITLE
Hold builder-bundle publish until the agent has joined the conversation

### DIFF
--- a/Convos/Agent Builder/AgentBuilderViewModel.swift
+++ b/Convos/Agent Builder/AgentBuilderViewModel.swift
@@ -746,9 +746,29 @@ final class AgentBuilderViewModel: Identifiable {
         // owns its own message writer, so it sends independently of the
         // dismissed builder.
         Task { @MainActor [innerVM, voiceMemoSnapshot, summaryToPersist, conversationIdForPersist, textMessageId, bundleMessageId, session] in
-            // Persist the summary first so the chat the user returns to renders
-            // the card immediately (its `summaryPublisher` picks this up) and
-            // the filter set is on disk before the bundle lands.
+            // Request the agent join before anything else: the bundle publish
+            // below holds until the agent is a verified member (XMTP members
+            // can't read messages published before they joined), so the join
+            // must already be in flight by the time the send runs -- and the
+            // head start lets the backend add the agent while the summary
+            // persists and uploads finish. The join must finish even after
+            // the builder sheet dismisses. Unlike the draft flow, there is no
+            // draft to discard -- the user's group stays -- so the join
+            // survives the view closing (like `ConversationViewModel`'s
+            // committed-conversation join, the opposite of the draft path).
+            let slug = innerVM.conversation.invite?.urlSlug ?? ""
+            if slug.isEmpty {
+                Log.warning("AgentBuilder(existing): no invite slug; skipping agent join")
+            } else {
+                do {
+                    _ = try await session.requestAgentJoin(slug: slug, options: .agentBuilder)
+                } catch {
+                    Log.error("AgentBuilder(existing): requestAgentJoin failed: \(error.localizedDescription)")
+                }
+            }
+            // Persist the summary before the send so the chat the user returns
+            // to renders the card immediately (its `summaryPublisher` picks
+            // this up) and the filter set is on disk before the bundle lands.
             do {
                 try await session.agentBuilderSummaryWriter().save(summaryToPersist, for: conversationIdForPersist)
             } catch {
@@ -765,21 +785,6 @@ final class AgentBuilderViewModel: Identifiable {
                 textMessageId: textMessageId,
                 bundleMessageId: bundleMessageId
             )
-            let slug = innerVM.conversation.invite?.urlSlug ?? ""
-            guard !slug.isEmpty else {
-                Log.warning("AgentBuilder(existing): no invite slug; skipping agent join")
-                return
-            }
-            // The join must finish even after the builder sheet dismisses.
-            // Unlike the draft flow, there is no draft to discard -- the user's
-            // group stays -- so the join survives the view closing (like
-            // `ConversationViewModel`'s committed-conversation join, the
-            // opposite of the draft path).
-            do {
-                _ = try await session.requestAgentJoin(slug: slug, options: .agentBuilder)
-            } catch {
-                Log.error("AgentBuilder(existing): requestAgentJoin failed: \(error.localizedDescription)")
-            }
         }
         // No in-sheet morph: the builder targets a conversation the user is
         // already in, so `AgentBuilderView` dismisses the sheet on Make and the

--- a/Convos/Agent Builder/AgentBuilderViewModel.swift
+++ b/Convos/Agent Builder/AgentBuilderViewModel.swift
@@ -610,6 +610,12 @@ final class AgentBuilderViewModel: Identifiable {
             let summaryToPersist: AgentBuilderSummary = plan.summary
             let conversationIdForPersist: String = innerVM.conversation.id
             let sessionForPersist = session
+            // Detach the agent-join task from this VM: the builder sheet tears
+            // down after Make and `deinit` cancels `agentJoinTask`, which
+            // could abort the join request mid-flight -- the bundle send below
+            // then waits for an agent that never joins. Dropping the
+            // reference (without cancelling) lets the join finish on its own.
+            agentJoinTask = nil
             Task { @MainActor [weak innerVM, voiceMemoSnapshot, textMessageId, bundleMessageId, summaryToPersist, conversationIdForPersist, sessionForPersist] in
                 guard let innerVM else { return }
                 // Persist the summary (with its `bundledMessageIds`) before
@@ -757,11 +763,13 @@ final class AgentBuilderViewModel: Identifiable {
             // survives the view closing (like `ConversationViewModel`'s
             // committed-conversation join, the opposite of the draft path).
             let slug = innerVM.conversation.invite?.urlSlug ?? ""
+            var joinRequested = false
             if slug.isEmpty {
                 Log.warning("AgentBuilder(existing): no invite slug; skipping agent join")
             } else {
                 do {
                     _ = try await session.requestAgentJoin(slug: slug, options: .agentBuilder)
+                    joinRequested = true
                 } catch {
                     Log.error("AgentBuilder(existing): requestAgentJoin failed: \(error.localizedDescription)")
                 }
@@ -779,11 +787,15 @@ final class AgentBuilderViewModel: Identifiable {
             } catch {
                 Log.error("AgentBuilder(existing): pending media upload await failed: \(error.localizedDescription)")
             }
+            // `awaitsAgentJoin: false` when the join was never requested (no
+            // slug) or its request failed -- holding the bundle for an agent
+            // that will never arrive only delays the inevitable publish.
             await innerVM.sendBuilderBundle(
                 text: summaryToPersist.prompt,
                 voiceMemo: voiceMemoSnapshot,
                 textMessageId: textMessageId,
-                bundleMessageId: bundleMessageId
+                bundleMessageId: bundleMessageId,
+                awaitsAgentJoin: joinRequested
             )
         }
         // No in-sheet morph: the builder targets a conversation the user is

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -2577,7 +2577,8 @@ extension ConversationViewModel {
         text: String,
         voiceMemo: BuilderVoiceMemoSnapshot?,
         textMessageId: String? = nil,
-        bundleMessageId: String? = nil
+        bundleMessageId: String? = nil,
+        awaitsAgentJoin: Bool = true
     ) async {
         defer { isAwaitingBuilderBundleSend = false }
         let writer = cachedMessageWriter
@@ -2623,7 +2624,8 @@ extension ConversationViewModel {
                 text: text,
                 bundleItems: bundleItems,
                 textClientMessageId: resolvedTextClientMessageId,
-                bundleClientMessageId: resolvedBundleClientMessageId
+                bundleClientMessageId: resolvedBundleClientMessageId,
+                awaitsAgentJoin: awaitsAgentJoin
             )
         } catch {
             Log.error("AgentBuilder bundle: failed to send builder bundle: \(error.localizedDescription)")

--- a/ConvosCore/Sources/ConvosCore/Inboxes/ConversationStateMachine.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/ConversationStateMachine.swift
@@ -1321,14 +1321,16 @@ extension ConversationStateMachine {
         text: String,
         bundleItems: [MultiAttachmentBundleItem],
         textClientMessageId: String,
-        bundleClientMessageId: String
+        bundleClientMessageId: String,
+        awaitsAgentJoin: Bool
     ) async throws {
         let writer = try await getOrCreateMessageWriter()
         try await writer.sendBuilderBundle(
             text: text,
             bundleItems: bundleItems,
             textClientMessageId: textClientMessageId,
-            bundleClientMessageId: bundleClientMessageId
+            bundleClientMessageId: bundleClientMessageId,
+            awaitsAgentJoin: awaitsAgentJoin
         )
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Mocks/MockConversationStateManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Mocks/MockConversationStateManager.swift
@@ -108,7 +108,7 @@ public final class MockConversationStateManager: ConversationStateManagerProtoco
     public func awaitEagerUpload(trackingKey: String) async throws {}
     public func sendMultiRemoteAttachment(items: [MultiAttachmentBundleItem]) async throws -> String { UUID().uuidString }
     public func sendMultiRemoteAttachment(items: [MultiAttachmentBundleItem], clientMessageId: String) async throws -> String { clientMessageId }
-    public func sendBuilderBundle(text: String, bundleItems: [MultiAttachmentBundleItem], textClientMessageId: String, bundleClientMessageId: String) async throws {}
+    public func sendBuilderBundle(text: String, bundleItems: [MultiAttachmentBundleItem], textClientMessageId: String, bundleClientMessageId: String, awaitsAgentJoin: Bool) async throws {}
     public func sendVideo(at fileURL: URL, replyToMessageId: String?) async throws -> String { UUID().uuidString }
     public func sendVoiceMemo(at fileURL: URL, duration: TimeInterval, waveformLevels: [Float]?, replyToMessageId: String?) async throws -> String { UUID().uuidString }
     public func sendFile(at fileURL: URL, filename: String, mimeType: String, replyToMessageId: String?) async throws -> String { UUID().uuidString }

--- a/ConvosCore/Sources/ConvosCore/Mocks/MockOutgoingMessageWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Mocks/MockOutgoingMessageWriter.swift
@@ -76,7 +76,8 @@ public final class MockOutgoingMessageWriter: OutgoingMessageWriterProtocol, @un
         text: String,
         bundleItems: [MultiAttachmentBundleItem],
         textClientMessageId: String,
-        bundleClientMessageId: String
+        bundleClientMessageId: String,
+        awaitsAgentJoin: Bool
     ) async throws {
         sentImageCount += bundleItems.count
     }

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationStateManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationStateManager.swift
@@ -306,13 +306,15 @@ public final class ConversationStateManager: ConversationStateManagerProtocol, @
         text: String,
         bundleItems: [MultiAttachmentBundleItem],
         textClientMessageId: String,
-        bundleClientMessageId: String
+        bundleClientMessageId: String,
+        awaitsAgentJoin: Bool
     ) async throws {
         try await stateMachine.sendBuilderBundle(
             text: text,
             bundleItems: bundleItems,
             textClientMessageId: textClientMessageId,
-            bundleClientMessageId: bundleClientMessageId
+            bundleClientMessageId: bundleClientMessageId,
+            awaitsAgentJoin: awaitsAgentJoin
         )
     }
 

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/OutgoingMessageWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/OutgoingMessageWriter.swift
@@ -104,11 +104,17 @@ public protocol OutgoingMessageWriterProtocol: Sendable {
     /// `textClientMessageId` / `bundleClientMessageId` are the optimistic ids
     /// the caller persisted into `AgentBuilderSummary.bundledMessageIds`, so
     /// the sender's own copy stays hidden via the summary filter too.
+    /// `awaitsAgentJoin` holds the XMTP prepare + publish until the
+    /// conversation has a current agent member (the brief is addressed to a
+    /// joining agent, and XMTP members can't read messages from before they
+    /// joined). Pass `false` when no agent join was requested so the bundle
+    /// isn't held for an agent that will never arrive.
     func sendBuilderBundle(
         text: String,
         bundleItems: [MultiAttachmentBundleItem],
         textClientMessageId: String,
-        bundleClientMessageId: String
+        bundleClientMessageId: String,
+        awaitsAgentJoin: Bool
     ) async throws
 
     // MARK: - Replies
@@ -866,7 +872,8 @@ actor OutgoingMessageWriter: OutgoingMessageWriterProtocol {
         text: String,
         bundleItems: [MultiAttachmentBundleItem],
         textClientMessageId: String,
-        bundleClientMessageId: String
+        bundleClientMessageId: String,
+        awaitsAgentJoin: Bool
     ) async throws {
         let mimeTypes: [String] = bundleItems.map { item -> String in
             switch item {
@@ -883,7 +890,8 @@ actor OutgoingMessageWriter: OutgoingMessageWriterProtocol {
                 text: text,
                 bundleItems: bundleItems,
                 textClientMessageId: textClientMessageId,
-                bundleClientMessageId: bundleClientMessageId
+                bundleClientMessageId: bundleClientMessageId,
+                awaitsAgentJoin: awaitsAgentJoin
             )
             await emitSentMessage(clientMessageId: metricKey, isSuccess: true)
         } catch {
@@ -896,7 +904,8 @@ actor OutgoingMessageWriter: OutgoingMessageWriterProtocol {
         text: String,
         bundleItems: [MultiAttachmentBundleItem],
         textClientMessageId: String,
-        bundleClientMessageId: String
+        bundleClientMessageId: String,
+        awaitsAgentJoin: Bool
     ) async throws {
         let inboxReady = try await sessionStateManager.waitForInboxReadyResult()
         await persistLocalBundleHiddenIds(
@@ -905,6 +914,20 @@ actor OutgoingMessageWriter: OutgoingMessageWriterProtocol {
             textClientMessageId: textClientMessageId,
             bundleClientMessageId: bundleClientMessageId
         )
+
+        // The gate must run BEFORE any prepare call: preparing queues libxmtp
+        // send intents, and any concurrent publish or group sync flushes every
+        // pending intent to the network (a read receipt fires the moment the
+        // user lands in the chat after Make, and the agent-join polling itself
+        // syncs the group every few seconds). Held here, no part of the brief
+        // exists in the XMTP store until the agent can read it.
+        if awaitsAgentJoin {
+            await Self.waitForAgentMember(
+                in: databaseWriter,
+                conversationId: conversationId,
+                timeout: Self.agentMemberWaitTimeout
+            )
+        }
 
         // Prepare (but don't publish) the bundle messages so the manifest can
         // reference their real XMTP ids. Attachments are prepared before the
@@ -928,13 +951,6 @@ actor OutgoingMessageWriter: OutgoingMessageWriterProtocol {
         let bundledMessageIds: [String] = [prepared?.messageId, textMessageId].compactMap { $0 }
         guard !bundledMessageIds.isEmpty else { return }
 
-        // The bundle exists to brief the agent the builder is adding, and
-        // XMTP members can't read messages published before they joined.
-        // Every builder path requests the join before this send, so hold
-        // the publish (local rows above are already persisted, and they're
-        // hidden from the sender's UI) until the agent is a verified member.
-        await waitForVerifiedAgentMember()
-
         try await publishPreparedBuilderBundle(
             manifestIds: bundledMessageIds,
             prepared: prepared,
@@ -944,21 +960,36 @@ actor OutgoingMessageWriter: OutgoingMessageWriterProtocol {
         )
     }
 
-    /// How long the builder-bundle publish waits for the joining agent to
-    /// become a verified member before publishing anyway. Matches the
-    /// agent-join polling window in `SessionStateManager`; on expiry the
-    /// bundle publishes regardless so a failed or slow join doesn't strand
-    /// the user's brief (the pre-fix behavior, just delayed).
-    private static let verifiedAgentWaitTimeout: TimeInterval = 150
+    /// How long the builder-bundle send waits for the joining agent to become
+    /// a member before proceeding anyway. Matches the agent-join polling
+    /// window in `SessionStateManager`; on expiry the bundle sends regardless
+    /// so a failed or slow join doesn't strand the user's brief (the pre-fix
+    /// behavior, just delayed).
+    private static let agentMemberWaitTimeout: TimeInterval = 150
 
-    private func waitForVerifiedAgentMember() async {
-        let convoId: String = conversationId
-        let reader: any DatabaseReader = databaseWriter
+    /// Waits until the conversation has a current agent member, or the
+    /// timeout elapses. Returns whether an agent member was found.
+    ///
+    /// The predicate is "some current member whose profile is an agent":
+    /// membership comes from `DBConversationMember` (profile rows alone
+    /// outlive removals, so a previously-removed agent must not open the
+    /// gate), and attestation verification is deliberately not required --
+    /// the agent can read group messages the moment it's a member,
+    /// regardless of whether this client has verified it yet.
+    ///
+    /// Known limit: `AgentJoinResponse` carries no agent identity, so the
+    /// gate can't wait for a SPECIFIC agent. A brief addressed to a second
+    /// agent in a conversation that already has one can still publish before
+    /// that agent joins; closing that needs the backend to return the
+    /// joining agent's inboxId.
+    @discardableResult
+    static func waitForAgentMember(
+        in reader: any DatabaseReader,
+        conversationId: String,
+        timeout: TimeInterval
+    ) async -> Bool {
         let observation = ValueObservation.tracking { db -> Bool in
-            try DBMemberProfile
-                .filter(DBMemberProfile.Columns.conversationId == convoId)
-                .fetchAll(db)
-                .contains { $0.isAgent && $0.agentVerification.isVerified }
+            try Self.hasCurrentAgentMember(db: db, conversationId: conversationId)
         }
         let joined: Bool = await withTaskGroup(of: Bool.self) { group in
             group.addTask {
@@ -967,12 +998,21 @@ actor OutgoingMessageWriter: OutgoingMessageWriterProtocol {
                         return true
                     }
                 } catch {
-                    Log.error("Builder bundle agent wait: observation failed: \(error.localizedDescription)")
+                    Log.warning("Builder bundle agent wait: observation failed (\(error.localizedDescription)); falling back to polling")
+                }
+                // The observation stream died; poll until the timeout child
+                // wins the race and cancels this loop.
+                while !Task.isCancelled {
+                    try? await Task.sleep(nanoseconds: 2_000_000_000)
+                    let hasAgent: Bool = (try? await reader.read { db in
+                        try Self.hasCurrentAgentMember(db: db, conversationId: conversationId)
+                    }) ?? false
+                    if hasAgent { return true }
                 }
                 return false
             }
             group.addTask {
-                try? await Task.sleep(nanoseconds: UInt64(Self.verifiedAgentWaitTimeout * 1_000_000_000))
+                try? await Task.sleep(nanoseconds: UInt64(timeout * 1_000_000_000))
                 return false
             }
             let first: Bool = await group.next() ?? false
@@ -980,8 +1020,22 @@ actor OutgoingMessageWriter: OutgoingMessageWriterProtocol {
             return first
         }
         if !joined {
-            Log.warning("Builder bundle: no verified agent member in \(convoId) after \(Int(Self.verifiedAgentWaitTimeout))s; publishing anyway")
+            Log.warning("Builder bundle: no agent member in \(conversationId) after waiting; publishing anyway")
         }
+        return joined
+    }
+
+    static func hasCurrentAgentMember(db: Database, conversationId: String) throws -> Bool {
+        let memberInboxIds: [String] = try DBConversationMember
+            .filter(DBConversationMember.Columns.conversationId == conversationId)
+            .fetchAll(db)
+            .map(\.inboxId)
+        guard !memberInboxIds.isEmpty else { return false }
+        return try DBMemberProfile
+            .filter(DBMemberProfile.Columns.conversationId == conversationId)
+            .filter(memberInboxIds.contains(DBMemberProfile.Columns.inboxId))
+            .fetchAll(db)
+            .contains { $0.isAgent }
     }
 
     /// Hide the bundle on this (sender's) client from the first render. The

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/OutgoingMessageWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/OutgoingMessageWriter.swift
@@ -928,6 +928,13 @@ actor OutgoingMessageWriter: OutgoingMessageWriterProtocol {
         let bundledMessageIds: [String] = [prepared?.messageId, textMessageId].compactMap { $0 }
         guard !bundledMessageIds.isEmpty else { return }
 
+        // The bundle exists to brief the agent the builder is adding, and
+        // XMTP members can't read messages published before they joined.
+        // Every builder path requests the join before this send, so hold
+        // the publish (local rows above are already persisted, and they're
+        // hidden from the sender's UI) until the agent is a verified member.
+        await waitForVerifiedAgentMember()
+
         try await publishPreparedBuilderBundle(
             manifestIds: bundledMessageIds,
             prepared: prepared,
@@ -935,6 +942,46 @@ actor OutgoingMessageWriter: OutgoingMessageWriterProtocol {
             sentText: text,
             inboxReady: inboxReady
         )
+    }
+
+    /// How long the builder-bundle publish waits for the joining agent to
+    /// become a verified member before publishing anyway. Matches the
+    /// agent-join polling window in `SessionStateManager`; on expiry the
+    /// bundle publishes regardless so a failed or slow join doesn't strand
+    /// the user's brief (the pre-fix behavior, just delayed).
+    private static let verifiedAgentWaitTimeout: TimeInterval = 150
+
+    private func waitForVerifiedAgentMember() async {
+        let convoId: String = conversationId
+        let reader: any DatabaseReader = databaseWriter
+        let observation = ValueObservation.tracking { db -> Bool in
+            try DBMemberProfile
+                .filter(DBMemberProfile.Columns.conversationId == convoId)
+                .fetchAll(db)
+                .contains { $0.isAgent && $0.agentVerification.isVerified }
+        }
+        let joined: Bool = await withTaskGroup(of: Bool.self) { group in
+            group.addTask {
+                do {
+                    for try await hasAgent in observation.values(in: reader) where hasAgent {
+                        return true
+                    }
+                } catch {
+                    Log.error("Builder bundle agent wait: observation failed: \(error.localizedDescription)")
+                }
+                return false
+            }
+            group.addTask {
+                try? await Task.sleep(nanoseconds: UInt64(Self.verifiedAgentWaitTimeout * 1_000_000_000))
+                return false
+            }
+            let first: Bool = await group.next() ?? false
+            group.cancelAll()
+            return first
+        }
+        if !joined {
+            Log.warning("Builder bundle: no verified agent member in \(convoId) after \(Int(Self.verifiedAgentWaitTimeout))s; publishing anyway")
+        }
     }
 
     /// Hide the bundle on this (sender's) client from the first render. The

--- a/ConvosCore/Tests/ConvosCoreTests/BuilderBundleAgentGateTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/BuilderBundleAgentGateTests.swift
@@ -1,0 +1,198 @@
+@testable import ConvosCore
+import Foundation
+import GRDB
+import Testing
+
+/// Coverage for the agent-join gate that holds the builder-bundle publish
+/// until the requested agent is a member of the conversation
+/// (`OutgoingMessageWriter.waitForAgentMember`). The brief is addressed to a
+/// joining agent, and XMTP members can't read messages sent before they
+/// joined -- so the gate must open only on a CURRENT agent member (stale
+/// profile rows for removed agents must not count) and must fall through on
+/// timeout rather than strand the send.
+@Suite("Builder bundle agent gate Tests", .serialized)
+struct BuilderBundleAgentGateTests {
+    private static let currentInboxId: String = "inbox-current"
+    private static let humanInboxId: String = "inbox-human"
+    private static let agentInboxId: String = "inbox-agent"
+    private static let conversationId: String = "convo-gate"
+
+    // MARK: - Seeding
+
+    private static func seedConversation(db: Database) throws {
+        for inboxId in [currentInboxId, humanInboxId, agentInboxId] {
+            try DBMember(inboxId: inboxId).save(db, onConflict: .ignore)
+        }
+        try DBInbox(
+            inboxId: currentInboxId,
+            clientId: "client-current",
+            createdAt: Date()
+        ).save(db, onConflict: .ignore)
+
+        try DBConversation(
+            id: conversationId,
+            clientConversationId: "client-\(conversationId)",
+            inviteTag: "tag-\(conversationId)",
+            creatorId: currentInboxId,
+            kind: .group,
+            consent: .allowed,
+            createdAt: Date(),
+            name: nil,
+            description: nil,
+            imageURLString: nil,
+            publicImageURLString: nil,
+            includeInfoInPublicPreview: false,
+            expiresAt: nil,
+            debugInfo: .empty,
+            isLocked: false,
+            imageSalt: nil,
+            imageNonce: nil,
+            imageEncryptionKey: nil,
+            conversationEmoji: nil,
+            imageLastRenewed: nil,
+            isUnused: false,
+            hasHadVerifiedAgent: false
+        ).insert(db)
+
+        try addMember(db: db, inboxId: currentInboxId, kind: nil)
+        try addMember(db: db, inboxId: humanInboxId, kind: nil)
+    }
+
+    private static func addMember(db: Database, inboxId: String, kind: DBMemberKind?) throws {
+        try DBConversationMember(
+            conversationId: conversationId,
+            inboxId: inboxId,
+            role: .member,
+            consent: .allowed,
+            createdAt: Date(),
+            invitedByInboxId: nil
+        ).insert(db)
+        try DBMemberProfile(
+            conversationId: conversationId,
+            inboxId: inboxId,
+            name: inboxId,
+            avatar: nil,
+            memberKind: kind
+        ).insert(db, onConflict: .ignore)
+    }
+
+    /// An agent that has a profile row (never deleted on removal) but no
+    /// current `DBConversationMember` row -- the shape left behind after the
+    /// agent was removed from the group.
+    private static func addStaleAgentProfile(db: Database) throws {
+        try DBMemberProfile(
+            conversationId: conversationId,
+            inboxId: agentInboxId,
+            name: agentInboxId,
+            avatar: nil,
+            memberKind: .verifiedConvos
+        ).insert(db, onConflict: .ignore)
+    }
+
+    // MARK: - hasCurrentAgentMember
+
+    @Test("No agent member: predicate is false")
+    func testNoAgentMember() throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        try dbManager.dbWriter.write { db in
+            try Self.seedConversation(db: db)
+        }
+        let hasAgent = try dbManager.dbReader.read { db in
+            try OutgoingMessageWriter.hasCurrentAgentMember(db: db, conversationId: Self.conversationId)
+        }
+        #expect(hasAgent == false)
+    }
+
+    @Test("Current agent member opens the predicate, even unverified")
+    func testCurrentAgentMember() throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        try dbManager.dbWriter.write { db in
+            try Self.seedConversation(db: db)
+            try Self.addMember(db: db, inboxId: Self.agentInboxId, kind: .agent)
+        }
+        let hasAgent = try dbManager.dbReader.read { db in
+            try OutgoingMessageWriter.hasCurrentAgentMember(db: db, conversationId: Self.conversationId)
+        }
+        #expect(hasAgent == true)
+    }
+
+    @Test("Stale agent profile without current membership does not open the predicate")
+    func testStaleAgentProfileDoesNotCount() throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        try dbManager.dbWriter.write { db in
+            try Self.seedConversation(db: db)
+            try Self.addStaleAgentProfile(db: db)
+        }
+        let hasAgent = try dbManager.dbReader.read { db in
+            try OutgoingMessageWriter.hasCurrentAgentMember(db: db, conversationId: Self.conversationId)
+        }
+        #expect(hasAgent == false)
+    }
+
+    @Test("Agent member in a different conversation does not open the predicate")
+    func testOtherConversationAgentDoesNotCount() throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        try dbManager.dbWriter.write { db in
+            try Self.seedConversation(db: db)
+        }
+        let hasAgent = try dbManager.dbReader.read { db in
+            try OutgoingMessageWriter.hasCurrentAgentMember(db: db, conversationId: "some-other-convo")
+        }
+        #expect(hasAgent == false)
+    }
+
+    // MARK: - waitForAgentMember
+
+    @Test("Gate opens immediately when an agent is already a member")
+    func testGateOpensImmediately() async throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        try await dbManager.dbWriter.write { db in
+            try Self.seedConversation(db: db)
+            try Self.addMember(db: db, inboxId: Self.agentInboxId, kind: .verifiedConvos)
+        }
+        let joined = await OutgoingMessageWriter.waitForAgentMember(
+            in: dbManager.dbReader,
+            conversationId: Self.conversationId,
+            timeout: 5
+        )
+        #expect(joined == true)
+    }
+
+    @Test("Gate opens when the agent member row arrives mid-wait")
+    func testGateOpensOnJoin() async throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        try await dbManager.dbWriter.write { db in
+            try Self.seedConversation(db: db)
+        }
+        let writer = dbManager.dbWriter
+        Task {
+            try await Task.sleep(nanoseconds: 300_000_000)
+            try await writer.write { db in
+                try Self.addMember(db: db, inboxId: Self.agentInboxId, kind: .agent)
+            }
+        }
+        let joined = await OutgoingMessageWriter.waitForAgentMember(
+            in: dbManager.dbReader,
+            conversationId: Self.conversationId,
+            timeout: 10
+        )
+        #expect(joined == true)
+    }
+
+    @Test("Gate times out and falls through when no agent ever joins")
+    func testGateTimesOut() async throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        try await dbManager.dbWriter.write { db in
+            try Self.seedConversation(db: db)
+            try Self.addStaleAgentProfile(db: db)
+        }
+        let start = Date()
+        let joined = await OutgoingMessageWriter.waitForAgentMember(
+            in: dbManager.dbReader,
+            conversationId: Self.conversationId,
+            timeout: 0.5
+        )
+        #expect(joined == false)
+        #expect(Date().timeIntervalSince(start) < 5)
+    }
+}


### PR DESCRIPTION
## Summary

The agent-builder brief (manifest + attachments + prompt text) was published to XMTP **before the agent joined the group**, so the agent could never read it (XMTP members can't see messages published before their join):

- The existing-conversation flow sent the bundle first and called `requestAgentJoin` after.
- The home flow requests the join at `.ready`, but the join is async, so the publish could still race the actual membership.

## Fix (two layers)

1. **`AgentBuilderViewModel.commitToExistingConversation`** — request the agent join *before* persist/uploads/send (matches the home flow's ordering, and gives the backend a head start while uploads finish).
2. **`OutgoingMessageWriter.sendBuilderBundleImpl`** — gate the publish on a **verified agent member** appearing in the conversation (GRDB `ValueObservation`, instant if already joined), with a 150s timeout fallback matching the join polling window so a failed/slow join still publishes rather than stranding the brief. The gate sits between local prepare (optimistic rows, hidden from the sender's UI) and network publish, so nothing visibly stalls and the manifest still references the real XMTP ids.

This closes the race in both flows regardless of how fast the agent joins.

## Test plan

- [x] Full ConvosCore suite: 1148 tests in 166 suites, all passing
- [x] Full app build (Convos (Local)) compiles
- [x] SwiftLint clean on both files
- [ ] Manual: build an agent via the builder against the local stack and confirm (via `convos.log`) the publish happens after the member-added event

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1041"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783799559&installation_id=128169237&pr_number=1041&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1041&signature=60d5e20742cdbab01e2b741854b57e07182eb428b79eedb0996b12fb50eeb84c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Hold builder bundle publish until an agent has joined the conversation
> - Before publishing a builder bundle in an existing conversation, `OutgoingMessageWriter.sendBuilderBundleImpl` now waits for an agent to appear as a current conversation member, preventing the agent from missing content it cannot read after joining.
> - A new `waitForAgentMember` helper observes the database for agent membership and falls back to polling, with a 150-second timeout before proceeding anyway.
> - In `AgentBuilderViewModel`, the agent join is requested before persisting/sending (previously after), and the join task is detached from the builder VM so sheet dismissal no longer cancels it.
> - A new `awaitsAgentJoin` parameter (default `true`) threads through `sendBuilderBundle` at every layer from `OutgoingMessageWriterProtocol` down to the state machine and mocks.
> - Risk: if the agent never joins, publish is delayed up to 150 seconds before proceeding.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0d4a37d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->