### PR TITLE
Revert "feat(agents): direct-add agent joins" (#1033)

### DIFF
--- a/Convos/Agent Builder/AgentBuilderViewModel.swift
+++ b/Convos/Agent Builder/AgentBuilderViewModel.swift
@@ -765,18 +765,20 @@ final class AgentBuilderViewModel: Identifiable {
                 textMessageId: textMessageId,
                 bundleMessageId: bundleMessageId
             )
+            let slug = innerVM.conversation.invite?.urlSlug ?? ""
+            guard !slug.isEmpty else {
+                Log.warning("AgentBuilder(existing): no invite slug; skipping agent join")
+                return
+            }
             // The join must finish even after the builder sheet dismisses.
             // Unlike the draft flow, there is no draft to discard -- the user's
             // group stays -- so the join survives the view closing (like
             // `ConversationViewModel`'s committed-conversation join, the
             // opposite of the draft path).
             do {
-                _ = try await session.addAgentToConversation(
-                    conversationId: innerVM.conversation.id,
-                    options: .agentBuilder
-                )
+                _ = try await session.requestAgentJoin(slug: slug, options: .agentBuilder)
             } catch {
-                Log.error("AgentBuilder(existing): addAgentToConversation failed: \(error.localizedDescription)")
+                Log.error("AgentBuilder(existing): requestAgentJoin failed: \(error.localizedDescription)")
             }
         }
         // No in-sheet morph: the builder targets a conversation the user is
@@ -935,9 +937,13 @@ final class AgentBuilderViewModel: Identifiable {
             Log.warning("AgentBuilderViewModel: reached .ready but no conversation available")
             return
         }
+        let slug = conversation.invite?.urlSlug ?? ""
+        guard !slug.isEmpty else {
+            Log.warning("AgentBuilderViewModel: reached .ready but invite slug is empty")
+            return
+        }
         didRequestAgentJoin = true
 
-        let conversationId = conversation.id
         agentJoinTask?.cancel()
         // Capture `session` only, not `self`: the join needs nothing back from
         // the VM, and not capturing `self` avoids a cycle through the stored
