### PR TITLE
Harden the contact card anchor against multi-Make and multi-agent lists

### DIFF
--- a/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupView.swift
@@ -123,7 +123,9 @@ struct MessagesGroupView: View {
     }
 
     private var singleTyperIndicator: some View {
-        let isTypingOnly = displayGroup.allMessages.isEmpty
+        // The contact-card section already renders the sender label above
+        // the card, so a typing-only card group must not add a second one.
+        let isTypingOnly = displayGroup.allMessages.isEmpty && displayGroup.agentContactCard == nil
 
         return Group {
             if isTypingOnly && !displayGroup.sender.isCurrentUser {
@@ -303,7 +305,7 @@ struct MessagesGroupView: View {
         // visual end of the agent's run: nothing else in this group below it
         // and no agent message group directly underneath. When the agent's
         // messages sit directly below, that group's avatar overlay handles
-        // the leading avatar — we don't want to double up.
+        // the leading avatar - we don't want to double up.
         let cardIsLast: Bool = displayGroup.allMessages.isEmpty
             && !displayGroup.showsTypingIndicator
             && !displayGroup.showsThinkingIndicator

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessagesListRepository.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessagesListRepository.swift
@@ -19,8 +19,8 @@ protocol MessagesListRepositoryProtocol {
     /// The verified Convos agent in the conversation, if any. When set,
     /// the processor inserts a standalone contact-card row (an empty
     /// `MessagesGroup` carrying an `AgentContactCardInfo`) at a stable
-    /// anchor in the list and suppresses the legacy "Agent joined" update
-    /// bubble.
+    /// anchor in the list. (The "Agent joined" update row is suppressed
+    /// separately, gated on `isInAgentBuilderFlow`.)
     var verifiedAgent: ConversationMember? { get set }
     /// The persisted Agent Builder summary for this conversation, if any.
     /// When set, the processor prepends a `.agentBuilderSummary` cell and

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/MessagesListProcessor.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/MessagesListProcessor.swift
@@ -735,12 +735,15 @@ private extension MessagesListProcessor {
     /// Insert the agent contact card as its own standalone row. The card has
     /// a single placement rule, so it never relocates as the agent's
     /// messages, connection events, or user replies stream in around it.
-    /// Anchor chain: right after the last builder summary card (the summary
-    /// always sits above the card -- in the home flow the agent joins before
-    /// the Make bundle, so anchoring on the join row there would put the
-    /// card first); else right after the agent-join update row (non-builder
-    /// agent conversations); else right before the agent's first message
-    /// group (join row outside the loaded window); else the top of the list.
+    /// Anchor chain: right after this agent's builder summary card (the
+    /// first summary between the agent's join row and the agent's first
+    /// message group -- the summary always sits above the card, and later
+    /// Makes add summaries further down that must not steal the card); else
+    /// right after this agent's most recent join update row (non-builder
+    /// agent conversations; matching on inboxId keeps the card off other or
+    /// former agents' join rows, and re-adds anchor on the latest join);
+    /// else right before the agent's first message group (join row outside
+    /// the loaded window); else the top of the list.
     static func insertingContactCard(
         in baseItems: [MessagesListItemType],
         agent: ConversationMember
@@ -757,17 +760,27 @@ private extension MessagesListProcessor {
             profile: agent.profile,
             agentDescription: agent.profile.agentDescription
         )
-        let builderCardIndex: Int? = items.lastIndex { item in
-            if case .agentBuilderSummary = item { return true }
-            return false
-        }
-        let joinUpdateIndex: Int? = items.firstIndex { item in
+        let joinUpdateIndex: Int? = items.lastIndex { item in
             guard case .update(_, let update, _) = item else { return false }
             return update.addedVerifiedAgent
+                && update.addedMembers.contains { $0.profile.inboxId == agent.profile.inboxId }
         }
         let firstAgentGroupIndex: Int? = items.firstIndex { item in
             guard case .messages(let group) = item else { return false }
             return group.sender.profile.inboxId == agent.profile.inboxId
+        }
+        // This agent's Make summary lives between its join row and its first
+        // message group (in the home flow the join sorts directly above the
+        // summary). Bounding the search keeps the card anchored to its own
+        // summary when later Makes append summaries further down the list.
+        // A re-added agent's old messages can sit above its latest join row;
+        // the clamp collapses the range so the card anchors on the join.
+        let searchStart: Int = joinUpdateIndex ?? 0
+        let searchEnd: Int = max(searchStart, firstAgentGroupIndex ?? items.count)
+        let summarySearchRange: Range<Int> = searchStart..<searchEnd
+        let builderCardIndex: Int? = items[summarySearchRange].firstIndex { item in
+            if case .agentBuilderSummary = item { return true }
+            return false
         }
         let insertionIndex: Int = builderCardIndex.map { $0 + 1 }
             ?? joinUpdateIndex.map { $0 + 1 }
@@ -783,6 +796,18 @@ private extension MessagesListProcessor {
             below.hidesSenderLabel = true
             items[insertionIndex] = .messages(below)
             cardGroup.contactCardPrecedesAgentMessages = true
+        }
+        // The full-bleed adjacency pass ran before the splice, so groups on
+        // either side of the card may still carry flags from when they were
+        // adjacent to each other. The card row is never full bleed; clear
+        // the flags facing it.
+        if insertionIndex > 0, case .messages(var above) = items[insertionIndex - 1] {
+            above.adjacentToFullBleedBelow = false
+            items[insertionIndex - 1] = .messages(above)
+        }
+        if insertionIndex < items.count, case .messages(var below) = items[insertionIndex] {
+            below.adjacentToFullBleedAbove = false
+            items[insertionIndex] = .messages(below)
         }
         items.insert(.messages(cardGroup), at: insertionIndex)
         return items

--- a/ConvosCore/Tests/ConvosCoreTests/MessagesListProcessorTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/MessagesListProcessorTests.swift
@@ -1409,6 +1409,20 @@ private func contactCardIndex(in items: [MessagesListItemType]) -> Int? {
     }
 }
 
+private func contactCardCount(in items: [MessagesListItemType]) -> Int {
+    items.count {
+        if case .messages(let group) = $0 { return group.agentContactCard != nil }
+        return false
+    }
+}
+
+private func summaryIndices(in items: [MessagesListItemType]) -> [Int] {
+    items.indices.filter {
+        if case .agentBuilderSummary = items[$0] { return true }
+        return false
+    }
+}
+
 private func contactCardGroup(in items: [MessagesListItemType]) -> MessagesGroup? {
     groups(from: items).first { $0.agentContactCard != nil }
 }
@@ -1546,5 +1560,117 @@ struct MessagesListProcessorContactCardPlacementTests {
             #expect(cardIndex == greetingIndex - 1)
         }
         #expect(contactCardGroup(in: result)?.contactCardPrecedesAgentMessages == true)
+    }
+
+    @Test("Card stays under its own summary when a later Make adds a second summary card")
+    func cardStaysOnOwnSummaryWhenSecondSummaryAppears() {
+        let now = Date()
+        let messages = [
+            makeUpdate(id: "agent-joined", date: now, addedMembers: [verifiedAgentMember]),
+            makeMessage(id: "b1", sender: currentUser, text: "First agent", date: now.addingTimeInterval(10)),
+            makeMessage(id: "greeting", sender: verifiedAgentMember, text: "Hello!", date: now.addingTimeInterval(20)),
+            makeMessage(id: "mid", sender: currentUser, text: "Another one please", date: now.addingTimeInterval(30)),
+            makeMessage(id: "b2", sender: currentUser, text: "Second agent", date: now.addingTimeInterval(40)),
+        ]
+        let result = MessagesListProcessor.process(
+            messages,
+            verifiedAgent: verifiedAgentMember,
+            hiddenBundleMessageIds: ["b1", "b2"]
+        )
+        let summaries = summaryIndices(in: result)
+        #expect(summaries.count == 2)
+        // The card anchors on the first summary (the Make that created this
+        // agent), not the latest one further down the list.
+        if let firstSummary = summaries.first {
+            #expect(contactCardIndex(in: result) == firstSummary + 1)
+        }
+        #expect(contactCardCount(in: result) == 1)
+    }
+
+    @Test("Join-row anchor matches this agent's join, not another verified agent's")
+    func joinAnchorIgnoresOtherAgentsJoinRows() {
+        let now = Date()
+        let otherAgent: ConversationMember = .mock(
+            isCurrentUser: false,
+            name: "OtherAgent",
+            isAgent: true,
+            agentVerification: .verified(.convos)
+        )
+        let messages = [
+            makeUpdate(id: "other-joined", date: now, addedMembers: [otherAgent]),
+            makeMessage(id: "user-text", sender: currentUser, text: "Hi", date: now.addingTimeInterval(5)),
+            makeUpdate(id: "agent-joined", date: now.addingTimeInterval(10), addedMembers: [verifiedAgentMember]),
+        ]
+        let result = MessagesListProcessor.process(
+            messages,
+            verifiedAgent: verifiedAgentMember
+        )
+        let agentJoinIndex = result.firstIndex {
+            guard case .update(_, let update, _) = $0 else { return false }
+            return update.addedMembers.contains { $0.profile.inboxId == verifiedAgentMember.profile.inboxId }
+        }
+        #expect(agentJoinIndex != nil)
+        if let agentJoinIndex {
+            #expect(contactCardIndex(in: result) == agentJoinIndex + 1)
+        }
+        #expect(contactCardCount(in: result) == 1)
+    }
+
+    @Test("Re-added agent anchors on its latest join row, below its older messages")
+    func reAddedAgentAnchorsOnLatestJoinRow() {
+        let now = Date()
+        let messages = [
+            makeUpdate(id: "join-1", date: now, addedMembers: [verifiedAgentMember]),
+            makeMessage(id: "old-msg", sender: verifiedAgentMember, text: "First stint", date: now.addingTimeInterval(5)),
+            makeUpdate(id: "join-2", date: now.addingTimeInterval(20), addedMembers: [verifiedAgentMember]),
+        ]
+        let result = MessagesListProcessor.process(
+            messages,
+            verifiedAgent: verifiedAgentMember
+        )
+        let joinIndices = result.indices.filter {
+            guard case .update(_, let update, _) = result[$0] else { return false }
+            return update.addedVerifiedAgent
+        }
+        #expect(joinIndices.count == 2)
+        if let latestJoin = joinIndices.last {
+            #expect(contactCardIndex(in: result) == latestJoin + 1)
+        }
+        #expect(contactCardCount(in: result) == 1)
+    }
+
+    @Test("Without any anchor the card sits at the top of the list")
+    func cardFallsBackToTopWhenNoAnchorsExist() {
+        let now = Date()
+        let messages = [
+            makeMessage(id: "user-text", sender: currentUser, text: "Hi", date: now),
+        ]
+        let result = MessagesListProcessor.process(
+            messages,
+            verifiedAgent: verifiedAgentMember
+        )
+        #expect(contactCardIndex(in: result) == 0)
+        #expect(contactCardCount(in: result) == 1)
+    }
+
+    @Test("No merge flags when a non-message row sits directly below the insertion point")
+    func noMergeFlagsWhenUpdateRowBelowInsertionPoint() {
+        let now = Date()
+        let messages = [
+            makeMessage(id: "b1", sender: currentUser, text: "Make it", date: now),
+            makeUpdate(id: "member-joined", date: now.addingTimeInterval(10)),
+        ]
+        let result = MessagesListProcessor.process(
+            messages,
+            verifiedAgent: verifiedAgentMember,
+            hiddenBundleMessageIds: ["b1"]
+        )
+        let summaries = summaryIndices(in: result)
+        #expect(summaries.count == 1)
+        if let summary = summaries.first {
+            #expect(contactCardIndex(in: result) == summary + 1)
+        }
+        #expect(contactCardGroup(in: result)?.contactCardPrecedesAgentMessages == false)
+        #expect(contactCardCount(in: result) == 1)
     }
 }


### PR DESCRIPTION
Follow-up to #1031, fixing the confirmed findings from an adversarial multi-agent review of the anchor chain.

## Fixes

1. **Card relocated when a later Make added a second summary card** (medium). The anchor used `lastIndex` of `.agentBuilderSummary`; a second Make in the same conversation appended a summary lower in the list and the card jumped under it, past every intervening message — the exact class of jump #1031 set out to kill. The summary search is now bounded between this agent's join row and its first message group, so the card stays on the summary that created it.
2. **Join-row anchor matched any verified agent's join, and always the oldest** (low). The predicate now requires the update's `addedMembers` to contain this agent's inboxId and takes the latest such row, so re-added agents anchor at their most recent join and replaced agents don't anchor on a predecessor's join row. The summary search range clamps when a re-added agent's older messages sit above its latest join.
3. **Duplicate sender label while the agent typed on the card row** (medium). The typing-only path rendered `senderLabel` a second time above the indicator; the card section already renders it.
4. **Stale full-bleed adjacency flags around the spliced card** (low). The `adjacentToFullBleed` pass runs before the card splice; both neighbors could keep flags from when they were adjacent to each other. The splice now clears the flags facing the card.
5. Doc/comment hygiene: the repository doc no longer claims `verifiedAgent` suppresses the join row (that's gated on `isInAgentBuilderFlow`), and an em dash in a comment is now ASCII per convention.

## Testing

Five new processor tests pin: second-summary stability, this-agent join matching, re-add latest-join anchoring, top-of-list fallback, and the non-message-row adjacency guard — each also asserts exactly one card row exists (the old helpers only ever inspected the first, so a double insertion would have passed silently). All 81 processor tests pass; app target builds clean under the 100ms type-check budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1052"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783828696&installation_id=128169237&pr_number=1052&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1052&signature=48c637ffb7d7ed68ca7079ce320b546defe44df283784f42193a837b8cf584dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Harden contact card anchoring against multi-Make and multi-agent conversation lists
> - Reworks `MessagesListProcessor.insertingContactCard` to anchor the contact card after the most recent join row for the specific agent (not any agent), bounded between that join row and the agent's first message group, preventing later summaries from re-anchoring the card.
> - Clears full-bleed adjacency flags (`adjacentToFullBleedBelow`/`adjacentToFullBleedAbove`) on neighboring groups when the card is inserted, so merge styling does not bleed across the card row.
> - Fixes `MessagesGroupView.singleTyperIndicator` to suppress the sender label for typing-only groups when a contact card is already present in the group.
> - Adds 7 new tests in `MessagesListProcessorContactCardPlacementTests` covering standalone card rendering, stable summary anchoring, agent-specific join matching, re-add anchoring, top-of-list fallback, and adjacency flag clearing.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5f32076.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->