### PR TITLE
fix: time-box the optimistic agent overlay and log fallback matches

### DIFF
--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -291,9 +291,19 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
     /// state (title and avatar cluster) inside `conversation.members`.
     @ObservationIgnored
     private var pendingSyntheticAgentMembers: [ConversationMember] = []
+    /// Time-box for the synthetic overlay, mirroring
+    /// `optimisticAgentExpiryTask` above: if a provisioned instance never
+    /// surfaces as a member with matching template metadata (e.g. an
+    /// agent that joins but never publishes its profile), the synthetics
+    /// are dropped after the same window instead of promising the picked
+    /// agents forever.
+    @ObservationIgnored
+    private var pendingSyntheticAgentExpiryTask: Task<Void, Never>?
     /// Latest conversation as emitted by the DB publisher, before any
     /// synthetic-member overlay. Kept so optimistic state can be rolled
-    /// back to ground truth when an add-members or agents/join call fails.
+    /// back to ground truth when an add-members or agents/join call
+    /// fails. Only retained while the seeded gate or the synthetic
+    /// overlay is active; dropped on steady-state emissions.
     @ObservationIgnored
     private var latestRawConversation: Conversation?
     let typingIndicatorManager: TypingIndicatorManager
@@ -1073,6 +1083,7 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
         convosButtonTask?.cancel()
         explodeDurationTask?.cancel()
         agentBuilderPlaceholderExpiryTask?.cancel()
+        pendingSyntheticAgentExpiryTask?.cancel()
         assistantJoinTimeoutTask?.cancel()
     }
 
@@ -1405,7 +1416,11 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
                 // stays open so later member additions / removals
                 // propagate normally. Non-seeded VMs default to "gate
                 // open", so this is a no-op for them.
