### PR TITLE
Render the agent-builder summary card optimistically before the agent joins

### DIFF
--- a/Convos/Agent Builder/AgentBuilderViewModel.swift
+++ b/Convos/Agent Builder/AgentBuilderViewModel.swift
@@ -752,26 +752,30 @@ final class AgentBuilderViewModel: Identifiable {
         // owns its own message writer, so it sends independently of the
         // dismissed builder.
         Task { @MainActor [innerVM, voiceMemoSnapshot, summaryToPersist, conversationIdForPersist, textMessageId, bundleMessageId, session] in
-            // Request the agent join before anything else: the bundle publish
-            // below holds until the agent is a verified member (XMTP members
-            // can't read messages published before they joined), so the join
-            // must already be in flight by the time the send runs -- and the
-            // head start lets the backend add the agent while the summary
-            // persists and uploads finish. The join must finish even after
+            // Kick the agent join off first but don't block on it: the request
+            // can take seconds (the backend provisions the agent), and the
+            // summary persist below is what renders the card in the chat the
+            // user lands in -- serializing persist behind the join visibly
+            // delays Make feedback. The bundle publish holds until the agent
+            // is a member anyway (XMTP members can't read messages published
+            // before they joined), so the join only has to be IN FLIGHT
+            // before the send, not finished. The join must finish even after
             // the builder sheet dismisses. Unlike the draft flow, there is no
             // draft to discard -- the user's group stays -- so the join
             // survives the view closing (like `ConversationViewModel`'s
             // committed-conversation join, the opposite of the draft path).
             let slug = innerVM.conversation.invite?.urlSlug ?? ""
-            var joinRequested = false
-            if slug.isEmpty {
-                Log.warning("AgentBuilder(existing): no invite slug; skipping agent join")
-            } else {
+            let joinTask: Task<Bool, Never> = Task { [session] in
+                guard !slug.isEmpty else {
+                    Log.warning("AgentBuilder(existing): no invite slug; skipping agent join")
+                    return false
+                }
                 do {
                     _ = try await session.requestAgentJoin(slug: slug, options: .agentBuilder)
-                    joinRequested = true
+                    return true
                 } catch {
                     Log.error("AgentBuilder(existing): requestAgentJoin failed: \(error.localizedDescription)")
+                    return false
                 }
             }
             // Persist the summary before the send so the chat the user returns
@@ -790,6 +794,7 @@ final class AgentBuilderViewModel: Identifiable {
             // `awaitsAgentJoin: false` when the join was never requested (no
             // slug) or its request failed -- holding the bundle for an agent
             // that will never arrive only delays the inevitable publish.
+            let joinRequested: Bool = await joinTask.value
             await innerVM.sendBuilderBundle(
                 text: summaryToPersist.prompt,
                 voiceMemo: voiceMemoSnapshot,

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/MessagesListProcessor.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/MessagesListProcessor.swift
@@ -282,7 +282,10 @@ public final class MessagesListProcessor: Sendable {
             let summaryIds: Set<String> = summary.bundledMessageIds
             let summaryRowsLanded: Bool = rawMessages.contains { summaryIds.contains($0.messageId) }
             if !summaryRowsLanded {
-                items.append(.agentBuilderSummary(makePendingCardContent(summary: summary)))
+                items.insert(
+                    .agentBuilderSummary(makePendingCardContent(summary: summary)),
+                    at: pendingCardInsertionIndex(in: items, cutoffDate: summary.cutoffDate)
+                )
             }
         }
 
@@ -291,64 +294,6 @@ public final class MessagesListProcessor: Sendable {
         }
 
         return items
-    }
-
-    /// How long after Make the summary-only card may render while its build
-    /// messages haven't landed. Covers the writer's agent-join hold (150s)
-    /// with margin; past it, a row-less summary is history, not a pending
-    /// build.
-    private static let pendingCardDisplayWindow: TimeInterval = 180
-
-    /// Card content built from the summary alone, for the window between Make
-    /// and the build messages landing. Mirrors `makeCardContent` with the
-    /// summary's stored snapshots standing in for the not-yet-persisted
-    /// messages; the anchor reuses the first bundled id so the cell identity
-    /// is stable when the real run-anchored card takes over.
-    private static func makePendingCardContent(summary: AgentBuilderSummary) -> AgentBuilderCardContent {
-        let anchor: String = summary.bundledMessageIds.sorted().first ?? summary.id.uuidString
-        let attachments: [HydratedAttachment] = summary.attachments.compactMap { attachment in
-            switch attachment {
-            case let .photo(id, thumbnailData):
-                return HydratedAttachment(
-                    key: id.uuidString,
-                    mimeType: "image/jpeg",
-                    thumbnailDataBase64: thumbnailData?.base64EncodedString()
-                )
-            case let .video(id, thumbnailData):
-                return HydratedAttachment(
-                    key: id.uuidString,
-                    mimeType: "video/mp4",
-                    thumbnailDataBase64: thumbnailData?.base64EncodedString()
-                )
-            case let .file(id, filename, mimeType, fileSize):
-                return HydratedAttachment(
-                    key: id.uuidString,
-                    mimeType: mimeType,
-                    fileSize: fileSize,
-                    filename: filename
-                )
-            case let .voiceMemo(id, duration, levels):
-                return HydratedAttachment(
-                    key: id.uuidString,
-                    mimeType: "audio/m4a",
-                    duration: duration,
-                    waveformLevels: levels
-                )
-            case .connection:
-                // Rendered via `connectionIdentifiers`, not as a media chip.
-                return nil
-            }
-        }
-        return AgentBuilderCardContent(
-            id: "agent-builder-card-" + anchor,
-            prompt: summary.prompt,
-            attachments: attachments,
-            creatorIsCurrentUser: true,
-            creatorDisplayName: "",
-            connectionIdentifiers: builderConnectionIdentifiers(from: summary),
-            existingConversation: summary.existingConversation,
-            transitionEligible: !summary.existingConversation
-        )
     }
 
     /// Strip date separators that no longer precede a message group. A
@@ -918,5 +863,80 @@ private extension MessagesListProcessor {
 
             items.append(.messages(group))
         }
+    }
+
+    /// How long after Make the summary-only card may render while its build
+    /// messages haven't landed. Covers the writer's agent-join hold (150s)
+    /// with margin; past it, a row-less summary is history, not a pending
+    /// build.
+    private static let pendingCardDisplayWindow: TimeInterval = 180
+
+    /// Chronological slot for the pending card: right after the bottom-most
+    /// message group whose newest message predates Make (`cutoffDate`), so
+    /// messages sent while the bundle is held render below the card in true
+    /// order -- the same spot the run-anchored card takes once the build's
+    /// rows land. Falls back to the top of the newer groups (none older) or
+    /// the end of the list (no message groups at all).
+    private static func pendingCardInsertionIndex(in items: [MessagesListItemType], cutoffDate: Date) -> Int {
+        var firstNewerGroupIndex: Int = items.count
+        for (index, item) in items.enumerated().reversed() {
+            guard case .messages(let group) = item,
+                  let lastDate = group.messages.last?.date else { continue }
+            if lastDate <= cutoffDate { return index + 1 }
+            firstNewerGroupIndex = index
+        }
+        return firstNewerGroupIndex
+    }
+
+    /// Card content built from the summary alone, for the window between Make
+    /// and the build messages landing. Mirrors `makeCardContent` with the
+    /// summary's stored snapshots standing in for the not-yet-persisted
+    /// messages; the anchor reuses the first bundled id so the cell identity
+    /// is stable when the real run-anchored card takes over.
+    private static func makePendingCardContent(summary: AgentBuilderSummary) -> AgentBuilderCardContent {
+        let anchor: String = summary.bundledMessageIds.min() ?? summary.id.uuidString
+        let attachments: [HydratedAttachment] = summary.attachments.compactMap { attachment in
+            switch attachment {
+            case let .photo(id, thumbnailData):
+                return HydratedAttachment(
+                    key: id.uuidString,
+                    mimeType: "image/jpeg",
+                    thumbnailDataBase64: thumbnailData?.base64EncodedString()
+                )
+            case let .video(id, thumbnailData):
+                return HydratedAttachment(
+                    key: id.uuidString,
+                    mimeType: "video/mp4",
+                    thumbnailDataBase64: thumbnailData?.base64EncodedString()
+                )
+            case let .file(id, filename, mimeType, fileSize):
+                return HydratedAttachment(
+                    key: id.uuidString,
+                    mimeType: mimeType,
+                    fileSize: fileSize,
+                    filename: filename
+                )
+            case let .voiceMemo(id, duration, levels):
+                return HydratedAttachment(
+                    key: id.uuidString,
+                    mimeType: "audio/m4a",
+                    duration: duration,
+                    waveformLevels: levels
+                )
+            case .connection:
+                // Rendered via `connectionIdentifiers`, not as a media chip.
+                return nil
+            }
+        }
+        return AgentBuilderCardContent(
+            id: "agent-builder-card-" + anchor,
+            prompt: summary.prompt,
+            attachments: attachments,
+            creatorIsCurrentUser: true,
+            creatorDisplayName: "",
+            connectionIdentifiers: builderConnectionIdentifiers(from: summary),
+            existingConversation: summary.existingConversation,
+            transitionEligible: !summary.existingConversation
+        )
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/MessagesListProcessor.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/MessagesListProcessor.swift
@@ -269,11 +269,86 @@ public final class MessagesListProcessor: Sendable {
             items = dropOrphanDateSeparators(in: items)
         }
 
+        // Creator-side optimistic card: right after Make the build's message
+        // rows don't exist yet -- the bundle send is held until the agent has
+        // joined the conversation -- so the run-anchored reconstruction above
+        // has nothing to anchor on and the card would only appear once the
+        // agent joins. Render it from the summary alone (only the creator has
+        // the summary) until the summary's own rows land. Time-boxed so a
+        // summary whose build messages later expire (disappearing messages)
+        // doesn't resurrect a card at the bottom of an old chat.
+        if let summary = agentBuilderSummary,
+           Date().timeIntervalSince(summary.cutoffDate) < Self.pendingCardDisplayWindow {
+            let summaryIds: Set<String> = summary.bundledMessageIds
+            let summaryRowsLanded: Bool = rawMessages.contains { summaryIds.contains($0.messageId) }
+            if !summaryRowsLanded {
+                items.append(.agentBuilderSummary(makePendingCardContent(summary: summary)))
+            }
+        }
+
         if let agent = verifiedAgent {
             items = insertingContactCard(in: items, agent: agent)
         }
 
         return items
+    }
+
+    /// How long after Make the summary-only card may render while its build
+    /// messages haven't landed. Covers the writer's agent-join hold (150s)
+    /// with margin; past it, a row-less summary is history, not a pending
+    /// build.
+    private static let pendingCardDisplayWindow: TimeInterval = 180
+
+    /// Card content built from the summary alone, for the window between Make
+    /// and the build messages landing. Mirrors `makeCardContent` with the
+    /// summary's stored snapshots standing in for the not-yet-persisted
+    /// messages; the anchor reuses the first bundled id so the cell identity
+    /// is stable when the real run-anchored card takes over.
+    private static func makePendingCardContent(summary: AgentBuilderSummary) -> AgentBuilderCardContent {
+        let anchor: String = summary.bundledMessageIds.sorted().first ?? summary.id.uuidString
+        let attachments: [HydratedAttachment] = summary.attachments.compactMap { attachment in
+            switch attachment {
+            case let .photo(id, thumbnailData):
+                return HydratedAttachment(
+                    key: id.uuidString,
+                    mimeType: "image/jpeg",
+                    thumbnailDataBase64: thumbnailData?.base64EncodedString()
+                )
+            case let .video(id, thumbnailData):
+                return HydratedAttachment(
+                    key: id.uuidString,
+                    mimeType: "video/mp4",
+                    thumbnailDataBase64: thumbnailData?.base64EncodedString()
+                )
+            case let .file(id, filename, mimeType, fileSize):
+                return HydratedAttachment(
+                    key: id.uuidString,
+                    mimeType: mimeType,
+                    fileSize: fileSize,
+                    filename: filename
+                )
+            case let .voiceMemo(id, duration, levels):
+                return HydratedAttachment(
+                    key: id.uuidString,
+                    mimeType: "audio/m4a",
+                    duration: duration,
+                    waveformLevels: levels
+                )
+            case .connection:
+                // Rendered via `connectionIdentifiers`, not as a media chip.
+                return nil
+            }
+        }
+        return AgentBuilderCardContent(
+            id: "agent-builder-card-" + anchor,
+            prompt: summary.prompt,
+            attachments: attachments,
+            creatorIsCurrentUser: true,
+            creatorDisplayName: "",
+            connectionIdentifiers: builderConnectionIdentifiers(from: summary),
+            existingConversation: summary.existingConversation,
+            transitionEligible: !summary.existingConversation
+        )
     }
 
     /// Strip date separators that no longer precede a message group. A

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/MessagesListProcessor.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/MessagesListProcessor.swift
@@ -290,9 +290,10 @@ public final class MessagesListProcessor: Sendable {
             let withinWindow: Bool = Date().timeIntervalSince(summary.cutoffDate) < Self.pendingCardDisplayWindow
             let awaitingHistory: Bool = rawMessages.isEmpty && summary.existingConversation
             if rowsLanded || (withinWindow && !awaitingHistory) {
-                items.insert(
+                insertSummaryCard(
                     .agentBuilderSummary(makePendingCardContent(summary: summary)),
-                    at: pendingCardInsertionIndex(in: items, cutoffDate: summary.cutoffDate)
+                    into: &items,
+                    cutoffDate: summary.cutoffDate
                 )
             }
         }
@@ -879,21 +880,42 @@ private extension MessagesListProcessor {
     /// build.
     private static let pendingCardDisplayWindow: TimeInterval = 180
 
-    /// Chronological slot for the pending card: right after the bottom-most
-    /// message group whose newest message predates Make (`cutoffDate`), so
-    /// messages sent while the bundle is held render below the card in true
-    /// order -- the same spot the run-anchored card takes once the build's
-    /// rows land. Falls back to the top of the newer groups (none older) or
-    /// the end of the list (no message groups at all).
-    private static func pendingCardInsertionIndex(in items: [MessagesListItemType], cutoffDate: Date) -> Int {
+    /// Insert the summary card at its chronological Make slot: right after
+    /// the bottom-most message older than `cutoffDate`. Consecutive
+    /// same-sender messages merge into one group, so messages sent around
+    /// Make routinely share a group whose span straddles the boundary --
+    /// comparing whole groups would shove the card above the entire merged
+    /// group (the top of the list in a fresh chat). When the boundary falls
+    /// inside a group, split it at the boundary and seat the card between
+    /// the halves, the same way `reconstructBuilderCards` splices run cards
+    /// into groups. Falls back to the top of the newer groups (nothing
+    /// older) or the end of the list (no message groups at all).
+    private static func insertSummaryCard(
+        _ card: MessagesListItemType,
+        into items: inout [MessagesListItemType],
+        cutoffDate: Date
+    ) {
         var firstNewerGroupIndex: Int = items.count
         for (index, item) in items.enumerated().reversed() {
             guard case .messages(let group) = item,
+                  let firstDate = group.messages.first?.date,
                   let lastDate = group.messages.last?.date else { continue }
-            if lastDate <= cutoffDate { return index + 1 }
+            if lastDate <= cutoffDate {
+                items.insert(card, at: index + 1)
+                return
+            }
+            if firstDate <= cutoffDate {
+                let older: [AnyMessage] = group.messages.filter { $0.date <= cutoffDate }
+                let newer: [AnyMessage] = group.messages.filter { $0.date > cutoffDate }
+                guard let olderFirst = older.first, let newerFirst = newer.first else { continue }
+                let olderGroup: MessagesGroup = rebuiltGroup(group, id: "group-" + olderFirst.messageId, messages: older)
+                let newerGroup: MessagesGroup = rebuiltGroup(group, id: "group-" + newerFirst.messageId, messages: newer)
+                items.replaceSubrange(index...index, with: [.messages(olderGroup), card, .messages(newerGroup)])
+                return
+            }
             firstNewerGroupIndex = index
         }
-        return firstNewerGroupIndex
+        items.insert(card, at: firstNewerGroupIndex)
     }
 
     /// Card content built from the summary alone, for the window between Make

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/MessagesListProcessor.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/MessagesListProcessor.swift
@@ -177,11 +177,14 @@ public final class MessagesListProcessor: Sendable {
             guard let anchor = run.first?.messageId else { continue }
             for message in run { anchorByMessageId[message.messageId] = anchor }
             let ownsSummary: Bool = !summaryIds.isEmpty && run.contains { summaryIds.contains($0.messageId) }
-            cardByAnchor[anchor] = makeCardContent(
-                run: run,
-                anchor: anchor,
-                summary: ownsSummary ? agentBuilderSummary : nil
-            )
+            // The creator's own latest build renders via the Make-anchored
+            // summary card (see applyAgentBuilderCardsAndContactCard): its
+            // position tracks when the user tapped Make, not when the held
+            // bundle eventually published. Swallow those rows without
+            // emitting a run card; every other build (recipients, older
+            // builds whose summary was replaced) keeps its run-anchored card.
+            guard !ownsSummary else { continue }
+            cardByAnchor[anchor] = makeCardContent(run: run, anchor: anchor, summary: nil)
         }
 
         var result: [MessagesListItemType] = []
@@ -269,19 +272,24 @@ public final class MessagesListProcessor: Sendable {
             items = dropOrphanDateSeparators(in: items)
         }
 
-        // Creator-side optimistic card: right after Make the build's message
-        // rows don't exist yet -- the bundle send is held until the agent has
-        // joined the conversation -- so the run-anchored reconstruction above
-        // has nothing to anchor on and the card would only appear once the
-        // agent joins. Render it from the summary alone (only the creator has
-        // the summary) until the summary's own rows land. Time-boxed so a
-        // summary whose build messages later expire (disappearing messages)
-        // doesn't resurrect a card at the bottom of an old chat.
-        if let summary = agentBuilderSummary,
-           Date().timeIntervalSince(summary.cutoffDate) < Self.pendingCardDisplayWindow {
+        // The creator's card, anchored at the Make moment (the summary's
+        // cutoffDate) rather than at the position the held bundle eventually
+        // published -- messages sent while the send waited for the agent to
+        // join stay below the card. The run reconstruction above swallows the
+        // summary's own rows without emitting a card, so this is the sole
+        // creator-side card and it never relocates when the rows land.
+        // Before the rows land it renders from the summary alone, time-boxed
+        // so a summary whose rows later expire (disappearing messages)
+        // doesn't resurrect a card in an old chat. An empty raw snapshot of
+        // an existing conversation means history hasn't loaded yet -- skip
+        // that emission (the loaded one follows immediately) instead of
+        // flashing the card at the top of a one-item list.
+        if let summary = agentBuilderSummary {
             let summaryIds: Set<String> = summary.bundledMessageIds
-            let summaryRowsLanded: Bool = rawMessages.contains { summaryIds.contains($0.messageId) }
-            if !summaryRowsLanded {
+            let rowsLanded: Bool = rawMessages.contains { summaryIds.contains($0.messageId) }
+            let withinWindow: Bool = Date().timeIntervalSince(summary.cutoffDate) < Self.pendingCardDisplayWindow
+            let awaitingHistory: Bool = rawMessages.isEmpty && summary.existingConversation
+            if rowsLanded || (withinWindow && !awaitingHistory) {
                 items.insert(
                     .agentBuilderSummary(makePendingCardContent(summary: summary)),
                     at: pendingCardInsertionIndex(in: items, cutoffDate: summary.cutoffDate)

--- a/ConvosCore/Tests/ConvosCoreTests/MessagesListProcessorTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/MessagesListProcessorTests.swift
@@ -1886,3 +1886,44 @@ extension MessagesListProcessorPendingBuilderCardTests {
         #expect(builderCards(from: result).isEmpty)
     }
 }
+
+extension MessagesListProcessorPendingBuilderCardTests {
+    @Test("Same-sender messages spanning Make split around the card instead of dragging it to the top")
+    func cardSplitsMergedGroupAtMakeBoundary() {
+        let make = Date()
+        // All from the current user, consecutive -- the processor merges them
+        // into one group spanning the Make boundary.
+        let messages = [
+            makeMessage(id: "pre-1", sender: currentUser, text: "Hi", date: make.addingTimeInterval(-120)),
+            makeMessage(id: "pre-2", sender: currentUser, text: "Setting up", date: make.addingTimeInterval(-60)),
+            makeMessage(id: "post-1", sender: currentUser, text: "Sent right after Make", date: make.addingTimeInterval(20)),
+            makeMessage(id: "post-2", sender: currentUser, text: "And another", date: make.addingTimeInterval(40)),
+        ]
+        let summary = AgentBuilderSummary(
+            prompt: "Be my assistant",
+            attachments: [],
+            cutoffDate: make,
+            bundledMessageIds: ["b-text"]
+        )
+        let result = MessagesListProcessor.process(
+            messages,
+            agentBuilderSummary: summary,
+            hiddenBundleMessageIds: []
+        )
+        #expect(builderCards(from: result).count == 1)
+        let cardIndex = result.firstIndex { if case .agentBuilderSummary = $0 { return true } else { return false } }
+        func groupIndex(containing id: String) -> Int? {
+            result.firstIndex { item in
+                guard case .messages(let group) = item else { return false }
+                return group.messages.contains { $0.messageId == id }
+            }
+        }
+        #expect(cardIndex != nil)
+        if let cardIndex {
+            #expect(groupIndex(containing: "pre-2")! < cardIndex)
+            #expect(cardIndex < groupIndex(containing: "post-1")!)
+        }
+        // No message is lost in the split.
+        #expect(Set(messageIds(from: result)) == ["pre-1", "pre-2", "post-1", "post-2"])
+    }
+}

--- a/ConvosCore/Tests/ConvosCoreTests/MessagesListProcessorTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/MessagesListProcessorTests.swift
@@ -1791,3 +1791,39 @@ extension MessagesListProcessorPendingBuilderCardTests {
         }
     }
 }
+
+extension MessagesListProcessorPendingBuilderCardTests {
+    @Test("Messages sent while the bundle is held render below the pending card")
+    func pendingCardStaysChronological() {
+        let now = Date()
+        let messages = [
+            makeMessage(id: "before", sender: otherUser, text: "Earlier chat", date: now.addingTimeInterval(-60)),
+            makeMessage(id: "after", sender: currentUser, text: "Sent during the hold", date: now.addingTimeInterval(30)),
+        ]
+        let summary = AgentBuilderSummary(
+            prompt: "Be my assistant",
+            attachments: [],
+            cutoffDate: now,
+            bundledMessageIds: ["b-text"]
+        )
+        let result = MessagesListProcessor.process(
+            messages,
+            agentBuilderSummary: summary,
+            hiddenBundleMessageIds: []
+        )
+        let cardIndex = result.firstIndex { if case .agentBuilderSummary = $0 { return true } else { return false } }
+        let beforeIndex = result.firstIndex { item in
+            guard case .messages(let group) = item else { return false }
+            return group.messages.contains { $0.messageId == "before" }
+        }
+        let afterIndex = result.firstIndex { item in
+            guard case .messages(let group) = item else { return false }
+            return group.messages.contains { $0.messageId == "after" }
+        }
+        #expect(cardIndex != nil && beforeIndex != nil && afterIndex != nil)
+        if let cardIndex, let beforeIndex, let afterIndex {
+            #expect(beforeIndex < cardIndex)
+            #expect(cardIndex < afterIndex)
+        }
+    }
+}

--- a/ConvosCore/Tests/ConvosCoreTests/MessagesListProcessorTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/MessagesListProcessorTests.swift
@@ -1148,10 +1148,11 @@ private func builderCards(from items: [MessagesListItemType]) -> [AgentBuilderCa
 private func builderSummary(
     bundledMessageIds: Set<String>,
     connectionIdentifiers: [String] = [],
-    existingConversation: Bool = false
+    existingConversation: Bool = false,
+    prompt: String = ""
 ) -> AgentBuilderSummary {
     AgentBuilderSummary(
-        prompt: "",
+        prompt: prompt,
         attachments: connectionIdentifiers.map { .connection(id: UUID(), identifier: $0) },
         cutoffDate: Date(),
         bundledMessageIds: bundledMessageIds,
@@ -1210,7 +1211,7 @@ struct MessagesListProcessorAgentBuilderCardTests {
         // the local summary knows the bundle ids.
         let result = MessagesListProcessor.process(
             messages,
-            agentBuilderSummary: builderSummary(bundledMessageIds: ["b-text"]),
+            agentBuilderSummary: builderSummary(bundledMessageIds: ["b-text"], prompt: "Be my assistant"),
             hiddenBundleMessageIds: []
         )
         #expect(messageIds(from: result) == ["hey"])
@@ -1825,5 +1826,63 @@ extension MessagesListProcessorPendingBuilderCardTests {
             #expect(beforeIndex < cardIndex)
             #expect(cardIndex < afterIndex)
         }
+    }
+}
+
+extension MessagesListProcessorPendingBuilderCardTests {
+    @Test("Card stays at the Make position after the held bundle publishes below later messages")
+    func cardStaysAtMakePositionAfterRowsLand() {
+        let make = Date()
+        let messages = [
+            makeMessage(id: "before", sender: otherUser, text: "Earlier chat", date: make.addingTimeInterval(-60)),
+            makeMessage(id: "during", sender: currentUser, text: "Sent during the hold", date: make.addingTimeInterval(30)),
+            // The bundle publishes only after the agent joins, so its row is
+            // dated later than the message sent during the hold.
+            makeMessage(id: "b-text", sender: currentUser, text: "Be my assistant", date: make.addingTimeInterval(60)),
+        ]
+        let summary = AgentBuilderSummary(
+            prompt: "Be my assistant",
+            attachments: [],
+            cutoffDate: make,
+            bundledMessageIds: ["b-text"]
+        )
+        let result = MessagesListProcessor.process(
+            messages,
+            agentBuilderSummary: summary,
+            hiddenBundleMessageIds: []
+        )
+        let cards = builderCards(from: result)
+        #expect(cards.count == 1)
+        #expect(messageIds(from: result) == ["before", "during"])
+        let cardIndex = result.firstIndex { if case .agentBuilderSummary = $0 { return true } else { return false } }
+        let beforeIndex = result.firstIndex { item in
+            guard case .messages(let group) = item else { return false }
+            return group.messages.contains { $0.messageId == "before" }
+        }
+        let duringIndex = result.firstIndex { item in
+            guard case .messages(let group) = item else { return false }
+            return group.messages.contains { $0.messageId == "during" }
+        }
+        if let cardIndex, let beforeIndex, let duringIndex {
+            #expect(beforeIndex < cardIndex)
+            #expect(cardIndex < duringIndex)
+        }
+    }
+
+    @Test("Existing conversation with unloaded history defers the card instead of pinning it at the top")
+    func emptySnapshotDefersCardForExistingConversation() {
+        let summary = AgentBuilderSummary(
+            prompt: "Be my assistant",
+            attachments: [],
+            cutoffDate: Date(),
+            bundledMessageIds: ["b-text"],
+            existingConversation: true
+        )
+        let result = MessagesListProcessor.process(
+            [],
+            agentBuilderSummary: summary,
+            hiddenBundleMessageIds: []
+        )
+        #expect(builderCards(from: result).isEmpty)
     }
 }

--- a/ConvosCore/Tests/ConvosCoreTests/MessagesListProcessorTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/MessagesListProcessorTests.swift
@@ -1757,3 +1757,37 @@ struct MessagesListProcessorPendingBuilderCardTests {
         #expect(cards.first?.attachments.isEmpty == true)
     }
 }
+
+extension MessagesListProcessorPendingBuilderCardTests {
+    @Test("Verified agent's contact card anchors under the pending summary card")
+    func contactCardAnchorsUnderPendingCard() {
+        let agent = verifiedAgentMember
+        let summary = AgentBuilderSummary(
+            prompt: "Be my assistant",
+            attachments: [],
+            cutoffDate: Date(),
+            bundledMessageIds: ["b-text"]
+        )
+        // The agent has joined (verified) but the build's rows haven't landed
+        // yet -- the window right after the join gate opens. The pending card
+        // must render and the contact card must anchor directly beneath it.
+        let result = MessagesListProcessor.process(
+            [],
+            verifiedAgent: agent,
+            agentBuilderSummary: summary,
+            hiddenBundleMessageIds: []
+        )
+        let cards = builderCards(from: result)
+        #expect(cards.count == 1)
+        let summaryIndex = result.firstIndex { if case .agentBuilderSummary = $0 { return true } else { return false } }
+        let contactIndex = result.firstIndex { item in
+            guard case .messages(let group) = item else { return false }
+            return group.agentContactCard != nil
+        }
+        #expect(summaryIndex != nil)
+        #expect(contactIndex != nil)
+        if let summaryIndex, let contactIndex {
+            #expect(contactIndex == summaryIndex + 1)
+        }
+    }
+}

--- a/ConvosCore/Tests/ConvosCoreTests/MessagesListProcessorTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/MessagesListProcessorTests.swift
@@ -1674,3 +1674,86 @@ struct MessagesListProcessorContactCardPlacementTests {
         #expect(contactCardCount(in: result) == 1)
     }
 }
+
+// Coverage for the creator-side optimistic card: after Make, the bundle send
+// is held until the agent joins (OutgoingMessageWriter.waitForAgentMember), so
+// the build's message rows don't exist yet and the run-anchored reconstruction
+// has nothing to render. The processor must show the card from the summary
+// alone within the pending window, hand off to the run-anchored card once the
+// rows land, and never resurrect a card for an old row-less summary.
+struct MessagesListProcessorPendingBuilderCardTests {
+    @Test("Summary with no landed rows renders the card optimistically")
+    func pendingCardRendersBeforeRowsLand() {
+        let summary = AgentBuilderSummary(
+            prompt: "Be my assistant",
+            attachments: [],
+            cutoffDate: Date(),
+            bundledMessageIds: ["b-att", "b-text"]
+        )
+        let result = MessagesListProcessor.process(
+            [],
+            agentBuilderSummary: summary,
+            hiddenBundleMessageIds: []
+        )
+        let cards = builderCards(from: result)
+        #expect(cards.count == 1)
+        #expect(cards.first?.prompt == "Be my assistant")
+        #expect(cards.first?.creatorIsCurrentUser == true)
+    }
+
+    @Test("Once the summary's rows land, only the run-anchored card renders")
+    func pendingCardHandsOffToRunAnchoredCard() {
+        let now = Date()
+        let messages = [
+            makeMessage(id: "b-text", sender: currentUser, text: "Be my assistant", date: now),
+        ]
+        let summary = AgentBuilderSummary(
+            prompt: "Be my assistant",
+            attachments: [],
+            cutoffDate: now,
+            bundledMessageIds: ["b-text"]
+        )
+        let result = MessagesListProcessor.process(
+            messages,
+            agentBuilderSummary: summary,
+            hiddenBundleMessageIds: []
+        )
+        let cards = builderCards(from: result)
+        #expect(cards.count == 1)
+        #expect(messageIds(from: result).isEmpty)
+    }
+
+    @Test("An old summary whose rows are gone does not resurrect a card")
+    func expiredPendingSummaryRendersNoCard() {
+        let summary = AgentBuilderSummary(
+            prompt: "Be my assistant",
+            attachments: [],
+            cutoffDate: Date().addingTimeInterval(-3600),
+            bundledMessageIds: ["b-att", "b-text"]
+        )
+        let result = MessagesListProcessor.process(
+            [],
+            agentBuilderSummary: summary,
+            hiddenBundleMessageIds: []
+        )
+        #expect(builderCards(from: result).isEmpty)
+    }
+
+    @Test("Pending card carries the summary's connection identifiers")
+    func pendingCardCarriesConnections() {
+        let summary = AgentBuilderSummary(
+            prompt: "Track my calendar",
+            attachments: [.connection(id: UUID(), identifier: "googleCalendar")],
+            cutoffDate: Date(),
+            bundledMessageIds: ["b-text"]
+        )
+        let result = MessagesListProcessor.process(
+            [],
+            agentBuilderSummary: summary,
+            hiddenBundleMessageIds: []
+        )
+        let cards = builderCards(from: result)
+        #expect(cards.first?.connectionIdentifiers == ["googleCalendar"])
+        #expect(cards.first?.attachments.isEmpty == true)
+    }
+}


### PR DESCRIPTION
## Summary

Follow-up to #1041. The join gate holds the bundle `prepare` until the agent is a member, so the build's message rows don't exist at Make time — and the summary card is rebuilt from those rows (`reconstructBuilderCards` has nothing to anchor on), so the card only appeared after the agent joined. The summary data was on disk the whole time; the renderer just refused to draw it.

`MessagesListProcessor` now appends a creator-side optimistic card built from the summary alone whenever the summary's own `bundledMessageIds` rows haven't landed:

- **Time-boxed to 180s** after Make (covers the 150s join hold) so an old summary whose build messages later expire (disappearing messages) can't resurrect a card at the bottom of a dead chat
- **Dedupe keys on the summary's own row ids** — when the rows land, the run-anchored card takes over with no duplicate, and re-running the builder in a chat that already shows an older build's card still renders the new pending card immediately
- Attachment chips (photo/video/file/voice memo) hydrate from the summary's stored thumbnails; connection chips come through `connectionIdentifiers` as before
- Recipients are unaffected (they never have the summary; their card still comes from the manifest rows)

## Test plan

- [x] 4 new processor tests: optimistic render with no rows, hand-off to the run-anchored card without duplicates, no resurrection for expired summaries, connection identifiers carried
- [x] All 80 MessagesListProcessor tests pass; full ConvosCore suite green (1160 tests)
- [x] Full app build (Convos (Local)) compiles; SwiftLint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1054"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783830096&installation_id=128169237&pr_number=1054&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1054&signature=1a4eada9087720adcf9d3dd485ff80014585db5b58339d320fc2fd5e6591c590"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Render the agent builder summary card optimistically before bundle rows arrive
> - In [MessagesListProcessor.swift](https://github.com/xmtplabs/convos-ios/pull/1054/files#diff-c32ba383ca53d832eed02dc83f3d0a9546aad74da5c5919555079a4fc07383d7), the creator's latest build now renders a summary-anchored card at the Make time instead of waiting for bundle rows to land, within a 180-second pending window.
> - When bundle rows have not yet arrived, the card content is synthesized directly from `AgentBuilderSummary`, including attachments (excluding connections, which surface via identifiers).
> - A new `insertSummaryCard` helper places the card at the precise chronological cutoff, splitting merged same-sender message groups at the boundary when needed.
> - In [AgentBuilderViewModel.swift](https://github.com/xmtplabs/convos-ios/pull/1054/files#diff-8b71893f1830eea03680a58b5237f2369242000afbb064e57463171dfe38db65), the agent join request now runs concurrently with summary persistence and media upload awaiting instead of blocking them.
> - Behavioral Change: creator-side builds no longer emit a run-anchored card for the latest build; stale summaries with no bundle rows and no history suppress the pending card entirely to avoid rendering at the top.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f9cf274.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->