### PR TITLE
feat(connections): connect prompt in transcript, single-toggle sheet, connected broadcast

### DIFF
--- a/Convos/Capabilities/CapabilityApprovalSheetView.swift
+++ b/Convos/Capabilities/CapabilityApprovalSheetView.swift
@@ -25,6 +25,9 @@ struct CapabilityApprovalSheetView: View {
                 agentName: agentName,
                 onApprove: onApprove
             )
+            // Reseed the toggle state if a newer request replaces the layout
+            // while the sheet is up — @State survives re-render otherwise.
+            .id(layout.request.requestId)
         } else {
             CapabilityPickerCardView(
                 layout: layout,

--- a/Convos/Capabilities/CapabilityApprovalSheetView.swift
+++ b/Convos/Capabilities/CapabilityApprovalSheetView.swift
@@ -1,0 +1,285 @@
+import ConvosConnections
+import ConvosCore
+import SwiftUI
+
+/// Connection approval sheet (Figma frame 4899/4313), presented when the user
+/// taps a pending capability connect pill in the transcript: branded service
+/// header, the catalog-driven permission bundle rows with wide toggles, and a
+/// single Done button that approves the request.
+///
+/// The Figma layout only covers the single-linked-provider + catalog-bundles
+/// shape (`.confirm`). Every other picker variant (provider choice,
+/// connect-and-approve, bundle-less services) falls back to the existing
+/// `CapabilityPickerCardView` inside the same sheet so no flow loses its UI.
+struct CapabilityApprovalSheetView: View {
+    let layout: CapabilityPickerLayout
+    let agentName: String?
+    let onApprove: (Set<ProviderID>, [String: Set<String>]) -> Void
+    let onDeny: () -> Void
+    let onConnect: (ProviderID) -> Void
+
+    var body: some View {
+        if let content = BundleApprovalContent(layout: layout) {
+            BundleApprovalSheetContent(
+                content: content,
+                agentName: agentName,
+                onApprove: onApprove
+            )
+        } else {
+            CapabilityPickerCardView(
+                layout: layout,
+                agentName: agentName,
+                onApprove: onApprove,
+                onDeny: onDeny,
+                onConnect: onConnect
+            )
+            .padding(.vertical, DesignConstants.Spacing.step6x)
+        }
+    }
+}
+
+/// The single-provider, catalog-bundle shape the Figma sheet renders.
+private struct BundleApprovalContent {
+    let provider: CapabilityPickerLayout.ProviderSummary
+    let group: CapabilityPickerLayout.ServiceBundles
+
+    init?(layout: CapabilityPickerLayout) {
+        guard layout.variant == .confirm,
+              layout.defaultSelection.count == 1,
+              let providerId = layout.defaultSelection.first,
+              let provider = layout.providers.first(where: { $0.id == providerId }),
+              provider.linked,
+              let group = layout.serviceBundles.first(where: { $0.providerId == providerId }),
+              !group.rows.isEmpty else {
+            return nil
+        }
+        self.provider = provider
+        self.group = group
+    }
+}
+
+private struct BundleApprovalSheetContent: View {
+    let content: BundleApprovalContent
+    let agentName: String?
+    let onApprove: (Set<ProviderID>, [String: Set<String>]) -> Void
+
+    /// All rows start ON: the user expressed intent by tapping the connect
+    /// pill, so the sheet is a confirmation with per-bundle opt-out (the
+    /// catalog's defaultEnabled seeds the out-of-band card flow instead).
+    @State private var enabledBundleIds: Set<String>
+
+    init(
+        content: BundleApprovalContent,
+        agentName: String?,
+        onApprove: @escaping (Set<ProviderID>, [String: Set<String>]) -> Void
+    ) {
+        self.content = content
+        self.agentName = agentName
+        self.onApprove = onApprove
+        _enabledBundleIds = State(initialValue: Set(content.group.rows.map(\.id)))
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: DesignConstants.Spacing.step8x) {
+            header
+            permissionsSection
+            doneButton
+        }
+        .padding(.horizontal, DesignConstants.Spacing.step6x)
+        .padding(.top, DesignConstants.Spacing.step10x)
+        .padding(.bottom, DesignConstants.Spacing.step6x)
+        .sheetDragIndicator(.visible)
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: DesignConstants.Spacing.step4x) {
+            serviceIcon
+
+            VStack(alignment: .leading, spacing: DesignConstants.Spacing.stepX) {
+                Text("\(agentName ?? "Agent") can use your")
+                    .font(.caption)
+                    .foregroundStyle(.colorTextSecondary)
+                Text(content.provider.displayName)
+                    .font(.convosTitle)
+                    .tracking(Font.convosTitleTracking)
+                    .foregroundStyle(.colorTextPrimary)
+            }
+        }
+        .padding(.horizontal, DesignConstants.Spacing.step4x)
+    }
+
+    @ViewBuilder
+    private var serviceIcon: some View {
+        if let assetName = ConnectionServiceIcon.assetName(forServiceId: content.provider.id.cloudServiceId) {
+            Image(assetName)
+                .resizable()
+                .scaledToFit()
+                .frame(width: Constant.iconSize, height: Constant.iconSize)
+                .clipShape(RoundedRectangle(cornerRadius: DesignConstants.CornerRadius.medium))
+                .overlay(
+                    RoundedRectangle(cornerRadius: DesignConstants.CornerRadius.medium)
+                        .stroke(Color.colorBorderEdge, lineWidth: Constant.iconBorderWidth)
+                )
+        } else {
+            Image(systemName: content.provider.iconName.isEmpty ? "link" : content.provider.iconName)
+                .font(.title)
+                .foregroundStyle(.colorTextPrimary)
+                .frame(width: Constant.iconSize, height: Constant.iconSize)
+                .background(
+                    RoundedRectangle(cornerRadius: DesignConstants.CornerRadius.medium)
+                        .fill(Color.colorFillMinimal)
+                )
+        }
+    }
+
+    private var permissionsSection: some View {
+        VStack(alignment: .leading, spacing: DesignConstants.Spacing.step2x) {
+            Text("Permissions requested")
+                .font(.caption)
+                .foregroundStyle(.colorTextSecondary)
+                .padding(.horizontal, DesignConstants.Spacing.step4x)
+
+            VStack(spacing: Constant.rowGap) {
+                ForEach(content.group.rows, id: \.id) { row in
+                    permissionRow(row)
+                }
+            }
+            .clipShape(RoundedRectangle(cornerRadius: DesignConstants.CornerRadius.mediumLarge))
+        }
+    }
+
+    private func permissionRow(_ row: CapabilityPickerLayout.ServiceBundles.Row) -> some View {
+        HStack(spacing: DesignConstants.Spacing.step2x) {
+            VStack(alignment: .leading, spacing: DesignConstants.Spacing.stepHalf) {
+                Text(row.title)
+                    .font(.body)
+                    .foregroundStyle(.colorTextPrimary)
+                if !row.description.isEmpty {
+                    Text(row.description)
+                        .font(.caption)
+                        .foregroundStyle(.colorTextSecondary)
+                }
+            }
+            Spacer(minLength: 0)
+            Toggle(row.title, isOn: bundleBinding(row.id))
+                .toggleStyle(WideSwitchToggleStyle())
+                .labelsHidden()
+        }
+        .padding(DesignConstants.Spacing.step4x)
+        .background(Color.colorBackgroundSurfaceless)
+    }
+
+    private var doneButton: some View {
+        let approveAction = {
+            onApprove([content.provider.id], [content.group.serviceId: enabledBundleIds])
+        }
+        // An empty toggle set must never approve: it would read as consent
+        // while granting nothing (and an empty bundle list is forbidden to
+        // ever reach the grant writer).
+        return Button("Done", action: approveAction)
+            .convosButtonStyle(.rounded(fullWidth: true))
+            .disabled(enabledBundleIds.isEmpty)
+            .padding(.horizontal, DesignConstants.Spacing.step4x)
+    }
+
+    private func bundleBinding(_ bundleId: String) -> Binding<Bool> {
+        Binding(
+            get: { enabledBundleIds.contains(bundleId) },
+            set: { isOn in
+                if isOn {
+                    enabledBundleIds.insert(bundleId)
+                } else {
+                    enabledBundleIds.remove(bundleId)
+                }
+            }
+        )
+    }
+
+    private enum Constant {
+        static let titleSize: CGFloat = 40.0
+        static let iconSize: CGFloat = 56.0
+        static let iconBorderWidth: CGFloat = 0.4
+        static let rowGap: CGFloat = 1.0
+    }
+}
+
+/// The design system's wide switch (68x28 track, 39x24 knob) from the Figma
+/// permission row — a stock `UISwitch` is 51x31 and visibly different.
+private struct WideSwitchToggleStyle: ToggleStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        let action = { configuration.isOn.toggle() }
+        return Button(action: action) {
+            RoundedRectangle(cornerRadius: Constant.trackCornerRadius)
+                .fill(configuration.isOn ? Color.colorFillPrimary : Color.colorFillTertiary)
+                .frame(width: Constant.trackWidth, height: Constant.trackHeight)
+                .overlay(alignment: configuration.isOn ? .trailing : .leading) {
+                    RoundedRectangle(cornerRadius: Constant.trackCornerRadius)
+                        .fill(.white)
+                        .frame(width: Constant.knobWidth, height: Constant.knobHeight)
+                        .shadow(color: .colorDarkAlpha15, radius: 4.0, x: 0.0, y: 2.0)
+                        .padding(Constant.knobInset)
+                }
+        }
+        .buttonStyle(.plain)
+        .animation(.spring(duration: 0.2), value: configuration.isOn)
+        .accessibilityAddTraits(.isToggle)
+    }
+
+    private enum Constant {
+        static let trackWidth: CGFloat = 68.0
+        static let trackHeight: CGFloat = 28.0
+        static let trackCornerRadius: CGFloat = 16.0
+        static let knobWidth: CGFloat = 39.0
+        static let knobHeight: CGFloat = 24.0
+        static let knobInset: CGFloat = 2.0
+    }
+}
+
+// MARK: - Previews
+
+#if DEBUG
+#Preview("Bundle approval (Google Calendar)") {
+    CapabilityApprovalSheetView(
+        layout: CapabilityPickerLayout(
+            request: CapabilityRequest(
+                requestId: "preview-1",
+                askerInboxId: "preview-asker",
+                subject: .calendar,
+                capability: .read,
+                rationale: "To book that meeting"
+            ),
+            variant: .confirm,
+            providers: [
+                CapabilityPickerLayout.ProviderSummary(
+                    id: ProviderID(rawValue: "composio.googlecalendar"),
+                    displayName: "Google Calendar",
+                    iconName: "calendar",
+                    subject: .calendar,
+                    linked: true,
+                    supportsCapability: true
+                ),
+            ],
+            defaultSelection: [ProviderID(rawValue: "composio.googlecalendar")],
+            serviceBundles: [
+                CapabilityPickerLayout.ServiceBundles(
+                    providerId: ProviderID(rawValue: "composio.googlecalendar"),
+                    serviceId: "googlecalendar",
+                    serviceVersion: 5,
+                    rows: [
+                        .init(
+                            id: "calendar.events",
+                            title: "Events",
+                            description: "View and edit events on all calendars",
+                            defaultEnabled: false
+                        ),
+                    ]
+                ),
+            ]
+        ),
+        agentName: "Assistant",
+        onApprove: { _, _ in },
+        onDeny: {},
+        onConnect: { _ in }
+    )
+}
+#endif