@@ -948,16 +954,13 @@ final class AgentBuilderViewModel: Identifiable {
         // leaving / deleting the group -- so there's nothing left to join.
         agentJoinTask = Task { [session] in
             do {
-                _ = try await session.addAgentToConversation(
-                    conversationId: conversationId,
-                    options: .agentBuilder
-                )
+                _ = try await session.requestAgentJoin(slug: slug, options: .agentBuilder)
             } catch is CancellationError {
                 return
             } catch let urlError as URLError where urlError.code == .cancelled {
                 return
             } catch {
-                Log.error("AgentBuilderViewModel: addAgentToConversation failed: \(error.localizedDescription)")
+                Log.error("AgentBuilderViewModel: requestAgentJoin failed: \(error.localizedDescription)")
             }
         }
     }

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -3291,6 +3291,9 @@ extension ConversationViewModel {
     /// `requestAgentJoins(templateIds:)` instead -- it runs the calls
     /// sequentially without cancelling each other.
     func requestAgentJoin(templateId: String?, requestId: String = UUID().uuidString) {
+        let slug = invite.urlSlug
+        guard !slug.isEmpty else { return }
+
         agentJoinTask?.cancel()
 
         // Anchor the wait measurement at request time (the pending UI starts
@@ -3308,6 +3311,7 @@ extension ConversationViewModel {
         agentJoinTask = Task { [weak self] in
             let outcome = await Self.performAgentJoinCall(
                 templateId: templateId,
+                slug: slug,
                 conversationId: conversationId,
                 requestId: requestId,
                 forceErrorCode: forceErrorCode,
@@ -3385,6 +3389,8 @@ extension ConversationViewModel {
 
     private func runSequentialAgentJoins(_ joins: [AgentJoinAttempt]) {
         guard !joins.isEmpty else { return }
+        let slug = invite.urlSlug
+        guard !slug.isEmpty else { return }
 
         // Batch adds return to the chat, so the join progress shows as
         // in-stream pending status bubbles. Anchored at request time for the
@@ -3407,6 +3413,7 @@ extension ConversationViewModel {
                 }
                 let outcome = await Self.performAgentJoinCall(
                     templateId: join.templateId,
+                    slug: slug,
                     conversationId: conversationId,
                     requestId: join.requestId,
                     forceErrorCode: forceErrorCode,
@@ -3528,6 +3535,7 @@ extension ConversationViewModel {
     /// holding `self`.
     private static func performAgentJoinCall(
         templateId: String?,
+        slug: String,
         conversationId: String,
         requestId: String,
         forceErrorCode: Int?,
@@ -3540,8 +3548,8 @@ extension ConversationViewModel {
         )
         Log.info("performAgentJoinCall about to POST agents/join templateId=\(templateId ?? "nil") requestId=\(requestId)")
         do {
-            _ = try await session.addAgentToConversation(
-                conversationId: conversationId,
+            _ = try await session.requestAgentJoin(
+                slug: slug,
                 templateId: templateId,
                 options: nil,
                 forceErrorCode: forceErrorCode

--- a/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient+Models.swift
+++ b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient+Models.swift
@@ -164,29 +164,16 @@ public enum ConvosAPI {
     // POST /v2/agents/join
     // The body is validated strictly server-side: unknown keys are rejected.
     // `templateId` is optional - omitting it requests a bare join (the
-    // backend provisions a default agent). Nil optionals are omitted from
-    // the encoded JSON by Codable's synthesized encoder.
-    //
-    // Exactly one of `slug` (invite flow) or `conversationId` (direct-add).
-    // In direct-add mode the backend provisions the agent and responds with
-    // its `inboxId`; the client adds that inbox to the declared group with
-    // addMembers and is done — the runtime observes the resulting group
-    // welcome and attaches, with no confirmation call.
+    // backend provisions a default agent). A nil `templateId` is omitted
+    // from the encoded JSON by Codable's synthesized encoder.
 
     public struct AgentJoinRequest: Codable {
-        public let slug: String?
-        public let conversationId: String?
+        public let slug: String
         public let templateId: String?
         public let options: AgentJoinOptions?
 
-        public init(
-            slug: String? = nil,
-            conversationId: String? = nil,
-            templateId: String? = nil,
-            options: AgentJoinOptions? = nil
-        ) {
+        public init(slug: String, templateId: String? = nil, options: AgentJoinOptions? = nil) {
             self.slug = slug
-            self.conversationId = conversationId
             self.templateId = templateId
             self.options = options
         }
@@ -212,48 +199,10 @@ public enum ConvosAPI {
     public struct AgentJoinResponse: Codable {
         public let success: Bool
         public let joined: Bool
-        /// Populated on every dispatch; required for the join-status poll.
-        public let instanceId: String?
-        /// Direct-add only: the agent's XMTP inbox to add with addMembers.
-        /// Nil when registration outlasted the backend's wait budget — poll
-        /// GET /v2/agents/join/:instanceId until it lands.
-        public let inboxId: String?
 
-        public init(success: Bool, joined: Bool, instanceId: String? = nil, inboxId: String? = nil) {
+        public init(success: Bool, joined: Bool) {
             self.success = success
             self.joined = joined
-            self.instanceId = instanceId
-            self.inboxId = inboxId
-        }
-    }
-
-    // MARK: - v2/agents/join/:instanceId
-
-    public struct AgentJoinStatusResponse: Codable {
-        public let success: Bool
-        public let instanceId: String
-        public let joinStatus: String
-        public let joined: Bool
-        public let inboxId: String?
-        public let conversationId: String?
-        public let joinFailureReason: String?
-
-        public init(
-            success: Bool,
-            instanceId: String,
-            joinStatus: String,
-            joined: Bool,
-            inboxId: String? = nil,
-            conversationId: String? = nil,
-            joinFailureReason: String? = nil
-        ) {
-            self.success = success
-            self.instanceId = instanceId
-            self.joinStatus = joinStatus
-            self.joined = joined
-            self.inboxId = inboxId
-            self.conversationId = conversationId
-            self.joinFailureReason = joinFailureReason
         }
     }
 

--- a/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift
+++ b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift
@@ -83,22 +83,12 @@ public protocol ConvosAPIClientProtocol: AnyObject, Sendable {
     func renewAssetsBatch(assetKeys: [String]) async throws -> AssetRenewalResult
 
     // Agents
-    /// Exactly one of `slug` (invite flow) and `conversationId` (direct-add).
-    /// In direct-add mode the backend provisions the agent and returns its
-    /// `inboxId`; the caller adds that inbox to the declared group with
-    /// addMembers and the runtime attaches when it observes the resulting
-    /// group welcome — no further calls.
     func requestAgentJoin(
-        slug: String?,
-        conversationId: String?,
+        slug: String,
         templateId: String?,
         options: ConvosAPI.AgentJoinOptions?,
         forceErrorCode: Int?
     ) async throws -> ConvosAPI.AgentJoinResponse
-
-    /// Polls a dispatched agent's provisioning status. Direct-add callers
-    /// use it to obtain `inboxId` when the join response didn't carry one.
-    func getAgentJoinStatus(instanceId: String) async throws -> ConvosAPI.AgentJoinStatusResponse
 
     // Agent templates
     /// Public detail fetch for a published agent template, keyed by its
@@ -129,21 +119,21 @@ public protocol ConvosAPIClientProtocol: AnyObject, Sendable {
 
 extension ConvosAPIClientProtocol {
     func requestAgentJoin(slug: String) async throws -> ConvosAPI.AgentJoinResponse {
-        try await requestAgentJoin(slug: slug, conversationId: nil, templateId: nil, options: nil, forceErrorCode: nil)
+        try await requestAgentJoin(slug: slug, templateId: nil, options: nil, forceErrorCode: nil)
     }
 
     func requestAgentJoin(
         slug: String,
         options: ConvosAPI.AgentJoinOptions?
     ) async throws -> ConvosAPI.AgentJoinResponse {
-        try await requestAgentJoin(slug: slug, conversationId: nil, templateId: nil, options: options, forceErrorCode: nil)
+        try await requestAgentJoin(slug: slug, templateId: nil, options: options, forceErrorCode: nil)
     }
 
     func requestAgentJoin(
         slug: String,
         templateId: String?
     ) async throws -> ConvosAPI.AgentJoinResponse {
-        try await requestAgentJoin(slug: slug, conversationId: nil, templateId: templateId, options: nil, forceErrorCode: nil)
+        try await requestAgentJoin(slug: slug, templateId: templateId, options: nil, forceErrorCode: nil)
     }
 }
 
@@ -722,8 +712,7 @@ final class ConvosAPIClient: ConvosAPIClientProtocol, Sendable {
     // MARK: - Agents
 
     func requestAgentJoin(
-        slug: String? = nil,
-        conversationId: String? = nil,
+        slug: String,
         templateId: String? = nil,
         options: ConvosAPI.AgentJoinOptions? = nil,
         forceErrorCode: Int? = nil
@@ -740,7 +729,6 @@ final class ConvosAPIClient: ConvosAPIClientProtocol, Sendable {
         request.httpBody = try JSONEncoder().encode(
             ConvosAPI.AgentJoinRequest(
                 slug: slug,
-                conversationId: conversationId,
                 templateId: templateId,
                 options: options
             )
@@ -771,12 +759,6 @@ final class ConvosAPIClient: ConvosAPIClientProtocol, Sendable {
         default:
             throw APIError.serverError(parseErrorMessage(from: data))
         }
-    }
-
-    func getAgentJoinStatus(instanceId: String) async throws -> ConvosAPI.AgentJoinStatusResponse {
-        let encoded = instanceId.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? instanceId
-        let request = try authenticatedRequest(for: "v2/agents/join/\(encoded)", method: "GET")
-        return try await performRequest(request)
     }
 
     // MARK: - Agent templates

--- a/ConvosCore/Sources/ConvosCore/API/MockAPIClient.swift
+++ b/ConvosCore/Sources/ConvosCore/API/MockAPIClient.swift
@@ -96,23 +96,12 @@ final class MockAPIClient: ConvosAPIClientProtocol, Sendable {
     }
 
     func requestAgentJoin(
-        slug: String? = nil,
-        conversationId: String? = nil,
+        slug: String,
         templateId: String? = nil,
         options: ConvosAPI.AgentJoinOptions? = nil,
         forceErrorCode: Int? = nil
     ) async throws -> ConvosAPI.AgentJoinResponse {
-        .init(success: true, joined: true, instanceId: "mock-instance", inboxId: "mock-agent-inbox")
-    }
-
-    func getAgentJoinStatus(instanceId: String) async throws -> ConvosAPI.AgentJoinStatusResponse {
-        .init(
-            success: true,
-            instanceId: instanceId,
-            joinStatus: "starting",
-            joined: false,
-            inboxId: "mock-agent-inbox"
-        )
+        .init(success: true, joined: true)
     }
 
     func getAgentTemplate(idOrUrlSlug: String) async throws -> ConvosAPI.AgentTemplate {

--- a/ConvosCore/Sources/ConvosCore/Inboxes/MockInboxesService.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/MockInboxesService.swift
@@ -92,8 +92,8 @@ public final class MockInboxesService: SessionManagerProtocol, @unchecked Sendab
         MockInviteRepository()
     }
 
-    public func addAgentToConversation(
-        conversationId: String,
+    public func requestAgentJoin(
+        slug: String,
         templateId: String? = nil,
         options: ConvosAPI.AgentJoinOptions? = nil,
         forceErrorCode: Int? = nil
@@ -106,7 +106,7 @@ public final class MockInboxesService: SessionManagerProtocol, @unchecked Sendab
             default: throw APIError.serverError("Mock forced error \(forceErrorCode)")
             }
         }
-        return .init(success: true, joined: true, instanceId: "mock-instance", inboxId: "mock-agent-inbox")
+        return .init(success: true, joined: true)
     }
 
     public func conversationRepository(for conversationId: String) -> any ConversationRepositoryProtocol {

--- a/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
@@ -591,6 +591,28 @@ public final class SessionManager: SessionManagerProtocol, @unchecked Sendable {
         )
     }
 
+    public func requestAgentJoin(
+        slug: String,
+        templateId: String? = nil,
+        options: ConvosAPI.AgentJoinOptions? = nil,
+        forceErrorCode: Int? = nil
+    ) async throws -> ConvosAPI.AgentJoinResponse {
+        let response = try await apiClient.requestAgentJoin(
+            slug: slug,
+            templateId: templateId,
+            options: options,
+            forceErrorCode: forceErrorCode
+        )
+        // Temporary diagnostic: the agent now sends a join-request DM that
+        // the message stream is expected to deliver. Poll for it for a
+        // bounded window in case the stream has died, so the agent doesn't
+        // time out and stream death shows up in the logs. Covers every
+        // agents/join entry point (add agent, contacts picker, compose,
+        // agent builder) since they all route through here.
+        await messagingService().sessionStateManager.startAgentJoinRequestPolling()
+        return response
+    }
+
     public func agentShareResolver() -> any AgentShareResolving {
         ApiAgentShareResolver(
             apiClient: apiClient,
@@ -1098,60 +1120,5 @@ public extension SessionManager {
 extension SessionManager {
     public func builderBundleHiddenMessagesRepository() -> any BuilderBundleHiddenMessagesRepositoryProtocol {
         BuilderBundleHiddenMessagesRepository(databaseReader: databaseReader)
-    }
-}
-
-// MARK: - Direct-add agent join
-
-extension SessionManager {
-    /// How long to keep polling for the agent's inboxId when registration
-    /// outlasts the backend's synchronous wait budget.
-    private static var agentRegistrationDeadline: TimeInterval { 30 }
-    private static var agentRegistrationPollInterval: TimeInterval { 1 }
-
-    public func addAgentToConversation(
-        conversationId: String,
-        templateId: String? = nil,
-        options: ConvosAPI.AgentJoinOptions? = nil,
-        forceErrorCode: Int? = nil
-    ) async throws -> ConvosAPI.AgentJoinResponse {
-        // 1. Provision: the backend registers the agent's XMTP inbox and
-        //    returns it. No invite slug — this device performs the add, and
-        //    the declared conversationId tells the runtime which group to
-        //    watch for the resulting welcome.
-        let response = try await apiClient.requestAgentJoin(
-            slug: nil,
-            conversationId: conversationId.lowercased(),
-            templateId: templateId,
-            options: options,
-            forceErrorCode: forceErrorCode
-        )
-        guard let instanceId = response.instanceId else {
-            throw APIError.agentProvisionFailed
-        }
-
-        var inboxId = response.inboxId
-        let deadline = Date().addingTimeInterval(Self.agentRegistrationDeadline)
-        while inboxId == nil {
-            guard Date() < deadline else { throw APIError.agentPoolTimeout }
-            try await Task.sleep(nanoseconds: UInt64(Self.agentRegistrationPollInterval * 1_000_000_000))
-            let status = try await apiClient.getAgentJoinStatus(instanceId: instanceId)
-            guard status.joinStatus != "failed" else {
-                throw APIError.agentProvisionFailed
-            }
-            inboxId = status.inboxId
-        }
-        guard let agentInboxId = inboxId else {
-            throw APIError.agentPoolTimeout
-        }
-
-        // 2. Add: a plain member add by this device — synchronous, no DM
-        //    round-trip, no online-accepter dependency. The add durably
-        //    publishes a group welcome for the agent's inbox; the runtime
-        //    observes it and attaches, so the agent boots even if this app
-        //    is killed on the next line.
-        try await messagingService().conversationMetadataWriter()
-            .addMembers([agentInboxId], to: conversationId)
-        return response
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Sessions/SessionManagerProtocol.swift
+++ b/ConvosCore/Sources/ConvosCore/Sessions/SessionManagerProtocol.swift
@@ -100,14 +100,8 @@ public protocol SessionManagerProtocol: AnyObject, Sendable {
     // MARK: Factory methods for repositories
 
     func inviteRepository(for conversationId: String) -> any InviteRepositoryProtocol
-
-    /// Direct-add agent join: provisions the agent via the backend (declaring
-    /// the target conversation) and adds its XMTP inbox with addMembers. The
-    /// runtime observes the resulting group welcome and attaches — once the
-    /// add lands, the agent boots with no further calls. No invite slug
-    /// involved.
-    func addAgentToConversation(
-        conversationId: String,
+    func requestAgentJoin(
+        slug: String,
         templateId: String?,
         options: ConvosAPI.AgentJoinOptions?,
         forceErrorCode: Int?
@@ -236,21 +230,21 @@ extension SessionManagerProtocol {
         NoopInviteMembershipResolver()
     }
 
-    public func addAgentToConversation(conversationId: String) async throws -> ConvosAPI.AgentJoinResponse {
-        try await addAgentToConversation(conversationId: conversationId, templateId: nil, options: nil, forceErrorCode: nil)
+    public func requestAgentJoin(slug: String) async throws -> ConvosAPI.AgentJoinResponse {
+        try await requestAgentJoin(slug: slug, templateId: nil, options: nil, forceErrorCode: nil)
     }
 
-    public func addAgentToConversation(
-        conversationId: String,
+    public func requestAgentJoin(
+        slug: String,
         options: ConvosAPI.AgentJoinOptions?
     ) async throws -> ConvosAPI.AgentJoinResponse {
-        try await addAgentToConversation(conversationId: conversationId, templateId: nil, options: options, forceErrorCode: nil)
+        try await requestAgentJoin(slug: slug, templateId: nil, options: options, forceErrorCode: nil)
     }
 
-    public func addAgentToConversation(
-        conversationId: String,
+    public func requestAgentJoin(
+        slug: String,
         templateId: String?
     ) async throws -> ConvosAPI.AgentJoinResponse {
-        try await addAgentToConversation(conversationId: conversationId, templateId: templateId, options: nil, forceErrorCode: nil)
+        try await requestAgentJoin(slug: slug, templateId: templateId, options: nil, forceErrorCode: nil)
     }
 }

--- a/ConvosCore/Tests/ConvosCoreTests/TestStubAPIClientDefaults.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/TestStubAPIClientDefaults.swift
@@ -36,31 +36,12 @@ extension ConvosAPIClientProtocol {
     /// `requestAgentJoin` specifically should still override this on
     /// their fixture.
     func requestAgentJoin(
-        slug: String?,
-        conversationId: String?,
+        slug: String,
         templateId: String?,
         options: ConvosAPI.AgentJoinOptions?,
         forceErrorCode: Int?
     ) async throws -> ConvosAPI.AgentJoinResponse {
-        ConvosAPI.AgentJoinResponse(
-            success: true,
-            joined: true,
-            instanceId: "test-instance",
-            inboxId: "test-agent-inbox"
-        )
-    }
-
-    /// Default for the direct-add status poll so pre-existing stubs don't
-    /// re-stub it. Tests that exercise the direct-add flow specifically
-    /// should override this on their fixture.
-    func getAgentJoinStatus(instanceId: String) async throws -> ConvosAPI.AgentJoinStatusResponse {
-        ConvosAPI.AgentJoinStatusResponse(
-            success: true,
-            instanceId: instanceId,
-            joinStatus: "starting",
-            joined: false,
-            inboxId: "test-agent-inbox"
-        )
+        ConvosAPI.AgentJoinResponse(success: true, joined: true)
     }
 
     /// Default for the public agent-template detail fetch used by the

--- a/ConvosTests/ConversationViewModelGlobalDefaultsTests.swift
+++ b/ConvosTests/ConversationViewModelGlobalDefaultsTests.swift
@@ -293,14 +293,14 @@ private final class TestSessionManager: SessionManagerProtocol, @unchecked Senda
         await base.inboxId(for: conversationId)
     }
 
-    func addAgentToConversation(
-        conversationId: String,
+    func requestAgentJoin(
+        slug: String,
         templateId: String?,
         options: ConvosAPI.AgentJoinOptions?,
         forceErrorCode: Int?
     ) async throws -> ConvosAPI.AgentJoinResponse {
-        try await base.addAgentToConversation(
-            conversationId: conversationId,
+        try await base.requestAgentJoin(
+            slug: slug,
             templateId: templateId,
             options: options,
             forceErrorCode: forceErrorCode

--- a/ConvosTests/ConversationsViewModelDeleteTests.swift
+++ b/ConvosTests/ConversationsViewModelDeleteTests.swift
@@ -293,14 +293,14 @@ private final class TestSessionManager: SessionManagerProtocol, @unchecked Senda
         await base.inboxId(for: conversationId)
     }
 
-    func addAgentToConversation(
-        conversationId: String,
+    func requestAgentJoin(
+        slug: String,
         templateId: String?,
         options: ConvosAPI.AgentJoinOptions?,
         forceErrorCode: Int?
     ) async throws -> ConvosAPI.AgentJoinResponse {
-        try await base.addAgentToConversation(
-            conversationId: conversationId,
+        try await base.requestAgentJoin(
+            slug: slug,
             templateId: templateId,
             options: options,
             forceErrorCode: forceErrorCode


### PR DESCRIPTION
## Summary

Temporary revert of #1033. The direct-add flow hard-requires the new Herald → assistants-worker → backend chain, which is live on **dev** but not yet promoted to **prod** — and `testflight-prod.yml` builds every push to `dev`, so #1033 shipped a build to the prod TestFlight track whose agent add/spawn flows 400 against the prod backend (messaging unaffected). The iOS team also wants a testing window with the dev stack before adopting the flow.

Re-land #1033 unchanged once the server chain is promoted to prod (server side is backward compatible with this reverted app code — the invite/slug path is fully intact everywhere).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1045"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783805460&installation_id=128169237&pr_number=1045&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1045&signature=55e1d6cc7a0ef21633fee382480eef3d8f08143841c40d87db8de93b67f9719b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Revert direct-add agent joins to use slug-based `requestAgentJoin`
> - Replaces `addAgentToConversation(conversationId:)` with `requestAgentJoin(slug:)` across the session manager, API client, and view models; the join request now uses an invite URL slug instead of a conversation ID.
> - `AgentJoinRequest` drops `conversationId` and requires `slug`; `AgentJoinResponse` drops `instanceId` and `inboxId`; `AgentJoinStatusResponse` and `getAgentJoinStatus` are removed entirely.
> - Both `ConversationViewModel` and `AgentBuilderViewModel` now guard for a non-empty invite slug before attempting any join, silently skipping if absent.
> - After a join request, `SessionManager` triggers message-stream polling via `startAgentJoinRequestPolling()` to detect stream failures.
> - Behavioral Change: callers that previously relied on `instanceId`/`inboxId` in the join response or on `getAgentJoinStatus` polling will no longer receive those values.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fe8697c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->