### PR TITLE
fix(debug): persist "Use real backend credits" override across launches

### DIFF
--- a/ConvosCore/Sources/ConvosCore/Services/Credits/CreditsServices.swift
+++ b/ConvosCore/Sources/ConvosCore/Services/Credits/CreditsServices.swift
@@ -42,29 +42,33 @@ public enum CreditsServices {
     }
 
     public static var useRealBackend: Bool {
-        let environment = ConfigManager.shared.currentEnvironment
+        resolveUseRealBackend(
+            environment: ConfigManager.shared.currentEnvironment,
+            defaults: .standard
+        )
+    }
+
+    /// Testable core of `useRealBackend`.
+    ///
+    /// Do NOT gate the stored override on `#if DEBUG` here. ConvosCore is a
+    /// Swift package, and Xcode compiles package dependencies in the
+    /// package's *release* configuration for any app build configuration
+    /// not named exactly "Debug" — this project runs with "Dev" / "Local",
+    /// so a `#if DEBUG` in this file is inactive even in simulator runs
+    /// (unlike in app-target files, where the xcconfigs define DEBUG).
+    /// That made the Debug-menu toggle's stored value silently ignored:
+    /// it re-defaulted to ON every launch. Gate at runtime instead:
+    /// production always short-circuits to the real backend, and the only
+    /// writer of the override is the Debug menu, which is reachable in
+    /// internal (dev/local) builds only.
+    static func resolveUseRealBackend(environment: AppEnvironment, defaults: UserDefaults) -> Bool {
         if environment.isProduction { return true }
-        // The UserDefaults override is intentionally DEBUG-only. On
-        // Release builds (TestFlight / App Store / Ad-Hoc) we always
-        // return the build-config default below so a stored `false`
-        // from a previous Debug build on the same device can't quietly
-        // pin a TestFlight tester to the mock service — UserDefaults
-        // survives reinstalls under the same bundle ID. The Debug menu
-        // toggle still works in Debug builds (where it's reachable).
-        #if DEBUG
-        if let stored = UserDefaults.standard.object(forKey: Constant.useRealBackendKey) as? Bool {
+        if let stored = defaults.object(forKey: Constant.useRealBackendKey) as? Bool {
             return stored
         }
-        return false
-        #else
-        // The previous `buildEnvironment == .distribution` check relied on
-        // `hasEmbeddedMobileProvision()` returning `false`, but TestFlight
-        // builds also ship `embedded.mobileprovision` — so they were being
-        // classified as `.development` and silently falling back to the
-        // mock. Anchor on the build configuration instead: Release builds
-        // (TestFlight / App Store / Ad-Hoc) hit the real backend.
+        // Default ON: anyone who never touched the toggle gets real
+        // backend credits, including TestFlight dev builds.
         return true
-        #endif
     }
 
     public static func setUseRealBackend(_ value: Bool) {
@@ -72,7 +76,7 @@ public enum CreditsServices {
         UserDefaults.standard.set(value, forKey: Constant.useRealBackendKey)
     }
 
-    private enum Constant {
+    enum Constant {
         static let useRealBackendKey: String = "creditsServices.useRealBackend"
     }
 }

--- a/ConvosCore/Tests/ConvosCoreTests/CreditsServicesUseRealBackendTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/CreditsServicesUseRealBackendTests.swift
@@ -1,0 +1,53 @@
+@testable import ConvosCore
+import Foundation
+import Testing
+
+@Suite("CreditsServices useRealBackend resolution")
+struct CreditsServicesUseRealBackendTests {
+    private static func makeDefaults() -> UserDefaults {
+        let suiteName = "CreditsServicesUseRealBackendTests-\(UUID().uuidString)"
+        // swiftlint:disable:next force_unwrapping
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        return defaults
+    }
+
+    private static var productionEnvironment: AppEnvironment {
+        .production(config: ConvosConfiguration(
+            apiBaseURL: "https://api.example.com",
+            appGroupIdentifier: "group.test",
+            relyingPartyIdentifier: "example.com",
+            siweConfiguration: SIWEConfiguration(domain: "example.com", uri: "https://example.com", chainId: 1)
+        ))
+    }
+
+    @Test("defaults to real backend when the toggle was never touched")
+    func defaultsToRealBackend() {
+        let defaults = Self.makeDefaults()
+        #expect(CreditsServices.resolveUseRealBackend(environment: .tests, defaults: defaults) == true)
+    }
+
+    @Test("a stored OFF override persists in non-production environments")
+    func storedOffOverridePersists() {
+        let defaults = Self.makeDefaults()
+        defaults.set(false, forKey: CreditsServices.Constant.useRealBackendKey)
+        #expect(CreditsServices.resolveUseRealBackend(environment: .tests, defaults: defaults) == false)
+    }
+
+    @Test("a stored ON override is honored in non-production environments")
+    func storedOnOverrideHonored() {
+        let defaults = Self.makeDefaults()
+        defaults.set(true, forKey: CreditsServices.Constant.useRealBackendKey)
+        #expect(CreditsServices.resolveUseRealBackend(environment: .tests, defaults: defaults) == true)
+    }
+
+    @Test("production ignores a stored OFF override and always uses the real backend")
+    func productionIgnoresStoredOverride() {
+        let defaults = Self.makeDefaults()
+        defaults.set(false, forKey: CreditsServices.Constant.useRealBackendKey)
+        #expect(CreditsServices.resolveUseRealBackend(
+            environment: Self.productionEnvironment,
+            defaults: defaults
+        ) == true)
+    }
+}


