### PR TITLE
Keep one Sent row when the builder bundle splits a same-sender group

### DIFF
--- a/ConvosCore/Sources/ConvosCore/Storage/Models/MessagesListProcessor.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/MessagesListProcessor.swift
@@ -197,30 +197,30 @@ public final class MessagesListProcessor: Sendable {
                 result.append(item)
                 continue
             }
-            // Walk the group, splitting it into build vs non-build segments.
-            // Build segments collapse into their run's card (emitted once);
-            // non-build segments stay as their own group with a stable id.
+            // Walk the group, collapsing build rows into their run's card
+            // (emitted once, where the run's first row sat); non-build
+            // messages stay as their own group with a stable id. A swallowed
+            // run (the creator's own latest build, which renders via the
+            // Make-anchored summary card instead) leaves nothing behind, so
+            // it must not split the surrounding same-sender messages into
+            // two groups -- that would render two "Sent" rows.
             var segment: [AnyMessage] = []
-            var segmentIsBuild: Bool = false
             func flushSegment() {
                 guard let first = segment.first else { return }
-                if segmentIsBuild {
-                    if let anchor = anchorByMessageId[first.messageId],
-                       !emittedAnchors.contains(anchor),
-                       let card = cardByAnchor[anchor] {
-                        emittedAnchors.insert(anchor)
-                        result.append(.agentBuilderSummary(card))
-                    }
-                } else {
-                    result.append(.messages(rebuiltGroup(group, id: "group-" + first.messageId, messages: segment)))
-                }
+                result.append(.messages(rebuiltGroup(group, id: "group-" + first.messageId, messages: segment)))
                 segment = []
             }
             for message in group.messages {
-                let isBuild: Bool = buildMessageIds.contains(message.messageId)
-                if !segment.isEmpty, isBuild != segmentIsBuild { flushSegment() }
-                segmentIsBuild = isBuild
-                segment.append(message)
+                guard buildMessageIds.contains(message.messageId) else {
+                    segment.append(message)
+                    continue
+                }
+                guard let anchor = anchorByMessageId[message.messageId],
+                      !emittedAnchors.contains(anchor),
+                      let card = cardByAnchor[anchor] else { continue }
+                emittedAnchors.insert(anchor)
+                flushSegment()
+                result.append(.agentBuilderSummary(card))
             }
             flushSegment()
         }
@@ -302,7 +302,7 @@ public final class MessagesListProcessor: Sendable {
             items = insertingContactCard(in: items, agent: agent)
         }
 
-        return items
+        return clearingDuplicatedLastGroupFlags(in: items)
     }
 
     /// Strip date separators that no longer precede a message group. A
