### PR TITLE
feat(connections): permission-bundle picker, bundle-scoped grants

### DIFF
--- a/Convos/Capabilities/CapabilityPickerCardView.swift
+++ b/Convos/Capabilities/CapabilityPickerCardView.swift
@@ -12,16 +12,20 @@ import SwiftUI
 struct CapabilityPickerCardView: View {
     let layout: CapabilityPickerLayout
     let agentName: String?
-    let onApprove: (Set<ProviderID>) -> Void
+    /// Approve posts the provider selection plus the permission-bundle toggle
+    /// state (service id → toggled-on bundle ids) for the selected cloud
+    /// providers. Empty map when the catalog had no bundles for them.
+    let onApprove: (Set<ProviderID>, [String: Set<String>]) -> Void
     let onDeny: () -> Void
     let onConnect: (ProviderID) -> Void
 
     @State private var selection: Set<ProviderID>
+    @State private var bundleSelection: [String: Set<String>]
 
     init(
         layout: CapabilityPickerLayout,
         agentName: String? = nil,
-        onApprove: @escaping (Set<ProviderID>) -> Void,
+        onApprove: @escaping (Set<ProviderID>, [String: Set<String>]) -> Void,
         onDeny: @escaping () -> Void,
         onConnect: @escaping (ProviderID) -> Void
     ) {
@@ -31,6 +35,7 @@ struct CapabilityPickerCardView: View {
         self.onDeny = onDeny
         self.onConnect = onConnect
         _selection = State(initialValue: layout.defaultSelection)
+        _bundleSelection = State(initialValue: layout.defaultBundleSelection)
     }
 
     var body: some View {
@@ -48,6 +53,9 @@ struct CapabilityPickerCardView: View {
             // checked.
             .onChange(of: layout.defaultSelection) { _, newValue in
                 selection = newValue
+            }
+            .onChange(of: layout.serviceBundles) { _, _ in
+                bundleSelection = layout.defaultBundleSelection
             }
     }
 
@@ -77,7 +85,8 @@ struct CapabilityPickerCardView: View {
             if let onlyProvider {
                 providerRow(onlyProvider, style: .checkmark(checked: true))
             }
-            actionButtons(approveEnabled: !selection.isEmpty)
+            bundleRowsSection
+            actionButtons(approveEnabled: approveEnabled)
         }
     }
 
@@ -94,7 +103,8 @@ struct CapabilityPickerCardView: View {
                         .onTapGesture { selectSingle(provider) }
                 }
             }
-            actionButtons(approveEnabled: !selection.isEmpty)
+            bundleRowsSection
+            actionButtons(approveEnabled: approveEnabled)
         }
     }
 
@@ -111,7 +121,8 @@ struct CapabilityPickerCardView: View {
                         .onTapGesture { toggleMulti(provider) }
                 }
             }
-            actionButtons(approveEnabled: !selection.isEmpty)
+            bundleRowsSection
+            actionButtons(approveEnabled: approveEnabled)
         }
     }
 
@@ -169,7 +180,8 @@ struct CapabilityPickerCardView: View {
                 Spacer(minLength: 0)
             }
             .padding(.horizontal, DesignConstants.Spacing.step2x)
-            actionButtons(approveEnabled: !selection.isEmpty)
+            bundleRowsSection
+            actionButtons(approveEnabled: approveEnabled)
         }
     }
 
@@ -220,6 +232,87 @@ struct CapabilityPickerCardView: View {
         case .writeUpdate: return "update entries in"
         case .writeDelete: return "delete entries in"
         }
+    }
+
+    // MARK: - Permission bundles
+
+    /// Bundle groups for the providers currently selected — the rows the user
+    /// is consenting to when tapping Approve.
+    private var selectedBundleGroups: [CapabilityPickerLayout.ServiceBundles] {
+        layout.serviceBundles.filter { selection.contains($0.providerId) }
+    }
+
+    /// Approve needs a provider selection, and every selected bundle-scoped
+    /// service needs at least one bundle toggled on — an empty bundle set
+    /// would grant nothing (and must never escalate to whole-service access).
+    private var approveEnabled: Bool {
+        guard !selection.isEmpty else { return false }
+        return selectedBundleGroups.allSatisfy { group in
+            !bundleSelection[group.serviceId, default: []].isEmpty
+        }
+    }
+
+    /// The bundle toggle state pruned to the services the approval covers.
+    private var approvedBundleSelection: [String: Set<String>] {
+        var approved: [String: Set<String>] = [:]
+        for group in selectedBundleGroups {
+            approved[group.serviceId] = bundleSelection[group.serviceId, default: []]
+        }
+        return approved
+    }
+
+    @ViewBuilder
+    private var bundleRowsSection: some View {
+        let groups = selectedBundleGroups
+        if !groups.isEmpty {
+            VStack(spacing: DesignConstants.Spacing.stepX) {
+                ForEach(groups, id: \.serviceId) { group in
+                    ForEach(group.rows, id: \.id) { row in
+                        bundleRow(row, serviceId: group.serviceId)
+                    }
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func bundleRow(
+        _ row: CapabilityPickerLayout.ServiceBundles.Row,
+        serviceId: String
+    ) -> some View {
+        HStack(spacing: DesignConstants.Spacing.step2x) {
+            VStack(alignment: .leading, spacing: DesignConstants.Spacing.stepHalf) {
+                Text(row.title)
+                    .font(.body.weight(.semibold))
+                    .foregroundStyle(.colorTextPrimary)
+                if !row.description.isEmpty {
+                    Text(row.description)
+                        .font(.footnote)
+                        .foregroundStyle(.colorTextSecondary)
+                        .lineLimit(3)
+                }
+            }
+            Spacer(minLength: 0)
+            Toggle(row.title, isOn: bundleBinding(serviceId: serviceId, bundleId: row.id))
+                .labelsHidden()
+                .tint(.colorFillPrimary)
+        }
+        .padding(DesignConstants.Spacing.step2x)
+    }
+
+    private func bundleBinding(serviceId: String, bundleId: String) -> Binding<Bool> {
+        Binding(
+            get: { bundleSelection[serviceId, default: []].contains(bundleId) },
+            set: { isOn in
+                var ids = bundleSelection[serviceId, default: []]
+                if isOn {
+                    ids.insert(bundleId)
+                } else {
+                    ids.remove(bundleId)
+                }
+                bundleSelection[serviceId] = ids
+            }
+        )
     }
 
     private enum RowStyle {
@@ -317,11 +410,12 @@ struct CapabilityPickerCardView: View {
                 .convosButtonStyle(.text)
                 .frame(maxWidth: .infinity)
 
-            Button("Approve") {
-                onApprove(selection)
+            let approveAction = {
+                onApprove(selection, approvedBundleSelection)
             }
-            .convosButtonStyle(.rounded(fullWidth: true))
-            .disabled(!approveEnabled)
+            Button("Approve", action: approveAction)
+                .convosButtonStyle(.rounded(fullWidth: true))
+                .disabled(!approveEnabled)
         }
     }
 }
@@ -385,7 +479,7 @@ private struct PreviewBackground<Content: View>: View {
                 providers: [.sample(id: "device.calendar", displayName: "Apple Calendar", iconName: "calendar", subject: .calendar)],
                 defaultSelection: [ProviderID(rawValue: "device.calendar")]
             ),
-            onApprove: { _ in },
+            onApprove: { _, _ in },
             onDeny: {},
             onConnect: { _ in }
         )
@@ -405,7 +499,7 @@ private struct PreviewBackground<Content: View>: View {
                 ],
                 defaultSelection: [ProviderID(rawValue: "device.calendar")]
             ),
-            onApprove: { _ in },
+            onApprove: { _, _ in },
             onDeny: {},
             onConnect: { _ in }
         )
@@ -424,7 +518,7 @@ private struct PreviewBackground<Content: View>: View {
                 ],
                 defaultSelection: []
             ),
-            onApprove: { _ in },
+            onApprove: { _, _ in },
             onDeny: {},
             onConnect: { _ in }
         )
@@ -447,7 +541,7 @@ private struct PreviewBackground<Content: View>: View {
                     ProviderID(rawValue: "composio.strava"),
                 ]
             ),
-            onApprove: { _ in },
+            onApprove: { _, _ in },
             onDeny: {},
             onConnect: { _ in }
         )
@@ -466,7 +560,46 @@ private struct PreviewBackground<Content: View>: View {
                 ],
                 defaultSelection: []
             ),
-            onApprove: { _ in },
+            onApprove: { _, _ in },
+            onDeny: {},
+            onConnect: { _ in }
+        )
+    }
+}
+
+#Preview("Variant 1 — permission bundles (Google Calendar)") {
+    PreviewBackground {
+        CapabilityPickerCardView(
+            layout: CapabilityPickerLayout(
+                request: .sample(),
+                variant: .confirm,
+                providers: [
+                    .sample(id: "composio.googlecalendar", displayName: "Google Calendar", iconName: "calendar", subject: .calendar),
+                ],
+                defaultSelection: [ProviderID(rawValue: "composio.googlecalendar")],
+                serviceBundles: [
+                    CapabilityPickerLayout.ServiceBundles(
+                        providerId: ProviderID(rawValue: "composio.googlecalendar"),
+                        serviceId: "googlecalendar",
+                        serviceVersion: 2,
+                        rows: [
+                            .init(
+                                id: "calendar.events",
+                                title: "Events",
+                                description: "View and edit events on all calendars",
+                                defaultEnabled: false
+                            ),
+                            .init(
+                                id: "calendar.events.read",
+                                title: "View events",
+                                description: "View events on all calendars",
+                                defaultEnabled: true
+                            ),
+                        ]
+                    ),
+                ]
+            ),
+            onApprove: { _, _ in },
             onDeny: {},
             onConnect: { _ in }
         )
@@ -482,7 +615,7 @@ private struct PreviewBackground<Content: View>: View {
                 providers: [.sample(id: "device.calendar", displayName: "Apple Calendar", iconName: "calendar", subject: .calendar)],
                 defaultSelection: [ProviderID(rawValue: "device.calendar")]
             ),
-            onApprove: { _ in },
+            onApprove: { _, _ in },
             onDeny: {},
             onConnect: { _ in }
         )

