### PR TITLE
fix: preserve agent verification on read receipts resolved from the member profile cache

### DIFF
--- a/ConvosCore/Sources/ConvosCore/Storage/Models/MessagesListProcessor.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/MessagesListProcessor.swift
@@ -619,7 +619,9 @@ public final class MessagesListProcessor: Sendable {
                         return ConversationMember(
                             profile: profile,
                             role: .member,
-                            isCurrentUser: false
+                            isCurrentUser: false,
+                            isAgent: info.isAgent,
+                            agentVerification: info.agentVerification
                         )
                     }
                     return nil

--- a/ConvosCore/Sources/ConvosCore/Storage/Repositories/MessagesRepository.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Repositories/MessagesRepository.swift
@@ -15,20 +15,27 @@ public struct MemberProfileInfo: Sendable {
     public let conversationId: String
     public let name: String?
     public let avatar: String?
-    public let isVerifiedConvosAgent: Bool
+    public let isAgent: Bool
+    public let agentVerification: AgentVerification
+
+    public var isVerifiedConvosAgent: Bool {
+        agentVerification.isConvosAgent
+    }
 
     public init(
         inboxId: String,
         conversationId: String,
         name: String?,
         avatar: String?,
-        isVerifiedConvosAgent: Bool = false
+        isAgent: Bool = false,
+        agentVerification: AgentVerification = .unverified
     ) {
         self.inboxId = inboxId
         self.conversationId = conversationId
         self.name = name
         self.avatar = avatar
-        self.isVerifiedConvosAgent = isVerifiedConvosAgent
+        self.isAgent = isAgent
+        self.agentVerification = agentVerification
     }
 }
 
@@ -411,7 +418,8 @@ class MessagesRepository: MessagesRepositoryProtocol {
                 conversationId: conversationId,
                 name: row.name,
                 avatar: row.avatar,
-                isVerifiedConvosAgent: row.agentVerification.isConvosAgent
+                isAgent: row.isAgent,
+                agentVerification: row.agentVerification
             )
         }
         return result

--- a/ConvosCore/Tests/ConvosCoreTests/MessagesListProcessorTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/MessagesListProcessorTests.swift
@@ -1134,6 +1134,54 @@ struct MessagesListProcessorReadReceiptTests {
         #expect(readers.first?.profile.inboxId == absentInboxId)
         #expect(readers.first?.agentVerification == .unverified)
     }
+
+    @Test("Read-by members resolved from the memberProfiles cache keep their agent verification")
+    func readByMembersFallbackPreservesAgentVerification() {
+        let now = Date()
+        let conversationId = "conv-1"
+        let convosAgentInboxId = "quiet-convos-agent"
+        let oauthAgentInboxId = "quiet-oauth-agent"
+        let messages = [
+            makeMessage(id: "me-1", sender: currentUser, text: "Hello", date: now),
+        ]
+        let readAtNs = Int64(now.addingTimeInterval(5).timeIntervalSince1970 * 1_000_000_000)
+        let receipts = [
+            ReadReceiptEntry(inboxId: convosAgentInboxId, readAtNs: readAtNs),
+            ReadReceiptEntry(inboxId: oauthAgentInboxId, readAtNs: readAtNs + 1),
+        ]
+        let memberProfiles: [String: MemberProfileInfo] = [
+            convosAgentInboxId: MemberProfileInfo(
+                inboxId: convosAgentInboxId,
+                conversationId: conversationId,
+                name: "Quiet Convos Agent",
+                avatar: nil,
+                isAgent: true,
+                agentVerification: .verified(.convos)
+            ),
+            oauthAgentInboxId: MemberProfileInfo(
+                inboxId: oauthAgentInboxId,
+                conversationId: conversationId,
+                name: "Quiet OAuth Agent",
+                avatar: nil,
+                isAgent: true,
+                agentVerification: .verified(.userOAuth)
+            ),
+        ]
+        let result = MessagesListProcessor.process(
+            messages,
+            readReceipts: receipts,
+            memberProfiles: memberProfiles,
+            currentOtherMemberCount: 2
+        )
+        let g = groups(from: result)
+        let readers = g.last { $0.isLastGroupSentByCurrentUser }?.readByMembers ?? []
+        #expect(readers.count == 2)
+        let byInbox = Dictionary(uniqueKeysWithValues: readers.map { ($0.profile.inboxId, $0) })
+        #expect(byInbox[convosAgentInboxId]?.isAgent == true)
+        #expect(byInbox[convosAgentInboxId]?.agentVerification == .verified(.convos))
+        #expect(byInbox[oauthAgentInboxId]?.isAgent == true)
+        #expect(byInbox[oauthAgentInboxId]?.agentVerification == .verified(.userOAuth))
+    }
 }
 
 // MARK: - Agent Builder Card Reconstruction Tests


### PR DESCRIPTION
## Problem

Read receipts for verified agents didn't always show their agent verification badge.

The read-receipt avatar row resolves each reader in two steps: it first reuses the sender snapshot from a message in the loaded window (which carries full verification), and otherwise falls back to the `memberProfiles` cache. That fallback constructed the `ConversationMember` without passing `isAgent` or `agentVerification`, so both silently defaulted to `false` / `.unverified` and the badge disappeared. This is why it was intermittent: a verified agent that had spoken recently showed its badge; one that had only read (or whose messages were paged out of the loaded window) didn't.

`MemberProfileInfo` also only carried `isVerifiedConvosAgent: Bool`, which couldn't represent OAuth-verified agents at all.

## Fix

- `MemberProfileInfo` now carries `isAgent` and the full `AgentVerification` enum, populated from the database row in `fetchMemberProfiles`. `isVerifiedConvosAgent` is kept as a computed property so existing call sites are unaffected.
- The read-receipt fallback in `MessagesListProcessor` passes `isAgent` and `agentVerification` through to the resolved `ConversationMember`.

## Testing

- New test `readByMembersFallbackPreservesAgentVerification` covers Convos-verified and OAuth-verified agents resolved via the cache path; the existing test still verifies plain members stay unverified.
- Full ConvosCore suite: 1174 tests in 168 suites, all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1058"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783843695&installation_id=128169237&pr_number=1058&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1058&signature=9f7ecc5be01655017cfa78225d398e2d6464f07c817e83169ba6b52493624677"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve `isAgent` and `agentVerification` on read receipt members resolved from the member profile cache
> - Expands `MemberProfileInfo` in [`MessagesRepository.swift`](https://github.com/xmtplabs/convos-ios/pull/1058/files#diff-e28ef7ea258a8f4aa4b0f172d269bea58cfb2d103c92ec33a4eb24e1f49beb86) to store `isAgent` and `agentVerification` instead of a single `isVerifiedConvosAgent` boolean; the old boolean remains available as a computed property.
> - Updates [`MessagesListProcessor.process`](https://github.com/xmtplabs/convos-ios/pull/1058/files#diff-c32ba383ca53d832eed02dc83f3d0a9546aad74da5c5919555079a4fc07383d7) to copy `isAgent` and `agentVerification` from the cache into `ConversationMember` instances built for read receipts, so agent state is no longer lost when the member is resolved from the profile cache rather than a live member list.
> - Adds a regression test in [`MessagesListProcessorTests.swift`](https://github.com/xmtplabs/convos-ios/pull/1058/files#diff-02e4f56ebdce0ca714f81c9e2a1d074ff74e2ae60e2747c9d74bf3bbf942a213) covering two agent profiles with different verification types (`.convos` and `.userOAuth`).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e5d5a02.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->