-                latestRawConversation = conversation
+                if !hasMetSeededExpectation || !pendingSyntheticAgentMembers.isEmpty {
+                    latestRawConversation = conversation
+                } else {
+                    latestRawConversation = nil
+                }
                 if !hasMetSeededExpectation {
                     if conversation.membersWithoutCurrent.count < expectedSeededMemberCount {
                         return
@@ -1578,6 +1593,9 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
     /// `pendingSyntheticAgentMembers`).
     func markSeeded(expectingMemberCount count: Int, pendingAgentMembers: [ConversationMember] = []) {
         pendingSyntheticAgentMembers = pendingAgentMembers
+        if !pendingAgentMembers.isEmpty {
+            armPendingSyntheticAgentExpiry()
+        }
         guard count > 0 else { return }
         expectedSeededMemberCount = count
         hasMetSeededExpectation = false
@@ -1617,6 +1635,9 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
             latestRawConversation = conversation
         }
         pendingSyntheticAgentMembers += agentMembers
+        if !agentMembers.isEmpty {
+            armPendingSyntheticAgentExpiry()
+        }
         if !humanMembers.isEmpty {
             expectedSeededMemberCount = conversation.membersWithoutCurrent.count + humanMembers.count
             hasMetSeededExpectation = false
@@ -1670,7 +1691,15 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
                 stillPending.append(synthetic)
             }
         }
+        let fallbackMatchCount = unmatchedSynthetics.count - stillPending.count
+        if fallbackMatchCount > 0 {
+            Log.info("Optimistic agent overlay: count-based fallback matched \(fallbackMatchCount) joined agent(s) without templateId metadata")
+        }
         pendingSyntheticAgentMembers = stillPending
+        if stillPending.isEmpty {
+            pendingSyntheticAgentExpiryTask?.cancel()
+            pendingSyntheticAgentExpiryTask = nil
+        }
         // An emission can already carry the synthetics themselves (the
         // placeholder VM's mock repository re-emits the seeded draft);
         // skip those so members never duplicate.
@@ -1684,11 +1713,27 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
     /// from the latest raw DB emission, so a failed agents/join doesn't
     /// leave the indicator promising an agent that will never arrive.
     private func clearPendingSyntheticAgents() {
+        pendingSyntheticAgentExpiryTask?.cancel()
+        pendingSyntheticAgentExpiryTask = nil
         guard !pendingSyntheticAgentMembers.isEmpty else { return }
         pendingSyntheticAgentMembers = []
         guard let raw = latestRawConversation else { return }
         guard hasMetSeededExpectation else { return }
         conversation = raw
+    }
+
+    /// Starts (or restarts) the synthetic-overlay time-box. Fires only if
+    /// synthetics are still pending when the window elapses - the overlay
+    /// cancels the task as soon as the last synthetic is matched by a
+    /// real member.
+    private func armPendingSyntheticAgentExpiry() {
+        pendingSyntheticAgentExpiryTask?.cancel()
+        pendingSyntheticAgentExpiryTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .seconds(AgentBuilderPlaceholder.displayDuration))
+            guard !Task.isCancelled, let self, !self.pendingSyntheticAgentMembers.isEmpty else { return }
+            Log.info("Optimistic agent overlay expired with \(self.pendingSyntheticAgentMembers.count) synthetic(s) still pending - dropping")
+            self.clearPendingSyntheticAgents()
+        }
     }
 
     func startOnboarding() {


### PR DESCRIPTION
## Summary

Post-merge hardening for #1028's synthetic agent overlay, addressing the residual risk from the post-merge review:

- **Time-box the overlay.** The synthetic members now expire after `AgentBuilderPlaceholder.displayDuration` (same window as the single-agent optimism's `optimisticAgentExpiryTask`). Previously, an agent that joined but never published its profile metadata would leave its synthetic member rendered forever — `onAgentJoinError` only covered failed joins, not succeeded-then-silent ones. The expiry task is cancelled the moment the last synthetic is matched by a real member, and on deinit.
- **Log reconciliation edge paths.** A `Log.info` fires when the count-based fallback consumes a joined agent without `templateId` metadata, and when the overlay expires with synthetics still pending — so field reports can distinguish metadata lag from agents that never surface.
- **Snapshot hygiene.** `latestRawConversation` is now only retained while the seeded gate or overlay is active, instead of holding a redundant copy of every DB emission in steady state.

Re the review's second finding ("memory leak" in the copy-on-emit overlay): rebutted — `Conversation` is a value type with CoW arrays, the overlay's first guard already makes steady state zero-copy, and skipping the overlay on member-unchanged emissions would drop the synthetics from the displayed conversation whenever a message arrives mid-provisioning. The snapshot-retention tweak above is the only actionable part.

## Test plan

- SwiftLint clean; `Convos (Dev)` builds.
- App-target-only change (ConversationViewModel); ConvosCore is untouched, so the package suite is unaffected by this diff — CI runs it regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1043"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783801807&installation_id=128169237&pr_number=1043&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1043&signature=3d72468778c665c7378eede05dc0f70eeb667dd2ff327944475357c25822ad9c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Time-box the optimistic agent overlay in `ConversationViewModel` and log fallback matches
> - Adds `armPendingSyntheticAgentExpiry()` to `ConversationViewModel`, which starts a cancellable `Task` that sleeps for `AgentBuilderPlaceholder.displayDuration` and then calls `clearPendingSyntheticAgents()` if any synthetic agents remain unmatched.
> - The expiry task is armed when `markSeeded` is called with pending agent members, or when optimistic agent members are added via the overlay method.
> - When all synthetics are matched in `overlayingPendingSyntheticAgents(on:)`, the expiry task is cancelled immediately; the method also logs how many agents were matched via fallback (without `templateId`).
> - `latestRawConversation` is now cleared once both the seeded gate and synthetic overlay are inactive, reducing unnecessary state retention.
> - The expiry task is cancelled in `deinit` and `clearPendingSyntheticAgents()` to prevent stale callbacks after teardown.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f426f65.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->