### PR TITLE
Harden builder-bundle delivery: noSend prepares, gate semantics, brief replay

### DIFF
--- a/Convos/Agent Builder/AgentBuilderViewModel.swift
+++ b/Convos/Agent Builder/AgentBuilderViewModel.swift
@@ -610,12 +610,21 @@ final class AgentBuilderViewModel: Identifiable {
             let summaryToPersist: AgentBuilderSummary = plan.summary
             let conversationIdForPersist: String = innerVM.conversation.id
             let sessionForPersist = session
+            // The `.ready`-time join can have been skipped (conversation not
+            // ready yet, slug not hydrated) -- re-fire it now that the user
+            // committed; the `didRequestAgentJoin` latch makes this a no-op
+            // when the early join already ran.
+            requestAgentJoinIfNeeded()
             // Detach the agent-join task from this VM: the builder sheet tears
             // down after Make and `deinit` cancels `agentJoinTask`, which
             // could abort the join request mid-flight -- the bundle send below
             // then waits for an agent that never joins. Dropping the
             // reference (without cancelling) lets the join finish on its own.
             agentJoinTask = nil
+            // Gate the send on the agent joining only when a join request was
+            // actually launched; if it never was (no slug even at Make), the
+            // hold would wait for an agent that was never asked to come.
+            let joinAttempted: Bool = didRequestAgentJoin
             Task { @MainActor [weak innerVM, voiceMemoSnapshot, textMessageId, bundleMessageId, summaryToPersist, conversationIdForPersist, sessionForPersist] in
                 guard let innerVM else { return }
                 // Persist the summary (with its `bundledMessageIds`) before
@@ -645,7 +654,8 @@ final class AgentBuilderViewModel: Identifiable {
                     text: summaryToPersist.prompt,
                     voiceMemo: voiceMemoSnapshot,
                     textMessageId: textMessageId,
-                    bundleMessageId: bundleMessageId
+                    bundleMessageId: bundleMessageId,
+                    awaitsAgentJoin: joinAttempted
                 )
             }
         }
@@ -772,11 +782,16 @@ final class AgentBuilderViewModel: Identifiable {
                 }
                 do {
                     _ = try await session.requestAgentJoin(slug: slug, options: .agentBuilder)
-                    return true
                 } catch {
+                    // Still gate the send: a thrown request is ambiguous --
+                    // the server may have received it and provisioned the
+                    // agent (client-side timeout, connection dropped after
+                    // the request went out). Publishing immediately would
+                    // ship the brief into the pre-join epoch; the gate's
+                    // timeout already covers the agent truly never arriving.
                     Log.error("AgentBuilder(existing): requestAgentJoin failed: \(error.localizedDescription)")
-                    return false
                 }
+                return true
             }
             // Persist the summary before the send so the chat the user returns
             // to renders the card immediately (its `summaryPublisher` picks
@@ -791,9 +806,11 @@ final class AgentBuilderViewModel: Identifiable {
             } catch {
                 Log.error("AgentBuilder(existing): pending media upload await failed: \(error.localizedDescription)")
             }
