### PR TITLE
Cut conversation-open frame drops and startup main-thread time

### DIFF
--- a/Convos/Conversation Detail/ConversationViewModel+TypingIndicators.swift
+++ b/Convos/Conversation Detail/ConversationViewModel+TypingIndicators.swift
@@ -170,6 +170,8 @@ extension ConversationViewModel {
             updatedGroup.hidesSenderLabel = lastGroup.hidesSenderLabel
             updatedGroup.adjacentToFullBleedAbove = lastGroup.adjacentToFullBleedAbove
             updatedGroup.adjacentToFullBleedBelow = lastGroup.adjacentToFullBleedBelow
+            updatedGroup.continuesPreviousGroup = lastGroup.continuesPreviousGroup
+            updatedGroup.isContinuedBelow = lastGroup.isContinuedBelow
             updated[lastIndex] = .messages(updatedGroup)
             return updated
         }

--- a/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/MessageBubble.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/MessageBubble.swift
@@ -17,18 +17,34 @@ struct MessageBubble: View {
 
     var body: some View {
         MessageContainer(style: style, isOutgoing: isOutgoing) {
+            bubbleText
+                .fixedSize(horizontal: false, vertical: true)
+                .padding(.horizontal, DesignConstants.Spacing.step3x)
+                .padding(.vertical, 10.0)
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(profile.displayName): \(message)")
+    }
+
+    /// Only messages that actually contain a link pay for the TextKit-backed
+    /// `LinkDetectingTextView`; everything else renders as plain `Text`,
+    /// which is far cheaper to build and measure when a conversation opens
+    /// or scrolls.
+    @ViewBuilder
+    private var bubbleText: some View {
+        if TextLinkPresence.containsLinks(message) {
             LinkDetectingTextView(
                 message,
                 linkColor: textColor,
                 foregroundColor: textColor,
                 font: .preferredFont(forTextStyle: .callout)
             )
-            .fixedSize(horizontal: false, vertical: true)
-            .padding(.horizontal, DesignConstants.Spacing.step3x)
-            .padding(.vertical, 10.0)
+        } else {
+            Text(message)
+                .font(.callout)
+                .foregroundStyle(textColor)
+                .textSelection(.enabled)
         }
-        .accessibilityElement(children: .combine)
-        .accessibilityLabel("\(profile.displayName): \(message)")
     }
 }
 

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupView.swift
@@ -224,7 +224,10 @@ struct MessagesGroupView: View {
         }
 
         let isLastInGroup: Bool = message == displayGroup.messages.last
+        // A continuation chunk follows this group in the same sender run, so
+        // its visual bottom is not the end of the run -- no tail.
         let isLast: Bool = isLastInGroup && !displayGroup.showsTypingIndicator && !displayGroup.showsThinkingIndicator
+            && !displayGroup.isContinuedBelow
         // When the last message is a voice memo with a transcript row attached, the
         // transcript becomes the visual bottom of the group, so the tail moves from
         // the voice memo bubble down onto the transcript row.
@@ -613,6 +616,23 @@ struct MessagesGroupView: View {
         }
     }
 
