### PR TITLE
feat(connections): push per-agent consent grants to the backend

### DIFF
--- a/ConvosCore/Sources/ConvosCore/API/CloudConnectionsAPI.swift
+++ b/ConvosCore/Sources/ConvosCore/API/CloudConnectionsAPI.swift
@@ -27,4 +27,12 @@ public enum CloudConnectionsAPI {
     public struct ListResponse: Codable, Sendable {
         public let connections: [ConnectionResponse]
     }
+
+    public struct CreateGrantResponse: Codable, Sendable {
+        public let id: String
+
+        public init(id: String) {
+            self.id = id
+        }
+    }
 }

--- a/ConvosCore/Sources/ConvosCore/API/CloudConnectionsAPI.swift
+++ b/ConvosCore/Sources/ConvosCore/API/CloudConnectionsAPI.swift
@@ -35,4 +35,12 @@ public enum CloudConnectionsAPI {
             self.id = id
         }
     }
+
+    public struct RevokeGrantResponse: Codable, Sendable {
+        public let revoked: Int
+
+        public init(revoked: Int) {
+            self.revoked = revoked
+        }
+    }
 }

--- a/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift
+++ b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift
@@ -126,11 +126,17 @@ public protocol ConvosAPIClientProtocol: AnyObject, Sendable {
     /// the push the agent gets 403. Re-posting the same (owner, grantee,
     /// conversation, toolkit) tuple upserts (also un-revokes) and returns the
     /// same id.
+    ///
+    /// `actions` lists the Composio action slugs the grant authorizes. An empty
+    /// array is whole-toolkit access (the backend's fallback): the agent may
+    /// call any action on the toolkit. Pass the user-approved action slugs to
+    /// scope the grant; pass `[]` only when no per-action scope is available.
     func createConnectionGrant(
         ownerInboxId: String,
         granteeInboxId: String,
         conversationId: String,
         toolkit: String,
+        actions: [String],
         connectionId: String?
     ) async throws -> CloudConnectionsAPI.CreateGrantResponse
 
@@ -138,6 +144,18 @@ public protocol ConvosAPIClientProtocol: AnyObject, Sendable {
     /// `createConnectionGrant`. The backend returns 404 for unknown or
     /// not-owned ids; that surfaces here as an error the caller can log.
     func revokeConnectionGrant(id: String) async throws
+
+    /// Revokes the caller's own grants by natural key. Reliable even when no
+    /// backend grant id was stored locally (the by-id path can't run then).
+    /// `toolkit` alone revokes every grant for that connection (full
+    /// disconnect); adding `conversationId` scopes to one conversation; adding
+    /// `granteeInboxId` scopes to a single agent. Returns the number revoked.
+    @discardableResult
+    func revokeConnectionGrantByNaturalKey(
+        toolkit: String,
+        conversationId: String?,
+        granteeInboxId: String?
+    ) async throws -> Int
 
     // IAP credits + subscriptions
     func getCreditBalance() async throws -> CreditBalance
@@ -868,6 +886,7 @@ final class ConvosAPIClient: ConvosAPIClientProtocol, Sendable {
         granteeInboxId: String,
         conversationId: String,
         toolkit: String,
+        actions: [String],
         connectionId: String?
     ) async throws -> CloudConnectionsAPI.CreateGrantResponse {
         var request = try authenticatedRequest(for: "v2/connections/grants", method: "POST")
@@ -878,6 +897,7 @@ final class ConvosAPIClient: ConvosAPIClientProtocol, Sendable {
             let granteeInboxId: String
             let conversationId: String
             let toolkit: String
+            let actions: [String]
             let connectionId: String?
         }
         request.httpBody = try JSONEncoder().encode(
@@ -886,6 +906,7 @@ final class ConvosAPIClient: ConvosAPIClientProtocol, Sendable {
                 granteeInboxId: granteeInboxId,
                 conversationId: conversationId,
                 toolkit: toolkit,
+                actions: actions,
                 connectionId: connectionId
             )
         )
@@ -896,6 +917,32 @@ final class ConvosAPIClient: ConvosAPIClientProtocol, Sendable {
     func revokeConnectionGrant(id: String) async throws {
         let request = try authenticatedRequest(for: "v2/connections/grants/\(id)", method: "DELETE")
         let _: EmptyResponse = try await performRequest(request)
+    }
+
+    @discardableResult
+    func revokeConnectionGrantByNaturalKey(
+        toolkit: String,
+        conversationId: String?,
+        granteeInboxId: String?
+    ) async throws -> Int {
+        var request = try authenticatedRequest(for: "v2/connections/grants/revoke", method: "POST")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        struct RevokeBody: Codable {
+            let toolkit: String
+            let conversationId: String?
+            let granteeInboxId: String?
+        }
+        request.httpBody = try JSONEncoder().encode(
+            RevokeBody(
+                toolkit: toolkit,
+                conversationId: conversationId,
+                granteeInboxId: granteeInboxId
+            )
+        )
+
+        let response: CloudConnectionsAPI.RevokeGrantResponse = try await performRequest(request)
+        return response.revoked
     }
 
     // MARK: - IAP Credits + Subscriptions

--- a/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift
+++ b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift
@@ -121,6 +121,24 @@ public protocol ConvosAPIClientProtocol: AnyObject, Sendable {
     func listCloudConnections() async throws -> [CloudConnectionsAPI.ConnectionResponse]
     func revokeCloudConnection(connectionId: String) async throws
 
+    /// Pushes one per-agent consent record to the backend grant store. The
+    /// backend uses these records to authorize agent tool execution; without
+    /// the push the agent gets 403. Re-posting the same (owner, grantee,
+    /// conversation, toolkit) tuple upserts (also un-revokes) and returns the
+    /// same id.
+    func createConnectionGrant(
+        ownerInboxId: String,
+        granteeInboxId: String,
+        conversationId: String,
+        toolkit: String,
+        connectionId: String?
+    ) async throws -> CloudConnectionsAPI.CreateGrantResponse
+
+    /// Revokes a backend consent record previously created by
+    /// `createConnectionGrant`. The backend returns 404 for unknown or
+    /// not-owned ids; that surfaces here as an error the caller can log.
+    func revokeConnectionGrant(id: String) async throws
+
     // IAP credits + subscriptions
     func getCreditBalance() async throws -> CreditBalance
     func getSubscription() async throws -> UserSubscription?
@@ -842,6 +860,41 @@ final class ConvosAPIClient: ConvosAPIClientProtocol, Sendable {
 
     func revokeCloudConnection(connectionId: String) async throws {
         let request = try authenticatedRequest(for: "v2/connections/\(connectionId)", method: "DELETE")
+        let _: EmptyResponse = try await performRequest(request)
+    }
+
+    func createConnectionGrant(
+        ownerInboxId: String,
+        granteeInboxId: String,
+        conversationId: String,
+        toolkit: String,
+        connectionId: String?
+    ) async throws -> CloudConnectionsAPI.CreateGrantResponse {
+        var request = try authenticatedRequest(for: "v2/connections/grants", method: "POST")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        struct GrantBody: Codable {
+            let ownerInboxId: String
+            let granteeInboxId: String
+            let conversationId: String
+            let toolkit: String
+            let connectionId: String?
+        }
+        request.httpBody = try JSONEncoder().encode(
+            GrantBody(
+                ownerInboxId: ownerInboxId,
+                granteeInboxId: granteeInboxId,
+                conversationId: conversationId,
+                toolkit: toolkit,
+                connectionId: connectionId
+            )
+        )
+
+        return try await performRequest(request)
+    }
+
+    func revokeConnectionGrant(id: String) async throws {
+        let request = try authenticatedRequest(for: "v2/connections/grants/\(id)", method: "DELETE")
         let _: EmptyResponse = try await performRequest(request)
     }
 

--- a/ConvosCore/Sources/ConvosCore/API/MockAPIClient.swift
+++ b/ConvosCore/Sources/ConvosCore/API/MockAPIClient.swift
@@ -165,12 +165,21 @@ final class MockAPIClient: ConvosAPIClientProtocol, Sendable {
         granteeInboxId: String,
         conversationId: String,
         toolkit: String,
+        actions: [String],
         connectionId: String?
     ) async throws -> CloudConnectionsAPI.CreateGrantResponse {
         .init(id: "mock-grant-\(UUID().uuidString)")
     }
 
     func revokeConnectionGrant(id: String) async throws {}
+
+    func revokeConnectionGrantByNaturalKey(
+        toolkit: String,
+        conversationId: String?,
+        granteeInboxId: String?
+    ) async throws -> Int {
+        0
+    }
 
     func getCreditBalance() async throws -> CreditBalance {
         CreditBalance(

--- a/ConvosCore/Sources/ConvosCore/API/MockAPIClient.swift
+++ b/ConvosCore/Sources/ConvosCore/API/MockAPIClient.swift
@@ -160,6 +160,18 @@ final class MockAPIClient: ConvosAPIClientProtocol, Sendable {
 
     func revokeCloudConnection(connectionId: String) async throws {}
 
+    func createConnectionGrant(
+        ownerInboxId: String,
+        granteeInboxId: String,
+        conversationId: String,
+        toolkit: String,
+        connectionId: String?
+    ) async throws -> CloudConnectionsAPI.CreateGrantResponse {
+        .init(id: "mock-grant-\(UUID().uuidString)")
+    }
+
+    func revokeConnectionGrant(id: String) async throws {}
+
     func getCreditBalance() async throws -> CreditBalance {
         CreditBalance(
             balance: 0,

--- a/ConvosCore/Sources/ConvosCore/CloudConnections/CloudConnectionGrantWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/CloudConnections/CloudConnectionGrantWriter.swift
@@ -72,6 +72,8 @@ final class CloudConnectionGrantWriter: CloudConnectionGrantWriterProtocol, @unc
         try await databaseWriter.write { db in
             try grant.save(db)
         }
+
+        await pushGrantToBackend(grant, connection: connection)
     }
 
     func revokeGrant(
@@ -91,7 +93,7 @@ final class CloudConnectionGrantWriter: CloudConnectionGrantWriterProtocol, @unc
                 )
                 .fetchOne(db)
         }
-        guard existing != nil else {
+        guard let existing else {
             // Nothing to revoke, no-op.
             return
         }
@@ -114,6 +116,62 @@ final class CloudConnectionGrantWriter: CloudConnectionGrantWriterProtocol, @unc
                         && DBCloudConnectionGrant.Columns.grantedToInboxId == grantedToInboxId
                 )
                 .deleteAll(db)
+        }
+
+        if let backendGrantId = existing.backendGrantId {
+            await revokeBackendGrant(backendGrantId, for: existing)
+        }
+    }
+
+    /// Pushes one per-agent consent record to the backend grant store and
+    /// remembers the returned id on the local row so revocation can target it.
+    /// Best-effort with no retry: on failure the local grant stands, but the
+    /// backend will deny the agent's tool execution (403) until the user
+    /// re-grants, so the failure is logged at error level.
+    private func pushGrantToBackend(_ grant: DBCloudConnectionGrant, connection: DBCloudConnection) async {
+        do {
+            let inboxReady = try await sessionStateManager.waitForInboxReadyResult()
+            let response = try await inboxReady.apiClient.createConnectionGrant(
+                ownerInboxId: inboxReady.client.inboxId,
+                granteeInboxId: grant.grantedToInboxId,
+                conversationId: grant.conversationId,
+                toolkit: connection.serviceId,
+                connectionId: connection.composioConnectionId
+            )
+            let updated = DBCloudConnectionGrant(
+                connectionId: grant.connectionId,
+                conversationId: grant.conversationId,
+                serviceId: grant.serviceId,
+                grantedToInboxId: grant.grantedToInboxId,
+                grantedAt: grant.grantedAt,
+                backendGrantId: response.id
+            )
+            try await databaseWriter.write { db in
+                try updated.save(db)
+            }
+        } catch {
+            Log.error(
+                "[CloudConnections] backend grant push failed; agent will get 403 from backend-mediated " +
+                "execution until the user re-grants (connectionId=\(grant.connectionId), " +
+                "conversationId=\(grant.conversationId), grantedToInboxId=\(grant.grantedToInboxId)): " +
+                error.localizedDescription
+            )
+        }
+    }
+
+    /// Revokes the backend consent record for a grant that was just removed
+    /// locally. Best-effort: a failure is logged and not retried; the backend
+    /// connection-level revoke (disconnect) independently cuts off execution.
+    private func revokeBackendGrant(_ backendGrantId: String, for grant: DBCloudConnectionGrant) async {
+        do {
+            let inboxReady = try await sessionStateManager.waitForInboxReadyResult()
+            try await inboxReady.apiClient.revokeConnectionGrant(id: backendGrantId)
+        } catch {
+            Log.warning(
+                "[CloudConnections] backend grant revoke failed (backendGrantId=\(backendGrantId), " +
+                "connectionId=\(grant.connectionId), conversationId=\(grant.conversationId), " +
+                "grantedToInboxId=\(grant.grantedToInboxId)): \(error.localizedDescription)"
+            )
         }
     }
 

--- a/ConvosCore/Sources/ConvosCore/CloudConnections/CloudConnectionGrantWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/CloudConnections/CloudConnectionGrantWriter.swift
@@ -118,9 +118,7 @@ final class CloudConnectionGrantWriter: CloudConnectionGrantWriterProtocol, @unc
                 .deleteAll(db)
         }
 
-        if let backendGrantId = existing.backendGrantId {
-            await revokeBackendGrant(backendGrantId, for: existing)
-        }
+        await revokeBackendGrant(for: existing)
     }
 
     /// Pushes one per-agent consent record to the backend grant store and
@@ -131,11 +129,26 @@ final class CloudConnectionGrantWriter: CloudConnectionGrantWriterProtocol, @unc
     private func pushGrantToBackend(_ grant: DBCloudConnectionGrant, connection: DBCloudConnection) async {
         do {
             let inboxReady = try await sessionStateManager.waitForInboxReadyResult()
+            // `actions` would scope the grant to specific Composio action slugs
+            // (e.g. "GOOGLECALENDAR_CREATE_EVENT"). iOS has no source of those
+            // slugs at grant time: the consent model only carries a coarse
+            // verb set (read / write_*), and CapabilityRequestResult.availableActions
+            // holds device-action names, not Composio slugs. Until a
+            // capability->Composio-action mapping exists, every grant is
+            // whole-toolkit (empty actions). Logged so the scoping gap is visible
+            // rather than silently implied.
+            let actions: [String] = []
+            Log.warning(
+                "[CloudConnections] pushing whole-toolkit grant (no per-action scope available): " +
+                "toolkit=\(connection.serviceId), conversationId=\(grant.conversationId), " +
+                "grantedToInboxId=\(grant.grantedToInboxId)"
+            )
             let response = try await inboxReady.apiClient.createConnectionGrant(
                 ownerInboxId: inboxReady.client.inboxId,
                 granteeInboxId: grant.grantedToInboxId,
                 conversationId: grant.conversationId,
                 toolkit: connection.serviceId,
+                actions: actions,
                 connectionId: connection.composioConnectionId
             )
             let updated = DBCloudConnectionGrant(
@@ -160,17 +173,25 @@ final class CloudConnectionGrantWriter: CloudConnectionGrantWriterProtocol, @unc
     }
 
     /// Revokes the backend consent record for a grant that was just removed
-    /// locally. Best-effort: a failure is logged and not retried; the backend
-    /// connection-level revoke (disconnect) independently cuts off execution.
-    private func revokeBackendGrant(_ backendGrantId: String, for grant: DBCloudConnectionGrant) async {
+    /// locally. Uses the natural-key revoke (toolkit, conversation, grantee) so
+    /// it succeeds even when no backendGrantId was stored (the by-id path can't
+    /// run for those rows). Best-effort: a failure is logged and not retried;
+    /// the backend connection-level revoke (disconnect) independently cuts off
+    /// execution.
+    private func revokeBackendGrant(for grant: DBCloudConnectionGrant) async {
         do {
             let inboxReady = try await sessionStateManager.waitForInboxReadyResult()
-            try await inboxReady.apiClient.revokeConnectionGrant(id: backendGrantId)
+            try await inboxReady.apiClient.revokeConnectionGrantByNaturalKey(
+                toolkit: grant.serviceId,
+                conversationId: grant.conversationId,
+                granteeInboxId: grant.grantedToInboxId
+            )
         } catch {
             Log.warning(
-                "[CloudConnections] backend grant revoke failed (backendGrantId=\(backendGrantId), " +
-                "connectionId=\(grant.connectionId), conversationId=\(grant.conversationId), " +
-                "grantedToInboxId=\(grant.grantedToInboxId)): \(error.localizedDescription)"
+                "[CloudConnections] backend grant revoke failed " +
+                "(toolkit=\(grant.serviceId), connectionId=\(grant.connectionId), " +
+                "conversationId=\(grant.conversationId), grantedToInboxId=\(grant.grantedToInboxId)): " +
+                error.localizedDescription
             )
         }
     }

--- a/ConvosCore/Sources/ConvosCore/CloudConnections/CloudConnectionManager.swift
+++ b/ConvosCore/Sources/ConvosCore/CloudConnections/CloudConnectionManager.swift
@@ -226,6 +226,10 @@ public final class CloudConnectionManager: CloudConnectionManagerProtocol, @unch
                 "[CloudConnections] \(context) had no grant writer injected; metadata for " +
                 "\(conversationCount) conversation(s) will remain stale until the next grant/revoke"
             )
+            // The writer normally revokes the backend consent records as part of
+            // revokeGrant; with no writer injected that path can't run, so revoke
+            // them directly to keep the backend grant store in sync.
+            await revokeBackendGrants(grants, context: context)
             return
         }
         for grant in grants {
@@ -240,6 +244,30 @@ public final class CloudConnectionManager: CloudConnectionManagerProtocol, @unch
                     "[CloudConnections] failed to republish grants \(context) " +
                     "(connectionId=\(grant.connectionId), conversationId=\(grant.conversationId), " +
                     "grantedToInboxId=\(grant.grantedToInboxId)): \(error.localizedDescription)"
+                )
+                // The writer only revokes the backend record after a successful
+                // metadata publish, so a throw here means the backend grant
+                // survived. Revoke it directly; the row is about to be cascade-
+                // deleted with the connection, taking the stored id with it.
+                await revokeBackendGrants([grant], context: context)
+            }
+        }
+    }
+
+    /// Directly revokes the backend consent records for grants whose normal
+    /// writer-mediated revocation didn't run. Best-effort: failures are logged
+    /// and never propagate; the connection-level backend revoke independently
+    /// cuts off agent execution.
+    private func revokeBackendGrants(_ grants: [DBCloudConnectionGrant], context: String) async {
+        for grant in grants {
+            guard let backendGrantId = grant.backendGrantId else { continue }
+            do {
+                try await apiClient.revokeConnectionGrant(id: backendGrantId)
+            } catch {
+                Log.warning(
+                    "[CloudConnections] failed to revoke backend grant \(context) " +
+                    "(backendGrantId=\(backendGrantId), connectionId=\(grant.connectionId), " +
+                    "conversationId=\(grant.conversationId)): \(error.localizedDescription)"
                 )
             }
         }

--- a/ConvosCore/Sources/ConvosCore/CloudConnections/CloudConnectionManager.swift
+++ b/ConvosCore/Sources/ConvosCore/CloudConnections/CloudConnectionManager.swift
@@ -255,19 +255,25 @@ public final class CloudConnectionManager: CloudConnectionManagerProtocol, @unch
     }
 
     /// Directly revokes the backend consent records for grants whose normal
-    /// writer-mediated revocation didn't run. Best-effort: failures are logged
-    /// and never propagate; the connection-level backend revoke independently
-    /// cuts off agent execution.
+    /// writer-mediated revocation didn't run. Uses the natural-key revoke so it
+    /// works even for rows that never stored a backendGrantId (push failed or
+    /// hadn't happened). Best-effort: failures are logged and never propagate;
+    /// the connection-level backend revoke independently cuts off agent
+    /// execution.
     private func revokeBackendGrants(_ grants: [DBCloudConnectionGrant], context: String) async {
         for grant in grants {
-            guard let backendGrantId = grant.backendGrantId else { continue }
             do {
-                try await apiClient.revokeConnectionGrant(id: backendGrantId)
+                try await apiClient.revokeConnectionGrantByNaturalKey(
+                    toolkit: grant.serviceId,
+                    conversationId: grant.conversationId,
+                    granteeInboxId: grant.grantedToInboxId
+                )
             } catch {
                 Log.warning(
                     "[CloudConnections] failed to revoke backend grant \(context) " +
-                    "(backendGrantId=\(backendGrantId), connectionId=\(grant.connectionId), " +
-                    "conversationId=\(grant.conversationId)): \(error.localizedDescription)"
+                    "(toolkit=\(grant.serviceId), connectionId=\(grant.connectionId), " +
+                    "conversationId=\(grant.conversationId), grantedToInboxId=\(grant.grantedToInboxId)): " +
+                    error.localizedDescription
                 )
             }
         }

--- a/ConvosCore/Sources/ConvosCore/Storage/Database Models/DBCloudConnectionGrant.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Database Models/DBCloudConnectionGrant.swift
@@ -10,6 +10,7 @@ struct DBCloudConnectionGrant: Codable, FetchableRecord, PersistableRecord, Hash
         static let serviceId: Column = Column(CodingKeys.serviceId)
         static let grantedToInboxId: Column = Column(CodingKeys.grantedToInboxId)
         static let grantedAt: Column = Column(CodingKeys.grantedAt)
+        static let backendGrantId: Column = Column(CodingKeys.backendGrantId)
     }
 
     let connectionId: String
@@ -17,6 +18,26 @@ struct DBCloudConnectionGrant: Codable, FetchableRecord, PersistableRecord, Hash
     let serviceId: String
     let grantedToInboxId: String
     let grantedAt: Date
+    /// Id of the backend ConnectionGrant record created when this grant was
+    /// pushed to the server. Nil when the push hasn't happened or failed;
+    /// backend revocation is skipped for those rows.
+    let backendGrantId: String?
+
+    init(
+        connectionId: String,
+        conversationId: String,
+        serviceId: String,
+        grantedToInboxId: String,
+        grantedAt: Date,
+        backendGrantId: String? = nil
+    ) {
+        self.connectionId = connectionId
+        self.conversationId = conversationId
+        self.serviceId = serviceId
+        self.grantedToInboxId = grantedToInboxId
+        self.grantedAt = grantedAt
+        self.backendGrantId = backendGrantId
+    }
 }
 
 extension DBCloudConnectionGrant {
@@ -36,5 +57,6 @@ extension DBCloudConnectionGrant {
         self.serviceId = grant.serviceId
         self.grantedToInboxId = grant.grantedToInboxId
         self.grantedAt = grant.grantedAt
+        self.backendGrantId = nil
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Storage/SharedDatabaseMigrator.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/SharedDatabaseMigrator.swift
@@ -196,10 +196,8 @@ extension SharedDatabaseMigrator {
             }
         }
 
-        migrator.registerMigration(
-            "backfillContactAgentTemplateFieldsFromMemberProfiles",
-            migrate: Self.backfillContactAgentTemplateFieldsFromMemberProfiles
-        )
+        migrator.registerMigration("backfillContactAgentTemplateFieldsFromMemberProfiles",
+                                   migrate: Self.backfillContactAgentTemplateFieldsFromMemberProfiles)
 
         migrator.registerMigration("addAgentTemplateDescriptionAndSlug", migrate: Self.addAgentTemplateDescriptionAndSlug)
 

--- a/ConvosCore/Sources/ConvosCore/Storage/SharedDatabaseMigrator.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/SharedDatabaseMigrator.swift
@@ -205,6 +205,8 @@ extension SharedDatabaseMigrator {
 
         Self.registerRemovedStateMigrations(on: &migrator)
 
+        migrator.registerMigration("addConnectionGrantBackendGrantId", migrate: Self.addConnectionGrantBackendGrantId)
+
         return migrator
     }
 
@@ -424,6 +426,16 @@ extension SharedDatabaseMigrator {
             ON agentTemplate(slug)
             WHERE slug IS NOT NULL
             """)
+    }
+
+    /// Id of the backend ConnectionGrant record (POST /v2/connections/grants)
+    /// created when a local grant is pushed to the server. Nullable: rows
+    /// that predate the backend push, or whose push failed, have no backend
+    /// id and are skipped during backend revocation.
+    private static func addConnectionGrantBackendGrantId(_ db: Database) throws {
+        try db.alter(table: "connectionGrant") { t in
+            t.add(column: "backendGrantId", .text)
+        }
     }
 
     /// Rename `conversation.hasHadVerifiedAssistant` -> `hasHadVerifiedAgent`

--- a/ConvosCore/Tests/ConvosCoreTests/ConnectionGrantWriterTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ConnectionGrantWriterTests.swift
@@ -20,11 +20,11 @@ struct ConnectionGrantWriterTests {
         let profileWriter: MockMyProfileWriter
         let writer: CloudConnectionGrantWriter
 
-        init(inboxId: String = "mock-inbox-id") {
+        init(inboxId: String = "mock-inbox-id", apiClient: (any ConvosAPIClientProtocol)? = nil) {
             let databaseManager = MockDatabaseManager.makeTestDatabase()
             let profileWriter = MockMyProfileWriter()
             let mockClient = MockXMTPClientProvider(inboxId: inboxId)
-            let sessionStateManager = MockSessionStateManager(mockClient: mockClient)
+            let sessionStateManager = MockSessionStateManager(mockClient: mockClient, mockAPIClient: apiClient)
             self.databaseManager = databaseManager
             self.sessionStateManager = sessionStateManager
             self.profileWriter = profileWriter
@@ -91,14 +91,16 @@ struct ConnectionGrantWriterTests {
             connectionId: String,
             conversationId: String,
             serviceId: String,
-            grantedToInboxId: String = "agent-1"
+            grantedToInboxId: String = "agent-1",
+            backendGrantId: String? = nil
         ) throws {
             let grant = DBCloudConnectionGrant(
                 connectionId: connectionId,
                 conversationId: conversationId,
                 serviceId: serviceId,
                 grantedToInboxId: grantedToInboxId,
-                grantedAt: Date()
+                grantedAt: Date(),
+                backendGrantId: backendGrantId
             )
             try databaseManager.dbWriter.write { db in
                 try grant.save(db)
@@ -306,5 +308,131 @@ struct ConnectionGrantWriterTests {
         #expect(payload.grants.count == 2)
         let serviceIds = Set(payload.grants.map(\.service))
         #expect(serviceIds == ["googlecalendar", "googledrive"])
+    }
+
+    // MARK: - Backend grant push
+
+    @Test("Grant: pushes one backend consent record and stores the returned id")
+    func grantPushesBackendGrantAndStoresId() async throws {
+        let recordingClient = RecordingGrantAPIClient()
+        let fixture = Fixture(apiClient: recordingClient)
+        defer { fixture.cleanup() }
+
+        let connection = try fixture.seedConnection()
+        let conversationId = "conv_backend"
+        try fixture.seedConversation(id: conversationId)
+
+        try await fixture.writer.grantConnection(connection.id, to: conversationId, grantedToInboxId: "agent-1")
+
+        #expect(recordingClient.createCalls.count == 1)
+        let call = try #require(recordingClient.createCalls.first)
+        #expect(call.ownerInboxId == "mock-inbox-id")
+        #expect(call.granteeInboxId == "agent-1")
+        #expect(call.conversationId == conversationId)
+        #expect(call.toolkit == connection.serviceId)
+        #expect(call.connectionId == connection.composioConnectionId)
+
+        let stored = try fixture.storedGrants(for: conversationId)
+        #expect(stored.first?.backendGrantId == "backend-grant-1")
+    }
+
+    @Test("Grant: backend push failure keeps the local grant with a nil backend id")
+    func grantSurvivesBackendPushFailure() async throws {
+        let recordingClient = RecordingGrantAPIClient()
+        struct PushFailure: Error {}
+        recordingClient.createError = PushFailure()
+        let fixture = Fixture(apiClient: recordingClient)
+        defer { fixture.cleanup() }
+
+        let connection = try fixture.seedConnection()
+        let conversationId = "conv_backend_fail"
+        try fixture.seedConversation(id: conversationId)
+
+        try await fixture.writer.grantConnection(connection.id, to: conversationId, grantedToInboxId: "agent-1")
+
+        let stored = try fixture.storedGrants(for: conversationId)
+        #expect(stored.count == 1, "local grant should stand when the backend push fails")
+        #expect(stored.first?.backendGrantId == nil)
+    }
+
+    @Test("Revoke: revokes the backend consent record when an id is stored")
+    func revokeRevokesBackendGrant() async throws {
+        let recordingClient = RecordingGrantAPIClient()
+        let fixture = Fixture(apiClient: recordingClient)
+        defer { fixture.cleanup() }
+
+        let connection = try fixture.seedConnection()
+        let conversationId = "conv_backend_rev"
+        try fixture.seedConversation(id: conversationId)
+        try fixture.seedGrant(
+            connectionId: connection.id,
+            conversationId: conversationId,
+            serviceId: connection.serviceId,
+            backendGrantId: "backend-grant-42"
+        )
+
+        try await fixture.writer.revokeGrant(connectionId: connection.id, from: conversationId, grantedToInboxId: "agent-1")
+
+        #expect(recordingClient.revokeCalls == ["backend-grant-42"])
+    }
+
+    @Test("Revoke: skips the backend call when no backend id is stored")
+    func revokeSkipsBackendWithoutId() async throws {
+        let recordingClient = RecordingGrantAPIClient()
+        let fixture = Fixture(apiClient: recordingClient)
+        defer { fixture.cleanup() }
+
+        let connection = try fixture.seedConnection()
+        let conversationId = "conv_backend_skip"
+        try fixture.seedConversation(id: conversationId)
+        try fixture.seedGrant(
+            connectionId: connection.id,
+            conversationId: conversationId,
+            serviceId: connection.serviceId
+        )
+
+        try await fixture.writer.revokeGrant(connectionId: connection.id, from: conversationId, grantedToInboxId: "agent-1")
+
+        #expect(recordingClient.revokeCalls.isEmpty)
+    }
+}
+
+/// Records backend grant push/revoke calls made by `CloudConnectionGrantWriter`
+/// so tests can assert the consent records sent to the server.
+private final class RecordingGrantAPIClient: TestStubAPIClient {
+    struct CreateCall: Sendable {
+        let ownerInboxId: String
+        let granteeInboxId: String
+        let conversationId: String
+        let toolkit: String
+        let connectionId: String?
+    }
+
+    var createCalls: [CreateCall] = []
+    var revokeCalls: [String] = []
+    var createError: Error?
+
+    override func createConnectionGrant(
+        ownerInboxId: String,
+        granteeInboxId: String,
+        conversationId: String,
+        toolkit: String,
+        connectionId: String?
+    ) async throws -> CloudConnectionsAPI.CreateGrantResponse {
+        if let createError {
+            throw createError
+        }
+        createCalls.append(CreateCall(
+            ownerInboxId: ownerInboxId,
+            granteeInboxId: granteeInboxId,
+            conversationId: conversationId,
+            toolkit: toolkit,
+            connectionId: connectionId
+        ))
+        return CloudConnectionsAPI.CreateGrantResponse(id: "backend-grant-\(createCalls.count)")
+    }
+
+    override func revokeConnectionGrant(id: String) async throws {
+        revokeCalls.append(id)
     }
 }

--- a/ConvosCore/Tests/ConvosCoreTests/ConnectionGrantWriterTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ConnectionGrantWriterTests.swift
@@ -331,6 +331,9 @@ struct ConnectionGrantWriterTests {
         #expect(call.conversationId == conversationId)
         #expect(call.toolkit == connection.serviceId)
         #expect(call.connectionId == connection.composioConnectionId)
+        // No per-action scope is available at grant time, so the writer sends an
+        // empty actions array and the backend treats the grant as whole-toolkit.
+        #expect(call.actions.isEmpty)
 
         let stored = try fixture.storedGrants(for: conversationId)
         #expect(stored.first?.backendGrantId == "backend-grant-1")
@@ -355,7 +358,7 @@ struct ConnectionGrantWriterTests {
         #expect(stored.first?.backendGrantId == nil)
     }
 
-    @Test("Revoke: revokes the backend consent record when an id is stored")
+    @Test("Revoke: revokes the backend grant by natural key when a backend id is stored")
     func revokeRevokesBackendGrant() async throws {
         let recordingClient = RecordingGrantAPIClient()
         let fixture = Fixture(apiClient: recordingClient)
@@ -373,17 +376,22 @@ struct ConnectionGrantWriterTests {
 
         try await fixture.writer.revokeGrant(connectionId: connection.id, from: conversationId, grantedToInboxId: "agent-1")
 
-        #expect(recordingClient.revokeCalls == ["backend-grant-42"])
+        // The natural-key revoke is the primary path; the unreliable by-id DELETE
+        // is no longer used.
+        #expect(recordingClient.revokeCalls.isEmpty)
+        #expect(recordingClient.naturalKeyRevokeCalls == [
+            .init(toolkit: connection.serviceId, conversationId: conversationId, granteeInboxId: "agent-1"),
+        ])
     }
 
-    @Test("Revoke: skips the backend call when no backend id is stored")
-    func revokeSkipsBackendWithoutId() async throws {
+    @Test("Revoke: still revokes the backend grant by natural key when no backend id is stored")
+    func revokeUsesNaturalKeyWithoutStoredId() async throws {
         let recordingClient = RecordingGrantAPIClient()
         let fixture = Fixture(apiClient: recordingClient)
         defer { fixture.cleanup() }
 
         let connection = try fixture.seedConnection()
-        let conversationId = "conv_backend_skip"
+        let conversationId = "conv_backend_natural"
         try fixture.seedConversation(id: conversationId)
         try fixture.seedGrant(
             connectionId: connection.id,
@@ -393,7 +401,12 @@ struct ConnectionGrantWriterTests {
 
         try await fixture.writer.revokeGrant(connectionId: connection.id, from: conversationId, grantedToInboxId: "agent-1")
 
+        // Natural-key revoke succeeds even though no backendGrantId was ever
+        // stored -- this is the reliability fix over the by-id DELETE.
         #expect(recordingClient.revokeCalls.isEmpty)
+        #expect(recordingClient.naturalKeyRevokeCalls == [
+            .init(toolkit: connection.serviceId, conversationId: conversationId, granteeInboxId: "agent-1"),
+        ])
     }
 }
 
@@ -405,11 +418,19 @@ private final class RecordingGrantAPIClient: TestStubAPIClient {
         let granteeInboxId: String
         let conversationId: String
         let toolkit: String
+        let actions: [String]
         let connectionId: String?
+    }
+
+    struct NaturalKeyRevokeCall: Sendable, Equatable {
+        let toolkit: String
+        let conversationId: String?
+        let granteeInboxId: String?
     }
 
     var createCalls: [CreateCall] = []
     var revokeCalls: [String] = []
+    var naturalKeyRevokeCalls: [NaturalKeyRevokeCall] = []
     var createError: Error?
 
     override func createConnectionGrant(
@@ -417,6 +438,7 @@ private final class RecordingGrantAPIClient: TestStubAPIClient {
         granteeInboxId: String,
         conversationId: String,
         toolkit: String,
+        actions: [String],
         connectionId: String?
     ) async throws -> CloudConnectionsAPI.CreateGrantResponse {
         if let createError {
@@ -427,6 +449,7 @@ private final class RecordingGrantAPIClient: TestStubAPIClient {
             granteeInboxId: granteeInboxId,
             conversationId: conversationId,
             toolkit: toolkit,
+            actions: actions,
             connectionId: connectionId
         ))
         return CloudConnectionsAPI.CreateGrantResponse(id: "backend-grant-\(createCalls.count)")
@@ -434,5 +457,18 @@ private final class RecordingGrantAPIClient: TestStubAPIClient {
 
     override func revokeConnectionGrant(id: String) async throws {
         revokeCalls.append(id)
+    }
+
+    override func revokeConnectionGrantByNaturalKey(
+        toolkit: String,
+        conversationId: String?,
+        granteeInboxId: String?
+    ) async throws -> Int {
+        naturalKeyRevokeCalls.append(NaturalKeyRevokeCall(
+            toolkit: toolkit,
+            conversationId: conversationId,
+            granteeInboxId: granteeInboxId
+        ))
+        return 1
     }
 }

--- a/ConvosCore/Tests/ConvosCoreTests/TestStubAPIClientDefaults.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/TestStubAPIClientDefaults.swift
@@ -85,6 +85,21 @@ extension ConvosAPIClientProtocol {
     func getFeaturedAgentTemplates(limit: Int, cursor: String?) async throws -> ConvosAPI.AgentTemplatesPage {
         ConvosAPI.AgentTemplatesPage(data: [], hasMore: false, nextCursor: nil)
     }
+
+    /// Defaults for the backend connection-grant push so pre-existing fixtures
+    /// don't have to re-stub them. Tests that exercise the push specifically
+    /// should override on their fixture.
+    func createConnectionGrant(
+        ownerInboxId: String,
+        granteeInboxId: String,
+        conversationId: String,
+        toolkit: String,
+        connectionId: String?
+    ) async throws -> CloudConnectionsAPI.CreateGrantResponse {
+        CloudConnectionsAPI.CreateGrantResponse(id: "test-grant-\(UUID().uuidString)")
+    }
+
+    func revokeConnectionGrant(id: String) async throws {}
 }
 
 /// Open, fully-conforming `ConvosAPIClientProtocol` base for test fixtures that
@@ -127,4 +142,18 @@ class TestStubAPIClient: ConvosAPIClientProtocol, @unchecked Sendable {
     func getAgentTemplate(idOrUrlSlug: String) async throws -> ConvosAPI.AgentTemplate {
         ConvosAPI.AgentTemplate(id: UUID().uuidString, status: "published", publishedUrl: nil)
     }
+
+    /// Declared on the base (not just the protocol-extension default) so
+    /// subclasses can `override` them.
+    func createConnectionGrant(
+        ownerInboxId: String,
+        granteeInboxId: String,
+        conversationId: String,
+        toolkit: String,
+        connectionId: String?
+    ) async throws -> CloudConnectionsAPI.CreateGrantResponse {
+        CloudConnectionsAPI.CreateGrantResponse(id: "test-grant-\(UUID().uuidString)")
+    }
+
+    func revokeConnectionGrant(id: String) async throws {}
 }

--- a/ConvosCore/Tests/ConvosCoreTests/TestStubAPIClientDefaults.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/TestStubAPIClientDefaults.swift
@@ -94,12 +94,21 @@ extension ConvosAPIClientProtocol {
         granteeInboxId: String,
         conversationId: String,
         toolkit: String,
+        actions: [String],
         connectionId: String?
     ) async throws -> CloudConnectionsAPI.CreateGrantResponse {
         CloudConnectionsAPI.CreateGrantResponse(id: "test-grant-\(UUID().uuidString)")
     }
 
     func revokeConnectionGrant(id: String) async throws {}
+
+    func revokeConnectionGrantByNaturalKey(
+        toolkit: String,
+        conversationId: String?,
+        granteeInboxId: String?
+    ) async throws -> Int {
+        0
+    }
 }
 
 /// Open, fully-conforming `ConvosAPIClientProtocol` base for test fixtures that
@@ -150,10 +159,19 @@ class TestStubAPIClient: ConvosAPIClientProtocol, @unchecked Sendable {
         granteeInboxId: String,
         conversationId: String,
         toolkit: String,
+        actions: [String],
         connectionId: String?
     ) async throws -> CloudConnectionsAPI.CreateGrantResponse {
         CloudConnectionsAPI.CreateGrantResponse(id: "test-grant-\(UUID().uuidString)")
     }
 
     func revokeConnectionGrant(id: String) async throws {}
+
+    func revokeConnectionGrantByNaturalKey(
+        toolkit: String,
+        conversationId: String?,
+        granteeInboxId: String?
+    ) async throws -> Int {
+        0
+    }
 }


### PR DESCRIPTION
## Summary
- Pushes per-agent connection consent grants to the backend when the user approves a capability request (backend is now the source of truth for what an agent may execute).
- Scopes grant actions and revokes grants by natural key (inboxId + toolkit + agent), matching the backend's reliable-revocation API.

Part 1 of 2 of the connections permission-bundles stack (plan: #869). Part 2 (bundle picker UI) is stacked on this branch.

Backend counterpart: `convos-backend` branch `louis/connections-bundles`.

## Test plan
- Unit tests included for the grant push/revoke paths.
- E2E (agent → backend exec with grant check) verified against the local backend; full calendar round-trip pending one backend fix in review.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1047"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783806638&installation_id=128169237&pr_number=1047&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1047&signature=09da66042e04ba9d6fad78f54eee1099a33a7ce7b530760196ace9c6d9416d10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Push per-agent consent grants to the backend on connection grant and revoke
> - Adds three new API methods to `ConvosAPIClient` (`createConnectionGrant`, `revokeConnectionGrant`, `revokeConnectionGrantByNaturalKey`) backed by new `v2/connections/grants` endpoints.
> - `CloudConnectionGrantWriter` now calls `pushGrantToBackend` after a local grant succeeds and `revokeBackendGrant` after a local revoke; both are best-effort and log failures without blocking the local operation.
> - `CloudConnectionManager` gains a `revokeBackendGrants` fallback that revokes backend consent records when the grant writer is unavailable or fails.
> - Adds a `backendGrantId` column to the `connectionGrant` DB table via a new migration in [SharedDatabaseMigrator.swift](https://github.com/xmtplabs/convos-ios/pull/1047/files#diff-1d28d03ee0fb38381b6052060082c7561fa8ccc71fda470214d763f53a4414df) and persists the returned id after a successful backend push.
> - Risk: if backend grant creation fails, the local grant remains but the backend will deny agent actions until a retry mechanism (not yet implemented) resolves the inconsistency.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 05a3365.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->