### PR TITLE
Carry #843 build learnings into the run skill (#1020 follow-up)

### DIFF
--- a/.pi/skills/run/SKILL.md
+++ b/.pi/skills/run/SKILL.md
@@ -28,19 +28,25 @@ Build and launch the Convos iOS app on the worktree's dedicated simulator.
 
 Run xcodebuild directly via bash (**never** use MCP `build_sim` — it has a known bug with app extension SPM dependencies):
 
+Pass an explicit `-configuration` matching the scheme (`Convos (Dev)` -> `Dev`, `Convos (Local)` -> `Local`, `Convos (Prod)` -> `Prod`). Without it the scheme builds targets under mismatched configurations: the SPM packages land in one config dir while the NotificationService extension looks in another (`unable to resolve module dependency: ConvosCore`), and the app's entitlements/identifiers stop matching `config.json`, surfacing at runtime as a nil app-group container crash (`Failed getting container URL`) or `-34018` (`errSecMissingEntitlement`) on first identity read. Those are one configuration signature, not simulator limitations (issue #843, #1019); `rm -rf .derivedData` does not fix them, an explicit `-configuration` does.
+
 ```bash
+set -o pipefail
 xcodebuild build \
   -project Convos.xcodeproj \
-  -scheme "Convos (Dev)" \
+  -scheme "Convos (Dev)" -configuration Dev \
   -destination "platform=iOS Simulator,name=<SIMULATOR_NAME>" \
   -derivedDataPath .derivedData 2>&1 | tail -100
 ```
 
+`set -o pipefail` is load-bearing: without it `| tail` makes a failed build exit 0, so check for `** BUILD FAILED **` in the tail rather than trusting the exit code alone.
+
 Use a timeout of 300 seconds for the build.
 
 If the build fails:
-- Show the compilation errors
-- Try `rm -rf .derivedData` and rebuild if module-not-found errors appear
+- Show the compilation errors.
+- `unable to resolve module dependency` in the NotificationService extension means `-configuration` was omitted (config split, see above) — set it; `rm -rf .derivedData` does not fix this one. For other `module not found` errors, `rm -rf .derivedData` and rebuild once.
+- A `took NNNms to type-check` failure on a *trivial* expression that *moves between files* across builds is CPU contention, not a code problem — rebuild with `-jobs 2` (and close heavy apps); do not edit the flagged code or raise the threshold.
 
 ### Step 3: Install and Launch
 


### PR DESCRIPTION
Follow-up to #1020, closing out #843.

#1020 made `-configuration` explicit in `.claude/commands/build.md` and `.claude/commands/run.md`, but the separate **`.pi/skills/run/SKILL.md`** was missed. It still:

- built `Convos (Dev)` **without `-configuration Dev`**, and
- pointed at `rm -rf .derivedData` for the `unable to resolve module dependency: ConvosCore` failure — which is the config-split signature that `rm -rf` does **not** fix.

This mirrors the #1020 guidance into the run skill:

- explicit `-configuration` per scheme, with the nil app-group / keychain `-34018` config signature explained (issue #843, #1019),
- `set -o pipefail` so a failed build doesn't exit 0 through `| tail`,
- the `-jobs 2` CPU-contention note for `took NNNms to type-check` failures on trivial expressions.

Verified today on a clean `convos-dev` simulator (iOS 26.x, Xcode 26.5): `Convos (Dev) -configuration Dev` builds and launches (`org.convos.ios-preview`) with **none** of the issue's Step 1-3 source accommodations. The first build also reproduced the contention type-check timeout, which a plain rebuild cleared — exactly the `-jobs` note's case.

Docs-only; no source changes.

Closes #843

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1050"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783815056&installation_id=128169237&pr_number=1050&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1050&signature=d498ba062c9c555785d7512e5a169ae9162916ab3c0125b37c21be4840d9f394"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update run skill documentation with xcodebuild build learnings
> Updates [SKILL.md](.pi/skills/run/SKILL.md) for the run skill with lessons from the build skill (#843).
>
> - Adds `-configuration Dev` (matching the selected scheme) to the example `xcodebuild` invocation and explains failures that occur when it is omitted
> - Adds `set -o pipefail` before `xcodebuild` commands and explains that piping to `tail` otherwise masks nonzero exit codes; advises searching for `** BUILD FAILED **` in output
> - Distinguishes `NotificationService` 'unable to resolve module dependency' errors as a configuration mismatch, not a derived data issue
> - Adds guidance to rebuild with `-jobs 2` for intermittent 'took NNNms to type-check' errors
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized caad63c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->