-            // `awaitsAgentJoin: false` when the join was never requested (no
-            // slug) or its request failed -- holding the bundle for an agent
-            // that will never arrive only delays the inevitable publish.
+            // `awaitsAgentJoin: false` only when the join was never requested
+            // at all (no slug) -- an agent that was never asked to come will
+            // never arrive, so holding the bundle just delays the inevitable
+            // publish. A request that was sent but threw still gates (see the
+            // join task above).
             let joinRequested: Bool = await joinTask.value
             await innerVM.sendBuilderBundle(
                 text: summaryToPersist.prompt,

--- a/ConvosCore/Sources/ConvosCore/AgentBuilder/UnsentBuilderBriefReplayer.swift
+++ b/ConvosCore/Sources/ConvosCore/AgentBuilder/UnsentBuilderBriefReplayer.swift
@@ -1,0 +1,116 @@
+import Foundation
+import GRDB
+import os
+
+/// Session-wide recovery for builder briefs the app died holding.
+///
+/// The summary (prompt + `bundledMessageIds`) is persisted before the bundle
+/// send, and the send can hold for up to 150s waiting for the agent to join
+/// (`OutgoingMessageWriter.waitForAgentMember`). If the process dies in that
+/// window, nothing re-sends the brief: the agent joins a conversation whose
+/// instructions never arrived, while the persisted summary renders a card
+/// implying they did.
+///
+/// A summary whose bundled rows are absent from the message table is that
+/// exact signature -- the rows are created at prepare time, after the hold.
+/// On session start this replayer scans for them and re-sends the prompt
+/// text through the normal builder-bundle path (gated on agent membership
+/// like any other builder send). The replay is self-extinguishing: the send
+/// persists a row under the same client id the scan checks. Media staged in
+/// memory at Make is not recoverable after process death and is skipped.
+public final class UnsentBuilderBriefReplayer: Sendable {
+    public struct PendingBrief: Sendable, Equatable {
+        public let conversationId: String
+        public let prompt: String
+        public let textClientMessageId: String
+    }
+
+    /// Summaries older than this are history, not an interrupted send --
+    /// among other things, message expiry can delete a delivered brief's
+    /// rows long after the fact, and that must not resurrect it.
+    static let replayWindow: TimeInterval = 30 * 60
+
+    private let databaseReader: any DatabaseReader
+    private let sendBrief: @Sendable (PendingBrief) async -> Void
+    /// Only summaries persisted before this process started are candidates:
+    /// a summary created in this process has its send in flight right here
+    /// (the hold), and replaying it would double-send.
+    private let processStart: Date
+    private let replayTask: OSAllocatedUnfairLock<Task<Void, Never>?> = .init(initialState: nil)
+
+    public init(
+        databaseReader: any DatabaseReader,
+        processStart: Date = Date(),
+        sendBrief: @escaping @Sendable (PendingBrief) async -> Void
+    ) {
+        self.databaseReader = databaseReader
+        self.processStart = processStart
+        self.sendBrief = sendBrief
+    }
+
+    /// One-shot scan + replay. Safe to call repeatedly -- a running replay
+    /// is cancelled and restarted.
+    public func start() {
+        let new: Task<Void, Never> = Task { [weak self] in
+            await self?.replayPendingBriefs()
+        }
+        replayTask.withLock { existing in
+            existing?.cancel()
+            existing = new
+        }
+    }
+
+    public func stop() {
+        replayTask.withLock { existing in
+            existing?.cancel()
+            existing = nil
+        }
+    }
+
+    private func replayPendingBriefs() async {
+        let reader = databaseReader
+        let start = processStart
+        let briefs: [PendingBrief]
+        do {
+            briefs = try await reader.read { db in
+                try Self.pendingBriefs(db: db, processStart: start, now: Date())
+            }
+        } catch {
+            Log.error("UnsentBuilderBriefReplayer: scan failed: \(error.localizedDescription)")
+            return
+        }
+        for brief in briefs {
+            if Task.isCancelled { return }
+            Log.info("UnsentBuilderBriefReplayer: replaying brief for \(brief.conversationId)")
+            QAEvent.emit(.message, "builder_brief_replayed", ["conversationId": brief.conversationId])
+            await sendBrief(brief)
+        }
+    }
+
+    /// A pending brief is a summary persisted before this process started,
+    /// recent enough to be an interrupted send, with a non-empty prompt and
+    /// none of its bundled client ids present in the message table (by id or
+    /// clientMessageId -- the sender's row keeps the client id in both until
+    /// prepare swaps the id column).
+    static func pendingBriefs(db: Database, processStart: Date, now: Date) throws -> [PendingBrief] {
+        let summaryRows: [DBAgentBuilderSummary] = try DBAgentBuilderSummary.fetchAll(db)
+        var briefs: [PendingBrief] = []
+        for row in summaryRows {
+            guard let summary = try? row.toAgentBuilderSummary() else { continue }
+            guard !summary.prompt.isEmpty, !summary.bundledMessageIds.isEmpty else { continue }
+            guard summary.createdAt < processStart else { continue }
+            guard now.timeIntervalSince(summary.createdAt) < Self.replayWindow else { continue }
+            let ids: [String] = Array(summary.bundledMessageIds)
+            let rowCount: Int = try DBMessage
+                .filter(ids.contains(DBMessage.Columns.id) || ids.contains(DBMessage.Columns.clientMessageId))
+                .fetchCount(db)
+            guard rowCount == 0 else { continue }
+            briefs.append(PendingBrief(
+                conversationId: row.conversationId,
+                prompt: summary.prompt,
+                textClientMessageId: summary.bundledMessageIds.min() ?? UUID().uuidString
+            ))
+        }
+        return briefs
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Messaging/XMTPClientProvider.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/XMTPClientProvider.swift
@@ -12,6 +12,16 @@ public protocol MessageSender {
     func prepare(multiRemoteAttachment: MultiRemoteAttachment) async throws -> String
     func prepare(reply: Reply) async throws -> String
     func prepare(builderBundleManifest: BuilderBundleManifest) async throws -> String
+    /// Variants that stage the message in the local store without queueing a
+    /// libxmtp send intent (`prepareMessage(noSend: true)`). A queued intent
+    /// is flushed by any subsequent publish or group sync on the conversation
+    /// in queue order, which destroys a caller-controlled publish order;
+    /// these leave publication entirely to `publishMessage(messageId:)`. The
+    /// agent-builder bundle uses them so the manifest actually reaches the
+    /// network before the brief messages it hides.
+    func prepareForManualPublish(text: String) async throws -> String
+    func prepareForManualPublish(multiRemoteAttachment: MultiRemoteAttachment) async throws -> String
+    func prepareForManualPublish(builderBundleManifest: BuilderBundleManifest) async throws -> String
     func publish() async throws
     func publishMessage(messageId: String) async throws
     func consentState() throws -> ConsentState
@@ -316,6 +326,26 @@ extension XMTPiOS.Conversation: MessageSender {
         return try await prepareMessage(
             content: builderBundleManifest,
             options: .init(contentType: BuilderBundleManifestCodec().contentType)
+        )
+    }
+
+    public func prepareForManualPublish(text: String) async throws -> String {
+        return try await prepareMessage(content: text, noSend: true)
+    }
+
+    public func prepareForManualPublish(multiRemoteAttachment: MultiRemoteAttachment) async throws -> String {
+        return try await prepareMessage(
+            content: multiRemoteAttachment,
+            options: .init(contentType: ContentTypeMultiRemoteAttachment),
+            noSend: true
+        )
+    }
+
+    public func prepareForManualPublish(builderBundleManifest: BuilderBundleManifest) async throws -> String {
+        return try await prepareMessage(
+            content: builderBundleManifest,
+            options: .init(contentType: BuilderBundleManifestCodec().contentType),
+            noSend: true
         )
     }
 

--- a/ConvosCore/Sources/ConvosCore/Mocks/MockMessageSender.swift
+++ b/ConvosCore/Sources/ConvosCore/Mocks/MockMessageSender.swift
@@ -55,6 +55,24 @@ public final class MockMessageSender: MessageSender, @unchecked Sendable {
         return messageId
     }
 
+    public func prepareForManualPublish(text: String) async throws -> String {
+        let messageId = UUID().uuidString
+        preparedMessages.append(messageId)
+        return messageId
+    }
+
+    public func prepareForManualPublish(multiRemoteAttachment: MultiRemoteAttachment) async throws -> String {
+        let messageId = UUID().uuidString
+        preparedMessages.append(messageId)
+        return messageId
+    }
+
+    public func prepareForManualPublish(builderBundleManifest: BuilderBundleManifest) async throws -> String {
+        let messageId = UUID().uuidString
+        preparedMessages.append(messageId)
+        return messageId
+    }
+
     public func publish() async throws {
         publishedCount += 1
     }

--- a/ConvosCore/Sources/ConvosCore/Sessions/SessionManager+UnsentBriefReplayer.swift
+++ b/ConvosCore/Sources/ConvosCore/Sessions/SessionManager+UnsentBriefReplayer.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+extension SessionManager {
+    /// Returns the session-wide unsent-brief replayer, instantiating and
+    /// starting it on first access. Replays builder briefs whose send the
+    /// app died holding (see `UnsentBuilderBriefReplayer`); the replay goes
+    /// through the normal builder-bundle path, so it is gated on agent
+    /// membership like any other builder send.
+    public func unsentBuilderBriefReplayer() -> UnsentBuilderBriefReplayer {
+        unsentBriefReplayerLock.withLock { replayer in
+            if let replayer { return replayer }
+            let new = UnsentBuilderBriefReplayer(
+                databaseReader: databaseReader
+            ) { [weak self] brief in
+                guard let self else { return }
+                let writer = self.messagingService().messageWriter(
+                    for: brief.conversationId,
+                    backgroundUploadManager: UnavailableBackgroundUploadManager()
+                )
+                do {
+                    try await writer.sendBuilderBundle(
+                        text: brief.prompt,
+                        bundleItems: [],
+                        textClientMessageId: brief.textClientMessageId,
+                        bundleClientMessageId: UUID().uuidString,
+                        awaitsAgentJoin: true
+                    )
+                } catch {
+                    Log.error("UnsentBuilderBriefReplayer: replay send failed for \(brief.conversationId): \(error.localizedDescription)")
+                }
+            }
+            new.start()
+            replayer = new
+            return new
+        }
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
@@ -153,6 +153,11 @@ public final class SessionManager: SessionManagerProtocol, @unchecked Sendable {
             // and enablement stores being ready to query.
             _ = self.agentBuilderConnectionGrantReplayer()
 
+            // Replay any builder brief whose send a previous process died
+            // holding (the agent-join hold can last 150s; see
+            // UnsentBuilderBriefReplayer).
+            _ = self.unsentBuilderBriefReplayer()
+
             self.assetRenewalTask = Task(priority: .utility) { [weak self] in
                 guard let self, !Task.isCancelled else { return }
                 let recoveryHandler = ExpiredAssetRecoveryHandler(databaseWriter: self.databaseWriter)
@@ -846,6 +851,10 @@ public final class SessionManager: SessionManagerProtocol, @unchecked Sendable {
     /// stream over `agentBuilderSummary` + member rows. Constructed by
     /// the accessor in `SessionManager+AgentBuilderGrantReplayer.swift`.
     let agentBuilderGrantReplayerLock: OSAllocatedUnfairLock<AgentBuilderConnectionGrantReplayer?> = .init(initialState: nil)
+
+    /// Session-wide unsent-brief replayer (one-shot scan at session start).
+    /// Constructed by the accessor in `SessionManager+UnsentBriefReplayer.swift`.
+    let unsentBriefReplayerLock: OSAllocatedUnfairLock<UnsentBuilderBriefReplayer?> = .init(initialState: nil)
 
     public func capabilityProviderRegistry() -> any CapabilityProviderRegistry {
         capabilityRegistryLock.withLock { registry in

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/OutgoingMessageWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/OutgoingMessageWriter.swift
@@ -321,6 +321,15 @@ actor OutgoingMessageWriter: OutgoingMessageWriterProtocol {
         )
     }
 
+    private func restartSendClock(clientMessageId: String) {
+        guard let data = sendMetricData[clientMessageId] else { return }
+        sendMetricData[clientMessageId] = SendMetricData(
+            startTime: CFAbsoluteTimeGetCurrent(),
+            attachmentMimeTypes: data.attachmentMimeTypes,
+            hasText: data.hasText
+        )
+    }
+
     private func emitSentMessage(clientMessageId: String, isSuccess: Bool) async {
         guard let data = sendMetricData.removeValue(forKey: clientMessageId) else { return }
         // Skip the member-count + agent-presence DB read on the hot send path
@@ -915,18 +924,32 @@ actor OutgoingMessageWriter: OutgoingMessageWriterProtocol {
             bundleClientMessageId: bundleClientMessageId
         )
 
-        // The gate must run BEFORE any prepare call: preparing queues libxmtp
-        // send intents, and any concurrent publish or group sync flushes every
-        // pending intent to the network (a read receipt fires the moment the
-        // user lands in the chat after Make, and the agent-join polling itself
-        // syncs the group every few seconds). Held here, no part of the brief
-        // exists in the XMTP store until the agent can read it.
+        // The gate must run BEFORE any prepare call so no part of the brief
+        // exists in the XMTP store until the agent can read it. The builder
+        // prepares use `prepareForManualPublish` (no queued send intent), but
+        // rows prepared pre-join would still publish into the pre-join epoch
+        // when the explicit publishes below run -- the hold has to come first
+        // either way.
         if awaitsAgentJoin {
-            await Self.waitForAgentMember(
+            let joined: Bool = await Self.waitForAgentMember(
                 in: databaseWriter,
                 conversationId: conversationId,
                 timeout: Self.agentMemberWaitTimeout
             )
+            // A cancelled hold must abort, not publish: cancellation resolves
+            // the gate's race immediately and is otherwise indistinguishable
+            // from a timeout, and publishing now would ship the brief into a
+            // pre-join epoch -- the bug this gate exists to prevent.
+            try Task.checkCancellation()
+            if !joined {
+                QAEvent.emit(.message, "builder_bundle_gate_timeout", [
+                    "conversationId": conversationId,
+                    "timeoutSecs": String(Int(Self.agentMemberWaitTimeout)),
+                ])
+            }
+            // Restart the send clock so the metric measures the send itself,
+            // not however long the agent took to join.
+            restartSendClock(clientMessageId: text.isEmpty ? bundleClientMessageId : textClientMessageId)
         }
 
         // Prepare (but don't publish) the bundle messages so the manifest can
@@ -961,10 +984,13 @@ actor OutgoingMessageWriter: OutgoingMessageWriterProtocol {
     }
 
     /// How long the builder-bundle send waits for the joining agent to become
-    /// a member before proceeding anyway. Matches the agent-join polling
-    /// window in `SessionStateManager`; on expiry the bundle sends regardless
-    /// so a failed or slow join doesn't strand the user's brief (the pre-fix
-    /// behavior, just delayed).
+    /// a member before proceeding anyway. Matches
+    /// `SyncingManager.Constant.agentJoinPollWindow` (and the agent backend's
+    /// own give-up window); `MessagesListProcessor.pendingCardDisplayWindow`
+    /// (180) must stay larger than this hold. On expiry the bundle sends
+    /// regardless so a failed or slow join doesn't strand the user's brief,
+    /// a `builder_bundle_gate_timeout` event is emitted, and the
+    /// `UnsentBuilderBriefReplayer` covers the process dying mid-hold.
     private static let agentMemberWaitTimeout: TimeInterval = 150
 
     /// Waits until the conversation has a current agent member, or the
@@ -1020,7 +1046,11 @@ actor OutgoingMessageWriter: OutgoingMessageWriterProtocol {
             return first
         }
         if !joined {
-            Log.warning("Builder bundle: no agent member in \(conversationId) after waiting; publishing anyway")
+            if Task.isCancelled {
+                Log.warning("Builder bundle: agent wait cancelled for \(conversationId)")
+            } else {
+                Log.warning("Builder bundle: no agent member in \(conversationId) after waiting; publishing anyway")
+            }
         }
         return joined
     }
@@ -1087,7 +1117,7 @@ actor OutgoingMessageWriter: OutgoingMessageWriterProtocol {
         }
         let messageId: String
         do {
-            messageId = try await sender.prepare(multiRemoteAttachment: staged.multi)
+            messageId = try await sender.prepareForManualPublish(multiRemoteAttachment: staged.multi)
             try await rewriteBundleMessageRow(clientMessageId: clientMessageId, messageId: messageId, jsonList: staged.jsonList)
         } catch {
             try? await markMessageFailed(clientMessageId: clientMessageId)
@@ -1112,7 +1142,7 @@ actor OutgoingMessageWriter: OutgoingMessageWriterProtocol {
         }
         let xmtpMessageId: String
         do {
-            xmtpMessageId = try await sender.prepare(text: text)
+            xmtpMessageId = try await sender.prepareForManualPublish(text: text)
         } catch {
             try? await markMessageFailed(clientMessageId: clientMessageId)
             throw error
@@ -1137,15 +1167,17 @@ actor OutgoingMessageWriter: OutgoingMessageWriterProtocol {
         return xmtpMessageId
     }
 
-    /// Publish the manifest first, then the bundle, then the text. Publishing
-    /// the manifest commit first means it is the first to reach the network, so
-    /// recipients usually process it before the messages it hides. This is
-    /// best-effort ordering, not a guarantee -- delivery/sort order on
-    /// recipients can differ. Final correctness does not depend on it: the
-    /// reactive `builder_bundle_hidden_message` filter re-runs when the manifest
-    /// lands, so a late manifest only means a brief flash, never a permanently
-    /// visible brief. All three were prepared into the group's shared local
-    /// store, so a freshly-resolved sender publishes them by id.
+    /// Publish the manifest first, then the bundle, then the text. The call
+    /// order here IS the wire order only because all three were prepared via
+    /// `prepareForManualPublish` (no queued send intents): an intent-queueing
+    /// prepare would let any concurrent publish or group sync flush the
+    /// bundle and text ahead of the manifest in queue order. Delivery/sort
+    /// order on recipients can still differ, so final correctness does not
+    /// depend on it: the reactive `builder_bundle_hidden_message` filter
+    /// re-runs when the manifest lands, so a late manifest only means a
+    /// brief flash, never a permanently visible brief. All three were
+    /// prepared into the group's shared local store, so a freshly-resolved
+    /// sender publishes them by id.
     private func publishPreparedBuilderBundle(
         manifestIds: [String],
         prepared: PreparedAttachmentBundle?,
@@ -1161,7 +1193,7 @@ actor OutgoingMessageWriter: OutgoingMessageWriterProtocol {
                 throw OutgoingMessageWriterError.conversationNotFound(conversationId: conversationIdLocal)
             }
             sender = resolvedSender
-            manifestMessageId = try await resolvedSender.prepare(builderBundleManifest: BuilderBundleManifest(messageIds: manifestIds))
+            manifestMessageId = try await resolvedSender.prepareForManualPublish(builderBundleManifest: BuilderBundleManifest(messageIds: manifestIds))
         } catch {
             // Sender resolution and the manifest prepare run before anything
             // publishes, but the bundle and text are already persisted

--- a/ConvosCore/Tests/ConvosCoreTests/SyncingManagerTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/SyncingManagerTests.swift
@@ -340,6 +340,18 @@ class TestableMockMessageSender: MessageSender {
         ""
     }
 
+    func prepareForManualPublish(text: String) async throws -> String {
+        ""
+    }
+
+    func prepareForManualPublish(multiRemoteAttachment: MultiRemoteAttachment) async throws -> String {
+        ""
+    }
+
+    func prepareForManualPublish(builderBundleManifest: BuilderBundleManifest) async throws -> String {
+        ""
+    }
+
     func publish() async throws {
     }
 

--- a/ConvosCore/Tests/ConvosCoreTests/UnsentBuilderBriefReplayerTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/UnsentBuilderBriefReplayerTests.swift
@@ -1,0 +1,191 @@
+@testable import ConvosCore
+import Foundation
+import GRDB
+import Testing
+
+/// Coverage for the unsent-brief scan: a summary persisted before this
+/// process started, recent, with a prompt and none of its bundled rows in
+/// the message table, identifies a builder brief the previous process died
+/// holding (the agent-join hold lasts up to 150s). The scan must not match
+/// briefs whose rows landed, briefs created in this process (their send is
+/// in flight here), or old summaries whose rows expired.
+@Suite("Unsent builder brief replayer Tests", .serialized)
+struct UnsentBuilderBriefReplayerTests {
+    private static let conversationId: String = "convo-brief"
+
+    private static func seedConversation(db: Database) throws {
+        try DBMember(inboxId: "inbox-current").save(db, onConflict: .ignore)
+        try DBInbox(
+            inboxId: "inbox-current",
+            clientId: "client-current",
+            createdAt: Date()
+        ).save(db, onConflict: .ignore)
+        try DBConversation(
+            id: conversationId,
+            clientConversationId: "client-\(conversationId)",
+            inviteTag: "tag-\(conversationId)",
+            creatorId: "inbox-current",
+            kind: .group,
+            consent: .allowed,
+            createdAt: Date(),
+            name: nil,
+            description: nil,
+            imageURLString: nil,
+            publicImageURLString: nil,
+            includeInfoInPublicPreview: false,
+            expiresAt: nil,
+            debugInfo: .empty,
+            isLocked: false,
+            imageSalt: nil,
+            imageNonce: nil,
+            imageEncryptionKey: nil,
+            conversationEmoji: nil,
+            imageLastRenewed: nil,
+            isUnused: false,
+            hasHadVerifiedAgent: false
+        ).insert(db)
+    }
+
+    private static func seedSummary(
+        db: Database,
+        createdAt: Date,
+        prompt: String = "Be my assistant",
+        bundledMessageIds: [String] = ["b-text"]
+    ) throws {
+        let idsJSON = String(data: try JSONEncoder().encode(bundledMessageIds), encoding: .utf8) ?? "[]"
+        try DBAgentBuilderSummary(
+            conversationId: conversationId,
+            summaryId: UUID().uuidString,
+            prompt: prompt,
+            attachmentsJSON: "[]",
+            createdAt: createdAt,
+            cutoffDate: createdAt,
+            bundledMessageIdsJSON: idsJSON,
+            cloudConnectionIdsJSON: "{}"
+        ).insert(db)
+    }
+
+    private static func seedBundledRow(db: Database, clientMessageId: String) throws {
+        try DBMember(inboxId: "inbox-current").save(db, onConflict: .ignore)
+        try DBMessage(
+            id: clientMessageId,
+            clientMessageId: clientMessageId,
+            conversationId: conversationId,
+            senderId: "inbox-current",
+            dateNs: 1,
+            date: Date(),
+            sortId: nil,
+            status: .published,
+            messageType: .original,
+            contentType: .text,
+            text: "Be my assistant",
+            emoji: nil,
+            invite: nil,
+            linkPreview: nil,
+            sourceMessageId: nil,
+            attachmentUrls: [],
+            update: nil
+        ).insert(db)
+    }
+
+    @Test("Pre-process summary with no landed rows is pending")
+    func interruptedBriefIsPending() throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        let processStart = Date()
+        try dbManager.dbWriter.write { db in
+            try Self.seedConversation(db: db)
+            try Self.seedSummary(db: db, createdAt: processStart.addingTimeInterval(-120))
+        }
+        let briefs = try dbManager.dbReader.read { db in
+            try UnsentBuilderBriefReplayer.pendingBriefs(db: db, processStart: processStart, now: Date())
+        }
+        #expect(briefs.count == 1)
+        #expect(briefs.first?.conversationId == Self.conversationId)
+        #expect(briefs.first?.prompt == "Be my assistant")
+        #expect(briefs.first?.textClientMessageId == "b-text")
+    }
+
+    @Test("Landed rows extinguish the pending brief")
+    func landedRowsExtinguish() throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        let processStart = Date()
+        try dbManager.dbWriter.write { db in
+            try Self.seedConversation(db: db)
+            try Self.seedSummary(db: db, createdAt: processStart.addingTimeInterval(-120))
+            try Self.seedBundledRow(db: db, clientMessageId: "b-text")
+        }
+        let briefs = try dbManager.dbReader.read { db in
+            try UnsentBuilderBriefReplayer.pendingBriefs(db: db, processStart: processStart, now: Date())
+        }
+        #expect(briefs.isEmpty)
+    }
+
+    @Test("Summary created in this process is not replayed (send in flight)")
+    func inFlightSummaryNotReplayed() throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        let processStart = Date().addingTimeInterval(-300)
+        try dbManager.dbWriter.write { db in
+            try Self.seedConversation(db: db)
+            try Self.seedSummary(db: db, createdAt: processStart.addingTimeInterval(60))
+        }
+        let briefs = try dbManager.dbReader.read { db in
+            try UnsentBuilderBriefReplayer.pendingBriefs(db: db, processStart: processStart, now: Date())
+        }
+        #expect(briefs.isEmpty)
+    }
+
+    @Test("Summaries older than the replay window are history, not pending")
+    func oldSummaryNotReplayed() throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        let processStart = Date()
+        try dbManager.dbWriter.write { db in
+            try Self.seedConversation(db: db)
+            try Self.seedSummary(
+                db: db,
+                createdAt: processStart.addingTimeInterval(-(UnsentBuilderBriefReplayer.replayWindow + 60))
+            )
+        }
+        let briefs = try dbManager.dbReader.read { db in
+            try UnsentBuilderBriefReplayer.pendingBriefs(db: db, processStart: processStart, now: Date())
+        }
+        #expect(briefs.isEmpty)
+    }
+
+    @Test("Replayer start() sends pending briefs through the injected closure")
+    func startSendsPendingBriefs() async throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        let processStart = Date()
+        try await dbManager.dbWriter.write { db in
+            try Self.seedConversation(db: db)
+            try Self.seedSummary(db: db, createdAt: processStart.addingTimeInterval(-120))
+        }
+        let sent: OSAllocatedUnfairLockBox<[UnsentBuilderBriefReplayer.PendingBrief]> = .init([])
+        let replayer = UnsentBuilderBriefReplayer(
+            databaseReader: dbManager.dbReader,
+            processStart: processStart
+        ) { brief in
+            sent.withLock { $0.append(brief) }
+        }
+        replayer.start()
+        for _ in 0..<50 {
+            if !sent.withLock({ $0 }).isEmpty { break }
+            try await Task.sleep(nanoseconds: 100_000_000)
+        }
+        replayer.stop()
+        let briefs = sent.withLock { $0 }
+        #expect(briefs.count == 1)
+        #expect(briefs.first?.prompt == "Be my assistant")
+    }
+}
+
+/// Tiny lock box for collecting values from a Sendable closure in tests.
+private final class OSAllocatedUnfairLockBox<Value>: @unchecked Sendable {
+    private var value: Value
+    private let lock = NSLock()
+    init(_ value: Value) { self.value = value }
+    func withLock<R>(_ body: (inout Value) -> R) -> R {
+        lock.lock()
+        defer { lock.unlock() }
+        return body(&value)
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the confirmed findings from a two-agent adversarial review of the agent-join gate (#1041) as merged. The reviewers verified the gate's core ordering holds (intent-flush protection, MLS readability, predicate soundness) and converged on the failure modes around it:

1. **Manifest-first was a fiction** (proven from libxmtp source): intent-queueing prepares meant the wire order was bundle → text → manifest on *every* send, with the downstream per-message error handling dead. Builder prepares now use `prepareForManualPublish` (`prepareMessage(noSend: true)`) so `publishMessage` call order is the wire order — the manifest genuinely lands first.
2. **Cancellation aborted into the bug**: a cancelled hold looked like a timeout and published the brief pre-join. It now throws `CancellationError`. Genuine timeouts emit a `builder_bundle_gate_timeout` QA event, and the send-metric clock restarts post-hold so `sendingTime` stops absorbing the join wait.
3. **Ambiguous join failures published immediately**: a thrown `requestAgentJoin` may still have provisioned the agent server-side. `awaitsAgentJoin` now means "a join was attempted" — only a never-requested join (no slug) skips the gate. The home flow re-fires its one-shot join at Make if the `.ready`-time attempt never ran, and passes its real join state instead of an unconditional `true`.
4. **Force-kill/backgrounding during the 150s hold permanently lost the brief** — no recovery, no trace (the optimistic card even self-erases at 180s). New `UnsentBuilderBriefReplayer` (one-shot scan at session start, modeled on `AgentBuilderConnectionGrantReplayer`) detects summaries whose bundled rows never landed and replays the prompt text through the normal gated path. Self-extinguishing; in-process sends excluded via a process-start cutoff; 30-minute window so expired-message history can't resurrect.
5. **Comment/constant hygiene**: timeout constant attribution corrected, the 150/150/180 coupling documented at each site.

**Known remaining limit (needs backend)**: `AgentJoinResponse` carries no agent identity, so a brief for a *second* agent in a conversation that already has one can still publish before that agent joins.

## Test plan

- [x] 5 new `UnsentBuilderBriefReplayerTests` (pending detection, row extinguishing, in-process exclusion, window expiry, end-to-end replay closure)
- [x] Full ConvosCore suite: 1175 tests in 169 suites, green
- [x] Full app build (Convos (Local)); strict SwiftLint clean on the diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1056"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783842463&installation_id=128169237&pr_number=1056&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1056&signature=262fefa1a69d7f747623869c1dff7961a30faef2abd62b5eb866c23f11e0f1f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Harden builder-bundle delivery with `noSend` prepares, agent-join gating, and brief replay
> - All builder-bundle message parts (attachments, prompt text, manifest) are now staged with `prepareForManualPublish` variants that skip libxmtp send intents, ensuring explicit publish order is enforced in [`OutgoingMessageWriter`](https://github.com/xmtplabs/convos-ios/pull/1056/files#diff-2ba8cf409a96f2eb22ac537fb59817aae89c4fdf4a953c1683a27be30a6107b6).
> - Agent membership gating now runs before any publish, with cancellation handling and a QA timeout event emitted if the agent never joins; the send clock resets after the gate so metrics exclude wait time.
> - A new [`UnsentBuilderBriefReplayer`](https://github.com/xmtplabs/convos-ios/pull/1056/files#diff-7c3adfcc7e615cd09925a7f063f730714e8f20b494cccf0e333473e784a57934) scans the database at session startup for builder briefs whose send was interrupted by process death and re-sends them via the normal bundle path.
> - `AgentBuilderViewModel.commit` now re-issues the agent-join request before sending and gates the send only when a join was actually attempted; a thrown join error still triggers gating instead of bypassing it.
> - Risk: builder-bundle sends that previously queued intents implicitly now rely entirely on the explicit publish step — any failure before publish leaves messages staged but unsent.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 67ffad6.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->