### PR TITLE
Add Share to the thing message context menu and fix its transition

### DIFF
--- a/Convos/Conversation Detail/Messages/MessagesListView/MessageContextMenu/MessageContextMenuOverlay.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessageContextMenu/MessageContextMenuOverlay.swift
@@ -1,4 +1,5 @@
 import ConvosCore
+import LinkPresentation
 import Photos
 import SwiftUI
 
@@ -26,6 +27,7 @@ struct MessageContextMenuOverlay: View {
     @State private var isPoofDismissing: Bool = false
     @State private var keyboardHeight: CGFloat = 0
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass: UserInterfaceSizeClass?
+    @Environment(\.colorScheme) private var colorScheme: ColorScheme
 
     private var message: AnyMessage? { state.presentedMessage }
 
@@ -123,11 +125,20 @@ struct MessageContextMenuOverlay: View {
                 height: state.bubbleFrame.height
             )
             let isPhoto: Bool = photoAttachment != nil
+            // HTML tiles are fixed 160pt squares, not full-bleed photos; the
+            // photo layout would shrink and recenter them, so keep them on
+            // the text-bubble path where the tile holds its size and place.
+            let isHTMLTile: Bool = photoAttachment?.isHTMLFile == true
+            let usesPhotoLayout: Bool = isPhoto && !isHTMLTile && !state.isReplyParent
+            let menuEstimatedHeight: CGFloat = isPhoto && !state.isReplyParent
+                ? C.photoMenuEstimatedHeight
+                : C.textMenuEstimatedHeight
             let endBubble = endBubbleRect(
                 source: localBubble,
                 screenSize: screenSize,
                 safeTop: safeTop,
-                isPhoto: isPhoto && !state.isReplyParent
+                isPhoto: usesPhotoLayout,
+                menuHeight: menuEstimatedHeight
             )
             let activeBubble: CGRect = appeared ? endBubble : localBubble
             let keyboardTop: CGFloat = keyboardHeight > 0 ? screenSize.height - keyboardHeight : screenSize.height
@@ -305,7 +316,8 @@ struct MessageContextMenuOverlay: View {
         source: CGRect,
         screenSize: CGSize,
         safeTop: CGFloat,
-        isPhoto: Bool = false
+        isPhoto: Bool = false,
+        menuHeight: CGFloat = C.textMenuEstimatedHeight
     ) -> CGRect {
         let topInset: CGFloat = safeTop + C.topInset
         let minY: CGFloat = topInset + C.drawerHeight + C.sectionSpacing
@@ -313,7 +325,6 @@ struct MessageContextMenuOverlay: View {
         var endWidth: CGFloat = source.width - (photoInset * 2)
         var endHeight: CGFloat = isPhoto ? endWidth * (source.height / max(source.width, 1)) : source.height
 
-        let menuHeight: CGFloat = isPhoto ? C.photoMenuEstimatedHeight : C.textMenuEstimatedHeight
         let bottomPadding: CGFloat = C.sectionSpacing + menuHeight + C.verticalBreathingRoom
         let maxContentHeight: CGFloat = screenSize.height - minY - bottomPadding - C.verticalBreathingRoom
 
@@ -484,6 +495,16 @@ struct MessageContextMenuOverlay: View {
                 }
 
                 if let attachment = photoAttachment {
+                    if attachment.isHTMLFile {
+                        let senderName = message.sender.profile.displayName
+                        let appearance = colorScheme.uiUserInterfaceStyle
+                        let shareAction = {
+                            shareRenderedAttachment(attachment, fallbackTitle: senderName, appearance: appearance)
+                            dismissMenu()
+                        }
+                        ContextMenuRow(icon: "square.and.arrow.up", title: "Share", action: shareAction)
+                    }
+
                     let saveAction = {
                         saveAttachment(attachment)
                         dismissMenu()
@@ -619,9 +640,12 @@ struct MessageContextMenuOverlay: View {
                 )
             }
         } else if attachment.isHTMLFile {
-            let radius: CGFloat = state.isReplyParent
+            // The tile rests at its natural corner radius in the list, so
+            // keep it constant during the menu transition instead of
+            // animating from square; only reply-parent thumbnails shrink it.
+            let radius: CGFloat? = state.isReplyParent
                 ? DesignConstants.CornerRadius.regular
-                : (appeared ? C.photoCornerRadius : 0)
+                : nil
             HTMLAttachmentBubble(
                 attachment: attachment,
                 profile: profile,
@@ -932,6 +956,105 @@ private func saveFileToFiles(key: String, filename: String?) {
         } catch {
             Log.error("Failed to save file: \(error)")
         }
+    }
+}
+
+/// Shares an HTML or Markdown attachment with the same payload as
+/// `AttachmentShareLink` (the share button on the attachment preview and
+/// thing detail screens): the full-page rendered image for HTML, titled
+/// after the artifact, with the square tile as the share sheet preview.
+private func shareRenderedAttachment(
+    _ attachment: HydratedAttachment,
+    fallbackTitle: String?,
+    appearance: UIUserInterfaceStyle
+) {
+    Task { @MainActor in
+        do {
+            let fileURL = try await FileAttachmentLoader.loadFile(for: attachment)
+            guard let payload = await AttachmentSharePayload.resolve(
+                attachment: attachment,
+                fileURL: fileURL,
+                appearance: appearance,
+                fallbackTitle: fallbackTitle
+            ) else {
+                Log.error("Share skipped: no share payload resolved for attachment")
+                return
+            }
+            presentShareSheet(for: payload)
+        } catch {
+            Log.error("Failed to share attachment: \(error)")
+        }
+    }
+}
+
+@MainActor
+private func presentShareSheet(for payload: AttachmentSharePayload) {
+    guard let primaryItem = payload.items.first else { return }
+    let itemSource = SharePayloadItemSource(
+        url: primaryItem,
+        title: payload.title,
+        previewImage: payload.previewImage
+    )
+    var activityItems: [Any] = [itemSource]
+    for item in payload.items.dropFirst() {
+        activityItems.append(item)
+    }
+    let activityVC = UIActivityViewController(activityItems: activityItems, applicationActivities: nil)
+    guard let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+          let root = scene.keyWindow?.rootViewController else { return }
+    var presenter = root
+    while let presented = presenter.presentedViewController {
+        presenter = presented
+    }
+    activityVC.popoverPresentationController?.sourceView = presenter.view
+    activityVC.popoverPresentationController?.sourceRect = CGRect(
+        x: presenter.view.bounds.midX,
+        y: presenter.view.bounds.midY,
+        width: 0, height: 0
+    )
+    presenter.present(activityVC, animated: true)
+}
+
+/// Wraps the primary share URL so the activity sheet header shows the
+/// artifact title and tile thumbnail, matching `ShareLink`'s `SharePreview`
+/// in `AttachmentShareLink`.
+private final class SharePayloadItemSource: NSObject, UIActivityItemSource {
+    private let url: URL
+    private let title: String
+    private let previewImage: UIImage?
+
+    init(url: URL, title: String, previewImage: UIImage?) {
+        self.url = url
+        self.title = title
+        self.previewImage = previewImage
+    }
+
+    func activityViewControllerPlaceholderItem(_ activityViewController: UIActivityViewController) -> Any {
+        url
+    }
+
+    func activityViewController(
+        _ activityViewController: UIActivityViewController,
+        itemForActivityType activityType: UIActivity.ActivityType?
+    ) -> Any? {
+        url
+    }
+
+    func activityViewController(
+        _ activityViewController: UIActivityViewController,
+        subjectForActivityType activityType: UIActivity.ActivityType?
+    ) -> String {
+        title
+    }
+
+    func activityViewControllerLinkMetadata(_ activityViewController: UIActivityViewController) -> LPLinkMetadata? {
+        let metadata = LPLinkMetadata()
+        metadata.title = title
+        metadata.originalURL = url
+        if let previewImage {
+            metadata.imageProvider = NSItemProvider(object: previewImage)
+        }
+        return metadata
     }
 }
 

--- a/Convos/Shared Views/AttachmentShareLink.swift
+++ b/Convos/Shared Views/AttachmentShareLink.swift
@@ -3,12 +3,194 @@ import ConvosLogging
 import SwiftUI
 import UIKit
 
+/// The resolved share content for an HTML or Markdown attachment, shared by
+/// `AttachmentShareLink` and the message context menu's Share action so the
+/// payload stays identical everywhere. HTML shares the full-page rendered
+/// image only (the share sheet preview stays the square tile); Markdown
+/// shares the underlying file, adding the rendered thumbnail image once it
+/// resolves.
+struct AttachmentSharePayload {
+    let items: [URL]
+    let title: String
+    let previewImage: UIImage?
+
+    /// Resolves the share payload, rendering and disk-caching share images
+    /// as needed. Returns nil when there is nothing shareable yet (e.g. the
+    /// HTML full-page render and tile thumbnail both failed).
+    @MainActor
+    static func resolve(
+        attachment: HydratedAttachment,
+        fileURL: URL,
+        appearance: UIUserInterfaceStyle,
+        fallbackTitle: String?
+    ) async -> AttachmentSharePayload? {
+        if attachment.isHTMLFile {
+            return await resolveHTML(
+                attachment: attachment,
+                fileURL: fileURL,
+                appearance: appearance,
+                fallbackTitle: fallbackTitle
+            )
+        }
+        if attachment.isMarkdownFile {
+            return await resolveMarkdown(
+                attachment: attachment,
+                fileURL: fileURL,
+                fallbackTitle: fallbackTitle
+            )
+        }
+        return nil
+    }
+
+    @MainActor
+    private static func resolveHTML(
+        attachment: HydratedAttachment,
+        fileURL: URL,
+        appearance: UIUserInterfaceStyle,
+        fallbackTitle: String?
+    ) async -> AttachmentSharePayload? {
+        // The user-facing share name. For HTML artifacts the raw filename is
+        // never shown - the artifact's title, then the agent's name, stand in.
+        let resolvedTitle: String?
+        if let cached = HTMLPageMetadata.shared.cachedTitle(for: attachment.key) {
+            resolvedTitle = cached
+        } else {
+            resolvedTitle = await HTMLPageMetadata.shared.title(for: attachment.key, fileURL: fileURL)
+        }
+        let title: String = resolvedTitle ?? fallbackTitle ?? "Attachment"
+        let basename: String = sanitizeFilename(
+            resolvedTitle ?? fallbackTitle ?? String(attachment.key.prefix(32))
+        )
+
+        let thumbnail: UIImage? = await resolveHTMLThumbnail(
+            attachment: attachment,
+            fileURL: fileURL,
+            appearance: appearance
+        )
+        // Share the full-page render when available; the square tile stays
+        // the share sheet preview so it reads as a card, not a tall sliver.
+        // The PNG is rendered once and disk-cached, so re-sharing arms
+        // instantly.
+        let fullPageURL: URL? = await HTMLThumbnailRenderer.shared.fullPagePNGURL(
+            for: attachment.key,
+            fileURL: fileURL,
+            appearance: appearance,
+            basename: basename
+        )
+        if let fullPageURL {
+            // Arm even when the tile thumbnail failed - the share sheet
+            // then shows a title-only preview instead of staying dimmed.
+            return AttachmentSharePayload(items: [fullPageURL], title: title, previewImage: thumbnail)
+        }
+        // Full-page render failed; fall back to sharing the tile image.
+        guard let thumbnail,
+              let fallbackURL = await writeSharePNG(image: thumbnail, basename: basename, attachmentKey: attachment.key) else {
+            return nil
+        }
+        return AttachmentSharePayload(items: [fallbackURL], title: title, previewImage: thumbnail)
+    }
+
+    @MainActor
+    private static func resolveMarkdown(
+        attachment: HydratedAttachment,
+        fileURL: URL,
+        fallbackTitle: String?
+    ) async -> AttachmentSharePayload? {
+        guard let image = await resolveMarkdownShareImage(attachment: attachment, fileURL: fileURL) else {
+            return nil
+        }
+        // The basename is the filename recipients see on the delivered
+        // image, so it follows the share title rather than the raw
+        // attachment filename.
+        let raw: String
+        if let filename = attachment.filename, !filename.isEmpty {
+            raw = (filename as NSString).deletingPathExtension
+        } else {
+            raw = String(attachment.key.prefix(32))
+        }
+        guard let url = await writeSharePNG(image: image, basename: sanitizeFilename(raw), attachmentKey: attachment.key) else {
+            return nil
+        }
+        let title: String = attachment.filename ?? fallbackTitle ?? "Attachment"
+        return AttachmentSharePayload(items: [fileURL, url], title: title, previewImage: image)
+    }
+
+    @MainActor
+    private static func resolveHTMLThumbnail(
+        attachment: HydratedAttachment,
+        fileURL: URL,
+        appearance: UIUserInterfaceStyle
+    ) async -> UIImage? {
+        if let cached = HTMLThumbnailRenderer.shared.cachedThumbnail(for: attachment.key, appearance: appearance) {
+            return cached
+        }
+        return await HTMLThumbnailRenderer.shared.thumbnail(
+            for: attachment.key,
+            fileURL: fileURL,
+            appearance: appearance
+        )
+    }
+
+    @MainActor
+    private static func resolveMarkdownShareImage(
+        attachment: HydratedAttachment,
+        fileURL: URL
+    ) async -> UIImage? {
+        if let cached = FileThumbnailRenderer.shared.cachedThumbnail(for: attachment.key),
+           cached.isContentThumbnail {
+            return cached.image
+        }
+        guard let result = await FileThumbnailRenderer.shared.thumbnail(for: attachment.key, fileURL: fileURL),
+              result.isContentThumbnail else {
+            return nil
+        }
+        return result.image
+    }
+
+    private static func sanitizeFilename(_ raw: String) -> String {
+        let allowed: CharacterSet = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "-_. "))
+        var output: String = ""
+        for scalar in raw.unicodeScalars {
+            output.append(allowed.contains(scalar) ? Character(scalar) : "_")
+        }
+        let trimmed: String = output.trimmingCharacters(in: .whitespaces)
+        let fallback: String = trimmed.isEmpty ? "image" : trimmed
+        return String(fallback.prefix(64))
+    }
+
+    private static func writeSharePNG(image: UIImage, basename: String, attachmentKey: String) async -> URL? {
+        // Namespace by attachment key so same-named attachments cannot
+        // overwrite each other's armed share payload.
+        let url: URL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("share-" + HTMLThumbnailRenderer.stableKeyComponent(for: attachmentKey), isDirectory: true)
+            .appendingPathComponent("\(basename).png")
+        // Full-page renders are large bitmaps; encode and write off the main
+        // actor so the share button does not stall the UI.
+        let written: Bool = await Task.detached(priority: .utility) {
+            guard let pngData = image.pngData() else {
+                Log.error("AttachmentSharePayload: failed to encode share image PNG")
+                return false
+            }
+            do {
+                try FileManager.default.createDirectory(
+                    at: url.deletingLastPathComponent(),
+                    withIntermediateDirectories: true
+                )
+                try pngData.write(to: url, options: .atomic)
+                return true
+            } catch {
+                Log.error("AttachmentSharePayload: failed to write share PNG: \(error)")
+                return false
+            }
+        }.value
+        return written ? url : nil
+    }
+}
+
 /// Share button for HTML and Markdown attachments, used by both the
-/// in-conversation attachment preview and the Stuff detail screen so the
-/// share payload stays identical everywhere. HTML shares the full-page
-/// rendered image only (the share sheet preview stays the square tile);
-/// Markdown shares the underlying file, adding the rendered thumbnail
-/// image once it resolves.
+/// in-conversation attachment preview and the Stuff detail screen. The
+/// share content comes from `AttachmentSharePayload` so it matches the
+/// message context menu's Share action.
 struct AttachmentShareLink: View {
     let attachment: HydratedAttachment
     let fileURL: URL
@@ -17,9 +199,7 @@ struct AttachmentShareLink: View {
     var fallbackTitle: String?
 
     @Environment(\.colorScheme) private var colorScheme: ColorScheme
-    @State private var resolvedHTMLTitle: String?
-    @State private var sharedImage: UIImage?
-    @State private var sharedImageURL: URL?
+    @State private var payload: AttachmentSharePayload?
 
     static func canShare(_ attachment: HydratedAttachment) -> Bool {
         attachment.isHTMLFile || attachment.isMarkdownFile
@@ -32,38 +212,29 @@ struct AttachmentShareLink: View {
         shareLink
             .accessibilityLabel("Share")
             .task(id: "\(attachment.key)-\(appearanceSuffix)") {
-                resolvedHTMLTitle = nil
-                sharedImage = nil
-                sharedImageURL = nil
-                await resolveTitleIfNeeded()
-                await resolveShareImageIfNeeded()
+                payload = nil
+                payload = await AttachmentSharePayload.resolve(
+                    attachment: attachment,
+                    fileURL: fileURL,
+                    appearance: colorScheme.uiUserInterfaceStyle,
+                    fallbackTitle: fallbackTitle
+                )
             }
-    }
-
-    /// The user-facing share name. For HTML artifacts the raw filename is
-    /// never shown - the artifact's title, then the agent's name, stand in.
-    private var shareTitle: String {
-        if attachment.isHTMLFile {
-            return resolvedHTMLTitle ?? fallbackTitle ?? "Attachment"
-        }
-        return attachment.filename ?? fallbackTitle ?? "Attachment"
     }
 
     @ViewBuilder
     private var shareLink: some View {
-        let title: String = shareTitle
-        if let url = sharedImageURL {
-            let items: [URL] = attachment.isHTMLFile ? [url] : [fileURL, url]
-            if let image = sharedImage {
+        if let payload {
+            if let image = payload.previewImage {
                 let previewImage: Image = Image(uiImage: image)
-                ShareLink(items: items, preview: { (_: URL) in
-                    SharePreview(title, image: previewImage)
+                ShareLink(items: payload.items, preview: { (_: URL) in
+                    SharePreview(payload.title, image: previewImage)
                 }, label: {
                     Image(systemName: "square.and.arrow.up")
                 })
             } else {
-                ShareLink(items: items, preview: { (_: URL) in
-                    SharePreview(title)
+                ShareLink(items: payload.items, preview: { (_: URL) in
+                    SharePreview(payload.title)
                 }, label: {
                     Image(systemName: "square.and.arrow.up")
                 })
@@ -75,138 +246,10 @@ struct AttachmentShareLink: View {
                 .foregroundStyle(.secondary)
         } else {
             ShareLink(items: [fileURL], preview: { (_: URL) in
-                SharePreview(title)
+                SharePreview(attachment.filename ?? fallbackTitle ?? "Attachment")
             }, label: {
                 Image(systemName: "square.and.arrow.up")
             })
         }
-    }
-
-    private func resolveTitleIfNeeded() async {
-        guard attachment.isHTMLFile else { return }
-        if let cached = HTMLPageMetadata.shared.cachedTitle(for: attachment.key) {
-            resolvedHTMLTitle = cached
-            return
-        }
-        resolvedHTMLTitle = await HTMLPageMetadata.shared.title(for: attachment.key, fileURL: fileURL)
-    }
-
-    private func resolveShareImageIfNeeded() async {
-        if attachment.isHTMLFile {
-            await resolveHTMLShareContent()
-            return
-        }
-        guard attachment.isMarkdownFile, let image = await resolveMarkdownShareImage() else { return }
-        let url: URL? = await writeSharePNG(image: image, basename: shareImageBasename())
-        sharedImage = image
-        sharedImageURL = url
-    }
-
-    private func resolveHTMLShareContent() async {
-        let appearance = colorScheme.uiUserInterfaceStyle
-        let thumbnail: UIImage? = await resolveHTMLThumbnail(appearance: appearance)
-        // Share the full-page render when available; the square tile stays
-        // the share sheet preview so it reads as a card, not a tall sliver.
-        // The PNG is rendered once and disk-cached, so reopening the
-        // detail view arms the share button instantly.
-        let fullPageURL: URL? = await HTMLThumbnailRenderer.shared.fullPagePNGURL(
-            for: attachment.key,
-            fileURL: fileURL,
-            appearance: appearance,
-            basename: shareImageBasename()
-        )
-        if let fullPageURL {
-            // Arm even when the tile thumbnail failed - the share sheet
-            // then shows a title-only preview instead of staying dimmed.
-            sharedImage = thumbnail
-            sharedImageURL = fullPageURL
-            return
-        }
-        // Full-page render failed; fall back to sharing the tile image.
-        guard let thumbnail else { return }
-        let fallbackURL: URL? = await writeSharePNG(image: thumbnail, basename: shareImageBasename())
-        sharedImage = thumbnail
-        sharedImageURL = fallbackURL
-    }
-
-    private func resolveHTMLThumbnail(appearance: UIUserInterfaceStyle) async -> UIImage? {
-        if let cached = HTMLThumbnailRenderer.shared.cachedThumbnail(for: attachment.key, appearance: appearance) {
-            return cached
-        }
-        return await HTMLThumbnailRenderer.shared.thumbnail(
-            for: attachment.key,
-            fileURL: fileURL,
-            appearance: appearance
-        )
-    }
-
-    private func resolveMarkdownShareImage() async -> UIImage? {
-        if let cached = FileThumbnailRenderer.shared.cachedThumbnail(for: attachment.key),
-           cached.isContentThumbnail {
-            return cached.image
-        }
-        guard let result = await FileThumbnailRenderer.shared.thumbnail(for: attachment.key, fileURL: fileURL),
-              result.isContentThumbnail else {
-            return nil
-        }
-        return result.image
-    }
-
-    private func shareImageBasename() -> String {
-        // The basename is the filename recipients see on the delivered
-        // image, so it follows the share title rather than the raw
-        // attachment filename.
-        if attachment.isHTMLFile {
-            if let title = resolvedHTMLTitle ?? fallbackTitle {
-                return sanitizeFilename(title)
-            }
-            return sanitizeFilename(String(attachment.key.prefix(32)))
-        }
-        let raw: String
-        if let filename = attachment.filename, !filename.isEmpty {
-            raw = (filename as NSString).deletingPathExtension
-        } else {
-            raw = String(attachment.key.prefix(32))
-        }
-        return sanitizeFilename(raw)
-    }
-
-    private func sanitizeFilename(_ raw: String) -> String {
-        let allowed: CharacterSet = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "-_. "))
-        var output: String = ""
-        for scalar in raw.unicodeScalars {
-            output.append(allowed.contains(scalar) ? Character(scalar) : "_")
-        }
-        let trimmed: String = output.trimmingCharacters(in: .whitespaces)
-        let fallback: String = trimmed.isEmpty ? "image" : trimmed
-        return String(fallback.prefix(64))
-    }
-
-    private func writeSharePNG(image: UIImage, basename: String) async -> URL? {
-        // Namespace by attachment key so same-named attachments cannot
-        // overwrite each other's armed share payload.
-        let url: URL = FileManager.default.temporaryDirectory
-            .appendingPathComponent("share-" + HTMLThumbnailRenderer.stableKeyComponent(for: attachment.key), isDirectory: true)
-            .appendingPathComponent("\(basename).png")
-        // Full-page renders are large bitmaps; encode and write off the main
-        // actor so the share button does not stall the UI.
-        let written: Bool = await Task.detached(priority: .utility) {
-            guard let pngData = image.pngData() else {
-                Log.error("AttachmentShareLink: failed to encode share image PNG")
-                return false
-            }
-            do {
-                try FileManager.default.createDirectory(
-                    at: url.deletingLastPathComponent(),
-                    withIntermediateDirectories: true
-                )
-                try pngData.write(to: url, options: .atomic)
-                return true
-            } catch {
-                Log.error("AttachmentShareLink: failed to write share PNG: \(error)")
-                return false
-            }
-        }.value
-        return written ? url : nil
     }
 }


### PR DESCRIPTION
## What

Long-pressing a thing/artifact (HTML attachment) message now shows a **Share** row below Reply in the custom context menu, and the cell-to-menu transition for thing tiles is fixed.

## Share row

- Shares the **same payload** as the share button on the thing detail view and the attachment preview sheet: the full-page rendered image, titled after the artifact (falling back to the agent's display name), with the square tile as the share sheet preview.
- The payload resolution is extracted out of `AttachmentShareLink` into `AttachmentSharePayload`, and `AttachmentShareLink` now consumes it, so all three surfaces stay identical by construction.
- The context menu presents the sheet via `UIActivityViewController` with an `LPLinkMetadata` item source so the sheet header matches `ShareLink`'s `SharePreview` (title + tile thumbnail).

## Transition fix

Thing tiles were routed through the full-bleed photo layout in `endBubbleRect`, which shrank the 160pt tile by the photo insets, moved it to the screen edge, vertically centered it, and animated the corner radius from 0 — producing the misplaced blank block during the transition. Now:

- The tile takes the text-bubble path: it keeps its 160x160 size and stays anchored where the cell was (sliding only if too close to a screen edge), with the menu below and reactions above.
- The preview keeps the tile's natural 20pt corner radius through present and dismiss instead of animating 0 -> 18pt.
- `endBubbleRect` takes the estimated menu height as a parameter so the taller thing menu (timestamp + Reply + Share + Save) is accounted for when clamping the resting position.

## Testing

- Full ConvosCore suite: 1156 tests in 167 suites passed.
- SwiftLint + SwiftFormat clean; `Convos (Dev)` builds.
- Manually launched on a simulator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Share action for HTML attachments in the message context menu
> - Adds a Share option to the message context menu for HTML attachment tiles, presenting an iOS share sheet with the artifact title and tile thumbnail via `shareRenderedAttachment` in [MessageContextMenuOverlay.swift](https://github.com/xmtplabs/convos-ios/pull/1055/files#diff-3841c67fb70fc3069c2f14c71cff885be69b673383e92f30a46cbc89b69e6411).
> - Introduces `AttachmentSharePayload` in [AttachmentShareLink.swift](https://github.com/xmtplabs/convos-ios/pull/1055/files#diff-5107407b40633988aea4c026ae8cf7a897de0095302ff69540727a00e72b90f3) to centralize resolution of share items, title, and preview image — reused by both the context menu and `AttachmentShareLink`.
> - HTML tiles no longer adopt photo-bubble layout during the context menu transition; they keep their natural size and corner radius (reply-parent thumbnails still use the regular radius).
> - `endBubbleRect` now accepts a caller-provided `menuHeight` instead of computing it internally, allowing different heights for photo vs. non-photo (including HTML) cases.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8a7049f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->