### PR TITLE
Open agent contact card from Thing detail conversation indicator

### DIFF
--- a/Convos/Conversation Detail/AttachmentPreviewSheet.swift
+++ b/Convos/Conversation Detail/AttachmentPreviewSheet.swift
@@ -178,7 +178,11 @@ private struct AttachmentSenderIndicator: View {
     }
 }
 
-private struct SentDateFormatter {
+/// Formats the "sent" date shown for a thing: "Today", "Yesterday", the
+/// weekday name within the last week, else a medium date. Shared by the
+/// sheet's sender pill and the Things detail push's conversation
+/// indicator subtitle (see MainTabView).
+struct SentDateFormatter {
     private let calendar: Calendar = .current
     private let weekdayFormatter: DateFormatter = {
         let formatter = DateFormatter()

--- a/Convos/Conversations List/ThingsOverviewViewModel.swift
+++ b/Convos/Conversations List/ThingsOverviewViewModel.swift
@@ -8,6 +8,9 @@ import Foundation
 /// dot under it.
 struct ThingOverviewItem: Identifiable, Hashable {
     let conversation: Conversation
+    /// Inbox id of the agent that sent the attachment, so the detail
+    /// view's indicator can open that agent's contact card.
+    let senderInboxId: String
     let attachmentKey: String
     let filename: String?
     let mimeType: String?
@@ -104,6 +107,7 @@ final class ThingsOverviewViewModel {
             guard let convo = conversationsById[id] else { return nil }
             return ThingOverviewItem(
                 conversation: convo,
+                senderInboxId: file.senderInboxId,
                 attachmentKey: file.attachmentKey,
                 filename: file.filename,
                 mimeType: file.mimeType,

--- a/Convos/MainTabView.swift
+++ b/Convos/MainTabView.swift
@@ -36,6 +36,10 @@ struct MainTabView: View {
     /// (same morph as a chats push). Synced via `.onChange` on
     /// `thingsPushedItems` — created lazily, cleared on pop.
     @State private var thingsPushedConvoVM: ConversationViewModel?
+    /// Member whose contact card is presented when the user taps the
+    /// centered conversation indicator while a Things detail is pushed:
+    /// the agent that sent the pushed item's attachment.
+    @State private var thingsAgentContactMember: ConversationMember?
     /// NavigationStack path for the Contacts tab, lifted here so the shared
     /// app-indicator overlay can tell when a contact detail is pushed and
     /// re-center the pill (mirrors how `thingsPushedItems` lifts the Things
@@ -574,6 +578,11 @@ struct MainTabView: View {
             : nil
         let pendingAgentIdentity: PendingAgentAvatarIdentity? = convoVM.pendingAgentPresentation?.avatarIdentity
         let isReadOnly: Bool = conversationsViewModel.staleDeviceObserver.isDeviceRemoved || convoVM.conversation.wasRemoved
+        // While a Things item is pushed (no chats selection), tapping the
+        // indicator opens the contact card of the agent that made the thing
+        // instead of the conversation quick editor / info sheet.
+        let isThingsIndicator: Bool = conversationsViewModel.selectedConversationViewModel == nil
+        let thingsAgentTapOverride: (() -> Void)? = isThingsIndicator ? { presentThingsAgentContact() } : nil
         HStack {
             ConversationIndicatorWrapper(
                 viewModel: convoVM,
@@ -581,7 +590,8 @@ struct MainTabView: View {
                 subtitleOverride: nil,
                 allowsEditing: !isReadOnly,
                 focusState: $liftedIndicatorFocus,
-                focusCoordinator: liftedIndicatorFocusCoordinator
+                focusCoordinator: liftedIndicatorFocusCoordinator,
+                onTapOverride: thingsAgentTapOverride
             )
             .environment(\.forcedAgentVerification, pendingAgentOverride)
             .environment(\.pendingAgentIdentity, pendingAgentIdentity)
@@ -618,12 +628,28 @@ struct MainTabView: View {
         conversationsViewModel.selectedConversationViewModel ?? thingsPushedConvoVM
     }
 
+    /// Opens the contact card of the agent that sent the pushed Things
+    /// item's attachment. Falls back to the default conversation-info tap
+    /// if the sender is no longer a member of the convo.
+    private func presentThingsAgentContact() {
+        guard let convoVM = thingsPushedConvoVM else { return }
+        let senderInboxId: String? = thingsPushedItems.last?.senderInboxId
+        let senderMember: ConversationMember? = convoVM.conversation.members
+            .first { $0.profile.inboxId == senderInboxId }
+        guard let senderMember else {
+            convoVM.onConversationInfoTap(focusCoordinator: liftedIndicatorFocusCoordinator)
+            return
+        }
+        thingsAgentContactMember = senderMember
+    }
+
     /// Keeps `thingsPushedConvoVM` aligned with `thingsPushedItems.last`
     /// so the shared indicator overlay can render its centered
     /// conversation pill for the pushed Things item.
     private func syncThingsPushedConvoVM(with items: [ThingOverviewItem]) {
         guard let item = items.last else {
             thingsPushedConvoVM = nil
+            thingsAgentContactMember = nil
             return
         }
         guard thingsPushedConvoVM?.conversation.id != item.conversation.id else { return }
@@ -897,6 +923,8 @@ struct MainTabSheetsModifier: ViewModifier {
     @Binding var isPhotoPickerPresented: Bool
     @Binding var isCameraPresented: Bool
     @Binding var selectedPhotos: [PhotosPickerItem]
+    @Binding var thingsAgentContactMember: ConversationMember?
+    let thingsPushedConvoVM: ConversationViewModel?
     let namespace: Namespace.ID
     let onPhotosChanged: ([PhotosPickerItem]) -> Void
     let onCameraImageCaptured: (UIImage) -> Void
@@ -972,6 +1000,24 @@ struct MainTabSheetsModifier: ViewModifier {
                     )
                 }
             })
+            .sheet(item: $thingsAgentContactMember) { member in
+                thingsAgentContactSheet(for: member)
+            }
+    }
+
+    /// Contact card for the agent that made the pushed Things item,
+    /// presented when the user taps the centered conversation indicator
+    /// on the Things detail. Same content the member-avatar tap inside a
+    /// chat presents.
+    @ViewBuilder
+    private func thingsAgentContactSheet(for member: ConversationMember) -> some View {
+        if let thingsPushedConvoVM {
+            MemberContactDetailSheetContent(
+                viewModel: thingsPushedConvoVM,
+                member: member,
+                profileSettingsViewModel: profileSettingsViewModel
+            )
+        }
     }
 }
 
@@ -1032,6 +1078,8 @@ extension MainTabView {
             isPhotoPickerPresented: $isPhotoPickerPresented,
             isCameraPresented: $isCameraPresented,
             selectedPhotos: $selectedPhotos,
+            thingsAgentContactMember: $thingsAgentContactMember,
+            thingsPushedConvoVM: thingsPushedConvoVM,
             namespace: namespace,
             onPhotosChanged: handleSelectedPhotosChanged(to:),
             onCameraImageCaptured: handleCameraImageCaptured,

--- a/Convos/MainTabView.swift
+++ b/Convos/MainTabView.swift
@@ -571,6 +571,10 @@ struct MainTabView: View {
             : DesignConstants.Spacing.step3x
     }
 
+    /// Shared with `AttachmentPreviewSheet`'s sender pill so the Things
+    /// detail indicator subtitle uses the same sent-date wording.
+    private static let sentDateFormatter: SentDateFormatter = SentDateFormatter()
+
     @ViewBuilder
     private func centeredConversationIndicator(for convoVM: ConversationViewModel) -> some View {
         let pendingAgentOverride: AgentVerification? = convoVM.shouldRenderAsPendingAgent
@@ -583,11 +587,17 @@ struct MainTabView: View {
         // instead of the conversation quick editor / info sheet.
         let isThingsIndicator: Bool = conversationsViewModel.selectedConversationViewModel == nil
         let thingsAgentTapOverride: (() -> Void)? = isThingsIndicator ? { presentThingsAgentContact() } : nil
+        // On a Things push the indicator subtitle shows when the thing was
+        // sent (same label as the in-conversation preview sheet's sender
+        // pill) instead of the member count.
+        let thingsSentDateSubtitle: String? = isThingsIndicator
+            ? thingsPushedItems.last.map { Self.sentDateFormatter.string(for: $0.date) }
+            : nil
         HStack {
             ConversationIndicatorWrapper(
                 viewModel: convoVM,
                 placeholderOverride: nil,
-                subtitleOverride: nil,
+                subtitleOverride: thingsSentDateSubtitle,
                 allowsEditing: !isReadOnly,
                 focusState: $liftedIndicatorFocus,
                 focusCoordinator: liftedIndicatorFocusCoordinator,

--- a/Convos/Shared Views/ConversationPresenter.swift
+++ b/Convos/Shared Views/ConversationPresenter.swift
@@ -242,6 +242,11 @@ struct ConversationIndicatorWrapper: View {
     let allowsEditing: Bool
     @FocusState.Binding var focusState: MessagesViewInputFocus?
     let focusCoordinator: FocusCoordinator
+    /// When set, a tap on the collapsed indicator invokes this instead of
+    /// the default quick-edit / conversation-info behavior. Used by the
+    /// Things detail push, where tapping the indicator opens the contact
+    /// card of the agent that made the thing.
+    var onTapOverride: (() -> Void)?
 
     var body: some View {
         ConversationIndicator(
@@ -263,6 +268,10 @@ struct ConversationIndicatorWrapper: View {
             showsExplodeNowButton: viewModel.showsExplodeNowButton,
             explodeState: viewModel.explodeState,
             onConversationInfoTapped: {
+                if let onTapOverride {
+                    onTapOverride()
+                    return
+                }
                 guard allowsEditing else { return }
                 viewModel.onConversationInfoTap(focusCoordinator: focusCoordinator)
             },


### PR DESCRIPTION
## Summary

While a Things detail is pushed, the centered conversation indicator now belongs to the thing rather than the conversation:

- **Tap opens the agent's contact card.** `ThingOverviewItem` carries the `senderInboxId` of the agent that sent the HTML attachment (from `AgentFile`); tapping the indicator looks that member up and presents the existing `MemberContactDetailSheetContent` contact card. If the sender is no longer a member, the tap falls back to the conversation info view.
- **Subtitle shows when the thing was sent.** Instead of the member count, the indicator subtitle shows the sent date using the same `SentDateFormatter` wording as the in-conversation preview sheet's sender pill ("Today", "Yesterday", weekday within a week, else a medium date).

Mechanics:

- `ConversationIndicatorWrapper` gains an optional `onTapOverride` that replaces the default quick-edit / conversation-info tap behavior when set (long-press rename is unchanged)
- `MainTabView` sets the override and the subtitle only when the indicator is showing for a Things push (no chats selection); indicator behavior in regular chat pushes is unchanged
- Sheet state clears when the Things detail is popped

## Testing

- Full ConvosCore test suite: 1148 tests in 166 suites passed
- arm64 simulator build succeeds with no errors or type-check-budget warnings
- SwiftLint clean on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Open agent contact card from Thing detail conversation indicator
> - Tapping the centered conversation indicator while viewing a Thing detail now opens the sender agent's contact card, rather than the default conversation info sheet.
> - The indicator subtitle now shows the Thing's sent date instead of the member count in this context.
> - `ThingOverviewItem` gains a `senderInboxId` property, populated in `ThingsOverviewViewModel.rebuildItems`, to carry the sender's identity to the detail view.
> - `ConversationIndicatorWrapper` in [ConversationPresenter.swift](https://github.com/xmtplabs/convos-ios/pull/1042/files#diff-b43cd7da077f6223cf5e0d1281de02cd00c32eb7b922b573c843b347811dec97) gains an optional `onTapOverride` closure so callers can substitute custom tap behavior.
> - Falls back to the default conversation info behavior if the sender is no longer a member of the conversation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7ef4829.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->