@@ -730,6 +730,41 @@ public final class MessagesListProcessor: Sendable {
 }
 
 private extension MessagesListProcessor {
+    /// Splitting a message group (run-card splice, Make-boundary insert)
+    /// copies the group's presentation flags into every half, but the
+    /// "last group" flags are positional -- if more than one group carries
+    /// one, each renders its own "Sent" status row. Keep each flag only on
+    /// its bottom-most carrier.
+    static func clearingDuplicatedLastGroupFlags(
+        in baseItems: [MessagesListItemType]
+    ) -> [MessagesListItemType] {
+        var items: [MessagesListItemType] = baseItems
+        var seenLastSentByCurrentUser: Bool = false
+        var seenLastBeforeOtherMembers: Bool = false
+        for index in items.indices.reversed() {
+            guard case .messages(var group) = items[index] else { continue }
+            var changed: Bool = false
+            if group.isLastGroupSentByCurrentUser {
+                if seenLastSentByCurrentUser {
+                    group.isLastGroupSentByCurrentUser = false
+                    changed = true
+                } else {
+                    seenLastSentByCurrentUser = true
+                }
+            }
+            if group.isLastGroupBeforeOtherMembers {
+                if seenLastBeforeOtherMembers {
+                    group.isLastGroupBeforeOtherMembers = false
+                    changed = true
+                } else {
+                    seenLastBeforeOtherMembers = true
+                }
+            }
+            if changed { items[index] = .messages(group) }
+        }
+        return items
+    }
+
     /// Insert the agent contact card as its own standalone row. The card has
     /// a single placement rule, so it never relocates as the agent's
     /// messages, connection events, or user replies stream in around it.

--- a/ConvosCore/Tests/ConvosCoreTests/MessagesListProcessorTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/MessagesListProcessorTests.swift
@@ -1926,4 +1926,93 @@ extension MessagesListProcessorPendingBuilderCardTests {
         // No message is lost in the split.
         #expect(Set(messageIds(from: result)) == ["pre-1", "pre-2", "post-1", "post-2"])
     }
+
+    @Test("Make-boundary split keeps the Sent row only on the newer half")
+    func makeBoundarySplitKeepsSingleSentRow() {
+        let make = Date()
+        let messages = [
+            makeMessage(id: "pre", sender: currentUser, text: "Before Make", date: make.addingTimeInterval(-60)),
+            makeMessage(id: "post", sender: currentUser, text: "After Make", date: make.addingTimeInterval(20)),
+        ]
+        let summary = AgentBuilderSummary(
+            prompt: "Be my assistant",
+            attachments: [],
+            cutoffDate: make,
+            bundledMessageIds: ["b-text"]
+        )
+        let result = MessagesListProcessor.process(
+            messages,
+            agentBuilderSummary: summary,
+            hiddenBundleMessageIds: []
+        )
+        let flagged = groups(from: result).filter(\.isLastGroupSentByCurrentUser)
+        #expect(flagged.count == 1)
+        #expect(flagged.first?.messages.map(\.messageId) == ["post"])
+    }
+}
+
+extension MessagesListProcessorPendingBuilderCardTests {
+    @Test("Messages straddling the swallowed build bundle stay one group with one Sent row")
+    func messagesAroundSwallowedBundleStayGrouped() {
+        let make = Date()
+        // The user sends one message right after Make, the agent joins and the
+        // held bundle publishes (its row dated between the sends), then the
+        // user sends again. All rows share a sender, so the processor merges
+        // them into one group; swallowing the bundle row must not split it.
+        let messages = [
+            makeMessage(id: "please", sender: currentUser, text: "Please", date: make.addingTimeInterval(5)),
+            makeMessage(id: "b-text", sender: currentUser, text: "Help me get healthier", date: make.addingTimeInterval(12)),
+            makeMessage(id: "ugh", sender: currentUser, text: "Ugh", date: make.addingTimeInterval(20)),
+        ]
+        let summary = AgentBuilderSummary(
+            prompt: "Help me get healthier",
+            attachments: [],
+            cutoffDate: make,
+            bundledMessageIds: ["b-text"]
+        )
+        let result = MessagesListProcessor.process(
+            messages,
+            agentBuilderSummary: summary,
+            hiddenBundleMessageIds: ["b-text"]
+        )
+        #expect(builderCards(from: result).count == 1)
+        let g = groups(from: result)
+        #expect(g.count == 1)
+        #expect(g.first?.messages.map(\.messageId) == ["please", "ugh"])
+        #expect(g.filter(\.isLastGroupSentByCurrentUser).count == 1)
+
+        // The card renders at the Make slot, above both sends.
+        let cardIndex = result.firstIndex { if case .agentBuilderSummary = $0 { return true } else { return false } }
+        let groupIndex = result.firstIndex { item in
+            guard case .messages(let group) = item else { return false }
+            return group.messages.contains { $0.messageId == "please" }
+        }
+        #expect(cardIndex != nil && groupIndex != nil)
+        if let cardIndex, let groupIndex {
+            #expect(cardIndex < groupIndex)
+        }
+    }
+
+    @Test("Recipient run card between same-sender messages splits the group with one Sent row")
+    func runCardBetweenSameSenderMessagesKeepsSingleSentRow() {
+        let now = Date()
+        // No summary: the run keeps its run-anchored card (recipient view),
+        // which genuinely separates the two sends -- but only the bottom
+        // group may carry the Sent row.
+        let messages = [
+            makeMessage(id: "first", sender: currentUser, text: "First", date: now),
+            makeMessage(id: "b-text", sender: currentUser, text: "Be my assistant", date: now.addingTimeInterval(10)),
+            makeMessage(id: "second", sender: currentUser, text: "Second", date: now.addingTimeInterval(20)),
+        ]
+        let result = MessagesListProcessor.process(
+            messages,
+            hiddenBundleMessageIds: ["b-text"]
+        )
+        #expect(builderCards(from: result).count == 1)
+        let g = groups(from: result)
+        #expect(g.count == 2)
+        let flagged = g.filter(\.isLastGroupSentByCurrentUser)
+        #expect(flagged.count == 1)
+        #expect(flagged.first?.messages.map(\.messageId) == ["second"])
+    }
 }