### PR DESCRIPTION
## Problem

Unchecking **Use real backend credits** in the Debug menu never stuck — it re-defaulted to ON every launch, pinning local simulator runs to real backend credits (a no-credits / no-power state against a local backend).

## Root cause

The stored UserDefaults override (`creditsServices.useRealBackend`) was gated behind `#if DEBUG` inside `CreditsServices` (ConvosCore). ConvosCore is a Swift package, and Xcode compiles package dependencies in the package's **release** configuration for any app build configuration not named exactly "Debug" — this project runs with "Dev" / "Local". So `DEBUG` was never defined there (build log shows `swiftc -module-name ConvosCore -O` with no `-DDEBUG`) and `useRealBackend` always took the `#else` branch returning `true`, ignoring the stored value. The sibling `SubscriptionServices.useRealStoreKit` toggle is unaffected because it lives in the app target, where the xcconfigs define `DEBUG`.

This regressed when CreditsServices moved into ConvosCore (#862).

## Fix

Replace the compile-time gate with a runtime gate in `resolveUseRealBackend(environment:defaults:)`:
- production always uses the real backend (read short-circuit + existing write guard),
- non-production builds honor the stored override,
- default stays **ON** when the toggle was never touched.

The only writer remains the Debug menu, reachable in internal (dev/local) builds only.

## Testing

- New `CreditsServicesUseRealBackendTests` (4 cases: default ON, stored OFF persists, stored ON honored, production ignores override) — passed on iPhone 17 simulator.
- `xcodebuild build` of `Convos (Local)` for iOS Simulator: **BUILD SUCCEEDED**.
- SwiftLint --strict on changed files: 0 violations.

Manual flow: Debug menu → uncheck "Use real backend credits" → relaunch → toggle stays unchecked and the app uses `MockCreditsService` (powered mock state via the persisted credits preset).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783844558&installation_id=128169237&pr_number=1059&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1059&signature=ded7b7622ff1f3ffa2e0aac3d651d649effb6b24ccbcbddf8516ad2a5c01c70c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Persist "Use real backend credits" debug override across launches in non-production builds
> The `CreditsServices.useRealBackend` property previously lost its debug override on relaunch. It now delegates to a new `resolveUseRealBackend(environment:defaults:)` helper that reads the override from `UserDefaults` (key `creditsServices.useRealBackend`) in non-production environments, defaulting to `true` when no override is stored. Production always returns `true` regardless of stored values.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1224fb9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->