--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -328,8 +328,11 @@ struct ConversationView<MessagesBottomBar: View>: View {
                             CapabilityPickerCardView(
                                 layout: layout,
                                 agentName: viewModel.askerDisplayName(for: layout.request),
-                                onApprove: { providerIds in
-                                    viewModel.onCapabilityApprove(providerIds: providerIds)
+                                onApprove: { providerIds, bundleSelection in
+                                    viewModel.onCapabilityApprove(
+                                        providerIds: providerIds,
+                                        bundleSelection: bundleSelection
+                                    )
                                 },
                                 onDeny: {
                                     viewModel.onCapabilityDeny()

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -2210,7 +2210,15 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
                     // Also pass the captured conversationId so the result lands in
                     // the conversation that originated the request even if the user
                     // navigated away during the prompt.
-                    self.approveCapabilityRequest(request, providerIds: [providerId], conversationId: conversationId)
+                    // Device providers carry no permission bundles (bundles attach to
+                    // cloud services only), so there is no selection to thread here;
+                    // an empty map means "no per-service selection".
+                    self.approveCapabilityRequest(
+                        request,
+                        providerIds: [providerId],
+                        bundleSelection: [:],
+                        conversationId: conversationId
+                    )
                 } else {
                     self.recomputeCapabilityPickerLayout(for: request, conversationId: conversationId)
                 }
@@ -2230,7 +2238,17 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
                     // The cloud-connection observer in SessionManager will register the
                     // newly-linked provider; approving here is safe even if that hasn't
                     // ticked yet because the resolver only stores the providerId.
-                    self.approveCapabilityRequest(request, providerIds: [providerId], conversationId: conversationId)
+                    // The Connect tap carries no bundle toggle state (onConnect is
+                    // provider-id only), so pass no selection: a nil per-service
+                    // lookup routes the grant through the writer's full-service
+                    // consent path (all catalog bundles, fail closed on a catalog
+                    // outage) — never an empty bundleIds array.
+                    self.approveCapabilityRequest(
+                        request,
+                        providerIds: [providerId],
+                        bundleSelection: [:],
+                        conversationId: conversationId
+                    )
                 }
             } catch let oauthError as OAuthError {
                 if case .cancelled = oauthError {

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -1514,11 +1514,15 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
                 }
                 Task { @MainActor [weak self] in
                     guard let self else { return }
+                    // Best-effort: the picker renders provider-only rows when the
+                    // services catalog is unreachable; bundle rows appear once it is.
+                    let services = (try? await self.messagingService.connectionServicesStore().catalog()) ?? []
                     let layout = await handler.computeLayout(
                         request: request,
                         registry: registry,
                         resolver: resolver,
-                        conversationId: conversationId
+                        conversationId: conversationId,
+                        services: services
                     )
                     // Discard if a newer request arrived while we were computing —
                     // otherwise an out-of-order completion can stomp the latest UI.
@@ -1787,12 +1791,22 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
     /// User tapped Approve in the picker card with this provider selection.
     /// Persists the resolution so future tool calls route to the same set, then
     /// posts a `capability_request_result(.approved)` reply for the agent.
-    func onCapabilityApprove(providerIds: Set<ProviderID>) {
+    /// `bundleSelection` is the per-service permission-bundle toggle state
+    /// (service id → toggled-on bundle ids) for the cloud providers approved.
+    func onCapabilityApprove(
+        providerIds: Set<ProviderID>,
+        bundleSelection: [String: Set<String>] = [:]
+    ) {
         guard let request = pendingCapabilityPickerLayout?.request else {
             pendingCapabilityPickerLayout = nil
             return
         }
-        approveCapabilityRequest(request, providerIds: providerIds, conversationId: conversation.id)
+        approveCapabilityRequest(
+            request,
+            providerIds: providerIds,
+            bundleSelection: bundleSelection,
+            conversationId: conversation.id
+        )
     }
 
     /// User tapped Deny. Clears any prior resolution for this verb so a subsequent
@@ -1809,6 +1823,7 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
     private func approveCapabilityRequest(
         _ request: CapabilityRequest,
         providerIds: Set<ProviderID>,
+        bundleSelection: [String: Set<String>],
         conversationId: String
     ) {
         locallyHandledCapabilityRequestIds.insert(request.requestId)
@@ -1822,6 +1837,7 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
             request: request,
             status: .approved,
             providerIds: providerIds,
+            bundleSelection: bundleSelection,
             conversationId: conversationId
         )
     }
@@ -1843,6 +1859,7 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
         request: CapabilityRequest,
         status: CapabilityRequestResult.Status,
         providerIds: Set<ProviderID>,
+        bundleSelection: [String: Set<String>] = [:],
         conversationId: String
     ) {
         let resolver = session.capabilityResolver()
@@ -1919,6 +1936,7 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
                 await Self.persistApprovedCloudCapabilities(
                     providerIds: sortedIds,
                     newlyApprovedProviderIds: newlyApprovedProviderIds,
+                    bundleSelection: bundleSelection,
                     capability: request.capability,
                     conversationId: conversationId,
                     grantedToInboxId: askerInboxId,
@@ -2025,9 +2043,10 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
     /// whose CloudConnection isn't active locally — those would have been created by the
     /// caller (e.g. picker → connectCloudProvider) and the publisher snapshot taken here
     /// races against that path; if we miss it the next sync corrects state.
-    private static func persistApprovedCloudCapabilities(
+    private static func persistApprovedCloudCapabilities( // swiftlint:disable:this function_parameter_count
         providerIds: [ProviderID],
         newlyApprovedProviderIds: Set<ProviderID>,
+        bundleSelection: [String: Set<String>],
         capability: ConnectionCapability,
         conversationId: String,
         grantedToInboxId: String,
@@ -2047,15 +2066,25 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
 
             // The grant row is per-(connection, conversation, agent). Two agents
             // approved for the same connection get two rows; the same agent re-
-            // approving the same connection is a no-op for the grant write but
-            // still needs its own connection_event.
+            // approving the same connection with the same bundle scope is a no-op
+            // for the grant write but still needs its own connection_event. A
+            // re-approval with a *different* bundle selection re-grants so the
+            // backend scope follows the user's latest picker state.
+            let bundleIds = bundleSelection[serviceId].map { $0.sorted() }
             let grantKey = GrantKey(connectionId: connection.id, grantedToInboxId: grantedToInboxId)
-            if !existingGrantedKeys.contains(grantKey) {
+            let existingGrant = existingGrants.first {
+                $0.connectionId == connection.id && $0.grantedToInboxId == grantedToInboxId
+            }
+            let bundleScopeChanged = existingGrant.map {
+                bundleIds != nil && Set($0.bundleIds ?? []) != Set(bundleIds ?? [])
+            } ?? false
+            if !existingGrantedKeys.contains(grantKey) || bundleScopeChanged {
                 do {
                     try await grantWriter.grantConnection(
                         connection.id,
                         to: conversationId,
-                        grantedToInboxId: grantedToInboxId
+                        grantedToInboxId: grantedToInboxId,
+                        bundleIds: bundleIds
                     )
                 } catch {
                     Log.error("Failed to persist cloud grant for \(providerId.rawValue) → \(grantedToInboxId): \(error.localizedDescription)")

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -1900,7 +1900,7 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
                         conversationId: conversationId,
                         grantedToInboxId: askerInboxId
                     )
-                case .denied, .cancelled:
+                case .denied, .cancelled, .staleResource, .unknown:
                     try await resolver.clearResolution(
                         subject: request.subject,
                         capability: request.capability,

--- a/ConvosCore/Sources/ConvosCore/API/CloudConnectionsAPI.swift
+++ b/ConvosCore/Sources/ConvosCore/API/CloudConnectionsAPI.swift
@@ -36,6 +36,111 @@ public enum CloudConnectionsAPI {
         }
     }
 
+    /// Typed failure surfaced by `createConnectionGrant` when the backend
+    /// rejects a bundle id that isn't in its catalog for the toolkit
+    /// (HTTP 400 `{"code": "unknown_bundle", "bundleId": "<the bad id>"}`).
+    /// This is the staleness signal on the HTTP path: callers refetch
+    /// `GET /v2/connections/services`, drop unknown ids, and retry once.
+    public enum GrantError: Error, Sendable, Equatable {
+        case unknownBundle(bundleId: String?)
+    }
+
+    // MARK: - Services catalog (GET /v2/connections/services)
+
+    /// A localized string map from the services catalog. Always carries an
+    /// `"en"` key (the guaranteed fallback); may carry more locales.
+    public struct LocalizedString: Codable, Sendable, Hashable {
+        public let values: [String: String]
+
+        public init(values: [String: String]) {
+            self.values = values
+        }
+
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.singleValueContainer()
+            self.values = try container.decode([String: String].self)
+        }
+
+        public func encode(to encoder: Encoder) throws {
+            var container = encoder.singleValueContainer()
+            try container.encode(values)
+        }
+
+        /// Renders for `locale` with the plan's fallback chain:
+        /// `map[locale.languageCode] ?? map["en"] ?? ""`.
+        public func resolved(for locale: Locale = .current) -> String {
+            if let code = locale.language.languageCode?.identifier, let value = values[code] {
+                return value
+            }
+            return values["en"] ?? ""
+        }
+    }
+
+    /// One permission bundle row in the picker: a stable id the grant
+    /// persists, plus the localized copy and the toggle's initial state.
+    public struct ServiceBundle: Codable, Sendable, Hashable {
+        public let id: String
+        public let title: LocalizedString
+        public let description: LocalizedString
+        public let defaultEnabled: Bool
+
+        public init(id: String, title: LocalizedString, description: LocalizedString, defaultEnabled: Bool) {
+            self.id = id
+            self.title = title
+            self.description = description
+            self.defaultEnabled = defaultEnabled
+        }
+    }
+
+    /// Optional service icon. Omitted by the backend in v1.
+    public struct ServiceIcon: Codable, Sendable, Hashable {
+        public let format: String
+        public let base64: String
+
+        public init(format: String, base64: String) {
+            self.format = format
+            self.base64 = base64
+        }
+    }
+
+    /// One backend-owned service in the connections-picker catalog. `id`
+    /// equals the Composio toolkit slug and is sent back as `toolkit` on a
+    /// grant. `version` bumps whenever anything about the service changes;
+    /// clients refetch on a mismatch (stale detection). Composio action slugs
+    /// are deliberately absent: the backend alone resolves bundle → actions.
+    public struct ServiceConfig: Codable, Sendable, Hashable {
+        public let id: String
+        public let composioSlug: String
+        public let version: Int
+        public let displayName: LocalizedString
+        public let icon: ServiceIcon?
+        public let bundles: [ServiceBundle]
+
+        public init(
+            id: String,
+            composioSlug: String,
+            version: Int,
+            displayName: LocalizedString,
+            icon: ServiceIcon? = nil,
+            bundles: [ServiceBundle]
+        ) {
+            self.id = id
+            self.composioSlug = composioSlug
+            self.version = version
+            self.displayName = displayName
+            self.icon = icon
+            self.bundles = bundles
+        }
+    }
+
+    public struct ServicesResponse: Codable, Sendable {
+        public let services: [ServiceConfig]
+
+        public init(services: [ServiceConfig]) {
+            self.services = services
+        }
+    }
+
     public struct RevokeGrantResponse: Codable, Sendable {
         public let revoked: Int
 

--- a/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift
+++ b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift
@@ -111,23 +111,33 @@ public protocol ConvosAPIClientProtocol: AnyObject, Sendable {
     func listCloudConnections() async throws -> [CloudConnectionsAPI.ConnectionResponse]
     func revokeCloudConnection(connectionId: String) async throws
 
+    /// Fetches the backend-owned connections-picker catalog: one entry per
+    /// service, each with its permission bundles. The response is served with
+    /// `Cache-Control: private, max-age=300`; callers should go through
+    /// `ConnectionServicesStore`, which honors that TTL client-side, instead
+    /// of hitting this directly.
+    func getConnectionServices() async throws -> CloudConnectionsAPI.ServicesResponse
+
     /// Pushes one per-agent consent record to the backend grant store. The
     /// backend uses these records to authorize agent tool execution; without
     /// the push the agent gets 403. Re-posting the same (owner, grantee,
     /// conversation, toolkit) tuple upserts (also un-revokes) and returns the
     /// same id.
     ///
-    /// `actions` lists the Composio action slugs the grant authorizes. An empty
-    /// array is whole-toolkit access (the backend's fallback): the agent may
-    /// call any action on the toolkit. Pass the user-approved action slugs to
-    /// scope the grant; pass `[]` only when no per-action scope is available.
+    /// `bundleIds` lists the permission-bundle ids the user toggled on
+    /// (e.g. "calendar.events"); the backend resolves them to Composio
+    /// actions at exec time. `nil` omits the field — for toolkits outside
+    /// the catalog the backend treats that as the legacy whole-toolkit
+    /// grant. `serviceVersion` is the catalog version the device granted
+    /// against (audit/stale telemetry). An unknown bundle id surfaces as
+    /// `CloudConnectionsAPI.GrantError.unknownBundle`.
     func createConnectionGrant(
         ownerInboxId: String,
         granteeInboxId: String,
         conversationId: String,
         toolkit: String,
-        actions: [String],
-        connectionId: String?
+        bundleIds: [String]?,
+        serviceVersion: Int?
     ) async throws -> CloudConnectionsAPI.CreateGrantResponse
 
     /// Revokes a backend consent record previously created by
@@ -863,13 +873,18 @@ final class ConvosAPIClient: ConvosAPIClientProtocol, Sendable {
         let _: EmptyResponse = try await performRequest(request)
     }
 
+    func getConnectionServices() async throws -> CloudConnectionsAPI.ServicesResponse {
+        let request = try authenticatedRequest(for: "v2/connections/services", method: "GET")
+        return try await performRequest(request)
+    }
+
     func createConnectionGrant(
         ownerInboxId: String,
         granteeInboxId: String,
         conversationId: String,
         toolkit: String,
-        actions: [String],
-        connectionId: String?
+        bundleIds: [String]?,
+        serviceVersion: Int?
     ) async throws -> CloudConnectionsAPI.CreateGrantResponse {
         var request = try authenticatedRequest(for: "v2/connections/grants", method: "POST")
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
@@ -879,8 +894,8 @@ final class ConvosAPIClient: ConvosAPIClientProtocol, Sendable {
             let granteeInboxId: String
             let conversationId: String
             let toolkit: String
-            let actions: [String]
-            let connectionId: String?
+            let bundleIds: [String]?
+            let serviceVersion: Int?
         }
         request.httpBody = try JSONEncoder().encode(
             GrantBody(
@@ -888,12 +903,30 @@ final class ConvosAPIClient: ConvosAPIClientProtocol, Sendable {
                 granteeInboxId: granteeInboxId,
                 conversationId: conversationId,
                 toolkit: toolkit,
-                actions: actions,
-                connectionId: connectionId
+                bundleIds: bundleIds,
+                serviceVersion: serviceVersion
             )
         )
 
-        return try await performRequest(request)
+        do {
+            return try await performRequest(request)
+        } catch let APIError.badRequest(message) {
+            // The unknown-bundle 400 body is `{"code": "unknown_bundle",
+            // "bundleId": "<id>"}` — no `message`/`error` key, so
+            // `parseErrorMessage` passes the raw JSON body through. Decode it
+            // here so callers get a typed staleness signal they can retry on.
+            struct GrantErrorBody: Decodable {
+                let code: String
+                let bundleId: String?
+            }
+            if let message,
+               let data = message.data(using: .utf8),
+               let body = try? JSONDecoder().decode(GrantErrorBody.self, from: data),
+               body.code == "unknown_bundle" {
+                throw CloudConnectionsAPI.GrantError.unknownBundle(bundleId: body.bundleId)
+            }
+            throw APIError.badRequest(message)
+        }
     }
 
     func revokeConnectionGrant(id: String) async throws {

--- a/ConvosCore/Sources/ConvosCore/API/MockAPIClient.swift
+++ b/ConvosCore/Sources/ConvosCore/API/MockAPIClient.swift
@@ -149,13 +149,38 @@ final class MockAPIClient: ConvosAPIClientProtocol, Sendable {
 
     func revokeCloudConnection(connectionId: String) async throws {}
 
+    func getConnectionServices() async throws -> CloudConnectionsAPI.ServicesResponse {
+        .init(services: [
+            .init(
+                id: "googlecalendar",
+                composioSlug: "googlecalendar",
+                version: 1,
+                displayName: .init(values: ["en": "Google Calendar"]),
+                bundles: [
+                    .init(
+                        id: "calendar.events",
+                        title: .init(values: ["en": "Events"]),
+                        description: .init(values: ["en": "View and edit events on all calendars"]),
+                        defaultEnabled: false
+                    ),
+                    .init(
+                        id: "calendar.events.read",
+                        title: .init(values: ["en": "View events"]),
+                        description: .init(values: ["en": "View events on all calendars"]),
+                        defaultEnabled: false
+                    ),
+                ]
+            ),
+        ])
+    }
+
     func createConnectionGrant(
         ownerInboxId: String,
         granteeInboxId: String,
         conversationId: String,
         toolkit: String,
-        actions: [String],
-        connectionId: String?
+        bundleIds: [String]?,
+        serviceVersion: Int?
     ) async throws -> CloudConnectionsAPI.CreateGrantResponse {
         .init(id: "mock-grant-\(UUID().uuidString)")
     }

--- a/ConvosCore/Sources/ConvosCore/CapabilityResolution/CapabilityPickerLayout.swift
+++ b/ConvosCore/Sources/ConvosCore/CapabilityResolution/CapabilityPickerLayout.swift
@@ -10,17 +10,65 @@ public struct CapabilityPickerLayout: Sendable, Equatable {
     public let variant: Variant
     public let providers: [ProviderSummary]
     public let defaultSelection: Set<ProviderID>
+    /// Permission-bundle rows for the cloud providers on this card, one group
+    /// per provider whose service exists in the backend catalog
+    /// (`GET /v2/connections/services`). Empty when the catalog has no entry
+    /// for any provider (or wasn't reachable) — the card then renders the
+    /// pre-bundle provider rows only.
+    public let serviceBundles: [ServiceBundles]
 
     public init(
         request: CapabilityRequest,
         variant: Variant,
         providers: [ProviderSummary],
-        defaultSelection: Set<ProviderID>
+        defaultSelection: Set<ProviderID>,
+        serviceBundles: [ServiceBundles] = []
     ) {
         self.request = request
         self.variant = variant
         self.providers = providers
         self.defaultSelection = defaultSelection
+        self.serviceBundles = serviceBundles
+    }
+
+    /// Initial toggle state per service: the ids of bundles whose catalog
+    /// `defaultEnabled` is true, keyed by service id.
+    public var defaultBundleSelection: [String: Set<String>] {
+        var selection: [String: Set<String>] = [:]
+        for group in serviceBundles {
+            selection[group.serviceId] = Set(group.rows.filter(\.defaultEnabled).map(\.id))
+        }
+        return selection
+    }
+
+    /// Bundle rows for one cloud provider, resolved against the services
+    /// catalog at layout time (strings already localized for display).
+    public struct ServiceBundles: Sendable, Equatable, Hashable {
+        public let providerId: ProviderID
+        public let serviceId: String
+        public let serviceVersion: Int
+        public let rows: [Row]
+
+        public init(providerId: ProviderID, serviceId: String, serviceVersion: Int, rows: [Row]) {
+            self.providerId = providerId
+            self.serviceId = serviceId
+            self.serviceVersion = serviceVersion
+            self.rows = rows
+        }
+
+        public struct Row: Sendable, Equatable, Hashable {
+            public let id: String
+            public let title: String
+            public let description: String
+            public let defaultEnabled: Bool
+
+            public init(id: String, title: String, description: String, defaultEnabled: Bool) {
+                self.id = id
+                self.title = title
+                self.description = description
+                self.defaultEnabled = defaultEnabled
+            }
+        }
     }
 
     public enum Variant: Sendable, Equatable {

--- a/ConvosCore/Sources/ConvosCore/CapabilityResolution/CapabilityRequestHandler.swift
+++ b/ConvosCore/Sources/ConvosCore/CapabilityResolution/CapabilityRequestHandler.swift
@@ -12,12 +12,16 @@ public struct CapabilityRequestHandler: Sendable {
     public init() {}
 
     /// Snapshot the registry + resolver state for this request and decide which card
-    /// variant to render.
+    /// variant to render. `services` is the (cached) backend connections catalog;
+    /// providers whose service appears there get permission-bundle rows on the
+    /// returned layout. Pass `[]` when the catalog is unavailable — the card then
+    /// falls back to plain provider rows.
     public func computeLayout(
         request: CapabilityRequest,
         registry: any CapabilityProviderRegistry,
         resolver: any CapabilityResolver,
-        conversationId: String
+        conversationId: String,
+        services: [CloudConnectionsAPI.ServiceConfig] = []
     ) async -> CapabilityPickerLayout {
         let providersForSubject = await registry.providers(for: request.subject)
         let summaries = await Self.summarize(
@@ -49,7 +53,8 @@ public struct CapabilityRequestHandler: Sendable {
         if let consent = verbConsentLayout(
             request: request,
             summaries: summaries,
-            existingResolutions: existingResolutions
+            existingResolutions: existingResolutions,
+            services: services
         ) {
             return consent
         }
@@ -58,11 +63,13 @@ public struct CapabilityRequestHandler: Sendable {
         let allowsFederationOnRead = request.subject.allowsReadFederation && request.capability == .read
 
         if linkedSummaries.isEmpty {
+            let providers = summaries.filter(\.supportsCapability)
             return CapabilityPickerLayout(
                 request: request,
                 variant: .connectAndApprove,
-                providers: summaries.filter(\.supportsCapability),
-                defaultSelection: []
+                providers: providers,
+                defaultSelection: [],
+                serviceBundles: Self.serviceBundles(for: providers, services: services)
             )
         }
 
@@ -71,7 +78,8 @@ public struct CapabilityRequestHandler: Sendable {
                 request: request,
                 variant: .confirm,
                 providers: summaries,
-                defaultSelection: [only.id]
+                defaultSelection: [only.id],
+                serviceBundles: Self.serviceBundles(for: summaries, services: services)
             )
         }
 
@@ -85,7 +93,8 @@ public struct CapabilityRequestHandler: Sendable {
             request: request,
             variant: variant,
             providers: summaries,
-            defaultSelection: defaultSelection
+            defaultSelection: defaultSelection,
+            serviceBundles: Self.serviceBundles(for: summaries, services: services)
         )
     }
 
@@ -184,7 +193,8 @@ public struct CapabilityRequestHandler: Sendable {
     private func verbConsentLayout(
         request: CapabilityRequest,
         summaries: [CapabilityPickerLayout.ProviderSummary],
-        existingResolutions: [ConnectionCapability: Set<ProviderID>]
+        existingResolutions: [ConnectionCapability: Set<ProviderID>],
+        services: [CloudConnectionsAPI.ServiceConfig]
     ) -> CapabilityPickerLayout? {
         // The new verb already has a resolution → no card needed at all; caller
         // shouldn't have invoked this path. Defensive nil — picker layer treats nil
@@ -252,8 +262,40 @@ public struct CapabilityRequestHandler: Sendable {
             request: request,
             variant: .verbConsent,
             providers: relevant,
-            defaultSelection: Set(relevant.map(\.id))
+            defaultSelection: Set(relevant.map(\.id)),
+            serviceBundles: Self.serviceBundles(for: relevant, services: services)
         )
+    }
+
+    /// One bundle group per cloud provider on the card whose service exists in
+    /// the catalog. Localized copy is resolved here so the layout stays a pure
+    /// render snapshot.
+    private static func serviceBundles(
+        for providers: [CapabilityPickerLayout.ProviderSummary],
+        services: [CloudConnectionsAPI.ServiceConfig]
+    ) -> [CapabilityPickerLayout.ServiceBundles] {
+        guard !services.isEmpty else { return [] }
+        let servicesById = Dictionary(uniqueKeysWithValues: services.map { ($0.id, $0) })
+        return providers.compactMap { provider in
+            guard let serviceId = provider.id.cloudServiceId,
+                  let service = servicesById[serviceId],
+                  !service.bundles.isEmpty else {
+                return nil
+            }
+            return CapabilityPickerLayout.ServiceBundles(
+                providerId: provider.id,
+                serviceId: serviceId,
+                serviceVersion: service.version,
+                rows: service.bundles.map { bundle in
+                    CapabilityPickerLayout.ServiceBundles.Row(
+                        id: bundle.id,
+                        title: bundle.title.resolved(),
+                        description: bundle.description.resolved(),
+                        defaultEnabled: bundle.defaultEnabled
+                    )
+                }
+            )
+        }
     }
 
     private func honorPreferredProviders(

--- a/ConvosCore/Sources/ConvosCore/CapabilityResolution/CapabilityRequestResult.swift
+++ b/ConvosCore/Sources/ConvosCore/CapabilityResolution/CapabilityRequestResult.swift
@@ -14,6 +14,32 @@ public struct CapabilityRequestResult: Codable, Sendable, Hashable {
         case approved
         case denied
         case cancelled
+        /// Agent → device: the device granted against a stale services-catalog
+        /// version. `staleServices` names the services to refetch; the device
+        /// refetches their config and retries the capability call once.
+        case staleResource = "stale_resource"
+        /// Forward-compat catch-all: a status this build doesn't know yet.
+        /// Never sent by this client; decoding maps unrecognized raw values
+        /// here instead of throwing so newer peers can't break old devices.
+        case unknown
+
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.singleValueContainer()
+            let raw = try container.decode(String.self)
+            self = Status(rawValue: raw) ?? .unknown
+        }
+    }
+
+    /// One stale catalog entry named by a `stale_resource` reply: the service
+    /// id and the version the agent expects the device to know about.
+    public struct StaleService: Codable, Sendable, Hashable {
+        public let id: String
+        public let expectedVersion: Int
+
+        public init(id: String, expectedVersion: Int) {
+            self.id = id
+            self.expectedVersion = expectedVersion
+        }
     }
 
     public let version: Int
@@ -29,6 +55,9 @@ public struct CapabilityRequestResult: Codable, Sendable, Hashable {
     /// Action schemas compatible with the approved capability, filtered to the providers
     /// returned above. Empty for `.denied` / `.cancelled`.
     public let availableActions: [AvailableAction]
+    /// Only populated on `.staleResource`: the services whose catalog config
+    /// the device should refetch before retrying. Empty for every other status.
+    public let staleServices: [StaleService]
 
     public init(
         version: Int = CapabilityRequestResult.supportedVersion,
@@ -37,7 +66,8 @@ public struct CapabilityRequestResult: Codable, Sendable, Hashable {
         subject: CapabilitySubject,
         capability: ConnectionCapability,
         providers: [ProviderID] = [],
-        availableActions: [AvailableAction] = []
+        availableActions: [AvailableAction] = [],
+        staleServices: [StaleService] = []
     ) {
         self.version = version
         self.requestId = requestId
@@ -46,10 +76,11 @@ public struct CapabilityRequestResult: Codable, Sendable, Hashable {
         self.capability = capability
         self.providers = Self.truncatedProviders(providers)
         self.availableActions = Self.truncatedAvailableActions(availableActions)
+        self.staleServices = staleServices
     }
 
     private enum CodingKeys: String, CodingKey {
-        case version, requestId, status, subject, capability, providers, availableActions
+        case version, requestId, status, subject, capability, providers, availableActions, staleServices
     }
 
     public init(from decoder: Decoder) throws {
@@ -63,6 +94,7 @@ public struct CapabilityRequestResult: Codable, Sendable, Hashable {
         let rawAvailableActions = try container.decodeIfPresent([AvailableAction].self, forKey: .availableActions) ?? []
         self.providers = Self.truncatedProviders(rawProviders)
         self.availableActions = Self.truncatedAvailableActions(rawAvailableActions)
+        self.staleServices = try container.decodeIfPresent([StaleService].self, forKey: .staleServices) ?? []
     }
 
     private static func truncatedProviders(_ providers: [ProviderID]) -> [ProviderID] {

--- a/ConvosCore/Sources/ConvosCore/CloudConnections/CloudConnectionGrant.swift
+++ b/ConvosCore/Sources/ConvosCore/CloudConnections/CloudConnectionGrant.swift
@@ -8,18 +8,24 @@ public struct CloudConnectionGrant: Codable, Sendable, Hashable {
     /// have independent grant rows; a grant for one doesn't authorize the other.
     public let grantedToInboxId: String
     public let grantedAt: Date
+    /// Permission-bundle ids this grant authorizes (catalog ids like
+    /// "calendar.events"). Nil for legacy whole-toolkit grants or services
+    /// outside the catalog.
+    public let bundleIds: [String]?
 
     public init(
         connectionId: String,
         conversationId: String,
         serviceId: String,
         grantedToInboxId: String,
-        grantedAt: Date
+        grantedAt: Date,
+        bundleIds: [String]? = nil
     ) {
         self.connectionId = connectionId
         self.conversationId = conversationId
         self.serviceId = serviceId
         self.grantedToInboxId = grantedToInboxId
         self.grantedAt = grantedAt
+        self.bundleIds = bundleIds
     }
 }

--- a/ConvosCore/Sources/ConvosCore/CloudConnections/CloudConnectionGrantWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/CloudConnections/CloudConnectionGrantWriter.swift
@@ -3,10 +3,15 @@ import GRDB
 @preconcurrency import XMTPiOS
 
 public protocol CloudConnectionGrantWriterProtocol: Sendable {
+    /// `bundleIds` is the picker's bundle selection for the connection's
+    /// service (catalog ids like "calendar.events"). Pass nil when no picker
+    /// was involved (full-service consent paths); the writer then grants
+    /// every bundle the catalog lists for the service.
     func grantConnection(
         _ connectionId: String,
         to conversationId: String,
-        grantedToInboxId: String
+        grantedToInboxId: String,
+        bundleIds: [String]?
     ) async throws
     func revokeGrant(
         connectionId: String,
@@ -15,28 +20,48 @@ public protocol CloudConnectionGrantWriterProtocol: Sendable {
     ) async throws
 }
 
+public extension CloudConnectionGrantWriterProtocol {
+    /// Full-service consent convenience: no explicit bundle selection.
+    func grantConnection(
+        _ connectionId: String,
+        to conversationId: String,
+        grantedToInboxId: String
+    ) async throws {
+        try await grantConnection(
+            connectionId,
+            to: conversationId,
+            grantedToInboxId: grantedToInboxId,
+            bundleIds: nil
+        )
+    }
+}
+
 final class CloudConnectionGrantWriter: CloudConnectionGrantWriterProtocol, @unchecked Sendable {
     private let sessionStateManager: any SessionStateManagerProtocol
     private let databaseWriter: any DatabaseWriter
     private let databaseReader: any DatabaseReader
     private let myProfileWriter: any MyProfileWriterProtocol
+    private let servicesStore: any ConnectionServicesStoreProtocol
 
     init(
         sessionStateManager: any SessionStateManagerProtocol,
         databaseWriter: any DatabaseWriter,
         databaseReader: any DatabaseReader,
-        myProfileWriter: any MyProfileWriterProtocol
+        myProfileWriter: any MyProfileWriterProtocol,
+        servicesStore: any ConnectionServicesStoreProtocol
     ) {
         self.sessionStateManager = sessionStateManager
         self.databaseWriter = databaseWriter
         self.databaseReader = databaseReader
         self.myProfileWriter = myProfileWriter
+        self.servicesStore = servicesStore
     }
 
     func grantConnection(
         _ connectionId: String,
         to conversationId: String,
-        grantedToInboxId: String
+        grantedToInboxId: String,
+        bundleIds: [String]?
     ) async throws {
         guard !grantedToInboxId.isEmpty else {
             throw CloudConnectionGrantError.missingGrantedToInboxId
@@ -56,7 +81,8 @@ final class CloudConnectionGrantWriter: CloudConnectionGrantWriterProtocol, @unc
             conversationId: conversationId,
             serviceId: connection.serviceId,
             grantedToInboxId: grantedToInboxId,
-            grantedAt: Date()
+            grantedAt: Date(),
+            bundleIds: bundleIds
         )
 
         // Publish before persisting. If the publish fails we never commit the grant
@@ -123,41 +149,62 @@ final class CloudConnectionGrantWriter: CloudConnectionGrantWriterProtocol, @unc
 
     /// Pushes one per-agent consent record to the backend grant store and
     /// remembers the returned id on the local row so revocation can target it.
-    /// Best-effort with no retry: on failure the local grant stands, but the
+    /// Grants are bundle-scoped against the services catalog (see
+    /// `resolveBundleScope`); a 400 `unknown_bundle` rejection means our
+    /// catalog cache is stale, so the push refetches it, drops ids the fresh
+    /// catalog no longer knows, and retries exactly once. Otherwise
+    /// best-effort with no retry: on failure the local grant stands, but the
     /// backend will deny the agent's tool execution (403) until the user
     /// re-grants, so the failure is logged at error level.
     private func pushGrantToBackend(_ grant: DBCloudConnectionGrant, connection: DBCloudConnection) async {
         do {
             let inboxReady = try await sessionStateManager.waitForInboxReadyResult()
-            // `actions` would scope the grant to specific Composio action slugs
-            // (e.g. "GOOGLECALENDAR_CREATE_EVENT"). iOS has no source of those
-            // slugs at grant time: the consent model only carries a coarse
-            // verb set (read / write_*), and CapabilityRequestResult.availableActions
-            // holds device-action names, not Composio slugs. Until a
-            // capability->Composio-action mapping exists, every grant is
-            // whole-toolkit (empty actions). Logged so the scoping gap is visible
-            // rather than silently implied.
-            let actions: [String] = []
-            Log.warning(
-                "[CloudConnections] pushing whole-toolkit grant (no per-action scope available): " +
-                "toolkit=\(connection.serviceId), conversationId=\(grant.conversationId), " +
-                "grantedToInboxId=\(grant.grantedToInboxId)"
-            )
-            let response = try await inboxReady.apiClient.createConnectionGrant(
-                ownerInboxId: inboxReady.client.inboxId,
-                granteeInboxId: grant.grantedToInboxId,
-                conversationId: grant.conversationId,
+            guard let scope = await resolveBundleScope(
                 toolkit: connection.serviceId,
-                actions: actions,
-                connectionId: connection.composioConnectionId
-            )
+                explicitSelection: grant.bundleIds
+            ) else { return }
+            let response: CloudConnectionsAPI.CreateGrantResponse
+            let pushedScope: BundleScope
+            do {
+                response = try await inboxReady.apiClient.createConnectionGrant(
+                    ownerInboxId: inboxReady.client.inboxId,
+                    granteeInboxId: grant.grantedToInboxId,
+                    conversationId: grant.conversationId,
+                    toolkit: connection.serviceId,
+                    bundleIds: scope.bundleIds,
+                    serviceVersion: scope.serviceVersion
+                )
+                pushedScope = scope
+            } catch CloudConnectionsAPI.GrantError.unknownBundle(let bundleId) {
+                Log.warning(
+                    "[CloudConnections] grant rejected for stale bundle id " +
+                    "(toolkit=\(connection.serviceId), bundleId=\(bundleId ?? "?")); " +
+                    "refetching services catalog and retrying once"
+                )
+                await servicesStore.invalidate()
+                guard let retryScope = await resolveBundleScope(
+                    toolkit: connection.serviceId,
+                    explicitSelection: grant.bundleIds
+                ) else { return }
+                response = try await inboxReady.apiClient.createConnectionGrant(
+                    ownerInboxId: inboxReady.client.inboxId,
+                    granteeInboxId: grant.grantedToInboxId,
+                    conversationId: grant.conversationId,
+                    toolkit: connection.serviceId,
+                    bundleIds: retryScope.bundleIds,
+                    serviceVersion: retryScope.serviceVersion
+                )
+                pushedScope = retryScope
+            }
             let updated = DBCloudConnectionGrant(
                 connectionId: grant.connectionId,
                 conversationId: grant.conversationId,
                 serviceId: grant.serviceId,
                 grantedToInboxId: grant.grantedToInboxId,
                 grantedAt: grant.grantedAt,
-                backendGrantId: response.id
+                backendGrantId: response.id,
+                bundleIds: pushedScope.bundleIds,
+                serviceVersion: pushedScope.serviceVersion
             )
             try await databaseWriter.write { db in
                 try updated.save(db)
@@ -170,6 +217,56 @@ final class CloudConnectionGrantWriter: CloudConnectionGrantWriterProtocol, @unc
                 error.localizedDescription
             )
         }
+    }
+
+    private struct BundleScope {
+        /// Nil omits `bundleIds` from the request body — the backend's legacy
+        /// whole-toolkit path, used for services outside the catalog.
+        let bundleIds: [String]?
+        let serviceVersion: Int?
+    }
+
+    /// Maps the user's bundle selection (nil = full-service consent with no
+    /// picker involved) onto the cached services catalog:
+    /// - service in catalog + explicit selection → ids kept as picked,
+    ///   filtered to the catalog (the backend validates anyway; the filter
+    ///   matters on the post-`unknown_bundle` retry where the catalog was
+    ///   just refetched)
+    /// - service in catalog + nil selection → every catalog bundle id
+    /// - service missing / catalog unreachable → explicit selection as-is, or
+    ///   the legacy whole-toolkit grant when there is none
+    ///
+    /// Returns nil to fail closed: an explicit selection that no longer maps
+    /// to any known bundle must not be pushed, because the backend treats an
+    /// empty `bundleIds` array as whole-toolkit access — strictly more than
+    /// the user approved.
+    private func resolveBundleScope(toolkit: String, explicitSelection: [String]?) async -> BundleScope? {
+        var service: CloudConnectionsAPI.ServiceConfig?
+        do {
+            service = try await servicesStore.service(id: toolkit)
+        } catch {
+            Log.warning(
+                "[CloudConnections] services catalog unavailable for \(toolkit); " +
+                "pushing grant without catalog scope: \(error.localizedDescription)"
+            )
+        }
+        guard let service else {
+            return BundleScope(bundleIds: explicitSelection, serviceVersion: nil)
+        }
+        let known = service.bundles.map(\.id)
+        guard let explicitSelection else {
+            return BundleScope(bundleIds: known, serviceVersion: service.version)
+        }
+        let kept = explicitSelection.filter(Set(known).contains)
+        guard !kept.isEmpty else {
+            Log.error(
+                "[CloudConnections] none of the selected bundle ids exist in the catalog for " +
+                "\(toolkit) (selected=\(explicitSelection)); skipping backend push to avoid " +
+                "escalating an empty selection to whole-toolkit access"
+            )
+            return nil
+        }
+        return BundleScope(bundleIds: kept, serviceVersion: service.version)
     }
 
     /// Revokes the backend consent record for a grant that was just removed

--- a/ConvosCore/Sources/ConvosCore/CloudConnections/CloudConnectionGrantWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/CloudConnections/CloudConnectionGrantWriter.swift
@@ -181,10 +181,9 @@ final class CloudConnectionGrantWriter: CloudConnectionGrantWriterProtocol, @unc
                     "(toolkit=\(connection.serviceId), bundleId=\(bundleId ?? "?")); " +
                     "refetching services catalog and retrying once"
                 )
-                await servicesStore.invalidate()
-                guard let retryScope = await resolveBundleScope(
-                    toolkit: connection.serviceId,
-                    explicitSelection: grant.bundleIds
+                guard let retryScope = try await retryScope(
+                    afterUnknownBundleFor: connection.serviceId,
+                    firstAttempt: scope
                 ) else { return }
                 response = try await inboxReady.apiClient.createConnectionGrant(
                     ownerInboxId: inboxReady.client.inboxId,
@@ -229,26 +228,40 @@ final class CloudConnectionGrantWriter: CloudConnectionGrantWriterProtocol, @unc
     /// Maps the user's bundle selection (nil = full-service consent with no
     /// picker involved) onto the cached services catalog:
     /// - service in catalog + explicit selection → ids kept as picked,
-    ///   filtered to the catalog (the backend validates anyway; the filter
-    ///   matters on the post-`unknown_bundle` retry where the catalog was
-    ///   just refetched)
-    /// - service in catalog + nil selection → every catalog bundle id
-    /// - service missing / catalog unreachable → explicit selection as-is, or
-    ///   the legacy whole-toolkit grant when there is none
+    ///   filtered to the catalog
+    /// - service in catalog + nil selection → every catalog bundle id,
+    ///   materialized here once so a later retry can only ever narrow it
+    /// - service proven absent from a successfully fetched catalog →
+    ///   explicit selection as-is, or the legacy whole-toolkit grant when
+    ///   there is none
+    /// - catalog UNREACHABLE → explicit selection as-is (the backend
+    ///   validates it), but a nil selection fails closed: without a
+    ///   successful fetch proving the service is uncataloged, omitting
+    ///   `bundleIds` could silently escalate a cataloged service to
+    ///   whole-toolkit access
     ///
     /// Returns nil to fail closed: an explicit selection that no longer maps
     /// to any known bundle must not be pushed, because the backend treats an
     /// empty `bundleIds` array as whole-toolkit access — strictly more than
     /// the user approved.
     private func resolveBundleScope(toolkit: String, explicitSelection: [String]?) async -> BundleScope? {
-        var service: CloudConnectionsAPI.ServiceConfig?
+        let service: CloudConnectionsAPI.ServiceConfig?
         do {
             service = try await servicesStore.service(id: toolkit)
         } catch {
+            guard let explicitSelection, !explicitSelection.isEmpty else {
+                Log.error(
+                    "[CloudConnections] services catalog unavailable for \(toolkit) and no explicit " +
+                    "bundle selection to fall back on; skipping backend push rather than risk " +
+                    "escalating to whole-toolkit access: \(error.localizedDescription)"
+                )
+                return nil
+            }
             Log.warning(
                 "[CloudConnections] services catalog unavailable for \(toolkit); " +
-                "pushing grant without catalog scope: \(error.localizedDescription)"
+                "pushing the explicit bundle selection unfiltered: \(error.localizedDescription)"
             )
+            return BundleScope(bundleIds: explicitSelection, serviceVersion: nil)
         }
         guard let service else {
             return BundleScope(bundleIds: explicitSelection, serviceVersion: nil)
@@ -267,6 +280,46 @@ final class CloudConnectionGrantWriter: CloudConnectionGrantWriterProtocol, @unc
             return nil
         }
         return BundleScope(bundleIds: kept, serviceVersion: service.version)
+    }
+
+    /// Recovery scope after a 400 `unknown_bundle`: invalidate + refetch the
+    /// catalog, then intersect the ids of the FIRST attempt with the refreshed
+    /// catalog. The retry can only ever narrow the originally pushed scope —
+    /// recomputing from a nil selection against a refreshed catalog could
+    /// widen it past what was first materialized. Returns nil to give up
+    /// (fail closed): no bundles survived, the service vanished from the
+    /// catalog, or the rejected attempt didn't carry bundle ids at all
+    /// (the server only validates non-empty `bundleIds`, so that rejection
+    /// is unexpected and not retryable).
+    private func retryScope(
+        afterUnknownBundleFor toolkit: String,
+        firstAttempt: BundleScope
+    ) async throws -> BundleScope? {
+        guard let firstIds = firstAttempt.bundleIds, !firstIds.isEmpty else {
+            Log.error(
+                "[CloudConnections] unknown_bundle rejection for a grant that sent no bundle ids " +
+                "(toolkit=\(toolkit)); not retrying"
+            )
+            return nil
+        }
+        await servicesStore.invalidate()
+        guard let refreshed = try await servicesStore.service(id: toolkit) else {
+            Log.error(
+                "[CloudConnections] \(toolkit) is gone from the refreshed services catalog; " +
+                "failing closed instead of retrying the grant push"
+            )
+            return nil
+        }
+        let known = Set(refreshed.bundles.map(\.id))
+        let kept = firstIds.filter(known.contains)
+        guard !kept.isEmpty else {
+            Log.error(
+                "[CloudConnections] none of the pushed bundle ids survive the refreshed catalog for " +
+                "\(toolkit) (pushed=\(firstIds)); failing closed instead of retrying the grant push"
+            )
+            return nil
+        }
+        return BundleScope(bundleIds: kept, serviceVersion: refreshed.version)
     }
 
     /// Revokes the backend consent record for a grant that was just removed

--- a/ConvosCore/Sources/ConvosCore/CloudConnections/CloudConnectionGrantWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/CloudConnections/CloudConnectionGrantWriter.swift
@@ -240,11 +240,21 @@ final class CloudConnectionGrantWriter: CloudConnectionGrantWriterProtocol, @unc
     ///   `bundleIds` could silently escalate a cataloged service to
     ///   whole-toolkit access
     ///
-    /// Returns nil to fail closed: an explicit selection that no longer maps
-    /// to any known bundle must not be pushed, because the backend treats an
-    /// empty `bundleIds` array as whole-toolkit access — strictly more than
-    /// the user approved.
+    /// Returns nil to fail closed: a scope that would carry an empty
+    /// `bundleIds` array must never be pushed, because the backend treats an
+    /// empty array as whole-toolkit access — strictly more than the user
+    /// approved. That covers an explicit selection that is empty or no longer
+    /// maps to any known bundle, and a cataloged service that lists no
+    /// bundles at all.
     private func resolveBundleScope(toolkit: String, explicitSelection: [String]?) async -> BundleScope? {
+        if let explicitSelection, explicitSelection.isEmpty {
+            Log.error(
+                "[CloudConnections] explicit bundle selection for \(toolkit) is empty; " +
+                "skipping backend push to avoid escalating an empty selection to " +
+                "whole-toolkit access"
+            )
+            return nil
+        }
         let service: CloudConnectionsAPI.ServiceConfig?
         do {
             service = try await servicesStore.service(id: toolkit)
@@ -268,6 +278,14 @@ final class CloudConnectionGrantWriter: CloudConnectionGrantWriterProtocol, @unc
         }
         let known = service.bundles.map(\.id)
         guard let explicitSelection else {
+            guard !known.isEmpty else {
+                Log.error(
+                    "[CloudConnections] catalog lists no bundles for \(toolkit); skipping " +
+                    "backend push rather than escalating an empty bundle list to " +
+                    "whole-toolkit access"
+                )
+                return nil
+            }
             return BundleScope(bundleIds: known, serviceVersion: service.version)
         }
         let kept = explicitSelection.filter(Set(known).contains)

--- a/ConvosCore/Sources/ConvosCore/CloudConnections/ConnectionServicesStore.swift
+++ b/ConvosCore/Sources/ConvosCore/CloudConnections/ConnectionServicesStore.swift
@@ -37,7 +37,13 @@ public actor ConnectionServicesStore: ConnectionServicesStoreProtocol {
 
     private var cachedServices: [CloudConnectionsAPI.ServiceConfig]?
     private var fetchedAt: Date?
-    private var inflight: Task<[CloudConnectionsAPI.ServiceConfig], Error>?
+    private var inflight: (generation: Int, task: Task<[CloudConnectionsAPI.ServiceConfig], Error>)?
+    /// Bumped by `invalidate()`. A fetch started before the bump still returns
+    /// to its original awaiters, but it can no longer populate the cache or be
+    /// joined by later reads — otherwise an `unknown_bundle` retry could await
+    /// a stale in-flight fetch and re-cache the very catalog the server just
+    /// rejected, for another full TTL.
+    private var generation: Int = 0
 
     public init(
         ttl: TimeInterval = ConnectionServicesStore.cacheTTL,
@@ -70,20 +76,29 @@ public actor ConnectionServicesStore: ConnectionServicesStoreProtocol {
     public func invalidate() {
         cachedServices = nil
         fetchedAt = nil
+        generation += 1
+        inflight = nil
     }
 
     private func refetch() async throws -> [CloudConnectionsAPI.ServiceConfig] {
-        if let inflight {
-            return try await inflight.value
+        if let inflight, inflight.generation == generation {
+            return try await inflight.task.value
         }
+        let fetchGeneration = generation
         let task = Task { [fetchServices] in
             try await fetchServices().services
         }
-        inflight = task
-        defer { inflight = nil }
+        inflight = (fetchGeneration, task)
+        defer {
+            if inflight?.generation == fetchGeneration {
+                inflight = nil
+            }
+        }
         let services = try await task.value
-        cachedServices = services
-        fetchedAt = now()
+        if generation == fetchGeneration {
+            cachedServices = services
+            fetchedAt = now()
+        }
         return services
     }
 }

--- a/ConvosCore/Sources/ConvosCore/CloudConnections/ConnectionServicesStore.swift
+++ b/ConvosCore/Sources/ConvosCore/CloudConnections/ConnectionServicesStore.swift
@@ -1,0 +1,89 @@
+import Foundation
+
+/// Read-side of the backend-owned connections-picker catalog
+/// (`GET /v2/connections/services`): services and their permission bundles.
+public protocol ConnectionServicesStoreProtocol: Sendable {
+    /// The full catalog, served from cache while fresh.
+    func catalog() async throws -> [CloudConnectionsAPI.ServiceConfig]
+    /// One service by id (the Composio toolkit slug), or nil when the catalog
+    /// has no entry for it.
+    func service(id: String) async throws -> CloudConnectionsAPI.ServiceConfig?
+    /// Like `service(id:)`, but refetches the catalog when the cached entry is
+    /// older than `minimumVersion` — the recovery path for `stale_resource`
+    /// replies that name an expected version. Returns whatever the backend
+    /// currently serves, even if still older than asked (the caller decides
+    /// whether that's fatal).
+    func service(id: String, minimumVersion: Int) async throws -> CloudConnectionsAPI.ServiceConfig?
+    /// Drops the cached catalog so the next read refetches. Called when the
+    /// backend signals staleness out of band (400 `unknown_bundle`).
+    func invalidate() async
+}
+
+/// In-memory TTL cache over `GET /v2/connections/services`.
+///
+/// The backend serves the catalog with `Cache-Control: private, max-age=300`;
+/// `cacheTTL` mirrors that contract client-side. Entries are version-aware:
+/// a consumer that learns a newer `version` exists (stale_resource, or an
+/// `unknown_bundle` rejection) can force a refetch via
+/// `service(id:minimumVersion:)` / `invalidate()` without waiting out the TTL.
+/// Concurrent reads share one in-flight fetch.
+public actor ConnectionServicesStore: ConnectionServicesStoreProtocol {
+    /// Mirrors the backend's `Cache-Control: private, max-age=300`.
+    public static let cacheTTL: TimeInterval = 300
+
+    private let fetchServices: @Sendable () async throws -> CloudConnectionsAPI.ServicesResponse
+    private let ttl: TimeInterval
+    private let now: @Sendable () -> Date
+
+    private var cachedServices: [CloudConnectionsAPI.ServiceConfig]?
+    private var fetchedAt: Date?
+    private var inflight: Task<[CloudConnectionsAPI.ServiceConfig], Error>?
+
+    public init(
+        ttl: TimeInterval = ConnectionServicesStore.cacheTTL,
+        now: @escaping @Sendable () -> Date = { Date() },
+        fetchServices: @escaping @Sendable () async throws -> CloudConnectionsAPI.ServicesResponse
+    ) {
+        self.ttl = ttl
+        self.now = now
+        self.fetchServices = fetchServices
+    }
+
+    public func catalog() async throws -> [CloudConnectionsAPI.ServiceConfig] {
+        if let cachedServices, let fetchedAt, now().timeIntervalSince(fetchedAt) < ttl {
+            return cachedServices
+        }
+        return try await refetch()
+    }
+
+    public func service(id: String) async throws -> CloudConnectionsAPI.ServiceConfig? {
+        try await catalog().first { $0.id == id }
+    }
+
+    public func service(id: String, minimumVersion: Int) async throws -> CloudConnectionsAPI.ServiceConfig? {
+        if let cached = try await catalog().first(where: { $0.id == id }), cached.version >= minimumVersion {
+            return cached
+        }
+        return try await refetch().first { $0.id == id }
+    }
+
+    public func invalidate() {
+        cachedServices = nil
+        fetchedAt = nil
+    }
+
+    private func refetch() async throws -> [CloudConnectionsAPI.ServiceConfig] {
+        if let inflight {
+            return try await inflight.value
+        }
+        let task = Task { [fetchServices] in
+            try await fetchServices().services
+        }
+        inflight = task
+        defer { inflight = nil }
+        let services = try await task.value
+        cachedServices = services
+        fetchedAt = now()
+        return services
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/CloudConnections/MockCloudConnectionManager.swift
+++ b/ConvosCore/Sources/ConvosCore/CloudConnections/MockCloudConnectionManager.swift
@@ -53,7 +53,8 @@ public final class MockConnectionGrantWriter: CloudConnectionGrantWriterProtocol
     public func grantConnection(
         _ connectionId: String,
         to conversationId: String,
-        grantedToInboxId: String
+        grantedToInboxId: String,
+        bundleIds: [String]?
     ) async throws {}
 
     public func revokeGrant(

--- a/ConvosCore/Sources/ConvosCore/Custom Content Types/CapabilityRequestResultCodec.swift
+++ b/ConvosCore/Sources/ConvosCore/Custom Content Types/CapabilityRequestResultCodec.swift
@@ -63,6 +63,10 @@ public struct CapabilityRequestResultCodec: ContentCodec {
             "Declined \(content.subject.displayName.lowercased()) access"
         case .cancelled:
             "Cancelled \(content.subject.displayName.lowercased()) access request"
+        case .staleResource:
+            "Asked to refresh \(content.subject.displayName.lowercased()) permissions"
+        case .unknown:
+            "Updated \(content.subject.displayName.lowercased()) access request"
         }
     }
 

--- a/ConvosCore/Sources/ConvosCore/Messaging/MessagingService.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/MessagingService.swift
@@ -293,12 +293,27 @@ final class MessagingService: MessagingServiceProtocol, @unchecked Sendable {
                                           databaseReader: databaseReader)
     }
 
+    /// One store per service instance so every grant writer (and the picker)
+    /// shares a single TTL'd catalog cache; `connectionGrantWriter()` returns
+    /// a fresh writer per call, so the cache can't live there.
+    private lazy var servicesStore: ConnectionServicesStore = ConnectionServicesStore(
+        fetchServices: { [sessionStateManager] in
+            let inboxReady = try await sessionStateManager.waitForInboxReadyResult()
+            return try await inboxReady.apiClient.getConnectionServices()
+        }
+    )
+
+    func connectionServicesStore() -> any ConnectionServicesStoreProtocol {
+        servicesStore
+    }
+
     func connectionGrantWriter() -> any CloudConnectionGrantWriterProtocol {
         CloudConnectionGrantWriter(
             sessionStateManager: sessionStateManager,
             databaseWriter: databaseWriter,
             databaseReader: databaseReader,
-            myProfileWriter: myProfileWriter()
+            myProfileWriter: myProfileWriter(),
+            servicesStore: servicesStore
         )
     }
 

--- a/ConvosCore/Sources/ConvosCore/Messaging/MessagingServiceProtocol.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/MessagingServiceProtocol.swift
@@ -82,6 +82,7 @@ public protocol MessagingServiceProtocol: AnyObject, Sendable, PostPairBroadcast
     func conversationExplosionWriter() -> any ConversationExplosionWriterProtocol
     func conversationPermissionsRepository() -> any ConversationPermissionsRepositoryProtocol
     func connectionGrantWriter() -> any CloudConnectionGrantWriterProtocol
+    func connectionServicesStore() -> any ConnectionServicesStoreProtocol
     func connectionEventWriter() -> any ConnectionEventWriterProtocol
     func capabilityRequestResultWriter() -> any CapabilityRequestResultWriterProtocol
 

--- a/ConvosCore/Sources/ConvosCore/Mocks/MockMessagingService.swift
+++ b/ConvosCore/Sources/ConvosCore/Mocks/MockMessagingService.swift
@@ -133,6 +133,10 @@ public final class MockMessagingService: MessagingServiceProtocol, @unchecked Se
         MockConnectionGrantWriter()
     }
 
+    public func connectionServicesStore() -> any ConnectionServicesStoreProtocol {
+        ConnectionServicesStore(fetchServices: { CloudConnectionsAPI.ServicesResponse(services: []) })
+    }
+
     public func connectionEventWriter() -> any ConnectionEventWriterProtocol {
         MockConnectionEventWriter()
     }

--- a/ConvosCore/Sources/ConvosCore/Storage/Database Models/DBCloudConnectionGrant.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Database Models/DBCloudConnectionGrant.swift
@@ -11,6 +11,8 @@ struct DBCloudConnectionGrant: Codable, FetchableRecord, PersistableRecord, Hash
         static let grantedToInboxId: Column = Column(CodingKeys.grantedToInboxId)
         static let grantedAt: Column = Column(CodingKeys.grantedAt)
         static let backendGrantId: Column = Column(CodingKeys.backendGrantId)
+        static let bundleIds: Column = Column(CodingKeys.bundleIds)
+        static let serviceVersion: Column = Column(CodingKeys.serviceVersion)
     }
 
     let connectionId: String
@@ -22,6 +24,13 @@ struct DBCloudConnectionGrant: Codable, FetchableRecord, PersistableRecord, Hash
     /// pushed to the server. Nil when the push hasn't happened or failed;
     /// backend revocation is skipped for those rows.
     let backendGrantId: String?
+    /// Permission-bundle ids this grant authorizes (catalog ids like
+    /// "calendar.events", stored as JSON). Nil for rows that predate bundles
+    /// or whose service isn't in the catalog (legacy whole-toolkit grants).
+    let bundleIds: [String]?
+    /// Catalog service version the bundles were granted against. Nil when no
+    /// catalog entry existed at push time.
+    let serviceVersion: Int?
 
     init(
         connectionId: String,
@@ -29,7 +38,9 @@ struct DBCloudConnectionGrant: Codable, FetchableRecord, PersistableRecord, Hash
         serviceId: String,
         grantedToInboxId: String,
         grantedAt: Date,
-        backendGrantId: String? = nil
+        backendGrantId: String? = nil,
+        bundleIds: [String]? = nil,
+        serviceVersion: Int? = nil
     ) {
         self.connectionId = connectionId
         self.conversationId = conversationId
@@ -37,6 +48,8 @@ struct DBCloudConnectionGrant: Codable, FetchableRecord, PersistableRecord, Hash
         self.grantedToInboxId = grantedToInboxId
         self.grantedAt = grantedAt
         self.backendGrantId = backendGrantId
+        self.bundleIds = bundleIds
+        self.serviceVersion = serviceVersion
     }
 }
 
@@ -47,7 +60,8 @@ extension DBCloudConnectionGrant {
             conversationId: conversationId,
             serviceId: serviceId,
             grantedToInboxId: grantedToInboxId,
-            grantedAt: grantedAt
+            grantedAt: grantedAt,
+            bundleIds: bundleIds
         )
     }
 
@@ -58,5 +72,7 @@ extension DBCloudConnectionGrant {
         self.grantedToInboxId = grant.grantedToInboxId
         self.grantedAt = grant.grantedAt
         self.backendGrantId = nil
+        self.bundleIds = grant.bundleIds
+        self.serviceVersion = nil
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Storage/SharedDatabaseMigrator.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/SharedDatabaseMigrator.swift
@@ -205,6 +205,8 @@ extension SharedDatabaseMigrator {
 
         migrator.registerMigration("addConnectionGrantBackendGrantId", migrate: Self.addConnectionGrantBackendGrantId)
 
+        migrator.registerMigration("addConnectionGrantBundleScope", migrate: Self.addConnectionGrantBundleScope)
+
         return migrator
     }
 
@@ -433,6 +435,18 @@ extension SharedDatabaseMigrator {
     private static func addConnectionGrantBackendGrantId(_ db: Database) throws {
         try db.alter(table: "connectionGrant") { t in
             t.add(column: "backendGrantId", .text)
+        }
+    }
+
+    /// Bundle-scoped grants (connections picker): `bundleIds` is the JSON
+    /// array of permission-bundle ids the user toggled on (catalog ids like
+    /// "calendar.events"); `serviceVersion` is the catalog version the device
+    /// granted against. Both nullable: rows that predate bundles, or whose
+    /// service isn't in the catalog, are legacy whole-toolkit grants.
+    private static func addConnectionGrantBundleScope(_ db: Database) throws {
+        try db.alter(table: "connectionGrant") { t in
+            t.add(column: "bundleIds", .text)
+            t.add(column: "serviceVersion", .integer)
         }
     }
 

--- a/ConvosCore/Tests/ConvosCoreTests/CapabilityRequestHandlerTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/CapabilityRequestHandlerTests.swift
@@ -462,3 +462,129 @@ struct CommitDenyCancelTests {
         #expect(result.providers.isEmpty)
     }
 }
+
+@Suite("CapabilityRequestHandler.computeLayout — service bundles")
+struct ComputeLayoutServiceBundlesTests {
+    private let handler: CapabilityRequestHandler = CapabilityRequestHandler()
+    private let googleCalendar: ProviderID = ProviderID(rawValue: "composio.googlecalendar")
+    private let appleCalendar: ProviderID = ProviderID(rawValue: "device.calendar")
+
+    private func makeRequest() -> CapabilityRequest {
+        CapabilityRequest(
+            requestId: "req-1",
+            askerInboxId: "agent-1",
+            subject: .calendar,
+            capability: .read,
+            rationale: "test"
+        )
+    }
+
+    private func makeRegistry(_ providers: [StubProvider]) async -> any CapabilityProviderRegistry {
+        let registry = InMemoryCapabilityProviderRegistry()
+        for provider in providers { await registry.register(provider) }
+        return registry
+    }
+
+    private func calendarService(version: Int = 2) -> CloudConnectionsAPI.ServiceConfig {
+        CloudConnectionsAPI.ServiceConfig(
+            id: "googlecalendar",
+            composioSlug: "googlecalendar",
+            version: version,
+            displayName: .init(values: ["en": "Google Calendar"]),
+            bundles: [
+                .init(
+                    id: "calendar.events",
+                    title: .init(values: ["en": "Events"]),
+                    description: .init(values: ["en": "View and edit events on all calendars"]),
+                    defaultEnabled: false
+                ),
+                .init(
+                    id: "calendar.events.read",
+                    title: .init(values: ["en": "View events"]),
+                    description: .init(values: ["en": "View events on all calendars"]),
+                    defaultEnabled: true
+                ),
+            ]
+        )
+    }
+
+    @Test("cloud providers with a catalog entry get bundle rows; device providers don't")
+    func bundlesAttachToCloudProviders() async {
+        let registry = await makeRegistry([
+            StubProvider(
+                id: googleCalendar,
+                subject: .calendar,
+                displayName: "Google Calendar",
+                capabilities: [.read],
+                linkedByUserValue: true
+            ),
+            StubProvider(
+                id: appleCalendar,
+                subject: .calendar,
+                displayName: "Apple Calendar",
+                capabilities: [.read],
+                linkedByUserValue: true
+            ),
+        ])
+        let resolver = InMemoryCapabilityResolver(registry: registry)
+        let layout = await handler.computeLayout(
+            request: makeRequest(),
+            registry: registry,
+            resolver: resolver,
+            conversationId: "conv-1",
+            services: [calendarService()]
+        )
+        #expect(layout.serviceBundles.count == 1)
+        let group = layout.serviceBundles.first
+        #expect(group?.providerId == googleCalendar)
+        #expect(group?.serviceId == "googlecalendar")
+        #expect(group?.serviceVersion == 2)
+        #expect(group?.rows.map(\.id) == ["calendar.events", "calendar.events.read"])
+        #expect(group?.rows.first?.title == "Events")
+        #expect(group?.rows.first?.description == "View and edit events on all calendars")
+    }
+
+    @Test("defaultBundleSelection seeds from the catalog's defaultEnabled flags")
+    func defaultSelectionFollowsDefaultEnabled() async {
+        let registry = await makeRegistry([
+            StubProvider(
+                id: googleCalendar,
+                subject: .calendar,
+                displayName: "Google Calendar",
+                capabilities: [.read],
+                linkedByUserValue: true
+            ),
+        ])
+        let resolver = InMemoryCapabilityResolver(registry: registry)
+        let layout = await handler.computeLayout(
+            request: makeRequest(),
+            registry: registry,
+            resolver: resolver,
+            conversationId: "conv-1",
+            services: [calendarService()]
+        )
+        #expect(layout.defaultBundleSelection == ["googlecalendar": ["calendar.events.read"]])
+    }
+
+    @Test("an empty catalog leaves the layout bundle-free")
+    func emptyCatalogMeansNoBundles() async {
+        let registry = await makeRegistry([
+            StubProvider(
+                id: googleCalendar,
+                subject: .calendar,
+                displayName: "Google Calendar",
+                capabilities: [.read],
+                linkedByUserValue: true
+            ),
+        ])
+        let resolver = InMemoryCapabilityResolver(registry: registry)
+        let layout = await handler.computeLayout(
+            request: makeRequest(),
+            registry: registry,
+            resolver: resolver,
+            conversationId: "conv-1"
+        )
+        #expect(layout.serviceBundles.isEmpty)
+        #expect(layout.defaultBundleSelection.isEmpty)
+    }
+}

--- a/ConvosCore/Tests/ConvosCoreTests/CapabilityRequestResultStaleResourceTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/CapabilityRequestResultStaleResourceTests.swift
@@ -1,0 +1,112 @@
+import ConvosConnections
+@testable import ConvosCore
+import Foundation
+import Testing
+@preconcurrency import XMTPiOS
+
+/// Wire-compat tests for `convos.org/capability_request_result/1.0`, focused
+/// on the `stale_resource` status added for the connections-picker bundles
+/// flow and on unknown-status forward compatibility. (Baseline round-trip
+/// coverage lives in `CapabilityRequestResultCodecTests` in
+/// CapabilityRequestCodecTests.swift.)
+@Suite("CapabilityRequestResult codec — stale_resource + forward compat")
+struct CapabilityRequestResultStaleResourceTests {
+    private let codec: CapabilityRequestResultCodec = CapabilityRequestResultCodec()
+
+    private func encodedContent(json: String) throws -> EncodedContent {
+        var content = EncodedContent()
+        content.type = ContentTypeCapabilityRequestResult
+        content.content = try #require(json.data(using: .utf8))
+        return content
+    }
+
+    @Test("pre-bundles payloads (no staleServices key) still decode")
+    func decodesLegacyPayload() throws {
+        let json = """
+        {
+          "version": 1,
+          "requestId": "req-1",
+          "status": "approved",
+          "subject": "calendar",
+          "capability": "read",
+          "providers": ["device.calendar"]
+        }
+        """
+        let result = try codec.decode(content: encodedContent(json: json))
+        #expect(result.status == .approved)
+        #expect(result.requestId == "req-1")
+        #expect(result.providers == [ProviderID(rawValue: "device.calendar")])
+        #expect(result.staleServices.isEmpty)
+    }
+
+    @Test("stale_resource decodes with its camelCase staleServices payload")
+    func decodesStaleResource() throws {
+        let json = """
+        {
+          "version": 1,
+          "requestId": "req-2",
+          "status": "stale_resource",
+          "subject": "calendar",
+          "capability": "read",
+          "staleServices": [
+            { "id": "googlecalendar", "expectedVersion": 3 }
+          ]
+        }
+        """
+        let result = try codec.decode(content: encodedContent(json: json))
+        #expect(result.status == .staleResource)
+        #expect(result.staleServices == [
+            CapabilityRequestResult.StaleService(id: "googlecalendar", expectedVersion: 3),
+        ])
+    }
+
+    @Test("an unrecognized status decodes to .unknown instead of throwing")
+    func unknownStatusIsSafe() throws {
+        let json = """
+        {
+          "version": 1,
+          "requestId": "req-3",
+          "status": "some_future_status",
+          "subject": "calendar",
+          "capability": "read"
+        }
+        """
+        let result = try codec.decode(content: encodedContent(json: json))
+        #expect(result.status == .unknown)
+        #expect(result.requestId == "req-3")
+    }
+
+    @Test("encode/decode round-trips a stale_resource result")
+    func roundTripsStaleResource() throws {
+        let original = CapabilityRequestResult(
+            requestId: "req-4",
+            status: .staleResource,
+            subject: .calendar,
+            capability: .read,
+            staleServices: [.init(id: "googlecalendar", expectedVersion: 7)]
+        )
+        let decoded = try codec.decode(content: codec.encode(content: original))
+        #expect(decoded == original)
+
+        // The status raw value on the wire is snake_case per the plan.
+        let data = try codec.encode(content: original).content
+        let object = try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+        #expect(object["status"] as? String == "stale_resource")
+        let staleServices = try #require(object["staleServices"] as? [[String: Any]])
+        #expect(staleServices.first?["expectedVersion"] as? Int == 7)
+    }
+
+    @Test("fallback copy exists for every status")
+    func fallbackCoversAllStatuses() throws {
+        for status in [CapabilityRequestResult.Status.approved, .denied, .cancelled, .staleResource, .unknown] {
+            let result = CapabilityRequestResult(
+                requestId: "req-5",
+                status: status,
+                subject: .calendar,
+                capability: .read
+            )
+            let fallback = try codec.fallback(content: result)
+            #expect(fallback?.isEmpty == false)
+        }
+    }
+}

--- a/ConvosCore/Tests/ConvosCoreTests/ConnectionGrantWriterTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ConnectionGrantWriterTests.swift
@@ -510,6 +510,83 @@ struct ConnectionGrantWriterTests {
         #expect(stored.first?.serviceVersion == 5)
     }
 
+    @Test("Grant: fails closed when the cataloged service lists no bundles and there is no selection")
+    func grantFailsClosedWhenCatalogServiceHasNoBundles() async throws {
+        let recordingClient = RecordingGrantAPIClient()
+        recordingClient.servicesCatalogQueue = [
+            Self.calendarCatalog(version: 4, bundleIds: []),
+        ]
+        let fixture = Fixture(apiClient: recordingClient)
+        defer { fixture.cleanup() }
+
+        let connection = try fixture.seedConnection()
+        let conversationId = "conv_zero_bundles"
+        try fixture.seedConversation(id: conversationId)
+
+        try await fixture.writer.grantConnection(connection.id, to: conversationId, grantedToInboxId: "agent-1")
+
+        // A cataloged service with zero bundles must not materialize an empty
+        // bundleIds array: the backend's legacy path treats that as
+        // whole-toolkit access. The push is skipped entirely.
+        #expect(recordingClient.createCalls.isEmpty)
+        let stored = try fixture.storedGrants(for: conversationId)
+        #expect(stored.count == 1, "the local grant still stands, same as any push failure")
+        #expect(stored.first?.backendGrantId == nil)
+    }
+
+    @Test("Grant: fails closed on an explicit empty selection — never pushed as whole-toolkit")
+    func grantFailsClosedOnExplicitEmptySelection() async throws {
+        let recordingClient = RecordingGrantAPIClient()
+        recordingClient.servicesCatalogQueue = [
+            Self.calendarCatalog(version: 4, bundleIds: []),
+        ]
+        let fixture = Fixture(apiClient: recordingClient)
+        defer { fixture.cleanup() }
+
+        let connection = try fixture.seedConnection()
+        let conversationId = "conv_empty_selection"
+        try fixture.seedConversation(id: conversationId)
+
+        try await fixture.writer.grantConnection(
+            connection.id,
+            to: conversationId,
+            grantedToInboxId: "agent-1",
+            bundleIds: []
+        )
+
+        // An explicit empty selection means the user approved zero bundles;
+        // pushing it would escalate to whole-toolkit access (the backend
+        // treats an empty array as the legacy whole-toolkit path).
+        #expect(recordingClient.createCalls.isEmpty)
+        let stored = try fixture.storedGrants(for: conversationId)
+        #expect(stored.first?.backendGrantId == nil)
+    }
+
+    @Test("Grant: explicit empty selection fails closed even for an uncataloged service")
+    func grantFailsClosedOnExplicitEmptySelectionForUncatalogedService() async throws {
+        let recordingClient = RecordingGrantAPIClient()
+        // Empty catalog: the service is proven absent, the path that would
+        // otherwise pass the selection through as-is.
+        recordingClient.servicesCatalogQueue = []
+        let fixture = Fixture(apiClient: recordingClient)
+        defer { fixture.cleanup() }
+
+        let connection = try fixture.seedConnection()
+        let conversationId = "conv_empty_uncataloged"
+        try fixture.seedConversation(id: conversationId)
+
+        try await fixture.writer.grantConnection(
+            connection.id,
+            to: conversationId,
+            grantedToInboxId: "agent-1",
+            bundleIds: []
+        )
+
+        #expect(recordingClient.createCalls.isEmpty)
+        let stored = try fixture.storedGrants(for: conversationId)
+        #expect(stored.first?.backendGrantId == nil)
+    }
+
     @Test("Grant: unknown_bundle refetches the catalog, drops unknown ids, and retries once")
     func grantRetriesOnceOnUnknownBundle() async throws {
         let recordingClient = RecordingGrantAPIClient()

--- a/ConvosCore/Tests/ConvosCoreTests/ConnectionGrantWriterTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ConnectionGrantWriterTests.swift
@@ -32,8 +32,25 @@ struct ConnectionGrantWriterTests {
                 sessionStateManager: sessionStateManager,
                 databaseWriter: databaseManager.dbWriter,
                 databaseReader: databaseManager.dbReader,
-                myProfileWriter: profileWriter
+                myProfileWriter: profileWriter,
+                servicesStore: Self.makeServicesStore(apiClient: apiClient)
             )
+        }
+
+        /// Catalog reads go through the same (stubbed) API client the push
+        /// uses, mirroring production wiring. Fixtures without a client get an
+        /// empty catalog: every push takes the legacy whole-toolkit path.
+        private static func makeServicesStore(
+            apiClient: (any ConvosAPIClientProtocol)?
+        ) -> ConnectionServicesStore {
+            guard let apiClient else {
+                return ConnectionServicesStore(fetchServices: {
+                    CloudConnectionsAPI.ServicesResponse(services: [])
+                })
+            }
+            return ConnectionServicesStore(fetchServices: {
+                try await apiClient.getConnectionServices()
+            })
         }
 
         func seedConnection(
@@ -330,10 +347,12 @@ struct ConnectionGrantWriterTests {
         #expect(call.granteeInboxId == "agent-1")
         #expect(call.conversationId == conversationId)
         #expect(call.toolkit == connection.serviceId)
-        #expect(call.connectionId == connection.composioConnectionId)
-        // No per-action scope is available at grant time, so the writer sends an
-        // empty actions array and the backend treats the grant as whole-toolkit.
-        #expect(call.actions.isEmpty)
+        // No catalog entry for the service: the writer omits bundleIds and
+        // serviceVersion, which the backend treats as a legacy whole-toolkit
+        // grant. The legacy `actions` and `connectionId` fields are gone from
+        // the API surface entirely.
+        #expect(call.bundleIds == nil)
+        #expect(call.serviceVersion == nil)
 
         let stored = try fixture.storedGrants(for: conversationId)
         #expect(stored.first?.backendGrantId == "backend-grant-1")
@@ -408,18 +427,204 @@ struct ConnectionGrantWriterTests {
             .init(toolkit: connection.serviceId, conversationId: conversationId, granteeInboxId: "agent-1"),
         ])
     }
+
+    // MARK: - Bundle-scoped grants
+
+    /// Catalog fixture for the default `seedConnection` service
+    /// ("googlecalendar").
+    private static func calendarCatalog(
+        version: Int,
+        bundleIds: [String]
+    ) -> [CloudConnectionsAPI.ServiceConfig] {
+        [
+            CloudConnectionsAPI.ServiceConfig(
+                id: "googlecalendar",
+                composioSlug: "googlecalendar",
+                version: version,
+                displayName: .init(values: ["en": "Google Calendar"]),
+                bundles: bundleIds.map { id in
+                    CloudConnectionsAPI.ServiceBundle(
+                        id: id,
+                        title: .init(values: ["en": id]),
+                        description: .init(values: ["en": "About \(id)"]),
+                        defaultEnabled: false
+                    )
+                }
+            ),
+        ]
+    }
+
+    @Test("Grant: explicit bundle selection is pushed with the catalog service version")
+    func grantPushesExplicitBundleSelection() async throws {
+        let recordingClient = RecordingGrantAPIClient()
+        recordingClient.servicesCatalogQueue = [
+            Self.calendarCatalog(version: 2, bundleIds: ["calendar.events", "calendar.events.read"]),
+        ]
+        let fixture = Fixture(apiClient: recordingClient)
+        defer { fixture.cleanup() }
+
+        let connection = try fixture.seedConnection()
+        let conversationId = "conv_bundles"
+        try fixture.seedConversation(id: conversationId)
+
+        try await fixture.writer.grantConnection(
+            connection.id,
+            to: conversationId,
+            grantedToInboxId: "agent-1",
+            bundleIds: ["calendar.events"]
+        )
+
+        #expect(recordingClient.createCalls.count == 1)
+        let call = try #require(recordingClient.createCalls.first)
+        #expect(call.bundleIds == ["calendar.events"])
+        #expect(call.serviceVersion == 2)
+
+        let stored = try fixture.storedGrants(for: conversationId)
+        #expect(stored.first?.bundleIds == ["calendar.events"])
+        #expect(stored.first?.serviceVersion == 2)
+        #expect(stored.first?.backendGrantId == "backend-grant-1")
+    }
+
+    @Test("Grant: no explicit selection grants every catalog bundle for the service")
+    func grantWithoutSelectionGrantsAllCatalogBundles() async throws {
+        let recordingClient = RecordingGrantAPIClient()
+        recordingClient.servicesCatalogQueue = [
+            Self.calendarCatalog(version: 5, bundleIds: ["calendar.events", "calendar.events.read"]),
+        ]
+        let fixture = Fixture(apiClient: recordingClient)
+        defer { fixture.cleanup() }
+
+        let connection = try fixture.seedConnection()
+        let conversationId = "conv_bundles_all"
+        try fixture.seedConversation(id: conversationId)
+
+        try await fixture.writer.grantConnection(connection.id, to: conversationId, grantedToInboxId: "agent-1")
+
+        #expect(recordingClient.createCalls.count == 1)
+        let call = try #require(recordingClient.createCalls.first)
+        #expect(call.bundleIds == ["calendar.events", "calendar.events.read"])
+        #expect(call.serviceVersion == 5)
+
+        let stored = try fixture.storedGrants(for: conversationId)
+        #expect(stored.first?.bundleIds == ["calendar.events", "calendar.events.read"])
+        #expect(stored.first?.serviceVersion == 5)
+    }
+
+    @Test("Grant: unknown_bundle refetches the catalog, drops unknown ids, and retries once")
+    func grantRetriesOnceOnUnknownBundle() async throws {
+        let recordingClient = RecordingGrantAPIClient()
+        recordingClient.servicesCatalogQueue = [
+            Self.calendarCatalog(version: 2, bundleIds: ["calendar.old", "calendar.events"]),
+            Self.calendarCatalog(version: 3, bundleIds: ["calendar.events"]),
+        ]
+        recordingClient.createErrorQueue = [
+            CloudConnectionsAPI.GrantError.unknownBundle(bundleId: "calendar.old"),
+        ]
+        let fixture = Fixture(apiClient: recordingClient)
+        defer { fixture.cleanup() }
+
+        let connection = try fixture.seedConnection()
+        let conversationId = "conv_stale"
+        try fixture.seedConversation(id: conversationId)
+
+        try await fixture.writer.grantConnection(
+            connection.id,
+            to: conversationId,
+            grantedToInboxId: "agent-1",
+            bundleIds: ["calendar.old", "calendar.events"]
+        )
+
+        #expect(recordingClient.createCalls.count == 2)
+        #expect(recordingClient.createCalls.first?.bundleIds == ["calendar.old", "calendar.events"])
+        let retry = try #require(recordingClient.createCalls.last)
+        #expect(retry.bundleIds == ["calendar.events"])
+        #expect(retry.serviceVersion == 3)
+        #expect(recordingClient.servicesFetchCount == 2)
+
+        let stored = try fixture.storedGrants(for: conversationId)
+        #expect(stored.first?.bundleIds == ["calendar.events"])
+        #expect(stored.first?.serviceVersion == 3)
+        #expect(stored.first?.backendGrantId == "backend-grant-2")
+    }
+
+    @Test("Grant: a second unknown_bundle rejection gives up — exactly one retry, no loop")
+    func grantGivesUpAfterOneUnknownBundleRetry() async throws {
+        let recordingClient = RecordingGrantAPIClient()
+        recordingClient.servicesCatalogQueue = [
+            Self.calendarCatalog(version: 2, bundleIds: ["calendar.events"]),
+            Self.calendarCatalog(version: 3, bundleIds: ["calendar.events"]),
+        ]
+        recordingClient.createErrorQueue = [
+            CloudConnectionsAPI.GrantError.unknownBundle(bundleId: "calendar.events"),
+            CloudConnectionsAPI.GrantError.unknownBundle(bundleId: "calendar.events"),
+        ]
+        let fixture = Fixture(apiClient: recordingClient)
+        defer { fixture.cleanup() }
+
+        let connection = try fixture.seedConnection()
+        let conversationId = "conv_stale_twice"
+        try fixture.seedConversation(id: conversationId)
+
+        try await fixture.writer.grantConnection(
+            connection.id,
+            to: conversationId,
+            grantedToInboxId: "agent-1",
+            bundleIds: ["calendar.events"]
+        )
+
+        // Two attempts (original + one retry), then the push is abandoned:
+        // the local grant stands with no backend id, same as any push failure.
+        #expect(recordingClient.createCalls.count == 2)
+        let stored = try fixture.storedGrants(for: conversationId)
+        #expect(stored.count == 1)
+        #expect(stored.first?.backendGrantId == nil)
+    }
+
+    @Test("Grant: fails closed when the refreshed catalog knows none of the selected bundles")
+    func grantFailsClosedWhenSelectionVanishesFromCatalog() async throws {
+        let recordingClient = RecordingGrantAPIClient()
+        recordingClient.servicesCatalogQueue = [
+            Self.calendarCatalog(version: 2, bundleIds: ["calendar.old"]),
+            Self.calendarCatalog(version: 3, bundleIds: ["calendar.events"]),
+        ]
+        recordingClient.createErrorQueue = [
+            CloudConnectionsAPI.GrantError.unknownBundle(bundleId: "calendar.old"),
+        ]
+        let fixture = Fixture(apiClient: recordingClient)
+        defer { fixture.cleanup() }
+
+        let connection = try fixture.seedConnection()
+        let conversationId = "conv_vanished"
+        try fixture.seedConversation(id: conversationId)
+
+        try await fixture.writer.grantConnection(
+            connection.id,
+            to: conversationId,
+            grantedToInboxId: "agent-1",
+            bundleIds: ["calendar.old"]
+        )
+
+        // No retry: pushing an empty bundle set would escalate to whole-toolkit
+        // access, strictly more than the user approved.
+        #expect(recordingClient.createCalls.count == 1)
+        let stored = try fixture.storedGrants(for: conversationId)
+        #expect(stored.first?.backendGrantId == nil)
+    }
 }
 
 /// Records backend grant push/revoke calls made by `CloudConnectionGrantWriter`
-/// so tests can assert the consent records sent to the server.
+/// so tests can assert the consent records sent to the server. Also serves the
+/// services catalog: `servicesCatalogQueue` is consumed one response per fetch
+/// (the last entry repeats), so tests can model a stale catalog that changes
+/// across the unknown_bundle refetch.
 private final class RecordingGrantAPIClient: TestStubAPIClient {
     struct CreateCall: Sendable {
         let ownerInboxId: String
         let granteeInboxId: String
         let conversationId: String
         let toolkit: String
-        let actions: [String]
-        let connectionId: String?
+        let bundleIds: [String]?
+        let serviceVersion: Int?
     }
 
     struct NaturalKeyRevokeCall: Sendable, Equatable {
@@ -432,26 +637,45 @@ private final class RecordingGrantAPIClient: TestStubAPIClient {
     var revokeCalls: [String] = []
     var naturalKeyRevokeCalls: [NaturalKeyRevokeCall] = []
     var createError: Error?
+    /// Thrown once per entry (after the attempt is recorded), then discarded —
+    /// models a 400 the server rejects before a later attempt succeeds.
+    var createErrorQueue: [Error] = []
+    var servicesCatalogQueue: [[CloudConnectionsAPI.ServiceConfig]] = []
+    var servicesFetchCount: Int = 0
+
+    override func getConnectionServices() async throws -> CloudConnectionsAPI.ServicesResponse {
+        servicesFetchCount += 1
+        guard let catalog = servicesCatalogQueue.first else {
+            return CloudConnectionsAPI.ServicesResponse(services: [])
+        }
+        if servicesCatalogQueue.count > 1 {
+            servicesCatalogQueue.removeFirst()
+        }
+        return CloudConnectionsAPI.ServicesResponse(services: catalog)
+    }
 
     override func createConnectionGrant(
         ownerInboxId: String,
         granteeInboxId: String,
         conversationId: String,
         toolkit: String,
-        actions: [String],
-        connectionId: String?
+        bundleIds: [String]?,
+        serviceVersion: Int?
     ) async throws -> CloudConnectionsAPI.CreateGrantResponse {
-        if let createError {
-            throw createError
-        }
         createCalls.append(CreateCall(
             ownerInboxId: ownerInboxId,
             granteeInboxId: granteeInboxId,
             conversationId: conversationId,
             toolkit: toolkit,
-            actions: actions,
-            connectionId: connectionId
+            bundleIds: bundleIds,
+            serviceVersion: serviceVersion
         ))
+        if let createError {
+            throw createError
+        }
+        if !createErrorQueue.isEmpty {
+            throw createErrorQueue.removeFirst()
+        }
         return CloudConnectionsAPI.CreateGrantResponse(id: "backend-grant-\(createCalls.count)")
     }
 

--- a/ConvosCore/Tests/ConvosCoreTests/ConnectionGrantWriterTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ConnectionGrantWriterTests.swift
@@ -610,6 +610,89 @@ struct ConnectionGrantWriterTests {
         let stored = try fixture.storedGrants(for: conversationId)
         #expect(stored.first?.backendGrantId == nil)
     }
+
+    @Test("Grant: catalog outage with no explicit selection fails closed — no whole-toolkit push")
+    func grantFailsClosedOnCatalogOutageWithoutSelection() async throws {
+        struct CatalogDown: Error {}
+        let recordingClient = RecordingGrantAPIClient()
+        recordingClient.servicesError = CatalogDown()
+        let fixture = Fixture(apiClient: recordingClient)
+        defer { fixture.cleanup() }
+
+        let connection = try fixture.seedConnection()
+        let conversationId = "conv_outage"
+        try fixture.seedConversation(id: conversationId)
+
+        try await fixture.writer.grantConnection(connection.id, to: conversationId, grantedToInboxId: "agent-1")
+
+        // An unreachable catalog must not be conflated with "service not in
+        // catalog": omitting bundleIds here could grant whole-toolkit access
+        // for a service that IS cataloged. The push is skipped entirely.
+        #expect(recordingClient.createCalls.isEmpty)
+        let stored = try fixture.storedGrants(for: conversationId)
+        #expect(stored.count == 1, "the local grant still stands, same as any push failure")
+        #expect(stored.first?.backendGrantId == nil)
+    }
+
+    @Test("Grant: catalog outage with an explicit selection pushes it unfiltered, no version")
+    func grantPushesExplicitSelectionDuringCatalogOutage() async throws {
+        struct CatalogDown: Error {}
+        let recordingClient = RecordingGrantAPIClient()
+        recordingClient.servicesError = CatalogDown()
+        let fixture = Fixture(apiClient: recordingClient)
+        defer { fixture.cleanup() }
+
+        let connection = try fixture.seedConnection()
+        let conversationId = "conv_outage_explicit"
+        try fixture.seedConversation(id: conversationId)
+
+        try await fixture.writer.grantConnection(
+            connection.id,
+            to: conversationId,
+            grantedToInboxId: "agent-1",
+            bundleIds: ["calendar.events"]
+        )
+
+        // The user's explicit picks are safe to transmit — the backend
+        // validates them against its own catalog.
+        #expect(recordingClient.createCalls.count == 1)
+        let call = try #require(recordingClient.createCalls.first)
+        #expect(call.bundleIds == ["calendar.events"])
+        #expect(call.serviceVersion == nil)
+    }
+
+    @Test("Grant: the unknown_bundle retry never widens a nil-selection grant past the first attempt")
+    func grantRetryNeverWidensScope() async throws {
+        let recordingClient = RecordingGrantAPIClient()
+        recordingClient.servicesCatalogQueue = [
+            Self.calendarCatalog(version: 2, bundleIds: ["calendar.events"]),
+            Self.calendarCatalog(version: 3, bundleIds: ["calendar.events", "calendar.brand.new"]),
+        ]
+        recordingClient.createErrorQueue = [
+            CloudConnectionsAPI.GrantError.unknownBundle(bundleId: "calendar.events"),
+        ]
+        let fixture = Fixture(apiClient: recordingClient)
+        defer { fixture.cleanup() }
+
+        let connection = try fixture.seedConnection()
+        let conversationId = "conv_no_widen"
+        try fixture.seedConversation(id: conversationId)
+
+        try await fixture.writer.grantConnection(connection.id, to: conversationId, grantedToInboxId: "agent-1")
+
+        // The nil selection materialized to the v2 catalog (["calendar.events"])
+        // on the first attempt. The retry intersects THAT with the refreshed
+        // catalog — it must not pick up v3's extra bundle.
+        #expect(recordingClient.createCalls.count == 2)
+        #expect(recordingClient.createCalls.first?.bundleIds == ["calendar.events"])
+        let retry = try #require(recordingClient.createCalls.last)
+        #expect(retry.bundleIds == ["calendar.events"])
+        #expect(retry.bundleIds?.contains("calendar.brand.new") == false)
+        #expect(retry.serviceVersion == 3)
+
+        let stored = try fixture.storedGrants(for: conversationId)
+        #expect(stored.first?.bundleIds == ["calendar.events"])
+    }
 }
 
 /// Records backend grant push/revoke calls made by `CloudConnectionGrantWriter`
@@ -642,9 +725,14 @@ private final class RecordingGrantAPIClient: TestStubAPIClient {
     var createErrorQueue: [Error] = []
     var servicesCatalogQueue: [[CloudConnectionsAPI.ServiceConfig]] = []
     var servicesFetchCount: Int = 0
+    /// When set, every catalog fetch fails — models a backend/network outage.
+    var servicesError: Error?
 
     override func getConnectionServices() async throws -> CloudConnectionsAPI.ServicesResponse {
         servicesFetchCount += 1
+        if let servicesError {
+            throw servicesError
+        }
         guard let catalog = servicesCatalogQueue.first else {
             return CloudConnectionsAPI.ServicesResponse(services: [])
         }

--- a/ConvosCore/Tests/ConvosCoreTests/ConnectionManagerTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ConnectionManagerTests.swift
@@ -675,7 +675,8 @@ private actor RecordingGrantWriter: CloudConnectionGrantWriterProtocol {
     nonisolated func grantConnection(
         _ connectionId: String,
         to conversationId: String,
-        grantedToInboxId: String
+        grantedToInboxId: String,
+        bundleIds: [String]?
     ) async throws {}
 
     func revokeGrant(

--- a/ConvosCore/Tests/ConvosCoreTests/ConnectionServicesStoreTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ConnectionServicesStoreTests.swift
@@ -17,18 +17,24 @@ struct ConnectionServicesStoreTests {
             self.responses = responses
         }
 
+        /// One simulated backend fetch: bumps the counter and consumes the
+        /// response queue (last entry repeats).
+        func fetch() async throws -> CloudConnectionsAPI.ServicesResponse {
+            fetchCount += 1
+            let catalog = responses.first ?? []
+            if responses.count > 1 {
+                responses.removeFirst()
+            }
+            return CloudConnectionsAPI.ServicesResponse(services: catalog)
+        }
+
         func makeStore(ttl: TimeInterval = ConnectionServicesStore.cacheTTL) -> ConnectionServicesStore {
             ConnectionServicesStore(
                 ttl: ttl,
                 now: { [weak self] in self?.currentDate ?? Date() },
                 fetchServices: { [weak self] in
                     guard let self else { return CloudConnectionsAPI.ServicesResponse(services: []) }
-                    self.fetchCount += 1
-                    let catalog = self.responses.first ?? []
-                    if self.responses.count > 1 {
-                        self.responses.removeFirst()
-                    }
-                    return CloudConnectionsAPI.ServicesResponse(services: catalog)
+                    return try await self.fetch()
                 }
             )
         }
@@ -87,6 +93,69 @@ struct ConnectionServicesStoreTests {
         let second = try await store.service(id: "googlecalendar")
         #expect(second?.version == 2)
         #expect(harness.fetchCount == 2)
+    }
+
+    @Test("invalidate() abandons an in-flight fetch: later reads refetch and the stale result can't re-cache")
+    func invalidateAbandonsInflightFetch() async throws {
+        /// Holds the FIRST fetch open until released, so the test can
+        /// invalidate while it is in flight.
+        final class Gate: @unchecked Sendable {
+            private let lock = NSLock()
+            private var continuations: [CheckedContinuation<Void, Never>] = []
+            func wait() async {
+                await withCheckedContinuation { continuation in
+                    lock.lock()
+                    continuations.append(continuation)
+                    lock.unlock()
+                }
+            }
+            func open() {
+                lock.lock()
+                let waiting = continuations
+                continuations = []
+                lock.unlock()
+                waiting.forEach { $0.resume() }
+            }
+        }
+
+        let gate = Gate()
+        let harness = Harness(responses: [[Self.service(version: 1)], [Self.service(version: 2)]])
+        let counter = harness
+        let store = ConnectionServicesStore(
+            ttl: ConnectionServicesStore.cacheTTL,
+            now: { Date() },
+            fetchServices: { [weak counter] in
+                guard let counter else { return CloudConnectionsAPI.ServicesResponse(services: []) }
+                let isFirst = counter.fetchCount == 0
+                let response = try await counter.fetch()
+                if isFirst {
+                    await gate.wait()
+                }
+                return response
+            }
+        )
+
+        let staleRead = Task { try await store.catalog() }
+        // Let the first fetch actually start before invalidating.
+        while harness.fetchCount < 1 {
+            await Task.yield()
+        }
+
+        await store.invalidate()
+
+        // A read after invalidation must start a fresh fetch, not join the
+        // stale in-flight one (which is still blocked on the gate).
+        let fresh = try await store.service(id: "googlecalendar")
+        #expect(fresh?.version == 2)
+        #expect(harness.fetchCount == 2)
+
+        // Release the stale fetch: its original awaiter still gets an answer,
+        // but it must not stomp the cache with the pre-invalidation catalog.
+        gate.open()
+        _ = try? await staleRead.value
+        let cached = try await store.service(id: "googlecalendar")
+        #expect(cached?.version == 2, "the stale fetch must not re-cache the rejected catalog")
+        #expect(harness.fetchCount == 2, "the cached v2 catalog is still fresh; no extra fetch")
     }
 
     // MARK: - Version-mismatch invalidation

--- a/ConvosCore/Tests/ConvosCoreTests/ConnectionServicesStoreTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ConnectionServicesStoreTests.swift
@@ -1,0 +1,212 @@
+@testable import ConvosCore
+import Foundation
+import Testing
+
+/// Tests for `ConnectionServicesStore` (the client-side cache over
+/// `GET /v2/connections/services`) and the catalog's Codable shapes.
+@Suite("ConnectionServicesStore Tests")
+struct ConnectionServicesStoreTests {
+    /// Serves catalogs from a queue (last entry repeats) and counts fetches,
+    /// with a mutable clock so the TTL is testable without sleeping.
+    private final class Harness: @unchecked Sendable {
+        private(set) var fetchCount: Int = 0
+        var responses: [[CloudConnectionsAPI.ServiceConfig]]
+        var currentDate: Date = Date(timeIntervalSince1970: 1_000_000)
+
+        init(responses: [[CloudConnectionsAPI.ServiceConfig]]) {
+            self.responses = responses
+        }
+
+        func makeStore(ttl: TimeInterval = ConnectionServicesStore.cacheTTL) -> ConnectionServicesStore {
+            ConnectionServicesStore(
+                ttl: ttl,
+                now: { [weak self] in self?.currentDate ?? Date() },
+                fetchServices: { [weak self] in
+                    guard let self else { return CloudConnectionsAPI.ServicesResponse(services: []) }
+                    self.fetchCount += 1
+                    let catalog = self.responses.first ?? []
+                    if self.responses.count > 1 {
+                        self.responses.removeFirst()
+                    }
+                    return CloudConnectionsAPI.ServicesResponse(services: catalog)
+                }
+            )
+        }
+    }
+
+    private static func service(
+        id: String = "googlecalendar",
+        version: Int,
+        bundleIds: [String] = ["calendar.events"]
+    ) -> CloudConnectionsAPI.ServiceConfig {
+        CloudConnectionsAPI.ServiceConfig(
+            id: id,
+            composioSlug: id,
+            version: version,
+            displayName: .init(values: ["en": id]),
+            bundles: bundleIds.map {
+                .init(
+                    id: $0,
+                    title: .init(values: ["en": $0]),
+                    description: .init(values: ["en": "About \($0)"]),
+                    defaultEnabled: false
+                )
+            }
+        )
+    }
+
+    // MARK: - TTL
+
+    @Test("Catalog reads within the TTL are served from cache; a read past it refetches")
+    func ttlIsRespected() async throws {
+        let harness = Harness(responses: [[Self.service(version: 1)]])
+        let store = harness.makeStore()
+
+        _ = try await store.catalog()
+        _ = try await store.catalog()
+        #expect(harness.fetchCount == 1)
+
+        harness.currentDate.addTimeInterval(ConnectionServicesStore.cacheTTL - 1)
+        _ = try await store.catalog()
+        #expect(harness.fetchCount == 1, "a read just inside the TTL must not refetch")
+
+        harness.currentDate.addTimeInterval(2)
+        _ = try await store.catalog()
+        #expect(harness.fetchCount == 2, "a read past the TTL must refetch")
+    }
+
+    @Test("invalidate() forces the next read to refetch regardless of TTL")
+    func invalidateForcesRefetch() async throws {
+        let harness = Harness(responses: [[Self.service(version: 1)], [Self.service(version: 2)]])
+        let store = harness.makeStore()
+
+        let first = try await store.service(id: "googlecalendar")
+        #expect(first?.version == 1)
+
+        await store.invalidate()
+        let second = try await store.service(id: "googlecalendar")
+        #expect(second?.version == 2)
+        #expect(harness.fetchCount == 2)
+    }
+
+    // MARK: - Version-mismatch invalidation
+
+    @Test("service(id:minimumVersion:) refetches when the cached entry is older than asked")
+    func versionMismatchInvalidates() async throws {
+        let harness = Harness(responses: [[Self.service(version: 1)], [Self.service(version: 3)]])
+        let store = harness.makeStore()
+
+        let cached = try await store.service(id: "googlecalendar")
+        #expect(cached?.version == 1)
+
+        let refreshed = try await store.service(id: "googlecalendar", minimumVersion: 3)
+        #expect(refreshed?.version == 3)
+        #expect(harness.fetchCount == 2)
+    }
+
+    @Test("service(id:minimumVersion:) serves the cache when it already satisfies the version")
+    func versionMatchServesCache() async throws {
+        let harness = Harness(responses: [[Self.service(version: 4)]])
+        let store = harness.makeStore()
+
+        _ = try await store.catalog()
+        let hit = try await store.service(id: "googlecalendar", minimumVersion: 4)
+        #expect(hit?.version == 4)
+        #expect(harness.fetchCount == 1)
+    }
+
+    @Test("unknown service id resolves to nil without extra fetches")
+    func unknownServiceIsNil() async throws {
+        let harness = Harness(responses: [[Self.service(version: 1)]])
+        let store = harness.makeStore()
+
+        let missing = try await store.service(id: "not-a-service")
+        #expect(missing == nil)
+        #expect(harness.fetchCount == 1)
+    }
+
+    // MARK: - LocalizedString
+
+    @Test("localized rendering picks the locale's language and falls back to en")
+    func localizedFallsBackToEnglish() {
+        let text = CloudConnectionsAPI.LocalizedString(values: ["en": "Events", "fr": "Événements"])
+        #expect(text.resolved(for: Locale(identifier: "fr_FR")) == "Événements")
+        #expect(text.resolved(for: Locale(identifier: "de_DE")) == "Events")
+
+        let englishOnly = CloudConnectionsAPI.LocalizedString(values: ["en": "Events"])
+        #expect(englishOnly.resolved(for: Locale(identifier: "ja_JP")) == "Events")
+
+        let empty = CloudConnectionsAPI.LocalizedString(values: [:])
+        #expect(empty.resolved(for: Locale(identifier: "en_US")).isEmpty)
+    }
+
+    // MARK: - Wire shape
+
+    @Test("services response decodes the documented camelCase shape, tolerating unknown fields")
+    func servicesResponseDecodes() throws {
+        let json = """
+        {
+          "services": [
+            {
+              "id": "googlecalendar",
+              "composioSlug": "googlecalendar",
+              "version": 2,
+              "displayName": { "en": "Google Calendar", "fr": "Google Agenda" },
+              "someFutureField": { "nested": true },
+              "bundles": [
+                {
+                  "id": "calendar.events",
+                  "title": { "en": "Events" },
+                  "description": { "en": "View and edit events on all calendars" },
+                  "defaultEnabled": false,
+                  "anotherFutureField": 7
+                },
+                {
+                  "id": "calendar.events.read",
+                  "title": { "en": "View events" },
+                  "description": { "en": "View events on all calendars" },
+                  "defaultEnabled": true
+                }
+              ]
+            }
+          ],
+          "topLevelFutureField": "ignored"
+        }
+        """
+        let data = try #require(json.data(using: .utf8))
+        let response = try JSONDecoder().decode(CloudConnectionsAPI.ServicesResponse.self, from: data)
+
+        let service = try #require(response.services.first)
+        #expect(service.id == "googlecalendar")
+        #expect(service.composioSlug == "googlecalendar")
+        #expect(service.version == 2)
+        #expect(service.displayName.resolved(for: Locale(identifier: "en_US")) == "Google Calendar")
+        #expect(service.icon == nil, "icon is optional and omitted in v1")
+        #expect(service.bundles.count == 2)
+        #expect(service.bundles.first?.id == "calendar.events")
+        #expect(service.bundles.first?.defaultEnabled == false)
+        #expect(service.bundles.last?.defaultEnabled == true)
+    }
+
+    @Test("an optional icon decodes when present")
+    func iconDecodesWhenPresent() throws {
+        let json = """
+        {
+          "services": [
+            {
+              "id": "googlecalendar",
+              "composioSlug": "googlecalendar",
+              "version": 1,
+              "displayName": { "en": "Google Calendar" },
+              "icon": { "format": "png", "base64": "aWNvbg==" },
+              "bundles": []
+            }
+          ]
+        }
+        """
+        let data = try #require(json.data(using: .utf8))
+        let response = try JSONDecoder().decode(CloudConnectionsAPI.ServicesResponse.self, from: data)
+        #expect(response.services.first?.icon?.format == "png")
+        #expect(response.services.first?.icon?.base64 == "aWNvbg==")
+    }
+}

--- a/ConvosCore/Tests/ConvosCoreTests/TestStubAPIClientDefaults.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/TestStubAPIClientDefaults.swift
@@ -70,13 +70,17 @@ extension ConvosAPIClientProtocol {
     /// Defaults for the backend connection-grant push so pre-existing fixtures
     /// don't have to re-stub them. Tests that exercise the push specifically
     /// should override on their fixture.
+    func getConnectionServices() async throws -> CloudConnectionsAPI.ServicesResponse {
+        CloudConnectionsAPI.ServicesResponse(services: [])
+    }
+
     func createConnectionGrant(
         ownerInboxId: String,
         granteeInboxId: String,
         conversationId: String,
         toolkit: String,
-        actions: [String],
-        connectionId: String?
+        bundleIds: [String]?,
+        serviceVersion: Int?
     ) async throws -> CloudConnectionsAPI.CreateGrantResponse {
         CloudConnectionsAPI.CreateGrantResponse(id: "test-grant-\(UUID().uuidString)")
     }
@@ -135,13 +139,17 @@ class TestStubAPIClient: ConvosAPIClientProtocol, @unchecked Sendable {
 
     /// Declared on the base (not just the protocol-extension default) so
     /// subclasses can `override` them.
+    func getConnectionServices() async throws -> CloudConnectionsAPI.ServicesResponse {
+        CloudConnectionsAPI.ServicesResponse(services: [])
+    }
+
     func createConnectionGrant(
         ownerInboxId: String,
         granteeInboxId: String,
         conversationId: String,
         toolkit: String,
-        actions: [String],
-        connectionId: String?
+        bundleIds: [String]?,
+        serviceVersion: Int?
     ) async throws -> CloudConnectionsAPI.CreateGrantResponse {
         CloudConnectionsAPI.CreateGrantResponse(id: "test-grant-\(UUID().uuidString)")
     }


### PR DESCRIPTION
## Summary
- Bundle-scoped grants via the backend services catalog (`GET /v2/connections/services`): the picker shows permission-bundle rows per service and grants carry the selected `bundleIds`.
- `ConnectionServicesStore` actor caches the catalog (300s TTL, generation-gated invalidation); fails closed on catalog outage (nil selection — never escalates to whole-toolkit).
- `unknown_bundle` backend rejection retried exactly once with monotonic narrowing (intersect with the refreshed catalog).
- `stale_resource` capability result status, decode-compatible with `.unknown` fallback.
- All grant call sites pass an explicit `bundleSelection` (empty dict = documented full-service consent path).

Part 2 of 2, stacked on #1047 (plan: #869). Merge #1047 first; this PR then retargets to `dev` automatically.

Backend counterpart: `convos-backend` branch `louis/connections-bundles`.

## Test plan
- Regression tests for catalog-outage fail-closed, retry narrowing, and stale-resource decoding included.
- Builds verified on a concrete arm64 simulator destination.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1048"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783806649&installation_id=128169237&pr_number=1048&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1048&signature=37b7c79bf2345a1076a690379b6131d30c27fe264976011095d3fea8393c04a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add permission-bundle picker and bundle-scoped connection grants
> - Introduces a services catalog (`ConnectionServicesStore`) fetched from `GET /v2/connections/services` with a 300s TTL, in-flight coalescing, and version-aware invalidation.
> - Extends `CapabilityPickerCardView` with per-service bundle toggle rows seeded from catalog defaults; the Approve button is disabled until every bundle-scoped service has at least one bundle selected.
> - Reworks `CloudConnectionGrantWriter` to send `bundleIds`/`serviceVersion` instead of `actions`/`connectionId`; on a `400 unknown_bundle` response it invalidates the cache, narrows the selection, and retries once before failing closed.
> - Adds `staleResource` and `unknown` statuses to `CapabilityRequestResult`, with forward-compatible decoding that maps unrecognized values to `.unknown`.
> - Persists `bundleIds` and `serviceVersion` on `DBCloudConnectionGrant` via a new `addConnectionGrantBundleScope` database migration.
> - Risk: `createConnectionGrant` API signature is a breaking change — callers using `actions`/`connectionId` must migrate to `bundleIds`/`serviceVersion`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 96ab4f5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->