### PR TITLE
Hotfix: restore plain-text join-request acceptance for pre-typed joiners

### DIFF
--- a/ConvosCore/Tests/ConvosCoreTests/Integration/InviteCoordinatorIntegrationTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/Integration/InviteCoordinatorIntegrationTests.swift
@@ -109,12 +109,12 @@ struct InviteCoordinatorIntegrationTests {
         #expect(!secondAccepted.contains { $0.conversationId == group1.id })
     }
 
-    /// Plain-text slug messages are no longer join requests: no member is
-    /// added and, critically, no invite_join_error is sent back. Herald
-    /// still sends a text copy of the slug next to its typed join request,
-    /// and the text copy must be inert.
-    @Test("Plain-text slug message is ignored: no join, no error reply")
-    func plainTextSlugIsIgnored() async throws {
+    /// Plain-text slug messages are still join requests: builds that predate
+    /// the typed joiner path (2.0.0 and earlier) send text only, so the
+    /// creator must keep accepting them until the installed fleet is on
+    /// typed-sending builds.
+    @Test("Plain-text slug message joins the group")
+    func plainTextSlugJoins() async throws {
         let creatorClient = try await createClient()
         let joinerClient = try await createClient()
         defer {
@@ -138,13 +138,46 @@ struct InviteCoordinatorIntegrationTests {
             client: creatorClient
         )
 
-        #expect(outcomes.compactMap(\.joinResult).isEmpty, "Text slug must not join the group")
+        #expect(outcomes.compactMap(\.joinResult).contains { $0.conversationId == group.id })
 
         let memberInboxIds = try await group.members.map(\.inboxId)
-        #expect(!memberInboxIds.contains(joinerClient.inboxID))
+        #expect(memberInboxIds.contains(joinerClient.inboxID), "Text-slug joiner must be added to the group")
+    }
+
+    /// Herald sends a typed join_request plus a plain-text slug copy. A
+    /// failing pair must produce exactly one invite_join_error (the
+    /// per-attempt dedupe suppresses the second copy's reply) - this is the
+    /// flood-regression guard for keeping text acceptance enabled.
+    @Test("Typed plus text pair for a failing invite produces exactly one error")
+    func typedAndTextPairProducesSingleError() async throws {
+        let creatorClient = try await createClient()
+        let joinerClient = try await createClient()
+        defer {
+            try? creatorClient.deleteLocalDatabase()
+            try? joinerClient.deleteLocalDatabase()
+        }
+        let coordinator = makeCoordinator()
+
+        let group = try await creatorClient.conversations.newGroup(with: [])
+        try await group.updateConsentState(state: .allowed)
+        _ = try await coordinator.revokeInvites(for: group)
+        let invite = try await coordinator.createInvite(for: group, client: creatorClient)
+        // Rotate the tag so the invite above is revoked and the join fails
+        // down the error-sending path.
+        _ = try await coordinator.revokeInvites(for: group)
+
+        // sendJoinRequest sends the typed message; follow with the text
+        // copy the way Herald does.
+        let dm = try await coordinator.sendJoinRequest(for: invite.signedInvite, client: joinerClient)
+        _ = try await dm.send(content: invite.slug)
+
+        _ = try await creatorClient.conversations.syncAllConversations(consentStates: nil)
+        _ = await coordinator.processJoinRequestOutcomes(since: nil, client: creatorClient)
+        // Revalidate, as batch catch-up and the agent-join poll do.
+        _ = await coordinator.processJoinRequestOutcomes(since: nil, client: creatorClient)
 
         let errorCount = try await joinErrorCount(inDmWith: joinerClient.inboxID, client: creatorClient)
-        #expect(errorCount == 0, "Ignored text slug must not produce an error reply")
+        #expect(errorCount == 1, "A failing typed+text pair must produce exactly one error reply")
     }
 
     /// The error-reply dedupe: revalidating the same failed join request

--- a/ConvosInvites/Sources/ConvosInvites/InviteCoordinator.swift
+++ b/ConvosInvites/Sources/ConvosInvites/InviteCoordinator.swift
@@ -144,16 +144,29 @@ public final class InviteCoordinator: @unchecked Sendable {
     ) async -> JoinRequestDMOutcome {
         guard message.senderInboxId != client.inviteInboxId else { return .noJoinRequest }
 
-        // Only the typed join_request content type is accepted. Plain-text
-        // slug messages (the original wire format, kept as a fallback until
-        // mid-2026) are deliberately ignored: senders that still emit a text
-        // copy alongside the typed message would otherwise produce duplicate
-        // processing and duplicate error replies.
-        guard let joinRequest: JoinRequestContent = try? message.content() else {
+        // The typed join_request content type is preferred, but a plain-text
+        // slug is still accepted: every app build that predates the typed
+        // joiner path sends text only, so dropping it strands those joiners
+        // with no reply at all. Senders like Herald emit a text copy next to
+        // the typed message; the duplicate does not produce a second error
+        // reply because sendJoinError dedupes per attempt (both copies of a
+        // pair predate whichever error is sent first). Text acceptance can
+        // only be removed once the installed fleet sends typed requests.
+        let slug: String
+        var profile: JoinRequestProfile?
+        var metadata: [String: String]?
+
+        if let joinRequest: JoinRequestContent = try? message.content() {
+            slug = joinRequest.inviteSlug
+            profile = joinRequest.profile
+            metadata = joinRequest.metadata
+        } else if let text: String = try? message.content() {
+            slug = text
+        } else {
             return .noJoinRequest
         }
 
-        guard let signedInvite = try? SignedInvite.fromURLSafeSlug(joinRequest.inviteSlug) else {
+        guard let signedInvite = try? SignedInvite.fromURLSafeSlug(slug) else {
             return .noJoinRequest
         }
 
@@ -163,8 +176,8 @@ public final class InviteCoordinator: @unchecked Sendable {
             signedInvite: signedInvite,
             messageId: message.id,
             sentAt: message.sentAt,
-            profile: joinRequest.profile,
-            metadata: joinRequest.metadata
+            profile: profile,
+            metadata: metadata
         )
 
         return await processJoinRequest(request, client: client)
@@ -530,14 +543,14 @@ public final class InviteCoordinator: @unchecked Sendable {
             )
         }
 
-        // ContentTypeText is deliberately absent: plain-text slug messages
-        // are no longer join requests. Senders like Herald still emit a text
-        // copy next to the typed message for older creators; treating it as
-        // a second join request produced duplicate processing and duplicate
-        // error replies. Do not re-add text support here.
+        // Text slugs are still join requests: every build that predates the
+        // typed joiner path (2.0.0 and earlier) sends text only. The Herald
+        // typed+text pair does not double-reply because sendJoinError
+        // dedupes per attempt. Remove ContentTypeText here only once the
+        // installed fleet sends typed requests.
         let candidates = messages.filter { message in
             guard let contentType = try? message.encodedContent.type,
-                  contentType == ContentTypeJoinRequest,
+                  contentType == ContentTypeText || contentType == ContentTypeJoinRequest,
                   message.senderInboxId != client.inviteInboxId else {
                 return false
             }


### PR DESCRIPTION
## Problem

#1034 removed plain-text slug handling on the creator side, treating text as a legacy fallback. It was actually the **only** format the production iOS joiner has ever sent: `ConversationStateMachine.handleJoin` on the 2.0.0 tag (and every earlier build) does `dm.prepare(text: slug)` — the typed `join_request` content type added in #556 was never wired into the joiner until #1034 itself.

Result in the field: a 2.0.0 user joining a conversation hosted by a post-#1034 build gets **no member add and no error reply** — the text message is silently ignored, and their state machine waits forever (it only exits `.joining` on group arrival or a streamed `invite_join_error`).

## Fix

Re-accept text slugs in `processMessageOutcome` and `processDm` (typed still preferred). This does **not** reintroduce the Herald duplicate-error flood that motivated the removal:

- `sendJoinError`'s per-attempt dedupe (added in #1034) suppresses the second reply for a typed+text pair — both copies predate whichever error is sent first.
- `.alreadyMember` already prevents double-adds on success.
- New integration test fails a typed+text pair, revalidates, and asserts exactly **one** error reply (the flood-regression guard).
- The previous "text is ignored" test flips to "text slug joins".

All other #1034 behavior (typed joiner sends, `reason` field, per-attempt dedupe, 24h clamp, sync-before-not-found, agent-join retry) is unchanged. Text acceptance should be removed again only once the installed fleet sends typed requests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1051"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783827956&installation_id=128169237&pr_number=1051&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1051&signature=391d618d751ba7eb932c5f879e7d14b911b76497d1a4577ad01e07e733de7661"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restore plain-text invite slug handling in join-request DMs
> - [`InviteCoordinator.processJoinRequestsInDm`](https://github.com/xmtplabs/convos-ios/pull/1051/files#diff-87d55c5ffa790402965a59c8132ef0a34a6485257304dd2f6de696c14cf22917) now includes `ContentTypeText` messages (in addition to typed `join_request` messages) as join-request candidates, restoring support for pre-typed joiners who send only a plain-text slug.
> - [`InviteCoordinator.processMessageOutcome`](https://github.com/xmtplabs/convos-ios/pull/1051/files#diff-87d55c5ffa790402965a59c8132ef0a34a6485257304dd2f6de696c14cf22917) falls back to parsing the message body as a plain-text slug when no typed `JoinRequestContent` is present; profile and metadata are `nil` in the plain-text path.
> - A new integration test (`typedAndTextPairProducesSingleError`) verifies that a typed + plain-text pair for the same failed attempt produces exactly one `invite_join_error` reply via per-attempt deduplication.
> - Behavioral Change: plain-text DMs in a join-request conversation now trigger a group join attempt rather than being silently ignored.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b6dcc80.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->