### PR TITLE
Fix spurious profile-setup onboarding for users with an existing profile

### DIFF
--- a/Convos/Conversation Detail/ConversationOnboardingCoordinator.swift
+++ b/Convos/Conversation Detail/ConversationOnboardingCoordinator.swift
@@ -103,7 +103,7 @@ final class ConversationOnboardingCoordinator {
 
     var state: ConversationOnboardingState = .idle
 
-    private var profileSettingsViewModel: ProfileSettingsViewModel = .shared
+    private let profileSettingsViewModel: ProfileSettingsViewModel
 
     var isSettingUpProfile: Bool {
         switch state {
@@ -242,6 +242,11 @@ final class ConversationOnboardingCoordinator {
 
     private let notificationCenter: NotificationCenterProtocol
     private let autodismissDurationOverride: CGFloat?
+    /// How long `startProfileSetupFlow` waits for the global profile to load
+    /// before giving up. On timeout the coordinator goes quiet rather than
+    /// guess: prompting an already-onboarded user is worse than prompting a
+    /// new user one conversation-open late.
+    private let profileLoadTimeout: TimeInterval
     @ObservationIgnored
     private var appLifecycleTask: Task<Void, Never>?
     @ObservationIgnored
@@ -249,10 +254,14 @@ final class ConversationOnboardingCoordinator {
 
     init(
         notificationCenter: NotificationCenterProtocol = SystemNotificationCenter(),
-        autodismissDurationOverride: CGFloat? = nil
+        autodismissDurationOverride: CGFloat? = nil,
+        profileSettingsViewModel: ProfileSettingsViewModel = .shared,
+        profileLoadTimeout: TimeInterval = 10
     ) {
         self.notificationCenter = notificationCenter
         self.autodismissDurationOverride = autodismissDurationOverride
+        self.profileSettingsViewModel = profileSettingsViewModel
+        self.profileLoadTimeout = profileLoadTimeout
         observeAppLifecycle()
     }
 
@@ -399,27 +408,48 @@ final class ConversationOnboardingCoordinator {
 
     /// Start or continue the profile onboarding flow
     private func startProfileSetupFlow(for conversationId: String) async {
+        // Don't decide on an unloaded snapshot: at cold launch (and right
+        // after pairing adoption) the shared profile view model still holds
+        // default values even for a fully-onboarded user, because the global
+        // profile only arrives once the inbox is ready. `.started` renders
+        // nothing, so waiting here shows no UI either way.
+        let profileLoaded = await profileSettingsViewModel.waitForProfileLoad(timeout: profileLoadTimeout)
+        guard profileLoaded else {
+            QAEvent.emit(.onboarding, "profile_load_timeout")
+            state = .idle
+            handleStateChange()
+            return
+        }
+
         let hasSetProfileForConversation = hasSetProfile(for: conversationId)
 
         let profileSettings = profileSettingsViewModel.profileSettings
 
-        if !hasShownProfileEditor {
-            shouldAnimateAvatarForProfileSetup = true
-            state = .setupProfile
-            QAEvent.emit(.onboarding, "setup_profile", ["reason": "first_time"])
-            handleStateChange()
-        } else if profileSettings.isDefault && !hasSetProfileForConversation {
-            shouldAnimateAvatarForProfileSetup = true
-            state = .setupProfile
-            QAEvent.emit(.onboarding, "setup_profile", ["reason": "no_profile"])
-            handleStateChange()
-        } else {
+        if !profileSettings.isDefault {
+            // A profile already exists, so never prompt — regardless of the
+            // device-local editor flag, which can lag the profile (e.g. it is
+            // set asynchronously on a freshly paired device). Backfill it so
+            // related gates (like the input bar's "Chat as Somebody") agree.
+            hasShownProfileEditor = true
             if !hasSetProfileForConversation {
                 setHasSetProfile(true, for: conversationId)
                 QAEvent.emit(.onboarding, "profile_auto_applied", ["name": profileSettings.profile.displayName])
             } else {
                 QAEvent.emit(.onboarding, "profile_skipped", ["reason": "already_set"])
             }
+            await transitionAfterProfileSetup()
+        } else if !hasShownProfileEditor {
+            shouldAnimateAvatarForProfileSetup = true
+            state = .setupProfile
+            QAEvent.emit(.onboarding, "setup_profile", ["reason": "first_time"])
+            handleStateChange()
+        } else if !hasSetProfileForConversation {
+            shouldAnimateAvatarForProfileSetup = true
+            state = .setupProfile
+            QAEvent.emit(.onboarding, "setup_profile", ["reason": "no_profile"])
+            handleStateChange()
+        } else {
+            QAEvent.emit(.onboarding, "profile_skipped", ["reason": "already_set"])
             await transitionAfterProfileSetup()
         }
     }

--- a/Convos/Profile/ProfileSettingsViewModel.swift
+++ b/Convos/Profile/ProfileSettingsViewModel.swift
@@ -6,6 +6,16 @@ enum ProfileSettingsError: Error {
     case notBound
 }
 
+/// Whether the global profile has been definitively loaded from the active
+/// inbox. Distinct from the profile being empty: `.loading` means the answer
+/// is not known yet (cold launch before inbox ready, pairing transition), so
+/// consumers like the onboarding coordinator must not treat the current
+/// (default) values as "the user has no profile".
+enum ProfileLoadState: Equatable {
+    case loading
+    case loaded
+}
+
 @MainActor
 @Observable
 class ProfileSettingsViewModel {
@@ -31,12 +41,38 @@ class ProfileSettingsViewModel {
 
     var exampleDisplayName: String = "Somebody"
 
+    /// `.loading` until the bound repository delivers its first definitive
+    /// answer. The setter is internal so tests can preset the state; production
+    /// code must only write it from `bindInternal`/`rebind`.
+    var loadState: ProfileLoadState = .loading {
+        didSet { loadStateSubject.send(loadState) }
+    }
+    @ObservationIgnored
+    private let loadStateSubject: CurrentValueSubject<ProfileLoadState, Never> = .init(.loading)
+
     private var session: (any SessionManagerProtocol)?
     private var writer: (any MyGlobalProfileWriterProtocol)?
     private var repository: (any MyGlobalProfileRepositoryProtocol)?
     private var cancellables: Set<AnyCancellable> = []
 
     private init() {}
+
+    /// Suspends until the profile load state is known, returning true, or
+    /// until `timeout` elapses, returning false. Returns immediately when the
+    /// profile is already loaded.
+    func waitForProfileLoad(timeout: TimeInterval) async -> Bool {
+        if loadState == .loaded { return true }
+        let timeoutPublisher = Just(ProfileLoadState.loading)
+            .delay(for: .seconds(timeout), scheduler: DispatchQueue.main)
+        let firstResolution = loadStateSubject
+            .filter { $0 == .loaded }
+            .merge(with: timeoutPublisher)
+            .first()
+        for await state in firstResolution.values {
+            return state == .loaded
+        }
+        return loadState == .loaded
+    }
 
     func bind(session: any SessionManagerProtocol) {
         guard self.session == nil else { return }
@@ -60,6 +96,7 @@ class ProfileSettingsViewModel {
         profileImage = nil
         profileImageAssetIdentifier = nil
         profileImageContentDigest = nil
+        loadState = .loading
         bindInternal(session: session)
     }
 
@@ -69,13 +106,22 @@ class ProfileSettingsViewModel {
         self.writer = messagingService.myGlobalProfileWriter()
         let repository = messagingService.myGlobalProfileRepository()
         self.repository = repository
+        // Synchronous fast path: succeeds when the inbox is already ready and
+        // a profile row exists (warm starts), so dependents don't have to wait
+        // for the async observation's first emission.
         if let profile = try? repository.fetch() {
             apply(profile: profile)
+            loadState = .loaded
         }
-        repository.myGlobalProfilePublisher
+        // `.pending` deliberately doesn't downgrade `loadState`: it is the
+        // subject's replayed initial value and would otherwise undo the fast
+        // path above. Transitions back to loading happen only via `rebind`.
+        repository.myGlobalProfileLoadStatePublisher
             .receive(on: DispatchQueue.main)
-            .sink { [weak self] profile in
+            .sink { [weak self] state in
+                guard case .loaded(let profile) = state else { return }
                 self?.apply(profile: profile)
+                self?.loadState = .loaded
             }
             .store(in: &cancellables)
     }

--- a/ConvosCore/Sources/ConvosCore/Mocks/MockMyGlobalProfile.swift
+++ b/ConvosCore/Sources/ConvosCore/Mocks/MockMyGlobalProfile.swift
@@ -77,19 +77,31 @@ public final class MockMyGlobalProfileWriter: MyGlobalProfileWriterProtocol, @un
 
 public final class MockMyGlobalProfileRepository: MyGlobalProfileRepositoryProtocol, @unchecked Sendable {
     public let myGlobalProfilePublisher: AnyPublisher<MyProfile?, Never>
-    private let subject: CurrentValueSubject<MyProfile?, Never>
+    public let myGlobalProfileLoadStatePublisher: AnyPublisher<MyGlobalProfileLoadState, Never>
+    private let subject: CurrentValueSubject<MyGlobalProfileLoadState, Never>
 
     public init(initial: MyProfile? = nil) {
-        let subject = CurrentValueSubject<MyProfile?, Never>(initial)
+        let subject = CurrentValueSubject<MyGlobalProfileLoadState, Never>(.loaded(initial))
         self.subject = subject
-        self.myGlobalProfilePublisher = subject.eraseToAnyPublisher()
+        self.myGlobalProfileLoadStatePublisher = subject.eraseToAnyPublisher()
+        self.myGlobalProfilePublisher = subject
+            .compactMap { (state: MyGlobalProfileLoadState) -> MyProfile?? in
+                guard case .loaded(let profile) = state else { return nil }
+                return .some(profile)
+            }
+            .eraseToAnyPublisher()
     }
 
     public func fetch() throws -> MyProfile? {
-        subject.value
+        guard case .loaded(let profile) = subject.value else { return nil }
+        return profile
     }
 
     public func setForTesting(_ profile: MyProfile?) {
-        subject.send(profile)
+        subject.send(.loaded(profile))
+    }
+
+    public func setLoadStateForTesting(_ state: MyGlobalProfileLoadState) {
+        subject.send(state)
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Storage/Repositories/MyGlobalProfileRepository.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Repositories/MyGlobalProfileRepository.swift
@@ -2,18 +2,31 @@ import Combine
 import Foundation
 import GRDB
 
+/// Loading status of the local user's global profile. `pending` means the
+/// active inbox has not delivered a definitive answer yet (cold launch,
+/// pairing transition); `loaded` carries the row, or nil when the user
+/// genuinely has no global profile. Consumers that act on the profile being
+/// absent (e.g. onboarding prompts) must wait for `loaded` rather than
+/// treating `pending` as "no profile".
+public enum MyGlobalProfileLoadState: Equatable, Sendable {
+    case pending
+    case loaded(MyProfile?)
+}
+
 /// Read access to the local user's global profile (`DBMyProfile`).
 public protocol MyGlobalProfileRepositoryProtocol {
     var myGlobalProfilePublisher: AnyPublisher<MyProfile?, Never> { get }
+    var myGlobalProfileLoadStatePublisher: AnyPublisher<MyGlobalProfileLoadState, Never> { get }
     func fetch() throws -> MyProfile?
 }
 
 final class MyGlobalProfileRepository: MyGlobalProfileRepositoryProtocol {
     let myGlobalProfilePublisher: AnyPublisher<MyProfile?, Never>
+    let myGlobalProfileLoadStatePublisher: AnyPublisher<MyGlobalProfileLoadState, Never>
 
     private let databaseReader: any DatabaseReader
     private let sessionStateManager: any SessionStateManagerProtocol
-    private let profileSubject: CurrentValueSubject<MyProfile?, Never> = .init(nil)
+    private let stateSubject: CurrentValueSubject<MyGlobalProfileLoadState, Never> = .init(.pending)
     private var stateObserver: StateObserverHandle?
     private var observationCancellable: AnyCancellable?
     private var observingInboxId: String?
@@ -24,7 +37,16 @@ final class MyGlobalProfileRepository: MyGlobalProfileRepositoryProtocol {
     ) {
         self.databaseReader = databaseReader
         self.sessionStateManager = sessionStateManager
-        self.myGlobalProfilePublisher = profileSubject.eraseToAnyPublisher()
+        self.myGlobalProfileLoadStatePublisher = stateSubject.eraseToAnyPublisher()
+        // The profile publisher stays quiet until the first definitive
+        // answer, so subscribers no longer receive a synthetic nil replay
+        // that is indistinguishable from "user has no profile".
+        self.myGlobalProfilePublisher = stateSubject
+            .compactMap { (state: MyGlobalProfileLoadState) -> MyProfile?? in
+                guard case .loaded(let profile) = state else { return nil }
+                return .some(profile)
+            }
+            .eraseToAnyPublisher()
 
         stateObserver = sessionStateManager.observeState { [weak self] state in
             self?.handleInboxStateChange(state)
@@ -53,7 +75,10 @@ final class MyGlobalProfileRepository: MyGlobalProfileRepositoryProtocol {
         case .ready(let result):
             startObserving(inboxId: result.client.inboxId)
         case .idle:
-            profileSubject.send(nil)
+            // No active inbox means the profile is unknown again, not
+            // known-absent: teardown and pairing transitions pass through
+            // here and must not read as "user has no profile".
+            stateSubject.send(.pending)
             observationCancellable?.cancel()
             observingInboxId = nil
         default:
@@ -75,7 +100,7 @@ final class MyGlobalProfileRepository: MyGlobalProfileRepositoryProtocol {
             .publisher(in: databaseReader)
             .replaceError(with: nil)
             .sink { [weak self] profile in
-                self?.profileSubject.send(profile)
+                self?.stateSubject.send(.loaded(profile))
             }
     }
 }

--- a/ConvosTests/ConversationOnboardingCoordinatorTests.swift
+++ b/ConvosTests/ConversationOnboardingCoordinatorTests.swift
@@ -32,9 +32,12 @@ final class ConversationOnboardingCoordinatorTests: XCTestCase {
 
         // The coordinator reads `ProfileSettingsViewModel.shared` (a
         // singleton); reset it so a non-default profile left by another
-        // test can't push `start()` down the auto-apply branch.
+        // test can't push `start()` down the auto-apply branch. Mark it
+        // loaded so `start()` doesn't wait out the profile-load gate;
+        // tests covering the gate set `.loading` explicitly.
         ProfileSettingsViewModel.shared.editingDisplayName = ""
         ProfileSettingsViewModel.shared.profileImage = nil
+        ProfileSettingsViewModel.shared.loadState = .loaded
     }
 
     override func tearDown() async throws {
@@ -42,6 +45,10 @@ final class ConversationOnboardingCoordinatorTests: XCTestCase {
         mockNotificationCenter = nil
 
         cleanUpUserDefaults()
+
+        ProfileSettingsViewModel.shared.editingDisplayName = ""
+        ProfileSettingsViewModel.shared.profileImage = nil
+        ProfileSettingsViewModel.shared.loadState = .loaded
 
         try await super.tearDown()
     }
@@ -314,6 +321,73 @@ final class ConversationOnboardingCoordinatorTests: XCTestCase {
         }
 
         UserDefaults.standard.removeObject(forKey: "hasSetProfileForConversation_\(conversationId)")
+    }
+
+    // MARK: - Profile Load Gate Tests
+
+    func testStart_ProfileNotLoaded_TimesOutQuietly() async {
+        ProfileSettingsViewModel.shared.loadState = .loading
+        let gatedCoordinator = ConversationOnboardingCoordinator(
+            notificationCenter: mockNotificationCenter,
+            autodismissDurationOverride: testAutodismissDuration,
+            profileLoadTimeout: 0.05
+        )
+
+        await gatedCoordinator.start(for: testConversationId)
+
+        XCTAssertEqual(
+            gatedCoordinator.state, .idle,
+            "With the profile state unknown, the coordinator must go quiet instead of prompting"
+        )
+        XCTAssertFalse(
+            UserDefaults.standard.bool(forKey: "hasShownProfileEditor"),
+            "A timed-out start must not mutate onboarding flags"
+        )
+    }
+
+    func testStart_ProfileLoadsWhileWaiting_AutoAppliesExistingProfile() async {
+        ProfileSettingsViewModel.shared.loadState = .loading
+        ProfileSettingsViewModel.shared.editingDisplayName = "Alice"
+        mockNotificationCenter.authStatus = .notDetermined
+
+        let startTask = Task { await coordinator.start(for: testConversationId) }
+        // Let start() reach the profile-load gate before resolving it.
+        try? await Task.sleep(for: .milliseconds(20))
+        ProfileSettingsViewModel.shared.loadState = .loaded
+        await startTask.value
+
+        XCTAssertEqual(
+            coordinator.state, .requestNotifications,
+            "A profile arriving while the coordinator waits must auto-apply, not prompt"
+        )
+        XCTAssertTrue(UserDefaults.standard.bool(forKey: "hasSetProfileForConversation_\(testConversationId)"))
+    }
+
+    func testStart_ExistingProfile_EditorFlagUnset_DoesNotPrompt() async {
+        // A populated profile with no device-local editor flag is the
+        // freshly-paired-device shape (flags are written asynchronously
+        // after the identity seed): the profile itself must win.
+        ProfileSettingsViewModel.shared.editingDisplayName = "Alice"
+        mockNotificationCenter.authStatus = .notDetermined
+
+        await coordinator.start(for: testConversationId)
+
+        XCTAssertEqual(coordinator.state, .requestNotifications)
+        XCTAssertTrue(
+            UserDefaults.standard.bool(forKey: "hasShownProfileEditor"),
+            "Auto-apply must backfill the editor flag so dependent gates agree a profile exists"
+        )
+        XCTAssertTrue(UserDefaults.standard.bool(forKey: "hasSetProfileForConversation_\(testConversationId)"))
+    }
+
+    func testStart_ExistingProfile_PerConversationFlagSet_Skips() async {
+        ProfileSettingsViewModel.shared.editingDisplayName = "Alice"
+        UserDefaults.standard.set(true, forKey: "hasSetProfileForConversation_\(testConversationId)")
+        mockNotificationCenter.authStatus = .authorized
+
+        await coordinator.start(for: testConversationId)
+
+        XCTAssertEqual(coordinator.state, .idle, "Known profile + per-conversation flag must skip straight through")
     }
 
     // MARK: - App Lifecycle Tests

--- a/ConvosTests/ConversationViewModelGlobalDefaultsTests.swift
+++ b/ConvosTests/ConversationViewModelGlobalDefaultsTests.swift
@@ -225,6 +225,10 @@ private final class TestSessionManager: SessionManagerProtocol, @unchecked Senda
         try await base.deleteAllInboxes()
     }
 
+    func registerClaimedConversation(id conversationId: String) async {
+        await base.registerClaimedConversation(id: conversationId)
+    }
+
     func deleteAllInboxesWithProgress() -> AsyncThrowingStream<InboxDeletionProgress, Error> {
         base.deleteAllInboxesWithProgress()
     }

--- a/ConvosTests/ConversationsViewModelDeleteTests.swift
+++ b/ConvosTests/ConversationsViewModelDeleteTests.swift
@@ -225,6 +225,10 @@ private final class TestSessionManager: SessionManagerProtocol, @unchecked Senda
         try await base.deleteAllInboxes()
     }
 
+    func registerClaimedConversation(id conversationId: String) async {
+        await base.registerClaimedConversation(id: conversationId)
+    }
+
     func deleteAllInboxesWithProgress() -> AsyncThrowingStream<InboxDeletionProgress, Error> {
         base.deleteAllInboxesWithProgress()
     }


### PR DESCRIPTION
## Problem

Users who already have a name and profile photo were seeing the "setup name and pic" onboarding step in the conversation view.

`ConversationOnboardingCoordinator.startProfileSetupFlow` decided whether to prompt by reading `ProfileSettingsViewModel.shared` once, synchronously, when a conversation opened. That snapshot is seeded asynchronously and the empty/default state was indistinguishable from "not loaded yet":

- At cold launch, `MyGlobalProfileRepository.fetch()` throws `inboxNotReady` until the session reaches `.ready`, so the synchronous seed silently failed (`try?`).
- Even when the seed succeeded, subscribing to the repository's `CurrentValueSubject(nil)` immediately replayed `nil` and wiped the seeded values one main-queue hop later.
- Nothing re-checked once the real profile loaded, so a misfired prompt stayed up.

A fully onboarded user opening a not-previously-opened conversation during that window (e.g. cold launch from a push for a new conversation, or a freshly paired device whose profile seed and onboarding flags land asynchronously after identity adoption) was prompted to set up a profile they already had.

## Fix

Make "not yet loaded" representable, and gate the decision on a definitive answer:

- **`MyGlobalProfileRepository`** publishes `MyGlobalProfileLoadState` (`pending` -> `loaded(MyProfile?)`). The legacy profile publisher stays quiet until the first definitive answer (no synthetic `nil` replay), and inbox teardown/pairing transitions reset to `pending` instead of emitting a fake empty profile.
- **`ProfileSettingsViewModel`** tracks `loadState` (reset to `.loading` on the pairing `rebind`), keeps the synchronous warm-start fast path (no longer wiped by the replay), and exposes `waitForProfileLoad(timeout:)`.
- **`ConversationOnboardingCoordinator.startProfileSetupFlow`** awaits the gate before branching. While waiting it sits in `.started`, which renders nothing — no flash in either direction. On timeout (e.g. offline cold launch) it goes quietly back to `.idle` rather than guess. The branch order changes so an existing profile always auto-applies and backfills `hasShownProfileEditor`, covering the freshly paired device. All genuinely-new-user paths (`first_time` / `no_profile` prompts) are unchanged.

## Also

The `ConvosTests` bundle didn't compile at HEAD: two private `TestSessionManager` doubles were missing the `registerClaimedConversation(id:)` requirement added in #986. Added delegating conformances.

## Testing

- 4 new coordinator tests: timeout goes quiet without mutating flags; a profile arriving mid-wait auto-applies; a populated profile with the editor flag unset doesn't prompt (paired-device shape); profile + per-conversation flag skips through.
- Full `ConvosCore` suite: 1173 tests / 168 suites passed (against the local XMTP stack).
- Full `ConvosTests` app bundle passed; SwiftLint strict clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1061"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783867294&installation_id=128169237&pr_number=1061&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1061&signature=f7e5c1cbafd03213fbf0016f8304c1c88b4d64dd3a55ca31382460fde683d04c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix spurious profile-setup onboarding prompt for users with an existing profile
> - Introduces `MyGlobalProfileLoadState` (pending/loaded) in [`MyGlobalProfileRepository`](https://github.com/xmtplabs/convos-ios/pull/1061/files#diff-2fb41b8bfb5c728a54c7a32bb783ed0b4988f25c9a74b136b9dfd3ae90641962) so subscribers can distinguish "not yet loaded" from "no profile exists", preventing an initial nil value from being treated as a missing profile.
> - `ConversationOnboardingCoordinator.startProfileSetupFlow` now waits up to a configurable timeout for the profile to load before deciding whether to prompt; on timeout it goes idle and emits a `profile_load_timeout` QA event without changing onboarding flags.
> - When a non-default profile already exists, the coordinator marks the editor as shown and skips the setup prompt rather than re-prompting.
> - `ProfileSettingsViewModel` and the load timeout are now injectable dependencies on `ConversationOnboardingCoordinator`, improving testability.
> - Behavioral Change: `myGlobalProfilePublisher` no longer emits an initial nil before the inbox is ready; subscribers only receive values once the load state is `loaded`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1911208.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->