### PR DESCRIPTION
## Problem

Two consecutive messages from the same sender each rendered their own "Sent" status row after triggering Make in the agent builder (TestFlight screenshot: "Please" / "Ugh" both labeled Sent, ungrouped).

Sequence on device: Make tapped → user sends a message → agent joins, the held build bundle publishes (its rows are the creator's own, dated between the sends) → user sends again. The grouping pass correctly merges all of it into one same-sender group, but since #1054 `reconstructBuilderCards` swallows the creator's own build rows without emitting a run card in their place — and the walk still split the group at the build boundary. Both halves inherit `isLastGroupSentByCurrentUser` from `rebuiltGroup`'s flag copy, so each shows "Sent".

## Fix

- `reconstructBuilderCards` only breaks the group where a run actually emits a card. Swallowed runs (the creator's latest build, rendered by the Make-anchored summary card instead) drop their rows without splitting, so messages around the held bundle stay one group with one Sent row.
- New `clearingDuplicatedLastGroupFlags` sweep after all card splicing keeps `isLastGroupSentByCurrentUser` / `isLastGroupBeforeOtherMembers` only on the bottom-most carrier. This also fixes the latent flag duplication on legitimate splits (recipient run cards between same-sender messages, the Make-boundary split), which predates #1054.

The merged group reuses the natural `"group-" + firstMessageId` id, so cell identity is stable when the bundle rows land.

## Tests

Three regression tests in `MessagesListProcessorTests`: the swallowed-bundle merge (screenshot scenario), the Make-boundary split, and the recipient run-card split. All three fail against the unfixed processor (verified by stashing the source change). Full ConvosCore suite passes: 1173 tests in 168 suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1057"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783842886&installation_id=128169237&pr_number=1057&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1057&signature=156515cc009243cd5be0abd4a3f8d9f2b96101924d3d2385c985247e48439b47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Keep a single 'Sent' row when a builder bundle splits a same-sender message group
> - In [`MessagesListProcessor`](https://github.com/xmtplabs/convos-ios/pull/1057/files#diff-c32ba383ca53d832eed02dc83f3d0a9546aad74da5c5919555079a4fc07383d7), build messages now only split a same-sender group when a new run card is actually emitted; swallowed or already-emitted build anchors leave the surrounding messages merged.
> - Adds a `clearingDuplicatedLastGroupFlags` pass at the end of the pipeline that walks items bottom-up and clears duplicate `isLastGroupSentByCurrentUser` and `isLastGroupBeforeOtherMembers` flags, so only the bottom-most qualifying group retains each flag.
> - Three new tests in [`MessagesListProcessorTests`](https://github.com/xmtplabs/convos-ios/pull/1057/files#diff-02e4f56ebdce0ca714f81c9e2a1d074ff74e2ae60e2747c9d74bf3bbf942a213) cover the boundary-split case, the swallowed-bundle case, and the recipient-view run-card case.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1734df1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->