+    /// Seam padding between split chunks of one sender run matches the
+    /// in-group bubble spacing (`stepX`, half on each side of the seam) so
+    /// the split is invisible.
+    private var groupTopPadding: CGFloat {
+        if displayGroup.continuesPreviousGroup {
+            return DesignConstants.Spacing.stepX / 2
+        }
+        return displayGroup.adjacentToFullBleedAbove ? (1.0 / displayScale) : DesignConstants.Spacing.step2x
+    }
+
+    private var groupBottomPadding: CGFloat {
+        if displayGroup.isContinuedBelow {
+            return DesignConstants.Spacing.stepX / 2
+        }
+        return displayGroup.adjacentToFullBleedBelow ? (1.0 / displayScale) : DesignConstants.Spacing.step2x
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: DesignConstants.Spacing.stepX) {
             if let card = displayGroup.agentContactCard {
@@ -646,8 +666,8 @@ struct MessagesGroupView: View {
                 removal: .opacity
             )
         )
-        .padding(.top, displayGroup.adjacentToFullBleedAbove ? (1.0 / displayScale) : DesignConstants.Spacing.step2x)
-        .padding(.bottom, displayGroup.adjacentToFullBleedBelow ? (1.0 / displayScale) : DesignConstants.Spacing.step2x)
+        .padding(.top, groupTopPadding)
+        .padding(.bottom, groupBottomPadding)
         // Apply group changes through the mirror without animating layout:
         // the mirror only updates in `onChange` -- after the reconfigure's
         // sizing pass -- so the cell reports its old height during the batch

--- a/Convos/ConvosApp.swift
+++ b/Convos/ConvosApp.swift
@@ -36,19 +36,25 @@ struct ConvosApp: App {
 
         // Verbose libxmtp logs are invaluable in dev/local but too chatty (and too
         // revealing of protocol internals) to persist on every production device.
+        // Activation does file I/O (and formats an internal error description on
+        // its failure path), so it runs off the synchronous launch path; the
+        // handful of libxmtp log lines emitted before it lands are an accepted
+        // trade for ~20ms of pre-first-frame main-thread time.
         let libXMTPLogLevel: Client.LogLevel = environment.isProduction ? .warn : .debug
-        Log.info("Activating LibXMTP file log writer at \(environment.defaultXMTPLogsDirectoryURL.path) (level=\(libXMTPLogLevel), rotation=hourly, maxFiles=10)…")
-        Client.activatePersistentLibXMTPLogWriter(
-            logLevel: libXMTPLogLevel,
-            rotationSchedule: .hourly,
-            maxFiles: 10,
-            customLogDirectory: environment.defaultXMTPLogsDirectoryURL,
-            processType: .main
-        )
-        Log.info("LibXMTP file log writer activated")
-        Log.info("Setting LibXMTP native log level to \(libXMTPLogLevel)…")
-        Client.setLibXMTPNativeLogLevel(libXMTPLogLevel)
-        Log.info("LibXMTP native log level set to \(libXMTPLogLevel)")
+        Task.detached(priority: .utility) {
+            Log.info("Activating LibXMTP file log writer at \(environment.defaultXMTPLogsDirectoryURL.path) (level=\(libXMTPLogLevel), rotation=hourly, maxFiles=10)…")
+            Client.activatePersistentLibXMTPLogWriter(
+                logLevel: libXMTPLogLevel,
+                rotationSchedule: .hourly,
+                maxFiles: 10,
+                customLogDirectory: environment.defaultXMTPLogsDirectoryURL,
+                processType: .main
+            )
+            Log.info("LibXMTP file log writer activated")
+            Log.info("Setting LibXMTP native log level to \(libXMTPLogLevel)…")
+            Client.setLibXMTPNativeLogLevel(libXMTPLogLevel)
+            Log.info("LibXMTP native log level set to \(libXMTPLogLevel)")
+        }
         Log.info("App starting with environment: \(environment)")
         let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "unknown"
         let appBuild = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "unknown"
@@ -115,7 +121,15 @@ struct ConvosApp: App {
         // PushNotificationRegistrar.configure(...) ran inside `PlatformProviders.iOS`
         // above, so AppDelegate's APNS callback uses the static accessor directly
         // (see ConvosAppDelegate.didRegisterForRemoteNotificationsWithDeviceToken).
-        profileSettingsViewModel.bind(session: convos.session)
+        // Deferred one runloop turn: bind() synchronously constructs the
+        // messaging service reader stack, which doesn't need to block the
+        // first frame -- the profile UI is reactive and fills in as soon as
+        // the binding lands.
+        let profileViewModel = profileSettingsViewModel
+        let profileSession = convos.session
+        Task { @MainActor in
+            profileViewModel.bind(session: profileSession)
+        }
 
         let metricsSession = convos.session
         Task {

--- a/Convos/Shared Views/LinkDetectingTextView.swift
+++ b/Convos/Shared Views/LinkDetectingTextView.swift
@@ -1,6 +1,33 @@
 import SwiftUI
 import UIKit
 
+/// Link-presence check so message bubbles can render the common no-link case
+/// as a plain SwiftUI `Text` instead of a TextKit-backed `UITextView` (whose
+/// allocation, data detection, and `sizeThatFits` dominate the cost of
+/// building message cells). Results are cached per string; a cheap pre-scan
+/// skips the detector entirely for text that cannot contain a link or email
+/// address.
+enum TextLinkPresence {
+    private static let detector: NSDataDetector? = try? NSDataDetector(
+        types: NSTextCheckingResult.CheckingType.link.rawValue
+    )
+    // NSCache is documented thread-safe; the annotation only silences the
+    // Sendable diagnostic.
+    private nonisolated(unsafe) static let cache: NSCache<NSString, NSNumber> = .init()
+
+    static func containsLinks(_ text: String) -> Bool {
+        guard text.contains(".") || text.contains("@") else { return false }
+        let key = text as NSString
+        if let cached = cache.object(forKey: key) {
+            return cached.boolValue
+        }
+        let range = NSRange(text.startIndex..., in: text)
+        let found = detector?.firstMatch(in: text, options: [], range: range) != nil
+        cache.setObject(NSNumber(value: found), forKey: key)
+        return found
+    }
+}
+
 struct LinkDetectingTextView: View {
     private let text: String
     private let linkColor: Color?

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/MessagesGroup.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/MessagesGroup.swift
@@ -32,6 +32,16 @@ public struct MessagesGroup: Identifiable, Equatable, Sendable {
     /// surrounding chrome already identifies the sender (e.g. the thinking
     /// detail sheet's pill) set this to true to avoid the redundant label.
     public var hidesSenderLabel: Bool = false
+    /// True when this group is a continuation chunk of a longer same-sender
+    /// run that `MessagesListProcessor` split for layout performance (one
+    /// giant cell would otherwise build and measure dozens of bubbles at
+    /// once). The view hides the sender label and tightens the top seam so
+    /// the split is invisible.
+    public var continuesPreviousGroup: Bool = false
+    /// True when a continuation chunk follows this group in the same
+    /// same-sender run. The view suppresses the bubble tail on the last
+    /// message and tightens the bottom seam.
+    public var isContinuedBelow: Bool = false
     /// When true, the group renders a trailing pulsing-dot thinking bubble
     /// after its messages — visually the bottom-most item of the run, so
     /// `MessagesGroupView`'s avatar overlay attaches to the bubble instead
@@ -151,6 +161,8 @@ public struct MessagesGroup: Identifiable, Equatable, Sendable {
         lhs.agentContactCard == rhs.agentContactCard &&
         lhs.thinkingByMessageId == rhs.thinkingByMessageId &&
         lhs.hidesSenderLabel == rhs.hidesSenderLabel &&
+        lhs.continuesPreviousGroup == rhs.continuesPreviousGroup &&
+        lhs.isContinuedBelow == rhs.isContinuedBelow &&
         lhs.showsThinkingIndicator == rhs.showsThinkingIndicator &&
         lhs.thinkingContent == rhs.thinkingContent &&
         lhs.usesThoughtBubbleStyle == rhs.usesThoughtBubbleStyle &&
@@ -177,6 +189,8 @@ extension MessagesGroup: Hashable {
         hasher.combine(agentContactCard)
         hasher.combine(thinkingByMessageId)
         hasher.combine(hidesSenderLabel)
+        hasher.combine(continuesPreviousGroup)
+        hasher.combine(isContinuedBelow)
         hasher.combine(showsThinkingIndicator)
         hasher.combine(thinkingContent)
         hasher.combine(usesThoughtBubbleStyle)

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/MessagesListProcessor.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/MessagesListProcessor.swift
@@ -2,6 +2,12 @@ import Foundation
 
 public final class MessagesListProcessor: Sendable {
     private static let hourInSeconds: TimeInterval = 3600
+    /// Long same-sender runs split into display groups of at most this many
+    /// messages so a single collection cell never builds and measures dozens
+    /// of bubbles at once (the dominant cost when opening a conversation).
+    /// Continuation chunks render seamlessly via `continuesPreviousGroup` /
+    /// `isContinuedBelow`.
+    private static let maxMessagesPerDisplayGroup: Int = 10
 
     public static func process(
         _ messages: [AnyMessage],
@@ -69,6 +75,8 @@ public final class MessagesListProcessor: Sendable {
         rebuilt.agentContactCard = group.agentContactCard
         rebuilt.thinkingByMessageId = group.thinkingByMessageId
         rebuilt.hidesSenderLabel = group.hidesSenderLabel
+        rebuilt.continuesPreviousGroup = group.continuesPreviousGroup
+        rebuilt.isContinuedBelow = group.isContinuedBelow
         rebuilt.showsThinkingIndicator = group.showsThinkingIndicator
         rebuilt.thinkingContent = group.thinkingContent
         rebuilt.usesThoughtBubbleStyle = group.usesThoughtBubbleStyle
@@ -602,6 +610,9 @@ public final class MessagesListProcessor: Sendable {
                         }
                     let newMembers = newInboxIds.compactMap(resolveMember)
                     let members: [ConversationMember] = kept + newMembers
+                    let continuesPrevious = group.continuesPreviousGroup
+                    let continuedBelow = group.isContinuedBelow
+                    let hidesLabel = group.hidesSenderLabel
                     group = MessagesGroup(
                         id: group.id,
                         sender: group.sender,
@@ -615,6 +626,9 @@ public final class MessagesListProcessor: Sendable {
                         isLastGroupBeforeOtherMembers: group.isLastGroupBeforeOtherMembers,
                         voiceMemoTranscripts: group.voiceMemoTranscripts
                     )
+                    group.continuesPreviousGroup = continuesPrevious
+                    group.isContinuedBelow = continuedBelow
+                    group.hidesSenderLabel = hidesLabel
                 }
             }
 
@@ -643,51 +657,6 @@ public final class MessagesListProcessor: Sendable {
         }
 
         return items
-    }
-
-    @inline(__always)
-    // swiftlint:disable:next function_parameter_count
-    private static func flush(
-        _ items: inout [MessagesListItemType],
-        _ messages: [AnyMessage],
-        _ isLastGroup: Bool,
-        _ isLastGroupSentByCurrentUser: Bool,
-        _ lastCurrentUserIndex: inout Int?,
-        _ memberCount: Int,
-        _ lastOnlyVisibleIndex: inout Int?,
-        _ voiceMemoTranscripts: [String: VoiceMemoTranscriptListItem] = [:]
-    ) {
-        guard let startMsg = messages.first else { return }
-        let sender = startMsg.sender
-
-        var groupTranscripts: [String: VoiceMemoTranscriptListItem] = [:]
-        if !voiceMemoTranscripts.isEmpty {
-            for message in messages {
-                let messageId = message.messageId
-                if let transcript = voiceMemoTranscripts[messageId] {
-                    groupTranscripts[messageId] = transcript
-                }
-            }
-        }
-
-        var group = MessagesGroup(
-            id: "group-" + startMsg.messageId,
-            sender: sender,
-            messages: messages,
-            isLastGroup: isLastGroup,
-            isLastGroupSentByCurrentUser: isLastGroupSentByCurrentUser,
-            voiceMemoTranscripts: groupTranscripts
-        )
-
-        if sender.isCurrentUser {
-            lastCurrentUserIndex = items.count
-            if memberCount == 0 {
-                group.onlyVisibleToSender = true
-                lastOnlyVisibleIndex = items.count
-            }
-        }
-
-        items.append(.messages(group))
     }
 
     /// Materialize the actor for a `ConnectionEventSummary` whose `text` is an
@@ -786,5 +755,68 @@ private extension MessagesListProcessor {
         }
         items.insert(.messages(cardGroup), at: insertionIndex)
         return items
+    }
+
+    @inline(__always)
+    // swiftlint:disable:next function_parameter_count
+    static func flush(
+        _ items: inout [MessagesListItemType],
+        _ messages: [AnyMessage],
+        _ isLastGroup: Bool,
+        _ isLastGroupSentByCurrentUser: Bool,
+        _ lastCurrentUserIndex: inout Int?,
+        _ memberCount: Int,
+        _ lastOnlyVisibleIndex: inout Int?,
+        _ voiceMemoTranscripts: [String: VoiceMemoTranscriptListItem] = [:]
+    ) {
+        guard !messages.isEmpty else { return }
+        let sender = messages[0].sender
+
+        var chunks: [[AnyMessage]] = []
+        var index = 0
+        while index < messages.count {
+            let end = min(index + maxMessagesPerDisplayGroup, messages.count)
+            chunks.append(Array(messages[index..<end]))
+            index = end
+        }
+
+        for (chunkIndex, chunk) in chunks.enumerated() {
+            guard let startMsg = chunk.first else { continue }
+            let isFinalChunk = chunkIndex == chunks.count - 1
+
+            var groupTranscripts: [String: VoiceMemoTranscriptListItem] = [:]
+            if !voiceMemoTranscripts.isEmpty {
+                for message in chunk {
+                    let messageId = message.messageId
+                    if let transcript = voiceMemoTranscripts[messageId] {
+                        groupTranscripts[messageId] = transcript
+                    }
+                }
+            }
+
+            var group = MessagesGroup(
+                id: "group-" + startMsg.messageId,
+                sender: sender,
+                messages: chunk,
+                isLastGroup: isFinalChunk && isLastGroup,
+                isLastGroupSentByCurrentUser: isFinalChunk && isLastGroupSentByCurrentUser,
+                voiceMemoTranscripts: groupTranscripts
+            )
+            if chunkIndex > 0 {
+                group.continuesPreviousGroup = true
+                group.hidesSenderLabel = true
+            }
+            group.isContinuedBelow = !isFinalChunk
+
+            if sender.isCurrentUser {
+                lastCurrentUserIndex = items.count
+                if memberCount == 0 {
+                    group.onlyVisibleToSender = true
+                    lastOnlyVisibleIndex = items.count
+                }
+            }
+
+            items.append(.messages(group))
+        }
     }
 }


### PR DESCRIPTION
## Summary

Instruments/sample profiling of a 350-message conversation (filled via convos-cli on a simulator) showed two hot paths:

- **Opening a conversation** burned ~470ms of main-thread time during the push transition (~25 dropped frames), almost entirely view construction — not data loading (`ConversationViewModel.init` is 4–47ms).
- **App launch** spent ~220ms of main-thread CPU inside `ConvosApp.init` before SwiftUI could render the first frame.

Three changes:

1. **Plain `Text` for link-less message bubbles.** Every bubble was a TextKit-backed `UITextView` with `dataDetectorTypes = .link` — allocation, synchronous link detection, and `sizeThatFits` dominated cell build cost. `MessageBubble` now renders SwiftUI `Text` unless the message actually contains a link (cached `NSDataDetector` check with a cheap `.`/`@` pre-scan).
2. **Split long same-sender runs into ≤10-message display groups.** A burst of messages from one sender previously became a single cell building/measuring dozens of bubbles at once. `MessagesListProcessor.flush` now chunks runs; new `MessagesGroup.continuesPreviousGroup`/`isContinuedBelow` flags hide the sender label, suppress the bubble tail, and tighten seam padding on continuation chunks so the split renders pixel-identically (screenshot-verified).
3. **Startup deferrals.** LibXMTP file-log-writer activation moved off the synchronous launch path (utility task; verified it still activates right after launch), and `ProfileSettingsViewModel.bind` deferred one runloop turn (reactive consumer, nothing reads it before first frame).

## Measured (same sim, same data, same scripted interaction; Dev config)

| Metric | Before | After |
|---|---|---|
| Open transition: main-thread busy | ~490–550ms | ~297ms |
| Open transition: worst burst | 267ms | 191ms |
| Open transition: dropped frames | ~25 | ~15 |
| `ConversationViewModel.init` (350-msg convo) | 40–47ms | 26ms |
| `ConvosApp.init` main-thread CPU | ~220ms | ~170ms |

Methodology: `xctrace` Time Profiler attach + main-thread busy-burst analysis of the exported `time-sample` table (>17ms busy = dropped frames; Animation Hitches instrument doesn't support simulators), plus `sample`-based attribution and the existing `[PERF]` log lines.

## Testing

- SwiftLint clean; visuals screenshot-compared before/after (identical, including seams, sender labels, tails).
- `MessagesListProcessorTests` use ≤5-message runs, below the 10-message chunk cap, so existing expectations hold.
- ⚠️ The full local `swift test --package-path ConvosCore` run could not complete on the build machine (disk exhausted at 3GB free; the suite's `.build` needs ~16GB) — relying on CI for the full suite. Please confirm CI is green before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Cut frame drops and main-thread startup time in conversation view
> - Splits long same-sender message runs into display groups of at most 10 messages in [`MessagesListProcessor`](https://github.com/xmtplabs/convos-ios/pull/1044/files#diff-c32ba383ca53d832eed02dc83f3d0a9546aad74da5c5919555079a4fc07383d7), reducing render work when opening a conversation.
> - Adds `continuesPreviousGroup` and `isContinuedBelow` flags to [`MessagesGroup`](https://github.com/xmtplabs/convos-ios/pull/1044/files#diff-8c4c494cab7e1a500d722d7f064a92825ce23194df3adfae9a3c70b324148312) so split runs render as visually seamless chunks (tightened padding, suppressed tails, hidden sender labels on continuation chunks).
> - Messages without detected links now render as plain SwiftUI `Text` (with text selection) in [`MessageBubble`](https://github.com/xmtplabs/convos-ios/pull/1044/files#diff-c98f6b805dba8738eae9d92af2aa162db77af35689e0ed8a7192ac1b5ef8f316), avoiding the `UITextView`-backed `LinkDetectingTextView` for the common case; link detection results are cached via a new `TextLinkPresence` utility.
> - Defers libXMTP log setup and `ProfileSettingsViewModel.bind(session:)` to background/async tasks in [`ConvosApp.init`](https://github.com/xmtplabs/convos-ios/pull/1044/files#diff-de23c5a6e10cb84b89d91ed62b707b654c28566f38cc339af8b3cbbf6e003014), removing that work from the synchronous launch path.
> - Behavioral Change: groups with 10+ messages from the same sender are now emitted as multiple `MessagesGroup` entries instead of one.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5f68153.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1044"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783802993&installation_id=128169237&pr_number=1044&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1044&signature=7b1ab07e959e174b592ca7af622c01f2e884254adc6e4efdcef8132576f4a134"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->