--- a/Convos/Capabilities/CapabilityApprovalSheetView.swift
+++ b/Convos/Capabilities/CapabilityApprovalSheetView.swift
@@ -152,7 +152,8 @@ private struct BundleApprovalSheetContent: View {
     }
 
     private func permissionRow(_ row: CapabilityPickerLayout.ServiceBundles.Row) -> some View {
-        HStack(spacing: DesignConstants.Spacing.step2x) {
+        let binding: Binding<Bool> = bundleBinding(row.id)
+        return HStack(spacing: DesignConstants.Spacing.step2x) {
             VStack(alignment: .leading, spacing: DesignConstants.Spacing.stepHalf) {
                 Text(row.title)
                     .font(.body)
@@ -164,7 +165,7 @@ private struct BundleApprovalSheetContent: View {
                 }
             }
             Spacer(minLength: 0)
-            Toggle(row.title, isOn: bundleBinding(row.id))
+            Toggle(row.title, isOn: binding)
                 .toggleStyle(WideSwitchToggleStyle())
                 .labelsHidden()
         }
@@ -173,7 +174,7 @@ private struct BundleApprovalSheetContent: View {
     }
 
     private var doneButton: some View {
-        let approveAction = {
+        let approveAction: () -> Void = {
             onApprove([content.provider.id], [content.group.serviceId: enabledBundleIds])
         }
         // An empty toggle set must never approve: it would read as consent

--- a/Convos/Capabilities/ConnectionServiceIcon.swift
+++ b/Convos/Capabilities/ConnectionServiceIcon.swift
@@ -4,6 +4,16 @@ import Foundation
 /// Maps connection services to their branded icon assets in the asset catalog.
 /// Returns nil for services without a bundled asset so callers can fall back
 /// to an SF Symbol.
+///
+/// Contract: `serviceId` is the backend services-catalog slug — the cloud
+/// service id embedded in `composio.*` provider ids (e.g. "googlecalendar"
+/// from "composio.googlecalendar"). Every case must return the name of an
+/// image set that exists in `Convos/Assets.xcassets`, following the
+/// `connection<ServiceDisplayName>` naming convention (e.g.
+/// "connectionGoogleCalendar", "connectionAppleHealth"). When the catalog
+/// gains a new branded service: add the asset under that name, then add the
+/// matching case here. Unmapped slugs intentionally return nil — callers
+/// render the provider's SF Symbol instead of a missing-asset image.
 enum ConnectionServiceIcon {
     static func assetName(forServiceId serviceId: String?) -> String? {
         switch serviceId {

--- a/Convos/Capabilities/ConnectionServiceIcon.swift
+++ b/Convos/Capabilities/ConnectionServiceIcon.swift
@@ -1,0 +1,24 @@
+import ConvosCore
+import Foundation
+
+/// Maps connection services to their branded icon assets in the asset catalog.
+/// Returns nil for services without a bundled asset so callers can fall back
+/// to an SF Symbol.
+enum ConnectionServiceIcon {
+    static func assetName(forServiceId serviceId: String?) -> String? {
+        switch serviceId {
+        case "googlecalendar":
+            return "connectionGoogleCalendar"
+        default:
+            return nil
+        }
+    }
+
+    static func assetName(forProviderId providerId: String?) -> String? {
+        guard let providerId else { return nil }
+        if providerId == "device.health" {
+            return "connectionAppleHealth"
+        }
+        return assetName(forServiceId: ProviderID(rawValue: providerId).cloudServiceId)
+    }
+}

--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -289,6 +289,12 @@ struct ConversationView<MessagesBottomBar: View>: View {
             onAgentOutOfCredits: { viewModel.presentingPaywall = true },
             creditsDepleted: viewModel.creditsDepleted,
             onTapUpdateMember: { viewModel.presentingProfileForMember = $0 },
+            onTapCapabilityConnect: { prompt in
+                // Read-only viewers see the pill but can't answer the request
+                // (a result message couldn't be sent on their behalf anyway).
+                guard !effectiveReadOnly else { return }
+                viewModel.onTapCapabilityConnectPrompt(prompt)
+            },
             onRetryMessage: viewModel.retryMessage(_:),
             onDeleteMessage: viewModel.deleteMessage(_:),
             onRetryAgentJoin: { viewModel.retryAgentJoin() },
@@ -320,28 +326,14 @@ struct ConversationView<MessagesBottomBar: View>: View {
                 VStack(spacing: DesignConstants.Spacing.step3x) {
                     bottomBarContent()
 
+                    // Capability requests no longer auto-present a card here:
+                    // the transcript's connect pill is the single entry point
+                    // and opens the approval sheet. The slot keeps the
+                    // post-approval toast and the onboarding view.
                     Group {
                         if viewModel.showsCapabilityApprovedToast {
                             CapabilityApprovedToastView()
                                 .transition(.blurReplace)
-                        } else if let layout = viewModel.pendingCapabilityPickerLayout {
-                            CapabilityPickerCardView(
-                                layout: layout,
-                                agentName: viewModel.askerDisplayName(for: layout.request),
-                                onApprove: { providerIds, bundleSelection in
-                                    viewModel.onCapabilityApprove(
-                                        providerIds: providerIds,
-                                        bundleSelection: bundleSelection
-                                    )
-                                },
-                                onDeny: {
-                                    viewModel.onCapabilityDeny()
-                                },
-                                onConnect: { providerId in
-                                    viewModel.onCapabilityConnect(providerId: providerId)
-                                }
-                            )
-                            .transition(.blurReplace)
                         } else {
                             ConversationOnboardingView(
                                 coordinator: onboardingCoordinator,
@@ -357,7 +349,6 @@ struct ConversationView<MessagesBottomBar: View>: View {
                             .transition(.blurReplace)
                         }
                     }
-                    .animation(.spring(duration: 0.4, bounce: 0.2), value: viewModel.pendingCapabilityPickerLayout)
                     .animation(.spring(duration: 0.4, bounce: 0.2), value: viewModel.showsCapabilityApprovedToast)
                 }
                 .padding(.horizontal, DesignConstants.Spacing.step4x)
@@ -464,6 +455,35 @@ struct ConversationView<MessagesBottomBar: View>: View {
 
     private func profileSheetForMember(_ member: ConversationMember) -> AnyView {
         AnyView(MemberContactDetailSheetContent(viewModel: viewModel, member: member, profileSettingsViewModel: profileSettingsViewModel))
+    }
+
+    /// Approval sheet for the pending capability request, opened from the
+    /// transcript's connect pill. Extracted to keep `body`'s type-check time
+    /// in budget. The layout can clear while the sheet is up (another device
+    /// resolved the request) — the view model auto-dismisses in that case and
+    /// the EmptyView only covers the dismissal animation frame.
+    @ViewBuilder
+    private var capabilityApprovalSheet: some View {
+        if let layout = viewModel.pendingCapabilityPickerLayout {
+            CapabilityApprovalSheetView(
+                layout: layout,
+                agentName: viewModel.askerDisplayName(for: layout.request),
+                onApprove: { providerIds, bundleSelection in
+                    viewModel.onCapabilityApprove(
+                        providerIds: providerIds,
+                        bundleSelection: bundleSelection
+                    )
+                },
+                onDeny: {
+                    viewModel.onCapabilityDeny()
+                },
+                onConnect: { providerId in
+                    viewModel.onCapabilityConnect(providerId: providerId)
+                }
+            )
+        } else {
+            EmptyView()
+        }
     }
 
     /// Shared content for the invite- and agent-share-driven new-conversation
@@ -580,6 +600,9 @@ struct ConversationView<MessagesBottomBar: View>: View {
             ConversationForkedInfoView {
                 viewModel.leaveConvo()
             }
+        }
+        .selfSizingSheet(isPresented: $viewModel.presentingCapabilityApproval) {
+            capabilityApprovalSheet
         }
         .sheet(isPresented: $viewModel.presentingProfileSettings) {
             MyInfoView(

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -1788,14 +1788,6 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
 
     // MARK: - Capability picker
 
-    /// Replaces any pending capability request with `layout`. When the agent sends a new
-    /// `capability_request` and we want the picker to display, the host computes the
-    /// layout via `CapabilityRequestHandler.computeLayout` and calls this. Setting nil
-    /// hides the picker and lets the onboarding view take its slot back.
-    func presentCapabilityPicker(_ layout: CapabilityPickerLayout?) {
-        pendingCapabilityPickerLayout = layout
-    }
-
     /// User tapped the transcript's capability connect pill. Pending pills open
     /// the approval sheet for the request they carry; connected/dismissed pills
     /// are inert. Only the latest observed request has a computed layout (the

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -1524,15 +1524,13 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
                 }
                 Task { @MainActor [weak self] in
                     guard let self else { return }
-                    // Best-effort: the picker renders provider-only rows when the
-                    // services catalog is unreachable; bundle rows appear once it is.
-                    let services = (try? await self.messagingService.connectionServicesStore().catalog()) ?? []
-                    let layout = await handler.computeLayout(
+                    let layout = await Self.computeCapabilityPickerLayout(
                         request: request,
                         registry: registry,
                         resolver: resolver,
-                        conversationId: conversationId,
-                        services: services
+                        handler: handler,
+                        servicesStore: self.messagingService.connectionServicesStore(),
+                        conversationId: conversationId
                     )
                     // Discard if a newer request arrived while we were computing —
                     // otherwise an out-of-order completion can stomp the latest UI.
@@ -2299,17 +2297,13 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
         let handler = CapabilityRequestHandler()
         Task { @MainActor [weak self] in
             guard let self else { return }
-            // Mirror the initial layout's catalog fetch: omitting `services:`
-            // drops the bundle rows, and a subsequent approve would silently
-            // escalate to full-service consent instead of the user's earlier
-            // per-bundle selection.
-            let services = (try? await self.messagingService.connectionServicesStore().catalog()) ?? []
-            let layout = await handler.computeLayout(
+            let layout = await Self.computeCapabilityPickerLayout(
                 request: request,
                 registry: registry,
                 resolver: resolver,
-                conversationId: conversationId,
-                services: services
+                handler: handler,
+                servicesStore: self.messagingService.connectionServicesStore(),
+                conversationId: conversationId
             )
             // If a newer request arrived OR the user already approved/denied this one,
             // don't revive the picker with a stale layout.
@@ -2319,6 +2313,30 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
             }
             self.pendingCapabilityPickerLayout = layout
         }
+    }
+
+    /// The one place a picker layout is computed: every path MUST resolve the
+    /// services catalog or bundle rows silently disappear and a subsequent
+    /// approve escalates to full-service consent instead of the user's earlier
+    /// per-bundle selection. Best-effort fetch: when the catalog is
+    /// unreachable the sheet renders provider-only rows, and the grant writer
+    /// fails closed on its own catalog resolution.
+    static func computeCapabilityPickerLayout(
+        request: CapabilityRequest,
+        registry: any CapabilityProviderRegistry,
+        resolver: any CapabilityResolver,
+        handler: CapabilityRequestHandler,
+        servicesStore: any ConnectionServicesStoreProtocol,
+        conversationId: String
+    ) async -> CapabilityPickerLayout {
+        let services = (try? await servicesStore.catalog()) ?? []
+        return await handler.computeLayout(
+            request: request,
+            registry: registry,
+            resolver: resolver,
+            conversationId: conversationId,
+            services: services
+        )
     }
 
     func onConversationInfoTap(focusCoordinator: FocusCoordinator) {

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -875,11 +875,21 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
     var presentingProfileSettings: Bool = false
 
     /// The agent's most-recent unresolved `capability_request` for this conversation.
-    /// When non-nil, `ConversationView` renders the picker card in the same slot the
-    /// `ConversationOnboardingView` would otherwise occupy. Cleared on Approve / Deny /
-    /// dismiss; replaced wholesale when a newer request arrives (per the "only show the
-    /// last request" rule).
-    var pendingCapabilityPickerLayout: CapabilityPickerLayout?
+    /// The transcript's connect pill is the entry point: while non-nil, tapping the
+    /// matching pending pill presents the approval sheet built from this layout.
+    /// Cleared on Approve / Deny / out-of-band resolution; replaced wholesale when a
+    /// newer request arrives (per the "only show the last request" rule).
+    var pendingCapabilityPickerLayout: CapabilityPickerLayout? {
+        didSet {
+            if pendingCapabilityPickerLayout == nil {
+                presentingCapabilityApproval = false
+            }
+        }
+    }
+    /// Drives the approval sheet presentation for `pendingCapabilityPickerLayout`.
+    /// Auto-dismissed whenever the layout clears (another device resolved the
+    /// request, the request was answered here, or observation reset).
+    var presentingCapabilityApproval: Bool = false
     var showsCapabilityApprovedToast: Bool = false
     var presentingProfileForMember: ConversationMember?
     var presentingNewConversationForInvite: NewConversationViewModel? {
@@ -1788,7 +1798,19 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
         pendingCapabilityPickerLayout = layout
     }
 
-    /// User tapped Approve in the picker card with this provider selection.
+    /// User tapped the transcript's capability connect pill. Pending pills open
+    /// the approval sheet for the request they carry; connected/dismissed pills
+    /// are inert. Only the latest observed request has a computed layout (the
+    /// "only show the last request" rule), so taps on superseded pending pills
+    /// are no-ops.
+    func onTapCapabilityConnectPrompt(_ prompt: CapabilityConnectPrompt) {
+        guard prompt.status == .pending else { return }
+        guard let layout = pendingCapabilityPickerLayout,
+              layout.request.requestId == prompt.requestId else { return }
+        presentingCapabilityApproval = true
+    }
+
+    /// User tapped Approve in the approval sheet with this provider selection.
     /// Persists the resolution so future tool calls route to the same set, then
     /// posts a `capability_request_result(.approved)` reply for the agent.
     /// `bundleSelection` is the per-service permission-bundle toggle state
@@ -2277,11 +2299,17 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
         let handler = CapabilityRequestHandler()
         Task { @MainActor [weak self] in
             guard let self else { return }
+            // Mirror the initial layout's catalog fetch: omitting `services:`
+            // drops the bundle rows, and a subsequent approve would silently
+            // escalate to full-service consent instead of the user's earlier
+            // per-bundle selection.
+            let services = (try? await self.messagingService.connectionServicesStore().catalog()) ?? []
             let layout = await handler.computeLayout(
                 request: request,
                 registry: registry,
                 resolver: resolver,
-                conversationId: conversationId
+                conversationId: conversationId,
+                services: services
             )
             // If a newer request arrived OR the user already approved/denied this one,
             // don't revive the picker with a stale layout.

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -1789,10 +1789,12 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
     // MARK: - Capability picker
 
     /// User tapped the transcript's capability connect pill. Pending pills open
-    /// the approval sheet for the request they carry; connected/dismissed pills
-    /// are inert. Only the latest observed request has a computed layout (the
-    /// "only show the last request" rule), so taps on superseded pending pills
-    /// are no-ops.
+    /// the approval sheet for the request they carry; connected/dismissed/
+    /// superseded pills are inert. The derivation only renders `.pending` on
+    /// the request `CapabilityRequestRepository` surfaces as the layout (same
+    /// shared rule), so the layout-match guard below is just a race guard: it
+    /// covers the gap while a freshly answered or newly superseded request
+    /// hasn't re-derived yet (e.g. `locallyHandledCapabilityRequestIds`).
     func onTapCapabilityConnectPrompt(_ prompt: CapabilityConnectPrompt) {
         guard prompt.status == .pending else { return }
         guard let layout = pendingCapabilityPickerLayout,

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Cells/MessagesListItemTypeCell.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Cells/MessagesListItemTypeCell.swift
@@ -136,6 +136,15 @@ class MessagesListItemTypeCell: UICollectionViewCell {
                         .padding(.vertical, DesignConstants.Spacing.step4x)
                         .padding(.horizontal, DesignConstants.Spacing.step4x)
 
+                case let .capabilityConnect(_, prompt, agentName, _):
+                    CapabilityConnectPromptView(
+                        prompt: prompt,
+                        agentName: agentName,
+                        onTap: { config.onTapCapabilityConnect(prompt) }
+                    )
+                    .padding(.vertical, DesignConstants.Spacing.step4x)
+                    .padding(.horizontal, DesignConstants.Spacing.step4x)
+
                 case .agentBuilderSummary(let content):
                     AgentBuilderSummaryView(
                         content: content,

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Data Source/CellFactory.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Data Source/CellFactory.swift
@@ -37,6 +37,9 @@ struct CellConfig {
     let onRetryAgentJoin: () -> Void
     let onPhotoDimensionsLoaded: (String, Int, Int) -> Void
     let onTapUpdateMember: (ConversationMember) -> Void
+    /// Fired when a pending capability connect pill is tapped — opens the
+    /// approval sheet for the request it carries.
+    let onTapCapabilityConnect: (CapabilityConnectPrompt) -> Void
     let onOpenFile: ((HydratedAttachment, AnyMessage) -> Void)?
     let onRetryMessage: (AnyMessage) -> Void
     let onDeleteMessage: (AnyMessage) -> Void

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Data Source/DefaultMessagesLayoutDelegate.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Data Source/DefaultMessagesLayoutDelegate.swift
@@ -45,6 +45,9 @@ final class DefaultMessagesLayoutDelegate: MessagesLayoutDelegate {
                 return .estimated(CGSize(width: width, height: 48.0))
             case .connectionEvent:
                 return .estimated(CGSize(width: width, height: 48.0))
+            case .capabilityConnect:
+                // Caption row + 8pt gap + 44pt pill + vertical padding.
+                return .estimated(CGSize(width: width, height: 100.0))
             case .agentBuilderSummary:
                 // Composer-card height plus "You created an agent" footer.
                 return .estimated(CGSize(width: width, height: 320.0))
@@ -197,7 +200,7 @@ final class DefaultMessagesLayoutDelegate: MessagesLayoutDelegate {
             height = 30.0
         case .connectionGrantRequest:
             height = 160.0
-        case .connectionEvent, .connectionInvocation, .connectionInvocationResult, .connectionPayload:
+        case .capabilityConnect, .connectionEvent, .connectionInvocation, .connectionInvocationResult, .connectionPayload:
             height = 0.0
         }
 

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Data Source/MessagesCollectionDataSource.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Data Source/MessagesCollectionDataSource.swift
@@ -26,6 +26,7 @@ protocol MessagesCollectionDataSource: UICollectionViewDataSource, MessagesLayou
     var onAgentOutOfCredits: (() -> Void)? { get set }
     var creditsDepleted: Bool { get set }
     var onTapUpdateMember: ((ConversationMember) -> Void)? { get set }
+    var onTapCapabilityConnect: ((CapabilityConnectPrompt) -> Void)? { get set }
     var onOpenFile: ((HydratedAttachment, AnyMessage) -> Void)? { get set }
     var onRetryMessage: ((AnyMessage) -> Void)? { get set }
     var onDeleteMessage: ((AnyMessage) -> Void)? { get set }

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Data Source/MessagesCollectionViewDataSource.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Data Source/MessagesCollectionViewDataSource.swift
@@ -33,6 +33,7 @@ final class MessagesCollectionViewDataSource: NSObject {
     var onAgentOutOfCredits: (() -> Void)?
     var creditsDepleted: Bool = false
     var onTapUpdateMember: ((ConversationMember) -> Void)?
+    var onTapCapabilityConnect: ((CapabilityConnectPrompt) -> Void)?
     var onOpenFile: ((HydratedAttachment, AnyMessage) -> Void)?
     var onRetryMessage: ((AnyMessage) -> Void)?
     var onDeleteMessage: ((AnyMessage) -> Void)?
@@ -142,6 +143,9 @@ extension MessagesCollectionViewDataSource: UICollectionViewDataSource {
             },
             onTapUpdateMember: { [weak self] member in
                 self?.onTapUpdateMember?(member)
+            },
+            onTapCapabilityConnect: { [weak self] prompt in
+                self?.onTapCapabilityConnect?(prompt)
             },
             onOpenFile: { [weak self] attachment, message in
                 self?.onOpenFile?(attachment, message)

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/MessagesViewController.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/MessagesViewController.swift
@@ -417,6 +417,7 @@ final class MessagesViewController: UIViewController {
         }
     }
     var onTapUpdateMember: ((ConversationMember) -> Void)?
+    var onTapCapabilityConnect: ((CapabilityConnectPrompt) -> Void)?
     var onRetryMessage: ((AnyMessage) -> Void)?
     var onDeleteMessage: ((AnyMessage) -> Void)?
     var onRetryAgentJoin: (() -> Void)?
@@ -670,6 +671,9 @@ final class MessagesViewController: UIViewController {
         }
         dataSource.onTapUpdateMember = { [weak self] member in
             self?.onTapUpdateMember?(member)
+        }
+        dataSource.onTapCapabilityConnect = { [weak self] prompt in
+            self?.onTapCapabilityConnect?(prompt)
         }
         dataSource.onOpenFile = { [weak self] attachment, message in
             self?.openFileAttachment(attachment, from: message)

--- a/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/CapabilityConnectPromptView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/CapabilityConnectPromptView.swift
@@ -1,0 +1,150 @@
+import ConvosCore
+import SwiftUI
+
+/// Transcript row for a capability request: centered "<Agent> wants to connect"
+/// caption above a tappable service pill (Figma frame 4900). The pill persists
+/// in history; its trailing accessory reflects the derived status — chevron
+/// while pending (tap opens the approval sheet), checkmark once any member's
+/// approval lands, nothing once dismissed.
+struct CapabilityConnectPromptView: View {
+    let prompt: CapabilityConnectPrompt
+    let agentName: String
+    let onTap: () -> Void
+
+    var body: some View {
+        VStack(spacing: DesignConstants.Spacing.step2x) {
+            Text("\(agentName) wants to connect")
+                .font(.caption)
+                .foregroundStyle(.colorTextSecondary)
+                .lineLimit(1)
+
+            let action = onTap
+            Button(action: action) {
+                pillContent
+            }
+            .buttonStyle(.plain)
+            .disabled(prompt.status != .pending)
+        }
+        .frame(maxWidth: .infinity, alignment: .center)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(agentName) wants to connect \(prompt.serviceName)")
+    }
+
+    private var pillContent: some View {
+        HStack(spacing: DesignConstants.Spacing.step2x) {
+            serviceIcon
+
+            Text(prompt.serviceName)
+                .font(.callout)
+                .foregroundStyle(.colorTextPrimary)
+                .lineLimit(1)
+
+            statusAccessory
+        }
+        .padding(.horizontal, DesignConstants.Spacing.step4x)
+        .frame(height: Constant.pillHeight)
+        .background(
+            RoundedRectangle(cornerRadius: DesignConstants.CornerRadius.mediumLarge)
+                .fill(Color.colorFillMinimal)
+        )
+        .contentShape(.rect)
+    }
+
+    @ViewBuilder
+    private var serviceIcon: some View {
+        if let assetName = ConnectionServiceIcon.assetName(forServiceId: prompt.serviceId) {
+            Image(assetName)
+                .resizable()
+                .scaledToFit()
+                .frame(width: Constant.iconSize, height: Constant.iconSize)
+                .clipShape(RoundedRectangle(cornerRadius: DesignConstants.CornerRadius.small))
+                .overlay(
+                    RoundedRectangle(cornerRadius: DesignConstants.CornerRadius.small)
+                        .stroke(Color.colorBorderEdge, lineWidth: Constant.iconBorderWidth)
+                )
+        } else {
+            Image(systemName: fallbackSymbolName)
+                .font(.body)
+                .foregroundStyle(.colorTextPrimary)
+                .frame(width: Constant.iconSize, height: Constant.iconSize)
+        }
+    }
+
+    @ViewBuilder
+    private var statusAccessory: some View {
+        switch prompt.status {
+        case .pending:
+            Image(systemName: "chevron.right")
+                .font(.footnote)
+                .foregroundStyle(.colorTextTertiary)
+        case .connected:
+            Image(systemName: "checkmark")
+                .font(.footnote)
+                .foregroundStyle(.colorTextSecondary)
+        case .dismissed:
+            EmptyView()
+        }
+    }
+
+    private var fallbackSymbolName: String {
+        switch prompt.icon {
+        case .health: return "heart.text.square"
+        case .calendar: return "calendar"
+        case .contacts: return "person.crop.circle"
+        case .photos: return "photo"
+        case .music: return "music.note"
+        case .home: return "house"
+        case .generic, .error: return "bolt.horizontal"
+        }
+    }
+
+    private enum Constant {
+        static let pillHeight: CGFloat = 44.0
+        static let iconSize: CGFloat = 24.0
+        static let iconBorderWidth: CGFloat = 0.4
+    }
+}
+
+#if DEBUG
+#Preview("Pending / Connected / Dismissed") {
+    VStack(spacing: DesignConstants.Spacing.step6x) {
+        CapabilityConnectPromptView(
+            prompt: CapabilityConnectPrompt(
+                requestId: "req-1",
+                askerInboxId: "agent",
+                serviceName: "Google Calendar",
+                serviceId: "googlecalendar",
+                icon: .calendar,
+                status: .pending
+            ),
+            agentName: "Assistant",
+            onTap: {}
+        )
+        CapabilityConnectPromptView(
+            prompt: CapabilityConnectPrompt(
+                requestId: "req-2",
+                askerInboxId: "agent",
+                serviceName: "Google Calendar",
+                serviceId: "googlecalendar",
+                icon: .calendar,
+                status: .connected
+            ),
+            agentName: "Assistant",
+            onTap: {}
+        )
+        CapabilityConnectPromptView(
+            prompt: CapabilityConnectPrompt(
+                requestId: "req-3",
+                askerInboxId: "agent",
+                serviceName: "Calendar",
+                serviceId: nil,
+                icon: .calendar,
+                status: .dismissed
+            ),
+            agentName: "Assistant",
+            onTap: {}
+        )
+    }
+    .padding()
+}
+#endif

--- a/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/CapabilityConnectPromptView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/CapabilityConnectPromptView.swift
@@ -5,7 +5,8 @@ import SwiftUI
 /// caption above a tappable service pill (Figma frame 4900). The pill persists
 /// in history; its trailing accessory reflects the derived status — chevron
 /// while pending (tap opens the approval sheet), checkmark once any member's
-/// approval lands, nothing once dismissed.
+/// approval lands, nothing once dismissed or superseded by a newer request
+/// (both render inert: no accessory, taps disabled).
 struct CapabilityConnectPromptView: View {
     let prompt: CapabilityConnectPrompt
     let agentName: String
@@ -81,7 +82,7 @@ struct CapabilityConnectPromptView: View {
             Image(systemName: "checkmark")
                 .font(.footnote)
                 .foregroundStyle(.colorTextSecondary)
-        case .dismissed:
+        case .dismissed, .superseded:
             EmptyView()
         }
     }
@@ -106,7 +107,7 @@ struct CapabilityConnectPromptView: View {
 }
 
 #if DEBUG
-#Preview("Pending / Connected / Dismissed") {
+#Preview("Pending / Connected / Dismissed / Superseded") {
     VStack(spacing: DesignConstants.Spacing.step6x) {
         CapabilityConnectPromptView(
             prompt: CapabilityConnectPrompt(
@@ -140,6 +141,18 @@ struct CapabilityConnectPromptView: View {
                 serviceId: nil,
                 icon: .calendar,
                 status: .dismissed
+            ),
+            agentName: "Assistant",
+            onTap: {}
+        )
+        CapabilityConnectPromptView(
+            prompt: CapabilityConnectPrompt(
+                requestId: "req-4",
+                askerInboxId: "agent",
+                serviceName: "Google Calendar",
+                serviceId: "googlecalendar",
+                icon: .calendar,
+                status: .superseded
             ),
             agentName: "Assistant",
             onTap: {}

--- a/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/ConnectionEventSummaryView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/ConnectionEventSummaryView.swift
@@ -6,9 +6,7 @@ struct ConnectionEventSummaryView: View {
 
     var body: some View {
         HStack(spacing: DesignConstants.Spacing.stepX) {
-            Image(systemName: iconName)
-                .font(.caption)
-                .foregroundStyle(iconColor)
+            iconView
 
             Text(summary.text)
                 .lineLimit(1)
@@ -18,6 +16,26 @@ struct ConnectionEventSummaryView: View {
         .frame(maxWidth: .infinity, alignment: .center)
         .accessibilityElement(children: .combine)
         .accessibilityLabel(summary.text)
+    }
+
+    @ViewBuilder
+    private var iconView: some View {
+        if summary.outcome != .failure,
+           let assetName = ConnectionServiceIcon.assetName(forProviderId: summary.providerId) {
+            Image(assetName)
+                .resizable()
+                .scaledToFit()
+                .frame(width: Constant.brandedIconSize, height: Constant.brandedIconSize)
+                .clipShape(RoundedRectangle(cornerRadius: Constant.brandedIconCornerRadius))
+                .overlay(
+                    RoundedRectangle(cornerRadius: Constant.brandedIconCornerRadius)
+                        .stroke(Color.colorBorderEdge, lineWidth: Constant.brandedIconBorderWidth)
+                )
+        } else {
+            Image(systemName: iconName)
+                .font(.caption)
+                .foregroundStyle(iconColor)
+        }
     }
 
     private var iconName: String {
@@ -48,5 +66,11 @@ struct ConnectionEventSummaryView: View {
         case .pending, .success:
             return .secondary
         }
+    }
+
+    private enum Constant {
+        static let brandedIconSize: CGFloat = 16.0
+        static let brandedIconCornerRadius: CGFloat = 4.0
+        static let brandedIconBorderWidth: CGFloat = 0.4
     }
 }

--- a/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/ReplyReferenceView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/ReplyReferenceView.swift
@@ -33,7 +33,7 @@ struct ReplyReferenceView: View {
             return "agent"
         case .linkPreview(let preview):
             return preview.title ?? preview.displayHost
-        case .update, .assistantJoinRequest, .connectionGrantRequest:
+        case .update, .assistantJoinRequest, .connectionGrantRequest, .capabilityConnect:
             return ""
         case .connectionEvent(let summary),
              .connectionInvocation(let summary),

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
@@ -133,7 +133,7 @@ struct MessagesGroupItemView: View {
             EmptyView()
         case .connectionGrantRequest(let request):
             connectionGrantRequestBubble(request: request)
-        case .connectionEvent, .connectionInvocation, .connectionInvocationResult, .connectionPayload:
+        case .capabilityConnect, .connectionEvent, .connectionInvocation, .connectionInvocationResult, .connectionPayload:
             EmptyView()
         }
     }

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessagesListView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessagesListView.swift
@@ -19,6 +19,7 @@ struct MessagesListView: View {
     let onPhotoHidden: (String) -> Void
     let onPhotoDimensionsLoaded: (String, Int, Int) -> Void
     let onTapUpdateMember: (ConversationMember) -> Void
+    var onTapCapabilityConnect: (CapabilityConnectPrompt) -> Void = { _ in }
     let onAgentOutOfCredits: () -> Void
     let onRetryAgentJoin: () -> Void
     let onCopyInviteLink: () -> Void
@@ -135,6 +136,14 @@ var body: some View {
         case let .connectionEvent(_, summary, _):
             ConnectionEventSummaryView(summary: summary)
                 .padding(.vertical, DesignConstants.Spacing.step2x)
+
+        case let .capabilityConnect(_, prompt, agentName, _):
+            CapabilityConnectPromptView(
+                prompt: prompt,
+                agentName: agentName,
+                onTap: { onTapCapabilityConnect(prompt) }
+            )
+            .padding(.vertical, DesignConstants.Spacing.step2x)
 
         case .agentBuilderSummary(let content):
             AgentBuilderSummaryView(content: content)

--- a/Convos/Conversation Detail/Messages/MessagesView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesView.swift
@@ -83,6 +83,7 @@ struct MessagesView<BottomBarContent: View>: View {
     let onAgentOutOfCredits: () -> Void
     let creditsDepleted: Bool
     let onTapUpdateMember: (ConversationMember) -> Void
+    var onTapCapabilityConnect: (CapabilityConnectPrompt) -> Void = { _ in }
     let onRetryMessage: (AnyMessage) -> Void
     let onDeleteMessage: (AnyMessage) -> Void
     let onRetryAgentJoin: () -> Void
@@ -146,6 +147,7 @@ struct MessagesView<BottomBarContent: View>: View {
             onAgentOutOfCredits: onAgentOutOfCredits,
             creditsDepleted: creditsDepleted,
             onTapUpdateMember: onTapUpdateMember,
+            onTapCapabilityConnect: onTapCapabilityConnect,
             onRetryMessage: onRetryMessage,
             onDeleteMessage: onDeleteMessage,
             onRetryAgentJoin: onRetryAgentJoin,

--- a/Convos/Conversation Detail/Messages/MessagesViewRepresentable.swift
+++ b/Convos/Conversation Detail/Messages/MessagesViewRepresentable.swift
@@ -29,6 +29,7 @@ struct MessagesViewRepresentable: UIViewControllerRepresentable {
     let onAgentOutOfCredits: () -> Void
     let creditsDepleted: Bool
     let onTapUpdateMember: (ConversationMember) -> Void
+    var onTapCapabilityConnect: (CapabilityConnectPrompt) -> Void = { _ in }
     let onRetryMessage: (AnyMessage) -> Void
     let onDeleteMessage: (AnyMessage) -> Void
     let onRetryAgentJoin: () -> Void
@@ -118,6 +119,9 @@ struct MessagesViewRepresentable: UIViewControllerRepresentable {
         messagesViewController.creditsDepleted = creditsDepleted
         messagesViewController.onTapUpdateMember = { member in
             self.onTapUpdateMember(member)
+        }
+        messagesViewController.onTapCapabilityConnect = { prompt in
+            self.onTapCapabilityConnect(prompt)
         }
         messagesViewController.onRetryMessage = { message in
             self.onRetryMessage(message)

--- a/ConvosCore/Sources/ConvosCore/CapabilityResolution/CapabilityRequestRepository.swift
+++ b/ConvosCore/Sources/ConvosCore/CapabilityResolution/CapabilityRequestRepository.swift
@@ -12,9 +12,9 @@ import GRDB
 /// Resolution detection joins result rows on `requestId` and applies
 /// `CapabilityConnectPrompt.resolution` — the SAME validated rule the transcript
 /// pill derives its display state from, so "tap path open" and "pill pending"
-/// can never disagree. First responder wins: any member's validated
-/// approve/deny/cancel resolves the request for the whole conversation;
-/// asker-authored rows and non-decision statuses never resolve it.
+/// can never disagree. First decision wins, in message-time order: the earliest
+/// validated approve/deny/cancel resolves the request for the whole
+/// conversation; asker-authored rows and non-decision statuses never resolve it.
 public protocol CapabilityRequestRepositoryProtocol: Sendable {
     var pendingRequestPublisher: AnyPublisher<CapabilityRequest?, Never> { get }
 }
@@ -51,6 +51,7 @@ public final class CapabilityRequestRepository: CapabilityRequestRepositoryProto
                 resultsByRequestId: resultsByRequestId
             )
         } catch {
+            Log.error("CapabilityRequestRepository: computeLatestPendingRequest failed for \(conversationId): \(error)")
             return nil
         }
     }
@@ -59,8 +60,8 @@ public final class CapabilityRequestRepository: CapabilityRequestRepositoryProto
     /// returned request to decide which unresolved pill renders `.pending`
     /// (actionable) versus `.superseded` — keeping the transcript and the tap
     /// path on one verdict. Resolution per request is
-    /// `CapabilityConnectPrompt.resolution`: first validated responder wins,
-    /// asker-authored rows never count.
+    /// `CapabilityConnectPrompt.resolution`: the first validated decision in
+    /// message-time order wins, asker-authored rows never count.
     static func computeLatestPendingRequest(
         conversationId: String,
         db: Database,
@@ -90,7 +91,12 @@ public final class CapabilityRequestRepository: CapabilityRequestRepositoryProto
 
     /// Every capability_request_result row in the conversation, decoded and
     /// keyed by `requestId`, each carrying the row's XMTP-attested `senderId`
-    /// — the inputs `CapabilityConnectPrompt.resolution` validates against.
+    /// plus its message-time position (`dateNs` + message id) — the inputs
+    /// `CapabilityConnectPrompt.resolution` validates and orders against.
+    /// The query orders by sent timestamp with the message id as a stable
+    /// tiebreaker so each bucket is already in message-time order, and
+    /// `resolution` re-sorts on the same key anyway, so first-decision-wins
+    /// cannot be bypassed by an unordered caller.
     static func resultRecordsByRequestId(
         conversationId: String,
         db: Database
@@ -98,6 +104,7 @@ public final class CapabilityRequestRepository: CapabilityRequestRepositoryProto
         let results = try DBMessage
             .filter(DBMessage.Columns.conversationId == conversationId)
             .filter(DBMessage.Columns.contentType == MessageContentType.capabilityRequestResult.rawValue)
+            .order(DBMessage.Columns.dateNs.asc, DBMessage.Columns.id.asc)
             .fetchAll(db)
         var recordsByRequestId: [String: [CapabilityConnectPrompt.ResultRecord]] = [:]
         for row in results {
@@ -107,7 +114,7 @@ public final class CapabilityRequestRepository: CapabilityRequestRepositoryProto
                 continue
             }
             recordsByRequestId[result.requestId, default: []].append(
-                .init(senderId: row.senderId, status: result.status)
+                .init(senderId: row.senderId, status: result.status, sentAtNs: row.dateNs, messageId: row.id)
             )
         }
         return recordsByRequestId

--- a/ConvosCore/Sources/ConvosCore/CapabilityResolution/CapabilityRequestRepository.swift
+++ b/ConvosCore/Sources/ConvosCore/CapabilityResolution/CapabilityRequestRepository.swift
@@ -7,10 +7,14 @@ import GRDB
 /// publishes the latest one that hasn't been resolved by a matching
 /// `capability_request_result` yet. The picker UI subscribes — when the publisher
 /// emits a non-nil `CapabilityRequest`, the conversation view model recomputes the
-/// `CapabilityPickerLayout` and surfaces the card.
+/// `CapabilityPickerLayout` and surfaces the approval sheet.
 ///
-/// Resolution detection is by `requestId`: a `capability_request_result` with the same
-/// `requestId` (regardless of status) marks the request as resolved.
+/// Resolution detection joins result rows on `requestId` and applies
+/// `CapabilityConnectPrompt.resolution` — the SAME validated rule the transcript
+/// pill derives its display state from, so "tap path open" and "pill pending"
+/// can never disagree. First responder wins: any member's validated
+/// approve/deny/cancel resolves the request for the whole conversation;
+/// asker-authored rows and non-decision statuses never resolve it.
 public protocol CapabilityRequestRepositoryProtocol: Sendable {
     var pendingRequestPublisher: AnyPublisher<CapabilityRequest?, Never> { get }
 }
@@ -35,48 +39,77 @@ public final class CapabilityRequestRepository: CapabilityRequestRepositoryProto
             .eraseToAnyPublisher()
     }()
 
-    /// Visible for testing — pure function over a `Database`. Walks every
-    /// capability_request message for the conversation in descending date order, and
-    /// returns the first one whose `requestId` doesn't appear in any
-    /// capability_request_result row.
+    /// Pure function over a `Database` (visible for testing). Walks every
+    /// capability_request message for the conversation in descending date
+    /// order and returns the first one that no validated result resolves.
     static func computeLatestPendingRequest(conversationId: String, db: Database) -> CapabilityRequest? {
         do {
-            let resolvedIds = try resolvedRequestIds(conversationId: conversationId, db: db)
-            let requests = try DBMessage
-                .filter(DBMessage.Columns.conversationId == conversationId)
-                .filter(DBMessage.Columns.contentType == MessageContentType.capabilityRequest.rawValue)
-                .order(DBMessage.Columns.dateNs.desc)
-                .fetchAll(db)
-            for row in requests {
-                guard let text = row.text,
-                      let data = text.data(using: .utf8),
-                      let request = try? JSONDecoder().decode(CapabilityRequest.self, from: data) else {
-                    continue
-                }
-                if !resolvedIds.contains(request.requestId) {
-                    return request
-                }
-            }
-            return nil
+            let resultsByRequestId = try resultRecordsByRequestId(conversationId: conversationId, db: db)
+            return try computeLatestPendingRequest(
+                conversationId: conversationId,
+                db: db,
+                resultsByRequestId: resultsByRequestId
+            )
         } catch {
             return nil
         }
     }
 
-    private static func resolvedRequestIds(conversationId: String, db: Database) throws -> Set<String> {
+    /// Shared with `MessagesRepository`'s compose-time join, which uses the
+    /// returned request to decide which unresolved pill renders `.pending`
+    /// (actionable) versus `.superseded` — keeping the transcript and the tap
+    /// path on one verdict. Resolution per request is
+    /// `CapabilityConnectPrompt.resolution`: first validated responder wins,
+    /// asker-authored rows never count.
+    static func computeLatestPendingRequest(
+        conversationId: String,
+        db: Database,
+        resultsByRequestId: [String: [CapabilityConnectPrompt.ResultRecord]]
+    ) throws -> CapabilityRequest? {
+        let requests = try DBMessage
+            .filter(DBMessage.Columns.conversationId == conversationId)
+            .filter(DBMessage.Columns.contentType == MessageContentType.capabilityRequest.rawValue)
+            .order(DBMessage.Columns.dateNs.desc)
+            .fetchAll(db)
+        for row in requests {
+            guard let text = row.text,
+                  let data = text.data(using: .utf8),
+                  let request = try? JSONDecoder().decode(CapabilityRequest.self, from: data) else {
+                continue
+            }
+            let resolution = CapabilityConnectPrompt.resolution(
+                results: resultsByRequestId[request.requestId] ?? [],
+                askerInboxId: request.askerInboxId
+            )
+            if resolution == nil {
+                return request
+            }
+        }
+        return nil
+    }
+
+    /// Every capability_request_result row in the conversation, decoded and
+    /// keyed by `requestId`, each carrying the row's XMTP-attested `senderId`
+    /// — the inputs `CapabilityConnectPrompt.resolution` validates against.
+    static func resultRecordsByRequestId(
+        conversationId: String,
+        db: Database
+    ) throws -> [String: [CapabilityConnectPrompt.ResultRecord]] {
         let results = try DBMessage
             .filter(DBMessage.Columns.conversationId == conversationId)
             .filter(DBMessage.Columns.contentType == MessageContentType.capabilityRequestResult.rawValue)
             .fetchAll(db)
-        var ids: Set<String> = []
+        var recordsByRequestId: [String: [CapabilityConnectPrompt.ResultRecord]] = [:]
         for row in results {
             guard let text = row.text,
                   let data = text.data(using: .utf8),
                   let result = try? JSONDecoder().decode(CapabilityRequestResult.self, from: data) else {
                 continue
             }
-            ids.insert(result.requestId)
+            recordsByRequestId[result.requestId, default: []].append(
+                .init(senderId: row.senderId, status: result.status)
+            )
         }
-        return ids
+        return recordsByRequestId
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Connections/ConnectionMessageSummaryFormatter.swift
+++ b/ConvosCore/Sources/ConvosCore/Connections/ConnectionMessageSummaryFormatter.swift
@@ -5,13 +5,16 @@ public enum ConnectionMessageSummaryFormatter {
     public static func eventSummary(_ event: ConnectionEvent) -> ConnectionEventSummary {
         switch event.action {
         case .granted:
-            let actor: ConnectionEventSummary.Actor? = event.grantedToInboxId == nil ? nil : .grantedAgent
+            // Service-branded status line: the message sender IS the granter, so
+            // `.messageSender` gives "You/<Name> connected Google Calendar" for
+            // free at render time — no extra identity on the wire.
             return .init(
-                text: grantedText(forProviderId: event.providerId, capability: event.capability),
+                text: "connected \(serviceDisplayName(forProviderId: event.providerId))",
                 outcome: .success,
                 icon: icon(forProviderId: event.providerId),
-                actor: actor,
-                grantedToInboxId: event.grantedToInboxId
+                actor: .messageSender,
+                grantedToInboxId: event.grantedToInboxId,
+                providerId: event.providerId
             )
         case .revoked:
             let actor: ConnectionEventSummary.Actor? = event.grantedToInboxId == nil ? nil : .grantedAgent
@@ -20,9 +23,25 @@ public enum ConnectionMessageSummaryFormatter {
                 outcome: .success,
                 icon: icon(forProviderId: event.providerId),
                 actor: actor,
-                grantedToInboxId: event.grantedToInboxId
+                grantedToInboxId: event.grantedToInboxId,
+                providerId: event.providerId
             )
         }
+    }
+
+    /// User-facing brand name for a provider id: "Google Calendar" for
+    /// `composio.googlecalendar`, "Apple Health" for `device.health`.
+    public static func serviceDisplayName(forProviderId providerId: String) -> String {
+        let id = ProviderID(rawValue: providerId)
+        if let kind = ConnectionKind.fromDeviceProviderId(id) {
+            return DeviceCapabilityProvider.defaultSpecs.first(where: { $0.kind == kind })?.displayName
+                ?? kind.displayName
+        }
+        if let serviceId = id.cloudServiceId {
+            return CloudCapabilityProvider.serviceDisplayNames[serviceId]
+                ?? CloudConnectionServiceNaming.displayName(for: "", fallbackFrom: serviceId)
+        }
+        return "a service"
     }
 
     public static func invocationSummary(_ invocation: ConnectionInvocation) -> ConnectionEventSummary {
@@ -114,18 +133,6 @@ public enum ConnectionMessageSummaryFormatter {
         }
     }
 
-    private static func grantedText(forProviderId providerId: String, capability: ConnectionCapability?) -> String {
-        let id = ProviderID(rawValue: providerId)
-        if let kind = ConnectionKind.fromDeviceProviderId(id) {
-            return grantedText(forDeviceKind: kind, capability: capability)
-        }
-        if let serviceId = id.cloudServiceId,
-           let subject = CloudCapabilityProvider.serviceSubjectMap[serviceId] {
-            return grantedText(forSubject: subject, capability: capability)
-        }
-        return "has access to connection data"
-    }
-
     private static func revokedText(forProviderId providerId: String, capability: ConnectionCapability?) -> String {
         let id = ProviderID(rawValue: providerId)
         if let kind = ConnectionKind.fromDeviceProviderId(id) {
@@ -138,37 +145,14 @@ public enum ConnectionMessageSummaryFormatter {
         return "Connection removed"
     }
 
-    private static func grantedText(forDeviceKind kind: ConnectionKind, capability: ConnectionCapability?) -> String {
-        guard let capability else { return defaultGrantedText(forDeviceKind: kind) }
-        return "can \(verb(for: capability)) \(noun(forDeviceKind: kind))"
-    }
-
     private static func revokedText(forDeviceKind kind: ConnectionKind, capability: ConnectionCapability?) -> String {
         guard let capability else { return defaultRevokedText(forDeviceKind: kind) }
         return "\(noun(forDeviceKind: kind, capitalized: true)) \(capability.displayName.lowercased()) access removed"
     }
 
-    private static func grantedText(forSubject subject: CapabilitySubject, capability: ConnectionCapability?) -> String {
-        guard let capability else { return defaultGrantedText(forSubject: subject) }
-        return "can \(verb(for: capability)) \(noun(forSubject: subject))"
-    }
-
     private static func revokedText(forSubject subject: CapabilitySubject, capability: ConnectionCapability?) -> String {
         guard let capability else { return defaultRevokedText(forSubject: subject) }
         return "\(noun(forSubject: subject, capitalized: true)) \(capability.displayName.lowercased()) access removed"
-    }
-
-    private static func verb(for capability: ConnectionCapability) -> String {
-        switch capability {
-        case .read:
-            return "read"
-        case .writeCreate:
-            return "create"
-        case .writeUpdate:
-            return "edit"
-        case .writeDelete:
-            return "delete"
-        }
     }
 
     private static func noun(forDeviceKind kind: ConnectionKind, capitalized: Bool = false) -> String {
@@ -223,29 +207,6 @@ public enum ConnectionMessageSummaryFormatter {
         return capitalized ? value.prefix(1).uppercased() + value.dropFirst() : value
     }
 
-    private static func defaultGrantedText(forDeviceKind kind: ConnectionKind) -> String {
-        switch kind {
-        case .health:
-            return "has access to health data"
-        case .calendar:
-            return "has access to calendar data"
-        case .contacts:
-            return "has access to contacts data"
-        case .photos:
-            return "has access to photos"
-        case .music:
-            return "has access to music data"
-        case .homeKit:
-            return "has access to home data"
-        case .location:
-            return "has access to location data"
-        case .screenTime:
-            return "has access to Screen Time data"
-        case .motion:
-            return "has access to motion data"
-        }
-    }
-
     private static func defaultRevokedText(forDeviceKind kind: ConnectionKind) -> String {
         switch kind {
         case .health:
@@ -266,31 +227,6 @@ public enum ConnectionMessageSummaryFormatter {
             return "Screen Time connection removed"
         case .motion:
             return "Motion data connection removed"
-        }
-    }
-
-    private static func defaultGrantedText(forSubject subject: CapabilitySubject) -> String {
-        switch subject {
-        case .calendar:
-            return "has access to calendar data"
-        case .contacts:
-            return "has access to contacts data"
-        case .tasks:
-            return "has access to tasks"
-        case .mail:
-            return "has access to mail"
-        case .photos:
-            return "has access to photos"
-        case .fitness:
-            return "has access to fitness data"
-        case .music:
-            return "has access to music data"
-        case .location:
-            return "has access to location data"
-        case .home:
-            return "has access to home data"
-        case .screenTime:
-            return "has access to Screen Time data"
         }
     }
 
@@ -330,7 +266,7 @@ public enum ConnectionMessageSummaryFormatter {
         }
     }
 
-    private static func icon(forProviderId providerId: String) -> ConnectionEventSummary.Icon {
+    public static func icon(forProviderId providerId: String) -> ConnectionEventSummary.Icon {
         let id = ProviderID(rawValue: providerId)
         if let kind = ConnectionKind.fromDeviceProviderId(id) {
             return icon(for: kind)
@@ -340,6 +276,10 @@ public enum ConnectionMessageSummaryFormatter {
             return icon(for: subject)
         }
         return .generic
+    }
+
+    public static func icon(forSubject subject: CapabilitySubject) -> ConnectionEventSummary.Icon {
+        icon(for: subject)
     }
 
     private static func icon(for subject: CapabilitySubject) -> ConnectionEventSummary.Icon {

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/CapabilityConnectPrompt.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/CapabilityConnectPrompt.swift
@@ -11,13 +11,18 @@ import Foundation
 /// device as result rows sync in.
 public struct CapabilityConnectPrompt: Hashable, Codable, Sendable {
     public enum Status: String, Hashable, Codable, Sendable {
-        /// No result row references the request yet — tapping opens the
-        /// approval sheet.
+        /// No validated result row resolves the request yet and it is the
+        /// conversation's latest unresolved ask — tapping opens the approval
+        /// sheet.
         case pending
         /// An approved result row landed (from any member's device).
         case connected
         /// A denied or cancelled result row landed and no approval exists.
         case dismissed
+        /// Still unresolved, but a newer unresolved request has taken over as
+        /// the conversation's single actionable ask. Rendered inert; flips
+        /// back to `.pending` if the newer request resolves first.
+        case superseded
     }
 
     /// One `capability_request_result` row reduced to what status derivation
@@ -62,7 +67,16 @@ public struct CapabilityConnectPrompt: Hashable, Codable, Sendable {
 }
 
 public extension CapabilityConnectPrompt {
-    static func make(request: CapabilityRequest, results: [ResultRecord]) -> CapabilityConnectPrompt {
+    /// `isLatestUnresolvedRequest`: whether this request is the one
+    /// `CapabilityRequestRepository.computeLatestPendingRequest` would surface
+    /// — i.e. the conversation's single actionable ask. Unresolved requests
+    /// that aren't it render `.superseded` instead of `.pending`, so the pill
+    /// is never tappable-looking while the tap path would refuse it.
+    static func make(
+        request: CapabilityRequest,
+        results: [ResultRecord],
+        isLatestUnresolvedRequest: Bool
+    ) -> CapabilityConnectPrompt {
         let preferredProviderId = request.preferredProviders?.first
         return CapabilityConnectPrompt(
             requestId: request.requestId,
@@ -70,16 +84,35 @@ public extension CapabilityConnectPrompt {
             serviceName: serviceName(forPreferredProvider: preferredProviderId, subject: request.subject),
             serviceId: preferredProviderId?.cloudServiceId,
             icon: icon(forPreferredProvider: preferredProviderId, subject: request.subject),
-            status: displayStatus(results: results, askerInboxId: request.askerInboxId)
+            status: displayStatus(
+                results: results,
+                askerInboxId: request.askerInboxId,
+                isLatestUnresolvedRequest: isLatestUnresolvedRequest
+            )
         )
     }
 
-    /// Folds the result rows correlated to a request into the pill's display
-    /// state. Results sent by the asker itself are ignored for approval/denial
-    /// (an agent must not be able to mark its own request as connected);
+    /// THE single definition of a "resolving" result, shared by the display
+    /// derivation (pill status) and `CapabilityRequestRepository` (pending
+    /// picker layout, i.e. the tap path) — both layers must always agree on
+    /// whether a request is still open.
+    ///
+    /// First responder wins: one capability request is one connection ask for
+    /// the whole conversation. The first validated result resolves it for
+    /// every member — on approval the pill flips to `.connected`
+    /// conversation-wide (and the grant separately broadcasts as a
+    /// `connection_event`); an agent that needs more access re-requests under
+    /// a new `requestId`.
+    ///
+    /// Validation: a result only counts when its XMTP-attested sender (the
+    /// envelope's `senderInboxId`, persisted as the row's `senderId`) is not
+    /// the request's asker — the requesting agent can't approve, deny, or
+    /// cancel its own ask. This mirrors the attested-sender posture of
+    /// `validateConnectionGrantRequest`; the result payload carries no sender
+    /// claim of its own, so the envelope identity is the only trusted input.
     /// `staleResource` and forward-compat `unknown` statuses are not user
-    /// decisions, so they leave the prompt pending.
-    static func displayStatus(results: [ResultRecord], askerInboxId: String) -> Status {
+    /// decisions, so they never resolve. Returns nil while unresolved.
+    static func resolution(results: [ResultRecord], askerInboxId: String) -> Status? {
         let decisions = results.filter { $0.senderId != askerInboxId }
         if decisions.contains(where: { $0.status == .approved }) {
             return .connected
@@ -87,7 +120,22 @@ public extension CapabilityConnectPrompt {
         if decisions.contains(where: { $0.status == .denied || $0.status == .cancelled }) {
             return .dismissed
         }
-        return .pending
+        return nil
+    }
+
+    /// Folds the validated resolution (see `resolution(results:askerInboxId:)`)
+    /// into the pill's display state. Unresolved requests are `.pending` only
+    /// when they are the conversation's latest unresolved ask; older ones are
+    /// `.superseded` (visible but inert).
+    static func displayStatus(
+        results: [ResultRecord],
+        askerInboxId: String,
+        isLatestUnresolvedRequest: Bool
+    ) -> Status {
+        if let resolution = resolution(results: results, askerInboxId: askerInboxId) {
+            return resolution
+        }
+        return isLatestUnresolvedRequest ? .pending : .superseded
     }
 
     private static func serviceName(forPreferredProvider providerId: ProviderID?, subject: CapabilitySubject) -> String {

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/CapabilityConnectPrompt.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/CapabilityConnectPrompt.swift
@@ -1,0 +1,112 @@
+import ConvosConnections
+import Foundation
+
+/// Render model for a `capability_request` row in the transcript: the centered
+/// "<Agent> wants to connect" caption plus the tappable service pill.
+///
+/// Built at compose time. `status` is derived by joining
+/// `capability_request_result` rows on `requestId` (same shape as the
+/// reaction join on `sourceMessageId`) — the request row itself is never
+/// edited, so the pill stays in history and flips state on every member's
+/// device as result rows sync in.
+public struct CapabilityConnectPrompt: Hashable, Codable, Sendable {
+    public enum Status: String, Hashable, Codable, Sendable {
+        /// No result row references the request yet — tapping opens the
+        /// approval sheet.
+        case pending
+        /// An approved result row landed (from any member's device).
+        case connected
+        /// A denied or cancelled result row landed and no approval exists.
+        case dismissed
+    }
+
+    /// One `capability_request_result` row reduced to what status derivation
+    /// needs: who sent it and what they decided.
+    public struct ResultRecord: Hashable, Sendable {
+        public let senderId: String
+        public let status: CapabilityRequestResult.Status
+
+        public init(senderId: String, status: CapabilityRequestResult.Status) {
+            self.senderId = senderId
+            self.status = status
+        }
+    }
+
+    public let requestId: String
+    public let askerInboxId: String
+    /// Brand label for the pill ("Google Calendar"). Resolved from the
+    /// request's preferred providers, falling back to the subject name.
+    public let serviceName: String
+    /// Cloud service slug ("googlecalendar") when the request targets a
+    /// `composio.*` provider. The app maps it to a branded icon asset;
+    /// nil falls back to the `icon` symbol.
+    public let serviceId: String?
+    public let icon: ConnectionEventSummary.Icon
+    public let status: Status
+
+    public init(
+        requestId: String,
+        askerInboxId: String,
+        serviceName: String,
+        serviceId: String?,
+        icon: ConnectionEventSummary.Icon,
+        status: Status
+    ) {
+        self.requestId = requestId
+        self.askerInboxId = askerInboxId
+        self.serviceName = serviceName
+        self.serviceId = serviceId
+        self.icon = icon
+        self.status = status
+    }
+}
+
+public extension CapabilityConnectPrompt {
+    static func make(request: CapabilityRequest, results: [ResultRecord]) -> CapabilityConnectPrompt {
+        let preferredProviderId = request.preferredProviders?.first
+        return CapabilityConnectPrompt(
+            requestId: request.requestId,
+            askerInboxId: request.askerInboxId,
+            serviceName: serviceName(forPreferredProvider: preferredProviderId, subject: request.subject),
+            serviceId: preferredProviderId?.cloudServiceId,
+            icon: icon(forPreferredProvider: preferredProviderId, subject: request.subject),
+            status: displayStatus(results: results, askerInboxId: request.askerInboxId)
+        )
+    }
+
+    /// Folds the result rows correlated to a request into the pill's display
+    /// state. Results sent by the asker itself are ignored for approval/denial
+    /// (an agent must not be able to mark its own request as connected);
+    /// `staleResource` and forward-compat `unknown` statuses are not user
+    /// decisions, so they leave the prompt pending.
+    static func displayStatus(results: [ResultRecord], askerInboxId: String) -> Status {
+        let decisions = results.filter { $0.senderId != askerInboxId }
+        if decisions.contains(where: { $0.status == .approved }) {
+            return .connected
+        }
+        if decisions.contains(where: { $0.status == .denied || $0.status == .cancelled }) {
+            return .dismissed
+        }
+        return .pending
+    }
+
+    private static func serviceName(forPreferredProvider providerId: ProviderID?, subject: CapabilitySubject) -> String {
+        guard let providerId else { return subject.displayName }
+        if let serviceId = providerId.cloudServiceId {
+            return CloudCapabilityProvider.serviceDisplayNames[serviceId]
+                ?? CloudConnectionServiceNaming.displayName(for: "", fallbackFrom: serviceId)
+        }
+        if let kind = ConnectionKind.fromDeviceProviderId(providerId),
+           let spec = DeviceCapabilityProvider.defaultSpecs.first(where: { $0.kind == kind }) {
+            return spec.displayName
+        }
+        return subject.displayName
+    }
+
+    private static func icon(forPreferredProvider providerId: ProviderID?, subject: CapabilitySubject) -> ConnectionEventSummary.Icon {
+        guard let providerId else {
+            return ConnectionMessageSummaryFormatter.icon(forSubject: subject)
+        }
+        return ConnectionMessageSummaryFormatter.icon(forProviderId: providerId.rawValue)
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/CapabilityConnectPrompt.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/CapabilityConnectPrompt.swift
@@ -15,9 +15,11 @@ public struct CapabilityConnectPrompt: Hashable, Codable, Sendable {
         /// conversation's latest unresolved ask — tapping opens the approval
         /// sheet.
         case pending
-        /// An approved result row landed (from any member's device).
+        /// The first validated result row (in message-time order, from any
+        /// member's device) was an approval.
         case connected
-        /// A denied or cancelled result row landed and no approval exists.
+        /// The first validated result row (in message-time order) was a
+        /// denial or cancellation.
         case dismissed
         /// Still unresolved, but a newer unresolved request has taken over as
         /// the conversation's single actionable ask. Rendered inert; flips
@@ -26,14 +28,27 @@ public struct CapabilityConnectPrompt: Hashable, Codable, Sendable {
     }
 
     /// One `capability_request_result` row reduced to what status derivation
-    /// needs: who sent it and what they decided.
+    /// needs: who sent it, what they decided, and where the row sits in
+    /// message time. `sentAtNs` (the message's `dateNs`) plus `messageId` (the
+    /// stable tiebreaker for identical timestamps) give
+    /// `resolution(results:askerInboxId:)` its first-decision ordering; both
+    /// come off the synced message row, so every device sorts identically.
     public struct ResultRecord: Hashable, Sendable {
         public let senderId: String
         public let status: CapabilityRequestResult.Status
+        public let sentAtNs: Int64
+        public let messageId: String
 
-        public init(senderId: String, status: CapabilityRequestResult.Status) {
+        public init(
+            senderId: String,
+            status: CapabilityRequestResult.Status,
+            sentAtNs: Int64,
+            messageId: String
+        ) {
             self.senderId = senderId
             self.status = status
+            self.sentAtNs = sentAtNs
+            self.messageId = messageId
         }
     }
 
@@ -97,12 +112,16 @@ public extension CapabilityConnectPrompt {
     /// picker layout, i.e. the tap path) — both layers must always agree on
     /// whether a request is still open.
     ///
-    /// First responder wins: one capability request is one connection ask for
-    /// the whole conversation. The first validated result resolves it for
-    /// every member — on approval the pill flips to `.connected`
-    /// conversation-wide (and the grant separately broadcasts as a
-    /// `connection_event`); an agent that needs more access re-requests under
-    /// a new `requestId`.
+    /// First decision wins, in message-time order: one capability request is
+    /// one connection ask for the whole conversation, and the EARLIEST
+    /// validated result resolves it for every member — approved flips the
+    /// pill to `.connected` conversation-wide (and the grant separately
+    /// broadcasts as a `connection_event`); denied/cancelled resolves to
+    /// `.dismissed` just as finally — an agent that still needs access
+    /// re-requests under a new `requestId`. Results are sorted here (sent
+    /// timestamp, then message id as the stable tiebreaker) rather than
+    /// trusting callers to pass them ordered, so the temporal guarantee
+    /// holds in every call path.
     ///
     /// Validation: a result only counts when its XMTP-attested sender (the
     /// envelope's `senderInboxId`, persisted as the row's `senderId`) is not
@@ -111,14 +130,21 @@ public extension CapabilityConnectPrompt {
     /// `validateConnectionGrantRequest`; the result payload carries no sender
     /// claim of its own, so the envelope identity is the only trusted input.
     /// `staleResource` and forward-compat `unknown` statuses are not user
-    /// decisions, so they never resolve. Returns nil while unresolved.
+    /// decisions, so they are skipped, never resolving. Returns nil while
+    /// unresolved.
     static func resolution(results: [ResultRecord], askerInboxId: String) -> Status? {
-        let decisions = results.filter { $0.senderId != askerInboxId }
-        if decisions.contains(where: { $0.status == .approved }) {
-            return .connected
+        let ordered = results.sorted {
+            ($0.sentAtNs, $0.messageId) < ($1.sentAtNs, $1.messageId)
         }
-        if decisions.contains(where: { $0.status == .denied || $0.status == .cancelled }) {
-            return .dismissed
+        for record in ordered where record.senderId != askerInboxId {
+            switch record.status {
+            case .approved:
+                return .connected
+            case .denied, .cancelled:
+                return .dismissed
+            case .staleResource, .unknown:
+                continue
+            }
         }
         return nil
     }

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/MessageContent.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/MessageContent.swift
@@ -41,19 +41,25 @@ public struct ConnectionEventSummary: Hashable, Codable, Sendable {
     /// nil otherwise. Renderer prefers a live member-list lookup keyed off this id and
     /// falls back to bare text only when the agent is no longer in the conversation.
     public let grantedToInboxId: String?
+    /// Provider the event concerns ("composio.googlecalendar"). Lets the renderer
+    /// substitute a branded service icon for the generic `icon` symbol. Optional so
+    /// summaries persisted before this field existed keep decoding.
+    public let providerId: String?
 
     public init(
         text: String,
         outcome: Outcome,
         icon: Icon,
         actor: Actor? = nil,
-        grantedToInboxId: String? = nil
+        grantedToInboxId: String? = nil,
+        providerId: String? = nil
     ) {
         self.text = text
         self.outcome = outcome
         self.icon = icon
         self.actor = actor
         self.grantedToInboxId = grantedToInboxId
+        self.providerId = providerId
     }
 }
 
@@ -70,6 +76,7 @@ public enum MessageContent: Hashable, Codable, Sendable {
          linkPreview(LinkPreview),
          assistantJoinRequest(status: AgentJoinStatus, requestedByInboxId: String),
          connectionGrantRequest(CloudConnectionGrantRequest),
+         capabilityConnect(prompt: CapabilityConnectPrompt),
          connectionEvent(summary: ConnectionEventSummary),
          connectionInvocation(summary: ConnectionEventSummary),
          connectionInvocationResult(summary: ConnectionEventSummary),
@@ -107,6 +114,7 @@ public enum MessageContent: Hashable, Codable, Sendable {
         case .update,
              .assistantJoinRequest,
              .connectionGrantRequest,
+             .capabilityConnect,
              .connectionEvent,
              .connectionInvocation,
              .connectionInvocationResult,

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/MessagesListItemType.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/MessagesListItemType.swift
@@ -52,6 +52,7 @@ public enum MessagesListItemType: Identifiable, Equatable, Hashable, Sendable {
     case agentJoinStatus(AgentJoinStatus, requesterName: String?, date: Date)
     case agentPresentInfo(agent: ConversationMember, inviterName: String?)
     case connectionEvent(id: String, summary: ConnectionEventSummary, origin: AnyMessage.Origin)
+    case capabilityConnect(id: String, prompt: CapabilityConnectPrompt, agentName: String, origin: AnyMessage.Origin)
     case agentBuilderSummary(AgentBuilderCardContent)
     case typingIndicator(typers: [ConversationMember])
 
@@ -75,6 +76,8 @@ public enum MessagesListItemType: Identifiable, Equatable, Hashable, Sendable {
             return "agent-present-info"
         case .connectionEvent(let id, _, _):
             return "connection-event-\(id)"
+        case .capabilityConnect(let id, _, _, _):
+            return "capability-connect-\(id)"
         case .agentBuilderSummary(let content):
             return "agent-builder-summary-\(content.id)"
         case .typingIndicator:
@@ -119,6 +122,8 @@ public enum MessagesListItemType: Identifiable, Equatable, Hashable, Sendable {
             return nil
         case .connectionEvent(_, _, let origin):
             return origin
+        case .capabilityConnect(_, _, _, let origin):
+            return origin
         }
     }
 
@@ -157,6 +162,8 @@ public enum MessagesListItemType: Identifiable, Equatable, Hashable, Sendable {
             return "MessagesListItemTypeCell-agentPresentInfo"
         case .connectionEvent:
             return "MessagesListItemTypeCell-connectionEvent"
+        case .capabilityConnect:
+            return "MessagesListItemTypeCell-capabilityConnect"
         case .agentBuilderSummary:
             return "MessagesListItemTypeCell-agentBuilderSummary"
         case .typingIndicator:
@@ -175,6 +182,7 @@ public enum MessagesListItemType: Identifiable, Equatable, Hashable, Sendable {
             "MessagesListItemTypeCell-agentJoinStatus",
             "MessagesListItemTypeCell-agentPresentInfo",
             "MessagesListItemTypeCell-connectionEvent",
+            "MessagesListItemTypeCell-capabilityConnect",
             "MessagesListItemTypeCell-agentBuilderSummary",
             "TypingIndicatorCollectionCell",
         ]

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/MessagesListProcessor.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/MessagesListProcessor.swift
@@ -471,6 +471,23 @@ public final class MessagesListProcessor: Sendable {
                 continue
             }
 
+            if case .capabilityConnect(let prompt) = content {
+                lastMessageDate = msg.date
+                if !currentGroupMessages.isEmpty, currentSenderId != nil {
+                    flush(
+                        &items, currentGroupMessages,
+                        false, false, &lastCUGroupIdx, trackedMemberCount, &lastOVIdx,
+                        voiceMemoTranscripts
+                    )
+                    currentGroupMessages.removeAll(keepingCapacity: true)
+                    currentSenderId = nil
+                }
+                let agentName = resolvedAskerName(for: prompt, sender: msg.sender, memberProfiles: memberProfiles)
+                items.append(.capabilityConnect(id: msg.messageId, prompt: prompt, agentName: agentName, origin: msg.origin))
+                lastWasAttachment = false
+                continue
+            }
+
             if case .connectionInvocationResult(let resultSummary) = content {
                 lastMessageDate = msg.date
                 if !currentGroupMessages.isEmpty, currentSenderId != nil {
@@ -726,8 +743,24 @@ public final class MessagesListProcessor: Sendable {
             outcome: summary.outcome,
             icon: summary.icon,
             actor: summary.actor,
-            grantedToInboxId: summary.grantedToInboxId
+            grantedToInboxId: summary.grantedToInboxId,
+            providerId: summary.providerId
         )
+    }
+
+    /// Display name for the agent behind a connect prompt's "<Agent> wants to
+    /// connect" caption. Prefers the live member-profile lookup by the request's
+    /// `askerInboxId` (renames propagate like connection events); falls back to
+    /// the message sender's snapshot, which is the asker in practice.
+    private static func resolvedAskerName(
+        for prompt: CapabilityConnectPrompt,
+        sender: ConversationMember,
+        memberProfiles: [String: MemberProfileInfo]
+    ) -> String {
+        if let name = memberProfiles[prompt.askerInboxId]?.name, !name.isEmpty {
+            return name
+        }
+        return sender.profile.displayName
     }
 }
 

--- a/ConvosCore/Sources/ConvosCore/Storage/Repositories/MessagesRepository.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Repositories/MessagesRepository.swift
@@ -434,6 +434,7 @@ extension Array where Element == DBMessage {
                          sourceMessagesById: [String: DBMessage],
                          attachmentLocalStates: [String: AttachmentLocalState] = [:],
                          capabilityResultsByRequestId: [String: [CapabilityConnectPrompt.ResultRecord]] = [:],
+                         latestPendingCapabilityRequestId: String? = nil,
                          seenMessageIds: Set<String>,
                          isInitialLoad: Bool = false,
                          isPaginating: Bool = false) -> ([AnyMessage], Set<String>) {
@@ -465,7 +466,8 @@ extension Array where Element == DBMessage {
                     currentInboxId: currentInboxId,
                     memberProfileCache: memberProfileCache,
                     attachmentLocalStates: attachmentLocalStates,
-                    capabilityResultsByRequestId: capabilityResultsByRequestId
+                    capabilityResultsByRequestId: capabilityResultsByRequestId,
+                    latestPendingCapabilityRequestId: latestPendingCapabilityRequestId
                 ) else { return nil }
 
                 let message = Message(
@@ -499,7 +501,8 @@ extension Array where Element == DBMessage {
         currentInboxId: String,
         memberProfileCache: MemberProfileCache,
         attachmentLocalStates: [String: AttachmentLocalState],
-        capabilityResultsByRequestId: [String: [CapabilityConnectPrompt.ResultRecord]] = [:]
+        capabilityResultsByRequestId: [String: [CapabilityConnectPrompt.ResultRecord]] = [:],
+        latestPendingCapabilityRequestId: String? = nil
     ) -> MessageContent? {
         switch dbMessage.contentType {
         case .text:
@@ -540,7 +543,8 @@ extension Array where Element == DBMessage {
         case .capabilityRequest:
             return resolveCapabilityConnectContent(
                 jsonText: dbMessage.text,
-                resultsByRequestId: capabilityResultsByRequestId
+                resultsByRequestId: capabilityResultsByRequestId,
+                latestPendingRequestId: latestPendingCapabilityRequestId
             )
         case .capabilityRequestResult:
             // Results render indirectly: they flip the request row's pill state via
@@ -564,7 +568,8 @@ extension Array where Element == DBMessage {
 
     private static func resolveCapabilityConnectContent(
         jsonText: String?,
-        resultsByRequestId: [String: [CapabilityConnectPrompt.ResultRecord]]
+        resultsByRequestId: [String: [CapabilityConnectPrompt.ResultRecord]],
+        latestPendingRequestId: String?
     ) -> MessageContent? {
         guard let jsonText,
               let request = try? JSONDecoder().decode(CapabilityRequest.self, from: Data(jsonText.utf8)) else {
@@ -572,7 +577,8 @@ extension Array where Element == DBMessage {
         }
         let prompt = CapabilityConnectPrompt.make(
             request: request,
-            results: resultsByRequestId[request.requestId] ?? []
+            results: resultsByRequestId[request.requestId] ?? [],
+            isLatestUnresolvedRequest: request.requestId == latestPendingRequestId
         )
         return .capabilityConnect(prompt: prompt)
     }
@@ -1030,21 +1036,26 @@ fileprivate extension Database {
         // Skipping the query when no request row is visible is safe for the
         // ValueObservation: the main message query already tracks the table,
         // so a late-arriving result row still re-fires composition.
+        //
+        // First responder wins: one capability request is one connection ask
+        // for the whole conversation — the first validated (non-asker) result
+        // flips the pill for every member; the agent re-requests under a new
+        // requestId if it needs more. Both the resolution rule and the
+        // latest-pending computation are shared with CapabilityRequestRepository
+        // (the tap path), so a pill rendered `.pending` is always the request
+        // the approval sheet would open for.
         var capabilityResultsByRequestId: [String: [CapabilityConnectPrompt.ResultRecord]] = [:]
+        var latestPendingCapabilityRequestId: String?
         if rawMessages.contains(where: { $0.contentType == .capabilityRequest }) {
-            let resultRows = try DBMessage
-                .filter(DBMessage.Columns.conversationId == conversationId)
-                .filter(DBMessage.Columns.contentType == MessageContentType.capabilityRequestResult.rawValue)
-                .fetchAll(self)
-            for row in resultRows {
-                guard let text = row.text,
-                      let result = try? JSONDecoder().decode(CapabilityRequestResult.self, from: Data(text.utf8)) else {
-                    continue
-                }
-                capabilityResultsByRequestId[result.requestId, default: []].append(
-                    .init(senderId: row.senderId, status: result.status)
-                )
-            }
+            capabilityResultsByRequestId = try CapabilityRequestRepository.resultRecordsByRequestId(
+                conversationId: conversationId,
+                db: self
+            )
+            latestPendingCapabilityRequestId = try CapabilityRequestRepository.computeLatestPendingRequest(
+                conversationId: conversationId,
+                db: self,
+                resultsByRequestId: capabilityResultsByRequestId
+            )?.requestId
         }
 
         let localStates: [AttachmentLocalState]
@@ -1072,6 +1083,7 @@ fileprivate extension Database {
             sourceMessagesById: sourceMessagesById,
             attachmentLocalStates: attachmentLocalStates,
             capabilityResultsByRequestId: capabilityResultsByRequestId,
+            latestPendingCapabilityRequestId: latestPendingCapabilityRequestId,
             seenMessageIds: seenMessageIds,
             isInitialLoad: isInitialLoad,
             isPaginating: isPaginating

--- a/ConvosCore/Sources/ConvosCore/Storage/Repositories/MessagesRepository.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Repositories/MessagesRepository.swift
@@ -433,6 +433,7 @@ extension Array where Element == DBMessage {
                          reactionsBySourceId: [String: [DBMessage]],
                          sourceMessagesById: [String: DBMessage],
                          attachmentLocalStates: [String: AttachmentLocalState] = [:],
+                         capabilityResultsByRequestId: [String: [CapabilityConnectPrompt.ResultRecord]] = [:],
                          seenMessageIds: Set<String>,
                          isInitialLoad: Bool = false,
                          isPaginating: Bool = false) -> ([AnyMessage], Set<String>) {
@@ -463,7 +464,8 @@ extension Array where Element == DBMessage {
                     for: dbMessage,
                     currentInboxId: currentInboxId,
                     memberProfileCache: memberProfileCache,
-                    attachmentLocalStates: attachmentLocalStates
+                    attachmentLocalStates: attachmentLocalStates,
+                    capabilityResultsByRequestId: capabilityResultsByRequestId
                 ) else { return nil }
 
                 let message = Message(
@@ -496,7 +498,8 @@ extension Array where Element == DBMessage {
         for dbMessage: DBMessage,
         currentInboxId: String,
         memberProfileCache: MemberProfileCache,
-        attachmentLocalStates: [String: AttachmentLocalState]
+        attachmentLocalStates: [String: AttachmentLocalState],
+        capabilityResultsByRequestId: [String: [CapabilityConnectPrompt.ResultRecord]] = [:]
     ) -> MessageContent? {
         switch dbMessage.contentType {
         case .text:
@@ -534,8 +537,14 @@ extension Array where Element == DBMessage {
                 return .connectionGrantRequest(request)
             }
             return .text("")
-        case .capabilityRequest, .capabilityRequestResult:
-            // Picker presentation is driven out-of-band; these aren't user-visible in the list.
+        case .capabilityRequest:
+            return resolveCapabilityConnectContent(
+                jsonText: dbMessage.text,
+                resultsByRequestId: capabilityResultsByRequestId
+            )
+        case .capabilityRequestResult:
+            // Results render indirectly: they flip the request row's pill state via
+            // the compose-time join, and approvals emit their own connection_event.
             return nil
         case .connectionEvent:
             return decodeConnectionSummary(jsonText: dbMessage.text).map { .connectionEvent(summary: $0) } ?? .text("")
@@ -551,6 +560,21 @@ extension Array where Element == DBMessage {
     private static func decodeConnectionSummary(jsonText: String?) -> ConnectionEventSummary? {
         guard let jsonText else { return nil }
         return try? JSONDecoder().decode(ConnectionEventSummary.self, from: Data(jsonText.utf8))
+    }
+
+    private static func resolveCapabilityConnectContent(
+        jsonText: String?,
+        resultsByRequestId: [String: [CapabilityConnectPrompt.ResultRecord]]
+    ) -> MessageContent? {
+        guard let jsonText,
+              let request = try? JSONDecoder().decode(CapabilityRequest.self, from: Data(jsonText.utf8)) else {
+            return nil
+        }
+        let prompt = CapabilityConnectPrompt.make(
+            request: request,
+            results: resultsByRequestId[request.requestId] ?? []
+        )
+        return .capabilityConnect(prompt: prompt)
     }
 
     private static func resolveUpdateContent(
@@ -999,6 +1023,30 @@ fileprivate extension Database {
             }
         }
 
+        // Correlate capability_request_result rows to the request rows in the
+        // window by requestId (mirrors the reaction join on sourceMessageId).
+        // Results are fetched conversation-wide because the correlation key
+        // lives in the JSON payload, not in sourceMessageId; the rows are rare.
+        // Skipping the query when no request row is visible is safe for the
+        // ValueObservation: the main message query already tracks the table,
+        // so a late-arriving result row still re-fires composition.
+        var capabilityResultsByRequestId: [String: [CapabilityConnectPrompt.ResultRecord]] = [:]
+        if rawMessages.contains(where: { $0.contentType == .capabilityRequest }) {
+            let resultRows = try DBMessage
+                .filter(DBMessage.Columns.conversationId == conversationId)
+                .filter(DBMessage.Columns.contentType == MessageContentType.capabilityRequestResult.rawValue)
+                .fetchAll(self)
+            for row in resultRows {
+                guard let text = row.text,
+                      let result = try? JSONDecoder().decode(CapabilityRequestResult.self, from: Data(text.utf8)) else {
+                    continue
+                }
+                capabilityResultsByRequestId[result.requestId, default: []].append(
+                    .init(senderId: row.senderId, status: result.status)
+                )
+            }
+        }
+
         let localStates: [AttachmentLocalState]
         if let prefetchedLocalStates {
             localStates = prefetchedLocalStates
@@ -1023,6 +1071,7 @@ fileprivate extension Database {
             reactionsBySourceId: reactionsBySourceId,
             sourceMessagesById: sourceMessagesById,
             attachmentLocalStates: attachmentLocalStates,
+            capabilityResultsByRequestId: capabilityResultsByRequestId,
             seenMessageIds: seenMessageIds,
             isInitialLoad: isInitialLoad,
             isPaginating: isPaginating

--- a/ConvosCore/Sources/ConvosCore/Storage/Repositories/MessagesRepository.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Repositories/MessagesRepository.swift
@@ -1037,13 +1037,13 @@ fileprivate extension Database {
         // ValueObservation: the main message query already tracks the table,
         // so a late-arriving result row still re-fires composition.
         //
-        // First responder wins: one capability request is one connection ask
-        // for the whole conversation — the first validated (non-asker) result
-        // flips the pill for every member; the agent re-requests under a new
-        // requestId if it needs more. Both the resolution rule and the
-        // latest-pending computation are shared with CapabilityRequestRepository
-        // (the tap path), so a pill rendered `.pending` is always the request
-        // the approval sheet would open for.
+        // First decision wins, in message-time order: one capability request
+        // is one connection ask for the whole conversation — the earliest
+        // validated (non-asker) result flips the pill for every member; the
+        // agent re-requests under a new requestId if it needs more. Both the
+        // resolution rule and the latest-pending computation are shared with
+        // CapabilityRequestRepository (the tap path), so a pill rendered
+        // `.pending` is always the request the approval sheet would open for.
         var capabilityResultsByRequestId: [String: [CapabilityConnectPrompt.ResultRecord]] = [:]
         var latestPendingCapabilityRequestId: String?
         if rawMessages.contains(where: { $0.contentType == .capabilityRequest }) {

--- a/ConvosCore/Sources/ConvosCore/Storage/XMTP DB Representations/DecodedMessage+DBRepresentation.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/XMTP DB Representations/DecodedMessage+DBRepresentation.swift
@@ -570,6 +570,13 @@ extension XMTPiOS.DecodedMessage {
         )
     }
 
+    /// Result rows are persisted verbatim; legitimacy is enforced at derivation
+    /// time by `CapabilityConnectPrompt.resolution`, which only lets a result
+    /// resolve a request when the row's XMTP-attested sender differs from the
+    /// request's asker. Unlike `CloudConnectionGrantRequest` (validated above
+    /// via `validateConnectionGrantRequest`), the result payload carries no
+    /// sender claim to cross-check here — and the matching request row may not
+    /// have synced yet, so the asker comparison can only happen at the join.
     private func handleCapabilityRequestResultContent() throws -> DBMessageComponents {
         let content = try content() as Any
         guard let result = content as? CapabilityRequestResult else {

--- a/ConvosCore/Tests/ConvosCoreTests/CapabilityConnectTranscriptTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/CapabilityConnectTranscriptTests.swift
@@ -27,14 +27,20 @@ struct CapabilityConnectTranscriptTests {
 
     @Test("no result rows leaves the prompt pending")
     func pendingWithoutResults() {
-        #expect(CapabilityConnectPrompt.displayStatus(results: [], askerInboxId: asker) == .pending)
+        let status = CapabilityConnectPrompt.displayStatus(
+            results: [],
+            askerInboxId: asker,
+            isLatestUnresolvedRequest: true
+        )
+        #expect(status == .pending)
     }
 
     @Test("an approved result row flips the prompt to connected")
     func connectedOnApproval() {
         let status = CapabilityConnectPrompt.displayStatus(
             results: [.init(senderId: approver, status: .approved)],
-            askerInboxId: asker
+            askerInboxId: asker,
+            isLatestUnresolvedRequest: true
         )
         #expect(status == .connected)
     }
@@ -46,7 +52,8 @@ struct CapabilityConnectTranscriptTests {
                 .init(senderId: approver, status: .denied),
                 .init(senderId: "another-member", status: .approved),
             ],
-            askerInboxId: asker
+            askerInboxId: asker,
+            isLatestUnresolvedRequest: true
         )
         #expect(status == .connected)
     }
@@ -55,11 +62,13 @@ struct CapabilityConnectTranscriptTests {
     func dismissedOnDenyOrCancel() {
         let denied = CapabilityConnectPrompt.displayStatus(
             results: [.init(senderId: approver, status: .denied)],
-            askerInboxId: asker
+            askerInboxId: asker,
+            isLatestUnresolvedRequest: true
         )
         let cancelled = CapabilityConnectPrompt.displayStatus(
             results: [.init(senderId: approver, status: .cancelled)],
-            askerInboxId: asker
+            askerInboxId: asker,
+            isLatestUnresolvedRequest: true
         )
         #expect(denied == .dismissed)
         #expect(cancelled == .dismissed)
@@ -69,7 +78,8 @@ struct CapabilityConnectTranscriptTests {
     func askerResultsIgnored() {
         let status = CapabilityConnectPrompt.displayStatus(
             results: [.init(senderId: asker, status: .approved)],
-            askerInboxId: asker
+            askerInboxId: asker,
+            isLatestUnresolvedRequest: true
         )
         #expect(status == .pending)
     }
@@ -81,16 +91,41 @@ struct CapabilityConnectTranscriptTests {
                 .init(senderId: approver, status: .staleResource),
                 .init(senderId: approver, status: .unknown),
             ],
-            askerInboxId: asker
+            askerInboxId: asker,
+            isLatestUnresolvedRequest: true
         )
         #expect(status == .pending)
+    }
+
+    @Test("an unresolved request that is not the latest renders superseded")
+    func supersededWhenNotLatestUnresolved() {
+        let status = CapabilityConnectPrompt.displayStatus(
+            results: [],
+            askerInboxId: asker,
+            isLatestUnresolvedRequest: false
+        )
+        #expect(status == .superseded)
+    }
+
+    @Test("a resolved request stays resolved even when a newer request exists")
+    func resolutionWinsOverSupersession() {
+        let status = CapabilityConnectPrompt.displayStatus(
+            results: [.init(senderId: approver, status: .approved)],
+            askerInboxId: asker,
+            isLatestUnresolvedRequest: false
+        )
+        #expect(status == .connected)
     }
 
     // MARK: - Prompt factory
 
     @Test("cloud preferred provider resolves brand name, slug, and icon")
     func cloudProviderBranding() {
-        let prompt = CapabilityConnectPrompt.make(request: makeRequest(), results: [])
+        let prompt = CapabilityConnectPrompt.make(
+            request: makeRequest(),
+            results: [],
+            isLatestUnresolvedRequest: true
+        )
         #expect(prompt.serviceName == "Google Calendar")
         #expect(prompt.serviceId == "googlecalendar")
         #expect(prompt.icon == .calendar)
@@ -100,7 +135,11 @@ struct CapabilityConnectTranscriptTests {
 
     @Test("missing preferred providers falls back to the subject name")
     func subjectFallback() {
-        let prompt = CapabilityConnectPrompt.make(request: makeRequest(preferredProviders: nil), results: [])
+        let prompt = CapabilityConnectPrompt.make(
+            request: makeRequest(preferredProviders: nil),
+            results: [],
+            isLatestUnresolvedRequest: true
+        )
         #expect(prompt.serviceName == "Calendar")
         #expect(prompt.serviceId == nil)
         #expect(prompt.icon == .calendar)
@@ -110,7 +149,8 @@ struct CapabilityConnectTranscriptTests {
     func deviceProviderName() {
         let prompt = CapabilityConnectPrompt.make(
             request: makeRequest(preferredProviders: [ProviderID(rawValue: "device.calendar")]),
-            results: []
+            results: [],
+            isLatestUnresolvedRequest: true
         )
         #expect(prompt.serviceName == "Apple Calendar")
         #expect(prompt.serviceId == nil)
@@ -174,6 +214,90 @@ struct CapabilityConnectTranscriptTests {
 
         let messages = try harness.fetchMessages()
         #expect(messages.isEmpty)
+    }
+
+    // MARK: - Layer agreement (pill derivation vs CapabilityRequestRepository)
+
+    // Both layers share CapabilityConnectPrompt.resolution: the pill shows
+    // `.pending` exactly when the repository surfaces that request as the
+    // pending picker layout (the tap path). Each test pins both verdicts on
+    // the same database so the pill can never look actionable while the tap
+    // path would refuse it, or vice versa.
+
+    @Test("non-asker approval resolves the request in both layers")
+    func agreementOnNonAskerApproval() throws {
+        let harness = try HydrationHarness(asker: asker, approver: approver)
+        try harness.insertRequestRow(makeRequest(), sortId: 1)
+        try harness.insertResultRow(requestId: "req-1", senderId: approver, status: .approved, sortId: 2)
+
+        #expect(try harness.fetchPrompt(requestId: "req-1")?.status == .connected)
+        #expect(try harness.latestPendingRequestId() == nil)
+    }
+
+    @Test("asker-authored approval leaves the request open in both layers")
+    func agreementOnAskerAuthoredApproval() throws {
+        let harness = try HydrationHarness(asker: asker, approver: approver)
+        try harness.insertRequestRow(makeRequest(), sortId: 1)
+        try harness.insertResultRow(requestId: "req-1", senderId: asker, status: .approved, sortId: 2)
+
+        #expect(try harness.fetchPrompt(requestId: "req-1")?.status == .pending)
+        #expect(try harness.latestPendingRequestId() == "req-1")
+    }
+
+    @Test("asker-authored cancellation cannot kill the request for the room")
+    func agreementOnAskerAuthoredCancellation() throws {
+        let harness = try HydrationHarness(asker: asker, approver: approver)
+        try harness.insertRequestRow(makeRequest(), sortId: 1)
+        try harness.insertResultRow(requestId: "req-1", senderId: asker, status: .cancelled, sortId: 2)
+
+        #expect(try harness.fetchPrompt(requestId: "req-1")?.status == .pending)
+        #expect(try harness.latestPendingRequestId() == "req-1")
+    }
+
+    @Test("duplicate results agree: first approval wins for both layers")
+    func agreementOnDuplicateResults() throws {
+        let harness = try HydrationHarness(asker: asker, approver: approver)
+        try harness.insertRequestRow(makeRequest(), sortId: 1)
+        try harness.insertResultRow(requestId: "req-1", senderId: approver, status: .denied, sortId: 2)
+        try harness.insertResultRow(requestId: "req-1", senderId: harness.currentInboxId, status: .approved, sortId: 3)
+        try harness.insertResultRow(requestId: "req-1", senderId: approver, status: .approved, sortId: 4)
+
+        #expect(try harness.fetchPrompt(requestId: "req-1")?.status == .connected)
+        #expect(try harness.latestPendingRequestId() == nil)
+    }
+
+    @Test("non-decision statuses leave the request open in both layers")
+    func agreementOnNonDecisionStatuses() throws {
+        let harness = try HydrationHarness(asker: asker, approver: approver)
+        try harness.insertRequestRow(makeRequest(), sortId: 1)
+        try harness.insertResultRow(requestId: "req-1", senderId: approver, status: .staleResource, sortId: 2)
+        try harness.insertResultRow(requestId: "req-1", senderId: approver, status: .unknown, sortId: 3)
+
+        #expect(try harness.fetchPrompt(requestId: "req-1")?.status == .pending)
+        #expect(try harness.latestPendingRequestId() == "req-1")
+    }
+
+    @Test("a newer unresolved request supersedes the older one in both layers")
+    func agreementOnSupersededRequest() throws {
+        let harness = try HydrationHarness(asker: asker, approver: approver)
+        try harness.insertRequestRow(makeRequest(requestId: "req-1"), sortId: 1)
+        try harness.insertRequestRow(makeRequest(requestId: "req-2"), sortId: 2)
+
+        #expect(try harness.fetchPrompt(requestId: "req-1")?.status == .superseded)
+        #expect(try harness.fetchPrompt(requestId: "req-2")?.status == .pending)
+        #expect(try harness.latestPendingRequestId() == "req-2")
+    }
+
+    @Test("resolving the newer request hands actionability back to the older one")
+    func agreementOnSupersededFlipBack() throws {
+        let harness = try HydrationHarness(asker: asker, approver: approver)
+        try harness.insertRequestRow(makeRequest(requestId: "req-1"), sortId: 1)
+        try harness.insertRequestRow(makeRequest(requestId: "req-2"), sortId: 2)
+        try harness.insertResultRow(requestId: "req-2", senderId: approver, status: .approved, sortId: 3)
+
+        #expect(try harness.fetchPrompt(requestId: "req-1")?.status == .pending)
+        #expect(try harness.fetchPrompt(requestId: "req-2")?.status == .connected)
+        #expect(try harness.latestPendingRequestId() == "req-1")
     }
 }
 
@@ -242,13 +366,32 @@ private struct HydrationHarness {
     }
 
     func fetchPrompt() throws -> CapabilityConnectPrompt? {
-        for anyMessage in try fetchMessages() {
+        try fetchPrompts().first
+    }
+
+    func fetchPrompt(requestId: String) throws -> CapabilityConnectPrompt? {
+        try fetchPrompts().first { $0.requestId == requestId }
+    }
+
+    /// The repository half of the layer-agreement assertions: the request the
+    /// tap path would open the approval sheet for, nil when none is pending.
+    func latestPendingRequestId() throws -> String? {
+        try dbManager.dbReader.read { db in
+            CapabilityRequestRepository.computeLatestPendingRequest(
+                conversationId: conversationId,
+                db: db
+            )?.requestId
+        }
+    }
+
+    private func fetchPrompts() throws -> [CapabilityConnectPrompt] {
+        try fetchMessages().compactMap { anyMessage in
             if case .message(let message, _) = anyMessage,
                case .capabilityConnect(let prompt) = message.content {
                 return prompt
             }
+            return nil
         }
-        return nil
     }
 
     private func insertRow(

--- a/ConvosCore/Tests/ConvosCoreTests/CapabilityConnectTranscriptTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/CapabilityConnectTranscriptTests.swift
@@ -23,6 +23,23 @@ struct CapabilityConnectTranscriptTests {
         )
     }
 
+    /// `sentAtNs`/`messageId` position the record in message time for the
+    /// first-decision-wins ordering; the id defaults to one derived from the
+    /// timestamp so single-record tests stay terse.
+    private func record(
+        from senderId: String,
+        _ status: CapabilityRequestResult.Status,
+        at sentAtNs: Int64 = 0,
+        id messageId: String? = nil
+    ) -> CapabilityConnectPrompt.ResultRecord {
+        .init(
+            senderId: senderId,
+            status: status,
+            sentAtNs: sentAtNs,
+            messageId: messageId ?? "message-\(sentAtNs)"
+        )
+    }
+
     // MARK: - Status derivation (requestId join)
 
     @Test("no result rows leaves the prompt pending")
@@ -38,19 +55,32 @@ struct CapabilityConnectTranscriptTests {
     @Test("an approved result row flips the prompt to connected")
     func connectedOnApproval() {
         let status = CapabilityConnectPrompt.displayStatus(
-            results: [.init(senderId: approver, status: .approved)],
+            results: [record(from: approver, .approved)],
             askerInboxId: asker,
             isLatestUnresolvedRequest: true
         )
         #expect(status == .connected)
     }
 
-    @Test("approval wins over an earlier denial")
-    func approvalWinsOverDenial() {
+    @Test("an earlier denial dismisses even when an approval lands later")
+    func earlierDenialWinsOverLaterApproval() {
         let status = CapabilityConnectPrompt.displayStatus(
             results: [
-                .init(senderId: approver, status: .denied),
-                .init(senderId: "another-member", status: .approved),
+                record(from: approver, .denied, at: 1),
+                record(from: "another-member", .approved, at: 2),
+            ],
+            askerInboxId: asker,
+            isLatestUnresolvedRequest: true
+        )
+        #expect(status == .dismissed)
+    }
+
+    @Test("an earlier approval connects even when a denial lands later")
+    func earlierApprovalWinsOverLaterDenial() {
+        let status = CapabilityConnectPrompt.displayStatus(
+            results: [
+                record(from: approver, .approved, at: 1),
+                record(from: "another-member", .denied, at: 2),
             ],
             askerInboxId: asker,
             isLatestUnresolvedRequest: true
@@ -58,15 +88,64 @@ struct CapabilityConnectTranscriptTests {
         #expect(status == .connected)
     }
 
+    @Test("resolution orders by message time, not by array order")
+    func resolutionIgnoresArrayOrder() {
+        // The approval comes first in the array but was sent later — the
+        // earlier denial must still win.
+        let status = CapabilityConnectPrompt.displayStatus(
+            results: [
+                record(from: "another-member", .approved, at: 2),
+                record(from: approver, .denied, at: 1),
+            ],
+            askerInboxId: asker,
+            isLatestUnresolvedRequest: true
+        )
+        #expect(status == .dismissed)
+    }
+
+    @Test("an asker denial earlier than a valid approval still connects")
+    func askerDenialSkippedBeforeValidApproval() {
+        let status = CapabilityConnectPrompt.displayStatus(
+            results: [
+                record(from: asker, .denied, at: 1),
+                record(from: approver, .approved, at: 2),
+            ],
+            askerInboxId: asker,
+            isLatestUnresolvedRequest: true
+        )
+        #expect(status == .connected)
+    }
+
+    @Test("identical timestamps resolve deterministically via the message id tiebreaker")
+    func identicalTimestampsUseMessageIdTiebreaker() {
+        let results = [
+            record(from: approver, .denied, at: 5, id: "message-b"),
+            record(from: "another-member", .approved, at: 5, id: "message-a"),
+        ]
+        let status = CapabilityConnectPrompt.displayStatus(
+            results: results,
+            askerInboxId: asker,
+            isLatestUnresolvedRequest: true
+        )
+        let reversedStatus = CapabilityConnectPrompt.displayStatus(
+            results: results.reversed(),
+            askerInboxId: asker,
+            isLatestUnresolvedRequest: true
+        )
+        // "message-a" (the approval) sorts first regardless of array order.
+        #expect(status == .connected)
+        #expect(reversedStatus == .connected)
+    }
+
     @Test("denied and cancelled results dismiss the prompt")
     func dismissedOnDenyOrCancel() {
         let denied = CapabilityConnectPrompt.displayStatus(
-            results: [.init(senderId: approver, status: .denied)],
+            results: [record(from: approver, .denied)],
             askerInboxId: asker,
             isLatestUnresolvedRequest: true
         )
         let cancelled = CapabilityConnectPrompt.displayStatus(
-            results: [.init(senderId: approver, status: .cancelled)],
+            results: [record(from: approver, .cancelled)],
             askerInboxId: asker,
             isLatestUnresolvedRequest: true
         )
@@ -77,7 +156,7 @@ struct CapabilityConnectTranscriptTests {
     @Test("the asker cannot resolve its own request")
     func askerResultsIgnored() {
         let status = CapabilityConnectPrompt.displayStatus(
-            results: [.init(senderId: asker, status: .approved)],
+            results: [record(from: asker, .approved)],
             askerInboxId: asker,
             isLatestUnresolvedRequest: true
         )
@@ -88,8 +167,8 @@ struct CapabilityConnectTranscriptTests {
     func nonDecisionStatusesStayPending() {
         let status = CapabilityConnectPrompt.displayStatus(
             results: [
-                .init(senderId: approver, status: .staleResource),
-                .init(senderId: approver, status: .unknown),
+                record(from: approver, .staleResource, at: 1),
+                record(from: approver, .unknown, at: 2),
             ],
             askerInboxId: asker,
             isLatestUnresolvedRequest: true
@@ -110,7 +189,7 @@ struct CapabilityConnectTranscriptTests {
     @Test("a resolved request stays resolved even when a newer request exists")
     func resolutionWinsOverSupersession() {
         let status = CapabilityConnectPrompt.displayStatus(
-            results: [.init(senderId: approver, status: .approved)],
+            results: [record(from: approver, .approved)],
             askerInboxId: asker,
             isLatestUnresolvedRequest: false
         )
@@ -254,13 +333,60 @@ struct CapabilityConnectTranscriptTests {
         #expect(try harness.latestPendingRequestId() == "req-1")
     }
 
-    @Test("duplicate results agree: first approval wins for both layers")
+    @Test("duplicate results agree: the earliest decision wins for both layers")
     func agreementOnDuplicateResults() throws {
         let harness = try HydrationHarness(asker: asker, approver: approver)
         try harness.insertRequestRow(makeRequest(), sortId: 1)
         try harness.insertResultRow(requestId: "req-1", senderId: approver, status: .denied, sortId: 2)
         try harness.insertResultRow(requestId: "req-1", senderId: harness.currentInboxId, status: .approved, sortId: 3)
         try harness.insertResultRow(requestId: "req-1", senderId: approver, status: .approved, sortId: 4)
+
+        #expect(try harness.fetchPrompt(requestId: "req-1")?.status == .dismissed)
+        #expect(try harness.latestPendingRequestId() == nil)
+    }
+
+    @Test("denial before approval dismisses in both layers")
+    func agreementOnDenialBeforeApproval() throws {
+        let harness = try HydrationHarness(asker: asker, approver: approver)
+        try harness.insertRequestRow(makeRequest(), sortId: 1)
+        try harness.insertResultRow(requestId: "req-1", senderId: approver, status: .denied, sortId: 2)
+        try harness.insertResultRow(requestId: "req-1", senderId: harness.currentInboxId, status: .approved, sortId: 3)
+
+        #expect(try harness.fetchPrompt(requestId: "req-1")?.status == .dismissed)
+        #expect(try harness.latestPendingRequestId() == nil)
+    }
+
+    @Test("approval before denial connects in both layers")
+    func agreementOnApprovalBeforeDenial() throws {
+        let harness = try HydrationHarness(asker: asker, approver: approver)
+        try harness.insertRequestRow(makeRequest(), sortId: 1)
+        try harness.insertResultRow(requestId: "req-1", senderId: approver, status: .approved, sortId: 2)
+        try harness.insertResultRow(requestId: "req-1", senderId: harness.currentInboxId, status: .denied, sortId: 3)
+
+        #expect(try harness.fetchPrompt(requestId: "req-1")?.status == .connected)
+        #expect(try harness.latestPendingRequestId() == nil)
+    }
+
+    @Test("an asker denial then a valid approval connects in both layers")
+    func agreementOnAskerDenialThenApproval() throws {
+        let harness = try HydrationHarness(asker: asker, approver: approver)
+        try harness.insertRequestRow(makeRequest(), sortId: 1)
+        try harness.insertResultRow(requestId: "req-1", senderId: asker, status: .denied, sortId: 2)
+        try harness.insertResultRow(requestId: "req-1", senderId: approver, status: .approved, sortId: 3)
+
+        #expect(try harness.fetchPrompt(requestId: "req-1")?.status == .connected)
+        #expect(try harness.latestPendingRequestId() == nil)
+    }
+
+    @Test("identical timestamps agree deterministically via the message id tiebreaker")
+    func agreementOnIdenticalTimestamps() throws {
+        let harness = try HydrationHarness(asker: asker, approver: approver)
+        try harness.insertRequestRow(makeRequest(), sortId: 1)
+        let sharedNs = Int64(harness.now.timeIntervalSince1970 * 1_000_000_000) + 10
+        // Same dateNs on both rows; the lower message id ("message-2", the
+        // approval) must win in both layers regardless of insertion order.
+        try harness.insertResultRow(requestId: "req-1", senderId: approver, status: .denied, sortId: 3, dateNs: sharedNs)
+        try harness.insertResultRow(requestId: "req-1", senderId: approver, status: .approved, sortId: 2, dateNs: sharedNs)
 
         #expect(try harness.fetchPrompt(requestId: "req-1")?.status == .connected)
         #expect(try harness.latestPendingRequestId() == nil)
@@ -339,7 +465,8 @@ private struct HydrationHarness {
         requestId: String,
         senderId: String,
         status: CapabilityRequestResult.Status,
-        sortId: Int64
+        sortId: Int64,
+        dateNs: Int64? = nil
     ) throws {
         let result = CapabilityRequestResult(
             requestId: requestId,
@@ -352,7 +479,8 @@ private struct HydrationHarness {
             contentType: .capabilityRequestResult,
             senderId: senderId,
             text: String(decoding: json, as: UTF8.self),
-            sortId: sortId
+            sortId: sortId,
+            dateNs: dateNs
         )
     }
 
@@ -398,7 +526,8 @@ private struct HydrationHarness {
         contentType: MessageContentType,
         senderId: String,
         text: String,
-        sortId: Int64
+        sortId: Int64,
+        dateNs: Int64? = nil
     ) throws {
         try dbManager.dbWriter.write { db in
             try DBMessage(
@@ -406,7 +535,7 @@ private struct HydrationHarness {
                 clientMessageId: "message-\(sortId)",
                 conversationId: conversationId,
                 senderId: senderId,
-                dateNs: Int64(now.timeIntervalSince1970 * 1_000_000_000) + sortId,
+                dateNs: dateNs ?? Int64(now.timeIntervalSince1970 * 1_000_000_000) + sortId,
                 date: now,
                 sortId: sortId,
                 status: .published,

--- a/ConvosCore/Tests/ConvosCoreTests/CapabilityConnectTranscriptTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/CapabilityConnectTranscriptTests.swift
@@ -1,0 +1,349 @@
+import ConvosConnections
+@testable import ConvosCore
+import Foundation
+import GRDB
+import Testing
+
+@Suite("Capability connect transcript")
+struct CapabilityConnectTranscriptTests {
+    private let asker: String = "agent-inbox"
+    private let approver: String = "member-inbox"
+
+    private func makeRequest(
+        requestId: String = "req-1",
+        preferredProviders: [ProviderID]? = [ProviderID(rawValue: "composio.googlecalendar")]
+    ) -> CapabilityRequest {
+        CapabilityRequest(
+            requestId: requestId,
+            askerInboxId: asker,
+            subject: .calendar,
+            capability: .read,
+            rationale: "To book that meeting",
+            preferredProviders: preferredProviders
+        )
+    }
+
+    // MARK: - Status derivation (requestId join)
+
+    @Test("no result rows leaves the prompt pending")
+    func pendingWithoutResults() {
+        #expect(CapabilityConnectPrompt.displayStatus(results: [], askerInboxId: asker) == .pending)
+    }
+
+    @Test("an approved result row flips the prompt to connected")
+    func connectedOnApproval() {
+        let status = CapabilityConnectPrompt.displayStatus(
+            results: [.init(senderId: approver, status: .approved)],
+            askerInboxId: asker
+        )
+        #expect(status == .connected)
+    }
+
+    @Test("approval wins over an earlier denial")
+    func approvalWinsOverDenial() {
+        let status = CapabilityConnectPrompt.displayStatus(
+            results: [
+                .init(senderId: approver, status: .denied),
+                .init(senderId: "another-member", status: .approved),
+            ],
+            askerInboxId: asker
+        )
+        #expect(status == .connected)
+    }
+
+    @Test("denied and cancelled results dismiss the prompt")
+    func dismissedOnDenyOrCancel() {
+        let denied = CapabilityConnectPrompt.displayStatus(
+            results: [.init(senderId: approver, status: .denied)],
+            askerInboxId: asker
+        )
+        let cancelled = CapabilityConnectPrompt.displayStatus(
+            results: [.init(senderId: approver, status: .cancelled)],
+            askerInboxId: asker
+        )
+        #expect(denied == .dismissed)
+        #expect(cancelled == .dismissed)
+    }
+
+    @Test("the asker cannot resolve its own request")
+    func askerResultsIgnored() {
+        let status = CapabilityConnectPrompt.displayStatus(
+            results: [.init(senderId: asker, status: .approved)],
+            askerInboxId: asker
+        )
+        #expect(status == .pending)
+    }
+
+    @Test("staleResource and unknown statuses are not user decisions")
+    func nonDecisionStatusesStayPending() {
+        let status = CapabilityConnectPrompt.displayStatus(
+            results: [
+                .init(senderId: approver, status: .staleResource),
+                .init(senderId: approver, status: .unknown),
+            ],
+            askerInboxId: asker
+        )
+        #expect(status == .pending)
+    }
+
+    // MARK: - Prompt factory
+
+    @Test("cloud preferred provider resolves brand name, slug, and icon")
+    func cloudProviderBranding() {
+        let prompt = CapabilityConnectPrompt.make(request: makeRequest(), results: [])
+        #expect(prompt.serviceName == "Google Calendar")
+        #expect(prompt.serviceId == "googlecalendar")
+        #expect(prompt.icon == .calendar)
+        #expect(prompt.askerInboxId == asker)
+        #expect(prompt.status == .pending)
+    }
+
+    @Test("missing preferred providers falls back to the subject name")
+    func subjectFallback() {
+        let prompt = CapabilityConnectPrompt.make(request: makeRequest(preferredProviders: nil), results: [])
+        #expect(prompt.serviceName == "Calendar")
+        #expect(prompt.serviceId == nil)
+        #expect(prompt.icon == .calendar)
+    }
+
+    @Test("device preferred provider uses the device spec display name")
+    func deviceProviderName() {
+        let prompt = CapabilityConnectPrompt.make(
+            request: makeRequest(preferredProviders: [ProviderID(rawValue: "device.calendar")]),
+            results: []
+        )
+        #expect(prompt.serviceName == "Apple Calendar")
+        #expect(prompt.serviceId == nil)
+    }
+
+    // MARK: - Hydration (compose-time join against GRDB rows)
+
+    @Test("capability request row hydrates as a pending connect prompt")
+    func hydratesPendingPrompt() throws {
+        let harness = try HydrationHarness(asker: asker, approver: approver)
+        try harness.insertRequestRow(makeRequest(), sortId: 1)
+
+        let prompt = try #require(try harness.fetchPrompt())
+        #expect(prompt.requestId == "req-1")
+        #expect(prompt.status == .pending)
+        #expect(prompt.serviceName == "Google Calendar")
+    }
+
+    @Test("approved result row from another member hydrates the prompt as connected")
+    func hydratesConnectedPrompt() throws {
+        let harness = try HydrationHarness(asker: asker, approver: approver)
+        try harness.insertRequestRow(makeRequest(), sortId: 1)
+        try harness.insertResultRow(requestId: "req-1", senderId: approver, status: .approved, sortId: 2)
+
+        let prompt = try #require(try harness.fetchPrompt())
+        #expect(prompt.status == .connected)
+    }
+
+    @Test("approved result row from the asker leaves the prompt pending")
+    func hydrationIgnoresAskerResults() throws {
+        let harness = try HydrationHarness(asker: asker, approver: approver)
+        try harness.insertRequestRow(makeRequest(), sortId: 1)
+        try harness.insertResultRow(requestId: "req-1", senderId: asker, status: .approved, sortId: 2)
+
+        let prompt = try #require(try harness.fetchPrompt())
+        #expect(prompt.status == .pending)
+    }
+
+    @Test("result rows for other requests do not affect the prompt")
+    func hydrationJoinsByRequestId() throws {
+        let harness = try HydrationHarness(asker: asker, approver: approver)
+        try harness.insertRequestRow(makeRequest(), sortId: 1)
+        try harness.insertResultRow(requestId: "req-other", senderId: approver, status: .approved, sortId: 2)
+
+        let prompt = try #require(try harness.fetchPrompt())
+        #expect(prompt.status == .pending)
+    }
+
+    @Test("undecodable request JSON keeps the row hidden")
+    func hydrationHidesMalformedRequests() throws {
+        let harness = try HydrationHarness(asker: asker, approver: approver)
+        try harness.insertRawRequestRow(text: "{not json", sortId: 1)
+
+        #expect(try harness.fetchPrompt() == nil)
+    }
+
+    @Test("result rows themselves stay hidden in the transcript")
+    func resultRowsStayHidden() throws {
+        let harness = try HydrationHarness(asker: asker, approver: approver)
+        try harness.insertResultRow(requestId: "req-1", senderId: approver, status: .approved, sortId: 1)
+
+        let messages = try harness.fetchMessages()
+        #expect(messages.isEmpty)
+    }
+}
+
+// MARK: - GRDB harness
+
+private struct HydrationHarness {
+    let dbManager: any DatabaseManagerProtocol
+    let conversationId: String = "conversation-1"
+    let currentInboxId: String = "current-user"
+    let asker: String
+    let approver: String
+    let now: Date = Date()
+
+    init(asker: String, approver: String) throws {
+        self.asker = asker
+        self.approver = approver
+        dbManager = MockDatabaseManager.makeTestDatabase()
+        try dbManager.dbWriter.write { db in
+            try Self.seedConversation(
+                db: db,
+                conversationId: conversationId,
+                currentInboxId: currentInboxId,
+                otherInboxIds: [asker, approver],
+                now: now
+            )
+        }
+    }
+
+    func insertRequestRow(_ request: CapabilityRequest, sortId: Int64) throws {
+        let json = try JSONEncoder().encode(request)
+        try insertRawRequestRow(text: String(decoding: json, as: UTF8.self), sortId: sortId)
+    }
+
+    func insertRawRequestRow(text: String, sortId: Int64) throws {
+        try insertRow(contentType: .capabilityRequest, senderId: asker, text: text, sortId: sortId)
+    }
+
+    func insertResultRow(
+        requestId: String,
+        senderId: String,
+        status: CapabilityRequestResult.Status,
+        sortId: Int64
+    ) throws {
+        let result = CapabilityRequestResult(
+            requestId: requestId,
+            status: status,
+            subject: .calendar,
+            capability: .read
+        )
+        let json = try JSONEncoder().encode(result)
+        try insertRow(
+            contentType: .capabilityRequestResult,
+            senderId: senderId,
+            text: String(decoding: json, as: UTF8.self),
+            sortId: sortId
+        )
+    }
+
+    func fetchMessages() throws -> [AnyMessage] {
+        let repository = MessagesRepository(
+            dbReader: dbManager.dbReader,
+            conversationId: conversationId,
+            currentInboxId: currentInboxId
+        )
+        return try repository.fetchInitial()
+    }
+
+    func fetchPrompt() throws -> CapabilityConnectPrompt? {
+        for anyMessage in try fetchMessages() {
+            if case .message(let message, _) = anyMessage,
+               case .capabilityConnect(let prompt) = message.content {
+                return prompt
+            }
+        }
+        return nil
+    }
+
+    private func insertRow(
+        contentType: MessageContentType,
+        senderId: String,
+        text: String,
+        sortId: Int64
+    ) throws {
+        try dbManager.dbWriter.write { db in
+            try DBMessage(
+                id: "message-\(sortId)",
+                clientMessageId: "message-\(sortId)",
+                conversationId: conversationId,
+                senderId: senderId,
+                dateNs: Int64(now.timeIntervalSince1970 * 1_000_000_000) + sortId,
+                date: now,
+                sortId: sortId,
+                status: .published,
+                messageType: .original,
+                contentType: contentType,
+                text: text,
+                emoji: nil,
+                invite: nil,
+                linkPreview: nil,
+                sourceMessageId: nil,
+                attachmentUrls: [],
+                update: nil
+            ).insert(db)
+        }
+    }
+
+    private static func seedConversation(
+        db: Database,
+        conversationId: String,
+        currentInboxId: String,
+        otherInboxIds: [String],
+        now: Date
+    ) throws {
+        try DBMember(inboxId: currentInboxId).save(db, onConflict: .ignore)
+        for inboxId in otherInboxIds {
+            try DBMember(inboxId: inboxId).save(db, onConflict: .ignore)
+        }
+
+        try DBConversation(
+            id: conversationId,
+            clientConversationId: "client-\(conversationId)",
+            inviteTag: "invite-tag-\(conversationId)",
+            creatorId: currentInboxId,
+            kind: .group,
+            consent: .allowed,
+            createdAt: now,
+            name: "Test",
+            description: nil,
+            imageURLString: nil,
+            publicImageURLString: nil,
+            includeInfoInPublicPreview: false,
+            expiresAt: nil,
+            debugInfo: .empty,
+            isLocked: false,
+            imageSalt: nil,
+            imageNonce: nil,
+            imageEncryptionKey: nil,
+            conversationEmoji: nil,
+            imageLastRenewed: nil,
+            isUnused: false,
+            hasHadVerifiedAgent: false,
+        ).insert(db)
+
+        try ConversationLocalState(
+            conversationId: conversationId,
+            isPinned: false,
+            isUnread: false,
+            isUnreadUpdatedAt: now,
+            isMuted: false,
+            pinnedOrder: nil,
+            hidesInviteCard: false,
+            wasRemoved: false
+        ).insert(db)
+
+        for (index, inboxId) in ([currentInboxId] + otherInboxIds).enumerated() {
+            try DBConversationMember(
+                conversationId: conversationId,
+                inboxId: inboxId,
+                role: index == 0 ? .superAdmin : .member,
+                consent: .allowed,
+                createdAt: now,
+                invitedByInboxId: nil
+            ).insert(db)
+
+            try DBMemberProfile(
+                conversationId: conversationId,
+                inboxId: inboxId,
+                name: "Member \(index)",
+                avatar: nil
+            ).insert(db)
+        }
+    }
+}

--- a/ConvosCore/Tests/ConvosCoreTests/ConnectionEventBrandingTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ConnectionEventBrandingTests.swift
@@ -1,0 +1,189 @@
+import ConvosConnections
+@testable import ConvosCore
+import Foundation
+import Testing
+
+@Suite("Connection event branding")
+struct ConnectionEventBrandingTests {
+    @Test("granted events format as a sender-actor 'connected <Service>' line")
+    func grantedUsesMessageSenderActor() {
+        let summary = ConnectionMessageSummaryFormatter.eventSummary(
+            ConnectionEvent(
+                providerId: "composio.googlecalendar",
+                action: .granted,
+                capability: .read,
+                grantedToInboxId: "agent-inbox"
+            )
+        )
+        #expect(summary.text == "connected Google Calendar")
+        #expect(summary.actor == .messageSender)
+        #expect(summary.outcome == .success)
+        #expect(summary.icon == .calendar)
+        #expect(summary.providerId == "composio.googlecalendar")
+    }
+
+    @Test("granted device events brand with the device spec name")
+    func grantedDeviceBranding() {
+        let summary = ConnectionMessageSummaryFormatter.eventSummary(
+            ConnectionEvent(providerId: "device.health", action: .granted)
+        )
+        #expect(summary.text == "connected Apple Health")
+        #expect(summary.actor == .messageSender)
+    }
+
+    @Test("granted events for unknown providers fall back to a generic phrase")
+    func grantedUnknownProviderFallback() {
+        let summary = ConnectionMessageSummaryFormatter.eventSummary(
+            ConnectionEvent(providerId: "mystery.service", action: .granted)
+        )
+        #expect(summary.text == "connected a service")
+        #expect(summary.icon == .generic)
+    }
+
+    @Test("revoked events keep the agent-actor phrasing")
+    func revokedUnchanged() {
+        let summary = ConnectionMessageSummaryFormatter.eventSummary(
+            ConnectionEvent(
+                providerId: "composio.googlecalendar",
+                action: .revoked,
+                capability: .read,
+                grantedToInboxId: "agent-inbox"
+            )
+        )
+        #expect(summary.actor == .grantedAgent)
+        #expect(summary.providerId == "composio.googlecalendar")
+    }
+
+    @Test("summaries persisted before the providerId field still decode")
+    func legacySummaryDecodes() throws {
+        let legacyJSON = #"{"text":"can read calendar events","outcome":"success","icon":"calendar","actor":"granted_agent","grantedToInboxId":"agent-inbox"}"#
+        let summary = try JSONDecoder().decode(ConnectionEventSummary.self, from: Data(legacyJSON.utf8))
+        #expect(summary.providerId == nil)
+        #expect(summary.text == "can read calendar events")
+    }
+
+    @Test("processor resolves the sender actor to You for the granter's own device")
+    func processorResolvesYou() throws {
+        let summary = ConnectionMessageSummaryFormatter.eventSummary(
+            ConnectionEvent(providerId: "composio.googlecalendar", action: .granted, grantedToInboxId: "agent-inbox")
+        )
+        let sender = ConversationMember.mock(isCurrentUser: true)
+        let items = MessagesListProcessor.process([
+            .message(Message(
+                id: "event-1",
+                sender: sender,
+                source: .outgoing,
+                status: .published,
+                content: .connectionEvent(summary: summary),
+                date: Date(),
+                reactions: []
+            ), .existing),
+        ])
+        let resolved = try #require(items.compactMap { item -> ConnectionEventSummary? in
+            if case .connectionEvent(_, let summary, _) = item { return summary }
+            return nil
+        }.first)
+        #expect(resolved.text == "You connected Google Calendar")
+        #expect(resolved.providerId == "composio.googlecalendar")
+    }
+
+    @Test("processor resolves the sender actor to the member display name elsewhere")
+    func processorResolvesDisplayName() throws {
+        let summary = ConnectionMessageSummaryFormatter.eventSummary(
+            ConnectionEvent(providerId: "composio.googlecalendar", action: .granted, grantedToInboxId: "agent-inbox")
+        )
+        let sender = ConversationMember.mock(isCurrentUser: false, name: "Louis")
+        let items = MessagesListProcessor.process([
+            .message(Message(
+                id: "event-1",
+                sender: sender,
+                source: .incoming,
+                status: .published,
+                content: .connectionEvent(summary: summary),
+                date: Date(),
+                reactions: []
+            ), .existing),
+        ])
+        let resolved = try #require(items.compactMap { item -> ConnectionEventSummary? in
+            if case .connectionEvent(_, let summary, _) = item { return summary }
+            return nil
+        }.first)
+        #expect(resolved.text == "Louis connected Google Calendar")
+    }
+
+    @Test("processor emits a capability connect item with the asker's live name")
+    func processorEmitsCapabilityConnectItem() throws {
+        let prompt = CapabilityConnectPrompt(
+            requestId: "req-1",
+            askerInboxId: "agent-inbox",
+            serviceName: "Google Calendar",
+            serviceId: "googlecalendar",
+            icon: .calendar,
+            status: .pending
+        )
+        let sender = ConversationMember.mock(isCurrentUser: false, name: "Stale Snapshot")
+        let items = MessagesListProcessor.process(
+            [
+                .message(Message(
+                    id: "request-1",
+                    sender: sender,
+                    source: .incoming,
+                    status: .published,
+                    content: .capabilityConnect(prompt: prompt),
+                    date: Date(),
+                    reactions: []
+                ), .existing),
+            ],
+            memberProfiles: [
+                "agent-inbox": MemberProfileInfo(
+                    inboxId: "agent-inbox",
+                    conversationId: "conversation-1",
+                    name: "Assistant",
+                    avatar: nil
+                ),
+            ]
+        )
+        guard case .capabilityConnect(let id, let resolvedPrompt, let agentName, _)? = items.first(where: {
+            if case .capabilityConnect = $0 { return true }
+            return false
+        }) else {
+            Issue.record("Expected a capabilityConnect item")
+            return
+        }
+        #expect(id == "request-1")
+        #expect(resolvedPrompt == prompt)
+        #expect(agentName == "Assistant")
+    }
+
+    @Test("capability connect agent name falls back to the sender snapshot")
+    func processorAgentNameFallsBackToSender() throws {
+        let prompt = CapabilityConnectPrompt(
+            requestId: "req-1",
+            askerInboxId: "agent-inbox",
+            serviceName: "Google Calendar",
+            serviceId: "googlecalendar",
+            icon: .calendar,
+            status: .pending
+        )
+        let sender = ConversationMember.mock(isCurrentUser: false, name: "Agent Snapshot")
+        let items = MessagesListProcessor.process([
+            .message(Message(
+                id: "request-1",
+                sender: sender,
+                source: .incoming,
+                status: .published,
+                content: .capabilityConnect(prompt: prompt),
+                date: Date(),
+                reactions: []
+            ), .existing),
+        ])
+        guard case .capabilityConnect(_, _, let agentName, _)? = items.first(where: {
+            if case .capabilityConnect = $0 { return true }
+            return false
+        }) else {
+            Issue.record("Expected a capabilityConnect item")
+            return
+        }
+        #expect(agentName == "Agent Snapshot")
+    }
+}

--- a/ConvosCore/Tests/ConvosCoreTests/ConnectionEventCodecTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ConnectionEventCodecTests.swift
@@ -62,41 +62,31 @@ struct ConnectionEventCodecTests {
 
 @Suite("ConnectionMessageSummaryFormatter capability text")
 struct ConnectionMessageSummaryFormatterCapabilityTests {
-    @Test("granted device calendar varies by capability")
-    func grantedDeviceCalendarVariesByCapability() {
-        let cases: [(ConnectionCapability, String)] = [
-            (.read, "can read calendar events"),
-            (.writeCreate, "can create calendar events"),
-            (.writeUpdate, "can edit calendar events"),
-            (.writeDelete, "can delete calendar events"),
-        ]
-        for (capability, expected) in cases {
+    @Test("granted device calendar brands the service regardless of capability")
+    func grantedDeviceCalendarBrandsService() {
+        for capability in [ConnectionCapability.read, .writeCreate, .writeUpdate, .writeDelete] {
             let event = ConnectionEvent(
                 providerId: "device.calendar",
                 action: .granted,
                 capability: capability
             )
             let summary = ConnectionMessageSummaryFormatter.eventSummary(event)
-            #expect(summary.text == expected, "expected \(expected) for \(capability)")
+            #expect(summary.text == "connected Apple Calendar", "unexpected text for \(capability)")
+            #expect(summary.actor == .messageSender)
         }
     }
 
-    @Test("granted cloud googlecalendar varies by capability")
-    func grantedCloudCalendarVariesByCapability() {
-        let cases: [(ConnectionCapability, String)] = [
-            (.read, "can read calendar events"),
-            (.writeCreate, "can create calendar events"),
-            (.writeUpdate, "can edit calendar events"),
-            (.writeDelete, "can delete calendar events"),
-        ]
-        for (capability, expected) in cases {
+    @Test("granted cloud googlecalendar brands the service regardless of capability")
+    func grantedCloudCalendarBrandsService() {
+        for capability in [ConnectionCapability.read, .writeCreate, .writeUpdate, .writeDelete] {
             let event = ConnectionEvent(
                 providerId: "composio.googlecalendar",
                 action: .granted,
                 capability: capability
             )
             let summary = ConnectionMessageSummaryFormatter.eventSummary(event)
-            #expect(summary.text == expected, "expected \(expected) for \(capability)")
+            #expect(summary.text == "connected Google Calendar", "unexpected text for \(capability)")
+            #expect(summary.actor == .messageSender)
         }
     }
 
@@ -119,14 +109,14 @@ struct ConnectionMessageSummaryFormatterCapabilityTests {
         }
     }
 
-    @Test("nil capability falls back to legacy text")
-    func nilCapabilityFallsBackToLegacyText() {
+    @Test("nil capability still brands the granted service")
+    func nilCapabilityStillBrandsService() {
         let event = ConnectionEvent(
             providerId: "device.calendar",
             action: .granted,
             capability: nil
         )
         let summary = ConnectionMessageSummaryFormatter.eventSummary(event)
-        #expect(summary.text == "has access to calendar data")
+        #expect(summary.text == "connected Apple Calendar")
     }
 }

--- a/ConvosTests/ConversationViewModelCapabilityConnectTests.swift
+++ b/ConvosTests/ConversationViewModelCapabilityConnectTests.swift
@@ -79,10 +79,23 @@ final class ConversationViewModelCapabilityConnectTests: XCTestCase {
         let viewModel = makeViewModel()
         viewModel.pendingCapabilityPickerLayout = makeLayout(requestId: "req-2")
 
+        viewModel.onTapCapabilityConnectPrompt(makePrompt(requestId: "req-1", status: .superseded))
+
+        XCTAssertFalse(viewModel.presentingCapabilityApproval,
+                       "Superseded pills derive a non-pending status and stay inert")
+    }
+
+    func testTapPendingPromptWithMismatchedLayoutIsInert() {
+        // Race guard: the derivation re-renders asynchronously, so a pill can
+        // still read `.pending` for one frame after the layout moved on (e.g.
+        // locally answered request). The layout-match guard must absorb that.
+        let viewModel = makeViewModel()
+        viewModel.pendingCapabilityPickerLayout = makeLayout(requestId: "req-2")
+
         viewModel.onTapCapabilityConnectPrompt(makePrompt(requestId: "req-1", status: .pending))
 
         XCTAssertFalse(viewModel.presentingCapabilityApproval,
-                       "Only the latest observed request is actionable")
+                       "Only the request backing the pending layout is actionable")
     }
 
     func testClearingLayoutDismissesApprovalSheet() {

--- a/ConvosTests/ConversationViewModelCapabilityConnectTests.swift
+++ b/ConvosTests/ConversationViewModelCapabilityConnectTests.swift
@@ -1,0 +1,150 @@
+@testable import Convos
+import ConvosCore
+import XCTest
+
+/// Covers the transcript connect pill's view-model seam: the tap handler
+/// gating, the auto-dismiss tie between the pending layout and the approval
+/// sheet, and the shared layout computation that must always resolve the
+/// services catalog (the OAuth-error recompute path used to omit it, dropping
+/// bundle rows so an approve silently escalated to full-service consent).
+@MainActor
+final class ConversationViewModelCapabilityConnectTests: XCTestCase {
+    func testComputeCapabilityPickerLayoutPopulatesBundleRows() async {
+        let registry = InMemoryCapabilityProviderRegistry()
+        await registry.register(
+            CloudCapabilityProvider(
+                id: ProviderID(rawValue: "composio.googlecalendar"),
+                serviceId: "googlecalendar",
+                subject: .calendar,
+                displayName: "Google Calendar",
+                iconName: "calendar",
+                capabilities: [.read, .writeCreate, .writeUpdate, .writeDelete],
+                linked: true
+            )
+        )
+        let resolver = InMemoryCapabilityResolver(registry: registry)
+        let servicesStore = ConnectionServicesStore(fetchServices: {
+            CloudConnectionsAPI.ServicesResponse(services: [
+                .init(
+                    id: "googlecalendar",
+                    composioSlug: "googlecalendar",
+                    version: 5,
+                    displayName: .init(values: ["en": "Google Calendar"]),
+                    bundles: [
+                        .init(
+                            id: "calendar.events",
+                            title: .init(values: ["en": "Events"]),
+                            description: .init(values: ["en": "View and edit events on all calendars"]),
+                            defaultEnabled: false
+                        ),
+                    ]
+                ),
+            ])
+        })
+
+        let layout = await ConversationViewModel.computeCapabilityPickerLayout(
+            request: makeRequest(),
+            registry: registry,
+            resolver: resolver,
+            handler: CapabilityRequestHandler(),
+            servicesStore: servicesStore,
+            conversationId: "test-convo"
+        )
+
+        XCTAssertEqual(layout.serviceBundles.count, 1,
+                       "Catalog-backed services must surface their bundle rows")
+        XCTAssertEqual(layout.serviceBundles.first?.serviceId, "googlecalendar")
+        XCTAssertEqual(layout.serviceBundles.first?.rows.map(\.id), ["calendar.events"])
+    }
+
+    func testTapPendingPromptPresentsApprovalSheet() {
+        let viewModel = makeViewModel()
+        viewModel.pendingCapabilityPickerLayout = makeLayout(requestId: "req-1")
+
+        viewModel.onTapCapabilityConnectPrompt(makePrompt(requestId: "req-1", status: .pending))
+
+        XCTAssertTrue(viewModel.presentingCapabilityApproval)
+    }
+
+    func testTapConnectedPromptIsInert() {
+        let viewModel = makeViewModel()
+        viewModel.pendingCapabilityPickerLayout = makeLayout(requestId: "req-1")
+
+        viewModel.onTapCapabilityConnectPrompt(makePrompt(requestId: "req-1", status: .connected))
+
+        XCTAssertFalse(viewModel.presentingCapabilityApproval)
+    }
+
+    func testTapSupersededPromptIsInert() {
+        let viewModel = makeViewModel()
+        viewModel.pendingCapabilityPickerLayout = makeLayout(requestId: "req-2")
+
+        viewModel.onTapCapabilityConnectPrompt(makePrompt(requestId: "req-1", status: .pending))
+
+        XCTAssertFalse(viewModel.presentingCapabilityApproval,
+                       "Only the latest observed request is actionable")
+    }
+
+    func testClearingLayoutDismissesApprovalSheet() {
+        let viewModel = makeViewModel()
+        viewModel.pendingCapabilityPickerLayout = makeLayout(requestId: "req-1")
+        viewModel.onTapCapabilityConnectPrompt(makePrompt(requestId: "req-1", status: .pending))
+        XCTAssertTrue(viewModel.presentingCapabilityApproval)
+
+        viewModel.pendingCapabilityPickerLayout = nil
+
+        XCTAssertFalse(viewModel.presentingCapabilityApproval,
+                       "Resolving the request elsewhere must close the sheet")
+    }
+
+    // MARK: - Helpers
+
+    private func makeViewModel() -> ConversationViewModel {
+        ConversationViewModel(
+            conversation: .mock(id: "test-convo"),
+            session: MockInboxesService(),
+            messagingService: MockMessagingService(),
+            applyGlobalDefaultsForNewConversation: false
+        )
+    }
+
+    private func makeRequest(requestId: String = "req-1") -> CapabilityRequest {
+        CapabilityRequest(
+            requestId: requestId,
+            askerInboxId: "agent-inbox",
+            subject: .calendar,
+            capability: .read,
+            rationale: "To book that meeting",
+            preferredProviders: [ProviderID(rawValue: "composio.googlecalendar")]
+        )
+    }
+
+    private func makeLayout(requestId: String) -> CapabilityPickerLayout {
+        CapabilityPickerLayout(
+            request: makeRequest(requestId: requestId),
+            variant: .confirm,
+            providers: [
+                CapabilityPickerLayout.ProviderSummary(
+                    id: ProviderID(rawValue: "composio.googlecalendar"),
+                    displayName: "Google Calendar",
+                    iconName: "calendar",
+                    subject: .calendar,
+                    linked: true,
+                    supportsCapability: true
+                ),
+            ],
+            defaultSelection: [ProviderID(rawValue: "composio.googlecalendar")]
+        )
+    }
+
+    private func makePrompt(requestId: String, status: CapabilityConnectPrompt.Status) -> CapabilityConnectPrompt {
+        CapabilityConnectPrompt(
+            requestId: requestId,
+            askerInboxId: "agent-inbox",
+            serviceName: "Google Calendar",
+            serviceId: "googlecalendar",
+            icon: .calendar,
+            status: status
+        )
+    }
+}

--- a/ConvosTests/ConversationViewModelCapabilityConnectTests.swift
+++ b/ConvosTests/ConversationViewModelCapabilityConnectTests.swift
@@ -54,7 +54,10 @@ final class ConversationViewModelCapabilityConnectTests: XCTestCase {
         XCTAssertEqual(layout.serviceBundles.count, 1,
                        "Catalog-backed services must surface their bundle rows")
         XCTAssertEqual(layout.serviceBundles.first?.serviceId, "googlecalendar")
-        XCTAssertEqual(layout.serviceBundles.first?.rows.map(\.id), ["calendar.events"])
+        let rows = layout.serviceBundles.first?.rows ?? []
+        XCTAssertFalse(rows.isEmpty,
+                       "Empty bundle rows would silently escalate an approve to full-service consent")
+        XCTAssertEqual(rows.map(\.id), ["calendar.events"])
     }
 
     func testTapPendingPromptPresentsApprovalSheet() {

--- a/ConvosTests/ConversationViewModelGlobalDefaultsTests.swift
+++ b/ConvosTests/ConversationViewModelGlobalDefaultsTests.swift
@@ -363,6 +363,10 @@ private final class TestSessionManager: SessionManagerProtocol, @unchecked Senda
         await base.commitClaimedConversation(id: conversationId)
     }
 
+    func registerClaimedConversation(id conversationId: String) async {
+        await base.registerClaimedConversation(id: conversationId)
+    }
+
     func releaseClaimedConversation(id conversationId: String) async {
         await base.releaseClaimedConversation(id: conversationId)
     }

--- a/ConvosTests/ConversationsViewModelDeleteTests.swift
+++ b/ConvosTests/ConversationsViewModelDeleteTests.swift
@@ -363,6 +363,10 @@ private final class TestSessionManager: SessionManagerProtocol, @unchecked Senda
         await base.commitClaimedConversation(id: conversationId)
     }
 
+    func registerClaimedConversation(id conversationId: String) async {
+        await base.registerClaimedConversation(id: conversationId)
+    }
+
     func releaseClaimedConversation(id conversationId: String) async {
         await base.releaseClaimedConversation(id: conversationId)
     }


### PR DESCRIPTION
## Summary
Implements the Figma connections flow (Convos 26, nodes 1803-17194 / 1846-18062 / 1846-17859):
- **Connect prompt in history** — `capability_request` rows (already on every member's device, previously hidden) now render as a centered caption + tappable pill ("Assistant wants to connect" / Google Calendar). Pending → connected derived at compose time by joining result rows on `requestId` (no schema change, no message editing); first-responder-wins semantics with XMTP-attested sender validation (a result only resolves a request when the envelope sender differs from the asker and the status is a user decision). Superseded pending requests render inert.
- **Approval sheet** — floating card per design: branded icon, catalog-driven row (backend service v5: "Events" / "View and edit events on all calendars"), single wide toggle (seeds ON), Done disabled when all toggles off, swipe-dismiss leaves the request pending. The bottom-bar capability card is retired; the pill is the single entry point.
- **Connected broadcast** — on approval the granter's device sends the existing `connection_event` type: "You/Someone/<Name> connected Google Calendar" rendered centered for all members with the branded 16pt icon, nickname precedence intact. No new content type, no enum raw-value additions — old clients degrade gracefully.
- **Over-grant fix** — `recomputeCapabilityPickerLayout` no longer passes `services: []`; both layout paths share one catalog-fetching computation, so error-path approvals can't silently escalate to full-service consent.

Stacked on #1048 (merge #1047 → #1048 → this). Backend: xmtplabs/convos-backend#303. Assistants: xmtplabs/convos-assistants#2112.

## Review
Adversarial codex review (consent paths, requestId join races, wire/DB decode compat, card-retirement orphans): 0 critical; both HIGHs and the MED fixed in `499a8804` with a layer-agreement test suite.

## Test plan
- ConvosCore: 1210 tests / 171 suites passed (33 new across build + fix passes).
- App: `TEST SUCCEEDED`, final `BUILD SUCCEEDED` (concrete arm64 simulator, isolated DerivedData), SwiftLint --strict clean.
- Manual: pill tap → sheet → approve → connected state + broadcast verified in the transcript for approver and observers.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1049"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783814651&installation_id=128169237&pr_number=1049&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1049&signature=13d3e060d85cb91b6ee9dfff558f4e5154b6a5d73acecf10407d91de25080eee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add capability connect prompts to transcript with single-toggle approval sheet and bundle-scoped grants
> - Capability request messages now render as tappable `CapabilityConnectPromptView` pills in the conversation transcript, showing service branding and a status indicator (pending, connected, dismissed, superseded).
> - Tapping a pending pill opens a `CapabilityApprovalSheetView` instead of an inline picker card; the sheet shows per-bundle toggles defaulted ON and submits the enabled bundle ids on approval.
> - `CloudConnectionGrantWriter` now resolves bundle scope against a TTL-cached `ConnectionServicesStore` catalog before pushing grants, retries once on `unknown_bundle` errors with a narrowed scope, and persists `bundleIds`/`serviceVersion` on the local grant.
> - `CapabilityRequestRepository` now uses `CapabilityConnectPrompt.resolution` (respecting sender identity and timestamp ordering) to determine the latest pending request, replacing a simple result-presence check.
> - A database migration adds nullable `bundleIds` and `serviceVersion` columns to the `connectionGrant` table.
> - Connection event summaries now read
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6bc07b2.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->