### PR TITLE
Reland "feat(agents): direct-add agent joins" (#1033)

### DIFF
--- a/Convos/Agent Builder/AgentBuilderViewModel.swift
+++ b/Convos/Agent Builder/AgentBuilderViewModel.swift
@@ -611,9 +611,9 @@ final class AgentBuilderViewModel: Identifiable {
             let conversationIdForPersist: String = innerVM.conversation.id
             let sessionForPersist = session
             // The `.ready`-time join can have been skipped (conversation not
-            // ready yet, slug not hydrated) -- re-fire it now that the user
-            // committed; the `didRequestAgentJoin` latch makes this a no-op
-            // when the early join already ran.
+            // ready yet) -- re-fire it now that the user committed; the
+            // `didRequestAgentJoin` latch makes this a no-op when the early
+            // join already ran.
             requestAgentJoinIfNeeded()
             // Detach the agent-join task from this VM: the builder sheet tears
             // down after Make and `deinit` cancels `agentJoinTask`, which
@@ -622,8 +622,9 @@ final class AgentBuilderViewModel: Identifiable {
             // reference (without cancelling) lets the join finish on its own.
             agentJoinTask = nil
             // Gate the send on the agent joining only when a join request was
-            // actually launched; if it never was (no slug even at Make), the
-            // hold would wait for an agent that was never asked to come.
+            // actually launched; if it never was (no messaging service --
+            // test-only mode), the hold would wait for an agent that was
+            // never asked to come.
             let joinAttempted: Bool = didRequestAgentJoin
             Task { @MainActor [weak innerVM, voiceMemoSnapshot, textMessageId, bundleMessageId, summaryToPersist, conversationIdForPersist, sessionForPersist] in
                 guard let innerVM else { return }
@@ -774,14 +775,12 @@ final class AgentBuilderViewModel: Identifiable {
             // draft to discard -- the user's group stays -- so the join
             // survives the view closing (like `ConversationViewModel`'s
             // committed-conversation join, the opposite of the draft path).
-            let slug = innerVM.conversation.invite?.urlSlug ?? ""
-            let joinTask: Task<Bool, Never> = Task { [session] in
-                guard !slug.isEmpty else {
-                    Log.warning("AgentBuilder(existing): no invite slug; skipping agent join")
-                    return false
-                }
+            let joinTask: Task<Void, Never> = Task { [session] in
                 do {
-                    _ = try await session.requestAgentJoin(slug: slug, options: .agentBuilder)
+                    _ = try await session.addAgentToConversation(
+                        conversationId: conversationIdForPersist,
+                        options: .agentBuilder
+                    )
                 } catch {
                     // Still gate the send: a thrown request is ambiguous --
                     // the server may have received it and provisioned the
@@ -789,9 +788,8 @@ final class AgentBuilderViewModel: Identifiable {
                     // the request went out). Publishing immediately would
                     // ship the brief into the pre-join epoch; the gate's
                     // timeout already covers the agent truly never arriving.
-                    Log.error("AgentBuilder(existing): requestAgentJoin failed: \(error.localizedDescription)")
+                    Log.error("AgentBuilder(existing): addAgentToConversation failed: \(error.localizedDescription)")
                 }
-                return true
             }
             // Persist the summary before the send so the chat the user returns
             // to renders the card immediately (its `summaryPublisher` picks
@@ -806,18 +804,17 @@ final class AgentBuilderViewModel: Identifiable {
             } catch {
                 Log.error("AgentBuilder(existing): pending media upload await failed: \(error.localizedDescription)")
             }
-            // `awaitsAgentJoin: false` only when the join was never requested
-            // at all (no slug) -- an agent that was never asked to come will
-            // never arrive, so holding the bundle just delays the inevitable
-            // publish. A request that was sent but threw still gates (see the
-            // join task above).
-            let joinRequested: Bool = await joinTask.value
+            // Direct-add always launches the join (there is no slug to be
+            // missing), so the send always gates on the agent's membership.
+            // A request that was sent but threw still gates (see the join
+            // task above).
+            await joinTask.value
             await innerVM.sendBuilderBundle(
                 text: summaryToPersist.prompt,
                 voiceMemo: voiceMemoSnapshot,
                 textMessageId: textMessageId,
                 bundleMessageId: bundleMessageId,
-                awaitsAgentJoin: joinRequested
+                awaitsAgentJoin: true
             )
         }
         // No in-sheet morph: the builder targets a conversation the user is
@@ -976,13 +973,9 @@ final class AgentBuilderViewModel: Identifiable {
             Log.warning("AgentBuilderViewModel: reached .ready but no conversation available")
             return
         }
-        let slug = conversation.invite?.urlSlug ?? ""
-        guard !slug.isEmpty else {
-            Log.warning("AgentBuilderViewModel: reached .ready but invite slug is empty")
-            return
-        }
         didRequestAgentJoin = true
 
+        let conversationId = conversation.id
         agentJoinTask?.cancel()
         // Capture `session` only, not `self`: the join needs nothing back from
         // the VM, and not capturing `self` avoids a cycle through the stored
@@ -993,13 +986,16 @@ final class AgentBuilderViewModel: Identifiable {
         // leaving / deleting the group -- so there's nothing left to join.
         agentJoinTask = Task { [session] in
             do {
-                _ = try await session.requestAgentJoin(slug: slug, options: .agentBuilder)
+                _ = try await session.addAgentToConversation(
+                    conversationId: conversationId,
+                    options: .agentBuilder
+                )
             } catch is CancellationError {
                 return
             } catch let urlError as URLError where urlError.code == .cancelled {
                 return
             } catch {
-                Log.error("AgentBuilderViewModel: requestAgentJoin failed: \(error.localizedDescription)")
+                Log.error("AgentBuilderViewModel: addAgentToConversation failed: \(error.localizedDescription)")
             }
         }
     }

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -3582,9 +3582,6 @@ extension ConversationViewModel {
     /// `requestAgentJoins(templateIds:)` instead -- it runs the calls
     /// sequentially without cancelling each other.
     func requestAgentJoin(templateId: String?, requestId: String = UUID().uuidString) {
-        let slug = invite.urlSlug
-        guard !slug.isEmpty else { return }
-
         agentJoinTask?.cancel()
 
         // Anchor the wait measurement at request time (the pending UI starts
@@ -3602,7 +3599,6 @@ extension ConversationViewModel {
         agentJoinTask = Task { [weak self] in
             let outcome = await Self.performAgentJoinCall(
                 templateId: templateId,
-                slug: slug,
                 conversationId: conversationId,
                 requestId: requestId,
                 forceErrorCode: forceErrorCode,
@@ -3680,8 +3676,6 @@ extension ConversationViewModel {
 
     private func runSequentialAgentJoins(_ joins: [AgentJoinAttempt]) {
         guard !joins.isEmpty else { return }
-        let slug = invite.urlSlug
-        guard !slug.isEmpty else { return }
 
         // Batch adds return to the chat, so the join progress shows as
         // in-stream pending status bubbles. Anchored at request time for the
@@ -3704,7 +3698,6 @@ extension ConversationViewModel {
                 }
                 let outcome = await Self.performAgentJoinCall(
                     templateId: join.templateId,
-                    slug: slug,
                     conversationId: conversationId,
                     requestId: join.requestId,
                     forceErrorCode: forceErrorCode,
@@ -3826,7 +3819,6 @@ extension ConversationViewModel {
     /// holding `self`.
     private static func performAgentJoinCall(
         templateId: String?,
-        slug: String,
         conversationId: String,
         requestId: String,
         forceErrorCode: Int?,
@@ -3839,8 +3831,8 @@ extension ConversationViewModel {
         )
         Log.info("performAgentJoinCall about to POST agents/join templateId=\(templateId ?? "nil") requestId=\(requestId)")
         do {
-            _ = try await session.requestAgentJoin(
-                slug: slug,
+            _ = try await session.addAgentToConversation(
+                conversationId: conversationId,
                 templateId: templateId,
                 options: nil,
                 forceErrorCode: forceErrorCode

--- a/ConvosCore/Sources/ConvosCore/API/AgentProvisionStatus.swift
+++ b/ConvosCore/Sources/ConvosCore/API/AgentProvisionStatus.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+/// Lifecycle of a provisioning agent instance as reported by the backend's
+/// `GET /v2/agents/join/:instanceId` poll. Distinct from `AgentJoinStatus`,
+/// which is the in-conversation join row rendered in the message list — the
+/// two have different value sets and live on different code paths.
+///
+/// Modeled as a closed `switch` with an `.unknown` escape hatch rather than a
+/// raw `String`: the poll loop switches over this so that a terminal status
+/// this client build doesn't yet model surfaces as a handled `.unknown` case
+/// (logged, deadline-bounded) instead of being silently treated as
+/// "keep waiting". Decoding stays lenient — an unmodeled status maps to
+/// `.unknown` rather than throwing — so a backend that adds a new status can't
+/// break the poll outright.
+public enum AgentProvisionStatus: Equatable, Sendable {
+    /// Registering the agent's XMTP identity / publishing key packages. In
+    /// direct-add this persists until the caller's `addMembers` lands; the
+    /// agent's `inboxId` becomes available partway through (see below).
+    case starting
+    /// The agent has joined the group (slug flow).
+    case joined
+    /// The agent's container has booted — strictly after `joined`; treated as
+    /// joined wherever a join is awaited.
+    case ready
+    /// Slug flow only: provisioned, waiting on an online accepter. Not emitted
+    /// for direct-add.
+    case pendingAcceptance
+    /// Pool exhausted — no agent instance could be allocated. Terminal.
+    /// Normally surfaced as a 503 on the provision POST; modeled here too so
+    /// the poll reports "no agents available" rather than spinning to a
+    /// generic timeout if the backend ever reports it mid-poll.
+    case noAgentsAvailable
+    /// Terminal failure; pair with `joinFailureReason` for the cause.
+    case failed
+    /// A status string this build does not model. Never silently swallowed —
+    /// the poll loop logs it and lets its own deadline bound the wait.
+    case unknown(String)
+
+    public init(wire: String) {
+        switch wire {
+        case "starting": self = .starting
+        case "joined": self = .joined
+        case "ready": self = .ready
+        case "pending_acceptance": self = .pendingAcceptance
+        case "no_agents_available": self = .noAgentsAvailable
+        case "failed": self = .failed
+        default: self = .unknown(wire)
+        }
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient+Models.swift
+++ b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient+Models.swift
@@ -164,16 +164,29 @@ public enum ConvosAPI {
     // POST /v2/agents/join
     // The body is validated strictly server-side: unknown keys are rejected.
     // `templateId` is optional - omitting it requests a bare join (the
-    // backend provisions a default agent). A nil `templateId` is omitted
-    // from the encoded JSON by Codable's synthesized encoder.
+    // backend provisions a default agent). Nil optionals are omitted from
+    // the encoded JSON by Codable's synthesized encoder.
+    //
+    // Exactly one of `slug` (invite flow) or `conversationId` (direct-add).
+    // In direct-add mode the backend provisions the agent and responds with
+    // its `inboxId`; the client adds that inbox to the declared group with
+    // addMembers and is done — the runtime observes the resulting group
+    // welcome and attaches, with no confirmation call.
 
     public struct AgentJoinRequest: Codable {
-        public let slug: String
+        public let slug: String?
+        public let conversationId: String?
         public let templateId: String?
         public let options: AgentJoinOptions?
 
-        public init(slug: String, templateId: String? = nil, options: AgentJoinOptions? = nil) {
+        public init(
+            slug: String? = nil,
+            conversationId: String? = nil,
+            templateId: String? = nil,
+            options: AgentJoinOptions? = nil
+        ) {
             self.slug = slug
+            self.conversationId = conversationId
             self.templateId = templateId
             self.options = options
         }
@@ -199,10 +212,48 @@ public enum ConvosAPI {
     public struct AgentJoinResponse: Codable {
         public let success: Bool
         public let joined: Bool
+        /// Populated on every dispatch; required for the join-status poll.
+        public let instanceId: String?
+        /// Direct-add only: the agent's XMTP inbox to add with addMembers.
+        /// Nil when registration outlasted the backend's wait budget — poll
+        /// GET /v2/agents/join/:instanceId until it lands.
+        public let inboxId: String?
 
-        public init(success: Bool, joined: Bool) {
+        public init(success: Bool, joined: Bool, instanceId: String? = nil, inboxId: String? = nil) {
             self.success = success
             self.joined = joined
+            self.instanceId = instanceId
+            self.inboxId = inboxId
+        }
+    }
+
+    // MARK: - v2/agents/join/:instanceId
+
+    public struct AgentJoinStatusResponse: Codable {
+        public let success: Bool
+        public let instanceId: String
+        public let joinStatus: String
+        public let joined: Bool
+        public let inboxId: String?
+        public let conversationId: String?
+        public let joinFailureReason: String?
+
+        public init(
+            success: Bool,
+            instanceId: String,
+            joinStatus: String,
+            joined: Bool,
+            inboxId: String? = nil,
+            conversationId: String? = nil,
+            joinFailureReason: String? = nil
+        ) {
+            self.success = success
+            self.instanceId = instanceId
+            self.joinStatus = joinStatus
+            self.joined = joined
+            self.inboxId = inboxId
+            self.conversationId = conversationId
+            self.joinFailureReason = joinFailureReason
         }
     }
 

--- a/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient+Models.swift
+++ b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient+Models.swift
@@ -255,6 +255,13 @@ public enum ConvosAPI {
             self.conversationId = conversationId
             self.joinFailureReason = joinFailureReason
         }
+
+        /// Typed view of the wire `joinStatus`. Switch over this (not the
+        /// raw string) so a terminal backend status can't be silently
+        /// missed at the call site.
+        public var provisionStatus: AgentProvisionStatus {
+            AgentProvisionStatus(wire: joinStatus)
+        }
     }
 
     // MARK: - v2/agent-templates/:id

--- a/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift
+++ b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift
@@ -821,7 +821,13 @@ final class ConvosAPIClient: ConvosAPIClientProtocol, Sendable {
 
     func getAgentJoinStatus(instanceId: String) async throws -> ConvosAPI.AgentJoinStatusResponse {
         let encoded = instanceId.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? instanceId
-        let request = try authenticatedRequest(for: "v2/agents/join/\(encoded)", method: "GET")
+        var request = try authenticatedRequest(for: "v2/agents/join/\(encoded)", method: "GET")
+        // Bound a single poll: without this a hung GET stalls the caller's
+        // registration loop indefinitely, since the loop's own deadline is
+        // only checked between iterations and can't interrupt an in-flight
+        // request. Kept well under the loop's overall deadline so a stuck
+        // request fails fast and the next iteration's deadline check fires.
+        request.timeoutInterval = 10
         return try await performRequest(request)
     }
 

--- a/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift
+++ b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift
@@ -83,12 +83,22 @@ public protocol ConvosAPIClientProtocol: AnyObject, Sendable {
     func renewAssetsBatch(assetKeys: [String]) async throws -> AssetRenewalResult
 
     // Agents
+    /// Exactly one of `slug` (invite flow) and `conversationId` (direct-add).
+    /// In direct-add mode the backend provisions the agent and returns its
+    /// `inboxId`; the caller adds that inbox to the declared group with
+    /// addMembers and the runtime attaches when it observes the resulting
+    /// group welcome — no further calls.
     func requestAgentJoin(
-        slug: String,
+        slug: String?,
+        conversationId: String?,
         templateId: String?,
         options: ConvosAPI.AgentJoinOptions?,
         forceErrorCode: Int?
     ) async throws -> ConvosAPI.AgentJoinResponse
+
+    /// Polls a dispatched agent's provisioning status. Direct-add callers
+    /// use it to obtain `inboxId` when the join response didn't carry one.
+    func getAgentJoinStatus(instanceId: String) async throws -> ConvosAPI.AgentJoinStatusResponse
 
     // Agent templates
     /// Public detail fetch for a published agent template, keyed by its
@@ -165,21 +175,21 @@ public protocol ConvosAPIClientProtocol: AnyObject, Sendable {
 
 extension ConvosAPIClientProtocol {
     func requestAgentJoin(slug: String) async throws -> ConvosAPI.AgentJoinResponse {
-        try await requestAgentJoin(slug: slug, templateId: nil, options: nil, forceErrorCode: nil)
+        try await requestAgentJoin(slug: slug, conversationId: nil, templateId: nil, options: nil, forceErrorCode: nil)
     }
 
     func requestAgentJoin(
         slug: String,
         options: ConvosAPI.AgentJoinOptions?
     ) async throws -> ConvosAPI.AgentJoinResponse {
-        try await requestAgentJoin(slug: slug, templateId: nil, options: options, forceErrorCode: nil)
+        try await requestAgentJoin(slug: slug, conversationId: nil, templateId: nil, options: options, forceErrorCode: nil)
     }
 
     func requestAgentJoin(
         slug: String,
         templateId: String?
     ) async throws -> ConvosAPI.AgentJoinResponse {
-        try await requestAgentJoin(slug: slug, templateId: templateId, options: nil, forceErrorCode: nil)
+        try await requestAgentJoin(slug: slug, conversationId: nil, templateId: templateId, options: nil, forceErrorCode: nil)
     }
 }
 
@@ -758,7 +768,8 @@ final class ConvosAPIClient: ConvosAPIClientProtocol, Sendable {
     // MARK: - Agents
 
     func requestAgentJoin(
-        slug: String,
+        slug: String? = nil,
+        conversationId: String? = nil,
         templateId: String? = nil,
         options: ConvosAPI.AgentJoinOptions? = nil,
         forceErrorCode: Int? = nil
@@ -775,6 +786,7 @@ final class ConvosAPIClient: ConvosAPIClientProtocol, Sendable {
         request.httpBody = try JSONEncoder().encode(
             ConvosAPI.AgentJoinRequest(
                 slug: slug,
+                conversationId: conversationId,
                 templateId: templateId,
                 options: options
             )
@@ -805,6 +817,12 @@ final class ConvosAPIClient: ConvosAPIClientProtocol, Sendable {
         default:
             throw APIError.serverError(parseErrorMessage(from: data))
         }
+    }
+
+    func getAgentJoinStatus(instanceId: String) async throws -> ConvosAPI.AgentJoinStatusResponse {
+        let encoded = instanceId.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? instanceId
+        let request = try authenticatedRequest(for: "v2/agents/join/\(encoded)", method: "GET")
+        return try await performRequest(request)
     }
 
     // MARK: - Agent templates

--- a/ConvosCore/Sources/ConvosCore/API/MockAPIClient.swift
+++ b/ConvosCore/Sources/ConvosCore/API/MockAPIClient.swift
@@ -106,11 +106,14 @@ final class MockAPIClient: ConvosAPIClientProtocol, Sendable {
     }
 
     func getAgentJoinStatus(instanceId: String) async throws -> ConvosAPI.AgentJoinStatusResponse {
+        // A registered, joined agent — a coherent terminal state (joined ⇒
+        // inbox present), not "starting" paired with an inbox, which masks the
+        // poll loop and can't be told apart from a real in-flight state.
         .init(
             success: true,
             instanceId: instanceId,
-            joinStatus: "starting",
-            joined: false,
+            joinStatus: "joined",
+            joined: true,
             inboxId: "mock-agent-inbox"
         )
     }

--- a/ConvosCore/Sources/ConvosCore/API/MockAPIClient.swift
+++ b/ConvosCore/Sources/ConvosCore/API/MockAPIClient.swift
@@ -96,12 +96,23 @@ final class MockAPIClient: ConvosAPIClientProtocol, Sendable {
     }
 
     func requestAgentJoin(
-        slug: String,
+        slug: String? = nil,
+        conversationId: String? = nil,
         templateId: String? = nil,
         options: ConvosAPI.AgentJoinOptions? = nil,
         forceErrorCode: Int? = nil
     ) async throws -> ConvosAPI.AgentJoinResponse {
-        .init(success: true, joined: true)
+        .init(success: true, joined: true, instanceId: "mock-instance", inboxId: "mock-agent-inbox")
+    }
+
+    func getAgentJoinStatus(instanceId: String) async throws -> ConvosAPI.AgentJoinStatusResponse {
+        .init(
+            success: true,
+            instanceId: instanceId,
+            joinStatus: "starting",
+            joined: false,
+            inboxId: "mock-agent-inbox"
+        )
     }
 
     func getAgentTemplate(idOrUrlSlug: String) async throws -> ConvosAPI.AgentTemplate {

--- a/ConvosCore/Sources/ConvosCore/Inboxes/MockInboxesService.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/MockInboxesService.swift
@@ -92,8 +92,8 @@ public final class MockInboxesService: SessionManagerProtocol, @unchecked Sendab
         MockInviteRepository()
     }
 
-    public func requestAgentJoin(
-        slug: String,
+    public func addAgentToConversation(
+        conversationId: String,
         templateId: String? = nil,
         options: ConvosAPI.AgentJoinOptions? = nil,
         forceErrorCode: Int? = nil
@@ -106,7 +106,7 @@ public final class MockInboxesService: SessionManagerProtocol, @unchecked Sendab
             default: throw APIError.serverError("Mock forced error \(forceErrorCode)")
             }
         }
-        return .init(success: true, joined: true)
+        return .init(success: true, joined: true, instanceId: "mock-instance", inboxId: "mock-agent-inbox")
     }
 
     public func conversationRepository(for conversationId: String) -> any ConversationRepositoryProtocol {

--- a/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
@@ -596,28 +596,6 @@ public final class SessionManager: SessionManagerProtocol, @unchecked Sendable {
         )
     }
 
-    public func requestAgentJoin(
-        slug: String,
-        templateId: String? = nil,
-        options: ConvosAPI.AgentJoinOptions? = nil,
-        forceErrorCode: Int? = nil
-    ) async throws -> ConvosAPI.AgentJoinResponse {
-        let response = try await apiClient.requestAgentJoin(
-            slug: slug,
-            templateId: templateId,
-            options: options,
-            forceErrorCode: forceErrorCode
-        )
-        // Temporary diagnostic: the agent now sends a join-request DM that
-        // the message stream is expected to deliver. Poll for it for a
-        // bounded window in case the stream has died, so the agent doesn't
-        // time out and stream death shows up in the logs. Covers every
-        // agents/join entry point (add agent, contacts picker, compose,
-        // agent builder) since they all route through here.
-        await messagingService().sessionStateManager.startAgentJoinRequestPolling()
-        return response
-    }
-
     public func agentShareResolver() -> any AgentShareResolving {
         ApiAgentShareResolver(
             apiClient: apiClient,
@@ -1129,5 +1107,60 @@ public extension SessionManager {
 extension SessionManager {
     public func builderBundleHiddenMessagesRepository() -> any BuilderBundleHiddenMessagesRepositoryProtocol {
         BuilderBundleHiddenMessagesRepository(databaseReader: databaseReader)
+    }
+}
+
+// MARK: - Direct-add agent join
+
+extension SessionManager {
+    /// How long to keep polling for the agent's inboxId when registration
+    /// outlasts the backend's synchronous wait budget.
+    private static var agentRegistrationDeadline: TimeInterval { 30 }
+    private static var agentRegistrationPollInterval: TimeInterval { 1 }
+
+    public func addAgentToConversation(
+        conversationId: String,
+        templateId: String? = nil,
+        options: ConvosAPI.AgentJoinOptions? = nil,
+        forceErrorCode: Int? = nil
+    ) async throws -> ConvosAPI.AgentJoinResponse {
+        // 1. Provision: the backend registers the agent's XMTP inbox and
+        //    returns it. No invite slug — this device performs the add, and
+        //    the declared conversationId tells the runtime which group to
+        //    watch for the resulting welcome.
+        let response = try await apiClient.requestAgentJoin(
+            slug: nil,
+            conversationId: conversationId.lowercased(),
+            templateId: templateId,
+            options: options,
+            forceErrorCode: forceErrorCode
+        )
+        guard let instanceId = response.instanceId else {
+            throw APIError.agentProvisionFailed
+        }
+
+        var inboxId = response.inboxId
+        let deadline = Date().addingTimeInterval(Self.agentRegistrationDeadline)
+        while inboxId == nil {
+            guard Date() < deadline else { throw APIError.agentPoolTimeout }
+            try await Task.sleep(nanoseconds: UInt64(Self.agentRegistrationPollInterval * 1_000_000_000))
+            let status = try await apiClient.getAgentJoinStatus(instanceId: instanceId)
+            guard status.joinStatus != "failed" else {
+                throw APIError.agentProvisionFailed
+            }
+            inboxId = status.inboxId
+        }
+        guard let agentInboxId = inboxId else {
+            throw APIError.agentPoolTimeout
+        }
+
+        // 2. Add: a plain member add by this device — synchronous, no DM
+        //    round-trip, no online-accepter dependency. The add durably
+        //    publishes a group welcome for the agent's inbox; the runtime
+        //    observes it and attaches, so the agent boots even if this app
+        //    is killed on the next line.
+        try await messagingService().conversationMetadataWriter()
+            .addMembers([agentInboxId], to: conversationId)
+        return response
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
@@ -1117,6 +1117,12 @@ extension SessionManager {
     /// outlasts the backend's synchronous wait budget.
     private static var agentRegistrationDeadline: TimeInterval { 30 }
     private static var agentRegistrationPollInterval: TimeInterval { 1 }
+    /// Bounded retries of the local member add for an already-provisioned
+    /// agent. The add can fail transiently (MLS commit race, key package not
+    /// yet propagated to this device, network blip); we retry the *same*
+    /// inboxId rather than re-provisioning.
+    private static var agentAddMaxAttempts: Int { 3 }
+    private static var agentAddRetryDelay: TimeInterval { 1 }
 
     public func addAgentToConversation(
         conversationId: String,
@@ -1124,43 +1130,130 @@ extension SessionManager {
         options: ConvosAPI.AgentJoinOptions? = nil,
         forceErrorCode: Int? = nil
     ) async throws -> ConvosAPI.AgentJoinResponse {
-        // 1. Provision: the backend registers the agent's XMTP inbox and
-        //    returns it. No invite slug — this device performs the add, and
-        //    the declared conversationId tells the runtime which group to
-        //    watch for the resulting welcome.
-        let response = try await apiClient.requestAgentJoin(
-            slug: nil,
-            conversationId: conversationId.lowercased(),
-            templateId: templateId,
-            options: options,
-            forceErrorCode: forceErrorCode
+        // 1. Provision the agent and wait until its XMTP inbox is registered.
+        //    Extracted to a helper that touches only the API client (no
+        //    messaging service) so the poll loop and its terminal/timeout/
+        //    unknown branches are unit-testable — see DirectAddProvisionPollTests.
+        let resolved = try await Self.awaitProvisionedAgentInbox(
+            requestJoin: {
+                try await self.apiClient.requestAgentJoin(
+                    slug: nil,
+                    conversationId: conversationId.lowercased(),
+                    templateId: templateId,
+                    options: options,
+                    forceErrorCode: forceErrorCode
+                )
+            },
+            fetchStatus: { try await self.apiClient.getAgentJoinStatus(instanceId: $0) }
         )
-        guard let instanceId = response.instanceId else {
-            throw APIError.agentProvisionFailed
-        }
-
-        var inboxId = response.inboxId
-        let deadline = Date().addingTimeInterval(Self.agentRegistrationDeadline)
-        while inboxId == nil {
-            guard Date() < deadline else { throw APIError.agentPoolTimeout }
-            try await Task.sleep(nanoseconds: UInt64(Self.agentRegistrationPollInterval * 1_000_000_000))
-            let status = try await apiClient.getAgentJoinStatus(instanceId: instanceId)
-            guard status.joinStatus != "failed" else {
-                throw APIError.agentProvisionFailed
-            }
-            inboxId = status.inboxId
-        }
-        guard let agentInboxId = inboxId else {
-            throw APIError.agentPoolTimeout
-        }
+        let instanceId = resolved.instanceId
+        let agentInboxId = resolved.inboxId
 
         // 2. Add: a plain member add by this device — synchronous, no DM
         //    round-trip, no online-accepter dependency. The add durably
         //    publishes a group welcome for the agent's inbox; the runtime
-        //    observes it and attaches, so the agent boots even if this app
-        //    is killed on the next line.
-        try await messagingService().conversationMetadataWriter()
-            .addMembers([agentInboxId], to: conversationId)
-        return response
+        //    observes it and attaches, so the agent boots even if this app is
+        //    killed on the next line.
+        //
+        //    On failure we retry the add for the *same* inboxId; we never
+        //    re-provision here. Re-provisioning would spawn a second instance
+        //    (the backend does not dedupe by conversationId) and orphan the
+        //    first, risking two agents in one conversation. An add that
+        //    exhausts its retries leaves a provisioned-but-unadded instance,
+        //    which the runtime reaps on its own attach timeout; we log the
+        //    instanceId/inboxId on every failure so it can be correlated.
+        var lastError: Error?
+        for attempt in 1...Self.agentAddMaxAttempts {
+            do {
+                try await messagingService().conversationMetadataWriter()
+                    .addMembers([agentInboxId], to: conversationId)
+                return resolved.response
+            } catch {
+                lastError = error
+                Log.error(
+                    "Direct-add: addMembers failed (attempt \(attempt)/\(Self.agentAddMaxAttempts)) "
+                        + "for agent inbox \(agentInboxId), instance \(instanceId), "
+                        + "conversation \(conversationId): \(error.localizedDescription)"
+                )
+                if attempt < Self.agentAddMaxAttempts {
+                    try await Task.sleep(nanoseconds: UInt64(Self.agentAddRetryDelay * 1_000_000_000))
+                }
+            }
+        }
+        throw lastError ?? APIError.invalidResponse
+    }
+
+    /// A provisioned agent whose XMTP inbox has registered and is ready to add.
+    struct ProvisionedAgent {
+        let response: ConvosAPI.AgentJoinResponse
+        let instanceId: String
+        let inboxId: String
+    }
+
+    /// Provisions an agent (`POST /v2/agents/join`) and polls
+    /// `GET /v2/agents/join/:instanceId` until its XMTP inbox is registered,
+    /// the backend reports a terminal status, or the deadline elapses.
+    ///
+    /// Touches only the two injected API operations — no messaging service —
+    /// so the loop is unit-testable with plain closures, and `now`/`sleep` are
+    /// injectable so deadline and poll timing can be driven without real waits.
+    ///
+    /// `inboxId` presence is the readiness signal: the backend (`pollUntilRegistered`)
+    /// populates it only once the agent's identity is registered and key
+    /// packages are published, so the caller's subsequent `addMembers` has key
+    /// packages to consume. In direct-add the status legitimately stays
+    /// `.starting` while the inbox is already present (the agent has not
+    /// *joined* yet — that happens after the add), so the inbox check, not the
+    /// status, is what ends the wait.
+    static func awaitProvisionedAgentInbox(
+        deadline: TimeInterval = agentRegistrationDeadline,
+        pollInterval: TimeInterval = agentRegistrationPollInterval,
+        now: @Sendable () -> Date = { Date() },
+        sleep: @Sendable (TimeInterval) async throws -> Void = {
+            try await Task.sleep(nanoseconds: UInt64($0 * 1_000_000_000))
+        },
+        requestJoin: @Sendable () async throws -> ConvosAPI.AgentJoinResponse,
+        fetchStatus: @Sendable (_ instanceId: String) async throws -> ConvosAPI.AgentJoinStatusResponse
+    ) async throws -> ProvisionedAgent {
+        let response = try await requestJoin()
+        guard let instanceId = response.instanceId else {
+            throw APIError.agentProvisionFailed
+        }
+
+        // Fast path: registration completed within the provision call itself.
+        if let inboxId = response.inboxId {
+            return ProvisionedAgent(response: response, instanceId: instanceId, inboxId: inboxId)
+        }
+
+        let deadlineDate = now().addingTimeInterval(deadline)
+        while now() < deadlineDate {
+            try await sleep(pollInterval)
+            let status = try await fetchStatus(instanceId)
+
+            switch status.provisionStatus {
+            case .failed:
+                Log.error(
+                    "Direct-add: provision failed for instance \(instanceId): "
+                        + "\(status.joinFailureReason ?? "no reason given")"
+                )
+                throw APIError.agentProvisionFailed
+            case .noAgentsAvailable:
+                Log.error("Direct-add: no agents available for instance \(instanceId)")
+                throw APIError.noAgentsAvailable
+            case .starting, .joined, .ready, .pendingAcceptance:
+                break  // still registering; readiness is signaled by inboxId
+            case .unknown(let raw):
+                // A status this build doesn't model — not treated as ready or
+                // as failure. Logged (so it isn't silently missed) while the
+                // deadline bounds the wait.
+                Log.warning("Direct-add: unexpected join status \"\(raw)\" for instance \(instanceId)")
+            }
+
+            if let inboxId = status.inboxId {
+                return ProvisionedAgent(response: response, instanceId: instanceId, inboxId: inboxId)
+            }
+        }
+        Log.error("Direct-add: timed out awaiting agent inbox for instance \(instanceId)")
+        throw APIError.agentPoolTimeout
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Sessions/SessionManagerProtocol.swift
+++ b/ConvosCore/Sources/ConvosCore/Sessions/SessionManagerProtocol.swift
@@ -100,8 +100,14 @@ public protocol SessionManagerProtocol: AnyObject, Sendable {
     // MARK: Factory methods for repositories
 
     func inviteRepository(for conversationId: String) -> any InviteRepositoryProtocol
-    func requestAgentJoin(
-        slug: String,
+
+    /// Direct-add agent join: provisions the agent via the backend (declaring
+    /// the target conversation) and adds its XMTP inbox with addMembers. The
+    /// runtime observes the resulting group welcome and attaches — once the
+    /// add lands, the agent boots with no further calls. No invite slug
+    /// involved.
+    func addAgentToConversation(
+        conversationId: String,
         templateId: String?,
         options: ConvosAPI.AgentJoinOptions?,
         forceErrorCode: Int?
@@ -230,21 +236,21 @@ extension SessionManagerProtocol {
         NoopInviteMembershipResolver()
     }
 
-    public func requestAgentJoin(slug: String) async throws -> ConvosAPI.AgentJoinResponse {
-        try await requestAgentJoin(slug: slug, templateId: nil, options: nil, forceErrorCode: nil)
+    public func addAgentToConversation(conversationId: String) async throws -> ConvosAPI.AgentJoinResponse {
+        try await addAgentToConversation(conversationId: conversationId, templateId: nil, options: nil, forceErrorCode: nil)
     }
 
-    public func requestAgentJoin(
-        slug: String,
+    public func addAgentToConversation(
+        conversationId: String,
         options: ConvosAPI.AgentJoinOptions?
     ) async throws -> ConvosAPI.AgentJoinResponse {
-        try await requestAgentJoin(slug: slug, templateId: nil, options: options, forceErrorCode: nil)
+        try await addAgentToConversation(conversationId: conversationId, templateId: nil, options: options, forceErrorCode: nil)
     }
 
-    public func requestAgentJoin(
-        slug: String,
+    public func addAgentToConversation(
+        conversationId: String,
         templateId: String?
     ) async throws -> ConvosAPI.AgentJoinResponse {
-        try await requestAgentJoin(slug: slug, templateId: templateId, options: nil, forceErrorCode: nil)
+        try await addAgentToConversation(conversationId: conversationId, templateId: templateId, options: nil, forceErrorCode: nil)
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationMetadataWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationMetadataWriter.swift
@@ -429,6 +429,12 @@ final class ConversationMetadataWriter: ConversationMetadataWriterProtocol, @unc
         let currentInboxId = inboxReady.client.inboxId
         try await databaseWriter.write { db in
             for memberInboxId in memberInboxIds {
+                // A directly-added inbox (e.g. a freshly provisioned agent) may
+                // never have been seen locally, so the member parent row the
+                // membership row references doesn't exist yet — create it
+                // first. Members arriving via the stream get theirs from the
+                // welcome/profile path instead.
+                try DBMember(inboxId: memberInboxId).save(db, onConflict: .ignore)
                 let conversationMember = DBConversationMember(
                     conversationId: conversationId,
                     inboxId: memberInboxId,

--- a/ConvosCore/Tests/ConvosCoreTests/DirectAddMemberPersistenceTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/DirectAddMemberPersistenceTests.swift
@@ -1,0 +1,85 @@
+@preconcurrency @testable import ConvosCore
+import Foundation
+import GRDB
+import Testing
+
+private let testEnvironment = AppEnvironment.tests
+
+/// Direct-add regression coverage for `ConversationMetadataWriter.addMembers`.
+///
+/// `conversation_members.inboxId` references `member(inboxId)`. In the invite
+/// flow every member's parent row was written by the stream (welcome/profile)
+/// before any membership row, so the writer never had to create one.
+/// Direct-add is the first path that locally inserts an inboxId the database
+/// has never seen — a freshly provisioned agent — which used to fail with
+/// SQLite error 19 (FOREIGN KEY constraint) and surface in the UI as
+/// "Agent not able to join".
+@Suite("Direct-add member persistence", .serialized, .timeLimit(.minutes(3)))
+struct DirectAddMemberPersistenceTests {
+    @Test("addMembers persists a never-seen inboxId without violating the member FK")
+    func testAddMembersPersistsNeverSeenInbox() async throws {
+        let fixtures = TestFixtures()
+        let messagingService = fixtures.makeFreshMessagingService()
+
+        let stateMachine = ConversationStateMachine(
+            sessionStateManager: messagingService.sessionStateManager,
+            identityStore: fixtures.identityStore,
+            databaseReader: fixtures.databaseManager.dbReader,
+            databaseWriter: fixtures.databaseManager.dbWriter,
+            environment: testEnvironment,
+            clientConversationId: DBConversation.generateDraftConversationId(),
+            coreActions: NoOpCoreActions()
+        )
+
+        await stateMachine.create(initialMemberInboxIds: [])
+
+        var conversationId: String?
+        do {
+            conversationId = try await withTimeout(seconds: 30) {
+                for await state in await stateMachine.stateSequence {
+                    if case .ready(let readyResult) = state {
+                        return readyResult.conversationId
+                    }
+                    if case .error(let error) = state {
+                        Issue.record("Unexpected error: \(error)")
+                        return nil
+                    }
+                }
+                return nil
+            }
+        } catch {
+            Issue.record("Timed out waiting for ready: \(error)")
+        }
+        let convId = try #require(conversationId, "Should reach ready with a conversation id")
+
+        // A second real inbox that exists on the network but that this
+        // client's local database has never observed — the same shape as a
+        // freshly provisioned agent inbox in the direct-add flow.
+        let (clientB, _, _) = try await fixtures.createClient()
+        let neverSeenInboxId = clientB.inboxId
+
+        let preExisting = try await fixtures.databaseManager.dbReader.read { db in
+            try DBMember.fetchOne(db, key: neverSeenInboxId)
+        }
+        #expect(preExisting == nil, "Test premise: the inbox must be unknown to the local database")
+
+        try await messagingService.conversationMetadataWriter()
+            .addMembers([neverSeenInboxId], to: convId)
+
+        let membershipRow = try await fixtures.databaseManager.dbReader.read { db in
+            try DBConversationMember.fetchOne(
+                db,
+                key: ["conversationId": convId, "inboxId": neverSeenInboxId]
+            )
+        }
+        #expect(membershipRow != nil, "Membership row must persist for a never-seen inbox")
+
+        let parentRow = try await fixtures.databaseManager.dbReader.read { db in
+            try DBMember.fetchOne(db, key: neverSeenInboxId)
+        }
+        #expect(parentRow != nil, "Member parent row must be created alongside the membership row")
+
+        await messagingService.stopAndDelete()
+        try? await fixtures.cleanup()
+    }
+}

--- a/ConvosCore/Tests/ConvosCoreTests/DirectAddProvisionPollTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/DirectAddProvisionPollTests.swift
@@ -1,0 +1,179 @@
+@testable import ConvosCore
+import Foundation
+import Testing
+
+/// Coverage for `SessionManager.awaitProvisionedAgentInbox` — the direct-add
+/// provision + registration poll. Before this the loop was untested: the API
+/// stubs returned a non-nil `inboxId` on the provision call, so the
+/// `while`-poll never iterated and `getAgentJoinStatus` was never exercised.
+///
+/// The helper takes plain closures for the two API calls plus injectable
+/// `now`/`sleep`, so each branch (fast path, poll-until-registered, terminal
+/// statuses, unknown status, deadline) is driven deterministically with no
+/// real waiting.
+@Suite("Direct-add provision poll")
+struct DirectAddProvisionPollTests {
+    /// Thread-safe mutable cell so the `@Sendable` closures can record calls
+    /// and advance a logical clock.
+    private final class Box<T>: @unchecked Sendable {
+        private let lock = NSLock()
+        private var value: T
+        init(_ value: T) { self.value = value }
+        func get() -> T { lock.lock(); defer { lock.unlock() }; return value }
+        @discardableResult func mutate<R>(_ body: (inout T) -> R) -> R {
+            lock.lock(); defer { lock.unlock() }; return body(&value)
+        }
+    }
+
+    private func provisionResponse(
+        instanceId: String? = "instance-1",
+        inboxId: String? = nil
+    ) -> ConvosAPI.AgentJoinResponse {
+        ConvosAPI.AgentJoinResponse(
+            success: true,
+            joined: false,
+            instanceId: instanceId,
+            inboxId: inboxId
+        )
+    }
+
+    private func statusResponse(
+        instanceId: String = "instance-1",
+        joinStatus: String,
+        inboxId: String? = nil,
+        joinFailureReason: String? = nil
+    ) -> ConvosAPI.AgentJoinStatusResponse {
+        ConvosAPI.AgentJoinStatusResponse(
+            success: true,
+            instanceId: instanceId,
+            joinStatus: joinStatus,
+            joined: joinStatus == "joined" || joinStatus == "ready",
+            inboxId: inboxId,
+            joinFailureReason: joinFailureReason
+        )
+    }
+
+    @Test("Fast path: inbox already on the provision response — no polling")
+    func fastPathSkipsPoll() async throws {
+        let statusCalls = Box(0)
+        let resolved = try await SessionManager.awaitProvisionedAgentInbox(
+            sleep: { _ in },
+            requestJoin: { self.provisionResponse(inboxId: "agent-inbox") },
+            fetchStatus: { _ in statusCalls.mutate { $0 += 1 }; return self.statusResponse(joinStatus: "joined", inboxId: "agent-inbox") }
+        )
+        #expect(resolved.inboxId == "agent-inbox")
+        #expect(resolved.instanceId == "instance-1")
+        #expect(statusCalls.get() == 0, "Inbox present on provision must short-circuit the poll")
+    }
+
+    @Test("Polls until the inbox registers, then returns it")
+    func pollsUntilRegistered() async throws {
+        let statusCalls = Box(0)
+        let resolved = try await SessionManager.awaitProvisionedAgentInbox(
+            sleep: { _ in },
+            requestJoin: { self.provisionResponse(inboxId: nil) },
+            fetchStatus: { _ in
+                let n = statusCalls.mutate { $0 += 1; return $0 }
+                // Registration in flight for the first two polls, then the
+                // inbox lands — status legitimately stays "starting" since the
+                // agent has not *joined* yet (that happens after addMembers).
+                return n < 3
+                    ? self.statusResponse(joinStatus: "starting", inboxId: nil)
+                    : self.statusResponse(joinStatus: "starting", inboxId: "agent-inbox")
+            }
+        )
+        #expect(resolved.inboxId == "agent-inbox")
+        #expect(statusCalls.get() == 3, "Should poll until the inbox appears")
+    }
+
+    @Test("`failed` status is terminal — throws immediately, no spin to deadline")
+    func failedIsTerminal() async throws {
+        let statusCalls = Box(0)
+        await #expect(throws: APIError.self) {
+            _ = try await SessionManager.awaitProvisionedAgentInbox(
+                sleep: { _ in },
+                requestJoin: { self.provisionResponse(inboxId: nil) },
+                fetchStatus: { _ in
+                    statusCalls.mutate { $0 += 1 }
+                    return self.statusResponse(joinStatus: "failed", joinFailureReason: "boom")
+                }
+            )
+        }
+        #expect(statusCalls.get() == 1, "A terminal status must stop the poll on the first observation")
+    }
+
+    @Test("`no_agents_available` surfaces as noAgentsAvailable, not a timeout")
+    func noAgentsAvailableIsTerminal() async throws {
+        var caught: APIError?
+        do {
+            _ = try await SessionManager.awaitProvisionedAgentInbox(
+                sleep: { _ in },
+                requestJoin: { self.provisionResponse(inboxId: nil) },
+                fetchStatus: { _ in self.statusResponse(joinStatus: "no_agents_available") }
+            )
+        } catch let error as APIError {
+            caught = error
+        }
+        guard case .noAgentsAvailable = caught else {
+            Issue.record("Expected APIError.noAgentsAvailable, got \(String(describing: caught))")
+            return
+        }
+    }
+
+    @Test("An unmodeled status keeps polling rather than throwing or exiting early")
+    func unknownStatusKeepsPolling() async throws {
+        let statusCalls = Box(0)
+        let resolved = try await SessionManager.awaitProvisionedAgentInbox(
+            sleep: { _ in },
+            requestJoin: { self.provisionResponse(inboxId: nil) },
+            fetchStatus: { _ in
+                let n = statusCalls.mutate { $0 += 1; return $0 }
+                return n < 2
+                    ? self.statusResponse(joinStatus: "queued", inboxId: nil)  // not modeled → .unknown
+                    : self.statusResponse(joinStatus: "starting", inboxId: "agent-inbox")
+            }
+        )
+        #expect(resolved.inboxId == "agent-inbox")
+        #expect(statusCalls.get() == 2)
+    }
+
+    @Test("Times out with agentPoolTimeout when the inbox never registers")
+    func timesOut() async throws {
+        // Logical clock advanced by `sleep` so the 30s deadline is reached
+        // without real waiting.
+        let clock = Box(Date(timeIntervalSince1970: 0))
+        var caught: APIError?
+        do {
+            _ = try await SessionManager.awaitProvisionedAgentInbox(
+                now: { clock.get() },
+                sleep: { dt in clock.mutate { $0 = $0.addingTimeInterval(dt) } },
+                requestJoin: { self.provisionResponse(inboxId: nil) },
+                fetchStatus: { _ in self.statusResponse(joinStatus: "starting", inboxId: nil) }
+            )
+        } catch let error as APIError {
+            caught = error
+        }
+        guard case .agentPoolTimeout = caught else {
+            Issue.record("Expected APIError.agentPoolTimeout, got \(String(describing: caught))")
+            return
+        }
+    }
+
+    @Test("Missing instanceId on the provision response fails fast")
+    func missingInstanceIdThrows() async throws {
+        var caught: APIError?
+        do {
+            _ = try await SessionManager.awaitProvisionedAgentInbox(
+                sleep: { _ in },
+                requestJoin: { self.provisionResponse(instanceId: nil, inboxId: nil) },
+                fetchStatus: { _ in self.statusResponse(joinStatus: "starting") }
+            )
+        } catch let error as APIError {
+            caught = error
+        }
+        guard case .agentProvisionFailed = caught else {
+            Issue.record("Expected APIError.agentProvisionFailed, got \(String(describing: caught))")
+            return
+        }
+    }
+}

--- a/ConvosCore/Tests/ConvosCoreTests/TestStubAPIClientDefaults.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/TestStubAPIClientDefaults.swift
@@ -51,14 +51,16 @@ extension ConvosAPIClientProtocol {
     }
 
     /// Default for the direct-add status poll so pre-existing stubs don't
-    /// re-stub it. Tests that exercise the direct-add flow specifically
-    /// should override this on their fixture.
+    /// re-stub it. A coherent terminal state — joined ⇒ inbox present — so
+    /// unrelated tests don't iterate the poll loop. Tests that exercise the
+    /// poll specifically program their own status sequence (see
+    /// DirectAddProvisionPollTests).
     func getAgentJoinStatus(instanceId: String) async throws -> ConvosAPI.AgentJoinStatusResponse {
         ConvosAPI.AgentJoinStatusResponse(
             success: true,
             instanceId: instanceId,
-            joinStatus: "starting",
-            joined: false,
+            joinStatus: "joined",
+            joined: true,
             inboxId: "test-agent-inbox"
         )
     }

--- a/ConvosCore/Tests/ConvosCoreTests/TestStubAPIClientDefaults.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/TestStubAPIClientDefaults.swift
@@ -36,12 +36,31 @@ extension ConvosAPIClientProtocol {
     /// `requestAgentJoin` specifically should still override this on
     /// their fixture.
     func requestAgentJoin(
-        slug: String,
+        slug: String?,
+        conversationId: String?,
         templateId: String?,
         options: ConvosAPI.AgentJoinOptions?,
         forceErrorCode: Int?
     ) async throws -> ConvosAPI.AgentJoinResponse {
-        ConvosAPI.AgentJoinResponse(success: true, joined: true)
+        ConvosAPI.AgentJoinResponse(
+            success: true,
+            joined: true,
+            instanceId: "test-instance",
+            inboxId: "test-agent-inbox"
+        )
+    }
+
+    /// Default for the direct-add status poll so pre-existing stubs don't
+    /// re-stub it. Tests that exercise the direct-add flow specifically
+    /// should override this on their fixture.
+    func getAgentJoinStatus(instanceId: String) async throws -> ConvosAPI.AgentJoinStatusResponse {
+        ConvosAPI.AgentJoinStatusResponse(
+            success: true,
+            instanceId: instanceId,
+            joinStatus: "starting",
+            joined: false,
+            inboxId: "test-agent-inbox"
+        )
     }
 
     /// Default for the public agent-template detail fetch used by the

--- a/ConvosTests/ConversationViewModelGlobalDefaultsTests.swift
+++ b/ConvosTests/ConversationViewModelGlobalDefaultsTests.swift
@@ -293,14 +293,14 @@ private final class TestSessionManager: SessionManagerProtocol, @unchecked Senda
         await base.inboxId(for: conversationId)
     }
 
-    func requestAgentJoin(
-        slug: String,
+    func addAgentToConversation(
+        conversationId: String,
         templateId: String?,
         options: ConvosAPI.AgentJoinOptions?,
         forceErrorCode: Int?
     ) async throws -> ConvosAPI.AgentJoinResponse {
-        try await base.requestAgentJoin(
-            slug: slug,
+        try await base.addAgentToConversation(
+            conversationId: conversationId,
             templateId: templateId,
             options: options,
             forceErrorCode: forceErrorCode

--- a/ConvosTests/ConversationsViewModelDeleteTests.swift
+++ b/ConvosTests/ConversationsViewModelDeleteTests.swift
@@ -293,14 +293,14 @@ private final class TestSessionManager: SessionManagerProtocol, @unchecked Senda
         await base.inboxId(for: conversationId)
     }
 
-    func requestAgentJoin(
-        slug: String,
+    func addAgentToConversation(
+        conversationId: String,
         templateId: String?,
         options: ConvosAPI.AgentJoinOptions?,
         forceErrorCode: Int?
     ) async throws -> ConvosAPI.AgentJoinResponse {
-        try await base.requestAgentJoin(
-            slug: slug,
+        try await base.addAgentToConversation(
+            conversationId: conversationId,
             templateId: templateId,
             options: options,
             forceErrorCode: forceErrorCode


### PR DESCRIPTION
## Summary

Revert of the temporary revert (#1045) — the content of #1033 **plus one fix found by manual testing on the dev stack**: `ConversationMetadataWriter.addMembers` now upserts the `member` parent row before inserting `conversation_members`. A directly-added inbox (a freshly provisioned agent) has never been seen locally, so the previous insert hit `SQLite error 19: FOREIGN KEY constraint failed` — the invite flow never exercised this path because members always arrived via the stream, profile first. (Server side confirmed working in the same test: the agent provisioned, attached via the group welcome, and reached `ready` on dev.) A regression test (`DirectAddMemberPersistenceTests`) pins the fix — verified red without the upsert, green with it.

**⛔ Do not merge until the server chain is promoted to prod** (Herald → assistants worker → backend, in that order). `testflight-prod.yml` builds every push to `dev`, so merging early puts a build on the prod TestFlight track whose agent add/spawn flows 400 against the prod backend. Draft status is the merge gate; flip to ready once prod promotion is done. Note: prod Herald already has the attach endpoint (#109 merged to `main`, which deploys the prod pool — see herald-lite#111 for the dev-pool catch-up).

The dev stack runs the full chain, so dev builds exercise this flow today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace slug-based agent join with direct-add by conversationId across agent and conversation flows
> - Replaces `session.requestAgentJoin(slug:)` with `session.addAgentToConversation(conversationId:)` in `AgentBuilderViewModel`, `ConversationViewModel`, and `SessionManagerProtocol`, removing all slug derivation and empty-slug guards.
> - `SessionManager.addAgentToConversation` provisions an agent via the join API, polls `getAgentJoinStatus` until an `inboxId` appears or a terminal state/timeout occurs, then adds the inbox to the conversation with retries.
> - Adds `AgentProvisionStatus` enum and `AgentJoinStatusResponse` model for typed consumption of poll responses, plus `ConvosAPIClient.getAgentJoinStatus` for the new polling endpoint.
> - Fixes a foreign-key violation in `ConversationMetadataWriter.addMembers` by inserting the parent `DBMember` row before persisting membership for never-before-seen inboxes.
> - Risk: join attempts that previously short-circuited on a missing slug now always proceed, and the full provision+poll cycle runs synchronously before the builder bundle is published.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 381a125.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->
